### PR TITLE
Maxime/start dogstatd with agent

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -138,15 +138,10 @@ func start(cmd *cobra.Command, args []string) {
 	select {
 	case <-common.Stopper:
 		log.Info("Received stop command, shutting down...")
-		goto teardown
 	case sig := <-signalCh:
 		log.Infof("Received signal '%s', shutting down...", sig)
-		if sig == os.Interrupt || sig == syscall.SIGTERM {
-			goto teardown
-		}
 	}
 
-teardown:
 	// gracefully shut down any component
 	common.Collector.Stop()
 	api.StopServer()

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -16,3 +16,19 @@ api_key:
 
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
+
+# ========================================================================== #
+# DogStatsd configuration                                                    #
+# ========================================================================== #
+
+# If you don't want to enable the DogStatsd server, set this option to no
+# use_dogstatsd: yes
+
+# DogStatsd is a small server that aggregates your custom app metrics. For
+# usage information, check out http://api.datadoghq.com
+
+# Make sure your client is sending to the same port.
+# dogstatsd_port : 8125
+#
+# The buffer size use to receive statsd packet (defaults 1024)
+# dogstatsd_buffer_size: 1024

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,9 @@ func init() {
 	Datadog.SetDefault("dd_url", "http://localhost:17123")
 	Datadog.SetDefault("hostname", "")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
+	Datadog.SetDefault("use_dogstatsd", true)
+	Datadog.SetDefault("dogstatsd_port", 8125)
+	Datadog.SetDefault("dogstatsd_buffer_size", 1024)
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -1,18 +1,44 @@
 package dogstatsd
 
 import (
-
-	// stdlib
+	"fmt"
+	"net"
 	"testing"
 
-	// 3p
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func TestUDPAccept(t *testing.T) {
-	assert.Equal(t, 1, 1)
+func TestNewServer(t *testing.T) {
+	s := NewServer(nil)
+	defer s.Stop()
+	assert.NotNil(t, s)
+	assert.True(t, s.Started)
 }
 
-func TestSubmitToParser(t *testing.T) {
-	assert.Equal(t, 1, 1)
+func TestStopServer(t *testing.T) {
+	s := NewServer(nil)
+	s.Stop()
+
+	// check that the port can be bind
+	address, _ := net.ResolveUDPAddr("udp", "localhost:8126")
+	conn, err := net.ListenUDP("udp", address)
+	assert.Nil(t, err)
+	conn.Close()
+}
+
+func TestUPDReceive(t *testing.T) {
+	output := make(chan *aggregator.MetricSample)
+	s := NewServer(output)
+	defer s.Stop()
+
+	url := fmt.Sprintf("localhost:%d", config.Datadog.GetInt("dogstatsd_port"))
+	conn, _ := net.Dial("udp", url)
+	defer conn.Close()
+	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+
+	res := <-output
+	assert.NotNil(t, res)
 }


### PR DESCRIPTION
### What does this PR do?

Use dogstatsd within the main agent:
- Updating dogstatsd to work as a server in its own goroutine.
- Parse each packet in a goroutine not to block the read on the UDP socket
- Dogstatsd uses the agent configuration instead of hardcoded value

Also cleanup agent teardown by removing useless label.

### Motivation

We need to be able to run dogstatd with the main agent.