### PR TITLE
StickyLock cosmetics

### DIFF
--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -40,8 +40,8 @@ func NewPythonCheck(name string, class *python.PyObject) *PythonCheck {
 // Run a Python check
 func (c *PythonCheck) Run() error {
 	// Lock the GIL and release it at the end of the run
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	// call run function, it takes no args so we pass an empty tuple
 	emptyTuple := python.PyTuple_New(0)
@@ -82,8 +82,8 @@ func (c *PythonCheck) String() string {
 // of  the defer calls stack.
 func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObject, error) {
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	if args == nil {
 		args = python.PyTuple_New(0)
@@ -163,10 +163,10 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 		}
 
 		// Add new 'agentConfig' key to the dict...
-		gstate := NewStickyLock()
+		gstate := newStickyLock()
 		key := python.PyString_FromString("agentConfig")
 		python.PyDict_SetItem(kwargs, key, agentConfig)
-		gstate.Unlock()
+		gstate.unlock()
 
 		// ...and retry to get an instance
 		instance, err = c.getInstance(nil, kwargs)

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -18,8 +18,8 @@ var (
 
 func getClass(moduleName, className string) (checkClass *python.PyObject) {
 	// Lock the GIL while operating with go-python
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	module := python.PyImport_ImportModule(moduleName)
 	if module == nil {
@@ -45,8 +45,8 @@ func getCheckInstance(moduleName, className string) (*PythonCheck, error) {
 
 func TestNewPythonCheck(t *testing.T) {
 	// Lock the GIL and release it at the end of the run
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	tuple := python.PyTuple_New(0)
 	res := NewPythonCheck("FooBar", tuple)

--- a/pkg/collector/py/config.go
+++ b/pkg/collector/py/config.go
@@ -1,9 +1,10 @@
 package py
 
 import (
-	log "github.com/cihub/seelog"
 	"reflect"
 	"time"
+
+	log "github.com/cihub/seelog"
 
 	"github.com/mitchellh/reflectwalk"
 	"github.com/sbinet/go-python"
@@ -33,8 +34,8 @@ func (w *walker) Primitive(v reflect.Value) error {
 	}
 
 	// if not: we are converting a simple type
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	w.result = ifToPy(v)
 	return nil
@@ -78,8 +79,8 @@ func (w *walker) pop() {
 // the walker is about to enter a new type, we only need to take action for
 // Maps and Slices.
 func (w *walker) Enter(l reflectwalk.Location) error {
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	switch l {
 	case reflectwalk.Map:
@@ -161,8 +162,8 @@ func ifToPy(v reflect.Value) *python.PyObject {
 // go through map elements and convert to Python dict elements
 func (w *walker) MapElem(m, k, v reflect.Value) error {
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	w.lastKey = k.Interface().(string)
 	dictKey := python.PyString_FromString(w.lastKey)
@@ -179,8 +180,8 @@ func (w *walker) MapElem(m, k, v reflect.Value) error {
 // go through slice items and convert to Python list items
 func (w *walker) SliceElem(i int, v reflect.Value) error {
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	pyval := ifToPy(v)
 	if pyval != nil {

--- a/pkg/collector/py/config_test.go
+++ b/pkg/collector/py/config_test.go
@@ -37,8 +37,8 @@ func TestToPython(t *testing.T) {
 	}
 
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	if !python.PyDict_Check(res) {
 		t.Fatalf("Result is not a Python dict")
@@ -72,8 +72,8 @@ func TestToPythonInt(t *testing.T) {
 	require.Nil(t, err, "Expected empty error message")
 
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	assert.True(t, python.PyInt_Check(res), "Result is not a Python dict")
 
@@ -92,8 +92,8 @@ func TestToPythonfloat(t *testing.T) {
 	require.Nil(t, err, "Expected empty error message")
 
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	assert.True(t, python.PyFloat_Check(res), "Result is not a Python float")
 
@@ -110,8 +110,8 @@ func TestToPythonBool(t *testing.T) {
 	require.Nil(t, err, "Expected empty error message")
 
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	assert.True(t, python.PyBool_Check(res), "Result is not a Python bool")
 }
@@ -124,8 +124,8 @@ func TestToPythonString(t *testing.T) {
 	require.Nil(t, err, "Expected empty error message")
 
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	assert.True(t, python.PyString_Check(res), "Result is not a Python string")
 }
@@ -138,15 +138,15 @@ func TestToPythonDuration(t *testing.T) {
 	require.Nil(t, err, "Expected empty error message")
 
 	// Lock the GIL and release it at the end
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	assert.True(t, python.PyInt_Check(res), "Result is not a Python string")
 }
 
 func TestWalkerPush(t *testing.T) {
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	w := new(walker)
 	d := python.PyDict_New()
@@ -185,8 +185,8 @@ func TestWalkerPush(t *testing.T) {
 }
 
 func TestWalkerPop(t *testing.T) {
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	w := new(walker)
 	d := python.PyDict_New()
@@ -251,9 +251,9 @@ func TestWalkerExit(t *testing.T) {
 	}
 
 	// fill the stack to test cleanup procedure
-	gstate := NewStickyLock()
+	gstate := newStickyLock()
 	w.push(python.PyDict_New())
-	gstate.Unlock()
+	gstate.unlock()
 	w.Exit(reflectwalk.WalkLoc)
 	if w.containersStack != nil {
 		t.Fatalf("Stack should be nil, found: %v", w.containersStack)
@@ -265,8 +265,8 @@ func TestWalkerExit(t *testing.T) {
 
 func TestIfToPy(t *testing.T) {
 	// ifToPy is supposed to be invoked holding the GIL
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	var i interface{}
 

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -22,8 +22,8 @@ type PythonCheckLoader struct {
 // NewPythonCheckLoader creates an instance of the Python checks loader
 func NewPythonCheckLoader() *PythonCheckLoader {
 	// Lock the GIL and release it at the end of the run
-	glock := NewStickyLock()
-	defer glock.Unlock()
+	glock := newStickyLock()
+	defer glock.unlock()
 
 	agentCheckModule := python.PyImport_ImportModule(agentCheckModuleName)
 	if agentCheckModule == nil {
@@ -47,7 +47,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	moduleName := config.Name
 
 	// Lock the GIL while working with go-python directly
-	glock := NewStickyLock()
+	glock := newStickyLock()
 
 	// import python module containing the check
 	checkModule := python.PyImport_ImportModule(moduleName)
@@ -61,7 +61,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	}
 
 	// release the GIL, some functions we're going to call might need it
-	glock.Unlock()
+	glock.unlock()
 
 	// Try to find a class inheriting from AgentCheck within the module
 	checkClass, err := findSubclassOf(cl.agentCheckClass, checkModule)

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -11,7 +11,7 @@ import (
 // #include <Python.h>
 import "C"
 
-// StickyLock is a convenient wrapper to interact with the Python GIL
+// stickyLock is a convenient wrapper to interact with the Python GIL
 // from go code when using `go-python`.
 //
 // We are going to call the Python C API from different goroutines that
@@ -23,27 +23,27 @@ import "C"
 // in fact, the Python interpreter will check lock/unlock requests against
 // the thread ID they are called from, raising a runtime assertion if
 // they don't match. To avoid this, even if giving up on some performance,
-// we ask the go runtime to be sure any goroutine using a `StickyLock`
+// we ask the go runtime to be sure any goroutine using a `stickyLock`
 // will be always paused and resumed on the same thread.
 //
 // [0]: https://docs.python.org/2/c-api/init.html#non-python-created-threads
-type StickyLock struct {
+type stickyLock struct {
 	gstate python.PyGILState
 }
 
-// NewStickyLock register the current thread with the interpreter and locks
+// newStickyLock register the current thread with the interpreter and locks
 // the GIL. It also sticks the goroutine to the current thread so that a
 // subsequent call to `Unlock` will unregister the very same thread.
-func NewStickyLock() *StickyLock {
+func newStickyLock() *stickyLock {
 	runtime.LockOSThread()
-	return &StickyLock{
+	return &stickyLock{
 		gstate: python.PyGILState_Ensure(),
 	}
 }
 
-// Unlock deregisters the current thread from the interpreter, unlocks the GIL
+// unlock deregisters the current thread from the interpreter, unlocks the GIL
 // and detaches the goroutine from the current thread.
-func (sl *StickyLock) Unlock() {
+func (sl *stickyLock) unlock() {
 	python.PyGILState_Release(sl.gstate)
 	runtime.UnlockOSThread()
 }
@@ -104,8 +104,8 @@ func Initialize(paths ...string) *python.PyThreadState {
 // Search in module for a class deriving from baseClass and return the first match if any.
 func findSubclassOf(base, module *python.PyObject) (*python.PyObject, error) {
 	// Lock the GIL and release it at the end of the run
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	if base == nil || module == nil {
 		return nil, fmt.Errorf("both base class and module must be not nil")
@@ -198,8 +198,8 @@ func getPythonError() (string, error) {
 // GetInterpreterVersion should go in `go-python`, TODO.
 func GetInterpreterVersion() string {
 	// Lock the GIL and release it at the end of the run
-	gstate := NewStickyLock()
-	defer gstate.Unlock()
+	gstate := newStickyLock()
+	defer gstate.unlock()
 
 	res := C.Py_GetVersion()
 	if res == nil {

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -102,11 +102,8 @@ func Initialize(paths ...string) *python.PyThreadState {
 }
 
 // Search in module for a class deriving from baseClass and return the first match if any.
+// Notice: the GIL must be acquired before calling this method
 func findSubclassOf(base, module *python.PyObject) (*python.PyObject, error) {
-	// Lock the GIL and release it at the end of the run
-	gstate := newStickyLock()
-	defer gstate.unlock()
-
 	if base == nil || module == nil {
 		return nil, fmt.Errorf("both base class and module must be not nil")
 	}

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -27,11 +27,12 @@ func TestMain(m *testing.M) {
 
 func TestFindSubclassOf(t *testing.T) {
 	gstate := newStickyLock()
+	defer gstate.unlock()
+
 	fooModule := python.PyImport_ImportModuleNoBlock("foo")
 	fooClass := fooModule.GetAttrString("Foo")
 	barModule := python.PyImport_ImportModuleNoBlock("bar")
 	barClass := barModule.GetAttrString("Bar")
-	gstate.unlock()
 
 	// invalid input
 	sclass, err := findSubclassOf(nil, nil)

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -26,12 +26,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestFindSubclassOf(t *testing.T) {
-	gstate := NewStickyLock()
+	gstate := newStickyLock()
 	fooModule := python.PyImport_ImportModuleNoBlock("foo")
 	fooClass := fooModule.GetAttrString("Foo")
 	barModule := python.PyImport_ImportModuleNoBlock("bar")
 	barClass := barModule.GetAttrString("Bar")
-	gstate.Unlock()
+	gstate.unlock()
 
 	// invalid input
 	sclass, err := findSubclassOf(nil, nil)

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -16,8 +16,9 @@ namespace :agent do
 
   desc "Build the agent, pass 'race=true' to invoke the race detector, 'incremental=true' to build incrementally"
   task :build do
-    # -race option
+    # `race` option
     race_opt = ENV['race'] == "true" ? "-race" : ""
+    # `incremental` option
     build_type = ENV['incremental'] == "true" ? "-i" : "-a"
 
     # Check if we should use Embedded or System Python,
@@ -30,7 +31,7 @@ namespace :agent do
     commit = `git rev-parse --short HEAD`.strip
     ldflags = "-X #{REPO_PATH}/pkg/version.commit=#{commit}"
     if ENV["WINDOWS_DELVE"]
-      # On windows, need to build with the extra arguments -gcflags "-N -l" -ldflags="-linkmode internal" 
+      # On windows, need to build with the extra arguments -gcflags "-N -l" -ldflags="-linkmode internal"
       # if you want to be able to use the delve debugger.
       system(env, "go build #{race_opt} #{build_type} -o #{BIN_PATH}/#{agent_bin_name}  -gcflags \"-N -l\" -ldflags=\"-linkmode internal\" -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/agent")
     else
@@ -84,7 +85,7 @@ namespace :agent do
       else
         system("omnibus build datadog-agent6 --log-level=#{log_level} #{overrides_cmd}")
       end
-      
+
     end
   end
 


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

The usage of `StickyLock` is still very prone to error, the PR contains two minor details to slightly improve the coding conventions that at the moment are the only way to enforce a safe GIL handling:

1. `stickyLock` is now unexported, was never meant to be used outside `py`
2. removed the locking from `findSubclassOf`, meaning you have to do that manually before calling that function. This is coherent with the rest of the code where Exported methods take care of locking while unexported utility functions require the caller to do that.

### Motivation

Consistency, even if the lack of a mechanism to enforce lock safety is still an issue.


