### PR TITLE
[forwarder] Add API keys to HTTP header

### DIFF
--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -16,7 +16,7 @@ type HTTPTransaction struct {
 	// Endpoint is the API Endpoint used by the HTTPTransaction.
 	Endpoint string
 	// Headers are the HTTP headers used by the HTTPTransaction.
-	Headers map[string][]string
+	Headers http.Header
 	// Payload is the content delivered to the backend.
 	Payload *[]byte
 	// ErrorCount is the number of times this HTTPTransaction failed to be processed.
@@ -37,6 +37,7 @@ func NewHTTPTransaction() *HTTPTransaction {
 		nextFlush:  time.Now(),
 		createdAt:  time.Now(),
 		ErrorCount: 0,
+		Headers:    make(http.Header),
 	}
 }
 
@@ -67,7 +68,7 @@ func (t *HTTPTransaction) Process(client *http.Client) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 400 || resp.StatusCode == 413 {
-		log.Error("Error code '%s' receive while sending transaction to '%s' (dropping it)", resp.Status, t.Domain+t.Endpoint)
+		log.Errorf("Error code '%s' received while sending transaction to '%s' (dropping it)", resp.Status, t.Domain+t.Endpoint)
 	} else if resp.StatusCode > 400 {
 		t.ErrorCount++
 		return fmt.Errorf("Error '%s' while sending transaction, rescheduling it", resp.Status)


### PR DESCRIPTION

### What does this PR do?

The forwarder now receive a list of API keys per domain. One transaction is created per API key. The Api key is sent using a custom HTTP header.