### PR TITLE
[aggregator] Add `source_type_name` to metric series

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c6738d0e9aa4b030a8b36e9940b14ab5a96351b7d3a2de89e43be53ae8378c24
-updated: 2017-06-19T10:35:24.569426126+02:00
+hash: 6be0f021e623aae13e159648f0d6090b9a0eecefd08194124dd13ff910b081db
+updated: 2017-06-21T11:58:55.579976083-04:00
 imports:
 - name: github.com/beevik/ntp
   version: cb3dae3a7588ae35829eb5724df611cd75152fba
@@ -12,7 +12,7 @@ imports:
   - pkg/pathutil
   - pkg/types
 - name: github.com/DataDog/agent-payload
-  version: 091e000da55ab18aca225f8338abe8338b959aea
+  version: 0b7d55a8fb246702cc0321f68631d746c07d6ddb
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-go

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,7 @@ import:
   subpackages:
   - proto
 - package: github.com/DataDog/agent-payload
-  version: ^4.0
+  version: ^4.1
 - package: github.com/patrickmn/go-cache
   version: ^2.0.0
 - package: github.com/k-sone/snmpgo

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -2,6 +2,8 @@ package aggregator
 
 import "time"
 
+const checksSourceTypeName = "System"
+
 // CheckSampler aggregates metrics from one Check instance
 type CheckSampler struct {
 	series          []*Serie
@@ -32,6 +34,7 @@ func (cs *CheckSampler) commit(timestamp int64) {
 		context := cs.contextResolver.contextsByKey[serie.contextKey]
 		serie.Name = context.Name + serie.nameSuffix
 		serie.Tags = context.Tags
+		serie.SourceTypeName = checksSourceTypeName // this source type is required for metrics coming from the checks
 		if context.Host != "" {
 			serie.Host = context.Host
 		} else {

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -48,21 +48,23 @@ func TestCheckGaugeSampling(t *testing.T) {
 	series := orderedSeries.series
 
 	expectedSerie1 := &Serie{
-		Name:       "my.metric.name",
-		Tags:       []string{"foo", "bar"},
-		Points:     []Point{{int64(12349), mSample2.Value}},
-		MType:      APIGaugeType,
-		contextKey: generateContextKey(&mSample2),
-		nameSuffix: "",
+		Name:           "my.metric.name",
+		Tags:           []string{"foo", "bar"},
+		Points:         []Point{{int64(12349), mSample2.Value}},
+		MType:          APIGaugeType,
+		SourceTypeName: checksSourceTypeName,
+		contextKey:     generateContextKey(&mSample2),
+		nameSuffix:     "",
 	}
 
 	expectedSerie2 := &Serie{
-		Name:       "my.metric.name",
-		Tags:       []string{"foo", "bar", "baz"},
-		Points:     []Point{{int64(12349), mSample3.Value}},
-		MType:      APIGaugeType,
-		contextKey: generateContextKey(&mSample3),
-		nameSuffix: "",
+		Name:           "my.metric.name",
+		Tags:           []string{"foo", "bar", "baz"},
+		Points:         []Point{{int64(12349), mSample3.Value}},
+		MType:          APIGaugeType,
+		SourceTypeName: checksSourceTypeName,
+		contextKey:     generateContextKey(&mSample3),
+		nameSuffix:     "",
 	}
 
 	orderedExpectedSeries := OrderedSeries{[]*Serie{expectedSerie1, expectedSerie2}}
@@ -111,11 +113,12 @@ func TestCheckRateSampling(t *testing.T) {
 	series := checkSampler.flush()
 
 	expectedSerie := &Serie{
-		Name:       "my.metric.name",
-		Tags:       []string{"foo", "bar"},
-		Points:     []Point{{int64(12347), 0.5}},
-		MType:      APIGaugeType,
-		nameSuffix: "",
+		Name:           "my.metric.name",
+		Tags:           []string{"foo", "bar"},
+		Points:         []Point{{int64(12347), 0.5}},
+		MType:          APIGaugeType,
+		SourceTypeName: checksSourceTypeName,
+		nameSuffix:     "",
 	}
 
 	if assert.Equal(t, 1, len(series)) {

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -18,14 +18,15 @@ func (p *Point) MarshalJSON() ([]byte, error) {
 
 // Serie holds a timeseries (w/ json serialization to DD API format)
 type Serie struct {
-	Name       string        `json:"metric"`
-	Points     []Point       `json:"points"`
-	Tags       []string      `json:"tags"`
-	Host       string        `json:"host"`
-	MType      APIMetricType `json:"type"`
-	Interval   int64         `json:"interval"`
-	contextKey string
-	nameSuffix string
+	Name           string        `json:"metric"`
+	Points         []Point       `json:"points"`
+	Tags           []string      `json:"tags"`
+	Host           string        `json:"host"`
+	MType          APIMetricType `json:"type"`
+	Interval       int64         `json:"interval"`
+	SourceTypeName string        `json:"source_type_name,omitempty"`
+	contextKey     string
+	nameSuffix     string
 }
 
 // APIMetricType represents an API metric type

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -31,11 +31,12 @@ func MarshalSeries(series []*Serie) ([]byte, error) {
 	for _, s := range series {
 		payload.Samples = append(payload.Samples,
 			&agentpayload.MetricsPayload_Sample{
-				Metric: s.Name,
-				Type:   s.MType.String(),
-				Host:   s.Host,
-				Points: marshalPoints(s.Points),
-				Tags:   s.Tags,
+				Metric:         s.Name,
+				Type:           s.MType.String(),
+				Host:           s.Host,
+				Points:         marshalPoints(s.Points),
+				Tags:           s.Tags,
+				SourceTypeName: s.SourceTypeName,
 			})
 	}
 

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -116,16 +116,17 @@ func TestMarshalJSONSeries(t *testing.T) {
 			{int64(12345), float64(21.21)},
 			{int64(67890), float64(12.12)},
 		},
-		MType: APIGaugeType,
-		Name:  "test.metrics",
-		Host:  "localHost",
-		Tags:  []string{"tag1", "tag2:yes"},
+		MType:          APIGaugeType,
+		Name:           "test.metrics",
+		Host:           "localHost",
+		Tags:           []string{"tag1", "tag2:yes"},
+		SourceTypeName: "System",
 	}}
 
 	payload, err := MarshalJSONSeries(series)
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
-	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"type\":\"gauge\",\"interval\":0}]}\n"))
+	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"type\":\"gauge\",\"interval\":0,\"source_type_name\":\"System\"}]}\n"))
 }
 
 func TestMarshalJSONServiceChecks(t *testing.T) {

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -21,6 +21,7 @@ func AssertSerieEqual(t *testing.T, expected, actual *Serie) {
 	assert.Equal(t, expected.Host, actual.Host)
 	assert.Equal(t, expected.MType, actual.MType)
 	assert.Equal(t, expected.Interval, actual.Interval)
+	assert.Equal(t, expected.SourceTypeName, actual.SourceTypeName)
 	if expected.contextKey != "" {
 		// Only test the contextKey if it's set in the expected Serie
 		assert.Equal(t, expected.contextKey, actual.contextKey)


### PR DESCRIPTION
### What does this PR do?

Adds `source_type_name` to metric series.

### Motivation

This field is important for backwards-compatibility on the backend:
different `source_type_name`s lead to different contexts.

By default all metrics posted to the metrics API get assigned the
`API` source type name, but metrics coming from the agent's collector
have always had the `System` source type name.

In order to use the same contexts as the agent5, we need to set this
source type name on all metrics coming from the collector.

This behavior is unlikely to change in the backend in the near future,
even after the v2 API release.

### Additional Notes

For the CI to pass on the second commit, https://github.com/DataDog/agent-payload/pull/7 and an update of `agent-payload` in `glide.yaml` are required.
