### PR TITLE
[dogstatsd] Remove deb and rpm packages from gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,31 +138,6 @@ agent_deb-x64:
     paths:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
-# build dogstatsd for deb-x64
-dogstatsd_deb-x64:
-  stage: package_build
-  image: $DEB_X64
-  tags:
-    - docker
-  variables:
-    # Artifacts and cache must live within project directory but we run omnibus from the GOPATH (see above).
-    # We then instrument `rake` to invoke `omnibus` with custom parameter, pointing to a gitlab-friendly location.
-    AGENT_OMNIBUS_BASE_DIR: $CI_PROJECT_DIR/.omnibus/var/
-    # Uncomment the following to see debug logs from omnibus, it defaults to info
-    # AGENT_OMNIBUS_LOG_LEVEL: debug
-  script:
-    - rake dogstatsd:omnibus
-    - dpkg -c $AGENT_OMNIBUS_PACKAGE_DIR/*.deb
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $AGENT_OMNIBUS_BASE_DIR
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - $AGENT_OMNIBUS_PACKAGE_DIR
-
 # build the package for rpm-x64
 agent_rpm-x64:
   stage: package_build
@@ -188,32 +163,6 @@ agent_rpm-x64:
     expire_in: 2 weeks
     paths:
       - $AGENT_OMNIBUS_PACKAGE_DIR
-
-# build dogstatsd for deb-x64
-dogstatsd_rpm-x64:
-  stage: package_build
-  image: $RPM_X64
-  tags:
-    - docker
-  variables:
-    # Artifacts and cache must live within project directory but we run omnibus from the GOPATH (see above).
-    # We then instrument `rake` to invoke `omnibus` with custom parameter, pointing to a gitlab-friendly location.
-    AGENT_OMNIBUS_BASE_DIR: $CI_PROJECT_DIR/.omnibus/var/
-    # Uncomment the following to see debug logs from omnibus, it defaults to info
-    # AGENT_OMNIBUS_LOG_LEVEL: debug
-  script:
-    - rake dogstatsd:omnibus
-    - rpm -i $AGENT_OMNIBUS_PACKAGE_DIR/*.rpm
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $AGENT_OMNIBUS_BASE_DIR
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - $AGENT_OMNIBUS_PACKAGE_DIR
-
 
 # deploy debian packages to apt staging repo
 deploy_deb:

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -5,6 +5,12 @@
 #
 require "./lib/ostools.rb"
 
+# --------------------------------------------------
+# WIP / FIXME:
+# The dogstatsd package is currently not working as
+# a standalone package. Work will be put into making
+# it fully contained and stable in the future.
+# --------------------------------------------------
 name 'dogstatsd'
 maintainer 'Datadog Packages <package@datadoghq.com>'
 homepage 'http://www.datadoghq.com'


### PR DESCRIPTION
### What does this PR do?

As discussed, remove dogstatsd deb and rpm packages from gitlab pipeline.

 I've removed them entirely from `.gitlab-ci.yml` since there's nothing very specific to the gitlab tasks. We can re-add them once we've put some work into actually making them fully standalone.

### Motivation

Avoid having half-working/half-broken stuff in the `datadog-agent` project as we're getting closer to prime time.
