### PR TITLE
install psycopg2 deps at package build time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ run_tests_deb-x64:
     USE_SYSTEM_PY: "1"
   script:
     - echo "deb http://deb.debian.org/debian wheezy contrib non-free" >> /etc/apt/sources.list
-    - apt-get update && apt-get install -y -qq libsnmp-base libsnmp-dev snmp-mibs-downloader libpq-dev
+    - apt-get update && apt-get install -y -qq libsnmp-base libsnmp-dev snmp-mibs-downloader # required by snmp check
     - rake test
 
 # build the package for deb-x64
@@ -47,6 +47,7 @@ agent_deb-x64:
     # Uncomment the following to see debug logs from omnibus, it defaults to info
     # AGENT_OMNIBUS_LOG_LEVEL: debug
   script:
+    - apt-get install -y -qq libpq-dev  # this has to be removed as soon as we upgrade to psycopg2 2.7
     - rake agent:omnibus
     - dpkg -c $AGENT_OMNIBUS_PACKAGE_DIR/*.deb
   cache:


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Install psycopg2 dependencies in the right place, it's not needed on tests but for packaging
