### PR TITLE
Add hostname detection for azure cloud provider

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -99,9 +99,10 @@ func start(cmd *cobra.Command, args []string) error {
 
 	hname, err := util.GetHostname()
 	if err != nil {
-		log.Warnf("Error getting hostname: %s\n", err)
+		log.Warnf("Error getting hostname: %s", err)
 		hname = ""
 	}
+	log.Debugf("Using hostname: %s", hname)
 
 	var metaScheduler *metadata.Scheduler
 	if config.Datadog.GetBool("enable_metadata_collection") {

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
@@ -17,12 +18,13 @@ type HostCollector struct{}
 // Send collects the data needed and submits the payload
 func (hp *HostCollector) Send(fwd forwarder.Forwarder) error {
 	var hostname string
-	x, found := util.Cache.Get("hostname")
+	x, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
 	if found {
 		hostname = x.(string)
 	}
 
 	payload := v5.GetPayload(hostname)
+
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("unable to serialize host metadata payload, %s", err)

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -29,7 +29,7 @@ func GetPayload(hostname string) *Payload {
 		PythonVersion:    getPythonVersion(),
 		InternalHostname: hostname,
 		UUID:             getHostInfo().HostID,
-		SytemStats:       getSystemStats(),
+		SystemStats:      getSystemStats(),
 		Meta:             meta,
 	}
 }

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 
+	"github.com/DataDog/datadog-agent/pkg/util/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	log "github.com/cihub/seelog"
 )
@@ -112,6 +113,20 @@ func getHostInfo() *host.InfoStat {
 	return info
 }
 
+// getHostAliases returns the hostname aliases from different provider
+// This should include GCE, Azure, Cloud foundry.
+func getHostAliases() []string {
+	aliases := []string{}
+
+	azureAliases, err := azure.GetHostAlias()
+	if err != nil {
+		log.Errorf("no Azure Host Aliases: %s", err)
+	} else if azureAliases != "" {
+		aliases = append(aliases, azureAliases)
+	}
+	return aliases
+}
+
 func getMeta() *meta {
 	hostname, _ := os.Hostname()
 	tzname, _ := time.Now().Zone()
@@ -122,6 +137,7 @@ func getMeta() *meta {
 		Timezones:      []string{tzname},
 		SocketFqdn:     util.Fqdn(hostname),
 		EC2Hostname:    ec2Hostname,
+		HostAliases:    getHostAliases(),
 	}
 }
 

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -17,7 +17,7 @@ func TestGetPayload(t *testing.T) {
 	assert.NotEmpty(t, p.PythonVersion)
 	assert.Equal(t, "myhostname", p.InternalHostname)
 	assert.NotEmpty(t, p.UUID)
-	assert.NotNil(t, p.SytemStats)
+	assert.NotNil(t, p.SystemStats)
 	assert.NotNil(t, p.Meta)
 }
 

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -26,6 +26,6 @@ type Payload struct {
 	PythonVersion    string       `json:"python"`
 	InternalHostname string       `json:"internalHostname"`
 	UUID             string       `json:"uuid"`
-	SytemStats       *systemStats `json:"systemStats"`
+	SystemStats      *systemStats `json:"systemStats"`
 	Meta             *meta        `json:"meta"`
 }

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -18,6 +18,7 @@ type meta struct {
 	SocketFqdn     string   `json:"socket-fqdn"`
 	EC2Hostname    string   `json:"ec2-hostname"`
 	Hostname       string   `json:"hostname"`
+	HostAliases    []string `json:"host_aliases"`
 }
 
 // Payload handles the JSON unmarshalling of the metadata payload

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
@@ -17,7 +18,7 @@ type ResourcesCollector struct{}
 // Send collects the data needed and submits the payload
 func (rp *ResourcesCollector) Send(fwd forwarder.Forwarder) error {
 	var hostname string
-	x, found := util.Cache.Get("hostname")
+	x, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
 	if found {
 		hostname = x.(string)
 	}

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -19,7 +19,7 @@ type HostPayload struct {
 
 // ResourcesPayload wraps Payload from the resources package
 type ResourcesPayload struct {
-	resources.Payload
+	resources.Payload `json:"resources"`
 }
 
 // GohaiPayload wraps Payload from the gohai package

--- a/pkg/util/azure/azure_test.go
+++ b/pkg/util/azure/azure_test.go
@@ -1,0 +1,28 @@
+package azure
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostname(t *testing.T) {
+	expected := "5d33a910-a7a0-4443-9f01-6a807801b29b"
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetHostAlias()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/vmId")
+	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-04-02&format=text")
+}


### PR DESCRIPTION
### What does this PR do?

- Add detection for azure VM ID using the metadata service
- fix hostname in metadata payload
- fix `resources` serialization who was shadowing the `meta` section from the host metadata
- small typo and logging improvements