### PR TITLE
[aggregator] Add python bindings for service checks submission

### DIFF
--- a/pkg/collector/check/py/api.c
+++ b/pkg/collector/check/py/api.c
@@ -61,7 +61,7 @@ PyObject* _none() {
 	Py_RETURN_NONE;
 }
 
-bool _is_none(PyObject *o) {
+int _is_none(PyObject *o) {
   return o == Py_None;
 }
 

--- a/pkg/collector/check/py/api.c
+++ b/pkg/collector/check/py/api.c
@@ -61,6 +61,10 @@ PyObject* _none() {
 	Py_RETURN_NONE;
 }
 
+bool _is_none(PyObject *o) {
+  return o == Py_None;
+}
+
 void initaggregator()
 {
   PyGILState_STATE gstate;

--- a/pkg/collector/check/py/api.c
+++ b/pkg/collector/check/py/api.c
@@ -1,6 +1,7 @@
 #include "api.h"
 
 PyObject* SubmitMetric(PyObject*, MetricType, char*, float, PyObject*);
+PyObject* SubmitServiceCheck(PyObject*, char*, int, PyObject*, char*);
 
 char* MetricTypeNames[] = {
   "GAUGE",
@@ -30,8 +31,29 @@ static PyObject *submit_metric(PyObject *self, PyObject *args) {
     return SubmitMetric(check, mt, name, value, tags);
 }
 
+static PyObject *submit_service_check(PyObject *self, PyObject *args) {
+    PyObject *check = NULL;
+    char *name;
+    int status;
+    PyObject *tags = NULL;
+    char *message = NULL;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    // aggregator.submit_service_check(self, name, status, tags, message)
+    if (!PyArg_ParseTuple(args, "OsiOs", &check, &name, &status, &tags, &message)) {
+      PyGILState_Release(gstate);
+      Py_RETURN_NONE;
+    }
+
+    PyGILState_Release(gstate);
+    return SubmitServiceCheck(check, name, status, tags, message);
+}
+
 static PyMethodDef AggMethods[] = {
   {"submit_metric", (PyCFunction)submit_metric, METH_VARARGS, "Submit metrics to the aggregator."},
+  {"submit_service_check", (PyCFunction)submit_service_check, METH_VARARGS, "Submit service checks to the aggregator."},
   {NULL, NULL}  // guards
 };
 

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -31,10 +31,12 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 
 	errMsg := C.CString("expected a sequence") // this has to be freed
 	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
-	var i C.Py_ssize_t
-	for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
-		item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
-		_tags = append(_tags, C.GoString(C.PyString_AsString(item))) // TODO: YOLO! Please add error checking
+	if !C._is_none(tags) {
+		var i C.Py_ssize_t
+		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
+			item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
+			_tags = append(_tags, C.GoString(C.PyString_AsString(item))) // TODO: YOLO! Please add error checking
+		}
 	}
 
 	switch mt {
@@ -75,10 +77,12 @@ func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.P
 
 	errMsg := C.CString("expected a sequence") // this has to be freed
 	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
-	var i C.Py_ssize_t
-	for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
-		item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
-		_tags = append(_tags, C.GoString(C.PyString_AsString(item))) // TODO: YOLO! Please add error checking
+	if !C._is_none(tags) {
+		var i C.Py_ssize_t
+		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
+			item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
+			_tags = append(_tags, C.GoString(C.PyString_AsString(item))) // TODO: YOLO! Please add error checking
+		}
 	}
 
 	sender.ServiceCheck(_name, _status, "", _tags, _message)

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -9,6 +9,7 @@ import (
 )
 
 // #cgo pkg-config: python-2.7
+// #cgo windows LDFLAGS: -Wl,--allow-multiple-definition
 // #include "api.h"
 // #include "stdlib.h"
 import "C"

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -9,7 +9,6 @@ import (
 )
 
 // #cgo pkg-config: python-2.7
-// #cgo linux CFLAGS: -std=gnu99
 // #include "api.h"
 // #include "stdlib.h"
 import "C"
@@ -31,7 +30,7 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 
 	errMsg := C.CString("expected a sequence") // this has to be freed
 	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
-	if !C._is_none(tags) {
+	if !isNone(tags) {
 		var i C.Py_ssize_t
 		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
 			item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
@@ -77,7 +76,7 @@ func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.P
 
 	errMsg := C.CString("expected a sequence") // this has to be freed
 	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
-	if !C._is_none(tags) {
+	if !isNone(tags) {
 		var i C.Py_ssize_t
 		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
 			item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
@@ -92,6 +91,10 @@ func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.P
 	C.free(unsafe.Pointer(errMsg))
 
 	return C._none()
+}
+
+func isNone(o *C.PyObject) bool {
+	return int(C._is_none(o)) != 0
 }
 
 func initAPI() {

--- a/pkg/collector/check/py/api.go
+++ b/pkg/collector/check/py/api.go
@@ -20,7 +20,7 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 
 	sender, err := aggregator.GetDefaultSender()
 	if err != nil {
-		log.Errorf("Error submitting data to the Sender: %v", err)
+		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return C._none()
 	}
 
@@ -49,6 +49,39 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 	case C.HISTOGRAM:
 		sender.Histogram(_name, _value, "", _tags)
 	}
+
+	// cleanup
+	C.Py_DecRef(seq)
+	C.free(unsafe.Pointer(errMsg))
+
+	return C._none()
+}
+
+// SubmitServiceCheck is the method exposed to Python scripts to submit service checks
+//export SubmitServiceCheck
+func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.PyObject, message *C.char) *C.PyObject {
+
+	sender, err := aggregator.GetDefaultSender()
+	if err != nil {
+		log.Errorf("Error submitting service check to the Sender: %v", err)
+		return C._none()
+	}
+
+	_name := C.GoString(name)
+	_status := aggregator.ServiceCheckStatus(status)
+	var _tags []string
+	var seq *C.PyObject
+	_message := C.GoString(message)
+
+	errMsg := C.CString("expected a sequence") // this has to be freed
+	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
+	var i C.Py_ssize_t
+	for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
+		item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
+		_tags = append(_tags, C.GoString(C.PyString_AsString(item))) // TODO: YOLO! Please add error checking
+	}
+
+	sender.ServiceCheck(_name, _status, "", _tags, _message)
 
 	// cleanup
 	C.Py_DecRef(seq)

--- a/pkg/collector/check/py/api.h
+++ b/pkg/collector/check/py/api.h
@@ -1,5 +1,4 @@
 #include <Python.h>
-#include <stdbool.h>
 
 typedef enum {
   MT_FIRST = 0,
@@ -13,6 +12,6 @@ typedef enum {
 
 void initaggregator();
 PyObject* _none();
-bool _is_none(PyObject*);
+int _is_none(PyObject*);
 PyObject* PySequence_Fast_Get_Item(PyObject*, Py_ssize_t);
 Py_ssize_t PySequence_Fast_Get_Size(PyObject*);

--- a/pkg/collector/check/py/api.h
+++ b/pkg/collector/check/py/api.h
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include <stdbool.h>
 
 typedef enum {
   MT_FIRST = 0,
@@ -12,5 +13,6 @@ typedef enum {
 
 void initaggregator();
 PyObject* _none();
+bool _is_none(PyObject*);
 PyObject* PySequence_Fast_Get_Item(PyObject*, Py_ssize_t);
 Py_ssize_t PySequence_Fast_Get_Size(PyObject*);

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -52,8 +52,8 @@ class AgentCheck(object):
     def histogram(self, name, value, tags=None, hostname=None, device_name=None):
         aggregator.submit_metric(self, aggregator.HISTOGRAM, name, value, tags)
 
-    def service_check(self, *args, **kwargs):
-        pass
+    def service_check(self, name, status, tags=None, message=""):
+        aggregator.submit_service_check(self, name, status, tags, message)
 
     def check(self, instance):
         raise NotImplementedError


### PR DESCRIPTION
### What does this PR do?

* Adds python bindings for service checks submission
* Fixes an issue when the passed tags list is `None`

### Testing Guidelines

There are no automated tests, I did some manual testing. I could work on adding a basic test though (loading a py check that uses the `service_check` method and running it ; that would check that the submission doesn't crash the agent at least).

### Additional Notes

I've added a check on whether `tags` is `None`, I'm not sure it's the best way to do it though.
