### PR TITLE
Fix memory 'used' metric who used MemAvailable instead of MemFree

### DIFF
--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -56,7 +56,7 @@ func (c *MemoryCheck) Run() error {
 
 	c.sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
 	c.sender.Gauge("system.mem.free", float64(v.Free)/mbSize, "", nil)
-	c.sender.Gauge("system.mem.used", float64(v.Used)/mbSize, "", nil)
+	c.sender.Gauge("system.mem.used", float64(v.Total-v.Free)/mbSize, "", nil)
 	c.sender.Gauge("system.mem.usable", float64(v.Available)/mbSize, "", nil)
 	c.sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
 

--- a/pkg/collector/corechecks/system/memory_test.go
+++ b/pkg/collector/corechecks/system/memory_test.go
@@ -50,7 +50,7 @@ func TestMemoryCheckLinux(t *testing.T) {
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.free", 11554304000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.used", 10000000000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.pct_usable", 0.19, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.cached", 2596446142464.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -81,7 +81,7 @@ func TestMemoryCheckFreebsd(t *testing.T) {
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.free", 11554304000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.used", 10000000000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.pct_usable", 0.19, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.cached", 2596446142464.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -108,7 +108,7 @@ func TestMemoryCheckDarwin(t *testing.T) {
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.free", 11554304000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.used", 10000000000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.pct_usable", 0.19, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.total", 100000.0/mbSize, "", []string(nil)).Return().Times(1)


### PR DESCRIPTION
### What does this PR do?

Fix memory 'used' metric who used MemAvailable instead of MemFree

### Motivation

We need to have the same value between agent5 and agent6
