### PR TITLE
Expose the hostname to python checks.

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/gorilla/mux"
 )
@@ -27,7 +27,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 
 func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	hname := common.GetHostname()
+	hname := util.GetHostname()
 	j, _ := json.Marshal(hname)
 	w.Write(j)
 }

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -48,7 +48,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 	// Global Agent configuration
 	common.SetupConfig(confFilePath)
 
-	hostname := common.GetHostname()
+	hostname := util.GetHostname()
 	// store the computed hostname in the global cache
 	key := path.Join(util.AgentCachePrefix, "hostname")
 	util.Cache.Set(key, hostname, util.NoExpiration)

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -10,12 +9,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	"github.com/DataDog/datadog-agent/pkg/util/ec2"
-	"github.com/DataDog/datadog-agent/pkg/util/ecs"
-	"github.com/DataDog/datadog-agent/pkg/util/gce"
-	log "github.com/cihub/seelog"
 )
 
 // GetConfigProviders builds a list of providers for checks' configurations, the sequence defines
@@ -61,82 +54,4 @@ func SetupConfig(confFilePath string) {
 	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	config.Datadog.BindEnv("cmd_sock")
 	config.Datadog.SetDefault("check_runners", int64(4))
-}
-
-// GetHostname retrieve the host name for the Agent, trying to query these
-// environments/api, in order:
-// * GCE
-// * Docker
-// * kubernetes
-// * os
-// * EC2
-func GetHostname() string {
-	var hostName string
-
-	// try the name provided in the configuration file
-	name := config.Datadog.GetString("hostname")
-	err := util.ValidHostname(name)
-	if err == nil {
-		return name
-	}
-
-	log.Warnf("unable to get the hostname from the config file: %s", err)
-	log.Warn("trying to determine a reliable host name automatically...")
-
-	// GCE metadata
-	log.Debug("GetHostname trying GCE metadata...")
-	name, err = gce.GetHostname()
-	if err == nil {
-		return name
-	}
-
-	if isContainerized() {
-		// Docker
-		log.Debug("GetHostname trying Docker API...")
-		name, err = docker.GetHostname()
-		if err == nil && util.ValidHostname(name) == nil {
-			hostName = name
-		} else if isKubernetes() {
-			log.Debug("GetHostname trying k8s...")
-			// TODO
-		}
-	}
-
-	if hostName == "" {
-		// os
-		log.Debug("GetHostname trying os...")
-		name, err = os.Hostname()
-		if err == nil {
-			hostName = name
-		}
-	}
-
-	/* at this point we've either the hostname from the os or an empty string */
-
-	// We use the instance id if we're on an ECS cluster or we're on EC2
-	// and the hostname is one of the default ones
-	if ecs.IsInstance() || ec2.IsDefaultHostname(hostName) {
-		log.Debug("GetHostname trying EC2 metadata...")
-		instanceID, err := ec2.GetInstanceID()
-		if err == nil {
-			hostName = instanceID
-		}
-	}
-
-	// If at this point we don't have a name, bail out
-	if hostName == "" {
-		panic(fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file"))
-	}
-
-	return hostName
-}
-
-// IsContainerized returns whether the Agent is running on a Docker container
-func isContainerized() bool {
-	return os.Getenv("DOCKER_DD_AGENT") == "yes"
-}
-
-// IsKubernetes returns whether the Agent is running on a kubernetes cluster
-func isKubernetes() bool {
-	return os.Getenv("KUBERNETES_PORT") != ""
 }

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	f.Start()
 
 	// FIXME: the aggregator should probably be initialized with the resolved hostname instead
-	aggregatorInstance := aggregator.InitAggregator(f, config.Datadog.GetString("hostname"))
+	aggregatorInstance := aggregator.InitAggregator(f, util.GetHostname())
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {
 		log.Error(err.Error())

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -1,7 +1,8 @@
 #include "datadog_agent.h"
 
-PyObject* GetVersion();
-PyObject* Headers();
+PyObject* GetVersion(PyObject *self, PyObject *args);
+PyObject* Headers(PyObject *self, PyObject *args);
+PyObject* GetHostname(PyObject *self, PyObject *args);
 PyObject* GetConfig(char *key);
 
 static PyObject *get_config(PyObject *self, PyObject *args) {
@@ -20,9 +21,10 @@ static PyObject *get_config(PyObject *self, PyObject *args) {
 }
 
 static PyMethodDef datadogAgentMethods[] = {
-  {"get_version", (PyCFunction)GetVersion, METH_VARARGS, "Get the Agent version."},
+  {"get_version", GetVersion, METH_VARARGS, "Get the Agent version."},
   {"get_config", get_config, METH_VARARGS, "Get value from the agent configuration."},
-  {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {"headers", Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
   {NULL, NULL}
 };
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -16,9 +16,9 @@ import (
 // #include "datadog_agent.h"
 import "C"
 
-// GetVersion expose the version of the agent to python check
+// GetVersion expose the version of the agent to python check (used as a PyCFunction in the datadog_agent python module)
 //export GetVersion
-func GetVersion() *C.PyObject {
+func GetVersion(self *C.PyObject, args *C.PyObject) *C.PyObject {
 	av, _ := version.New(version.AgentVersion)
 
 	cStr := C.CString(av.GetNumber())
@@ -27,9 +27,20 @@ func GetVersion() *C.PyObject {
 	return pyStr
 }
 
-// Headers return HTTP headers with basic information like UserAgent already set
+// GetHostname expose the current hostname of the agent to python check (used as a PyCFunction in the datadog_agent python module)
+//export GetHostname
+func GetHostname(self *C.PyObject, args *C.PyObject) *C.PyObject {
+	hostname := util.GetHostname()
+
+	cStr := C.CString(hostname)
+	pyStr := C.PyString_FromString(cStr)
+	C.free(unsafe.Pointer(cStr))
+	return pyStr
+}
+
+// Headers return HTTP headers with basic information like UserAgent already set (used as a PyCFunction in the datadog_agent python module)
 //export Headers
-func Headers() *C.PyObject {
+func Headers(self *C.PyObject, args *C.PyObject) *C.PyObject {
 	h := util.HTTPHeaders()
 
 	dict := C.PyDict_New()

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -3,8 +3,17 @@ package util
 import (
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"strings"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"github.com/DataDog/datadog-agent/pkg/util/gce"
 )
 
 const maxLength = 255
@@ -66,4 +75,82 @@ func Fqdn(hostname string) string {
 		}
 	}
 	return hostname
+}
+
+// GetHostname retrieve the host name for the Agent, trying to query these
+// environments/api, in order:
+// * GCE
+// * Docker
+// * kubernetes
+// * os
+// * EC2
+func GetHostname() string {
+	var hostName string
+
+	// try the name provided in the configuration file
+	name := config.Datadog.GetString("hostname")
+	err := ValidHostname(name)
+	if err == nil {
+		return name
+	}
+
+	log.Warnf("unable to get the hostname from the config file: %s", err)
+	log.Warn("trying to determine a reliable host name automatically...")
+
+	// GCE metadata
+	log.Debug("GetHostname trying GCE metadata...")
+	name, err = gce.GetHostname()
+	if err == nil {
+		return name
+	}
+
+	if isContainerized() {
+		// Docker
+		log.Debug("GetHostname trying Docker API...")
+		name, err = docker.GetHostname()
+		if err == nil && ValidHostname(name) == nil {
+			hostName = name
+		} else if isKubernetes() {
+			log.Debug("GetHostname trying k8s...")
+			// TODO
+		}
+	}
+
+	if hostName == "" {
+		// os
+		log.Debug("GetHostname trying os...")
+		name, err = os.Hostname()
+		if err == nil {
+			hostName = name
+		}
+	}
+
+	/* at this point we've either the hostname from the os or an empty string */
+
+	// We use the instance id if we're on an ECS cluster or we're on EC2
+	// and the hostname is one of the default ones
+	if ecs.IsInstance() || ec2.IsDefaultHostname(hostName) {
+		log.Debug("GetHostname trying EC2 metadata...")
+		instanceID, err := ec2.GetInstanceID()
+		if err == nil {
+			hostName = instanceID
+		}
+	}
+
+	// If at this point we don't have a name, bail out
+	if hostName == "" {
+		panic(fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file"))
+	}
+
+	return hostName
+}
+
+// IsContainerized returns whether the Agent is running on a Docker container
+func isContainerized() bool {
+	return os.Getenv("DOCKER_DD_AGENT") == "yes"
+}
+
+// IsKubernetes returns whether the Agent is running on a kubernetes cluster
+func isKubernetes() bool {
+	return os.Getenv("KUBERNETES_PORT") != ""
 }


### PR DESCRIPTION
### What does this PR do?

We move the hostname detection to the util package since it is needed by the agent, the python checks and soon dogstatsd.

### Motivation

Some python checks needs it.