### PR TITLE
[loader] Python checks loader

### DIFF
--- a/cmd/agent/app/main.go
+++ b/cmd/agent/app/main.go
@@ -79,10 +79,15 @@ func Start() {
 		configs = append(configs, c...)
 	}
 
-	// Search for and import all the desired Python checks
-	// TODO: this functionality will be implemented by a generic Collector able to
-	// search for and load different checks (Python, Go, whatever...)
-	checks := py.CollectChecks(configs)
+	// try to import corresponding checks using the PythonCheckLoader
+	checks := []checks.Check{}
+	checksLoader := py.NewPythonCheckLoader()
+	for _, conf := range configs {
+		res, err := checksLoader.Load(conf)
+		if err == nil {
+			checks = append(checks, res...)
+		}
+	}
 
 	// Run memory check, this is a native check, not Python
 	// TODO: see above, this should be done elsewhere, not manually here

--- a/pkg/checks/common.go
+++ b/pkg/checks/common.go
@@ -4,10 +4,14 @@ import "github.com/op/go-logging"
 
 var log = logging.MustGetLogger("datadog-agent")
 
+// ConfigData contains YAML code
+type ConfigData []byte
+
 // Check is an interface for types capable to run checks
 type Check interface {
 	Run() error
 	String() string
+	Configure(data ConfigData)
 }
 
 // Runner waits for checks and run them as long as they arrive on the channel

--- a/pkg/checks/common_test.go
+++ b/pkg/checks/common_test.go
@@ -12,6 +12,8 @@ type TestCheck struct {
 
 func (c *TestCheck) String() string { return "TestCheck" }
 
+func (c *TestCheck) Configure(ConfigData) {}
+
 func (c *TestCheck) Run() error {
 	if c.doErr {
 		msg := "A tremendous error occurred."

--- a/pkg/checks/system/memory.go
+++ b/pkg/checks/system/memory.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/checks"
 	"github.com/op/go-logging"
 	"github.com/shirou/gopsutil/mem"
 
@@ -21,4 +22,9 @@ func (c *MemoryCheck) Run() error {
 	v, _ := mem.VirtualMemory()
 	aggregator.GetSender(MEMORY_CHECK_INTERVAL).Gauge("system.mem.total", float64(v.Total), "", []string{})
 	return nil
+}
+
+// Configure the Python check from YAML data
+func (c *MemoryCheck) Configure(data checks.ConfigData) {
+	// do nothing
 }

--- a/pkg/loader/README.md
+++ b/pkg/loader/README.md
@@ -1,10 +1,16 @@
-This package is responsible of scanning different sources searching for Agent checks' configuration files.
+This package is responsible of scanning different sources searching for Agent checks' configuration files. Check
+configurations consist in one or more `instance`s, every loader must be capable to break down such `instance`s
+into distinct elements.
 
 Check configurations may be contained within files on disk, environment variables, external databases: for
 each source, the Agent has a specific _Provider_ implementing the `ConfigProvider` interface.
 
-Check configurations may come in different format, for example Yaml code in the case of config files on disk.
-Every configuration, regardless of the format, must be unmarshalled into a `CheckConfig` struct.
+Check configurations may come in different format, for example Yaml code in the case of config files on disk, or
+environment variables following certain conventions for their names.
+
+Every configuration, regardless of the format, must specify at least one check `instance`: each instance will be
+translated to Yaml code, the common language to carry around instance configurations within the Agent code. A
+ `CheckConfig` struct contains a list of Yaml configuration text elements, one per instance.
 
 Usage example:
 ```go

--- a/pkg/loader/README.md
+++ b/pkg/loader/README.md
@@ -1,16 +1,14 @@
-This package is responsible of scanning different sources searching for Agent checks' configuration files. Check
-configurations consist in one or more `instance`s, every loader must be capable to break down such `instance`s
-into distinct elements.
+## loader
 
-Check configurations may be contained within files on disk, environment variables, external databases: for
-each source, the Agent has a specific _Provider_ implementing the `ConfigProvider` interface.
+This package is responsible of scanning different sources searching for Agent checks' configuration files, extract
+configuration instances and provide the corresponding check objects.
 
-Check configurations may come in different format, for example Yaml code in the case of config files on disk, or
-environment variables following certain conventions for their names.
-
-Every configuration, regardless of the format, must specify at least one check `instance`: each instance will be
-translated to Yaml code, the common language to carry around instance configurations within the Agent code. A
- `CheckConfig` struct contains a list of Yaml configuration text elements, one per instance.
+### Configuration Providers
+Providers implement the `ConfigProvider` interface and are responsible for scanning different sources like files on
+disk, environment variables or databases, searching for check configurations. Every configuration, regardless of the
+format, must specify at least one check `instance`. Providers dump every configuration they find into a `CheckConfig`
+struct containing an array of configuration instances. Configuration instances are converted in YAML format so that a
+check object will be eventually able to convert them into the appropriate data structure.
 
 Usage example:
 ```go
@@ -19,4 +17,24 @@ for _, provider := range configProviders {
   c, _ := provider.Collect()
   configs = append(configs, c...)
 }
+```
+
+### Check Loaders
+Loaders implement the `CheckLoader` interface, they are responsible to instantiate one object of type `check.Check` for
+every configuration instance within a `CheckConfig` object. A Loader usually invokes the `Configure` method on check
+objects passing in the configuration instance in YAML format: how to use it, it's up to the check itself.
+
+Usage example:
+```go
+// given a list of configurations, try to load corresponding checks using different loaders
+checks := []check.Check{}
+for _, conf := range configs {
+  for _, loader := range loaders {
+    res, err := loader.Load(conf)
+    if err == nil {
+      checks = append(checks, res...)
+    }
+  }
+}
+// `checks` contains one check per configuration instance found.
 ```

--- a/pkg/loader/types.go
+++ b/pkg/loader/types.go
@@ -1,9 +1,14 @@
 package loader
 
+import "github.com/DataDog/datadog-agent/pkg/checks"
+
+// RawConfigMap is the generic type to hold YAML configurations
+type RawConfigMap map[interface{}]interface{}
+
 // CheckConfig is a generic container for configuration files
 type CheckConfig struct {
-	Name string                 // the name of the check
-	Data map[string]interface{} // raw configuration content, unmarshalled from Yaml
+	Name string       // the name of the check
+	Data RawConfigMap // raw configuration content
 }
 
 // ConfigProvider is the interface that wraps the Collect method
@@ -16,4 +21,13 @@ type CheckConfig struct {
 // or data needed to access the resource providing the configuration.
 type ConfigProvider interface {
 	Collect() ([]CheckConfig, error)
+}
+
+// CheckLoader is the interface wrapping the operations to load a check from
+// different sources, like Python modules or Go objects.
+//
+// A check is loaded for every `instance` found in the configuration file.
+// Load is supposed to break down instances and return different checks.
+type CheckLoader interface {
+	Load(config CheckConfig) ([]checks.Check, error)
 }

--- a/pkg/loader/types.go
+++ b/pkg/loader/types.go
@@ -7,8 +7,9 @@ type RawConfigMap map[interface{}]interface{}
 
 // CheckConfig is a generic container for configuration files
 type CheckConfig struct {
-	Name string       // the name of the check
-	Data RawConfigMap // raw configuration content
+	Name      string       // the name of the check
+	Data      RawConfigMap // raw configuration content
+	Instances []checks.ConfigData
 }
 
 // ConfigProvider is the interface that wraps the Collect method

--- a/pkg/py/check.go
+++ b/pkg/py/check.go
@@ -2,6 +2,7 @@ package py
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/checks"
@@ -20,14 +21,11 @@ const agentCheckModuleName = "checks"
 type PythonCheck struct {
 	Instance   *python.PyObject
 	ModuleName string
-	Config     loader.CheckConfig
+	Config     *python.PyObject
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
-func NewPythonCheck(class *python.PyObject, config loader.CheckConfig) *PythonCheck {
-	// pack arguments
-	kwargs, _ := ToPythonDict(&config)
-
+func NewPythonCheck(class *python.PyObject, configDict *python.PyObject) *PythonCheck {
 	// Lock the GIL and release it at the end
 	_gstate := python.PyGILState_Ensure()
 	defer func() {
@@ -36,7 +34,7 @@ func NewPythonCheck(class *python.PyObject, config loader.CheckConfig) *PythonCh
 
 	// invoke constructor
 	emptyTuple := python.PyTuple_New(0)
-	instance := class.Call(emptyTuple, kwargs)
+	instance := class.Call(emptyTuple, configDict)
 	if instance == nil {
 		python.PyErr_Print()
 		return nil
@@ -44,7 +42,7 @@ func NewPythonCheck(class *python.PyObject, config loader.CheckConfig) *PythonCh
 
 	modName := python.PyString_AsString(instance.GetAttrString("__module__"))
 
-	return &PythonCheck{Instance: instance, ModuleName: modName, Config: config}
+	return &PythonCheck{Instance: instance, ModuleName: modName, Config: configDict}
 }
 
 // Run a Python check
@@ -82,54 +80,89 @@ func (c *PythonCheck) String() string {
 	return ""
 }
 
-// CollectChecks return an array of checks to be performed
-func CollectChecks(configs []loader.CheckConfig) []checks.Check {
+// PythonCheckLoader is a specific loader for checks living in Python modules
+type PythonCheckLoader struct {
+	agentCheckClass *python.PyObject
+}
+
+// NewPythonCheckLoader creates an instance of the Python checks loader
+func NewPythonCheckLoader() *PythonCheckLoader {
 	// Lock the GIL and release it at the end of the run
 	_gstate := python.PyGILState_Ensure()
 	defer func() {
 		python.PyGILState_Release(_gstate)
 	}()
 
-	checks := []checks.Check{}
-
 	agentCheckModule := python.PyImport_ImportModuleNoBlock(agentCheckModuleName)
 	if agentCheckModule == nil {
 		log.Errorf("Unable to import Python module: %s", agentCheckModuleName)
-		return checks
+		return nil
 	}
 
 	agentCheckClass := agentCheckModule.GetAttrString(agentCheckClassName)
 	if agentCheckClass == nil {
 		log.Errorf("Unable to import %s class from Python module: %s", agentCheckClassName, agentCheckModuleName)
-		return checks
+		return nil
 	}
 
-	for _, config := range configs {
-		moduleName := config.Name
+	return &PythonCheckLoader{agentCheckClass}
+}
 
-		// import python module containing the check
-		checkModule := python.PyImport_ImportModuleNoBlock(moduleName)
-		if checkModule == nil {
-			log.Warningf("Unable to import %v", moduleName)
-			python.PyErr_Print() // TODO: remove this or redirect to the Go logger
-			python.PyErr_Clear()
+// Load tries to import a Python module with the same name found in config.Name, searches for
+// subclasses of the AgentCheck class and returns the corresponding Check
+func (cl *PythonCheckLoader) Load(config loader.CheckConfig) ([]checks.Check, error) {
+	checks := []checks.Check{}
+	moduleName := config.Name
+
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	// import python module containing the check
+	checkModule := python.PyImport_ImportModuleNoBlock(moduleName)
+	if checkModule == nil {
+		msg := fmt.Sprintf("Unable to import %v", moduleName)
+		log.Warningf(msg)
+		python.PyErr_Print() // TODO: remove this or redirect to the Go logger
+		python.PyErr_Clear()
+
+		return checks, errors.New(msg)
+	}
+
+	// Try to find a class inheriting from AgentCheck within the module
+	checkClass := findSubclassOf(cl.agentCheckClass, checkModule)
+	if checkClass == nil {
+		msg := fmt.Sprintf("Unable to find a check class in the module: %v", python.PyString_AS_STRING(checkModule.Str()))
+		log.Warningf(msg)
+		return checks, errors.New(msg)
+	}
+
+	// Get an AgentCheck for each configuration instance and add it to the registry
+	instances, found := config.Data["instances"]
+	if !found {
+		return checks, errors.New("`instances` keyword not found in configuration data")
+	}
+
+	instancesList, _ := instances.([]interface{})
+	for _, instanceMap := range instancesList {
+		// To be retrocompatible with the Python code, still use an `instance` dictionary
+		// to contain the (now) unique instance for the check
+		conf := make(loader.RawConfigMap)
+		conf["instances"] = []interface{}{instanceMap}
+		pyConf, err := ToPythonDict(&conf)
+		if err != nil {
+			log.Errorf("Error parsing check configuration: %v", err)
 			continue
 		}
 
-		// Try to find a class inheriting from AgentCheck within the module
-		checkClass := findSubclassOf(agentCheckClass, checkModule)
-		if checkClass == nil {
-			log.Warningf("Unable to find a check class in the module %v", checkModule)
-			continue
-		}
-
-		// Get an AgentCheck instance and add it to the registry
-		check := NewPythonCheck(checkClass, config)
+		check := NewPythonCheck(checkClass, pyConf)
 		if check != nil {
-			log.Infof("Found check: %v", python.PyString_AsString(checkClass.Str()))
+			log.Infof("Loading check: %v", python.PyString_AsString(checkClass.Str()))
 			checks = append(checks, check)
 		}
 	}
 
-	return checks
+	return checks, nil
 }

--- a/pkg/py/check.go
+++ b/pkg/py/check.go
@@ -2,20 +2,13 @@ package py
 
 import (
 	"errors"
-	"fmt"
 	"runtime"
 
-	"github.com/DataDog/datadog-agent/pkg/checks"
-	"github.com/DataDog/datadog-agent/pkg/loader"
 	"github.com/op/go-logging"
 	"github.com/sbinet/go-python"
 )
 
 var log = logging.MustGetLogger("datadog-agent")
-
-// const things
-const agentCheckClassName = "AgentCheck"
-const agentCheckModuleName = "checks"
 
 // PythonCheck represents a Python check, implements `Check` interface
 type PythonCheck struct {
@@ -78,91 +71,4 @@ func (c *PythonCheck) String() string {
 		return python.PyString_AsString(c.Instance.GetAttrString("__class__").GetAttrString("__name__"))
 	}
 	return ""
-}
-
-// PythonCheckLoader is a specific loader for checks living in Python modules
-type PythonCheckLoader struct {
-	agentCheckClass *python.PyObject
-}
-
-// NewPythonCheckLoader creates an instance of the Python checks loader
-func NewPythonCheckLoader() *PythonCheckLoader {
-	// Lock the GIL and release it at the end of the run
-	_gstate := python.PyGILState_Ensure()
-	defer func() {
-		python.PyGILState_Release(_gstate)
-	}()
-
-	agentCheckModule := python.PyImport_ImportModuleNoBlock(agentCheckModuleName)
-	if agentCheckModule == nil {
-		log.Errorf("Unable to import Python module: %s", agentCheckModuleName)
-		return nil
-	}
-
-	agentCheckClass := agentCheckModule.GetAttrString(agentCheckClassName)
-	if agentCheckClass == nil {
-		log.Errorf("Unable to import %s class from Python module: %s", agentCheckClassName, agentCheckModuleName)
-		return nil
-	}
-
-	return &PythonCheckLoader{agentCheckClass}
-}
-
-// Load tries to import a Python module with the same name found in config.Name, searches for
-// subclasses of the AgentCheck class and returns the corresponding Check
-func (cl *PythonCheckLoader) Load(config loader.CheckConfig) ([]checks.Check, error) {
-	checks := []checks.Check{}
-	moduleName := config.Name
-
-	// Lock the GIL and release it at the end of the run
-	_gstate := python.PyGILState_Ensure()
-	defer func() {
-		python.PyGILState_Release(_gstate)
-	}()
-
-	// import python module containing the check
-	checkModule := python.PyImport_ImportModuleNoBlock(moduleName)
-	if checkModule == nil {
-		msg := fmt.Sprintf("Unable to import %v", moduleName)
-		log.Warningf(msg)
-		python.PyErr_Print() // TODO: remove this or redirect to the Go logger
-		python.PyErr_Clear()
-
-		return checks, errors.New(msg)
-	}
-
-	// Try to find a class inheriting from AgentCheck within the module
-	checkClass := findSubclassOf(cl.agentCheckClass, checkModule)
-	if checkClass == nil {
-		msg := fmt.Sprintf("Unable to find a check class in the module: %v", python.PyString_AS_STRING(checkModule.Str()))
-		log.Warningf(msg)
-		return checks, errors.New(msg)
-	}
-
-	// Get an AgentCheck for each configuration instance and add it to the registry
-	instances, found := config.Data["instances"]
-	if !found {
-		return checks, errors.New("`instances` keyword not found in configuration data")
-	}
-
-	instancesList, _ := instances.([]interface{})
-	for _, instanceMap := range instancesList {
-		// To be retrocompatible with the Python code, still use an `instance` dictionary
-		// to contain the (now) unique instance for the check
-		conf := make(loader.RawConfigMap)
-		conf["instances"] = []interface{}{instanceMap}
-		pyConf, err := ToPythonDict(&conf)
-		if err != nil {
-			log.Errorf("Error parsing check configuration: %v", err)
-			continue
-		}
-
-		check := NewPythonCheck(checkClass, pyConf)
-		if check != nil {
-			log.Infof("Loading check: %v", python.PyString_AsString(checkClass.Str()))
-			checks = append(checks, check)
-		}
-	}
-
-	return checks, nil
 }

--- a/pkg/py/check_test.go
+++ b/pkg/py/check_test.go
@@ -15,10 +15,11 @@ func getCheckInstance() *PythonCheck {
 
 	module := python.PyImport_ImportModuleNoBlock("testcheck")
 	checkClass := module.GetAttrString("TestCheck")
-	return NewPythonCheck(checkClass, python.PyTuple_New(0))
+	check := NewPythonCheck("testcheck", checkClass)
+	check.Configure([]byte("foo: bar"))
+	return check
 }
 
-// TODO check arguments as soon as the feature is complete
 func TestNewPythonCheck(t *testing.T) {
 	// Lock the GIL and release it at the end of the run
 	_gstate := python.PyGILState_Ensure()
@@ -26,22 +27,42 @@ func TestNewPythonCheck(t *testing.T) {
 		python.PyGILState_Release(_gstate)
 	}()
 
-	module := python.PyImport_ImportModuleNoBlock("testcheck")
-	checkClass := module.GetAttrString("TestCheck")
-	check := NewPythonCheck(checkClass, python.PyTuple_New(0))
+	tuple := python.PyTuple_New(0)
+	res := NewPythonCheck("FooBar", tuple)
 
-	if check.Instance.IsInstance(checkClass) != 1 {
-		t.Fatalf("Expected instance of class TestCheck, found: %s",
-			python.PyString_AsString(check.Instance.GetAttrString("__class__")))
+	if res.Class != tuple {
+		t.Fatalf("Expected %v, found: %v", tuple, res.Class)
 	}
 
-	// this should fail b/c FooCheck constructors takes parameters
-	fooClass := module.GetAttrString("FooCheck")
-	check = NewPythonCheck(fooClass, python.PyTuple_New(0))
-
-	if check != nil {
-		t.Fatalf("nil expected, found: %v", check)
+	if res.ModuleName != "FooBar" {
+		t.Fatalf("Expected FooBar, found: %v", res.ModuleName)
 	}
+}
+
+// TODO check arguments as soon as the feature is complete
+func _TestNewPythonCheck(t *testing.T) {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	// module := python.PyImport_ImportModuleNoBlock("testcheck")
+	// checkClass := module.GetAttrString("TestCheck")
+	// check := NewPythonCheck(checkClass, python.PyTuple_New(0))
+	//
+	// if check.Instance.IsInstance(checkClass) != 1 {
+	// 	t.Fatalf("Expected instance of class TestCheck, found: %s",
+	// 		python.PyString_AsString(check.Instance.GetAttrString("__class__")))
+	// }
+	//
+	// // this should fail b/c FooCheck constructors takes parameters
+	// fooClass := module.GetAttrString("FooCheck")
+	// check = NewPythonCheck(fooClass, python.PyTuple_New(0))
+	//
+	// if check != nil {
+	// 	t.Fatalf("nil expected, found: %v", check)
+	// }
 }
 
 func TestRun(t *testing.T) {

--- a/pkg/py/check_test.go
+++ b/pkg/py/check_test.go
@@ -1,13 +1,8 @@
 package py
 
 import (
-	"fmt"
-	"io/ioutil"
 	"testing"
 
-	"gopkg.in/yaml.v2"
-
-	"github.com/DataDog/datadog-agent/pkg/loader"
 	"github.com/sbinet/go-python"
 )
 
@@ -66,47 +61,6 @@ func TestStr(t *testing.T) {
 	check.Instance = nil
 	if check.String() != "" {
 		t.Fatalf("Expected empty string, found: %v", check)
-	}
-}
-
-func TestLoad(t *testing.T) {
-	l := NewPythonCheckLoader()
-
-	var configData loader.RawConfigMap
-	yamlFile, err := ioutil.ReadFile("tests/testcheck.yaml")
-	yaml.Unmarshal(yamlFile, &configData)
-	fmt.Println(configData)
-
-	config := loader.CheckConfig{Name: "testcheck", Data: configData}
-	instances, err := l.Load(config)
-	if err != nil {
-		t.Fatalf("Expected nil, found: %v", err)
-	}
-	if len(instances) != 2 {
-		t.Fatalf("Expected len 2, found: %d", len(instances))
-	}
-
-	config = loader.CheckConfig{Name: "doesntexist", Data: configData}
-	instances, err = l.Load(config)
-	if err == nil {
-		t.Fatal("Expected err, found: nil")
-	}
-	if len(instances) != 0 {
-		t.Fatalf("Expected len 0, found: %d", len(instances))
-	}
-
-}
-
-func TestNewPythonCheckLoader(t *testing.T) {
-	// Lock the GIL and release it at the end of the run
-	_gstate := python.PyGILState_Ensure()
-	defer func() {
-		python.PyGILState_Release(_gstate)
-	}()
-
-	loader := NewPythonCheckLoader()
-	if loader == nil {
-		t.Fatalf("Expected PythonCheckLoader instance, found nil")
 	}
 }
 

--- a/pkg/py/check_test.go
+++ b/pkg/py/check_test.go
@@ -1,8 +1,13 @@
 package py
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
+	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/loader"
 	"github.com/sbinet/go-python"
 )
 
@@ -34,6 +39,14 @@ func TestNewPythonCheck(t *testing.T) {
 		t.Fatalf("Expected instance of class TestCheck, found: %s",
 			python.PyString_AsString(check.Instance.GetAttrString("__class__")))
 	}
+
+	// this should fail b/c FooCheck constructors takes parameters
+	fooClass := module.GetAttrString("FooCheck")
+	check = NewPythonCheck(fooClass, python.PyTuple_New(0))
+
+	if check != nil {
+		t.Fatalf("nil expected, found: %v", check)
+	}
 }
 
 func TestRun(t *testing.T) {
@@ -53,6 +66,47 @@ func TestStr(t *testing.T) {
 	check.Instance = nil
 	if check.String() != "" {
 		t.Fatalf("Expected empty string, found: %v", check)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	l := NewPythonCheckLoader()
+
+	var configData loader.RawConfigMap
+	yamlFile, err := ioutil.ReadFile("tests/testcheck.yaml")
+	yaml.Unmarshal(yamlFile, &configData)
+	fmt.Println(configData)
+
+	config := loader.CheckConfig{Name: "testcheck", Data: configData}
+	instances, err := l.Load(config)
+	if err != nil {
+		t.Fatalf("Expected nil, found: %v", err)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("Expected len 2, found: %d", len(instances))
+	}
+
+	config = loader.CheckConfig{Name: "doesntexist", Data: configData}
+	instances, err = l.Load(config)
+	if err == nil {
+		t.Fatal("Expected err, found: nil")
+	}
+	if len(instances) != 0 {
+		t.Fatalf("Expected len 0, found: %d", len(instances))
+	}
+
+}
+
+func TestNewPythonCheckLoader(t *testing.T) {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	loader := NewPythonCheckLoader()
+	if loader == nil {
+		t.Fatalf("Expected PythonCheckLoader instance, found nil")
 	}
 }
 

--- a/pkg/py/check_test.go
+++ b/pkg/py/check_test.go
@@ -3,7 +3,6 @@ package py
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/loader"
 	"github.com/sbinet/go-python"
 )
 
@@ -16,8 +15,7 @@ func getCheckInstance() *PythonCheck {
 
 	module := python.PyImport_ImportModuleNoBlock("testcheck")
 	checkClass := module.GetAttrString("TestCheck")
-	checkConfig := loader.CheckConfig{Name: "testcheck"}
-	return NewPythonCheck(checkClass, checkConfig)
+	return NewPythonCheck(checkClass, python.PyTuple_New(0))
 }
 
 // TODO check arguments as soon as the feature is complete
@@ -30,7 +28,7 @@ func TestNewPythonCheck(t *testing.T) {
 
 	module := python.PyImport_ImportModuleNoBlock("testcheck")
 	checkClass := module.GetAttrString("TestCheck")
-	check := NewPythonCheck(checkClass, loader.CheckConfig{})
+	check := NewPythonCheck(checkClass, python.PyTuple_New(0))
 
 	if check.Instance.IsInstance(checkClass) != 1 {
 		t.Fatalf("Expected instance of class TestCheck, found: %s",
@@ -55,19 +53,6 @@ func TestStr(t *testing.T) {
 	check.Instance = nil
 	if check.String() != "" {
 		t.Fatalf("Expected empty string, found: %v", check)
-	}
-}
-
-func TestCollectChecks(t *testing.T) {
-	configs := []loader.CheckConfig{
-		loader.CheckConfig{Name: "testcheck"},
-		loader.CheckConfig{Name: "doesnt.exist"},
-		loader.CheckConfig{Name: "foo"},
-	}
-
-	checks := CollectChecks(configs)
-	if len(checks) != 1 {
-		t.Fatalf("Expected 1 check loaded, found: %d", len(checks))
 	}
 }
 

--- a/pkg/py/config.go
+++ b/pkg/py/config.go
@@ -16,10 +16,10 @@ type walker struct {
 	currentContainer *python.PyObject
 }
 
-// ToPythonDict dumps CheckConfig data into a Python dictionary
-func ToPythonDict(c *loader.CheckConfig) (*python.PyObject, error) {
+// ToPythonDict dumps a RawConfigMap into a Python dictionary
+func ToPythonDict(m *loader.RawConfigMap) (*python.PyObject, error) {
 	w := new(walker)
-	err := reflectwalk.Walk(c.Data, w)
+	err := reflectwalk.Walk(m, w)
 
 	return w.result, err
 }

--- a/pkg/py/config_test.go
+++ b/pkg/py/config_test.go
@@ -20,9 +20,9 @@ func TestToPythonDict(t *testing.T) {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
 
-	c := loader.CheckConfig{}
+	c := make(loader.RawConfigMap)
 
-	err = yaml.Unmarshal(yamlFile, &c.Data)
+	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}

--- a/pkg/py/loader.go
+++ b/pkg/py/loader.go
@@ -1,0 +1,101 @@
+package py
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/checks"
+	"github.com/DataDog/datadog-agent/pkg/loader"
+	"github.com/sbinet/go-python"
+)
+
+// const things
+const agentCheckClassName = "AgentCheck"
+const agentCheckModuleName = "checks"
+
+// PythonCheckLoader is a specific loader for checks living in Python modules
+type PythonCheckLoader struct {
+	agentCheckClass *python.PyObject
+}
+
+// NewPythonCheckLoader creates an instance of the Python checks loader
+func NewPythonCheckLoader() *PythonCheckLoader {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	agentCheckModule := python.PyImport_ImportModuleNoBlock(agentCheckModuleName)
+	if agentCheckModule == nil {
+		log.Errorf("Unable to import Python module: %s", agentCheckModuleName)
+		return nil
+	}
+
+	agentCheckClass := agentCheckModule.GetAttrString(agentCheckClassName)
+	if agentCheckClass == nil {
+		log.Errorf("Unable to import %s class from Python module: %s", agentCheckClassName, agentCheckModuleName)
+		return nil
+	}
+
+	return &PythonCheckLoader{agentCheckClass}
+}
+
+// Load tries to import a Python module with the same name found in config.Name, searches for
+// subclasses of the AgentCheck class and returns the corresponding Check
+func (cl *PythonCheckLoader) Load(config loader.CheckConfig) ([]checks.Check, error) {
+	checks := []checks.Check{}
+	moduleName := config.Name
+
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	// import python module containing the check
+	checkModule := python.PyImport_ImportModuleNoBlock(moduleName)
+	if checkModule == nil {
+		msg := fmt.Sprintf("Unable to import %v", moduleName)
+		log.Warningf(msg)
+		python.PyErr_Print() // TODO: remove this or redirect to the Go logger
+		python.PyErr_Clear()
+
+		return checks, errors.New(msg)
+	}
+
+	// Try to find a class inheriting from AgentCheck within the module
+	checkClass := findSubclassOf(cl.agentCheckClass, checkModule)
+	if checkClass == nil {
+		msg := fmt.Sprintf("Unable to find a check class in the module: %v", python.PyString_AS_STRING(checkModule.Str()))
+		log.Warningf(msg)
+		return checks, errors.New(msg)
+	}
+
+	// Get an AgentCheck for each configuration instance and add it to the registry
+	instances, found := config.Data["instances"]
+	if !found {
+		return checks, errors.New("`instances` keyword not found in configuration data")
+	}
+
+	instancesList, _ := instances.([]interface{})
+	for _, instanceMap := range instancesList {
+		// To be retrocompatible with the Python code, still use an `instance` dictionary
+		// to contain the (now) unique instance for the check
+		conf := make(loader.RawConfigMap)
+		conf["instances"] = []interface{}{instanceMap}
+		pyConf, err := ToPythonDict(&conf)
+		if err != nil {
+			log.Errorf("Error parsing check configuration: %v", err)
+			continue
+		}
+
+		check := NewPythonCheck(checkClass, pyConf)
+		if check != nil {
+			log.Infof("Loading check: %v", python.PyString_AsString(checkClass.Str()))
+			checks = append(checks, check)
+		}
+	}
+
+	return checks, nil
+}

--- a/pkg/py/loader_test.go
+++ b/pkg/py/loader_test.go
@@ -1,24 +1,18 @@
 package py
 
 import (
-	"fmt"
-	"io/ioutil"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/loader"
 	"github.com/sbinet/go-python"
-	"gopkg.in/yaml.v2"
 )
 
 func TestLoad(t *testing.T) {
 	l := NewPythonCheckLoader()
+	config := loader.CheckConfig{Name: "testcheck"}
+	config.Instances = append(config.Instances, []byte("foo: bar"))
+	config.Instances = append(config.Instances, []byte("bar: baz"))
 
-	var configData loader.RawConfigMap
-	yamlFile, err := ioutil.ReadFile("tests/testcheck.yaml")
-	yaml.Unmarshal(yamlFile, &configData)
-	fmt.Println(configData)
-
-	config := loader.CheckConfig{Name: "testcheck", Data: configData}
 	instances, err := l.Load(config)
 	if err != nil {
 		t.Fatalf("Expected nil, found: %v", err)
@@ -27,7 +21,7 @@ func TestLoad(t *testing.T) {
 		t.Fatalf("Expected len 2, found: %d", len(instances))
 	}
 
-	config = loader.CheckConfig{Name: "doesntexist", Data: configData}
+	config = loader.CheckConfig{Name: "doesntexist"}
 	instances, err = l.Load(config)
 	if err == nil {
 		t.Fatal("Expected err, found: nil")

--- a/pkg/py/loader_test.go
+++ b/pkg/py/loader_test.go
@@ -1,0 +1,52 @@
+package py
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/loader"
+	"github.com/sbinet/go-python"
+	"gopkg.in/yaml.v2"
+)
+
+func TestLoad(t *testing.T) {
+	l := NewPythonCheckLoader()
+
+	var configData loader.RawConfigMap
+	yamlFile, err := ioutil.ReadFile("tests/testcheck.yaml")
+	yaml.Unmarshal(yamlFile, &configData)
+	fmt.Println(configData)
+
+	config := loader.CheckConfig{Name: "testcheck", Data: configData}
+	instances, err := l.Load(config)
+	if err != nil {
+		t.Fatalf("Expected nil, found: %v", err)
+	}
+	if len(instances) != 2 {
+		t.Fatalf("Expected len 2, found: %d", len(instances))
+	}
+
+	config = loader.CheckConfig{Name: "doesntexist", Data: configData}
+	instances, err = l.Load(config)
+	if err == nil {
+		t.Fatal("Expected err, found: nil")
+	}
+	if len(instances) != 0 {
+		t.Fatalf("Expected len 0, found: %d", len(instances))
+	}
+
+}
+
+func TestNewPythonCheckLoader(t *testing.T) {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	loader := NewPythonCheckLoader()
+	if loader == nil {
+		t.Fatalf("Expected PythonCheckLoader instance, found nil")
+	}
+}

--- a/pkg/py/tests/testcheck.py
+++ b/pkg/py/tests/testcheck.py
@@ -7,3 +7,8 @@ class TestCheck(AgentCheck):
         unit tests. Doing anything is ok here.
         """
         pass
+
+
+class FooCheck:
+    def __init__(self, foo, bar, baz):
+        pass

--- a/pkg/py/tests/testcheck.yaml
+++ b/pkg/py/tests/testcheck.yaml
@@ -1,5 +1,6 @@
 init_config:
 
 instances:
-  # No configuration is needed for this check.
   - foo: bar
+    baz: bar
+  - bar: baz


### PR DESCRIPTION
## Premise

We are changing the strategy for checks loading, from try to import all the checks, ensuring each of them has a valid configuration file, to the other way around: try to search for and import checks for which we already have a configuration (coming from different sources).
## Why

Right now:
- Python checks are still loaded in the old manner, scanning a directory and trying to import all the things
- We get one check for every configuration file but we want a check instance for every `instance` found in the configuration.
## How
- Provide a `CheckLoader` interface that any loader (Python, Go, whatever) has to implement
- Rewrite the python checks loading strategy implementing a `CheckLoader`
- While at the point, break down configuration data and return one check for each `instance` we find in it

_see package's [README](https://github.com/DataDog/datadog-agent/blob/5fa8359eecc5cc6c01433c783870b7d559ec1ba8/pkg/loader/README.md) for more details._
