### PR TITLE
[rake] Update `agent:run` task with correct agent command

### DIFF
--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -44,7 +44,7 @@ namespace :agent do
 
   desc "Run the agent"
   task :run => %w[agent:build] do
-    sh("#{BIN_PATH}/agent start -f")
+    sh("#{BIN_PATH}/agent start")
   end
 
   desc "Build omnibus installer"


### PR DESCRIPTION
### What does this PR do?

Fix `agent:run` task

### Additional Notes

Haven't found a way to pass `incremental=true` to the dependent `agent:build` task so that the build is incremental by default. So the recommended usage is `rake agent:run incremental=true`
