### PR TITLE
[rake][agent] Quote variable in shell command

### DIFF
--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -27,7 +27,7 @@ namespace :agent do
     ldflags = []
     if !ENV["USE_SYSTEM_PY"]
       env["PKG_CONFIG_LIBDIR"] = "#{PKG_CONFIG_LIBDIR}"
-      libdir = `PKG_CONFIG_LIBDIR=#{PKG_CONFIG_LIBDIR} pkg-config --variable=libdir python-2.7`.strip
+      libdir = `PKG_CONFIG_LIBDIR="#{PKG_CONFIG_LIBDIR}" pkg-config --variable=libdir python-2.7`.strip
       fail "Can't find path to embedded lib directory with pkg-config" if libdir.empty?
       ldflags << "-r #{libdir}"
     end


### PR DESCRIPTION
### What does this PR do?

Quotes a variable in a shell command.

If the variable is left unquoted, the command doesn't work on old versions of Ruby
(reproduced on ruby 1.9, shipped by default in the internal devenv VM).

### Additional Notes

The fix is very simple so let's fix it even if we don't want to support
old versions of ruby in the long term.
