### PR TITLE
[upstart] Run agent in foreground

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -8,5 +8,5 @@ respawn
 console log  # redirect daemon's outputs to `/var/log/upstart/datadog-agent6.log`
 
 script
-  exec <%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
+  exec <%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid -f
 end script


### PR DESCRIPTION
### What does this PR do?

Fixes upstart service definition after https://github.com/DataDog/datadog-agent/pull/83

### Motivation

Fixing stuff in general, and the QA host in particular

### Testing

It works

### Additional Notes

Unfortunately `upstart` doesn't seem to be able to keep track of the
forking agent even with the `expect fork` or `expect daemon` stanzas
are specified. Could be related to how the go runtime forks internally
to keep track of its own threads.

