### PR TITLE
[CI] Add dogstatsd size test to the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,21 @@ dogstatsd_static-x64:
     paths:
       - dogstatsd
 
+# check the size of the static dogstatsd binary
+run_dogstatsd_size_test:
+  stage: integration_test
+  image: $DEB_X64
+  tags:
+    - docker
+  dependencies:
+    - dogstatsd_static-x64 # Reuse artifact from build stage
+  before_script:
+    # Disable global before_script
+    - mkdir -p $STATIC_BINARIES_DIR
+    - ln dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+  script:
+    - rake dogstatsd:size_test skip_rebuild=true
+
 # run integration tests for deb-x64
 run_docker_integration_tests_deb-x64:
   stage: integration_test

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -45,6 +45,28 @@ namespace :dogstatsd do
     system("DOGSTATSD_BIN=\"#{bin_path}\" go test -v #{REPO_PATH}/test/system/dogstatsd/") || exit(1)
   end
 
+  desc "Run Dogstatsd size test"
+  task :size_test do
+    if ENV['skip_rebuild'] == "true" then
+      puts "Skipping DogStatsD build"
+    else
+      puts "Building DogStatsD"
+      Rake::Task["dogstatsd:build"].invoke
+    end
+
+    root = `git rev-parse --show-toplevel`.strip
+    bin_path = File.join(root, STATIC_BIN_PATH, "dogstatsd")
+    size = File.size(bin_path) / 1024
+
+    if size > 15 * 1024 then
+      puts "DogStatsD static build size too big: #{size} kB"
+      puts "This means your PR added big classes or dependencies in the packages dogstatsd uses"
+      exit(1)
+    else
+      puts "DogStatsD static build size OK: #{size} kB"
+    end
+  end
+
   desc "Build omnibus installer"
   task :omnibus do
     # omnibus log level


### PR DESCRIPTION
### What does this PR do?

Our goal with the standalone dogstatsd is to have a lightweight binary. Our current (informal) goal is to keep the alpine image size under 20MB, which means a static binary size of 15MB.

As PRs in the agent codebase might introduce additional dependencies in the packages dsd uses. this PR adds a CI step to check the dsd binary size on every PR. As it reuses the artifact from the dogstatsd_static-x64 step, it shouldn't slow down the pipeline, and finish before the other integration tests.

Our current binary size on master is `10932 kB`. The test is set to fail at 15MB, but we could aim for 13MB. Thoughts?