### PR TITLE
[upstart] respawn on panic/crash

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -1,7 +1,7 @@
 description "Datadog Agent"
 
 start on started networking
-stop on shutdown
+stop on runlevel [!2345]
 
 respawn
 

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -1,7 +1,7 @@
 description "Datadog Agent"
 
 start on started networking
-stop on runlevel [!2345]
+stop on shutdown
 
 respawn
 
@@ -9,4 +9,9 @@ console log  # redirect daemon's outputs to `/var/log/upstart/datadog-agent6.log
 
 script
   exec <%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid -f
+end script
+
+post-stop script
+ rm -f /var/run/datadog/agent.pid
+ rm -f /tmp/agent.sock
 end script


### PR DESCRIPTION
### What does this PR do?

Cleans up files after the agent exits. Cleanup operations are performed by the agent itself on clear shutdowns but this should help in case of crash/panic
