### PR TITLE
[forwarder] Fix api key handling for multiple v1 endpoints

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -103,7 +103,7 @@ func StartAgent() {
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 	// setup the metadata collector, this needs a working Python env to function
-	common.MetadataScheduler = metadata.NewScheduler(common.Forwarder, config.Datadog.GetString("api_key"), hostname)
+	common.MetadataScheduler = metadata.NewScheduler(common.Forwarder, hostname)
 	var C []config.MetadataProviders
 	err = config.Datadog.UnmarshalKey("metadata_providers", &C)
 	if err == nil {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -104,7 +104,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	// start metadata collection
-	metaCollector := metadata.NewScheduler(f, config.Datadog.GetString("api_key"), hname)
+	metaCollector := metadata.NewScheduler(f, hname)
 
 	// add the host metadata collector
 	err = metaCollector.AddCollector("host", hostMetadataCollectorInterval*time.Second)

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -241,7 +241,7 @@ func (agg *BufferedAggregator) flushSeries() {
 			log.Error("could not serialize series, dropping it:", err)
 			return
 		}
-		agg.forwarder.SubmitV1Series(config.Datadog.GetString("api_key"), &payload)
+		agg.forwarder.SubmitV1Series(&payload)
 		addFlushTime("ChecksMetricSampleFlushTime", int64(time.Since(start)))
 		aggregatorExpvar.Add("SeriesFlushed", int64(len(series)))
 	}()
@@ -267,7 +267,7 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 			log.Error("could not serialize service checks, dropping them: ", err)
 			return
 		}
-		agg.forwarder.SubmitV1CheckRuns(config.Datadog.GetString("api_key"), &payload)
+		agg.forwarder.SubmitV1CheckRuns(&payload)
 		addFlushTime("ServiceCheckFlushTime", int64(time.Since(start)))
 		aggregatorExpvar.Add("ServiceCheckFlushed", int64(len(serviceChecks)))
 	}()
@@ -288,7 +288,7 @@ func (agg *BufferedAggregator) flushSketches() {
 		if err != nil {
 			log.Error("could not serialize sketches, dropping them:", err)
 		}
-		agg.forwarder.SubmitV1SketchSeries(config.Datadog.GetString("api_key"), &payload)
+		agg.forwarder.SubmitV1SketchSeries(&payload)
 		addFlushTime("MetricSketchFlushTime", int64(time.Since(start)))
 		aggregatorExpvar.Add("SketchesFlushed", int64(len(sketchSeries)))
 	}()
@@ -313,7 +313,7 @@ func (agg *BufferedAggregator) flushEvents() {
 			return
 		}
 		// We use the agent 5 intake endpoint until the v2 events endpoint is ready
-		agg.forwarder.SubmitV1Intake(config.Datadog.GetString("api_key"), &payload)
+		agg.forwarder.SubmitV1Intake(&payload)
 		addFlushTime("EventFlushTime", int64(time.Since(start)))
 		aggregatorExpvar.Add("EventsFlushed", int64(len(events)))
 	}(agg.hostname)

--- a/pkg/aggregator/serializer.go
+++ b/pkg/aggregator/serializer.go
@@ -147,7 +147,7 @@ func MarshalJSONEvents(events []Event, apiKey string, hostname string) ([]byte, 
 
 	// Build intake payload containing events and serialize
 	data := map[string]interface{}{
-		"apiKey":           apiKey,
+		"apiKey":           apiKey, // legacy field, it isn't actually used by the backend
 		"events":           eventsBySourceType,
 		"internalHostname": hostname,
 	}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -31,10 +31,10 @@ const (
 	defaultNumberOfWorkers = 4
 	chanBufferSize         = 100
 
-	v1SeriesEndpoint       = "/api/v1/series?api_key=%s"
-	v1CheckRunsEndpoint    = "/api/v1/check_run?api_key=%s"
-	v1IntakeEndpoint       = "/intake/?api_key=%s"
-	v1SketchSeriesEndpoint = "/api/v1/sketches?api_key=%s"
+	v1SeriesEndpoint       = "/api/v1/series"
+	v1CheckRunsEndpoint    = "/api/v1/check_run"
+	v1IntakeEndpoint       = "/intake/"
+	v1SketchSeriesEndpoint = "/api/v1/sketches"
 
 	seriesEndpoint       = "/api/v2/series"
 	eventsEndpoint       = "/api/v2/events"
@@ -64,15 +64,15 @@ type Transaction interface {
 type Forwarder interface {
 	Start() error
 	Stop()
-	SubmitV1Series(apiKey string, payload *[]byte) error
-	SubmitV1Intake(apiKey string, payload *[]byte) error
-	SubmitV1CheckRuns(apiKey string, payload *[]byte) error
-	SubmitV2Series(apikey string, payload *[]byte) error
-	SubmitV2Events(apikey string, payload *[]byte) error
-	SubmitV2CheckRuns(apikey string, payload *[]byte) error
-	SubmitV2HostMeta(apikey string, payload *[]byte) error
-	SubmitV2GenericMeta(apikey string, payload *[]byte) error
-	SubmitV1SketchSeries(apiKey string, payload *[]byte) error
+	SubmitV1Series(payload *[]byte) error
+	SubmitV1Intake(payload *[]byte) error
+	SubmitV1CheckRuns(payload *[]byte) error
+	SubmitV2Series(payload *[]byte) error
+	SubmitV2Events(payload *[]byte) error
+	SubmitV2CheckRuns(payload *[]byte) error
+	SubmitV2HostMeta(payload *[]byte) error
+	SubmitV2GenericMeta(payload *[]byte) error
+	SubmitV1SketchSeries(payload *[]byte) error
 }
 
 // DefaultForwarder is in charge of receiving transaction payloads and sending them to Datadog backend over HTTP.
@@ -212,7 +212,7 @@ func (f *DefaultForwarder) Stop() {
 	log.Info("DefaultForwarder stopped")
 }
 
-func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payload *[]byte, compress bool) ([]*HTTPTransaction, error) {
+func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payload *[]byte, compress bool, apiKeyInQueryString bool) ([]*HTTPTransaction, error) {
 	if compress && payload != nil {
 		compressPayload, err := zstd.Compress(nil, *payload)
 		if err != nil {
@@ -224,9 +224,13 @@ func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payload *[]by
 	transactions := []*HTTPTransaction{}
 	for domain, apiKeys := range f.KeysPerDomains {
 		for _, apiKey := range apiKeys {
+			transactionEndpoint := endpoint
+			if apiKeyInQueryString {
+				transactionEndpoint = fmt.Sprintf("%s?api_key=%s", endpoint, apiKey)
+			}
 			t := NewHTTPTransaction()
 			t.Domain = domain
-			t.Endpoint = endpoint
+			t.Endpoint = transactionEndpoint
 			t.Payload = payload
 			t.Headers.Set(apiHTTPHeaderKey, apiKey)
 			transactions = append(transactions, t)
@@ -249,7 +253,7 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*HTTPTransaction)
 
 // SubmitTimeseries will send a timeserie type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitTimeseries(payload *[]byte) error {
-	transactions, err := f.createHTTPTransactions(seriesEndpoint, payload, true)
+	transactions, err := f.createHTTPTransactions(seriesEndpoint, payload, true, false)
 	if err != nil {
 		return err
 	}
@@ -260,7 +264,7 @@ func (f *DefaultForwarder) SubmitTimeseries(payload *[]byte) error {
 
 // SubmitEvent will send a event type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitEvent(payload *[]byte) error {
-	transactions, err := f.createHTTPTransactions(eventsEndpoint, payload, true)
+	transactions, err := f.createHTTPTransactions(eventsEndpoint, payload, true, false)
 	if err != nil {
 		return err
 	}
@@ -271,7 +275,7 @@ func (f *DefaultForwarder) SubmitEvent(payload *[]byte) error {
 
 // SubmitCheckRun will send a check_run type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitCheckRun(payload *[]byte) error {
-	transactions, err := f.createHTTPTransactions(checkRunsEndpoint, payload, true)
+	transactions, err := f.createHTTPTransactions(checkRunsEndpoint, payload, true, false)
 	if err != nil {
 		return err
 	}
@@ -282,7 +286,7 @@ func (f *DefaultForwarder) SubmitCheckRun(payload *[]byte) error {
 
 // SubmitHostMetadata will send a host_metadata tag type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitHostMetadata(payload *[]byte) error {
-	transactions, err := f.createHTTPTransactions(hostMetadataEndpoint, payload, true)
+	transactions, err := f.createHTTPTransactions(hostMetadataEndpoint, payload, true, false)
 	if err != nil {
 		return err
 	}
@@ -293,7 +297,7 @@ func (f *DefaultForwarder) SubmitHostMetadata(payload *[]byte) error {
 
 // SubmitMetadata will send a metadata type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitMetadata(payload *[]byte) error {
-	transactions, err := f.createHTTPTransactions(metadataEndpoint, payload, true)
+	transactions, err := f.createHTTPTransactions(metadataEndpoint, payload, true, false)
 	if err != nil {
 		return err
 	}
@@ -304,9 +308,8 @@ func (f *DefaultForwarder) SubmitMetadata(payload *[]byte) error {
 
 // SubmitV1Series will send timeserie to v1 endpoint (this will be remove once
 // the backend handles v2 endpoints).
-func (f *DefaultForwarder) SubmitV1Series(apiKey string, payload *[]byte) error {
-	endpoint := fmt.Sprintf(v1SeriesEndpoint, apiKey)
-	transactions, err := f.createHTTPTransactions(endpoint, payload, false)
+func (f *DefaultForwarder) SubmitV1Series(payload *[]byte) error {
+	transactions, err := f.createHTTPTransactions(v1SeriesEndpoint, payload, false, true)
 	if err != nil {
 		return err
 	}
@@ -317,9 +320,8 @@ func (f *DefaultForwarder) SubmitV1Series(apiKey string, payload *[]byte) error 
 
 // SubmitV1CheckRuns will send service checks to v1 endpoint (this will be removed once
 // the backend handles v2 endpoints).
-func (f *DefaultForwarder) SubmitV1CheckRuns(apiKey string, payload *[]byte) error {
-	endpoint := fmt.Sprintf(v1CheckRunsEndpoint, apiKey)
-	transactions, err := f.createHTTPTransactions(endpoint, payload, false)
+func (f *DefaultForwarder) SubmitV1CheckRuns(payload *[]byte) error {
+	transactions, err := f.createHTTPTransactions(v1CheckRunsEndpoint, payload, false, true)
 	if err != nil {
 		return err
 	}
@@ -329,9 +331,8 @@ func (f *DefaultForwarder) SubmitV1CheckRuns(apiKey string, payload *[]byte) err
 }
 
 // SubmitV1Intake will send payloads to the universal `/intake/` endpoint used by Agent v.5
-func (f *DefaultForwarder) SubmitV1Intake(apiKey string, payload *[]byte) error {
-	endpoint := fmt.Sprintf(v1IntakeEndpoint, apiKey)
-	transactions, err := f.createHTTPTransactions(endpoint, payload, false)
+func (f *DefaultForwarder) SubmitV1Intake(payload *[]byte) error {
+	transactions, err := f.createHTTPTransactions(v1IntakeEndpoint, payload, false, true)
 	if err != nil {
 		return err
 	}
@@ -346,9 +347,8 @@ func (f *DefaultForwarder) SubmitV1Intake(apiKey string, payload *[]byte) error 
 }
 
 // SubmitV1SketchSeries will send payloads to v1 endpoint
-func (f *DefaultForwarder) SubmitV1SketchSeries(apiKey string, payload *[]byte) error {
-	endpoint := fmt.Sprintf(v1SketchSeriesEndpoint, apiKey)
-	transactions, err := f.createHTTPTransactions(endpoint, payload, false)
+func (f *DefaultForwarder) SubmitV1SketchSeries(payload *[]byte) error {
+	transactions, err := f.createHTTPTransactions(v1SketchSeriesEndpoint, payload, false, true)
 	if err != nil {
 		return err
 	}
@@ -357,26 +357,26 @@ func (f *DefaultForwarder) SubmitV1SketchSeries(apiKey string, payload *[]byte) 
 }
 
 // SubmitV2Series will send service checks to v2 endpoint - UNIMPLEMENTED
-func (f *DefaultForwarder) SubmitV2Series(apikey string, payload *[]byte) error {
+func (f *DefaultForwarder) SubmitV2Series(payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
 
 // SubmitV2Events will send events to v2 endpoint - UNIMPLEMENTED
-func (f *DefaultForwarder) SubmitV2Events(apikey string, payload *[]byte) error {
+func (f *DefaultForwarder) SubmitV2Events(payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
 
 // SubmitV2CheckRuns will send service checks to v2 endpoint - UNIMPLEMENTED
-func (f *DefaultForwarder) SubmitV2CheckRuns(apikey string, payload *[]byte) error {
+func (f *DefaultForwarder) SubmitV2CheckRuns(payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
 
 // SubmitV2HostMeta will send host metadata to v2 endpoint - UNIMPLEMENTED
-func (f *DefaultForwarder) SubmitV2HostMeta(apikey string, payload *[]byte) error {
+func (f *DefaultForwarder) SubmitV2HostMeta(payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
 
 // SubmitV2GenericMeta will send generic metadata to v2 endpoint - UNIMPLEMENTED
-func (f *DefaultForwarder) SubmitV2GenericMeta(apikey string, payload *[]byte) error {
+func (f *DefaultForwarder) SubmitV2GenericMeta(payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }

--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -55,9 +55,10 @@ func (t *HTTPTransaction) GetCreatedAt() time.Time {
 // Process sends the Payload of the transaction to the right Endpoint and Domain.
 func (t *HTTPTransaction) Process(client *http.Client) error {
 	reader := bytes.NewReader(*t.Payload)
-	req, err := http.NewRequest("POST", t.Domain+t.Endpoint, reader)
+	url := t.Domain + t.Endpoint
+	req, err := http.NewRequest("POST", url, reader)
 	if err != nil {
-		log.Errorf("Could not create request for transaction to invalid URL '%s' (dropping transaction): %s", t.Domain+t.Endpoint, err)
+		log.Errorf("Could not create request for transaction to invalid URL '%s' (dropping transaction): %s", url, err)
 		transactionsCreation.Add("Errors", 1)
 		return nil
 	}
@@ -66,23 +67,23 @@ func (t *HTTPTransaction) Process(client *http.Client) error {
 	if err != nil {
 		t.ErrorCount++
 		transactionsCreation.Add("Errors", 1)
-		return fmt.Errorf("Error while sending transaction, rescheduling it: %s", err)
+		return fmt.Errorf("Error while sending transaction to '%s', rescheduling it: %s", url, err)
 	}
 	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode == 400 || resp.StatusCode == 413 {
-		log.Errorf("Error code '%s' received while sending transaction to '%s': %s, dropping it", resp.Status, t.Domain+t.Endpoint, string(body))
+		log.Errorf("Error code '%s' received while sending transaction to '%s': %s, dropping it", resp.Status, url, string(body))
 		transactionsCreation.Add("Dropped", 1)
 		return nil
 	} else if resp.StatusCode > 400 {
 		t.ErrorCount++
 		transactionsCreation.Add("Errors", 1)
-		return fmt.Errorf("Error '%s' while sending transaction, rescheduling it", resp.Status)
+		return fmt.Errorf("Error '%s' while sending transaction to '%s', rescheduling it", resp.Status, url)
 	}
 
 	transactionsCreation.Add("Success", 1)
-	log.Debugf("successfully posted payload to '%s': %s", t.Domain+t.Endpoint, string(body))
+	log.Debugf("successfully posted payload to '%s': %s", url, string(body))
 	return nil
 }
 

--- a/pkg/forwarder/transaction_test.go
+++ b/pkg/forwarder/transaction_test.go
@@ -130,7 +130,7 @@ func TestProcessHTTPError(t *testing.T) {
 
 	err := transaction.Process(client)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Error(), "Error '404 Not Found' while sending transaction, rescheduling it")
+	assert.Contains(t, err.Error(), "Error '404 Not Found' while sending transaction")
 	assert.Equal(t, transaction.ErrorCount, 1)
 
 	errorCode = http.StatusBadRequest

--- a/pkg/metadata/common/common.go
+++ b/pkg/metadata/common/common.go
@@ -18,6 +18,8 @@ const CachePrefix = "metadata"
 // GetPayload fills and return the common metadata payload
 func GetPayload() *Payload {
 	return &Payload{
+		// olivier: I _think_ `APIKey` is only a legacy field, and
+		// is not actually used by the backend
 		AgentVersion: version.AgentVersion,
 		APIKey:       getAPIKey(),
 	}

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -15,7 +15,7 @@ import (
 type HostCollector struct{}
 
 // Send collects the data needed and submits the payload
-func (hp *HostCollector) Send(apiKey string, fwd forwarder.Forwarder) error {
+func (hp *HostCollector) Send(fwd forwarder.Forwarder) error {
 	var hostname string
 	x, found := util.Cache.Get("hostname")
 	if found {
@@ -28,7 +28,7 @@ func (hp *HostCollector) Send(apiKey string, fwd forwarder.Forwarder) error {
 		return fmt.Errorf("unable to serialize host metadata payload, %s", err)
 	}
 
-	err = fwd.SubmitV1Intake(apiKey, &payloadBytes)
+	err = fwd.SubmitV1Intake(&payloadBytes)
 	if err != nil {
 		return fmt.Errorf("unable to submit host metadata payload to the forwarder, %s", err)
 	}

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -15,7 +15,7 @@ import (
 type ResourcesCollector struct{}
 
 // Send collects the data needed and submits the payload
-func (rp *ResourcesCollector) Send(apiKey string, fwd forwarder.Forwarder) error {
+func (rp *ResourcesCollector) Send(fwd forwarder.Forwarder) error {
 	var hostname string
 	x, found := util.Cache.Get("hostname")
 	if found {
@@ -31,7 +31,7 @@ func (rp *ResourcesCollector) Send(apiKey string, fwd forwarder.Forwarder) error
 		return fmt.Errorf("unable to serialize processes metadata payload, %s", err)
 	}
 
-	err = fwd.SubmitV1Intake(apiKey, &payloadBytes)
+	err = fwd.SubmitV1Intake(&payloadBytes)
 	if err != nil {
 		return fmt.Errorf("unable to submit processes metadata payload to the forwarder, %s", err)
 	}

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -15,16 +15,14 @@ var catalog = make(map[string]Collector)
 // time intervals
 type Scheduler struct {
 	fwd      forwarder.Forwarder
-	apikey   string // the api key to use to send metadata
 	hostname string
 	tickers  []*time.Ticker
 }
 
 // NewScheduler builds and returns a new Metadata Scheduler
-func NewScheduler(fwd forwarder.Forwarder, apikey, hostname string) *Scheduler {
+func NewScheduler(fwd forwarder.Forwarder, hostname string) *Scheduler {
 	scheduler := &Scheduler{
 		fwd:      fwd,
-		apikey:   apikey,
 		hostname: hostname,
 	}
 
@@ -53,7 +51,7 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 	ticker := time.NewTicker(interval)
 	go func() {
 		for _ = range ticker.C {
-			p.Send(c.apikey, c.fwd)
+			p.Send(c.fwd)
 		}
 	}()
 	c.tickers = append(c.tickers, ticker)
@@ -67,5 +65,5 @@ func (c *Scheduler) firstRun() error {
 	if !found {
 		panic("Unable to find 'host' metadata collector in the catalog!")
 	}
-	return p.Send(c.apikey, c.fwd)
+	return p.Send(c.fwd)
 }

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 func TestNewScheduler(t *testing.T) {
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
-	c := NewScheduler(fwd, "apikey", "hostname")
-	assert.Equal(t, "apikey", c.apikey)
+	c := NewScheduler(fwd, "hostname")
+	assert.Equal(t, fwd, c.fwd)
 	assert.Equal(t, "hostname", c.hostname)
 }

--- a/pkg/metadata/types.go
+++ b/pkg/metadata/types.go
@@ -6,5 +6,5 @@ import "github.com/DataDog/datadog-agent/pkg/forwarder"
 // through the forwarder.
 // A Metadata Collector normally uses a Metadata Provider to fill the payload.
 type Collector interface {
-	Send(apiKey string, fwd forwarder.Forwarder) error
+	Send(fwd forwarder.Forwarder) error
 }


### PR DESCRIPTION
### What does this PR do?

* Fix multiple endpoints feature with v1 endpoints. The same api key was used for all endpoints.
* Remove `api_key` value from URLs that are logged when transactions fail

### Motivation

Fix stuff (especially stuff that we need to replace the agent 5 on staging)

### Additional Notes

The forwarder should be the only piece of the agent that's aware of the
api keys of each endpoint, and can decide when to use them.

Remove all usage of `api_key` outside of the forwarder, except when
used as a "placeholder" api key that are needed in some legacy payloads