### PR TITLE
[core] Use check `ID` type instead of `string` for stats struct/map

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -36,7 +36,7 @@ type Check interface {
 // Stats holds basic runtime statistics about check instances
 type Stats struct {
 	CheckName         string
-	CheckID           string
+	CheckID           ID
 	TotalRuns         uint64
 	TotalErrors       uint64
 	ExecutionTimes    [32]int64 // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]

--- a/pkg/collector/check/runner.go
+++ b/pkg/collector/check/runner.go
@@ -13,14 +13,14 @@ const stopCheckTimeoutMs = 500 // Time to wait for a check to stop in millisecon
 
 var (
 	runnerStats *expvar.Map
-	checkStats  map[string]*Stats
+	checkStats  map[ID]*Stats
 	checkStatsM sync.RWMutex
 )
 
 func init() {
 	runnerStats = expvar.NewMap("runner")
 	runnerStats.Set("Checks", expvar.Func(expCheckStats))
-	checkStats = make(map[string]*Stats)
+	checkStats = make(map[ID]*Stats)
 }
 
 // Runner ...


### PR DESCRIPTION
Fixes the tests (wasn't caught on the PR because the tests ran before the PR that added `Stats` - #134 was merged)