### PR TITLE
let define the path to conf.d through the command line

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -25,6 +25,7 @@ var (
 	// flags variables
 	runForeground bool
 	pidfilePath   string
+	confdPath     string
 
 	startCmd = &cobra.Command{
 		Use:   "start",
@@ -41,6 +42,7 @@ func init() {
 	// local flags
 	startCmd.Flags().BoolVarP(&runForeground, "foreground", "f", false, "run in foreground")
 	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
+	startCmd.Flags().StringVarP(&confdPath, "confd", "c", "", "path to the confd folder")
 }
 
 // runBackground spawns a child so that the main process can exit.
@@ -87,7 +89,7 @@ func start(cmd *cobra.Command, args []string) {
 
 	// Get a list of config checks from the configured providers
 	var configs []check.Config
-	for _, provider := range common.GetConfigProviders() {
+	for _, provider := range common.GetConfigProviders(confdPath) {
 		c, _ := provider.Collect()
 		configs = append(configs, c...)
 	}

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -1,6 +1,4 @@
 package common
 
-var configPaths = []string{
-	"/opt/datadog-agent/etc",
-	DistPath,
-}
+const defaultConfPath = "/opt/datadog-agent/etc"
+const defaultConfdPath = "/opt/datadog-agent/etc/conf.d"

--- a/cmd/agent/common/common_linux.go
+++ b/cmd/agent/common/common_linux.go
@@ -1,6 +1,4 @@
 package common
 
-var configPaths = []string{
-	"/etc/dd-agent",
-	DistPath,
-}
+const defaultConfPath = "/etc/dd-agent"
+const defaultConfdPath = "/etc/dd-agent/conf.d"

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -1,6 +1,5 @@
 package common
 
 // BUG(massi): which is the final destination of the DIST folder on Windows?
-var configPaths = []string{
-	DistPath,
-}
+const defaultConfPath = ""
+const defaultConfdPath = ""

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -12,10 +12,14 @@ import (
 
 // GetConfigProviders builds a list of providers for checks' configurations, the sequence defines
 // the precedence.
-func GetConfigProviders() (providers []loader.ConfigProvider) {
-	confSearchPaths := []string{}
-	for _, path := range configPaths {
-		confSearchPaths = append(confSearchPaths, filepath.Join(path, "conf.d"))
+func GetConfigProviders(confdPath string) (providers []loader.ConfigProvider) {
+	if confdPath == "" {
+		confdPath = defaultConfdPath
+	}
+
+	confSearchPaths := []string{
+		confdPath,
+		filepath.Join(DistPath, "conf.d"),
 	}
 
 	// File Provider
@@ -35,9 +39,8 @@ func GetCheckLoaders() []loader.CheckLoader {
 // SetupConfig fires up the configuration system
 func SetupConfig() {
 	// set the paths where a config file is expected
-	for _, path := range configPaths {
-		config.Datadog.AddConfigPath(path)
-	}
+	config.Datadog.AddConfigPath(defaultConfPath)
+	config.Datadog.AddConfigPath(DistPath)
 
 	// load the configuration
 	err := config.Datadog.ReadInConfig()


### PR DESCRIPTION
### What does this PR do?

Use the command line to pass the path to the `conf.d` folder, default remains the same

### Motivation

This way we can have a completely different set of configuration files for both agent 5 and 6 on the same host.