### PR TITLE
[aggregator] Allow setting a hostname on the aggregator

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -70,7 +70,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 	fwd.Start()
 
 	// setup the aggregator
-	agg := aggregator.InitAggregator(fwd)
+	agg := aggregator.InitAggregator(fwd, hostname)
 
 	// start dogstatsd
 	var statsd *dogstatsd.Server

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -30,7 +30,8 @@ func main() {
 	f := forwarder.NewForwarder(keysPerDomain)
 	f.Start()
 
-	aggregatorInstance := aggregator.InitAggregator(f)
+	// FIXME: the aggregator should probably be initialized with the resolved hostname instead
+	aggregatorInstance := aggregator.InitAggregator(f, config.Datadog.GetString("hostname"))
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {
 		log.Error(err.Error())

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -14,12 +14,11 @@ func resetAggregator() {
 	aggregatorInit = sync.Once{}
 	senderInstance = nil
 	senderInit = sync.Once{}
-
-	InitAggregator(nil)
 }
 
 func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 	resetAggregator()
+	InitAggregator(nil, "")
 
 	s, err := GetDefaultSender()
 	assert.Nil(t, err)
@@ -35,6 +34,7 @@ func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 
 func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 	resetAggregator()
+	InitAggregator(nil, "")
 
 	s, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -57,6 +57,7 @@ func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 
 func TestGetSenderWithSameIDsReturnsError(t *testing.T) {
 	resetAggregator()
+	InitAggregator(nil, "")
 
 	_, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -70,6 +71,7 @@ func TestGetSenderWithSameIDsReturnsError(t *testing.T) {
 
 func TestDestroySender(t *testing.T) {
 	resetAggregator()
+	InitAggregator(nil, "")
 
 	_, err := GetSender(checkID1)
 	assert.Nil(t, err)

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 
 	// testing this package needs an inited aggregator
 	// to work properly
-	aggregator.InitAggregator(nil)
+	aggregator.InitAggregator(nil, "")
 
 	ret := m.Run()
 


### PR DESCRIPTION
### What does this PR do?

Makes the aggregator use the resolved hostname instead of the one defined in the main configuration.

The hostname used by default by the aggregator can be set at initialization and/or later with a setter.

### Additional Notes

The synchronization code of the setter may be slightly over-complex for what it does.
In particular the setter is blocking until the hostname is fully updated on the aggregator mostly because otherwise I don't know how to test it. Open to suggestions
