### PR TITLE
Add configuration option for the forwarder http timeout

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ func init() {
 	Datadog.SetDefault("use_dogstatsd", true)
 	Datadog.SetDefault("dogstatsd_port", 8125)
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024)
+	Datadog.SetDefault("forwarder_timeout", 20)
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")

--- a/pkg/forwarder/worker.go
+++ b/pkg/forwarder/worker.go
@@ -11,8 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-const httpTimeout = 20 * time.Second
-
 // Worker comsumes Transaction (aka transactions) from the Forwarder and
 // process them. If the transaction fail to be processed the Worker will send
 // it back to the Forwarder to be retried later.
@@ -56,7 +54,7 @@ func NewWorker(inputChan chan Transaction, requeueChan chan Transaction) *Worker
 	}
 
 	httpClient := &http.Client{
-		Timeout:   httpTimeout,
+		Timeout:   config.Datadog.GetDuration("forwarder_timeout") * time.Second,
 		Transport: transport,
 	}
 

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func TestNewWorker(t *testing.T) {
 
 	w := NewWorker(input, requeue)
 	assert.NotNil(t, w)
-	assert.Equal(t, w.Client.Timeout, httpTimeout)
+	assert.Equal(t, w.Client.Timeout, config.Datadog.GetDuration("forwarder_timeout")*time.Second)
 }
 
 func TestNewNoSSLWorker(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Set the timeout for the forwarder configurable

### Motivation

This is to be compatible with the agent5 configuration
