### PR TITLE
[runner] avoid running a check if it's already running

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -26,24 +26,10 @@ type Config struct {
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error
-	String() string
-	Configure(data ConfigData)
-	InitSender()
-	Interval() time.Duration
-}
-
-// Runner waits for checks and run them as long as they arrive on the channel
-func Runner(in <-chan Check) {
-	log.Debug("Ready to process checks...")
-	for check := range in {
-		// create call arguments
-		log.Infof("Running check %s", check)
-		// run the check
-		err := check.Run()
-		if err != nil {
-			log.Errorf("Error running check %s: %s", check, err)
-		}
-		log.Infof("Done running check %s", check)
-	}
+	Run() error                // run the check
+	String() string            // provide a printable version of the check name
+	Configure(data ConfigData) // configure the check from the outside
+	InitSender()               // initialize what's needed to send data to the aggregator
+	Interval() time.Duration   // return the interval time for the check
+	ID() string                // provide a unique identifier for every check instance
 }

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -2,13 +2,13 @@ package check
 
 import (
 	"errors"
-	"testing"
 	"time"
 )
 
 // FIXTURE
 type TestCheck struct {
-	doErr bool
+	doErr  bool
+	hasRun bool
 }
 
 func (c *TestCheck) String() string          { return "TestCheck" }
@@ -20,13 +20,7 @@ func (c *TestCheck) Run() error {
 		msg := "A tremendous error occurred."
 		return errors.New(msg)
 	}
+	c.hasRun = true
 	return nil
 }
-
-func TestRunner(t *testing.T) {
-	pending := make(chan Check)
-	go Runner(pending)
-
-	pending <- &TestCheck{doErr: false}
-	pending <- &TestCheck{doErr: true}
-}
+func (c *TestCheck) ID() string { return c.String() }

--- a/pkg/collector/check/core/loader_test.go
+++ b/pkg/collector/check/core/loader_test.go
@@ -15,6 +15,7 @@ func (c *TestCheck) Configure(check.ConfigData) {}
 func (c *TestCheck) InitSender()                {}
 func (c *TestCheck) Run() error                 { return nil }
 func (c *TestCheck) Interval() time.Duration    { return 1 }
+func (c *TestCheck) ID() string                 { return c.String() }
 
 func TestNewGoCheckLoader(t *testing.T) {
 	if NewGoCheckLoader() == nil {

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -45,6 +45,11 @@ func (c *MemoryCheck) Interval() time.Duration {
 	return check.DefaultCheckInterval
 }
 
+// ID FIXME: this should return a real identifier
+func (c *MemoryCheck) ID() string {
+	return c.String()
+}
+
 func init() {
 	core.RegisterCheck("memory", &MemoryCheck{})
 }

--- a/pkg/collector/check/py/check.go
+++ b/pkg/collector/check/py/check.go
@@ -129,3 +129,8 @@ func (c *PythonCheck) InitSender() {
 func (c *PythonCheck) Interval() time.Duration {
 	return c.interval
 }
+
+// ID FIXME: this should return a real identifier
+func (c *PythonCheck) ID() string {
+	return c.String()
+}

--- a/pkg/collector/check/runner.go
+++ b/pkg/collector/check/runner.go
@@ -1,0 +1,93 @@
+package check
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Runner ...
+type Runner struct {
+	pending       chan Check          // The channel where checks come from
+	done          chan bool           // Guard for the main loop
+	runningChecks map[string]struct{} // the list of checks running
+	m             sync.Mutex          // to control races on runningChecks
+	running       uint32              // Flag to see if the Runner is, well, running
+}
+
+// NewRunner ...
+func NewRunner() *Runner {
+	return &Runner{}
+}
+
+// Run takes the number of desired goroutines processing incoming checks.
+// It's designed to be stopped and restarted, that's why some of the initialization is
+// done here.
+func (r *Runner) Run(numWorkers int) {
+	if atomic.LoadUint32(&r.running) != 0 {
+		log.Debug("Runner was already started, nothing to do here...")
+		return
+	}
+
+	// initialize the channel
+	r.pending = make(chan Check)
+
+	// initialize the running list
+	r.runningChecks = make(map[string]struct{})
+
+	for i := 0; i < numWorkers; i++ {
+		go r.work()
+	}
+
+	log.Infof("Runner started with %d workers.", numWorkers)
+	atomic.StoreUint32(&r.running, 1)
+}
+
+// Stop closes the pending channel so all workers will exit their loop and terminate
+func (r *Runner) Stop() {
+	if atomic.LoadUint32(&r.running) == 0 {
+		log.Debug("Runner already stopped, nothing to do here...")
+		return
+	}
+
+	atomic.StoreUint32(&r.running, 0)
+	close(r.pending)
+}
+
+// GetChan returns a write-only version of the pending channel
+func (r *Runner) GetChan() chan<- Check {
+	return r.pending
+}
+
+// Run waits for checks and run them as long as they arrive on the channel
+func (r *Runner) work() {
+	log.Debug("Ready to process checks...")
+
+	for check := range r.pending {
+		// see if the check is already running
+		r.m.Lock()
+		_, running := r.runningChecks[check.ID()]
+		if running {
+			log.Debugf("Check %s is already running, skip execution...", check)
+			continue
+		} else {
+			r.runningChecks[check.ID()] = struct{}{}
+		}
+		r.m.Unlock()
+
+		log.Infof("Running check %s", check)
+		// run the check
+		err := check.Run()
+		if err != nil {
+			log.Errorf("Error running check %s: %s", check, err)
+		}
+
+		// remove the check from the running list
+		r.m.Lock()
+		delete(r.runningChecks, check.ID())
+		r.m.Unlock()
+
+		log.Infof("Done running check %s", check)
+	}
+
+	log.Debug("Finished to process checks.")
+}

--- a/pkg/collector/check/runner.go
+++ b/pkg/collector/check/runner.go
@@ -49,8 +49,8 @@ func (r *Runner) Stop() {
 		return
 	}
 
-	atomic.StoreUint32(&r.running, 0)
 	close(r.pending)
+	atomic.StoreUint32(&r.running, 0)
 }
 
 // GetChan returns a write-only version of the pending channel

--- a/pkg/collector/check/runner_test.go
+++ b/pkg/collector/check/runner_test.go
@@ -1,0 +1,67 @@
+package check
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRunner(t *testing.T) {
+	r := NewRunner()
+	assert.Nil(t, r.pending)
+}
+
+func TestRun(t *testing.T) {
+	r := NewRunner()
+
+	// let's fake the runner already started, this should be a noop
+	r.pending = make(chan Check)
+	r.Run(1)
+
+	r = NewRunner()
+	r.Run(1)
+	assert.NotNil(t, r.pending)
+	assert.NotNil(t, r.runningChecks)
+	close(r.pending)
+}
+
+func TestStop(t *testing.T) {
+	r := NewRunner()
+	r.Run(1)
+	r.Stop()
+	_, ok := <-r.pending
+	assert.False(t, ok)
+
+	// calling Stop on a stopped runner should be a noop
+	r.Stop()
+}
+
+func TestGetChan(t *testing.T) {
+	r := NewRunner()
+	assert.Nil(t, r.GetChan())
+	r.Run(1)
+	assert.NotNil(t, r.GetChan())
+}
+
+func TestWork(t *testing.T) {
+	r := NewRunner()
+	r.Run(1)
+	c1 := TestCheck{}
+	c2 := TestCheck{doErr: true}
+
+	r.pending <- &c1
+	r.pending <- &c2
+	assert.True(t, c1.hasRun)
+	r.Stop()
+
+	// fake a check is already running
+	r = NewRunner()
+	r.Run(1)
+	c3 := TestCheck{}
+	r.runningChecks[c3.String()] = struct{}{}
+	r.pending <- &c3
+	// wait to be sure the worker tried to run the check
+	time.Sleep(100 * time.Millisecond)
+	assert.False(t, c3.hasRun)
+}


### PR DESCRIPTION
### What does this PR do?

Provides the logic to avoid running a check if it is already running in a separate goroutine.
### Motivation

This is convenient in general but it's also important for the aggregator to collect rates from the same check once at a time to avoid scrambling data.
### Additional Notes

The code also contains a small refactoring of the runner. In the first implementation it was a simple function invoked asynchronously from the `main`. Now the runner is responsible for providing the running queue exposing a dedicated channel. It also responsible to run more than one running job if requested.
