### PR TITLE
[deps] Bump agent-payload requirement, update imports.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -34,7 +34,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/DataDog/agent-payload
-  version: 164709ae846c628091e670009226c2874fa36c1e
+  version: 091e000da55ab18aca225f8338abe8338b959aea
   subpackages:
   - go
 - name: github.com/DataDog/datadog-go

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	agentpayload "github.com/DataDog/agent-payload/go"
+	agentpayload "github.com/DataDog/agent-payload/gogen"
 )
 
 func marshalPoints(points []Point) []*agentpayload.MetricsPayload_Sample_Point {

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	agentpayload "github.com/DataDog/agent-payload/go"
+	agentpayload "github.com/DataDog/agent-payload/gogen"
 )
 
 func TestMarshalSeries(t *testing.T) {

--- a/pkg/metadata/kubernetes/kubernetes.go
+++ b/pkg/metadata/kubernetes/kubernetes.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
 
-	payload "github.com/DataDog/agent-payload/go"
+	payload "github.com/DataDog/agent-payload/gogen"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 )
 

--- a/pkg/metadata/kubernetes/kubernetes_test.go
+++ b/pkg/metadata/kubernetes/kubernetes_test.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"testing"
 
-	payload "github.com/DataDog/agent-payload/go"
+	payload "github.com/DataDog/agent-payload/gogen"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/pkg/api/v1"
 )


### PR DESCRIPTION
### What does this PR do?

Bump the agent-payload dependency version and sync the imports for the changes in https://github.com/DataDog/agent-payload/pull/6. For context, we moved to the `gogen` package to avoid having a `package go` which is invalid/not allowed.

### Motivation

https://github.com/DataDog/agent-payload/pull/6

