### PR TITLE
[py] Fix handling of `init_config` and `agentConfig` for args init

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -31,23 +31,28 @@ class AgentCheck(object):
     CRITICAL = 2
 
     def __init__(self, *args, **kwargs):
+        # `args` order is `name`, `init_config`, `agentConfig` (deprecated), `instances`
+
         self.metrics = defaultdict(list)
 
-        if len(args) == 0:
-            self.instances = kwargs.get('instances', [])
-            self.name = kwargs.get('name', '')
-            self.agentConfig = kwargs.get('agentConfig', {})
-        else:
+        self.instances = kwargs.get('instances', [])
+        self.name = kwargs.get('name', '')
+        self.init_config = kwargs.get('init_config', {})
+        self.agentConfig = kwargs.get('agentConfig', {})
+
+        if len(args) > 0:
             self.name = args[0]
-            self.agentConfig = args[1]
-            if 'instances' in kwargs:
-                self.instances = kwargs['instances']
-            elif len(args) == 3:
-                # no agentConfig
-                self.instances = args[2]
+        if len(args) > 1:
+            self.init_config = args[1]
+        if len(args) > 2:
+            if len(args) > 3 or 'instances' in kwargs:
+                # old-style init: the 3rd argument is `agentConfig`
+                self.agentConfig = args[2]
+                if len(args) > 3:
+                    self.instances = args[3]
             else:
-                # with agentConfig
-                self.instances = args[3]
+                # new-style init: the 3rd argument is `instances`
+                self.instances = args[2]
 
         # the agent5 'AgentCheck' setup a log attribute.
         self.log = logging.getLogger('%s.%s' % (__name__, self.name))

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -155,7 +155,7 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	instance, err := c.getInstance(nil, kwargs)
 	if err != nil {
 		log.Warnf("could not get a check instance with the new api: %s", err)
-		log.Warn("trying to instantiate the check with the old api, passing initConfig to the constructor")
+		log.Warn("trying to instantiate the check with the old api, passing agentConfig to the constructor")
 
 		// try again, assuming the check is good but has still the old api
 		// we pass initConfig but emit a deprecation notice

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,9 +38,12 @@ func getClass(moduleName, className string) (checkClass *python.PyObject) {
 }
 
 func getCheckInstance(moduleName, className string) (*PythonCheck, error) {
+	config.Datadog.Set("foo_agent", "bar_agent")
+	defer config.Datadog.Set("foo_agent", nil)
+
 	checkClass := getClass(moduleName, className)
 	check := NewPythonCheck(moduleName, checkClass)
-	err := check.Configure([]byte("foo: bar"), []byte("foo: bar"))
+	err := check.Configure([]byte("foo_instance: bar_instance"), []byte("foo_init: bar_init"))
 	return check, err
 }
 

--- a/pkg/collector/py/tests/common.py
+++ b/pkg/collector/py/tests/common.py
@@ -1,0 +1,28 @@
+## Common functions for tests ##
+
+def assert_instance_init(check):
+    # assertions on `instances`
+    assert hasattr(check, 'instances')
+    assert isinstance(check.instances, list)
+    assert len(check.instances) > 0
+    assert 'foo_instance' in check.instances[0]
+
+def assert_agent_config_init(check, new_style=True):
+    # assertions on `agentConfig`
+    assert hasattr(check, 'agentConfig')
+    assert isinstance(check.agentConfig, dict)
+
+    if new_style:
+        assert len(check.agentConfig) == 0
+    else:
+        # old style: the full agent config should be initialized
+        assert 'foo_agent' in check.agentConfig
+        assert 'bar_agent' == check.agentConfig['foo_agent']
+
+def assert_init_config_init(check):
+    # assertions on `init_config`
+    assert hasattr(check, 'init_config')
+    assert isinstance(check.init_config, dict)
+    assert 'foo_init' in check.init_config
+    assert 'bar_init' == check.init_config['foo_init']
+

--- a/pkg/collector/py/tests/kwargs_init_signature.py
+++ b/pkg/collector/py/tests/kwargs_init_signature.py
@@ -1,13 +1,14 @@
 from checks import AgentCheck
+from common import assert_init_config_init, assert_agent_config_init, assert_instance_init
 
 
 class TestCheck(AgentCheck):
     def __init__(self, *args, **kwargs):
         super(TestCheck, self).__init__(*args, **kwargs)
-        assert hasattr(self, 'instances')
-        assert isinstance(self.instances, list)
-        assert len(self.instances) > 0
-        assert 'foo' in self.instances[0]
+
+        assert_init_config_init(self)
+        assert_agent_config_init(self, True)
+        assert_instance_init(self)
 
     def check(self, instance):
         pass

--- a/pkg/collector/py/tests/new_init_signature.py
+++ b/pkg/collector/py/tests/new_init_signature.py
@@ -1,9 +1,14 @@
 from checks import AgentCheck
+from common import assert_init_config_init, assert_agent_config_init, assert_instance_init
 
 
 class TestCheck(AgentCheck):
     def __init__(self, name, init_config, instances):
         super(TestCheck, self).__init__(name, init_config, instances)
+
+        assert_init_config_init(self)
+        assert_agent_config_init(self, True)
+        assert_instance_init(self)
 
     def check(self, instance):
         pass

--- a/pkg/collector/py/tests/old_alt_init_signature.py
+++ b/pkg/collector/py/tests/old_alt_init_signature.py
@@ -1,13 +1,14 @@
 from checks import AgentCheck
+from common import assert_init_config_init, assert_agent_config_init, assert_instance_init
 
 
 class TestCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(TestCheck, self).__init__(name, init_config, agentConfig, instances=instances)
-        assert hasattr(self, 'instances')
-        assert isinstance(self.instances, list)
-        assert len(self.instances) > 0
-        assert 'foo' in self.instances[0]
+
+        assert_init_config_init(self)
+        assert_agent_config_init(self, False)
+        assert_instance_init(self)
 
     def check(self, instance):
         pass

--- a/pkg/collector/py/tests/old_init_signature.py
+++ b/pkg/collector/py/tests/old_init_signature.py
@@ -1,13 +1,14 @@
 from checks import AgentCheck
+from common import assert_init_config_init, assert_agent_config_init, assert_instance_init
 
 
 class TestCheck(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances):
         super(TestCheck, self).__init__(name, init_config, agentConfig, instances)
-        assert hasattr(self, 'instances')
-        assert isinstance(self.instances, list)
-        assert len(self.instances) > 0
-        assert 'foo' in self.instances[0]
+
+        assert_init_config_init(self)
+        assert_agent_config_init(self, False)
+        assert_instance_init(self)
 
     def check(self, instance):
         pass


### PR DESCRIPTION
The initialization of `init_config` and `agentConfig` used to be wrong when `*args` are used.

Fix this with a more flexible approach in `__init__` function (to handle cases where only part of the arguments are passed in `kwargs`), and add more complete tests.
