### PR TITLE
[py] Log complete python errors + tracebacks when check import fails

### DIFF
--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -95,48 +95,12 @@ func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObje
 		return instance, nil
 	}
 
-	// Gather infos about the Python error
-	ptype, pvalue, ptraceback := python.PyErr_Fetch() // new references, have to be decref'd
-	defer python.PyErr_Clear()
-	defer ptype.DecRef()
-	defer pvalue.DecRef()
-	defer ptraceback.DecRef()
-
-	if ptraceback != nil && ptraceback.Type() != nil {
-		// There's a traceback, try to format it nicely
-		traceback := python.PyImport_ImportModule("traceback")
-		formatExcFn := traceback.GetAttrString("format_exception")
-		if formatExcFn != nil {
-			defer formatExcFn.DecRef()
-			pyFormattedExc := formatExcFn.CallFunction(ptype, pvalue, ptraceback)
-			if pyFormattedExc != nil {
-				defer pyFormattedExc.DecRef()
-				pyStringExc := pyFormattedExc.Str()
-				if pyStringExc != nil {
-					defer pyStringExc.DecRef()
-					return nil, fmt.Errorf(python.PyString_AsString(pyStringExc))
-				}
-			}
-		}
-
-		// If we reach this point, there was an error while formatting the exception
-		return nil, fmt.Errorf("Error while formatting exception")
+	// there was an error, retrieve it
+	pyErr, err := getPythonError()
+	if err != nil {
+		return nil, fmt.Errorf("An error occurred while invoking the python check constructor, and couldn't be formatted: %v", err)
 	}
-
-	// If the constructor is invalid we do not get a traceback but an error in pvalue.
-	if pvalue != nil && pvalue.Type() != nil {
-		return nil, fmt.Errorf(python.PyString_AsString(pvalue))
-	}
-
-	if ptype != nil {
-		strPtype := ptype.Str()
-		if strPtype != nil {
-			defer strPtype.DecRef()
-			return nil, fmt.Errorf(python.PyString_AsString(strPtype))
-		}
-	}
-
-	return nil, fmt.Errorf("unknown error from python")
+	return nil, errors.New(pyErr)
 }
 
 // Configure the Python check from YAML data

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -52,11 +52,12 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	// import python module containing the check
 	checkModule := python.PyImport_ImportModule(moduleName)
 	if checkModule == nil {
-		// we don't expect a traceback here so we use the error msg in `pvalue`
-		_, pvalue, _ := python.PyErr_Fetch()
-		msg := python.PyString_AsString(pvalue)
+		pyErr, err := getPythonError()
 		glock.Unlock()
-		return checks, errors.New(msg)
+		if err != nil {
+			return nil, fmt.Errorf("An error occurred while loading the python module and couldn't be formatted: %v", err)
+		}
+		return nil, errors.New(pyErr)
 	}
 
 	// release the GIL, some functions we're going to call might need it

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -149,10 +149,9 @@ func getModuleName(modulePath string) string {
 
 // getPythonError returns string-formatted info about a Python interpreter error that occurred,
 // and clears the error flag in the Python interpreter
+// WARNING: make sure a StickyLock is locked when calling this function (i.e. the GIL is locked and the goroutine
+// is locked to its thread)
 func getPythonError() (string, error) {
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
-
 	ptype, pvalue, ptraceback := python.PyErr_Fetch() // new references, have to be decref'd
 	defer python.PyErr_Clear()
 	defer ptype.DecRef()

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -147,6 +147,55 @@ func getModuleName(modulePath string) string {
 	return toks[len(toks)-1]
 }
 
+// getPythonError returns string-formatted info about a Python interpreter error that occurred,
+// and clears the error flag in the Python interpreter
+func getPythonError() (string, error) {
+	gstate := NewStickyLock()
+	defer gstate.Unlock()
+
+	ptype, pvalue, ptraceback := python.PyErr_Fetch() // new references, have to be decref'd
+	defer python.PyErr_Clear()
+	defer ptype.DecRef()
+	defer pvalue.DecRef()
+	defer ptraceback.DecRef()
+
+	if ptraceback != nil && ptraceback.Type() != nil {
+		// There's a traceback, try to format it nicely
+		traceback := python.PyImport_ImportModule("traceback")
+		formatExcFn := traceback.GetAttrString("format_exception")
+		if formatExcFn != nil {
+			defer formatExcFn.DecRef()
+			pyFormattedExc := formatExcFn.CallFunction(ptype, pvalue, ptraceback)
+			if pyFormattedExc != nil {
+				defer pyFormattedExc.DecRef()
+				pyStringExc := pyFormattedExc.Str()
+				if pyStringExc != nil {
+					defer pyStringExc.DecRef()
+					return python.PyString_AsString(pyStringExc), nil
+				}
+			}
+		}
+
+		// If we reach this point, there was an error while formatting the exception
+		return "", fmt.Errorf("can't format exception")
+	}
+
+	// we sometimes do not get a traceback but an error in pvalue.
+	if pvalue != nil && pvalue.Type() != nil {
+		return python.PyString_AsString(pvalue), nil
+	}
+
+	if ptype != nil {
+		strPtype := ptype.Str()
+		if strPtype != nil {
+			defer strPtype.DecRef()
+			return python.PyString_AsString(strPtype), nil
+		}
+	}
+
+	return "", fmt.Errorf("unknown error")
+}
+
 // GetInterpreterVersion should go in `go-python`, TODO.
 func GetInterpreterVersion() string {
 	// Lock the GIL and release it at the end of the run


### PR DESCRIPTION
### What does this PR do?

In some cases the python module of a check can't be imported because
of a python code issue, in that case logging the traceback is useful. This PR
does just that.

### Motivation

Without this change it's impossible to debug an issue with the import of a python
check module, based on the logs alone.

### Additional Notes

Use a common function that retrieves and formats the python
interpreter error, and clears the error flag in the interpreter.
Any python c api call that returns an error should be followed by
a call of that common function to get a formatted string of the error.

The signature of that function could be changed at some point to return
something more meaningful than just a string, but I didn't feel the need for that
right now.