### PR TITLE
[dogstatsd] Set a default buffer size that's consistent with agent 5

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ func init() {
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
 	Datadog.SetDefault("use_dogstatsd", true)
 	Datadog.SetDefault("dogstatsd_port", 8125)
-	Datadog.SetDefault("dogstatsd_buffer_size", 1024)
+	Datadog.SetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("dogstatsd_non_local_traffic", false)
 


### PR DESCRIPTION
### What does this PR do?

Sets a default buffer size that's consistent with agent 5, i.e. 8KB

### Motivation

Having a default that's lower than the agent5's would by default make
the dogstatsd server fail to parse dogstatsd datagrams that would be
parsed fine by the agent5's dogstatsd.
