### PR TITLE
The Collector™

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	log "github.com/cihub/seelog"
@@ -94,19 +93,6 @@ func start(cmd *cobra.Command, args []string) {
 		c, _ := provider.Collect()
 		configs = append(configs, c...)
 	}
-
-	// for now we handle only one key and one domain
-	keysPerDomain := map[string][]string{
-		config.Datadog.GetString("dd_url"): {
-			config.Datadog.GetString("api_key"),
-		},
-	}
-
-	f := forwarder.NewForwarder(keysPerDomain)
-	f.Start()
-
-	// Instance the Aggregator
-	_ = aggregator.InitAggregator(f)
 
 	// given a list of configurations, try to load corresponding checks using different loaders
 	// TODO add check type to the conf file so that we avoid the inner for

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -1,25 +1,22 @@
 package app
 
 import (
+	"path/filepath"
 	"syscall"
 
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
-	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	log "github.com/cihub/seelog"
-	python "github.com/sbinet/go-python"
 	"github.com/spf13/cobra"
 )
 
@@ -88,8 +85,8 @@ func start(cmd *cobra.Command, args []string) {
 	// start the cmd HTTP server
 	api.StartServer()
 
-	// Initialize the CPython interpreter
-	state := py.Initialize(common.DistPath, filepath.Join(common.DistPath, "checks"))
+	// create the Collector instance
+	common.Collector = collector.NewCollector()
 
 	// Get a list of config checks from the configured providers
 	var configs []check.Config
@@ -97,12 +94,6 @@ func start(cmd *cobra.Command, args []string) {
 		c, _ := provider.Collect()
 		configs = append(configs, c...)
 	}
-
-	// Get a Runner instance
-	common.AgentRunner = check.NewRunner(config.Datadog.GetInt("check_runners"))
-
-	// Instance the scheduler
-	common.AgentScheduler = scheduler.NewScheduler(common.AgentRunner.GetChan())
 
 	// for now we handle only one key and one domain
 	keysPerDomain := map[string][]string{
@@ -125,14 +116,15 @@ func start(cmd *cobra.Command, args []string) {
 			res, err := loader.Load(conf)
 			if err == nil {
 				for _, check := range res {
-					common.AgentScheduler.Enter(check)
+					common.Collector.RunCheck(check)
 				}
 			}
 		}
 	}
 
-	// Run the scheduler
-	common.AgentScheduler.Run()
+	// Start collecting metrics
+	// this will also setup the Python environment
+	common.Collector.Start(common.DistPath, filepath.Join(common.DistPath, "checks"))
 
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
@@ -152,10 +144,7 @@ func start(cmd *cobra.Command, args []string) {
 
 teardown:
 	// gracefully shut down any component
-	common.AgentRunner.Stop()
-	common.AgentScheduler.Stop()
-	f.Stop()
-	python.PyEval_RestoreThread(state)
+	common.Collector.Stop()
 	api.StopServer()
 	os.Remove(pidfilePath)
 	log.Info("See ya!")

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -5,20 +5,15 @@ package common
 import (
 	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/kardianos/osext"
 )
 
 var (
+	// Collector is the global object orchestrating check runs
+	Collector *collector.Collector
 	// Stopper is the channel used by other packages to ask for stopping the agent
 	Stopper = make(chan bool)
-
-	// AgentRunner is the current global checks Runner
-	AgentRunner *check.Runner
-
-	// AgentScheduler is the current global Scheduler
-	AgentScheduler *scheduler.Scheduler
 
 	// utility variables
 	_here, _ = osext.ExecutableFolder()

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -24,13 +24,13 @@ type Config struct {
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                                             // run the check
-	Stop()                                                  // stop the check if it's running
-	String() string                                         // provide a printable version of the check name
-	Configure(data ConfigData, initConfig ConfigData) error // configure the check from the outside
-	InitSender()                                            // initialize what's needed to send data to the aggregator
-	Interval() time.Duration                                // return the interval time for the check
-	ID() ID                                                 // provide a unique identifier for every check instance
+	Run() error                                    // run the check
+	Stop()                                         // stop the check if it's running
+	String() string                                // provide a printable version of the check name
+	Configure(config, initConfig ConfigData) error // configure the check from the outside
+	InitSender()                                   // initialize what's needed to send data to the aggregator
+	Interval() time.Duration                       // return the interval time for the check
+	ID() ID                                        // provide a unique identifier for every check instance
 }
 
 // Stats holds basic runtime statistics about check instances

--- a/pkg/collector/check/runner_test.go
+++ b/pkg/collector/check/runner_test.go
@@ -59,19 +59,16 @@ func (tc *TimingoutCheck) Stop() {
 
 func TestStopCheck(t *testing.T) {
 	r := NewRunner(1)
-	ok, err := r.StopCheck("")
-	assert.False(t, ok)
+	err := r.StopCheck("foo")
 	assert.Nil(t, err)
 
 	c1 := &TestCheck{}
 	r.runningChecks[c1.ID()] = c1
-	ok, err = r.StopCheck(c1.ID())
-	assert.True(t, ok)
+	err = r.StopCheck(c1.ID())
 	assert.Nil(t, err)
 
 	c2 := &TimingoutCheck{}
 	r.runningChecks[c2.ID()] = c2
-	ok, err = r.StopCheck(c2.ID())
-	assert.False(t, ok)
-	assert.NotNil(t, err)
+	err = r.StopCheck(c2.ID())
+	assert.Equal(t, "timeout during stop operation on check id TestCheck", err.Error())
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,0 +1,195 @@
+package collector
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
+	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	python "github.com/sbinet/go-python"
+)
+
+const (
+	// NumRunnerWorkers is the number of workers the Runner should spawn
+	NumRunnerWorkers = 4
+)
+
+const (
+	stopped uint32 = iota
+	started
+)
+
+// Collector abstract common operations about running a Check
+type Collector struct {
+	scheduler  *scheduler.Scheduler
+	runner     *check.Runner
+	aggregator *aggregator.BufferedAggregator
+	pyState    *python.PyThreadState
+	checks     map[check.ID]check.Check
+	state      uint32
+	m          sync.RWMutex
+}
+
+// NewCollector create a Collector instance and sets up the Python Environment
+func NewCollector() *Collector {
+	return &Collector{
+		checks: make(map[check.ID]check.Check),
+		state:  stopped,
+	}
+}
+
+// Start begins the loop finalized to run Checks
+func (c *Collector) Start(paths ...string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.state == started {
+		return
+	}
+
+	runner := check.NewRunner(NumRunnerWorkers)
+	c.scheduler = scheduler.NewScheduler(runner.GetChan())
+	c.runner = runner
+	c.pyState = py.Initialize(paths...)
+	c.aggregator = aggregator.GetAggregator()
+
+	c.scheduler.Run()
+	c.state = started
+}
+
+// Stop halts any component involved in running a Check and shuts down
+// the Python Environment
+func (c *Collector) Stop() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.state == stopped {
+		return
+	}
+
+	c.runner.Stop()
+	c.runner = nil
+	c.scheduler.Stop()
+	c.scheduler = nil
+	python.PyEval_RestoreThread(c.pyState)
+	c.pyState = nil
+	// aggregator has no stop/shutdown function
+	c.aggregator = nil
+	c.state = stopped
+}
+
+// RunCheck sends a Check in the execution queue
+func (c *Collector) RunCheck(check check.Check) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if c.state != started {
+		return fmt.Errorf("the collector is not running")
+	}
+
+	if _, found := c.checks[check.ID()]; found {
+		return fmt.Errorf("a check with ID %s is already running", check.ID())
+	}
+
+	err := c.scheduler.Enter(check)
+	if err != nil {
+		return fmt.Errorf("unable to schedule the check for running: %s", err)
+	}
+
+	c.checks[check.ID()] = check
+	return nil
+}
+
+// ReloadCheck stops and restart a check with a new configuration
+func (c *Collector) ReloadCheck(id check.ID, config, initConfig check.ConfigData) error {
+	if !c.started() {
+		return fmt.Errorf("the collector is not running")
+	}
+
+	// do we know this check instance?
+	// BUG(massi): we could create the Check if it doesn't exist, see https://github.com/DataDog/datadog-agent/pull/148
+	// for reference
+	if !c.find(id) {
+		return fmt.Errorf("cannot find a check with ID %s", id)
+	}
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	// re-configure
+	check := c.checks[id]
+	err := check.Configure(config, initConfig)
+	if err != nil {
+		return fmt.Errorf("error configuring the check with ID %s", id)
+	}
+
+	// unschedule the instance
+	err = c.scheduler.Cancel(id)
+	if err != nil {
+		return fmt.Errorf("an error occurred while cancelling the check schedule: %s", err)
+	}
+
+	// stop the instance
+	err = c.runner.StopCheck(id)
+	if err != nil {
+		return fmt.Errorf("an error occurred while stopping the check: %s", err)
+	}
+
+	// re-schedule
+	c.scheduler.Enter(check)
+
+	return nil
+}
+
+// StopCheck halts a check and remove the instance
+func (c *Collector) StopCheck(id check.ID) error {
+	if !c.started() {
+		return fmt.Errorf("the collector is not running")
+	}
+
+	if !c.find(id) {
+		return fmt.Errorf("cannot find a check with ID %s", id)
+	}
+
+	// unschedule the instance
+	err := c.scheduler.Cancel(id)
+	if err != nil {
+		return fmt.Errorf("an error occurred while cancelling the check schedule: %s", err)
+	}
+
+	// stop the instance
+	err = c.runner.StopCheck(id)
+	if err != nil {
+		return fmt.Errorf("an error occurred while stopping the check: %s", err)
+	}
+
+	// vaporize the check
+	c.delete(id)
+
+	return nil
+}
+
+// check if the check is on the list
+func (c *Collector) find(id check.ID) bool {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	_, found := c.checks[id]
+	return found
+}
+
+// remove the check from the list
+func (c *Collector) delete(id check.ID) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	delete(c.checks, id)
+}
+
+// lightweight shortcut to see if the collector has started
+func (c *Collector) started() bool {
+	return atomic.LoadUint32(&(c.state)) == started
+}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -119,15 +119,8 @@ func (c *Collector) ReloadCheck(id check.ID, config, initConfig check.ConfigData
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	// re-configure
-	check := c.checks[id]
-	err := check.Configure(config, initConfig)
-	if err != nil {
-		return fmt.Errorf("error configuring the check with ID %s", id)
-	}
-
 	// unschedule the instance
-	err = c.scheduler.Cancel(id)
+	err := c.scheduler.Cancel(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while cancelling the check schedule: %s", err)
 	}
@@ -136,6 +129,13 @@ func (c *Collector) ReloadCheck(id check.ID, config, initConfig check.ConfigData
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
+	}
+
+	// re-configure
+	check := c.checks[id]
+	err = check.Configure(config, initConfig)
+	if err != nil {
+		return fmt.Errorf("error configuring the check with ID %s", id)
 	}
 
 	// re-schedule

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -1,0 +1,151 @@
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/stretchr/testify/assert"
+)
+
+// FIXTURE
+type TestCheck struct {
+	stop chan bool
+}
+
+func (c *TestCheck) String() string                        { return "TestCheck" }
+func (c *TestCheck) Stop()                                 { c.stop <- true }
+func (c *TestCheck) Configure(a, b check.ConfigData) error { return nil }
+func (c *TestCheck) InitSender()                           {}
+func (c *TestCheck) Interval() time.Duration               { return 1 }
+func (c *TestCheck) Run() error                            { <-c.stop; return nil }
+func (c *TestCheck) ID() check.ID                          { return check.ID(c.String()) }
+
+func NewCheck() *TestCheck { return &TestCheck{stop: make(chan bool)} }
+
+func TestNewCollector(t *testing.T) {
+	c := NewCollector()
+	assert.Nil(t, c.aggregator)
+	assert.Nil(t, c.runner)
+	assert.Nil(t, c.scheduler)
+	assert.Nil(t, c.pyState)
+	assert.Equal(t, stopped, c.state)
+}
+
+func TestStartStop(t *testing.T) {
+	c := NewCollector()
+	c.Start(".")
+	assert.NotNil(t, c.aggregator)
+	assert.NotNil(t, c.runner)
+	assert.NotNil(t, c.scheduler)
+	assert.NotNil(t, c.pyState)
+	assert.Equal(t, started, c.state)
+	c.Stop()
+	assert.Nil(t, c.aggregator)
+	assert.Nil(t, c.runner)
+	assert.Nil(t, c.scheduler)
+	assert.Nil(t, c.pyState)
+	assert.Equal(t, stopped, c.state)
+}
+
+func TestRunCheck(t *testing.T) {
+	ch := NewCheck()
+	c := NewCollector()
+
+	// collector hasn't started
+	err := c.RunCheck(ch)
+	assert.NotNil(t, err)
+	assert.Equal(t, "the collector is not running", err.Error())
+
+	// start the collector
+	c.Start(".")
+
+	// schedule a check
+	err = c.RunCheck(ch)
+	assert.Equal(t, 1, len(c.checks))
+	assert.Equal(t, ch, c.checks["TestCheck"])
+
+	// schedule the same check twice
+	err = c.RunCheck(ch)
+	assert.NotNil(t, err)
+	assert.Equal(t, "a check with ID TestCheck is already running", err.Error())
+
+	c.Stop()
+}
+
+func TestReloadCheck(t *testing.T) {
+	ch := NewCheck()
+	c := NewCollector()
+
+	// collector hasn't started
+	empty := check.ConfigData{}
+	err := c.ReloadCheck("foo", empty, empty)
+	assert.NotNil(t, err)
+	assert.Equal(t, "the collector is not running", err.Error())
+
+	// start the collector and schedule a check
+	c.Start(".")
+	err = c.RunCheck(ch)
+
+	// check doesn't exist
+	err = c.ReloadCheck("foo", empty, empty)
+	assert.NotNil(t, err)
+	assert.Equal(t, "cannot find a check with ID foo", err.Error())
+
+	// all good
+	err = c.ReloadCheck("TestCheck", empty, empty)
+	assert.Nil(t, err)
+
+	c.Stop()
+}
+
+func TestStopCheck(t *testing.T) {
+	ch := NewCheck()
+	c := NewCollector()
+
+	// collector hasn't started
+	empty := check.ConfigData{}
+	err := c.ReloadCheck("foo", empty, empty)
+	assert.NotNil(t, err)
+	assert.Equal(t, "the collector is not running", err.Error())
+
+	// start the collector and schedule a check
+	c.Start(".")
+	err = c.RunCheck(ch)
+
+	// all good
+	err = c.StopCheck("TestCheck")
+	assert.Nil(t, err)
+	assert.Zero(t, len(c.checks))
+
+	c.Stop()
+}
+
+func TestFind(t *testing.T) {
+	c := NewCollector()
+	assert.False(t, c.find("bar"))
+
+	c.checks["bar"] = nil
+	assert.False(t, c.find("foo"))
+	assert.True(t, c.find("bar"))
+}
+
+func TestDelete(t *testing.T) {
+	c := NewCollector()
+	c.checks["bar"] = nil
+	// delete a key that doesn't exist should be a noop
+	c.delete("foo")
+
+	// for good
+	assert.True(t, c.find("bar"))
+	c.delete("bar")
+	assert.False(t, c.find("bar"))
+}
+
+func TestStarted(t *testing.T) {
+	c := NewCollector()
+	assert.False(t, c.started())
+	c.Start(".")
+	assert.True(t, c.started())
+	c.Stop()
+}

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -72,22 +72,23 @@ func (s *Scheduler) Enter(check check.Check) error {
 	return nil
 }
 
-// Cancel remove a Check from the scheduled queue
-func (s *Scheduler) Cancel(id check.ID) (bool, error) {
+// Cancel remove a Check from the scheduled queue. If the check is not
+// in the scheduler, this is a noop.
+func (s *Scheduler) Cancel(id check.ID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, ok := s.checkToQueue[id]; !ok {
-		return false, fmt.Errorf("check %s is not scheduled", id)
+		return nil
 	}
 
 	// remove it from the queue
 	err := s.checkToQueue[id].removeJob(id)
 	if err != nil {
-		return false, fmt.Errorf("unable to remove the Job from the queue: %s", err)
+		return fmt.Errorf("unable to remove the Job from the queue: %s", err)
 	}
 
-	return true, nil
+	return nil
 }
 
 // Run is the Scheduler main loop.


### PR DESCRIPTION
### What does this PR do?

Adds a new component called `Collector` that wraps the common operations needed to start collecting data from checks. The `Collector` beside wrapping some code is responsible to keep the list of "active" check instances.

To simplify the code and the API, `scheduler.Cancel` and `runner.StopCheck` were made noops in case the check is not there.

### Motivation

Having a clean and consistent API to interact with check instances, something the Service Discovery will heavily rely on.
