### PR TITLE
Add PIDfiles support

### DIFF
--- a/cmd/agent/app/common_darwin.go
+++ b/cmd/agent/app/common_darwin.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package app
 
 var configPaths = []string{

--- a/cmd/agent/app/common_linux.go
+++ b/cmd/agent/app/common_linux.go
@@ -1,5 +1,3 @@
-// +build dragonfly freebsd linux nacl netbsd openbsd solaris
-
 package app
 
 var configPaths = []string{

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -3,8 +3,10 @@ Description="Datadog Agent"
 After=network.target
 
 [Service]
+Type=forking
+PIDFile=/var/run/datadog/agent.pid
 User=root
-ExecStart=<%= install_dir %>/bin/agent/agent
+ExecStart=<%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -8,5 +8,5 @@ respawn
 console log  # redirect daemon's outputs to `/var/log/upstart/datadog-agent6.log`
 
 script
-  exec <%= install_dir %>/bin/agent/agent
+  exec <%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
 end script

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -1,0 +1,53 @@
+package pidfile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// WritePID writes the current PID to a file, ensuring that the file
+// doesn't exist or doesn't contain a PID for a running process. If
+// WritePID is invoked without params, Path() is used to determine
+// the pidfile path
+func WritePID(path ...string) error {
+	var pidFilePath string
+	// default value
+	if len(path) == 0 {
+		pidFilePath = Path()
+	} else {
+		pidFilePath = path[0]
+	}
+
+	// check whether the pidfile exists and contains the PID for a running proc...
+	exists := false
+	if byteContent, err := ioutil.ReadFile(pidFilePath); err == nil {
+		pidStr := strings.TrimSpace(string(byteContent))
+		if pid, err := strconv.Atoi(pidStr); err == nil {
+			exists = isProcess(pid)
+		}
+	}
+
+	// ...and return an error in case
+	if exists {
+		return fmt.Errorf("Pidfile already exists, please check %s isn't running or remove %s",
+			os.Args[0], pidFilePath)
+	}
+
+	// create the full path to the pidfile
+	if err := os.MkdirAll(filepath.Dir(pidFilePath), os.FileMode(0755)); err != nil {
+		return err
+	}
+
+	// write current pid in it
+	pidStr := fmt.Sprintf("%d", os.Getpid())
+	if err := ioutil.WriteFile(pidFilePath, []byte(pidStr), 0644); err != nil {
+		return err
+	}
+
+	// all good
+	return nil
+}

--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -10,31 +10,17 @@ import (
 )
 
 // WritePID writes the current PID to a file, ensuring that the file
-// doesn't exist or doesn't contain a PID for a running process. If
-// WritePID is invoked without params, Path() is used to determine
-// the pidfile path
-func WritePID(path ...string) error {
-	var pidFilePath string
-	// default value
-	if len(path) == 0 {
-		pidFilePath = Path()
-	} else {
-		pidFilePath = path[0]
-	}
-
+// doesn't exist or doesn't contain a PID for a running process.
+func WritePID(pidFilePath string) error {
 	// check whether the pidfile exists and contains the PID for a running proc...
-	exists := false
 	if byteContent, err := ioutil.ReadFile(pidFilePath); err == nil {
 		pidStr := strings.TrimSpace(string(byteContent))
-		if pid, err := strconv.Atoi(pidStr); err == nil {
-			exists = isProcess(pid)
+		pid, err := strconv.Atoi(pidStr)
+		if err == nil && isProcess(pid) {
+			// ...and return an error in case
+			return fmt.Errorf("Pidfile already exists, please check %s isn't running or remove %s",
+				os.Args[0], pidFilePath)
 		}
-	}
-
-	// ...and return an error in case
-	if exists {
-		return fmt.Errorf("Pidfile already exists, please check %s isn't running or remove %s",
-			os.Args[0], pidFilePath)
 	}
 
 	// create the full path to the pidfile

--- a/pkg/pidfile/pidfile_darwin.go
+++ b/pkg/pidfile/pidfile_darwin.go
@@ -1,0 +1,15 @@
+package pidfile
+
+import (
+	"syscall"
+)
+
+// isProcess uses `kill -0` to check whether a process is running
+func isProcess(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+// Path returns a suitable location for the pidfile under OSX
+func Path() string {
+	return "/var/run/datadog/datadog-agent.pid"
+}

--- a/pkg/pidfile/pidfile_linux.go
+++ b/pkg/pidfile/pidfile_linux.go
@@ -1,0 +1,18 @@
+package pidfile
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// isProcess searches for the PID under /proc
+func isProcess(pid int) bool {
+	_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
+	return err == nil
+}
+
+// Path returns a suitable location for the pidfile under Linux
+func Path() string {
+	return "/var/run/datadog/datadog-agent.pid"
+}

--- a/pkg/pidfile/pidfile_nix.go
+++ b/pkg/pidfile/pidfile_nix.go
@@ -1,3 +1,5 @@
+// +build freebsd linux
+
 package pidfile
 
 import (

--- a/pkg/pidfile/pidfile_test.go
+++ b/pkg/pidfile/pidfile_test.go
@@ -1,0 +1,29 @@
+package pidfile
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWritePID(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "agent_test")
+	defer os.RemoveAll(dir)
+
+	pidFilePath := filepath.Join(dir, "this_should_be_created", "agent.pid")
+	err := WritePID(pidFilePath)
+	assert.Nil(t, err)
+	data, err := ioutil.ReadFile(pidFilePath)
+	assert.Nil(t, err)
+	pid, err := strconv.Atoi(string(data))
+	assert.Nil(t, err)
+	assert.Equal(t, pid, os.Getpid())
+}
+
+func TestIsProcess(t *testing.T) {
+	assert.True(t, isProcess(os.Getpid()))
+}


### PR DESCRIPTION
### What does this PR do?

 * Adds a function to check and create pidfiles.
 * Adds a command line option to specify a pidfile
 * Provide platform dependent defaults for pidfile paths

### Motivation

We need a way to know whether the agent is running or not, also this plays very well with systemd
