### PR TITLE
Add artifacts expiration date

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,7 @@ agent_deb-x64:
     paths:
       - $AGENT_OMNIBUS_BASE_DIR
   artifacts:
+    expire_in: 2 weeks
     paths:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
@@ -80,6 +81,7 @@ dogstatsd_deb-x64:
     paths:
       - $AGENT_OMNIBUS_BASE_DIR
   artifacts:
+    expire_in: 2 weeks
     paths:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 


### PR DESCRIPTION
This allows @DataDog/ube to run a GC in our artifacts directory on the gitlab master. 
Please let me know if the artifacts are needed for a longer time or if you have a specific use case involving them.
Cheers!

See DataDog/ube#6