### PR TITLE
Forward python logs to the agent logger

### DIFF
--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -3,6 +3,7 @@
 PyObject* GetVersion(PyObject *self, PyObject *args);
 PyObject* Headers(PyObject *self, PyObject *args);
 PyObject* GetHostname(PyObject *self, PyObject *args);
+PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 
 static PyObject *get_config(PyObject *self, PyObject *args) {
@@ -20,11 +21,29 @@ static PyObject *get_config(PyObject *self, PyObject *args) {
     return GetConfig(key);
 }
 
+static PyObject *log_message(PyObject *self, PyObject *args) {
+    char *message;
+    int  log_level;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    // datadog_agent.log(message, log_level)
+    if (!PyArg_ParseTuple(args, "si", &message, &log_level)) {
+      PyGILState_Release(gstate);
+      Py_RETURN_NONE;
+    }
+
+    PyGILState_Release(gstate);
+    return LogMessage(message, log_level);
+}
+
 static PyMethodDef datadogAgentMethods[] = {
   {"get_version", GetVersion, METH_VARARGS, "Get the Agent version."},
   {"get_config", get_config, METH_VARARGS, "Get value from the agent configuration."},
   {"headers", Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
   {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
+  {"log", log_message, METH_VARARGS, "Log a message through the agent logger."},
   {NULL, NULL}
 };
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -76,6 +76,30 @@ func GetConfig(key *C.char) *C.PyObject {
 	return (*C.PyObject)(unsafe.Pointer(pyValue.GetCPointer()))
 }
 
+// LogMessage logs a message from python through the agent logger (see
+// https://docs.python.org/2.7/library/logging.html#logging-levels)
+//export LogMessage
+func LogMessage(message *C.char, logLevel C.int) *C.PyObject {
+	goMsg := C.GoString(message)
+
+	switch logLevel {
+	case 50: // CRITICAL
+		log.Critical(goMsg)
+	case 40: // ERROR
+		log.Error(goMsg)
+	case 30: // WARNING
+		log.Warn(goMsg)
+	case 20: // INFO
+		log.Info(goMsg)
+	case 10: // DEBUG
+		log.Debug(goMsg)
+	default: // unknown log level
+		log.Info(goMsg)
+	}
+
+	return C._none()
+}
+
 func initDatadogAgent() {
 	C.initdatadogagent()
 }


### PR DESCRIPTION
### What does this PR do?

This commit add a Handler to every check logger to forward log lines to the agent logger.

this python code in a check:

```
self.log.debug("this is a debug")
self.log.info("this is a info")
self.log.warn("this is a warn")
self.log.warning("this is a warning")
self.log.error("this is a error")
self.log.critical("this is a critical")
self.log.log(21, "this is log at level 21")

try:
    raise Exception("haaaa")
except Exception:
    self.log.exception("this is a exception")
```

will produce in the logs:

```
2017-05-10 15:18:52 CEST | INFO | (datadog_agent.go:92) | (process.py:54) | this is a info
2017-05-10 15:18:52 CEST | WARN | (datadog_agent.go:90) | (process.py:55) | this is a warn
2017-05-10 15:18:52 CEST | WARN | (datadog_agent.go:90) | (process.py:56) | this is a warning
2017-05-10 15:18:52 CEST | ERROR | (datadog_agent.go:88) | (process.py:57) | this is a error
2017-05-10 15:18:52 CEST | CRITICAL | (datadog_agent.go:86) | (process.py:58) | this is a critical
2017-05-10 15:18:52 CEST | INFO | (datadog_agent.go:96) | (process.py:59) | this is log at level 21
2017-05-10 15:18:52 CEST | ERROR | (datadog_agent.go:88) | (process.py:64) | this is a exception
Traceback (most recent call last):
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/checks/process.py", line 62, in __init__
    raise Exception("some error")
Exception: some error
```