### PR TITLE
Add service check to dogstatsd

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -71,7 +71,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 	var statsd *dogstatsd.Server
 	if config.Datadog.GetBool("use_dogstatsd") {
 		var err error
-		statsd, err = dogstatsd.NewServer(agg.GetChannel())
+		statsd, err = dogstatsd.NewServer(agg.GetChannels())
 		if err != nil {
 			log.Errorf("Could not start dogstatsd: %s", err)
 		}

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -18,7 +17,8 @@ func main() {
 	config.Datadog.AddConfigPath(".")
 	err := config.Datadog.ReadInConfig()
 	if err != nil {
-		panic(fmt.Errorf("unable to load Datadog config file: %s", err))
+		log.Criticalf("unable to load Datadog config file: %s", err)
+		return
 	}
 
 	// for now we handle only one key and one domain

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -31,7 +31,7 @@ func main() {
 	f.Start()
 
 	aggregatorInstance := aggregator.InitAggregator(f)
-	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannel())
+	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {
 		log.Error(err.Error())
 		return

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -60,9 +60,9 @@ func newBufferedAggregator(f *forwarder.Forwarder) *BufferedAggregator {
 	return aggregator
 }
 
-// GetChannel returns a channel which can be subsequently used to send MetricSamples
-func (agg *BufferedAggregator) GetChannel() chan *MetricSample {
-	return agg.dogstatsdIn
+// GetChannels returns a channel which can be subsequently used to send MetricSamples, Event or ServiceCheck
+func (agg *BufferedAggregator) GetChannels() (chan *MetricSample, chan Event, chan ServiceCheck) {
+	return agg.dogstatsdIn, agg.eventIn, agg.serviceCheckIn
 }
 
 func (agg *BufferedAggregator) registerSender(id check.ID) error {

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -45,6 +45,30 @@ func MarshalSeries(series []*Serie) ([]byte, error) {
 	return proto.Marshal(payload)
 }
 
+// MarshalServiceChecks serialize check runs payload using agent-payload definition
+func MarshalServiceChecks(checkRuns []*ServiceCheck) ([]byte, error) {
+	payload := &agentpayload.CheckRunsPayload{
+		CheckRuns: []*agentpayload.CheckRunsPayload_CheckRun{},
+		Metadata:  &agentpayload.CommonMetadata{},
+	}
+
+	for _, c := range checkRuns {
+		payload.CheckRuns = append(payload.CheckRuns,
+			&agentpayload.CheckRunsPayload_CheckRun{
+				Name:    c.CheckName,
+				Host:    c.Host,
+				Ts:      c.Ts,
+				Status:  int32(c.Status),
+				Message: c.Message,
+				Tags:    c.Tags,
+			})
+	}
+
+	writer, _ := log.NewConsoleWriter()
+	proto.MarshalText(writer, payload)
+	return proto.Marshal(payload)
+}
+
 // MarshalJSONSeries serializea timeserie to JSON so it can be sent to V1 endpoints
 //FIXME(maxime): to be removed when v2 endpoints are available
 func MarshalJSONSeries(series []*Serie) ([]byte, error) {

--- a/pkg/aggregator/service_check.go
+++ b/pkg/aggregator/service_check.go
@@ -1,5 +1,9 @@
 package aggregator
 
+import (
+	"fmt"
+)
+
 // ServiceCheckStatus represents the status associated with a service check
 type ServiceCheckStatus int
 
@@ -10,6 +14,22 @@ const (
 	ServiceCheckCritical ServiceCheckStatus = 2
 	ServiceCheckUnknown  ServiceCheckStatus = 3
 )
+
+// GetServiceCheckStatus returns the ServiceCheckStatus from and integer value
+func GetServiceCheckStatus(val int) (ServiceCheckStatus, error) {
+	switch val {
+	case int(ServiceCheckOK):
+		return ServiceCheckOK, nil
+	case int(ServiceCheckWarning):
+		return ServiceCheckWarning, nil
+	case int(ServiceCheckCritical):
+		return ServiceCheckCritical, nil
+	case int(ServiceCheckUnknown):
+		return ServiceCheckUnknown, nil
+	default:
+		return ServiceCheckUnknown, fmt.Errorf("invalid value for a ServiceCheckStatus")
+	}
+}
 
 // String returns a string representation of ServiceCheckStatus
 func (s ServiceCheckStatus) String() string {

--- a/pkg/dogstatsd/README.md
+++ b/pkg/dogstatsd/README.md
@@ -13,7 +13,7 @@ Usage example:
 // you must first initialize the aggregator, see aggregator.InitAggregator
 
 // This will return an already running statd server ready to receive metrics
-statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannel())
+statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 
 // ...
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -1,6 +1,7 @@
 package dogstatsd
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"strings"
@@ -18,7 +19,7 @@ type Server struct {
 }
 
 // NewServer returns a running Dogstatsd server
-func NewServer(out chan *aggregator.MetricSample) (*Server, error) {
+func NewServer(metricOut chan<- *aggregator.MetricSample, eventOut chan<- aggregator.Event, serviceCheckOut chan<- aggregator.ServiceCheck) (*Server, error) {
 	var url string
 	if config.Datadog.GetBool("dogstatsd_non_local_traffic") == true {
 		// Listen to all network interfaces
@@ -41,12 +42,12 @@ func NewServer(out chan *aggregator.MetricSample) (*Server, error) {
 		Started: true,
 		conn:    conn,
 	}
-	go s.handleMessages(out)
+	go s.handleMessages(metricOut, eventOut, serviceCheckOut)
 	log.Infof("dogstatsd: listening on %s", address)
 	return s, nil
 }
 
-func (s *Server) handleMessages(out chan *aggregator.MetricSample) {
+func (s *Server) handleMessages(metricOut chan<- *aggregator.MetricSample, eventOut chan<- aggregator.Event, serviceCheckOut chan<- aggregator.ServiceCheck) {
 	for {
 		buf := make([]byte, config.Datadog.GetInt("dogstatsd_buffer_size"))
 		n, _, err := s.conn.ReadFromUDP(buf)
@@ -64,17 +65,33 @@ func (s *Server) handleMessages(out chan *aggregator.MetricSample) {
 
 		go func() {
 			for {
-				sample, err := nextMetric(&datagram)
-				if err != nil {
-					log.Errorf("dogstatsd: error parsing datagram: %s", err)
-					continue
-				}
-
-				if sample == nil {
+				packet := nextPacket(&datagram)
+				if packet == nil {
 					break
 				}
 
-				out <- sample
+				if bytes.HasPrefix(packet, []byte("_sc")) {
+					serviceCheck, err := parseServiceCheckPacket(packet)
+					if err != nil {
+						log.Errorf("dogstatsd: error parsing service check: %s", err)
+						continue
+					}
+					serviceCheckOut <- *serviceCheck
+				} else if bytes.HasPrefix(packet, []byte("_e")) {
+					event, err := parseEventPacket(packet)
+					if err != nil {
+						log.Errorf("dogstatsd: error parsing evet: %s", err)
+						continue
+					}
+					eventOut <- *event
+				} else {
+					sample, err := parseMetricPacket(packet)
+					if err != nil {
+						log.Errorf("dogstatsd: error parsing metrics: %s", err)
+						continue
+					}
+					metricOut <- sample
+				}
 			}
 		}()
 	}

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
-	s, err := NewServer(nil)
+	s, err := NewServer(nil, nil, nil)
 	assert.Nil(t, err)
 	defer s.Stop()
 	assert.NotNil(t, s)
@@ -21,7 +21,7 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestStopServer(t *testing.T) {
-	s, err := NewServer(nil)
+	s, err := NewServer(nil, nil, nil)
 	assert.Nil(t, err)
 	s.Stop()
 
@@ -33,8 +33,10 @@ func TestStopServer(t *testing.T) {
 }
 
 func TestUPDReceive(t *testing.T) {
-	output := make(chan *aggregator.MetricSample)
-	s, err := NewServer(output)
+	metricOut := make(chan *aggregator.MetricSample)
+	eventOut := make(chan aggregator.Event)
+	serviceOut := make(chan aggregator.ServiceCheck)
+	s, err := NewServer(metricOut, eventOut, serviceOut)
 	assert.Nil(t, err)
 	defer s.Stop()
 
@@ -42,13 +44,46 @@ func TestUPDReceive(t *testing.T) {
 	conn, err := net.Dial("udp", url)
 	assert.Nil(t, err)
 	defer conn.Close()
+
+	// Test metric
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 
 	select {
-	case res := <-output:
+	case res := <-metricOut:
 		assert.NotNil(t, res)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
 
+	// Test erroneous metric
+	conn.Write([]byte("daemon1:666:777|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+
+	select {
+	case res := <-metricOut:
+		assert.NotNil(t, res)
+		assert.Equal(t, res.Name, "daemon2")
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+
+	// Test Service Check
+	conn.Write([]byte("_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
+
+	select {
+	case res := <-serviceOut:
+		assert.NotNil(t, res)
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+
+	// Test erroneous Service Check
+	conn.Write([]byte("_sc|agen.down\n_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
+
+	select {
+	case res := <-serviceOut:
+		assert.NotNil(t, res)
+		assert.Equal(t, res.CheckName, "agent.up")
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
 }


### PR DESCRIPTION
### What does this PR do?
  
Dogstatsd now is able to receive service check and send them the the aggregator. The aggregator for now serialize everything to JSON and use the V1 endpoint but the protobuf serialization is ready.