### PR TITLE
Implement in-memory cache

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7239603a0736c0475ad9d62140d73414d3c5365e9440e4fc71522702819bfece
-updated: 2017-02-15T14:13:19.586416096+01:00
+hash: 05b941ad03b7ad7d55eda3f7cabda42c83cadf889c9430f34d8329da084a45ce
+updated: 2017-02-21T15:29:07.723066381+01:00
 imports:
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
@@ -18,49 +18,49 @@ imports:
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: fb0bebc4b64e3881cc52a2478d749845ed76d2a8
+  version: df5327f76fb6468b84a87771e361762b8be23fdb
   subpackages:
-  - digestset
   - reference
+  - digestset
 - name: github.com/docker/docker
   version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
   subpackages:
+  - client
   - api/types
-  - api/types/blkiodev
   - api/types/container
   - api/types/events
   - api/types/filters
-  - api/types/mount
   - api/types/network
   - api/types/reference
   - api/types/registry
-  - api/types/strslice
   - api/types/swarm
   - api/types/time
   - api/types/versions
   - api/types/volume
-  - client
   - pkg/tlsconfig
+  - api/types/mount
+  - api/types/blkiodev
+  - api/types/strslice
 - name: github.com/docker/go-connections
   version: 7da10c8c50cad14494ec818dcdfb6506265c0086
   subpackages:
-  - nat
   - sockets
   - tlsconfig
+  - nat
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/go-ole/go-ole
-  version: 5e9c030faf78847db7aa77e3661b9cc449de29b7
+  version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
   - oleutil
 - name: github.com/gogo/protobuf
-  version: 9c5b7bafbfccf2b40d274e0496f3a09418a87af4
+  version: 3ea128ab69017b2bb9720f38a32e2dcfc22c0546
   subpackages:
   - proto
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: 69b215d01a5606c843240eab4937eab3acee6530
   subpackages:
   - proto
 - name: github.com/gorilla/context
@@ -68,20 +68,20 @@ imports:
 - name: github.com/gorilla/mux
   version: 392c28fe23e1c45ddba891b0320b3b5df220beea
 - name: github.com/hashicorp/hcl
-  version: 372e8ddaa16fd67e371e9323807d056b799360af
+  version: 630949a3c5fa3c613328e1b8256052cbc2327c9b
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/scanner
+  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/kardianos/osext
-  version: c2c54e542fb797ad986b31721e1baedf214ca413
+  version: 9b883c5eb462dd5cb1b0a7a104fe86bc6b9bd391
 - name: github.com/magiconair/properties
   version: b3b15ef068fd0b17ddf408a23669f20811d194d2
 - name: github.com/Microsoft/go-winio
@@ -94,10 +94,12 @@ imports:
   version: aa2ec055abd10d26d539eb630a92241b781ce4bc
 - name: github.com/PagerDuty/godspeed
   version: 6d136386b5f291797c77764dfd2acc950dc27347
+- name: github.com/patrickmn/go-cache
+  version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: d1fa2118c12c44e4f5004da216d1efad10cb4924
+  version: 22139eb5469018e7374b3e7ef653de37ffb44f72
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
 - name: github.com/pmezard/go-difflib
@@ -107,21 +109,21 @@ imports:
 - name: github.com/sbinet/go-python
   version: a2acb64fbdf8703949837e5ebf50c71319fe03a4
 - name: github.com/shirou/gopsutil
-  version: 32b6636de04b303274daac3ca2b10d3b0e4afc35
+  version: c14b242c603c1fc5e2dc92a90d65a2c1da935407
   subpackages:
+  - mem
   - cpu
   - internal/common
-  - mem
 - name: github.com/Sirupsen/logrus
-  version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
+  version: 7f4b1adc791766938c29457bed0703fb9134421a
 - name: github.com/spf13/afero
-  version: 72b31426848c6ef12a7a8e216708cb0d1530f074
+  version: 9be650865eab0c12963d8753212f4f9c66cdcf12
   subpackages:
   - mem
 - name: github.com/spf13/cast
   version: d1139bab1c07d5ad390a65e7305876b3c1a8370b
 - name: github.com/spf13/cobra
-  version: 35136c09d8da66b901337c6e86fd8e88a1a255bd
+  version: ee4055870c2d5f7ce112642377e32c9929c3bbaf
   subpackages:
   - cobra
 - name: github.com/spf13/jwalterweatherman
@@ -129,32 +131,34 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/spf13/viper
-  version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
+  version: 7538d73b4eb9511d85a9f1dfef202eeb8ac260f4
 - name: github.com/StackExchange/wmi
-  version: e54cbda6595d7293a7a468ccf9525f6bc8887f99
+  version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
-  - assert
   - mock
+  - assert
+  - suite
+  - require
 - name: golang.org/x/net
-  version: 236b8f043b920452504e263bc21d354427127473
+  version: 6b27048ae5e6ad1ef927e72e437531493de612fe
   subpackages:
   - context
   - context/ctxhttp
   - proxy
 - name: golang.org/x/sys
-  version: 7a6e5648d140666db5d920909e082ca00a87ba2c
+  version: 075e574b89e4c2d22f2286a7e2b919519c6f3547
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 506f9d5c962f284575e88337e7d9296d27e729d3
+  version: 85c29909967d7f171f821e7a42e7b7af76fb9598
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/yaml.v2
-  version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,6 +29,10 @@ import:
   subpackages:
   - client
 - package: github.com/DataDog/zstd
-- package: github.com/gogo/protobuf/proto
+- package: github.com/gogo/protobuf
+  subpackages:
+  - proto
 - package: github.com/DataDog/agent-payload
   version: ^1.0
+- package: github.com/patrickmn/go-cache
+  version: ^2.0.0

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	cache "github.com/patrickmn/go-cache"
 	python "github.com/sbinet/go-python"
 )
 
@@ -16,6 +18,14 @@ const (
 	stopped uint32 = iota
 	started
 )
+
+const (
+	defaultCacheExpire = 5 * time.Minute
+	defaultCachePurge  = 30 * time.Second
+)
+
+// Cache provides an in-memory key:value store similar to memcached
+var Cache = cache.New(defaultCacheExpire, defaultCachePurge)
 
 // Collector abstract common operations about running a Check
 type Collector struct {


### PR DESCRIPTION
### What does this PR do?

As a first implementation, just use a third party package called `go-cache`.
We provide a global cache resource from the `collector` package to be used by any component of the Agent.

Example usage:
```
collector.Cache.Set("foo", &MyStruct, cache.DefaultExpiration)
        
// and later...
if x, found := collector.Cache.Get("foo"); found {
    foo := x.(*MyStruct)  // type assert to get your type back    
}
```

The API is pretty straightforward so we can replace/rewrite it at any time.