### PR TITLE
Setup rotating log file

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -50,7 +50,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 	common.SetupConfig(confFilePath)
 
 	// Setup logger
-	err := config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("agent_log_file"))
+	err := config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("log_file"))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -50,7 +50,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 	common.SetupConfig(confFilePath)
 
 	// Setup logger
-	err := config.SetupLogger(config.Datadog.GetString("agent_log_file"))
+	err := config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("agent_log_file"))
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -45,8 +45,15 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, *forwarder.Forwarder)
 			panic(err)
 		}
 	}
+
 	// Global Agent configuration
 	common.SetupConfig(confFilePath)
+
+	// Setup logger
+	err := config.SetupLogger(config.Datadog.GetString("agent_log_file"))
+	if err != nil {
+		panic(err)
+	}
 
 	hostname := util.GetHostname()
 	// store the computed hostname in the global cache

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -1,3 +1,4 @@
 package common
 
 const defaultConfPath = "/opt/datadog-agent/etc"
+const defaultLogPath = "/var/log/datadog/agent.log"

--- a/cmd/agent/common/common_linux.go
+++ b/cmd/agent/common/common_linux.go
@@ -1,3 +1,4 @@
 package common
 
 const defaultConfPath = "/etc/dd-agent"
+const defaultLogPath = "/var/log/datadog/agent.log"

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -1,3 +1,4 @@
 package common
 
 const defaultConfPath = "c:\\programdata\\datadog"
+const defaultLogPath = "c:\\programdata\\datadog\\logs\\agent.log"

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -59,6 +59,7 @@ func SetupConfig(confFilePath string) {
 	}
 
 	// define defaults for the Agent
+	config.Datadog.SetDefault("agent_log_file", defaultLogPath)
 	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	config.Datadog.BindEnv("cmd_sock")
 	config.Datadog.SetDefault("check_runners", int64(4))

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -59,7 +59,7 @@ func SetupConfig(confFilePath string) {
 	}
 
 	// define defaults for the Agent
-	config.Datadog.SetDefault("agent_log_file", defaultLogPath)
+	config.Datadog.SetDefault("log_file", defaultLogPath)
 	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	config.Datadog.BindEnv("cmd_sock")
 	config.Datadog.SetDefault("check_runners", int64(4))

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -59,7 +59,7 @@ func init() {
 	// ENV vars bindings
 	config.Datadog.BindEnv("conf_path")
 	config.Datadog.SetDefault("conf_path", ".")
-	config.Datadog.SetDefault("dogstatsd_log_file", defaultLogPath)
+	config.Datadog.SetDefault("log_file", defaultLogPath)
 
 	// local flags
 	startCmd.Flags().StringVarP(&confPath, "conf", "c", "", "path to the datadog.yaml file")
@@ -75,7 +75,8 @@ func start(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("dogstatsd_log_file"))
+	// Setup logger
+	err = config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("log_file"))
 	if err != nil {
 		log.Criticalf("Unable to setup logger: %s", err)
 		return nil

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -25,9 +25,9 @@ var (
 		Use:   "dogstatsd [command]",
 		Short: "Datadog dogstatsd at your service.",
 		Long: `
-DogStatsD accepts custom application metrics points over UDP, and then 
-periodically aggregates and forwards them to Datadog, where they can be graphed 
-on dashboards. DogStatsD implements the StatsD protocol, along with a few 
+DogStatsD accepts custom application metrics points over UDP, and then
+periodically aggregates and forwards them to Datadog, where they can be graphed
+on dashboards. DogStatsD implements the StatsD protocol, along with a few
 extensions for special Datadog features.`,
 	}
 
@@ -59,6 +59,7 @@ func init() {
 	// ENV vars bindings
 	config.Datadog.BindEnv("conf_path")
 	config.Datadog.SetDefault("conf_path", ".")
+	config.Datadog.SetDefault("dogstatsd_log_file", defaultLogPath)
 
 	// local flags
 	startCmd.Flags().StringVarP(&confPath, "conf", "c", "", "path to the datadog.yaml file")
@@ -71,6 +72,12 @@ func start(cmd *cobra.Command, args []string) error {
 	err := config.Datadog.ReadInConfig()
 	if err != nil {
 		log.Criticalf("unable to load Datadog config file: %s", err)
+		return nil
+	}
+
+	err = config.SetupLogger(config.Datadog.GetString("dogstatsd_log_file"))
+	if err != nil {
+		log.Criticalf("Unable to setup logger: %s", err)
 		return nil
 	}
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -75,7 +75,7 @@ func start(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = config.SetupLogger(config.Datadog.GetString("dogstatsd_log_file"))
+	err = config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("dogstatsd_log_file"))
 	if err != nil {
 		log.Criticalf("Unable to setup logger: %s", err)
 		return nil

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package main
+
+const defaultLogPath = "/var/log/datadog/dogstatsd.log"

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -1,0 +1,3 @@
+package main
+
+const defaultLogPath = "c:\\programdata\\datadog\\logs\\dogstatsd.log"

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -5,7 +5,7 @@ stop on runlevel [!2345]
 
 respawn
 
-console log  # redirect daemon's outputs to `/var/log/upstart/datadog-agent6.log`
+console none
 
 script
   exec <%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -32,3 +32,11 @@ api_key:
 #
 # The buffer size use to receive statsd packet (defaults 1024)
 # dogstatsd_buffer_size: 1024
+
+# ========================================================================== #
+# Logging
+# ========================================================================== #
+
+# log_level: info
+
+# log_file: /var/log/datadog/agent.log

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"fmt"
+
+	log "github.com/cihub/seelog"
+)
+
+const logFileMaxSize = 10 * 1024 * 1024 // 10MB
+
+func SetupLogger(logFile string) error {
+	configTemplate := `<seelog>
+    <outputs>
+        <console />
+        <rollingfile type="size" filename="%s" maxsize="%d" maxrolls="1" />
+    </outputs>
+</seelog>`
+	config := fmt.Sprintf(configTemplate, logFile, logFileMaxSize)
+
+	logger, err := log.LoggerFromConfigAsString(config)
+	if err != nil {
+		return err
+	}
+	log.ReplaceLogger(logger)
+	return nil
+}

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -2,21 +2,27 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/cihub/seelog"
 )
 
+const defaultLogLevel = "info"
 const logFileMaxSize = 10 * 1024 * 1024 // 10MB
 
+func init() {
+	Datadog.SetDefault("log_level", defaultLogLevel)
+}
+
 // SetupLogger sets up the default logger
-func SetupLogger(logFile string) error {
-	configTemplate := `<seelog>
+func SetupLogger(logLevel, logFile string) error {
+	configTemplate := `<seelog minlevel="%s">
     <outputs>
         <console />
         <rollingfile type="size" filename="%s" maxsize="%d" maxrolls="1" />
     </outputs>
 </seelog>`
-	config := fmt.Sprintf(configTemplate, logFile, logFileMaxSize)
+	config := fmt.Sprintf(configTemplate, strings.ToLower(logLevel), logFile, logFileMaxSize)
 
 	logger, err := log.LoggerFromConfigAsString(config)
 	if err != nil {

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -8,7 +8,8 @@ import (
 )
 
 const defaultLogLevel = "info"
-const logFileMaxSize = 10 * 1024 * 1024 // 10MB
+const logFileMaxSize = 10 * 1024 * 1024         // 10MB
+const logDateFormat = "2006-01-02 15:04:05 MST" // see time.Format for format syntax
 
 func init() {
 	Datadog.SetDefault("log_level", defaultLogLevel)
@@ -17,12 +18,15 @@ func init() {
 // SetupLogger sets up the default logger
 func SetupLogger(logLevel, logFile string) error {
 	configTemplate := `<seelog minlevel="%s">
-    <outputs>
+    <outputs formatid="common">
         <console />
         <rollingfile type="size" filename="%s" maxsize="%d" maxrolls="1" />
     </outputs>
+    <formats>
+        <format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line) | %%Msg%%n"/>
+    </formats>
 </seelog>`
-	config := fmt.Sprintf(configTemplate, strings.ToLower(logLevel), logFile, logFileMaxSize)
+	config := fmt.Sprintf(configTemplate, strings.ToLower(logLevel), logFile, logFileMaxSize, logDateFormat)
 
 	logger, err := log.LoggerFromConfigAsString(config)
 	if err != nil {

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -8,6 +8,7 @@ import (
 
 const logFileMaxSize = 10 * 1024 * 1024 // 10MB
 
+// SetupLogger sets up the default logger
 func SetupLogger(logFile string) error {
 	configTemplate := `<seelog>
     <outputs>


### PR DESCRIPTION
### What does this PR do?

* start logging to an actual log file, in both the agent and dogstatsd. Its rotation is handled by seelog
* add a log level option
* format log entries with a format that's close to the agent 5

### Motivation

During testing, I realized that by default `upstart` rotates the log files only once it's quite huge (> 1GB), which is not reasonable for the agent. With these changes, the agent uses the same rotation settings as the agent5.

### Additional Notes

See also commit descriptions

Logging in the agent 6 in general would deserve much more work and options (log to syslog, etc), which is out of the scope of this PR.