### PR TITLE
tag dogstatsd metrics with a default hostname

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -314,7 +314,7 @@ func (agg *BufferedAggregator) run() {
 			agg.hostname = h
 			agg.mu.Lock()
 			for _, checkSampler := range agg.checkSamplers {
-				checkSampler.hostname = h
+				checkSampler.defaultHostname = h
 			}
 			agg.sampler.defaultHostname = h
 			agg.mu.Unlock()

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -105,7 +105,7 @@ func NewBufferedAggregator(f forwarder.Forwarder, hostname string) *BufferedAggr
 		checkMetricIn:      make(chan senderMetricSample, 100), // TODO make buffer size configurable
 		serviceCheckIn:     make(chan ServiceCheck, 100),       // TODO make buffer size configurable
 		eventIn:            make(chan Event, 100),              // TODO make buffer size configurable
-		sampler:            *NewTimeSampler(bucketSize),
+		sampler:            *NewTimeSampler(bucketSize, hostname),
 		checkSamplers:      make(map[check.ID]*CheckSampler),
 		flushInterval:      defaultFlushInterval,
 		forwarder:          f,
@@ -316,6 +316,7 @@ func (agg *BufferedAggregator) run() {
 			for _, checkSampler := range agg.checkSamplers {
 				checkSampler.hostname = h
 			}
+			agg.sampler.defaultHostname = h
 			agg.mu.Unlock()
 			agg.hostnameUpdateDone <- struct{}{}
 		}

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -7,7 +7,7 @@ type CheckSampler struct {
 	series          []*Serie
 	contextResolver *ContextResolver
 	metrics         ContextMetrics
-	hostname        string
+	defaultHostname string
 }
 
 // newCheckSampler returns a newly initialized CheckSample
@@ -16,7 +16,7 @@ func newCheckSampler(hostname string) *CheckSampler {
 		series:          make([]*Serie, 0),
 		contextResolver: newContextResolver(),
 		metrics:         makeContextMetrics(),
-		hostname:        hostname,
+		defaultHostname: hostname,
 	}
 }
 
@@ -32,7 +32,11 @@ func (cs *CheckSampler) commit(timestamp int64) {
 		context := cs.contextResolver.contextsByKey[serie.contextKey]
 		serie.Name = context.Name + serie.nameSuffix
 		serie.Tags = context.Tags
-		serie.Host = cs.hostname // FIXME: take into account the hostname of the context if it's specified
+		if context.Host != "" {
+			serie.Host = context.Host
+		} else {
+			serie.Host = cs.defaultHostname
+		}
 		serie.DeviceName = context.DeviceName
 
 		cs.series = append(cs.series, serie)

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -19,11 +19,13 @@ type TimeSampler struct {
 	interval           int64
 	contextResolver    *ContextResolver
 	metricsByTimestamp map[int64]ContextMetrics
+	defaultHostname    string
 }
 
 // NewTimeSampler returns a newly initialized TimeSampler
-func NewTimeSampler(interval int64) *TimeSampler {
-	return &TimeSampler{interval, newContextResolver(), map[int64]ContextMetrics{}}
+func NewTimeSampler(interval int64, defaultHostname string) *TimeSampler {
+	return &TimeSampler{interval, newContextResolver(),
+		map[int64]ContextMetrics{}, defaultHostname}
 }
 
 func (s *TimeSampler) calculateBucketStart(timestamp int64) int64 {
@@ -73,7 +75,11 @@ func (s *TimeSampler) flush(timestamp int64) []*Serie {
 				context := s.contextResolver.contextsByKey[serie.contextKey]
 				serie.Name = context.Name + serie.nameSuffix
 				serie.Tags = context.Tags
-				serie.Host = context.Host
+				if context.Host != "" {
+					serie.Host = context.Host
+				} else {
+					serie.Host = s.defaultHostname
+				}
 				serie.DeviceName = context.DeviceName
 				serie.Interval = s.interval
 

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -24,8 +24,12 @@ type TimeSampler struct {
 
 // NewTimeSampler returns a newly initialized TimeSampler
 func NewTimeSampler(interval int64, defaultHostname string) *TimeSampler {
-	return &TimeSampler{interval, newContextResolver(),
-		map[int64]ContextMetrics{}, defaultHostname}
+	return &TimeSampler{
+		interval:           interval,
+		contextResolver:    newContextResolver(),
+		metricsByTimestamp: map[int64]ContextMetrics{},
+		defaultHostname:    defaultHostname,
+	}
 }
 
 func (s *TimeSampler) calculateBucketStart(timestamp int64) int64 {

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -63,7 +63,7 @@ func (os OrderedSeries) Swap(i, j int) {
 
 // TimeSampler
 func TestCalculateBucketStart(t *testing.T) {
-	sampler := NewTimeSampler(10)
+	sampler := NewTimeSampler(10, "")
 
 	assert.Equal(t, int64(123450), sampler.calculateBucketStart(123456))
 	assert.Equal(t, int64(123460), sampler.calculateBucketStart(123460))
@@ -71,7 +71,7 @@ func TestCalculateBucketStart(t *testing.T) {
 }
 
 func TestBucketSampling(t *testing.T) {
-	sampler := NewTimeSampler(10)
+	sampler := NewTimeSampler(10, "")
 
 	mSample := MetricSample{
 		Name:       "my.metric.name",
@@ -102,7 +102,7 @@ func TestBucketSampling(t *testing.T) {
 }
 
 func TestContextSampling(t *testing.T) {
-	sampler := NewTimeSampler(10)
+	sampler := NewTimeSampler(10, "")
 
 	mSample1 := MetricSample{
 		Name:       "my.metric.name1",


### PR DESCRIPTION
### What does this PR do?

- If the incoming custom metrics have no host tag, tag them with the system's hostname (via timeSampler.defaultHostname)
- Rename checkSampler.hostname to defaultHostname for consistency, and test whether the context has a hostname before overwriting with default hostname

### Motivation

Getting dogstatsd6 ready for standalone deployment
