### PR TITLE
Remove call to get ec2 hostname from tests

### DIFF
--- a/pkg/collector/metadata/host/host_test.go
+++ b/pkg/collector/metadata/host/host_test.go
@@ -74,7 +74,6 @@ func TestGetMeta(t *testing.T) {
 	assert.NotEmpty(t, meta.SocketHostname)
 	assert.NotEmpty(t, meta.Timezones)
 	assert.NotEmpty(t, meta.SocketFqdn)
-	assert.Empty(t, meta.EC2Hostname) // this is temporary
 }
 
 func TestBuildKey(t *testing.T) {


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Removes a useless test that also fails when the runner is on an EC2 node.
