### PR TITLE
[aggregator] Avoid zero divisions

### DIFF
--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -106,7 +106,7 @@ func (r *Rate) flush(timestamp int64) ([]*Serie, error) {
 		return []*Serie{}, NoSerieError{}
 	}
 
-	if r.timestamp-r.previousTimestamp == 0 {
+	if r.timestamp == r.previousTimestamp {
 		return []*Serie{}, fmt.Errorf("Rate was sampled twice at the same timestamp, can't compute a rate")
 	}
 

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -106,6 +106,10 @@ func (r *Rate) flush(timestamp int64) ([]*Serie, error) {
 		return []*Serie{}, NoSerieError{}
 	}
 
+	if r.timestamp-r.previousTimestamp == 0 {
+		return []*Serie{}, fmt.Errorf("Rate was sampled twice at the same timestamp, can't compute a rate")
+	}
+
 	value, ts := (r.sample-r.previousSample)/float64(r.timestamp-r.previousTimestamp), r.timestamp
 	r.previousSample, r.previousTimestamp = r.sample, r.timestamp
 	r.sample, r.timestamp = 0, 0

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -96,6 +96,20 @@ func TestRateSamplingNoSampleForOneFlush(t *testing.T) {
 	assert.EqualValues(t, series[0].Points[0][0], 60)
 }
 
+func TestRateSamplingSamplesAtSameTimestamp(t *testing.T) {
+	// Initialize rate
+	mRate := Rate{}
+
+	// Add samples
+	mRate.addSample(1, 50)
+	mRate.addSample(2, 50)
+
+	series, err := mRate.flush(60)
+
+	assert.NotNil(t, err)
+	assert.Len(t, series, 0)
+}
+
 func TestDefaultHistogramSampling(t *testing.T) {
 	// Initialize default histogram
 	mHistogram := Histogram{}

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -136,7 +136,7 @@ func (m Metrics) flush(timestamp int64) []*Serie {
 		} else {
 			switch err.(type) {
 			case NoSerieError:
-				log.Debugf("%s on context key %s", err, contextKey)
+				// this error happens in nominal conditions and shouldn't be logged
 			default:
 				log.Info(err)
 			}

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -1,6 +1,7 @@
 package aggregator
 
 import (
+	"math"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -101,6 +102,10 @@ func (s *Sampler) flush(timestamp int64) []*Serie {
 
 // TODO: Pass a reference to *MetricSample instead
 func (m Metrics) addSample(contextKey string, mType MetricType, value float64, timestamp int64) {
+	if math.IsInf(value, 0) {
+		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
+		return
+	}
 	if _, ok := m[contextKey]; !ok {
 		switch mType {
 		case GaugeType:

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	// stdlib
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 
@@ -102,6 +103,27 @@ func TestMetricsGaugeSamplingNoSample(t *testing.T) {
 
 	series = metrics.flush(12355)
 	// No series flushed since there's no new sample since last flush
+	assert.Equal(t, 0, len(series))
+}
+
+// No series should be flushed when the samples have values of +Inf/-Inf
+func TestMetricsGaugeSamplingInfinity(t *testing.T) {
+	metrics := makeMetrics()
+	contextKey1 := "context_key1"
+	contextKey2 := "context_key2"
+	mSample1 := MetricSample{
+		Value: math.Inf(1),
+		Mtype: GaugeType,
+	}
+	mSample2 := MetricSample{
+		Value: math.Inf(-1),
+		Mtype: GaugeType,
+	}
+
+	metrics.addSample(contextKey1, mSample1.Mtype, mSample1.Value, 1)
+	metrics.addSample(contextKey2, mSample2.Mtype, mSample2.Value, 1)
+	series := metrics.flush(12345)
+
 	assert.Equal(t, 0, len(series))
 }
 


### PR DESCRIPTION
### What does this PR do?

* Avoids divisions by zero in the aggregator:
  * In Rate metric when the 2 samples have the same timestamp
  * When a sample is added to the aggregator with +/-Inf values
  (which is usually the result of a division by zero in the code that
  added the sample)
* Removes a spammy log entry

### Motivation

* Make the aggregator more resilient
* Make logs readable

### Testing Guidelines

Added related tests
