### PR TITLE
[core] Config loader: first draft

### DIFF
--- a/pkg/loader/README.md
+++ b/pkg/loader/README.md
@@ -1,0 +1,16 @@
+This package is responsible of scanning different sources searching for Agent checks' configuration files.
+
+Check configurations may be contained within files on disk, environment variables, external databases: for
+each source, the Agent has a specific _Provider_ implementing the `ConfigProvider` interface.
+
+Check configurations may come in different format, for example Yaml code in the case of config files on disk.
+Every configuration, regardless of the format, must be unmarshalled into a `CheckConfig` struct.
+
+Usage example:
+```go
+var configs []loader.CheckConfig
+for _, provider := range configProviders {
+  c, _ := provider.Collect()
+  configs = append(configs, c...)
+}
+```

--- a/pkg/loader/file_provider.go
+++ b/pkg/loader/file_provider.go
@@ -1,0 +1,77 @@
+package loader
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/op/go-logging"
+
+	"gopkg.in/yaml.v2"
+)
+
+var log = logging.MustGetLogger("datadog-agent")
+
+// FileConfigProvider collect configuration files from disk
+type FileConfigProvider struct {
+	paths []string
+}
+
+// NewFileConfigProvider creates a new FileConfigProvider searching for
+// configuration files on the given paths
+func NewFileConfigProvider(paths []string) *FileConfigProvider {
+	return &FileConfigProvider{paths: paths}
+}
+
+// Collect scans provided paths searching for configuration files. When found,
+// it parses the files and try to unmarshall Yaml contents into a CheckConfig
+// instance
+func (c *FileConfigProvider) Collect() ([]CheckConfig, error) {
+	configs := []CheckConfig{}
+
+	for _, path := range c.paths {
+		log.Debug("Searching for yaml files at:", path)
+
+		files, err := ioutil.ReadDir(path)
+		if err != nil {
+			log.Warningf("Unable to access dir: %s, skipping...", err)
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				log.Warningf("%s is a dir, skipping...", f.Name())
+				continue
+			}
+
+			fName := f.Name()
+			extName := filepath.Ext(fName)
+			bName := fName[:len(f.Name())-len(extName)]
+			conf, err := getCheckConfig(bName, filepath.Join(path, fName))
+			if err != nil {
+				log.Warningf("%s is not a valid config file: %s", f.Name(), err)
+				continue
+			}
+
+			log.Debug("Found valid configuration in file:", f.Name())
+			configs = append(configs, conf)
+		}
+	}
+
+	return configs, nil
+}
+
+// getCheckConfig returns an instance of CheckConfig if `fpath` points to a valid config file
+func getCheckConfig(name, fpath string) (CheckConfig, error) {
+	conf := CheckConfig{Name: name}
+
+	// Read file contents
+	// FIXME: ReadFile reads the entire file, possible security implications
+	yamlFile, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return conf, err
+	}
+
+	// Parse configuration
+	err = yaml.Unmarshal(yamlFile, &conf.Data)
+	return conf, err
+}

--- a/pkg/loader/file_provider_test.go
+++ b/pkg/loader/file_provider_test.go
@@ -1,0 +1,56 @@
+package loader
+
+import "testing"
+
+func Test_GetCheckConfig(t *testing.T) {
+	config, err := getCheckConfig("foo", "tests/wrong.yaml")
+	if err == nil {
+		t.Fatal("Expecting error")
+	}
+
+	config, err = getCheckConfig("foo", "foo.yaml")
+	if err == nil {
+		t.Fatal("Expecting error")
+	}
+
+	config, err = getCheckConfig("foo", "tests/testcheck.yaml")
+	if err != nil {
+		t.Fatalf("Expecting nil, found: %s", err)
+	}
+	if config.Name != "foo" {
+		t.Fatalf("Expecting `foo`, found: %s", config.Name)
+	}
+}
+
+func TestNewYamlConfigProvider(t *testing.T) {
+	paths := []string{"foo", "bar", "foo/bar"}
+	provider := NewFileConfigProvider(paths)
+	if len(provider.paths) != len(paths) {
+		t.Fatalf("Expecting length %d, found: %d", len(provider.paths), len(paths))
+	}
+
+	for i, p := range provider.paths {
+		if p != paths[i] {
+			t.Fatalf("Expecting %s, found: %s", paths[i], p)
+		}
+	}
+}
+
+func TestCollect(t *testing.T) {
+	paths := []string{"tests", "foo/bar"}
+	provider := NewFileConfigProvider(paths)
+	configs, err := provider.Collect()
+
+	if err != nil {
+		t.Fatalf("Expecting nil, found: %s", err)
+	}
+
+	if len(configs) != 1 {
+		t.Fatalf("Expecting length 1, found: %d", len(configs))
+	}
+
+	config := configs[0]
+	if config.Name != "testcheck" {
+		t.Fatalf("Expecting testcheck, found: %s", config.Name)
+	}
+}

--- a/pkg/loader/tests/testcheck.yaml
+++ b/pkg/loader/tests/testcheck.yaml
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar

--- a/pkg/loader/tests/wrong.yaml
+++ b/pkg/loader/tests/wrong.yaml
@@ -1,0 +1,1 @@
+// not valid Yaml

--- a/pkg/loader/types.go
+++ b/pkg/loader/types.go
@@ -1,0 +1,19 @@
+package loader
+
+// CheckConfig is a generic container for configuration files
+type CheckConfig struct {
+	Name string                 // the name of the check
+	Data map[string]interface{} // raw configuration content, unmarshalled from Yaml
+}
+
+// ConfigProvider is the interface that wraps the Collect method
+//
+// Collect is responsible of populating a list of CheckConfig instances
+// by retrieving configuration patterns from external resources: files
+// on disk, databases, environment variables are just few examples.
+//
+// Any type implementing the interface will take care of any dependency
+// or data needed to access the resource providing the configuration.
+type ConfigProvider interface {
+	Collect() ([]CheckConfig, error)
+}

--- a/pkg/py/config_test.go
+++ b/pkg/py/config_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/loader"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/sbinet/go-python"
 
@@ -19,14 +20,14 @@ func TestToPythonDict(t *testing.T) {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
 
-	c := CheckConfig{}
+	c := loader.CheckConfig{}
 
-	err = yaml.Unmarshal(yamlFile, &c.rawData)
+	err = yaml.Unmarshal(yamlFile, &c.Data)
 	if err != nil {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
 
-	res, err := c.ToPythonDict()
+	res, err := ToPythonDict(&c)
 	if err != nil {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
@@ -223,31 +224,5 @@ func TestSliceElem(t *testing.T) {
 	l := python.PyList_Size(w.currentContainer)
 	if l != 1 {
 		t.Fatalf("Expected list lenght 1, found %d", l)
-	}
-}
-
-func TestGetCheckConfig(t *testing.T) {
-	conf, err := getCheckConfig("foo", "bar")
-	if err == nil {
-		t.Fatal("Expecting error")
-	}
-	if len(conf.rawData) != 0 {
-		t.Fatalf("Expecting empty Config, found: %d", len(conf.rawData))
-	}
-
-	conf, err = getCheckConfig("tests", "bad")
-	if err == nil {
-		t.Fatal("Expecting error")
-	}
-	if len(conf.rawData) != 0 {
-		t.Fatalf("Expecting empty Config, found: %v", conf)
-	}
-
-	conf, err = getCheckConfig("tests", "testcheck")
-	if err != nil {
-		t.Fatalf("Error: %v", err)
-	}
-	if len(conf.rawData) != 2 {
-		t.Fatalf("Expecting 2 elem in Config, found: %d", len(conf.rawData))
 	}
 }

--- a/pkg/py/tests/bar.py
+++ b/pkg/py/tests/bar.py
@@ -1,4 +1,4 @@
-from tests import foo
+import foo
 
 class Bar(foo.Foo):
     pass

--- a/pkg/py/utils_test.go
+++ b/pkg/py/utils_test.go
@@ -17,6 +17,7 @@ func TestMain(m *testing.M) {
 	// Set the PYTHONPATH
 	path := python.PySys_GetObject("path")
 	python.PyList_Append(path, python.PyString_FromString("."))
+	python.PyList_Append(path, python.PyString_FromString("tests"))
 	python.PyList_Append(path, python.PyString_FromString("dist"))
 
 	// Initialize acquires the GIL but we don't need it, release it
@@ -47,9 +48,9 @@ func TestFindSubclassOf(t *testing.T) {
 		python.PyGILState_Release(_gstate)
 	}()
 
-	fooModule := python.PyImport_ImportModuleNoBlock("tests.foo")
+	fooModule := python.PyImport_ImportModuleNoBlock("foo")
 	fooClass := fooModule.GetAttrString("Foo")
-	barModule := python.PyImport_ImportModuleNoBlock("tests.bar")
+	barModule := python.PyImport_ImportModuleNoBlock("bar")
 	barClass := barModule.GetAttrString("Bar")
 
 	// invalid input


### PR DESCRIPTION
First draft of the loader system for checks' configurations.
The `agent` main module was adapted to follow the new logic (first search for the configuration, then search for the corresponding checks) but only for the Python checks atm.

More details on the [README](https://github.com/DataDog/datadog-agent/blob/52f2d5285ab663cd62c3a40671bf25e970ad27f7/pkg/loader/README.md) file
