### PR TITLE
[aggregator] Send agent startup event on startup

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -71,6 +71,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 
 	// setup the aggregator
 	agg := aggregator.InitAggregator(fwd, hostname)
+	agg.AddAgentStartupEvent(version.AgentVersion)
 
 	// start dogstatsd
 	var statsd *dogstatsd.Server

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -78,6 +78,16 @@ func (agg *BufferedAggregator) SetHostname(hostname string) {
 	<-agg.hostnameUpdateDone
 }
 
+// AddAgentStartupEvent adds the startup event to the events that'll be sent on the next flush
+func (agg *BufferedAggregator) AddAgentStartupEvent(agentVersion string) {
+	event := Event{
+		Text:           fmt.Sprintf("Version %s", agentVersion),
+		SourceTypeName: "System",
+		EventType:      "Agent Startup",
+	}
+	agg.eventIn <- event
+}
+
 func (agg *BufferedAggregator) registerSender(id check.ID) error {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()

--- a/pkg/aggregator/event.go
+++ b/pkg/aggregator/event.go
@@ -31,4 +31,5 @@ type Event struct {
 	AlertType      EventAlertType `json:"alert_type,omitempty"`
 	AggregationKey string         `json:"aggregation_key,omitempty"`
 	SourceTypeName string         `json:"source_type_name,omitempty"`
+	EventType      string         `json:"event_type,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

Makes the Agent send a startup event on startup.

### Testing

No tests, but it works: see https://app.datadoghq.com/event/event?id=3810454643121593250 on our dev account for instance (the event is aggregated nicely)

### Additional Notes

Requires an additional field (`event_type`) on the `Event` struct so that
the event aggregation that's specific to this event on the backend
works as expected. It's a nice event/aggregation when users first
set up their account/agents, so I decided to add the field anyway
(see also #191)