### PR TITLE
[dogstatsd][benchmark] adding memory metric to output + improvments.

### DIFF
--- a/pkg/util/stat.go
+++ b/pkg/util/stat.go
@@ -33,7 +33,7 @@ func NewStats(sz uint32) (*Stats, error) {
 		valExpvar:  expvar.NewInt("pktsec"),
 		last:       time.Now(),
 		incoming:   make(chan int64, sz),
-		Aggregated: make(chan Stat, 2),
+		Aggregated: make(chan Stat, 3),
 	}
 
 	return s, nil

--- a/rake/benchmarks.rb
+++ b/rake/benchmarks.rb
@@ -31,7 +31,7 @@ namespace :benchmark do
     task :run => %w[benchmark:dogstatsd:build] do
       root = `git rev-parse --show-toplevel`.strip
       bin_path = File.join(root, BENCHMARK_BIN_PATH, "dogstatsd")
-      system("#{bin_path} -pps=1000 -dur 30 -ser 5 -brk -inc 500")
+      system("#{bin_path} -pps=5000 -dur 45 -ser 5 -brk -inc 1000")
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?

Adds some basic memory metrics to the dogstatsd benchmark.

### Motivation

Memory profiling/benchmarking necessary.

### Additional Notes

Memory utilization from dogstatsd is completely constant (the entire benchmarking process, including the generator remain constant over time and runtime.memStats.Allocated lingers around the 2-2.5MB line). It is independent of the rate and the number of contexts. This PR introduces a new flag to the benchmarking utility (-rnd) that basically ensure every packet submitted is random (random tags, random metric name), the size of the actual allocated memory does not change during the benchmark execution - even during longer benchmarking runs. This is consistent with the logic. The interesting element to benchmark however will be the aggregator, as that can (and in all likelihood will) be affected by the number of contexts.