### PR TITLE
[agent/app] Support custom py checks in conf folder

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -85,7 +85,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 
 	// create the Collector instance and start all the components
 	// NOTICE: this will also setup the Python environment
-	common.Collector = collector.NewCollector(common.DistPath, filepath.Join(common.DistPath, "checks"), common.PyChecksPath)
+	common.Collector = collector.NewCollector(common.DistPath, filepath.Join(common.DistPath, "checks"), config.Datadog.GetString("additional_checksd"), common.PyChecksPath)
 
 	// setup the metadata collector, this needs a working Python env to function
 	metaCollector := metadata.NewCollector(fwd, config.Datadog.GetString("api_key"), hostname)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ func init() {
 	Datadog.SetDefault("dd_url", "http://localhost:17123")
 	Datadog.SetDefault("hostname", "")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
+	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
 	Datadog.SetDefault("use_dogstatsd", true)
 	Datadog.SetDefault("dogstatsd_port", 8125)
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024)

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -1,3 +1,4 @@
 package config
 
 const defaultConfdPath = "/opt/datadog-agent/etc/conf.d"
+const defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,3 +1,4 @@
 package config
 
 const defaultConfdPath = "/etc/dd-agent/conf.d"
+const defaultAdditionalChecksPath = "/etc/dd-agent/checks.d"

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,3 +1,4 @@
 package config
 
 const defaultConfdPath = "c:\\programdata\\datadog\\conf.d"
+const defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"


### PR DESCRIPTION
### What does this PR do?

Adds to the py check loading path the "conf folder"'s `checks.d` folder (ex. `/etc/dd-agent/checks.d` on Linux)

### Motivation

Supported in Agent5, makes sense to support it as-is in Agent 6.

### Additional Notes

Configurable via the `additional_checksd` option. Same behavior as
in the agent 5:

* the option has a sensible default
* the checks from the conf folder take precedence over the ones
from `integrations-core`

