### PR TITLE
Skip building the SNMP check on Windows

### DIFF
--- a/pkg/collector/corechecks/network/doc.go
+++ b/pkg/collector/corechecks/network/doc.go
@@ -1,0 +1,5 @@
+/*
+Package network provides core checks for networking
+
+*/
+package network

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package network
 
 /*

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package network
 
 import (


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Conditional building of the SNMP check to exclude windows

### Motivation

We still need to investigate how to build on win in a sane way, disabling for now.

