### PR TITLE
[deps] Bump version of agent-payload to get Kube metadata format.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -12,7 +12,7 @@ imports:
   - pkg/pathutil
   - pkg/types
 - name: github.com/DataDog/agent-payload
-  version: d185e425fded4bdda8495d072e811a686d8ef20d
+  version: 164709ae846c628091e670009226c2874fa36c1e
   subpackages:
   - go
 - name: github.com/DataDog/datadog-go


### PR DESCRIPTION
### What does this PR do?

Update the version of the agent-payload package for the changes in https://github.com/DataDog/datadog-agent/pull/270.

### Motivation

Fixing a dependency in the merged PR. Oops!
