### PR TITLE
configure conf.d from datadog.yaml

### DIFF
--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -1,4 +1,3 @@
 package common
 
 const defaultConfPath = "/opt/datadog-agent/etc"
-const defaultConfdPath = "/opt/datadog-agent/etc/conf.d"

--- a/cmd/agent/common/common_linux.go
+++ b/cmd/agent/common/common_linux.go
@@ -1,4 +1,3 @@
 package common
 
 const defaultConfPath = "/etc/dd-agent"
-const defaultConfdPath = "/etc/dd-agent/conf.d"

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -13,10 +13,6 @@ import (
 // GetConfigProviders builds a list of providers for checks' configurations, the sequence defines
 // the precedence.
 func GetConfigProviders(confdPath string) (providers []loader.ConfigProvider) {
-	if confdPath == "" {
-		confdPath = defaultConfdPath
-	}
-
 	confSearchPaths := []string{
 		confdPath,
 		filepath.Join(DistPath, "conf.d"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ func init() {
 	// configuration defaults
 	Datadog.SetDefault("dd_url", "http://localhost:17123")
 	Datadog.SetDefault("hostname", "")
+	Datadog.SetDefault("confd_path", defaultConfdPath)
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -1,0 +1,3 @@
+package config
+
+const defaultConfdPath = "/opt/datadog-agent/etc/conf.d"

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,0 +1,3 @@
+package config
+
+const defaultConfdPath = "/etc/dd-agent/conf.d"

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,4 +1,4 @@
-package common
+package config
 
 // BUG(massi): which is the final destination of the DIST folder on Windows?
-const defaultConfPath = ""
+const defaultConfdPath = ""


### PR DESCRIPTION
### What does this PR do?

configure the path to `conf.d` through either the command line or the `datadog.yaml` file

