### PR TITLE
[rake] Build with `go build -a` by default, optionally incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Binary distributions are not provided yet, to try out the Agent you can build th
 
    Make sure that `GOPATH/bin` is in your `PATH` otherwise this step might fail. Alternatively  you can
    install [glide](https://github.com/Masterminds/glide) manually on your system before running `rake deps`
-3. build the project: `rake build`
+3. build the project: `rake build` (use `rake build incremental=true` for incremental builds)
 
 Build and tests are orchestrated by a `Rakefile`, write `rake -T` on a shell to see the available tasks.
 If you're using the DogBox, ask `gimme` to provide a recent version of go, like:

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -14,10 +14,11 @@ namespace :agent do
   BIN_PATH="./bin/agent"
   CLOBBER.include(BIN_PATH)
 
-  desc "Build the agent, pass 'race=true' to invoke the race detector"
+  desc "Build the agent, pass 'race=true' to invoke the race detector, 'incremental=true' to build incrementally"
   task :build do
     # -race option
     race_opt = ENV['race'] == "true" ? "-race" : ""
+    build_type = ENV['incremental'] == "true" ? "-i" : "-a"
 
     # Check if we should use Embedded or System Python,
     # default to the embedded one.
@@ -28,7 +29,7 @@ namespace :agent do
 
     commit = `git rev-parse --short HEAD`.strip
     ldflags = "-X #{REPO_PATH}/pkg/version.commit=#{commit}"
-    system(env, "go build #{race_opt} -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/agent")
+    system(env, "go build #{race_opt} #{build_type} -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/agent")
     Rake::Task["agent:refresh_assets"].invoke
   end
 


### PR DESCRIPTION
### What does this PR do?

Build with `go build -a` by default, optionally use incremental builds with `incremental=true` option of `rake agent:build`.

"Actual" builds should be built with `go build -a`, hence the default.

During dev, recommend using `go build -i` for faster builds.

### Motivation

Incremental builds are fine in dev, I was tired of waiting for builds to finish.
