### PR TITLE
[pkg-scripts] Remove `==` bashism in tests

### DIFF
--- a/omnibus/package-scripts/datadog-agent6/postinst
+++ b/omnibus/package-scripts/datadog-agent6/postinst
@@ -21,13 +21,13 @@ fi
 
 # Linux installation
 if [ "$DISTRIBUTION" != "Darwin" ]; then
-    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
         DISTRIBUTION_FAMILY="Debian"
     fi
 
     CONFIG_DIR=/etc/dd-agent
 
-    if [ "$DISTRIBUTION_FAMILY" == "Debian" ]; then
+    if [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         set -e
         case "$1" in
             configure)
@@ -74,7 +74,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
     # Restart the agent here on Debian platforms
     # On RHEL, the restart is done in the posttrans script
-    if [ "$DISTRIBUTION_FAMILY" == "Debian" ]; then
+    if [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
         # and avoid restarting when a check conf is invalid
         if [ -f "$CONFIG_DIR/datadog.yaml" ]; then

--- a/omnibus/package-scripts/datadog-agent6/postrm
+++ b/omnibus/package-scripts/datadog-agent6/postrm
@@ -11,7 +11,7 @@ INSTALL_DIR=/opt/datadog-agent6
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/dd-agent
 
-if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     set -e
 
     case "$1" in
@@ -31,7 +31,7 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRI
         *)
         ;;
     esac
-elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
+elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
     case "$*" in
         0)
             # We're uninstalling.

--- a/omnibus/package-scripts/datadog-agent6/preinst
+++ b/omnibus/package-scripts/datadog-agent6/preinst
@@ -30,11 +30,11 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         fi
     fi
 
-    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+    if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
         # Nothing specific on Debian
         :
         #DEBHELPER#
-    elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
+    elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
         # Set up `dd-agent` user and group
         getent group dd-agent >/dev/null || groupadd -r dd-agent
         getent passwd dd-agent >/dev/null || \

--- a/omnibus/package-scripts/datadog-agent6/prerm
+++ b/omnibus/package-scripts/datadog-agent6/prerm
@@ -48,11 +48,11 @@ remove_py_compiled_files()
     fi
 }
 
-if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
+if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     stop_agent
     deregister_agent
     remove_py_compiled_files
-elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "Arista" ]; then
+elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
     case "$*" in
         0)
             # We're uninstalling.


### PR DESCRIPTION
### What does this PR do?

Replaces `==` with `=` in package scripts.

`==` in tests is a bashism that's not supported by Debian's `dash`, so let's
always use `=` instead

### Motivation

Using `==` breaks the scripts on Debian/Ubuntu.

### Additional Notes

We could also just decide to use `/bin/bash` instead of `/bin/sh`. Not sure if it'd affect the portability of the package that much.