### PR TITLE
Fix regression: pick num of runners from settings

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -8,12 +8,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	python "github.com/sbinet/go-python"
-)
-
-const (
-	// NumRunnerWorkers is the number of workers the Runner should spawn
-	NumRunnerWorkers = 4
 )
 
 const (
@@ -33,7 +29,7 @@ type Collector struct {
 
 // NewCollector create a Collector instance and sets up the Python Environment
 func NewCollector(paths ...string) *Collector {
-	run := check.NewRunner(NumRunnerWorkers)
+	run := check.NewRunner(config.Datadog.GetInt("check_runners"))
 	sched := scheduler.NewScheduler(run.GetChan())
 	sched.Run()
 


### PR DESCRIPTION
### What does this PR do?

As per title, when moving the Runner into the Collector I accidentally removed the dynamic parameter we added to specify how many runners should go, this PR fixes it back.