### PR TITLE
Maxime/dogstatsd system tests

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -197,6 +197,10 @@ func (agg *BufferedAggregator) flushEvents() {
 	events := agg.events
 	agg.events = nil
 
+	if len(events) == 0 {
+		return
+	}
+
 	// Serialize and forward in a separate goroutine
 	go func(hostname string) {
 		log.Debug("Flushing ", len(events), " events to the forwarder")

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -62,6 +62,7 @@ func (s *Server) handleMessages(metricOut chan<- *aggregator.MetricSample, event
 		}
 
 		datagram := buf[:n]
+		log.Debugf("dogstatsd receive: %s", datagram)
 
 		go func() {
 			for {

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -32,6 +32,13 @@ namespace :dogstatsd do
     system("#{DOGSTATSD_BIN_PATH}/dogstatsd")
   end
 
+  desc "Run Dogstatsd system tests"
+  task :system_test do
+    root = `git rev-parse --show-toplevel`.strip
+    bin_path = File.join(root, DOGSTATSD_BIN_PATH, "dogstatsd")
+    system("DOGSTATSD_BIN=\"#{bin_path}\" go test -v #{REPO_PATH}/test/system/dogstatsd/")
+  end
+
   desc "Build omnibus installer"
   task :omnibus do
     # omnibus log level

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,19 @@
+Test
+====
+
+This folder contains different tests for the project.
+
+System Tests
+============
+
+Unit tests validate each Go packages in a quick but incomplete way. Some test
+requires more context (proxy, external software ...). For those we have End to
+End tests (E2E) using Test Kitchen.
+
+In between we have System Tests. Those tests validate that all the packages
+compiled together produce a viable binary capable of the most simple features
+(for example: start the agent, collect at least one metric and send it to the backend).
+System Tests are launched with unit tests on every commit.
+
+System tests must not extend the project requirements and are therefore written
+in Go, Python or Shell.

--- a/test/system/dogstatsd/dogstatsd_test.go
+++ b/test/system/dogstatsd/dogstatsd_test.go
@@ -1,0 +1,124 @@
+package dogstatsd_test
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dogstatsdBin = os.Getenv("DOGSTATSD_BIN")
+)
+
+type dogstatsdTest struct {
+	tmpDir       string
+	ctx          context.Context
+	cancel       context.CancelFunc
+	requests     []string
+	ts           *httptest.Server
+	conn         net.Conn
+	requestReady chan bool
+	m            sync.Mutex
+}
+
+func setupDogstatsd(t *testing.T) *dogstatsdTest {
+	d := &dogstatsdTest{
+		requestReady: make(chan bool, 10),
+	}
+	d.setup(t)
+	return d
+}
+
+func (d *dogstatsdTest) setup(t *testing.T) {
+	require.NotEqual(t, dogstatsdBin, "", "dogstatsd binary path not set in env")
+
+	// start fake backend
+	d.ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err, "Could not read request Body")
+
+		d.m.Lock()
+		d.requests = append(d.requests, string(body))
+		d.m.Unlock()
+		fmt.Fprintln(w, "OK")
+		d.requestReady <- true
+	}))
+
+	// create temp dir
+	dir, err := ioutil.TempDir("", "test_system_dogstatsd")
+	require.NoError(t, err, "Could not create temp dir")
+	d.tmpDir = dir
+
+	// write temp conf
+	content := []byte("dd_url: " + d.ts.URL + "\n")
+	tmpConf := filepath.Join(dir, "datadog.yaml")
+	err = ioutil.WriteFile(tmpConf, content, 0666)
+	require.NoError(t, err, "Could not write temp conf")
+
+	// start dogstatsd
+	d.ctx, d.cancel = context.WithCancel(context.Background())
+	e := exec.CommandContext(d.ctx, dogstatsdBin, "start", "-c", tmpConf)
+	stdout, err := e.StdoutPipe()
+	require.NoError(t, err, "Could get StdoutPipe from command")
+	go func() {
+		in := bufio.NewScanner(stdout)
+
+		for in.Scan() {
+			log.Infof(in.Text())
+		}
+		if err := in.Err(); err != nil {
+			log.Errorf("error: %s", err)
+		}
+	}()
+
+	go e.Run()
+	// give it a second to start
+	time.Sleep(1 * time.Second)
+
+	// prepare UDP conn
+	conn, err := net.Dial("udp", "127.0.0.1:8125")
+	require.Nil(t, err, "could not connect to dogstatsd UDP port")
+	d.conn = conn
+}
+
+func (d *dogstatsdTest) teardown() {
+	// close UDP conn
+	d.conn.Close()
+
+	// stop dogstatsd
+	d.cancel()
+
+	// stop fake backend
+	d.ts.Close()
+
+	// clean up temp dir
+	os.RemoveAll(d.tmpDir)
+}
+
+func (d *dogstatsdTest) getRequests() []string {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	requests := d.requests
+	d.requests = nil
+	return requests
+}
+
+// Helpers
+
+func (d *dogstatsdTest) sendUDP(msg string) {
+	d.conn.Write([]byte(msg))
+}

--- a/test/system/dogstatsd/receive_and_forward_test.go
+++ b/test/system/dogstatsd/receive_and_forward_test.go
@@ -1,0 +1,42 @@
+package dogstatsd_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+func TestReceiveAndForward(t *testing.T) {
+	d := setupDogstatsd(t)
+	defer d.teardown()
+	defer log.Flush()
+
+	d.sendUDP("_sc|test.ServiceCheck|0")
+
+	timeOut := time.Tick(30 * time.Second)
+	select {
+	case <-d.requestReady:
+	case <-timeOut:
+		require.Fail(t, "Timeout: the backend never receive a requests from dogstatsd")
+	}
+
+	requests := d.getRequests()
+	require.Len(t, requests, 1)
+
+	sc := []aggregator.ServiceCheck{}
+	err := json.Unmarshal([]byte(requests[0]), &sc)
+	require.NoError(t, err, "Could not Unmarshal request")
+
+	require.Len(t, sc, 2)
+	assert.Equal(t, sc[0].CheckName, "test.ServiceCheck")
+	assert.Equal(t, sc[0].Status, aggregator.ServiceCheckOK)
+
+	assert.Equal(t, sc[1].CheckName, "datadog.agent.up")
+	assert.Equal(t, sc[1].Status, aggregator.ServiceCheckOK)
+}


### PR DESCRIPTION
### What does this PR do?

The goal is to have system tests for dogstatsd. For that I added cobra command to allow custom path for the configuration file.

We only test start, receive and forward for now.

### Motivation

We unit test every package but not the final binary.

### Additional Notes

In the futur we could have the default flush time of the forwarder configurable. This would allow a shorter test time (15s right now).

For now the system tests aren't included in the CI, this will come if when we agree on a way to write system tests.