### PR TITLE
[agent build] Set `RPATH` with `-r` ldflag in rake build task

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -12,13 +12,9 @@ source path: '..'
 
 relative_path 'datadog-agent'
 
-build_env = {
-  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-}
-
 build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
-  command 'rake agent:build', :env => build_env
+  command 'rake agent:build'
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -37,10 +37,12 @@ namespace :agent do
       # On windows, need to build with the extra arguments -gcflags "-N -l" -ldflags="-linkmode internal"
       # if you want to be able to use the delve debugger.
       ldflags << "-linkmode internal"
-      system(env, "go build #{race_opt} #{build_type} -o #{BIN_PATH}/#{agent_bin_name}  -gcflags \"-N -l\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
+      build_success = system(env, "go build #{race_opt} #{build_type} -o #{BIN_PATH}/#{agent_bin_name}  -gcflags \"-N -l\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
     else
-      system(env, "go build #{race_opt} #{build_type} -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
+      build_success = system(env, "go build #{race_opt} #{build_type} -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
     end
+    fail "Agent build failed with code #{$?.exitstatus}" if !build_success
+
     Rake::Task["agent:refresh_assets"].invoke
   end
 


### PR DESCRIPTION
### What does this PR do?

Makes omnibus and the `agent:build` rake task build the same binary (both with `RPATH` set to
the embedded lib dir).

I've also sneaked in a change to make the rake task fail if the `go build` command fails.

### Motivation

Having a consistent build of the agent binary. Helpful when replacing an installed agent bin with a locally-built agent bin.

### Additional Notes

I've checked on Linux and macOS that building the agent with:
- `LD_RUN_PATH="<embedded_lib_dir>" rake agent:build` without the present changes
- `rake agent:build` with the present changes

results in the same `agent.bin` binary, with an RPATH header set to `embedded_lib_dir`.

I haven't tested the change on windows, but I think it should work too (?)

See also commit description for details.

Docs on `go tool link`, which uses the `-r` parameter: https://golang.org/cmd/link/