### PR TITLE
[hackathon] improve OS support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ task :vet do
   end
 end
 
-desc "Run testsuite [race=false|tags=*]"
+desc "Run testsuite [race=false|tags=*|puppy=false]"
 task :test => %w[fmt lint vet] do
   PROFILE = "profile.cov"  # collect global coverage data in this file
   `echo "mode: count" > #{PROFILE}`

--- a/Rakefile
+++ b/Rakefile
@@ -56,9 +56,6 @@ task :test => %w[fmt lint vet] do
     # without getting false positives from the cover counter
     covermode_opt = "-covermode=atomic"
   end
-  # `tags` option
-  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython"
-  build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
 
   TARGETS.each do |t|
     Dir.glob("#{t}/**/*").select {|f| File.directory? f }.each do |pkg_folder|  # recursively search for go packages
@@ -72,7 +69,7 @@ task :test => %w[fmt lint vet] do
         env["PKG_CONFIG_LIBDIR"] = "#{PKG_CONFIG_LIBDIR}"
       end
 
-      system(env, "go test -tags '#{build_tags}' #{race_opt} -short #{covermode_opt} -coverprofile=#{profile_tmp} #{pkg_folder}") || exit(1)
+      system(env, "go test -tags '#{go_build_tags}' #{race_opt} -short #{covermode_opt} -coverprofile=#{profile_tmp} #{pkg_folder}") || exit(1)
       if File.file?(profile_tmp)
         `cat #{profile_tmp} | tail -n +2 >> #{PROFILE}`
         File.delete(profile_tmp)

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -1,3 +1,5 @@
+// +build freebsd netbsd openbsd solaris dragonfly linux
+
 package common
 
 import (

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -1,3 +1,5 @@
+// +build apm
+
 package embed
 
 import (

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -1,3 +1,5 @@
+// +build jmx
+
 package embed
 
 import (

--- a/pkg/collector/corechecks/embed/jmx_test.go
+++ b/pkg/collector/corechecks/embed/jmx_test.go
@@ -1,3 +1,5 @@
+// +build jmx
+
 package embed
 
 import (

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -1,3 +1,5 @@
+// +build jmx
+
 package embed
 
 import (

--- a/pkg/collector/corechecks/embed/jmxloader_test.go
+++ b/pkg/collector/corechecks/embed/jmxloader_test.go
@@ -1,3 +1,5 @@
+// +build jmx
+
 package embed
 
 import (

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -4,4 +4,5 @@ const (
 	defaultConfdPath            = "/opt/datadog-agent/etc/conf.d"
 	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
 	defaultLogPath              = "/var/log/datadog/agent.log"
+	defaultJMXPipePath          = "/opt/datadog-agent/run"
 )

--- a/pkg/config/config_linux.go
+++ b/pkg/config/config_linux.go
@@ -1,7 +1,0 @@
-package config
-
-const (
-	defaultConfdPath            = "/etc/dd-agent/conf.d"
-	defaultAdditionalChecksPath = "/etc/dd-agent/checks.d"
-	defaultLogPath              = "/var/log/datadog/agent.log"
-)

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -1,5 +1,10 @@
-// +build darwin freebsd linux
+// +build darwin linux freebsd netbsd openbsd solaris dragonfly
 
 package config
 
-const defaultJMXPipePath = "/opt/datadog-agent/run"
+const (
+	defaultConfdPath            = "/etc/dd-agent/conf.d"
+	defaultAdditionalChecksPath = "/etc/dd-agent/checks.d"
+	defaultLogPath              = "/var/log/datadog/agent.log"
+	defaultJMXPipePath          = "/opt/datadog-agent/run"
+)

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -1,4 +1,4 @@
-// +build darwin linux freebsd netbsd openbsd solaris dragonfly
+// +build linux freebsd netbsd openbsd solaris dragonfly
 
 package config
 

--- a/pkg/metadata/host/host_linux.go
+++ b/pkg/metadata/host/host_linux.go
@@ -1,9 +1,0 @@
-package host
-
-import "github.com/shirou/gopsutil/host"
-
-type osVersion [3]string
-
-func fillOsVersion(stats *systemStats, info *host.InfoStat) {
-	stats.Nixver = osVersion{info.PlatformFamily, info.PlatformVersion, ""}
-}

--- a/pkg/metadata/host/host_nix.go
+++ b/pkg/metadata/host/host_nix.go
@@ -1,0 +1,11 @@
+// +build freebsd netbsd openbsd solaris dragonfly
+
+package host
+
+import "github.com/shirou/gopsutil/host"
+
+type osVersion [3]string
+
+func fillOsVersion(stats *systemStats, info *host.InfoStat) {
+	stats.Nixver = osVersion{info.PlatformFamily, info.PlatformVersion, ""}
+}

--- a/pkg/metadata/host/host_nix.go
+++ b/pkg/metadata/host/host_nix.go
@@ -1,4 +1,4 @@
-// +build freebsd netbsd openbsd solaris dragonfly
+// +build linux freebsd netbsd openbsd solaris dragonfly
 
 package host
 

--- a/pkg/metadata/resources/resources.go
+++ b/pkg/metadata/resources/resources.go
@@ -1,3 +1,5 @@
+// +build linux windows darwin
+
 package resources
 
 import (

--- a/pkg/metadata/resources/resources_other.go
+++ b/pkg/metadata/resources/resources_other.go
@@ -1,0 +1,10 @@
+// +build freebsd netbsd openbsd solaris dragonfly
+
+package resources
+
+// GetPayload currently just a stub.
+func GetPayload(hostname string) *Payload {
+
+	//unimplemented for misc platforms.
+	return &Payload{}
+}

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -2,7 +2,6 @@ package v5
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
-	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
@@ -20,20 +19,4 @@ type HostPayload struct {
 // ResourcesPayload wraps Payload from the resources package
 type ResourcesPayload struct {
 	resources.Payload
-}
-
-// GohaiPayload wraps Payload from the gohai package
-type GohaiPayload struct {
-	gohai.Payload
-}
-
-// Payload handles the JSON unmarshalling of the metadata payload
-type Payload struct {
-	CommonPayload
-	HostPayload
-	ResourcesPayload
-	// TODO: host-tags
-	// TODO: external_host_tags
-	GohaiPayload
-	// TODO: agent_checks
 }

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -1,0 +1,23 @@
+// +build linux windows darwin
+
+package v5
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
+)
+
+// GohaiPayload wraps Payload from the gohai package
+type GohaiPayload struct {
+	gohai.Payload
+}
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	CommonPayload
+	HostPayload
+	ResourcesPayload
+	// TODO: host-tags
+	// TODO: external_host_tags
+	GohaiPayload
+	// TODO: agent_checks
+}

--- a/pkg/metadata/v5/payload_other.go
+++ b/pkg/metadata/v5/payload_other.go
@@ -1,0 +1,14 @@
+// +build freebsd netbsd openbsd solaris dragonfly
+
+package v5
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	CommonPayload
+	HostPayload
+	ResourcesPayload
+	// TODO: host-tags
+	// TODO: external_host_tags
+	// TODO: gohai alternative (or fix gohai)
+	// TODO: agent_checks
+}

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -1,4 +1,4 @@
-// +build linux windows
+// +build linux windows darwin
 
 package v5
 

--- a/pkg/metadata/v5/v5_other.go
+++ b/pkg/metadata/v5/v5_other.go
@@ -1,10 +1,9 @@
-// +build linux windows
+// +build freebsd netbsd openbsd solaris dragonfly
 
 package v5
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
-	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
@@ -14,11 +13,9 @@ func GetPayload(hostname string) *Payload {
 	cp := common.GetPayload()
 	hp := host.GetPayload(hostname)
 	rp := resources.GetPayload(hostname)
-	gp := gohai.GetPayload()
 	return &Payload{
 		CommonPayload:    CommonPayload{*cp},
 		HostPayload:      HostPayload{*hp},
 		ResourcesPayload: ResourcesPayload{*rp},
-		GohaiPayload:     GohaiPayload{*gp},
 	}
 }

--- a/pkg/pidfile/pidfile_nix.go
+++ b/pkg/pidfile/pidfile_nix.go
@@ -1,4 +1,4 @@
-// +build freebsd linux
+// +build freebsd linux netbsd openbsd solaris dragonfly
 
 package pidfile
 

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -10,7 +10,6 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
@@ -105,16 +104,9 @@ func GetHostname() (string, error) {
 		return name, err
 	}
 
-	if isContainerized() {
-		// Docker
-		log.Debug("GetHostname trying Docker API...")
-		name, err = docker.GetHostname()
-		if err == nil && ValidHostname(name) == nil {
-			hostName = name
-		} else if isKubernetes() {
-			log.Debug("GetHostname trying k8s...")
-			// TODO
-		}
+	isContainerized, name := getContainerHostname()
+	if isContainerized && name != "" {
+		hostName = name
 	}
 
 	if hostName == "" {

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -1,0 +1,29 @@
+// +build linux windows darwin
+// I don't think windows and darwin can actually be docker hosts
+// but keeping it this way for build consistency (for now)
+
+package util
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	log "github.com/cihub/seelog"
+)
+
+func getContainerHostname() (bool, string) {
+	var hostName string
+	if isContainerized() {
+		// Docker
+		log.Debug("GetHostname trying Docker API...")
+		name, err := docker.GetHostname()
+		if err == nil && ValidHostname(name) == nil {
+			hostName = name
+		} else if isKubernetes() {
+			log.Debug("GetHostname trying k8s...")
+			// TODO
+		}
+	} else {
+		return false, hostName
+	}
+
+	return true, hostName
+}

--- a/pkg/util/hostname_docker_stub.go
+++ b/pkg/util/hostname_docker_stub.go
@@ -1,0 +1,7 @@
+// +build freebsd netbsd openbsd solaris dragonfly
+
+package util
+
+func getContainerHostname() (bool, string) {
+	return false, ""
+}

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -19,9 +19,6 @@ namespace :agent do
     race_opt = ENV['race'] == "true" ? "-race" : ""
     # `incremental` option
     build_type = ENV['incremental'] == "true" ? "-i" : "-a"
-    # `tags` option
-    build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm"
-    build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
 
     # Check if we should use Embedded or System Python,
     # default to the embedded one.
@@ -40,9 +37,9 @@ namespace :agent do
       # On windows, need to build with the extra arguments -gcflags "-N -l" -ldflags="-linkmode internal"
       # if you want to be able to use the delve debugger.
       ldflags << "-linkmode internal"
-      build_success = system(env, "go build #{race_opt} #{build_type} -tags '#{build_tags}' -o #{BIN_PATH}/#{agent_bin_name}  -gcflags \"-N -l\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
+      build_success = system(env, "go build #{race_opt} #{build_type} -tags '#{go_build_tags}' -o #{BIN_PATH}/#{agent_bin_name}  -gcflags \"-N -l\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
     else
-      build_success = system(env, "go build #{race_opt} #{build_type} -tags '#{build_tags}' -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
+      build_success = system(env, "go build #{race_opt} #{build_type} -tags '#{go_build_tags}' -o #{BIN_PATH}/#{agent_bin_name} -ldflags \"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent")
     end
     fail "Agent build failed with code #{$?.exitstatus}" if !build_success
 

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -13,7 +13,7 @@ end
 namespace :agent do
   BIN_PATH="./bin/agent"
   CLOBBER.include(BIN_PATH)
-  desc "Build the Agent [race=false|incremental=false|tags=*]"
+  desc "Build the Agent [race=false|incremental=false|tags=*|puppy=false]"
   task :build do
     # `race` option
     race_opt = ENV['race'] == "true" ? "-race" : ""

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -20,7 +20,7 @@ namespace :agent do
     # `incremental` option
     build_type = ENV['incremental'] == "true" ? "-i" : "-a"
     # `tags` option
-    build_tags = ENV['tags'] || "zstd snmp etcd zk cpython"
+    build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm"
     build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
 
     # Check if we should use Embedded or System Python,

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -13,6 +13,12 @@ def os
   end
 end
 
+# `tags` option
+def go_build_tags
+  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm"
+  build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
+end
+
 def go_fmt(path, fail_on_mod)
   out = `go fmt #{path}/...`
   errors = out.split("\n")


### PR DESCRIPTION
### What does this PR do?

Enables builds for `freebsd`, `netbsd`, `dragonfly` and `solaris` (in their stripped versions).

### Motivation

Improve agent portability.

### Additional Notes

This was put together quickly, things may break in some of the new platform/architecture combos.
