### PR TITLE
centos6 changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,7 @@ run_test_rpm-x64:
   variables:
     USE_SYSTEM_PY: "1"
   script:
+    - source /opt/rh/python27/enable # Enable the alternative python
     - yum install -y net-snmp net-snmp-devel  # required by snmp check
     - rake test
 

--- a/omnibus/config/projects/datadog-agent6.rb
+++ b/omnibus/config/projects/datadog-agent6.rb
@@ -107,12 +107,7 @@ end
 
 # Linux
 if linux?
-  if debian?
-    extra_package_file '/etc/init/datadog-agent6.conf'
-    extra_package_file '/lib/systemd/system/datadog-agent6.service'
-  end
-
-  if redhat?
+  if debian? || redhat?
     extra_package_file '/etc/init/datadog-agent6.conf'
     extra_package_file '/lib/systemd/system/datadog-agent6.service'
   end

--- a/omnibus/config/projects/datadog-agent6.rb
+++ b/omnibus/config/projects/datadog-agent6.rb
@@ -113,6 +113,7 @@ if linux?
   end
 
   if redhat?
+    extra_package_file '/etc/init/datadog-agent6.conf'
     extra_package_file '/lib/systemd/system/datadog-agent6.service'
   end
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -25,13 +25,15 @@ build do
     move 'bin/agent/dist/datadog.yaml', '/etc/dd-agent/datadog.yaml.example'
     mkdir '/etc/dd-agent/checks.d'
 
-    if debian?
+    mkdir "/etc/init/"
+    if debian? || redhat?
       erb source: "upstart.conf.erb",
           dest: "/etc/init/datadog-agent6.conf",
           mode: 0755,
           vars: { install_dir: install_dir }
     end
 
+    mkdir "/lib/systemd/system/"
     if redhat? || debian?
       erb source: "systemd.service.erb",
           dest: "/lib/systemd/system/datadog-agent6.service",


### PR DESCRIPTION
### What does this PR do?

This is what we needed to change to get this working on centos6. We needed to enable the alternative python ([see the related container PR](https://github.com/DataDog/datadog-agent-builders/pull/7)). And we needed to add an upstart file.

### Motivation

It had to be done.

### Additional Notes

Kenafah needs to sign off on all these changes as well, as mentioned in the container PR this will affect them as well.