### PR TITLE
[aggregator] Use `device` field for v1 metric endpoints

### DIFF
--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -22,6 +22,7 @@ type Serie struct {
 	Points         []Point       `json:"points"`
 	Tags           []string      `json:"tags"`
 	Host           string        `json:"host"`
+	Device         string        `json:"device,omitempty"` // FIXME(olivier): remove as soon as the v1 API can handle `device` as a regular tag
 	MType          APIMetricType `json:"type"`
 	Interval       int64         `json:"interval"`
 	SourceTypeName string        `json:"source_type_name,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Use an explicit `device` field for the v1 metric endpoint.

### Motivation

Unfortunately the v1 metric endpoint does not currently handle a
`device:` tag in the same way as the `device` field (using a `device:`
tag leads to very confusing results).

Given that the v2 endpoint should handle `device:` tags correctly,
I use a quick fix and populate the `device` field right before
the serialization for the v1 endpoint. I left the serialization
itself untouched as it's quite error-prone.

### Additional Notes

If the v1 metric endpoint handles `device:` tags correctly at some point,
we should be able to revert this PR safely.
Otherwise, we can remove this code when we switch to the v2 endpoints
once and for all.
