### PR TITLE
Initialize 'pending' queue at runner creation

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -93,7 +93,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	// Get a Runner instance
-	common.AgentRunner = check.NewRunner()
+	common.AgentRunner = check.NewRunner(common.RunnerNumWorkers)
 
 	// Instance the scheduler
 	common.AgentScheduler = scheduler.NewScheduler(common.AgentRunner.GetChan())
@@ -114,9 +114,6 @@ func start(cmd *cobra.Command, args []string) {
 			}
 		}
 	}
-
-	// Start the Runner using only one worker, i.e. we process checks sequentially
-	common.AgentRunner.Run(common.RunnerNumWorkers)
 
 	// Run the scheduler
 	common.AgentScheduler.Run()

--- a/pkg/collector/check/runner_test.go
+++ b/pkg/collector/check/runner_test.go
@@ -8,27 +8,13 @@ import (
 )
 
 func TestNewRunner(t *testing.T) {
-	r := NewRunner()
-	assert.Nil(t, r.pending)
-}
-
-func TestRun(t *testing.T) {
-	r := NewRunner()
-
-	// let's fake the runner already started, this should be a noop
-	r.pending = make(chan Check)
-	r.Run(1)
-
-	r = NewRunner()
-	r.Run(1)
+	r := NewRunner(1)
 	assert.NotNil(t, r.pending)
 	assert.NotNil(t, r.runningChecks)
-	close(r.pending)
 }
 
 func TestStop(t *testing.T) {
-	r := NewRunner()
-	r.Run(1)
+	r := NewRunner(1)
 	r.Stop()
 	_, ok := <-r.pending
 	assert.False(t, ok)
@@ -38,15 +24,12 @@ func TestStop(t *testing.T) {
 }
 
 func TestGetChan(t *testing.T) {
-	r := NewRunner()
-	assert.Nil(t, r.GetChan())
-	r.Run(1)
+	r := NewRunner(1)
 	assert.NotNil(t, r.GetChan())
 }
 
 func TestWork(t *testing.T) {
-	r := NewRunner()
-	r.Run(1)
+	r := NewRunner(1)
 	c1 := TestCheck{}
 	c2 := TestCheck{doErr: true}
 
@@ -56,8 +39,7 @@ func TestWork(t *testing.T) {
 	r.Stop()
 
 	// fake a check is already running
-	r = NewRunner()
-	r.Run(1)
+	r = NewRunner(1)
 	c3 := new(TestCheck)
 	r.runningChecks[c3.String()] = c3
 	r.pending <- c3


### PR DESCRIPTION
### What does this PR do?
   
The 'GetChan' method return the pending queue (to initialize the
scheduler). Therefore the internal channel should initialize before
running the runner. NewRunner now return a valid runner.

### Motivation

No check where run anymore (except long running one).