### PR TITLE
[rake] Don't fail when `go fmt` does its job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,8 +31,9 @@ end
 
 desc "Run go fmt on #{TARGETS}"
 task :fmt do
+  fail_on_mod = ENV["CI"] # only fail on modification when we're running in CI env
   TARGETS.each do |t|
-    go_fmt(t)
+    go_fmt(t, fail_on_mod)
   end
 end
 

--- a/go.rb
+++ b/go.rb
@@ -5,7 +5,6 @@ def go_fmt(path)
   errors = out.split("\n")
   if errors.length > 0
     puts out
-    fail
   end
 end
 

--- a/go.rb
+++ b/go.rb
@@ -1,10 +1,12 @@
 
 
-def go_fmt(path)
+def go_fmt(path, fail_on_mod)
   out = `go fmt #{path}/...`
   errors = out.split("\n")
   if errors.length > 0
+    puts "Reformatted the following files:"
     puts out
+    fail if fail_on_mod
   end
 end
 


### PR DESCRIPTION
We shouldn't make the rake task fail when `go fmt` reformats code.

The previous behavior was especially frustrating when running the
`test` task.