### PR TITLE
[py] Improve handling of py interpreter errors

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -89,7 +89,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 		for _, check := range ac.loadChecks(config) {
 			err := ac.collector.RunCheck(check)
 			if err != nil {
-				log.Errorf("Unable to run Check %s", check)
+				log.Errorf("Unable to run Check %s: %v", check, err)
 			}
 		}
 	}

--- a/pkg/collector/py/README.md
+++ b/pkg/collector/py/README.md
@@ -9,4 +9,5 @@ python checks
 * the bindings that python checks can use to fetch information from and submit data to the core agent
 
 Before making modifications to the bindings, please make sure you understand the basics of the [Python
-C API](https://docs.python.org/2/c-api/intro.html) usage.
+C API](https://docs.python.org/2/c-api/intro.html) usage. Also, make sure you have a good understanding
+of the necessity and usage of the `stickyLock` struct (see inline documentation).

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -47,8 +47,11 @@ func (c *PythonCheck) Run() error {
 	emptyTuple := python.PyTuple_New(0)
 	result := c.Instance.CallMethod("run", emptyTuple)
 	if result == nil {
-		python.PyErr_Print()
-		return errors.New("Unable to run Python check")
+		pyErr, err := getPythonError()
+		if err != nil {
+			return fmt.Errorf("An error occurred while running python check and couldn't be formatted: %v", err)
+		}
+		return errors.New(pyErr)
 	}
 
 	s, err := aggregator.GetDefaultSender()

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -47,7 +47,7 @@ func (c *PythonCheck) Run() error {
 	emptyTuple := python.PyTuple_New(0)
 	result := c.Instance.CallMethod("run", emptyTuple)
 	if result == nil {
-		pyErr, err := getPythonError()
+		pyErr, err := gstate.getPythonError()
 		if err != nil {
 			return fmt.Errorf("An error occurred while running python check and couldn't be formatted: %v", err)
 		}
@@ -99,7 +99,7 @@ func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObje
 	}
 
 	// there was an error, retrieve it
-	pyErr, err := getPythonError()
+	pyErr, err := gstate.getPythonError()
 	if err != nil {
 		return nil, fmt.Errorf("An error occurred while invoking the python check constructor, and couldn't be formatted: %v", err)
 	}

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -52,7 +52,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	checkModule := python.PyImport_ImportModule(moduleName)
 	if checkModule == nil {
 		defer glock.unlock()
-		pyErr, err := getPythonError()
+		pyErr, err := glock.getPythonError()
 		if err != nil {
 			return nil, fmt.Errorf("An error occurred while loading the python module and couldn't be formatted: %v", err)
 		}

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -50,11 +50,9 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	// Lock the GIL while working with go-python directly
 	glock := newStickyLock()
 	checkModule := python.PyImport_ImportModule(moduleName)
-	glock.unlock()
 	if checkModule == nil {
-		glock = newStickyLock()
+		defer glock.unlock()
 		pyErr, err := getPythonError()
-		glock.unlock()
 		if err != nil {
 			return nil, fmt.Errorf("An error occurred while loading the python module and couldn't be formatted: %v", err)
 		}
@@ -62,7 +60,6 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	}
 
 	// Try to find a class inheriting from AgentCheck within the module
-	glock = newStickyLock()
 	checkClass, err := findSubclassOf(cl.agentCheckClass, checkModule)
 	glock.unlock()
 	if err != nil {

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -155,8 +155,9 @@ func getModuleName(modulePath string) string {
 
 // getPythonError returns string-formatted info about a Python interpreter error that occurred,
 // and clears the error flag in the Python interpreter
-// WARNING: make sure a StickyLock is locked when calling this function (i.e. the GIL is locked and the goroutine
-// is locked to its thread)
+// WARNINGS:
+// - make sure a StickyLock is locked when calling this function
+// - make sure the same StickyLock was already locked when the error flag was set on the python interpreter
 func getPythonError() (string, error) {
 	ptype, pvalue, ptraceback := python.PyErr_Fetch() // new references, have to be decref'd
 	defer python.PyErr_Clear()

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -53,9 +53,15 @@ func (sl *stickyLock) unlock() {
 	runtime.UnlockOSThread()
 }
 
-// getPythonError returns string-formatted info about a Python interpreter error that occurred,
-// and clears the error flag in the Python interpreter
-// WARNING: make sure the same stickyLock was already locked when the error flag was set on the python interpreter
+// getPythonError returns string-formatted info about a Python interpreter error
+// that occurred and clears the error flag in the Python interpreter.
+//
+// For many C python functions, a `NULL` return value indicates an error (always
+// refer to the python C API docs to check the meaning of return values).
+// If an error did occur, use this function to handle it properly.
+//
+// WARNING: make sure the same stickyLock was already locked when the error flag
+// was set on the python interpreter
 func (sl *stickyLock) getPythonError() (string, error) {
 	if !sl.locked {
 		return "", fmt.Errorf("the stickyLock is unlocked, can't interact with python interpreter")


### PR DESCRIPTION
### What does this PR do?
2 things:
1. fix a regression introduced in https://github.com/DataDog/datadog-agent/pull/266 by using the same stickyLock when calling the interpreter and fetching the error (see commit description of 77a91da)
2. Various minor improvements of `getPythonError()` (see commit description of 392287c)

### Motivation

Specifically, changing locks between a python call that sets the error indicator
on the interpreter and a fetch of that error can result in the
error indicator not being there anymore when the fetch is attempted. When that happens
we "lose" the error and have no idea what the py interpreter error was.

Generally, this change makes the py loader and runner more reliable, which is pretty
critical when troubleshooting issues on the agent.

### Additional Notes

Generally, I'm a bit concerned about how the goroutine thread scheduling made by the go runtime can affect the python interpreter state. Touching anything in the `py` package is pretty error-prone... Having "system" tests on the bindings will definitely help. We could also add a big warning in the README of the `py` package :)