### PR TITLE
Migrate to seelog

### DIFF
--- a/cmd/agent/app/main.go
+++ b/cmd/agent/app/main.go
@@ -11,8 +11,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/kardianos/osext"
-	"github.com/op/go-logging"
 	"github.com/sbinet/go-python"
+
+	log "github.com/cihub/seelog"
 
 	// register core checks
 	_ "github.com/DataDog/datadog-agent/pkg/collector/check/core/system"
@@ -22,7 +23,6 @@ const agentVersion = "6.0.0"
 
 var here, _ = osext.ExecutableFolder()
 var distPath = filepath.Join(here, "dist")
-var log = logging.MustGetLogger("datadog-agent")
 
 // for testing purposes only: collect and log check results
 type metric struct {
@@ -63,6 +63,7 @@ func getAgentConfigProviders() (providers []config.Provider) {
 
 // Start the main check loop
 func Start() {
+	defer log.Flush()
 
 	log.Infof("Starting Datadog Agent v%v", agentVersion)
 
@@ -70,7 +71,7 @@ func Start() {
 	cfg := config.NewConfig()
 	for _, provider := range getAgentConfigProviders() {
 		if err := provider.Configure(cfg); err != nil {
-			log.Warningf("Unable to load configuration from %v: %v", provider, err)
+			log.Warnf("Unable to load configuration from %v: %v", provider, err)
 		}
 	}
 

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -7,12 +7,10 @@ import (
 	"time"
 
 	"github.com/PagerDuty/godspeed"
-	"github.com/op/go-logging"
+	log "github.com/cihub/seelog"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-var log = logging.MustGetLogger("datadog-agent")
 
 func sendGauge(gStress, gStats *godspeed.Godspeed, metric string, value float64, tags []string) {
 	// err := gStress.Gauge("example.stat", 1, tags)

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,6 @@ import:
   subpackages:
   - statsd
 - package: github.com/mitchellh/reflectwalk
-- package: github.com/op/go-logging
 - package: github.com/sbinet/go-python
 - package: github.com/shirou/gopsutil
   subpackages:
@@ -13,3 +12,5 @@ import:
 - package: github.com/kardianos/osext
 - package: github.com/stretchr/testify
   version: ^1.1.3
+- package: github.com/cihub/seelog
+  version: ^2.6.0

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -5,13 +5,10 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/op/go-logging"
 )
 
 const defaultFlushInterval = 15 // flush interval in seconds
 const bucketSize = 10           // fixed for now
-
-var log = logging.MustGetLogger("datadog-agent")
 
 var aggregatorInstance *BufferedAggregator
 var aggregatorInit sync.Once

--- a/pkg/aggregator/reporter.go
+++ b/pkg/aggregator/reporter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	log "github.com/cihub/seelog"
 )
 
 const apiHost = "http://localhost:17123"

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -2,11 +2,7 @@ package check
 
 import (
 	"time"
-
-	"github.com/op/go-logging"
 )
-
-var log = logging.MustGetLogger("datadog-agent")
 
 // DefaultCheckInterval is the interval in seconds the scheduler should apply
 // when no value was provided in Check configuration.

--- a/pkg/collector/check/core/loader.go
+++ b/pkg/collector/check/core/loader.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/op/go-logging"
+	log "github.com/cihub/seelog"
 )
-
-var log = logging.MustGetLogger("datadog-agent")
 
 // Catalog keeps track of Go checks by name
 var catalog = make(map[string]check.Check)
@@ -34,7 +32,7 @@ func (gl *GoCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	c, found := catalog[config.Name]
 	if !found {
 		msg := fmt.Sprintf("Check %s not found in Catalog", config.Name)
-		log.Warning(msg)
+		log.Warn(msg)
 		return checks, fmt.Errorf(msg)
 	}
 

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -5,13 +5,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/core"
-	"github.com/op/go-logging"
+	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/mem"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
-
-var log = logging.MustGetLogger("datadog-agent")
 
 // MemoryCheck doesn't need additional fields
 type MemoryCheck struct {

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -3,6 +3,8 @@ package py
 import (
 	"fmt"
 
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 

--- a/pkg/collector/check/py/check.go
+++ b/pkg/collector/check/py/check.go
@@ -10,11 +10,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/op/go-logging"
 	"github.com/sbinet/go-python"
-)
 
-var log = logging.MustGetLogger("datadog-agent")
+	log "github.com/cihub/seelog"
+)
 
 // PythonCheck represents a Python check, implements `Check` interface
 type PythonCheck struct {

--- a/pkg/collector/check/py/loader.go
+++ b/pkg/collector/check/py/loader.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/sbinet/go-python"
+
+	log "github.com/cihub/seelog"
 )
 
 // const things
@@ -56,7 +58,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	checkModule := python.PyImport_ImportModuleNoBlock(moduleName)
 	if checkModule == nil {
 		msg := fmt.Sprintf("Unable to import %v", moduleName)
-		log.Warningf(msg)
+		log.Warnf(msg)
 		python.PyErr_Print() // TODO: remove this or redirect to the Go logger
 		python.PyErr_Clear()
 		return checks, errors.New(msg)
@@ -66,7 +68,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	checkClass := findSubclassOf(cl.agentCheckClass, checkModule)
 	if checkClass == nil {
 		msg := fmt.Sprintf("Unable to find a check class in the module: %v", python.PyString_AS_STRING(checkModule.Str()))
-		log.Warningf(msg)
+		log.Warnf(msg)
 		return checks, errors.New(msg)
 	}
 

--- a/pkg/collector/check/runner.go
+++ b/pkg/collector/check/runner.go
@@ -3,6 +3,8 @@ package check
 import (
 	"sync"
 	"sync/atomic"
+
+	log "github.com/cihub/seelog"
 )
 
 // Runner ...

--- a/pkg/collector/loader/file_provider.go
+++ b/pkg/collector/loader/file_provider.go
@@ -6,12 +6,10 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/op/go-logging"
+	log "github.com/cihub/seelog"
 
 	"gopkg.in/yaml.v2"
 )
-
-var log = logging.MustGetLogger("datadog-agent")
 
 type configFormat struct {
 	Instances []check.ConfigRawMap
@@ -39,13 +37,13 @@ func (c *FileConfigProvider) Collect() ([]check.Config, error) {
 
 		files, err := ioutil.ReadDir(path)
 		if err != nil {
-			log.Warningf("Unable to access dir: %s, skipping...", err)
+			log.Warnf("Unable to access dir: %s, skipping...", err)
 			continue
 		}
 
 		for _, f := range files {
 			if f.IsDir() {
-				log.Warningf("%s is a dir, skipping...", f.Name())
+				log.Warnf("%s is a dir, skipping...", f.Name())
 				continue
 			}
 
@@ -54,7 +52,7 @@ func (c *FileConfigProvider) Collect() ([]check.Config, error) {
 			bName := fName[:len(f.Name())-len(extName)]
 			conf, err := getCheckConfig(bName, filepath.Join(path, fName))
 			if err != nil {
-				log.Warningf("%s is not a valid config file: %s", f.Name(), err)
+				log.Warnf("%s is not a valid config file: %s", f.Name(), err)
 				continue
 			}
 

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/op/go-logging"
+	log "github.com/cihub/seelog"
 )
-
-var log = logging.MustGetLogger("datadog-agent")
 
 const defaultTimeout time.Duration = 5000 * time.Millisecond
 

--- a/pkg/config/file_provider.go
+++ b/pkg/config/file_provider.go
@@ -5,12 +5,10 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/op/go-logging"
+	log "github.com/cihub/seelog"
 )
 
 const configFileName = "datadog.yaml"
-
-var log = logging.MustGetLogger("datadog-agent")
 
 // FileProvider retrieves configuration data from text files on the
 // filesystem containing YAML code.

--- a/pkg/dogstatsd/dogstatsd.go
+++ b/pkg/dogstatsd/dogstatsd.go
@@ -1,1 +1,0 @@
-package dogstatsd

--- a/pkg/dogstatsd/dogstatsd.go
+++ b/pkg/dogstatsd/dogstatsd.go
@@ -1,8 +1,1 @@
 package dogstatsd
-
-import (
-	// 3p
-	"github.com/op/go-logging"
-)
-
-var log = logging.MustGetLogger("datadog-agent")

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	log "github.com/cihub/seelog"
 )
 
 // RunServer starts and run a dogstatsd server


### PR DESCRIPTION
### What does this PR do?

Start using seelog for logs as we do in the rest of Datadog realm.

### Motivation

We've more expertise on seelog.

### Additional Notes

I'm doing this now as part of the work needed to run the QA agent

