### PR TITLE
[aggregator] Add support of Count

### DIFF
--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -13,6 +13,26 @@ const (
 	HistogramType
 )
 
+// String returns a string representation of MetricType
+func (m MetricType) String() string {
+	switch m {
+	case GaugeType:
+		return "Gauge"
+	case RateType:
+		return "Rate"
+	case CountType:
+		return "Count"
+	case MonotonicCountType:
+		return "MonotonicCount"
+	case CounterType:
+		return "Counter"
+	case HistogramType:
+		return "Histogram"
+	default:
+		return ""
+	}
+}
+
 // MetricSample represents a raw metric sample
 type MetricSample struct {
 	Name       string

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -7,6 +7,7 @@ type MetricType int
 const (
 	GaugeType MetricType = iota
 	RateType
+	CountType
 	MonotonicCountType
 	CounterType
 	HistogramType

--- a/pkg/aggregator/metric_test.go
+++ b/pkg/aggregator/metric_test.go
@@ -110,6 +110,43 @@ func TestRateSamplingSamplesAtSameTimestamp(t *testing.T) {
 	assert.Len(t, series, 0)
 }
 
+func TestCountSampling(t *testing.T) {
+	// Initialize count
+	count := Count{}
+
+	// Flush w/o samples: error
+	_, err := count.flush(50)
+	assert.NotNil(t, err)
+
+	// Add samples
+	sampleValues := []float64{1, 2, 5, 0, 8, 3}
+	for _, sampleValue := range sampleValues {
+		count.addSample(sampleValue, 55)
+	}
+	series, err := count.flush(60)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
+		assert.InEpsilon(t, 1+2+5+0+8+3, series[0].Points[0].Value, epsilon)
+		assert.EqualValues(t, 60, series[0].Points[0].Ts)
+	}
+
+	// Add a few new samples and flush: the count should've been reset after the previous flush
+	sampleValues = []float64{5, 3}
+	for _, sampleValue := range sampleValues {
+		count.addSample(sampleValue, 65)
+	}
+	series, err = count.flush(70)
+	assert.Nil(t, err)
+	if assert.Len(t, series, 1) && assert.Len(t, series[0].Points, 1) {
+		assert.InEpsilon(t, 5+3, series[0].Points[0].Value, epsilon)
+		assert.EqualValues(t, 70, series[0].Points[0].Ts)
+	}
+
+	// Flush w/o samples: error
+	_, err = count.flush(80)
+	assert.NotNil(t, err)
+}
+
 func TestMonotonicCountSampling(t *testing.T) {
 	// Initialize monotonic count
 	monotonicCount := MonotonicCount{}

--- a/pkg/aggregator/sampler.go
+++ b/pkg/aggregator/sampler.go
@@ -112,6 +112,8 @@ func (m Metrics) addSample(contextKey string, mType MetricType, value float64, t
 			m[contextKey] = &Gauge{}
 		case RateType:
 			m[contextKey] = &Rate{}
+		case CountType:
+			m[contextKey] = &Count{}
 		case MonotonicCountType:
 			m[contextKey] = &MonotonicCount{}
 		case HistogramType:

--- a/pkg/aggregator/sampler_test.go
+++ b/pkg/aggregator/sampler_test.go
@@ -153,6 +153,25 @@ func TestMetricsRateSampling(t *testing.T) {
 	}
 }
 
+func TestMetricsCountSampling(t *testing.T) {
+	metrics := makeMetrics()
+	contextKey := "context_key"
+
+	metrics.addSample(contextKey, CountType, 1, 12340)
+	metrics.addSample(contextKey, CountType, 5, 12345)
+	series := metrics.flush(12350)
+	expectedSerie := &Serie{
+		contextKey: contextKey,
+		Points:     []Point{{int64(12350), 6.}},
+		MType:      APICountType,
+		nameSuffix: "",
+	}
+
+	if assert.Len(t, series, 1) {
+		AssertSerieEqual(t, expectedSerie, series[0])
+	}
+}
+
 func TestMetricsMonotonicCountSampling(t *testing.T) {
 	metrics := makeMetrics()
 	contextKey := "context_key"

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -82,8 +82,8 @@ func (s *checkSender) Commit() {
 	s.ssOut <- senderSample{s.id, &MetricSample{}, true}
 }
 
-func (s *checkSender) sendSample(metric string, value float64, hostname string, tags []string, mType MetricType, logMtype string) {
-	log.Debug(logMtype, " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+func (s *checkSender) sendSample(metric string, value float64, hostname string, tags []string, mType MetricType) {
+	log.Debug(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
 	metricSample := &MetricSample{
 		Name:       metric,
 		Value:      value,
@@ -98,25 +98,25 @@ func (s *checkSender) sendSample(metric string, value float64, hostname string, 
 
 // Gauge implements the Sender interface
 func (s *checkSender) Gauge(metric string, value float64, hostname string, tags []string) {
-	s.sendSample(metric, value, hostname, tags, GaugeType, "Gauge")
+	s.sendSample(metric, value, hostname, tags, GaugeType)
 }
 
 // Rate implements the Sender interface
 func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
-	s.sendSample(metric, value, hostname, tags, RateType, "Rate")
+	s.sendSample(metric, value, hostname, tags, RateType)
 }
 
 // Count implements the Sender interface
 func (s *checkSender) Count(metric string, value float64, hostname string, tags []string) {
-	s.sendSample(metric, value, hostname, tags, CountType, "Count")
+	s.sendSample(metric, value, hostname, tags, CountType)
 }
 
 // MonotonicCount implements the Sender interface
 func (s *checkSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
-	s.sendSample(metric, value, hostname, tags, MonotonicCountType, "MonotonicCount")
+	s.sendSample(metric, value, hostname, tags, MonotonicCountType)
 }
 
 // Histogram implements the Sender interface
 func (s *checkSender) Histogram(metric string, value float64, hostname string, tags []string) {
-	s.sendSample(metric, value, hostname, tags, HistogramType, "Histogram")
+	s.sendSample(metric, value, hostname, tags, HistogramType)
 }

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -18,6 +18,7 @@ type Sender interface {
 	Commit()
 	Gauge(metric string, value float64, hostname string, tags []string)
 	Rate(metric string, value float64, hostname string, tags []string)
+	Count(metric string, value float64, hostname string, tags []string)
 	MonotonicCount(metric string, value float64, hostname string, tags []string)
 	Histogram(metric string, value float64, hostname string, tags []string)
 }
@@ -103,6 +104,11 @@ func (s *checkSender) Gauge(metric string, value float64, hostname string, tags 
 // Rate implements the Sender interface
 func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, RateType, "Rate")
+}
+
+// Count implements the Sender interface
+func (s *checkSender) Count(metric string, value float64, hostname string, tags []string) {
+	s.sendSample(metric, value, hostname, tags, CountType, "Count")
 }
 
 // MonotonicCount implements the Sender interface

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -96,27 +96,28 @@ func (s *checkSender) sendSample(metric string, value float64, hostname string, 
 	s.ssOut <- senderSample{s.id, metricSample, false}
 }
 
-// Gauge implements the Sender interface
+// Gauge should be used to send a simple gauge value to the aggregator. Only the last value sampled is kept at commit time.
 func (s *checkSender) Gauge(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, GaugeType)
 }
 
-// Rate implements the Sender interface
+// Rate should be used to track the rate of a metric over each check run
 func (s *checkSender) Rate(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, RateType)
 }
 
-// Count implements the Sender interface
+// Count should be used to count a number of events that occurred during the check run
 func (s *checkSender) Count(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, CountType)
 }
 
-// MonotonicCount implements the Sender interface
+// MonotonicCount should be used to track the increase of a monotonic raw counter
 func (s *checkSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, MonotonicCountType)
 }
 
-// Histogram implements the Sender interface
+// Histogram should be used to track the statistical distribution of a set of values during a check run
+// Should be called multiple times on the same (metric, hostname, tags) so that a distribution can be computed
 func (s *checkSender) Histogram(metric string, value float64, hostname string, tags []string) {
 	s.sendSample(metric, value, hostname, tags, HistogramType)
 }

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -85,11 +85,12 @@ func TestDestroySender(t *testing.T) {
 	assert.Len(t, aggregatorInstance.checkSamplers, 1)
 }
 
-func TestSenderInterface(t *testing.T) {
+func TestCheckSenderInterface(t *testing.T) {
 	senderSampleChan := make(chan senderSample, 10)
 	checkSender := newCheckSender(checkID1, senderSampleChan)
 	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
+	checkSender.Count("my.count_metric", 123.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.MonotonicCount("my.monotonic_count_metric", 12.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Histogram("my.histo_metric", 3.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Commit()
@@ -103,6 +104,11 @@ func TestSenderInterface(t *testing.T) {
 	assert.EqualValues(t, checkID1, rateSenderSample.id)
 	assert.Equal(t, RateType, rateSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, rateSenderSample.commit)
+
+	countSenderSample := <-senderSampleChan
+	assert.EqualValues(t, checkID1, countSenderSample.id)
+	assert.Equal(t, CountType, countSenderSample.metricSample.Mtype)
+	assert.Equal(t, false, countSenderSample.commit)
 
 	monotonicCountSenderSample := <-senderSampleChan
 	assert.EqualValues(t, checkID1, monotonicCountSenderSample.id)

--- a/pkg/collector/check/core/system/common_test.go
+++ b/pkg/collector/check/core/system/common_test.go
@@ -12,6 +12,10 @@ func (m *MockSender) Rate(metric string, value float64, hostname string, tags []
 	m.Called(metric, value, hostname, tags)
 }
 
+func (m *MockSender) Count(metric string, value float64, hostname string, tags []string) {
+	m.Called(metric, value, hostname, tags)
+}
+
 func (m *MockSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)
 }

--- a/pkg/collector/check/py/api.c
+++ b/pkg/collector/check/py/api.c
@@ -5,6 +5,7 @@ PyObject* SubmitData(PyObject*, MetricType, char*, float, PyObject*);
 char* MetricTypeNames[] = {
   "GAUGE",
   "RATE",
+  "COUNT",
   "MONOTONIC_COUNT",
   "HISTOGRAM"
 };

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -42,6 +42,8 @@ func SubmitData(check *C.PyObject, mt C.MetricType, name *C.char, value C.float,
 		sender.Gauge(_name, _value, "", _tags)
 	case C.RATE:
 		sender.Rate(_name, _value, "", _tags)
+	case C.COUNT:
+		sender.Count(_name, _value, "", _tags)
 	case C.MONOTONIC_COUNT:
 		sender.MonotonicCount(_name, _value, "", _tags)
 	case C.HISTOGRAM:

--- a/pkg/collector/check/py/api.h
+++ b/pkg/collector/check/py/api.h
@@ -4,6 +4,7 @@ typedef enum {
   MT_FIRST = 0,
   GAUGE = MT_FIRST,
   RATE,
+  COUNT,
   MONOTONIC_COUNT,
   HISTOGRAM,
   MT_LAST = HISTOGRAM

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -40,6 +40,9 @@ class AgentCheck(object):
     def gauge(self, name, value, tags=None):
         aggregator.submit_data(self, aggregator.GAUGE, name, value, tags)
 
+    def count(self, name, value, tags=None):
+        aggregator.submit_data(self, aggregator.COUNT, name, value, tags)
+
     def monotonic_count(self, name, value, tags=None):
         aggregator.submit_data(self, aggregator.MONOTONIC_COUNT, name, value, tags)
 


### PR DESCRIPTION
### What does this PR do?

Adds support of Count (`count` for py checks) metrics

### Motivation

More check metric types

### Additional Notes

The first commit adds Count, the 2 following commits are some other minor changes