### PR TITLE
Add a python module called 'datadog_agent' to expose core feature to python check

### DIFF
--- a/pkg/collector/check/py/api.h
+++ b/pkg/collector/check/py/api.h
@@ -1,3 +1,6 @@
+#ifndef API
+#define API
+
 #include <Python.h>
 
 typedef enum {
@@ -15,3 +18,5 @@ PyObject* _none();
 int _is_none(PyObject*);
 PyObject* PySequence_Fast_Get_Item(PyObject*, Py_ssize_t);
 Py_ssize_t PySequence_Fast_Get_Size(PyObject*);
+
+#endif /* API */

--- a/pkg/collector/check/py/datadog_agent.c
+++ b/pkg/collector/check/py/datadog_agent.c
@@ -1,0 +1,30 @@
+#include "datadog_agent.h"
+
+PyObject* GetVersion();
+PyObject* Headers();
+
+static PyMethodDef datadogAgentMethods[] = {
+  {"get_version", (PyCFunction)GetVersion, METH_VARARGS, "Get the Agent version."},
+  {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {NULL, NULL}
+};
+
+/*
+ * Util package emulate the features within 'util' from agent5. It is
+ * deprecated in favor of 'datadog_agent' package.
+ */
+static PyMethodDef utilMethods[] = {
+  {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {NULL, NULL}
+};
+
+void initdatadogagent()
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *da = Py_InitModule("datadog_agent", datadogAgentMethods);
+  PyObject *util = Py_InitModule("util", utilMethods);
+
+  PyGILState_Release(gstate);
+}

--- a/pkg/collector/check/py/datadog_agent.go
+++ b/pkg/collector/check/py/datadog_agent.go
@@ -1,0 +1,49 @@
+package py
+
+import (
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// #cgo pkg-config: python-2.7
+// #cgo linux CFLAGS: -std=gnu99
+// #include "api.h"
+// #include "datadog_agent.h"
+import "C"
+
+// GetVersion expose the version of the agent to python check
+//export GetVersion
+func GetVersion() *C.PyObject {
+	av, _ := version.New(version.AgentVersion)
+
+	cStr := C.CString(av.GetNumber())
+	pyStr := C.PyString_FromString(cStr)
+	C.free(unsafe.Pointer(cStr))
+	return pyStr
+}
+
+// Headers return HTTP headers with basic information like UserAgent already set
+//export Headers
+func Headers() *C.PyObject {
+	h := util.HTTPHeaders()
+
+	dict := C.PyDict_New()
+	for k, v := range h {
+		cKey := C.CString(k)
+		pyKey := C.PyString_FromString(cKey)
+		C.free(unsafe.Pointer(cKey))
+
+		cVal := C.CString(v)
+		pyVal := C.PyString_FromString(cVal)
+		C.free(unsafe.Pointer(cVal))
+
+		C.PyDict_SetItem(dict, pyKey, pyVal)
+	}
+	return dict
+}
+
+func initDatadogAgent() {
+	C.initdatadogagent()
+}

--- a/pkg/collector/check/py/datadog_agent.h
+++ b/pkg/collector/check/py/datadog_agent.h
@@ -1,0 +1,8 @@
+#ifndef DATADOG_HEADER
+#define DATADOG_HEADER
+
+#include <Python.h>
+
+void initdatadogagent();
+
+#endif /* DATADOG_HEADER */

--- a/pkg/collector/check/py/utils.go
+++ b/pkg/collector/check/py/utils.go
@@ -47,6 +47,10 @@ func Initialize(paths ...string) *python.PyThreadState {
 	// (it will handle the GIL by itself)
 	initAPI()
 
+	// inject the datadog_agent package into global namespace
+	// (it will handle the GIL by itself)
+	initDatadogAgent()
+
 	// return the state so the caller can resume
 	return state
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// HTTPHeaders returns a http headers including various basic information (User-Agent, Content-Type...).
+func HTTPHeaders() map[string]string {
+	av, _ := version.New(version.AgentVersion)
+	return map[string]string{
+		"User-Agent":   fmt.Sprintf("Datadog Agent/%s", av.GetNumber()),
+		"Content-Type": "application/x-www-form-urlencoded",
+		"Accept":       "text/html, */*",
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add a python module called 'datadog_agent' to expose core feature to python check
    
Some features in this package are also shared with the 'util' module.
'util' is a legacy package to support agent5 checks.
    
This package only contains 'get_version' and 'headers' for now, but more
information/features will be exposed over time (agent config, logs, ...)

### Motivation

We need to offer the same functionalities to python check than the agent5 in order to use the integration-core.