### PR TITLE
[aggregator] Add support of MonotonicCount

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -111,7 +111,7 @@ func (agg *BufferedAggregator) run() {
 
 			payload, err := MarshalJSONSeries(series)
 			if err != nil {
-				log.Error("could not serialize series, droping it: %s", err)
+				log.Error("could not serialize series, dropping it:", err)
 				continue
 			}
 			agg.forwarder.SubmitV1Series(config.Datadog.GetString("api_key"), &payload)

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -147,9 +147,10 @@ func (r *Rate) flush(timestamp int64) ([]*Serie, error) {
 
 // MonotonicCount tracks a raw counter, based on increasing counter values.
 // Samples that have a lower value than the previous sample are ignored (since it usually
-// means that the underlying raw count has been reset).
+// means that the underlying raw counter has been reset).
 // Example:
-// * samples 2, 3, 6, 7 returns 5 (i.e. 7-2) on 1st flush, then sample 11 returns 4 (i.e. 11-7) on 2nd flush
+//  submitting samples 2, 3, 6, 7 returns 5 (i.e. 7-2) on flush ;
+//  then submitting samples 10, 11 on the same MonotonicCount returns 4 (i.e. 11-7) on flush
 type MonotonicCount struct {
 	previousSample        float64
 	currentSample         float64
@@ -167,6 +168,8 @@ func (mc *MonotonicCount) addSample(sample float64, timestamp int64) {
 		mc.hasPreviousSample = true
 	}
 
+	// To handle cases where the samples are not monotonically increasing, we always add the difference
+	// between 2 consecutive samples to the value that'll be flushed (if the difference is >0).
 	diff := mc.currentSample - mc.previousSample
 	if mc.sampledSinceLastFlush && mc.hasPreviousSample && diff > 0. {
 		mc.value += diff
@@ -179,6 +182,7 @@ func (mc *MonotonicCount) flush(timestamp int64) ([]*Serie, error) {
 	}
 
 	value := mc.value
+	// reset struct fields
 	mc.previousSample, mc.currentSample, mc.value = mc.currentSample, 0., 0.
 	mc.sampledSinceLastFlush = false
 

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -7,6 +7,7 @@ type MetricType int
 const (
 	GaugeType MetricType = iota
 	RateType
+	MonotonicCountType
 	CounterType
 	HistogramType
 )

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -110,6 +110,60 @@ func TestRateSamplingSamplesAtSameTimestamp(t *testing.T) {
 	assert.Len(t, series, 0)
 }
 
+func TestMonotonicCountSampling(t *testing.T) {
+	// Initialize monotonic count
+	monotonicCount := MonotonicCount{}
+
+	// Flush w/o samples: error
+	_, err := monotonicCount.flush(40)
+	assert.NotNil(t, err)
+
+	// Flush with one sample only and no prior samples: error
+	monotonicCount.addSample(1, 45)
+	_, err = monotonicCount.flush(40)
+	assert.NotNil(t, err)
+
+	// Add samples
+	monotonicCount.addSample(2, 50)
+	monotonicCount.addSample(3, 55)
+	monotonicCount.addSample(6, 55)
+	monotonicCount.addSample(7, 58)
+	series, err := monotonicCount.flush(60)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
+		assert.InEpsilon(t, 6, series[0].Points[0].Value, epsilon)
+		assert.EqualValues(t, series[0].Points[0].Ts, 60)
+	}
+
+	// Flush w/o samples: error
+	series, err = monotonicCount.flush(70)
+	assert.NotNil(t, err)
+
+	// Add a single sample
+	monotonicCount.addSample(11, 75)
+	series, err = monotonicCount.flush(80)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
+		assert.InEpsilon(t, 4, series[0].Points[0].Value, epsilon)
+		assert.EqualValues(t, 80, series[0].Points[0].Ts)
+	}
+
+	// Add sequence of non-monotonic samples
+	monotonicCount.addSample(12, 85)
+	monotonicCount.addSample(10, 85)
+	monotonicCount.addSample(20, 85)
+	monotonicCount.addSample(13, 85)
+	monotonicCount.addSample(17, 85)
+	series, err = monotonicCount.flush(90)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
+		// should skip when counter is reset, i.e. between 12 and 10, and btw 20 and 13
+		// 15 = (12 - 11) + (20 - 10) + (17 - 13)
+		assert.InEpsilon(t, 15, series[0].Points[0].Value, epsilon)
+		assert.EqualValues(t, series[0].Points[0].Ts, 90)
+	}
+}
+
 func TestDefaultHistogramSampling(t *testing.T) {
 	// Initialize default histogram
 	mHistogram := Histogram{}

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -25,7 +25,7 @@ func TestGaugeSampling(t *testing.T) {
 	assert.Len(t, series, 1)
 	assert.Len(t, series[0].Points, 1)
 	assert.InEpsilon(t, 2, series[0].Points[0].Value, epsilon)
-	assert.EqualValues(t, series[0].Points[0].Ts, 60)
+	assert.EqualValues(t, 60, series[0].Points[0].Ts)
 }
 
 func TestRateSampling(t *testing.T) {
@@ -44,7 +44,7 @@ func TestRateSampling(t *testing.T) {
 	assert.Len(t, series, 1)
 	assert.Len(t, series[0].Points, 1)
 	assert.InEpsilon(t, 0.2, series[0].Points[0].Value, epsilon)
-	assert.EqualValues(t, series[0].Points[0].Ts, 55)
+	assert.EqualValues(t, 55, series[0].Points[0].Ts)
 
 	// Second rate (should return error)
 	_, err = mRate2.flush(60)
@@ -66,7 +66,7 @@ func TestRateSamplingMultipleSamplesInSameFlush(t *testing.T) {
 	assert.Len(t, series, 1)
 	assert.Len(t, series[0].Points, 1)
 	assert.InEpsilon(t, 2./6., series[0].Points[0].Value, epsilon)
-	assert.EqualValues(t, series[0].Points[0].Ts, 61)
+	assert.EqualValues(t, 61, series[0].Points[0].Ts)
 }
 
 func TestRateSamplingNoSampleForOneFlush(t *testing.T) {
@@ -93,7 +93,7 @@ func TestRateSamplingNoSampleForOneFlush(t *testing.T) {
 	assert.Len(t, series, 1)
 	assert.Len(t, series[0].Points, 1)
 	assert.InEpsilon(t, 2./5., series[0].Points[0].Value, epsilon)
-	assert.EqualValues(t, series[0].Points[0].Ts, 60)
+	assert.EqualValues(t, 60, series[0].Points[0].Ts)
 }
 
 func TestRateSamplingSamplesAtSameTimestamp(t *testing.T) {
@@ -132,7 +132,7 @@ func TestMonotonicCountSampling(t *testing.T) {
 	assert.Nil(t, err)
 	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
 		assert.InEpsilon(t, 6, series[0].Points[0].Value, epsilon)
-		assert.EqualValues(t, series[0].Points[0].Ts, 60)
+		assert.EqualValues(t, 60, series[0].Points[0].Ts)
 	}
 
 	// Flush w/o samples: error
@@ -160,7 +160,7 @@ func TestMonotonicCountSampling(t *testing.T) {
 		// should skip when counter is reset, i.e. between 12 and 10, and btw 20 and 13
 		// 15 = (12 - 11) + (20 - 10) + (17 - 13)
 		assert.InEpsilon(t, 15, series[0].Points[0].Value, epsilon)
-		assert.EqualValues(t, series[0].Points[0].Ts, 90)
+		assert.EqualValues(t, 90, series[0].Points[0].Ts)
 	}
 }
 
@@ -185,7 +185,7 @@ func TestDefaultHistogramSampling(t *testing.T) {
 	if assert.Len(t, series, 5) {
 		for _, serie := range series {
 			assert.Len(t, serie.Points, 1)
-			assert.EqualValues(t, serie.Points[0].Ts, 60)
+			assert.EqualValues(t, 60, serie.Points[0].Ts)
 		}
 		assert.InEpsilon(t, 10, series[0].Points[0].Value, epsilon)     // max
 		assert.Equal(t, ".max", series[0].nameSuffix)                   // max
@@ -226,7 +226,7 @@ func TestCustomHistogramSampling(t *testing.T) {
 		// Only 2 series are returned (the invalid aggregate is ignored)
 		for _, serie := range series {
 			assert.Len(t, serie.Points, 1)
-			assert.EqualValues(t, serie.Points[0].Ts, 60)
+			assert.EqualValues(t, 60, serie.Points[0].Ts)
 		}
 		assert.InEpsilon(t, 1, series[0].Points[0].Value, epsilon)            // min
 		assert.Equal(t, ".min", series[0].nameSuffix)                         // min
@@ -275,7 +275,7 @@ func TestHistogramPercentiles(t *testing.T) {
 	if assert.Len(t, series, 7) {
 		for _, serie := range series {
 			assert.Len(t, serie.Points, 1)
-			assert.EqualValues(t, serie.Points[0].Ts, 60)
+			assert.EqualValues(t, 60, serie.Points[0].Ts)
 		}
 		assert.InEpsilon(t, 100, series[0].Points[0].Value, epsilon)    // max
 		assert.Equal(t, ".max", series[0].nameSuffix)                   // max

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -112,6 +112,8 @@ func (m Metrics) addSample(contextKey string, mType MetricType, value float64, t
 			m[contextKey] = &Gauge{}
 		case RateType:
 			m[contextKey] = &Rate{}
+		case MonotonicCountType:
+			m[contextKey] = &MonotonicCount{}
 		case HistogramType:
 			m[contextKey] = &Histogram{} // default histogram configuration for now
 		default:

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -153,6 +153,25 @@ func TestMetricsRateSampling(t *testing.T) {
 	}
 }
 
+func TestMetricsMonotonicCountSampling(t *testing.T) {
+	metrics := makeMetrics()
+	contextKey := "context_key"
+
+	metrics.addSample(contextKey, MonotonicCountType, 1, 12340)
+	metrics.addSample(contextKey, MonotonicCountType, 5, 12345)
+	series := metrics.flush(12350)
+	expectedSerie := &Serie{
+		contextKey: contextKey,
+		Points:     []Point{{int64(12350), 4.}},
+		MType:      APICountType,
+		nameSuffix: "",
+	}
+
+	if assert.Equal(t, 1, len(series)) {
+		AssertSerieEqual(t, expectedSerie, series[0])
+	}
+}
+
 func TestMetricsHistogramSampling(t *testing.T) {
 	metrics := makeMetrics()
 	contextKey := "context_key"

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -18,6 +18,7 @@ type Sender interface {
 	Commit()
 	Gauge(metric string, value float64, hostname string, tags []string)
 	Rate(metric string, value float64, hostname string, tags []string)
+	MonotonicCount(metric string, value float64, hostname string, tags []string)
 	Histogram(metric string, value float64, hostname string, tags []string)
 }
 
@@ -102,6 +103,11 @@ func (s *checkSender) Gauge(metric string, value float64, hostname string, tags 
 // Rate implements the Sender interface
 func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, RateType, "Rate")
+}
+
+// MonotonicCount implements the Sender interface
+func (s *checkSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
+	s.sendSample(metric, value, hostname, tags, MonotonicCountType, "MonotonicCount")
 }
 
 // Histogram implements the Sender interface

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -90,6 +90,7 @@ func TestSenderInterface(t *testing.T) {
 	checkSender := newCheckSender(checkID1, senderSampleChan)
 	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
+	checkSender.MonotonicCount("my.monotonic_count_metric", 12.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Commit()
 
@@ -102,6 +103,11 @@ func TestSenderInterface(t *testing.T) {
 	assert.EqualValues(t, checkID1, rateSenderSample.id)
 	assert.Equal(t, RateType, rateSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, rateSenderSample.commit)
+
+	monotonicCountSenderSample := <-senderSampleChan
+	assert.EqualValues(t, checkID1, monotonicCountSenderSample.id)
+	assert.Equal(t, MonotonicCountType, monotonicCountSenderSample.metricSample.Mtype)
+	assert.Equal(t, false, monotonicCountSenderSample.commit)
 
 	histoSenderSample := <-senderSampleChan
 	assert.EqualValues(t, checkID1, histoSenderSample.id)

--- a/pkg/collector/check/core/system/common_test.go
+++ b/pkg/collector/check/core/system/common_test.go
@@ -12,6 +12,10 @@ func (m *MockSender) Rate(metric string, value float64, hostname string, tags []
 	m.Called(metric, value, hostname, tags)
 }
 
+func (m *MockSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
+	m.Called(metric, value, hostname, tags)
+}
+
 func (m *MockSender) Histogram(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)
 }

--- a/pkg/collector/check/py/api.c
+++ b/pkg/collector/check/py/api.c
@@ -5,6 +5,7 @@ PyObject* SubmitData(PyObject*, MetricType, char*, float, PyObject*);
 char* MetricTypeNames[] = {
   "GAUGE",
   "RATE",
+  "MONOTONIC_COUNT",
   "HISTOGRAM"
 };
 

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -38,10 +38,12 @@ func SubmitData(check *C.PyObject, mt C.MetricType, name *C.char, value C.float,
 	}
 
 	switch mt {
-	case C.RATE:
-		sender.Rate(_name, _value, "", _tags)
 	case C.GAUGE:
 		sender.Gauge(_name, _value, "", _tags)
+	case C.RATE:
+		sender.Rate(_name, _value, "", _tags)
+	case C.MONOTONIC_COUNT:
+		sender.MonotonicCount(_name, _value, "", _tags)
 	case C.HISTOGRAM:
 		sender.Histogram(_name, _value, "", _tags)
 	}

--- a/pkg/collector/check/py/api.h
+++ b/pkg/collector/check/py/api.h
@@ -4,6 +4,7 @@ typedef enum {
   MT_FIRST = 0,
   GAUGE = MT_FIRST,
   RATE,
+  MONOTONIC_COUNT,
   HISTOGRAM,
   MT_LAST = HISTOGRAM
 } MetricType;

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -40,6 +40,9 @@ class AgentCheck(object):
     def gauge(self, name, value, tags=None):
         aggregator.submit_data(self, aggregator.GAUGE, name, value, tags)
 
+    def monotonic_count(self, name, value, tags=None):
+        aggregator.submit_data(self, aggregator.MONOTONIC_COUNT, name, value, tags)
+
     def rate(self, name, value, tags=None):
         aggregator.submit_data(self, aggregator.RATE, name, value, tags)
 


### PR DESCRIPTION
### What does this PR do?

Support of a new check metric type: `MonotonicCount` (`monotonic_count` for py checks)

### Motivation

Support moar useful agent5 metric types

### Testing Guidelines

Added related tests
