### PR TITLE
Agent hostname detection

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -82,6 +82,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
+	log.Infof("Hostname is: %s", common.GetHostname())
 
 	// start the cmd HTTP server
 	api.StartServer()

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -2,12 +2,19 @@ package common
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check/core"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
 	"github.com/DataDog/datadog-agent/pkg/collector/loader"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"github.com/DataDog/datadog-agent/pkg/util/gce"
+	log "github.com/cihub/seelog"
 )
 
 // GetConfigProviders builds a list of providers for checks' configurations, the sequence defines
@@ -47,4 +54,82 @@ func SetupConfig() {
 	// define defaults for the Agent
 	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	config.Datadog.BindEnv("cmd_sock")
+}
+
+// GetHostname retrieve the host name for the Agent, trying to query these
+// environments/api, in order:
+// * GCE
+// * Docker
+// * kubernetes
+// * os
+// * EC2
+func GetHostname() string {
+	var hostName string
+
+	// try the name provided in the configuration file
+	name := config.Datadog.GetString("hostname")
+	err := util.ValidHostname(name)
+	if err == nil {
+		return name
+	}
+
+	log.Warnf("unable to get the hostname from the config file: %s", err)
+	log.Warn("trying to determine a reliable host name automatically...")
+
+	// GCE metadata
+	log.Debug("GetHostname trying GCE metadata...")
+	name, err = gce.GetHostname()
+	if err == nil {
+		return name
+	}
+
+	if isContainerized() {
+		// Docker
+		log.Debug("GetHostname trying Docker API...")
+		name, err = docker.GetHostname()
+		if err == nil && util.ValidHostname(name) == nil {
+			hostName = name
+		} else if isKubernetes() {
+			log.Debug("GetHostname trying k8s...")
+			// TODO
+		}
+	}
+
+	if hostName == "" {
+		// os
+		log.Debug("GetHostname trying os...")
+		name, err = os.Hostname()
+		if err == nil {
+			hostName = name
+		}
+	}
+
+	/* at this point we've either the hostname from the os or an empty string */
+
+	// We use the instance id if we're on an ECS cluster or we're on EC2
+	// and the hostname is one of the default ones
+	if ecs.IsInstance() || ec2.IsDefaultHostname(hostName) {
+		log.Debug("GetHostname trying EC2 metadata...")
+		instanceID, err := ec2.GetInstanceID()
+		if err == nil {
+			hostName = instanceID
+		}
+	}
+
+	// If at this point we don't have a name, bail out
+	if hostName == "" {
+		panic(fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file"))
+	}
+
+	return hostName
+}
+
+// IsContainerized returns whether the Agent is running on a Docker container
+func isContainerized() bool {
+	return os.Getenv("DOCKER_DD_AGENT") == "yes"
+}
+
+// IsKubernetes returns whether the Agent is running on a kubernetes cluster
+func isKubernetes() bool {
+	return os.Getenv("KUBERNETES_PORT") != ""
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,44 @@
-hash: c3511ba338bcdec8d3a72d5ff8fa2113b506549e39a8e2c8688babd29fd612d9
-updated: 2017-01-02T11:51:34.405512963+01:00
+hash: ffe4c03c2ce064b7a045ae1ca19bc038190759b7caea4e1989e43e5330f27a2d
+updated: 2017-02-06T12:08:02.903400978+01:00
 imports:
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
 - name: github.com/DataDog/datadog-go
-  version: 6ea09a7540648568ce58b3d00eb1da133c2dcdd7
+  version: 6fa3e39b86f8cbb638a971f2a90b9ebd98074c6b
   subpackages:
   - statsd
-- name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+- name: github.com/docker/distribution
+  version: fb0bebc4b64e3881cc52a2478d749845ed76d2a8
   subpackages:
-  - spew
+  - reference
+  - digestset
+- name: github.com/docker/docker
+  version: 2527cfcc49744f56a8d31c420a3ca4657f9fec2e
+  subpackages:
+  - client
+  - api/types
+  - api/types/container
+  - api/types/events
+  - api/types/filters
+  - api/types/network
+  - api/types/reference
+  - api/types/registry
+  - api/types/swarm
+  - api/types/time
+  - api/types/versions
+  - api/types/volume
+  - pkg/tlsconfig
+  - api/types/mount
+  - api/types/blkiodev
+  - api/types/strslice
+- name: github.com/docker/go-connections
+  version: 7da10c8c50cad14494ec818dcdfb6506265c0086
+  subpackages:
+  - sockets
+  - tlsconfig
+  - nat
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/go-ole/go-ole
@@ -20,9 +48,9 @@ imports:
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
-  version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
+  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/hashicorp/hcl
-  version: 80e628d796135357b3d2e33a985c666b9f35eee1
+  version: 372e8ddaa16fd67e371e9323807d056b799360af
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -37,63 +65,82 @@ imports:
 - name: github.com/kardianos/osext
   version: c2c54e542fb797ad986b31721e1baedf214ca413
 - name: github.com/magiconair/properties
-  version: 9c47895dc1ce54302908ab8a43385d1f5df2c11c
+  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
+- name: github.com/Microsoft/go-winio
+  version: fff283ad5116362ca252298cfc9b95828956d85d
 - name: github.com/mitchellh/mapstructure
-  version: bfdb1a85537d60bc7e954e600c250219ea497417
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/mitchellh/reflectwalk
-  version: 9ad27c461a633e32a235a061d523aefe8f18571d
+  version: 417edcfd99a4d472c262e58f22b4bfe97580f03e
+- name: github.com/opencontainers/go-digest
+  version: aa2ec055abd10d26d539eb630a92241b781ce4bc
 - name: github.com/PagerDuty/godspeed
   version: 6d136386b5f291797c77764dfd2acc950dc27347
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: 439fbba1f887c286024370cb4f281ba815c4c7d7
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
+  version: d1fa2118c12c44e4f5004da216d1efad10cb4924
+- name: github.com/pkg/errors
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/sbinet/go-python
-  version: ac4579f132fff506b2f6b3eda4c9282b4be59a08
+  version: a2acb64fbdf8703949837e5ebf50c71319fe03a4
 - name: github.com/shirou/gopsutil
-  version: 93564b314264efac01934715fad4c355ed6af1c5
+  version: 32b6636de04b303274daac3ca2b10d3b0e4afc35
   subpackages:
   - mem
   - cpu
   - internal/common
+- name: github.com/Sirupsen/logrus
+  version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
 - name: github.com/spf13/afero
-  version: 90dd71edc4d0a8b3511dc12ea15d617d03be09e0
+  version: 72b31426848c6ef12a7a8e216708cb0d1530f074
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: 56a7ecbeb18dde53c6db4bd96b541fd9741b8d44
+  version: d1139bab1c07d5ad390a65e7305876b3c1a8370b
 - name: github.com/spf13/cobra
-  version: 1dd5ff2e11b6dca62fdcb275eb804b94607d8b06
+  version: 35136c09d8da66b901337c6e86fd8e88a1a255bd
   subpackages:
   - cobra
 - name: github.com/spf13/jwalterweatherman
-  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
 - name: github.com/spf13/pflag
-  version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/spf13/viper
   version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
 - name: github.com/StackExchange/wmi
   version: e54cbda6595d7293a7a468ccf9525f6bc8887f99
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - mock
+- name: golang.org/x/net
+  version: 236b8f043b920452504e263bc21d354427127473
+  subpackages:
+  - context
+  - context/ctxhttp
+  - proxy
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: 7a6e5648d140666db5d920909e082ca00a87ba2c
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
-  version: fd889fe3a20f4878f5f47672fd3ca5b86db005e2
+  version: 506f9d5c962f284575e88337e7d9296d27e729d3
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
-testImports: []
+  version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,3 +24,7 @@ import:
   version: ^1.1.0
 - package: github.com/gorilla/context
   version: ^1.1.0
+- package: github.com/docker/docker
+  version: ^1.13.1-rc1
+  subpackages:
+  - client

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -1,0 +1,23 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/client"
+)
+
+// GetHostname queries Docker for the host name
+func GetHostname() (string, error) {
+	client, err := client.NewEnvClient()
+	if err != nil {
+		return "", err
+	}
+
+	info, err := client.Info(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("unable to get Docker info: %s", err)
+	}
+
+	return info.Name, nil
+}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -1,0 +1,61 @@
+package ec2
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	metadataURL               = "http://169.254.169.254/latest/meta-data/"
+	timeout     time.Duration = 100 * time.Millisecond
+)
+
+var (
+	defaultPrefixes = []string{"ip-", "domu"}
+)
+
+// GetInstanceID returns the EC2 instance id for this host
+func GetInstanceID() (string, error) {
+	return getInstanceID(metadataURL + "instance-id")
+}
+
+func getInstanceID(url string) (string, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return "", fmt.Errorf("status code %d trying to fetch %s", res.StatusCode, url)
+	}
+
+	responseData, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response body, %s", err)
+	}
+
+	return string(responseData), nil
+}
+
+// IsDefaultHostname returns whether the given hostname is a default one for EC2
+func IsDefaultHostname(hostname string) bool {
+	hostname = strings.ToLower(hostname)
+	isDefault := false
+	for _, val := range defaultPrefixes {
+		isDefault = isDefault || strings.HasPrefix(hostname, val)
+	}
+	return isDefault
+}

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -1,0 +1,30 @@
+package ec2
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var ecdInstanceString = "i-0123456789abcdef0"
+
+func TestIsDefaultHostname(t *testing.T) {
+	assert.True(t, IsDefaultHostname("IP-FOO"))
+	assert.True(t, IsDefaultHostname("domuarigato"))
+	assert.False(t, IsDefaultHostname(""))
+}
+
+func TestGetInstanceID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, ecdInstanceString)
+	}))
+	defer ts.Close()
+
+	val, err := getInstanceID(ts.URL)
+	assert.Nil(t, err)
+	assert.Equal(t, ecdInstanceString, val)
+}

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -1,0 +1,7 @@
+package ecs
+
+// IsInstance returns whether this host is part of an ECS cluster
+// BUG(massi) TODO
+func IsInstance() bool {
+	return false
+}

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -7,39 +7,47 @@ import (
 	"time"
 )
 
-const (
-	metadataURL               = "http://169.254.169.254/computeMetadata/v1/"
-	timeout     time.Duration = 300 * time.Millisecond
+// declare these as vars not const to ease testing
+var (
+	metadataURL = "http://169.254.169.254/computeMetadata/v1"
+	timeout     = 300 * time.Millisecond
 )
 
 // GetHostname returns the hostname querying GCE Metadata api
 func GetHostname() (string, error) {
-	client := http.Client{
-		Timeout: timeout,
-	}
-
-	url := metadataURL + "instance/hostname"
-
-	req, err := http.NewRequest("GET", url, nil)
+	res, err := getResponse(metadataURL + "/instance/hostname")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
 	}
 
-	req.Header.Add("Metadata-Flavor", "Google")
-	res, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
 	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return "", fmt.Errorf("GCE hostname, status code %d trying to GET %s", res.StatusCode, url)
-	}
-
 	all, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("GCE hostname, error reading response body: %s", err)
 	}
 
 	return string(all), nil
+}
+
+func getResponse(url string) (*http.Response, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
+	}
+
+	return res, nil
 }

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -1,8 +1,8 @@
 package gce
 
 import (
-	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 )
@@ -12,50 +12,34 @@ const (
 	timeout     time.Duration = 300 * time.Millisecond
 )
 
-type metadata struct {
-	instance struct {
-		hostname string
-	}
-}
-
 // GetHostname returns the hostname querying GCE Metadata api
 func GetHostname() (string, error) {
-	md, err := getMetadata()
-	if err != nil {
-		return "", fmt.Errorf("error fetching GCE hostname, %s", err)
-	}
-	return md.instance.hostname, nil
-}
-
-func getMetadata() (*metadata, error) {
 	client := http.Client{
 		Timeout: timeout,
 	}
 
-	url := metadataURL + "?recursive=true"
+	url := metadataURL + "instance/hostname"
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	req.Header.Add("Metadata-Flavor", "Google")
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
 	defer res.Body.Close()
+
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("status code %d trying to fetch %s", res.StatusCode, url)
+		return "", fmt.Errorf("GCE hostname, status code %d trying to GET %s", res.StatusCode, url)
 	}
 
-	decoder := json.NewDecoder(res.Body)
-	var md metadata
-	err = decoder.Decode(&md)
+	all, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal metadata, %s", err)
+		return "", fmt.Errorf("GCE hostname, error reading response body: %s", err)
 	}
 
-	return &md, nil
+	return string(all), nil
 }

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -1,0 +1,61 @@
+package gce
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	metadataURL               = "http://169.254.169.254/computeMetadata/v1/"
+	timeout     time.Duration = 300 * time.Millisecond
+)
+
+type metadata struct {
+	instance struct {
+		hostname string
+	}
+}
+
+// GetHostname returns the hostname querying GCE Metadata api
+func GetHostname() (string, error) {
+	md, err := getMetadata()
+	if err != nil {
+		return "", fmt.Errorf("error fetching GCE hostname, %s", err)
+	}
+	return md.instance.hostname, nil
+}
+
+func getMetadata() (*metadata, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	url := metadataURL + "?recursive=true"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("status code %d trying to fetch %s", res.StatusCode, url)
+	}
+
+	decoder := json.NewDecoder(res.Body)
+	var md metadata
+	err = decoder.Decode(&md)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal metadata, %s", err)
+	}
+
+	return &md, nil
+}

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -1,4 +1,4 @@
-package ec2
+package gce
 
 import (
 	"io"
@@ -9,14 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsDefaultHostname(t *testing.T) {
-	assert.True(t, IsDefaultHostname("IP-FOO"))
-	assert.True(t, IsDefaultHostname("domuarigato"))
-	assert.False(t, IsDefaultHostname(""))
-}
-
-func TestGetInstanceID(t *testing.T) {
-	expected := "i-0123456789abcdef0"
+func TestGetHostname(t *testing.T) {
+	expected := "gke-cluster-massi-agent59-default-pool-6087cc76-9cfa"
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -26,8 +20,8 @@ func TestGetInstanceID(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	val, err := GetInstanceID()
+	val, err := GetHostname()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, val)
-	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
+	assert.Equal(t, lastRequest.URL.Path, "/instance/hostname")
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const maxLength = 255
+
+var (
+	validHostnameRfc1123 = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+	localhostIdentifiers = []string{
+		"localhost",
+		"localhost.localdomain",
+		"localhost6.localdomain6",
+		"ip6-localhost",
+	}
+)
+
+// ValidHostname determines whether the passed string is a valid hostname.
+// In case it's not, the returned error contains the details of the failure.
+func ValidHostname(hostname string) error {
+	if hostname == "" {
+		return fmt.Errorf("host name is empty")
+	} else if isLocal(hostname) {
+		return fmt.Errorf("%s is a local hostname", hostname)
+	} else if len(hostname) > maxLength {
+		return fmt.Errorf("name exceeded the maximum length of %d characters", maxLength)
+	} else if !validHostnameRfc1123.MatchString(hostname) {
+		return fmt.Errorf("%s is not RFC1123 compliant", hostname)
+	}
+	return nil
+}
+
+// check whether the name is in the list of local hostnames
+func isLocal(name string) bool {
+	name = strings.ToLower(name)
+	for _, val := range localhostIdentifiers {
+		if val == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/hostname_test.go
+++ b/pkg/util/hostname_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLocal(t *testing.T) {
+	assert.False(t, isLocal("datadoghq.com"))
+	assert.True(t, isLocal("LOCALHOST"))
+	assert.True(t, isLocal("localhost.localdomain"))
+	assert.True(t, isLocal("localhost6.localdomain6"))
+	assert.True(t, isLocal("ip6-localhost"))
+}
+
+func TestValidHostname(t *testing.T) {
+	var err error
+	err = ValidHostname("")
+	assert.NotNil(t, err)
+	err = ValidHostname("localhost")
+	assert.NotNil(t, err)
+	err = ValidHostname(strings.Repeat("a", 256))
+	assert.NotNil(t, err)
+	err = ValidHostname("data🐕hq.com")
+	assert.NotNil(t, err)
+}

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1,0 +1,11 @@
+package k8s
+
+import "fmt"
+
+// GetNodeInfo returns the IP address and the hostname of the node where
+// this pod is running.
+// TODO: see https://github.com/kubernetes/client-go for the client
+func GetNodeInfo() (ip, name string, err error) {
+	err = fmt.Errorf("Not yet implemented")
+	return
+}


### PR DESCRIPTION
### What does this PR do?

This is a porting from the old agent of the logic used to determine the host name.

### Additional Notes

Changes were splitted between "general purpose" functionalities that might be useful to other `cmd`s than the agent (dogstatsd, dogstream, ...) and more specific stuff. 

A `util` package was added to implement the former while specific logic for the agent use case is in the `cmd/agent/common` package.
Getting the host name from kubernetes requires a lot of code so for now there's only a stub that will be filled in a subsequent PR.