### PR TITLE
[windows] implement windows IO check

### DIFF
--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -1,16 +1,12 @@
 package system
 
 import (
-	"bytes"
 	"regexp"
-	"runtime"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	log "github.com/cihub/seelog"
-	"github.com/shirou/gopsutil/disk"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
@@ -22,165 +18,8 @@ import (
 */
 import "C"
 
-// For testing purpose
-var ioCounters = disk.IOCounters
-
-// kernel ticks / sec
-var hz int64
-
-const (
-	// SectorSize is exported in github.com/shirou/gopsutil/disk (but not working!)
-	SectorSize = 512
-	kB         = (1 << 10)
-)
-
-// IOCheck doesn't need additional fields
-type IOCheck struct {
-	sender    aggregator.Sender
-	blacklist *regexp.Regexp
-}
-
 func (c *IOCheck) String() string {
 	return "IOCheck"
-}
-
-func (c *IOCheck) nixIO() error {
-	// See: https://www.xaprb.com/blog/2010/01/09/how-linux-iostat-computes-its-results/
-	//      https://www.kernel.org/doc/Documentation/iostats.txt
-	iomap, err := ioCounters()
-	if err != nil {
-		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
-		return err
-	}
-
-	//sleep and collect again
-	time.Sleep(time.Second)
-	iomap2, err := ioCounters()
-	if err != nil {
-		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
-		return err
-	}
-
-	var tagbuff bytes.Buffer
-	for device, ioStats := range iomap {
-		if c.blacklist != nil && c.blacklist.MatchString(device) {
-			continue
-		}
-
-		ioStats2, ok := iomap2[device]
-		if !ok {
-			log.Infof("New device stats (possible hotplug) - full stats unavailable this iteration.")
-			continue
-		}
-
-		// TODO: Different OS's might not have everything - make this OSX/Windows safe
-		rs := (ioStats2.ReadCount - ioStats.ReadCount)
-		ws := (ioStats2.WriteCount - ioStats.WriteCount)
-		rkbs := float64(ioStats2.ReadBytes-ioStats.ReadBytes) / kB
-		wkbs := float64(ioStats2.WriteBytes-ioStats.WriteBytes) / kB
-		rrqms := (ioStats2.MergedReadCount - ioStats.MergedReadCount)
-		wrqms := (ioStats2.MergedWriteCount - ioStats.MergedWriteCount)
-		avgqusz := float64(ioStats2.WeightedIO-ioStats.WeightedIO) / 1000
-
-		rAwait := 0.0
-		wAwait := 0.0
-		diffNRIO := float64(ioStats2.ReadCount - ioStats.ReadCount)
-		diffNWIO := float64(ioStats2.WriteCount - ioStats.WriteCount)
-		if diffNRIO != 0 {
-			rAwait = float64(ioStats2.ReadTime-ioStats.ReadTime) / diffNRIO
-		}
-		if diffNWIO != 0 {
-			wAwait = float64(ioStats2.WriteTime-ioStats.WriteTime) / diffNWIO
-		}
-
-		avgrqsz := 0.0
-		aWait := 0.0
-		diffNIO := diffNRIO + diffNWIO
-		if diffNIO != 0 {
-			avgrqsz = float64((ioStats2.ReadBytes-ioStats.ReadBytes+ioStats2.WriteBytes-ioStats.WriteBytes)/SectorSize) / diffNIO
-			aWait = float64(ioStats2.ReadTime-ioStats.ReadTime+ioStats2.WriteTime-ioStats.WriteTime) / diffNIO
-		}
-
-		tput := diffNIO * float64(hz)
-		util := float64(ioStats2.IoTime - ioStats.IoTime)
-		svctime := 0.0
-		if tput != 0 {
-			svctime = util / tput
-		}
-
-		tagbuff.Reset()
-		tagbuff.WriteString("device:")
-		tagbuff.WriteString(device)
-		tags := []string{tagbuff.String()}
-
-		c.sender.Gauge("system.io.r_s", float64(rs), "", tags)
-		c.sender.Gauge("system.io.w_s", float64(ws), "", tags)
-		c.sender.Gauge("system.io.rkb_s", rkbs, "", tags)
-		c.sender.Gauge("system.io.wkb_s", wkbs, "", tags)
-		c.sender.Gauge("system.io.avg_rq_sz", avgrqsz, "", tags)
-		c.sender.Gauge("system.io.await", aWait, "", tags)
-		c.sender.Gauge("system.io.r_await", float64(rAwait), "", tags)
-		c.sender.Gauge("system.io.w_await", float64(wAwait), "", tags)
-		c.sender.Gauge("system.io.rrqm_s", float64(rrqms), "", tags)
-		c.sender.Gauge("system.io.wrqm_s", float64(wrqms), "", tags)
-		c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
-		if hz > 0 { // only send if we were able to collect HZ
-			c.sender.Gauge("system.io.svctm", svctime, "", tags)
-		}
-
-		// Stats should be per device no device groups.
-		// If device groups ever become a thing - util / 10.0 / n_devs_in_group
-		// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
-		c.sender.Gauge("system.io.util", (util / 10.0), "", tags)
-
-	}
-
-	return nil
-}
-
-func (c *IOCheck) windowsIO() error {
-	iomap, err := ioCounters()
-	if err != nil {
-		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
-		return err
-	}
-
-	var tagbuff bytes.Buffer
-	for device, ioStats := range iomap {
-		if c.blacklist != nil && c.blacklist.MatchString(device) {
-			continue
-		}
-
-		tagbuff.Reset()
-		tagbuff.WriteString("device:")
-		tagbuff.WriteString(device)
-		tags := []string{tagbuff.String()}
-
-		c.sender.Gauge("system.io.r_s", float64(ioStats.ReadCount), "", tags)
-		c.sender.Gauge("system.io.w_s", float64(ioStats.WriteCount), "", tags)
-		c.sender.Gauge("system.io.rkb_s", float64(ioStats.ReadBytes)/kB, "", tags)
-		c.sender.Gauge("system.io.wkb_s", float64(ioStats.WriteBytes)/kB, "", tags)
-		// TODO: c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
-	}
-
-	return nil
-}
-
-// Run executes the check
-func (c *IOCheck) Run() error {
-	var err error
-
-	switch os := runtime.GOOS; os {
-	case "windows":
-		err = c.windowsIO()
-	default: // Should cover Unices (Linux, OSX, FreeBSD,...)
-		err = c.nixIO()
-	}
-
-	if err == nil {
-		c.sender.Commit()
-	}
-	return err
 }
 
 // Configure the IOstats check
@@ -217,26 +56,3 @@ func (c *IOCheck) ID() check.ID {
 
 // Stop does nothing
 func (c *IOCheck) Stop() {}
-
-func ioFactory() check.Check {
-	return &IOCheck{}
-}
-
-func init() {
-	core.RegisterCheck("io", ioFactory)
-
-	var scClkTck C.long
-
-	switch os := runtime.GOOS; os {
-	case "windows":
-		hz = -1
-	default: // Should cover Unices (Linux, OSX, FreeBSD,...)
-		scClkTck = C.sysconf(C._SC_CLK_TCK)
-		hz = int64(scClkTck)
-	}
-
-	if hz <= 0 {
-		log.Errorf("Unable to grab HZ: perhaps unavailable in your architecture" +
-			"(svctm will not be available)")
-	}
-}

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -16,7 +16,6 @@ import (
 /*
 #include <unistd.h>
 #include <sys/types.h>
-#include <pwd.h>
 #include <stdlib.h>
 */
 import "C"

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -68,10 +68,9 @@ func (c *IOCheck) Run() error {
 		tagbuff.WriteString("device:")
 		tagbuff.WriteString(device)
 
-		// TODO: Different OS have different fields.... account for that
+		// TODO: Different OS's might not have everything - make this OSX/Windows safe
 		// See: https://www.xaprb.com/blog/2010/01/09/how-linux-iostat-computes-its-results/
 		//      https://www.kernel.org/doc/Documentation/iostats.txt
-		// Linux
 		rrqms := (ioStats2.MergedReadCount - ioStats.MergedReadCount)
 		wrqms := (ioStats2.MergedWriteCount - ioStats.MergedWriteCount)
 		rs := (ioStats2.ReadCount - ioStats.ReadCount)

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -63,7 +63,7 @@ func (c *IOCheck) nixIO() error {
 
 	var tagbuff bytes.Buffer
 	for device, ioStats := range iomap {
-		if c.blacklist.MatchString(device) {
+		if c.blacklist != nil && c.blacklist.MatchString(device) {
 			continue
 		}
 
@@ -147,7 +147,7 @@ func (c *IOCheck) windowsIO() error {
 
 	var tagbuff bytes.Buffer
 	for device, ioStats := range iomap {
-		if c.blacklist.MatchString(device) {
+		if c.blacklist != nil && c.blacklist.MatchString(device) {
 			continue
 		}
 

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -42,37 +42,7 @@ func (c *IOCheck) String() string {
 	return "IOCheck"
 }
 
-func (c *IOCheck) nixSpecificIO(ioStats, ioStats2 *disk.IOCountersStat, tags []string) {
-	rrqms := (ioStats2.MergedReadCount - ioStats.MergedReadCount)
-	wrqms := (ioStats2.MergedWriteCount - ioStats.MergedWriteCount)
-	avgqusz := float64(ioStats2.WeightedIO-ioStats.WeightedIO) / 1000
-
-	diffNRIO := float64(ioStats2.ReadCount - ioStats.ReadCount)
-	diffNWIO := float64(ioStats2.WriteCount - ioStats.WriteCount)
-	diffNIO := diffNRIO + diffNWIO
-
-	tput := diffNIO * float64(hz)
-	util := float64(ioStats2.IoTime - ioStats.IoTime)
-	svctime := 0.0
-	if tput != 0 {
-		svctime = util / tput
-	}
-
-	c.sender.Gauge("system.io.rrqm_s", float64(rrqms), "", tags)
-	c.sender.Gauge("system.io.wrqm_s", float64(wrqms), "", tags)
-	c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
-	if hz > 0 { // only send if we were able to collect HZ
-		c.sender.Gauge("system.io.svctm", svctime, "", tags)
-	}
-
-	// Stats should be per device no device groups.
-	// If device groups ever become a thing - util / 10.0 / n_devs_in_group
-	// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
-	c.sender.Gauge("system.io.util", (util / 10.0), "", tags)
-}
-
-// Run executes the check
-func (c *IOCheck) Run() error {
+func (c *IOCheck) nixIO() error {
 	// See: https://www.xaprb.com/blog/2010/01/09/how-linux-iostat-computes-its-results/
 	//      https://www.kernel.org/doc/Documentation/iostats.txt
 	iomap, err := ioCounters()
@@ -89,6 +59,7 @@ func (c *IOCheck) Run() error {
 		return err
 	}
 
+	var tagbuff bytes.Buffer
 	for device, ioStats := range iomap {
 		ioStats2, ok := iomap2[device]
 		if !ok {
@@ -96,15 +67,14 @@ func (c *IOCheck) Run() error {
 			continue
 		}
 
-		var tagbuff bytes.Buffer
-		tagbuff.WriteString("device:")
-		tagbuff.WriteString(device)
-
 		// TODO: Different OS's might not have everything - make this OSX/Windows safe
 		rs := (ioStats2.ReadCount - ioStats.ReadCount)
 		ws := (ioStats2.WriteCount - ioStats.WriteCount)
 		rkbs := float64(ioStats2.ReadBytes-ioStats.ReadBytes) / kB
 		wkbs := float64(ioStats2.WriteBytes-ioStats.WriteBytes) / kB
+		rrqms := (ioStats2.MergedReadCount - ioStats.MergedReadCount)
+		wrqms := (ioStats2.MergedWriteCount - ioStats.MergedWriteCount)
+		avgqusz := float64(ioStats2.WeightedIO-ioStats.WeightedIO) / 1000
 
 		rAwait := 0.0
 		wAwait := 0.0
@@ -119,14 +89,24 @@ func (c *IOCheck) Run() error {
 
 		avgrqsz := 0.0
 		aWait := 0.0
-
-		diffNIO := float64(diffNRIO + diffNWIO)
+		diffNIO := diffNRIO + diffNWIO
 		if diffNIO != 0 {
 			avgrqsz = float64((ioStats2.ReadBytes-ioStats.ReadBytes+ioStats2.WriteBytes-ioStats.WriteBytes)/SectorSize) / diffNIO
 			aWait = float64(ioStats2.ReadTime-ioStats.ReadTime+ioStats2.WriteTime-ioStats.WriteTime) / diffNIO
 		}
 
+		tput := diffNIO * float64(hz)
+		util := float64(ioStats2.IoTime - ioStats.IoTime)
+		svctime := 0.0
+		if tput != 0 {
+			svctime = util / tput
+		}
+
+		tagbuff.Reset()
+		tagbuff.WriteString("device:")
+		tagbuff.WriteString(device)
 		tags := []string{tagbuff.String()}
+
 		c.sender.Gauge("system.io.r_s", float64(rs), "", tags)
 		c.sender.Gauge("system.io.w_s", float64(ws), "", tags)
 		c.sender.Gauge("system.io.rkb_s", rkbs, "", tags)
@@ -135,15 +115,62 @@ func (c *IOCheck) Run() error {
 		c.sender.Gauge("system.io.await", aWait, "", tags)
 		c.sender.Gauge("system.io.r_await", float64(rAwait), "", tags)
 		c.sender.Gauge("system.io.w_await", float64(wAwait), "", tags)
-
-		if runtime.GOOS != "windows" { //unavailable on windows
-			c.nixSpecificIO(&ioStats, &ioStats2, tags)
+		c.sender.Gauge("system.io.rrqm_s", float64(rrqms), "", tags)
+		c.sender.Gauge("system.io.wrqm_s", float64(wrqms), "", tags)
+		c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
+		if hz > 0 { // only send if we were able to collect HZ
+			c.sender.Gauge("system.io.svctm", svctime, "", tags)
 		}
 
-		c.sender.Commit()
+		// Stats should be per device no device groups.
+		// If device groups ever become a thing - util / 10.0 / n_devs_in_group
+		// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
+		c.sender.Gauge("system.io.util", (util / 10.0), "", tags)
+
 	}
 
 	return nil
+}
+
+func (c *IOCheck) windowsIO() error {
+	iomap, err := ioCounters()
+	if err != nil {
+		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
+		return err
+	}
+
+	var tagbuff bytes.Buffer
+	for device, ioStats := range iomap {
+		tagbuff.Reset()
+		tagbuff.WriteString("device:")
+		tagbuff.WriteString(device)
+		tags := []string{tagbuff.String()}
+
+		c.sender.Gauge("system.io.r_s", float64(ioStats.ReadCount), "", tags)
+		c.sender.Gauge("system.io.w_s", float64(ioStats.WriteCount), "", tags)
+		c.sender.Gauge("system.io.rkb_s", float64(ioStats.ReadBytes)/kB, "", tags)
+		c.sender.Gauge("system.io.wkb_s", float64(ioStats.WriteBytes)/kB, "", tags)
+		// TODO: c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
+	}
+
+	return nil
+}
+
+// Run executes the check
+func (c *IOCheck) Run() error {
+	var err error
+
+	switch os := runtime.GOOS; os {
+	case "windows":
+		err = c.windowsIO()
+	default: // Should cover Unices (Linux, OSX, FreeBSD,...)
+		err = c.nixIO()
+	}
+
+	if err == nil {
+		c.sender.Commit()
+	}
+	return err
 }
 
 // Configure the CPU check doesn't need configuration

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -1,0 +1,176 @@
+package system
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/disk"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+/*
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <stdlib.h>
+*/
+import "C"
+
+// For testing purpose
+var ioCounters = disk.IOCounters
+
+// kernel ticks / sec
+var hz uint64
+
+const (
+	// SectorSize is exported in github.com/shirou/gopsutil/disk (but not working!)
+	SectorSize = 512
+	kB         = 1024
+)
+
+// IOCheck doesn't need additional fields
+type IOCheck struct {
+	sender aggregator.Sender
+}
+
+func (c *IOCheck) String() string {
+	return "IOCheck"
+}
+
+// Run executes the check
+func (c *IOCheck) Run() error {
+	iomap, err := ioCounters()
+	if err != nil {
+		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
+		return err
+	}
+
+	//sleep and collect again
+	time.Sleep(time.Second)
+	iomap2, err := ioCounters()
+	if err != nil {
+		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
+		return err
+	}
+
+	for device, ioStats := range iomap {
+		ioStats2, ok := iomap2[device]
+		if !ok {
+			log.Infof("New device stats (possible hotplug) - full stats unavailable this iteration.")
+			continue
+		}
+
+		var tagbuff bytes.Buffer
+		tagbuff.WriteString("device:")
+		tagbuff.WriteString(device)
+
+		// TODO: Different OS have different fields.... account for that
+		// See: https://www.xaprb.com/blog/2010/01/09/how-linux-iostat-computes-its-results/
+		//      https://www.kernel.org/doc/Documentation/iostats.txt
+		// Linux
+		rrqms := (ioStats2.MergedReadCount - ioStats.MergedReadCount)
+		wrqms := (ioStats2.MergedWriteCount - ioStats.MergedWriteCount)
+		rs := (ioStats2.ReadCount - ioStats.ReadCount)
+		ws := (ioStats2.WriteCount - ioStats.WriteCount)
+		rkbs := float64(ioStats2.ReadBytes-ioStats.ReadBytes) / kB
+		wkbs := float64(ioStats2.WriteBytes-ioStats.WriteBytes) / kB
+		avgqusz := float64(ioStats2.WeightedIO-ioStats.WeightedIO) / 1000
+
+		rAwait := 0.0
+		wAwait := 0.0
+		diffNRIO := float64(ioStats2.ReadCount - ioStats.ReadCount)
+		diffNWIO := float64(ioStats2.WriteCount - ioStats.WriteCount)
+		if diffNRIO != 0 {
+			rAwait = float64(ioStats2.ReadTime-ioStats.ReadTime) / diffNRIO
+		}
+		if diffNWIO != 0 {
+			wAwait = float64(ioStats2.WriteTime-ioStats.WriteTime) / diffNWIO
+		}
+
+		avgrqsz := 0.0
+		await := 0.0
+		svctime := 0.0
+
+		diffNIO := float64(diffNRIO + diffNWIO)
+		if diffNIO != 0 {
+			avgrqsz = float64((ioStats2.ReadBytes-ioStats.ReadBytes+ioStats2.WriteBytes-ioStats.WriteBytes)/SectorSize) / diffNIO
+			await = float64(ioStats2.ReadTime-ioStats.ReadTime+ioStats2.WriteTime-ioStats.WriteTime) / diffNIO
+		}
+		tput := diffNIO * float64(hz)
+		util := float64(ioStats2.IoTime - ioStats.IoTime)
+		if tput != 0 {
+			svctime = util / tput
+		}
+
+		tags := []string{tagbuff.String()}
+		c.sender.Gauge("system.io.rrqm_s", float64(rrqms), "", tags)
+		c.sender.Gauge("system.io.wrqm_s", float64(wrqms), "", tags)
+		c.sender.Gauge("system.io.r_s", float64(rs), "", tags)
+		c.sender.Gauge("system.io.w_s", float64(ws), "", tags)
+		c.sender.Gauge("system.io.rkb_s", rkbs, "", tags)
+		c.sender.Gauge("system.io.wkb_s", wkbs, "", tags)
+		c.sender.Gauge("system.io.avg_rq_sz", avgrqsz, "", tags)
+		c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
+		c.sender.Gauge("system.io.await", await, "", tags)
+		c.sender.Gauge("system.io.r_await", float64(rAwait), "", tags)
+		c.sender.Gauge("system.io.w_await", float64(wAwait), "", tags)
+		c.sender.Gauge("system.io.svctm", svctime, "", tags)
+
+		// Stats should be per device no device groups.
+		// If device groups ever become a thing - util / 10.0 / n_devs_in_group
+		// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
+		c.sender.Gauge("system.io.util", (util / 10.0), "", tags)
+
+		// TODO: enable blacklist
+		c.sender.Commit()
+	}
+
+	return nil
+}
+
+// Configure the CPU check doesn't need configuration
+func (c *IOCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	return nil
+}
+
+// InitSender initializes a sender
+func (c *IOCheck) InitSender() {
+	s, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	c.sender = s
+}
+
+// Interval returns the scheduling time for the check
+func (c *IOCheck) Interval() time.Duration {
+	return check.DefaultCheckInterval
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (c *IOCheck) ID() check.ID {
+	return check.ID(c.String())
+}
+
+// Stop does nothing
+func (c *IOCheck) Stop() {}
+
+func ioFactory() check.Check {
+	return &IOCheck{}
+}
+
+func init() {
+	core.RegisterCheck("io", ioFactory)
+
+	// get the clock frequency - one time op
+	var scClkTck C.long
+	scClkTck = C.sysconf(C._SC_CLK_TCK)
+
+	hz = uint64(scClkTck)
+}

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -1,0 +1,163 @@
+// +build !windows
+
+package system
+
+import (
+	"bytes"
+	"regexp"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/disk"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+/*
+#include <unistd.h>
+#include <sys/types.h>
+#include <stdlib.h>
+*/
+import "C"
+
+// For testing purpose
+var ioCounters = disk.IOCounters
+
+// kernel ticks / sec
+var hz int64
+
+const (
+	// SectorSize is exported in github.com/shirou/gopsutil/disk (but not working!)
+	SectorSize = 512
+	kB         = (1 << 10)
+)
+
+// IOCheck doesn't need additional fields
+type IOCheck struct {
+	sender    aggregator.Sender
+	blacklist *regexp.Regexp
+}
+
+func (c *IOCheck) nixIO() error {
+	// See: https://www.xaprb.com/blog/2010/01/09/how-linux-iostat-computes-its-results/
+	//      https://www.kernel.org/doc/Documentation/iostats.txt
+	iomap, err := ioCounters()
+	if err != nil {
+		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
+		return err
+	}
+
+	//sleep and collect again
+	time.Sleep(time.Second)
+	iomap2, err := ioCounters()
+	if err != nil {
+		log.Errorf("system.IOCheck: could not retrieve io stats: %s", err)
+		return err
+	}
+
+	var tagbuff bytes.Buffer
+	for device, ioStats := range iomap {
+		if c.blacklist != nil && c.blacklist.MatchString(device) {
+			continue
+		}
+
+		ioStats2, ok := iomap2[device]
+		if !ok {
+			log.Infof("New device stats (possible hotplug) - full stats unavailable this iteration.")
+			continue
+		}
+
+		// TODO: Different OS's might not have everything - make this OSX/Windows safe
+		rs := (ioStats2.ReadCount - ioStats.ReadCount)
+		ws := (ioStats2.WriteCount - ioStats.WriteCount)
+		rkbs := float64(ioStats2.ReadBytes-ioStats.ReadBytes) / kB
+		wkbs := float64(ioStats2.WriteBytes-ioStats.WriteBytes) / kB
+		rrqms := (ioStats2.MergedReadCount - ioStats.MergedReadCount)
+		wrqms := (ioStats2.MergedWriteCount - ioStats.MergedWriteCount)
+		avgqusz := float64(ioStats2.WeightedIO-ioStats.WeightedIO) / 1000
+
+		rAwait := 0.0
+		wAwait := 0.0
+		diffNRIO := float64(ioStats2.ReadCount - ioStats.ReadCount)
+		diffNWIO := float64(ioStats2.WriteCount - ioStats.WriteCount)
+		if diffNRIO != 0 {
+			rAwait = float64(ioStats2.ReadTime-ioStats.ReadTime) / diffNRIO
+		}
+		if diffNWIO != 0 {
+			wAwait = float64(ioStats2.WriteTime-ioStats.WriteTime) / diffNWIO
+		}
+
+		avgrqsz := 0.0
+		aWait := 0.0
+		diffNIO := diffNRIO + diffNWIO
+		if diffNIO != 0 {
+			avgrqsz = float64((ioStats2.ReadBytes-ioStats.ReadBytes+ioStats2.WriteBytes-ioStats.WriteBytes)/SectorSize) / diffNIO
+			aWait = float64(ioStats2.ReadTime-ioStats.ReadTime+ioStats2.WriteTime-ioStats.WriteTime) / diffNIO
+		}
+
+		tput := diffNIO * float64(hz)
+		util := float64(ioStats2.IoTime - ioStats.IoTime)
+		svctime := 0.0
+		if tput != 0 {
+			svctime = util / tput
+		}
+
+		tagbuff.Reset()
+		tagbuff.WriteString("device:")
+		tagbuff.WriteString(device)
+		tags := []string{tagbuff.String()}
+
+		c.sender.Gauge("system.io.r_s", float64(rs), "", tags)
+		c.sender.Gauge("system.io.w_s", float64(ws), "", tags)
+		c.sender.Gauge("system.io.rkb_s", rkbs, "", tags)
+		c.sender.Gauge("system.io.wkb_s", wkbs, "", tags)
+		c.sender.Gauge("system.io.avg_rq_sz", avgrqsz, "", tags)
+		c.sender.Gauge("system.io.await", aWait, "", tags)
+		c.sender.Gauge("system.io.r_await", float64(rAwait), "", tags)
+		c.sender.Gauge("system.io.w_await", float64(wAwait), "", tags)
+		c.sender.Gauge("system.io.rrqm_s", float64(rrqms), "", tags)
+		c.sender.Gauge("system.io.wrqm_s", float64(wrqms), "", tags)
+		c.sender.Gauge("system.io.avg_q_sz", avgqusz, "", tags)
+		if hz > 0 { // only send if we were able to collect HZ
+			c.sender.Gauge("system.io.svctm", svctime, "", tags)
+		}
+
+		// Stats should be per device no device groups.
+		// If device groups ever become a thing - util / 10.0 / n_devs_in_group
+		// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
+		c.sender.Gauge("system.io.util", (util / 10.0), "", tags)
+
+	}
+
+	return nil
+}
+
+// Run executes the check
+func (c *IOCheck) Run() error {
+	var err error
+	err = c.nixIO()
+
+	if err == nil {
+		c.sender.Commit()
+	}
+	return err
+}
+
+func init() {
+	core.RegisterCheck("io", ioFactory)
+	var scClkTck C.long
+
+	scClkTck = C.sysconf(C._SC_CLK_TCK)
+	hz = int64(scClkTck)
+
+	if hz <= 0 {
+		log.Errorf("Unable to grab HZ: perhaps unavailable in your architecture" +
+			"(svctm will not be available)")
+	}
+}
+
+func ioFactory() check.Check {
+	return &IOCheck{}
+}

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -78,6 +78,6 @@ func TestIOCheckLinux(t *testing.T) {
 
 	ioCheck.Run()
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 6)
+	mock.AssertNumberOfCalls(t, "Gauge", 13)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -62,24 +62,30 @@ func TestIOCheckLinux(t *testing.T) {
 	mock := new(MockSender)
 	ioCheck.sender = mock
 
-	mock.On("Gauge", "system.io.r_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.w_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.rkb_s", 60.5, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.wkb_s", 37.5, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.avg_rq_sz", 0.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.await", 0.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.r_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
-	mock.On("Gauge", "system.io.w_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
-
-	expectedCalls := 8
-	if runtime.GOOS != "windows" {
+	expectedCalls := 4
+	switch os := runtime.GOOS; os {
+	case "windows":
+		mock.On("Gauge", "system.io.r_s", 443071.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.w_s", 10412454.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.rkb_s", float64(849293*SectorSize), "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.wkb_s", float64(1406995*SectorSize), "", []string{"device:sda"}).Return().Times(1)
+	default: // Should cover Unices (Linux, OSX, FreeBSD,...)
+		mock.On("Gauge", "system.io.r_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.w_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.rkb_s", 60.5, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.wkb_s", 37.5, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.avg_rq_sz", 0.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.await", 0.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.r_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.w_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.rrqm_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.wrqm_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.avg_q_sz", 0.028, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.util", 2.8, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.svctm", 0.0, "", []string{"device:sda"}).Return().Times(1)
-		expectedCalls = expectedCalls + 5
+		expectedCalls += 9
 	}
+
 	mock.On("Commit").Return().Times(1)
 
 	ioCheck.Run()

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -1,0 +1,83 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/disk"
+)
+
+var (
+	ioSamples = []map[string]disk.IOCountersStat{
+		map[string]disk.IOCountersStat{
+			"sda": disk.IOCountersStat{
+				ReadCount:        443071,
+				MergedReadCount:  104744,
+				WriteCount:       10412454,
+				MergedWriteCount: 310860,
+				ReadBytes:        849293 * SectorSize,
+				WriteBytes:       1406995 * SectorSize,
+				ReadTime:         19699308,
+				WriteTime:        418600,
+				IopsInProgress:   0,
+				IoTime:           343324,
+				WeightedIO:       727464,
+				Name:             "sda",
+				SerialNumber:     "123456789WD",
+			},
+		}, map[string]disk.IOCountersStat{
+			"sda": disk.IOCountersStat{
+				ReadCount:        443071,
+				MergedReadCount:  104744,
+				WriteCount:       10412454,
+				MergedWriteCount: 310860,
+				ReadBytes:        849414 * SectorSize,
+				WriteBytes:       1407070 * SectorSize,
+				ReadTime:         19700964,
+				WriteTime:        418628,
+				IopsInProgress:   0,
+				IoTime:           343352,
+				WeightedIO:       727492,
+				Name:             "sda",
+				SerialNumber:     "123456789WD",
+			},
+		},
+	}
+)
+
+var sampleIdx = 0
+
+func ioSampler() (map[string]disk.IOCountersStat, error) {
+	idx := sampleIdx
+	sampleIdx = sampleIdx + 1
+	sampleIdx = sampleIdx % len(ioSamples)
+	return ioSamples[idx], nil
+}
+
+func TestIOCheckLinux(t *testing.T) {
+	ioCounters = ioSampler
+	ioCheck := new(IOCheck)
+	ioCheck.Configure(nil, nil)
+
+	mock := new(MockSender)
+	ioCheck.sender = mock
+
+	mock.On("Gauge", "system.io.rrqm_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wrqm_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 60.5, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 37.5, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_rq_sz", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 0.028, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.await", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.util", 2.8, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Gauge", "system.io.svctm", 0.0, "", []string{"device:sda"}).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+
+	ioCheck.Run()
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 6)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/pkg/collector/corechecks/system/iostats_windows.go
+++ b/pkg/collector/corechecks/system/iostats_windows.go
@@ -1,0 +1,244 @@
+package system
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	log "github.com/cihub/seelog"
+)
+
+// PDH defines copied from winPDH.
+
+// PDH_FMT_COUNTERVALUE_DOUBLE for double values
+type PDH_FMT_COUNTERVALUE_DOUBLE struct {
+	CStatus     uint32
+	DoubleValue float64
+}
+
+// PDH_FMT_COUNTERVALUE_DOUBLE for 64 bit integer values
+type PDH_FMT_COUNTERVALUE_LARGE struct {
+	CStatus    uint32
+	LargeValue int64
+}
+
+// PDH_FMT_COUNTERVALUE_DOUBLE for long values
+type PDH_FMT_COUNTERVALUE_LONG struct {
+	CStatus   uint32
+	LongValue int32
+	padding   [4]byte
+}
+
+// windows system const
+const (
+	ERROR_SUCCESS        = 0
+	ERROR_FILE_NOT_FOUND = 2
+	DRIVE_REMOVABLE      = 2
+	DRIVE_FIXED          = 3
+	HKEY_LOCAL_MACHINE   = 0x80000002
+	RRF_RT_REG_SZ        = 0x00000002
+	RRF_RT_REG_DWORD     = 0x00000010
+	PDH_FMT_LONG         = 0x00000100
+	PDH_FMT_DOUBLE       = 0x00000200
+	PDH_FMT_LARGE        = 0x00000400
+	PDH_INVALID_DATA     = 0xc0000bc6
+	PDH_INVALID_HANDLE   = 0xC0000bbc
+	PDH_NO_DATA          = 0x800007d5
+)
+
+var (
+	Modkernel32 = syscall.NewLazyDLL("kernel32.dll")
+	ModNt       = syscall.NewLazyDLL("ntdll.dll")
+	ModPdh      = syscall.NewLazyDLL("pdh.dll")
+
+	ProcGetSystemTimes           = Modkernel32.NewProc("GetSystemTimes")
+	ProcNtQuerySystemInformation = ModNt.NewProc("NtQuerySystemInformation")
+	ProcGetLogicalDriveStringsW  = Modkernel32.NewProc("GetLogicalDriveStringsW")
+	ProcGetDriveType             = Modkernel32.NewProc("GetDriveTypeW")
+	PdhOpenQuery                 = ModPdh.NewProc("PdhOpenQuery")
+	PdhAddCounter                = ModPdh.NewProc("PdhAddCounterW")
+	PdhCollectQueryData          = ModPdh.NewProc("PdhCollectQueryData")
+	PdhGetFormattedCounterValue  = ModPdh.NewProc("PdhGetFormattedCounterValue")
+	PdhCloseQuery                = ModPdh.NewProc("PdhCloseQuery")
+)
+
+type FILETIME struct {
+	DwLowDateTime  uint32
+	DwHighDateTime uint32
+}
+
+// borrowed from net/interface_windows.go
+func BytePtrToString(p *uint8) string {
+	a := (*[10000]uint8)(unsafe.Pointer(p))
+	i := 0
+	for a[i] != 0 {
+		i++
+	}
+	return string(a[:i])
+}
+
+// CounterInfo
+// copied from https://github.com/mackerelio/mackerel-agent/
+type CounterInfo struct {
+	PostName    string
+	CounterName string
+	Counter     syscall.Handle
+}
+
+// CreateQuery XXX
+// copied from https://github.com/mackerelio/mackerel-agent/
+func CreateQuery() (syscall.Handle, error) {
+	var query syscall.Handle
+	r, _, err := PdhOpenQuery.Call(0, 0, uintptr(unsafe.Pointer(&query)))
+	if r != 0 {
+		return 0, err
+	}
+	return query, nil
+}
+
+// CreateCounter XXX
+func CreateCounter(query syscall.Handle, pname, cname string) (*CounterInfo, error) {
+	var counter syscall.Handle
+	r, _, err := PdhAddCounter.Call(
+		uintptr(query),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(cname))),
+		0,
+		uintptr(unsafe.Pointer(&counter)))
+	if r != 0 {
+		return nil, err
+	}
+	return &CounterInfo{
+		PostName:    pname,
+		CounterName: cname,
+		Counter:     counter,
+	}, nil
+}
+
+const (
+	// SectorSize is exported in github.com/shirou/gopsutil/disk (but not working!)
+	SectorSize = 512
+	kB         = (1 << 10)
+)
+
+// IOCheck doesn't need additional fields
+type IOCheck struct {
+	sender    aggregator.Sender
+	blacklist *regexp.Regexp
+	query     syscall.Handle
+	drivemap  map[string][]*CounterInfo
+}
+
+func init() {
+	core.RegisterCheck("io", ioFactory)
+}
+
+var metrics = map[string]string{
+	"system.io.wkb_s":    "Disk Write Bytes/sec",
+	"system.io.w_s":      "Disk Writes/sec",
+	"system.io.rkb_s":    "Disk Read Bytes/sec",
+	"system.io.r_s":      "Disk Reads/sec",
+	"system.io.avg_q_sz": "Current Disk Queue Length",
+}
+
+func ioFactory() check.Check {
+	log.Infof("IOCheck factory")
+	c := &IOCheck{}
+	q, err := CreateQuery()
+	if err != nil {
+		log.Errorf("IO factory failed to create query")
+		return nil
+	}
+	c.query = q
+	c.drivemap = make(map[string][]*CounterInfo, 0)
+
+	drivebuf := make([]byte, 256)
+
+	r, _, err := ProcGetLogicalDriveStringsW.Call(
+		uintptr(len(drivebuf)),
+		uintptr(unsafe.Pointer(&drivebuf[0])))
+	if r == 0 {
+		log.Errorf("IO Factory failed to get drive strings")
+		return nil
+	}
+	for _, v := range drivebuf {
+		// between 'A' & 'Z'
+		if v >= 65 && v <= 90 {
+			drive := string(v)
+			r, _, err = ProcGetDriveType.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(drive + `:\`))))
+			if r != DRIVE_FIXED {
+				continue
+			}
+			c.drivemap[drive] = make([]*CounterInfo, 0, len(metrics))
+			for k, m := range metrics {
+				var counter *CounterInfo
+				countername := fmt.Sprintf(`\PhysicalDisk(0 %s:)\%s`, drive, m)
+				counter, err = CreateCounter(c.query, k, countername)
+				if err != nil {
+					log.Errorf("Failed to create counter %s %d", countername, err)
+					continue
+				} else {
+					log.Infof("Created counter name %s", countername)
+				}
+				c.drivemap[drive] = append(c.drivemap[drive], counter)
+			}
+		}
+	}
+	log.Infof("IO Factory -- success")
+	return c
+}
+
+// Run executes the check
+func (c *IOCheck) Run() error {
+	log.Infof("Running IO Check")
+	var err error
+
+	r, _, err := PdhCollectQueryData.Call(uintptr(c.query))
+	if r != 0 && err != nil {
+		return err
+	}
+	time.Sleep(time.Second)
+	r, _, err = PdhCollectQueryData.Call(uintptr(c.query))
+	if r != 0 && err != nil {
+		return err
+	}
+	var tagbuff bytes.Buffer
+	for drive, counters := range c.drivemap {
+		log.Infof("checking drive %s against blacklist", drive)
+		if c.blacklist != nil && c.blacklist.MatchString(drive) {
+			continue
+		}
+
+		tagbuff.Reset()
+		tagbuff.WriteString("device:")
+		tagbuff.WriteString(drive)
+		tags := []string{tagbuff.String()}
+		log.Infof("counters map is size %d", len(counters))
+		for _, v := range counters {
+			log.Infof("Checking counter %s", v.PostName)
+			var fmtValue PDH_FMT_COUNTERVALUE_LARGE
+			r, _, err := PdhGetFormattedCounterValue.Call(uintptr(v.Counter),
+				PDH_FMT_LARGE,
+				uintptr(0),
+				uintptr(unsafe.Pointer(&fmtValue)))
+			if r != 0 && err != nil {
+				log.Warnf("GetFormattedCounterValue %d %d", r, err)
+				return err
+			}
+			val := fmtValue.LargeValue
+			if v.PostName == "system.io.wkb_s" ||
+				v.PostName == "system.io.rkb_s" {
+				val = val / 1024
+			}
+			log.Infof("Setting Gauge %s %f %s", v.PostName, float64(val), tags)
+			c.sender.Gauge(v.PostName, float64(val), "", tags)
+		}
+	}
+	c.sender.Commit()
+	return nil
+}

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -1,0 +1,92 @@
+package system
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/load"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+// For testing purpose
+var loadAvg = load.Avg
+
+// LoadCheck doesn't need additional fields
+type LoadCheck struct {
+	sender aggregator.Sender
+	nbCPU  int32
+}
+
+func (c *LoadCheck) String() string {
+	return "LoadCheck"
+}
+
+// Run executes the check
+func (c *LoadCheck) Run() error {
+	avg, err := loadAvg()
+	if err != nil {
+		log.Errorf("system.LoadCheck: could not retrieve load stats: %s", err)
+		return err
+	}
+
+	c.sender.Gauge("system.load.1", avg.Load1, "", nil)
+	c.sender.Gauge("system.load.5", avg.Load5, "", nil)
+	c.sender.Gauge("system.load.15", avg.Load15, "", nil)
+	cpus := float64(c.nbCPU)
+	c.sender.Gauge("system.load.norm.1", avg.Load1/cpus, "", nil)
+	c.sender.Gauge("system.load.norm.5", avg.Load5/cpus, "", nil)
+	c.sender.Gauge("system.load.norm.15", avg.Load15/cpus, "", nil)
+	c.sender.Commit()
+
+	fmt.Printf("THIS CHECK DID RUN!")
+	return nil
+}
+
+// Configure the CPU check doesn't need configuration
+func (c *LoadCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	// do nothing
+	info, err := cpuInfo()
+	if err != nil {
+		return fmt.Errorf("system.LoadCheck: could not query CPU info")
+	}
+	for _, i := range info {
+		c.nbCPU += i.Cores
+	}
+	return nil
+}
+
+// InitSender initializes a sender
+func (c *LoadCheck) InitSender() {
+	s, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	c.sender = s
+}
+
+// Interval returns the scheduling time for the check
+func (c *LoadCheck) Interval() time.Duration {
+	return check.DefaultCheckInterval
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (c *LoadCheck) ID() check.ID {
+	return check.ID(c.String())
+}
+
+// Stop does nothing
+func (c *LoadCheck) Stop() {}
+
+func loadFactory() check.Check {
+	return &LoadCheck{}
+}
+
+func init() {
+	core.RegisterCheck("load", loadFactory)
+}

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -42,7 +42,6 @@ func (c *LoadCheck) Run() error {
 	c.sender.Gauge("system.load.norm.15", avg.Load15/cpus, "", nil)
 	c.sender.Commit()
 
-	fmt.Printf("THIS CHECK DID RUN!")
 	return nil
 }
 

--- a/pkg/collector/corechecks/system/load_test.go
+++ b/pkg/collector/corechecks/system/load_test.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/shirou/gopsutil/load"
+)
+
+var (
+	avgSample = load.AvgStat{
+		Load1:  0.83,
+		Load5:  0.96,
+		Load15: 1.15,
+	}
+)
+
+func Avg() (*load.AvgStat, error) {
+	return &avgSample, nil
+}
+
+func TestLoadCheckLinux(t *testing.T) {
+	loadAvg = Avg
+	cpuInfo = CPUInfo
+	loadCheck := new(LoadCheck)
+	loadCheck.Configure(nil, nil)
+
+	mock := new(MockSender)
+	loadCheck.sender = mock
+
+	var nbCPU float64
+	info, _ := cpuInfo()
+	for _, i := range info {
+		nbCPU += float64(i.Cores)
+	}
+
+	mock.On("Gauge", "system.load.1", 0.83, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.load.5", 0.96, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.load.15", 1.15, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.load.norm.1", 0.83/nbCPU, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.load.norm.5", 0.96/nbCPU, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.load.norm.15", 1.15/nbCPU, "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+	loadCheck.Run()
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 6)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -1,0 +1,76 @@
+package system
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/host"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+// For testing purpose
+var uptime = host.Uptime
+
+// UptimeCheck doesn't need additional fields
+type UptimeCheck struct {
+	sender aggregator.Sender
+}
+
+func (c *UptimeCheck) String() string {
+	return "UptimeCheck"
+}
+
+// Run executes the check
+func (c *UptimeCheck) Run() error {
+	t, err := uptime()
+	if err != nil {
+		log.Errorf("system.UptimeCheck: could not retrieve uptime: %s", err)
+		return err
+	}
+
+	c.sender.Gauge("system.uptime", float64(t), "", nil)
+	c.sender.Commit()
+
+	return nil
+}
+
+// Configure the CPU check doesn't need configuration
+func (c *UptimeCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	// do nothing
+	return nil
+}
+
+// InitSender initializes a sender
+func (c *UptimeCheck) InitSender() {
+	s, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	c.sender = s
+}
+
+// Interval returns the scheduling time for the check
+func (c *UptimeCheck) Interval() time.Duration {
+	return check.DefaultCheckInterval
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (c *UptimeCheck) ID() check.ID {
+	return check.ID(c.String())
+}
+
+// Stop does nothing
+func (c *UptimeCheck) Stop() {}
+
+func uptimeFactory() check.Check {
+	return &UptimeCheck{}
+}
+
+func init() {
+	core.RegisterCheck("uptime", uptimeFactory)
+}

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"testing"
+)
+
+func uptimeSampler() (uint64, error) {
+	return 555, nil
+}
+
+func TestUptimeCheckLinux(t *testing.T) {
+	uptime = uptimeSampler
+	uptimeCheck := new(UptimeCheck)
+	uptimeCheck.Configure(nil, nil)
+
+	mock := new(MockSender)
+	uptimeCheck.sender = mock
+
+	mock.On("Gauge", "system.uptime", 555.0, "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+
+	uptimeCheck.Run()
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 1)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ func init() {
 	Datadog.SetDefault("hostname", "")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
+	Datadog.SetDefault("device_blacklist_re", "")
 	Datadog.SetDefault("use_dogstatsd", true)
 	Datadog.SetDefault("dogstatsd_port", 8125)
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer


### PR DESCRIPTION
Implements windows I/O check.

Uses WinPDH rather than gopsutil, because gopsutil doesn't return the statistics we're interested in.
Needs additional testing to verify that the metrics are the metrics we're expecting.

As implemented, at least on Windows, check named "io" still conflicts with the python "io" library.

This change is built upon https://github.com/DataDog/datadog-agent/pull/264