### PR TITLE
pick number of runner workers from the config

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -98,7 +98,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	// Get a Runner instance
-	common.AgentRunner = check.NewRunner(config.Datadog.GetInt("run_workers"))
+	common.AgentRunner = check.NewRunner(config.Datadog.GetInt("check_runners"))
 
 	// Instance the scheduler
 	common.AgentScheduler = scheduler.NewScheduler(common.AgentRunner.GetChan())

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -98,7 +98,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	// Get a Runner instance
-	common.AgentRunner = check.NewRunner(common.RunnerNumWorkers)
+	common.AgentRunner = check.NewRunner(config.Datadog.GetInt("run_workers"))
 
 	// Instance the scheduler
 	common.AgentScheduler = scheduler.NewScheduler(common.AgentRunner.GetChan())

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -10,11 +10,6 @@ import (
 	"github.com/kardianos/osext"
 )
 
-const (
-	// RunnerNumWorkers is the number of workers the Runner should spawn
-	RunnerNumWorkers = 4
-)
-
 var (
 	// Stopper is the channel used by other packages to ask for stopping the agent
 	Stopper = make(chan bool)

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -54,6 +54,7 @@ func SetupConfig() {
 	// define defaults for the Agent
 	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	config.Datadog.BindEnv("cmd_sock")
+	config.Datadog.SetDefault("run_workers", int64(4))
 }
 
 // GetHostname retrieve the host name for the Agent, trying to query these

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -54,7 +54,7 @@ func SetupConfig() {
 	// define defaults for the Agent
 	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	config.Datadog.BindEnv("cmd_sock")
-	config.Datadog.SetDefault("run_workers", int64(4))
+	config.Datadog.SetDefault("check_runners", int64(4))
 }
 
 // GetHostname retrieve the host name for the Agent, trying to query these


### PR DESCRIPTION
### What does this PR do?

Instead of hardcoding the number of workers the Runner should start, pick it up from the config file keeping the old value as the default.

### Motivation

Some customers might want to tweak this value.
