### PR TITLE
[py] Support yet another `AgentCheck.__init__` pattern

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -40,11 +40,13 @@ class AgentCheck(object):
         else:
             self.name = args[0]
             self.agentConfig = args[1]
-            # no agentConfig
-            if len(args) == 3:
+            if 'instances' in kwargs:
+                self.instances = kwargs['instances']
+            elif len(args) == 3:
+                # no agentConfig
                 self.instances = args[2]
-            # with agentConfig
             else:
+                # with agentConfig
                 self.instances = args[3]
 
         # the agent5 'AgentCheck' setup a log attribute.

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -86,6 +86,11 @@ func TestInitOldSignatureCheck(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestInitOldAltSignatureCheck(t *testing.T) {
+	_, err := getCheckInstance("old_alt_init_signature", "TestCheck")
+	assert.Nil(t, err)
+}
+
 func TestInitNewSignatureCheck(t *testing.T) {
 	_, err := getCheckInstance("new_init_signature", "TestCheck")
 	assert.Nil(t, err)

--- a/pkg/collector/py/tests/old_alt_init_signature.py
+++ b/pkg/collector/py/tests/old_alt_init_signature.py
@@ -2,8 +2,8 @@ from checks import AgentCheck
 
 
 class TestCheck(AgentCheck):
-    def __init__(self, *args, **kwargs):
-        super(TestCheck, self).__init__(*args, **kwargs)
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        super(TestCheck, self).__init__(name, init_config, agentConfig, instances=instances)
         assert hasattr(self, 'instances')
         assert isinstance(self.instances, list)
         assert len(self.instances) > 0

--- a/pkg/collector/py/tests/old_init_signature.py
+++ b/pkg/collector/py/tests/old_init_signature.py
@@ -4,6 +4,10 @@ from checks import AgentCheck
 class TestCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances):
         super(TestCheck, self).__init__(name, init_config, agentConfig, instances)
+        assert hasattr(self, 'instances')
+        assert isinstance(self.instances, list)
+        assert len(self.instances) > 0
+        assert 'foo' in self.instances[0]
 
     def check(self, instance):
         pass


### PR DESCRIPTION
### What does this PR do?

Supports yet another `AgentCheck.__init__` pattern, this time when `instances` is the only argument passed in `kwargs`.

### Motivation

This pattern is quite common in the existing checks (since it's the
signature of the agent5's `AgentCheck.__init__`), so it makes sense
to support it.

### Additional Notes

Added a test case, and assertions in the python test code.
