### PR TITLE
[py] Always add device tag when `device_name` is specified

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -189,9 +189,10 @@ class AgentCheck(object):
         - always return a list
         """
         if tags is None:
-            return []
+            normalized_tags = []
+        else:
+            normalized_tags = list(tags)  # normalize to `list` type, and make a copy
 
-        normalized_tags = list(tags)  # normalize to `list` type, and make a copy
         if device_name:
             self._log_deprecation("device_name")
             normalized_tags.append("device:%s" % device_name)


### PR DESCRIPTION
### What does this PR do?

Another fix to the `device_name` logic: we weren't adding the `device` tag when the passed `tags` were `None`

### Additional Notes

🤦‍♂️ 

(I really want to add unit tests to this part of the code... Maybe call `nosetests` programmatically with the go runtime through the python C api?)