### PR TITLE
[CI] install python dev on the testing machine

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   pre:
     - rm -Rf /home/ubuntu/.go_workspace/src/*
+    - sudo apt-get update; sudo apt-get install python2.7-dev
 
   override:
     - mkdir -p "$IMPORT_PATH"


### PR DESCRIPTION
Using the system-wide Python dev package to run tests on CircleCI
