### PR TITLE
Maxime/update python check api

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -16,17 +16,18 @@ type ConfigRawMap map[interface{}]interface{}
 
 // Config is a generic container for configuration files
 type Config struct {
-	Name      string       // the name of the check
-	Instances []ConfigData // array of Yaml configurations
+	Name       string       // the name of the check
+	Instances  []ConfigData // array of Yaml configurations
+	InitConfig ConfigData   // the init_config in Yaml (python check only)
 }
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                      // run the check
-	Stop()                           // stop the check if it's running
-	String() string                  // provide a printable version of the check name
-	Configure(data ConfigData) error // configure the check from the outside
-	InitSender()                     // initialize what's needed to send data to the aggregator
-	Interval() time.Duration         // return the interval time for the check
-	ID() string                      // provide a unique identifier for every check instance
+	Run() error                                             // run the check
+	Stop()                                                  // stop the check if it's running
+	String() string                                         // provide a printable version of the check name
+	Configure(data ConfigData, initConfig ConfigData) error // configure the check from the outside
+	InitSender()                                            // initialize what's needed to send data to the aggregator
+	Interval() time.Duration                                // return the interval time for the check
+	ID() string                                             // provide a unique identifier for every check instance
 }

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -11,11 +11,11 @@ type TestCheck struct {
 	hasRun bool
 }
 
-func (c *TestCheck) String() string             { return "TestCheck" }
-func (c *TestCheck) Stop()                      {}
-func (c *TestCheck) Configure(ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                {}
-func (c *TestCheck) Interval() time.Duration    { return 1 }
+func (c *TestCheck) String() string                         { return "TestCheck" }
+func (c *TestCheck) Stop()                                  {}
+func (c *TestCheck) Configure(ConfigData, ConfigData) error { return nil }
+func (c *TestCheck) InitSender()                            {}
+func (c *TestCheck) Interval() time.Duration                { return 1 }
 func (c *TestCheck) Run() error {
 	if c.doErr {
 		msg := "A tremendous error occurred."

--- a/pkg/collector/check/core/loader.go
+++ b/pkg/collector/check/core/loader.go
@@ -40,7 +40,7 @@ func (gl *GoCheckLoader) Load(config check.Config) ([]check.Check, error) {
 
 	for _, instance := range config.Instances {
 		newCheck := factory()
-		if err := newCheck.Configure(instance); err != nil {
+		if err := newCheck.Configure(instance, config.InitConfig); err != nil {
 			log.Errorf("core.loader: could not configure check %s: %s", newCheck, err)
 			continue
 		}

--- a/pkg/collector/check/core/loader_test.go
+++ b/pkg/collector/check/core/loader_test.go
@@ -10,13 +10,13 @@ import (
 // FIXTURE
 type TestCheck struct{}
 
-func (c *TestCheck) String() string                   { return "TestCheck" }
-func (c *TestCheck) Configure(check.ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                      {}
-func (c *TestCheck) Run() error                       { return nil }
-func (c *TestCheck) Stop()                            {}
-func (c *TestCheck) Interval() time.Duration          { return 1 }
-func (c *TestCheck) ID() string                       { return c.String() }
+func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
+func (c *TestCheck) InitSender()                                        {}
+func (c *TestCheck) Run() error                                         { return nil }
+func (c *TestCheck) Stop()                                              {}
+func (c *TestCheck) Interval() time.Duration                            { return 1 }
+func (c *TestCheck) ID() string                                         { return c.String() }
 
 func TestNewGoCheckLoader(t *testing.T) {
 	if NewGoCheckLoader() == nil {

--- a/pkg/collector/check/core/system/cpu.go
+++ b/pkg/collector/check/core/system/cpu.go
@@ -51,7 +51,7 @@ func (c *CPUCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *CPUCheck) Configure(data check.ConfigData) error {
+func (c *CPUCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
 	// do nothing
 	info, err := cpuInfo()
 	if err != nil {

--- a/pkg/collector/check/core/system/cpu_test.go
+++ b/pkg/collector/check/core/system/cpu_test.go
@@ -48,7 +48,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	times = CPUTimes
 	cpuInfo = CPUInfo
 	cpuCheck := new(CPUCheck)
-	cpuCheck.Configure(nil)
+	cpuCheck.Configure(nil, nil)
 
 	mock := new(MockSender) // from common_test.go
 	cpuCheck.sender = mock

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -77,7 +77,7 @@ func (c *MemoryCheck) Run() error {
 }
 
 // Configure the Python check from YAML data
-func (c *MemoryCheck) Configure(data check.ConfigData) error {
+func (c *MemoryCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/check/py/check.go
+++ b/pkg/collector/check/py/check.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -76,17 +77,70 @@ func (c *PythonCheck) String() string {
 	return c.ModuleName
 }
 
+func (c *PythonCheck) instantiateCheck(constructorParameters *python.PyObject, fixInitError bool) (*python.PyObject, error) {
+	// invoke constructor
+	emptyTuple := python.PyTuple_New(0)
+	instance := c.Class.Call(emptyTuple, constructorParameters)
+	if instance != nil {
+		return instance, nil
+	}
+
+	// If the constructor is invalid we do not get a traceback but
+	// an error in pvalue.
+	_, pvalue, ptraceback := python.PyErr_Fetch()
+
+	// The internal C pointer may be nill, the only way to check is
+	// it to ask for the type, since the internal "ptr" is not
+	// exposed.
+	if pvalue.Type() != nil {
+		pvalueError := python.PyString_AsString(pvalue)
+
+		// 'agentConfig' has been deprecated since agent 6.0.
+		// Until it's removed we try do detect error from
+		// __init__ missing one parameter and try to load the
+		// check again with an empty 'agentConfig' (since most
+		// user custom check expect the argument but don't use
+		// it).
+		if fixInitError && strings.HasPrefix(pvalueError, "__init__() takes ") {
+			// Add new 'agentConfig' key to the dict and retry instantiateCheck
+			key := python.PyString_FromString("agentConfig")
+			python.PyDict_SetItem(constructorParameters, key, python.PyDict_New())
+			instance, err := c.instantiateCheck(constructorParameters, false)
+			if instance != nil {
+				log.Warnf("'agentConfig' parameter in the '__init__' method is not supported anymore: an empty dict is given for now (%s).", c.ModuleName)
+			}
+			return instance, err
+		}
+
+		return nil, fmt.Errorf(pvalueError)
+	}
+	if ptraceback.Type() != nil {
+		return nil, fmt.Errorf(python.PyString_AsString(ptraceback))
+	}
+
+	return nil, fmt.Errorf("unknown error from python")
+}
+
 // Configure the Python check from YAML data
-func (c *PythonCheck) Configure(data check.ConfigData) error {
-	// Unmarshal ConfigData to a RawConfigMap
-	raw := check.ConfigRawMap{}
-	err := yaml.Unmarshal(data, &raw)
+func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	// Unmarshal instances config to a RawConfigMap
+	rawInstances := check.ConfigRawMap{}
+	err := yaml.Unmarshal(data, &rawInstances)
 	if err != nil {
+		log.Error("error in yaml %s", err)
+		return err
+	}
+
+	// Unmarshal initConfig to a RawConfigMap
+	rawInitConfig := check.ConfigRawMap{}
+	err = yaml.Unmarshal(initConfig, &rawInitConfig)
+	if err != nil {
+		log.Error("error in yaml %s", err)
 		return err
 	}
 
 	// See if a collection interval was specified
-	x, ok := raw["min_collection_interval"]
+	x, ok := rawInstances["min_collection_interval"]
 	if ok {
 		// we should receive an int from the unmarshaller
 		if intl, ok := x.(int); ok {
@@ -104,7 +158,9 @@ func (c *PythonCheck) Configure(data check.ConfigData) error {
 	// To be retrocompatible with the Python code, still use an `instance` dictionary
 	// to contain the (now) unique instance for the check
 	conf := make(check.ConfigRawMap)
-	conf["instances"] = []interface{}{raw}
+	conf["instances"] = []interface{}{rawInstances}
+	conf["init_config"] = rawInitConfig
+	conf["name"] = c.ModuleName
 
 	// Convert the RawConfigMap to a Python dictionary
 	configDict, err := ToPythonDict(&conf)
@@ -113,25 +169,9 @@ func (c *PythonCheck) Configure(data check.ConfigData) error {
 		return err
 	}
 
-	// invoke constructor
-	emptyTuple := python.PyTuple_New(0)
-	instance := c.Class.Call(emptyTuple, configDict)
+	instance, err := c.instantiateCheck(configDict, true)
 	if instance == nil {
-		// If the constructor is invalid we do not get a traceback but
-		// an error in pvalue.
-		_, pvalue, ptraceback := python.PyErr_Fetch()
-
-		// The internal C pointer may be nill, the only way to check is
-		// it to ask for the type, since the internal "ptr" is not
-		// exposed.
-		if pvalue.Type() != nil {
-			log.Error(python.PyString_AsString(pvalue))
-		}
-		if ptraceback.Type() != nil {
-			log.Error(python.PyString_AsString(ptraceback))
-		}
-		// python.PyErr_Print()
-		return fmt.Errorf("could not invoke python check constructor")
+		return fmt.Errorf("could not invoke python check constructor: %s", err)
 	}
 
 	c.Instance = instance

--- a/pkg/collector/check/py/loader.go
+++ b/pkg/collector/check/py/loader.go
@@ -78,8 +78,8 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	// Get an AgentCheck for each configuration instance and add it to the registry
 	for _, i := range config.Instances {
 		check := NewPythonCheck(moduleName, checkClass)
-		if err := check.Configure(i); err != nil {
-			log.Errorf("py.loader: could not configure check %s : %s", moduleName, err)
+		if err := check.Configure(i, config.InitConfig); err != nil {
+			log.Errorf("py.loader: could not configure check '%s': %s", moduleName, err)
 			continue
 		}
 		checks = append(checks, check)

--- a/pkg/collector/check/py/tests/kwargs_init_signature.py
+++ b/pkg/collector/check/py/tests/kwargs_init_signature.py
@@ -1,0 +1,9 @@
+from checks import AgentCheck
+
+
+class TestCheck(AgentCheck):
+    def __init__(self, *args, **kwargs):
+        super(TestCheck, self).__init__(*args, **kwargs)
+
+    def check(self, instance):
+        pass

--- a/pkg/collector/check/py/tests/new_init_signature.py
+++ b/pkg/collector/check/py/tests/new_init_signature.py
@@ -1,0 +1,9 @@
+from checks import AgentCheck
+
+
+class TestCheck(AgentCheck):
+    def __init__(self, name, init_config, instances):
+        super(TestCheck, self).__init__(name, init_config, instances)
+
+    def check(self, instance):
+        pass

--- a/pkg/collector/check/py/tests/old_init_signature.py
+++ b/pkg/collector/check/py/tests/old_init_signature.py
@@ -1,0 +1,9 @@
+from checks import AgentCheck
+
+
+class TestCheck(AgentCheck):
+    def __init__(self, name, init_config, agentConfig, instances):
+        super(TestCheck, self).__init__(name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        pass

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -19,9 +19,23 @@ class AgentCheck(object):
 
     def __init__(self, *args, **kwargs):
         self.metrics = defaultdict(list)
-        self.instances = kwargs.get('instances', [])
+
+        if len(args) == 0:
+            self.instances = kwargs.get('instances', [])
+            self.name = kwargs.get('name', '')
+            self.agentConfig = kwargs.get('agentConfig', {})
+        else:
+            self.name = args[0]
+            self.agentConfig = args[1]
+            # no agentConfig
+            if len(args) == 3:
+                self.instances = args[2]
+            # with agentConfig
+            else:
+                self.instances = args[3]
+
         # the agent5 'AgentCheck' setup a log attribute.
-        self.log = logging.getLogger('%s.%s' % (__name__, kwargs.get("name", "")))
+        self.log = logging.getLogger('%s.%s' % (__name__, self.name))
 
     def gauge(self, name, value, tags=None):
         aggregator.submit_data(self, aggregator.GAUGE, name, value, tags)

--- a/pkg/collector/dist/checks/process.py
+++ b/pkg/collector/dist/checks/process.py
@@ -47,14 +47,8 @@ ATTR_TO_METRIC_RATE = {
 
 
 class ProcessCheck(AgentCheck):
-    def __init__(self, *args, **kwargs):
-        super(ProcessCheck, self).__init__(*args, **kwargs)
-
-        # For the agent6 we have merged the 'init_config' section within the
-        # instance
-        init_config = {}
-        if len(self.instances) > 0 and isinstance(self.instances[0], dict):
-            init_config = self.instances[0]
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        super(ProcessCheck, self).__init__(name, init_config, agentConfig, instances)
 
         # ad stands for access denied
         # We cache the PIDs getting this error and don't iterate on them

--- a/pkg/collector/loader/file_provider.go
+++ b/pkg/collector/loader/file_provider.go
@@ -13,7 +13,8 @@ import (
 )
 
 type configFormat struct {
-	Instances []check.ConfigRawMap
+	InitConfig interface{} `yaml:"init_config"`
+	Instances  []check.ConfigRawMap
 }
 
 // FileConfigProvider collect configuration files from disk
@@ -91,6 +92,10 @@ func getCheckConfig(name, fpath string) (check.Config, error) {
 	if len(cf.Instances) < 1 {
 		return config, errors.New("Configuration file contains no valid instances")
 	}
+
+	// at this point the Yaml was already parsed, no need to check the error
+	rawInitConfig, _ := yaml.Marshal(cf.InitConfig)
+	config.InitConfig = rawInitConfig
 
 	// Go through instances and return corresponding []byte
 	for _, instance := range cf.Instances {

--- a/pkg/collector/loader/file_provider_test.go
+++ b/pkg/collector/loader/file_provider_test.go
@@ -1,50 +1,41 @@
 package loader
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestGetCheckConfig(t *testing.T) {
 	// file does not exist
 	config, err := getCheckConfig("foo", "")
-	if err == nil {
-		t.Fatal("Expecting error")
-	}
+	assert.NotNil(t, err)
 
 	// file contains invalid Yaml
 	config, err = getCheckConfig("foo", "tests/invalid.yaml")
-	if err == nil {
-		t.Fatal("Expecting error")
-	}
+	assert.NotNil(t, err)
 
 	// valid yaml, invalid configuration file
 	config, err = getCheckConfig("foo", "tests/notaconfig.yaml")
-	if err == nil {
-		t.Fatal("Expecting error")
-	}
-	if len(config.Instances) != 0 {
-		t.Fatalf("Expecting 0 instances, found: %d", len(config.Instances))
-	}
+	assert.NotNil(t, err)
+	assert.Equal(t, len(config.Instances), 0)
 
 	// valid configuration file
 	config, err = getCheckConfig("foo", "tests/testcheck.yaml")
-	if err != nil {
-		t.Fatalf("Expecting nil, found: %s", err)
-	}
-	if config.Name != "foo" {
-		t.Fatalf("Expecting `foo`, found: %s", config.Name)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, config.Name, "foo")
+
+	assert.Equal(t, []byte(config.InitConfig), []byte("- test: 21\n"))
+	assert.Equal(t, len(config.Instances), 1)
+	assert.Equal(t, []byte(config.Instances[0]), []byte("foo: bar\n"))
 }
 
 func TestNewYamlConfigProvider(t *testing.T) {
 	paths := []string{"foo", "bar", "foo/bar"}
 	provider := NewFileConfigProvider(paths)
-	if len(provider.paths) != len(paths) {
-		t.Fatalf("Expecting length %d, found: %d", len(provider.paths), len(paths))
-	}
+	assert.Equal(t, len(provider.paths), len(paths))
 
 	for i, p := range provider.paths {
-		if p != paths[i] {
-			t.Fatalf("Expecting %s, found: %s", paths[i], p)
-		}
+		assert.Equal(t, p, paths[i])
 	}
 }
 
@@ -53,16 +44,9 @@ func TestCollect(t *testing.T) {
 	provider := NewFileConfigProvider(paths)
 	configs, err := provider.Collect()
 
-	if err != nil {
-		t.Fatalf("Expecting nil, found: %s", err)
-	}
-
-	if len(configs) != 1 {
-		t.Fatalf("Expecting length 1, found: %d", len(configs))
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, len(configs), 1)
 
 	config := configs[0]
-	if config.Name != "testcheck" {
-		t.Fatalf("Expecting testcheck, found: %s", config.Name)
-	}
+	assert.Equal(t, config.Name, "testcheck")
 }

--- a/pkg/collector/loader/tests/testcheck.yaml
+++ b/pkg/collector/loader/tests/testcheck.yaml
@@ -1,4 +1,5 @@
 init_config:
+  - test: 21
 
 instances:
   # No configuration is needed for this check.

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -11,13 +11,13 @@ import (
 // FIXTURE
 type TestCheck struct{ intl time.Duration }
 
-func (c *TestCheck) String() string                   { return "TestCheck" }
-func (c *TestCheck) Configure(check.ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                      {}
-func (c *TestCheck) Interval() time.Duration          { return c.intl }
-func (c *TestCheck) Run() error                       { return nil }
-func (c *TestCheck) Stop()                            {}
-func (c *TestCheck) ID() string                       { return c.String() }
+func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
+func (c *TestCheck) InitSender()                                        {}
+func (c *TestCheck) Interval() time.Duration                            { return c.intl }
+func (c *TestCheck) Run() error                                         { return nil }
+func (c *TestCheck) Stop()                                              {}
+func (c *TestCheck) ID() string                                         { return c.String() }
 
 // wait 1s for a predicate function to return true, use polling
 // instead of a giant sleep.


### PR DESCRIPTION
### What does this PR do?

Update the check API to handle 'init_config' section. Since we want to import python checks from the agent5 we need to mimic its api (at least for python check).

### Motivation

We want to let users import there custom checks from the agent5.

### Additional Notes

For now we just flag 'agentConfig' as deprecated.
