### PR TITLE
Fix flush timestamp for distribution.

### DIFF
--- a/pkg/aggregator/dist_sampler.go
+++ b/pkg/aggregator/dist_sampler.go
@@ -49,8 +49,8 @@ func (d *DistSampler) flush(timestamp int64) []*percentile.SketchSeries {
 	sketchesByContext := make(map[string]*percentile.SketchSeries)
 
 	cutoffTime := d.calculateBucketStart(timestamp)
-	for timestamp, ctxSketch := range d.sketchesByTimestamp {
-		if cutoffTime <= timestamp {
+	for bucketTimestamp, ctxSketch := range d.sketchesByTimestamp {
+		if cutoffTime <= bucketTimestamp {
 			continue
 		}
 
@@ -75,7 +75,7 @@ func (d *DistSampler) flush(timestamp int64) []*percentile.SketchSeries {
 				result = append(result, sketchSeries)
 			}
 		}
-		delete(d.sketchesByTimestamp, timestamp)
+		delete(d.sketchesByTimestamp, bucketTimestamp)
 	}
 	d.contextResolver.expireContexts(timestamp - int64(defaultExpiry/time.Second))
 

--- a/pkg/aggregator/dist_sampler_test.go
+++ b/pkg/aggregator/dist_sampler_test.go
@@ -103,8 +103,8 @@ func TestDistSamplerBucketSampling(t *testing.T) {
 		Tags:     []string{"a", "b"},
 		Interval: 10,
 		Sketches: []percentile.Sketch{
-			percentile.Sketch{Timestamp: int64(10000), Sketch: expectedSketch},
-			percentile.Sketch{Timestamp: int64(10010), Sketch: expectedSketch},
+			percentile.Sketch{Timestamp: int64(10020), Sketch: expectedSketch},
+			percentile.Sketch{Timestamp: int64(10020), Sketch: expectedSketch},
 		},
 		ContextKey: "test.metric.name,a,b,",
 	}
@@ -147,7 +147,7 @@ func TestDistSamplerContextSampling(t *testing.T) {
 		Tags:     []string{"a", "b"},
 		Interval: 10,
 		Sketches: []percentile.Sketch{
-			percentile.Sketch{Timestamp: int64(10010), Sketch: expectedSketch},
+			percentile.Sketch{Timestamp: int64(10020), Sketch: expectedSketch},
 		},
 		ContextKey: "test.metric.name1,a,b,",
 	}
@@ -156,7 +156,7 @@ func TestDistSamplerContextSampling(t *testing.T) {
 		Tags:     []string{"a", "c"},
 		Interval: 10,
 		Sketches: []percentile.Sketch{
-			percentile.Sketch{Timestamp: int64(10010), Sketch: expectedSketch},
+			percentile.Sketch{Timestamp: int64(10020), Sketch: expectedSketch},
 		},
 		ContextKey: "test.metric.name2,a,c,",
 	}

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -62,9 +62,9 @@ func (s *TimeSampler) flush(timestamp int64) []*Serie {
 	cutoffTime := s.calculateBucketStart(timestamp)
 
 	// Iter on each bucket
-	for timestamp, metrics := range s.metricsByTimestamp {
+	for bucketTimestamp, metrics := range s.metricsByTimestamp {
 		// disregard when the timestamp is too recent
-		if cutoffTime <= timestamp {
+		if cutoffTime <= bucketTimestamp {
 			continue
 		}
 
@@ -91,7 +91,7 @@ func (s *TimeSampler) flush(timestamp int64) []*Serie {
 			}
 		}
 
-		delete(s.metricsByTimestamp, timestamp)
+		delete(s.metricsByTimestamp, bucketTimestamp)
 	}
 
 	s.contextResolver.expireContexts(timestamp - int64(defaultExpiry/time.Second))

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -89,7 +89,7 @@ func TestBucketSampling(t *testing.T) {
 	expectedSerie := &Serie{
 		Name:       "my.metric.name",
 		Tags:       []string{"foo", "bar"},
-		Points:     []Point{{int64(12340), mSample.Value}, {int64(12350), mSample.Value}},
+		Points:     []Point{{int64(12360), mSample.Value}, {int64(12360), mSample.Value}},
 		MType:      APIGaugeType,
 		Interval:   10,
 		nameSuffix: "",
@@ -138,7 +138,7 @@ func TestContextSampling(t *testing.T) {
 
 	expectedSerie1 := &Serie{
 		Name:     "my.metric.name1",
-		Points:   []Point{{int64(12340), float64(1)}},
+		Points:   []Point{{int64(12360), float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "default-hostname",
 		MType:    APIGaugeType,
@@ -146,7 +146,7 @@ func TestContextSampling(t *testing.T) {
 	}
 	expectedSerie2 := &Serie{
 		Name:     "my.metric.name2",
-		Points:   []Point{{int64(12340), float64(1)}},
+		Points:   []Point{{int64(12360), float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "default-hostname",
 		MType:    APIGaugeType,
@@ -154,7 +154,7 @@ func TestContextSampling(t *testing.T) {
 	}
 	expectedSerie3 := &Serie{
 		Name:     "my.metric.name3",
-		Points:   []Point{{int64(12340), float64(1)}},
+		Points:   []Point{{int64(12360), float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "metric-hostname",
 		MType:    APIGaugeType,


### PR DESCRIPTION
### What does this PR do?
Fix flush timestamp for distribution and time sampler.

The 'timestamp' was shadow by the bucket timestamp, so the timestamp of the serie was set to the bucket starting time and not the fush starting time.