### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/collector/metadata/gohai/gohai_test.go
+++ b/pkg/collector/metadata/gohai/gohai_test.go
@@ -1,17 +1,12 @@
 package gohai
 
 import (
-	"github.com/DataDog/gohai/cpu"
-	"github.com/DataDog/gohai/filesystem"
-	"github.com/DataDog/gohai/memory"
-	"github.com/DataDog/gohai/network"
-	"github.com/DataDog/gohai/platform"
-
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestGetPayload(t *testing.T) {
+	gohai := GetPayload()
 
 	assert.NotNil(t, gohai.Gohai.CPU)
 	assert.NotNil(t, gohai.Gohai.FileSystem)

--- a/pkg/collector/metadata/gohai/gohai_test.go
+++ b/pkg/collector/metadata/gohai/gohai_test.go
@@ -12,17 +12,10 @@ import (
 )
 
 func TestGetPayload(t *testing.T) {
-	cpuPayload, _ := new(cpu.Cpu).Collect()
-	fileSystemPayload, _ := new(filesystem.FileSystem).Collect()
-	memoryPayload, _ := new(memory.Memory).Collect()
-	networkPayload, _ := new(network.Network).Collect()
-	platformPayload, _ := new(platform.Platform).Collect()
 
-	gohai := GetPayload()
-
-	assert.Equal(t, cpuPayload, gohai.Gohai.CPU)
-	assert.Equal(t, fileSystemPayload, gohai.Gohai.FileSystem)
-	assert.Equal(t, memoryPayload, gohai.Gohai.Memory)
-	assert.Equal(t, networkPayload, gohai.Gohai.Network)
-	assert.Equal(t, platformPayload, gohai.Gohai.Platform)
+	assert.NotNil(t, gohai.Gohai.CPU)
+	assert.NotNil(t, gohai.Gohai.FileSystem)
+	assert.NotNil(t, gohai.Gohai.Memory)
+	assert.NotNil(t, gohai.Gohai.Network)
+	assert.NotNil(t, gohai.Gohai.Platform)
 }


### PR DESCRIPTION
In the output of gohai, the value in mhz of the processor speed could vary between two calls.
So now it's only testing that the field is present in the Payload object