### PR TITLE
pick up default configuration files

### DIFF
--- a/pkg/collector/loader/file_provider.go
+++ b/pkg/collector/loader/file_provider.go
@@ -82,8 +82,7 @@ func (c *FileConfigProvider) Collect() ([]check.Config, error) {
 	// add all the default enabled checks unless another regular
 	// configuration file was already provided for the same check
 	for _, conf := range defaultConfigs {
-		_, isThere := configNames[conf.Name]
-		if !isThere {
+		if _, isThere := configNames[conf.Name]; !isThere {
 			configs = append(configs, conf)
 		}
 	}

--- a/pkg/collector/loader/file_provider_test.go
+++ b/pkg/collector/loader/file_provider_test.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,22 +50,24 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, 5, len(configs))
 
 	// count how many configs were found for a given check
-	count := func(name string) int {
-		i := 0
+	get := func(name string) []check.Config {
+		out := []check.Config{}
 		for _, c := range configs {
 			if c.Name == name {
-				i++
+				out = append(out, c)
 			}
 		}
-		return i
+		return out
 	}
 
 	// the regular config
-	assert.Equal(t, 3, count("testcheck"))
+	assert.Equal(t, 3, len(get("testcheck")))
 
 	// default configs must be picked up
-	assert.Equal(t, 1, count("bar"))
+	assert.Equal(t, 1, len(get("bar")))
 
 	// regular configs override default ones
-	assert.Equal(t, 1, count("foo"))
+	rc := get("foo")
+	assert.Equal(t, 1, len(rc))
+	assert.Contains(t, string(rc[0].InitConfig), "IsNotOnTheDefaultFile")
 }

--- a/pkg/collector/loader/file_provider_test.go
+++ b/pkg/collector/loader/file_provider_test.go
@@ -24,7 +24,6 @@ func TestGetCheckConfig(t *testing.T) {
 	config, err = getCheckConfig("foo", "tests/testcheck.yaml")
 	assert.Nil(t, err)
 	assert.Equal(t, config.Name, "foo")
-
 	assert.Equal(t, []byte(config.InitConfig), []byte("- test: 21\n"))
 	assert.Equal(t, len(config.Instances), 1)
 	assert.Equal(t, []byte(config.Instances[0]), []byte("foo: bar\n"))
@@ -46,9 +45,26 @@ func TestCollect(t *testing.T) {
 	configs, err := provider.Collect()
 
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(configs))
+	// total number of configurations found
+	assert.Equal(t, 5, len(configs))
 
-	for _, c := range configs {
-		assert.Equal(t, c.Name, "testcheck")
+	// count how many configs were found for a given check
+	count := func(name string) int {
+		i := 0
+		for _, c := range configs {
+			if c.Name == name {
+				i++
+			}
+		}
+		return i
 	}
+
+	// the regular config
+	assert.Equal(t, 3, count("testcheck"))
+
+	// default configs must be picked up
+	assert.Equal(t, 1, count("bar"))
+
+	// regular configs override default ones
+	assert.Equal(t, 1, count("foo"))
 }

--- a/pkg/collector/loader/tests/bar.yaml.default
+++ b/pkg/collector/loader/tests/bar.yaml.default
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar

--- a/pkg/collector/loader/tests/foo.yaml
+++ b/pkg/collector/loader/tests/foo.yaml
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar

--- a/pkg/collector/loader/tests/foo.yaml
+++ b/pkg/collector/loader/tests/foo.yaml
@@ -1,4 +1,5 @@
 init_config:
+  - this: IsNotOnTheDefaultFile
 
 instances:
   # No configuration is needed for this check.

--- a/pkg/collector/loader/tests/foo.yaml.default
+++ b/pkg/collector/loader/tests/foo.yaml.default
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: baz


### PR DESCRIPTION
### What does this PR do?

Pick up `check.yaml.default` config files but let regular `check.yaml` files override them

