### PR TITLE
[aggregator][check] Add histograms

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -1,5 +1,7 @@
 package aggregator
 
+import "time"
+
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
 	series          []*Serie
@@ -36,7 +38,7 @@ func (cs *CheckSampler) commit(timestamp int64) {
 		cs.series = append(cs.series, serie)
 	}
 
-	cs.contextResolver.expireContexts(timestamp - defaultExpirySeconds)
+	cs.contextResolver.expireContexts(timestamp - int64(defaultExpiry/time.Second))
 }
 
 func (cs *CheckSampler) flush() []*Serie {

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -50,7 +50,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 		Name:       "my.metric.name",
 		Tags:       []string{"foo", "bar"},
 		Points:     [][]interface{}{{int64(12349), mSample2.Value}},
-		Mtype:      "gauge",
+		MType:      APIGaugeType,
 		contextKey: generateContextKey(&mSample2),
 		nameSuffix: "",
 	}
@@ -59,7 +59,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 		Name:       "my.metric.name",
 		Tags:       []string{"foo", "bar", "baz"},
 		Points:     [][]interface{}{{int64(12349), mSample3.Value}},
-		Mtype:      "gauge",
+		MType:      APIGaugeType,
 		contextKey: generateContextKey(&mSample3),
 		nameSuffix: "",
 	}
@@ -113,7 +113,7 @@ func TestCheckRateSampling(t *testing.T) {
 		Name:       "my.metric.name",
 		Tags:       []string{"foo", "bar"},
 		Points:     [][]interface{}{{int64(12347), 0.5}},
-		Mtype:      "gauge",
+		MType:      APIGaugeType,
 		nameSuffix: "",
 	}
 

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -174,9 +174,8 @@ func (h *Histogram) flush(timestamp int64) ([]*Serie, error) {
 	}
 
 	if !h.configured {
-		// Set default aggregates if configure() hasn't been called
-		h.aggregates = []string{"max", "median", "avg", "count"}
-		h.percentiles = []int{95}
+		// Set default aggregates/percentiles if configure() hasn't been called beforehand
+		h.configure([]string{"max", "median", "avg", "count"}, []int{95})
 	}
 
 	sort.Float64s(h.samples)

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -8,6 +8,7 @@ const (
 	GaugeType MetricType = iota
 	RateType
 	CounterType
+	HistogramType
 )
 
 // MetricSample represents a raw metric sample

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -1,13 +1,13 @@
 package aggregator
 
-// MetricType is the representation of a dogstatsd metric type
-type MetricType string
+// MetricType is the representation of an aggregator metric type
+type MetricType int
 
-// metric type constants
+// metric type constants enumeration
 const (
-	GaugeType   MetricType = "g"
-	RateType    MetricType = "rate"
-	CounterType MetricType = "c"
+	GaugeType MetricType = iota
+	RateType
+	CounterType
 )
 
 // MetricSample represents a raw metric sample

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -1,15 +1,16 @@
 package aggregator
 
 import (
-
 	// stdlib
+	"math/rand"
 	"testing"
+	"time"
 
 	// 3p
 	"github.com/stretchr/testify/assert"
 )
 
-const epsilon = 0.1
+const epsilon = 0.01
 
 func TestGaugeSampling(t *testing.T) {
 	// Initialize a new Gauge
@@ -96,7 +97,7 @@ func TestRateSamplingNoSampleForOneFlush(t *testing.T) {
 }
 
 func TestDefaultHistogramSampling(t *testing.T) {
-	// Initialize histogram
+	// Initialize default histogram
 	mHistogram := Histogram{}
 
 	// Empty flush
@@ -113,7 +114,7 @@ func TestDefaultHistogramSampling(t *testing.T) {
 
 	series, err := mHistogram.flush(60)
 	assert.Nil(t, err)
-	if assert.Len(t, series, 4) {
+	if assert.Len(t, series, 5) {
 		for _, serie := range series {
 			assert.Len(t, serie.Points, 1)
 			assert.EqualValues(t, serie.Points[0][0], 60)
@@ -126,6 +127,8 @@ func TestDefaultHistogramSampling(t *testing.T) {
 		assert.Equal(t, ".avg", series[2].nameSuffix)                // avg
 		assert.InEpsilon(t, 6, series[3].Points[0][1], epsilon)      // count
 		assert.Equal(t, ".count", series[3].nameSuffix)              // count
+		assert.InEpsilon(t, 10, series[4].Points[0][1], epsilon)     // 0.95
+		assert.Equal(t, ".95percentile", series[4].nameSuffix)       // 0.95
 	}
 
 	_, err = mHistogram.flush(61)
@@ -135,7 +138,7 @@ func TestDefaultHistogramSampling(t *testing.T) {
 func TestCustomHistogramSampling(t *testing.T) {
 	// Initialize custom histogram
 	mHistogram := Histogram{}
-	mHistogram.configure([]string{"min", "sum"})
+	mHistogram.configure([]string{"min", "sum"}, []int{})
 
 	// Empty flush
 	_, err := mHistogram.flush(50)
@@ -160,6 +163,65 @@ func TestCustomHistogramSampling(t *testing.T) {
 		assert.Equal(t, ".min", series[0].nameSuffix)                      // min
 		assert.InEpsilon(t, 1+10+4+5+2+2, series[1].Points[0][1], epsilon) // sum
 		assert.Equal(t, ".sum", series[1].nameSuffix)                      // sum
+	}
+
+	_, err = mHistogram.flush(61)
+	assert.NotNil(t, err)
+}
+
+func shuffle(slice []float64) {
+	t := time.Now()
+	rand.Seed(int64(t.Nanosecond()))
+
+	for i := len(slice) - 1; i > 0; i-- {
+		j := rand.Intn(i)
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}
+
+func TestHistogramPercentiles(t *testing.T) {
+	// Initialize custom histogram
+	mHistogram := Histogram{}
+	mHistogram.configure([]string{"max", "median", "avg", "count", "min"}, []int{95, 80})
+
+	// Empty flush
+	_, err := mHistogram.flush(50)
+	assert.NotNil(t, err)
+
+	// Sample 20 times all numbers between 1 and 100.
+	// This means our percentiles should be relatively close to themselves.
+	percentiles := make([]float64, 0)
+	for i := 1; i <= 100; i++ {
+		percentiles = append(percentiles, float64(i))
+	}
+	shuffle(percentiles) // in place
+	for _, p := range percentiles {
+		for j := 0; j < 20; j++ {
+			mHistogram.addSample(p, 50)
+		}
+	}
+
+	series, err := mHistogram.flush(60)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 7) {
+		for _, serie := range series {
+			assert.Len(t, serie.Points, 1)
+			assert.EqualValues(t, serie.Points[0][0], 60)
+		}
+		assert.InEpsilon(t, 100, series[0].Points[0][1], epsilon)    // max
+		assert.Equal(t, ".max", series[0].nameSuffix)                // max
+		assert.InEpsilon(t, 50, series[1].Points[0][1], epsilon)     // median
+		assert.Equal(t, ".median", series[1].nameSuffix)             // median
+		assert.InEpsilon(t, 50, series[2].Points[0][1], epsilon)     // avg
+		assert.Equal(t, ".avg", series[2].nameSuffix)                // avg
+		assert.InEpsilon(t, 100*20, series[3].Points[0][1], epsilon) // count
+		assert.Equal(t, ".count", series[3].nameSuffix)              // count
+		assert.InEpsilon(t, 1, series[4].Points[0][1], epsilon)      // min
+		assert.Equal(t, ".min", series[4].nameSuffix)                // min
+		assert.InEpsilon(t, 95, series[5].Points[0][1], epsilon)     // 0.95
+		assert.Equal(t, ".95percentile", series[5].nameSuffix)       // 0.95
+		assert.InEpsilon(t, 80, series[6].Points[0][1], epsilon)     // 0.80
+		assert.Equal(t, ".80percentile", series[6].nameSuffix)       // 0.80
 	}
 
 	_, err = mHistogram.flush(61)

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -136,9 +136,9 @@ func TestDefaultHistogramSampling(t *testing.T) {
 }
 
 func TestCustomHistogramSampling(t *testing.T) {
-	// Initialize custom histogram
+	// Initialize custom histogram, with an invalid aggregate
 	mHistogram := Histogram{}
-	mHistogram.configure([]string{"min", "sum"}, []int{})
+	mHistogram.configure([]string{"min", "sum", "invalid"}, []int{})
 
 	// Empty flush
 	_, err := mHistogram.flush(50)
@@ -155,6 +155,7 @@ func TestCustomHistogramSampling(t *testing.T) {
 	series, err := mHistogram.flush(60)
 	assert.Nil(t, err)
 	if assert.Len(t, series, 2) {
+		// Only 2 series are returned (the invalid aggregate is ignored)
 		for _, serie := range series {
 			assert.Len(t, serie.Points, 1)
 			assert.EqualValues(t, serie.Points[0][0], 60)

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -14,7 +14,7 @@ func makeMetrics() Metrics {
 // SerieSignature holds the elements that allow to know whether two similar `Serie`s
 // from the same bucket can be merged into one
 type SerieSignature struct {
-	mType      string
+	mType      APIMetricType
 	contextKey string
 	nameSuffix string
 }
@@ -69,7 +69,7 @@ func (s *Sampler) flush(timestamp int64) []*Serie {
 
 		series := metrics.flush(timestamp)
 		for _, serie := range series {
-			serieSignature := SerieSignature{serie.Mtype, serie.contextKey, serie.nameSuffix}
+			serieSignature := SerieSignature{serie.MType, serie.contextKey, serie.nameSuffix}
 
 			if existingSerie, ok := serieBySignature[serieSignature]; ok {
 				existingSerie.Points = append(existingSerie.Points, serie.Points[0])

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -104,7 +104,7 @@ func (m Metrics) addSample(contextKey string, mType MetricType, value float64, t
 		case RateType:
 			m[contextKey] = &Rate{}
 		case HistogramType:
-			m[contextKey] = &Histogram{}
+			m[contextKey] = &Histogram{} // default histogram configuration for now
 		default:
 			log.Error("Can't add unknown sample metric type:", mType)
 			return

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -1,8 +1,12 @@
 package aggregator
 
-import log "github.com/cihub/seelog"
+import (
+	"time"
 
-const defaultExpirySeconds = 300 // duration in seconds after which contexts are expired
+	log "github.com/cihub/seelog"
+)
+
+const defaultExpiry = 300 * time.Second // duration after which contexts are expired
 
 // Metrics stores all the metrics by context key
 type Metrics map[string]Metric
@@ -90,7 +94,7 @@ func (s *Sampler) flush(timestamp int64) []*Serie {
 		delete(s.metricsByTimestamp, timestamp)
 	}
 
-	s.contextResolver.expireContexts(timestamp - defaultExpirySeconds)
+	s.contextResolver.expireContexts(timestamp - int64(defaultExpiry/time.Second))
 
 	return result
 }

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -166,9 +166,15 @@ func TestMetricsHistogramSampling(t *testing.T) {
 			Mtype:      "rate",
 			nameSuffix: ".count",
 		},
+		&Serie{
+			contextKey: contextKey,
+			Points:     [][]interface{}{{int64(12351), 6.}},
+			Mtype:      "gauge",
+			nameSuffix: ".95percentile",
+		},
 	}
 
-	if assert.Equal(t, 4, len(series)) {
+	if assert.Len(t, series, len(expectedSeries)) {
 		for i := range expectedSeries {
 			AssertSerieEqual(t, expectedSeries[i], series[i])
 		}

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -19,7 +19,7 @@ func AssertSerieEqual(t *testing.T, expected, actual *Serie) {
 	}
 	assert.Equal(t, expected.Host, actual.Host)
 	assert.Equal(t, expected.DeviceName, actual.DeviceName)
-	assert.Equal(t, expected.Mtype, actual.Mtype)
+	assert.Equal(t, expected.MType, actual.MType)
 	assert.Equal(t, expected.Interval, actual.Interval)
 	if expected.contextKey != "" {
 		// Only test the contextKey if it's set in the expected Serie
@@ -76,7 +76,7 @@ func TestMetricsGaugeSampling(t *testing.T) {
 	expectedSerie := &Serie{
 		contextKey: contextKey,
 		Points:     [][]interface{}{{int64(12345), mSample.Value}},
-		Mtype:      "gauge",
+		MType:      APIGaugeType,
 		nameSuffix: "",
 	}
 
@@ -122,7 +122,7 @@ func TestMetricsRateSampling(t *testing.T) {
 	expectedSerie := &Serie{
 		contextKey: contextKey,
 		Points:     [][]interface{}{{int64(12350), 1. / 10.}},
-		Mtype:      "gauge",
+		MType:      APIGaugeType,
 		nameSuffix: "",
 	}
 
@@ -145,31 +145,31 @@ func TestMetricsHistogramSampling(t *testing.T) {
 		&Serie{
 			contextKey: contextKey,
 			Points:     [][]interface{}{{int64(12351), 6.}},
-			Mtype:      "gauge",
+			MType:      APIGaugeType,
 			nameSuffix: ".max",
 		},
 		&Serie{
 			contextKey: contextKey,
 			Points:     [][]interface{}{{int64(12351), 1.}},
-			Mtype:      "gauge",
+			MType:      APIGaugeType,
 			nameSuffix: ".median",
 		},
 		&Serie{
 			contextKey: contextKey,
 			Points:     [][]interface{}{{int64(12351), 2.5}},
-			Mtype:      "gauge",
+			MType:      APIGaugeType,
 			nameSuffix: ".avg",
 		},
 		&Serie{
 			contextKey: contextKey,
 			Points:     [][]interface{}{{int64(12351), 4.}},
-			Mtype:      "rate",
+			MType:      APIRateType,
 			nameSuffix: ".count",
 		},
 		&Serie{
 			contextKey: contextKey,
 			Points:     [][]interface{}{{int64(12351), 6.}},
-			Mtype:      "gauge",
+			MType:      APIGaugeType,
 			nameSuffix: ".95percentile",
 		},
 	}
@@ -210,7 +210,7 @@ func TestBucketSampling(t *testing.T) {
 		Name:       "my.metric.name",
 		Tags:       []string{"foo", "bar"},
 		Points:     [][]interface{}{{int64(12340), mSample.Value}, {int64(12350), mSample.Value}},
-		Mtype:      "gauge",
+		MType:      APIGaugeType,
 		Interval:   10,
 		nameSuffix: "",
 	}
@@ -251,14 +251,14 @@ func TestContextSampling(t *testing.T) {
 		Name:     "my.metric.name1",
 		Points:   [][]interface{}{{int64(12340), float64(1)}},
 		Tags:     []string{"bar", "foo"},
-		Mtype:    "gauge",
+		MType:    APIGaugeType,
 		Interval: 10,
 	}
 	expectedSerie2 := &Serie{
 		Name:     "my.metric.name2",
 		Points:   [][]interface{}{{int64(12340), float64(1)}},
 		Tags:     []string{"bar", "foo"},
-		Mtype:    "gauge",
+		MType:    APIGaugeType,
 		Interval: 10,
 	}
 

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -80,38 +80,31 @@ func (s *checkSender) Commit() {
 	s.ssOut <- senderSample{s.id, &MetricSample{}, true}
 }
 
-// Gauge implements the Sender interface
-func (s *checkSender) Gauge(metric string, value float64, hostname string, tags []string) {
-	log.Debug("Gauge: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+func (s *checkSender) sendSample(metric string, value float64, hostname string, tags []string, mType MetricType, logMtype string) {
+	log.Debug(logMtype, " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
 	metricSample := &MetricSample{
 		Name:       metric,
 		Value:      value,
-		Mtype:      GaugeType,
+		Mtype:      mType,
 		Tags:       &tags,
 		SampleRate: 1,
 		Timestamp:  time.Now().Unix(),
 	}
 
 	s.ssOut <- senderSample{s.id, metricSample, false}
+}
+
+// Gauge implements the Sender interface
+func (s *checkSender) Gauge(metric string, value float64, hostname string, tags []string) {
+	s.sendSample(metric, value, hostname, tags, GaugeType, "Gauge")
 }
 
 // Rate implements the Sender interface
 func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
-	log.Debug("Rate: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
-	metricSample := &MetricSample{
-		Name:       metric,
-		Value:      value,
-		Mtype:      RateType,
-		Tags:       &tags,
-		SampleRate: 1,
-		Timestamp:  time.Now().Unix(),
-	}
-
-	s.ssOut <- senderSample{s.id, metricSample, false}
+	s.sendSample(metric, value, hostname, tags, RateType, "Rate")
 }
 
 // Histogram implements the Sender interface
 func (s *checkSender) Histogram(metric string, value float64, hostname string, tags []string) {
-	// TODO
-	log.Debug("Histogram: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+	s.sendSample(metric, value, hostname, tags, HistogramType, "Histogram")
 }

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -90,15 +90,23 @@ func TestSenderInterface(t *testing.T) {
 	checkSender := newCheckSender(checkID1, senderSampleChan)
 	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
+	checkSender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Commit()
 
 	gaugeSenderSample := <-senderSampleChan
 	assert.EqualValues(t, checkID1, gaugeSenderSample.id)
+	assert.Equal(t, GaugeType, gaugeSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, gaugeSenderSample.commit)
 
 	rateSenderSample := <-senderSampleChan
 	assert.EqualValues(t, checkID1, rateSenderSample.id)
+	assert.Equal(t, RateType, rateSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, rateSenderSample.commit)
+
+	histoSenderSample := <-senderSampleChan
+	assert.EqualValues(t, checkID1, histoSenderSample.id)
+	assert.Equal(t, HistogramType, histoSenderSample.metricSample.Mtype)
+	assert.Equal(t, false, histoSenderSample.commit)
 
 	commitSenderSample := <-senderSampleChan
 	assert.EqualValues(t, checkID1, commitSenderSample.id)


### PR DESCRIPTION
Part of #33

Adds support for histograms in the check's aggregator.

Also normalizes the `flush` of the different `Metric`s in the aggregator, now part of the `Metric` interface.

More details in the commit messages.
