### PR TITLE
[linux] Make the package installable on its own

### DIFF
--- a/omnibus/config/projects/datadog-agent6.rb
+++ b/omnibus/config/projects/datadog-agent6.rb
@@ -142,6 +142,13 @@ end
 if windows?
   dependency 'datadog-upgrade-helper'
 end
+
+# Remove pyc/pyo files from package
+# should be built after all the other python-related software defs
+if linux?
+  dependency 'py-compiled-cleanup'
+end
+
 # version manifest file
 dependency 'version-manifest'
 

--- a/omnibus/config/projects/datadog-agent6.rb
+++ b/omnibus/config/projects/datadog-agent6.rb
@@ -116,6 +116,13 @@ if linux?
     extra_package_file '/lib/systemd/system/datadog-agent6.service'
   end
 
+  # Example configuration files for the agent and the checks
+  extra_package_file '/etc/dd-agent/datadog.yaml.example'
+  extra_package_file '/etc/dd-agent/conf.d'
+
+  # Custom checks directory
+  extra_package_file '/etc/dd-agent/checks.d'
+
   # Linux-specific dependencies
   dependency 'procps-ng'
   dependency 'sysstat'

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -29,6 +29,10 @@ build do
   # Enqueue "core" dependencies that are not listed in the checks requirements
   command "echo requests==2.11.1 >> check_requirements.txt"
 
+  # FIXME: when the package is renamed `datadog-agent` and replaces the agent5 pkg,
+  # ship all the '/etc/dd-agent/conf.d/*' files
+  delete '/etc/dd-agent/conf.d/*'
+
   # Install all the requirements
   if windows?
     pip_args = "install  -r check_requirements.txt"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -21,18 +21,25 @@ build do
   command 'rake agent:build', :env => build_env
   copy('bin', install_dir)
 
-  if debian?
-    erb source: "upstart.conf.erb",
-        dest: "/etc/init/datadog-agent6.conf",
-        mode: 0755,
-        vars: { install_dir: install_dir }
-  end
+  if linux?
+    # Config
+    mkdir '/etc/dd-agent'
+    move 'bin/agent/dist/datadog.yaml', '/etc/dd-agent/datadog.yaml.example'
+    mkdir '/etc/dd-agent/checks.d'
 
-  if redhat? || debian?
-    erb source: "systemd.service.erb",
-        dest: "/lib/systemd/system/datadog-agent6.service",
-        mode: 0755,
-        vars: { install_dir: install_dir }
+    if debian?
+      erb source: "upstart.conf.erb",
+          dest: "/etc/init/datadog-agent6.conf",
+          mode: 0755,
+          vars: { install_dir: install_dir }
+    end
+
+    if redhat? || debian?
+      erb source: "systemd.service.erb",
+          dest: "/lib/systemd/system/datadog-agent6.service",
+          mode: 0755,
+          vars: { install_dir: install_dir }
+    end
   end
 
   if windows?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -21,6 +21,8 @@ build do
   command 'rake agent:build', :env => build_env
   copy('bin', install_dir)
 
+  mkdir "#{install_dir}/run/"
+
   if linux?
     # Config
     mkdir '/etc/dd-agent'

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -4,11 +4,11 @@ After=network.target
 
 [Service]
 Type=simple
-PIDFile=/var/run/datadog/agent.pid
-User=root
+PIDFile=<%= install_dir %>/run/agent.pid
+User=dd-agent
 Restart=on-failure
 ExecStartPre=/bin/rm -f /tmp/agent.sock
-ExecStart=<%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
+ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -5,13 +5,14 @@ stop on runlevel [!2345]
 
 respawn
 
+setuid dd-agent
 console none
 
 script
-  exec <%= install_dir %>/bin/agent/agent start -p /var/run/datadog/agent.pid
+  exec <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
 end script
 
 post-stop script
- rm -f /var/run/datadog/agent.pid
+ rm -f <%= install_dir %>/run/agent.pid
  rm -f /tmp/agent.sock
 end script

--- a/omnibus/package-scripts/datadog-agent6/README.md
+++ b/omnibus/package-scripts/datadog-agent6/README.md
@@ -1,0 +1,26 @@
+The order in which these script are executed varies between APT and YUM which can lead to some
+rather sneaky bugs. Here's the standard order for updates:
+
+APT (source https://debian-handbook.info/browse/stable/sect.package-meta-information.html):
+-------------------------------------------------------------------------------------------
+* `prerm` script of the old package (with arguments: `upgrade <new-version>`)
+* `preinst` script of the new package (with arguments: `upgrade <old-version>`)
+* New files get unpacked based on the file list embedded in the `.deb` package
+* `postrm` script from the old package (with arguments `upgrade <new-version>`)
+* `dpkg` updates the files list, removes the files that don't exist anymore, etc.
+* `postinst` of the new script is run (with arguments `configure <lst-configured-version>`
+
+YUM (source: https://fedoraproject.org/wiki/Packaging:Scriptlets):
+--------------------------------------------------------------
+
+* `pretrans` of new package
+* `preinst` of new package
+* Files in the list get copied
+* `postinst` of new package
+* `prerm` of old package
+* Files in the old package file list that are not in the new one's get removed
+* `postrm` of the old package gets run
+* `posttrans` of the _new_ package is run
+
+One thing to notice is that if you remove files or other components in the `postrm` script,
+updates won't work as expected with YUM.

--- a/omnibus/package-scripts/datadog-agent6/README.md
+++ b/omnibus/package-scripts/datadog-agent6/README.md
@@ -12,7 +12,6 @@ APT (source https://debian-handbook.info/browse/stable/sect.package-meta-informa
 
 YUM (source: https://fedoraproject.org/wiki/Packaging:Scriptlets):
 --------------------------------------------------------------
-
 * `pretrans` of new package
 * `preinst` of new package
 * Files in the list get copied

--- a/omnibus/package-scripts/datadog-agent6/postinst
+++ b/omnibus/package-scripts/datadog-agent6/postinst
@@ -4,14 +4,91 @@
 # after package is installed.
 #
 
-PROGNAME=`basename $0`
+INSTALL_DIR=/opt/datadog-agent6
+LOG_DIR=/var/log/datadog
+SERVICE_NAME=datadog-agent6
 
-error_exit()
-{
-  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
-  exit 1
-}
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || uname -s)
 
-echo "Thank you for installing datadog-agent!"
+mkdir -p ${LOG_DIR}
+
+# If we are inside the Docker container, do nothing
+if [ -n "$DOCKER_DD_AGENT" ]; then
+    echo "Installation from docker-dd-agent, nothing to do in postinst"
+    exit 0
+fi
+
+# Linux installation
+if [ "$DISTRIBUTION" != "Darwin" ]; then
+    CONFIG_DIR=/etc/dd-agent
+
+    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+        set -e
+        case "$1" in
+            configure)
+                # Only create dd-agent group and/or user if they don't already exist
+                getent group dd-agent >/dev/null || (echo "Creating dd-agent group" && addgroup --system dd-agent --quiet)
+                set +e
+                id -u dd-agent >/dev/null 2>&1
+                USER_EXISTS=$?
+                set -e
+                if [ ! $USER_EXISTS -eq 0 ]; then
+                    echo "Creating dd-agent user"
+                    adduser --system dd-agent --disabled-login --shell /bin/sh --home ${INSTALL_DIR} --no-create-home --group --quiet
+                elif id -nG dd-agent | grep --invert-match --word-regexp --quiet 'dd-agent'; then
+                    # User exists but is not part of the dd-agent group
+                    echo "Adding dd-agent user to dd-agent group"
+                    usermod -g dd-agent dd-agent
+                fi
+                set +e
+            ;;
+            abort-upgrade|abort-remove|abort-deconfigure)
+            ;;
+
+            *)
+            ;;
+        esac
+        #DEBHELPER#
+    fi
+
+    # Set proper rights to the dd-agent user
+    chown -R dd-agent:dd-agent ${CONFIG_DIR}
+    chown -R dd-agent:dd-agent ${LOG_DIR}
+    chown -R dd-agent:dd-agent ${INSTALL_DIR}
+
+    # Only supports systemd and upstart
+    echo "Enabling service $SERVICE_NAME"
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl enable $SERVICE_NAME
+    elif command -v initctl >/dev/null 2>&1; then
+        # Nothing to do, this is defined directly in the upstart job file
+        :
+    else
+        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        exit 1
+    fi
+
+    # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
+    # and avoid restarting when a check conf is invalid
+    if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
+        echo "(Re)starting $SERVICE_NAME now..."
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl restart $SERVICE_NAME || true
+        elif command -v initctl >/dev/null 2>&1; then
+            initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+        else
+            echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+            exit 1
+        fi
+    else
+        # No datadog.yaml file is present. This is probably a clean install made with the
+        # step-by-step instructions/an automation tool, and the config file will be added next.
+        echo "No datadog.yaml file detected, not starting the agent"
+    fi
+else
+    echo "macOS: Not implemented yet"
+    exit 1
+fi
 
 exit 0

--- a/omnibus/package-scripts/datadog-agent6/postinst
+++ b/omnibus/package-scripts/datadog-agent6/postinst
@@ -21,9 +21,13 @@ fi
 
 # Linux installation
 if [ "$DISTRIBUTION" != "Darwin" ]; then
+    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+        DISTRIBUTION_FAMILY="Debian"
+    fi
+
     CONFIG_DIR=/etc/dd-agent
 
-    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+    if [ "$DISTRIBUTION_FAMILY" == "Debian" ]; then
         set -e
         case "$1" in
             configure)
@@ -69,22 +73,26 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         exit 1
     fi
 
-    # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
-    # and avoid restarting when a check conf is invalid
-    if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
-        echo "(Re)starting $SERVICE_NAME now..."
-        if command -v systemctl >/dev/null 2>&1; then
-            systemctl restart $SERVICE_NAME || true
-        elif command -v initctl >/dev/null 2>&1; then
-            initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+    # Restart the agent here on Debian platforms
+    # On RHEL, the restart is done in the posttrans script
+    if [ "$DISTRIBUTION_FAMILY" == "Debian" ]; then
+        # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
+        # and avoid restarting when a check conf is invalid
+        if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
+            echo "(Re)starting $SERVICE_NAME now..."
+            if command -v systemctl >/dev/null 2>&1; then
+                systemctl restart $SERVICE_NAME || true
+            elif command -v initctl >/dev/null 2>&1; then
+                initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+            else
+                echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+                exit 1
+            fi
         else
-            echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-            exit 1
+            # No datadog.yaml file is present. This is probably a clean install made with the
+            # step-by-step instructions/an automation tool, and the config file will be added next.
+            echo "No datadog.yaml file detected, not starting the agent"
         fi
-    else
-        # No datadog.yaml file is present. This is probably a clean install made with the
-        # step-by-step instructions/an automation tool, and the config file will be added next.
-        echo "No datadog.yaml file detected, not starting the agent"
     fi
 else
     echo "macOS: Not implemented yet"

--- a/omnibus/package-scripts/datadog-agent6/postinst
+++ b/omnibus/package-scripts/datadog-agent6/postinst
@@ -45,7 +45,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                     echo "Adding dd-agent user to dd-agent group"
                     usermod -g dd-agent dd-agent
                 fi
-                set +e
             ;;
             abort-upgrade|abort-remove|abort-deconfigure)
             ;;

--- a/omnibus/package-scripts/datadog-agent6/postrm
+++ b/omnibus/package-scripts/datadog-agent6/postrm
@@ -14,19 +14,23 @@ CONFIG_DIR=/etc/dd-agent
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
     set -e
 
-    if [ "$1" = purge ]; then
-        # FIXME: when the package is renamed `datadog-agent`, uncomment all the purge-related commands
-        # that remove users/directories currently set up by the `datadog-agent` (agent5) package
-        echo "Leaving dd-agent user and group in place"
-        # echo "Deleting dd-agent user"
-        # deluser dd-agent --quiet
-        # echo "Deleting dd-agent group"
-        # getent group dd-agent >/dev/null && delgroup dd-agent --quiet || true
-        echo "Force-deleting $INSTALL_DIR"
-        rm -rf $INSTALL_DIR
-        # rm -rf $LOG_DIR
-        # rm -rf $CONFIG_DIR
-    fi
+    case "$1" in
+        purge)
+            # FIXME: when the package is renamed `datadog-agent`, uncomment all the purge-related commands
+            # that remove users/directories currently set up by the `datadog-agent` (agent5) package
+            echo "Leaving dd-agent user and group in place"
+            # echo "Deleting dd-agent user"
+            # deluser dd-agent --quiet
+            # echo "Deleting dd-agent group"
+            # getent group dd-agent >/dev/null && delgroup dd-agent --quiet || true
+            echo "Force-deleting $INSTALL_DIR"
+            rm -rf $INSTALL_DIR
+            # rm -rf $LOG_DIR
+            # rm -rf $CONFIG_DIR
+        ;;
+        *)
+        ;;
+    esac
 elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
     case "$*" in
         0)
@@ -38,7 +42,7 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
         ;;
         *)
         ;;
-  esac
+    esac
 else
     echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
     exit 1;

--- a/omnibus/package-scripts/datadog-agent6/postrm
+++ b/omnibus/package-scripts/datadog-agent6/postrm
@@ -4,6 +4,44 @@
 # after package is uninstalled.
 #
 
-echo "datadog-agent has been uninstalled!"
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || uname -s)
+
+INSTALL_DIR=/opt/datadog-agent6
+LOG_DIR=/var/log/datadog
+CONFIG_DIR=/etc/dd-agent
+
+if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+    set -e
+
+    if [ "$1" = purge ]; then
+        # FIXME: when the package is renamed `datadog-agent`, uncomment all the purge-related commands
+        # that remove users/directories currently set up by the `datadog-agent` (agent5) package
+        echo "Leaving dd-agent user and group in place"
+        # echo "Deleting dd-agent user"
+        # deluser dd-agent --quiet
+        # echo "Deleting dd-agent group"
+        # getent group dd-agent >/dev/null && delgroup dd-agent --quiet || true
+        echo "Force-deleting $INSTALL_DIR"
+        rm -rf $INSTALL_DIR
+        # rm -rf $LOG_DIR
+        # rm -rf $CONFIG_DIR
+    fi
+elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
+    case "$*" in
+        0)
+            # We're uninstalling.
+            # We don't delete the dd-agent user/group (see https://fedoraproject.org/wiki/Packaging:UsersAndGroups#Allocation_Strategies)
+        ;;
+        1)
+            # We're upgrading.
+        ;;
+        *)
+        ;;
+  esac
+else
+    echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
+    exit 1;
+fi
 
 exit 0

--- a/omnibus/package-scripts/datadog-agent6/posttrans
+++ b/omnibus/package-scripts/datadog-agent6/posttrans
@@ -4,17 +4,25 @@
 # It is run at the very end of an install/upgrade of the package
 # It is NOT run on removal of the package
 
+CONFIG_DIR=/etc/dd-agent
 SERVICE_NAME=datadog-agent6
 
-# Restart the agent
-echo "(Re)starting $SERVICE_NAME now..."
-if command -v systemctl >/dev/null 2>&1; then
-    systemctl restart $SERVICE_NAME || true
-elif command -v initctl >/dev/null 2>&1; then
-    initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+# TODO: Use a configcheck command on the agent to determine if it's safe to restart,
+# and avoid restarting when a check conf is invalid
+if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
+    echo "(Re)starting $SERVICE_NAME now..."
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl restart $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+    else
+        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        exit 1
+    fi
 else
-    echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-    exit 1
+    # No datadog.yaml file is present. This is probably a clean install made with the
+    # step-by-step instructions/an automation tool, and the config file will be added next.
+    echo "No datadog.yaml file detected, not starting the agent"
 fi
 
 exit 0

--- a/omnibus/package-scripts/datadog-agent6/posttrans
+++ b/omnibus/package-scripts/datadog-agent6/posttrans
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+# This script is RPM-specific
+# It is run at the very end of an install/upgrade of the package
+# It is NOT run on removal of the package
+
+SERVICE_NAME=datadog-agent6
+
+# Restart the agent
+echo "(Re)starting $SERVICE_NAME now..."
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl restart $SERVICE_NAME || true
+elif command -v initctl >/dev/null 2>&1; then
+    initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
+else
+    echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+    exit 1
+fi
+
+exit 0

--- a/omnibus/package-scripts/datadog-agent6/preinst
+++ b/omnibus/package-scripts/datadog-agent6/preinst
@@ -4,4 +4,55 @@
 # before package is installed.
 #
 
-echo "You're about to install datadog-agent!"
+INSTALL_DIR=/opt/datadog-agent6
+LOG_DIR=/var/log/datadog
+SERVICE_NAME=datadog-agent6
+
+mkdir -p $LOG_DIR
+
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || uname -s)
+
+# Linux installation
+if [ "$DISTRIBUTION" != "Darwin" ]; then
+    set -e
+
+    if [ -f "/lib/systemd/system/datadog-agent6.service" ]; then
+        # Stop an already running agent
+        # Only supports systemd and upstart
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl stop $SERVICE_NAME || true
+        elif command -v initctl >/dev/null 2>&1; then
+            initctl stop $SERVICE_NAME || true
+        else
+            echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+            exit 1
+        fi
+    fi
+
+    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+        # Nothing specific on Debian
+        :
+        #DEBHELPER#
+    elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
+        # Set up `dd-agent` user and group
+        getent group dd-agent >/dev/null || groupadd -r dd-agent
+        getent passwd dd-agent >/dev/null || \
+            useradd -r -M -g dd-agent -d $INSTALL_DIR -s /bin/sh \
+                -c "Datadog Agent" dd-agent
+
+        # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
+        if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
+            # (commented lines are filtered out)
+            cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+        fi
+    else
+        echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
+        exit 1;
+    fi
+else
+    echo "macOS: Not implemented yet"
+    exit 1
+fi
+
+exit 0

--- a/omnibus/package-scripts/datadog-agent6/prerm
+++ b/omnibus/package-scripts/datadog-agent6/prerm
@@ -1,15 +1,79 @@
 #!/bin/sh
 #
 # Perform necessary datadog-agent setup steps
-# prior to installing package.
+# prior to removing package.
 #
 
-PROGNAME=`basename $0`
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || uname -s)
 
-error_exit()
+INSTALL_DIR=/opt/datadog-agent6
+SERVICE_NAME=datadog-agent6
+
+stop_agent()
 {
-  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
-  exit 1
+    # Stop an already running agent
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl stop $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        initctl stop $SERVICE_NAME || true
+    else
+        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        exit 1
+    fi
 }
+
+deregister_agent()
+{
+    # Disable agent start on system boot
+    # Only supports systemd and upstart
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl disable $SERVICE_NAME || true
+    elif command -v initctl >/dev/null 2>&1; then
+        # Nothing to do, this is defined directly in the upstart job file
+        :
+    else
+        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        exit 1
+    fi
+}
+
+remove_py_compiled_files()
+{
+    # Delete all the .pyc files in the embedded dir that are part of the agent's package
+    if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
+        # (commented lines are filtered out)
+        cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+    fi
+}
+
+if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+    stop_agent
+    deregister_agent
+    remove_py_compiled_files
+elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
+    case "$*" in
+        0)
+            # We're uninstalling.
+            stop_agent
+            deregister_agent
+            remove_py_compiled_files
+        ;;
+        1)
+            # We're upgrading. Do nothing.
+            # The preinst script has taken care of removing the .pyc/.pyo files
+        ;;
+        *)
+        ;;
+    esac
+else
+    echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
+    exit 1;
+fi
+
+# Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
+find $INSTALL_DIR/agent -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/agent"
+find $INSTALL_DIR/bin/agent/dist -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/bin/agent/dist"
 
 exit 0


### PR DESCRIPTION
### What does this PR do?

Updates the linux package scripts and the build defs so that the `datadog-agent6` pkg can be installed either:
- as a fully standalone package, on an environment where the agent5's `datadog-agent` has never been installed
- side-by-side with an existing agent5's `datadog-agent` install

The package scripts support `upstart` and `systemd` only, their code is based on the agent5 scripts.

Also, the PR includes 2 small improvements:
* add the `.py_compiled_files` file to the pkg (already present in the agent5) and uses it in the scripts to delete old pyc/pyo files: trims 10MB from the pkg size
* run the agent as the `dd-agent` user

### Motivation

In general this puts the agent6 linux package almost on-par with the agent5 package in terms of "out-of-the-box usability".

Allowing an agent6 alongside the agent5 enables a lot of flexibility when testing out the `datadog-agent6` package on actual environments.

## Testing

Tested the resulting pkgs manually on ubuntu `14.04` (upstart), debian 8 (systemd), and centos 7 (systemd), both as standalones and alongside agent5 `datadog-agent` packages.

There's no `dd-agent-testing`-like suite of tests for the agent6 yet, so there are no automated tests yet.

### Additional Notes

At some point the agent6's package and service should probably:
* be renamed `datadog-agent`
* fully _replace_ the existing agent5's package and service
* be installed in `/opt/datadog-agent`

This will be taken care of at a later point when we have a better idea of the exact implementation of the migration from version 5 to 6. I've added a few `FIXME` comments on the parts of the code where changes will have to be made when the transition occurs.
