### PR TITLE
[py] Fix swap of histogram and historate constants

### DIFF
--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -4,6 +4,7 @@ PyObject* SubmitMetric(PyObject*, MetricType, char*, float, PyObject*);
 PyObject* SubmitServiceCheck(PyObject*, char*, int, PyObject*, char*);
 PyObject* SubmitEvent(PyObject*, PyObject*);
 
+// _must_ be in the same order as the MetricType enum
 char* MetricTypeNames[] = {
   "GAUGE",
   "RATE",

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -9,9 +9,9 @@ typedef enum {
   RATE,
   COUNT,
   MONOTONIC_COUNT,
-  HISTORATE,
   HISTOGRAM,
-  MT_LAST = HISTOGRAM
+  HISTORATE,
+  MT_LAST = HISTORATE
 } MetricType;
 
 void initaggregator();


### PR DESCRIPTION
### What does this PR do?

Fix a swap of the histogram and historate submission methods.

### Motivation

Without this fix `self.histogram` would submit a historate, and vice versa.

### Additional Notes

Having tests on the bindings will be great :)