### PR TITLE
Using timestamp with nanosecond precision in the aggregator.

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -1,7 +1,5 @@
 package aggregator
 
-import "time"
-
 const checksSourceTypeName = "System"
 
 // CheckSampler aggregates metrics from one Check instance
@@ -28,7 +26,7 @@ func (cs *CheckSampler) addSample(metricSample *MetricSample) {
 	cs.metrics.addSample(contextKey, metricSample, metricSample.Timestamp, 1)
 }
 
-func (cs *CheckSampler) commit(timestamp int64) {
+func (cs *CheckSampler) commit(timestamp float64) {
 	for _, serie := range cs.metrics.flush(timestamp) {
 		// Resolve context and populate new []Serie
 		context := cs.contextResolver.contextsByKey[serie.contextKey]
@@ -44,7 +42,7 @@ func (cs *CheckSampler) commit(timestamp int64) {
 		cs.series = append(cs.series, serie)
 	}
 
-	cs.contextResolver.expireContexts(timestamp - int64(defaultExpiry/time.Second))
+	cs.contextResolver.expireContexts(timestamp - defaultExpiry)
 }
 
 func (cs *CheckSampler) flush() []*Serie {

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -19,7 +19,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 		Mtype:      GaugeType,
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
-		Timestamp:  12345,
+		Timestamp:  12345.0,
 	}
 	mSample2 := MetricSample{
 		Name:       "my.metric.name",
@@ -27,7 +27,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 		Mtype:      GaugeType,
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
-		Timestamp:  12347,
+		Timestamp:  12347.0,
 	}
 	mSample3 := MetricSample{
 		Name:       "my.metric.name",
@@ -35,14 +35,14 @@ func TestCheckGaugeSampling(t *testing.T) {
 		Mtype:      GaugeType,
 		Tags:       &[]string{"foo", "bar", "baz"},
 		SampleRate: 1,
-		Timestamp:  12348,
+		Timestamp:  12348.0,
 	}
 
 	checkSampler.addSample(&mSample1)
 	checkSampler.addSample(&mSample2)
 	checkSampler.addSample(&mSample3)
 
-	checkSampler.commit(12349)
+	checkSampler.commit(12349.0)
 	orderedSeries := OrderedSeries{checkSampler.flush()}
 	sort.Sort(orderedSeries)
 	series := orderedSeries.series
@@ -50,7 +50,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 	expectedSerie1 := &Serie{
 		Name:           "my.metric.name",
 		Tags:           []string{"foo", "bar"},
-		Points:         []Point{{int64(12349), mSample2.Value}},
+		Points:         []Point{{12349.0, mSample2.Value}},
 		MType:          APIGaugeType,
 		SourceTypeName: checksSourceTypeName,
 		contextKey:     generateContextKey(&mSample2),
@@ -60,7 +60,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 	expectedSerie2 := &Serie{
 		Name:           "my.metric.name",
 		Tags:           []string{"foo", "bar", "baz"},
-		Points:         []Point{{int64(12349), mSample3.Value}},
+		Points:         []Point{{12349.0, mSample3.Value}},
 		MType:          APIGaugeType,
 		SourceTypeName: checksSourceTypeName,
 		contextKey:     generateContextKey(&mSample3),
@@ -86,15 +86,15 @@ func TestCheckRateSampling(t *testing.T) {
 		Mtype:      RateType,
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
-		Timestamp:  12345,
+		Timestamp:  12345.0,
 	}
 	mSample2 := MetricSample{
 		Name:       "my.metric.name",
-		Value:      2,
+		Value:      10,
 		Mtype:      RateType,
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
-		Timestamp:  12347,
+		Timestamp:  12347.5,
 	}
 	mSample3 := MetricSample{
 		Name:       "my.metric.name",
@@ -102,20 +102,20 @@ func TestCheckRateSampling(t *testing.T) {
 		Mtype:      RateType,
 		Tags:       &[]string{"foo", "bar", "baz"},
 		SampleRate: 1,
-		Timestamp:  12348,
+		Timestamp:  12348.0,
 	}
 
 	checkSampler.addSample(&mSample1)
 	checkSampler.addSample(&mSample2)
 	checkSampler.addSample(&mSample3)
 
-	checkSampler.commit(12349)
+	checkSampler.commit(12349.0)
 	series := checkSampler.flush()
 
 	expectedSerie := &Serie{
 		Name:           "my.metric.name",
 		Tags:           []string{"foo", "bar"},
-		Points:         []Point{{int64(12347), 0.5}},
+		Points:         []Point{{12347.5, 3.6}},
 		MType:          APIGaugeType,
 		SourceTypeName: checksSourceTypeName,
 		nameSuffix:     "",
@@ -135,7 +135,7 @@ func TestCheckSamplerHostname(t *testing.T) {
 		Mtype:      GaugeType,
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
-		Timestamp:  12345,
+		Timestamp:  12345.0,
 	}
 	mSample2 := MetricSample{
 		Name:       "my.metric.name",
@@ -149,7 +149,7 @@ func TestCheckSamplerHostname(t *testing.T) {
 
 	checkSampler.addSample(&mSample1)
 	checkSampler.addSample(&mSample2)
-	checkSampler.commit(12346)
+	checkSampler.commit(12346.0)
 	series := checkSampler.flush()
 
 	require.Len(t, series, 2)

--- a/pkg/aggregator/context_metrics.go
+++ b/pkg/aggregator/context_metrics.go
@@ -14,7 +14,7 @@ func makeContextMetrics() ContextMetrics {
 }
 
 // TODO: Pass a reference to *MetricSample instead
-func (m ContextMetrics) addSample(contextKey string, sample *MetricSample, timestamp int64, interval int64) {
+func (m ContextMetrics) addSample(contextKey string, sample *MetricSample, timestamp float64, interval int64) {
 	if math.IsInf(sample.Value, 0) {
 		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
 		return
@@ -45,7 +45,7 @@ func (m ContextMetrics) addSample(contextKey string, sample *MetricSample, times
 	m[contextKey].addSample(sample, timestamp)
 }
 
-func (m ContextMetrics) flush(timestamp int64) []*Serie {
+func (m ContextMetrics) flush(timestamp float64) []*Serie {
 	var series []*Serie
 
 	for contextKey, metric := range m {

--- a/pkg/aggregator/context_metrics_test.go
+++ b/pkg/aggregator/context_metrics_test.go
@@ -23,7 +23,7 @@ func TestContextMetricsGaugeSampling(t *testing.T) {
 
 	expectedSerie := &Serie{
 		contextKey: contextKey,
-		Points:     []Point{{int64(12345), mSample.Value}},
+		Points:     []Point{{12345.0, mSample.Value}},
 		MType:      APIGaugeType,
 		nameSuffix: "",
 	}
@@ -90,7 +90,7 @@ func TestContextMetricsRateSampling(t *testing.T) {
 	series = metrics.flush(12351)
 	expectedSerie := &Serie{
 		contextKey: contextKey,
-		Points:     []Point{{int64(12350), 1. / 10.}},
+		Points:     []Point{{12350.0, 1. / 10.}},
 		MType:      APIGaugeType,
 		nameSuffix: "",
 	}
@@ -109,7 +109,7 @@ func TestContextMetricsCountSampling(t *testing.T) {
 	series := metrics.flush(12350)
 	expectedSerie := &Serie{
 		contextKey: contextKey,
-		Points:     []Point{{int64(12350), 6.}},
+		Points:     []Point{{12350.0, 6.}},
 		MType:      APICountType,
 		nameSuffix: "",
 	}
@@ -128,7 +128,7 @@ func TestContextMetricsMonotonicCountSampling(t *testing.T) {
 	series := metrics.flush(12350)
 	expectedSerie := &Serie{
 		contextKey: contextKey,
-		Points:     []Point{{int64(12350), 4.}},
+		Points:     []Point{{12350.0, 4.}},
 		MType:      APICountType,
 		nameSuffix: "",
 	}
@@ -151,31 +151,31 @@ func TestContextMetricsHistogramSampling(t *testing.T) {
 	expectedSeries := []*Serie{
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 6.}},
+			Points:     []Point{{12351.0, 6.}},
 			MType:      APIGaugeType,
 			nameSuffix: ".max",
 		},
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 1.}},
+			Points:     []Point{{12351.0, 1.}},
 			MType:      APIGaugeType,
 			nameSuffix: ".median",
 		},
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 2.5}},
+			Points:     []Point{{12351.0, 2.5}},
 			MType:      APIGaugeType,
 			nameSuffix: ".avg",
 		},
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 4.}},
+			Points:     []Point{{12351.0, 4.}},
 			MType:      APIRateType,
 			nameSuffix: ".count",
 		},
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 6.}},
+			Points:     []Point{{12351.0, 6.}},
 			MType:      APIGaugeType,
 			nameSuffix: ".95percentile",
 		},
@@ -202,7 +202,7 @@ func TestContextMetricsHistorateSampling(t *testing.T) {
 	AssertSerieEqual(t,
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 2.}},
+			Points:     []Point{{12351.0, 2.}},
 			MType:      APIGaugeType,
 			nameSuffix: ".max",
 		},
@@ -211,7 +211,7 @@ func TestContextMetricsHistorateSampling(t *testing.T) {
 	AssertSerieEqual(t,
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 1.}},
+			Points:     []Point{{12351.0, 1.}},
 			MType:      APIGaugeType,
 			nameSuffix: ".median",
 		},
@@ -220,7 +220,7 @@ func TestContextMetricsHistorateSampling(t *testing.T) {
 	AssertSerieEqual(t,
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 1.0}},
+			Points:     []Point{{12351.0, 1.0}},
 			MType:      APIGaugeType,
 			nameSuffix: ".avg",
 		},
@@ -229,7 +229,7 @@ func TestContextMetricsHistorateSampling(t *testing.T) {
 	AssertSerieEqual(t,
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 3.}},
+			Points:     []Point{{12351.0, 3.}},
 			MType:      APIRateType,
 			nameSuffix: ".count",
 		},
@@ -238,7 +238,7 @@ func TestContextMetricsHistorateSampling(t *testing.T) {
 	AssertSerieEqual(t,
 		&Serie{
 			contextKey: contextKey,
-			Points:     []Point{{int64(12351), 2.}},
+			Points:     []Point{{12351.0, 2.}},
 			MType:      APIGaugeType,
 			nameSuffix: ".95percentile",
 		},

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -19,7 +19,7 @@ type Context struct {
 // ContextResolver allows tracking and expiring contexts
 type ContextResolver struct {
 	contextsByKey map[string]*Context
-	lastSeenByKey map[string]int64
+	lastSeenByKey map[string]float64
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
@@ -37,12 +37,12 @@ func generateContextKey(metricSample *MetricSample) string {
 func newContextResolver() *ContextResolver {
 	return &ContextResolver{
 		contextsByKey: make(map[string]*Context),
-		lastSeenByKey: make(map[string]int64),
+		lastSeenByKey: make(map[string]float64),
 	}
 }
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimestamp int64) string {
+func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimestamp float64) string {
 	contextKey := generateContextKey(metricSample)
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		cr.contextsByKey[contextKey] = &Context{
@@ -58,7 +58,7 @@ func (cr *ContextResolver) trackContext(metricSample *MetricSample, currentTimes
 
 // expireContexts cleans up the contexts that haven't been tracked since the given timestamp
 // and returns the associated contextKeys
-func (cr *ContextResolver) expireContexts(expireTimestamp int64) []string {
+func (cr *ContextResolver) expireContexts(expireTimestamp float64) []string {
 	var expiredContextKeys []string
 
 	// Find expired context keys

--- a/pkg/aggregator/context_sketch.go
+++ b/pkg/aggregator/context_sketch.go
@@ -18,7 +18,7 @@ func makeContextSketch() ContextSketch {
 	return ContextSketch(make(map[string]*Distribution))
 }
 
-func (c ContextSketch) addSample(contextKey string, sample *MetricSample, timestamp int64, interval int64) {
+func (c ContextSketch) addSample(contextKey string, sample *MetricSample, timestamp float64, interval int64) {
 	if math.IsInf(sample.Value, 0) {
 		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
 		return
@@ -29,7 +29,7 @@ func (c ContextSketch) addSample(contextKey string, sample *MetricSample, timest
 	c[contextKey].addSample(sample, timestamp)
 }
 
-func (c ContextSketch) flush(timestamp int64) []*percentile.SketchSeries {
+func (c ContextSketch) flush(timestamp float64) []*percentile.SketchSeries {
 	var sketches []*percentile.SketchSeries
 
 	for contextKey, distribution := range c {

--- a/pkg/aggregator/context_sketch_test.go
+++ b/pkg/aggregator/context_sketch_test.go
@@ -15,7 +15,7 @@ func TestContextSketchSampling(t *testing.T) {
 
 	ctxSketch.addSample(contextKey, &MetricSample{Value: 1}, 1, 10)
 	ctxSketch.addSample(contextKey, &MetricSample{Value: 5}, 3, 10)
-	resultSeries := ctxSketch.flush(12345)
+	resultSeries := ctxSketch.flush(12345.0)
 
 	expectedSketch := percentile.NewQSketch()
 	expectedSketch.Add(1)
@@ -30,7 +30,7 @@ func TestContextSketchSampling(t *testing.T) {
 
 	// No sketches should be flushed when there's no new sample since
 	// last flush
-	resultSeries = ctxSketch.flush(12355)
+	resultSeries = ctxSketch.flush(12355.0)
 	assert.Equal(t, 0, len(resultSeries))
 }
 
@@ -41,7 +41,7 @@ func TestContextSketchSamplingInfinity(t *testing.T) {
 
 	ctxSketch.addSample(contextKey, &MetricSample{Value: math.Inf(1)}, 1, 10)
 	ctxSketch.addSample(contextKey, &MetricSample{Value: math.Inf(-1)}, 2, 10)
-	resultSeries := ctxSketch.flush(12345)
+	resultSeries := ctxSketch.flush(12345.0)
 
 	assert.Equal(t, 0, len(resultSeries))
 }
@@ -53,7 +53,7 @@ func TestContextSketchSamplingMultiContexts(t *testing.T) {
 	ctxSketch.addSample(contextKey1, &MetricSample{Value: 1}, 1, 10)
 	ctxSketch.addSample(contextKey2, &MetricSample{Value: 1}, 1, 10)
 	ctxSketch.addSample(contextKey1, &MetricSample{Value: 3}, 5, 10)
-	orderedSketchSeries := OrderedSketchSeries{ctxSketch.flush(12345)}
+	orderedSketchSeries := OrderedSketchSeries{ctxSketch.flush(12345.0)}
 	sort.Sort(orderedSketchSeries)
 
 	expectedSketch1 := percentile.NewQSketch()

--- a/pkg/aggregator/count.go
+++ b/pkg/aggregator/count.go
@@ -7,12 +7,12 @@ type Count struct {
 	sampled bool
 }
 
-func (c *Count) addSample(sample *MetricSample, timestamp int64) {
+func (c *Count) addSample(sample *MetricSample, timestamp float64) {
 	c.value += sample.Value
 	c.sampled = true
 }
 
-func (c *Count) flush(timestamp int64) ([]*Serie, error) {
+func (c *Count) flush(timestamp float64) ([]*Serie, error) {
 	value, sampled := c.value, c.sampled
 	c.value, c.sampled = 0, false
 

--- a/pkg/aggregator/counter.go
+++ b/pkg/aggregator/counter.go
@@ -17,12 +17,12 @@ func NewCounter(interval int64) *Counter {
 	}
 }
 
-func (c *Counter) addSample(sample *MetricSample, timestamp int64) {
+func (c *Counter) addSample(sample *MetricSample, timestamp float64) {
 	c.value += sample.Value * (1 / sample.SampleRate)
 	c.sampled = true
 }
 
-func (c *Counter) flush(timestamp int64) ([]*Serie, error) {
+func (c *Counter) flush(timestamp float64) ([]*Serie, error) {
 	value, sampled := c.value, c.sampled
 	c.value, c.sampled = 0, false
 

--- a/pkg/aggregator/dist_sampler_test.go
+++ b/pkg/aggregator/dist_sampler_test.go
@@ -92,7 +92,7 @@ func TestDistSamplerBucketSampling(t *testing.T) {
 	distSampler.addSample(&mSample2, 10012)
 	distSampler.addSample(&mSample1, 10021)
 
-	sketchSeries := distSampler.flush(10020)
+	sketchSeries := distSampler.flush(10020.0)
 
 	expectedSketch := percentile.NewQSketch()
 	expectedSketch.Add(1)
@@ -135,7 +135,7 @@ func TestDistSamplerContextSampling(t *testing.T) {
 	distSampler.addSample(&mSample1, 10011)
 	distSampler.addSample(&mSample2, 10011)
 
-	orderedSketchSeries := OrderedSketchSeries{distSampler.flush(10020)}
+	orderedSketchSeries := OrderedSketchSeries{distSampler.flush(10020.0)}
 	sort.Sort(orderedSketchSeries)
 	sketchSeries := orderedSketchSeries.sketchSeries
 

--- a/pkg/aggregator/distribution.go
+++ b/pkg/aggregator/distribution.go
@@ -16,20 +16,20 @@ func NewDistribution() *Distribution {
 	return &Distribution{sketch: percentile.NewQSketch()}
 }
 
-func (d *Distribution) addSample(sample *MetricSample, timestamp int64) {
+func (d *Distribution) addSample(sample *MetricSample, timestamp float64) {
 	// Insert sample value into the sketch
 	d.sketch.Add(sample.Value)
 	d.count++
 }
 
-func (d *Distribution) flush(timestamp int64) (*percentile.SketchSeries, error) {
+func (d *Distribution) flush(timestamp float64) (*percentile.SketchSeries, error) {
 	if d.count == 0 {
 		return &percentile.SketchSeries{}, percentile.NoSketchError{}
 	}
 	// compress the sketch before flushing
 	d.sketch.Compress()
 	sketch := &percentile.SketchSeries{
-		Sketches: []percentile.Sketch{{Timestamp: timestamp,
+		Sketches: []percentile.Sketch{{Timestamp: int64(timestamp),
 			Sketch: d.sketch}},
 	}
 	// reset the global histogram

--- a/pkg/aggregator/gauge.go
+++ b/pkg/aggregator/gauge.go
@@ -6,12 +6,12 @@ type Gauge struct {
 	sampled bool
 }
 
-func (g *Gauge) addSample(sample *MetricSample, timestamp int64) {
+func (g *Gauge) addSample(sample *MetricSample, timestamp float64) {
 	g.gauge = sample.Value
 	g.sampled = true
 }
 
-func (g *Gauge) flush(timestamp int64) ([]*Serie, error) {
+func (g *Gauge) flush(timestamp float64) ([]*Serie, error) {
 	value, sampled := g.gauge, g.sampled
 	g.gauge, g.sampled = 0, false
 

--- a/pkg/aggregator/histogram.go
+++ b/pkg/aggregator/histogram.go
@@ -45,7 +45,7 @@ func (h *Histogram) configure(aggregates []string, percentiles []int) {
 	h.percentiles = percentiles
 }
 
-func (h *Histogram) addSample(sample *MetricSample, timestamp int64) {
+func (h *Histogram) addSample(sample *MetricSample, timestamp float64) {
 	rate := sample.SampleRate
 	if rate == 0 {
 		rate = 1
@@ -56,7 +56,7 @@ func (h *Histogram) addSample(sample *MetricSample, timestamp int64) {
 	h.count += int64(1 / rate)
 }
 
-func (h *Histogram) flush(timestamp int64) ([]*Serie, error) {
+func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 	if len(h.samples) == 0 {
 		return []*Serie{}, NoSerieError{}
 	}

--- a/pkg/aggregator/historate.go
+++ b/pkg/aggregator/historate.go
@@ -6,20 +6,20 @@ package aggregator
 type Historate struct {
 	histogram         Histogram
 	previousSample    float64
-	previousTimestamp int64
+	previousTimestamp float64
 	sampled           bool
 }
 
-func (h *Historate) addSample(sample *MetricSample, timestamp int64) {
+func (h *Historate) addSample(sample *MetricSample, timestamp float64) {
 	if h.previousTimestamp != 0 {
-		v := (sample.Value - h.previousSample) / float64(timestamp-h.previousTimestamp)
+		v := (sample.Value - h.previousSample) / (timestamp - h.previousTimestamp)
 		h.histogram.addSample(&MetricSample{Value: v}, timestamp)
 		h.sampled = true
 	}
 	h.previousSample, h.previousTimestamp = sample.Value, timestamp
 }
 
-func (h *Historate) flush(timestamp int64) ([]*Serie, error) {
+func (h *Historate) flush(timestamp float64) ([]*Serie, error) {
 	if h.sampled == false {
 		return []*Serie{}, NoSerieError{}
 	}

--- a/pkg/aggregator/metric.go
+++ b/pkg/aggregator/metric.go
@@ -6,14 +6,14 @@ import (
 
 // Point represents a metric value at a specific time
 type Point struct {
-	Ts    int64
+	Ts    float64
 	Value float64
 }
 
 // MarshalJSON return a Point as an array of value (to be compatible with v1 API)
 // FIXME(maxime): to be removed when v2 endpoints are available
 func (p *Point) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("[%v, %v]", p.Ts, p.Value)), nil
+	return []byte(fmt.Sprintf("[%v, %v]", int64(p.Ts), p.Value)), nil
 }
 
 // Serie holds a timeseries (w/ json serialization to DD API format)
@@ -67,8 +67,8 @@ func (a APIMetricType) MarshalText() ([]byte, error) {
 
 // Metric is the interface of all metric types
 type Metric interface {
-	addSample(sample *MetricSample, timestamp int64)
-	flush(timestamp int64) ([]*Serie, error)
+	addSample(sample *MetricSample, timestamp float64)
+	flush(timestamp float64) ([]*Serie, error)
 }
 
 // NoSerieError is the error returned by a metric when not enough samples have been

--- a/pkg/aggregator/metric_sample.go
+++ b/pkg/aggregator/metric_sample.go
@@ -51,5 +51,5 @@ type MetricSample struct {
 	Tags       *[]string
 	Host       string
 	SampleRate float64
-	Timestamp  int64
+	Timestamp  float64
 }

--- a/pkg/aggregator/monotonic_count.go
+++ b/pkg/aggregator/monotonic_count.go
@@ -14,7 +14,7 @@ type MonotonicCount struct {
 	value                 float64
 }
 
-func (mc *MonotonicCount) addSample(sample *MetricSample, timestamp int64) {
+func (mc *MonotonicCount) addSample(sample *MetricSample, timestamp float64) {
 	if !mc.sampledSinceLastFlush {
 		mc.currentSample = sample.Value
 		mc.sampledSinceLastFlush = true
@@ -31,7 +31,7 @@ func (mc *MonotonicCount) addSample(sample *MetricSample, timestamp int64) {
 	}
 }
 
-func (mc *MonotonicCount) flush(timestamp int64) ([]*Serie, error) {
+func (mc *MonotonicCount) flush(timestamp float64) ([]*Serie, error) {
 	if !mc.sampledSinceLastFlush || !mc.hasPreviousSample {
 		return []*Serie{}, NoSerieError{}
 	}

--- a/pkg/aggregator/rate.go
+++ b/pkg/aggregator/rate.go
@@ -7,19 +7,20 @@ import (
 // Rate tracks the rate of a metric over 2 successive flushes
 type Rate struct {
 	previousSample    float64
-	previousTimestamp int64
+	previousTimestamp float64
 	sample            float64
-	timestamp         int64
+	timestamp         float64
 }
 
-func (r *Rate) addSample(sample *MetricSample, timestamp int64) {
+func (r *Rate) addSample(sample *MetricSample, timestamp float64) {
 	if r.timestamp != 0 {
 		r.previousSample, r.previousTimestamp = r.sample, r.timestamp
 	}
 	r.sample, r.timestamp = sample.Value, timestamp
+
 }
 
-func (r *Rate) flush(timestamp int64) ([]*Serie, error) {
+func (r *Rate) flush(timestamp float64) ([]*Serie, error) {
 	if r.previousTimestamp == 0 || r.timestamp == 0 {
 		return []*Serie{}, NoSerieError{}
 	}
@@ -28,9 +29,9 @@ func (r *Rate) flush(timestamp int64) ([]*Serie, error) {
 		return []*Serie{}, fmt.Errorf("Rate was sampled twice at the same timestamp, can't compute a rate")
 	}
 
-	value, ts := (r.sample-r.previousSample)/float64(r.timestamp-r.previousTimestamp), r.timestamp
+	value, ts := (r.sample-r.previousSample)/(r.timestamp-r.previousTimestamp), r.timestamp
 	r.previousSample, r.previousTimestamp = r.sample, r.timestamp
-	r.sample, r.timestamp = 0, 0
+	r.sample, r.timestamp = 0., 0.
 
 	return []*Serie{
 		&Serie{

--- a/pkg/aggregator/rate_test.go
+++ b/pkg/aggregator/rate_test.go
@@ -15,16 +15,16 @@ func TestRateSampling(t *testing.T) {
 
 	// Add samples
 	mRate1.addSample(&MetricSample{Value: 1}, 50)
-	mRate1.addSample(&MetricSample{Value: 2}, 55)
-	mRate2.addSample(&MetricSample{Value: 1}, 50)
+	mRate1.addSample(&MetricSample{Value: 11}, 52.5)
+	mRate2.addSample(&MetricSample{Value: 1}, 60)
 
 	// First rate
 	series, err := mRate1.flush(60)
 	assert.Nil(t, err)
 	assert.Len(t, series, 1)
 	assert.Len(t, series[0].Points, 1)
-	assert.InEpsilon(t, 0.2, series[0].Points[0].Value, epsilon)
-	assert.EqualValues(t, 55, series[0].Points[0].Ts)
+	assert.InEpsilon(t, 4., series[0].Points[0].Value, epsilon)
+	assert.EqualValues(t, 52.5, series[0].Points[0].Ts)
 
 	// Second rate (should return error)
 	_, err = mRate2.flush(60)

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -91,6 +91,7 @@ func (s *checkSender) Commit() {
 
 func (s *checkSender) sendMetricSample(metric string, value float64, hostname string, tags []string, mType MetricType) {
 	log.Debug(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+
 	metricSample := &MetricSample{
 		Name:       metric,
 		Value:      value,
@@ -98,7 +99,7 @@ func (s *checkSender) sendMetricSample(metric string, value float64, hostname st
 		Tags:       &tags,
 		Host:       hostname,
 		SampleRate: 1,
-		Timestamp:  time.Now().Unix(),
+		Timestamp:  timeNowNano(),
 	}
 
 	s.smsOut <- senderMetricSample{s.id, metricSample, false}

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -15,7 +15,7 @@ func marshalPoints(points []Point) []*agentpayload.MetricsPayload_Sample_Point {
 
 	for _, p := range points {
 		pointsPayload = append(pointsPayload, &agentpayload.MetricsPayload_Sample_Point{
-			Ts:    p.Ts,
+			Ts:    int64(p.Ts),
 			Value: p.Value,
 		})
 	}

--- a/pkg/aggregator/serializer_test.go
+++ b/pkg/aggregator/serializer_test.go
@@ -14,8 +14,8 @@ func TestMarshalSeries(t *testing.T) {
 	series := []*Serie{{
 		contextKey: "test_context",
 		Points: []Point{
-			{int64(12345), float64(21.21)},
-			{int64(67890), float64(12.12)},
+			{12345.0, float64(21.21)},
+			{67890.0, float64(12.12)},
 		},
 		MType: APIGaugeType,
 		Name:  "test.metrics",
@@ -139,8 +139,8 @@ func TestMarshalJSONSeries(t *testing.T) {
 	series := []*Serie{{
 		contextKey: "test_context",
 		Points: []Point{
-			{int64(12345), float64(21.21)},
-			{int64(67890), float64(12.12)},
+			{12345.0, float64(21.21)},
+			{67890.0, float64(12.12)},
 		},
 		MType:          APIGaugeType,
 		Name:           "test.metrics",

--- a/pkg/aggregator/set.go
+++ b/pkg/aggregator/set.go
@@ -11,11 +11,11 @@ func NewSet() *Set {
 	return &Set{values: make(map[string]bool)}
 }
 
-func (s *Set) addSample(sample *MetricSample, timestamp int64) {
+func (s *Set) addSample(sample *MetricSample, timestamp float64) {
 	s.values[sample.RawValue] = true
 }
 
-func (s *Set) flush(timestamp int64) ([]*Serie, error) {
+func (s *Set) flush(timestamp float64) ([]*Serie, error) {
 	if len(s.values) == 0 {
 		return []*Serie{}, NoSerieError{}
 	}

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -66,8 +66,8 @@ func (os OrderedSeries) Swap(i, j int) {
 func TestCalculateBucketStart(t *testing.T) {
 	sampler := NewTimeSampler(10, "")
 
-	assert.Equal(t, int64(123450), sampler.calculateBucketStart(123456))
-	assert.Equal(t, int64(123460), sampler.calculateBucketStart(123460))
+	assert.Equal(t, int64(123450), sampler.calculateBucketStart(123456.5))
+	assert.Equal(t, int64(123460), sampler.calculateBucketStart(123460.5))
 
 }
 
@@ -81,16 +81,16 @@ func TestBucketSampling(t *testing.T) {
 		Tags:       &[]string{"foo", "bar"},
 		SampleRate: 1,
 	}
-	sampler.addSample(&mSample, 12345)
-	sampler.addSample(&mSample, 12355)
-	sampler.addSample(&mSample, 12365)
+	sampler.addSample(&mSample, 12345.0)
+	sampler.addSample(&mSample, 12355.0)
+	sampler.addSample(&mSample, 12365.0)
 
-	series := sampler.flush(12360)
+	series := sampler.flush(12360.0)
 
 	expectedSerie := &Serie{
 		Name:       "my.metric.name",
 		Tags:       []string{"foo", "bar"},
-		Points:     []Point{{int64(12340), mSample.Value}, {int64(12350), mSample.Value}},
+		Points:     []Point{{12340.0, mSample.Value}, {12350.0, mSample.Value}},
 		MType:      APIGaugeType,
 		Interval:   10,
 		nameSuffix: "",
@@ -128,18 +128,18 @@ func TestContextSampling(t *testing.T) {
 		SampleRate: 1,
 	}
 
-	sampler.addSample(&mSample1, 12346)
-	sampler.addSample(&mSample2, 12346)
-	sampler.addSample(&mSample3, 12346)
+	sampler.addSample(&mSample1, 12346.0)
+	sampler.addSample(&mSample2, 12346.0)
+	sampler.addSample(&mSample3, 12346.0)
 
-	orderedSeries := OrderedSeries{sampler.flush(12360)}
+	orderedSeries := OrderedSeries{sampler.flush(12360.0)}
 	sort.Sort(orderedSeries)
 
 	series := orderedSeries.series
 
 	expectedSerie1 := &Serie{
 		Name:     "my.metric.name1",
-		Points:   []Point{{int64(12340), float64(1)}},
+		Points:   []Point{{12340.0, float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "default-hostname",
 		MType:    APIGaugeType,
@@ -147,7 +147,7 @@ func TestContextSampling(t *testing.T) {
 	}
 	expectedSerie2 := &Serie{
 		Name:     "my.metric.name2",
-		Points:   []Point{{int64(12340), float64(1)}},
+		Points:   []Point{{12340.0, float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "default-hostname",
 		MType:    APIGaugeType,
@@ -155,7 +155,7 @@ func TestContextSampling(t *testing.T) {
 	}
 	expectedSerie3 := &Serie{
 		Name:     "my.metric.name3",
-		Points:   []Point{{int64(12340), float64(1)}},
+		Points:   []Point{{12340.0, float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "metric-hostname",
 		MType:    APIGaugeType,


### PR DESCRIPTION
### What does this PR do?

Using timestamp with nanosecond precision in the aggregator.

### Motivation

This allow us to improve the accuracy of rate-like metrics.