### PR TITLE
Add commit hash to versioning scheme

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -17,6 +17,6 @@ var versionCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		av, _ := version.New(version.AgentVersion)
-		fmt.Println(fmt.Sprintf("Agent %s - Codename: %s", av.GetNumber(), av.Meta))
+		fmt.Println(fmt.Sprintf("Agent %s - Codename: %s - Commit: %s", av.GetNumber(), av.Meta, av.Commit))
 	},
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -60,6 +60,13 @@ func (v *Version) String() string {
 	if v.Meta != "" {
 		ver = fmt.Sprintf("%s+%s", ver, v.Meta)
 	}
+	if v.Commit != "" {
+		if v.Meta != "" {
+			ver = fmt.Sprintf("%s.commit.%s", ver, v.Commit)
+		} else {
+			ver = fmt.Sprintf("%s+commit.%s", ver, v.Commit)
+		}
+	}
 
 	return ver
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,10 @@ type Version struct {
 	Patch int64
 	Pre   string
 	Meta  string
+	Commit string
 }
+
+var commit string
 
 // New parses a version string like `0.0.0` and returns an AgentVersion instance
 func New(version string) (Version, error) {
@@ -43,6 +46,7 @@ func New(version string) (Version, error) {
 		Patch: patch,
 		Pre:   pre,
 		Meta:  meta,
+		Commit: commit,
 	}
 
 	return av, nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,11 +9,11 @@ import (
 
 // Version holds SemVer infos for the agent and friends
 type Version struct {
-	Major int64
-	Minor int64
-	Patch int64
-	Pre   string
-	Meta  string
+	Major  int64
+	Minor  int64
+	Patch  int64
+	Pre    string
+	Meta   string
 	Commit string
 }
 
@@ -41,11 +41,11 @@ func New(version string) (Version, error) {
 	meta := strings.Replace(toks[3], "+", "", 1)
 
 	av := Version{
-		Major: major,
-		Minor: minor,
-		Patch: patch,
-		Pre:   pre,
-		Meta:  meta,
+		Major:  major,
+		Minor:  minor,
+		Patch:  patch,
+		Pre:    pre,
+		Meta:   meta,
 		Commit: commit,
 	}
 

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -26,7 +26,9 @@ namespace :agent do
       env["PKG_CONFIG_LIBDIR"] = "#{PKG_CONFIG_LIBDIR}"
     end
 
-    system(env, "go build #{race_opt} -o #{BIN_PATH}/#{agent_bin_name} #{REPO_PATH}/cmd/agent")
+    commit = `git rev-parse --short HEAD`.strip
+    ldflags = "-X #{REPO_PATH}/pkg/version.commit=#{commit}"
+    system(env, "go build #{race_opt} -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/agent")
     Rake::Task["agent:refresh_assets"].invoke
   end
 


### PR DESCRIPTION
### What does this PR do?

It adds the commit hash as part of the version structure. When converting to string, the hash is added in the metadata part of the version string (cf http://semver.org/#spec-item-10)