### PR TITLE
Rename CheckRuns to ServiceChecks in aggregator.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -12,7 +12,7 @@ imports:
   - pkg/pathutil
   - pkg/types
 - name: github.com/DataDog/agent-payload
-  version: d185e425fded4bdda8495d072e811a686d8ef20d
+  version: 164709ae846c628091e670009226c2874fa36c1e
   subpackages:
   - go
 - name: github.com/DataDog/datadog-go

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -44,14 +44,14 @@ func MarshalSeries(series []*Serie) ([]byte, error) {
 
 // MarshalServiceChecks serialize check runs payload using agent-payload definition
 func MarshalServiceChecks(checkRuns []*ServiceCheck) ([]byte, error) {
-	payload := &agentpayload.CheckRunsPayload{
-		CheckRuns: []*agentpayload.CheckRunsPayload_CheckRun{},
-		Metadata:  &agentpayload.CommonMetadata{},
+	payload := &agentpayload.ServiceChecksPayload{
+		ServiceChecks: []*agentpayload.ServiceChecksPayload_ServiceCheck{},
+		Metadata:      &agentpayload.CommonMetadata{},
 	}
 
 	for _, c := range checkRuns {
-		payload.CheckRuns = append(payload.CheckRuns,
-			&agentpayload.CheckRunsPayload_CheckRun{
+		payload.ServiceChecks = append(payload.ServiceChecks,
+			&agentpayload.ServiceChecksPayload_ServiceCheck{
 				Name:    c.CheckName,
 				Host:    c.Host,
 				Ts:      c.Ts,

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -59,19 +59,19 @@ func TestMarshalServiceChecks(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
 
-	newPayload := &agentpayload.CheckRunsPayload{}
+	newPayload := &agentpayload.ServiceChecksPayload{}
 	err = proto.Unmarshal(payload, newPayload)
 	assert.Nil(t, err)
 
-	require.Len(t, newPayload.CheckRuns, 1)
-	assert.Equal(t, newPayload.CheckRuns[0].Name, "test.check")
-	assert.Equal(t, newPayload.CheckRuns[0].Host, "test.localhost")
-	assert.Equal(t, newPayload.CheckRuns[0].Ts, int64(1000))
-	assert.Equal(t, newPayload.CheckRuns[0].Status, int32(ServiceCheckOK))
-	assert.Equal(t, newPayload.CheckRuns[0].Message, "this is fine")
-	require.Len(t, newPayload.CheckRuns[0].Tags, 2)
-	assert.Equal(t, newPayload.CheckRuns[0].Tags[0], "tag1")
-	assert.Equal(t, newPayload.CheckRuns[0].Tags[1], "tag2:yes")
+	require.Len(t, newPayload.ServiceChecks, 1)
+	assert.Equal(t, newPayload.ServiceChecks[0].Name, "test.check")
+	assert.Equal(t, newPayload.ServiceChecks[0].Host, "test.localhost")
+	assert.Equal(t, newPayload.ServiceChecks[0].Ts, int64(1000))
+	assert.Equal(t, newPayload.ServiceChecks[0].Status, int32(ServiceCheckOK))
+	assert.Equal(t, newPayload.ServiceChecks[0].Message, "this is fine")
+	require.Len(t, newPayload.ServiceChecks[0].Tags, 2)
+	assert.Equal(t, newPayload.ServiceChecks[0].Tags[0], "tag1")
+	assert.Equal(t, newPayload.ServiceChecks[0].Tags[1], "tag2:yes")
 }
 
 func TestMarshalEvents(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Rename CheckRuns to ServiceChecks in aggregator to sync up with the change in https://github.com/DataDog/agent-payload/commit/e80426edf0327709b2ffa36c9e2739c7b9c0cc87.

### Motivation

So we can upgrade the `agent-payload` dependency for the kubernetes metadata change.
