### PR TITLE
[systemd] start/restart the agent

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -6,7 +6,7 @@ After=network.target
 Type=forking
 PIDFile=/var/run/datadog/agent.pid
 User=root
-Restart=always
+Restart=on-failure
 ExecStartPre=/bin/rm -f /tmp/agent.sock
 ExecStart=<%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
 

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -6,6 +6,8 @@ After=network.target
 Type=forking
 PIDFile=/var/run/datadog/agent.pid
 User=root
+Restart=always
+ExecStartPre=/bin/rm -f /tmp/agent.sock
 ExecStart=<%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
 
 [Install]


### PR DESCRIPTION
### What does this PR do?

Lets systemd take care of restarting the agent in case of crash/panic.
Systemd takes care of the pidfile while we manually clean up the Unix socket.
I've explored the opportunity of using systemd's `.socket` units but it requires changing the code so for now let's keep this straight simple.

Tested on Xenial