### PR TITLE
Schedule 1-time checks

### DIFF
--- a/cmd/agent/app/main.go
+++ b/cmd/agent/app/main.go
@@ -95,7 +95,9 @@ func Start() {
 		for _, loader := range loaders {
 			res, err := loader.Load(conf)
 			if err == nil {
-				scheduler.Enter(res)
+				for _, check := range res {
+					scheduler.Enter(check)
+				}
 			}
 		}
 	}

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -1,0 +1,60 @@
+package scheduler
+
+import (
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	log "github.com/cihub/seelog"
+)
+
+// jobQueue contains a list of checks (called jobs) that need to be
+// scheduled at a certain interval.
+type jobQueue struct {
+	interval time.Duration
+	stop     chan bool
+	ticker   *time.Ticker
+	jobs     []check.Check
+	running  bool
+	mu       sync.Mutex // to protect critical sections in struct's fields
+}
+
+// newJobQueue creates a new jobQueue instance
+// the stop channel is buffered so the scheduler loop can send a message to stop
+// without blocking
+func newJobQueue(interval time.Duration) *jobQueue {
+	return &jobQueue{
+		interval: interval,
+		ticker:   time.NewTicker(time.Second * time.Duration(interval)),
+		stop:     make(chan bool, 1),
+	}
+}
+
+// addJob is a convenience method to add a check to a queue
+func (jq *jobQueue) addJob(c check.Check) {
+	jq.mu.Lock()
+	defer jq.mu.Unlock()
+
+	jq.jobs = append(jq.jobs, c)
+}
+
+// run schedules the checks in the queue by posting them to the
+// execution pipeline.
+// This doesn't block.
+func (jq *jobQueue) run(out chan<- check.Check) {
+	go func() {
+		for {
+			select {
+			case <-jq.stop:
+				// someone asked to stop this queue
+				jq.ticker.Stop()
+			case <-jq.ticker.C:
+				// normal case, (re)schedule the queue
+				for _, check := range jq.jobs {
+					log.Debugf("Enqueuing check %s for queue %d", check, jq.interval)
+					out <- check
+				}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
### What does this PR do?

 * Explicitly pass an interval value to the `Enter` function so we don't tie to the checks `Interval`
 * Allow passing `0` as interval, meaning _schedule this just one time_
 * moved some code in its own module for clarity

### Motivation

This is the first part of a possible refactoring to implement checks that are started only once and run until the agent exits (see: JMX-fetch).
