### PR TITLE
Let the forwarder send the metadata payload

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -1,5 +1,5 @@
 # The host of the Datadog intake server to send Agent data to
-dd_url: https://foo.datadoghq.com
+dd_url: https://app.datadoghq.com
 
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:

--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -3,6 +3,7 @@ package forwarder
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -67,12 +68,15 @@ func (t *HTTPTransaction) Process(client *http.Client) error {
 	}
 	defer resp.Body.Close()
 
+	body, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode == 400 || resp.StatusCode == 413 {
-		log.Errorf("Error code '%s' received while sending transaction to '%s' (dropping it)", resp.Status, t.Domain+t.Endpoint)
+		log.Errorf("Error code '%s' received while sending transaction to '%s': %s, dropping it", resp.Status, t.Domain+t.Endpoint, string(body))
 	} else if resp.StatusCode > 400 {
 		t.ErrorCount++
 		return fmt.Errorf("Error '%s' while sending transaction, rescheduling it", resp.Status)
 	}
+
+	log.Debugf("successfully posted payload to '%s': %s", t.Domain+t.Endpoint, string(body))
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

The `intake` endpoint needs the `Content-Type` header set to accept a payload and this is done in the specific `SubmitV1Intake` method of the forwarder.

To be able to change the headers of an `HTTPTransaction` object, the forwarder needs to return an array of `HTTPTransaction` pointers instead of an array of `Transaction` interfaces from the helper method `createHTTPTransactions`, unless we want to add a new method to the interface to do this (I wouldn't do it).

Tests were updated accordingly.
