### PR TITLE
allow to run dogstatsd without a config file

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -10,4 +10,4 @@ COPY dogstatsd /dogstatsd
 EXPOSE 8125/udp
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/dogstatsd", "start", "-c", "/datadog.yaml"]
+CMD ["/dogstatsd", "start"]

--- a/Dockerfiles/dogstatsd/alpine/entrypoint.sh
+++ b/Dockerfiles/dogstatsd/alpine/entrypoint.sh
@@ -3,26 +3,21 @@
 
 ##### Core config #####
 
-touch /datadog.yaml
-
-if [[ $DD_API_KEY ]]; then
-	echo "api_key: ${API_KEY}/" >> /datadog.yaml
-else
+if [[ -z $DD_API_KEY ]]; then
 	echo "You must set DD_API_KEY environment variable to run the Datadog Agent container"
 	exit 1
 fi
 
-if [[ $DD_URL ]]; then
-    echo "dd_url: ${DD_URL}" >> /datadog.yaml
-else
-    echo "dd_url: https://app.datadoghq.com" >> /datadog.yaml
-
+if [[ -z $DD_DD_URL ]]; then
+    export DD_DD_URL="https://app.datadoghq.com"
 fi
 
 if [[ $DD_SOCKET ]]; then
-    echo "dogstatsd_socket: ${DD_SOCKET}" >> /datadog.yaml
-else
-    echo "dogstatsd_non_local_traffic: yes" >> /datadog.yaml
+    export DD_DOGSTATSD_SOCKET=$DD_SOCKET
+fi
+
+if [ -z $DD_DOGSTATSD_SOCKET ]; then
+    export DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
 fi
 
 ##### Starting up dogstatsd #####

--- a/Dockerfiles/dogstatsd/alpine/entrypoint.sh
+++ b/Dockerfiles/dogstatsd/alpine/entrypoint.sh
@@ -12,10 +12,6 @@ if [[ -z $DD_DD_URL ]]; then
     export DD_DD_URL="https://app.datadoghq.com"
 fi
 
-if [[ $DD_SOCKET ]]; then
-    export DD_DOGSTATSD_SOCKET=$DD_SOCKET
-fi
-
 if [ -z $DD_DOGSTATSD_SOCKET ]; then
     export DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
 fi

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -63,8 +63,8 @@ func init() {
 	config.Datadog.SetDefault("log_file", defaultLogPath)
 
 	// local flags
-	startCmd.Flags().StringVarP(&confPath, "conf", "c", "", "path to the datadog.yaml file")
-	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("conf"))
+	startCmd.Flags().StringVarP(&confPath, "cfgpath", "f", "", "path to datadog.yaml")
+	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath"))
 	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
 	config.Datadog.BindPFlag("dogstatsd_socket", startCmd.Flags().Lookup("socket"))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,4 +26,5 @@ func init() {
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")
 	Datadog.BindEnv("dogstatsd_socket")
+	Datadog.BindEnv("dogstatsd_non_local_traffic")
 }

--- a/test/system/dogstatsd/dogstatsd_test.go
+++ b/test/system/dogstatsd/dogstatsd_test.go
@@ -63,14 +63,14 @@ func (d *dogstatsdTest) setup(t *testing.T) {
 	d.tmpDir = dir
 
 	// write temp conf
-	content := []byte("dd_url: " + d.ts.URL + "\n")
+	content := []byte("dd_url: " + d.ts.URL + "\napi_key: dummy\n")
 	tmpConf := filepath.Join(dir, "datadog.yaml")
 	err = ioutil.WriteFile(tmpConf, content, 0666)
 	require.NoError(t, err, "Could not write temp conf")
 
 	// start dogstatsd
 	d.ctx, d.cancel = context.WithCancel(context.Background())
-	e := exec.CommandContext(d.ctx, dogstatsdBin, "start", "-c", tmpConf)
+	e := exec.CommandContext(d.ctx, dogstatsdBin, "start", "-f", tmpConf)
 	stdout, err := e.StdoutPipe()
 	require.NoError(t, err, "Could get StdoutPipe from command")
 	go func() {


### PR DESCRIPTION
- don't exit if config file not found, revert to envvars and defaults
- exit if api_key not set
- bind DD_DOGSTATSD_NON_LOCAL_TRAFFIC envvar
- update dogstatsd-alpine image to remove config file