### PR TITLE
Release lock if we skip a check

### DIFF
--- a/pkg/collector/check/runner.go
+++ b/pkg/collector/check/runner.go
@@ -82,6 +82,7 @@ func (r *Runner) work() {
 		r.m.Lock()
 		if _, isRunning := r.runningChecks[check.ID()]; isRunning {
 			log.Debugf("Check %s is already running, skip execution...", check)
+			r.m.Unlock()
 			continue
 		} else {
 			r.runningChecks[check.ID()] = check


### PR DESCRIPTION
### What does this PR do?

Release the runner lock if we skip a check (because it's already running).

### Motivation

We have a deadlock with multiple instances of the same check.
