### PR TITLE
[kubernetes] Add metadata provider

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,38 @@
-hash: 2ce2fc3ebbd3651d2afc44b20709541211459d31b4eadc729f58810363f2d9a3
-updated: 2017-04-28T16:28:42.854272518-04:00
+hash: ae3af36af2cb274fe6cf9a1f5df39536776f25558e091d0fccf54a4016e8a230
+updated: 2017-05-31T17:42:47.316653881-04:00
 imports:
+- name: cloud.google.com/go
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  subpackages:
+  - compute/metadata
+  - internal
 - name: github.com/beevik/ntp
   version: cb3dae3a7588ae35829eb5724df611cd75152fba
+- name: github.com/blang/semver
+  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
 - name: github.com/coreos/etcd
-  version: 43b75072bfaca5a7c35c718179defbcabd9a0886
+  version: d267ca9c184e953554257d0acdd1dc9c47d38229
   subpackages:
   - client
   - pkg/pathutil
   - pkg/types
+- name: github.com/coreos/go-oidc
+  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
+  subpackages:
+  - http
+  - jose
+  - key
+  - oauth2
+  - oidc
+- name: github.com/coreos/pkg
+  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+  subpackages:
+  - capnslog
+  - health
+  - httputil
+  - timeutil
 - name: github.com/DataDog/agent-payload
   version: 164709ae846c628091e670009226c2874fa36c1e
   subpackages:
@@ -23,6 +45,12 @@ imports:
   version: 92686dde04c3c01d4b1268d21e31ecbfffd29606
   subpackages:
   - cpu
+  - filesystem
+  - memory
+  - network
+  - platform
+  - processes
+  - processes/gops
 - name: github.com/DataDog/zstd
   version: dcab8fb122781db546af7aa75978ae681b6085f5
 - name: github.com/davecgh/go-spew
@@ -30,9 +58,9 @@ imports:
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: 1d7824702bb4763786d35b7553b18722c4afce4f
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
-  - digestset
+  - digest
   - reference
 - name: github.com/docker/docker
   version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
@@ -61,6 +89,11 @@ imports:
   - tlsconfig
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/emicklei/go-restful
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  subpackages:
+  - log
+  - swagger
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/geoffgarside/ber
@@ -71,18 +104,31 @@ imports:
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
   - oleutil
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: 30433562cfbf487fe1df7cd26c7bab168d2f14d0
+  version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
   - proto
+  - sortkeys
+- name: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
   version: 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
   subpackages:
   - proto
+- name: github.com/google/gofuzz
+  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a
 - name: github.com/gorilla/mux
-  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+  version: bcd8bc72b08df0f70df986b97f95590779502d31
 - name: github.com/hashicorp/hcl
   version: 7fa7fff964d035e8a162cce3a164b3ad02ad651b
   subpackages:
@@ -96,24 +142,32 @@ imports:
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/jonboulle/clockwork
+  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+- name: github.com/juju/ratelimit
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/k-sone/snmpgo
   version: de09377ff34857b08afdc16ea8c7c2929eb1fc6e
 - name: github.com/kardianos/osext
   version: 9d302b58e975387d0b4d9be876622c86cefe64be
 - name: github.com/magiconair/properties
   version: 51463bfca2576e06c62a8504b5c0f06d61312647
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
 - name: github.com/Microsoft/go-winio
   version: fff283ad5116362ca252298cfc9b95828956d85d
 - name: github.com/mitchellh/mapstructure
   version: cc8532a8e9a55ea36402aa21efdf403a60d34096
 - name: github.com/mitchellh/reflectwalk
   version: 417edcfd99a4d472c262e58f22b4bfe97580f03e
-- name: github.com/opencontainers/go-digest
-  version: aa2ec055abd10d26d539eb630a92241b781ce4bc
-- name: github.com/PagerDuty/godspeed
-  version: 6d136386b5f291797c77764dfd2acc950dc27347
 - name: github.com/patrickmn/go-cache
   version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pelletier/go-buffruneio
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
@@ -124,10 +178,14 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/sbinet/go-python
   version: ba7e58341058bdefb92b359870caf2dc0a05cfcf
 - name: github.com/shirou/gopsutil
-  version: e49a95f3d5f824c3f9875ca49e54e4fef17f82cf
+  version: 9af92986dda65a8c367157a82b484553e1ec1c55
   subpackages:
   - cpu
   - host
@@ -138,7 +196,9 @@ imports:
 - name: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/Sirupsen/logrus
-  version: 10f801ebc38b33738c9d17d50860f484a0988ff5
+  version: 55eb11d21d2a31a3cc93838241d04800f52e823d
+  subpackages:
+  - formatters/logstash
 - name: github.com/spf13/afero
   version: 9be650865eab0c12963d8753212f4f9c66cdcf12
   subpackages:
@@ -175,9 +235,20 @@ imports:
   subpackages:
   - context
   - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - lex/httplex
   - proxy
+- name: golang.org/x/oauth2
+  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
-  version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
   - windows
@@ -187,10 +258,139 @@ imports:
   - windows/svc/eventlog
   - windows/svc/mgr
 - name: golang.org/x/text
-  version: 470f45bf29f4147d6fbd7dfd0a02a848e49f5bf4
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
   - transform
+  - unicode/bidi
   - unicode/norm
+  - width
+- name: google.golang.org/appengine
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
-testImports: []
+- name: k8s.io/client-go
+  version: e121606b0d09b2e1c467183ee46217fa85a6b672
+  subpackages:
+  - discovery
+  - kubernetes
+  - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/certificates/v1alpha1
+  - kubernetes/typed/core/v1
+  - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/storage/v1beta1
+  - pkg/api
+  - pkg/api/errors
+  - pkg/api/install
+  - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/resource
+  - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/api/validation/path
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1beta1
+  - pkg/auth/user
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/genericapiserver/openapi/common
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/third_party/forked/golang/reflect
+  - pkg/third_party/forked/golang/template
+  - pkg/types
+  - pkg/util
+  - pkg/util/cert
+  - pkg/util/clock
+  - pkg/util/errors
+  - pkg/util/flowcontrol
+  - pkg/util/framer
+  - pkg/util/integer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/jsonpath
+  - pkg/util/labels
+  - pkg/util/net
+  - pkg/util/parsers
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/uuid
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - pkg/watch/versioned
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - rest
+  - tools/clientcmd/api
+  - tools/metrics
+  - transport

--- a/glide.yaml
+++ b/glide.yaml
@@ -48,3 +48,5 @@ import:
   - client
 - package: golang.org/x/net
 - package: github.com/DataDog/gohai
+- package: k8s.io/client-go
+  version: v2.0.0

--- a/pkg/metadata/kubernetes/kubernetes.go
+++ b/pkg/metadata/kubernetes/kubernetes.go
@@ -1,0 +1,223 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	batchv1 "k8s.io/client-go/pkg/apis/batch/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/rest"
+
+	payload "github.com/DataDog/agent-payload/go"
+	"github.com/DataDog/datadog-agent/pkg/metadata"
+)
+
+const (
+	createdByKey = "kubernetes.io/created-by"
+
+	// Kube creator types, from created-by annotation.
+	kindDaemonSet             = "DaemonSet"
+	kindReplicaSet            = "ReplicaSet"
+	kindReplicationController = "ReplicationController"
+	kindDeployment            = "Deployment"
+	kindJob                   = "Job"
+)
+
+// GetPayload returns a payload.KubernetesMetadata payload with metadata about
+// the state of a Kubernetes cluster. We will use this metadata for tagging
+// metrics and other services in the backend.
+func GetPayload() (metadata.Payload, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve config: %s", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get clientset: %s", err)
+	}
+	dr, err := clientset.Deployments("").List(v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployments: %s", err)
+	}
+	rr, err := clientset.ReplicaSets("").List(v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get replicasets: %s", err)
+	}
+	sr, err := clientset.Services("").List(v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %s", err)
+	}
+	dsr, err := clientset.DaemonSets("").List(v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get daemonsets: %s", err)
+	}
+	jr, err := clientset.BatchV1Client.Jobs("").List(v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get jobs: %s", err)
+	}
+	pr, err := clientset.Pods("").List(v1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pods: %s", err)
+	}
+
+	deployments := parseDeployments(dr.Items)
+	replicaSets := parseReplicaSets(rr.Items)
+	services := parseServices(sr.Items)
+	jobs := parseJobs(jr.Items)
+	daemonSets := parseDaemonSets(dsr.Items)
+	pods, containers := parsePods(pr.Items, services)
+	return &payload.KubeMetadataPayload{
+		Deployments: deployments,
+		ReplicaSets: replicaSets,
+		DaemonSets:  daemonSets,
+		Services:    services,
+		Jobs:        jobs,
+		Pods:        pods,
+		Containers:  containers,
+	}, nil
+}
+
+func parseDeployments(apiDeployments []v1beta1.Deployment) []*payload.KubeMetadataPayload_Deployment {
+	dss := make([]*payload.KubeMetadataPayload_Deployment, len(apiDeployments))
+	for _, d := range apiDeployments {
+		dss = append(dss, &payload.KubeMetadataPayload_Deployment{
+			Uid:       string(d.UID),
+			Name:      d.Name,
+			Namespace: d.Namespace,
+		})
+	}
+	return dss
+}
+
+func parseReplicaSets(apiRs []v1beta1.ReplicaSet) []*payload.KubeMetadataPayload_ReplicaSet {
+	rss := make([]*payload.KubeMetadataPayload_ReplicaSet, 0, len(apiRs))
+	for _, ar := range apiRs {
+		// Assumes only a single deployment per ReplicaSet
+		var deployment string
+		for _, o := range ar.OwnerReferences {
+			if o.Kind == kindDeployment {
+				deployment = o.Name
+			}
+		}
+		rss = append(rss, &payload.KubeMetadataPayload_ReplicaSet{
+			Uid:        string(ar.UID),
+			Name:       ar.Name,
+			Namespace:  ar.Namespace,
+			Deployment: deployment,
+		})
+	}
+	return rss
+}
+
+func parseServices(apiServices []v1.Service) []*payload.KubeMetadataPayload_Service {
+	services := make([]*payload.KubeMetadataPayload_Service, 0, len(apiServices))
+	for _, s := range apiServices {
+		services = append(services, &payload.KubeMetadataPayload_Service{
+			Uid:       string(s.UID),
+			Name:      s.Name,
+			Namespace: s.Namespace,
+			Selector:  s.Spec.Selector,
+			Type:      string(s.Spec.Type),
+		})
+	}
+	return services
+}
+
+func parseJobs(apiJobs []batchv1.Job) []*payload.KubeMetadataPayload_Job {
+	jobs := make([]*payload.KubeMetadataPayload_Job, 0, len(apiJobs))
+	for _, j := range apiJobs {
+		jobs = append(jobs, &payload.KubeMetadataPayload_Job{
+			Uid:       string(j.UID),
+			Name:      j.Name,
+			Namespace: j.Namespace,
+		})
+	}
+	return jobs
+}
+
+func parseDaemonSets(apiDs []v1beta1.DaemonSet) []*payload.KubeMetadataPayload_DaemonSet {
+	daemonSets := make([]*payload.KubeMetadataPayload_DaemonSet, 0, len(apiDs))
+	for _, ds := range apiDs {
+		daemonSets = append(daemonSets, &payload.KubeMetadataPayload_DaemonSet{
+			Uid:       string(ds.UID),
+			Name:      ds.Name,
+			Namespace: ds.Namespace,
+		})
+	}
+	return daemonSets
+}
+
+func parsePods(
+	apiPods []v1.Pod,
+	services []*payload.KubeMetadataPayload_Service,
+) ([]*payload.KubeMetadataPayload_Pod, []*payload.KubeMetadataPayload_Container) {
+	pods := make([]*payload.KubeMetadataPayload_Pod, 0, len(apiPods))
+	containers := make([]*payload.KubeMetadataPayload_Container, 0)
+	for _, ap := range apiPods {
+		cids := make([]string, 0, len(ap.Status.ContainerStatuses))
+		for _, c := range ap.Status.ContainerStatuses {
+			containers = append(containers, &payload.KubeMetadataPayload_Container{
+				Name:    c.Name,
+				Id:      c.ContainerID,
+				Image:   c.Image,
+				ImageId: c.ImageID,
+			})
+			cids = append(cids, c.ContainerID)
+		}
+
+		pod := &payload.KubeMetadataPayload_Pod{
+			Uid:          string(ap.UID),
+			Name:         ap.Name,
+			Namespace:    ap.Namespace,
+			HostIp:       ap.Status.HostIP,
+			PodIp:        ap.Status.PodIP,
+			Labels:       ap.Labels,
+			ServiceUids:  findPodServices(ap.Namespace, ap.Labels, services),
+			ContainerIds: cids,
+		}
+		setPodCreator(pod, ap.OwnerReferences)
+		pods = append(pods, pod)
+	}
+	return pods, containers
+}
+
+func findPodServices(
+	namespace string,
+	labels map[string]string,
+	services []*payload.KubeMetadataPayload_Service,
+) []string {
+	uids := make([]string, 0)
+	for _, s := range services {
+		if s.Namespace != namespace {
+			continue
+		}
+
+		match := true
+		for k, search := range s.Selector {
+			if v, ok := labels[k]; !ok || v != search {
+				match = false
+				break
+			}
+		}
+		if match {
+			uids = append(uids, s.Uid)
+		}
+	}
+	return uids
+}
+
+func setPodCreator(pod *payload.KubeMetadataPayload_Pod, ownerRefs []v1.OwnerReference) {
+	for _, o := range ownerRefs {
+		switch o.Kind {
+		case kindDaemonSet:
+			pod.DaemonSet = o.Name
+		case kindReplicaSet:
+			pod.ReplicaSet = o.Name
+		case kindReplicationController:
+			pod.ReplicationController = o.Name
+		case kindJob:
+			pod.Job = o.Name
+		}
+	}
+}

--- a/pkg/metadata/kubernetes/kubernetes_test.go
+++ b/pkg/metadata/kubernetes/kubernetes_test.go
@@ -1,0 +1,199 @@
+package kubernetes
+
+import (
+	"testing"
+
+	payload "github.com/DataDog/agent-payload/go"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func TestParsePods(t *testing.T) {
+	inPods := []v1.Pod{
+		v1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-pod-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					"test": "abcd",
+					"role": "intake",
+				},
+				OwnerReferences: []v1.OwnerReference{v1.OwnerReference{
+					Kind: "ReplicationController",
+					Name: "kubernetes-dashboard",
+				}},
+			},
+			Status: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					v1.ContainerStatus{
+						ContainerID: "e468b96ca4fcc9687cc3",
+						Image:       "datadog/docker-dd-agent",
+						ImageID:     "docker://sha256:7c4034e4",
+					},
+					v1.ContainerStatus{
+						ContainerID: "3dbeb56a5545f17c1af2",
+						Image:       "redis",
+						ImageID:     "docker://sha256:7c4034e4",
+					},
+				},
+			},
+		},
+		v1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-pod-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					"role":    "web",
+					"another": "label",
+					"bim":     "bop",
+				},
+				OwnerReferences: []v1.OwnerReference{v1.OwnerReference{
+					Kind: "ReplicaSet",
+					Name: "kube-dns-196007617",
+				}},
+			},
+			Status: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					v1.ContainerStatus{
+						ContainerID: "ce749d07a5645291f2f",
+						Image:       "dd/web-app",
+						ImageID:     "docker://sha256:7c4034e4",
+					},
+					v1.ContainerStatus{
+						ContainerID: "57bb7bcd0c5b1e58daa0",
+						Image:       "dd/redis-cache",
+						ImageID:     "docker://sha256:7c4034e4",
+					},
+				},
+			},
+		},
+	}
+
+	// Simple parsing with no services
+	pods, _ := parsePods(inPods, []*payload.KubeMetadataPayload_Service{})
+	assert := assert.New(t)
+	for i, p := range pods {
+		assert.Equal(inPods[i].Name, p.Name)
+		assert.Equal(inPods[i].Namespace, p.Namespace)
+		assert.Equal(inPods[i].Labels, p.Labels)
+		assert.Len(inPods[i].Status.ContainerStatuses, len(p.ContainerIds))
+		assert.Empty(p.ServiceUids)
+	}
+
+	assert.Equal(pods[0].ReplicationController, "kubernetes-dashboard")
+	assert.Equal(pods[1].ReplicaSet, "kube-dns-196007617")
+}
+
+func TestSetPodCreator(t *testing.T) {
+	for _, tc := range []struct {
+		ownerRefs   []v1.OwnerReference
+		annotations map[string]string
+		expected    *payload.KubeMetadataPayload_Pod
+	}{
+		{
+			// No refs
+			ownerRefs: []v1.OwnerReference{},
+			expected:  &payload.KubeMetadataPayload_Pod{},
+		},
+		{
+			ownerRefs: []v1.OwnerReference{v1.OwnerReference{
+				Kind: "ReplicationController",
+				Name: "kubernetes-dashboard",
+			}},
+			expected: &payload.KubeMetadataPayload_Pod{
+				ReplicationController: "kubernetes-dashboard",
+			},
+		},
+		{
+			ownerRefs: []v1.OwnerReference{v1.OwnerReference{
+				Kind: "ReplicaSet",
+				Name: "apptastic-app",
+			}},
+			expected: &payload.KubeMetadataPayload_Pod{
+				ReplicaSet: "apptastic-app",
+			},
+		},
+		{
+			ownerRefs: []v1.OwnerReference{v1.OwnerReference{
+				Kind: "Job",
+				Name: "hello",
+			}},
+			expected: &payload.KubeMetadataPayload_Pod{
+				Job: "hello",
+			},
+		},
+	} {
+		pod := &payload.KubeMetadataPayload_Pod{}
+		setPodCreator(pod, tc.ownerRefs)
+		assert.Equal(t, tc.expected, pod)
+	}
+}
+
+func TestFindPodServices(t *testing.T) {
+	services := []*payload.KubeMetadataPayload_Service{
+		&payload.KubeMetadataPayload_Service{
+			Namespace: "dd",
+			Name:      "intake",
+			Uid:       "intake",
+			Selector: map[string]string{
+				"role": "intake",
+			},
+		},
+		&payload.KubeMetadataPayload_Service{
+			Namespace: "default",
+			Name:      "gce-web",
+			Uid:       "gce-web",
+			Selector: map[string]string{
+				"class":    "web",
+				"provider": "gce",
+			},
+		},
+		&payload.KubeMetadataPayload_Service{
+			Namespace: "default",
+			Name:      "aws-web",
+			Uid:       "aws-web",
+			Selector: map[string]string{
+				"class":    "web",
+				"provider": "aws",
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		labels    map[string]string
+		namespace string
+		expected  []string
+	}{
+		{
+			labels:    map[string]string{},
+			namespace: "default",
+			expected:  []string{},
+		},
+		{
+			labels: map[string]string{
+				"role":  "intake",
+				"label": "with-something-else",
+			},
+			namespace: "dd",
+			expected:  []string{"intake"},
+		},
+		{
+			labels: map[string]string{
+				"role": "intake",
+			},
+			namespace: "default",
+			expected:  []string{},
+		},
+		{
+			labels: map[string]string{
+				"class":    "web",
+				"provider": "aws",
+			},
+			namespace: "default",
+			expected:  []string{"aws-web"},
+		},
+	} {
+		uids := findPodServices(tc.namespace, tc.labels, services)
+		assert.Equal(t, tc.expected, uids)
+	}
+}

--- a/pkg/metadata/payload.go
+++ b/pkg/metadata/payload.go
@@ -1,0 +1,10 @@
+package metadata
+
+// Payload is an interface shared by the output of the newer metadata providers.
+// Right now this interface simply satifies the Protobuf interface.
+type Payload interface {
+	Reset()
+	String() string
+	ProtoMessage()
+	Descriptor() ([]byte, []int)
+}

--- a/test/integration/metadata_providers/kubernetes/Dockerfile
+++ b/test/integration/metadata_providers/kubernetes/Dockerfile
@@ -1,0 +1,11 @@
+# Development Dockerfile
+FROM golang:1.8.3
+
+MAINTAINER Datadog <package@datadoghq.com>
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go-wrapper download   # "go get -d -v ./..."
+
+CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"

--- a/test/integration/metadata_providers/kubernetes/README.md
+++ b/test/integration/metadata_providers/kubernetes/README.md
@@ -1,0 +1,36 @@
+# Kubernetes Testing/Development
+
+To test and develop the Kubernetes metadata provider you need a semi-real environment that provides API.
+
+This folder provides some basic files to get you bootstrapped and running.
+
+## Prerequisites
+
+* You need a real/semi-real Kubernetes environment. We recommend using [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).
+
+* You need access to the environment with `kubectl`.
+
+* The `/path/to/go/src` in `pod-configuration.yaml` should be the full, absolute path to your GOPATH with the `datadog-agent` code.
+
+## Setup
+
+You will create a simple pod that deploys a dumb simple container that mounts your code code.
+
+```
+$ kubectl create -f pod-configuration.yaml
+```
+
+Wait until the pod is `Running`
+
+```
+$ kubectl get pods
+```
+
+Shell into the environment and run the code.
+
+```
+$ kubectl exec kubedev -c node -i -t -- bash
+
+root@kubedev:/go/src# cd github.com/DataDog/datadog-agent/pkg/metadata/kubernetes/
+root@kubedev:/go/src# go test
+```

--- a/test/integration/metadata_providers/kubernetes/pod-configuration.yaml
+++ b/test/integration/metadata_providers/kubernetes/pod-configuration.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: godev
+spec:
+  containers:
+  - name: node
+    image: conordd/godev:latest
+    ports:
+    - containerPort: 8080
+    volumeMounts:
+    - name: gocode
+      mountPath: /go/src/
+  volumes:
+  - name: gocode
+    hostPath:
+      path: /path/to/go/src/


### PR DESCRIPTION
### What does this PR do?

(Re-do of https://github.com/DataDog/datadog-agent/pull/270 with agent-payload version bump)

This creates a new metadata provider for Kubernetes that exposes information about the services, pods and containers within pods. This uses a new format defined in [agent-payload](https://github.com/DataDog/agent-payload/pull/5) and takes the liberty to update the `GetPayload` interface to use a common Proto-compatible interface.

There is another change in here that adds a show README for setting up an environment to
run, test and develop the k8 metadata provider since this is not particularly simple or obvious.

### Motivation

Exposing Kubernetes metadata in a sane, structured way that can be handled accordingly in different systems.