### PR TITLE
[metadata] retrieve the python version from the cache

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -17,7 +17,7 @@ var (
 		Use:   "start",
 		Short: "Start the Agent",
 		Long:  `Runs the agent in the foreground`,
-		RunE:  start,
+		Run:   start,
 	}
 )
 
@@ -33,8 +33,8 @@ func init() {
 }
 
 // Start the main loop
-func start(cmd *cobra.Command, args []string) error {
-	statsd, collector, forwarder := StartAgent()
+func start(cmd *cobra.Command, args []string) {
+	StartAgent()
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
@@ -47,6 +47,5 @@ func start(cmd *cobra.Command, args []string) error {
 	case sig := <-signalCh:
 		log.Infof("Received signal '%s', shutting down...", sig)
 	}
-	StopAgent(statsd, collector, forwarder)
-	return nil
+	StopAgent()
 }

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -6,12 +6,24 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/metadata"
 	"github.com/kardianos/osext"
 )
 
 var (
 	// AC is the global object orchestrating checks' loading and running
 	AC *autodiscovery.AutoConfig
+
+	// DSD is the global dogstastd instance
+	DSD *dogstatsd.Server
+
+	// MetadataScheduler is responsible to orchestrate metadata collection
+	MetadataScheduler *metadata.Scheduler
+
+	// Forwarder is the global forwarder instance
+	Forwarder forwarder.Forwarder
 
 	// Stopper is the channel used by other packages to ask for stopping the agent
 	Stopper = make(chan bool)

--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -44,7 +44,7 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 	changes <- svc.Status{State: svc.StartPending}
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 
-	statsd, collector, forwarder := app.StartAgent()
+	app.StartAgent()
 
 loop:
 	for {
@@ -57,14 +57,14 @@ loop:
 				time.Sleep(100 * time.Millisecond)
 				changes <- c.CurrentStatus
 			case svc.Stop, svc.Shutdown:
-				app.StopAgent(statsd, collector, forwarder)
+				app.StopAgent()
 				break loop
 			default:
 				elog.Error(1, fmt.Sprintf("unexpected control request #%d", c))
 			}
 		case <-common.Stopper:
 			elog.Info(1, "Received stop command, shutting down...")
-			app.StopAgent(statsd, collector, forwarder)
+			app.StopAgent()
 			break loop
 
 		}

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -2,9 +2,11 @@ package py
 
 import (
 	"fmt"
+	"path"
 	"runtime"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/sbinet/go-python"
 )
 
@@ -82,6 +84,13 @@ func Initialize(paths ...string) *python.PyThreadState {
 		for _, p := range paths {
 			python.PyList_Append(path, python.PyString_FromString(p))
 		}
+	}
+
+	// store the Python version in the global cache
+	res := C.Py_GetVersion()
+	if res != nil {
+		key := path.Join(util.AgentCachePrefix, "pythonVersion")
+		util.Cache.Set(key, C.GoString(res), util.NoExpiration)
 	}
 
 	// We acquired the GIL as a side effect of threading initialization (see above)
@@ -192,7 +201,8 @@ func getPythonError() (string, error) {
 	return "", fmt.Errorf("unknown error")
 }
 
-// GetInterpreterVersion should go in `go-python`, TODO.
+// GetInterpreterVersion returns the Python version as fetched from the C api
+// BUG(massi) submit a PR to add this func to `go-python`
 func GetInterpreterVersion() string {
 	// Lock the GIL and release it at the end of the run
 	gstate := newStickyLock()

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -200,18 +200,3 @@ func getPythonError() (string, error) {
 
 	return "", fmt.Errorf("unknown error")
 }
-
-// GetInterpreterVersion returns the Python version as fetched from the C api
-// BUG(massi) submit a PR to add this func to `go-python`
-func GetInterpreterVersion() string {
-	// Lock the GIL and release it at the end of the run
-	gstate := newStickyLock()
-	defer gstate.unlock()
-
-	res := C.Py_GetVersion()
-	if res == nil {
-		return ""
-	}
-
-	return C.GoString(res)
-}

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -2,11 +2,14 @@ package py
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Setup the test module
@@ -23,6 +26,14 @@ func TestMain(m *testing.M) {
 	// benchmarks don't like python.Finalize() for some reason, let's just not call it
 
 	os.Exit(ret)
+}
+
+func TestInitialize(t *testing.T) {
+	key := path.Join(util.AgentCachePrefix, "pythonVersion")
+	x, found := util.Cache.Get(key)
+	require.True(t, found)
+	require.NotEmpty(t, x)
+	require.NotEqual(t, "n/a", x)
 }
 
 func TestFindSubclassOf(t *testing.T) {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -59,6 +59,10 @@ func getSystemStats() *systemStats {
 	return stats
 }
 
+// getPythonVersion returns the version string as provided by the embedded Python
+// interpreter. The string is stored in the Agent cache when the interpreter is
+// initialized (see pkg/collector/py/utils.go), an empty value is expected when
+// using this package without embedding Python.
 func getPythonVersion() string {
 	// retrieve the Python version from the Agent cache
 	key := path.Join(util.AgentCachePrefix, "pythonVersion")

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/shirou/gopsutil/cpu"
@@ -61,16 +60,13 @@ func getSystemStats() *systemStats {
 }
 
 func getPythonVersion() string {
-	var pythonVersion string
-	key := buildKey("python")
+	// retrieve the Python version from the Agent cache
+	key := path.Join(util.AgentCachePrefix, "pythonVersion")
 	if x, found := util.Cache.Get(key); found {
-		pythonVersion = x.(string)
-	} else {
-		pythonVersion = py.GetInterpreterVersion()
-		util.Cache.Set(key, pythonVersion, util.NoExpiration)
+		return x.(string)
 	}
 
-	return pythonVersion
+	return "n/a"
 }
 
 // getCPUInfo returns InfoStat for the first CPU gopsutil found

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -1,28 +1,15 @@
 package host
 
 import (
-	"os"
+	"path"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	python "github.com/sbinet/go-python"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-// Setup the test module
-func TestMain(m *testing.M) {
-	state := py.Initialize()
-
-	ret := m.Run()
-
-	python.PyEval_RestoreThread(state)
-	python.Finalize()
-
-	os.Exit(ret)
-}
 
 func TestGetPayload(t *testing.T) {
 	p := GetPayload("myhostname")
@@ -45,10 +32,10 @@ func TestGetSystemStats(t *testing.T) {
 }
 
 func TestGetPythonVersion(t *testing.T) {
-	assert.NotEmpty(t, getPythonVersion())
-	key := buildKey("python")
+	require.Equal(t, "n/a", getPythonVersion())
+	key := path.Join(util.AgentCachePrefix, "pythonVersion")
 	util.Cache.Set(key, "Python 2.8", util.NoExpiration)
-	assert.Equal(t, "Python 2.8", getPythonVersion())
+	require.Equal(t, "Python 2.8", getPythonVersion())
 }
 
 func TestGetCPUInfo(t *testing.T) {


### PR DESCRIPTION


<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Retrieves the Python version from the global cache instead of calling the C Python API.
This should be enough to decouple the `metadata` package from `py`.

### Motivation

External softwares importing the `metadata` package had to build all the python dependencies for actually no reasons, being `py` only needed to build the `V5` host metadata payload.

### Additional Notes

Also fixed a weird handling of the startup variables in `cmd/agent/app`, since part were global variables stored in `cmd/app/common`, part were handled locally and passed around as function params. Now they're all global vars.