### PR TITLE
[rake] `rake deps` should install locked deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ To build the project you need:
  We use `pkg-config` to make compilers and linkers aware of CPython. If you need to adjust the build for your specific configuration, add or edit the files within the `pkg-config` folder.
 
 ## Getting started
-Binary distributions are not provided yet, to try out the Agent you can build the `master` branch. Checkout the repo within your `GOPATH`, then install the project's dependencies:
-```
-rake deps
-```
+Binary distributions are not provided yet, to try out the Agent you can build the `master` branch:
+
+1. checkout the repo within your `GOPATH`
+2. install the project's dependencies: `rake deps`
+
+   Make sure that `GOPATH/bin` is in your `PATH` otherwise this step might fail. Alternatively  you can
+   install [glide](https://github.com/Masterminds/glide) manually on your system before running `rake deps`
+3. build the project: `rake build`
 
 Build and tests are orchestrated by a `Rakefile`, write `rake -T` on a shell to see the available tasks.
 If you're using the DogBox, ask `gimme` to provide a recent version of go, like:

--- a/README.md
+++ b/README.md
@@ -15,19 +15,9 @@ To build the project you need:
  We use `pkg-config` to make compilers and linkers aware of CPython. If you need to adjust the build for your specific configuration, add or edit the files within the `pkg-config` folder.
 
 ## Getting started
-Binary distributions are not provided yet, to try out the Agent you can build the `master` branch. Checkout the repo within your `GOPATH`, then install `glide`:
+Binary distributions are not provided yet, to try out the Agent you can build the `master` branch. Checkout the repo within your `GOPATH`, then install the project's dependencies:
 ```
-go get github.com/Masterminds/glide
-```
-
-Use `glide` to fetch project dependencies:
-```
-glide up
-```
-
-To run the test suite `golint` has to be available on your system, if it is not, just install it with:
-```
-go get -u github.com/golang/lint/golint
+rake deps
 ```
 
 Build and tests are orchestrated by a `Rakefile`, write `rake -T` on a shell to see the available tasks.

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ desc "Setup Go dependencies"
 task :deps do
   system("go get github.com/Masterminds/glide")
   system("go get -u github.com/golang/lint/golint")
-  system("glide up")
+  system("glide install")
 end
 
 desc "Run go fmt on #{TARGETS}"


### PR DESCRIPTION
Now that the `glide.lock` file is committed in the repo.
Also, updates the readme with a mention of the `rake deps` command.

We may want to add an option on `rake deps` to upgrade the deps, for instance for the CI on circleCI.