### PR TITLE
[aggregator] Add support for events submission from checks (part 1)

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -6,6 +6,7 @@ import (
 
 	// 3p
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -40,12 +41,11 @@ func TestDeregisterCheckSampler(t *testing.T) {
 	assert.Len(t, aggregatorInstance.checkSamplers, 2)
 
 	agg.deregisterSender(checkID1)
-	if assert.Len(t, aggregatorInstance.checkSamplers, 1) {
-		_, ok := agg.checkSamplers[checkID1]
-		assert.False(t, ok)
-		_, ok = agg.checkSamplers[checkID2]
-		assert.True(t, ok)
-	}
+	require.Len(t, aggregatorInstance.checkSamplers, 1)
+	_, ok := agg.checkSamplers[checkID1]
+	assert.False(t, ok)
+	_, ok = agg.checkSamplers[checkID2]
+	assert.True(t, ok)
 }
 
 func TestAddServiceCheckDefaultValues(t *testing.T) {
@@ -71,12 +71,11 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 		Message:   "message",
 	})
 
-	if assert.Len(t, agg.serviceChecks, 2) {
-		assert.Equal(t, "config-hostname", agg.serviceChecks[0].Host)
-		assert.NotZero(t, agg.serviceChecks[0].Ts) // should be set to the current time, let's just check that it's not 0
-		assert.Equal(t, "my-hostname", agg.serviceChecks[1].Host)
-		assert.Equal(t, int64(12345), agg.serviceChecks[1].Ts)
-	}
+	require.Len(t, agg.serviceChecks, 2)
+	assert.Equal(t, "config-hostname", agg.serviceChecks[0].Host)
+	assert.NotZero(t, agg.serviceChecks[0].Ts) // should be set to the current time, let's just check that it's not 0
+	assert.Equal(t, "my-hostname", agg.serviceChecks[1].Host)
+	assert.Equal(t, int64(12345), agg.serviceChecks[1].Ts)
 }
 
 func TestAddEventDefaultValues(t *testing.T) {
@@ -104,27 +103,26 @@ func TestAddEventDefaultValues(t *testing.T) {
 		SourceTypeName: "custom_source_type",
 	})
 
-	if assert.Len(t, agg.events, 2) {
-		// Default values are set on Host and Ts only
-		event1 := agg.events[0]
-		assert.Equal(t, "An event occurred", event1.Title)
-		assert.Equal(t, "config-hostname", event1.Host)
-		assert.NotZero(t, event1.Ts) // should be set to the current time, let's just check that it's not 0
-		assert.Zero(t, event1.Priority)
-		assert.Zero(t, event1.Tags)
-		assert.Zero(t, event1.AlertType)
-		assert.Zero(t, event1.AggregationKey)
-		assert.Zero(t, event1.SourceTypeName)
+	require.Len(t, agg.events, 2)
+	// Default values are set on Host and Ts only
+	event1 := agg.events[0]
+	assert.Equal(t, "An event occurred", event1.Title)
+	assert.Equal(t, "config-hostname", event1.Host)
+	assert.NotZero(t, event1.Ts) // should be set to the current time, let's just check that it's not 0
+	assert.Zero(t, event1.Priority)
+	assert.Zero(t, event1.Tags)
+	assert.Zero(t, event1.AlertType)
+	assert.Zero(t, event1.AggregationKey)
+	assert.Zero(t, event1.SourceTypeName)
 
-		event2 := agg.events[1]
-		// No change is made
-		assert.Equal(t, "Another event occurred", event2.Title)
-		assert.Equal(t, "my-hostname", event2.Host)
-		assert.Equal(t, int64(12345), event2.Ts)
-		assert.Equal(t, EventPriorityNormal, event2.Priority)
-		assert.Equal(t, []string{"foo", "bar"}, event2.Tags)
-		assert.Equal(t, EventAlertTypeError, event2.AlertType)
-		assert.Equal(t, "my_agg_key", event2.AggregationKey)
-		assert.Equal(t, "custom_source_type", event2.SourceTypeName)
-	}
+	event2 := agg.events[1]
+	// No change is made
+	assert.Equal(t, "Another event occurred", event2.Title)
+	assert.Equal(t, "my-hostname", event2.Host)
+	assert.Equal(t, int64(12345), event2.Ts)
+	assert.Equal(t, EventPriorityNormal, event2.Priority)
+	assert.Equal(t, []string{"foo", "bar"}, event2.Tags)
+	assert.Equal(t, EventAlertTypeError, event2.AlertType)
+	assert.Equal(t, "my_agg_key", event2.AggregationKey)
+	assert.Equal(t, "custom_source_type", event2.SourceTypeName)
 }

--- a/pkg/aggregator/event.go
+++ b/pkg/aggregator/event.go
@@ -1,0 +1,34 @@
+package aggregator
+
+// EventPriority represents the priority of an event
+type EventPriority string
+
+// Enumeration of the existing event priorities, and their values
+const (
+	EventPriorityNormal EventPriority = "normal"
+	EventPriorityLow    EventPriority = "low"
+)
+
+// EventAlertType represents the alert type of an event
+type EventAlertType string
+
+// Enumeration of the existing event alert types, and their values
+const (
+	EventAlertTypeError   EventAlertType = "error"
+	EventAlertTypeWarning EventAlertType = "warning"
+	EventAlertTypeInfo    EventAlertType = "info"
+	EventAlertTypeSuccess EventAlertType = "success"
+)
+
+// Event holds an event (w/ serialization to DD agent 5 intake format)
+type Event struct {
+	Title          string         `json:"msg_title"`
+	Text           string         `json:"msg_text"`
+	Ts             int64          `json:"timestamp"`
+	Priority       EventPriority  `json:"priority,omitempty"`
+	Host           string         `json:"host"`
+	Tags           []string       `json:"tags,omitempty"`
+	AlertType      EventAlertType `json:"alert_type,omitempty"`
+	AggregationKey string         `json:"aggregation_key,omitempty"`
+	SourceTypeName string         `json:"source_type_name,omitempty"`
+}

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -123,6 +123,11 @@ func (m *MockSender) ServiceCheck(checkName string, status aggregator.ServiceChe
 	m.Called(checkName, status, hostname, tags, message)
 }
 
+//Event enables the event mock call.
+func (m *MockSender) Event(e aggregator.Event) {
+	m.Called(e)
+}
+
 //Commit enables the commit mock call.
 func (m *MockSender) Commit() {
 	m.Called()

--- a/pkg/collector/corechecks/system/common_test.go
+++ b/pkg/collector/corechecks/system/common_test.go
@@ -41,6 +41,11 @@ func (m *MockSender) ServiceCheck(checkName string, status aggregator.ServiceChe
 	m.Called(checkName, status, hostname, tags, message)
 }
 
+//Event enables the event mock call.
+func (m *MockSender) Event(e aggregator.Event) {
+	m.Called(e)
+}
+
 //Commit enables the commit mock call.
 func (m *MockSender) Commit() {
 	m.Called()


### PR DESCRIPTION
### What does this PR do?

Overall, events are handled by the aggregator in a similar way as service checks.

The whole `Event` struct has to be submitted from the agent checks, this allows handling all the optional fields of the event struct more nicely (specifying them all as parameters of an `Sender.Event` function wouldn't be very handy from checks).

The "Agent startup" event is slightly tricky to handle so it's not taken care of here (more on that below).

The events are sent to the agent 5 intake endpoint (see comments in code for explanation).

### Additional Notes

For now:
- Haven't added the python bindings for py checks yet (will come with part 2)
- It only supports the agent5 intake endpoint (I have work queued to support
the v2 events endpoint)

#### More on the "agent startup" event:

In the backend:
1. this event is used by the intake to determine which payload is the first payload containing metadata from an agent. So this event has an impact on the metadata handling. (cc @masci )
2. downstream, it's aggregated with other "agent startup" events by a custom aggregator so that it looks nice in the event stream (for instance so that the title of the aggregated event reads "`n` Agents have started"). The aggregation is based on rarely-used fields (`event_object` and `event_type`) which I'd prefer to avoid adding to the `Event` struct.

Let's discuss how we'd like to handle this. For `2.`, I think we should stop relying on the custom aggregation and just use the regular event aggregation, it will be slightly less nice in the event stream but it'll allow us to stop using the custom code that handles it.
