### PR TITLE
Metadata collection refactoring

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -103,12 +103,11 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, forwarder.Forwarder) 
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 	// setup the metadata collector, this needs a working Python env to function
-	var metaCollector *metadata.Collector
+	metaCollector := metadata.NewCollector(fwd, config.Datadog.GetString("api_key"), hostname)
 	var C []config.MetadataProviders
 	err = config.Datadog.UnmarshalKey("metadata_providers", &C)
 	if err == nil {
-		metaCollector = metadata.NewCollector(fwd, config.Datadog.GetString("api_key"), hostname)
-		log.Debugf("metaCollector created, adding providers")
+		log.Debugf("Adding configured providers to the metadata collector")
 		for _, c := range C {
 			if c.Name == "host" {
 				continue

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -38,6 +38,8 @@ var (
 	confFilePath string
 )
 
+const hostMetadataCollectorInterval = 14400
+
 // StartAgent Initializes the agent process
 func StartAgent() (*dogstatsd.Server, *metadata.Collector, forwarder.Forwarder) {
 
@@ -106,7 +108,12 @@ func StartAgent() (*dogstatsd.Server, *metadata.Collector, forwarder.Forwarder) 
 	if err == nil {
 		metaCollector = metadata.NewCollector(fwd, config.Datadog.GetString("api_key"), hostname)
 		log.Debugf("metaCollector created, adding providers")
+		// add the host metadata collector, this is not user-configurable by design
+		err = metaCollector.AddProvider("host", hostMetadataCollectorInterval)
 		for _, c := range C {
+			if c.Name == "host" {
+				continue
+			}
 			intl := c.Interval * time.Second
 			err = metaCollector.AddProvider(c.Name, intl)
 			if err != nil {

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -17,10 +17,10 @@ api_key:
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 
-# Metadata providers, add or remove from the list to enable or disable collection.
-# The host metadata provider cannot be configured and is enabled by default.
+# Metadata collectors, add or remove from the list to enable or disable collection.
+# The host metadata collector cannot be configured and is enabled by default.
 # Intervals are expressed in seconds.
-metadata_providers:
+metadata_collectors:
   - name: 'resources'
     interval: 60
 #  - name: k8s

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -17,6 +17,16 @@ api_key:
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 
+# Metadata providers, add or remove from the list to enable or disable collection.
+# Intervals are expressed in seconds.
+metadata_providers:
+  - name: 'host'
+    interval: 14400
+  - name: 'resources'
+    interval: 60
+#  - name: k8s
+#    interval: 60
+
 # ========================================================================== #
 # DogStatsd configuration                                                    #
 # ========================================================================== #
@@ -38,5 +48,4 @@ api_key:
 # ========================================================================== #
 
 # log_level: info
-
 # log_file: /var/log/datadog/agent.log

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -18,10 +18,9 @@ api_key:
 # hostname: mymachine.mydomain
 
 # Metadata providers, add or remove from the list to enable or disable collection.
+# The host metadata provider cannot be configured and is enabled by default.
 # Intervals are expressed in seconds.
 metadata_providers:
-  - name: 'host'
-    interval: 14400
   - name: 'resources'
     interval: 60
 #  - name: k8s

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,19 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"time"
+
+	"github.com/spf13/viper"
+)
 
 // Datadog is the global configuration object
 var Datadog = viper.New()
+
+// MetadataProviders helps unmarshalling `metadata_providers` config param
+type MetadataProviders struct {
+	Name     string        `mapstructure:"name"`
+	Interval time.Duration `mapstructure:"interval"`
+}
 
 func init() {
 	// config identifiers

--- a/pkg/metadata/README.md
+++ b/pkg/metadata/README.md
@@ -1,16 +1,27 @@
 ## package `metadata`
 
 This package is responsible to provide metadata in the right form to be directly sent to the backend.
-Single metadata providers are defined in the form of insulated sub packages that should expose a public
+
+### Providers
+Single metadata providers are defined in the form of insulated sub packages exposing a public
 method like:
 ```go
 func GetPayload() *Payload
 ```
-along with the specific `Payload` definition.
+along with their specific `Payload` definition. Payload formats can be different, that's why metadata
+providers are not implemented as interfaces. These components should be loosely coupled with the rest
+of the Agent, this way they can be used as independent go packages in different projects and different
+environments.
 
-For the time being, any subpackage provides a piece of information that is used in the `v5` package to
-compose a single metadata payload compatible with the one from Agent v.5. This way we can send
-metadata through the current backend endpoints, waiting for the new ones to be deployed. At that point,
-all the subpackages will be required to define their payloads with the new Protobuf format.
+### Collectors
+Collectors are used by the Agent and are supposed to be run periodically. They are
+responsible to invoke the configured `Provider`s, collect all the info needed, fill the appropriate
+payload and send it to the specific endpoint in the intake. Collectors are allowed to be strongly coupled
+to the rest of the Agent components because they're not supposed to be used elsewhere.
 
-Please keep this README updated.
+**Notice:** For the time being, several providers collect a piece of information that is used in
+the `v5` package to compose a single metadata payload compatible with the one from Agent v.5.
+This way we can send metadata through the current backend endpoints
+(see `HostCollector` and `ResourcesCollector`), waiting for the new ones to be deployed.
+At that point, all the subpackages will be required to define a payload with either the new Protobuf format
+or a custom JSON compatible with the v2 intake API.

--- a/pkg/metadata/README.md
+++ b/pkg/metadata/README.md
@@ -1,6 +1,8 @@
 ## package `metadata`
 
 This package is responsible to provide metadata in the right form to be directly sent to the backend.
+Metadata collection is iterated during Agent execution at different time intervals for different
+use cases.
 
 ### Providers
 Single metadata providers are defined in the form of insulated sub packages exposing a public
@@ -15,9 +17,11 @@ environments.
 
 ### Collectors
 Collectors are used by the Agent and are supposed to be run periodically. They are
-responsible to invoke the configured `Provider`s, collect all the info needed, fill the appropriate
+responsible to invoke the relevant `Provider`, collect all the info needed, fill the appropriate
 payload and send it to the specific endpoint in the intake. Collectors are allowed to be strongly coupled
 to the rest of the Agent components because they're not supposed to be used elsewhere.
+Collectors can be user configurable, except for the `host` metadata collector that is always scheduled
+with a default interval.
 
 **Notice:** For the time being, several providers collect a piece of information that is used in
 the `v5` package to compose a single metadata payload compatible with the one from Agent v.5.

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -1,0 +1,44 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	log "github.com/cihub/seelog"
+)
+
+// HostCollector fills and sends the old metadata payload used in the
+// Agent v5
+type HostCollector struct{}
+
+// Send collects the data needed and submits the payload
+func (hp *HostCollector) Send(apiKey string, fwd forwarder.Forwarder) error {
+	var hostname string
+	x, found := util.Cache.Get("hostname")
+	if found {
+		hostname = x.(string)
+	}
+
+	payload := v5.GetPayload(hostname)
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("unable to serialize host metadata payload, %s", err)
+	}
+
+	err = fwd.SubmitV1Intake(apiKey, &payloadBytes)
+	if err != nil {
+		return fmt.Errorf("unable to submit host metadata payload to the forwarder, %s", err)
+	}
+
+	log.Infof("Sent host metadata payload, size: %d bytes.", len(payloadBytes))
+	log.Debugf("Sent host metadata payload, content: %v", string(payloadBytes))
+
+	return nil
+}
+
+func init() {
+	catalog["host"] = new(HostCollector)
+}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// Catalog keeps track of Go checks by name
+// Catalog keeps track of metadata collectors by name
 var catalog = make(map[string]Provider)
 
 func init() {

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -26,10 +26,6 @@ func TestNewCollector(t *testing.T) {
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
 	c := NewCollector(fwd, "apikey", "hostname")
-	assert.NotNil(t, c.sendHostT)
-	assert.NotNil(t, c.sendExtHostT)
-	assert.NotNil(t, c.sendAgentCheckT)
-	assert.NotNil(t, c.sendProcessesT)
 	assert.Equal(t, "apikey", c.apikey)
 	assert.Equal(t, "hostname", c.hostname)
 }

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -1,0 +1,47 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	log "github.com/cihub/seelog"
+)
+
+// ResourcesCollector sends the old metadata payload used in the
+// Agent v5
+type ResourcesCollector struct{}
+
+// Send collects the data needed and submits the payload
+func (rp *ResourcesCollector) Send(apiKey string, fwd forwarder.Forwarder) error {
+	var hostname string
+	x, found := util.Cache.Get("hostname")
+	if found {
+		hostname = x.(string)
+	}
+
+	payload := map[string]interface{}{
+		"resources": resources.GetPayload(hostname),
+	}
+	payloadBytes, err := json.Marshal(payload)
+
+	if err != nil {
+		return fmt.Errorf("unable to serialize processes metadata payload, %s", err)
+	}
+
+	err = fwd.SubmitV1Intake(apiKey, &payloadBytes)
+	if err != nil {
+		return fmt.Errorf("unable to submit processes metadata payload to the forwarder, %s", err)
+	}
+
+	log.Infof("Sent processes metadata payload, size: %d bytes.", len(payloadBytes))
+	log.Debugf("Sent processes metadata payload, content: %v", string(payloadBytes))
+
+	return nil
+}
+
+func init() {
+	catalog["resources"] = new(ResourcesCollector)
+}

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -22,10 +22,10 @@ func TestMain(m *testing.M) {
 	os.Exit(ret)
 }
 
-func TestNewCollector(t *testing.T) {
+func TestNewScheduler(t *testing.T) {
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
-	c := NewCollector(fwd, "apikey", "hostname")
+	c := NewScheduler(fwd, "apikey", "hostname")
 	assert.Equal(t, "apikey", c.apikey)
 	assert.Equal(t, "hostname", c.hostname)
 }

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -2,8 +2,9 @@ package metadata
 
 import "github.com/DataDog/datadog-agent/pkg/forwarder"
 
-// Provider is anything capable to collect and send metadata payloads
-// through the forwarder
-type Provider interface {
+// Collector is anything capable to collect and send metadata payloads
+// through the forwarder.
+// A Metadata Collector normally uses a Metadata Provider to fill the payload.
+type Collector interface {
 	Send(apiKey string, fwd forwarder.Forwarder) error
 }

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -1,0 +1,9 @@
+package metadata
+
+import "github.com/DataDog/datadog-agent/pkg/forwarder"
+
+// Provider is anything capable to collect and send metadata payloads
+// through the forwarder
+type Provider interface {
+	Send(apiKey string, fwd forwarder.Forwarder) error
+}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

This is a rewrite of the Metadata collection, it was somehow on the todo list given the naive approach we used for the first draft.

This PR introduces the concept of `Metadata Collector` along with the existing `Metadata Provider`.

### Motivation

The agent codebase is going to be used in different environments other than the Agent itself and this applies also to Metadata Providers (see #270). To be able to import a Metadata Provider as a regular Go package from different projects we need to keep it loosely coupled to the rest of the agent in order to minimize dependencies. The drawback is we need something else responsible to actually send the metadata payload to the intake, thus the need of `Metadata Collectors`. 

**TL;DR** description of the requirements:

 * A Metadata Provider is responsible to define a payload and gather the informations needed to fill it (this is non-agent specific).
 * A Metadata Collector is responsible to periodically invoke one or more Providers, build and send the payload to the proper endpoint in the intake API.

### Additional Notes

This is a first step, once merged I'll break down the `host` metadata package so it can be used without an embedded CPython interpreter (this is needed to avoid bloating Dogstatsd, where we need host metadata without the Python info).
