### PR TITLE
[forwarder] Allow configuration of multiple endpoints

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -76,11 +76,9 @@ func StartAgent() {
 	api.StartServer()
 
 	// setup the forwarder
-	// for now we handle only one key and one domain
-	keysPerDomain := map[string][]string{
-		config.Datadog.GetString("dd_url"): {
-			config.Datadog.GetString("api_key"),
-		},
+	keysPerDomain, err := config.GetMultipleEndpoints()
+	if err != nil {
+		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
 	common.Forwarder = forwarder.NewDefaultForwarder(keysPerDomain)
 	log.Debugf("Starting forwarder")

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -89,11 +89,10 @@ func start(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// for now we handle only one key and one domain
-	keysPerDomain := map[string][]string{
-		config.Datadog.GetString("dd_url"): {
-			config.Datadog.GetString("api_key"),
-		},
+	// setup the forwarder
+	keysPerDomain, err := config.GetMultipleEndpoints()
+	if err != nil {
+		log.Error("Misconfiguration of agent endpoints: ", err)
 	}
 	f := forwarder.NewDefaultForwarder(keysPerDomain)
 	f.Start()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,18 +93,18 @@ func getMultipleEndpoints(config *viper.Viper) (map[string][]string, error) {
 
 	// dedupe api keys and remove domains with no api keys (or empty ones)
 	for domain, apiKeys := range keysPerDomain {
-		dedupedApiKeys := make([]string, 0, len(apiKeys))
+		dedupedAPIKeys := make([]string, 0, len(apiKeys))
 		seen := make(map[string]bool)
 		for _, apiKey := range apiKeys {
-			trimmedApiKey := strings.TrimSpace(apiKey)
-			if _, ok := seen[trimmedApiKey]; !ok && trimmedApiKey != "" {
-				seen[trimmedApiKey] = true
-				dedupedApiKeys = append(dedupedApiKeys, trimmedApiKey)
+			trimmedAPIKey := strings.TrimSpace(apiKey)
+			if _, ok := seen[trimmedAPIKey]; !ok && trimmedAPIKey != "" {
+				seen[trimmedAPIKey] = true
+				dedupedAPIKeys = append(dedupedAPIKeys, trimmedAPIKey)
 			}
 		}
 
-		if len(dedupedApiKeys) > 0 {
-			keysPerDomain[domain] = dedupedApiKeys
+		if len(dedupedAPIKeys) > 0 {
+			keysPerDomain[domain] = dedupedAPIKeys
 		} else {
 			log.Infof("No API key provided for domain \"%s\", removing domain from endpoints", domain)
 			delete(keysPerDomain, domain)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -51,6 +51,26 @@ additional_endpoints:
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }
 
+func TestGetMultipleEndpointsWithNoAdditionalEndpoints(t *testing.T) {
+	datadogYaml := `
+dd_url: "https://app.datadoghq.com"
+api_key: fakeapikey
+`
+
+	testConfig := setupViperConf(datadogYaml)
+
+	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+
+	expectedMultipleEndpoints := map[string][]string{
+		"https://app.datadoghq.com": {
+			"fakeapikey",
+		},
+	}
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
+}
+
 func TestGetMultipleEndpointseIgnoresDomainWithoutApiKey(t *testing.T) {
 	datadogYaml := `
 dd_url: "https://app.datadoghq.com"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,11 +1,52 @@
 package config
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaults(t *testing.T) {
 	assert.Equal(t, Datadog.GetString("dd_url"), "http://localhost:17123")
+}
+
+func setupViperConf(yamlConfig string) *viper.Viper {
+	conf := viper.New()
+	conf.SetConfigType("yaml")
+	conf.ReadConfig(bytes.NewBuffer([]byte(yamlConfig)))
+	return conf
+}
+
+func TestGetMultipleEndpoints(t *testing.T) {
+	var datadogYaml = `
+dd_url: "https://app.datadoghq.com"
+api_key: fakeapikey
+
+additional_endpoints:
+  "https://app.datadoghq.com":
+  - fakeapikey2
+  - fakeapikey3
+  "https://foo.datadoghq.com":
+  - someapikey
+`
+
+	testConfig := setupViperConf(datadogYaml)
+
+	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+
+	expectedMultipleEndpoints := map[string][]string{
+		"https://app.datadoghq.com": {
+			"fakeapikey",
+			"fakeapikey2",
+			"fakeapikey3",
+		},
+		"https://foo.datadoghq.com": {
+			"someapikey",
+		},
+	}
+
+	assert.Nil(t, err)
+	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 }

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -171,6 +172,14 @@ func (f *DefaultForwarder) Start() error {
 	go f.handleFailedTransactions()
 	f.internalState = Started
 	log.Infof("DefaultForwarder started (%v workers)", f.NumberOfWorkers)
+
+	// log endpoints configuration
+	endpointLogs := make([]string, 0, len(f.KeysPerDomains))
+	for domain, apiKeys := range f.KeysPerDomains {
+		endpointLogs = append(endpointLogs, fmt.Sprintf("\"%s\" (%v api key(s))", domain, len(apiKeys)))
+	}
+	log.Infof("DefaultForwarder sending to %v endpoint(s): %s", len(endpointLogs), strings.Join(endpointLogs, " ; "))
+
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Allows configuration of multiple endpoints (implements related RFC).

Also, adds some logging when the forwarder starts.

### Motivation

Support multiple endpoints. Needed for the agents running on our staging and prod infras.

### Additional Notes

The endpoints configuration is not documented in the example `datadog.yaml` since I don't think we want to advertise this feature. To be confirmed though.