### PR TITLE
Add proxy support to the forwarder.

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -1,2 +1,3 @@
 # The host of the Datadog intake server to send Agent data to
 dd_url: https://foo.datadoghq.com
+# proxy: http://user:password@host:port


### PR DESCRIPTION
### What does this PR do?

Add proxy support to the forwarder.

The http package from GO already handle proxy from ENV. We add support of proxy from configuration.

We don't need to split host, port, user and password information in the configuration like agent5 since url.Parse handle everything.

### Motivation

We need proxy support like in agent5.