### PR TITLE
[AD] auth support for etcd provider

### DIFF
--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -44,6 +44,16 @@ func NewEtcdConfigProvider() (*EtcdConfigProvider, error) {
 		Transport:               client.DefaultTransport,
 		HeaderTimeoutPerRequest: time.Second,
 	}
+
+	etcdUsername := config.Datadog.GetString("autoconf_template_username")
+	etcdPassword := config.Datadog.GetString("autoconf_template_password")
+
+	if len(etcdUsername) > 0 && len(etcdPassword) > 0 {
+		log.Info("Using provided etcd credentials: username ", etcdUsername)
+		clientCfg.Username = etcdUsername
+		clientCfg.Password = etcdPassword
+	}
+
 	cl, err := client.New(clientCfg)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to instantiate the etcd client: %s", err)

--- a/test/integration/config_providers/etcd_provider_test.go
+++ b/test/integration/config_providers/etcd_provider_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -21,11 +22,14 @@ const (
 	etcdImg       string = "quay.io/coreos/etcd:latest"
 	containerName string = "datadog-agent-etcd0"
 	etcdURL       string = "http://127.0.0.1:2379/"
+	etcdUser      string = "root"
+	etcdPass      string = "root"
 )
 
 type EtcdTestSuite struct {
 	suite.Suite
 	templates map[string]string
+	clientCfg etcd_client.Config
 }
 
 func (suite *EtcdTestSuite) SetupSuite() {
@@ -34,12 +38,21 @@ func (suite *EtcdTestSuite) SetupSuite() {
 		"/foo/nginx/init_configs": `[{}, {}]`,
 		"/foo/nginx/instances":    `[{"name": "test", "url": "http://%25%25host%25%25/", "timeout": 5}, {"foo": "bar"}]`,
 	}
+	suite.clientCfg = etcd_client.Config{
+		Endpoints:               []string{etcdURL},
+		Transport:               etcd_client.DefaultTransport,
+		HeaderTimeoutPerRequest: 1 * time.Second,
+		Username:                etcdUser,
+		Password:                etcdPass,
+	}
 
 	// pull the latest etcd image, create a standalone etcd container
 	suite.createEtcd()
 
 	// wait for etcd to start
 	time.Sleep(1 * time.Second)
+
+	suite.setEtcdPassword()
 }
 
 func (suite *EtcdTestSuite) TearDownSuite() {
@@ -57,6 +70,9 @@ func (suite *EtcdTestSuite) TearDownSuite() {
 func (suite *EtcdTestSuite) SetupTest() {
 	config.Datadog.Set("autoconf_template_url", etcdURL)
 	config.Datadog.Set("autoconf_template_dir", "/foo/")
+	config.Datadog.Set("autoconf_template_username", "")
+	config.Datadog.Set("autoconf_template_password", "")
+
 	suite.populateEtcd()
 }
 
@@ -76,13 +92,20 @@ func (suite *EtcdTestSuite) createEtcd() {
 	match := false
 	for _, img := range l {
 		if img.RepoTags[0] == etcdImg {
+			suite.T().Logf("Found image %s", etcdImg)
 			match = true
 			break
 		}
 	}
 
 	if !match {
-		_, err = cli.ImagePull(ctx, etcdImg, types.ImagePullOptions{})
+		suite.T().Logf("Image %s not found, pulling", etcdImg)
+		resp, err := cli.ImagePull(ctx, etcdImg, types.ImagePullOptions{})
+		if err != nil {
+			panic(err)
+		}
+		_, err = ioutil.ReadAll(resp) // Necessary for image pull to complete
+		resp.Close()
 		if err != nil {
 			panic(err)
 		}
@@ -106,7 +129,7 @@ func (suite *EtcdTestSuite) createEtcd() {
 	_, err = cli.ContainerCreate(ctx, containerConfig, hostConfig, nil, containerName)
 	if err != nil {
 		// containers already exists
-		suite.T().Logf("Container %s already exists, skipping creation...", containerName)
+		suite.T().Logf("Error creating container %s: %s", containerName, err)
 	}
 
 	if err := cli.ContainerStart(ctx, containerName, types.ContainerStartOptions{}); err != nil {
@@ -115,14 +138,7 @@ func (suite *EtcdTestSuite) createEtcd() {
 }
 
 func (suite *EtcdTestSuite) populateEtcd() {
-	// get etcd client
-	clientCfg := etcd_client.Config{
-		Endpoints:               []string{etcdURL},
-		Transport:               etcd_client.DefaultTransport,
-		HeaderTimeoutPerRequest: 1 * time.Second,
-	}
-
-	cl, err := etcd_client.New(clientCfg)
+	cl, err := etcd_client.New(suite.clientCfg)
 	if err != nil {
 		panic(err)
 	}
@@ -138,7 +154,41 @@ func (suite *EtcdTestSuite) populateEtcd() {
 	}
 }
 
-func (suite *EtcdTestSuite) TestWorkingConnection() {
+func (suite *EtcdTestSuite) setEtcdPassword() {
+	cl, err := etcd_client.New(suite.clientCfg)
+	if err != nil {
+		panic(err)
+	}
+
+	auth := etcd_client.NewAuthUserAPI(cl)
+	ctx := context.Background()
+
+	_, err = auth.ChangePassword(ctx, etcdUser, etcdPass)
+	/*if err != nil {
+		panic(err)
+	}*/
+}
+
+func (suite *EtcdTestSuite) toggleEtcdAuth(enable bool) {
+	cl, err := etcd_client.New(suite.clientCfg)
+	if err != nil {
+		panic(err)
+	}
+
+	c := etcd_client.NewAuthAPI(cl)
+	ctx := context.Background()
+
+	if enable {
+		c.Enable(ctx)
+	} else {
+		c.Disable(ctx)
+	}
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (suite *EtcdTestSuite) TestWorkingConnectionAnon() {
 	p, err := providers.NewEtcdConfigProvider()
 	if err != nil {
 		panic(err)
@@ -163,6 +213,36 @@ func (suite *EtcdTestSuite) TestBadConnection() {
 	checks, err := p.Collect()
 	assert.Nil(suite.T(), err)
 	assert.Empty(suite.T(), checks)
+}
+
+func (suite *EtcdTestSuite) TestWorkingAuth() {
+	suite.toggleEtcdAuth(true)
+	config.Datadog.Set("autoconf_template_username", etcdUser)
+	config.Datadog.Set("autoconf_template_password", etcdPass)
+
+	p, err := providers.NewEtcdConfigProvider()
+	assert.Nil(suite.T(), err)
+
+	checks, err := p.Collect()
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 2, len(checks))
+
+	suite.toggleEtcdAuth(false)
+}
+
+func (suite *EtcdTestSuite) TestBadAuth() {
+	suite.toggleEtcdAuth(true)
+	config.Datadog.Set("autoconf_template_username", etcdUser)
+	config.Datadog.Set("autoconf_template_password", "invalid")
+
+	p, err := providers.NewEtcdConfigProvider()
+	assert.Nil(suite.T(), err)
+
+	checks, err := p.Collect()
+	assert.Nil(suite.T(), err)
+	assert.Empty(suite.T(), checks)
+
+	suite.toggleEtcdAuth(false)
 }
 
 func TestEtcdSuite(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Mirroring https://github.com/DataDog/dd-agent/pull/3357 , add `sd_backend_username` & `sd_backend_password` options to enable authentication when connecting to the etcd datastore.

### Additional Notes

Etcd integration test runs with `go test github.com/DataDog/datadog-agent/test/integration/config_providers/etcd_provider_test.go` but is not yet enabled in CI.