### PR TITLE
Remove `device_name`/`DeviceName` specificity

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -37,7 +37,6 @@ func (cs *CheckSampler) commit(timestamp int64) {
 		} else {
 			serie.Host = cs.defaultHostname
 		}
-		serie.DeviceName = context.DeviceName
 
 		cs.series = append(cs.series, serie)
 	}

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -11,10 +11,9 @@ import (
 
 // Context holds the elements that form a context, and can be serialized into a context key
 type Context struct {
-	Name       string
-	Tags       []string
-	Host       string
-	DeviceName string
+	Name string
+	Tags []string
+	Host string
 }
 
 // ContextResolver allows tracking and expiring contexts
@@ -46,10 +45,9 @@ func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimes
 	contextKey := generateContextKey(metricSample)
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		cr.contextsByKey[contextKey] = &Context{
-			Name:       metricSample.Name,
-			Tags:       *(metricSample.Tags),
-			Host:       "",
-			DeviceName: "",
+			Name: metricSample.Name,
+			Tags: *(metricSample.Tags),
+			Host: "",
 		}
 	}
 	cr.lastSeenByKey[contextKey] = currentTimestamp

--- a/pkg/aggregator/dist_sampler.go
+++ b/pkg/aggregator/dist_sampler.go
@@ -67,7 +67,6 @@ func (d *DistSampler) flush(timestamp int64) []*SketchSerie {
 				} else {
 					sketchSerie.Host = d.defaultHostname
 				}
-				sketchSerie.DeviceName = context.DeviceName
 				sketchSerie.Interval = d.interval
 
 				sketchesByContext[contextKey] = sketchSerie

--- a/pkg/aggregator/dist_sampler_test.go
+++ b/pkg/aggregator/dist_sampler_test.go
@@ -14,7 +14,6 @@ func AssertSketchSerieEqual(t *testing.T, expected, actual *SketchSerie) {
 		AssertTagsEqual(t, expected.Tags, actual.Tags)
 	}
 	assert.Equal(t, expected.Host, actual.Host)
-	assert.Equal(t, expected.DeviceName, actual.DeviceName)
 	assert.Equal(t, expected.Interval, actual.Interval)
 	if expected.contextKey != "" {
 		assert.Equal(t, expected.contextKey, actual.contextKey)

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -22,7 +22,6 @@ type Serie struct {
 	Points     []Point       `json:"points"`
 	Tags       []string      `json:"tags"`
 	Host       string        `json:"host"`
-	DeviceName string        `json:"device_name"`
 	MType      APIMetricType `json:"type"`
 	Interval   int64         `json:"interval"`
 	contextKey string

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -125,7 +125,7 @@ func TestMarshalJSONSeries(t *testing.T) {
 	payload, err := MarshalJSONSeries(series)
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
-	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device_name\":\"\",\"type\":\"gauge\",\"interval\":0}]}\n"))
+	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"type\":\"gauge\",\"interval\":0}]}\n"))
 }
 
 func TestMarshalJSONServiceChecks(t *testing.T) {

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -194,5 +194,5 @@ func TestMarshalJSONSketchSeries(t *testing.T) {
 	payload, err := MarshalJSONSketchSeries(series)
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
-	assert.Equal(t, payload, []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device_name\":\"\",\"interval\":0,\"sketches\":[[12345,[[[1,1,0]],1]],[67890,[[[10,1,0],[14,3,0],[21,2,0]],3]]]}]}\n"))
+	assert.Equal(t, payload, []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[[12345,[[[1,1,0]],1]],[67890,[[[10,1,0],[14,3,0],[21,2,0]],3]]]}]}\n"))
 }

--- a/pkg/aggregator/sketch_series.go
+++ b/pkg/aggregator/sketch_series.go
@@ -15,7 +15,6 @@ type SketchSerie struct {
 	Name       string   `json:"metric"`
 	Tags       []string `json:"tags"`
 	Host       string   `json:"host"`
-	DeviceName string   `json:"device_name"`
 	Interval   int64    `json:"interval"`
 	Sketches   []Sketch `json:"sketches"`
 	contextKey string

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -84,7 +84,6 @@ func (s *TimeSampler) flush(timestamp int64) []*Serie {
 				} else {
 					serie.Host = s.defaultHostname
 				}
-				serie.DeviceName = context.DeviceName
 				serie.Interval = s.interval
 
 				serieBySignature[serieSignature] = serie

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -18,7 +18,6 @@ func AssertSerieEqual(t *testing.T, expected, actual *Serie) {
 		AssertTagsEqual(t, expected.Tags, actual.Tags)
 	}
 	assert.Equal(t, expected.Host, actual.Host)
-	assert.Equal(t, expected.DeviceName, actual.DeviceName)
 	assert.Equal(t, expected.MType, actual.MType)
 	assert.Equal(t, expected.Interval, actual.Interval)
 	if expected.contextKey != "" {


### PR DESCRIPTION
### What does this PR do?

* Treat `device_name` as any other tag instead of treating it as a specific field
* Make `AgentCheck` support the `device_name` parameter on metric submission methods, but log a deprecation warning

### Motivation

* Clean up aggregator
* Support python checks that use `device_name`

### Additional Notes

I can queue some work to remove all uses of `device_name` from our `integrations-core` checks, I can do that once we're 100% sure that this change won't make the backend create duplicate contexts.
