### PR TITLE
add dogstatsd_socket_path option to enable unix socket traffic to dogstatsd

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -48,7 +48,7 @@ extensions for special Datadog features.`,
 		},
 	}
 
-	confPath string
+	confPath   string
 	socketPath string
 )
 
@@ -66,7 +66,7 @@ func init() {
 	startCmd.Flags().StringVarP(&confPath, "conf", "c", "", "path to the datadog.yaml file")
 	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("conf"))
 	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
-	config.Datadog.BindPFlag("dogstatsd_socket_path", startCmd.Flags().Lookup("socket"))
+	config.Datadog.BindPFlag("dogstatsd_socket", startCmd.Flags().Lookup("socket"))
 }
 
 func start(cmd *cobra.Command, args []string) error {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -49,6 +49,7 @@ extensions for special Datadog features.`,
 	}
 
 	confPath string
+	socketPath string
 )
 
 func init() {
@@ -64,6 +65,8 @@ func init() {
 	// local flags
 	startCmd.Flags().StringVarP(&confPath, "conf", "c", "", "path to the datadog.yaml file")
 	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("conf"))
+	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
+	config.Datadog.BindPFlag("dogstatsd_socket_path", startCmd.Flags().Lookup("socket"))
 }
 
 func start(cmd *cobra.Command, args []string) error {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -95,7 +95,7 @@ func start(cmd *cobra.Command, args []string) error {
 	aggregatorInstance := aggregator.InitAggregator(f, util.GetHostname())
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {
-		log.Error(err.Error())
+		log.Criticalf("Unable to start dogstatsd: %s", err)
 		return nil
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,10 +20,10 @@ func init() {
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024)
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	Datadog.SetDefault("dogstatsd_socket_path", "")
+	Datadog.SetDefault("dogstatsd_socket", "")
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")
-	Datadog.BindEnv("dogstatsd_socket_path")
+	Datadog.BindEnv("dogstatsd_socket")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,4 +25,5 @@ func init() {
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")
+	Datadog.BindEnv("dogstatsd_socket_path")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ func init() {
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024)
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("dogstatsd_non_local_traffic", false)
+	Datadog.SetDefault("dogstatsd_socket_path", "")
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"os"
 
 	log "github.com/cihub/seelog"
 
@@ -46,7 +47,7 @@ func NewServer(metricOut chan<- *aggregator.MetricSample, eventOut chan<- aggreg
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("dogstatsd: can't listen: %s", err)
+		return nil, fmt.Errorf("can't listen: %s", err)
 	}
 
 	s := &Server{
@@ -119,5 +120,14 @@ func (s *Server) handleMessages(metricOut chan<- *aggregator.MetricSample, event
 // Stop stops a running Dogstatsd server
 func (s *Server) Stop() {
 	s.conn.Close()
+
+	// Socket cleanup on exit
+	socket_path := config.Datadog.GetString("dogstatsd_socket_path")
+	if len(socket_path) > 0 {
+		err := os.Remove(socket_path)
+		if err != nil {
+			log.Infof("dogstatsd: error removing socket file: %s", err)
+		}
+	}
 	s.Started = false
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -5,8 +5,8 @@ import (
 	"expvar"
 	"fmt"
 	"net"
-	"strings"
 	"os"
+	"strings"
 
 	log "github.com/cihub/seelog"
 
@@ -29,9 +29,9 @@ func NewServer(metricOut chan<- *aggregator.MetricSample, eventOut chan<- aggreg
 	var conn net.PacketConn
 	var err error
 
-	socket_path := config.Datadog.GetString("dogstatsd_socket_path")
+	socketPath := config.Datadog.GetString("dogstatsd_socket_path")
 
-	if len(socket_path) == 0 {
+	if len(socketPath) == 0 {
 		var url string
 
 		if config.Datadog.GetBool("dogstatsd_non_local_traffic") == true {
@@ -43,7 +43,7 @@ func NewServer(metricOut chan<- *aggregator.MetricSample, eventOut chan<- aggreg
 
 		conn, err = net.ListenPacket("udp", url)
 	} else {
-		conn, err = net.ListenPacket("unixgram", socket_path)
+		conn, err = net.ListenPacket("unixgram", socketPath)
 	}
 
 	if err != nil {
@@ -122,9 +122,9 @@ func (s *Server) Stop() {
 	s.conn.Close()
 
 	// Socket cleanup on exit
-	socket_path := config.Datadog.GetString("dogstatsd_socket_path")
-	if len(socket_path) > 0 {
-		err := os.Remove(socket_path)
+	socketPath := config.Datadog.GetString("dogstatsd_socket_path")
+	if len(socketPath) > 0 {
+		err := os.Remove(socketPath)
 		if err != nil {
 			log.Infof("dogstatsd: error removing socket file: %s", err)
 		}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -29,7 +29,7 @@ func NewServer(metricOut chan<- *aggregator.MetricSample, eventOut chan<- aggreg
 	var conn net.PacketConn
 	var err error
 
-	socketPath := config.Datadog.GetString("dogstatsd_socket_path")
+	socketPath := config.Datadog.GetString("dogstatsd_socket")
 
 	if len(socketPath) == 0 {
 		var url string
@@ -122,7 +122,7 @@ func (s *Server) Stop() {
 	s.conn.Close()
 
 	// Socket cleanup on exit
-	socketPath := config.Datadog.GetString("dogstatsd_socket_path")
+	socketPath := config.Datadog.GetString("dogstatsd_socket")
 	if len(socketPath) > 0 {
 		err := os.Remove(socketPath)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

Introduce a dogstatsd_socket_path option to listen to a unix socket instead of UDP.  As unix datagram and UDP share the same semantics, the patch is pretty small and unobstrusive.

### Motivation

Containers make it harder to reach the dogstatsd server from client applications and we don't have a future-proof network solution that could work across all orchestrators. This allows to bypass the network stack altogether and use a host-local protocol. See https://github.com/DataDog/docker-dd-agent/issues/195 for more context.

This patch has been benchmarked with a patched datadogpy library (see https://github.com/DataDog/datadogpy/pull/199): with 21 clients sending a total of 210k counter increase packets, dogstatsd managed to process 160k packets and send them to our backend (load of 14 on a n1-highcpu-8 instance [8 vCPUs, 7.2 GB memory]). The other packets were dropped silently as the clients were using non blocking sockets.
