### PR TITLE
Import fix for py checks

### DIFF
--- a/pkg/collector/check/py/loader.go
+++ b/pkg/collector/check/py/loader.go
@@ -27,7 +27,7 @@ func NewPythonCheckLoader() *PythonCheckLoader {
 		python.PyGILState_Release(_gstate)
 	}()
 
-	agentCheckModule := python.PyImport_ImportModuleNoBlock(agentCheckModuleName)
+	agentCheckModule := python.PyImport_ImportModule(agentCheckModuleName)
 	if agentCheckModule == nil {
 		log.Errorf("Unable to import Python module: %s", agentCheckModuleName)
 		return nil
@@ -55,7 +55,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	}()
 
 	// import python module containing the check
-	checkModule := python.PyImport_ImportModuleNoBlock(moduleName)
+	checkModule := python.PyImport_ImportModule(moduleName)
 	if checkModule == nil {
 		// we don't expect a traceback here so we use the error msg in `pvalue`
 		_, pvalue, _ := python.PyErr_Fetch()

--- a/pkg/collector/check/py/tests/testcheck.py
+++ b/pkg/collector/check/py/tests/testcheck.py
@@ -1,5 +1,6 @@
 from checks import AgentCheck
 
+
 class TestCheck(AgentCheck):
     def check(self, instance):
         """


### PR DESCRIPTION
### What does this PR do?

 * Adds more meaningful benchmarks for the Python checks
 * Avoid using `PyImport_ImportModuleNoBlock` to import modules

### Motivation

Benchmarks are useful to test concurrent execution of multiple check instances.

`PyImport_ImportModuleNoBlock` has an unforeseen side effect: if the imported module contains errors at import time, a valid PyObject containing only the symbols loaded at the time of the error is returned anyways.
