### PR TITLE
Adding new metric type: historate

### DIFF
--- a/pkg/aggregator/context_metrics.go
+++ b/pkg/aggregator/context_metrics.go
@@ -31,6 +31,8 @@ func (m ContextMetrics) addSample(contextKey string, sample *MetricSample, times
 			m[contextKey] = &MonotonicCount{}
 		case HistogramType:
 			m[contextKey] = &Histogram{} // default histogram configuration for now
+		case HistorateType:
+			m[contextKey] = &Historate{} // internal histogram have the configuration for now
 		case SetType:
 			m[contextKey] = NewSet()
 		case CounterType:

--- a/pkg/aggregator/historate.go
+++ b/pkg/aggregator/historate.go
@@ -1,0 +1,29 @@
+package aggregator
+
+// Historate tracks the distribution of samples added over one flush period for
+// "rate" like metrics. Warning this doesn't use the harmonic mean, beware of
+// what it means when using it.
+type Historate struct {
+	histogram         Histogram
+	previousSample    float64
+	previousTimestamp int64
+	sampled           bool
+}
+
+func (h *Historate) addSample(sample *MetricSample, timestamp int64) {
+	if h.previousTimestamp != 0 {
+		v := (sample.Value - h.previousSample) / float64(timestamp-h.previousTimestamp)
+		h.histogram.addSample(&MetricSample{Value: v}, timestamp)
+		h.sampled = true
+	}
+	h.previousSample, h.previousTimestamp = sample.Value, timestamp
+}
+
+func (h *Historate) flush(timestamp int64) ([]*Serie, error) {
+	if h.sampled == false {
+		return []*Serie{}, NoSerieError{}
+	}
+
+	h.previousSample, h.previousTimestamp, h.sampled = 0.0, 0, false
+	return h.histogram.flush(timestamp)
+}

--- a/pkg/aggregator/historate_test.go
+++ b/pkg/aggregator/historate_test.go
@@ -1,0 +1,56 @@
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistorateEmptyFlush(t *testing.T) {
+	h := Historate{}
+
+	// Flush w/o samples: error
+	_, err := h.flush(50)
+	assert.NotNil(t, err)
+}
+
+func TestHistorateAddSampleOnce(t *testing.T) {
+	h := Historate{}
+	h.addSample(&MetricSample{Value: 1}, 50)
+
+	// Flush one sample: error
+	_, err := h.flush(50)
+	assert.NotNil(t, err)
+}
+
+func TestHistorateAddSample(t *testing.T) {
+	h := Historate{}
+
+	h.addSample(&MetricSample{Value: 1}, 50)
+	h.addSample(&MetricSample{Value: 2}, 51)
+
+	// Flush one sample: error
+	series, err := h.flush(52)
+	require.Nil(t, err)
+	if assert.Len(t, series, 5) {
+		for _, serie := range series {
+			assert.Len(t, serie.Points, 1)
+			assert.EqualValues(t, 52, serie.Points[0].Ts)
+		}
+		assert.InEpsilon(t, 1, series[0].Points[0].Value, epsilon)  // max
+		assert.Equal(t, ".max", series[0].nameSuffix)               // max
+		assert.InEpsilon(t, 1, series[1].Points[0].Value, epsilon)  // median
+		assert.Equal(t, ".median", series[1].nameSuffix)            // median
+		assert.InEpsilon(t, 1., series[2].Points[0].Value, epsilon) // avg
+		assert.Equal(t, ".avg", series[2].nameSuffix)               // avg
+		assert.InEpsilon(t, 1, series[3].Points[0].Value, epsilon)  // count
+		assert.Equal(t, ".count", series[3].nameSuffix)             // count
+		assert.InEpsilon(t, 1, series[4].Points[0].Value, epsilon)  // 0.95
+		assert.Equal(t, ".95percentile", series[4].nameSuffix)      // 0.95
+	}
+
+	assert.Equal(t, false, h.sampled)
+	assert.Equal(t, 0.0, h.previousSample)
+	assert.EqualValues(t, 0, h.previousTimestamp)
+}

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -11,6 +11,7 @@ const (
 	MonotonicCountType
 	CounterType
 	HistogramType
+	HistorateType
 	SetType
 )
 
@@ -29,6 +30,8 @@ func (m MetricType) String() string {
 		return "Counter"
 	case HistogramType:
 		return "Histogram"
+	case HistorateType:
+		return "Historate"
 	case SetType:
 		return "Set"
 	default:

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -21,6 +21,7 @@ type Sender interface {
 	Count(metric string, value float64, hostname string, tags []string)
 	MonotonicCount(metric string, value float64, hostname string, tags []string)
 	Histogram(metric string, value float64, hostname string, tags []string)
+	Historate(metric string, value float64, hostname string, tags []string)
 	ServiceCheck(checkName string, status ServiceCheckStatus, hostname string, tags []string, message string)
 	Event(e Event)
 }
@@ -126,6 +127,12 @@ func (s *checkSender) MonotonicCount(metric string, value float64, hostname stri
 // Should be called multiple times on the same (metric, hostname, tags) so that a distribution can be computed
 func (s *checkSender) Histogram(metric string, value float64, hostname string, tags []string) {
 	s.sendMetricSample(metric, value, hostname, tags, HistogramType)
+}
+
+// Historate should be used to create a histogram metric for "rate" like metrics.
+// Warning this doesn't use the harmonic mean, beware of what it means when using it.
+func (s *checkSender) Historate(metric string, value float64, hostname string, tags []string) {
+	s.sendMetricSample(metric, value, hostname, tags, HistorateType)
 }
 
 // ServiceCheck submits a service check

--- a/pkg/collector/corechecks/network/common_test.go
+++ b/pkg/collector/corechecks/network/common_test.go
@@ -31,6 +31,11 @@ func (m *MockSender) Histogram(metric string, value float64, hostname string, ta
 	m.Called(metric, value, hostname, tags)
 }
 
+//Historate adds a historate type to the mock calls.
+func (m *MockSender) Historate(metric string, value float64, hostname string, tags []string) {
+	m.Called(metric, value, hostname, tags)
+}
+
 //Gauge adds a gauge type to the mock calls.
 func (m *MockSender) Gauge(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)

--- a/pkg/collector/corechecks/system/common_test.go
+++ b/pkg/collector/corechecks/system/common_test.go
@@ -31,6 +31,11 @@ func (m *MockSender) Histogram(metric string, value float64, hostname string, ta
 	m.Called(metric, value, hostname, tags)
 }
 
+//Historate adds a historate type to the mock calls.
+func (m *MockSender) Historate(metric string, value float64, hostname string, tags []string) {
+	m.Called(metric, value, hostname, tags)
+}
+
 //Gauge adds a gauge type to the mock calls.
 func (m *MockSender) Gauge(metric string, value float64, hostname string, tags []string) {
 	m.Called(metric, value, hostname, tags)

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -57,6 +57,10 @@ class AgentCheck(object):
         tags = self._normalize_tags(tags)
         aggregator.submit_metric(self, aggregator.HISTOGRAM, name, value, tags)
 
+    def historate(self, name, value, tags=None, hostname=None, device_name=None):
+        tags = self._normalize_tags(tags)
+        aggregator.submit_metric(self, aggregator.HISTORATE, name, value, tags)
+
     def service_check(self, name, status, tags=None, message=""):
         tags = self._normalize_tags(tags)
         aggregator.submit_service_check(self, name, status, tags, message)

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -9,7 +9,8 @@ char* MetricTypeNames[] = {
   "RATE",
   "COUNT",
   "MONOTONIC_COUNT",
-  "HISTOGRAM"
+  "HISTOGRAM",
+  "HISTORATE"
 };
 
 static PyObject *submit_metric(PyObject *self, PyObject *args) {

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -44,6 +44,8 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 		sender.MonotonicCount(_name, _value, "", _tags)
 	case C.HISTOGRAM:
 		sender.Histogram(_name, _value, "", _tags)
+	case C.HISTORATE:
+		sender.Historate(_name, _value, "", _tags)
 	}
 
 	return C._none()

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -9,6 +9,7 @@ typedef enum {
   RATE,
   COUNT,
   MONOTONIC_COUNT,
+  HISTORATE,
   HISTOGRAM,
   MT_LAST = HISTOGRAM
 } MetricType;


### PR DESCRIPTION
### What does this PR do?

Historate are used by a few checks from the agent 5 to track
distribution of rate like metrics.

### Motivation

We need it to support checks like kubernetes or docker_daemon