### PR TITLE
[HACKADOG] Dogstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 *.lock
 *.pyc
 *.swp
+.vscode/

--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"github.com/spf13/cobra"
+
+	// register core checks
+	_ "github.com/DataDog/datadog-agent/pkg/collector/check/core/system"
+)
+
+// AgentCmd is the root command
+var AgentCmd = &cobra.Command{
+	Use:   "agent [command]",
+	Short: "Datadog Agent at your service.",
+	Long: `
+The Datadog Agent faithfully collects events and metrics and brings them 
+to Datadog on your behalf so that you can do something useful with your 
+monitoring and performance data.`,
+}

--- a/cmd/agent/app/agent.go
+++ b/cmd/agent/app/agent.go
@@ -1,18 +1,32 @@
 package app
 
 import (
-	"github.com/spf13/cobra"
+	"path/filepath"
 
-	// register core checks
-	_ "github.com/DataDog/datadog-agent/pkg/collector/check/core/system"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	"github.com/kardianos/osext"
+	"github.com/spf13/cobra"
 )
 
-// AgentCmd is the root command
-var AgentCmd = &cobra.Command{
-	Use:   "agent [command]",
-	Short: "Datadog Agent at your service.",
-	Long: `
+var (
+	// AgentCmd is the root command
+	AgentCmd = &cobra.Command{
+		Use:   "agent [command]",
+		Short: "Datadog Agent at your service.",
+		Long: `
 The Datadog Agent faithfully collects events and metrics and brings them 
 to Datadog on your behalf so that you can do something useful with your 
 monitoring and performance data.`,
-}
+	}
+
+	// utility variables
+	_here, _  = osext.ExecutableFolder()
+	_distPath = filepath.Join(_here, "dist")
+
+	// The checks Runner
+	_runner *check.Runner
+
+	// The Scheduler
+	_scheduler *scheduler.Scheduler
+)

--- a/cmd/agent/app/api.go
+++ b/cmd/agent/app/api.go
@@ -1,0 +1,1 @@
+package app

--- a/cmd/agent/app/api.go
+++ b/cmd/agent/app/api.go
@@ -1,1 +1,19 @@
 package app
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func getRouter() *mux.Router {
+	// root HTTP router
+	r := mux.NewRouter()
+
+	// IPC REST API server
+
+	// go_expvar server
+	r.Handle("/debug/vars", http.DefaultServeMux)
+
+	return r
+}

--- a/cmd/agent/app/common_osx.go
+++ b/cmd/agent/app/common_osx.go
@@ -4,5 +4,5 @@ package app
 
 var configPaths = []string{
 	"/opt/datadog-agent/etc",
-	distPath,
+	_distPath,
 }

--- a/cmd/agent/app/common_osx.go
+++ b/cmd/agent/app/common_osx.go
@@ -1,6 +1,6 @@
 // +build darwin
 
-package ddagentmain
+package app
 
 var configPaths = []string{
 	"/opt/datadog-agent/etc",

--- a/cmd/agent/app/common_unix.go
+++ b/cmd/agent/app/common_unix.go
@@ -1,6 +1,6 @@
 // +build dragonfly freebsd linux nacl netbsd openbsd solaris
 
-package ddagentmain
+package app
 
 var configPaths = []string{
 	"/etc/dd-agent",

--- a/cmd/agent/app/common_unix.go
+++ b/cmd/agent/app/common_unix.go
@@ -4,5 +4,5 @@ package app
 
 var configPaths = []string{
 	"/etc/dd-agent",
-	distPath,
+	_distPath,
 }

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	AgentCmd.AddCommand(flareCmd)
+}
+
+var flareCmd = &cobra.Command{
+	Use:   "flare",
+	Short: "Collect a flare and send it to Datadog",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`I dunno how to make a flare ¯\_(ツ)_/¯`)
+	},
+}

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"fmt"
+	"net/http"
+
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,6 +59,15 @@ func getCheckLoaders() []loader.CheckLoader {
 	}
 }
 
+func startAPIServer() {
+	r := getRouter()
+	go http.ListenAndServe("localhost:5000", r)
+}
+
+// TODO
+// this should ideally support different execution protocols
+// so that we can go in background in a sane way. Something
+// like systemd notify or windows service
 func runBackground() {
 	args := os.Args
 	args = append(args, "-f")
@@ -66,7 +77,7 @@ func runBackground() {
 	cmd.Start()
 }
 
-// Start the main check loop
+// Start the main loop
 func start(cmd *cobra.Command, args []string) {
 	if !runForeground {
 		runBackground()
@@ -76,6 +87,8 @@ func start(cmd *cobra.Command, args []string) {
 	defer log.Flush()
 
 	log.Infof("Starting Datadog Agent v%v", agentVersion)
+
+	startAPIServer()
 
 	// Global Agent configuration
 	for _, path := range configPaths {

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -1,4 +1,4 @@
-package ddagentmain
+package app
 
 import (
 	"fmt"
@@ -11,28 +11,26 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/loader"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/kardianos/osext"
-	"github.com/sbinet/go-python"
-
 	log "github.com/cihub/seelog"
-
-	// register core checks
-	_ "github.com/DataDog/datadog-agent/pkg/collector/check/core/system"
+	"github.com/kardianos/osext"
+	python "github.com/sbinet/go-python"
+	"github.com/spf13/cobra"
 )
 
-const agentVersion = "6.0.0"
+var (
+	here, _  = osext.ExecutableFolder()
+	distPath = filepath.Join(here, "dist")
+	startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "Start the Agent",
+		Long:  ``,
+		Run:   start,
+	}
+)
 
-var here, _ = osext.ExecutableFolder()
-var distPath = filepath.Join(here, "dist")
-
-// for testing purposes only: collect and log check results
-type metric struct {
-	Name  string
-	Value float64
-	Tags  []string
+func init() {
+	AgentCmd.AddCommand(startCmd)
 }
-
-type metrics map[string][]metric
 
 // build a list of providers for checks' configurations, the sequence defines
 // the precedence.
@@ -55,7 +53,7 @@ func getCheckLoaders() []loader.CheckLoader {
 }
 
 // Start the main check loop
-func Start() {
+func start(cmd *cobra.Command, args []string) {
 	defer log.Flush()
 
 	log.Infof("Starting Datadog Agent v%v", agentVersion)

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -139,8 +139,8 @@ func start(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Start the Runner using only one worker, i.e. we process checks sequentially
-	_runner.Run(2)
+	// Start the Runner with 3 workers
+	_runner.Run(3)
 
 	// Run the scheduler
 	_scheduler.Run(_runner.GetChan())

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -140,7 +140,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	// Start the Runner using only one worker, i.e. we process checks sequentially
-	_runner.Run(1)
+	_runner.Run(2)
 
 	// Run the scheduler
 	_scheduler.Run(_runner.GetChan())

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	AgentCmd.AddCommand(statusCmd)
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print the current status",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`A hug would be perfect right now ༼ つ ಥ_ಥ ༽つ`)
+	},
+}

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -1,0 +1,1 @@
+package app

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -1,1 +1,16 @@
 package app
+
+import "github.com/spf13/cobra"
+
+var (
+	stopCmd = &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the Agent",
+		Long:  ``,
+		Run:   stop,
+	}
+)
+
+func stop(*cobra.Command, []string) {
+
+}

--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const agentVersion = "6.0.0"
+
+func init() {
+	AgentCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(fmt.Sprintf("Agent %s - Codename: Χελωνη", agentVersion))
+	},
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,11 +8,21 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
+	"github.com/gorilla/mux"
+
+	// register core checks
+	_ "github.com/DataDog/datadog-agent/pkg/collector/check/core/system"
 )
 
 func main() {
+	// root
+	r := mux.NewRouter()
+
+	// IPC REST API
+
 	// go_expvar server
-	go http.ListenAndServe("localhost:8080", http.DefaultServeMux)
+	r.Handle("/debug/vars", http.DefaultServeMux)
+	go http.ListenAndServe("localhost:5000", r)
 
 	if err := app.AgentCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	_ "expvar"
+	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
 )
@@ -12,5 +14,8 @@ func main() {
 	// go_expvar server
 	go http.ListenAndServe("localhost:8080", http.DefaultServeMux)
 
-	ddagentmain.Start()
+	if err := app.AgentCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -15,15 +15,16 @@ import (
 )
 
 func main() {
-	// root
+	// root HTTP router
 	r := mux.NewRouter()
 
-	// IPC REST API
+	// IPC REST API server
 
 	// go_expvar server
 	r.Handle("/debug/vars", http.DefaultServeMux)
 	go http.ListenAndServe("localhost:5000", r)
 
+	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -3,27 +3,16 @@ package main
 import (
 	_ "expvar"
 	"fmt"
-	"net/http"
 	_ "net/http/pprof"
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
-	"github.com/gorilla/mux"
 
 	// register core checks
 	_ "github.com/DataDog/datadog-agent/pkg/collector/check/core/system"
 )
 
 func main() {
-	// root HTTP router
-	r := mux.NewRouter()
-
-	// IPC REST API server
-
-	// go_expvar server
-	r.Handle("/debug/vars", http.DefaultServeMux)
-	go http.ListenAndServe("localhost:5000", r)
-
 	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,3 +17,6 @@ import:
 - package: github.com/spf13/viper
 - package: github.com/fsnotify/fsnotify
   version: ^1.4.2
+- package: github.com/spf13/cobra
+  subpackages:
+  - cobra

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,3 +24,4 @@ import:
   version: ^1.1.0
 - package: github.com/gorilla/context
   version: ^1.1.0
+- package: golang.org/x/sys

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,3 +20,7 @@ import:
 - package: github.com/spf13/cobra
   subpackages:
   - cobra
+- package: github.com/gorilla/mux
+  version: ^1.1.0
+- package: github.com/gorilla/context
+  version: ^1.1.0

--- a/pkg-config/linux/python-2.7.pc
+++ b/pkg-config/linux/python-2.7.pc
@@ -1,4 +1,4 @@
-prefix=/opt/datadog-agent6/embedded
+prefix=/opt/datadog-agent/embedded
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include

--- a/pkg/collector/check/core/dogstream.go
+++ b/pkg/collector/check/core/dogstream.go
@@ -63,7 +63,7 @@ func (c *DogstreamCheck) InitSender() {
 
 // Interval returns 0 since this is a long-running check
 func (c *DogstreamCheck) Interval() time.Duration {
-	return 15
+	return 0
 }
 
 // ID FIXME: this should return a real identifier

--- a/pkg/collector/check/core/dogstream.go
+++ b/pkg/collector/check/core/dogstream.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	log "github.com/cihub/seelog"
+	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/dogstream"
+	"github.com/DataDog/datadog-agent/pkg/dogstream/tailer"
+)
+
+// DogstreamCheck doesn't need additional fields
+type DogstreamCheck struct {
+	config dogstream.StreamEntry
+	tailer *tailer.Tailer
+}
+
+func (c *DogstreamCheck) String() string {
+	return "DogstreamCheck"
+}
+
+// Run executes the check
+func (c *DogstreamCheck) Run() error {
+	c.tailer.Run()
+	return nil
+}
+
+// Configure the Dogstream check from YAML data
+func (c *DogstreamCheck) Configure(data check.ConfigData) {
+	c.config = dogstream.StreamEntry{}
+	err := yaml.Unmarshal(data, &c.config)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	var parsers []dogstream.Parser
+	for _, parser := range c.config.Parser {
+		dsp, err := dogstream.Load(parser)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		parsers = append(parsers, dsp)
+	}
+
+	c.tailer = tailer.NewTailer()
+	err = c.tailer.AddFile(c.config.File, parsers)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	log.Infof("Configured Dogstream instance: %s", c.config.Name)
+}
+
+// InitSender does nothing for this check
+func (c *DogstreamCheck) InitSender() {
+}
+
+// Interval returns 0 since this is a long-running check
+func (c *DogstreamCheck) Interval() time.Duration {
+	return 0
+}
+
+// ID FIXME: this should return a real identifier
+func (c *DogstreamCheck) ID() string {
+	return c.String()
+}
+
+// Stop stops the check
+func (c *DogstreamCheck) Stop() {
+	c.tailer.Stop()
+}
+
+func init() {
+	RegisterCheck(
+		"dogstream",
+		&DogstreamCheck{},
+	)
+}

--- a/pkg/collector/check/core/dogstream.go
+++ b/pkg/collector/check/core/dogstream.go
@@ -23,7 +23,6 @@ func (c *DogstreamCheck) String() string {
 
 // Run executes the check
 func (c *DogstreamCheck) Run() error {
-	log.Infof("Running dogstream check")
 	c.tailer.Run()
 	return nil
 }

--- a/pkg/collector/check/core/dogstream.go
+++ b/pkg/collector/check/core/dogstream.go
@@ -23,6 +23,7 @@ func (c *DogstreamCheck) String() string {
 
 // Run executes the check
 func (c *DogstreamCheck) Run() error {
+	log.Infof("Running dogstream check")
 	c.tailer.Run()
 	return nil
 }
@@ -62,7 +63,7 @@ func (c *DogstreamCheck) InitSender() {
 
 // Interval returns 0 since this is a long-running check
 func (c *DogstreamCheck) Interval() time.Duration {
-	return 0
+	return 15
 }
 
 // ID FIXME: this should return a real identifier

--- a/pkg/collector/check/py/check.go
+++ b/pkg/collector/check/py/check.go
@@ -73,10 +73,7 @@ func (c *PythonCheck) Stop() {}
 
 // String representation (for debug and logging)
 func (c *PythonCheck) String() string {
-	if c.Instance != nil {
-		return python.PyString_AsString(c.Instance.GetAttrString("__class__").GetAttrString("__name__"))
-	}
-	return ""
+	return c.ModuleName
 }
 
 // Configure the Python check from YAML data

--- a/pkg/collector/check/py/check_test.go
+++ b/pkg/collector/check/py/check_test.go
@@ -84,14 +84,9 @@ func TestRun(t *testing.T) {
 
 func TestStr(t *testing.T) {
 	check := getCheckInstance()
-	name := "TestCheck"
+	name := "testcheck"
 	if check.String() != name {
 		t.Fatalf("Expected %s, found: %v", name, check)
-	}
-
-	check.Instance = nil
-	if check.String() != "" {
-		t.Fatalf("Expected empty string, found: %v", check)
 	}
 }
 

--- a/pkg/collector/dist/agent
+++ b/pkg/collector/dist/agent
@@ -2,4 +2,4 @@
 
 BASEPATH=/opt/datadog-agent6/embedded/lib/python2.7/
 DIRPATH=`dirname $0`
-PYTHONPATH=$BASEPATH:$BASEPATH/site-packages/:$BASEPATH/lib-dynload/ $DIRPATH/agent.bin
+PYTHONPATH=$BASEPATH:$BASEPATH/site-packages/:$BASEPATH/lib-dynload/ $DIRPATH/agent.bin "$@"

--- a/pkg/collector/dist/agent
+++ b/pkg/collector/dist/agent
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-BASEPATH=/opt/datadog-agent6/embedded/lib/python2.7/
+BASEPATH=/opt/datadog-agent/embedded/lib/python2.7/
 DIRPATH=`dirname $0`
 PYTHONPATH=$BASEPATH:$BASEPATH/site-packages/:$BASEPATH/lib-dynload/ $DIRPATH/agent.bin "$@"

--- a/pkg/collector/dist/checks/agent5_collector_parser.py
+++ b/pkg/collector/dist/checks/agent5_collector_parser.py
@@ -1,0 +1,8 @@
+from datadog import statsd
+import re
+
+exp = re.compile('debug', re.IGNORECASE)
+
+def parse(log, line):
+    if exp.search(line):
+        statsd.increment("logs.ddagent.debugs")

--- a/pkg/collector/dist/checks/supervisord_log.py
+++ b/pkg/collector/dist/checks/supervisord_log.py
@@ -1,0 +1,83 @@
+# (C) Datadog, Inc. 2012-2016
+# (C) Robert Leftwich <rleftwich@lightkeeper.com> 2012
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+"""
+Custom parser for supervisord log suitable for use by Datadog 'dogstreams'
+
+Add to datadog.conf as follows:
+
+dogstreams: [path_to_supervisord.log]:datadog.streams.supervisord:parse_supervisord
+
+"""
+# stdlib
+from datetime import datetime
+from datadog import statsd
+import re
+import time
+
+EVENT_TYPE = "supervisor"
+
+# supervisord log levels
+SUPERVISORD_LEVELS = [
+    'CRIT',   # messages that probably require immediate user attention
+    'ERRO',   # messages that indicate a potentially ignorable error condition
+    'WARN',   # messages that indicate issues which aren't errors
+    'INFO',   # normal informational output
+
+    # IGNORED...
+    #'DEBG',   # messages useful for users trying to debug configurations
+    #'TRAC',   # messages useful to developers trying to debug plugins
+    #'BLAT',   # messages useful for developers trying to debug supervisor
+
+]
+
+# mapping between datadog and supervisord log levels
+ALERT_TYPES_MAPPING = {
+    "CRIT": "error",
+    "ERRO": "error",
+    "WARN": "warning",
+    "INFO": "info",
+}
+
+# regex to extract the 'program' supervisord is managing from the text
+program_matcher = re.compile("^\w+:? '?(?P<program>\w+)'?")
+
+
+def parse(log, line):
+    """
+    Parse the supervisord.log line into a dogstream event
+    """
+    if len(line) == 0:
+        log.info("Skipping empty line of supervisord.log")
+        return None
+    if log:
+        log.debug('PARSE supervisord:%s' % line)
+    line_items = line.split(' ', 3)
+    timestamp = ' '.join(line_items[:2])
+    timestamp_parts = timestamp.split(',')
+    dt = datetime.strptime(timestamp_parts[0], "%Y-%m-%d %H:%M:%S")
+    dt = dt.replace(microsecond=int(timestamp_parts[1]))
+    date = time.mktime(dt.timetuple())
+    event_type = line_items[2]
+    msg = line_items[3]
+    if event_type in SUPERVISORD_LEVELS:
+        alert_type = ALERT_TYPES_MAPPING.get(event_type, 'info')
+        if alert_type == 'info' and 'success' in msg:
+            alert_type = 'success'
+
+        statsd.event(title = msg.strip(),
+                     text = msg,
+                     alert_type = alert_type,
+                    date_happened=date)
+        
+
+if __name__ == "__main__":
+    import sys
+    import pprint
+    import logging
+    logging.basicConfig()
+    log = logging.getLogger()
+    lines = open(sys.argv[1]).readlines()
+    pprint.pprint([parse_supervisord(log, line) for line in lines])

--- a/pkg/collector/dist/conf.d/dogstream.yaml
+++ b/pkg/collector/dist/conf.d/dogstream.yaml
@@ -1,0 +1,4 @@
+instances:
+  - name: agent5log
+    file: /var/log/datadog/collector.log
+    parser: ['agent5_collector_parser']

--- a/pkg/collector/dist/conf.d/go_expvar.yaml
+++ b/pkg/collector/dist/conf.d/go_expvar.yaml
@@ -1,6 +1,6 @@
 init_config:
 instances:
-  - expvar_url: http://localhost:8080/debug/vars
+  - expvar_url: http://localhost:5000/debug/vars
     tags:
       - check_type:python
     metrics:

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -40,17 +40,7 @@ func NewScheduler() *Scheduler {
 // If the interval is 0, the check is supposed to run only once.
 func (s *Scheduler) Enter(check check.Check) error {
 	if check.Interval() < 0 {
-		return fmt.Errorf("Schedule interval must be a positive integer or 0")
-	}
-
-	// send immediately to the checks Pipe if this is a one-time schedule
-	// do not block, in case the runner has not started
-	if check.Interval() == 0 {
-		log.Infof("Scheduling check %s for one-time execution", check.ID())
-		go func() {
-			s.checksPipe <- check
-		}()
-		return nil
+		return fmt.Errorf("Scheduler only accepts positive integer intervals")
 	}
 
 	// sync when accessing `jobQueues`

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -46,7 +46,7 @@ func (s *Scheduler) Enter(check check.Check) error {
 	// send immediately to the checks Pipe if this is a one-time schedule
 	// do not block, in case the runner has not started
 	if check.Interval() == 0 {
-		log.Info("Scheduling check for one-time execution")
+		log.Infof("Scheduling check %s for one-time execution", check.ID())
 		go func() {
 			s.checksPipe <- check
 		}()

--- a/pkg/dogstream/config.go
+++ b/pkg/dogstream/config.go
@@ -1,0 +1,41 @@
+package dogstream
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type streamEntry struct {
+	Name   string   `yaml:"name"`
+	File   string   `yaml:"file"`
+	Parser []string `yaml:"parser"`
+}
+
+type streamConfig struct {
+	Instances []streamEntry `yaml:"instances"`
+}
+
+func loadConfig(filename string) (map[string][]Parser, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	var config streamConfig
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, err
+	}
+	retmap := make(map[string][]Parser)
+
+	for _, inst := range config.Instances {
+		for _, parser := range inst.Parser {
+			dsp, err := Load(parser)
+			if err != nil {
+				return nil, err
+			}
+			retmap[inst.File] = append(retmap[inst.File], dsp)
+		}
+	}
+	return retmap, nil
+}

--- a/pkg/dogstream/config.go
+++ b/pkg/dogstream/config.go
@@ -6,14 +6,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type streamEntry struct {
+// StreamEntry represents an instance in the config file
+type StreamEntry struct {
 	Name   string   `yaml:"name"`
 	File   string   `yaml:"file"`
 	Parser []string `yaml:"parser"`
 }
 
 type streamConfig struct {
-	Instances []streamEntry `yaml:"instances"`
+	Instances []StreamEntry `yaml:"instances"`
 }
 
 func loadConfig(filename string) (map[string][]Parser, error) {

--- a/pkg/dogstream/config_test.go
+++ b/pkg/dogstream/config_test.go
@@ -1,0 +1,26 @@
+package dogstream
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Setup the test module
+
+func TestLoadConfig(t *testing.T) {
+
+	cfg, err := loadConfig("tests/doesnt_exist.yaml")
+	assert.NotNil(t, err)
+
+	cfg, err = loadConfig("tests/config_test.yaml")
+	assert.Nil(t, err)
+
+	fmt.Printf("Config: %v\n", cfg)
+	p := cfg["/var/log/auth.log"]
+	assert.NotNil(t, p)
+
+	fmt.Printf("returned %d loaders\n", len(p))
+	assert.Nil(t, p[0].Parse("foo", "bar"))
+}

--- a/pkg/dogstream/init.go
+++ b/pkg/dogstream/init.go
@@ -1,0 +1,46 @@
+package dogstream
+
+import python "github.com/sbinet/go-python"
+
+// #cgo pkg-config: python-2.7
+// #cgo linux CFLAGS: -std=gnu99
+// #include <Python.h>
+import "C"
+
+// Initialize wraps all the operations needed to start the Python interpreter and
+// configure the environment
+func Initialize(paths ...string) *python.PyThreadState {
+	// Disable Site initialization
+	C.Py_NoSiteFlag = 1
+
+	// Start the interpreter
+	if C.Py_IsInitialized() == 0 {
+		C.Py_Initialize()
+	}
+	if C.Py_IsInitialized() == 0 {
+		panic("python: could not initialize the python interpreter")
+	}
+
+	// make sure the GIL is correctly initialized
+	if C.PyEval_ThreadsInitialized() == 0 {
+		C.PyEval_InitThreads()
+	}
+	if C.PyEval_ThreadsInitialized() == 0 {
+		panic("python: could not initialize the GIL")
+	}
+
+	// Set the PYTHONPATH if needed
+	if len(paths) > 0 {
+		path := python.PySys_GetObject("path")
+		for _, p := range paths {
+			python.PyList_Append(path, python.PyString_FromString(p))
+		}
+	}
+
+	// we acquired the GIL to initialize threads but from this point
+	// we don't need it anymore, let's release it
+	state := python.PyEval_SaveThread()
+
+	// return the state so the caller can resume
+	return state
+}

--- a/pkg/dogstream/loader.go
+++ b/pkg/dogstream/loader.go
@@ -1,0 +1,47 @@
+package dogstream
+
+import (
+	"errors"
+
+	log "github.com/cihub/seelog"
+	python "github.com/sbinet/go-python"
+)
+
+func Load(parserName string) (DogstreamParser, error) {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	// import python module containing the parser
+	parserModule := python.PyImport_ImportModuleNoBlock(parserName)
+	if parserModule == nil || !python.PyModule_Check(parserModule) {
+		// we don't expect a traceback here so we use the error msg in `pvalue`
+		_, pvalue, _ := python.PyErr_Fetch()
+		msg := python.PyString_AsString(pvalue)
+		log.Warn(msg)
+		return nil, errors.New(msg)
+	}
+
+	// search for a `parse` function
+	// TODO: this can be way more sophisticated, searching
+	// for any callable with any name, etc...
+	dir := parserModule.PyObject_Dir()
+	var callable *python.PyObject
+	for i := 0; i < python.PyList_GET_SIZE(dir); i++ {
+		symbolName := python.PyString_AsString(python.PyList_GET_ITEM(dir, i))
+		obj := parserModule.GetAttrString(symbolName)
+
+		if symbolName == "parse" && obj.HasAttrString("__call__") == 1 {
+			callable = obj
+			break
+		}
+	}
+
+	parserInstance := &PythonParse{
+		callable: callable,
+	}
+
+	return parserInstance, nil
+}

--- a/pkg/dogstream/loader.go
+++ b/pkg/dogstream/loader.go
@@ -7,7 +7,8 @@ import (
 	python "github.com/sbinet/go-python"
 )
 
-func Load(parserName string) (DogstreamParser, error) {
+// Load searches and imports a Python module given the parser name
+func Load(parserName string) (Parser, error) {
 	// Lock the GIL and release it at the end of the run
 	_gstate := python.PyGILState_Ensure()
 	defer func() {

--- a/pkg/dogstream/loader.go
+++ b/pkg/dogstream/loader.go
@@ -21,7 +21,7 @@ func Load(parserName string) (Parser, error) {
 		// we don't expect a traceback here so we use the error msg in `pvalue`
 		_, pvalue, _ := python.PyErr_Fetch()
 		msg := python.PyString_AsString(pvalue)
-		log.Warn(msg)
+		log.Warnf("Failed loading python parser %s: %s", parserName, msg)
 		return nil, errors.New(msg)
 	}
 

--- a/pkg/dogstream/loader_test.go
+++ b/pkg/dogstream/loader_test.go
@@ -4,14 +4,13 @@ import (
 	"os"
 	"testing"
 
-	py "github.com/DataDog/datadog-agent/pkg/collector/check/py"
 	python "github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
 )
 
 // Setup the test module
 func TestMain(m *testing.M) {
-	state := py.Initialize("tests")
+	state := Initialize("tests")
 
 	ret := m.Run()
 
@@ -26,4 +25,17 @@ func TestLoad(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Nil(t, p.Parse("foo", "bar"))
+}
+
+func BenchmarkLoad(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Load("foo")
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	p, _ := Load("foo")
+	for n := 0; n < b.N; n++ {
+		p.Parse("foo", "bar")
+	}
 }

--- a/pkg/dogstream/loader_test.go
+++ b/pkg/dogstream/loader_test.go
@@ -1,0 +1,29 @@
+package dogstream
+
+import (
+	"os"
+	"testing"
+
+	py "github.com/DataDog/datadog-agent/pkg/collector/check/py"
+	python "github.com/sbinet/go-python"
+	"github.com/stretchr/testify/assert"
+)
+
+// Setup the test module
+func TestMain(m *testing.M) {
+	state := py.Initialize("tests")
+
+	ret := m.Run()
+
+	python.PyEval_RestoreThread(state)
+	python.Finalize()
+
+	os.Exit(ret)
+}
+
+func TestLoad(t *testing.T) {
+	p, err := Load("foo")
+	assert.Nil(t, err)
+
+	assert.Nil(t, p.Parse("foo", "bar"))
+}

--- a/pkg/dogstream/parsers.go
+++ b/pkg/dogstream/parsers.go
@@ -28,7 +28,7 @@ func (p *PythonParse) Parse(logfile, line string) error {
 	args := python.PyTuple_New(2)
 	kwargs := python.PyDict_New()
 	python.PyTuple_SetItem(args, 0, python.PyString_FromString(logfile))
-	python.PyTuple_SetItem(args, 1, python.PyString_FromString(logfile))
+	python.PyTuple_SetItem(args, 1, python.PyString_FromString(line))
 
 	result := p.callable.Call(args, kwargs)
 	if result == nil {

--- a/pkg/dogstream/parsers.go
+++ b/pkg/dogstream/parsers.go
@@ -1,0 +1,30 @@
+package dogstream
+
+import (
+	"fmt"
+
+	python "github.com/sbinet/go-python"
+)
+
+type DogstreamParser interface {
+	Parse(logFile, line string) error
+}
+
+type PythonParse struct {
+	callable *python.PyObject
+}
+
+func (p *PythonParse) Parse(logfile, line string) error {
+	// args
+	args := python.PyTuple_New(2)
+	kwargs := python.PyDict_New()
+	python.PyTuple_SetItem(args, 0, python.PyString_FromString(logfile))
+	python.PyTuple_SetItem(args, 1, python.PyString_FromString(logfile))
+
+	result := p.callable.Call(args, kwargs)
+	if result != nil {
+		return fmt.Errorf("Error invoking the parser")
+	}
+
+	return nil
+}

--- a/pkg/dogstream/parsers.go
+++ b/pkg/dogstream/parsers.go
@@ -6,15 +6,24 @@ import (
 	python "github.com/sbinet/go-python"
 )
 
-type DogstreamParser interface {
+// Parser is the parser interface
+type Parser interface {
 	Parse(logFile, line string) error
 }
 
+// PythonParse is for pure python parsers
 type PythonParse struct {
 	callable *python.PyObject
 }
 
+// Parse gets a line from the logs and does something with it
 func (p *PythonParse) Parse(logfile, line string) error {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
 	// args
 	args := python.PyTuple_New(2)
 	kwargs := python.PyDict_New()
@@ -22,7 +31,7 @@ func (p *PythonParse) Parse(logfile, line string) error {
 	python.PyTuple_SetItem(args, 1, python.PyString_FromString(logfile))
 
 	result := p.callable.Call(args, kwargs)
-	if result != nil {
+	if result == nil {
 		return fmt.Errorf("Error invoking the parser")
 	}
 

--- a/pkg/dogstream/tailer/tailer.go
+++ b/pkg/dogstream/tailer/tailer.go
@@ -1,10 +1,10 @@
 package tailer
 
 import (
-	"log"
 	"os"
 	"unicode/utf8"
 
+	log "github.com/cihub/seelog"
 	"github.com/fsnotify/fsnotify"
 
 	"github.com/DataDog/datadog-agent/pkg/dogstream"
@@ -92,7 +92,7 @@ func (t Tailer) read(file *os.File, dispatchLine func(string)) {
 	bytesRead, err := file.Read(buffer)
 
 	if err != nil {
-		log.Println("Error reading file:", err)
+		log.Infof("Error reading file: %s", err)
 	}
 
 	// Taken from google/mtail
@@ -144,7 +144,7 @@ func (d dispatcher) run() {
 func newWatcher() *watcher {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
-		log.Println("Can't instantiate fs watcher:", err)
+		log.Infof("Can't instantiate fs watcher: %s", err)
 	}
 	return &watcher{
 		w,
@@ -159,7 +159,7 @@ func (w *watcher) Run() {
 			select {
 			case err := <-w.Errors:
 				if err != nil {
-					log.Println("error:", err)
+					log.Infof("error: %s", err)
 				}
 			}
 		}

--- a/pkg/dogstream/tailer/tailer.go
+++ b/pkg/dogstream/tailer/tailer.go
@@ -94,10 +94,10 @@ func (t *Tailer) cleanUp() {
 func (t Tailer) read(file *os.File, previousPartial string, dispatchLine func(string)) string {
 	partial := previousPartial
 
-	// FIXME: reads at most 4096 bytes
-	buffer := make([]byte, 4096)
+	buffer := make([]byte, 0, 4096)
 	for {
-		bytesRead, err := file.Read(buffer)
+		bytesRead, err := file.Read(buffer[:cap(buffer)])
+		buffer = buffer[:bytesRead]
 
 		if err != nil {
 			if err != io.EOF {

--- a/pkg/dogstream/tailer/tailer.go
+++ b/pkg/dogstream/tailer/tailer.go
@@ -1,0 +1,183 @@
+package tailer
+
+import (
+	"log"
+	"os"
+	"unicode/utf8"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/DataDog/datadog-agent/pkg/dogstream"
+)
+
+// Tailer tails log files and forwards the lines to parsers
+type Tailer struct {
+	w           *watcher
+	files       map[string]*os.File
+	dispatchers map[string]*dispatcher
+}
+
+type dispatcher struct {
+	parsers []dogstream.Parser
+	lines   chan string
+}
+
+type watcher struct {
+	*fsnotify.Watcher
+	fileUpdates chan string
+}
+
+// NewTailer instantiates a new Tailer
+func NewTailer() *Tailer {
+	return &Tailer{
+		w:           newWatcher(),
+		files:       make(map[string]*os.File),
+		dispatchers: make(map[string]*dispatcher),
+	}
+}
+
+// AddFile adds a log file to the Tailer
+func (t *Tailer) AddFile(filePath string, parsers []dogstream.Parser) error {
+	_, ok := t.files[filePath]
+	if !ok {
+		newFile, err := t.openFile(filePath)
+		if err != nil {
+			return err
+		}
+		t.files[filePath] = newFile
+		t.dispatchers[filePath] = newDispatcher(parsers)
+		t.w.Add(filePath)
+	}
+
+	return nil
+}
+
+// Run starts the Tailer
+func (t *Tailer) Run() {
+	defer t.cleanUp()
+	t.w.Run()
+	for fileUpdated := range t.w.fileUpdates {
+		file := t.files[fileUpdated]
+		t.read(file, t.dispatchers[fileUpdated].dispatchLine)
+	}
+}
+
+// Stop stops the tailer and frees up all its resources
+func (t *Tailer) Stop() {
+	t.w.Stop()
+}
+
+func (t Tailer) openFile(filePath string) (*os.File, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	file.Seek(0, 2)
+	return file, nil
+}
+
+func (t *Tailer) cleanUp() {
+	for _, file := range t.files {
+		file.Close()
+	}
+
+	for _, d := range t.dispatchers {
+		d.Stop()
+	}
+}
+
+func (t Tailer) read(file *os.File, dispatchLine func(string)) {
+	// FIXME: reads at most 4096 bytes
+	buffer := make([]byte, 4096)
+	bytesRead, err := file.Read(buffer)
+
+	if err != nil {
+		log.Println("Error reading file:", err)
+	}
+
+	// Taken from google/mtail
+	buffer = buffer[:bytesRead]
+	var line string
+
+	for i, width := 0, 0; i < len(buffer) && i < bytesRead; i += width {
+		var r rune
+		r, width = utf8.DecodeRune(buffer[i:])
+		switch {
+		case r != '\n':
+			line += string(r)
+		default:
+			// dipatch line to parsers, blocks if not ready
+			dispatchLine(line)
+			// reset line
+			line = ""
+		}
+	}
+}
+
+func newDispatcher(parsers []dogstream.Parser) *dispatcher {
+	d := &dispatcher{
+		parsers: parsers,
+		lines:   make(chan string),
+	}
+
+	go d.run()
+
+	return d
+}
+
+func (d dispatcher) dispatchLine(line string) {
+	d.lines <- line
+}
+
+func (d dispatcher) Stop() {
+	close(d.lines)
+}
+
+func (d dispatcher) run() {
+	for line := range d.lines {
+		for _, parser := range d.parsers {
+			parser.Parse("FIXME", line)
+		}
+	}
+}
+
+func newWatcher() *watcher {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Println("Can't instantiate fs watcher:", err)
+	}
+	return &watcher{
+		w,
+		make(chan string),
+	}
+}
+
+func (w *watcher) Run() {
+	// flush out the errors
+	go func() {
+		for {
+			select {
+			case err := <-w.Errors:
+				if err != nil {
+					log.Println("error:", err)
+				}
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case event := <-w.Events:
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					w.fileUpdates <- event.Name
+				}
+			}
+		}
+	}()
+}
+
+func (w *watcher) Stop() {
+	w.Close()
+	close(w.fileUpdates)
+}

--- a/pkg/dogstream/tailer/tailer_test.go
+++ b/pkg/dogstream/tailer/tailer_test.go
@@ -1,0 +1,172 @@
+package tailer
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/dogstream"
+)
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+type FakeParser struct {
+	m     sync.Mutex
+	lines []string
+}
+
+func newFakeParser() *FakeParser {
+	return &FakeParser{
+		lines: []string{},
+	}
+}
+
+func (f *FakeParser) Parse(logFile, line string) error {
+	f.m.Lock()
+	f.lines = append(f.lines, line)
+	f.m.Unlock()
+	return nil
+}
+
+func testFilePath(filename string) string {
+	_, currentFilePath, _, _ := runtime.Caller(1)
+	return path.Join(path.Dir(currentFilePath), "test", filename)
+}
+
+func TestRead(t *testing.T) {
+	testContent := []byte("hello\ngo\n")
+	file, _ := os.Create(testFilePath("foo"))
+	defer file.Close()
+	file.Seek(0, 2)
+	_, err := file.Write(testContent)
+	check(err)
+
+	tailer := NewTailer()
+	readLines := []string{}
+	dispatch := func(line string) {
+		readLines = append(readLines, line)
+	}
+	tailerFile, _ := os.Open(testFilePath("foo"))
+	defer tailerFile.Close()
+	tailer.read(tailerFile, dispatch)
+
+	assert.Len(t, readLines, 2)
+}
+
+func TestTailerOneFile(t *testing.T) {
+	file, _ := os.Create(testFilePath("foo"))
+	defer file.Close()
+	file.Seek(0, 2)
+	garbageContent := []byte("garbage\nignore\n")
+	_, err := file.Write(garbageContent)
+	check(err)
+
+	tailer := NewTailer()
+	parsers := []dogstream.Parser{
+		newFakeParser(),
+		newFakeParser(),
+	}
+
+	err = tailer.AddFile(testFilePath("foo"), parsers)
+	check(err)
+	go tailer.Run()
+	defer tailer.Stop()
+
+	tailedContent := []byte("hello\ngo\n")
+	_, err = file.Write(tailedContent)
+	check(err)
+
+	tailedContent = []byte("more\ntext\n")
+	_, err = file.Write(tailedContent)
+	check(err)
+
+	time.Sleep(time.Millisecond)
+
+	for _, parser := range parsers {
+		fakeParser := parser.(*FakeParser)
+		if assert.Len(t, fakeParser.lines, 4) {
+			assert.Equal(t, "hello", fakeParser.lines[0])
+			assert.Equal(t, "go", fakeParser.lines[1])
+			assert.Equal(t, "more", fakeParser.lines[2])
+			assert.Equal(t, "text", fakeParser.lines[3])
+		}
+	}
+}
+
+func TestTailerMultipleFiles(t *testing.T) {
+	fileFoo, _ := os.Create(testFilePath("foo"))
+	defer fileFoo.Close()
+	fileFoo.Seek(0, 2)
+
+	fileBar, _ := os.Create(testFilePath("bar"))
+	defer fileBar.Close()
+	fileBar.Seek(0, 2)
+
+	tailer := NewTailer()
+	parserFoo := newFakeParser()
+	parserCommon := newFakeParser()
+	parserBar := newFakeParser()
+	parsersFoo := []dogstream.Parser{
+		parserCommon,
+		parserFoo,
+	}
+	parsersBar := []dogstream.Parser{
+		parserCommon,
+		parserBar,
+	}
+
+	err := tailer.AddFile(testFilePath("foo"), parsersFoo)
+	check(err)
+	err = tailer.AddFile(testFilePath("bar"), parsersBar)
+	check(err)
+	go tailer.Run()
+	defer tailer.Stop()
+
+	tailedContent := []byte("hello\ngo\n")
+	_, err = fileFoo.Write(tailedContent)
+	check(err)
+
+	tailedContent = []byte("more\ntext\n")
+	_, err = fileFoo.Write(tailedContent)
+	check(err)
+
+	tailedContent = []byte("bar\ncontent\n")
+	_, err = fileBar.Write(tailedContent)
+	check(err)
+
+	tailedContent = []byte("still\nbar here\n")
+	_, err = fileBar.Write(tailedContent)
+	check(err)
+
+	time.Sleep(time.Millisecond)
+
+	if assert.Len(t, parserFoo.lines, 4) {
+		assert.Equal(t, "hello", parserFoo.lines[0])
+		assert.Equal(t, "go", parserFoo.lines[1])
+		assert.Equal(t, "more", parserFoo.lines[2])
+		assert.Equal(t, "text", parserFoo.lines[3])
+	}
+
+	if assert.Len(t, parserBar.lines, 4) {
+		assert.Equal(t, "bar", parserBar.lines[0])
+		assert.Equal(t, "content", parserBar.lines[1])
+		assert.Equal(t, "still", parserBar.lines[2])
+		assert.Equal(t, "bar here", parserBar.lines[3])
+	}
+
+	if assert.Len(t, parserCommon.lines, 8) {
+		strings := []string{"hello", "go", "more", "text", "bar", "content", "still", "bar here"}
+		for _, str := range strings {
+			assert.Contains(t, parserCommon.lines, str)
+		}
+	}
+}

--- a/pkg/dogstream/tailer/test/bar
+++ b/pkg/dogstream/tailer/test/bar
@@ -1,0 +1,4 @@
+bar
+content
+still
+bar here

--- a/pkg/dogstream/tailer/test/foo
+++ b/pkg/dogstream/tailer/test/foo
@@ -1,4 +1,0 @@
-hello
-go
-more
-text

--- a/pkg/dogstream/tailer/test/foo
+++ b/pkg/dogstream/tailer/test/foo
@@ -1,0 +1,4 @@
+hello
+go
+more
+text

--- a/pkg/dogstream/tests/config_test.yaml
+++ b/pkg/dogstream/tests/config_test.yaml
@@ -1,0 +1,39 @@
+init_config:
+  # the check will refresh the matching pid list every X seconds
+  # except if it detects a change before. You might want to set it
+  # low if you want to alert on process service checks.
+  # pid_cache_duration: 120
+  #
+  # used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc
+  # procfs_path: /proc
+
+instances:
+# The `system.processes.cpu.pct` metric sent by this check is only accurate for processes that live
+# for more than 30 seconds. Do not expect its value to be accurate for shorter-lived processes.
+#
+#  - name: (required) STRING. It will be used to uniquely identify your metrics as they will be tagged with this name
+#    search_string: (required) LIST OF STRINGS. If one of the elements in the list matches,
+#                    return the counter of all the processes that contain the string
+#    exact_match: (optional) Boolean. Default to True, if you want to look for an arbitrary
+#                 string, use exact_match: False
+#    ignore_denied_access: (optional) Boolean. Default to True, when getting the number of files descriptors, dd-agent user might
+#    get a denied access. Set this to true to not issue a warning if that happens.
+#    thresholds: (optional) Two ranges: critical and warning
+#         warning: (optional) List of two values: If the number of processes found is below the first value or
+#                  above the second one, the process check will return WARNING.
+#         critical: (optional) List of two values: If the number of processes found is below the first value or
+#                   above the second one, the process check will return CRITICAL.
+#     In this example, process check will return OK for 3 to 5 process. WARNING for 1, 2, 6, 7 processes and Critical below 1 or above 7.
+#     CRITICAL is always dominant in case of overlapping.
+#
+#
+# Examples:
+#
+
+  - name: authlog
+    file: /var/log/auth.log
+    parser: ['foo']
+   
+  - name: dmesg
+    file: /var/log/dmesg.log
+    parser: ['foo']

--- a/pkg/dogstream/tests/foo.py
+++ b/pkg/dogstream/tests/foo.py
@@ -1,4 +1,4 @@
 
 
 def parse(log, line):
-    pass
+    return "FOO!"

--- a/pkg/dogstream/tests/foo.py
+++ b/pkg/dogstream/tests/foo.py
@@ -1,4 +1,4 @@
 
 
 def parse(log, line):
-    return "FOO!"
+    return line

--- a/pkg/dogstream/tests/foo.py
+++ b/pkg/dogstream/tests/foo.py
@@ -1,0 +1,4 @@
+
+
+def parse(log, line):
+    pass


### PR DESCRIPTION
# DO NOT MERGE
Just in case

## What it does

`dogstream` package contains the code to tail log files + invoking the parsers. Ideally, this will be moved to its own repo.

The "main loop" logic to run Dogstream is implemented as a go check, `dogstream.go`. We allow checks to specify `0` as an interval, that meaning the check has to run only once in the agent lifetime. Think about it as a check that never returns from `check()`

## Notes

The parsers are responsible to send metrics through dogstatsd on their own, the final goal would be using the internal API to post metrics.
