### PR TITLE
Add expvars to the scheduler

### DIFF
--- a/pkg/collector/dist/conf.d/go_expvar.yaml.default
+++ b/pkg/collector/dist/conf.d/go_expvar.yaml.default
@@ -82,3 +82,15 @@ instances:
         type: rate
       - path: aggregator/HostnameUpdate
         type: rate
+
+      # scheduler monitoring
+      - path: scheduler/ChecksEntered
+        type: gauge
+      - path: scheduler/Queues/.*/Size
+        type: gauge
+        alias: scheduler.queues.size
+      - path: scheduler/Queues/.*/Interval
+        type: gauge
+        alias: scheduler.queues.interval
+      - path: scheduler/QueuesCount
+        type: gauge


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Add expvars to the scheduler: 
 - number of queues and their interval and size
 - number of checks entered

We get something like this:
```"scheduler": {"ChecksEntered": 3, "Queues": [{"Interval":15,"Size":3}], "QueuesCount": 1}```