### PR TITLE
[snmp] further bugfixes

### DIFF
--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -425,7 +425,7 @@ func (c *snmpConfig) Parse(data []byte, initData []byte) error {
 
 	//build instance tag
 	tagbuff.Reset()
-	tagbuff.WriteString("instance:")
+	tagbuff.WriteString("snmp_device:")
 	tagbuff.WriteString(c.instance.Host)
 	tagbuff.WriteString(":")
 	tagbuff.WriteString(fmt.Sprintf("%d", c.instance.Port))
@@ -538,10 +538,14 @@ func (c *SNMPCheck) submitSNMP(oids snmpgo.Oids, vbs snmpgo.VarBinds) error {
 				}
 
 				switch metricType {
-				case "Counter64", "Counter32", "Gauge32", "Integer", "gauge":
+				case "Gauge32", "Integer", "gauge":
 					log.Debugf("Submitting gauge: %v = %v tagged with: %v", metricName, value, tagbundle)
 					//should report instance has hostname
 					c.sender.Gauge(metricName, float64(value.Int64()), "", tagbundle)
+				case "Counter64", "Counter32":
+					log.Debugf("Submitting rate: %v = %v tagged with: %v", metricName, value, tagbundle)
+					//should report instance has hostname
+					c.sender.Rate(metricName, float64(value.Int64()), "", tagbundle)
 				case "OctetString":
 				default:
 					continue

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -222,15 +222,27 @@ func TestSubmitSNMP(t *testing.T) {
 
 	//Mocked VarBinds
 	binds := []*snmpgo.VarBind{}
-	for i, oid := range oids {
+	mtype := make(map[string]string)
+	cnt := 0
+	for _, oid := range oids {
 		v := snmpgo.VarBind{Oid: oid}
-		switch i % 3 { // just different acceptable types.
-		case 0:
-			v.Variable = snmpgo.NewInteger(int32(42949670))
-		case 1:
+		if oid.String() == "1.3.6.1.4.1.3375.2.1.1.2.1.8.0" {
+			// forced type - gauge despite being counter
 			v.Variable = snmpgo.NewCounter32(uint32(42949670))
-		case 2:
-			v.Variable = snmpgo.NewCounter64(uint64(42949670))
+			mtype[oid.String()] = "Gauge"
+		} else {
+			switch cnt { // just different acceptable types.
+			case 0:
+				v.Variable = snmpgo.NewInteger(int32(42949670))
+				mtype[oid.String()] = "Gauge"
+			case 1:
+				v.Variable = snmpgo.NewGauge32(uint32(42949670))
+				mtype[oid.String()] = "Gauge"
+			case 2:
+				v.Variable = snmpgo.NewCounter64(uint64(42949670))
+				mtype[oid.String()] = "Rate"
+			}
+			cnt++
 		}
 		binds = append(binds, &v)
 	}
@@ -260,13 +272,18 @@ func TestSubmitSNMP(t *testing.T) {
 					name = "snmp." + m
 				}
 			}
-			mock.On("Gauge", name, float64(42949670), "", expectedTags).Return().Times(1)
+			mt, ok := mtype[oid.String()]
+			if !ok {
+				t.FailNow()
+			}
+			mock.On(mt, name, float64(42949670), "", expectedTags).Return().Times(1)
 		}
 	}
 	mock.On("Commit").Return().Times(1)
 	snmpCheck.submitSNMP(oids, binds)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 4)
+	mock.AssertNumberOfCalls(t, "Gauge", 3)
+	mock.AssertNumberOfCalls(t, "Rate", 1)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -238,7 +238,7 @@ func TestSubmitSNMP(t *testing.T) {
 	expectedTags := []string{
 		"optional_tag_1",
 		"optional_tag_2",
-		"instance:localhost:161"}
+		"snmp_device:localhost:161"}
 
 	for _, oid := range oids {
 		symbolicOID, err := snmpCheck.cfg.instance.OIDTranslator.GetKVReverse(oid.String())


### PR DESCRIPTION
### What does this PR do?

This PR now submits counters as rate, just like the agent5 counterpart. Additionally, it fixes bad tagging: should be `snmp_device:` not `instance:`.

### Motivation

Customer had some questions about the standalone check, I was then able to identify these two.

