### PR TITLE
added ec2-hostname field to the metadata payload

### DIFF
--- a/pkg/collector/metadata/host/host.go
+++ b/pkg/collector/metadata/host/host.go
@@ -13,6 +13,7 @@ import (
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	log "github.com/cihub/seelog"
 )
 
@@ -109,12 +110,13 @@ func getHostInfo() *host.InfoStat {
 func getMeta() *meta {
 	hostname, _ := os.Hostname()
 	tzname, _ := time.Now().Zone()
+	ec2Hostname, _ := ec2.GetHostname()
 
 	return &meta{
 		SocketHostname: hostname,
 		Timezones:      []string{tzname},
 		SocketFqdn:     util.Fqdn(hostname),
-		EC2Hostname:    "", // TODO
+		EC2Hostname:    ec2Hostname,
 	}
 }
 

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -15,14 +15,26 @@ var (
 	defaultPrefixes = []string{"ip-", "domu"}
 )
 
-// GetInstanceID returns the EC2 instance id for this host
+// GetInstanceID fetches the instance id for current host from the EC2 metadata API
 func GetInstanceID() (string, error) {
-	res, err := getResponse(metadataURL + "/instance-id")
+	return getMetadataItem("/instance-id")
+}
+
+// GetHostname fetches the hostname for current host from the EC2 metadata API
+func GetHostname() (string, error) {
+	return getMetadataItem("/hostname")
+}
+
+func getMetadataItem(endpoint string) (string, error) {
+	res, err := getResponse(metadataURL + endpoint)
+	if err != nil {
+		return "", fmt.Errorf("unable to fetch EC2 API, %s", err)
+	}
 
 	defer res.Body.Close()
 	all, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return "", fmt.Errorf("unable to retrieve Instance ID, %s", err)
+		return "", fmt.Errorf("unable to read response body, %s", err)
 	}
 
 	return string(all), nil

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -31,3 +31,27 @@ func TestGetInstanceID(t *testing.T) {
 	assert.Equal(t, expected, val)
 	assert.Equal(t, lastRequest.URL.Path, "/instance-id")
 }
+
+func TestGetHostname(t *testing.T) {
+	expected := "ip-10-10-10-10.ec2.internal"
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/hostname")
+
+	// ensure we get an empty string along with the error when not on EC2
+	metadataURL = "foo"
+	val, err = GetHostname()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", val)
+	assert.Equal(t, lastRequest.URL.Path, "/hostname")
+}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

As per title

### Motivation

That was still missing from the metadata payload
