### PR TITLE
Cleaned up dogstatsd rake commands

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ dogstatsd_static-x64:
     # Uncomment the following to see debug logs from omnibus, it defaults to info
     # AGENT_OMNIBUS_LOG_LEVEL: debug
   script:
-    - rake dogstatsd:build_static
+    - rake dogstatsd:build static=true
     - cp $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $CI_PROJECT_DIR
   artifacts:
     expire_in: 2 weeks

--- a/rake/docker.rb
+++ b/rake/docker.rb
@@ -3,13 +3,12 @@ require_relative './common'
 namespace :docker do
   DOGSTATSD_TAG="datadog/dogstatsd:master"
 
-  desc "Build datadog/dogstatsd docker image"
+  desc "Build datadog/dogstatsd docker image [skip_rebuild=false]"
   task :build_dogstatsd do
-    if ENV['skip_rebuild'] == "true" then
-      puts "Skipping DogStatsD build"
-    else
+    if ENV['skip_rebuild'] != "true" then
       puts "Building DogStatsD"
-      Rake::Task["dogstatsd:build_static"].invoke
+      ENV['static'] = 'true'
+      Rake::Task["dogstatsd:build"].invoke
     end
     FileUtils.cp("bin/static/dogstatsd", "Dockerfiles/dogstatsd/alpine/")
     system("docker build -t #{DOGSTATSD_TAG} Dockerfiles/dogstatsd/alpine/") || exit(1)

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -3,26 +3,24 @@ require_relative './common'
 
 namespace :dogstatsd do
   DOGSTATSD_BIN_PATH="./bin/dogstatsd"
-  CLOBBER.include(DOGSTATSD_BIN_PATH)
-
   STATIC_BIN_PATH="./bin/static"
-  STATIC_GO_FLAGS="--ldflags '-s -w -extldflags \"-static\"'"
+  CLOBBER.include(DOGSTATSD_BIN_PATH, STATIC_BIN_PATH)
 
-  desc "Build Dogstatsd"
+  desc "Build Dogstatsd [race=false|incremental=false|static=false]"
   task :build do
-    # -race option
     race_opt = ENV['race'] == "true" ? "-race" : ""
-    build_type = ENV['incremental'] == "true" ? "-i" : "-a"
+    build_type_opt = ENV['incremental'] == "true" ? "-i" : "-a"
+    static_bin = ENV['static'] == "true"
 
+    bin_path = DOGSTATSD_BIN_PATH
     commit = `git rev-parse --short HEAD`.strip
     ldflags = "-X #{REPO_PATH}/pkg/version.commit=#{commit}"
+    if static_bin then
+      ldflags += "-s -w -extldflags \"-static\""
+      bin_path = STATIC_BIN_PATH
+    end
 
-    system("go build #{race_opt} #{build_type} -o #{DOGSTATSD_BIN_PATH}/#{bin_name("dogstatsd")} -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/dogstatsd/")
-  end
-
-  desc "Build static Dogstatsd"
-  task :build_static do
-    system("go build #{STATIC_GO_FLAGS} -o #{STATIC_BIN_PATH}/#{bin_name("dogstatsd")} #{REPO_PATH}/cmd/dogstatsd/")
+    system("go build #{race_opt} #{build_type_opt} -o #{bin_path}/#{bin_name("dogstatsd")} -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/dogstatsd/")
   end
 
   desc "Run Dogstatsd"
@@ -30,11 +28,9 @@ namespace :dogstatsd do
     system("#{DOGSTATSD_BIN_PATH}/dogstatsd")
   end
 
-  desc "Run Dogstatsd system tests"
+  desc "Run Dogstatsd system tests [skip_rebuild=false]"
   task :system_test do
-    if ENV['skip_rebuild'] == "true" then
-      puts "Skipping DogStatsD build"
-    else
+    if ENV['skip_rebuild'] != "true" then
       puts "Building DogStatsD"
       Rake::Task["dogstatsd:build"].invoke
     end
@@ -45,11 +41,9 @@ namespace :dogstatsd do
     system("DOGSTATSD_BIN=\"#{bin_path}\" go test -v #{REPO_PATH}/test/system/dogstatsd/") || exit(1)
   end
 
-  desc "Run Dogstatsd size test"
+  desc "Run Dogstatsd size test [skip_rebuild=false]"
   task :size_test do
-    if ENV['skip_rebuild'] == "true" then
-      puts "Skipping DogStatsD build"
-    else
+    if ENV['skip_rebuild'] != "true" then
       puts "Building DogStatsD"
       Rake::Task["dogstatsd:build"].invoke
     end

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -45,6 +45,7 @@ namespace :dogstatsd do
   task :size_test do
     if ENV['skip_rebuild'] != "true" then
       puts "Building DogStatsD"
+      ENV['static'] = "true"
       Rake::Task["dogstatsd:build"].invoke
     end
 


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?
```
$ rake -T
[...]
rake dogstatsd:build             # Build Dogstatsd [race=false|incremental=false|static=false]
rake dogstatsd:omnibus           # Build omnibus installer
rake dogstatsd:run               # Run Dogstatsd
rake dogstatsd:size_test         # Run Dogstatsd size test [skip_rebuild=false]
rake dogstatsd:system_test       # Run Dogstatsd system tests [skip_rebuild=false]
```

