### PR TITLE
Add 'skip_ssl_validation' option to the forwarder

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -1,3 +1,8 @@
 # The host of the Datadog intake server to send Agent data to
 dd_url: https://foo.datadoghq.com
+
+# If you need a proxy to connect to the Internet, provide the settings here
 # proxy: http://user:password@host:port
+
+# If you run the agent behind haproxy, you might want to set this to yes
+# skip_ssl_validation: no

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -2,8 +2,10 @@ package forwarder
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,6 +16,17 @@ func TestNewWorker(t *testing.T) {
 	w := NewWorker(input, requeue)
 	assert.NotNil(t, w)
 	assert.Equal(t, w.Client.Timeout, httpTimeout)
+}
+
+func TestNewNoSSLWorker(t *testing.T) {
+	input := make(chan Transaction)
+	requeue := make(chan Transaction)
+
+	config.Datadog.Set("skip_ssl_validation", true)
+	defer config.Datadog.Set("skip_ssl_validation", false)
+
+	w := NewWorker(input, requeue)
+	assert.True(t, w.Client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 }
 
 func TestWorkerStart(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This option disable ssl validation in the forwarder

### Motivation

This option is already supported by the agent5 and allow the agent to run behind Haproxy.