### PR TITLE
First draft of AutoConfig

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -90,6 +90,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 		}
 	}
 	log.Debugf("statsd started")
+
 	// create and setup the Autoconfig instance
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -2,15 +2,12 @@ package app
 
 import (
 	"path"
-	"path/filepath"
 
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/collector"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/metadata"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
@@ -93,42 +90,12 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 		}
 	}
 	log.Debugf("statsd started")
-	// create the Collector instance and start all the components
-	// NOTICE: this will also setup the Python environment
-	common.Collector = collector.NewCollector(common.GetDistPath(), filepath.Join(common.GetDistPath(), "checks"),
-		config.Datadog.GetString("additional_checksd"), common.PyChecksPath)
+	// create and setup the Autoconfig instance
+	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
-	log.Debugf("commonCollector created")
 	// setup the metadata collector, this needs a working Python env to function
 	metaCollector := metadata.NewCollector(fwd, config.Datadog.GetString("api_key"), hostname)
 	log.Debugf("metaCollector created")
-	// Get a list of config checks from the configured providers
-	var configs []check.Config
-	for _, provider := range common.GetConfigProviders(config.Datadog.GetString("confd_path")) {
-		c, _ := provider.Collect()
-		configs = append(configs, c...)
-	}
-
-	// given a list of configurations, try to load corresponding checks using different loaders
-	// TODO add check type to the conf file so that we avoid the inner for
-	log.Debugf("before checkloaders")
-	loaders := common.GetCheckLoaders()
-	for _, conf := range configs {
-		for _, loader := range loaders {
-			res, err := loader.Load(conf)
-			if err != nil {
-				log.Warnf("Unable to load the check '%s' from the configuration: %s", conf.Name, err)
-				continue
-			}
-
-			for _, check := range res {
-				err := common.Collector.RunCheck(check)
-				if err != nil {
-					log.Warnf("Unable to run check %v: %s", check, err)
-				}
-			}
-		}
-	}
 	return statsd, metaCollector, fwd
 }
 
@@ -138,12 +105,11 @@ func StopAgent(statsd *dogstatsd.Server, metaCollector *metadata.Collector, fwd 
 	if statsd != nil {
 		statsd.Stop()
 	}
-	common.Collector.Stop()
+	common.AC.Stop()
 	metaCollector.Stop()
 	api.StopServer()
 	fwd.Stop()
 	os.Remove(pidfilePath)
 	log.Info("See ya!")
 	log.Flush()
-
 }

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -3,14 +3,16 @@
 package common
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/collector"
-	"github.com/kardianos/osext"
 	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/kardianos/osext"
 )
 
 var (
-	// Collector is the global object orchestrating check runs
-	Collector *collector.Collector
+	// AC is the global object orchestrating checks' loading and running
+	AC *autodiscovery.AutoConfig
+
 	// Stopper is the channel used by other packages to ask for stopping the agent
 	Stopper = make(chan bool)
 

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -18,7 +18,8 @@ import (
 func SetupAutoConfig(confdPath string) {
 	// create the Collector instance and start all the components
 	// NOTICE: this will also setup the Python environment
-	coll := collector.NewCollector(DistPath, filepath.Join(DistPath, "checks"), PyChecksPath)
+	coll := collector.NewCollector(GetDistPath(), filepath.Join(GetDistPath(), "checks"),
+		config.Datadog.GetString("additional_checksd"), PyChecksPath)
 
 	// create the Autoconfig instance
 	AC = autodiscovery.NewAutoConfig(coll)

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector"
+	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
@@ -12,32 +13,34 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// GetConfigProviders builds a list of providers for checks' configurations, the sequence defines
-// the precedence.
-func GetConfigProviders(confdPath string) (plist []providers.ConfigProvider) {
+// SetupAutoConfig instantiate the global AutoConfig object and sets up
+// the Agent configuration providers and check loaders
+func SetupAutoConfig(confdPath string) {
+	// create the Collector instance and start all the components
+	// NOTICE: this will also setup the Python environment
+	coll := collector.NewCollector(DistPath, filepath.Join(DistPath, "checks"), PyChecksPath)
+
+	// create the Autoconfig instance
+	AC = autodiscovery.NewAutoConfig(coll)
+
+	// add the check loaders
+	AC.AddLoader(py.NewPythonCheckLoader())
+	AC.AddLoader(core.NewGoCheckLoader())
+
+	// add the configuration providers
+	// File Provider
 	confSearchPaths := []string{
 		confdPath,
 		filepath.Join(GetDistPath(), "conf.d"),
 	}
-
-	// File Provider
-	plist = append(plist, providers.NewFileConfigProvider(confSearchPaths))
+	AC.AddProvider(providers.NewFileConfigProvider(confSearchPaths), false)
 
 	// Etcd Provider
 	etcd, err := providers.NewEtcdConfigProvider()
 	if err != nil {
-		log.Errorf("Creating the etcd config provider failed: %s", err)
+		log.Errorf("Cannot use the etcd config provider: %s", err)
 	} else {
-		plist = append(plist, etcd)
-	}
-	return plist
-}
-
-// GetCheckLoaders builds a list of check loaders, the sequence defines the precedence.
-func GetCheckLoaders() []check.Loader {
-	return []check.Loader{
-		py.NewPythonCheckLoader(),
-		core.NewGoCheckLoader(),
+		AC.AddProvider(etcd, true)
 	}
 }
 

--- a/pkg/collector/autoconfig/autoconfig.go
+++ b/pkg/collector/autoconfig/autoconfig.go
@@ -1,0 +1,126 @@
+package autoconfig
+
+import (
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/providers"
+)
+
+var (
+	configsPollIntl = 10 * time.Second
+	configPipeBuf   = 100
+)
+
+type providerDescriptor struct {
+	provider providers.ConfigProvider
+	configs  []check.Config
+	poll     bool
+}
+
+// AutoConfig is responsible to collect checks configurations from
+// different sources and then create, update or destroy check instances
+// with the help of the Collector.
+// It is also responsible to listen to containers related events and act
+// accordingly.
+type AutoConfig struct {
+	collector         *collector.Collector
+	providers         []*providerDescriptor
+	configsPollTicker *time.Ticker
+	stop              chan bool
+	m                 sync.RWMutex
+}
+
+// NewAutoConfig creates an AutoConfig instance and start the goroutine
+// responsible to poll the different configuration providers.
+func NewAutoConfig(collector *collector.Collector) *AutoConfig {
+	ac := &AutoConfig{
+		collector:         collector,
+		providers:         make([]*providerDescriptor, 5),
+		configsPollTicker: time.NewTicker(configsPollIntl),
+		stop:              make(chan bool),
+	}
+
+	ac.pollConfigs()
+
+	return ac
+}
+
+// Stop just shuts down AutoConfig in a clean way. AutoConfig is not
+// supposed to be stopped and restarted.
+func (ac *AutoConfig) Stop() {
+	ac.stop <- true
+}
+
+// AddProvider adds a new configuration provider to AutoConfig.
+// Callers must pass a flag to indicate whether the configuration provider
+// expects to be polled or it's fine for it to be invoked only once in the
+// Agent lifetime.
+func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll bool) {
+	ac.m.Lock()
+	defer ac.m.Unlock()
+
+	for _, pd := range ac.providers {
+		if pd.provider == provider {
+			// we already know this configuration provider, don't do anything
+			// TODO: log we won't add this provider
+			return
+		}
+	}
+
+	pd := &providerDescriptor{
+		provider: provider,
+		configs:  []check.Config{},
+		poll:     shouldPoll,
+	}
+	ac.providers = append(ac.providers, pd)
+
+	// call Collect() at least once
+	ac.collect(pd)
+}
+
+// pollConfigs periodically calls Collect() on all the configuration
+// providers that have been requested to be polled
+func (ac *AutoConfig) pollConfigs() {
+	go func() {
+		for {
+			select {
+			case <-ac.stop:
+				ac.configsPollTicker.Stop()
+				return
+			case <-ac.configsPollTicker.C:
+				ac.m.RLock()
+				// invoke Collect on the known providers
+				for _, pd := range ac.providers {
+					// skip providers that don't want to be polled
+					if !pd.poll {
+						continue
+					}
+
+					ac.collect(pd)
+					// new, changed, removed := ac.collect(pd)
+					// TODO tell the collector to stop/start/restart the corresponding checks
+				}
+				ac.m.RUnlock()
+			}
+		}
+	}()
+}
+
+// collect is just a convenient wrapper to fetch configurations from a provider and
+// see what changed from the last time we called Collect().
+func (ac *AutoConfig) collect(pd *providerDescriptor) (new, changed, removed []check.Config) {
+	new = []check.Config{}
+	changed = []check.Config{}
+	removed = []check.Config{}
+	configs, err := pd.provider.Collect()
+	if err != nil {
+		// TODO log error
+		return new, changed, removed
+	}
+
+	// TODO
+	return configs, changed, removed
+}

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
+	log "github.com/cihub/seelog"
 )
 
 var (
@@ -28,6 +29,7 @@ type providerDescriptor struct {
 type AutoConfig struct {
 	collector         *collector.Collector
 	providers         []*providerDescriptor
+	loaders           []check.Loader
 	configsPollTicker *time.Ticker
 	stop              chan bool
 	m                 sync.RWMutex
@@ -38,7 +40,8 @@ type AutoConfig struct {
 func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 	ac := &AutoConfig{
 		collector:         collector,
-		providers:         make([]*providerDescriptor, 5),
+		providers:         make([]*providerDescriptor, 0, 5),
+		loaders:           make([]check.Loader, 0, 5),
 		configsPollTicker: time.NewTicker(configsPollIntl),
 		stop:              make(chan bool),
 	}
@@ -48,10 +51,12 @@ func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 	return ac
 }
 
-// Stop just shuts down AutoConfig in a clean way. AutoConfig is not
-// supposed to be stopped and restarted.
+// Stop just shuts down AutoConfig in a clean way.
+// AutoConfig is not supposed to be restarted, so this is expected
+// to be called only once at program exit.
 func (ac *AutoConfig) Stop() {
 	ac.stop <- true
+	ac.collector.Stop()
 }
 
 // AddProvider adds a new configuration provider to AutoConfig.
@@ -65,7 +70,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 	for _, pd := range ac.providers {
 		if pd.provider == provider {
 			// we already know this configuration provider, don't do anything
-			// TODO: log we won't add this provider
+			log.Warnf("Provider %s was already added, skipping...", provider)
 			return
 		}
 	}
@@ -77,8 +82,29 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 	}
 	ac.providers = append(ac.providers, pd)
 
-	// call Collect() at least once
-	ac.collect(pd)
+	// call Collect() now, so providers that don't need polling will be called at least once.
+	configs, _ := ac.collect(pd)
+	for _, config := range configs {
+		// load the check instances and schedule them
+		for _, check := range ac.loadChecks(config) {
+			err := ac.collector.RunCheck(check)
+			if err != nil {
+				log.Errorf("Unable to run Check %s", check)
+			}
+		}
+	}
+}
+
+// AddLoader adds a new Loader that AutoConfig can use to load a check.
+func (ac *AutoConfig) AddLoader(loader check.Loader) {
+	for _, l := range ac.loaders {
+		if l == loader {
+			log.Warnf("Loader %s was already added, skipping...", loader)
+			return
+		}
+	}
+
+	ac.loaders = append(ac.loaders, loader)
 }
 
 // pollConfigs periodically calls Collect() on all the configuration
@@ -99,8 +125,8 @@ func (ac *AutoConfig) pollConfigs() {
 						continue
 					}
 
-					ac.collect(pd)
-					// new, changed, removed := ac.collect(pd)
+					_, _ = ac.collect(pd)
+
 					// TODO tell the collector to stop/start/restart the corresponding checks
 				}
 				ac.m.RUnlock()
@@ -111,16 +137,54 @@ func (ac *AutoConfig) pollConfigs() {
 
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
-func (ac *AutoConfig) collect(pd *providerDescriptor) (new, changed, removed []check.Config) {
+func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []check.Config) {
 	new = []check.Config{}
-	changed = []check.Config{}
 	removed = []check.Config{}
-	configs, err := pd.provider.Collect()
+
+	fetched, err := pd.provider.Collect()
 	if err != nil {
-		// TODO log error
-		return new, changed, removed
+		log.Errorf("Unable to collect configurations from provider %s: %s", pd.provider, err)
+		return
 	}
 
-	// TODO
-	return configs, changed, removed
+	for _, c := range fetched {
+		if !pd.contains(&c) {
+			new = append(new, c)
+		}
+	}
+
+	old := pd.configs
+	pd.configs = fetched
+
+	for _, c := range old {
+		if !pd.contains(&c) {
+			removed = append(removed, c)
+		}
+	}
+
+	return
+}
+
+func (ac *AutoConfig) loadChecks(config check.Config) []check.Check {
+	for _, loader := range ac.loaders {
+		res, err := loader.Load(config)
+		if err == nil {
+			return res
+		}
+
+		log.Warnf("Unable to load the check '%s': %s", config.Name, err)
+	}
+
+	return []check.Check{}
+}
+
+// check if the descriptor contains the Config passed
+func (pd *providerDescriptor) contains(c *check.Config) bool {
+	for _, config := range pd.configs {
+		if config.Equal(c) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -1,4 +1,4 @@
-package autoconfig
+package autodiscovery
 
 import (
 	"sync"

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -1,0 +1,56 @@
+package autodiscovery
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type MockProvider struct {
+	CollectCounter int
+}
+
+func (p *MockProvider) Collect() ([]check.Config, error) {
+	p.CollectCounter++
+	return []check.Config{}, nil
+}
+
+type MockProvider2 struct {
+	MockProvider
+}
+
+type MockLoader struct{}
+
+func (l *MockLoader) Load(config check.Config) ([]check.Check, error) { return []check.Check{}, nil }
+
+func TestAddProvider(t *testing.T) {
+	ac := NewAutoConfig(nil)
+	assert.Len(t, ac.providers, 0)
+	mp := &MockProvider{}
+	ac.AddProvider(mp, false)
+	ac.AddProvider(mp, false) // this should be a noop
+	ac.AddProvider(&MockProvider2{}, true)
+	require.Len(t, ac.providers, 2)
+	assert.Equal(t, 1, mp.CollectCounter)
+	assert.False(t, ac.providers[0].poll)
+	assert.True(t, ac.providers[1].poll)
+}
+
+func TestAddLoader(t *testing.T) {
+	ac := NewAutoConfig(nil)
+	assert.Len(t, ac.loaders, 0)
+	ac.AddLoader(&MockLoader{})
+	ac.AddLoader(&MockLoader{}) // noop
+	assert.Len(t, ac.loaders, 1)
+}
+
+func TestContains(t *testing.T) {
+	c1 := check.Config{Name: "bar"}
+	c2 := check.Config{Name: "foo"}
+	pd := providerDescriptor{}
+	pd.configs = append(pd.configs, c1)
+	assert.True(t, pd.contains(&c1))
+	assert.False(t, pd.contains(&c2))
+}

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"bytes"
 	"sync"
 	"time"
 )
@@ -70,4 +71,31 @@ func (cs *Stats) Add(t time.Duration, err error) {
 		cs.LastError = err.Error()
 	}
 	cs.UpdateTimestamp = time.Now().Unix()
+}
+
+// Equal determines whether the passed config is the same
+func (c *Config) Equal(config *Config) bool {
+	if config == nil {
+		return false
+	}
+
+	if c.Name != config.Name {
+		return false
+	}
+
+	if len(c.Instances) != len(config.Instances) {
+		return false
+	}
+
+	for i := range c.Instances {
+		if !bytes.Equal(c.Instances[i], config.Instances[i]) {
+			return false
+		}
+	}
+
+	if !bytes.Equal(c.InitConfig, config.InitConfig) {
+		return false
+	}
+
+	return true
 }

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -1,0 +1,30 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigEqual(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.Equal(nil))
+
+	another := &Config{}
+	assert.True(t, config.Equal(another))
+
+	another.Name = "foo"
+	assert.False(t, config.Equal(another))
+	config.Name = another.Name
+	assert.True(t, config.Equal(another))
+
+	another.InitConfig = ConfigData("fooBarBaz")
+	assert.False(t, config.Equal(another))
+	config.InitConfig = another.InitConfig
+	assert.True(t, config.Equal(another))
+
+	another.Instances = []ConfigData{ConfigData("justFoo")}
+	assert.False(t, config.Equal(another))
+	config.Instances = another.Instances
+	assert.True(t, config.Equal(another))
+}

--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -46,8 +46,9 @@ func NewEtcdConfigProvider() (*EtcdConfigProvider, error) {
 	}
 	cl, err := client.New(clientCfg)
 	if err != nil {
-		return nil, fmt.Errorf("Can't reach etcd for auto config templates: %s", err)
+		return nil, fmt.Errorf("Unable to instantiate the etcd client: %s", err)
 	}
+
 	c := client.NewKeysAPI(cl)
 	return &EtcdConfigProvider{c, tplDir}, nil
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

This is a first step towards having a set of components implementing the AutoConfig feature, something that should be (roughly) responsible for:
 
 * scan various configuration providers searching for configuration files and/or configuration templates. This might be reiterated with a polling strategy in some cases.
 * convert configurations templates into valid configurations
 * load valid configurations into check instances
 * ask the `Collector` to start/stop/reload such instances
 * listen to Docker events in order to decide whether a check should be started/restarted/stopped

All of this will come in separate PRs, for now the goal is to replicate the current set of features but bringing `AutoConfig` into the picture.
