### PR TITLE
Make metric hostname handling consistent across the agent

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -10,7 +10,7 @@ type CheckSampler struct {
 	defaultHostname string
 }
 
-// newCheckSampler returns a newly initialized CheckSample
+// newCheckSampler returns a newly initialized CheckSampler
 func newCheckSampler(hostname string) *CheckSampler {
 	return &CheckSampler{
 		series:          make([]*Serie, 0),

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -7,6 +7,7 @@ import (
 
 	// 3p
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckGaugeSampling(t *testing.T) {
@@ -133,12 +134,23 @@ func TestCheckSamplerHostname(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  12345,
 	}
+	mSample2 := MetricSample{
+		Name:       "my.metric.name",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		Host:       "metric-hostname",
+		SampleRate: 1,
+		Timestamp:  12345,
+	}
 
 	checkSampler.addSample(&mSample1)
+	checkSampler.addSample(&mSample2)
 	checkSampler.commit(12346)
 	series := checkSampler.flush()
 
-	if assert.Len(t, series, 1) {
-		assert.Equal(t, "my.test.hostname", series[0].Host)
-	}
+	require.Len(t, series, 2)
+	actualHostnames := []string{series[0].Host, series[1].Host}
+	assert.Contains(t, actualHostnames, "my.test.hostname")
+	assert.Contains(t, actualHostnames, "metric-hostname")
 }

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -29,6 +29,7 @@ func generateContextKey(metricSample *MetricSample) string {
 	contextFields = append(contextFields, metricSample.Name)
 	sort.Strings(*(metricSample.Tags))
 	contextFields = append(contextFields, *(metricSample.Tags)...)
+	contextFields = append(contextFields, metricSample.Host)
 
 	return strings.Join(contextFields, ",")
 }
@@ -47,7 +48,7 @@ func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimes
 		cr.contextsByKey[contextKey] = &Context{
 			Name: metricSample.Name,
 			Tags: *(metricSample.Tags),
-			Host: "",
+			Host: metricSample.Host,
 		}
 	}
 	cr.lastSeenByKey[contextKey] = currentTimestamp

--- a/pkg/aggregator/dist_sampler_test.go
+++ b/pkg/aggregator/dist_sampler_test.go
@@ -104,7 +104,6 @@ func TestDistSamplerBucketSampling(t *testing.T) {
 			Sketch{int64(10000), expectedSketch},
 			Sketch{int64(10010), expectedSketch},
 		},
-		contextKey: "test.metric.name,a,b",
 	}
 	assert.Equal(t, 1, len(sketchSeries))
 	AssertSketchSerieEqual(t, expectedSerie, sketchSeries[0])
@@ -140,18 +139,16 @@ func TestDistSamplerContextSampling(t *testing.T) {
 	expectedSketch := QSketch{}
 	expectedSketch.Insert(1)
 	expectedSerie1 := &SketchSerie{
-		Name:       "test.metric.name1",
-		Tags:       []string{"a", "b"},
-		Interval:   10,
-		Sketches:   []Sketch{Sketch{int64(10010), expectedSketch}},
-		contextKey: "test.metric.name1,a,b",
+		Name:     "test.metric.name1",
+		Tags:     []string{"a", "b"},
+		Interval: 10,
+		Sketches: []Sketch{Sketch{int64(10010), expectedSketch}},
 	}
 	expectedSerie2 := &SketchSerie{
-		Name:       "test.metric.name2",
-		Tags:       []string{"a", "c"},
-		Interval:   10,
-		Sketches:   []Sketch{Sketch{int64(10010), expectedSketch}},
-		contextKey: "test.metric.name2,a,c",
+		Name:     "test.metric.name2",
+		Tags:     []string{"a", "c"},
+		Interval: 10,
+		Sketches: []Sketch{Sketch{int64(10010), expectedSketch}},
 	}
 
 	assert.Equal(t, 2, len(sketchSeries))

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -49,6 +49,7 @@ type MetricSample struct {
 	RawValue   string
 	Mtype      MetricType
 	Tags       *[]string
+	Host       string
 	SampleRate float64
 	Timestamp  int64
 }

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -96,6 +96,7 @@ func (s *checkSender) sendMetricSample(metric string, value float64, hostname st
 		Value:      value,
 		Mtype:      mType,
 		Tags:       &tags,
+		Host:       hostname,
 		SampleRate: 1,
 		Timestamp:  time.Now().Unix(),
 	}

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -8,6 +8,7 @@ import (
 
 	// 3p
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Helper(s)
@@ -101,7 +102,7 @@ func TestBucketSampling(t *testing.T) {
 }
 
 func TestContextSampling(t *testing.T) {
-	sampler := NewTimeSampler(10, "")
+	sampler := NewTimeSampler(10, "default-hostname")
 
 	mSample1 := MetricSample{
 		Name:       "my.metric.name1",
@@ -117,9 +118,18 @@ func TestContextSampling(t *testing.T) {
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
 	}
+	mSample3 := MetricSample{
+		Name:       "my.metric.name3",
+		Value:      1,
+		Mtype:      GaugeType,
+		Tags:       &[]string{"foo", "bar"},
+		Host:       "metric-hostname",
+		SampleRate: 1,
+	}
 
 	sampler.addSample(&mSample1, 12346)
 	sampler.addSample(&mSample2, 12346)
+	sampler.addSample(&mSample3, 12346)
 
 	orderedSeries := OrderedSeries{sampler.flush(12360)}
 	sort.Sort(orderedSeries)
@@ -130,6 +140,7 @@ func TestContextSampling(t *testing.T) {
 		Name:     "my.metric.name1",
 		Points:   []Point{{int64(12340), float64(1)}},
 		Tags:     []string{"bar", "foo"},
+		Host:     "default-hostname",
 		MType:    APIGaugeType,
 		Interval: 10,
 	}
@@ -137,14 +148,23 @@ func TestContextSampling(t *testing.T) {
 		Name:     "my.metric.name2",
 		Points:   []Point{{int64(12340), float64(1)}},
 		Tags:     []string{"bar", "foo"},
+		Host:     "default-hostname",
+		MType:    APIGaugeType,
+		Interval: 10,
+	}
+	expectedSerie3 := &Serie{
+		Name:     "my.metric.name3",
+		Points:   []Point{{int64(12340), float64(1)}},
+		Tags:     []string{"bar", "foo"},
+		Host:     "metric-hostname",
 		MType:    APIGaugeType,
 		Interval: 10,
 	}
 
-	if assert.Equal(t, 2, len(series)) {
-		AssertSerieEqual(t, expectedSerie1, series[0])
-		AssertSerieEqual(t, expectedSerie2, series[1])
-	}
+	require.Equal(t, 3, len(series))
+	AssertSerieEqual(t, expectedSerie1, series[0])
+	AssertSerieEqual(t, expectedSerie2, series[1])
+	AssertSerieEqual(t, expectedSerie3, series[2])
 }
 
 //func TestOne(t *testing.T) {

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -67,37 +67,38 @@ class AgentCheck(object):
             ],
         }
 
-    def gauge(self, name, value, tags=None, hostname=None, device_name=None):
+    def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
         tags = self._normalize_tags(tags, device_name)
-        aggregator.submit_metric(self, aggregator.GAUGE, name, value, tags)
+        if hostname is None:
+            hostname = ""
+
+        aggregator.submit_metric(self, mtype, name, value, tags, hostname)
+
+    def gauge(self, name, value, tags=None, hostname=None, device_name=None):
+        self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)
 
     def count(self, name, value, tags=None, hostname=None, device_name=None):
-        tags = self._normalize_tags(tags, device_name)
-        aggregator.submit_metric(self, aggregator.COUNT, name, value, tags)
+        self._submit_metric(aggregator.COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name)
 
     def monotonic_count(self, name, value, tags=None, hostname=None, device_name=None):
-        tags = self._normalize_tags(tags, device_name)
-        aggregator.submit_metric(self, aggregator.MONOTONIC_COUNT, name, value, tags)
+        self._submit_metric(aggregator.MONOTONIC_COUNT, name, value, tags=tags, hostname=hostname, device_name=device_name)
 
     def rate(self, name, value, tags=None, hostname=None, device_name=None):
-        tags = self._normalize_tags(tags, device_name)
-        aggregator.submit_metric(self, aggregator.RATE, name, value, tags)
+        self._submit_metric(aggregator.RATE, name, value, tags=tags, hostname=hostname, device_name=device_name)
 
     def histogram(self, name, value, tags=None, hostname=None, device_name=None):
-        tags = self._normalize_tags(tags, device_name)
-        aggregator.submit_metric(self, aggregator.HISTOGRAM, name, value, tags)
+        self._submit_metric(aggregator.HISTOGRAM, name, value, tags=tags, hostname=hostname, device_name=device_name)
 
     def historate(self, name, value, tags=None, hostname=None, device_name=None):
-        tags = self._normalize_tags(tags, device_name)
-        aggregator.submit_metric(self, aggregator.HISTORATE, name, value, tags)
+        self._submit_metric(aggregator.HISTORATE, name, value, tags=tags, hostname=hostname, device_name=device_name)
 
     def increment(self, name, value=1, tags=None, hostname=None, device_name=None):
         self._log_deprecation("increment")
-        self.count(name + "_count", value, tags)
+        self.count(name + "_count", value, tags=tags, hostname=hostname, device_name=device_name)
 
     def decrement(self, name, value=-1, tags=None, hostname=None, device_name=None):
         self._log_deprecation("increment")
-        self.count(name + "_count", value, tags)
+        self.count(name + "_count", value, tags=tags, hostname=hostname, device_name=device_name)
 
     def _log_deprecation(self, deprecation_key):
         """

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -1,6 +1,6 @@
 #include "api.h"
 
-PyObject* SubmitMetric(PyObject*, MetricType, char*, float, PyObject*);
+PyObject* SubmitMetric(PyObject*, MetricType, char*, float, PyObject*, char*);
 PyObject* SubmitServiceCheck(PyObject*, char*, int, PyObject*, char*);
 PyObject* SubmitEvent(PyObject*, PyObject*);
 
@@ -20,18 +20,19 @@ static PyObject *submit_metric(PyObject *self, PyObject *args) {
     char *name;
     float value;
     PyObject *tags = NULL;
+    char *hostname;
 
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    // aggregator.submit_metric(self, aggregator.metric_type.GAUGE, name, value, tags)
-    if (!PyArg_ParseTuple(args, "OisfO", &check, &mt, &name, &value, &tags)) {
+    // aggregator.submit_metric(self, aggregator.metric_type.GAUGE, name, value, tags, hostname)
+    if (!PyArg_ParseTuple(args, "OisfOs", &check, &mt, &name, &value, &tags, &hostname)) {
       PyGILState_Release(gstate);
       return NULL;
     }
 
     PyGILState_Release(gstate);
-    return SubmitMetric(check, mt, name, value, tags);
+    return SubmitMetric(check, mt, name, value, tags, hostname);
 }
 
 static PyObject *submit_service_check(PyObject *self, PyObject *args) {

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -17,7 +17,7 @@ import "C"
 
 // SubmitMetric is the method exposed to Python scripts to submit metrics
 //export SubmitMetric
-func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject) *C.PyObject {
+func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject, hostname *C.char) *C.PyObject {
 
 	sender, err := aggregator.GetDefaultSender()
 	if err != nil {
@@ -32,20 +32,21 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 		log.Error(err)
 		return nil
 	}
+	_hostname := C.GoString(hostname)
 
 	switch mt {
 	case C.GAUGE:
-		sender.Gauge(_name, _value, "", _tags)
+		sender.Gauge(_name, _value, _hostname, _tags)
 	case C.RATE:
-		sender.Rate(_name, _value, "", _tags)
+		sender.Rate(_name, _value, _hostname, _tags)
 	case C.COUNT:
-		sender.Count(_name, _value, "", _tags)
+		sender.Count(_name, _value, _hostname, _tags)
 	case C.MONOTONIC_COUNT:
-		sender.MonotonicCount(_name, _value, "", _tags)
+		sender.MonotonicCount(_name, _value, _hostname, _tags)
 	case C.HISTOGRAM:
-		sender.Histogram(_name, _value, "", _tags)
+		sender.Histogram(_name, _value, _hostname, _tags)
 	case C.HISTORATE:
-		sender.Historate(_name, _value, "", _tags)
+		sender.Historate(_name, _value, _hostname, _tags)
 	}
 
 	return C._none()

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -157,6 +157,21 @@ func TestParseGaugeWithTags(t *testing.T) {
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
+func TestParseGaugeWithHostTag(t *testing.T) {
+	parsed, err := parseMetricPacket([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"))
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "daemon", parsed.Name)
+	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
+	assert.Equal(t, aggregator.GaugeType, parsed.Mtype)
+	require.Equal(t, 2, len(*(parsed.Tags)))
+	assert.Equal(t, "sometag1:somevalue1", (*parsed.Tags)[0])
+	assert.Equal(t, "sometag2:somevalue2", (*parsed.Tags)[1])
+	assert.Equal(t, "my-hostname", parsed.Host)
+	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+}
+
 func TestParseGaugeWithSampleRate(t *testing.T) {
 	parsed, err := parseMetricPacket([]byte("daemon:666|g|@0.21"))
 


### PR DESCRIPTION
### What does this PR do?

Make metric hostname handling consistent across the agent (dogstatsd and both go and python checks).

A hostname set on a metric overrides the agent hostname.

### Motivation

Makes the precedence rule (i.e. "metric hostname overrides agent hostname for that metric")  consistent across the agent, and consistent with agent5.