### PR TITLE
[aggregator][py] Improve error handling in py aggregator bindings

### DIFF
--- a/pkg/collector/py/README.md
+++ b/pkg/collector/py/README.md
@@ -1,0 +1,12 @@
+## package `py`
+
+This package provides all the concrete types needed to load and run python checks.
+
+In particular, it provides:
+
+* implementations of the `Check` and `Loader` interfaces defined in the `check` package, for
+python checks
+* the bindings that python checks can use to fetch information from and submit data to the core agent
+
+Before making modifications to the bindings, please make sure you understand the basics of the [Python
+C API](https://docs.python.org/2/c-api/intro.html) usage.

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -25,7 +25,7 @@ static PyObject *submit_metric(PyObject *self, PyObject *args) {
     // aggregator.submit_metric(self, aggregator.metric_type.GAUGE, name, value, tags)
     if (!PyArg_ParseTuple(args, "OisfO", &check, &mt, &name, &value, &tags)) {
       PyGILState_Release(gstate);
-      Py_RETURN_NONE;
+      return NULL;
     }
 
     PyGILState_Release(gstate);
@@ -45,7 +45,7 @@ static PyObject *submit_service_check(PyObject *self, PyObject *args) {
     // aggregator.submit_service_check(self, name, status, tags, message)
     if (!PyArg_ParseTuple(args, "OsiOs", &check, &name, &status, &tags, &message)) {
       PyGILState_Release(gstate);
-      Py_RETURN_NONE;
+      return NULL;
     }
 
     PyGILState_Release(gstate);
@@ -62,7 +62,7 @@ static PyObject *submit_event(PyObject *self, PyObject *args) {
     // aggregator.submit_event(self, event)
     if (!PyArg_ParseTuple(args, "OO", &check, &event)) {
       PyGILState_Release(gstate);
-      Py_RETURN_NONE;
+      return NULL;
     }
 
     PyGILState_Release(gstate);
@@ -101,6 +101,10 @@ void initaggregator()
 
 int _PyDict_Check(PyObject *o) {
   return PyDict_Check(o);
+}
+
+int _PyInt_Check(PyObject *o) {
+  return PyInt_Check(o);
 }
 
 int _PyString_Check(PyObject *o) {

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -126,7 +126,7 @@ func extractEventFromDict(event *C.PyObject) (aggregator.Event, error) {
 				// at this point we're sure that `pyValue` is a string, no further error checking needed
 				eventStringValues[key] = C.GoString(C.PyString_AsString(pyValue))
 			} else {
-				log.Infof("Can't parse value for key '%s' in event submitted from python check", key)
+				log.Errorf("Can't parse value for key '%s' in event submitted from python check", key)
 			}
 		}
 	}
@@ -148,10 +148,10 @@ func extractEventFromDict(event *C.PyObject) (aggregator.Event, error) {
 	timestamp := C.PyDict_GetItemString(event, pyKey) // borrowed ref
 	if timestamp != nil && !isNone(timestamp) {
 		if int(C._PyInt_Check(timestamp)) != 0 {
-			// at this point we're sure that `timestamp` an `int` so `PyInt_AsLong` won't raise an exception
+			// at this point we're sure that `timestamp` is an `int` so `PyInt_AsLong` won't raise an exception
 			_event.Ts = int64(C.PyInt_AsLong(timestamp))
 		} else {
-			log.Infof("Can't cast timestamp to integer in event submitted from python check")
+			log.Errorf("Can't cast timestamp to integer in event submitted from python check")
 		}
 	}
 
@@ -177,7 +177,7 @@ func extractEventFromDict(event *C.PyObject) (aggregator.Event, error) {
 func extractTags(tags *C.PyObject) (_tags []string, err error) {
 	if !isNone(tags) {
 		if int(C.PySequence_Check(tags)) == 0 {
-			log.Infof("Submitted `tags` is not a sequence, ignoring tags")
+			log.Errorf("Submitted `tags` is not a sequence, ignoring tags")
 			return
 		}
 
@@ -196,7 +196,7 @@ func extractTags(tags *C.PyObject) (_tags []string, err error) {
 		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
 			item := C.PySequence_Fast_Get_Item(seq, i) // `item` is borrowed, no need to decref
 			if int(C._PyString_Check(item)) == 0 {
-				log.Infof("One of the submitted tag is not a string, ignoring it")
+				log.Errorf("One of the submitted tag is not a string, ignoring it")
 				continue
 			}
 			// at this point we're sure that `item` is a string, no further error checking needed

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -17,6 +17,7 @@ void initaggregator();
 PyObject* _none();
 int _is_none(PyObject*);
 int _PyDict_Check(PyObject*);
+int _PyInt_Check(PyObject*);
 int _PyString_Check(PyObject*);
 PyObject* PySequence_Fast_Get_Item(PyObject*, Py_ssize_t);
 Py_ssize_t PySequence_Fast_Get_Size(PyObject*);

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -91,6 +91,16 @@ func TestInitNewSignatureCheck(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestInitException(t *testing.T) {
+	_, err := getCheckInstance("init_exception", "TestCheck")
+	assert.EqualError(t, err, "could not invoke python check constructor: ['Traceback (most recent call last):\\n', '  File \"tests/init_exception.py\", line 6, in __init__\\n    raise RuntimeError(\"unexpected error\")\\n', 'RuntimeError: unexpected error\\n']")
+}
+
+func TestInitNoTracebackException(t *testing.T) {
+	_, err := getCheckInstance("init_no_traceback_exception", "TestCheck")
+	assert.EqualError(t, err, "could not invoke python check constructor: __init__() takes exactly 8 arguments (5 given)")
+}
+
 // BenchmarkRun executes a single check: benchmark results
 // give an idea of the overhead of a CPython function call from go,
 // that's why we don't care about Run's result.

--- a/pkg/collector/py/tests/init_exception.py
+++ b/pkg/collector/py/tests/init_exception.py
@@ -1,0 +1,9 @@
+import aggregator
+from checks import AgentCheck
+
+class TestCheck(AgentCheck):
+    def __init__(self, name, init_config, agentConfig, instances):
+        raise RuntimeError("unexpected error")
+
+    def check(self, instance):
+        pass

--- a/pkg/collector/py/tests/init_no_traceback_exception.py
+++ b/pkg/collector/py/tests/init_no_traceback_exception.py
@@ -1,0 +1,9 @@
+import aggregator
+from checks import AgentCheck
+
+class TestCheck(AgentCheck):
+    def __init__(self, name, init_config, agentConfig, instances, one, two, three): # __init__ with many arguments
+        pass
+
+    def check(self, instance):
+        pass


### PR DESCRIPTION
### What does this PR do?

Improve error handling in py aggregator bindings by being
as defensive as possible in this part of the code.

### Motivation

Not handling errors from the C python API can lead to weird
behaviors from the python interpreter.

### Additional Notes

See commit description