### PR TITLE
Make text for cfgpath flag clearer

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -28,7 +28,7 @@ func init() {
 	// local flags
 	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
 	startCmd.Flags().StringVarP(&confdPath, "confd", "c", "", "path to the confd folder")
-	startCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to datadog.yaml")
+	startCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to directory containing datadog.yaml")
 	config.Datadog.BindPFlag("confd_path", startCmd.Flags().Lookup("confd"))
 }
 


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?


If you set the path in the following manner: `./bin/agent/agent start -f $(pwd)/datadog.yaml`, it will use the one in `./bin/agent/dist/`. This is because viper does not see a path and think, that's where the file is. It sees a path and thinks, that is a directory the file must be in. (See the logic [here](https://github.com/spf13/viper/blob/0967fc9aceab2ce9da34061253ac10fb99bba5b2/viper.go#L1533-L1559).)

This updates the text to make it more clear that it should be directed at the directory the config resides in, rather than at the config file itself. 

(We could also do some logic to add the parent path rather than the file itself, however I think this will result in less misunderstanding, as it has to be named datadog.yaml.)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
