### PR TITLE
[deb] Redirect outputs to standard upstart log file

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -5,6 +5,8 @@ stop on runlevel [!2345]
 
 respawn
 
+console log  # redirect daemon's outputs to `/var/log/upstart/datadog-agent6.log`
+
 script
   exec <%= install_dir %>/bin/agent/agent
 end script


### PR DESCRIPTION
So that our QA env is usable