### PR TITLE
[deps] Match `agent-payload` constraint in `glide.yaml` with lockfile

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,7 @@ import:
   subpackages:
   - proto
 - package: github.com/DataDog/agent-payload
-  version: ^1.0
+  version: ^4.0
 - package: github.com/patrickmn/go-cache
   version: ^2.0.0
 - package: github.com/k-sone/snmpgo


### PR DESCRIPTION
### What does this PR do?

Reconcile `agent-payload` constraint in `glide.yaml` with lockfile

`^1.0` means, per [glide docs](https://github.com/Masterminds/semver#caret-range-comparisons-major): `>=1.0` and `<2.0`, which conflicts with what has been specified manually in `glide.lock` (`agent-payload` is pinned to `4.0` there).

Let's reconcile the 2 files.

### Motivation

`glide up` currently fails because the constraint in `glide.yaml` pulls version 1.0 of `agent-payload`, which isn't compatible with our code anymore.

### Additional Notes

Bug introduced in https://github.com/DataDog/datadog-agent/pull/277

We should document this somewhere (question: where?), and maybe run `glide update` in the CI to check that the constraints in `glide.yaml` make sense? Thoughts?