### PR TITLE
[gitlab] Deploy deb pkg to apt repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,16 @@
 stages:
   - test
   - build
+  - deploy
 
 variables:
   DOCKER_REGISTRY: gitlab.datad0g.com:4567
   SRC_PATH: /src/github.com/DataDog/datadog-agent
   DEB_X64: $DOCKER_REGISTRY/datadog/datadog-agent-builders:deb_x64
   RPM_X64: $DOCKER_REGISTRY/datadog/datadog-agent-builders:rpm_x64
+  DEPLOY: $DOCKER_REGISTRY/datadog/datadog-agent-builders:deploy # For now, just a renamed version of the image datadog/mars-jenkins-scripts
+  AGENT_OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
+  DEB_S3_BUCKET: apt-agent6.datad0g.com
 
 before_script:
   # We need to install go deps from within the GOPATH, which we set to / on builder images; that's because pointing
@@ -38,7 +42,6 @@ build_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus from the GOPATH (see above).
     # We then instrument `rake` to invoke `omnibus` with custom parameter, pointing to a gitlab-friendly location.
     AGENT_OMNIBUS_BASE_DIR: $CI_PROJECT_DIR/.omnibus/var/
-    AGENT_OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
     # Uncomment the following to see debug logs from omnibus, it defaults to info
     # AGENT_OMNIBUS_LOG_LEVEL: debug
   script:
@@ -64,3 +67,24 @@ run_test_rpm-x64:
     - rake test
 
 # TODO: build the package for rpm-x64
+
+
+# deploy debian packages to apt staging repo
+deploy_deb:
+  before_script:
+    - ls $AGENT_OMNIBUS_PACKAGE_DIR
+  only:
+    - master
+  stage: deploy
+  image: $DEPLOY
+  tags:
+    - docker
+  script:
+    - source ~/.rvm/scripts/rvm
+    - rvm use 2.2.2@circleci
+    - echo "$APT_SIGNING_KEY_ID"
+    - echo "$APT_SIGNING_PRIVATE_KEY" | gpg --import
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
+
+# TODO: deploy rpm packages

--- a/omnibus/config/projects/datadog-agent6.rb
+++ b/omnibus/config/projects/datadog-agent6.rb
@@ -68,6 +68,11 @@ end
 
 # Linux
 if linux?
+  if debian?
+    extra_package_file '/etc/init/datadog-agent6.conf'
+    extra_package_file '/lib/systemd/system/datadog-agent6.service'
+  end
+
   # Linux-specific dependencies
   dependency 'procps-ng'
   dependency 'sysstat'

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -10,4 +10,20 @@ build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
   command 'rake build'
   copy('bin', install_dir)
+
+  if debian?
+    erb source: "upstart.conf.erb",
+        dest: "/etc/init/datadog-agent6.conf",
+        mode: 0755,
+        vars: { install_dir: install_dir }
+    erb source: "systemd.service.erb",
+        dest: "/lib/systemd/system/datadog-agent6.service",
+        mode: 0755,
+        vars: { install_dir: install_dir }
+  end
+
+  # The file below is touched by software builds that don't put anything in the installation
+  # directory (libgcc right now) so that the git_cache gets updated let's remove it from the
+  # final package
+  delete "#{install_dir}/uselessfile"
 end

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description="Datadog Agent"
+After=network.target
+
+[Service]
+User=root
+ExecStart=<%= install_dir %>/bin/agent/agent
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -1,0 +1,10 @@
+description "Datadog Agent"
+
+start on started networking
+stop on runlevel [!2345]
+
+respawn
+
+script
+  exec <%= install_dir %>/bin/agent/agent
+end script


### PR DESCRIPTION
Adds a `deploy` stage to our gitlab pipeline that releases the deb package to the `unstable` branch of the staging repo located at https://s3.amazonaws.com/apt-agent6.datad0g.com

Example of a gitlab pipeline that uses this code: https://gitlab.datad0g.com/datadog/datadog-agent/pipelines/22095 (without the `master` branch execution restriction)

Notes:
- This stage is executed only on the `master` branch
- The repo is signed with our latest staging GPG signing key
- Requires https://github.com/DataDog/omnibus-ruby/pull/28 for the release to the apt repo to work correctly
- Adds basic init scripts for `upstart` (legacy ubuntu systems) and `systemd` (recent debian and ubuntu systems) to the package to ease the installation/usage of the package.

FIXME:
- For now the deploy uses the docker image that's defined [here](https://github.com/DataDog/mars-jenkins-scripts/blob/master/Dockerfile) and that is used on Jenkins to run all of our deploy jobs. We'll have to use our own Dockerfile and add it to `datadog-agent-builders` at some point
- Debian only
- Very basic init scripts (and I didn't want to spend time writing a `sysvinit` script), that run the agent as `root`