### PR TITLE
[metadata] Fix unit of default interval of host metadata collector

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -125,7 +125,7 @@ func StartAgent() (*dogstatsd.Server, *metadata.Scheduler, forwarder.Forwarder) 
 	}
 
 	// always add the host metadata collector, this is not user-configurable by design
-	err = metadataScheduler.AddCollector("host", hostMetadataCollectorInterval)
+	err = metadataScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
 	if err != nil {
 		panic("Host metadata is supposed to be always available in the catalog!")
 	}


### PR DESCRIPTION
### What does this PR do?

Fix unit of default interval of host metadata collector (from `nanosecond` to `second`)

### Motivation

We want the host metadata to be sent every 4 hours, not every 14 microseconds

### Additional Notes

🐐 
