### PR TITLE
[forwarder] Add ZSTD compression on payload

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ffe4c03c2ce064b7a045ae1ca19bc038190759b7caea4e1989e43e5330f27a2d
-updated: 2017-02-06T12:08:02.903400978+01:00
+hash: ec60fe17401b638250d2b622f98dcad551cb524b09a14f95a05b6e28a3cbc8c6
+updated: 2017-02-13T13:51:43.748715533+01:00
 imports:
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
@@ -7,36 +7,42 @@ imports:
   version: 6fa3e39b86f8cbb638a971f2a90b9ebd98074c6b
   subpackages:
   - statsd
+- name: github.com/DataDog/zstd
+  version: add9e2ca52c03c1f6f8deffa22fcc7667dcb4ae2
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
 - name: github.com/docker/distribution
   version: fb0bebc4b64e3881cc52a2478d749845ed76d2a8
   subpackages:
-  - reference
   - digestset
+  - reference
 - name: github.com/docker/docker
-  version: 2527cfcc49744f56a8d31c420a3ca4657f9fec2e
+  version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
   subpackages:
-  - client
   - api/types
+  - api/types/blkiodev
   - api/types/container
   - api/types/events
   - api/types/filters
+  - api/types/mount
   - api/types/network
   - api/types/reference
   - api/types/registry
+  - api/types/strslice
   - api/types/swarm
   - api/types/time
   - api/types/versions
   - api/types/volume
+  - client
   - pkg/tlsconfig
-  - api/types/mount
-  - api/types/blkiodev
-  - api/types/strslice
 - name: github.com/docker/go-connections
   version: 7da10c8c50cad14494ec818dcdfb6506265c0086
   subpackages:
+  - nat
   - sockets
   - tlsconfig
-  - nat
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/fsnotify/fsnotify
@@ -54,10 +60,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/inconshreveable/mousetrap
@@ -82,14 +88,18 @@ imports:
   version: d1fa2118c12c44e4f5004da216d1efad10cb4924
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/sbinet/go-python
   version: a2acb64fbdf8703949837e5ebf50c71319fe03a4
 - name: github.com/shirou/gopsutil
   version: 32b6636de04b303274daac3ca2b10d3b0e4afc35
   subpackages:
-  - mem
   - cpu
   - internal/common
+  - mem
 - name: github.com/Sirupsen/logrus
   version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
 - name: github.com/spf13/afero
@@ -110,6 +120,8 @@ imports:
   version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
 - name: github.com/StackExchange/wmi
   version: e54cbda6595d7293a7a468ccf9525f6bc8887f99
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
@@ -133,14 +145,4 @@ imports:
   - unicode/norm
 - name: gopkg.in/yaml.v2
   version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
-testImports:
-- name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
-  subpackages:
-  - spew
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,3 +28,4 @@ import:
   version: ^1.13.1-rc1
   subpackages:
   - client
+- package: github.com/DataDog/zstd

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/zstd"
 )
 
 func TestNewForwarder(t *testing.T) {
@@ -100,38 +102,43 @@ func TestSubmit(t *testing.T) {
 	forwarder.Start()
 	defer forwarder.Stop()
 
-	expectedPayload = []byte("SubmitTimeseries payload")
+	payload := []byte("SubmitTimeseries payload")
+	expectedPayload, _ = zstd.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/series"
-	assert.Nil(t, forwarder.SubmitTimeseries(&expectedPayload))
+	assert.Nil(t, forwarder.SubmitTimeseries(&payload))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	expectedPayload = []byte("SubmitEvent payload")
+	payload = []byte("SubmitEvent payload")
+	expectedPayload, _ = zstd.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/events"
-	assert.Nil(t, forwarder.SubmitEvent(&expectedPayload))
+	assert.Nil(t, forwarder.SubmitEvent(&payload))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	expectedPayload = []byte("SubmitCheckRun payload")
+	payload = []byte("SubmitCheckRun payload")
+	expectedPayload, _ = zstd.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/check_runs"
-	assert.Nil(t, forwarder.SubmitCheckRun(&expectedPayload))
+	assert.Nil(t, forwarder.SubmitCheckRun(&payload))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	expectedPayload = []byte("SubmitHostMetadata payload")
+	payload = []byte("SubmitHostMetadata payload")
+	expectedPayload, _ = zstd.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/host_metadata"
-	assert.Nil(t, forwarder.SubmitHostMetadata(&expectedPayload))
+	assert.Nil(t, forwarder.SubmitHostMetadata(&payload))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	expectedPayload = []byte("SubmitMetadata payload")
+	payload = []byte("SubmitMetadata payload")
+	expectedPayload, _ = zstd.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/metadata"
-	assert.Nil(t, forwarder.SubmitMetadata(&expectedPayload))
+	assert.Nil(t, forwarder.SubmitMetadata(&payload))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)


### PR DESCRIPTION
### What does this PR do?

Add ZSTD compression to the forwarder payload

### Motivation

The ZSTD compression is part of the RFC on the new agent payload (https://github.com/DataDog/architecture/blob/master/rfcs/agent_payloads/rfc.md).

### Testing Guidelines

Unit tests are added to the PR.

### Additional Notes

Compression is dependent of the endpoint as we will have to handle V1 endpoints for a while and they don't use ZSTD.