### PR TITLE
[python] Add bindings to submit events from py checks

### DIFF
--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -145,7 +145,7 @@ func (s *checkSender) ServiceCheck(checkName string, status ServiceCheckStatus, 
 
 // Event submits an event
 func (s *checkSender) Event(e Event) {
-	log.Debug("Event submitted: ", e.Title, ": for hostname: ", e.Host, " tags: ", e.Tags)
+	log.Debug("Event submitted: ", e.Title, " for hostname: ", e.Host, " tags: ", e.Tags)
 
 	s.eventOut <- e
 }

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -55,6 +55,14 @@ class AgentCheck(object):
     def service_check(self, name, status, tags=None, message=""):
         aggregator.submit_service_check(self, name, status, tags, message)
 
+    def event(self, event):
+        # Enforce types of some fields, considerably facilitates handling in go bindings downstream
+        if event.get('timestamp'):
+            event['timestamp'] = int(event['timestamp'])
+        if event.get('aggregation_key'):
+            event['aggregation_key'] = str(event['aggregation_key'])
+        aggregator.submit_event(self, event)
+
     def check(self, instance):
         raise NotImplementedError
 

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -57,6 +57,14 @@ class AgentCheck(object):
 
     def event(self, event):
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream
+        for key, value in event.items():
+            # transform the unicode objects to plain strings with utf-8 encoding
+            if isinstance(value, unicode):
+                try:
+                    event[key] = event[key].encode('utf-8')
+                except UnicodeError:
+                    self.log.warning("Error encoding unicode field '%s' of event to utf-8 encoded string, can't submit event", key)
+                    return
         if event.get('timestamp'):
             event['timestamp'] = int(event['timestamp'])
         if event.get('aggregation_key'):

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -26,18 +26,7 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 
 	_name := C.GoString(name)
 	_value := float64(value)
-	var _tags []string
-	var seq *C.PyObject
-
-	errMsg := C.CString("expected a sequence") // this has to be freed
-	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
-	if !isNone(tags) {
-		var i C.Py_ssize_t
-		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
-			item := C.PySequence_Fast_Get_Item(seq, i)                   // `item` is borrowed, no need to decref
-			_tags = append(_tags, C.GoString(C.PyString_AsString(item))) // TODO: YOLO! Please add error checking
-		}
-	}
+	_tags := extractTags(tags)
 
 	switch mt {
 	case C.GAUGE:
@@ -51,10 +40,6 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 	case C.HISTOGRAM:
 		sender.Histogram(_name, _value, "", _tags)
 	}
-
-	// cleanup
-	C.Py_DecRef(seq)
-	C.free(unsafe.Pointer(errMsg))
 
 	return C._none()
 }
@@ -71,12 +56,105 @@ func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.P
 
 	_name := C.GoString(name)
 	_status := aggregator.ServiceCheckStatus(status)
-	var _tags []string
-	var seq *C.PyObject
+	_tags := extractTags(tags)
 	_message := C.GoString(message)
 
-	errMsg := C.CString("expected a sequence") // this has to be freed
-	seq = C.PySequence_Fast(tags, errMsg)      // seq is a new reference, has to be decref'd
+	sender.ServiceCheck(_name, _status, "", _tags, _message)
+
+	return C._none()
+}
+
+// SubmitEvent is the method exposed to Python scripts to submit events
+//export SubmitEvent
+func SubmitEvent(check *C.PyObject, event *C.PyObject) *C.PyObject {
+
+	sender, err := aggregator.GetDefaultSender()
+	if err != nil {
+		log.Errorf("Error submitting event to the Sender: %v", err)
+		return C._none()
+	}
+
+	if int(C._PyDict_Check(event)) == 0 {
+		log.Errorf("Error submitting event to the Sender, the submitted event is not a python dict")
+		return C._none()
+	}
+
+	_event := extractEventFromDict(event)
+
+	sender.Event(_event)
+
+	return C._none()
+}
+
+func extractEventFromDict(event *C.PyObject) aggregator.Event {
+	// Extract all string values
+	// Values that should be extracted from the python event dict as strings
+	eventStringValues := map[string]string{
+		"msg_title":        "",
+		"msg_text":         "",
+		"priority":         "",
+		"host":             "",
+		"alert_type":       "",
+		"aggregation_key":  "",
+		"source_type_name": "",
+	}
+
+	for key := range eventStringValues {
+		pyKey := C.CString(key)
+		defer C.free(unsafe.Pointer(pyKey))
+
+		pyValue := C.PyDict_GetItemString(event, pyKey) // borrowed ref
+		// key not in dict => nil ; value for key is None => None ; we need to check for both
+		if pyValue != nil && !isNone(pyValue) {
+			if int(C._PyString_Check(pyValue)) != 0 {
+				eventStringValues[key] = C.GoString(C.PyString_AsString(pyValue))
+			} else {
+				log.Infof("Can't parse value for key '%s' in event submitted from python check", key)
+			}
+		}
+	}
+
+	_event := aggregator.Event{
+		Title:          eventStringValues["msg_title"],
+		Text:           eventStringValues["msg_text"],
+		Priority:       aggregator.EventPriority(eventStringValues["priority"]),
+		Host:           eventStringValues["host"],
+		AlertType:      aggregator.EventAlertType(eventStringValues["alert_type"]),
+		AggregationKey: eventStringValues["aggregation_key"],
+		SourceTypeName: eventStringValues["source_type_name"],
+	}
+
+	// Extract timestamp
+	pyKey := C.CString("timestamp")
+	defer C.free(unsafe.Pointer(pyKey))
+
+	timestamp := C.PyDict_GetItemString(event, pyKey) // borrowed ref
+	if timestamp != nil && !isNone(timestamp) {
+		_event.Ts = int64(C.PyInt_AsLong(timestamp))
+	}
+
+	// Extract tags
+	pyKey = C.CString("tags")
+	defer C.free(unsafe.Pointer(pyKey))
+
+	tags := C.PyDict_GetItemString(event, pyKey) // borrowed ref
+	if tags != nil {
+		_event.Tags = extractTags(tags)
+	}
+
+	return _event
+}
+
+func extractTags(tags *C.PyObject) []string {
+	var _tags []string
+
+	errMsg := C.CString("expected a sequence")
+	defer C.free(unsafe.Pointer(errMsg))
+
+	var seq *C.PyObject
+	seq = C.PySequence_Fast(tags, errMsg) // seq is a new reference, has to be decref'd
+	defer C.Py_DecRef(seq)
+
 	if !isNone(tags) {
 		var i C.Py_ssize_t
 		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
@@ -85,13 +163,7 @@ func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.P
 		}
 	}
 
-	sender.ServiceCheck(_name, _status, "", _tags, _message)
-
-	// cleanup
-	C.Py_DecRef(seq)
-	C.free(unsafe.Pointer(errMsg))
-
-	return C._none()
+	return _tags
 }
 
 func isNone(o *C.PyObject) bool {

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -16,6 +16,8 @@ typedef enum {
 void initaggregator();
 PyObject* _none();
 int _is_none(PyObject*);
+int _PyDict_Check(PyObject*);
+int _PyString_Check(PyObject*);
 PyObject* PySequence_Fast_Get_Item(PyObject*, Py_ssize_t);
 Py_ssize_t PySequence_Fast_Get_Size(PyObject*);
 


### PR DESCRIPTION
### What does this PR do?

Adds bindings to submit events from py checks.

The approach to convert the python dict to a go Event struct is not
generic at all but I didn't find a strong reason to make it more generic.
Open to discussion though :)

### Testing

Tested manually from a custom python check.

### Additional Notes

The go code is written to be safe overall. The 3rd commit is an attempt to
improve the safety of one particular CPython call, but a more systematic
approach should probably be applied to all our bindings :)

There is some (limited) duplicated logic with some of `go-python`'s
internal API, don't know if we can really avoid that without making more
of `go-python`'s API public

`unicode` objects in the event dict are also supported (see related commit
description for more details).