### PR TITLE
[py] Add `increment`/`decrement` methods to `AgentCheck`

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -77,6 +77,14 @@ class AgentCheck(object):
         tags = self._normalize_tags(tags)
         aggregator.submit_metric(self, aggregator.HISTORATE, name, value, tags)
 
+    def increment(self, name, value=1, tags=None, hostname=None, device_name=None):
+        # DEPRECATED metric submission method
+        self.count(name + "_count", value, tags)
+
+    def decrement(self, name, value=-1, tags=None, hostname=None, device_name=None):
+        # DEPRECATED metric submission method
+        self.count(name + "_count", value, tags)
+
     def service_check(self, name, status, tags=None, message=""):
         tags = self._normalize_tags(tags)
         aggregator.submit_service_check(self, name, status, tags, message)

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -53,6 +53,8 @@ class AgentCheck(object):
         # FIXME: get the log level from the agent global config and apply it to the python one.
         self.log.setLevel(logging.DEBUG)
 
+        self._logged_increment_deprecation = False
+
     def gauge(self, name, value, tags=None):
         tags = self._normalize_tags(tags)
         aggregator.submit_metric(self, aggregator.GAUGE, name, value, tags)
@@ -78,12 +80,21 @@ class AgentCheck(object):
         aggregator.submit_metric(self, aggregator.HISTORATE, name, value, tags)
 
     def increment(self, name, value=1, tags=None, hostname=None, device_name=None):
-        # DEPRECATED metric submission method
+        self._log_increment_deprecation()
         self.count(name + "_count", value, tags)
 
     def decrement(self, name, value=-1, tags=None, hostname=None, device_name=None):
-        # DEPRECATED metric submission method
+        self._log_increment_deprecation()
         self.count(name + "_count", value, tags)
+
+    def _log_increment_deprecation(self):
+        """
+        Logs a deprecation notice on the first run of the check where increment/decrement is used
+        """
+        if not self._logged_increment_deprecation:
+            self.log.warning("DEPRECATION NOTICE: `AgentCheck.increment`/`AgentCheck.decrement` are deprecated, sending these " +
+                "metrics with `AgentCheck.count` and a '_count' suffix instead")
+            self._logged_increment_deprecation = True
 
     def service_check(self, name, status, tags=None, message=""):
         tags = self._normalize_tags(tags)


### PR DESCRIPTION
### What does this PR do?

Adds `increment`/`decrement` methods to `AgentCheck`. The methods use `count` after adding a suffix to the metric name.

### Motivation

Eases the transition from agent 5 to agent 6 for the checks. 

### Additional Notes

The suffix is required because `count` submits metrics with the `COUNT` api metric type, whereas in agent 5 `increment`/`decrement` use the `RATE` api metric type, so we need to use a different metric name (the backend doesn't support using a different API metric type for the same metric name).

Currently syncing with the agent-intake/query teams to determine if, in the agent 5, we could start sending the `increment`/`decrement` metrics 2 times: once as-is and once with the suffix and the `COUNT` type. This could ease the transition to the new metric name on the customers' side.