### PR TITLE
Prepare metadata payload

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 05b941ad03b7ad7d55eda3f7cabda42c83cadf889c9430f34d8329da084a45ce
-updated: 2017-02-21T15:29:07.723066381+01:00
+updated: 2017-02-27T10:08:49.505256266+01:00
 imports:
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
@@ -12,13 +12,13 @@ imports:
   subpackages:
   - statsd
 - name: github.com/DataDog/zstd
-  version: add9e2ca52c03c1f6f8deffa22fcc7667dcb4ae2
+  version: b95200223de728296c3bd0609039cbcb57e15223
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: df5327f76fb6468b84a87771e361762b8be23fdb
+  version: 50133d63723f8fa376e632a853739990a133be16
   subpackages:
   - reference
   - digestset
@@ -42,7 +42,7 @@ imports:
   - api/types/blkiodev
   - api/types/strslice
 - name: github.com/docker/go-connections
-  version: 7da10c8c50cad14494ec818dcdfb6506265c0086
+  version: 1b14b2d192e2f91cdc2bc6bf9aee0b0e116eed42
   subpackages:
   - sockets
   - tlsconfig
@@ -56,7 +56,7 @@ imports:
   subpackages:
   - oleutil
 - name: github.com/gogo/protobuf
-  version: 3ea128ab69017b2bb9720f38a32e2dcfc22c0546
+  version: 83faaee7bbbdf0c59310ec67d340bc0cbe77053f
   subpackages:
   - proto
 - name: github.com/golang/protobuf
@@ -109,11 +109,16 @@ imports:
 - name: github.com/sbinet/go-python
   version: a2acb64fbdf8703949837e5ebf50c71319fe03a4
 - name: github.com/shirou/gopsutil
-  version: c14b242c603c1fc5e2dc92a90d65a2c1da935407
+  version: d371ba1293cb48fedc6850526ea48b3846c54f2c
   subpackages:
   - mem
   - cpu
+  - host
   - internal/common
+  - process
+  - net
+- name: github.com/shirou/w32
+  version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/Sirupsen/logrus
   version: 7f4b1adc791766938c29457bed0703fb9134421a
 - name: github.com/spf13/afero
@@ -121,9 +126,9 @@ imports:
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: d1139bab1c07d5ad390a65e7305876b3c1a8370b
+  version: f820543c3592e283e311a60d2a600a664e39f6f7
 - name: github.com/spf13/cobra
-  version: ee4055870c2d5f7ce112642377e32c9929c3bbaf
+  version: 92ea23a837e66f46ac9e7d04fa826602b7b0a42d
   subpackages:
   - cobra
 - name: github.com/spf13/jwalterweatherman
@@ -144,18 +149,18 @@ imports:
   - suite
   - require
 - name: golang.org/x/net
-  version: 6b27048ae5e6ad1ef927e72e437531493de612fe
+  version: 10c134ea0df15f7e34d789338c7a2d76cc7a3ab9
   subpackages:
   - context
   - context/ctxhttp
   - proxy
 - name: golang.org/x/sys
-  version: 075e574b89e4c2d22f2286a7e2b919519c6f3547
+  version: e4594059fe4cde2daf423055a596c2cd1e6c9adf
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 85c29909967d7f171f821e7a42e7b7af76fb9598
+  version: 0ad425fe45e885577bef05dc1c50f72e33188b16
   subpackages:
   - transform
   - unicode/norm

--- a/pkg/collector/check/py/utils.go
+++ b/pkg/collector/check/py/utils.go
@@ -87,3 +87,19 @@ func getModuleName(modulePath string) string {
 	// no need to check toks length, worst case it contains only an empty string
 	return toks[len(toks)-1]
 }
+
+// GetInterpreterVersion should go in `go-python`, TODO.
+func GetInterpreterVersion() string {
+	// Lock the GIL and release it at the end of the run
+	_gstate := python.PyGILState_Ensure()
+	defer func() {
+		python.PyGILState_Release(_gstate)
+	}()
+
+	res := C.Py_GetVersion()
+	if res == nil {
+		return ""
+	}
+
+	return C.GoString(res)
+}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	cache "github.com/patrickmn/go-cache"
 	python "github.com/sbinet/go-python"
 )
 
@@ -18,14 +16,6 @@ const (
 	stopped uint32 = iota
 	started
 )
-
-const (
-	defaultCacheExpire = 5 * time.Minute
-	defaultCachePurge  = 30 * time.Second
-)
-
-// Cache provides an in-memory key:value store similar to memcached
-var Cache = cache.New(defaultCacheExpire, defaultCachePurge)
 
 // Collector abstract common operations about running a Check
 type Collector struct {

--- a/pkg/collector/metadata/README.md
+++ b/pkg/collector/metadata/README.md
@@ -1,0 +1,16 @@
+## package `metadata`
+
+This package is responsible to provide Agent's metadata in the right form to be directly sent to the backend.
+Single metadata providers are defined in the form of insulated sub packages that should expose a public
+method like:
+```go
+func GetPayload() *Payload
+```
+along with the specific `Payload` definition.
+
+For the time being, any subpackage provides a piece of information that is used in the `v5` package to
+compose a single metadata payload compatible with the one from Agent v.5. This way we can send
+metadata through the current backend endpoints, waiting for the new ones to be deployed. At that point,
+all the subpackages will be required to define their payloads with the new Protobuf format.
+
+Please keep this README updated.

--- a/pkg/collector/metadata/common/common.go
+++ b/pkg/collector/metadata/common/common.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+var (
+	apiKey string
+)
+
+// GetPayload fills and return the common metadata payload
+func GetPayload() *Payload {
+	return &Payload{
+		AgentVersion: version.AgentVersion,
+		APIKey:       getAPIKey(),
+	}
+}
+
+func getAPIKey() string {
+	if apiKey == "" {
+		apiKey = strings.Split(config.Datadog.GetString("api_key"), ",")[0]
+	}
+
+	return apiKey
+}

--- a/pkg/collector/metadata/common/common_test.go
+++ b/pkg/collector/metadata/common/common_test.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPayload(t *testing.T) {
+	apiKey = "foo"
+	p := GetPayload()
+	assert.Equal(t, p.APIKey, "foo")
+	assert.Equal(t, p.AgentVersion, version.AgentVersion)
+	apiKey = ""
+}
+
+func TestGetAPIKey(t *testing.T) {
+	config.Datadog.SetDefault("api_key", "bar,baz")
+	assert.Equal(t, "bar", getAPIKey())
+	assert.Equal(t, "bar", apiKey)
+	apiKey = "foo"
+	assert.Equal(t, "foo", getAPIKey())
+}

--- a/pkg/collector/metadata/common/payload.go
+++ b/pkg/collector/metadata/common/payload.go
@@ -1,0 +1,7 @@
+package common
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	APIKey       string `json:"apiKey"`
+	AgentVersion string `json:"agentVersion"`
+}

--- a/pkg/collector/metadata/host/host.go
+++ b/pkg/collector/metadata/host/host.go
@@ -1,0 +1,117 @@
+package host
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
+
+	log "github.com/cihub/seelog"
+)
+
+// GetPayload builds a metadata payload every time is called.
+// Some data is collected only once, some is cached, some is collected at every call.
+func GetPayload(hostname string) *Payload {
+	meta := getMeta()
+	meta.Hostname = hostname
+
+	return &Payload{
+		Os:               runtime.GOOS,
+		PythonVersion:    getPythonVersion(),
+		InternalHostname: hostname,
+		UUID:             getHostInfo().HostID,
+		SytemStats:       getSystemStats(),
+		Meta:             meta,
+	}
+}
+
+func getSystemStats() *systemStats {
+	var stats *systemStats
+	key := path.Join(metadata.CachePrefix, "systemStats")
+	if x, found := util.Cache.Get(key); found {
+		stats = x.(*systemStats)
+	} else {
+		cpuInfo := getCPUInfo()
+		hostInfo := getHostInfo()
+
+		stats = &systemStats{
+			Machine:   runtime.GOARCH,
+			Platform:  runtime.GOOS,
+			Processor: cpuInfo.ModelName,
+			CPUCores:  cpuInfo.Cores,
+			Pythonv:   strings.Split(getPythonVersion(), " ")[0],
+		}
+
+		// fill the platform dependent bits of info
+		fillOsVersion(stats, hostInfo)
+		util.Cache.Set(key, stats, util.NoExpiration)
+	}
+
+	return stats
+}
+
+func getPythonVersion() string {
+	var pythonVersion string
+	key := path.Join(metadata.CachePrefix, "python")
+	if x, found := util.Cache.Get(key); found {
+		pythonVersion = x.(string)
+	} else {
+		pythonVersion = py.GetInterpreterVersion()
+		util.Cache.Set(key, pythonVersion, util.NoExpiration)
+	}
+
+	return pythonVersion
+}
+
+// getCPUInfo returns InfoStat for the first CPU gopsutil found
+func getCPUInfo() *cpu.InfoStat {
+	key := path.Join(metadata.CachePrefix, "cpuInfo")
+	if x, found := util.Cache.Get(key); found {
+		return x.(*cpu.InfoStat)
+	}
+
+	i, err := cpu.Info()
+	if err != nil {
+		// don't cache and return zero value
+		log.Errorf("failed to retrieve cpu info: %s", err)
+		return &cpu.InfoStat{}
+	}
+	info := &i[0]
+	util.Cache.Set(key, info, util.NoExpiration)
+	return info
+}
+
+func getHostInfo() *host.InfoStat {
+	key := path.Join(metadata.CachePrefix, "hostInfo")
+	if x, found := util.Cache.Get(key); found {
+		return x.(*host.InfoStat)
+	}
+
+	info, err := host.Info()
+	if err != nil {
+		// don't cache and return zero value
+		log.Errorf("failed to retrieve host info: %s", err)
+		return &host.InfoStat{}
+	}
+	util.Cache.Set(key, info, util.NoExpiration)
+	return info
+}
+
+func getMeta() *meta {
+	hostname, _ := os.Hostname()
+	tzname, _ := time.Now().Zone()
+
+	return &meta{
+		SocketHostname: hostname,
+		Timezones:      []string{tzname},
+		SocketFqdn:     util.Fqdn(hostname),
+		EC2Hostname:    "", // TODO
+	}
+}

--- a/pkg/collector/metadata/host/host.go
+++ b/pkg/collector/metadata/host/host.go
@@ -16,6 +16,8 @@ import (
 	log "github.com/cihub/seelog"
 )
 
+const packageCachePrefix = "host"
+
 // GetPayload builds a metadata payload every time is called.
 // Some data is collected only once, some is cached, some is collected at every call.
 func GetPayload(hostname string) *Payload {
@@ -34,7 +36,7 @@ func GetPayload(hostname string) *Payload {
 
 func getSystemStats() *systemStats {
 	var stats *systemStats
-	key := path.Join(metadata.CachePrefix, "systemStats")
+	key := buildKey("systemStats")
 	if x, found := util.Cache.Get(key); found {
 		stats = x.(*systemStats)
 	} else {
@@ -59,7 +61,7 @@ func getSystemStats() *systemStats {
 
 func getPythonVersion() string {
 	var pythonVersion string
-	key := path.Join(metadata.CachePrefix, "python")
+	key := buildKey("python")
 	if x, found := util.Cache.Get(key); found {
 		pythonVersion = x.(string)
 	} else {
@@ -72,7 +74,7 @@ func getPythonVersion() string {
 
 // getCPUInfo returns InfoStat for the first CPU gopsutil found
 func getCPUInfo() *cpu.InfoStat {
-	key := path.Join(metadata.CachePrefix, "cpuInfo")
+	key := buildKey("cpuInfo")
 	if x, found := util.Cache.Get(key); found {
 		return x.(*cpu.InfoStat)
 	}
@@ -89,7 +91,7 @@ func getCPUInfo() *cpu.InfoStat {
 }
 
 func getHostInfo() *host.InfoStat {
-	key := path.Join(metadata.CachePrefix, "hostInfo")
+	key := buildKey("hostInfo")
 	if x, found := util.Cache.Get(key); found {
 		return x.(*host.InfoStat)
 	}
@@ -114,4 +116,8 @@ func getMeta() *meta {
 		SocketFqdn:     util.Fqdn(hostname),
 		EC2Hostname:    "", // TODO
 	}
+}
+
+func buildKey(key string) string {
+	return path.Join(metadata.CachePrefix, packageCachePrefix, key)
 }

--- a/pkg/collector/metadata/host/host_darwin.go
+++ b/pkg/collector/metadata/host/host_darwin.go
@@ -1,0 +1,21 @@
+package host
+
+import (
+	"runtime"
+
+	"github.com/shirou/gopsutil/host"
+)
+
+type osVersion struct {
+	Release     string    `json:"release"`
+	Versioninfo [3]string `json:"versioninfo"`
+	Machine     string    `json:"machine"`
+}
+
+func fillOsVersion(stats *systemStats, info *host.InfoStat) {
+	stats.Macver = osVersion{
+		Release:     info.PlatformVersion,
+		Versioninfo: [3]string{"", "", ""},
+		Machine:     runtime.GOARCH,
+	}
+}

--- a/pkg/collector/metadata/host/host_darwin_test.go
+++ b/pkg/collector/metadata/host/host_darwin_test.go
@@ -1,0 +1,15 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/host"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFillOsVersion(t *testing.T) {
+	stats := &systemStats{}
+	info, _ := host.Info()
+	fillOsVersion(stats, info)
+	assert.NotEmpty(t, stats.Macver.Release)
+}

--- a/pkg/collector/metadata/host/host_linux.go
+++ b/pkg/collector/metadata/host/host_linux.go
@@ -1,0 +1,9 @@
+package host
+
+import "github.com/shirou/gopsutil/host"
+
+type osVersion [3]string
+
+func fillOsVersion(stats *systemStats, info *host.InfoStat) {
+	stats.Nixver = osVersion{info.PlatformFamily, info.PlatformVersion, ""}
+}

--- a/pkg/collector/metadata/host/host_linux_test.go
+++ b/pkg/collector/metadata/host/host_linux_test.go
@@ -1,0 +1,18 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/host"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFillOsVersion(t *testing.T) {
+	stats := &systemStats{}
+	info, _ := host.Info()
+	fillOsVersion(stats, info)
+	assert.Len(t, stats.Nixver, 3)
+	assert.NotEmpty(t, stats.Nixver[0])
+	assert.NotEmpty(t, stats.Nixver[1])
+	assert.Empty(t, stats.Nixver[2])
+}

--- a/pkg/collector/metadata/host/host_test.go
+++ b/pkg/collector/metadata/host/host_test.go
@@ -1,0 +1,80 @@
+package host
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	python "github.com/sbinet/go-python"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
+	"github.com/stretchr/testify/assert"
+)
+
+// Setup the test module
+func TestMain(m *testing.M) {
+	state := py.Initialize()
+
+	ret := m.Run()
+
+	python.PyEval_RestoreThread(state)
+	python.Finalize()
+
+	os.Exit(ret)
+}
+
+func TestGetPayload(t *testing.T) {
+	p := GetPayload("myhostname")
+	assert.NotEmpty(t, p.Os)
+	assert.NotEmpty(t, p.PythonVersion)
+	assert.Equal(t, "myhostname", p.InternalHostname)
+	assert.NotEmpty(t, p.UUID)
+	assert.NotNil(t, p.SytemStats)
+	assert.NotNil(t, p.Meta)
+}
+
+func TestGetSystemStats(t *testing.T) {
+	assert.NotNil(t, getSystemStats())
+	fakeStats := &systemStats{Machine: "fooMachine"}
+	key := path.Join(metadata.CachePrefix, "systemStats")
+	util.Cache.Set(key, fakeStats, util.NoExpiration)
+	s := getSystemStats()
+	assert.NotNil(t, s)
+	assert.Equal(t, fakeStats.Machine, s.Machine)
+}
+
+func TestGetPythonVersion(t *testing.T) {
+	assert.NotEmpty(t, getPythonVersion())
+	key := path.Join(metadata.CachePrefix, "python")
+	util.Cache.Set(key, "Python 2.8", util.NoExpiration)
+	assert.Equal(t, "Python 2.8", getPythonVersion())
+}
+
+func TestGetCPUInfo(t *testing.T) {
+	assert.NotNil(t, getCPUInfo())
+	fakeInfo := &cpu.InfoStat{Cores: 42}
+	key := path.Join(metadata.CachePrefix, "cpuInfo")
+	util.Cache.Set(key, fakeInfo, util.NoExpiration)
+	info := getCPUInfo()
+	assert.Equal(t, int32(42), info.Cores)
+}
+
+func TestGetHostInfo(t *testing.T) {
+	assert.NotNil(t, getHostInfo())
+	fakeInfo := &host.InfoStat{HostID: "FOOBAR"}
+	key := path.Join(metadata.CachePrefix, "hostInfo")
+	util.Cache.Set(key, fakeInfo, util.NoExpiration)
+	info := getHostInfo()
+	assert.Equal(t, "FOOBAR", info.HostID)
+}
+
+func TestGetMeta(t *testing.T) {
+	meta := getMeta()
+	assert.NotEmpty(t, meta.SocketHostname)
+	assert.NotEmpty(t, meta.Timezones)
+	assert.NotEmpty(t, meta.SocketFqdn)
+	assert.Empty(t, meta.EC2Hostname) // this is temporary
+}

--- a/pkg/collector/metadata/host/host_test.go
+++ b/pkg/collector/metadata/host/host_test.go
@@ -2,11 +2,9 @@ package host
 
 import (
 	"os"
-	"path"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
-	"github.com/DataDog/datadog-agent/pkg/collector/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	python "github.com/sbinet/go-python"
 	"github.com/shirou/gopsutil/cpu"
@@ -39,7 +37,7 @@ func TestGetPayload(t *testing.T) {
 func TestGetSystemStats(t *testing.T) {
 	assert.NotNil(t, getSystemStats())
 	fakeStats := &systemStats{Machine: "fooMachine"}
-	key := path.Join(metadata.CachePrefix, "systemStats")
+	key := buildKey("systemStats")
 	util.Cache.Set(key, fakeStats, util.NoExpiration)
 	s := getSystemStats()
 	assert.NotNil(t, s)
@@ -48,7 +46,7 @@ func TestGetSystemStats(t *testing.T) {
 
 func TestGetPythonVersion(t *testing.T) {
 	assert.NotEmpty(t, getPythonVersion())
-	key := path.Join(metadata.CachePrefix, "python")
+	key := buildKey("python")
 	util.Cache.Set(key, "Python 2.8", util.NoExpiration)
 	assert.Equal(t, "Python 2.8", getPythonVersion())
 }
@@ -56,7 +54,7 @@ func TestGetPythonVersion(t *testing.T) {
 func TestGetCPUInfo(t *testing.T) {
 	assert.NotNil(t, getCPUInfo())
 	fakeInfo := &cpu.InfoStat{Cores: 42}
-	key := path.Join(metadata.CachePrefix, "cpuInfo")
+	key := buildKey("cpuInfo")
 	util.Cache.Set(key, fakeInfo, util.NoExpiration)
 	info := getCPUInfo()
 	assert.Equal(t, int32(42), info.Cores)
@@ -65,7 +63,7 @@ func TestGetCPUInfo(t *testing.T) {
 func TestGetHostInfo(t *testing.T) {
 	assert.NotNil(t, getHostInfo())
 	fakeInfo := &host.InfoStat{HostID: "FOOBAR"}
-	key := path.Join(metadata.CachePrefix, "hostInfo")
+	key := buildKey("hostInfo")
 	util.Cache.Set(key, fakeInfo, util.NoExpiration)
 	info := getHostInfo()
 	assert.Equal(t, "FOOBAR", info.HostID)
@@ -77,4 +75,8 @@ func TestGetMeta(t *testing.T) {
 	assert.NotEmpty(t, meta.Timezones)
 	assert.NotEmpty(t, meta.SocketFqdn)
 	assert.Empty(t, meta.EC2Hostname) // this is temporary
+}
+
+func TestBuildKey(t *testing.T) {
+	assert.Equal(t, "metadata/host/foo", buildKey("foo"))
 }

--- a/pkg/collector/metadata/host/host_windows.go
+++ b/pkg/collector/metadata/host/host_windows.go
@@ -1,0 +1,8 @@
+package host
+
+import "github.com/shirou/gopsutil/host"
+
+func fillOsVersion(stats *systemStats, info *host.InfoStat) {
+	// TODO
+	panic("TODO")
+}

--- a/pkg/collector/metadata/host/host_windows_test.go
+++ b/pkg/collector/metadata/host/host_windows_test.go
@@ -1,0 +1,13 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/host"
+)
+
+func TestFillOsVersion(t *testing.T) {
+	stats := &systemStats{}
+	info, _ := host.Info()
+	fillOsVersion(stats, info)
+}

--- a/pkg/collector/metadata/host/payload.go
+++ b/pkg/collector/metadata/host/payload.go
@@ -1,0 +1,31 @@
+package host
+
+type systemStats struct {
+	CPUCores  int32     `json:"cpuCores"`
+	Machine   string    `json:"machine"`
+	Platform  string    `json:"platform"`
+	Pythonv   string    `json:"pythonV"`
+	Processor string    `json:"processor"`
+	Macver    osVersion `json:"macV"`
+	Nixver    osVersion `json:"nixV"`
+	Fbsdver   osVersion `json:"fbsdV"`
+	Winver    osVersion `json:"winV"`
+}
+
+type meta struct {
+	SocketHostname string   `json:"socket-hostname"`
+	Timezones      []string `json:"timezones"`
+	SocketFqdn     string   `json:"socket-fqdn"`
+	EC2Hostname    string   `json:"ec2-hostname"`
+	Hostname       string   `json:"hostname"`
+}
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	Os               string       `json:"os"`
+	PythonVersion    string       `json:"python"`
+	InternalHostname string       `json:"internalHostname"`
+	UUID             string       `json:"uuid"`
+	SytemStats       *systemStats `json:"systemStats"`
+	Meta             *meta        `json:"meta"`
+}

--- a/pkg/collector/metadata/metadata.go
+++ b/pkg/collector/metadata/metadata.go
@@ -1,0 +1,5 @@
+package metadata
+
+// CachePrefix is the common root to use to prefix all the cache
+// keys for any metadata value
+const CachePrefix = "metadata"

--- a/pkg/collector/metadata/v5/payload.go
+++ b/pkg/collector/metadata/v5/payload.go
@@ -1,0 +1,27 @@
+package v5
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata/host"
+)
+
+// CommonPayload wraps Payload from the common package
+type CommonPayload struct {
+	common.Payload
+}
+
+// HostPayload wraps Payload from the host package
+type HostPayload struct {
+	host.Payload
+}
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	CommonPayload
+	HostPayload
+	// TODO: resources
+	// TODO: host-tags
+	// TODO: external_host_tags
+	// TODO: gohai
+	// TODO: agent_checks
+}

--- a/pkg/collector/metadata/v5/v5.go
+++ b/pkg/collector/metadata/v5/v5.go
@@ -1,0 +1,16 @@
+package v5
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata/host"
+)
+
+// GetPayload returns the complete metadata payload as seen in Agent v5
+func GetPayload(hostname string) *Payload {
+	cp := common.GetPayload()
+	hp := host.GetPayload(hostname)
+	return &Payload{
+		CommonPayload: CommonPayload{*cp},
+		HostPayload:   HostPayload{*hp},
+	}
+}

--- a/pkg/collector/metadata/v5/v5_test.go
+++ b/pkg/collector/metadata/v5/v5_test.go
@@ -1,0 +1,27 @@
+package v5
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
+	python "github.com/sbinet/go-python"
+	"github.com/stretchr/testify/assert"
+)
+
+// Setup the test module
+func TestMain(m *testing.M) {
+	state := py.Initialize()
+
+	ret := m.Run()
+
+	python.PyEval_RestoreThread(state)
+	python.Finalize()
+
+	os.Exit(ret)
+}
+
+func TestFoo(t *testing.T) {
+	pl := GetPayload("testhostname")
+	assert.NotNil(t, pl)
+}

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"time"
+
+	cache "github.com/patrickmn/go-cache"
+)
+
+const (
+	defaultCacheExpire = 5 * time.Minute
+	defaultCachePurge  = 30 * time.Second
+
+	// encapsulate the cache module for easy refactoring
+
+	// NoExpiration maps to go-cache corresponding value
+	NoExpiration = cache.NoExpiration
+)
+
+// Cache provides an in-memory key:value store similar to memcached
+var Cache = cache.New(defaultCacheExpire, defaultCachePurge)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 )
@@ -42,4 +43,27 @@ func isLocal(name string) bool {
 		}
 	}
 	return false
+}
+
+// Fqdn returns the FQDN for the host if any
+func Fqdn(hostname string) string {
+	addrs, err := net.LookupIP(hostname)
+	if err != nil {
+		return hostname
+	}
+
+	for _, addr := range addrs {
+		if ipv4 := addr.To4(); ipv4 != nil {
+			ip, err := ipv4.MarshalText()
+			if err != nil {
+				return hostname
+			}
+			hosts, err := net.LookupAddr(string(ip))
+			if err != nil || len(hosts) == 0 {
+				return hostname
+			}
+			return hosts[0]
+		}
+	}
+	return hostname
 }


### PR DESCRIPTION
### What does this PR do?

Builds the metadata payload using the same format as Agent5, though there are no guarantees the content will be exactly the same.

Please notice this is a temporary solution since we're going to have different metadata payloads we will send to different endpoints as soon as the backend is ready.

With this in mind, the current implementation reflects what we'll do for the new format: separate packages that are responsible for providing both the format and the data for each payload (common stuff, host, processes, checks, gohai, etc...). Missing metadata "providers" should be added to provide more contents.

The `v5` package exists only with the purpose of providing a v.5 compatible payload by composing other payloads coming from other packages, don't endear to it since it'll be killed hopefully soon.

This approach should ease the refactoring: packages will stay, same for the logic to collect relevant data, only the payload definitions will change.
