### PR TITLE
[aggregator] Use configured hostname as the `host` tag for collector

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -1,10 +1,15 @@
 package aggregator
 
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
 	series   []*Serie
 	contexts map[string]Context // TODO: this map grows constantly, we need to flush old contexts from time to time. It should also be a shared ContextResolver
 	metrics  Metrics
+	hostname string
 }
 
 // newCheckSampler returns a newly initialized CheckSample
@@ -13,6 +18,7 @@ func newCheckSampler() *CheckSampler {
 		series:   make([]*Serie, 0),
 		contexts: map[string]Context{},
 		metrics:  *newMetrics(),
+		hostname: config.Datadog.GetString("hostname"),
 	}
 }
 
@@ -22,7 +28,7 @@ func (cs *CheckSampler) addSample(metricSample *MetricSample) {
 		cs.contexts[contextKey] = Context{
 			Name:       metricSample.Name,
 			Tags:       metricSample.Tags,
-			Host:       "",
+			Host:       cs.hostname, // FIXME: take into account hostname in the sample if provided
 			DeviceName: "",
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ func init() {
 
 	// configuration defaults
 	Datadog.SetDefault("dd_url", "http://localhost:17123")
+	Datadog.SetDefault("hostname", "")
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")


### PR DESCRIPTION
Just so we can actually have this agent as a standalone and see its
metrics on DD (the `host` tag is required for that).

This will need to be re-worked to handle custom host tags set by checks (we have https://github.com/DataDog/datadog-agent/issues/36 open for that)