### PR TITLE
[hackathon] Make Hostname providers optional

### DIFF
--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -21,3 +21,7 @@ func GetHostname() (string, error) {
 
 	return info.Name, nil
 }
+
+func HostnameProvider(hostName string) (string, error) {
+	return GetHostname()
+}

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -22,6 +22,7 @@ func GetHostname() (string, error) {
 	return info.Name, nil
 }
 
+// HostnameProvider docker implementation for the hostname provider
 func HostnameProvider(hostName string) (string, error) {
 	return GetHostname()
 }

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
+	log "github.com/cihub/seelog"
 )
 
 // declare these as vars not const to ease testing
@@ -70,4 +73,13 @@ func IsDefaultHostname(hostname string) bool {
 		isDefault = isDefault || strings.HasPrefix(hostname, val)
 	}
 	return isDefault
+}
+
+// HostnameProvider gets the hostname
+func HostnameProvider(hostName string) (string, error) {
+	if ecs.IsInstance() || IsDefaultHostname(hostName) {
+		log.Debug("GetHostname trying EC2 metadata...")
+		return GetInstanceID()
+	}
+	return "", nil
 }

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -52,7 +52,7 @@ func getResponse(url string) (*http.Response, error) {
 	return res, nil
 }
 
-// This is the gce implementation of the HostnameProvider
+// HostnameProvider GCE implementation of the HostnameProvider
 func HostnameProvider(hostName string) (string, error) {
 	return GetHostname()
 }

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -51,3 +51,8 @@ func getResponse(url string) (*http.Response, error) {
 
 	return res, nil
 }
+
+// This is the gce implementation of the HostnameProvider
+func HostnameProvider(hostName string) (string, error) {
+	return GetHostname()
+}

--- a/pkg/util/hostname/docker.go
+++ b/pkg/util/hostname/docker.go
@@ -1,0 +1,9 @@
+// +build docker
+
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/docker"
+
+func init() {
+	RegisterHostnameProvider("docker", docker.HostnameProvider)
+}

--- a/pkg/util/hostname/ec2.go
+++ b/pkg/util/hostname/ec2.go
@@ -1,0 +1,9 @@
+// +build ec2
+
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/ec2"
+
+func init() {
+	RegisterHostnameProvider("ec2", ec2.HostnameProvider)
+}

--- a/pkg/util/hostname/gce.go
+++ b/pkg/util/hostname/gce.go
@@ -1,0 +1,9 @@
+// +build gce
+
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/gce"
+
+func init() {
+	RegisterHostnameProvider("gce", gce.HostnameProvider)
+}

--- a/pkg/util/hostname/providers.go
+++ b/pkg/util/hostname/providers.go
@@ -1,0 +1,12 @@
+package hostname
+
+// Provider is a generic function to grab the hostname and return it
+type Provider func(string) (string, error)
+
+// ProviderCatalog holds all the various kinds of hostname providers
+var ProviderCatalog = make(map[string]Provider)
+
+// RegisterHostnameProvider registers a hostname provider as part of the catalog
+func RegisterHostnameProvider(name string, p Provider) {
+	ProviderCatalog[name] = p
+}

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	log "github.com/cihub/seelog"
 )
 
@@ -14,12 +15,14 @@ func getContainerHostname() (bool, string) {
 	if isContainerized() {
 		// Docker
 		log.Debug("GetHostname trying Docker API...")
-		name, err := docker.GetHostname()
-		if err == nil && ValidHostname(name) == nil {
-			hostName = name
-		} else if isKubernetes() {
-			log.Debug("GetHostname trying k8s...")
-			// TODO
+		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
+			name, err := getDockerHostname()
+			if err == nil && ValidHostname(name) == nil {
+				hostName = name
+			} else if isKubernetes() {
+				log.Debug("GetHostname trying k8s...")
+				// TODO
+			}
 		}
 	} else {
 		return false, hostName

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -5,28 +5,25 @@
 package util
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	log "github.com/cihub/seelog"
 )
 
 func getContainerHostname() (bool, string) {
-	var hostName string
+	var name string
 	if isContainerized() {
 		// Docker
 		log.Debug("GetHostname trying Docker API...")
 		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
-			name, err := getDockerHostname()
+			name, err := getDockerHostname(name)
 			if err == nil && ValidHostname(name) == nil {
-				hostName = name
+				return true, name
 			} else if isKubernetes() {
 				log.Debug("GetHostname trying k8s...")
 				// TODO
 			}
 		}
-	} else {
-		return false, hostName
 	}
 
-	return true, hostName
+	return false, name
 }

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -15,7 +15,7 @@ end
 
 # `tags` option
 def go_build_tags
-  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm"
+  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm docker ec2 gce"
   build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
 end
 


### PR DESCRIPTION
### What does this PR do?

The hostname providers add a good bit of weight to the binary and to the memory footprint. They aren't needed in all cases. This modularizes it so we're no longer importing docker.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
