### PR TITLE
[AD] Introduce docker listener

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
-	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -47,20 +46,20 @@ func SetupAutoConfig(confdPath string) {
 	}
 
 	// add the service listeners
-	newService := make(chan listeners.Service)
-	delService := make(chan listeners.Service)
+	// newService := make(chan listeners.Service)
+	// delService := make(chan listeners.Service)
 
 	// Docker listener
-	docker, err := listeners.NewDockerListener(newService, delService)
-	if err != nil {
-		log.Errorf("Failed to create a Docker listener. Is Docker accessible by the agent? %s", err)
-	} else {
-		AC.AddListener(docker)
-	}
+	// docker, err := listeners.NewDockerListener(newService, delService)
+	// if err != nil {
+	// 	log.Errorf("Failed to create a Docker listener. Is Docker accessible by the agent? %s", err)
+	// } else {
+	// 	AC.AddListener(docker)
+	// }
 
 	// add the config resolver
-	resolver := autodiscovery.NewConfigResolver(newService, delService)
-	AC.RegisterConfigResolver(resolver)
+	// resolver := autodiscovery.NewConfigResolver(newService, delService)
+	// AC.RegisterConfigResolver(resolver)
 }
 
 // StartAutoConfig starts the autoconfig polling and loads the configs

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -44,6 +45,22 @@ func SetupAutoConfig(confdPath string) {
 		AC.AddProvider(provider, true)
 		log.Infof("Registering %s config provider", backend)
 	}
+
+	// add the service listeners
+	newService := make(chan listeners.Service)
+	delService := make(chan listeners.Service)
+
+	// Docker listener
+	docker, err := listeners.NewDockerListener(newService, delService)
+	if err != nil {
+		log.Errorf("Failed to create a Docker listener. Is Docker accessible by the agent? %s", err)
+	} else {
+		AC.AddListener(docker)
+	}
+
+	// add the config resolver
+	resolver := autodiscovery.NewConfigResolver(newService, delService)
+	AC.RegisterConfigResolver(resolver)
 }
 
 // StartAutoConfig starts the autoconfig polling and loads the configs

--- a/pkg/collector/autodiscovery/README.md
+++ b/pkg/collector/autodiscovery/README.md
@@ -1,0 +1,34 @@
+## package `autodiscovery`
+
+This package is a core piece of the agent. It is responsible for collecting checks configurations from different sources (see package [config providers](https://github.com/DataDog/datadog-agent/tree/master/pkg/collector/providers)) and then create, update or destroy check instances with the help of the Collector.
+
+It is also responsible for listening to container-related events and trigger check scheduling decisions based on them.
+
+
+### `AutoConfig`
+
+As a central component, `AutoConfig` owns and orchestrates several key modules:
+
+- it owns a reference to the `Collector` that it uses to (un)schedule checks when template or container updates warrant them
+- it stores a list of `ConfigProviders` and poll them according to their policy
+- it owns and uses [check loaders](https://github.com/DataDog/datadog-agent/tree/haissam/docker-listener/pkg/collector/check#check-loaders) to load configurations into `Check` objects
+- it owns [listeners](https://github.com/DataDog/datadog-agent/tree/haissam/docker-listener/pkg/collector/listeners) that it uses to listen to container lifecycle events
+- it runs the `ConfigResolver` that resolves a configuration template to an actual configuration based on data it extracts from a service that matches it the template
+
+**TODO:**
+- `pollConfigs` needs to send collected templates to ConfigResolver.FreshTemplates.
+- processTemplates needs to work on partial updates and not just full template lists.
+
+
+### ConfigResolver
+
+`ConfigResolver` resolves configuration templates with services and asks `AutoConfig` to schedule checks based on this resolving.
+
+To fulfill its task, it stores a cache of services (containers) and templates. It also keeps a live map of how they apply to each other and of the checks that it scheduled as a result.
+
+It also listens on three channels, one for fresh configuration templates, and two for newly started/stopped services.
+
+**TODO**:
+- ConfigResolver is responsible for too many things. Scheduling should go back to AutoConfig, or get its own module.
+- getters for template variables are all placeholder, they need to be implemented. Tags should just return svc.Tags, host and port should consider key/idx
+- IsConfigMatching is too simple. We need to re-implement the logic of agent5 matching

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -129,7 +129,9 @@ func (ac *AutoConfig) StartPolling() {
 func (ac *AutoConfig) Stop() {
 	ac.stop <- true
 	ac.collector.Stop()
-	ac.configResolver.Stop()
+	if ac.configResolver != nil {
+		ac.configResolver.Stop()
+	}
 
 	for _, l := range ac.listeners {
 		l.Stop()
@@ -241,7 +243,6 @@ func (ac *AutoConfig) AddLoader(loader check.Loader) {
 // events, template changes and update checks accordingly
 func (ac *AutoConfig) RegisterConfigResolver(cr *ConfigResolver) {
 	// ConfigResolver needs a reference to AC to schedule checks
-	cr.FreshTemplates = ac.templateChan
 	cr.AC = ac
 	ac.configResolver = cr
 	cr.Listen()

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	log "github.com/cihub/seelog"
 )
@@ -35,13 +36,16 @@ type providerDescriptor struct {
 // AutoConfig is responsible to collect checks configurations from
 // different sources and then create, update or destroy check instances
 // with the help of the Collector.
-// It is also responsible to listen to containers related events and act
-// accordingly.
+// It is also responsible to listen to container-related events and
+// trigger scheduling decisions based on them.
 type AutoConfig struct {
 	collector         *collector.Collector
 	providers         []*providerDescriptor
 	loaders           []check.Loader
 	templateCache     *TemplateCache
+	listeners         []listeners.ServiceListener
+	configResolver    *ConfigResolver
+	templateChan      chan []check.Config
 	configsPollTicker *time.Ticker
 	stop              chan bool
 	m                 sync.RWMutex
@@ -125,6 +129,11 @@ func (ac *AutoConfig) StartPolling() {
 func (ac *AutoConfig) Stop() {
 	ac.stop <- true
 	ac.collector.Stop()
+	ac.configResolver.Stop()
+
+	for _, l := range ac.listeners {
+		l.Stop()
+	}
 }
 
 // AddProvider adds a new configuration provider to AutoConfig.
@@ -190,7 +199,7 @@ func (ac *AutoConfig) collectChecks(checkName string) {
 			// load the check instances and schedule them
 			for _, check := range ac.loadChecks(config) {
 				if checkName == "" || checkName == check.String() {
-					err := ac.collector.RunCheck(check)
+					_, err := ac.collector.RunCheck(check)
 					if err != nil {
 						log.Errorf("Unable to run Check %s: %v", check, err)
 					}
@@ -198,6 +207,22 @@ func (ac *AutoConfig) collectChecks(checkName string) {
 			}
 		}
 	}
+}
+
+// AddListener adds a service listener to AutoConfig.
+func (ac *AutoConfig) AddListener(listener listeners.ServiceListener) {
+	ac.m.Lock()
+	defer ac.m.Unlock()
+
+	for _, l := range ac.listeners {
+		if l == listener {
+			log.Warnf("Listener %s was already added, skipping...", listener)
+			return
+		}
+	}
+
+	ac.listeners = append(ac.listeners, listener)
+	listener.Listen()
 }
 
 // AddLoader adds a new Loader that AutoConfig can use to load a check.
@@ -210,6 +235,16 @@ func (ac *AutoConfig) AddLoader(loader check.Loader) {
 	}
 
 	ac.loaders = append(ac.loaders, loader)
+}
+
+// RegisterConfigResolver adds a new ConfigResolver that will listen to service-related
+// events, template changes and update checks accordingly
+func (ac *AutoConfig) RegisterConfigResolver(cr *ConfigResolver) {
+	// ConfigResolver needs a reference to AC to schedule checks
+	cr.FreshTemplates = ac.templateChan
+	cr.AC = ac
+	ac.configResolver = cr
+	cr.Listen()
 }
 
 // pollConfigs periodically calls Collect() on all the configuration
@@ -310,6 +345,35 @@ func (ac *AutoConfig) loadChecks(config check.Config) []check.Check {
 
 	log.Errorf("Unable to load the check '%s', see debug logs for more details.", config.Name)
 	return []check.Check{}
+}
+
+// LoadAndRun takes a config, load it into (a) check(s)
+// and instructs the collector to run this/these check(s)
+func (ac *AutoConfig) LoadAndRun(conf check.Config) ([]check.ID, error) {
+	checks := ac.loadChecks(conf)
+	ids := make([]check.ID, len(checks))
+	for _, c := range checks {
+		id, err := ac.collector.RunCheck(c)
+		if err != nil {
+			log.Errorf("Unable to run Check '%s': %s", c, err)
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// StopCheck instructs the collector to stop a check and simply forwards any error it receives
+func (ac *AutoConfig) StopCheck(id check.ID) error {
+	return ac.collector.StopCheck(id)
+}
+
+// ReloadCheck extracts initConfig and instance from a config and instructs
+// the collector to re-configure a running check with them.
+func (ac *AutoConfig) ReloadCheck(id check.ID, config check.Config) error {
+	initConfig := config.InitConfig
+	instance := config.Instances[0]
+	return ac.collector.ReloadCheck(id, instance, initConfig)
 }
 
 // check if the descriptor contains the Config passed

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -25,6 +25,18 @@ type MockLoader struct{}
 
 func (l *MockLoader) Load(config check.Config) ([]check.Check, error) { return []check.Check{}, nil }
 
+type MockListener struct {
+	ListenCount int
+}
+
+func (l *MockListener) Listen() {
+	l.ListenCount++
+}
+
+func (l *MockListener) Stop() {
+	return
+}
+
 func TestAddProvider(t *testing.T) {
 	ac := NewAutoConfig(nil)
 	ac.StartPolling()
@@ -46,6 +58,15 @@ func TestAddLoader(t *testing.T) {
 	ac.AddLoader(&MockLoader{})
 	ac.AddLoader(&MockLoader{}) // noop
 	assert.Len(t, ac.loaders, 1)
+}
+
+func TestAddListener(t *testing.T) {
+	ac := NewAutoConfig(nil)
+	assert.Len(t, ac.listeners, 0)
+	ml := &MockListener{}
+	ac.AddListener(ml)
+	require.Len(t, ac.listeners, 1)
+	assert.Equal(t, 1, ml.ListenCount)
 }
 
 func TestContains(t *testing.T) {

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -1,0 +1,385 @@
+package autodiscovery
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"unicode"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
+	log "github.com/cihub/seelog"
+)
+
+var (
+	templateVariables = map[string]func(key []byte, tpl check.Config, svc listeners.Service) []byte{
+		"host":           getHost,
+		"pid":            getPid,
+		"port":           getPort,
+		"container-name": getContainerName,
+		"tags":           getOptTags,
+	}
+)
+
+// ConfigResolver stores services and templates in cache, and matches
+// services it hears about with templates to create valid configs.
+// It is also responsible to send scheduling orders to AutoConfig
+type ConfigResolver struct {
+	FreshTemplates   chan []check.Config
+	AC               *AutoConfig
+	templates        map[check.ID][]check.Config        // ConfigID --> []Config
+	services         map[listeners.ID]listeners.Service // Service.ID --> []Service
+	configToServices map[check.ID][]listeners.Service   // ConfigID --> []Service
+	serviceToChecks  map[listeners.ID][]check.ID        // Service.ID --> []CheckID
+	newService       chan listeners.Service
+	delService       chan listeners.Service
+	stop             chan bool
+	m                sync.Mutex
+}
+
+// NewConfigResolver returns a config resolver
+func NewConfigResolver(newSvc chan listeners.Service, delSvc chan listeners.Service) *ConfigResolver {
+	tpls := make(map[check.ID][]check.Config)
+	stop := make(chan bool)
+	return &ConfigResolver{
+		// these two references are set at registry time
+		FreshTemplates:   nil,
+		AC:               nil,
+		templates:        tpls,
+		configToServices: make(map[check.ID][]listeners.Service, 0),
+		serviceToChecks:  make(map[listeners.ID][]check.ID, 0),
+		newService:       newSvc,
+		delService:       delSvc,
+		stop:             stop,
+	}
+}
+
+// Listen waits on services and templates and process them as they come.
+// It can trigger scheduling decisions using its AC reference or just update its cache.
+func (cr *ConfigResolver) Listen() {
+	go func() {
+		for {
+			select {
+			case <-cr.stop:
+				return
+			case tpls := <-cr.FreshTemplates:
+				cr.processTemplates(tpls)
+			case svc := <-cr.newService:
+				cr.processNewService(svc)
+			case svc := <-cr.delService:
+				cr.processDelService(svc)
+			}
+		}
+	}()
+}
+
+// Stop shuts down the config resolver
+func (cr *ConfigResolver) Stop() {
+	cr.stop <- true
+}
+
+// processTemplates receives a template list, updates the ConfigResolver cache with them
+// and may trigger scheduling events if new/deleted templates warrant it.
+//
+// TODO: right now processTemplates only works on a full template list.
+// It needs to support partial updates
+func (cr *ConfigResolver) processTemplates(tpls []check.Config) {
+	tpls = removeDupeTemplates(tpls)
+	cr.m.Lock()
+	defer cr.m.Unlock()
+	// init
+	if len(cr.templates) == 0 {
+		for _, t := range tpls {
+			cr.templates[t.ID] = append(cr.templates[t.ID], t)
+			cr.startChecksForTemplate(t)
+		}
+		// update
+	} else {
+		oldTpls := cr.templates
+		cr.replaceInUseTemplates(tpls)
+		newTpls := cr.templates
+		// stop checks associated with templates that disappeared
+		for id, templates := range oldTpls {
+			if _, ok := newTpls[id]; !ok {
+				for _, tpl := range templates {
+					err := cr.stopChecksForTemplate(tpl)
+					if err == nil {
+						delete(cr.configToServices, tpl.ID)
+					}
+				}
+			}
+		}
+	}
+}
+
+// replaceInUseTemplates takes care of updating the template cache and
+// running services when the ConfigResolver receives templates that were modified
+func (cr *ConfigResolver) replaceInUseTemplates(tpls []check.Config) {
+	for _, t := range tpls {
+		if cachedTpls, ok := cr.templates[t.ID]; ok {
+			addedInPlace := false
+			for i, tpl := range cachedTpls {
+				if tpl.Name == t.Name {
+					cr.templates[t.ID][i] = t
+					addedInPlace = true
+					// it is an updated template, we need to update its checks
+					cr.updateChecksForTemplate(t)
+					break
+				}
+			}
+			if addedInPlace == false {
+				cr.templates[t.ID] = append(cachedTpls, t)
+				// it is a new template, we need to try and run its checks
+				cr.startChecksForTemplate(t)
+			}
+		} else {
+			cr.templates[t.ID] = []check.Config{t}
+			// in this case it is a new template for sure
+			cr.startChecksForTemplate(t)
+		}
+	}
+}
+
+// startChecksForTemplate takes a template, finds services that match it
+// and schedules checks based on this matching
+func (cr *ConfigResolver) startChecksForTemplate(t check.Config) {
+	for svcID := range cr.services {
+		svc, ok := cr.services[svcID]
+		if !ok {
+			log.Debugf("Service %s doesn't exist, skipping", svcID)
+			continue
+		}
+		if IsConfigMatching(svc.ConfigID, t.ID) {
+			cr.configToServices[t.ID] = append(cr.configToServices[t.ID], svc)
+			config, err := cr.ResolveConfig(t, svc)
+			if err != nil {
+				log.Errorf("Unable to generate a check config with template %s and service %s: %s", t.ID, svc.ConfigID, err)
+				return
+			}
+			ids, err := cr.AC.LoadAndRun(config)
+			if err == nil {
+				for _, id := range ids {
+					cr.serviceToChecks[svc.ID] = append(cr.serviceToChecks[svc.ID], id)
+				}
+			}
+		}
+	}
+	return
+}
+
+// stopChecksForTemplate takes a template, find running checks associated with it and stop them.
+func (cr *ConfigResolver) stopChecksForTemplate(t check.Config) error {
+	if services, ok := cr.configToServices[t.ID]; ok {
+		toDelete := make([]listeners.ID, 0)
+		for _, svc := range services {
+			if checks, ok := cr.serviceToChecks[svc.ID]; ok {
+				stopFailure := false
+				for _, check := range checks {
+					err := cr.AC.StopCheck(check)
+					if err != nil {
+						log.Errorf("Failed to stop check '%s': %s", check, err)
+						stopFailure = true
+					}
+				}
+				if !stopFailure {
+					toDelete = append(toDelete, svc.ID)
+				}
+			}
+		}
+		for _, s := range toDelete {
+			delete(cr.serviceToChecks, s)
+		}
+	}
+	return nil
+}
+
+// updateChecksForTemplate takes a template, find running checks associated with it
+// and update them with a fresh config based on the template's new version.
+func (cr *ConfigResolver) updateChecksForTemplate(t check.Config) {
+	// TODO: does that actually work? the Config ID might not be unique.
+	// What happens if several templates apply to the same services?
+	// Maybe we need check name + Config.ID as a key?
+	if services, ok := cr.configToServices[t.ID]; ok {
+		for _, svc := range services {
+			config, err := cr.ResolveConfig(t, svc)
+			if err != nil {
+				log.Errorf("Unable to generate a check config with template %s and service %s: %s", t.ID, svc.ConfigID, err)
+				return
+			}
+			if checks, ok := cr.serviceToChecks[svc.ID]; ok {
+				for _, check := range checks {
+					err := cr.AC.ReloadCheck(check, config)
+					if err != nil {
+						log.Errorf("Failed to reload check '%s', previous config left as-is. Error: %s", check, err)
+					}
+				}
+			} else {
+				// this should not happen, but if by any chance we can
+				// configure a check but not find the previous one
+				// let's run it anyway?
+				panic("TODO")
+			}
+		}
+	}
+}
+
+// ResolveConfig takes a template and a service and generates a config with
+// valid connection info and relevant tags.
+func (cr *ConfigResolver) ResolveConfig(tpl check.Config, svc listeners.Service) (check.Config, error) {
+	vars := tpl.GetTemplateVariables()
+	for _, v := range vars {
+		name, key := parseTemplateVar(v)
+		if f, ok := templateVariables[string(name)]; ok {
+			resolvedVar := f(key, tpl, svc)
+			if resolvedVar != nil {
+				tpl.InitConfig = bytes.Replace(tpl.InitConfig, v, resolvedVar, -1)
+				tpl.Instances[0] = bytes.Replace(tpl.Instances[0], v, resolvedVar, -1)
+			}
+		} else {
+			return check.Config{}, fmt.Errorf("template variable %s does not exist", name)
+		}
+	}
+	// TODO: call and add cr.getTags
+	return tpl, nil
+}
+
+// processNewService takes a service, tries to match it against templates and
+// triggers scheduling events if it finds a valid config for it.
+func (cr *ConfigResolver) processNewService(svc listeners.Service) {
+	cr.m.Lock()
+	defer cr.m.Unlock()
+
+	// in any case, register the service
+	cr.services[svc.ID] = svc
+	cr.serviceToChecks[svc.ID] = make([]check.ID, 0)
+
+	for configID, tpls := range cr.templates {
+		if IsConfigMatching(svc.ConfigID, configID) {
+			// add svc to the list of services matching tpl
+			// this is used when a template is removed and we want to remove its related checks
+			cr.configToServices[configID] = append(cr.configToServices[configID], svc)
+
+			for _, tpl := range tpls {
+				// actually resolve the config and run the check
+				conf, err := cr.ResolveConfig(tpl, svc)
+				if err != nil {
+					log.Errorf("Unable to generate a check config with template %s and service %s: %s", tpl.ID, svc.ConfigID, err)
+				} else {
+					checkIDs, err := cr.AC.LoadAndRun(conf)
+					if err == nil {
+						for _, id := range checkIDs {
+							// add the check to the list of checks running against the service
+							// this is used when a template or a service is removed
+							// and we want to stop their related checks
+							cr.serviceToChecks[svc.ID] = append(cr.serviceToChecks[svc.ID], id)
+						}
+					} else {
+						log.Errorf("Failed to run check(s) based on config %s: %s", conf.ID, err)
+					}
+				}
+			}
+		}
+	}
+}
+
+// processDelService takes a service, stops its associated checks, and updates the cache
+func (cr *ConfigResolver) processDelService(svc listeners.Service) {
+	cr.m.Lock()
+	defer cr.m.Unlock()
+
+	if checks, ok := cr.serviceToChecks[svc.ID]; ok {
+		stopFailure := false
+		for _, check := range checks {
+			err := cr.AC.StopCheck(check)
+			if err != nil {
+				log.Errorf("Failed to stop check '%s': %s", check, err)
+				stopFailure = true
+			}
+		}
+		if !stopFailure {
+			delete(cr.serviceToChecks, svc.ID)
+		}
+	}
+}
+
+// removeDupeTemplates walks through a list of templates and removes duplicates
+func removeDupeTemplates(tpls []check.Config) []check.Config {
+	cleanedTpls := make([]check.Config, len(tpls))
+	seenChecks := make(map[check.ID]map[string]struct{}, len(tpls))
+	// used to implement the set
+	var stub struct{}
+
+	for _, t := range tpls {
+		if names := seenChecks[t.ID]; len(names) > 0 {
+			if _, present := names[t.Name]; present {
+				log.Warnf("Duplicate template for resource %s and check %s. Using the first one only.", t.ID, t.Name)
+			} else {
+				seenChecks[t.ID][t.Name] = stub
+				cleanedTpls = append(cleanedTpls, t)
+			}
+		}
+	}
+	return cleanedTpls
+}
+
+// IsConfigMatching checks if a Service ConfigID and a config ID are a match
+// TODO: decomp the Service ConfigID for more advanced matching
+func IsConfigMatching(sID check.ID, tID check.ID) bool {
+	if sID == tID {
+		return true
+	}
+	return false
+}
+
+// TODO (use svc.Hosts)
+func getHost(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+	return []byte("127.0.0.1")
+}
+
+// TODO (use svc.Ports)
+func getPort(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+	return []byte("80")
+}
+
+// TODO
+func getPid(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+	return []byte("1")
+}
+
+// TODO
+func getContainerName(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+	return []byte("test-container-name")
+}
+
+// getTags returns tags that are appended by default to all metrics.
+// TODO (use svc.Tags)
+func getTags(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+	return []byte("[\"tag:foo\", \"tag:bar\"]")
+}
+
+// getOptTags returns tags that are to be applied to templates with %%tags%%.
+// This is generally reserved to high-cardinality tags that we want to provide,
+// but not by default.
+// TODO
+func getOptTags(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+	return []byte("[\"opt:tag1\", \"opt:tag2\"]")
+}
+
+// parseTemplateVar extracts the name of the var
+// and the key (or index if it can be cast to an int)
+func parseTemplateVar(v []byte) (name, key []byte) {
+	stripped := bytes.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, v)
+	split := bytes.Split(stripped, []byte("_"))
+	name = split[0]
+	if len(split) == 2 {
+		key = split[1]
+	} else {
+		key = []byte("")
+	}
+	return name, key
+}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -66,25 +66,27 @@ func (c *Collector) Stop() {
 }
 
 // RunCheck sends a Check in the execution queue
-func (c *Collector) RunCheck(check check.Check) error {
+func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	var emptyID check.ID
+
 	if c.state != started {
-		return fmt.Errorf("the collector is not running")
+		return emptyID, fmt.Errorf("the collector is not running")
 	}
 
-	if _, found := c.checks[check.ID()]; found {
-		return fmt.Errorf("a check with ID %s is already running", check.ID())
+	if _, found := c.checks[ch.ID()]; found {
+		return emptyID, fmt.Errorf("a check with ID %s is already running", ch.ID())
 	}
 
-	err := c.scheduler.Enter(check)
+	err := c.scheduler.Enter(ch)
 	if err != nil {
-		return fmt.Errorf("unable to schedule the check: %s", err)
+		return emptyID, fmt.Errorf("unable to schedule the check: %s", err)
 	}
 
-	c.checks[check.ID()] = check
-	return nil
+	c.checks[ch.ID()] = ch
+	return ch.ID(), nil
 }
 
 // ReloadCheck stops and restart a check with a new configuration

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -55,13 +55,14 @@ func (suite *CollectorTestSuite) TestRunCheck() {
 	ch := NewCheck()
 
 	// schedule a check
-	err := suite.c.RunCheck(ch)
+	id, err := suite.c.RunCheck(ch)
+	assert.NotNil(suite.T(), id)
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 1, len(suite.c.checks))
 	assert.Equal(suite.T(), ch, suite.c.checks["TestCheck"])
 
 	// schedule the same check twice
-	err = suite.c.RunCheck(ch)
+	_, err = suite.c.RunCheck(ch)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "a check with ID TestCheck is already running", err.Error())
 }
@@ -71,7 +72,7 @@ func (suite *CollectorTestSuite) TestReloadCheck() {
 	empty := check.ConfigData{}
 
 	// schedule a check
-	err := suite.c.RunCheck(ch)
+	_, err := suite.c.RunCheck(ch)
 
 	// check doesn't exist
 	err = suite.c.ReloadCheck("foo", empty, empty)
@@ -87,7 +88,7 @@ func (suite *CollectorTestSuite) TestStopCheck() {
 	ch := NewCheck()
 
 	// schedule a check
-	err := suite.c.RunCheck(ch)
+	_, err := suite.c.RunCheck(ch)
 
 	// all good
 	err = suite.c.StopCheck("TestCheck")

--- a/pkg/collector/listeners/README.md
+++ b/pkg/collector/listeners/README.md
@@ -1,0 +1,24 @@
+## package `listeners`
+
+This package is providing the `ServiceListener` concept to the agent. A `ServiceListener` listens for events related to services the agent should monitor.
+
+
+### `Service`
+
+`Service` reprensents an application we can run a check against. It should be matched with a check template by the ConfigResolver.
+Services can only be Docker containers for now.
+
+
+### `ServiceListener` (there is only a `DockerListener` for now)
+
+`ServiceListener` monitors events related to `Service` lifecycles. It then formats and transmits this data to `ConfigResolver`.
+
+
+### `DockerListener`
+
+`DockerListener` first gets current running containers and send these to `ConfigResolver`. Then it starts listening on the Docker event API for container activity and pass by `Services` mentioned in start/stop events to `ConfigResolver` through the corresponding channel.
+
+**TODO**:
+- `DockerListener` calls Docker directly. We need a caching layer there.
+- support TLS
+- getHosts, getPorts and getTags need to use a caching layer for docker **and** use the k8s api (also with caching)

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -1,0 +1,244 @@
+package listeners
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+const (
+	identifierLabel string = "io.datadog.check.id"
+)
+
+// DockerListener implements the ServiceListener interface.
+// It listens for Docker events and reports container updates to Auto Discovery
+// It also holds a cache of services that the ConfigResolver can query to
+// match templates against.
+type DockerListener struct {
+	Client     *client.Client
+	Services   map[ID]Service
+	newService chan Service
+	delService chan Service
+	stop       chan bool
+}
+
+// NewDockerListener creates a client connection to Docker and instanciate a DockerListener with it
+// TODO: TLS support
+func NewDockerListener(newSvc, delSvc chan Service) (*DockerListener, error) {
+	c, err := client.NewEnvClient()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to connect to Docker, auto discovery will not work: %s", err)
+	}
+
+	svc := make(map[ID]Service)
+	stop := make(chan bool)
+
+	return &DockerListener{c, svc, newSvc, delSvc, stop}, nil
+}
+
+// Listen streams container-related events from Docker and report said containers as Services.
+func (l *DockerListener) Listen() {
+	// Init
+	l.Services = l.GetCurrentServices()
+
+	// filters only match start/stop container events
+	filters := filters.NewArgs()
+	filters.Add("type", "container")
+	filters.Add("event", "start")
+	filters.Add("event", "die")
+	eventOptions := types.EventsOptions{
+		Since:   fmt.Sprintf("%d", time.Now().Unix()),
+		Filters: filters,
+	}
+
+	messages, errs := l.Client.Events(context.Background(), eventOptions)
+
+	go func() {
+		for {
+			select {
+			case <-l.stop:
+				return
+			case msg := <-messages:
+				l.processEvent(msg)
+			case err := <-errs:
+				if err != nil && err != io.EOF {
+					panic(err)
+				}
+				return
+			}
+		}
+	}()
+}
+
+// Stop queues a shutdown of DockerListener
+func (l *DockerListener) Stop() {
+	l.stop <- true
+}
+
+// GetCurrentServices looks at currently running Docker containers,
+// creates services for them, and pass them to the ConfigResolver.
+// It is typically called at start up.
+func (l *DockerListener) GetCurrentServices() map[ID]Service {
+	containers, err := l.Client.ContainerList(context.Background(), types.ContainerListOptions{})
+	if err != nil {
+		log.Errorf("Couldn't retrieve container list - %s", err)
+	}
+
+	services := make(map[ID]Service, 0)
+	for _, co := range containers {
+		id := ID(co.ID)
+		configID := l.getConfigIDFromPs(co)
+		hosts := l.getHostsFromPs(co)
+		ports := l.getPortsFromPs(co)
+		tags := l.getTagsFromPs(co)
+		svc := Service{id, check.ID(configID), hosts, ports, tags}
+		l.newService <- svc
+		services[id] = svc
+	}
+	return services
+}
+
+// processEvent takes a Docker Message, tries to find a service linked to it, and
+// figure out if the ConfigResolver could be interested to inspect it.
+func (l *DockerListener) processEvent(e events.Message) {
+	cID := ID(e.Actor.ID)
+	if _, found := l.Services[cID]; found {
+		if e.Action == "die" {
+			l.removeService(cID)
+		} else {
+			panic("TODO - this shouldn't happen")
+		}
+	} else {
+		if e.Action == "start" {
+			l.createService(cID)
+		} else {
+			panic("TODO - this shouldn't happen")
+		}
+	}
+}
+
+// startService takes a container ID, create a service for it in its cache
+// and tells the ConfigResolver that this service started.
+func (l *DockerListener) createService(cID ID) {
+	co, err := l.Client.ContainerInspect(context.Background(), string(cID))
+	if err != nil {
+		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
+
+	}
+	svc := Service{
+		cID,
+		l.getConfigIDFromInspect(co),
+		l.getHostsFromInspect(co),
+		l.getPortsFromInspect(co),
+		l.getTagsFromInspect(co),
+	}
+	l.Services[ID(cID)] = svc
+	l.newService <- svc
+}
+
+// removeService takes a container ID, removes the related service from its cache
+// and tells the ConfigResolver that this service stopped.
+func (l *DockerListener) removeService(cID ID) {
+	if svc, ok := l.Services[cID]; ok {
+		delete(l.Services, cID)
+		l.delService <- svc
+	} else {
+		log.Debugf("Container %s not found, not removing", cID[:12])
+	}
+
+}
+
+// getID returns the config ID for a container.
+func (l *DockerListener) getConfigIDFromInspect(co types.ContainerJSON) check.ID {
+	// check for an identifier label
+	for l, v := range co.Config.Labels {
+		if l == identifierLabel {
+			return check.ID(v)
+		}
+	}
+
+	// use the image name
+	// TODO: check if it's the sha256
+	return check.ID(co.Image)
+}
+
+// getHosts gets the addresss (for now IP address only) of a container on all its networks.
+// TODO: use the k8s API when no network config is found
+func (l *DockerListener) getHostsFromInspect(co types.ContainerJSON) map[string]string {
+	ips := make(map[string]string)
+	if co.NetworkSettings != nil {
+		for net, settings := range co.NetworkSettings.Networks {
+			ips[net] = settings.IPAddress
+		}
+	}
+	return ips
+}
+
+// getPorts gets the service ports of a container.
+// TODO: use the k8s API
+func (l *DockerListener) getPortsFromInspect(co types.ContainerJSON) []int {
+	ports := make([]int, 0)
+
+	for p := range co.NetworkSettings.Ports {
+		ports = append(ports, p.Int())
+	}
+	return ports
+}
+
+// getTags gets tags for a container.
+// TODO: use the container ID only and rely on container metadata providers?
+func (l *DockerListener) getTagsFromInspect(co types.ContainerJSON) []string {
+	return []string{}
+}
+
+// getID returns the config ID for a container.
+func (l *DockerListener) getConfigIDFromPs(co types.Container) string {
+	// check for an identifier label
+	for l, v := range co.Labels {
+		if l == identifierLabel {
+			return v
+		}
+	}
+
+	// use the image name
+	// TODO: check if it's the sha256
+	return co.Image
+}
+
+// getHosts gets the addresss (for now IP address only) of a container on all its networks.
+// TODO: use the k8s API when no network config is found
+func (l *DockerListener) getHostsFromPs(co types.Container) map[string]string {
+	ips := make(map[string]string)
+	if co.NetworkSettings != nil {
+		for net, settings := range co.NetworkSettings.Networks {
+			ips[net] = settings.IPAddress
+		}
+	}
+	return ips
+}
+
+// getPorts gets the service ports of a container.
+// TODO: use the k8s API
+func (l *DockerListener) getPortsFromPs(co types.Container) []int {
+	ports := make([]int, 0)
+
+	for _, p := range co.Ports {
+		ports = append(ports, int(p.PrivatePort))
+	}
+	return ports
+}
+
+// getTags gets tags for a container.
+// TODO: use the container ID only and rely on container metadata providers?
+func (l *DockerListener) getTagsFromPs(co types.Container) []string {
+	return []string{}
+}

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -1,0 +1,183 @@
+package listeners
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfigIDFromPs(t *testing.T) {
+	co := types.Container{
+		ID:    "deadbeef",
+		Image: "test",
+	}
+	dl := DockerListener{}
+
+	id := dl.getConfigIDFromPs(co)
+	assert.Equal(t, "test", id)
+
+	labeledCo := types.Container{
+		ID:     "deadbeef",
+		Image:  "test",
+		Labels: map[string]string{"io.datadog.check.id": "w00tw00t"},
+	}
+	id = dl.getConfigIDFromPs(labeledCo)
+	assert.Equal(t, "w00tw00t", id)
+}
+
+func TestGetHostsFromPs(t *testing.T) {
+	dl := DockerListener{}
+
+	co := types.Container{
+		ID:    "foo",
+		Image: "test",
+	}
+
+	assert.Empty(t, dl.getHostsFromPs(co))
+
+	nets := make(map[string]*network.EndpointSettings)
+	nets["bridge"] = &network.EndpointSettings{IPAddress: "172.17.0.2"}
+	nets["foo"] = &network.EndpointSettings{IPAddress: "172.17.0.3"}
+	networkSettings := types.SummaryNetworkSettings{
+		Networks: nets}
+
+	co = types.Container{
+		ID:              "deadbeef",
+		Image:           "test",
+		NetworkSettings: &networkSettings,
+		Ports:           []types.Port{types.Port{PrivatePort: 1337}, types.Port{PrivatePort: 42}},
+	}
+	hosts := dl.getHostsFromPs(co)
+
+	assert.Equal(t, "172.17.0.2", hosts["bridge"])
+	assert.Equal(t, "172.17.0.3", hosts["foo"])
+	assert.Equal(t, 2, len(hosts))
+}
+
+func TestGetPortsFromPs(t *testing.T) {
+	dl := DockerListener{}
+
+	co := types.Container{
+		ID:    "foo",
+		Image: "test",
+	}
+	assert.Empty(t, dl.getPortsFromPs(co))
+
+	co.Ports = make([]types.Port, 0)
+	assert.Empty(t, dl.getPortsFromPs(co))
+
+	co.Ports = append(co.Ports, types.Port{PrivatePort: 1234})
+	co.Ports = append(co.Ports, types.Port{PrivatePort: 4321})
+	ports := dl.getPortsFromPs(co)
+	assert.Equal(t, 2, len(ports))
+	assert.Contains(t, ports, 1234)
+	assert.Contains(t, ports, 4321)
+}
+
+func TestGetConfigIDFromInspect(t *testing.T) {
+	co := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "test"},
+		Mounts:            make([]types.MountPoint, 0),
+		Config:            &container.Config{},
+		NetworkSettings:   &types.NetworkSettings{},
+	}
+	dl := DockerListener{}
+
+	id := dl.getConfigIDFromInspect(co)
+	assert.Equal(t, "test", string(id))
+
+	labeledCo := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "test"},
+		Mounts:            make([]types.MountPoint, 0),
+		Config:            &container.Config{Labels: map[string]string{"io.datadog.check.id": "w00tw00t"}},
+		NetworkSettings:   &types.NetworkSettings{},
+	}
+	id = dl.getConfigIDFromInspect(labeledCo)
+	assert.Equal(t, "w00tw00t", string(id))
+}
+
+func TestGetHostsFromInspect(t *testing.T) {
+	dl := DockerListener{}
+
+	cBase := types.ContainerJSONBase{
+		ID:    "foo",
+		Image: "test",
+	}
+	co := types.ContainerJSON{
+		ContainerJSONBase: &cBase,
+		Mounts:            make([]types.MountPoint, 0),
+		Config:            &container.Config{Labels: map[string]string{"io.datadog.check.id": "w00tw00t"}},
+		NetworkSettings:   &types.NetworkSettings{},
+	}
+
+	assert.Empty(t, dl.getHostsFromInspect(co))
+
+	nets := make(map[string]*network.EndpointSettings)
+	nets["bridge"] = &network.EndpointSettings{IPAddress: "172.17.0.2"}
+	nets["foo"] = &network.EndpointSettings{IPAddress: "172.17.0.3"}
+	ports := make(nat.PortMap)
+	p, _ := nat.NewPort("tcp", "1337")
+	ports[p] = make([]nat.PortBinding, 0)
+	p, _ = nat.NewPort("tcp", "42")
+	ports[p] = make([]nat.PortBinding, 0)
+
+	cBase = types.ContainerJSONBase{
+		ID:    "deadbeef",
+		Image: "test",
+	}
+	networkSettings := types.NetworkSettings{
+		NetworkSettingsBase: types.NetworkSettingsBase{Ports: ports},
+		Networks:            nets,
+	}
+
+	co = types.ContainerJSON{
+		ContainerJSONBase: &cBase,
+		Mounts:            make([]types.MountPoint, 0),
+		Config:            &container.Config{},
+		NetworkSettings:   &networkSettings,
+	}
+	hosts := dl.getHostsFromInspect(co)
+
+	assert.Equal(t, "172.17.0.2", hosts["bridge"])
+	assert.Equal(t, "172.17.0.3", hosts["foo"])
+	assert.Equal(t, 2, len(hosts))
+}
+
+func TestGetPortsFromInspect(t *testing.T) {
+	dl := DockerListener{}
+
+	cBase := types.ContainerJSONBase{
+		ID:    "deadbeef",
+		Image: "test",
+	}
+
+	ports := make(nat.PortMap)
+	networkSettings := types.NetworkSettings{
+		NetworkSettingsBase: types.NetworkSettingsBase{Ports: ports},
+		Networks:            make(map[string]*network.EndpointSettings),
+	}
+
+	co := types.ContainerJSON{
+		ContainerJSONBase: &cBase,
+		Mounts:            make([]types.MountPoint, 0),
+		Config:            &container.Config{},
+		NetworkSettings:   &networkSettings,
+	}
+	assert.Empty(t, dl.getPortsFromInspect(co))
+
+	ports = make(nat.PortMap)
+	p, _ := nat.NewPort("tcp", "1234")
+	ports[p] = make([]nat.PortBinding, 0)
+	p, _ = nat.NewPort("tcp", "4321")
+	ports[p] = make([]nat.PortBinding, 0)
+
+	co.NetworkSettings.Ports = ports
+	pts := dl.getPortsFromInspect(co)
+	assert.Equal(t, 2, len(pts))
+	assert.Contains(t, pts, 1234)
+	assert.Contains(t, pts, 4321)
+}

--- a/pkg/collector/listeners/types.go
+++ b/pkg/collector/listeners/types.go
@@ -1,0 +1,27 @@
+package listeners
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+// ID is the representation of the unique ID of a service
+type ID string
+
+// Service reprensents an application we can run a check against.
+// It should be matched with a check template by the ConfigResolver.
+type Service struct {
+	ID       ID                // unique ID
+	ConfigID check.ID          // key on which templates will be matched
+	Hosts    map[string]string // network --> IP address
+	Ports    []int
+	Tags     []string
+}
+
+// ServiceListener monitors running services and triggers check (un)scheduling
+//
+// It holds a cache of running services, listens to new/killed services and
+// updates its cache, and the ConfigResolver with these events.
+type ServiceListener interface {
+	Listen()
+	Stop()
+}

--- a/test/integration/listeners/docker_listener_test.go
+++ b/test/integration/listeners/docker_listener_test.go
@@ -1,0 +1,167 @@
+package integration
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
+)
+
+const (
+	redisImage         string = "redis:latest"
+	redisContainerName string = "datadog-integration-redis"
+)
+
+func ResetContainers() {
+	c, err := client.NewEnvClient()
+	if err != nil {
+		panic(err)
+	}
+
+	c.ContainerRemove(context.Background(), redisContainerName, types.ContainerRemoveOptions{Force: true})
+}
+
+func removeFromImage(image string) {
+	c, err := client.NewEnvClient()
+	ctx := context.Background()
+
+	if err != nil {
+		panic(err)
+	}
+
+	l, err := c.ContainerList(ctx, types.ContainerListOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, ctr := range l {
+		if ctr.Image == image {
+			c.ContainerRemove(ctx, ctr.ID, types.ContainerRemoveOptions{Force: true})
+		}
+	}
+}
+
+// runFromImage runs a dead-simple container based on
+// an image name passed to it, and returns its ID
+func runFromImage(image string) (string, error) {
+	c, err := client.NewEnvClient()
+	ctx := context.Background()
+
+	if err != nil {
+		panic(err)
+	}
+
+	l, err := c.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	match := false
+	for _, img := range l {
+		if img.RepoTags[0] == image {
+			match = true
+			break
+		}
+	}
+
+	if !match {
+		resp, err := c.ImagePull(ctx, image, types.ImagePullOptions{})
+		if err != nil {
+			panic(err)
+		}
+		_, err = ioutil.ReadAll(resp) // Necessary for image pull to complete
+		resp.Close()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	resp, err := c.ContainerCreate(ctx, &container.Config{Image: image}, nil, nil, redisContainerName)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := c.ContainerStart(ctx, redisContainerName, types.ContainerStartOptions{}); err != nil {
+		panic(err)
+	}
+
+	return resp.ID, nil
+}
+
+// this tests getHostsFromPs, getPortsFromPs, and getTagsFromPs as well
+func GetCurrentServicesTest(t *testing.T) {
+	newSvc, delSvc := make(chan listeners.Service), make(chan listeners.Service)
+	stop := make(chan bool)
+
+	// make sure we don't block on writes to channels
+	go func() {
+		for {
+			select {
+			case <-newSvc:
+			case <-delSvc:
+			case <-stop:
+			}
+		}
+	}()
+
+	dl, err := listeners.NewDockerListener(stop, newSvc, delSvc)
+	if err != nil {
+		panic(err)
+	}
+
+	// make sure you stop running containers before running this test
+	// this tests a blank run
+	res := dl.GetCurrentServices()
+	assert.Len(t, res, 0)
+
+	// same test but with a simple redis container this time
+	id, _ := runFromImage(redisImage)
+	res = dl.GetCurrentServices()
+
+	assert.Len(t, res, 1)
+	assert.Equal(t, id, res[id].ID)
+	assert.Equal(t, 1, len(res[id].Hosts))
+	assert.Equal(t, "redis:latest", res[id].ConfigID)
+	assert.Equal(t, 0, len(res[id].Tags))
+}
+
+// this tests processEvent, createService and removeService as well
+func ListenTest(t *testing.T) {
+	newSvc, delSvc := make(chan listeners.Service), make(chan listeners.Service)
+	stop := make(chan bool)
+
+	dl, err := listeners.NewDockerListener(stop, newSvc, delSvc)
+	if err != nil {
+		panic(err)
+	}
+
+	dl.Listen()
+
+	id, _ := runFromImage(redisImage)
+	createdSvc := <-newSvc
+
+	assert.Equal(t, 1, len(dl.Services))
+	assert.Equal(t, createdSvc, dl.Services[id])
+	assert.Equal(t, id, createdSvc.ID)
+
+	removeFromImage(redisImage)
+
+	oldSvc := <-delSvc
+	assert.Equal(t, 0, len(dl.Services))
+	assert.Equal(t, oldSvc, createdSvc)
+}
+
+// actually run tests. Make sure to stop running containers on the machine before running this
+// otherwise it will block
+func TestDockerListener(t *testing.T) {
+	t.Run("GetCurrentServicesTest", func(t *testing.T) { GetCurrentServicesTest(t) })
+	ResetContainers()
+	t.Run("Listen", func(t *testing.T) { ListenTest(t) })
+	ResetContainers()
+}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

# WIP

### What does this PR do?

Add a Docker listener that triggers scheduling events when it detects container events.

### Motivation

Needed for completeness of auto discovery.

### Additional Notes

Missing:
- detect in config providers that a config is a template
- fill templates with the listener's info in `ConfigResolver`
- implement getTags
- integration tests
- Kubernetes part
