### PR TITLE
Fix the Collector

### DIFF
--- a/pkg/collector/check/core/loader.go
+++ b/pkg/collector/check/core/loader.go
@@ -32,7 +32,6 @@ func (gl *GoCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	factory, found := catalog[config.Name]
 	if !found {
 		msg := fmt.Sprintf("Check %s not found in Catalog", config.Name)
-		log.Warn(msg)
 		return checks, fmt.Errorf(msg)
 	}
 

--- a/pkg/collector/check/py/loader.go
+++ b/pkg/collector/check/py/loader.go
@@ -63,7 +63,6 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		// we don't expect a traceback here so we use the error msg in `pvalue`
 		_, pvalue, _ := python.PyErr_Fetch()
 		msg := python.PyString_AsString(pvalue)
-		log.Warn(msg)
 		return checks, errors.New(msg)
 	}
 
@@ -71,7 +70,6 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	checkClass := findSubclassOf(cl.agentCheckClass, checkModule)
 	if checkClass == nil {
 		msg := fmt.Sprintf("Unable to find a check class in the module: %v", python.PyString_AS_STRING(checkModule.Str()))
-		log.Warnf(msg)
 		return checks, errors.New(msg)
 	}
 

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 // FIXTURE
@@ -17,135 +18,110 @@ func (c *TestCheck) String() string                        { return "TestCheck" 
 func (c *TestCheck) Stop()                                 { c.stop <- true }
 func (c *TestCheck) Configure(a, b check.ConfigData) error { return nil }
 func (c *TestCheck) InitSender()                           {}
-func (c *TestCheck) Interval() time.Duration               { return 1 }
+func (c *TestCheck) Interval() time.Duration               { return 1 * time.Minute }
 func (c *TestCheck) Run() error                            { <-c.stop; return nil }
 func (c *TestCheck) ID() check.ID                          { return check.ID(c.String()) }
 
 func NewCheck() *TestCheck { return &TestCheck{stop: make(chan bool)} }
 
-func TestNewCollector(t *testing.T) {
-	c := NewCollector()
-	assert.Nil(t, c.aggregator)
-	assert.Nil(t, c.runner)
-	assert.Nil(t, c.scheduler)
-	assert.Nil(t, c.pyState)
-	assert.Equal(t, stopped, c.state)
+type CollectorTestSuite struct {
+	suite.Suite
+	c *Collector
 }
 
-func TestStartStop(t *testing.T) {
-	c := NewCollector()
-	c.Start(".")
-	assert.NotNil(t, c.aggregator)
-	assert.NotNil(t, c.runner)
-	assert.NotNil(t, c.scheduler)
-	assert.NotNil(t, c.pyState)
-	assert.Equal(t, started, c.state)
-	c.Stop()
-	assert.Nil(t, c.aggregator)
-	assert.Nil(t, c.runner)
-	assert.Nil(t, c.scheduler)
-	assert.Nil(t, c.pyState)
-	assert.Equal(t, stopped, c.state)
+func (suite *CollectorTestSuite) SetupTest() {
+	suite.c = NewCollector()
 }
 
-func TestRunCheck(t *testing.T) {
+func (suite *CollectorTestSuite) TearDownTest() {
+	suite.c.Stop()
+	suite.c = nil
+}
+
+func (suite *CollectorTestSuite) TestNewCollector() {
+	assert.NotNil(suite.T(), suite.c.runner)
+	assert.NotNil(suite.T(), suite.c.scheduler)
+	assert.NotNil(suite.T(), suite.c.pyState)
+	assert.Equal(suite.T(), started, suite.c.state)
+}
+
+func (suite *CollectorTestSuite) TestStop() {
+	suite.c.Stop()
+	assert.Nil(suite.T(), suite.c.runner)
+	assert.Nil(suite.T(), suite.c.scheduler)
+	assert.Nil(suite.T(), suite.c.pyState)
+	assert.Equal(suite.T(), stopped, suite.c.state)
+}
+
+func (suite *CollectorTestSuite) TestRunCheck() {
 	ch := NewCheck()
-	c := NewCollector()
-
-	// collector hasn't started
-	err := c.RunCheck(ch)
-	assert.NotNil(t, err)
-	assert.Equal(t, "the collector is not running", err.Error())
-
-	// start the collector
-	c.Start(".")
 
 	// schedule a check
-	err = c.RunCheck(ch)
-	assert.Equal(t, 1, len(c.checks))
-	assert.Equal(t, ch, c.checks["TestCheck"])
+	err := suite.c.RunCheck(ch)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 1, len(suite.c.checks))
+	assert.Equal(suite.T(), ch, suite.c.checks["TestCheck"])
 
 	// schedule the same check twice
-	err = c.RunCheck(ch)
-	assert.NotNil(t, err)
-	assert.Equal(t, "a check with ID TestCheck is already running", err.Error())
-
-	c.Stop()
+	err = suite.c.RunCheck(ch)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), "a check with ID TestCheck is already running", err.Error())
 }
 
-func TestReloadCheck(t *testing.T) {
+func (suite *CollectorTestSuite) TestReloadCheck() {
 	ch := NewCheck()
-	c := NewCollector()
-
-	// collector hasn't started
 	empty := check.ConfigData{}
-	err := c.ReloadCheck("foo", empty, empty)
-	assert.NotNil(t, err)
-	assert.Equal(t, "the collector is not running", err.Error())
 
-	// start the collector and schedule a check
-	c.Start(".")
-	err = c.RunCheck(ch)
+	// schedule a check
+	err := suite.c.RunCheck(ch)
 
 	// check doesn't exist
-	err = c.ReloadCheck("foo", empty, empty)
-	assert.NotNil(t, err)
-	assert.Equal(t, "cannot find a check with ID foo", err.Error())
+	err = suite.c.ReloadCheck("foo", empty, empty)
+	assert.NotNil(suite.T(), err)
+	assert.Equal(suite.T(), "cannot find a check with ID foo", err.Error())
 
 	// all good
-	err = c.ReloadCheck("TestCheck", empty, empty)
-	assert.Nil(t, err)
-
-	c.Stop()
+	err = suite.c.ReloadCheck("TestCheck", empty, empty)
+	assert.Nil(suite.T(), err)
 }
 
-func TestStopCheck(t *testing.T) {
+func (suite *CollectorTestSuite) TestStopCheck() {
 	ch := NewCheck()
-	c := NewCollector()
 
-	// collector hasn't started
-	empty := check.ConfigData{}
-	err := c.ReloadCheck("foo", empty, empty)
-	assert.NotNil(t, err)
-	assert.Equal(t, "the collector is not running", err.Error())
-
-	// start the collector and schedule a check
-	c.Start(".")
-	err = c.RunCheck(ch)
+	// schedule a check
+	err := suite.c.RunCheck(ch)
 
 	// all good
-	err = c.StopCheck("TestCheck")
-	assert.Nil(t, err)
-	assert.Zero(t, len(c.checks))
-
-	c.Stop()
+	err = suite.c.StopCheck("TestCheck")
+	assert.Nil(suite.T(), err)
+	assert.Zero(suite.T(), len(suite.c.checks))
 }
 
-func TestFind(t *testing.T) {
-	c := NewCollector()
-	assert.False(t, c.find("bar"))
-
-	c.checks["bar"] = nil
-	assert.False(t, c.find("foo"))
-	assert.True(t, c.find("bar"))
+func (suite *CollectorTestSuite) TestFind() {
+	assert.False(suite.T(), suite.c.find("bar"))
+	suite.c.checks["bar"] = nil
+	assert.False(suite.T(), suite.c.find("foo"))
+	assert.True(suite.T(), suite.c.find("bar"))
 }
 
-func TestDelete(t *testing.T) {
-	c := NewCollector()
-	c.checks["bar"] = nil
+func (suite *CollectorTestSuite) TestDelete() {
 	// delete a key that doesn't exist should be a noop
-	c.delete("foo")
+	assert.NotNil(suite.T(), suite.c)
+	suite.c.delete("foo")
 
 	// for good
-	assert.True(t, c.find("bar"))
-	c.delete("bar")
-	assert.False(t, c.find("bar"))
+	suite.c.checks["bar"] = nil
+	assert.True(suite.T(), suite.c.find("bar"))
+	suite.c.delete("bar")
+	assert.False(suite.T(), suite.c.find("bar"))
 }
 
-func TestStarted(t *testing.T) {
-	c := NewCollector()
-	assert.False(t, c.started())
-	c.Start(".")
-	assert.True(t, c.started())
-	c.Stop()
+func (suite *CollectorTestSuite) TestStarted() {
+	assert.True(suite.T(), suite.c.started())
+	suite.c.Stop()
+	assert.False(suite.T(), suite.c.started())
+}
+
+func TestCollectorSuite(t *testing.T) {
+	suite.Run(t, new(CollectorTestSuite))
 }

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -64,6 +64,7 @@ func (s *Scheduler) Enter(check check.Check) error {
 
 	if _, ok := s.jobQueues[check.Interval()]; !ok {
 		s.jobQueues[check.Interval()] = newJobQueue(check.Interval())
+		s.startQueue(s.jobQueues[check.Interval()])
 	}
 	s.jobQueues[check.Interval()].addJob(check)
 	// map each check to the Job Queue it was assigned to
@@ -181,7 +182,12 @@ func (s *Scheduler) stopQueues() {
 // startQueues loads the timer for each queue
 func (s *Scheduler) startQueues() {
 	for _, q := range s.jobQueues {
-		q.run(s.checksPipe)
-		q.running = true
+		s.startQueue(q)
 	}
+}
+
+// simple wrapper to have this in just one place
+func (s *Scheduler) startQueue(q *jobQueue) {
+	q.run(s.checksPipe)
+	q.running = true
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a bug exposed by changing the startup sequence: calling `scheduler.Enter` *after* the Runner started was not working, this patch addresses the issue.

Also shipped with this PR:
 * move Aggregator and Forwarder out of the Collector: this was a shortsighted choice that proved itself wrong when we tried to add Dogstatsd to the Agent (my bad).
 * kill the `Start` method on the Collector: as we already did for the Runner, there's no point in start/stopping the Collector, better have it fully functional upon creation. `Stop` is still implemented to provide a clean shutdown of the system.
 * removed the warning logs from Loaders: it's up to the caller to decide wether or not print the warnings

### Testing Guidelines

Using a test Suite to leverage Setup/Teardown operations and get a cleaner code
