### PR TITLE
[aggregator] Dedicated aggregation logic for checks

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -1,0 +1,50 @@
+package aggregator
+
+// CheckSampler aggregates metrics from one Check instance
+type CheckSampler struct {
+	series   []*Serie
+	contexts map[string]Context // TODO: this map grows constantly, we need to flush old contexts from time to time. It should also be a shared ContextResolver
+	metrics  Metrics
+}
+
+// newCheckSampler returns a newly initialized CheckSample
+func newCheckSampler() *CheckSampler {
+	return &CheckSampler{
+		series:   make([]*Serie, 0),
+		contexts: map[string]Context{},
+		metrics:  *newMetrics(),
+	}
+}
+
+func (cs *CheckSampler) addSample(metricSample *MetricSample) {
+	contextKey := generateContextKey(metricSample)
+	if _, ok := cs.contexts[contextKey]; !ok {
+		cs.contexts[contextKey] = Context{
+			Name:       metricSample.Name,
+			Tags:       metricSample.Tags,
+			Host:       "",
+			DeviceName: "",
+		}
+	}
+
+	cs.metrics.addSample(contextKey, metricSample.Mtype, metricSample.Value, metricSample.Timestamp)
+}
+
+func (cs *CheckSampler) commit(timestamp int64) {
+	for _, serie := range cs.metrics.flush(timestamp) {
+		// Resolve context and populate new []Serie
+		context := cs.contexts[serie.contextKey]
+		serie.Name = context.Name + serie.nameSuffix
+		serie.Tags = context.Tags
+		serie.Host = context.Host
+		serie.DeviceName = context.DeviceName
+
+		cs.series = append(cs.series, serie)
+	}
+}
+
+func (cs *CheckSampler) flush() []*Serie {
+	series := cs.series
+	cs.series = make([]*Serie, 0)
+	return series
+}

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -1,0 +1,123 @@
+package aggregator
+
+import (
+	// stdlib
+	"sort"
+	"testing"
+
+	// 3p
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckGaugeSampling(t *testing.T) {
+	checkSampler := newCheckSampler()
+
+	mSample1 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+		Timestamp:  12345,
+	}
+	mSample2 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      2,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+		Timestamp:  12347,
+	}
+	mSample3 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar", "baz"},
+		SampleRate: 1,
+		Timestamp:  12348,
+	}
+
+	checkSampler.addSample(&mSample1)
+	checkSampler.addSample(&mSample2)
+	checkSampler.addSample(&mSample3)
+
+	checkSampler.commit(12349)
+	orderedSeries := OrderedSeries{checkSampler.flush()}
+	sort.Sort(orderedSeries)
+	series := orderedSeries.series
+
+	expectedSerie1 := &Serie{
+		Name:       "my.metric.name",
+		Tags:       &[]string{"foo", "bar"},
+		Points:     [][]interface{}{{int64(12349), mSample2.Value}},
+		Mtype:      "gauge",
+		contextKey: generateContextKey(&mSample2),
+		nameSuffix: "",
+	}
+
+	expectedSerie2 := &Serie{
+		Name:       "my.metric.name",
+		Tags:       &[]string{"foo", "bar", "baz"},
+		Points:     [][]interface{}{{int64(12349), mSample3.Value}},
+		Mtype:      "gauge",
+		contextKey: generateContextKey(&mSample3),
+		nameSuffix: "",
+	}
+
+	orderedExpectedSeries := OrderedSeries{[]*Serie{expectedSerie1, expectedSerie2}}
+	sort.Sort(orderedExpectedSeries)
+	expectedSeries := orderedExpectedSeries.series
+
+	if assert.Equal(t, 2, len(series)) {
+		AssertSerieEqual(t, expectedSeries[0], series[0])
+		AssertSerieEqual(t, expectedSeries[1], series[1])
+	}
+}
+
+func TestCheckRateSampling(t *testing.T) {
+	checkSampler := newCheckSampler()
+
+	mSample1 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      RateType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+		Timestamp:  12345,
+	}
+	mSample2 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      2,
+		Mtype:      RateType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+		Timestamp:  12347,
+	}
+	mSample3 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      RateType,
+		Tags:       &[]string{"foo", "bar", "baz"},
+		SampleRate: 1,
+		Timestamp:  12348,
+	}
+
+	checkSampler.addSample(&mSample1)
+	checkSampler.addSample(&mSample2)
+	checkSampler.addSample(&mSample3)
+
+	checkSampler.commit(12349)
+	series := checkSampler.flush()
+
+	expectedSerie := &Serie{
+		Name:       "my.metric.name",
+		Tags:       &[]string{"foo", "bar"},
+		Points:     [][]interface{}{{int64(12347), 0.5}},
+		Mtype:      "gauge",
+		nameSuffix: "",
+	}
+
+	if assert.Equal(t, 1, len(series)) {
+		AssertSerieEqual(t, expectedSerie, series[0])
+	}
+}

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -1,5 +1,7 @@
 package aggregator
 
+import "errors"
+
 // Gauge stores and aggregates a gauge value
 type Gauge struct {
 	gauge     float64
@@ -11,8 +13,36 @@ func (g *Gauge) addSample(sample float64, timestamp int64) {
 	g.timestamp = timestamp
 }
 
-func (g *Gauge) flush() (float64, int64) {
-	return g.gauge, g.timestamp
+func (g *Gauge) flush() (value float64, timestamp int64) {
+	value, timestamp = g.gauge, g.timestamp
+	g.gauge, g.timestamp = 0, 0
+
+	return
+}
+
+// Rate stores and aggregates a rate value
+type Rate struct {
+	previousSample    float64
+	previousTimestamp int64
+	sample            float64
+	timestamp         int64
+}
+
+func (r *Rate) addSample(sample float64, timestamp int64) {
+	if r.timestamp != 0 {
+		r.previousSample, r.previousTimestamp = r.sample, r.timestamp
+	}
+	r.sample, r.timestamp = sample, timestamp
+}
+
+func (r *Rate) flush() (value float64, timestamp int64, err error) {
+	value, timestamp, err = 0, 0, errors.New("No value sampled at this check run or at previous check run, no rate value can be computed")
+	if r.previousTimestamp != 0 && r.timestamp != 0 {
+		value, timestamp, err = (r.sample-r.previousSample)/float64(r.timestamp-r.previousTimestamp), r.timestamp, nil
+		r.previousSample, r.previousTimestamp = r.sample, r.timestamp
+		r.sample, r.timestamp = 0, 0
+	}
+	return
 }
 
 // Counter stores and aggregates a counter values

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -2,22 +2,25 @@ package aggregator
 
 // Gauge stores and aggregates a gauge value
 type Gauge struct {
-	gauge float64
+	gauge     float64
+	timestamp int64
 }
 
-func (g *Gauge) addSample(sample float64) {
+func (g *Gauge) addSample(sample float64, timestamp int64) {
 	g.gauge = sample
+	g.timestamp = timestamp
 }
 
-func (g *Gauge) flush() float64 {
-	return g.gauge
+func (g *Gauge) flush() (float64, int64) {
+	return g.gauge, g.timestamp
 }
 
 // Counter stores and aggregates a counter values
 type Counter struct {
-	count int
+	count     int
+	timestamp int64
 }
 
-func (c *Counter) addSample(sample float64) {
+func (c *Counter) addSample(sample float64, timestamp int64) {
 	// TODO
 }

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -1,0 +1,20 @@
+package aggregator
+
+// MetricType is the representation of a dogstatsd metric type
+type MetricType string
+
+// metric type constants
+const (
+	GaugeType   MetricType = "g"
+	CounterType MetricType = "c"
+)
+
+// MetricSample represents a raw metric sample
+type MetricSample struct {
+	Name       string
+	Value      float64
+	Mtype      MetricType
+	Tags       *[]string
+	SampleRate float64
+	Timestamp  int64
+}

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -6,6 +6,7 @@ type MetricType string
 // metric type constants
 const (
 	GaugeType   MetricType = "g"
+	RateType    MetricType = "rate"
 	CounterType MetricType = "c"
 )
 

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -7,6 +7,9 @@ import (
 
 	// datadog
 	"github.com/DataDog/datadog-agent/pkg/util"
+
+	// 3p
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGaugeSampling(t *testing.T) {
@@ -20,5 +23,67 @@ func TestGaugeSampling(t *testing.T) {
 	value, timestamp := mGauge.flush()
 	// the last sample is flushed
 	util.AssertAlmostEqual(t, value, 2)
-	util.AssertAlmostEqual(t, timestamp, 55)
+	assert.EqualValues(t, timestamp, 55)
+}
+
+func TestRateSampling(t *testing.T) {
+	// Initialize rates
+	mRate1 := Rate{}
+	mRate2 := Rate{}
+
+	// Add samples
+	mRate1.addSample(1, 50)
+	mRate1.addSample(2, 55)
+	mRate2.addSample(1, 50)
+
+	// First rate
+	value, timestamp, err := mRate1.flush()
+	util.AssertAlmostEqual(t, value, 0.2)
+	assert.EqualValues(t, timestamp, 55)
+	assert.Nil(t, err)
+
+	// Second rate (should return error)
+	_, _, err = mRate2.flush()
+	assert.NotNil(t, err)
+}
+
+func TestRateSamplingMultipleSamplesInSameFlush(t *testing.T) {
+	// Initialize rate
+	mRate := Rate{}
+
+	// Add samples
+	mRate.addSample(1, 50)
+	mRate.addSample(2, 55)
+	mRate.addSample(4, 60)
+
+	// Should compute rate based on the last 2 samples
+	value, timestamp, err := mRate.flush()
+	util.AssertAlmostEqual(t, value, 2./5.)
+	assert.EqualValues(t, timestamp, 60)
+	assert.Nil(t, err)
+}
+
+func TestRateSamplingNoSampleForOneFlush(t *testing.T) {
+	// Initialize rate
+	mRate := Rate{}
+
+	// Add samples
+	mRate.addSample(1, 50)
+	mRate.addSample(2, 55)
+
+	// First flush: no error
+	_, _, err := mRate.flush()
+	assert.Nil(t, err)
+
+	// Second flush w/o sample: error
+	_, _, err = mRate.flush()
+	assert.NotNil(t, err)
+
+	// Third flush w/ sample
+	mRate.addSample(4, 60)
+	// Should compute rate based on the last 2 samples
+	value, timestamp, err := mRate.flush()
+	util.AssertAlmostEqual(t, value, 2./5.)
+	assert.EqualValues(t, timestamp, 60)
+	assert.Nil(t, err)
 }

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -11,9 +11,14 @@ import (
 
 func TestGaugeSampling(t *testing.T) {
 	// Initialize a new Gauge
-	mGauge := Gauge{1}
+	mGauge := Gauge{}
 
-	// Previous value is overriden
-	mGauge.addSample(2)
-	util.AssertAlmostEqual(t, mGauge.gauge, 2)
+	// Add samples
+	mGauge.addSample(1, 50)
+	mGauge.addSample(2, 55)
+
+	value, timestamp := mGauge.flush()
+	// the last sample is flushed
+	util.AssertAlmostEqual(t, value, 2)
+	util.AssertAlmostEqual(t, timestamp, 55)
 }

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -3,8 +3,6 @@ package aggregator
 import (
 	"sort"
 	"strings"
-
-	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 )
 
 // Metrics stores all the metrics by context key
@@ -28,7 +26,7 @@ type Context struct {
 	DeviceName string
 }
 
-// Serie holds a timeserie
+// Serie holds a timeserie (w/ json serialization to DD API format)
 type Serie struct {
 	Name       string          `json:"metric"`
 	Points     [][]interface{} `json:"points"`
@@ -51,41 +49,36 @@ type SerieSignature struct {
 
 // Sampler aggregates metrics
 type Sampler struct {
-	intervalSamplerByInterval map[int64]*IntervalSampler
-	contexts                  map[string]Context
-}
-
-// IntervalSampler aggregates metrics with buckets of one given interval only
-type IntervalSampler struct {
 	interval           int64
+	contexts           map[string]Context // TODO: this map grows constantly, we need to flush old contexts from time to time
 	metricsByTimestamp map[int64]*Metrics
 }
 
 // NewSampler returns a newly initialized Sampler
-func NewSampler() *Sampler {
-	return &Sampler{map[int64]*IntervalSampler{}, map[string]Context{}}
+func NewSampler(interval int64) *Sampler {
+	return &Sampler{interval, map[string]Context{}, map[int64]*Metrics{}}
 }
 
-func newIntervalSampler(interval int64) *IntervalSampler {
-	return &IntervalSampler{interval, map[int64]*Metrics{}}
+func generateContextKey(metricSample *MetricSample) string {
+	var contextFields []string
+
+	sort.Strings(*(metricSample.Tags))
+	contextFields = append(contextFields, *(metricSample.Tags)...)
+	contextFields = append(contextFields, metricSample.Name)
+
+	return strings.Join(contextFields, ",")
 }
 
-func (s *IntervalSampler) calculateBucketStart(timestamp int64) int64 {
+func (s *Sampler) calculateBucketStart(timestamp int64) int64 {
 	return timestamp - timestamp%s.interval
 }
 
-// Resolve an IntervalSampler and add the metricSample to it
-func (s *Sampler) addSample(metricSample *dogstatsd.MetricSample, timestamp int64) {
-	intervalSampler, ok := s.intervalSamplerByInterval[metricSample.Interval]
-
-	if !ok {
-		intervalSampler = newIntervalSampler(metricSample.Interval)
-		s.intervalSamplerByInterval[metricSample.Interval] = intervalSampler
-	}
-
-	sampleContextKey := generateContextKey(metricSample)
-	if _, ok := s.contexts[sampleContextKey]; !ok {
-		s.contexts[sampleContextKey] = Context{
+// Add the metricSample to the correct bucket
+func (s *Sampler) addSample(metricSample *MetricSample, timestamp int64) {
+	// Keep track of the context
+	contextKey := generateContextKey(metricSample)
+	if _, ok := s.contexts[contextKey]; !ok {
+		s.contexts[contextKey] = Context{
 			Name:       metricSample.Name,
 			Tags:       metricSample.Tags,
 			Host:       "",
@@ -93,44 +86,21 @@ func (s *Sampler) addSample(metricSample *dogstatsd.MetricSample, timestamp int6
 		}
 	}
 
-	intervalSampler.addSample(sampleContextKey, metricSample.Mtype, metricSample.Value, timestamp)
-}
-
-// Add a metricSample to the given IntervalSampler
-func (s *IntervalSampler) addSample(contextKey string, mType dogstatsd.MetricType, value float64, timestamp int64) {
 	bucketStart := s.calculateBucketStart(timestamp)
+	// If it's a new bucket, initialize it
 	metrics, ok := s.metricsByTimestamp[bucketStart]
-
 	if !ok {
 		metrics = newMetrics()
 		s.metricsByTimestamp[bucketStart] = metrics
 	}
 
-	metrics.addSample(contextKey, mType, value)
+	// Add sample to bucket
+	metrics.addSample(contextKey, metricSample.Mtype, metricSample.Value)
 }
 
 func (s *Sampler) flush(timestamp int64) []*Serie {
 	var result []*Serie
 
-	for _, intervalSampler := range s.intervalSamplerByInterval {
-		series := intervalSampler.flush(timestamp)
-
-		// Resolve context
-		for _, serie := range series {
-			context := s.contexts[serie.contextKey]
-			serie.Name = context.Name + serie.nameSuffix
-			serie.Tags = context.Tags
-			serie.Host = context.Host
-			serie.DeviceName = context.DeviceName
-			result = append(result, serie)
-		}
-	}
-
-	return result
-}
-
-func (s *IntervalSampler) flush(timestamp int64) []*Serie {
-	var result []*Serie
 	serieBySignature := make(map[SerieSignature]*Serie)
 
 	// Compute a limit timestamp
@@ -150,7 +120,14 @@ func (s *IntervalSampler) flush(timestamp int64) []*Serie {
 			if existingSerie, ok := serieBySignature[serieSignature]; ok {
 				existingSerie.Points = append(existingSerie.Points, serie.Points[0])
 			} else {
+				// Resolve context and populate new Serie
+				context := s.contexts[serie.contextKey]
+				serie.Name = context.Name + serie.nameSuffix
+				serie.Tags = context.Tags
+				serie.Host = context.Host
+				serie.DeviceName = context.DeviceName
 				serie.Interval = s.interval
+
 				serieBySignature[serieSignature] = serie
 				result = append(result, serie)
 			}
@@ -162,26 +139,17 @@ func (s *IntervalSampler) flush(timestamp int64) []*Serie {
 	return result
 }
 
-func generateContextKey(metricSample *dogstatsd.MetricSample) string {
-	var contextFields []string
-
-	sort.Strings(*(metricSample.Tags))
-	contextFields = append(contextFields, *(metricSample.Tags)...)
-	contextFields = append(contextFields, metricSample.Name)
-
-	return strings.Join(contextFields, ",")
-}
-
 // TODO: Pass a reference to *MetricSample instead
-func (m *Metrics) addSample(contextKey string, mType dogstatsd.MetricType, value float64) {
+func (m *Metrics) addSample(contextKey string, mType MetricType, value float64) {
 	switch mType {
-	case dogstatsd.Gauge:
+	case GaugeType:
 		_, ok := m.gauges[contextKey]
 		if !ok {
 			m.gauges[contextKey] = &Gauge{}
 		}
-		m.gauges[contextKey].addSample(value)
-	case dogstatsd.Counter:
+		// Leave the timestamp to an arbitrary value, we don't use it here
+		m.gauges[contextKey].addSample(value, 0)
+	case CounterType:
 		// pass
 	}
 }
@@ -191,7 +159,8 @@ func (m *Metrics) flush(timestamp int64) []*Serie {
 
 	// Gauges
 	for contextKey, gauge := range m.gauges {
-		value := gauge.flush()
+		// discard the timestamp returned here, we use the one passed to the flush
+		value, _ := gauge.flush()
 
 		serie := &Serie{
 			Points:     [][]interface{}{{timestamp, value}},

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	// stdlib
+	"fmt"
 	"sort"
 	"testing"
 
@@ -30,7 +31,7 @@ func AssertSerieEqual(t *testing.T, expected, actual *Serie) {
 }
 
 func AssertTagsEqual(t *testing.T, expected, actual []string) {
-	if assert.Equal(t, len(expected), len(actual)) {
+	if assert.Equal(t, len(expected), len(actual), fmt.Sprintf("Unexpected number of tags: expected %s, actual: %s", expected, actual)) {
 		for _, tag := range expected {
 			assert.Contains(t, actual, tag)
 		}
@@ -84,7 +85,7 @@ func TestMetricsGaugeSampling(t *testing.T) {
 		Mtype: GaugeType,
 	}
 
-	metrics.addSample(contextKey, mSample.Mtype, mSample.Value)
+	metrics.addSample(contextKey, mSample.Mtype, mSample.Value, mSample.Timestamp)
 	series := metrics.flush(12345)
 
 	expectedSerie := &Serie{

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -1,0 +1,101 @@
+package aggregator
+
+import "time"
+
+var _sender *checkSender
+
+// Sender allows sending metrics from checks/a check
+type Sender interface {
+	Commit()
+	Stop()
+	Gauge(metric string, value float64, hostname string, tags []string)
+	Rate(metric string, value float64, hostname string, tags []string)
+	Histogram(metric string, value float64, hostname string, tags []string)
+}
+
+// checkSender implements Sender
+type checkSender struct {
+	checkSamplerID int64
+	ssOut          chan<- senderSample
+}
+
+type senderSample struct {
+	checkSamplerID int64
+	metricSample   *MetricSample
+	commit         bool
+}
+
+func newCheckSender(checkSamplerID int64, ssOut chan<- senderSample) *checkSender {
+	return &checkSender{
+		checkSamplerID: checkSamplerID,
+		ssOut:          ssOut,
+	}
+}
+
+// GetSender returns a new Sender, properly registered with the aggregator
+func GetSender() Sender {
+	if _aggregator == nil {
+		_aggregator = newBufferedAggregator()
+	}
+
+	sender := newCheckSender(_aggregator.registerNewCheckSampler(), _aggregator.checkIn)
+
+	return sender
+}
+
+// GetDefaultSender returns the default sender
+func GetDefaultSender() Sender {
+	if _aggregator == nil {
+		_aggregator = newBufferedAggregator()
+	}
+	if _sender == nil {
+		_sender = newCheckSender(_aggregator.registerNewCheckSampler(), _aggregator.checkIn)
+	}
+
+	return _sender
+}
+
+// Commit commits the metric samples that were added during a check run
+// Should be called at the end of every check run
+func (s *checkSender) Commit() {
+	s.ssOut <- senderSample{s.checkSamplerID, &MetricSample{}, true}
+}
+
+// Stop stops the metrics aggregation and deregisters the sender
+// The metrics of this sender that haven't been flushed yet will be lost
+func (s *checkSender) Stop() {
+	_aggregator.deregisterCheckSampler(s.checkSamplerID)
+}
+
+// Gauge implements the Sender interface
+func (s *checkSender) Gauge(metric string, value float64, hostname string, tags []string) {
+	metricSample := &MetricSample{
+		Name:       metric,
+		Value:      value,
+		Mtype:      GaugeType,
+		Tags:       &tags,
+		SampleRate: 1,
+		Timestamp:  time.Now().Unix(),
+	}
+
+	s.ssOut <- senderSample{s.checkSamplerID, metricSample, false}
+}
+
+// Rate implements the Sender interface
+func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
+	metricSample := &MetricSample{
+		Name:       metric,
+		Value:      value,
+		Mtype:      RateType,
+		Tags:       &tags,
+		SampleRate: 1,
+		Timestamp:  time.Now().Unix(),
+	}
+
+	s.ssOut <- senderSample{s.checkSamplerID, metricSample, false}
+}
+
+// Histogram implements the Sender interface
+func (s *checkSender) Histogram(metric string, value float64, hostname string, tags []string) {
+	// TODO
+}

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -7,7 +7,7 @@ var _sender *checkSender
 // Sender allows sending metrics from checks/a check
 type Sender interface {
 	Commit()
-	Stop()
+	Destroy()
 	Gauge(metric string, value float64, hostname string, tags []string)
 	Rate(metric string, value float64, hostname string, tags []string)
 	Histogram(metric string, value float64, hostname string, tags []string)
@@ -61,9 +61,10 @@ func (s *checkSender) Commit() {
 	s.ssOut <- senderSample{s.checkSamplerID, &MetricSample{}, true}
 }
 
-// Stop stops the metrics aggregation and deregisters the sender
+// Destroy frees up the resources used by the sender (by deregistering it from the aggregator)
+// Should be called when the sender is not used anymore
 // The metrics of this sender that haven't been flushed yet will be lost
-func (s *checkSender) Stop() {
+func (s *checkSender) Destroy() {
 	_aggregator.deregisterCheckSampler(s.checkSamplerID)
 }
 

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -1,0 +1,61 @@
+package aggregator
+
+import (
+	// stdlib
+	"testing"
+
+	// 3p
+	"github.com/stretchr/testify/assert"
+)
+
+func resetAggregator() {
+	_aggregator = nil
+	_sender = nil
+}
+
+func TestGetDefaultSenderCreatesOneSender(t *testing.T) {
+	resetAggregator()
+
+	defaultSender1 := GetDefaultSender().(*checkSender)
+	assert.Len(t, _aggregator.checkSamplers, 1)
+
+	defaultSender2 := GetDefaultSender().(*checkSender)
+	assert.Len(t, _aggregator.checkSamplers, 1)
+	assert.Equal(t, defaultSender1.checkSamplerID, defaultSender2.checkSamplerID)
+}
+
+func TestGetSenderCreatesDifferentCheckSamplers(t *testing.T) {
+	resetAggregator()
+
+	sender1 := GetSender().(*checkSender)
+	assert.Len(t, _aggregator.checkSamplers, 1)
+
+	sender2 := GetSender().(*checkSender)
+	assert.Len(t, _aggregator.checkSamplers, 2)
+	assert.NotEqual(t, sender1.checkSamplerID, sender2.checkSamplerID)
+
+	defaultSender := GetDefaultSender().(*checkSender)
+	assert.Len(t, _aggregator.checkSamplers, 3)
+	assert.NotEqual(t, sender1.checkSamplerID, defaultSender.checkSamplerID)
+	assert.NotEqual(t, sender2.checkSamplerID, defaultSender.checkSamplerID)
+}
+
+func TestSenderInterface(t *testing.T) {
+	senderSampleChan := make(chan senderSample, 10)
+	checkSender := newCheckSender(1, senderSampleChan)
+	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
+	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
+	checkSender.Commit()
+
+	gaugeSenderSample := <-senderSampleChan
+	assert.EqualValues(t, 1, gaugeSenderSample.checkSamplerID)
+	assert.Equal(t, false, gaugeSenderSample.commit)
+
+	rateSenderSample := <-senderSampleChan
+	assert.EqualValues(t, 1, rateSenderSample.checkSamplerID)
+	assert.Equal(t, false, rateSenderSample.commit)
+
+	commitSenderSample := <-senderSampleChan
+	assert.EqualValues(t, 1, commitSenderSample.checkSamplerID)
+	assert.Equal(t, true, commitSenderSample.commit)
+}

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -29,6 +29,7 @@ type Check interface {
 	Run() error
 	String() string
 	Configure(data ConfigData)
+	InitSender()
 	Interval() time.Duration
 }
 

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -13,6 +13,7 @@ type TestCheck struct {
 
 func (c *TestCheck) String() string          { return "TestCheck" }
 func (c *TestCheck) Configure(ConfigData)    {}
+func (c *TestCheck) InitSender()             {}
 func (c *TestCheck) Interval() time.Duration { return 1 }
 func (c *TestCheck) Run() error {
 	if c.doErr {

--- a/pkg/collector/check/core/loader.go
+++ b/pkg/collector/check/core/loader.go
@@ -41,6 +41,7 @@ func (gl *GoCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	for _, instance := range config.Instances {
 		newCheck := c
 		newCheck.Configure(instance)
+		newCheck.InitSender()
 		checks = append(checks, newCheck)
 	}
 

--- a/pkg/collector/check/core/loader_test.go
+++ b/pkg/collector/check/core/loader_test.go
@@ -12,6 +12,7 @@ type TestCheck struct{}
 
 func (c *TestCheck) String() string             { return "TestCheck" }
 func (c *TestCheck) Configure(check.ConfigData) {}
+func (c *TestCheck) InitSender()                {}
 func (c *TestCheck) Run() error                 { return nil }
 func (c *TestCheck) Interval() time.Duration    { return 1 }
 

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -13,8 +13,6 @@ import (
 
 var log = logging.MustGetLogger("datadog-agent")
 
-const checkInterval = 5
-
 // MemoryCheck doesn't need additional fields
 type MemoryCheck struct{}
 
@@ -25,7 +23,7 @@ func (c *MemoryCheck) String() string {
 // Run executes the check
 func (c *MemoryCheck) Run() error {
 	v, _ := mem.VirtualMemory()
-	aggregator.GetSender(checkInterval).Gauge("system.mem.total", float64(v.Total), "", []string{})
+	aggregator.GetSender().Gauge("system.mem.total", float64(v.Total), "", []string{})
 	return nil
 }
 

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -14,7 +14,9 @@ import (
 var log = logging.MustGetLogger("datadog-agent")
 
 // MemoryCheck doesn't need additional fields
-type MemoryCheck struct{}
+type MemoryCheck struct {
+	sender aggregator.Sender
+}
 
 func (c *MemoryCheck) String() string {
 	return "MemoryCheck"
@@ -23,13 +25,19 @@ func (c *MemoryCheck) String() string {
 // Run executes the check
 func (c *MemoryCheck) Run() error {
 	v, _ := mem.VirtualMemory()
-	aggregator.GetSender().Gauge("system.mem.total", float64(v.Total), "", []string{})
+	c.sender.Gauge("system.mem.total", float64(v.Total), "", []string{})
+	c.sender.Commit()
 	return nil
 }
 
 // Configure the Python check from YAML data
 func (c *MemoryCheck) Configure(data check.ConfigData) {
 	// do nothing
+}
+
+// InitSender initializes a sender
+func (c *MemoryCheck) InitSender() {
+	c.sender = aggregator.GetSender()
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -15,7 +15,7 @@ import "C"
 //export SubmitData
 func SubmitData(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject) *C.PyObject {
 
-	agg := aggregator.GetSender()
+	agg := aggregator.GetDefaultSender()
 
 	// TODO: cleanup memory, C.stuff is going to stay there!!!
 
@@ -36,7 +36,7 @@ func SubmitData(check *C.PyObject, mt C.MetricType, name *C.char, value C.float,
 	switch mt {
 	case C.RATE:
 		fmt.Println("Submitting Rate to the aggregator...", _name, _value, _tags)
-		fallthrough
+		agg.Rate(_name, _value, "", _tags)
 	case C.GAUGE:
 		fmt.Println("Submitting Gauge to the aggregator...", _name, _value, _tags)
 		agg.Gauge(_name, _value, "", _tags)

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -11,13 +11,11 @@ import (
 // #include "api.h"
 import "C"
 
-const checkInterval = 5
-
 // SubmitData is the method exposed to Python scripts
 //export SubmitData
 func SubmitData(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject) *C.PyObject {
 
-	agg := aggregator.GetSender(checkInterval) // TODO: the interval should depend on the check/instance
+	agg := aggregator.GetSender()
 
 	// TODO: cleanup memory, C.stuff is going to stay there!!!
 

--- a/pkg/collector/check/py/check.go
+++ b/pkg/collector/check/py/check.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/op/go-logging"
 	"github.com/sbinet/go-python"
@@ -44,6 +45,7 @@ func (c *PythonCheck) Run() error {
 	// call run function, it takes no args so we pass an empty tuple
 	emptyTuple := python.PyTuple_New(0)
 	result := c.Instance.CallMethod("run", emptyTuple)
+	aggregator.GetDefaultSender().Commit()
 	var resultStr string
 	if result == nil {
 		python.PyErr_Print()
@@ -117,6 +119,10 @@ func (c *PythonCheck) Configure(data check.ConfigData) {
 	c.Instance = instance
 	c.ModuleName = python.PyString_AsString(instance.GetAttrString("__module__"))
 	c.Config = configDict
+}
+
+// InitSender does nothing here because all python checks use the default sender
+func (c *PythonCheck) InitSender() {
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -13,6 +13,7 @@ type TestCheck struct{ intl time.Duration }
 
 func (c *TestCheck) String() string             { return "TestCheck" }
 func (c *TestCheck) Configure(check.ConfigData) {}
+func (c *TestCheck) InitSender()                {}
 func (c *TestCheck) Interval() time.Duration    { return c.intl }
 func (c *TestCheck) Run() error                 { return nil }
 

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -7,6 +7,7 @@ import (
 	// 3p
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
@@ -73,7 +74,7 @@ func TestParseGauge(t *testing.T) {
 
 	assert.Equal(t, "daemon", parsed.Name)
 	util.AssertAlmostEqual(t, 666.0, parsed.Value)
-	assert.Equal(t, Gauge, parsed.Mtype)
+	assert.Equal(t, aggregator.GaugeType, parsed.Mtype)
 	assert.Equal(t, 0, len(*(parsed.Tags)))
 	util.AssertAlmostEqual(t, 1.0, parsed.SampleRate)
 }
@@ -85,7 +86,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 
 	assert.Equal(t, "daemon", parsed.Name)
 	util.AssertAlmostEqual(t, 666.0, parsed.Value)
-	assert.Equal(t, Gauge, parsed.Mtype)
+	assert.Equal(t, aggregator.GaugeType, parsed.Mtype)
 	if assert.Equal(t, 2, len(*(parsed.Tags))) {
 		assert.Equal(t, "sometag1:somevalue1", (*parsed.Tags)[0])
 		assert.Equal(t, "sometag2:somevalue2", (*parsed.Tags)[1])
@@ -100,7 +101,7 @@ func TestParseGaugeWithPoundOnly(t *testing.T) {
 
 	assert.Equal(t, "daemon", parsed.Name)
 	util.AssertAlmostEqual(t, 666.0, parsed.Value)
-	assert.Equal(t, Gauge, parsed.Mtype)
+	assert.Equal(t, aggregator.GaugeType, parsed.Mtype)
 	assert.Equal(t, 0, len(*(parsed.Tags)))
 	util.AssertAlmostEqual(t, 1.0, parsed.SampleRate)
 }
@@ -112,7 +113,7 @@ func TestParseGaugeWithUnicode(t *testing.T) {
 
 	assert.Equal(t, "♬†øU†øU¥ºuT0♪", parsed.Name)
 	util.AssertAlmostEqual(t, 666.0, parsed.Value)
-	assert.Equal(t, Gauge, parsed.Mtype)
+	assert.Equal(t, aggregator.GaugeType, parsed.Mtype)
 	if assert.Equal(t, 1, len(*(parsed.Tags))) {
 		assert.Equal(t, "intitulé:T0µ", (*parsed.Tags)[0])
 	}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -2,10 +2,12 @@ package dogstatsd
 
 import (
 	"net"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 // RunServer starts and run a dogstatsd server
-func RunServer(out chan *MetricSample) {
+func RunServer(out chan *aggregator.MetricSample) {
 	address, _ := net.ResolveUDPAddr("udp", "localhost:8126") // TODO: configurable bind address
 	serverConn, err := net.ListenUDP("udp", address)
 	log.Infof("listening on %s", address)


### PR DESCRIPTION
We stop using buckets for check metrics since it doesn't really make
sense for metrics like rates.

Use a new CheckSampler: there would be one CheckSampler for the python
checks (since they run sequentially) and one CheckSampler per go check
(since they could run concurrently).

Also implement Rate metrics to validate the design.

This still needs some polish: some abstractions of CheckSampler are
still close to the dogstatsd Sampler, and in some cases it doesn't
really make sense. I'll clean that up in a future PR when I start implementing
the other check metric types.

Fixes #31
