### PR TITLE
Send metadata payload compatible with v5 agent endpoints

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -33,6 +33,9 @@ func NewCollector(paths ...string) *Collector {
 	sched := scheduler.NewScheduler(run.GetChan())
 	sched.Run()
 
+	// Send the agent startup event
+	// TODO
+
 	return &Collector{
 		scheduler: sched,
 		runner:    run,

--- a/pkg/collector/metadata/common/common.go
+++ b/pkg/collector/metadata/common/common.go
@@ -11,6 +11,10 @@ var (
 	apiKey string
 )
 
+// CachePrefix is the common root to use to prefix all the cache
+// keys for any metadata value
+const CachePrefix = "metadata"
+
 // GetPayload fills and return the common metadata payload
 func GetPayload() *Payload {
 	return &Payload{

--- a/pkg/collector/metadata/host/host.go
+++ b/pkg/collector/metadata/host/host.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
-	"github.com/DataDog/datadog-agent/pkg/collector/metadata"
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
@@ -119,5 +119,5 @@ func getMeta() *meta {
 }
 
 func buildKey(key string) string {
-	return path.Join(metadata.CachePrefix, packageCachePrefix, key)
+	return path.Join(common.CachePrefix, packageCachePrefix, key)
 }

--- a/pkg/collector/metadata/metadata.go
+++ b/pkg/collector/metadata/metadata.go
@@ -77,8 +77,6 @@ func (c *Collector) loop() {
 }
 
 func (c *Collector) firstRun() {
-	// Send the agent startup event
-	// TODO
 	// Alway send host metadata at the first run
 	c.sendHost()
 }

--- a/pkg/collector/metadata/metadata.go
+++ b/pkg/collector/metadata/metadata.go
@@ -1,5 +1,117 @@
 package metadata
 
-// CachePrefix is the common root to use to prefix all the cache
-// keys for any metadata value
-const CachePrefix = "metadata"
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/metadata/v5"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	log "github.com/cihub/seelog"
+)
+
+func init() {
+	// define defaults for the Agent
+	config.Datadog.SetDefault("metadata_interval", 4*time.Hour)
+	config.Datadog.SetDefault("external_host_tags_interval", 5*time.Minute)
+	config.Datadog.SetDefault("agent_checks_interval", 10*time.Minute)
+	config.Datadog.SetDefault("processes_interval", time.Minute)
+}
+
+// Collector takes care of sending metadata at specific
+// time intervals
+type Collector struct {
+	fwd             *forwarder.Forwarder
+	sendHostT       *time.Ticker
+	sendExtHostT    *time.Ticker
+	sendAgentCheckT *time.Ticker
+	sendProcessesT  *time.Ticker
+	apikey          string // the api key to use to send metadata
+	hostname        string
+	stop            chan bool
+}
+
+// NewCollector builds and returns a new Metadata Collector
+func NewCollector(fwd *forwarder.Forwarder, apikey, hostname string) *Collector {
+	collector := &Collector{
+		fwd:             fwd,
+		sendHostT:       time.NewTicker(config.Datadog.GetDuration("metadata_interval")),
+		sendExtHostT:    time.NewTicker(config.Datadog.GetDuration("external_host_tags_interval")),
+		sendAgentCheckT: time.NewTicker(config.Datadog.GetDuration("agent_checks_interval")),
+		sendProcessesT:  time.NewTicker(config.Datadog.GetDuration("processes_interval")),
+		apikey:          apikey,
+		hostname:        hostname,
+		stop:            make(chan bool),
+	}
+
+	collector.firstRun()
+	go collector.loop()
+
+	return collector
+}
+
+// Stop the metadata collector
+func (c *Collector) Stop() {
+	c.stop <- true
+}
+
+func (c *Collector) loop() {
+	for {
+		select {
+		case <-c.sendHostT.C:
+			c.sendHost()
+		case <-c.sendExtHostT.C:
+			c.sendExtHost()
+		case <-c.sendAgentCheckT.C:
+			c.sendAgentCheck()
+		case <-c.sendProcessesT.C:
+			c.sendProcesses()
+		case <-c.stop:
+			c.sendHostT.Stop()
+			c.sendExtHostT.Stop()
+			c.sendAgentCheckT.Stop()
+			c.sendProcessesT.Stop()
+			return
+		}
+	}
+}
+
+func (c *Collector) firstRun() {
+	// Send the agent startup event
+	// TODO
+	// Alway send host metadata at the first run
+	c.sendHost()
+}
+
+func (c *Collector) sendHost() {
+	payload := v5.GetPayload(c.hostname)
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		log.Errorf("unable to serialize host metadata payload, %s", err)
+		return
+	}
+
+	err = c.fwd.SubmitV1Intake(c.apikey, &payloadBytes)
+	if err != nil {
+		log.Errorf("unable to submit host metadata payload to the forwarder, %s", err)
+		return
+	}
+
+	log.Infof("Sent host metadata payload, size: %d bytes.", len(payloadBytes))
+	log.Debugf("Sent host metadata payload, content: %v", string(payloadBytes))
+}
+
+func (c *Collector) sendExtHost() {
+	// TODO
+	log.Info("Sending external host tags metadata, NYI.")
+}
+
+func (c *Collector) sendAgentCheck() {
+	// TODO
+	log.Info("Sending agent check, NYI.")
+}
+
+func (c *Collector) sendProcesses() {
+	// TODO
+	log.Info("Sending processes metadata, NYI.")
+}

--- a/pkg/collector/metadata/metadata_test.go
+++ b/pkg/collector/metadata/metadata_test.go
@@ -1,0 +1,35 @@
+package metadata
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check/py"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	python "github.com/sbinet/go-python"
+	"github.com/stretchr/testify/assert"
+)
+
+// Setup the test module
+func TestMain(m *testing.M) {
+	state := py.Initialize()
+
+	ret := m.Run()
+
+	python.PyEval_RestoreThread(state)
+	python.Finalize()
+
+	os.Exit(ret)
+}
+
+func TestNewCollector(t *testing.T) {
+	fwd := forwarder.NewForwarder(nil)
+	fwd.Start()
+	c := NewCollector(fwd, "apikey", "hostname")
+	assert.NotNil(t, c.sendHostT)
+	assert.NotNil(t, c.sendExtHostT)
+	assert.NotNil(t, c.sendAgentCheckT)
+	assert.NotNil(t, c.sendProcessesT)
+	assert.Equal(t, "apikey", c.apikey)
+	assert.Equal(t, "hostname", c.hostname)
+}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -21,6 +21,7 @@ const (
 
 	v1SeriesEndpoint    = "/api/v1/series?api_key=%s"
 	v1CheckRunsEndpoint = "/api/v1/check_run?api_key=%s"
+	v1IntakeEndpoint    = "/intake/?api_key=%s"
 
 	seriesEndpoint       = "/api/v2/series"
 	eventsEndpoint       = "/api/v2/events"
@@ -236,5 +237,11 @@ func (f *Forwarder) SubmitV1Series(apiKey string, payload *[]byte) error {
 // the backend handles v2 endpoints).
 func (f *Forwarder) SubmitV1CheckRuns(apiKey string, payload *[]byte) error {
 	endpoint := fmt.Sprintf(v1CheckRunsEndpoint, apiKey)
+	return f.createTransaction(endpoint, payload, false)
+}
+
+// SubmitV1Intake will send payloads to the universal `/intake/` endpoint used by Agent v.5
+func (f *Forwarder) SubmitV1Intake(apiKey string, payload *[]byte) error {
+	endpoint := fmt.Sprintf(v1IntakeEndpoint, apiKey)
 	return f.createTransaction(endpoint, payload, false)
 }

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -163,6 +163,14 @@ func TestSubmit(t *testing.T) {
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
+
+	expectedPayload = []byte("SubmitV1Intake payload")
+	expectedEndpoint = "/intake/"
+	expectedQuery = "api_key=test_api_key"
+	assert.Nil(t, forwarder.SubmitV1Intake("test_api_key", &expectedPayload))
+	<-wait
+	<-wait
+	assert.Equal(t, len(forwarder.retryQueue), 0)
 }
 
 func TestSubmitWithProxy(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Implements a component responsible to send metadata at defined time intervals, the `metadata.Collector`.

This collector uses old payloads and old endpoints and part of the metadata are still a work in progress.