### PR TITLE
[gitlab] Allow failure of rpm build step

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,6 +142,7 @@ agent_deb-x64:
 agent_rpm-x64:
   stage: package_build
   image: $RPM_X64
+  allow_failure: true  # FIXME: when we start deploying the rpm package
   tags:
     - docker
   variables:


### PR DESCRIPTION
Temporary.

Enables deploying the deb package even if the rpm build fails.

OK until we actually deploy the rpm pkg.