### PR TITLE
Adding a method to acces agent configuration from python check.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -109,7 +109,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/sbinet/go-python
-  version: a2acb64fbdf8703949837e5ebf50c71319fe03a4
+  version: ba7e58341058bdefb92b359870caf2dc0a05cfcf
 - name: github.com/shirou/gopsutil
   version: d371ba1293cb48fedc6850526ea48b3846c54f2c
   subpackages:

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -150,7 +150,7 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	conf["instances"] = []interface{}{rawInstances}
 
 	// Convert the RawConfigMap to a Python dictionary
-	kwargs, err := ToPythonDict(&conf)
+	kwargs, err := ToPython(&conf)
 	if err != nil {
 		log.Errorf("Error parsing python check configuration: %v", err)
 		return err
@@ -165,7 +165,7 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 		// try again, assuming the check is good but has still the old api
 		// we pass initConfig but emit a deprecation notice
 		allSettings := config.Datadog.AllSettings()
-		agentConfig, err := ToPythonDict(allSettings)
+		agentConfig, err := ToPython(allSettings)
 		if err != nil {
 			return fmt.Errorf("could not convert agent configuration to python: %s", err)
 		}
@@ -182,7 +182,7 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 			return fmt.Errorf("could not invoke python check constructor: %s", err)
 		}
 
-		log.Warnf("passing `agentConfig` to the constructor is deprecated, please use the `agent_config` package (%s).", c.ModuleName)
+		log.Warnf("passing `agentConfig` to the constructor is deprecated, please use the `get_config` function from the 'datadog_agent' package (%s).", c.ModuleName)
 	}
 
 	c.Instance = instance

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -2,9 +2,26 @@
 
 PyObject* GetVersion();
 PyObject* Headers();
+PyObject* GetConfig(char *key);
+
+static PyObject *get_config(PyObject *self, PyObject *args) {
+    char *key;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    if (!PyArg_ParseTuple(args, "s", &key)) {
+      PyGILState_Release(gstate);
+      Py_RETURN_NONE;
+    }
+
+    PyGILState_Release(gstate);
+    return GetConfig(key);
+}
 
 static PyMethodDef datadogAgentMethods[] = {
   {"get_version", (PyCFunction)GetVersion, METH_VARARGS, "Get the Agent version."},
+  {"get_config", get_config, METH_VARARGS, "Get value from the agent configuration."},
   {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
   {NULL, NULL}
 };


### PR DESCRIPTION
### What does this PR do?
The 'config_get' method aim to replace the 'agentConfig' parameter from
the python checks.

We add the ability to convert simple types (int, string, ...) from Go to
Python. Some Go types can't be converted to Python for now, we will had
more types if needed in the futur, for now we emit a simple warning.

### Motivation

We need a equivalent to the `agentConfig` from agent5.

