### PR TITLE
[AutoConfig] Add an etcd config provider

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -22,6 +22,13 @@ func GetConfigProviders(confdPath string) (plist []providers.ConfigProvider) {
 	// File Provider
 	plist = append(plist, providers.NewFileConfigProvider(confSearchPaths))
 
+	// Etcd Provider
+	etcd, err := providers.NewEtcdConfigProvider()
+	if err != nil {
+		log.Errorf("Creating the etcd config provider failed: %s", err)
+	} else {
+		plist = append(plist, etcd)
+	}
 	return plist
 }
 

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	log "github.com/cihub/seelog"
 )
 
 // GetConfigProviders builds a list of providers for checks' configurations, the sequence defines

--- a/glide.lock
+++ b/glide.lock
@@ -5,6 +5,12 @@ imports:
   version: cb3dae3a7588ae35829eb5724df611cd75152fba
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
+- name: github.com/coreos/etcd
+  version: 20490caaf0dcd96bb4a95e40625559def8ef5b04
+  subpackages:
+  - client
+  - pkg/pathutil
+  - pkg/types
 - name: github.com/DataDog/agent-payload
   version: d185e425fded4bdda8495d072e811a686d8ef20d
   subpackages:
@@ -43,6 +49,9 @@ imports:
   - api/types/volume
   - client
   - pkg/tlsconfig
+  - api/types/mount
+  - api/types/blkiodev
+  - api/types/strslice
 - name: github.com/docker/go-connections
   version: 1b14b2d192e2f91cdc2bc6bf9aee0b0e116eed42
   subpackages:
@@ -55,6 +64,8 @@ imports:
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/geoffgarside/ber
   version: 854377f11dfb81f04121879829bc53487e377739
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
@@ -154,14 +165,18 @@ imports:
   - mock
   - require
   - suite
+- name: github.com/ugorji/go
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+  subpackages:
+  - codec
 - name: golang.org/x/net
-  version: 10c134ea0df15f7e34d789338c7a2d76cc7a3ab9
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
   - context/ctxhttp
   - proxy
 - name: golang.org/x/sys
-  version: e4594059fe4cde2daf423055a596c2cd1e6c9adf
+  version: e48874b42435b4347fc52bdee0424a52abc974d7
   subpackages:
   - unix
   - windows

--- a/glide.yaml
+++ b/glide.yaml
@@ -41,3 +41,8 @@ import:
 - package: github.com/Microsoft/go-winio
   version: v0.3.8
 - package: github.com/beevik/ntp
+- package: github.com/coreos/etcd
+  version: ~3.1.3
+  subpackages:
+  - client
+- package: golang.org/x/net

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -17,6 +17,7 @@ type ConfigRawMap map[interface{}]interface{}
 
 // Config is a generic container for configuration files
 type Config struct {
+	ID         ID           // the resource this Config applies to. Can be empty
 	Name       string       // the name of the check
 	Instances  []ConfigData // array of Yaml configurations
 	InitConfig ConfigData   // the init_config in Yaml (python check only)

--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -1,0 +1,248 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/coreos/etcd/client"
+	"github.com/ghodss/yaml"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+const (
+	instancePath   string = "instances"
+	checkNamePath  string = "check_names"
+	initConfigPath string = "init_configs"
+)
+
+func init() {
+	// Where to look for check templates if no custom path is defined
+	config.Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
+}
+
+// EtcdConfigProvider implements the Config Provider interface
+// It should be called periodically and returns templates from etcd for AutoConf.
+type EtcdConfigProvider struct {
+	Client      client.KeysAPI
+	TemplateDir string
+}
+
+// NewEtcdConfigProvider creates a client connection to etcd and create a new EtcdConfigProvider
+func NewEtcdConfigProvider() (*EtcdConfigProvider, error) {
+	tplDir := config.Datadog.GetString("autoconf_template_dir")
+	tplURL := config.Datadog.GetString("autoconf_template_url")
+
+	clientCfg := client.Config{
+		Endpoints:               []string{tplURL},
+		Transport:               client.DefaultTransport,
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	cl, err := client.New(clientCfg)
+	if err != nil {
+		return nil, fmt.Errorf("Can't reach etcd for auto config templates: %s", err)
+	}
+	c := client.NewKeysAPI(cl)
+	return &EtcdConfigProvider{c, tplDir}, nil
+}
+
+// Collect retrieves templates from etcd, builds Config objects and returns them
+// TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
+func (p *EtcdConfigProvider) Collect() ([]check.Config, error) {
+	configs := make([]check.Config, 0)
+	identifiers := p.getIdentifiers(p.TemplateDir)
+	for _, id := range identifiers {
+		templates := p.getTemplates(id)
+
+		for _, template := range templates {
+			c := check.Config{
+				ID:         check.ID(id),
+				Name:       template.Name,
+				InitConfig: template.InitConfig,
+				Instances:  template.Instances,
+			}
+			configs = append(configs, c)
+		}
+	}
+	return configs, nil
+}
+
+// getIdentifiers gets folders at the root of the TemplateDir
+// verifies they have the right content to be a valid template
+// and return their names.
+func (p *EtcdConfigProvider) getIdentifiers(key string) []string {
+	identifiers := make([]string, 0)
+	resp, err := p.Client.Get(context.Background(), key, &client.GetOptions{Recursive: true})
+	if err != nil {
+		log.Error("Can't get templates keys from etcd: ", err)
+		return identifiers
+	}
+	children := resp.Node.Nodes
+	for _, node := range children {
+		if node.Dir && hasTemplateFields(node.Nodes) {
+			split := strings.Split(node.Key, "/")
+			identifiers = append(identifiers, split[len(split)-1])
+		}
+	}
+	return identifiers
+}
+
+// getTemplates takes a path and returns a slice of templates if it finds
+// sufficient data under this path to build one.
+func (p *EtcdConfigProvider) getTemplates(key string) []check.Config {
+	templates := make([]check.Config, 0)
+
+	checkNameKey := buildStoreKey(key, checkNamePath)
+	initKey := buildStoreKey(key, initConfigPath)
+	instanceKey := buildStoreKey(key, instancePath)
+
+	checkNames, err := p.getCheckNames(checkNameKey)
+	if err != nil {
+		log.Errorf("Failed to retrieve check names at %s. Error: %s", checkNameKey, err)
+		return nil
+	}
+
+	initConfigs, err := p.getJsonValue(initKey)
+	if err != nil {
+		log.Errorf("Failed to retrieve init configs at %s. Error: %s", initKey, err)
+		return nil
+	}
+
+	instances, err := p.getJsonValue(instanceKey)
+	if err != nil {
+		log.Errorf("Failed to retrieve instances at %s. Error: %s", instanceKey, err)
+		return nil
+	}
+
+	// sanity check
+	if len(checkNames) != len(initConfigs) || len(checkNames) != len(instances) {
+		log.Error("Template entries don't all have the same length in etcd, not using them.")
+		return templates
+	}
+
+	for idx := range checkNames {
+		instance := check.ConfigData(instances[idx])
+
+		templates = append(templates, check.Config{
+			ID:         check.ID(key),
+			Name:       checkNames[idx],
+			InitConfig: check.ConfigData(initConfigs[idx]),
+			Instances:  []check.ConfigData{instance},
+		})
+	}
+	return templates
+}
+
+// getEtcdValue retrieves content from etcd
+func (p *EtcdConfigProvider) getEtcdValue(key string) (string, error) {
+
+	resp, err := p.Client.Get(context.Background(), key, nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve %s from etcd: %s", key, err)
+	}
+
+	return resp.Node.Value, nil
+}
+
+func (p *EtcdConfigProvider) getCheckNames(key string) ([]string, error) {
+	rawNames, err := p.getEtcdValue(key)
+	if err != nil {
+		err := fmt.Errorf("Couldn't get check names from etcd: %s", err)
+		return nil, err
+	}
+	if rawNames == "" {
+		err = fmt.Errorf("check_names is empty")
+		return nil, err
+	}
+
+	var res []string
+
+	if err = json.Unmarshal([]byte(rawNames), &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (p *EtcdConfigProvider) getJsonValue(key string) ([]check.ConfigData, error) {
+	rawValue, err := p.getEtcdValue(key)
+	if err != nil {
+		err := fmt.Errorf("Couldn't get key %s from etcd: %s", key, err)
+		return nil, err
+	}
+
+	if rawValue == "" {
+		err = fmt.Errorf("Value at %s is empty in etcd", key)
+		return nil, err
+	}
+
+	yamlValue, err := yaml.JSONToYAML([]byte(rawValue))
+	if err != nil {
+		err := fmt.Errorf("Couldn't decode JSON value at %s. Error: %s", key, err)
+		return nil, err
+	}
+
+	var rawRes interface{}
+	var result []check.ConfigData
+
+	err = yaml.Unmarshal(yamlValue, &rawRes)
+	if err != nil {
+		fmt.Println("Failed to unmarshal value at %s. Error: %s", key, err)
+
+	}
+
+	for _, r := range rawRes.([]interface{}) {
+		switch r.(type) {
+		case []byte:
+			result = append(result, r.([]byte))
+		case map[string]interface{}:
+			init, _ := yaml.Marshal(r)
+			result = append(result, init)
+		}
+
+	}
+	return result, nil
+}
+
+// getIdx gets the last-modified index of a key
+// it's useful if you want to verify something changed
+// before triggering a full read
+func (p *EtcdConfigProvider) getIdx(key string) int {
+	// TODO
+	return 0
+}
+
+func buildStoreKey(key ...string) string {
+	parts := []string{config.Datadog.GetString("autoconf_template_dir")}
+	parts = append(parts, key...)
+	return path.Join(parts...)
+}
+
+// hasTemplateFields verifies that a node array contains
+// the needed information to build a config template
+func hasTemplateFields(nodes client.Nodes) bool {
+	tplKeys := []string{instancePath, checkNamePath, initConfigPath}
+	if len(nodes) < 3 {
+		return false
+	}
+
+	for _, tpl := range tplKeys {
+		has := false
+		for _, k := range nodes {
+			split := strings.Split(k.Key, "/")
+			if split[len(split)-1] == tpl {
+				has = true
+			}
+		}
+		if !has {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -108,13 +108,13 @@ func (p *EtcdConfigProvider) getTemplates(key string) []check.Config {
 		return nil
 	}
 
-	initConfigs, err := p.getJsonValue(initKey)
+	initConfigs, err := p.getJSONValue(initKey)
 	if err != nil {
 		log.Errorf("Failed to retrieve init configs at %s. Error: %s", initKey, err)
 		return nil
 	}
 
-	instances, err := p.getJsonValue(instanceKey)
+	instances, err := p.getJSONValue(instanceKey)
 	if err != nil {
 		log.Errorf("Failed to retrieve instances at %s. Error: %s", instanceKey, err)
 		return nil
@@ -170,7 +170,7 @@ func (p *EtcdConfigProvider) getCheckNames(key string) ([]string, error) {
 	return res, nil
 }
 
-func (p *EtcdConfigProvider) getJsonValue(key string) ([]check.ConfigData, error) {
+func (p *EtcdConfigProvider) getJSONValue(key string) ([]check.ConfigData, error) {
 	rawValue, err := p.getEtcdValue(key)
 	if err != nil {
 		err := fmt.Errorf("Couldn't get key %s from etcd: %s", key, err)
@@ -193,8 +193,8 @@ func (p *EtcdConfigProvider) getJsonValue(key string) ([]check.ConfigData, error
 
 	err = yaml.Unmarshal(yamlValue, &rawRes)
 	if err != nil {
-		fmt.Println("Failed to unmarshal value at %s. Error: %s", key, err)
-
+		err := fmt.Errorf("Failed to unmarshal value at %s. Error: %s", key, err)
+		return nil, err
 	}
 
 	for _, r := range rawRes.([]interface{}) {

--- a/pkg/collector/providers/etcd_test.go
+++ b/pkg/collector/providers/etcd_test.go
@@ -1,0 +1,54 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestNode(key string) *client.Node {
+	return &client.Node{
+		Key:           key,
+		Value:         "test",
+		CreatedIndex:  123456,
+		ModifiedIndex: 123456,
+		TTL:           123456789,
+	}
+}
+
+func TestBuildStoreKey(t *testing.T) {
+	res := buildStoreKey()
+	assert.Equal(t, res, "/datadog/check_configs")
+	res = buildStoreKey("")
+	assert.Equal(t, res, "/datadog/check_configs")
+	res = buildStoreKey("foo")
+	assert.Equal(t, res, "/datadog/check_configs/foo")
+	res = buildStoreKey("foo", "bar")
+	assert.Equal(t, res, "/datadog/check_configs/foo/bar")
+	res = buildStoreKey("foo", "bar", "bazz")
+	assert.Equal(t, res, "/datadog/check_configs/foo/bar/bazz")
+}
+
+func TestHasTemplateFields(t *testing.T) {
+	emptyNodes := []*client.Node{}
+	node0 := createTestNode("foo")
+	node1 := createTestNode("check_names")
+	node2 := createTestNode("init_configs")
+	node3 := createTestNode("instances")
+
+	res := hasTemplateFields(emptyNodes)
+	assert.False(t, res)
+
+	tooFewNodes := []*client.Node{node0, node1}
+	res = hasTemplateFields(tooFewNodes)
+	assert.False(t, res)
+
+	invalidNodes := []*client.Node{node0, node1, node2}
+	res = hasTemplateFields(invalidNodes)
+	assert.False(t, res)
+
+	validNodes := []*client.Node{node1, node2, node3}
+	res = hasTemplateFields(validNodes)
+	assert.True(t, res)
+}

--- a/pkg/collector/providers/etcd_test.go
+++ b/pkg/collector/providers/etcd_test.go
@@ -19,15 +19,15 @@ func createTestNode(key string) *client.Node {
 
 func TestBuildStoreKey(t *testing.T) {
 	res := buildStoreKey()
-	assert.Equal(t, res, "/datadog/check_configs")
+	assert.Equal(t, "/datadog/check_configs", res)
 	res = buildStoreKey("")
-	assert.Equal(t, res, "/datadog/check_configs")
+	assert.Equal(t, "/datadog/check_configs", res)
 	res = buildStoreKey("foo")
-	assert.Equal(t, res, "/datadog/check_configs/foo")
+	assert.Equal(t, "/datadog/check_configs/foo", res)
 	res = buildStoreKey("foo", "bar")
-	assert.Equal(t, res, "/datadog/check_configs/foo/bar")
+	assert.Equal(t, "/datadog/check_configs/foo/bar", res)
 	res = buildStoreKey("foo", "bar", "bazz")
-	assert.Equal(t, res, "/datadog/check_configs/foo/bar/bazz")
+	assert.Equal(t, "/datadog/check_configs/foo/bar/bazz", res)
 }
 
 func TestHasTemplateFields(t *testing.T) {

--- a/test/integration/config_providers/etcd_provider_test.go
+++ b/test/integration/config_providers/etcd_provider_test.go
@@ -1,0 +1,181 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	etcd_client "github.com/coreos/etcd/client"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/providers"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+const (
+	etcdImg string = "quay.io/coreos/etcd:latest"
+)
+
+var etcdAddr string
+
+var templates = map[string]string{
+	"/foo/nginx/check_names":  "[\"http_check\", \"nginx\"]",
+	"/foo/nginx/init_configs": "[{}, {}]",
+	"/foo/nginx/instances":    "[{\"name\": \"test\", \"url\": \"http://%25%25host%25%25/\", \"timeout\": 5}, {\"foo\": \"bar\"}]",
+}
+
+// pull the latest etcd image, create a standalone etcd container
+func setup() string {
+
+	cID := createEtcd()
+	etcdAddr := getEtcdAddr(cID)
+
+	etcdURL := "http://" + etcdAddr + ":2379/"
+	config.Datadog.Set("autoconf_template_url", etcdURL)
+	config.Datadog.Set("autoconf_template_dir", "/foo/")
+
+	// wait for etcd to start
+	time.Sleep(time.Second)
+
+	populateEtcd(etcdURL)
+
+	return cID
+}
+
+func createEtcd() string {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	l, err := cli.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		panic(err)
+	}
+	match := false
+	for _, img := range l {
+		if img.RepoTags[0] == etcdImg {
+			match = true
+			break
+		}
+	}
+	if !match {
+		_, err = cli.ImagePull(ctx, etcdImg, types.ImagePullOptions{})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	containerConfig := &container.Config{
+		Image: etcdImg,
+		Cmd: []string{
+			"/usr/local/bin/etcd",
+			"-name", "etcd0",
+			"-advertise-client-urls", "http://0.0.0.0:2379",
+			"-listen-client-urls", "http://0.0.0.0:2379",
+			"-initial-advertise-peer-urls", "http://127.0.0.1:2379",
+			"-listen-peer-urls", "http://0.0.0.0:2800",
+			"-initial-cluster-token", "etcd-cluster-1",
+			"-initial-cluster", "etcd0=http://127.0.0.1:2379",
+			"-initial-cluster-state", "new",
+		},
+	}
+
+	resp, err := cli.ContainerCreate(ctx, containerConfig, nil, nil, "etcd0")
+	if err != nil {
+		panic(err)
+	}
+	cID := resp.ID
+
+	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+		panic(err)
+	}
+
+	return cID
+}
+
+func populateEtcd(addr string) {
+	// get etcd client
+	clientCfg := etcd_client.Config{
+		Endpoints:               []string{addr},
+		Transport:               etcd_client.DefaultTransport,
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	cl, err := etcd_client.New(clientCfg)
+	if err != nil {
+		panic(err)
+	}
+	c := etcd_client.NewKeysAPI(cl)
+
+	ctx := context.Background()
+
+	for k, v := range templates {
+		_, err := c.Set(ctx, k, v, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func getEtcdAddr(cID string) string {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		panic(err)
+	}
+
+	co, err := cli.ContainerInspect(context.Background(), cID)
+	if err != nil {
+		panic(err)
+	}
+
+	return co.NetworkSettings.IPAddress
+}
+
+// TODO: handle image
+func teardown(cID string) {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	cli.ContainerRemove(ctx, cID, types.ContainerRemoveOptions{Force: true})
+}
+
+func TestMain(m *testing.M) {
+	cID := setup()
+
+	m.Run()
+
+	teardown(cID)
+}
+
+func TestWorkingConnection(t *testing.T) {
+	p, err := providers.NewEtcdConfigProvider()
+	if err != nil {
+		panic(err)
+	}
+	checks, err := p.Collect()
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, len(checks), 2)
+}
+
+func TestBadConnection(t *testing.T) {
+	config.Datadog.Set("autoconf_template_url", "http://127.0.0.1:1337")
+
+	p, err := providers.NewEtcdConfigProvider()
+	assert.Nil(t, err)
+
+	checks, err := p.Collect()
+	assert.Nil(t, err)
+	assert.Empty(t, checks)
+}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Add an etcd config provider that will be used to provide templates for AutoConfig.
It also has integration tests, not sure yet how we want to instrument them.

### Motivation

First step towards AC.

### Additional Notes

- next step for this Provider is to cache templates and `last-modified` timestamp.