### PR TITLE
[py/utils] Add subprocess_output util

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -19,8 +19,8 @@ class AgentLogHandler(logging.Handler):
         msg =  self.format(record)
         datadog_agent.log("(%s:%s) | %s" % (record.filename, record.lineno, msg), record.levelno)
 
-rootLoggger = logging.getLogger()
-rootLoggger.addHandler(AgentLogHandler())
+rootLogger = logging.getLogger()
+rootLogger.addHandler(AgentLogHandler())
 
 class AgentCheck(object):
 

--- a/pkg/collector/dist/utils/platform.py
+++ b/pkg/collector/dist/utils/platform.py
@@ -1,6 +1,5 @@
 # (C) Datadog, Inc. 2010-2016
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
 import os

--- a/pkg/collector/dist/utils/subprocess_output.py
+++ b/pkg/collector/dist/utils/subprocess_output.py
@@ -1,0 +1,57 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+
+# stdlib
+from functools import wraps
+import logging
+import subprocess
+import tempfile
+
+log = logging.getLogger(__name__)
+
+
+class SubprocessOutputEmptyError(Exception):
+    pass
+
+
+def get_subprocess_output(command, log, raise_on_empty_output=True):
+    """
+    Run the given subprocess command and return its output. Raise an Exception
+    if an error occurs.
+    """
+
+    # Use tempfile, allowing a larger amount of memory. The subprocess.Popen
+    # docs warn that the data read is buffered in memory. They suggest not to
+    # use subprocess.PIPE if the data size is large or unlimited.
+    with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
+        proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
+        proc.wait()
+        stderr_f.seek(0)
+        err = stderr_f.read()
+        if err:
+            log.debug("Error while running {0} : {1}".format(" ".join(command), err))
+
+        stdout_f.seek(0)
+        output = stdout_f.read()
+
+    if not output and raise_on_empty_output:
+        raise SubprocessOutputEmptyError("get_subprocess_output expected output but had none.")
+
+    return (output, err, proc.returncode)
+
+
+def log_subprocess(func):
+    """
+    Wrapper around subprocess to log.debug commands.
+    """
+    @wraps(func)
+    def wrapper(*params, **kwargs):
+        fc = "%s(%s)" % (func.__name__, ', '.join(
+            [a.__repr__() for a in params] +
+            ["%s = %s" % (a, b) for a, b in kwargs.items()]
+        ))
+        log.debug("%s called" % fc)
+        return func(*params, **kwargs)
+    return wrapper
+
+subprocess.Popen = log_subprocess(subprocess.Popen)


### PR DESCRIPTION
### What does this PR do?

Adds `get_subprocess_output` util function, importable from py checks.

Taken as-is from the agent5, and confirmed it works in agent6.

### Motivation

Improve support of `integrations-core` checks, which use this helper quite a lot.

### Additional Notes

Since this helper doesn't rely on any core agent functionality, it
makes sense to define it as a pure python helper, at least for now.
We can revisit this later if needed.