### PR TITLE
util.GetHostname should not panic, instead it should return an error

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -27,7 +27,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 
 func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	hname := util.GetHostname()
+	hname, _ := util.GetHostname()
 	j, _ := json.Marshal(hname)
 	w.Write(j)
 }

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/gorilla/mux"
@@ -27,7 +29,11 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 
 func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	hname, _ := util.GetHostname()
+	hname, err := util.GetHostname()
+	if err != nil {
+		log.Warnf("Error getting hostname: %s\n", err) // or something like this
+		hname = ""
+	}
 	j, _ := json.Marshal(hname)
 	w.Write(j)
 }

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -60,7 +60,10 @@ func StartAgent() (*dogstatsd.Server, *metadata.Scheduler, forwarder.Forwarder) 
 		panic(err)
 	}
 
-	hostname := util.GetHostname()
+	hostname, err := util.GetHostname()
+	if err != nil {
+		panic(err)
+	}
 
 	// store the computed hostname in the global cache
 	key := path.Join(util.AgentCachePrefix, "hostname")

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -99,7 +99,8 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 
 	// FIXME: the aggregator should probably be initialized with the resolved hostname instead
-	aggregatorInstance := aggregator.InitAggregator(f, util.GetHostname())
+	hname, _ := util.GetHostname()
+	aggregatorInstance := aggregator.InitAggregator(f, hname)
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {
 		log.Criticalf("Unable to start dogstatsd: %s", err)

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -98,7 +98,11 @@ func start(cmd *cobra.Command, args []string) error {
 	f := forwarder.NewDefaultForwarder(keysPerDomain)
 	f.Start()
 
-	hname, _ := util.GetHostname()
+	hname, err := util.GetHostname()
+	if err != nil {
+		log.Warnf("Error getting hostname: %s\n", err)
+		hname = ""
+	}
 	aggregatorInstance := aggregator.InitAggregator(f, hname)
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -98,7 +98,6 @@ func start(cmd *cobra.Command, args []string) error {
 	f := forwarder.NewDefaultForwarder(keysPerDomain)
 	f.Start()
 
-	// FIXME: the aggregator should probably be initialized with the resolved hostname instead
 	hname, _ := util.GetHostname()
 	aggregatorInstance := aggregator.InitAggregator(f, hname)
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -30,7 +30,11 @@ func GetVersion(self *C.PyObject, args *C.PyObject) *C.PyObject {
 // GetHostname expose the current hostname of the agent to python check (used as a PyCFunction in the datadog_agent python module)
 //export GetHostname
 func GetHostname(self *C.PyObject, args *C.PyObject) *C.PyObject {
-	hostname, _ := util.GetHostname()
+	hostname, err := util.GetHostname()
+	if err != nil {
+		log.Warnf("Error getting hostname: %s\n", err)
+		hostname = ""
+	}
 
 	cStr := C.CString(hostname)
 	pyStr := C.PyString_FromString(cStr)

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -30,7 +30,7 @@ func GetVersion(self *C.PyObject, args *C.PyObject) *C.PyObject {
 // GetHostname expose the current hostname of the agent to python check (used as a PyCFunction in the datadog_agent python module)
 //export GetHostname
 func GetHostname(self *C.PyObject, args *C.PyObject) *C.PyObject {
-	hostname := util.GetHostname()
+	hostname, _ := util.GetHostname()
 
 	cStr := C.CString(hostname)
 	pyStr := C.PyString_FromString(cStr)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -84,14 +84,15 @@ func Fqdn(hostname string) string {
 // * kubernetes
 // * os
 // * EC2
-func GetHostname() string {
+func GetHostname() (string, error) {
 	var hostName string
+	var err error
 
 	// try the name provided in the configuration file
 	name := config.Datadog.GetString("hostname")
-	err := ValidHostname(name)
+	err = ValidHostname(name)
 	if err == nil {
-		return name
+		return name, err
 	}
 
 	log.Warnf("unable to get the hostname from the config file: %s", err)
@@ -101,7 +102,7 @@ func GetHostname() string {
 	log.Debug("GetHostname trying GCE metadata...")
 	name, err = gce.GetHostname()
 	if err == nil {
-		return name
+		return name, err
 	}
 
 	if isContainerized() {
@@ -139,10 +140,10 @@ func GetHostname() string {
 
 	// If at this point we don't have a name, bail out
 	if hostName == "" {
-		panic(fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file"))
+		err = fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file")
 	}
 
-	return hostName
+	return hostName, err
 }
 
 // IsContainerized returns whether the Agent is running on a Docker container


### PR DESCRIPTION
### What does this PR do?

util.GetHostname panics right now if it cannot get the hostname. Instead it should return an error that is handled as is appropriate.

### Motivation

We need a hostname for the Flare command. The Flare command should work even if it is not possible to get a hostname. This will ensure that the flare command does not break when it attempts to get the hostname.

### Additional Notes

I am not certain if I handled it properly everywhere. For example, in the aggregator I ignored the hostname failure, as I thought that was the appropriate course of action. If there had been a failure to grab it, it would have been handled much earlier.
