### PR TITLE
Consolidate default values for settings

### DIFF
--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -13,5 +13,3 @@ var distPath = filepath.Join(_here, "dist")
 func GetDistPath() string {
 	return distPath
 }
-
-const defaultLogPath = "/var/log/datadog/agent.log"

--- a/cmd/agent/common/common_linux.go
+++ b/cmd/agent/common/common_linux.go
@@ -13,5 +13,3 @@ var distPath = filepath.Join(_here, "dist")
 func GetDistPath() string {
 	return distPath
 }
-
-const defaultLogPath = "/var/log/datadog/agent.log"

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -8,7 +8,6 @@ import (
 )
 
 const defaultConfPath = "c:\\programdata\\datadog"
-const defaultLogPath = "c:\\programdata\\datadog\\logs\\agent.log"
 
 var distPath string
 

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -74,10 +74,4 @@ func SetupConfig(confFilePath string) {
 	if err != nil {
 		panic(fmt.Errorf("unable to load Datadog config file: %s", err))
 	}
-
-	// define defaults for the Agent
-	config.Datadog.SetDefault("log_file", defaultLogPath)
-	config.Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
-	config.Datadog.BindEnv("cmd_sock")
-	config.Datadog.SetDefault("check_runners", int64(4))
 }

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -57,11 +57,6 @@ func init() {
 	dogstatsdCmd.AddCommand(startCmd)
 	dogstatsdCmd.AddCommand(versionCmd)
 
-	// ENV vars bindings
-	config.Datadog.BindEnv("conf_path")
-	config.Datadog.SetDefault("conf_path", ".")
-	config.Datadog.SetDefault("log_file", defaultLogPath)
-
 	// local flags
 	startCmd.Flags().StringVarP(&confPath, "cfgpath", "f", "", "path to datadog.yaml")
 	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath"))

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -4,18 +4,25 @@ dd_url: https://app.datadoghq.com
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
-# This can be a comma-separated list of api keys.
-# (default: None, the agent doesn't start without it)
 api_key:
-
-# If you need a proxy to connect to the Internet, provide it here (default: disabled)
-# proxy: http://user:password@host:port
-
-# If you run the agent behind haproxy, you might want to set this to yes
-# skip_ssl_validation: no
 
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
+
+# The path containing check configuration files
+# confd_path:
+
+# Additional path where to search for Python checks
+# additional_checksd:
+
+# The path where the IPC api listens
+# cmd_sock:
+
+# How many workers will be used to run the checks
+# check_runners: 4
+
+# Forwarder timeout in seconds
+# forwarder_timeout: 20
 
 # Metadata collectors, add or remove from the list to enable or disable collection.
 # The host metadata collector cannot be configured and is enabled by default.
@@ -26,25 +33,40 @@ metadata_collectors:
 #  - name: k8s
 #    interval: 60
 
-# ========================================================================== #
-# DogStatsd configuration                                                    #
-# ========================================================================== #
-
+# DogStatsd
+#
 # If you don't want to enable the DogStatsd server, set this option to no
 # use_dogstatsd: yes
-
-# DogStatsd is a small server that aggregates your custom app metrics. For
-# usage information, check out http://api.datadoghq.com
-
-# Make sure your client is sending to the same port.
-# dogstatsd_port : 8125
 #
-# The buffer size use to receive statsd packet (defaults 1024)
+# Make sure your client is sending to the same port
+# dogstatsd_port: 8125
+#
+# Whether dogstatsd should listen to a Unix Socket instead of UDP
+# dogstatsd_socket:
+#
+# The buffer size use to receive statsd packet, in bytes
 # dogstatsd_buffer_size: 1024
+#
+# Whether dogstatsd should listen to non local traffic
+# dogstatsd_non_local_traffic: no
+#
+# Publish dogstatsd's internal stats as Go epxvars
+# dogstatsd_stats_enable: no
+#
+# How many items in the dogstatsd's stats circular buffer
+# dogstatsd_stats_buffer: 10
 
-# ========================================================================== #
+# JMX
+#
+# jmx_pipe_path:
+# jmx_pipe_name: dd-auto_discovery
+
+# Autoconfig
+#
+# Directory containing configuration templates
+# autoconf_template_dir: /datadog/check_configs
+
 # Logging
-# ========================================================================== #
-
+#
 # log_level: info
 # log_file: /var/log/datadog/agent.log

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -16,13 +16,18 @@ api_key:
 # hostname: mymachine.mydomain
 
 # The path containing check configuration files
+# By default, uses the conf.d folder located in the agent installation folder.
 # confd_path:
 
 # Additional path where to search for Python checks
+# By default, uses the checks.d folder located in the agent installation folder.
 # additional_checksd:
 
-# The path where the IPC api listens
-# cmd_sock:
+# The path to the Unix Socket where the IPC api listens on *nix
+# cmd_sock: /tmp/agent.sock
+
+# The path of the Named Pipe the IPC api uses on Windows
+# cmd_pipe_name: \\.\pipe\ddagent
 
 # How many workers will be used to run the checks
 # check_runners: 4
@@ -47,8 +52,8 @@ metadata_collectors:
 # Make sure your client is sending to the same port
 # dogstatsd_port: 8125
 #
-# Whether dogstatsd should listen to a Unix Socket instead of UDP
-# dogstatsd_socket:
+# Whether dogstatsd should listen to a Unix Socket instead of UDP (*nix only)
+# dogstatsd_socket: /tmp/dsd.sock
 #
 # The buffer size use to receive statsd packet, in bytes
 # dogstatsd_buffer_size: 1024

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -16,11 +16,11 @@ api_key:
 # hostname: mymachine.mydomain
 
 # The path containing check configuration files
-# By default, uses the conf.d folder located in the agent installation folder.
+# By default, uses the conf.d folder located in the agent configuration folder.
 # confd_path:
 
 # Additional path where to search for Python checks
-# By default, uses the checks.d folder located in the agent installation folder.
+# By default, uses the checks.d folder located in the agent configuration folder.
 # additional_checksd:
 
 # The path to the Unix Socket where the IPC api listens on *nix
@@ -52,8 +52,9 @@ metadata_collectors:
 # Make sure your client is sending to the same port
 # dogstatsd_port: 8125
 #
-# Whether dogstatsd should listen to a Unix Socket instead of UDP (*nix only)
-# dogstatsd_socket: /tmp/dsd.sock
+# Whether dogstatsd should listen to a Unix Socket instead of UDP (*nix only).
+# Set to a valid filesystem path to enable
+# dogstatsd_socket:
 #
 # The buffer size use to receive statsd packet, in bytes
 # dogstatsd_buffer_size: 1024

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -6,6 +6,12 @@ dd_url: https://app.datadoghq.com
 # https://app.datadoghq.com/account/settings
 api_key:
 
+# If you need a proxy to connect to the Internet, provide it here (default: disabled)
+# proxy: http://user:password@host:port
+
+# If you run the agent behind haproxy, you might want to set this to yes
+# skip_ssl_validation: no
+
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 

--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -22,11 +22,6 @@ const (
 	initConfigPath string = "init_configs"
 )
 
-func init() {
-	// Where to look for check templates if no custom path is defined
-	config.Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
-}
-
 // EtcdConfigProvider implements the Config Provider interface
 // It should be called periodically and returns templates from etcd for AutoConf.
 type EtcdConfigProvider struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,8 @@ func init() {
 	// Configuration defaults
 	// Agent
 	Datadog.SetDefault("dd_url", "http://localhost:17123")
+	Datadog.SetDefault("proxy", "")
+	Datadog.SetDefault("skip_ssl_validation", false)
 	Datadog.SetDefault("hostname", "")
 	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,7 @@ func init() {
 	Datadog.SetDefault("dogstatsd_port", 8125)
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
 	Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	Datadog.SetDefault("dogstatsd_socket", "/tmp/dsd.sock")
+	Datadog.SetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
 	Datadog.SetDefault("dogstatsd_stats_enable", false)
 	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
 	// JMX

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,12 +20,19 @@ func init() {
 	Datadog.SetConfigName("datadog")
 	Datadog.SetEnvPrefix("DD")
 
-	// configuration defaults
+	// Configuration defaults
+	// Agent
 	Datadog.SetDefault("dd_url", "http://localhost:17123")
 	Datadog.SetDefault("hostname", "")
+	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
+	Datadog.SetDefault("log_file", defaultLogPath)
+	Datadog.SetDefault("log_level", "info")
+	Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
+	Datadog.SetDefault("check_runners", int64(4))
 	Datadog.SetDefault("forwarder_timeout", 20)
+	// Dogstatsd
 	Datadog.SetDefault("use_dogstatsd", true)
 	Datadog.SetDefault("dogstatsd_port", 8125)
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
@@ -33,12 +40,17 @@ func init() {
 	Datadog.SetDefault("dogstatsd_socket", "")
 	Datadog.SetDefault("dogstatsd_stats_enable", false)
 	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
+	// JMX
 	Datadog.SetDefault("jmx_pipe_path", defaultJMXPipePath)
 	Datadog.SetDefault("jmx_pipe_name", "dd-auto_discovery")
+	// Autoconfig
+	Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")
+	Datadog.BindEnv("cmd_sock")
+	Datadog.BindEnv("conf_path")
 	Datadog.BindEnv("dogstatsd_socket")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,8 @@ func init() {
 	Datadog.SetDefault("log_file", defaultLogPath)
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
+	// BUG(massi): make the listener_windows.go module actually use the following:
+	Datadog.SetDefault("cmd_pipe_name", `\\.\pipe\ddagent`)
 	Datadog.SetDefault("check_runners", int64(4))
 	Datadog.SetDefault("forwarder_timeout", 20)
 	// Dogstatsd
@@ -39,7 +41,7 @@ func init() {
 	Datadog.SetDefault("dogstatsd_port", 8125)
 	Datadog.SetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
 	Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	Datadog.SetDefault("dogstatsd_socket", "")
+	Datadog.SetDefault("dogstatsd_socket", "/tmp/dsd.sock")
 	Datadog.SetDefault("dogstatsd_stats_enable", false)
 	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
 	// JMX

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -1,4 +1,7 @@
 package config
 
-const defaultConfdPath = "/opt/datadog-agent/etc/conf.d"
-const defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
+const (
+	defaultConfdPath            = "/opt/datadog-agent/etc/conf.d"
+	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
+	defaultLogPath              = "/var/log/datadog/agent.log"
+)

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,4 +1,7 @@
 package config
 
-const defaultConfdPath = "/etc/dd-agent/conf.d"
-const defaultAdditionalChecksPath = "/etc/dd-agent/checks.d"
+const (
+	defaultConfdPath            = "/etc/dd-agent/conf.d"
+	defaultAdditionalChecksPath = "/etc/dd-agent/checks.d"
+	defaultLogPath              = "/var/log/datadog/agent.log"
+)

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -1,5 +1,8 @@
 package config
 
-const defaultConfdPath = "c:\\programdata\\datadog\\conf.d"
-const defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
-const defaultJMXPipePath = "\\\\.\\pipe\\"
+const (
+	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
+	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
+	defaultJMXPipePath          = "\\\\.\\pipe\\"
+	defaultLogPath              = "c:\\programdata\\datadog\\logs\\agent.log"
+)

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -7,13 +7,8 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-const defaultLogLevel = "info"
 const logFileMaxSize = 10 * 1024 * 1024         // 10MB
 const logDateFormat = "2006-01-02 15:04:05 MST" // see time.Format for format syntax
-
-func init() {
-	Datadog.SetDefault("log_level", defaultLogLevel)
-}
 
 // SetupLogger sets up the default logger
 func SetupLogger(logLevel, logFile string) error {

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -4,21 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	log "github.com/cihub/seelog"
 )
 
 // Catalog keeps track of metadata collectors by name
 var catalog = make(map[string]Collector)
-
-func init() {
-	// define defaults for the Agent
-	config.Datadog.SetDefault("metadata_interval", 4*time.Hour)
-	config.Datadog.SetDefault("external_host_tags_interval", 5*time.Minute)
-	config.Datadog.SetDefault("agent_checks_interval", 10*time.Minute)
-	config.Datadog.SetDefault("processes_interval", time.Minute)
-}
 
 // Scheduler takes care of sending metadata at specific
 // time intervals


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Consolidates the use of `SetDefault` for any configuration setting.

### Motivation

Part of the defaults were set within packages, part in the common `config` package. Let's put them all in the same place so it's less error prone.
