### PR TITLE
changed scheduler to accomodate long running checks

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -96,7 +96,7 @@ func start(cmd *cobra.Command, args []string) {
 	common.AgentRunner = check.NewRunner()
 
 	// Instance the scheduler
-	common.AgentScheduler = scheduler.NewScheduler()
+	common.AgentScheduler = scheduler.NewScheduler(common.AgentRunner.GetChan())
 
 	// Instance the Aggregator
 	_ = aggregator.GetAggregator()
@@ -116,10 +116,10 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	// Start the Runner using only one worker, i.e. we process checks sequentially
-	common.AgentRunner.Run(1)
+	common.AgentRunner.Run(common.RunnerNumWorkers)
 
 	// Run the scheduler
-	common.AgentScheduler.Run(common.AgentRunner.GetChan())
+	common.AgentScheduler.Run()
 
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -10,6 +10,11 @@ import (
 	"github.com/kardianos/osext"
 )
 
+const (
+	// RunnerNumWorkers is the number of workers the Runner should spawn
+	RunnerNumWorkers = 4
+)
+
 var (
 	// Stopper is the channel used by other packages to ask for stopping the agent
 	Stopper = make(chan bool)


### PR DESCRIPTION
### What does this PR do?

Move passing the output channel for checks from the `Run` method to the constructor.

### Motivation

When I first designed the Scheduler, I though it was a good idea to pass the output channel as a parameter in the `Run` function. This would have allowed to stop a scheduler and restart it on a different channel but it turned out to be a bad idea b/c 1) this was a non-requirement and 2) this doesn't play well with long running checks.

Provided that long running checks are checks that:
  1. Does not return from `check()` 
  2. Are scheduled only once

we need a way to implement 2). It seems good to support intervals = 0 with the meaning of "run this only once". Problem is, `Enter` is supposed to be called on a scheduler even if the scheduler is not running (this is cool to have) but if the scheduler is not running we don't have the output channel available. The PR is supposed to address this.
