### PR TITLE
[aggregator] Add support for service checks from checks (part 1)

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -29,24 +29,27 @@ func InitAggregator(f *forwarder.Forwarder) *BufferedAggregator {
 
 // BufferedAggregator aggregates metrics in buckets for dogstatsd Metrics
 type BufferedAggregator struct {
-	dogstatsdIn   chan *MetricSample
-	checkIn       chan senderSample
-	sampler       Sampler
-	checkSamplers map[check.ID]*CheckSampler
-	flushInterval int64
-	mu            sync.Mutex // to protect the checkSamplers field
-	forwarder     *forwarder.Forwarder
+	dogstatsdIn    chan *MetricSample
+	checkIn        chan senderSample
+	serviceCheckIn chan ServiceCheck
+	sampler        Sampler
+	checkSamplers  map[check.ID]*CheckSampler
+	serviceChecks  []ServiceCheck
+	flushInterval  int64
+	mu             sync.Mutex // to protect the checkSamplers field
+	forwarder      *forwarder.Forwarder
 }
 
 // Instantiate a BufferedAggregator and run it
 func newBufferedAggregator(f *forwarder.Forwarder) *BufferedAggregator {
 	aggregator := &BufferedAggregator{
-		dogstatsdIn:   make(chan *MetricSample, 100), // TODO make buffer size configurable
-		checkIn:       make(chan senderSample, 100),  // TODO make buffer size configurable
-		sampler:       *NewSampler(bucketSize),
-		checkSamplers: make(map[check.ID]*CheckSampler),
-		flushInterval: defaultFlushInterval,
-		forwarder:     f,
+		dogstatsdIn:    make(chan *MetricSample, 100), // TODO make buffer size configurable
+		checkIn:        make(chan senderSample, 100),  // TODO make buffer size configurable
+		serviceCheckIn: make(chan ServiceCheck, 100),  // TODO make buffer size configurable
+		sampler:        *NewSampler(bucketSize),
+		checkSamplers:  make(map[check.ID]*CheckSampler),
+		flushInterval:  defaultFlushInterval,
+		forwarder:      f,
 	}
 
 	go aggregator.run()
@@ -91,35 +94,77 @@ func (agg *BufferedAggregator) handleSenderSample(ss senderSample) {
 	}
 }
 
+// addServiceCheck adds the service check to the slice of current service checks
+// FIXME: the default hostname should be the one that's resolved by the Agent logic instead of the one pulled from the main config
+func (agg *BufferedAggregator) addServiceCheck(sc ServiceCheck) {
+	if sc.Host == "" {
+		sc.Host = config.Datadog.GetString("hostname")
+	}
+	if sc.Ts == 0 {
+		sc.Ts = time.Now().Unix()
+	}
+
+	agg.serviceChecks = append(agg.serviceChecks, sc)
+}
+
+func (agg *BufferedAggregator) flushSeries() {
+	now := time.Now().Unix()
+	series := agg.sampler.flush(now)
+	agg.mu.Lock()
+	for _, checkSampler := range agg.checkSamplers {
+		series = append(series, checkSampler.flush()...)
+	}
+	agg.mu.Unlock()
+
+	if len(series) == 0 {
+		return
+	}
+
+	log.Debug("Flushing ", len(series), " series to the forwarder")
+	payload, err := MarshalJSONSeries(series)
+	if err != nil {
+		log.Error("could not serialize series, dropping it:", err)
+		return
+	}
+	agg.forwarder.SubmitV1Series(config.Datadog.GetString("api_key"), &payload)
+}
+
+func (agg *BufferedAggregator) flushServiceChecks() {
+	// Add a simple service check for the Agent status
+	agg.addServiceCheck(ServiceCheck{
+		CheckName: "datadog.agent.up",
+		Status:    ServiceCheckOK,
+	})
+
+	// Clear the current service check slice
+	serviceChecks := agg.serviceChecks
+	agg.serviceChecks = nil
+
+	log.Debug("Flushing ", len(serviceChecks), " service checks to the forwarder")
+	// Serialize and forward
+	payload, err := MarshalJSONServiceChecks(serviceChecks)
+	if err != nil {
+		log.Error("could not serialize service checks, dropping them: ", err)
+		return
+	}
+	agg.forwarder.SubmitV1CheckRuns(config.Datadog.GetString("api_key"), &payload)
+}
+
 func (agg *BufferedAggregator) run() {
 	flushPeriod := time.Duration(agg.flushInterval) * time.Second
 	flushTicker := time.NewTicker(flushPeriod)
 	for {
 		select {
 		case <-flushTicker.C:
-			now := time.Now().Unix()
-			series := agg.sampler.flush(now)
-			agg.mu.Lock()
-			for _, checkSampler := range agg.checkSamplers {
-				series = append(series, checkSampler.flush()...)
-			}
-			agg.mu.Unlock()
-
-			if len(series) == 0 {
-				continue
-			}
-
-			payload, err := MarshalJSONSeries(series)
-			if err != nil {
-				log.Error("could not serialize series, dropping it:", err)
-				continue
-			}
-			agg.forwarder.SubmitV1Series(config.Datadog.GetString("api_key"), &payload)
+			agg.flushSeries()
+			agg.flushServiceChecks()
 		case sample := <-agg.dogstatsdIn:
 			now := time.Now().Unix()
 			agg.sampler.addSample(sample, now)
 		case ss := <-agg.checkIn:
 			agg.handleSenderSample(ss)
+		case sc := <-agg.serviceCheckIn:
+			agg.addServiceCheck(sc)
 		}
 	}
 }

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var checkID1 check.ID = "1"
@@ -44,5 +45,36 @@ func TestDeregisterCheckSampler(t *testing.T) {
 		assert.False(t, ok)
 		_, ok = agg.checkSamplers[checkID2]
 		assert.True(t, ok)
+	}
+}
+
+func TestAddServiceCheckDefaultValues(t *testing.T) {
+	resetAggregator()
+	agg := InitAggregator(nil)
+
+	// For now the default hostname is the one pulled from the main config
+	config.Datadog.Set("hostname", "config-hostname")
+
+	agg.addServiceCheck(ServiceCheck{
+		// leave Host and Ts fields blank
+		CheckName: "my_service.can_connect",
+		Status:    ServiceCheckOK,
+		Tags:      []string{"foo", "bar"},
+		Message:   "message",
+	})
+	agg.addServiceCheck(ServiceCheck{
+		CheckName: "my_service.can_connect",
+		Status:    ServiceCheckOK,
+		Host:      "my-hostname",
+		Tags:      []string{"foo", "bar"},
+		Ts:        12345,
+		Message:   "message",
+	})
+
+	if assert.Len(t, agg.serviceChecks, 2) {
+		assert.Equal(t, "config-hostname", agg.serviceChecks[0].Host)
+		assert.NotEqual(t, 0., agg.serviceChecks[0].Ts) // should be set to the current time, let's just check that it's not 0
+		assert.Equal(t, "my-hostname", agg.serviceChecks[1].Host)
+		assert.Equal(t, int64(12345), agg.serviceChecks[1].Ts)
 	}
 }

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -84,9 +84,9 @@ func TestDestroySender(t *testing.T) {
 }
 
 func TestCheckSenderInterface(t *testing.T) {
-	senderSampleChan := make(chan senderSample, 10)
+	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan ServiceCheck, 10)
-	checkSender := newCheckSender(checkID1, senderSampleChan, serviceCheckChan)
+	checkSender := newCheckSender(checkID1, senderMetricSampleChan, serviceCheckChan)
 	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Count("my.count_metric", 123.0, "my-hostname", []string{"foo", "bar"})
@@ -95,32 +95,32 @@ func TestCheckSenderInterface(t *testing.T) {
 	checkSender.Commit()
 	checkSender.ServiceCheck("my_service.can_connect", ServiceCheckOK, "my-hostname", []string{"foo", "bar"}, "message")
 
-	gaugeSenderSample := <-senderSampleChan
+	gaugeSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, gaugeSenderSample.id)
 	assert.Equal(t, GaugeType, gaugeSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, gaugeSenderSample.commit)
 
-	rateSenderSample := <-senderSampleChan
+	rateSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, rateSenderSample.id)
 	assert.Equal(t, RateType, rateSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, rateSenderSample.commit)
 
-	countSenderSample := <-senderSampleChan
+	countSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, countSenderSample.id)
 	assert.Equal(t, CountType, countSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, countSenderSample.commit)
 
-	monotonicCountSenderSample := <-senderSampleChan
+	monotonicCountSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, monotonicCountSenderSample.id)
 	assert.Equal(t, MonotonicCountType, monotonicCountSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, monotonicCountSenderSample.commit)
 
-	histoSenderSample := <-senderSampleChan
+	histoSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, histoSenderSample.id)
 	assert.Equal(t, HistogramType, histoSenderSample.metricSample.Mtype)
 	assert.Equal(t, false, histoSenderSample.commit)
 
-	commitSenderSample := <-senderSampleChan
+	commitSenderSample := <-senderMetricSampleChan
 	assert.EqualValues(t, checkID1, commitSenderSample.id)
 	assert.Equal(t, true, commitSenderSample.commit)
 

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -55,3 +55,11 @@ func MarshalJSONSeries(series []*Serie) ([]byte, error) {
 	err := json.NewEncoder(reqBody).Encode(data)
 	return reqBody.Bytes(), err
 }
+
+// MarshalJSONServiceChecks serializes service checks to JSON so it can be sent to V1 endpoints
+//FIXME(olivier): to be removed when v2 endpoints are available
+func MarshalJSONServiceChecks(serviceChecks []ServiceCheck) ([]byte, error) {
+	reqBody := &bytes.Buffer{}
+	err := json.NewEncoder(reqBody).Encode(serviceChecks)
+	return reqBody.Bytes(), err
+}

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -62,3 +62,19 @@ func TestMarshalJSONSeries(t *testing.T) {
 	assert.NotNil(t, payload)
 	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device_name\":\"\",\"type\":\"gauge\",\"interval\":0}]}\n"))
 }
+
+func TestMarshalJSONServiceChecks(t *testing.T) {
+	serviceChecks := []ServiceCheck{{
+		CheckName: "my_service.can_connect",
+		Host:      "my-hostname",
+		Ts:        int64(12345),
+		Status:    ServiceCheckOK,
+		Message:   "my_service is up",
+		Tags:      []string{"tag1", "tag2:yes"},
+	}}
+
+	payload, err := MarshalJSONServiceChecks(serviceChecks)
+	assert.Nil(t, err)
+	assert.NotNil(t, payload)
+	assert.Equal(t, payload, []byte("[{\"check\":\"my_service.can_connect\",\"host_name\":\"my-hostname\",\"timestamp\":12345,\"status\":0,\"message\":\"my_service is up\",\"tags\":[\"tag1\",\"tag2:yes\"]}]\n"))
+}

--- a/pkg/aggregator/service_check.go
+++ b/pkg/aggregator/service_check.go
@@ -1,0 +1,38 @@
+package aggregator
+
+// ServiceCheckStatus represents the status associated with a service check
+type ServiceCheckStatus int
+
+// Enumeration of the existing service check statuses, and their values
+const (
+	ServiceCheckOK       ServiceCheckStatus = 0
+	ServiceCheckWarning  ServiceCheckStatus = 1
+	ServiceCheckCritical ServiceCheckStatus = 2
+	ServiceCheckUnknown  ServiceCheckStatus = 3
+)
+
+// String returns a string representation of ServiceCheckStatus
+func (s ServiceCheckStatus) String() string {
+	switch s {
+	case ServiceCheckOK:
+		return "OK"
+	case ServiceCheckWarning:
+		return "WARNING"
+	case ServiceCheckCritical:
+		return "CRITICAL"
+	case ServiceCheckUnknown:
+		return "UNKNOWN"
+	default:
+		return ""
+	}
+}
+
+// ServiceCheck holds a service check (w/ serialization to DD api format)
+type ServiceCheck struct {
+	CheckName string             `json:"check"`
+	Host      string             `json:"host_name"`
+	Ts        int64              `json:"timestamp"`
+	Status    ServiceCheckStatus `json:"status"`
+	Message   string             `json:"message"`
+	Tags      []string           `json:"tags"`
+}

--- a/pkg/collector/check/core/system/common_test.go
+++ b/pkg/collector/check/core/system/common_test.go
@@ -2,6 +2,8 @@ package system
 
 import (
 	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 type MockSender struct {
@@ -30,4 +32,8 @@ func (m *MockSender) Commit() {
 
 func (m *MockSender) Gauge(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)
+}
+
+func (m *MockSender) ServiceCheck(checkName string, status aggregator.ServiceCheckStatus, hostname string, tags []string, message string) {
+	m.Called(checkName, status, hostname, tags, message)
 }

--- a/pkg/collector/check/py/api.c
+++ b/pkg/collector/check/py/api.c
@@ -1,6 +1,6 @@
 #include "api.h"
 
-PyObject* SubmitData(PyObject*, MetricType, char*, float, PyObject*);
+PyObject* SubmitMetric(PyObject*, MetricType, char*, float, PyObject*);
 
 char* MetricTypeNames[] = {
   "GAUGE",
@@ -10,7 +10,7 @@ char* MetricTypeNames[] = {
   "HISTOGRAM"
 };
 
-static PyObject *submit_data(PyObject *self, PyObject *args) {
+static PyObject *submit_metric(PyObject *self, PyObject *args) {
     PyObject *check = NULL;
     int mt;
     char *name;
@@ -20,18 +20,18 @@ static PyObject *submit_data(PyObject *self, PyObject *args) {
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    // aggregator.submit_data(self, aggregator.metric_type.GAUGE, name, value, tags)
+    // aggregator.submit_metric(self, aggregator.metric_type.GAUGE, name, value, tags)
     if (!PyArg_ParseTuple(args, "OisfO", &check, &mt, &name, &value, &tags)) {
       PyGILState_Release(gstate);
       Py_RETURN_NONE;
     }
 
     PyGILState_Release(gstate);
-    return SubmitData(check, mt, name, value, tags);
+    return SubmitMetric(check, mt, name, value, tags);
 }
 
 static PyMethodDef AggMethods[] = {
-  {"submit_data", (PyCFunction)submit_data, METH_VARARGS, "Submit metrics to the aggregator."},
+  {"submit_metric", (PyCFunction)submit_metric, METH_VARARGS, "Submit metrics to the aggregator."},
   {NULL, NULL}  // guards
 };
 

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -14,9 +14,9 @@ import (
 // #include "stdlib.h"
 import "C"
 
-// SubmitData is the method exposed to Python scripts
-//export SubmitData
-func SubmitData(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject) *C.PyObject {
+// SubmitMetric is the method exposed to Python scripts
+//export SubmitMetric
+func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject) *C.PyObject {
 
 	sender, err := aggregator.GetDefaultSender()
 	if err != nil {

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -14,7 +14,7 @@ import (
 // #include "stdlib.h"
 import "C"
 
-// SubmitMetric is the method exposed to Python scripts
+// SubmitMetric is the method exposed to Python scripts to submit metrics
 //export SubmitMetric
 func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject) *C.PyObject {
 

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -38,19 +38,19 @@ class AgentCheck(object):
         self.log = logging.getLogger('%s.%s' % (__name__, self.name))
 
     def gauge(self, name, value, tags=None):
-        aggregator.submit_data(self, aggregator.GAUGE, name, value, tags)
+        aggregator.submit_metric(self, aggregator.GAUGE, name, value, tags)
 
     def count(self, name, value, tags=None):
-        aggregator.submit_data(self, aggregator.COUNT, name, value, tags)
+        aggregator.submit_metric(self, aggregator.COUNT, name, value, tags)
 
     def monotonic_count(self, name, value, tags=None):
-        aggregator.submit_data(self, aggregator.MONOTONIC_COUNT, name, value, tags)
+        aggregator.submit_metric(self, aggregator.MONOTONIC_COUNT, name, value, tags)
 
     def rate(self, name, value, tags=None):
-        aggregator.submit_data(self, aggregator.RATE, name, value, tags)
+        aggregator.submit_metric(self, aggregator.RATE, name, value, tags)
 
     def histogram(self, name, value, tags=None, hostname=None, device_name=None):
-        aggregator.submit_data(self, aggregator.HISTOGRAM, name, value, tags)
+        aggregator.submit_metric(self, aggregator.HISTOGRAM, name, value, tags)
 
     def service_check(self, *args, **kwargs):
         pass

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -19,7 +19,8 @@ const (
 	defaultNumberOfWorkers = 4
 	chanBufferSize         = 100
 
-	v1SeriesEndpoint = "/api/v1/series?api_key=%s"
+	v1SeriesEndpoint    = "/api/v1/series?api_key=%s"
+	v1CheckRunsEndpoint = "/api/v1/check_run?api_key=%s"
 
 	seriesEndpoint       = "/api/v2/series"
 	eventsEndpoint       = "/api/v2/events"
@@ -225,8 +226,15 @@ func (f *Forwarder) SubmitMetadata(payload *[]byte) error {
 }
 
 // SubmitV1Series will send timeserie to v1 endpoint (this will be remove once
-// the backend will handle v2 endpoints).
+// the backend handles v2 endpoints).
 func (f *Forwarder) SubmitV1Series(apiKey string, payload *[]byte) error {
 	endpoint := fmt.Sprintf(v1SeriesEndpoint, apiKey)
+	return f.createTransaction(endpoint, payload, false)
+}
+
+// SubmitV1CheckRuns will send service checks to v1 endpoint (this will be removed once
+// the backend handles v2 endpoints).
+func (f *Forwarder) SubmitV1CheckRuns(apiKey string, payload *[]byte) error {
+	endpoint := fmt.Sprintf(v1CheckRunsEndpoint, apiKey)
 	return f.createTransaction(endpoint, payload, false)
 }

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -155,6 +155,14 @@ func TestSubmit(t *testing.T) {
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
+
+	expectedPayload = []byte("SubmitV1CheckRuns payload")
+	expectedEndpoint = "/api/v1/check_run"
+	expectedQuery = "api_key=test_api_key"
+	assert.Nil(t, forwarder.SubmitV1CheckRuns("test_api_key", &expectedPayload))
+	<-wait
+	<-wait
+	assert.Equal(t, len(forwarder.retryQueue), 0)
 }
 
 func TestSubmitWithProxy(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds support for service checks for the go checks, and serialization to the `v1/check_run` endpoint.

Doesn't include:
- the python bindings for the py checks (will follow in an upcoming PR)
- the v2 endpoint support (I'll create a separate card for that)

### Testing Guidelines

Some basic tests. Also tested this manually.

The default service check `datadog.agent.up` does show up on DD.

### Additional Notes

See commit message for details. Easier to review by reviewing each commit one after the other.

The aggregator listens on a dedicated channel for service checks and stores them. It flushes them at the same time as the metrics (no specific reason to do that, except that it's slightly simpler to implement).

I also sneaked in a cosmetic change to the python check api implementation (renaming `submit_data` to `submit_metric`), so that adding a `submit_service_check` method (later) makes sense.