### PR TITLE
[percentile] add protobuf serialization for sketch series

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 496ebb52c95bf04b84b8beee352e431b677706b6949fa75a2991478c6ac48ab1
-updated: 2017-06-22T10:40:06.598557496+02:00
+hash: 53f3397071741b3e934291d6186d55d94b4c85607fc54efafe27457c20e64d98
+updated: 2017-06-29T16:03:56.41071368-04:00
 imports:
 - name: github.com/beevik/ntp
   version: cb3dae3a7588ae35829eb5724df611cd75152fba
@@ -12,7 +12,7 @@ imports:
   - pkg/pathutil
   - pkg/types
 - name: github.com/DataDog/agent-payload
-  version: 0b7d55a8fb246702cc0321f68631d746c07d6ddb
+  version: 81c6e466836dfc706380e4f060062836ce7197a6
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-go
@@ -110,10 +110,13 @@ imports:
 - name: github.com/gogo/protobuf
   version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
+  - gogoproto
   - proto
+  - protoc-gen-gogo/descriptor
 - name: github.com/golang/protobuf
-  version: 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
+  - jsonpb
   - proto
 - name: github.com/gorilla/context
   version: 1ea25387ff6f684839d82767c1733ff4d4d15d0a

--- a/glide.yaml
+++ b/glide.yaml
@@ -39,9 +39,10 @@ import:
 - package: github.com/DataDog/zstd
 - package: github.com/gogo/protobuf
   subpackages:
+  - gogoproto
   - proto
 - package: github.com/DataDog/agent-payload
-  version: ^4.1
+  version: ^4.2
 - package: github.com/patrickmn/go-cache
   version: ^2.0.0
 - package: github.com/k-sone/snmpgo

--- a/pkg/aggregator/percentile/gk_array.go
+++ b/pkg/aggregator/percentile/gk_array.go
@@ -37,11 +37,11 @@ type GKArray struct {
 	ValCount int     `json:"n"`
 }
 
-func marshalEntries(entries Entries) []*agentpayload.SketchPayload_Summary_Sketch_Entry {
-	entriesPayload := []*agentpayload.SketchPayload_Summary_Sketch_Entry{}
+func marshalEntries(entries Entries) []agentpayload.SketchPayload_Summary_Sketch_Entry {
+	entriesPayload := []agentpayload.SketchPayload_Summary_Sketch_Entry{}
 	for _, e := range entries {
 		entriesPayload = append(entriesPayload,
-			&agentpayload.SketchPayload_Summary_Sketch_Entry{
+			agentpayload.SketchPayload_Summary_Sketch_Entry{
 				V:     e.V,
 				G:     int64(e.G),
 				Delta: int64(e.Delta),
@@ -50,7 +50,7 @@ func marshalEntries(entries Entries) []*agentpayload.SketchPayload_Summary_Sketc
 	return entriesPayload
 }
 
-func unmarshalEntries(sketchEntries []*agentpayload.SketchPayload_Summary_Sketch_Entry) Entries {
+func unmarshalEntries(sketchEntries []agentpayload.SketchPayload_Summary_Sketch_Entry) Entries {
 	entries := Entries{}
 	for _, e := range sketchEntries {
 		entries = append(entries, Entry{V: e.V, G: int(e.G), Delta: int(e.Delta)})

--- a/pkg/aggregator/percentile/gk_array.go
+++ b/pkg/aggregator/percentile/gk_array.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"sort"
+
+	agentpayload "github.com/DataDog/agent-payload/gogen"
 )
 
 // EPSILON represents the accuracy of the sketch.
@@ -33,6 +35,27 @@ type GKArray struct {
 	// TODO[Charles]: incorporate min in entries so that we can get rid of the field.
 	Min      float64 `json:"min"`
 	ValCount int     `json:"n"`
+}
+
+func marshalEntries(entries Entries) []*agentpayload.SketchPayload_Summary_Sketch_Entry {
+	entriesPayload := []*agentpayload.SketchPayload_Summary_Sketch_Entry{}
+	for _, e := range entries {
+		entriesPayload = append(entriesPayload,
+			&agentpayload.SketchPayload_Summary_Sketch_Entry{
+				V:     e.V,
+				G:     int64(e.G),
+				Delta: int64(e.Delta),
+			})
+	}
+	return entriesPayload
+}
+
+func unmarshalEntries(sketchEntries []*agentpayload.SketchPayload_Summary_Sketch_Entry) Entries {
+	entries := Entries{}
+	for _, e := range sketchEntries {
+		entries = append(entries, Entry{V: e.V, G: int(e.G), Delta: int(e.Delta)})
+	}
+	return entries
 }
 
 // MarshalJSON encodes an Entry into an array of values

--- a/pkg/aggregator/percentile/sketch_series.go
+++ b/pkg/aggregator/percentile/sketch_series.go
@@ -3,6 +3,10 @@ package percentile
 import (
 	"bytes"
 	"encoding/json"
+
+	"github.com/gogo/protobuf/proto"
+
+	agentpayload "github.com/DataDog/agent-payload/gogen"
 )
 
 // Sketch represents a quantile sketch at a specific time
@@ -38,6 +42,76 @@ type NoSketchError struct{}
 
 func (e NoSketchError) Error() string {
 	return "Not enough samples to generate sketches"
+}
+
+func marshalSketches(sketches []Sketch) []*agentpayload.SketchPayload_Summary_Sketch {
+	sketchesPayload := []*agentpayload.SketchPayload_Summary_Sketch{}
+
+	for _, s := range sketches {
+		sketchesPayload = append(sketchesPayload,
+			&agentpayload.SketchPayload_Summary_Sketch{
+				Ts:      s.Timestamp,
+				N:       int64(s.Sketch.ValCount),
+				Min:     s.Sketch.Min,
+				Entries: marshalEntries(s.Sketch.Entries),
+			})
+	}
+	return sketchesPayload
+}
+
+func unmarshalSketches(summarySketches []*agentpayload.SketchPayload_Summary_Sketch) []Sketch {
+	sketches := []Sketch{}
+	for _, s := range summarySketches {
+		sketches = append(sketches,
+			Sketch{
+				Timestamp: s.Ts,
+				Sketch: QSketch{
+					GKArray{Min: s.Min,
+						ValCount: int(s.N),
+						Entries:  unmarshalEntries(s.Entries),
+						incoming: make([]float64, 0, int(1/EPSILON))}},
+			})
+	}
+	return sketches
+
+}
+
+// MarshalSketchSeries serializes sketch series using protocol buffers
+func MarshalSketchSeries(sketches []*SketchSeries) ([]byte, error) {
+	payload := &agentpayload.SketchPayload{
+		Summaries: []*agentpayload.SketchPayload_Summary{},
+		Metadata:  &agentpayload.CommonMetadata{},
+	}
+	for _, s := range sketches {
+		payload.Summaries = append(payload.Summaries,
+			&agentpayload.SketchPayload_Summary{
+				Metric:   s.Name,
+				Host:     s.Host,
+				Sketches: marshalSketches(s.Sketches),
+				Tags:     s.Tags,
+			})
+	}
+	return proto.Marshal(payload)
+}
+
+// UnmarshalSketchSeries deserializes a protobuf byte array into sketch series
+func UnmarshalSketchSeries(payload []byte) ([]*SketchSeries, agentpayload.CommonMetadata, error) {
+	sketches := []*SketchSeries{}
+	decodedPayload := &agentpayload.SketchPayload{}
+	err := proto.Unmarshal(payload, decodedPayload)
+	if err != nil {
+		return sketches, agentpayload.CommonMetadata{}, err
+	}
+	for _, s := range decodedPayload.Summaries {
+		sketches = append(sketches,
+			&SketchSeries{
+				Name:     s.Metric,
+				Tags:     s.Tags,
+				Host:     s.Host,
+				Sketches: unmarshalSketches(s.Sketches),
+			})
+	}
+	return sketches, *decodedPayload.Metadata, err
 }
 
 // MarshalJSONSketchSeries serializes sketch series to JSON so it can be sent to

--- a/pkg/aggregator/percentile/sketch_series.go
+++ b/pkg/aggregator/percentile/sketch_series.go
@@ -44,12 +44,12 @@ func (e NoSketchError) Error() string {
 	return "Not enough samples to generate sketches"
 }
 
-func marshalSketches(sketches []Sketch) []*agentpayload.SketchPayload_Summary_Sketch {
-	sketchesPayload := []*agentpayload.SketchPayload_Summary_Sketch{}
+func marshalSketches(sketches []Sketch) []agentpayload.SketchPayload_Summary_Sketch {
+	sketchesPayload := []agentpayload.SketchPayload_Summary_Sketch{}
 
 	for _, s := range sketches {
 		sketchesPayload = append(sketchesPayload,
-			&agentpayload.SketchPayload_Summary_Sketch{
+			agentpayload.SketchPayload_Summary_Sketch{
 				Ts:      s.Timestamp,
 				N:       int64(s.Sketch.ValCount),
 				Min:     s.Sketch.Min,
@@ -59,7 +59,7 @@ func marshalSketches(sketches []Sketch) []*agentpayload.SketchPayload_Summary_Sk
 	return sketchesPayload
 }
 
-func unmarshalSketches(summarySketches []*agentpayload.SketchPayload_Summary_Sketch) []Sketch {
+func unmarshalSketches(summarySketches []agentpayload.SketchPayload_Summary_Sketch) []Sketch {
 	sketches := []Sketch{}
 	for _, s := range summarySketches {
 		sketches = append(sketches,
@@ -79,12 +79,12 @@ func unmarshalSketches(summarySketches []*agentpayload.SketchPayload_Summary_Ske
 // MarshalSketchSeries serializes sketch series using protocol buffers
 func MarshalSketchSeries(sketches []*SketchSeries) ([]byte, error) {
 	payload := &agentpayload.SketchPayload{
-		Summaries: []*agentpayload.SketchPayload_Summary{},
-		Metadata:  &agentpayload.CommonMetadata{},
+		Summaries: []agentpayload.SketchPayload_Summary{},
+		Metadata:  agentpayload.CommonMetadata{},
 	}
 	for _, s := range sketches {
 		payload.Summaries = append(payload.Summaries,
-			&agentpayload.SketchPayload_Summary{
+			agentpayload.SketchPayload_Summary{
 				Metric:   s.Name,
 				Host:     s.Host,
 				Sketches: marshalSketches(s.Sketches),
@@ -111,7 +111,7 @@ func UnmarshalSketchSeries(payload []byte) ([]*SketchSeries, agentpayload.Common
 				Sketches: unmarshalSketches(s.Sketches),
 			})
 	}
-	return sketches, *decodedPayload.Metadata, err
+	return sketches, decodedPayload.Metadata, err
 }
 
 // MarshalJSONSketchSeries serializes sketch series to JSON so it can be sent to


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds protocol buffer serialization/deserialization for sketch series.

### Motivation

In preparation for the v2 endpoints for payloads.

### Additional Notes

The corresponding changes to the agent-payload repo is in this PR:
https://github.com/DataDog/agent-payload/pull/8

I've kept the `CommonMetadata` field, assuming that this will be populated at a later time. 