### PR TITLE
[hackathon][dogstatsd] make into module

### DIFF
--- a/cmd/agent/common/common_dsd.go
+++ b/cmd/agent/common/common_dsd.go
@@ -14,6 +14,7 @@ var (
 	DSD *dogstatsd.Server
 )
 
+// CreateDSD creates a new DSD server and assigns it to DSD global
 func CreateDSD(agg *aggregator.BufferedAggregator) error {
 	var err error
 	DSD, err = dogstatsd.NewServer(agg.GetChannels())
@@ -21,6 +22,7 @@ func CreateDSD(agg *aggregator.BufferedAggregator) error {
 	return err
 }
 
+// StopDSD stops the dogstatsd server
 func StopDSD() {
 	if DSD != nil {
 		DSD.Stop()

--- a/cmd/agent/common/common_dsd_stub.go
+++ b/cmd/agent/common/common_dsd_stub.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 )
 
+// CreateDSD a stub in this build
 func CreateDSD() error {
-	return errors.New("Dogstatsd support unavailable in build.")
+	return errors.New("dogstatsd support unavailable in build")
 }
 
+// StopDSD a stub in this build
 func StopDSD() {
 	return
 }


### PR DESCRIPTION
### What does this PR do?

Allows selectively building dogstatsd with the agent.

### Motivation
Trying to maximize weight-loss

### Additional Notes
Actual reduction in binary memory footprint is not great. This could still be desireable regardless, particularly in lightweight platforms, as dogstatsd can be CPU hungry if the volume of custom metrics is high. Memory can also grow in that scenario.  