### PR TITLE
Give the real agentConfig to python check instead of an empty dict

### DIFF
--- a/pkg/collector/check/py/config.go
+++ b/pkg/collector/check/py/config.go
@@ -3,7 +3,6 @@ package py
 import (
 	"reflect"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/sbinet/go-python"
 )
@@ -16,10 +15,10 @@ type walker struct {
 	currentContainer *python.PyObject
 }
 
-// ToPythonDict dumps a RawConfigMap into a Python dictionary
-func ToPythonDict(m *check.ConfigRawMap) (*python.PyObject, error) {
+// ToPythonDict converts a go object into a Python dictionary
+func ToPythonDict(obj interface{}) (*python.PyObject, error) {
 	w := new(walker)
-	err := reflectwalk.Walk(m, w)
+	err := reflectwalk.Walk(obj, w)
 
 	return w.result, err
 }


### PR DESCRIPTION
### What does this PR do?

We expose the agent configuration to python checks.

### Motivation

This is part of the effort to support the old check API (from agent5). `agentConfig` has been deprecated and a real python package will be available to python and Go check to offer the same information in a cleaner/simpler way.
