### PR TITLE
[scheduler] let Run and Stop wait for clean bootstrap/shutdown

### DIFF
--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -70,11 +70,11 @@ func (s *Scheduler) Run() {
 }
 
 // Stop the scheduler, optionally pass an integer to specify
-// the timeout in milliseconds
-func (s *Scheduler) Stop(timeout ...int) error {
-	to := time.Duration(defaultTimeout)
+// the timeout in nanoseconds
+func (s *Scheduler) Stop(timeout ...time.Duration) error {
+	to := defaultTimeout
 	if len(timeout) == 1 {
-		to = time.Duration(timeout[0])
+		to = timeout[0]
 	}
 
 	log.Debugf("Stopping scheduler loop, timeout after %dms.", to)
@@ -87,7 +87,7 @@ func (s *Scheduler) Stop(timeout ...int) error {
 }
 
 // Reload the scheduler
-func (s *Scheduler) Reload(timeout ...int) error {
+func (s *Scheduler) Reload(timeout ...time.Duration) error {
 	log.Debug("Reloading scheduler loop...")
 	if s.Stop(timeout...) == nil {
 		log.Debug("Scheduler stopped, running again...")

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -153,6 +153,7 @@ func (s *Scheduler) stopQueues() {
 func (s *Scheduler) startQueues() {
 	for _, q := range s.jobQueues {
 		q.run(s.checksPipe)
+		q.running = true
 	}
 }
 
@@ -178,14 +179,12 @@ func (jq *jobQueue) addJob(c check.Check) {
 // execution pipeline.
 // This doesn't block.
 func (jq *jobQueue) run(out chan<- check.Check) {
-	jq.running = true
 	go func() {
 		for {
 			select {
 			case <-jq.stop:
 				// someone asked to stop this queue
 				jq.ticker.Stop()
-				jq.running = false
 			case <-jq.ticker.C:
 				// normal case, (re)schedule the queue
 				for _, check := range jq.jobs {

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -18,8 +19,11 @@ const defaultTimeout time.Duration = 5000 * time.Millisecond
 type Scheduler struct {
 	checksPipe chan<- check.Check          // The pipe the Runner pops the checks from
 	done       chan bool                   // Guard for the main loop
+	halted     chan bool                   // Used to internally communicate all queues are done
+	started    chan bool                   // Used to internally communicate the queues are up
 	jobQueues  map[time.Duration]*jobQueue // We have one scheduling queue for every interval
-	mu         sync.Mutex                  // to protect critical sections in struct's fields
+	mu         sync.Mutex                  // To protect critical sections in struct's fields
+	running    uint32                      // Flag to see if the scheduler is running
 }
 
 // jobQueue contains a list of checks (called jobs) that need to be
@@ -29,7 +33,7 @@ type jobQueue struct {
 	stop     chan bool
 	ticker   *time.Ticker
 	jobs     []check.Check
-	started  bool
+	running  uint32
 	mu       sync.Mutex // to protect critical sections in struct's fields
 }
 
@@ -37,8 +41,11 @@ type jobQueue struct {
 func NewScheduler(out chan<- check.Check) *Scheduler {
 	return &Scheduler{
 		checksPipe: out,
-		done:       make(chan bool),
+		done:       make(chan bool, 1),
+		halted:     make(chan bool, 1),
+		started:    make(chan bool, 1),
 		jobQueues:  make(map[time.Duration]*jobQueue),
+		running:    0,
 	}
 }
 
@@ -56,32 +63,64 @@ func (s *Scheduler) Enter(checks []check.Check) {
 	s.mu.Unlock()
 }
 
-// Run is the Scheduler main loop
+// Run is the Scheduler main loop.
+// NOTE: it doesn't block but waits for the queues to be ready before returning.
 func (s *Scheduler) Run() {
+	// Invoking Run does nothing if the Scheduler is already running
+	if atomic.LoadUint32(&s.running) != 0 {
+		log.Debug("Scheduler is already running")
+		return
+	}
+
 	go func() {
 		log.Debug("Starting scheduler loop...")
 		s.startQueues()
 
+		// set internal state
+		atomic.StoreUint32(&s.running, 1)
+
+		// notify queues are up, channel is buffered this doesn't block
+		s.started <- true
+
+		// wait here untile we're done
 		<-s.done
 
-		log.Debug("Scheduler loop done, shutting down queues...")
+		// someone asked to stop
+		log.Debug("Exited Scheduler loop, shutting down queues...")
 		s.stopQueues()
+		atomic.StoreUint32(&s.running, 0)
+
+		// notify we're done, channel is buffered this doesn't block
+		s.halted <- true
 	}()
+
+	// Wait until queues are up
+	<-s.started
 }
 
 // Stop the scheduler, optionally pass an integer to specify
-// the timeout in nanoseconds
+// the timeout in `time.Duration` format.
 func (s *Scheduler) Stop(timeout ...time.Duration) error {
+	// Stopping when the Scheduler is not running is a noop.
+	if atomic.LoadUint32(&s.running) == 0 {
+		log.Debug("Scheduler is already stopped")
+		return nil
+	}
+
 	to := defaultTimeout
 	if len(timeout) == 1 {
 		to = timeout[0]
 	}
 
-	log.Debugf("Stopping scheduler loop, timeout after %dms.", to)
+	// Interrupt the main loop, proceeding to shut down all the queues
+	// `done` is buffered so we can proceed and wait for shutdown (or timeout)
+	s.done <- true
+	log.Debugf("Waiting for the scheduler to shutdown, timeout after %dns.", to)
+
 	select {
-	case s.done <- true:
+	case <-s.halted:
 		return nil
-	case <-time.After(to * time.Millisecond):
+	case <-time.After(to):
 		return errors.New("Stop operation timed out.")
 	}
 }
@@ -103,9 +142,9 @@ func (s *Scheduler) stopQueues() {
 	for _, q := range s.jobQueues {
 		// check that the queue is actually running or this blocks
 		// while posting to the channel
-		if q.started {
+		if atomic.LoadUint32(&q.running) != 0 {
 			q.stop <- true
-			q.started = false
+			atomic.StoreUint32(&q.running, 0)
 		}
 	}
 }
@@ -113,7 +152,7 @@ func (s *Scheduler) stopQueues() {
 // startQueues loads the timer for each queue
 func (s *Scheduler) startQueues() {
 	for _, q := range s.jobQueues {
-		go q.run(s.checksPipe)
+		q.run(s.checksPipe)
 	}
 }
 
@@ -125,6 +164,7 @@ func newJobQueue(interval time.Duration) *jobQueue {
 		interval: interval,
 		ticker:   time.NewTicker(time.Second * time.Duration(interval)),
 		stop:     make(chan bool, 1),
+		running:  0,
 	}
 }
 
@@ -136,20 +176,24 @@ func (jq *jobQueue) addJob(c check.Check) {
 }
 
 // run schedules the checks in the queue by posting them to the
-// execution pipeline
+// execution pipeline.
+// This doesn't block.
 func (jq *jobQueue) run(out chan<- check.Check) {
-	jq.started = true
-	for {
-		select {
-		case <-jq.stop:
-			// someone asked to stop this queue
-			jq.ticker.Stop()
-		case <-jq.ticker.C:
-			// normal case, (re)schedule the queue
-			for _, check := range jq.jobs {
-				log.Debugf("Enqueuing check %s for queue %d", check, jq.interval)
-				out <- check
+	atomic.StoreUint32(&jq.running, 1)
+	go func() {
+		for {
+			select {
+			case <-jq.stop:
+				// someone asked to stop this queue
+				jq.ticker.Stop()
+				atomic.StoreUint32(&jq.running, 0)
+			case <-jq.ticker.C:
+				// normal case, (re)schedule the queue
+				for _, check := range jq.jobs {
+					log.Debugf("Enqueuing check %s for queue %d", check, jq.interval)
+					out <- check
+				}
 			}
 		}
-	}
+	}()
 }

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 	s.Enter([]check.Check{&TestCheck{intl: 10}})
 	s.Run()
 	assert.Equal(t, uint32(1), s.running)
-	assert.Equal(t, uint32(1), s.jobQueues[10].running)
+	assert.True(t, s.jobQueues[10].running)
 
 	// Calling Run again should be a non blocking, noop procedure
 	s.Run()
@@ -88,7 +88,7 @@ func TestStop(t *testing.T) {
 	err := s.Stop()
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), s.running)
-	assert.Equal(t, uint32(0), s.jobQueues[10].running)
+	assert.False(t, s.jobQueues[10].running)
 
 	// stopping again should be non blocking, noop and return nil
 	assert.Nil(t, s.Stop())
@@ -121,5 +121,5 @@ func TestReload(t *testing.T) {
 
 	// check the scheduler is up again with the new queue running
 	assert.Equal(t, uint32(1), s.running)
-	assert.Equal(t, uint32(1), s.jobQueues[1].running)
+	assert.True(t, s.jobQueues[1].running)
 }

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -41,6 +41,7 @@ func TestNewScheduler(t *testing.T) {
 	s := NewScheduler(c)
 	assert.Equal(t, s.checksPipe, c)
 	assert.Equal(t, len(s.jobQueues), 0)
+	assert.Equal(t, s.running, uint32(0))
 }
 
 func TestEnter(t *testing.T) {
@@ -72,7 +73,11 @@ func TestRun(t *testing.T) {
 
 	s.Enter([]check.Check{&TestCheck{intl: 10}})
 	s.Run()
-	assert.True(t, consistently(func() bool { return s.jobQueues[10].started }))
+	assert.Equal(t, uint32(1), s.running)
+	assert.Equal(t, uint32(1), s.jobQueues[10].running)
+
+	// Calling Run again should be a non blocking, noop procedure
+	s.Run()
 }
 
 func TestStop(t *testing.T) {
@@ -82,7 +87,11 @@ func TestStop(t *testing.T) {
 
 	err := s.Stop()
 	assert.Nil(t, err)
-	assert.True(t, consistently(func() bool { return s.jobQueues[10].started == false }))
+	assert.Equal(t, uint32(0), s.running)
+	assert.Equal(t, uint32(0), s.jobQueues[10].running)
+
+	// stopping again should be non blocking, noop and return nil
+	assert.Nil(t, s.Stop())
 }
 
 func TestStopTimeout(t *testing.T) {
@@ -90,8 +99,12 @@ func TestStopTimeout(t *testing.T) {
 	s.Enter([]check.Check{&TestCheck{intl: 10}})
 	s.Run()
 	s.Stop()
-	// stopping a second time triggers the timeout, set it at 1ms
-	err := s.Stop(1)
+
+	// to trigger the timeout, fake scheduler state to `running`...
+	s.running = uint32(1)
+	// ...now, stopping should trigger the timeout, set it at 1ms
+	err := s.Stop(time.Millisecond)
+
 	assert.NotNil(t, err)
 }
 
@@ -100,9 +113,6 @@ func TestReload(t *testing.T) {
 	s.Enter([]check.Check{&TestCheck{intl: 10}})
 	s.Run()
 
-	// check the scheduler has booted
-	assert.True(t, consistently(func() bool { return s.jobQueues[10].started }))
-
 	// add a queue to check the reload picks it up
 	s.Enter([]check.Check{&TestCheck{intl: 1}})
 
@@ -110,5 +120,6 @@ func TestReload(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check the scheduler is up again with the new queue running
-	assert.True(t, consistently(func() bool { return s.jobQueues[1].started }))
+	assert.Equal(t, uint32(1), s.running)
+	assert.Equal(t, uint32(1), s.jobQueues[1].running)
 }

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -17,11 +17,11 @@ func (c *TestCheck) InitSender()                {}
 func (c *TestCheck) Interval() time.Duration    { return c.intl }
 func (c *TestCheck) Run() error                 { return nil }
 
-// wait 3s for a predicate function to return true, use polling
+// wait 1s for a predicate function to return true, use polling
 // instead of a giant sleep.
 // predicate f must return true if the desired condition is met
 func consistently(f func() bool) bool {
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 100; i++ {
 		if f() {
 			return true
 		}


### PR DESCRIPTION
The scheduler was refactored to have a more predictable behaviour on start, stop and reload.
The tests expected to be flaky are not needed anymore
