### PR TITLE
Avoid sharing internal states between multiple instances of a check.

### DIFF
--- a/pkg/collector/check/core/loader_test.go
+++ b/pkg/collector/check/core/loader_test.go
@@ -24,8 +24,12 @@ func TestNewGoCheckLoader(t *testing.T) {
 	}
 }
 
+func testCheckFactory() check.Check {
+	return &TestCheck{}
+}
+
 func TestRegisterCheck(t *testing.T) {
-	RegisterCheck("foo", new(TestCheck))
+	RegisterCheck("foo", testCheckFactory)
 	_, found := catalog["foo"]
 	if !found {
 		t.Fatal("Check foo not found in catalog")
@@ -33,7 +37,7 @@ func TestRegisterCheck(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
-	RegisterCheck("foo", new(TestCheck))
+	RegisterCheck("foo", testCheckFactory)
 
 	// check is in catalog, pass 2 instances
 	i := []check.ConfigData{

--- a/pkg/collector/check/core/system/cpu.go
+++ b/pkg/collector/check/core/system/cpu.go
@@ -87,6 +87,10 @@ func (c *CPUCheck) ID() string {
 // Stop does nothing
 func (c *CPUCheck) Stop() {}
 
+func cpuFactory() check.Check {
+	return &CPUCheck{}
+}
+
 func init() {
-	core.RegisterCheck("cpu", &CPUCheck{})
+	core.RegisterCheck("cpu", cpuFactory)
 }

--- a/pkg/collector/check/core/system/memory.go
+++ b/pkg/collector/check/core/system/memory.go
@@ -106,6 +106,9 @@ func (c *MemoryCheck) ID() string {
 // Stop does nothing
 func (c *MemoryCheck) Stop() {}
 
+func memFactory() check.Check {
+	return &MemoryCheck{}
+}
 func init() {
-	core.RegisterCheck("memory", &MemoryCheck{})
+	core.RegisterCheck("memory", memFactory)
 }


### PR DESCRIPTION
### What does this PR do?

When a check had multiple instances 'newCheck := c' would not create a
new instance of the underlying struct of the interface. This means that
we end up with multiple reference to the same struct and the
informations of the last instance would apply to all. One the the side
effect would be that all check of a certain type would share the same
Sender (which makes Rates failed).

To avoid that we now register a constructor function that allow us to
instantiate a new struct of the check type.

### Motivation

Agent would failed to serialize metric because of `NaN`. This would come from Rates that shared the same Sender (ie: timestamp would be the same everywhere leading us to divide by 0).