### PR TITLE
[percentiles] first pass at adding percentile sketch

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -59,6 +59,7 @@ func init() {
 	newStats("ServiceCheckFlushTime")
 	newStats("EventFlushTime")
 	newStats("MainFlushTime")
+	newStats("MetricSketchFlushTime")
 	aggregatorExpvar.Set("Flush", expvar.Func(expStats))
 }
 
@@ -87,6 +88,7 @@ type BufferedAggregator struct {
 	eventIn            chan Event
 	sampler            TimeSampler
 	checkSamplers      map[check.ID]*CheckSampler
+	distSampler        DistSampler
 	serviceChecks      []ServiceCheck
 	events             []Event
 	flushInterval      int64
@@ -107,6 +109,7 @@ func NewBufferedAggregator(f forwarder.Forwarder, hostname string) *BufferedAggr
 		eventIn:            make(chan Event, 100),              // TODO make buffer size configurable
 		sampler:            *NewTimeSampler(bucketSize, hostname),
 		checkSamplers:      make(map[check.ID]*CheckSampler),
+		distSampler:        *NewDistSampler(bucketSize, hostname),
 		flushInterval:      defaultFlushInterval,
 		forwarder:          f,
 		hostname:           hostname,
@@ -204,6 +207,17 @@ func (agg *BufferedAggregator) addEvent(e Event) {
 	agg.events = append(agg.events, e)
 }
 
+// addSample adds the metric sample to either the sampler or distSampler
+func (agg *BufferedAggregator) addSample(metricSample *MetricSample, timestamp int64) {
+	log.Infof("Adding sample of type %s", metricSample.Mtype)
+	if metricSample.Mtype == DistributionType {
+		log.Infof("Adding sample to Distribution %v", metricSample.Value)
+		agg.distSampler.addSample(metricSample, timestamp)
+	} else {
+		agg.sampler.addSample(metricSample, timestamp)
+	}
+}
+
 func (agg *BufferedAggregator) flushSeries() {
 	start := time.Now()
 	series := agg.sampler.flush(start.Unix())
@@ -257,6 +271,28 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 	}()
 }
 
+func (agg *BufferedAggregator) flushSketches() {
+	start := time.Now()
+	sketchSeries := agg.distSampler.flush(start.Unix())
+
+	if len(sketchSeries) == 0 {
+		return
+	}
+
+	// Serialize and forward in a separate goroutine
+	go func() {
+		log.Debug("Flushing ", len(sketchSeries), " sketches to the forwarder")
+		payload, err := MarshalJSONSketchSeries(sketchSeries)
+		if err != nil {
+			log.Error("could not serialize sketches, dropping them:", err)
+		}
+		agg.forwarder.SubmitV1SketchSeries(config.Datadog.GetString("api_key"), &payload)
+		log.Infof("Forwarding sketch %v", string(payload))
+		addFlushTime("MetricSketchFlushTIme", int64(time.Since(start)))
+		aggregatorExpvar.Add("SketchesFlushed", int64(len(sketchSeries)))
+	}()
+}
+
 func (agg *BufferedAggregator) flushEvents() {
 	// Clear the current event slice
 	start := time.Now()
@@ -292,6 +328,7 @@ func (agg *BufferedAggregator) run() {
 		case <-agg.TickerChan:
 			start := time.Now()
 			agg.flushSeries()
+			agg.flushSketches()
 			agg.flushServiceChecks()
 			agg.flushEvents()
 			addFlushTime("MainFlushTime", int64(time.Since(start)))
@@ -299,7 +336,7 @@ func (agg *BufferedAggregator) run() {
 		case sample := <-agg.dogstatsdIn:
 			aggregatorExpvar.Add("DogstatsdMetricSample", 1)
 			now := time.Now().Unix()
-			agg.sampler.addSample(sample, now)
+			agg.addSample(sample, now)
 		case ss := <-agg.checkMetricIn:
 			aggregatorExpvar.Add("ChecksMetricSample", 1)
 			agg.handleSenderSample(ss)

--- a/pkg/aggregator/context_sketch.go
+++ b/pkg/aggregator/context_sketch.go
@@ -1,0 +1,47 @@
+package aggregator
+
+import (
+	log "github.com/cihub/seelog"
+	"math"
+)
+
+// FIXME(Jee): This should be integrated into context_metrics.go as it duplicates
+// the logic.
+
+// ContextSketch stores the distributions by context key
+type ContextSketch map[string]*Distribution
+
+func makeContextSketch() ContextSketch {
+	return ContextSketch(make(map[string]*Distribution))
+}
+
+func (c ContextSketch) addSample(contextKey string, sample *MetricSample, timestamp int64, interval int64) {
+	if math.IsInf(sample.Value, 0) {
+		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
+		return
+	}
+	if _, ok := c[contextKey]; !ok {
+		c[contextKey] = NewDistribution()
+	}
+	c[contextKey].addSample(sample, timestamp)
+}
+
+func (c ContextSketch) flush(timestamp int64) []*SketchSerie {
+	var sketches []*SketchSerie
+
+	for contextKey, distribution := range c {
+		sketchSerie, err := distribution.flush(timestamp)
+		if err == nil {
+			sketchSerie.contextKey = contextKey
+			sketches = append(sketches, sketchSerie)
+		} else {
+			switch err.(type) {
+			case NoSketchError:
+			default:
+				log.Info("An error occurred while flushing metric summary on context key '%s': %s",
+					contextKey, err)
+			}
+		}
+	}
+	return sketches
+}

--- a/pkg/aggregator/context_sketch_test.go
+++ b/pkg/aggregator/context_sketch_test.go
@@ -1,0 +1,73 @@
+package aggregator
+
+import (
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextSketchSampling(t *testing.T) {
+	ctxSketch := makeContextSketch()
+	contextKey := "context_key"
+
+	ctxSketch.addSample(contextKey, &MetricSample{Value: 1}, 1, 10)
+	ctxSketch.addSample(contextKey, &MetricSample{Value: 5}, 3, 10)
+	resultSeries := ctxSketch.flush(12345)
+
+	expectedSketch := QSketch{}
+	expectedSketch.Insert(1)
+	expectedSketch.Insert(5)
+	expectedSerie := &SketchSerie{
+		contextKey: contextKey,
+		Sketches:   []Sketch{{int64(12345), expectedSketch}}}
+
+	assert.Equal(t, 1, len(resultSeries))
+	AssertSketchSerieEqual(t, expectedSerie, resultSeries[0])
+
+	// No sketches should be flushed when there's no new sample since
+	// last flush
+	resultSeries = ctxSketch.flush(12355)
+	assert.Equal(t, 0, len(resultSeries))
+}
+
+// The sketches ignore sample values of +Inf/-Inf
+func TestContextSketchSamplingInfinity(t *testing.T) {
+	ctxSketch := makeContextSketch()
+	contextKey := "context_key"
+
+	ctxSketch.addSample(contextKey, &MetricSample{Value: math.Inf(1)}, 1, 10)
+	ctxSketch.addSample(contextKey, &MetricSample{Value: math.Inf(-1)}, 2, 10)
+	resultSeries := ctxSketch.flush(12345)
+
+	assert.Equal(t, 0, len(resultSeries))
+}
+
+func TestContextSketchSamplingMultiContexts(t *testing.T) {
+	ctxSketch := makeContextSketch()
+	contextKey1 := "context_key1"
+	contextKey2 := "context_key2"
+	ctxSketch.addSample(contextKey1, &MetricSample{Value: 1}, 1, 10)
+	ctxSketch.addSample(contextKey2, &MetricSample{Value: 1}, 1, 10)
+	ctxSketch.addSample(contextKey1, &MetricSample{Value: 3}, 5, 10)
+	orderedSketchSeries := OrderedSketchSeries{ctxSketch.flush(12345)}
+	sort.Sort(orderedSketchSeries)
+
+	expectedSketch1 := QSketch{}
+	expectedSketch1.Insert(1)
+	expectedSketch1.Insert(3)
+	expectedSerie1 := &SketchSerie{
+		contextKey: contextKey1,
+		Sketches:   []Sketch{{int64(12345), expectedSketch1}}}
+	expectedSketch2 := QSketch{}
+	expectedSketch2.Insert(1)
+	expectedSerie2 := &SketchSerie{
+		contextKey: contextKey2,
+		Sketches:   []Sketch{{int64(12345), expectedSketch2}}}
+
+	assert.Equal(t, 2, orderedSketchSeries.Len())
+
+	AssertSketchSerieEqual(t, expectedSerie1, orderedSketchSeries.sketchSeries[0])
+	AssertSketchSerieEqual(t, expectedSerie2, orderedSketchSeries.sketchSeries[1])
+}

--- a/pkg/aggregator/dist_sampler.go
+++ b/pkg/aggregator/dist_sampler.go
@@ -1,0 +1,82 @@
+package aggregator
+
+import (
+	"time"
+)
+
+// FIXME(Jee) : This should be integrated with time_sampler.go since it
+// duplicates code/logic.
+
+// DistSampler creates sketches of metrics by buckets of 'interval' seconds
+type DistSampler struct {
+	interval            int64
+	contextResolver     *ContextResolver
+	sketchesByTimestamp map[int64]ContextSketch
+	defaultHostname     string
+}
+
+// NewDistSampler returns a newly initialized DistSampler
+func NewDistSampler(interval int64, defaultHostname string) *DistSampler {
+	return &DistSampler{
+		interval:            interval,
+		contextResolver:     newContextResolver(),
+		sketchesByTimestamp: map[int64]ContextSketch{},
+		defaultHostname:     defaultHostname,
+	}
+}
+
+func (d *DistSampler) calculateBucketStart(timestamp int64) int64 {
+	return timestamp - timestamp%d.interval
+}
+
+// Add the metricSample to the correct sketch
+func (d *DistSampler) addSample(metricSample *MetricSample, timestamp int64) {
+	contextKey := d.contextResolver.trackContext(metricSample, timestamp)
+	bucketStart := d.calculateBucketStart(timestamp)
+	sketch, ok := d.sketchesByTimestamp[bucketStart]
+	if !ok {
+		sketch = makeContextSketch()
+		d.sketchesByTimestamp[bucketStart] = sketch
+	}
+	sketch.addSample(contextKey, metricSample, timestamp, d.interval)
+}
+
+func (d *DistSampler) flush(timestamp int64) []*SketchSerie {
+	var result []*SketchSerie
+
+	sketchesByContext := make(map[string]*SketchSerie)
+
+	cutoffTime := d.calculateBucketStart(timestamp)
+	for timestamp, ctxSketch := range d.sketchesByTimestamp {
+		if cutoffTime <= timestamp {
+			continue
+		}
+
+		sketches := ctxSketch.flush(timestamp)
+		for _, sketchSerie := range sketches {
+			contextKey := sketchSerie.contextKey
+
+			if existingSerie, ok := sketchesByContext[contextKey]; ok {
+				existingSerie.Sketches = append(existingSerie.Sketches, sketchSerie.Sketches[0])
+			} else {
+				context := d.contextResolver.contextsByKey[contextKey]
+				sketchSerie.Name = context.Name
+				sketchSerie.Tags = context.Tags
+				if context.Host != "" {
+					sketchSerie.Host = context.Host
+				} else {
+					sketchSerie.Host = d.defaultHostname
+				}
+				sketchSerie.DeviceName = context.DeviceName
+				sketchSerie.Interval = d.interval
+
+				sketchesByContext[contextKey] = sketchSerie
+				result = append(result, sketchSerie)
+			}
+		}
+		delete(d.sketchesByTimestamp, timestamp)
+	}
+	d.contextResolver.expireContexts(timestamp - int64(defaultExpiry/time.Second))
+
+	return result
+}

--- a/pkg/aggregator/dist_sampler_test.go
+++ b/pkg/aggregator/dist_sampler_test.go
@@ -1,0 +1,161 @@
+package aggregator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertSketchSerieEqual(t *testing.T, expected, actual *SketchSerie) {
+	assert.Equal(t, expected.Name, actual.Name)
+	if expected.Tags != nil {
+		assert.NotNil(t, actual.Tags)
+		AssertTagsEqual(t, expected.Tags, actual.Tags)
+	}
+	assert.Equal(t, expected.Host, actual.Host)
+	assert.Equal(t, expected.DeviceName, actual.DeviceName)
+	assert.Equal(t, expected.Interval, actual.Interval)
+	if expected.contextKey != "" {
+		assert.Equal(t, expected.contextKey, actual.contextKey)
+	}
+	if expected.Sketches != nil {
+		assert.NotNil(t, actual.Sketches)
+		AssertSketchesEqual(t, expected.Sketches, actual.Sketches)
+	}
+}
+
+func AssertSketchesEqual(t *testing.T, expected, actual []Sketch) {
+	if assert.Equal(t, len(expected), len(actual)) {
+		actualOrdered := OrderedSketches{actual}
+		sort.Sort(actualOrdered)
+		for i, sketch := range expected {
+			assert.Equal(t, sketch, actualOrdered.sketches[i])
+		}
+	}
+}
+
+// OrderedSketches used to sort []Sketch
+type OrderedSketches struct {
+	sketches []Sketch
+}
+
+func (os OrderedSketches) Len() int {
+	return len(os.sketches)
+}
+
+func (os OrderedSketches) Less(i, j int) bool {
+	return os.sketches[i].timestamp < os.sketches[j].timestamp
+}
+
+func (os OrderedSketches) Swap(i, j int) {
+	os.sketches[i], os.sketches[j] = os.sketches[j], os.sketches[i]
+}
+
+// OrderedSketchSeries used to sort []*SketchSerie
+type OrderedSketchSeries struct {
+	sketchSeries []*SketchSerie
+}
+
+func (oss OrderedSketchSeries) Len() int {
+	return len(oss.sketchSeries)
+}
+
+func (oss OrderedSketchSeries) Less(i, j int) bool {
+	return oss.sketchSeries[i].contextKey < oss.sketchSeries[j].contextKey
+}
+
+func (oss OrderedSketchSeries) Swap(i, j int) {
+	oss.sketchSeries[i], oss.sketchSeries[j] = oss.sketchSeries[j], oss.sketchSeries[i]
+}
+
+func TestDistSamplerBucketSampling(t *testing.T) {
+	distSampler := NewDistSampler(10, "")
+
+	mSample1 := MetricSample{
+		Name:       "test.metric.name",
+		Value:      1,
+		Mtype:      DistributionType,
+		Tags:       &[]string{"a", "b"},
+		SampleRate: 1,
+	}
+	mSample2 := MetricSample{
+		Name:       "test.metric.name",
+		Value:      2,
+		Mtype:      DistributionType,
+		Tags:       &[]string{"a", "b"},
+		SampleRate: 1,
+	}
+	distSampler.addSample(&mSample1, 10001)
+	distSampler.addSample(&mSample2, 10002)
+	distSampler.addSample(&mSample1, 10011)
+	distSampler.addSample(&mSample2, 10012)
+	distSampler.addSample(&mSample1, 10021)
+
+	sketchSeries := distSampler.flush(10020)
+
+	expectedSketch := QSketch{}
+	expectedSketch.Insert(1)
+	expectedSketch.Insert(2)
+	expectedSerie := &SketchSerie{
+		Name:     "test.metric.name",
+		Tags:     []string{"a", "b"},
+		Interval: 10,
+		Sketches: []Sketch{
+			Sketch{int64(10000), expectedSketch},
+			Sketch{int64(10010), expectedSketch},
+		},
+		contextKey: "test.metric.name,a,b",
+	}
+	assert.Equal(t, 1, len(sketchSeries))
+	AssertSketchSerieEqual(t, expectedSerie, sketchSeries[0])
+
+	// The samples added after the flush time remains in the dist sampler
+	assert.Equal(t, 1, len(distSampler.sketchesByTimestamp))
+}
+
+func TestDistSamplerContextSampling(t *testing.T) {
+	distSampler := NewDistSampler(10, "")
+
+	mSample1 := MetricSample{
+		Name:       "test.metric.name1",
+		Value:      1,
+		Mtype:      DistributionType,
+		Tags:       &[]string{"a", "b"},
+		SampleRate: 1,
+	}
+	mSample2 := MetricSample{
+		Name:       "test.metric.name2",
+		Value:      1,
+		Mtype:      DistributionType,
+		Tags:       &[]string{"a", "c"},
+		SampleRate: 1,
+	}
+	distSampler.addSample(&mSample1, 10011)
+	distSampler.addSample(&mSample2, 10011)
+
+	orderedSketchSeries := OrderedSketchSeries{distSampler.flush(10020)}
+	sort.Sort(orderedSketchSeries)
+	sketchSeries := orderedSketchSeries.sketchSeries
+
+	expectedSketch := QSketch{}
+	expectedSketch.Insert(1)
+	expectedSerie1 := &SketchSerie{
+		Name:       "test.metric.name1",
+		Tags:       []string{"a", "b"},
+		Interval:   10,
+		Sketches:   []Sketch{Sketch{int64(10010), expectedSketch}},
+		contextKey: "test.metric.name1,a,b",
+	}
+	expectedSerie2 := &SketchSerie{
+		Name:       "test.metric.name2",
+		Tags:       []string{"a", "c"},
+		Interval:   10,
+		Sketches:   []Sketch{Sketch{int64(10010), expectedSketch}},
+		contextKey: "test.metric.name2,a,c",
+	}
+
+	assert.Equal(t, 2, len(sketchSeries))
+	AssertSketchSerieEqual(t, expectedSerie1, sketchSeries[0])
+	AssertSketchSerieEqual(t, expectedSerie2, sketchSeries[1])
+}

--- a/pkg/aggregator/distribution.go
+++ b/pkg/aggregator/distribution.go
@@ -1,0 +1,35 @@
+package aggregator
+
+// Distribution tracks the distribution of samples added over one flush
+// period. Designed to be globally accurate for percentiles.
+type Distribution struct {
+	sketch QSketch
+	count  int64
+}
+
+// NewDistribution creates a new Distribution
+func NewDistribution() *Distribution {
+	return &Distribution{}
+}
+
+func (d *Distribution) addSample(sample *MetricSample, timestamp int64) {
+	// Insert sample value into the sketch
+	d.sketch.Insert(sample.Value)
+	d.count++
+}
+
+func (d *Distribution) flush(timestamp int64) (*SketchSerie, error) {
+	if d.count == 0 {
+		return &SketchSerie{}, NoSketchError{}
+	}
+
+	sketch := &SketchSerie{
+		Sketches: []Sketch{{timestamp: timestamp,
+			sketch: d.sketch}},
+	}
+	// reset the global histogram
+	d.sketch = QSketch{}
+	d.count = 0
+
+	return sketch, nil
+}

--- a/pkg/aggregator/distribution_test.go
+++ b/pkg/aggregator/distribution_test.go
@@ -1,0 +1,40 @@
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDistributionSampling(t *testing.T) {
+	distro := NewDistribution()
+
+	// OK to flush an empty global histogram
+	_, err := distro.flush(10)
+	assert.NotNil(t, err)
+
+	// Add metric samples and check that the flushed summary series
+	// are correct
+	distro.addSample(&MetricSample{Value: 1}, 10)
+	distro.addSample(&MetricSample{Value: 10}, 11)
+	distro.addSample(&MetricSample{Value: 5}, 12)
+
+	assert.Equal(t, int64(3), distro.count)
+
+	sketchSerie, err := distro.flush(15)
+	assert.Nil(t, err)
+
+	expectedSketch := QSketch{}
+	expectedSketch.Insert(1)
+	expectedSketch.Insert(10)
+	expectedSketch.Insert(5)
+	expectedSerie := &SketchSerie{
+		Sketches: []Sketch{{int64(15), expectedSketch}}}
+	AssertSketchSerieEqual(t, expectedSerie, sketchSerie)
+
+	// Global histogram is reset after a flush
+	assert.Equal(t, int64(0), distro.count)
+
+	_, err = distro.flush(20)
+	assert.NotNil(t, err)
+}

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -13,6 +13,7 @@ const (
 	HistogramType
 	HistorateType
 	SetType
+	DistributionType
 )
 
 // String returns a string representation of MetricType
@@ -34,6 +35,8 @@ func (m MetricType) String() string {
 		return "Historate"
 	case SetType:
 		return "Set"
+	case DistributionType:
+		return "Distribution"
 	default:
 		return ""
 	}

--- a/pkg/aggregator/qsketch.go
+++ b/pkg/aggregator/qsketch.go
@@ -1,0 +1,234 @@
+package aggregator
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+// EPSILON represents the accuracy of the sketch.
+const EPSILON float64 = 0.01
+
+// QSketch is the sketch of the data.
+type QSketch struct {
+	Entries []Entry `json:"entries"`
+	N       int     `json:"n"`
+}
+
+// Entry is an element of the skiplist, see GK paper for description
+type Entry struct {
+	V     float64 `json:"v"`
+	G     int     `json:"g"`
+	Delta int     `json:"delta"`
+}
+
+// NewQSketch allocates a new GK summary backed by a DLL
+func NewQSketch() *QSketch {
+	return &QSketch{}
+}
+
+func (s QSketch) String() string {
+	var b bytes.Buffer
+	b.WriteString("summary size: ")
+	b.WriteString(fmt.Sprintf("%d", s.N))
+	b.WriteRune('\n')
+
+	gsum := 0
+
+	for i, e := range s.Entries {
+		gsum += e.G
+		b.WriteString(fmt.Sprintf("v:%6.02f g:%05d d:%05d rmin:%05d rmax: %05d   ",
+			e.V, e.G, e.Delta, gsum, gsum+e.Delta))
+		if i%3 == 2 {
+			b.WriteRune('\n')
+		}
+	}
+
+	return b.String()
+}
+
+// Insert inserts a new value v in the summary
+func (s *QSketch) Insert(v float64) {
+	newEntry := Entry{
+		V:     v,
+		G:     1,
+		Delta: int(2 * EPSILON * float64(s.N)),
+	}
+
+	i := sort.Search(len(s.Entries), func(i int) bool { return v < s.Entries[i].V })
+
+	if i == 0 || i == len(s.Entries) {
+		newEntry.Delta = 0
+	}
+
+	// allocate one more
+	s.Entries = append(s.Entries, Entry{})
+	copy(s.Entries[i+1:], s.Entries[i:])
+	s.Entries[i] = newEntry
+	s.N++
+
+	if s.N%int(1.0/float64(2.0*EPSILON)) == 0 {
+		s.compress()
+	}
+}
+
+func (s *QSketch) compress() {
+	epsN := int(2 * EPSILON * float64(s.N))
+
+	var j, sum int
+	for i := len(s.Entries) - 1; i >= 2; i = j - 1 {
+		j = i - 1
+		sum = s.Entries[j].G
+
+		for j >= 1 && sum+s.Entries[i].G+s.Entries[i].Delta < epsN {
+			j--
+			sum += s.Entries[j].G
+		}
+		sum -= s.Entries[j].G
+		j++
+
+		if j < i {
+			s.Entries[j].V = s.Entries[i].V
+			s.Entries[j].G = sum + s.Entries[i].G
+			s.Entries[j].Delta = s.Entries[i].Delta
+			// copy the rest
+			copy(s.Entries[j+1:], s.Entries[i+1:])
+			// truncate to the numbers of removed elements
+			s.Entries = s.Entries[:len(s.Entries)-(i-j)]
+		}
+	}
+}
+
+// Quantile returns an EPSILON estimate of the element at quantile 'q' (0 <= q <= 1)
+func (s *QSketch) Quantile(q float64) float64 {
+	if len(s.Entries) == 0 {
+		return 0
+	}
+
+	// convert quantile to rank
+	r := int(q*float64(s.N) + 0.5)
+
+	var rmin int
+	epsN := int(EPSILON * float64(s.N))
+
+	for i := 0; i < len(s.Entries)-1; i++ {
+		t := s.Entries[i]
+		n := s.Entries[i+1]
+
+		rmin += t.G
+
+		if r+epsN < rmin+n.G+n.Delta {
+			if r+epsN < rmin+n.G {
+				return t.V
+			}
+			return n.V
+		}
+	}
+
+	return s.Entries[len(s.Entries)-1].V
+}
+
+// Merge two summaries entries together
+func (s *QSketch) Merge(s2 *QSketch) {
+	if s2.N == 0 {
+		return
+	}
+	if s.N == 0 {
+		s.N = s2.N
+		s.Entries = make([]Entry, 0, len(s2.Entries))
+		s.Entries = append(s.Entries, s2.Entries...)
+		return
+	}
+
+	pos := 0
+	end := len(s.Entries) - 1
+
+	empties := make([]Entry, len(s2.Entries))
+	s.Entries = append(s.Entries, empties...)
+
+	for _, e := range s2.Entries {
+		for pos <= end {
+			if e.V > s.Entries[pos].V {
+				pos++
+				continue
+			}
+			copy(s.Entries[pos+1:end+2], s.Entries[pos:end+1])
+			s.Entries[pos] = e
+			pos++
+			end++
+			break
+		}
+		if pos > end {
+			s.Entries[pos] = e
+			pos++
+		}
+	}
+	s.N += s2.N
+
+	s.compress()
+}
+
+// Copy allocates a new summary with the same data
+func (s *QSketch) Copy() *QSketch {
+	s2 := NewQSketch()
+	s2.Entries = make([]Entry, len(s.Entries))
+	copy(s2.Entries, s.Entries)
+	s2.N = s.N
+	return s2
+}
+
+// SummarySlice reprensents how many values are in a [Start, End] range
+type SummarySlice struct {
+	Start  float64
+	End    float64
+	Weight int
+}
+
+// BySlices returns a slice of Summary slices that represents weighted ranges of
+// values
+// e.g.    [0, 1]  : 3
+//         [1, 23] : 12 ...
+// The number of intervals is related to the precision kept in the internal
+// data structure to ensure epsilon*s.N precision on quantiles, but it's bounded.
+// When the bounds of the interval are equal, the weight is the number of times
+// that exact value was inserted in the summary.
+func (s *QSketch) BySlices() []SummarySlice {
+	var slices []SummarySlice
+
+	if len(s.Entries) == 0 {
+		return slices
+	}
+
+	// by def in GK first val is always the min
+	fs := SummarySlice{
+		Start:  s.Entries[0].V,
+		End:    s.Entries[0].V,
+		Weight: 1,
+	}
+	slices = append(slices, fs)
+
+	last := fs.End
+
+	for _, cur := range s.Entries[1:] {
+		lastSlice := &slices[len(slices)-1]
+		if cur.V == lastSlice.Start && cur.V == lastSlice.End {
+			lastSlice.Weight += cur.G
+			continue
+		}
+
+		if cur.G == 1 {
+			last = cur.V
+		}
+
+		ss := SummarySlice{
+			Start:  last,
+			End:    cur.V,
+			Weight: cur.G,
+		}
+		slices = append(slices, ss)
+
+		last = cur.V
+	}
+
+	return slices
+}

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -133,3 +133,14 @@ func MarshalJSONEvents(events []Event, apiKey string, hostname string) ([]byte, 
 	err := json.NewEncoder(reqBody).Encode(data)
 	return reqBody.Bytes(), err
 }
+
+// MarshalJSONSketchSeries serializes sketch series to JSON so it can be sent to
+// endpoints
+func MarshalJSONSketchSeries(sketches []*SketchSerie) ([]byte, error) {
+	data := map[string][]*SketchSerie{
+		"sketch_series": sketches,
+	}
+	reqBody := &bytes.Buffer{}
+	err := json.NewEncoder(reqBody).Encode(data)
+	return reqBody.Bytes(), err
+}

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -178,3 +178,21 @@ func TestMarshalJSONEventsOmittedFields(t *testing.T) {
 	// These optional fields are not present in the serialized payload, and a default source type name is used
 	assert.Equal(t, payload, []byte("{\"apiKey\":\"testapikey\",\"events\":{\"api\":[{\"msg_title\":\"An event occurred\",\"msg_text\":\"event description\",\"timestamp\":12345,\"host\":\"my-hostname\"}]},\"internalHostname\":\"test-hostname\"}\n"))
 }
+
+func TestMarshalJSONSketchSeries(t *testing.T) {
+	series := []*SketchSerie{{
+		contextKey: "test_context",
+		Sketches: []Sketch{
+			{int64(12345), QSketch{[]Entry{{1, 1, 0}}, 1}},
+			{int64(67890), QSketch{[]Entry{{10, 1, 0}, {14, 3, 0}, {21, 2, 0}}, 3}},
+		},
+		Name: "test.metrics",
+		Host: "localHost",
+		Tags: []string{"tag1", "tag2:yes"},
+	}}
+
+	payload, err := MarshalJSONSketchSeries(series)
+	assert.Nil(t, err)
+	assert.NotNil(t, payload)
+	assert.Equal(t, payload, []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device_name\":\"\",\"interval\":0,\"sketches\":[[12345,[[[1,1,0]],1]],[67890,[[[10,1,0],[14,3,0],[21,2,0]],3]]]}]}\n"))
+}

--- a/pkg/aggregator/sketch_series.go
+++ b/pkg/aggregator/sketch_series.go
@@ -1,0 +1,42 @@
+package aggregator
+
+import (
+	"fmt"
+)
+
+// Sketch represents a quantile sketch at a specific time
+type Sketch struct {
+	timestamp int64
+	sketch    QSketch
+}
+
+// SketchSerie holds an array of sketches.
+type SketchSerie struct {
+	Name       string   `json:"metric"`
+	Tags       []string `json:"tags"`
+	Host       string   `json:"host"`
+	DeviceName string   `json:"device_name"`
+	Interval   int64    `json:"interval"`
+	Sketches   []Sketch `json:"sketches"`
+	contextKey string
+}
+
+// MarshalJSON returns a Sketch as an array of timestamp, percentile sketch pairs
+func (s *Sketch) MarshalJSON() ([]byte, error) {
+	sketchStr := fmt.Sprintf("[%v, [[", s.timestamp)
+	for _, entry := range s.sketch.Entries {
+		sketchStr += fmt.Sprintf("[%v, %v, %v],", entry.V, entry.G, entry.Delta)
+	}
+	// remove the last comma
+	sketchStr = sketchStr[:len(sketchStr)-1]
+	sketchStr += fmt.Sprintf("], %v]]", s.sketch.N)
+	return []byte(sketchStr), nil
+}
+
+// NoSketchError is the error returned when not enough samples have been
+//submitted to generate a sketch
+type NoSketchError struct{}
+
+func (e NoSketchError) Error() string {
+	return "Not enough samples to generate sketches"
+}

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -20,6 +20,7 @@ var metricTypes = map[string]aggregator.MetricType{
 	"s":  aggregator.SetType,
 	"h":  aggregator.HistogramType,
 	"ms": aggregator.HistogramType,
+	"d":  aggregator.DistributionType,
 }
 
 func nextPacket(datagram *[]byte) (packet []byte) {

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -120,6 +120,17 @@ func TestParseSet(t *testing.T) {
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
+func TestParseDistribution(t *testing.T) {
+	parsed, err := parseMetricPacket([]byte("daemon:3.5|d"))
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "daemon", parsed.Name)
+	assert.Equal(t, 3.5, parsed.Value)
+	assert.Equal(t, aggregator.DistributionType, parsed.Mtype)
+	assert.Equal(t, 0, len(*(parsed.Tags)))
+}
+
 func TestParseSetUnicode(t *testing.T) {
 	parsed, err := parseMetricPacket([]byte("daemon:♬†øU†øU¥ºuT0♪|s"))
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -30,9 +30,10 @@ const (
 	defaultNumberOfWorkers = 4
 	chanBufferSize         = 100
 
-	v1SeriesEndpoint    = "/api/v1/series?api_key=%s"
-	v1CheckRunsEndpoint = "/api/v1/check_run?api_key=%s"
-	v1IntakeEndpoint    = "/intake/?api_key=%s"
+	v1SeriesEndpoint       = "/api/v1/series?api_key=%s"
+	v1CheckRunsEndpoint    = "/api/v1/check_run?api_key=%s"
+	v1IntakeEndpoint       = "/intake/?api_key=%s"
+	v1SketchSeriesEndpoint = "/api/v1/sketches?api_key=%s"
 
 	seriesEndpoint       = "/api/v2/series"
 	eventsEndpoint       = "/api/v2/events"
@@ -70,6 +71,7 @@ type Forwarder interface {
 	SubmitV2CheckRuns(apikey string, payload *[]byte) error
 	SubmitV2HostMeta(apikey string, payload *[]byte) error
 	SubmitV2GenericMeta(apikey string, payload *[]byte) error
+	SubmitV1SketchSeries(apiKey string, payload *[]byte) error
 }
 
 // DefaultForwarder is in charge of receiving transaction payloads and sending them to Datadog backend over HTTP.
@@ -331,6 +333,17 @@ func (f *DefaultForwarder) SubmitV1Intake(apiKey string, payload *[]byte) error 
 	}
 
 	transactionsCreation.Add("IntakeV1", 1)
+	return f.sendHTTPTransactions(transactions)
+}
+
+// SubmitV1SketchSeries will send payloads to v1 endpoint
+func (f *DefaultForwarder) SubmitV1SketchSeries(apiKey string, payload *[]byte) error {
+	endpoint := fmt.Sprintf(v1SketchSeriesEndpoint, apiKey)
+	transactions, err := f.createHTTPTransactions(endpoint, payload, false)
+	if err != nil {
+		return err
+	}
+	transactionsCreation.Add("SketchSeries", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -159,6 +159,14 @@ func TestSubmit(t *testing.T) {
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
+	expectedPayload = []byte("SubmitV1SketchSeries payload")
+	expectedEndpoint = "/api/v1/sketches"
+	expectedQuery = "api_key=test_api_key"
+	assert.Nil(t, forwarder.SubmitV1SketchSeries("test_api_key", &expectedPayload))
+	<-wait
+	<-wait
+	assert.Equal(t, len(forwarder.retryQueue), 0)
+
 	expectedPayload = []byte("SubmitV1CheckRuns payload")
 	expectedEndpoint = "/api/v1/check_run"
 	expectedQuery = "api_key=test_api_key"


### PR DESCRIPTION
### What does this PR do?

Allow agent to generate and submit percentile sketches of the raw data. 

### Motivation

We're working on adding accurate percentile capabilities to the datadog metrics.

### Additional Notes

* The quantile sketch (qsketch.go) is a placeholder and needs to be updated to the correct one. 
* The payload is currently just a JSON, and needs to be changed to a more efficient encoding.
* I've kept the additions as separate as possible from the existing code at the cost of some code duplication.
