### PR TITLE
Prepare the code for long running checks

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -23,6 +23,7 @@ type Config struct {
 // Check is an interface for types capable to run checks
 type Check interface {
 	Run() error                // run the check
+	Stop()                     // stop the check if it's running
 	String() string            // provide a printable version of the check name
 	Configure(data ConfigData) // configure the check from the outside
 	InitSender()               // initialize what's needed to send data to the aggregator

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -12,6 +12,7 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) String() string          { return "TestCheck" }
+func (c *TestCheck) Stop()                   {}
 func (c *TestCheck) Configure(ConfigData)    {}
 func (c *TestCheck) InitSender()             {}
 func (c *TestCheck) Interval() time.Duration { return 1 }

--- a/pkg/collector/check/core/loader_test.go
+++ b/pkg/collector/check/core/loader_test.go
@@ -14,6 +14,7 @@ func (c *TestCheck) String() string             { return "TestCheck" }
 func (c *TestCheck) Configure(check.ConfigData) {}
 func (c *TestCheck) InitSender()                {}
 func (c *TestCheck) Run() error                 { return nil }
+func (c *TestCheck) Stop()                      {}
 func (c *TestCheck) Interval() time.Duration    { return 1 }
 func (c *TestCheck) ID() string                 { return c.String() }
 

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -54,6 +54,9 @@ func (c *MemoryCheck) ID() string {
 	return c.String()
 }
 
+// Stop does nothing
+func (c *MemoryCheck) Stop() {}
+
 func init() {
 	core.RegisterCheck("memory", &MemoryCheck{})
 }

--- a/pkg/collector/check/py/check.go
+++ b/pkg/collector/check/py/check.go
@@ -65,6 +65,9 @@ func (c *PythonCheck) Run() error {
 	return errors.New(resultStr)
 }
 
+// Stop does nothing
+func (c *PythonCheck) Stop() {}
+
 // String representation (for debug and logging)
 func (c *PythonCheck) String() string {
 	if c.Instance != nil {

--- a/pkg/collector/check/runner_test.go
+++ b/pkg/collector/check/runner_test.go
@@ -58,9 +58,9 @@ func TestWork(t *testing.T) {
 	// fake a check is already running
 	r = NewRunner()
 	r.Run(1)
-	c3 := TestCheck{}
-	r.runningChecks[c3.String()] = struct{}{}
-	r.pending <- &c3
+	c3 := new(TestCheck)
+	r.runningChecks[c3.String()] = c3
+	r.pending <- c3
 	// wait to be sure the worker tried to run the check
 	time.Sleep(100 * time.Millisecond)
 	assert.False(t, c3.hasRun)

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -16,6 +16,7 @@ func (c *TestCheck) Configure(check.ConfigData) {}
 func (c *TestCheck) InitSender()                {}
 func (c *TestCheck) Interval() time.Duration    { return c.intl }
 func (c *TestCheck) Run() error                 { return nil }
+func (c *TestCheck) Stop()                      {}
 func (c *TestCheck) ID() string                 { return c.String() }
 
 // wait 1s for a predicate function to return true, use polling


### PR DESCRIPTION
### What does this PR do?

Introduces the `Stop` method in the `Check` interface, implying that we might have checks that run for so long they might accept a stop request. 
Given the premise, the `Runner` should assume that by the time it stops, some check might still run, so it needs to be stopped.

### Motivation

We want to be agnostics about the time a check could need to run, at the point a check could behave like a daemon, running as long as the Agent itself does.


