### PR TITLE
[collector][file_provider] Make nested confs override default confs

### DIFF
--- a/pkg/collector/loader/file_provider_test.go
+++ b/pkg/collector/loader/file_provider_test.go
@@ -47,7 +47,7 @@ func TestCollect(t *testing.T) {
 
 	assert.Nil(t, err)
 	// total number of configurations found
-	assert.Equal(t, 5, len(configs))
+	assert.Equal(t, 6, len(configs))
 
 	// count how many configs were found for a given check
 	get := func(name string) []check.Config {
@@ -70,4 +70,10 @@ func TestCollect(t *testing.T) {
 	rc := get("foo")
 	assert.Equal(t, 1, len(rc))
 	assert.Contains(t, string(rc[0].InitConfig), "IsNotOnTheDefaultFile")
+
+	// nested configs override default ones
+	nc := get("baz")
+	if assert.Equal(t, 1, len(nc)) {
+		assert.Contains(t, string(nc[0].InitConfig), "IsNotOnTheDefaultFile")
+	}
 }

--- a/pkg/collector/loader/tests/baz.d/1.yaml
+++ b/pkg/collector/loader/tests/baz.d/1.yaml
@@ -1,0 +1,6 @@
+init_config:
+  - this: IsNotOnTheDefaultFile
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar

--- a/pkg/collector/loader/tests/baz.yaml.default
+++ b/pkg/collector/loader/tests/baz.yaml.default
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar


### PR DESCRIPTION
### What does this PR do?

Makes nested confs (e.g. `my_check.d/1.yaml`) override default confs (e.g. `my_check.yaml.default`)

### Motivation

I think any user-provided configuration on a check should override the default configuration. I was debugging something on the QA and found the current behavior counter-intuitive.

This is up for discussion though, please comment if you disagree :)

### Testing Guidelines

Updated the existing test

### Additional Notes

I also changed the implementation of the python-like set from `map[string]interface{}` to `map[string]struct{}` since it looks more idiomatic to me (instead of being "anything", the map values are explicitely "nothing"). As always, please comment if you disagree.
