### PR TITLE
Add '/etc/dd-agent/conf.d' to configuration search path

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -47,11 +47,13 @@ func init() {
 // build a list of providers for checks' configurations, the sequence defines
 // the precedence.
 func getConfigProviders() (providers []loader.ConfigProvider) {
-	confdPath := filepath.Join(_distPath, "conf.d")
-	configPaths := []string{confdPath}
+	confSearchPaths := []string{}
+	for _, path := range configPaths {
+		confSearchPaths = append(confSearchPaths, filepath.Join(path, "conf.d"))
+	}
 
 	// File Provider
-	providers = append(providers, loader.NewFileConfigProvider(configPaths))
+	providers = append(providers, loader.NewFileConfigProvider(confSearchPaths))
 
 	return providers
 }


### PR DESCRIPTION
### What does this PR do?

Add default '/etc/dd-agent/conf.d/' folder to configuration search path.

### Motivation

We need it already for QA
