### PR TITLE
Setup a Docker image for the agent.

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:jessie
+
+MAINTAINER Datadog <package@datadoghq.com>
+
+ENV DOCKER_DD_AGENT=yes \
+    AGENT_VERSION=1:6.0-1 \
+    DD_AGENT_HOME=/opt/datadog-agent6/
+
+# Install the Agent
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y apt-transport-https ca-certificates\
+ && echo "deb https://s3.amazonaws.com/apt-agent6.datad0g.com unstable main" > /etc/apt/sources.list.d/datadog.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
+ && apt-get update \
+ # TODO: pin the version
+ && apt-get install --no-install-recommends -y datadog-agent6 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY entrypoint.sh /entrypoint.sh
+
+EXPOSE 8125/udp
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/opt/datadog-agent6/bin/agent/agent", "start", "-f"]

--- a/Dockerfiles/entrypoint.sh
+++ b/Dockerfiles/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#set -e
+
+
+##### Core config #####
+
+if [[ -z $DD_API_KEY ]]; then
+    echo "You must set an API_KEY environment variable to run the Datadog Agent container"
+    exit 1
+fi
+
+##### Starting up #####
+
+export PATH="/opt/datadog-agent6/bin/agent/:/opt/datadog-agent6/bin/:$PATH"
+
+exec "$@"

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -1,8 +1,18 @@
 # The host of the Datadog intake server to send Agent data to
 dd_url: https://foo.datadoghq.com
 
-# If you need a proxy to connect to the Internet, provide the settings here
+# The Datadog api key to associate your Agent's data with your organization.
+# Can be found here:
+# https://app.datadoghq.com/account/settings
+# This can be a comma-separated list of api keys.
+# (default: None, the agent doesn't start without it)
+api_key:
+
+# If you need a proxy to connect to the Internet, provide it here (default: disabled)
 # proxy: http://user:password@host:port
 
 # If you run the agent behind haproxy, you might want to set this to yes
 # skip_ssl_validation: no
+
+# Force the hostname to whatever you want. (default: auto-detected)
+# hostname: mymachine.mydomain


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Setup a docker file for the agent. First version doesn't support alpine, will look into the agent build process to make it happen.

### Motivation

Dockerize :allthethings:!

### Testing Guidelines

- build it with `cd Dockerfiles && docker build -t datadog-agent .`
- profit
