### PR TITLE
[aggregator] Expire old contexts

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -56,7 +56,7 @@ func (agg *BufferedAggregator) GetChannel() chan *MetricSample {
 func (agg *BufferedAggregator) registerNewCheckSampler() int64 {
 	agg.mu.Lock()
 	agg.currentCheckSamplerID++
-	agg.checkSamplers[agg.currentCheckSamplerID] = newCheckSampler()
+	agg.checkSamplers[agg.currentCheckSamplerID] = newCheckSampler(config.Datadog.GetString("hostname"))
 	agg.mu.Unlock()
 
 	return agg.currentCheckSamplerID

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -1,37 +1,25 @@
 package aggregator
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/config"
-)
-
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
-	series   []*Serie
-	contexts map[string]Context // TODO: this map grows constantly, we need to flush old contexts from time to time. It should also be a shared ContextResolver
-	metrics  Metrics
-	hostname string
+	series          []*Serie
+	contextResolver *ContextResolver
+	metrics         Metrics
+	hostname        string
 }
 
 // newCheckSampler returns a newly initialized CheckSample
-func newCheckSampler() *CheckSampler {
+func newCheckSampler(hostname string) *CheckSampler {
 	return &CheckSampler{
-		series:   make([]*Serie, 0),
-		contexts: map[string]Context{},
-		metrics:  *newMetrics(),
-		hostname: config.Datadog.GetString("hostname"),
+		series:          make([]*Serie, 0),
+		contextResolver: newContextResolver(),
+		metrics:         *newMetrics(),
+		hostname:        hostname,
 	}
 }
 
 func (cs *CheckSampler) addSample(metricSample *MetricSample) {
-	contextKey := generateContextKey(metricSample)
-	if _, ok := cs.contexts[contextKey]; !ok {
-		cs.contexts[contextKey] = Context{
-			Name:       metricSample.Name,
-			Tags:       metricSample.Tags,
-			Host:       cs.hostname, // FIXME: take into account hostname in the sample if provided
-			DeviceName: "",
-		}
-	}
+	contextKey := cs.contextResolver.trackContext(metricSample, metricSample.Timestamp)
 
 	cs.metrics.addSample(contextKey, metricSample.Mtype, metricSample.Value, metricSample.Timestamp)
 }
@@ -39,14 +27,16 @@ func (cs *CheckSampler) addSample(metricSample *MetricSample) {
 func (cs *CheckSampler) commit(timestamp int64) {
 	for _, serie := range cs.metrics.flush(timestamp) {
 		// Resolve context and populate new []Serie
-		context := cs.contexts[serie.contextKey]
+		context, _ := cs.contextResolver.lookupContext(serie.contextKey)
 		serie.Name = context.Name + serie.nameSuffix
 		serie.Tags = context.Tags
-		serie.Host = context.Host
+		serie.Host = cs.hostname // FIXME: take into account the hostname of the context if it's specified
 		serie.DeviceName = context.DeviceName
 
 		cs.series = append(cs.series, serie)
 	}
+
+	cs.contextResolver.expireContexts(timestamp - defaultExpirySeconds)
 }
 
 func (cs *CheckSampler) flush() []*Serie {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -13,7 +13,7 @@ func newCheckSampler(hostname string) *CheckSampler {
 	return &CheckSampler{
 		series:          make([]*Serie, 0),
 		contextResolver: newContextResolver(),
-		metrics:         *newMetrics(),
+		metrics:         makeMetrics(),
 		hostname:        hostname,
 	}
 }

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -27,7 +27,7 @@ func (cs *CheckSampler) addSample(metricSample *MetricSample) {
 func (cs *CheckSampler) commit(timestamp int64) {
 	for _, serie := range cs.metrics.flush(timestamp) {
 		// Resolve context and populate new []Serie
-		context, _ := cs.contextResolver.lookupContext(serie.contextKey)
+		context := cs.contextResolver.contextsByKey[serie.contextKey]
 		serie.Name = context.Name + serie.nameSuffix
 		serie.Tags = context.Tags
 		serie.Host = cs.hostname // FIXME: take into account the hostname of the context if it's specified

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCheckGaugeSampling(t *testing.T) {
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler("")
 
 	mSample1 := MetricSample{
 		Name:       "my.metric.name",
@@ -48,7 +48,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 
 	expectedSerie1 := &Serie{
 		Name:       "my.metric.name",
-		Tags:       &[]string{"foo", "bar"},
+		Tags:       []string{"foo", "bar"},
 		Points:     [][]interface{}{{int64(12349), mSample2.Value}},
 		Mtype:      "gauge",
 		contextKey: generateContextKey(&mSample2),
@@ -57,7 +57,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 
 	expectedSerie2 := &Serie{
 		Name:       "my.metric.name",
-		Tags:       &[]string{"foo", "bar", "baz"},
+		Tags:       []string{"foo", "bar", "baz"},
 		Points:     [][]interface{}{{int64(12349), mSample3.Value}},
 		Mtype:      "gauge",
 		contextKey: generateContextKey(&mSample3),
@@ -75,7 +75,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 }
 
 func TestCheckRateSampling(t *testing.T) {
-	checkSampler := newCheckSampler()
+	checkSampler := newCheckSampler("")
 
 	mSample1 := MetricSample{
 		Name:       "my.metric.name",
@@ -111,7 +111,7 @@ func TestCheckRateSampling(t *testing.T) {
 
 	expectedSerie := &Serie{
 		Name:       "my.metric.name",
-		Tags:       &[]string{"foo", "bar"},
+		Tags:       []string{"foo", "bar"},
 		Points:     [][]interface{}{{int64(12347), 0.5}},
 		Mtype:      "gauge",
 		nameSuffix: "",
@@ -119,5 +119,26 @@ func TestCheckRateSampling(t *testing.T) {
 
 	if assert.Equal(t, 1, len(series)) {
 		AssertSerieEqual(t, expectedSerie, series[0])
+	}
+}
+
+func TestCheckSamplerHostname(t *testing.T) {
+	checkSampler := newCheckSampler("my.test.hostname")
+
+	mSample1 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+		Timestamp:  12345,
+	}
+
+	checkSampler.addSample(&mSample1)
+	checkSampler.commit(12346)
+	series := checkSampler.flush()
+
+	if assert.Len(t, series, 1) {
+		assert.Equal(t, "my.test.hostname", series[0].Host)
 	}
 }

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -2,7 +2,6 @@ package aggregator
 
 import (
 	// stdlib
-	"fmt"
 	"sort"
 	"strings"
 
@@ -56,16 +55,6 @@ func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimes
 	cr.lastSeenByKey[contextKey] = currentTimestamp
 
 	return contextKey
-}
-
-// lookupContext returns the context associated with a contextKey
-func (cr *ContextResolver) lookupContext(contextKey string) (*Context, error) {
-	context, ok := cr.contextsByKey[contextKey]
-	if !ok {
-		return nil, fmt.Errorf("Can't find context with key '%s'", contextKey)
-	}
-
-	return context, nil
 }
 
 // expireContexts cleans up the contexts that haven't been tracked since the given timestamp

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -1,0 +1,91 @@
+package aggregator
+
+import (
+	// stdlib
+	"fmt"
+	"sort"
+	"strings"
+
+	// 3p
+	log "github.com/cihub/seelog"
+)
+
+// Context holds the elements that form a context, and can be serialized into a context key
+type Context struct {
+	Name       string
+	Tags       []string
+	Host       string
+	DeviceName string
+}
+
+// ContextResolver allows tracking and expiring contexts
+type ContextResolver struct {
+	contextsByKey map[string]*Context
+	lastSeenByKey map[string]int64
+}
+
+// generateContextKey generates the contextKey associated with the context of the metricSample
+func generateContextKey(metricSample *MetricSample) string {
+	var contextFields []string
+
+	contextFields = append(contextFields, metricSample.Name)
+	sort.Strings(*(metricSample.Tags))
+	contextFields = append(contextFields, *(metricSample.Tags)...)
+
+	return strings.Join(contextFields, ",")
+}
+
+func newContextResolver() *ContextResolver {
+	return &ContextResolver{
+		contextsByKey: make(map[string]*Context),
+		lastSeenByKey: make(map[string]int64),
+	}
+}
+
+// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
+func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimestamp int64) string {
+	contextKey := generateContextKey(metricSample)
+	if _, ok := cr.contextsByKey[contextKey]; !ok {
+		cr.contextsByKey[contextKey] = &Context{
+			Name:       metricSample.Name,
+			Tags:       *(metricSample.Tags),
+			Host:       "",
+			DeviceName: "",
+		}
+	}
+	cr.lastSeenByKey[contextKey] = currentTimestamp
+
+	return contextKey
+}
+
+// lookupContext returns the context associated with a contextKey
+func (cr *ContextResolver) lookupContext(contextKey string) (*Context, error) {
+	context, ok := cr.contextsByKey[contextKey]
+	if !ok {
+		return nil, fmt.Errorf("Can't find context with key '%s'", contextKey)
+	}
+
+	return context, nil
+}
+
+// expireContexts cleans up the contexts that haven't been tracked since the given timestamp
+// and returns the associated contextKeys
+func (cr *ContextResolver) expireContexts(expireTimestamp int64) []string {
+	var expiredContextKeys []string
+
+	// Find expired context keys
+	for contextKey, lastSeen := range cr.lastSeenByKey {
+		if lastSeen < expireTimestamp {
+			expiredContextKeys = append(expiredContextKeys, contextKey)
+			log.Debugf("Context key '%s' expired", contextKey)
+		}
+	}
+
+	// Delete expired context keys
+	for _, expiredContextKey := range expiredContextKeys {
+		delete(cr.contextsByKey, expiredContextKey)
+		delete(cr.lastSeenByKey, expiredContextKey)
+	}
+
+	return expiredContextKeys
+}

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -51,17 +51,15 @@ func TestTrackContext(t *testing.T) {
 	contextKey2 := contextResolver.trackContext(&mSample2, 1)
 
 	// When we look up the 2 keys, they return the correct contexts
-	context1, err1 := contextResolver.lookupContext(contextKey1)
-	assert.Nil(t, err1)
+	context1 := contextResolver.contextsByKey[contextKey1]
 	assert.Equal(t, expectedContext1, *context1)
 
-	context2, err2 := contextResolver.lookupContext(contextKey2)
-	assert.Nil(t, err2)
+	context2 := contextResolver.contextsByKey[contextKey2]
 	assert.Equal(t, expectedContext2, *context2)
 
-	// Looking up a missing context key returns an error
-	_, err := contextResolver.lookupContext("missingContextKey")
-	assert.NotNil(t, err)
+	// Looking for a missing context key returns an error
+	_, ok := contextResolver.contextsByKey["missingContextKey"]
+	assert.False(t, ok)
 }
 
 func TestExpireContexts(t *testing.T) {
@@ -87,10 +85,10 @@ func TestExpireContexts(t *testing.T) {
 
 	// With an expireTimestap of 3, both contexts are still valid
 	assert.Len(t, contextResolver.expireContexts(3), 0)
-	_, err1 := contextResolver.lookupContext(contextKey1)
-	_, err2 := contextResolver.lookupContext(contextKey2)
-	assert.Nil(t, err1)
-	assert.Nil(t, err2)
+	_, ok1 := contextResolver.contextsByKey[contextKey1]
+	_, ok2 := contextResolver.contextsByKey[contextKey2]
+	assert.True(t, ok1)
+	assert.True(t, ok2)
 
 	// With an expireTimestap of 5, context 1 is expired
 	expiredContextKeys := contextResolver.expireContexts(5)
@@ -99,8 +97,8 @@ func TestExpireContexts(t *testing.T) {
 	}
 
 	// context 1 is not tracked anymore, but context 2 still is
-	_, err := contextResolver.lookupContext(contextKey1)
-	assert.NotNil(t, err)
-	_, err = contextResolver.lookupContext(contextKey2)
-	assert.Nil(t, err)
+	_, ok := contextResolver.contextsByKey[contextKey1]
+	assert.False(t, ok)
+	_, ok = contextResolver.contextsByKey[contextKey2]
+	assert.True(t, ok)
 }

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -1,0 +1,106 @@
+package aggregator
+
+import (
+	// stdlib
+	"testing"
+
+	// 3p
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateContextKey(t *testing.T) {
+	mSample := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+	}
+
+	contextKey := generateContextKey(&mSample)
+	assert.Equal(t, "my.metric.name,bar,foo", contextKey)
+}
+
+func TestTrackContext(t *testing.T) {
+	mSample1 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+	}
+	mSample2 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar", "baz"},
+		SampleRate: 1,
+	}
+	expectedContext1 := Context{
+		Name: mSample1.Name,
+		Tags: *(mSample1.Tags),
+	}
+	expectedContext2 := Context{
+		Name: mSample2.Name,
+		Tags: *(mSample2.Tags),
+	}
+	contextResolver := newContextResolver()
+
+	// Track the 2 contexts
+	contextKey1 := contextResolver.trackContext(&mSample1, 1)
+	contextKey2 := contextResolver.trackContext(&mSample2, 1)
+
+	// When we look up the 2 keys, they return the correct contexts
+	context1, err1 := contextResolver.lookupContext(contextKey1)
+	assert.Nil(t, err1)
+	assert.Equal(t, expectedContext1, *context1)
+
+	context2, err2 := contextResolver.lookupContext(contextKey2)
+	assert.Nil(t, err2)
+	assert.Equal(t, expectedContext2, *context2)
+
+	// Looking up a missing context key returns an error
+	_, err := contextResolver.lookupContext("missingContextKey")
+	assert.NotNil(t, err)
+}
+
+func TestExpireContexts(t *testing.T) {
+	mSample1 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		SampleRate: 1,
+	}
+	mSample2 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar", "baz"},
+		SampleRate: 1,
+	}
+	contextResolver := newContextResolver()
+
+	// Track the 2 contexts
+	contextKey1 := contextResolver.trackContext(&mSample1, 4)
+	contextKey2 := contextResolver.trackContext(&mSample2, 6)
+
+	// With an expireTimestap of 3, both contexts are still valid
+	assert.Len(t, contextResolver.expireContexts(3), 0)
+	_, err1 := contextResolver.lookupContext(contextKey1)
+	_, err2 := contextResolver.lookupContext(contextKey2)
+	assert.Nil(t, err1)
+	assert.Nil(t, err2)
+
+	// With an expireTimestap of 5, context 1 is expired
+	expiredContextKeys := contextResolver.expireContexts(5)
+	if assert.Len(t, expiredContextKeys, 1) {
+		assert.Equal(t, contextKey1, expiredContextKeys[0])
+	}
+
+	// context 1 is not tracked anymore, but context 2 still is
+	_, err := contextResolver.lookupContext(contextKey1)
+	assert.NotNil(t, err)
+	_, err = contextResolver.lookupContext(contextKey2)
+	assert.Nil(t, err)
+}

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -2,6 +2,11 @@ package aggregator
 
 import "errors"
 
+// Metric is the interface of all metric types
+type Metric interface {
+	addSample(sample float64, timestamp int64)
+}
+
 // Gauge stores and aggregates a gauge value
 type Gauge struct {
 	gauge     float64

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -88,7 +88,7 @@ func (s *Sampler) flush(timestamp int64) []*Serie {
 				existingSerie.Points = append(existingSerie.Points, serie.Points[0])
 			} else {
 				// Resolve context and populate new Serie
-				context, _ := s.contextResolver.lookupContext(serie.contextKey)
+				context := s.contextResolver.contextsByKey[serie.contextKey]
 				serie.Name = context.Name + serie.nameSuffix
 				serie.Tags = context.Tags
 				serie.Host = context.Host

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -1,9 +1,6 @@
 package aggregator
 
-import (
-	"sort"
-	"strings"
-)
+const defaultExpirySeconds = 300 // duration in seconds after which contexts are expired
 
 // Metrics stores all the metrics by context key
 type Metrics struct {
@@ -14,19 +11,11 @@ func newMetrics() *Metrics {
 	return &Metrics{make(map[string]Metric)}
 }
 
-// Context holds the elements that form a context, and can be serialized into a context key
-type Context struct {
-	Name       string
-	Tags       *[]string
-	Host       string
-	DeviceName string
-}
-
 // Serie holds a timeserie (w/ json serialization to DD API format)
 type Serie struct {
 	Name       string          `json:"metric"`
 	Points     [][]interface{} `json:"points"`
-	Tags       *[]string       `json:"tags"`
+	Tags       []string        `json:"tags"`
 	Host       string          `json:"host"`
 	DeviceName string          `json:"device_name"`
 	Mtype      string          `json:"type"`
@@ -46,23 +35,13 @@ type SerieSignature struct {
 // Sampler aggregates metrics
 type Sampler struct {
 	interval           int64
-	contexts           map[string]Context // TODO: this map grows constantly, we need to flush old contexts from time to time
+	contextResolver    *ContextResolver
 	metricsByTimestamp map[int64]*Metrics
 }
 
 // NewSampler returns a newly initialized Sampler
 func NewSampler(interval int64) *Sampler {
-	return &Sampler{interval, map[string]Context{}, map[int64]*Metrics{}}
-}
-
-func generateContextKey(metricSample *MetricSample) string {
-	var contextFields []string
-
-	sort.Strings(*(metricSample.Tags))
-	contextFields = append(contextFields, *(metricSample.Tags)...)
-	contextFields = append(contextFields, metricSample.Name)
-
-	return strings.Join(contextFields, ",")
+	return &Sampler{interval, newContextResolver(), map[int64]*Metrics{}}
 }
 
 func (s *Sampler) calculateBucketStart(timestamp int64) int64 {
@@ -72,15 +51,7 @@ func (s *Sampler) calculateBucketStart(timestamp int64) int64 {
 // Add the metricSample to the correct bucket
 func (s *Sampler) addSample(metricSample *MetricSample, timestamp int64) {
 	// Keep track of the context
-	contextKey := generateContextKey(metricSample)
-	if _, ok := s.contexts[contextKey]; !ok {
-		s.contexts[contextKey] = Context{
-			Name:       metricSample.Name,
-			Tags:       metricSample.Tags,
-			Host:       "",
-			DeviceName: "",
-		}
-	}
+	contextKey := s.contextResolver.trackContext(metricSample, timestamp)
 
 	bucketStart := s.calculateBucketStart(timestamp)
 	// If it's a new bucket, initialize it
@@ -117,7 +88,7 @@ func (s *Sampler) flush(timestamp int64) []*Serie {
 				existingSerie.Points = append(existingSerie.Points, serie.Points[0])
 			} else {
 				// Resolve context and populate new Serie
-				context := s.contexts[serie.contextKey]
+				context, _ := s.contextResolver.lookupContext(serie.contextKey)
 				serie.Name = context.Name + serie.nameSuffix
 				serie.Tags = context.Tags
 				serie.Host = context.Host
@@ -131,6 +102,8 @@ func (s *Sampler) flush(timestamp int64) []*Serie {
 
 		delete(s.metricsByTimestamp, timestamp)
 	}
+
+	s.contextResolver.expireContexts(timestamp - defaultExpirySeconds)
 
 	return result
 }

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -13,10 +13,9 @@ import (
 // Helper(s)
 func AssertSerieEqual(t *testing.T, expected, actual *Serie) {
 	assert.Equal(t, expected.Name, actual.Name)
-	if expected.Tags != actual.Tags {
+	if expected.Tags != nil {
 		assert.NotNil(t, actual.Tags)
-		assert.NotNil(t, expected.Tags)
-		AssertTagsEqual(t, *(expected.Tags), *(actual.Tags))
+		AssertTagsEqual(t, expected.Tags, actual.Tags)
 	}
 	assert.Equal(t, expected.Host, actual.Host)
 	assert.Equal(t, expected.DeviceName, actual.DeviceName)
@@ -60,20 +59,6 @@ func (os OrderedSeries) Less(i, j int) bool {
 
 func (os OrderedSeries) Swap(i, j int) {
 	os.series[j], os.series[i] = os.series[i], os.series[j]
-}
-
-// MetricSample
-func TestGenerateContextKey(t *testing.T) {
-	mSample := MetricSample{
-		Name:       "my.metric.name",
-		Value:      1,
-		Mtype:      GaugeType,
-		Tags:       &[]string{"foo", "bar"},
-		SampleRate: 1,
-	}
-
-	context := generateContextKey(&mSample)
-	assert.Equal(t, "bar,foo,my.metric.name", context)
 }
 
 // Metrics
@@ -173,7 +158,7 @@ func TestBucketSampling(t *testing.T) {
 
 	expectedSerie := &Serie{
 		Name:       "my.metric.name",
-		Tags:       &[]string{"foo", "bar"},
+		Tags:       []string{"foo", "bar"},
 		Points:     [][]interface{}{{int64(12340), mSample.Value}, {int64(12350), mSample.Value}},
 		Mtype:      "gauge",
 		Interval:   10,
@@ -215,19 +200,18 @@ func TestContextSampling(t *testing.T) {
 	expectedSerie1 := &Serie{
 		Name:     "my.metric.name1",
 		Points:   [][]interface{}{{int64(12340), float64(1)}},
-		Tags:     &[]string{"bar", "foo"},
+		Tags:     []string{"bar", "foo"},
 		Mtype:    "gauge",
 		Interval: 10,
 	}
 	expectedSerie2 := &Serie{
 		Name:     "my.metric.name2",
 		Points:   [][]interface{}{{int64(12340), float64(1)}},
-		Tags:     &[]string{"bar", "foo"},
+		Tags:     []string{"bar", "foo"},
 		Mtype:    "gauge",
 		Interval: 10,
 	}
 
-	assert.Equal(t, 2, len(sampler.contexts))
 	if assert.Equal(t, 2, len(series)) {
 		AssertSerieEqual(t, expectedSerie1, series[0])
 		AssertSerieEqual(t, expectedSerie2, series[1])

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -63,7 +63,7 @@ func (os OrderedSeries) Swap(i, j int) {
 
 // Metrics
 func TestMetricsGaugeSampling(t *testing.T) {
-	metrics := newMetrics()
+	metrics := makeMetrics()
 	contextKey := "context_key"
 	mSample := MetricSample{
 		Value: 1,
@@ -88,7 +88,7 @@ func TestMetricsGaugeSampling(t *testing.T) {
 // No series should be flushed when there's no new sample btw 2 flushes
 // Important for check metrics aggregation
 func TestMetricsGaugeSamplingNoSample(t *testing.T) {
-	metrics := newMetrics()
+	metrics := makeMetrics()
 	contextKey := "context_key"
 	mSample := MetricSample{
 		Value: 1,
@@ -108,7 +108,7 @@ func TestMetricsGaugeSamplingNoSample(t *testing.T) {
 // No series should be flushed when the rate has been sampled only once overall
 // Important for check metrics aggregation
 func TestMetricsRateSampling(t *testing.T) {
-	metrics := newMetrics()
+	metrics := makeMetrics()
 	contextKey := "context_key"
 
 	metrics.addSample(contextKey, RateType, 1, 12340)


### PR DESCRIPTION
Fixes #43

### What does this PR do?

Handles contexts in a `ContextResolver` that cleans up the contexts that haven't been encountered in the past `defaultExpirySeconds` seconds (hardcoded to `300` for now)

Used by the `Sampler` (-> dogstatsd) and the `CheckSampler` (-> collector).

### Additional Notes

I've also:
- added a test on the hostname set by the `CheckSampler`
- used a common `Metric` interface that's common to all metrics (`Gauge`, `Rate`, etc)