### PR TITLE
dogstatsd-socat-proxy dockerfile for unix domain socket beta users

### DIFF
--- a/Dockerfiles/dogstatsd/socat-proxy/Dockerfile
+++ b/Dockerfiles/dogstatsd/socat-proxy/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.5
+
+MAINTAINER Datadog <package@datadoghq.com>
+
+RUN apk add --no-cache socat
+
+EXPOSE 8125/udp
+
+CMD ["socat", "-s", "-u", "UDP-RECV:8125", "UNIX-SENDTO:/socket/statsd.socket"]

--- a/Dockerfiles/dogstatsd/socat-proxy/README.md
+++ b/Dockerfiles/dogstatsd/socat-proxy/README.md
@@ -1,0 +1,39 @@
+# UDP -> Unix Domain Socket proxy for DogStatsD
+
+This docker image runs a simple UDP -> UDS proxy with `socat`, to help with the transition to the Unix Domain Socket protocol if your client libraries are not patched yet. It is intended to be run as a sidecar container for your application and will forward UDP packets sent to `localhost:8125` to `/socket/statsd.socket`.
+
+To run it, you need to:
+
+  - expose the dogstatsd socket path to `/socket/statsd.socket` (for example `-v /var/run/datadog/:/socket:ro`)
+  - run the container with `--autorestart ALWAYS`, as `socat` will exit on write errors. Please note that packets will be dropped while the container is restarting.
+
+This is an example Kubernetes spec:
+
+```
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: test-producer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-producer
+    spec:
+      containers:
+        - **[insert producer container specs]**
+        - name: socat
+          image: datadog/dogstatsd-socat-proxy:beta
+          ports:
+            - containerPort: 8125
+              name: dogstatsdport
+              protocol: UDP
+          volumeMounts:
+            - name: dsdsocket
+              mountPath: /socket
+      volumes:
+        - hostPath:
+            path: /var/run/dogstatsd
+          name: dsdsocket
+```


### PR DESCRIPTION
### What does this PR do?

Adds the source dockerfile for `datadog/dogstatsd-socat-proxy`, a simple sidecar container clients can use to proxy statsd UDP packets to the Unix Domain Socket protocol available with dsd6. Its goal is to be as primitive as possible and rely on the orchestrator for error handling.

### Motivation

Ease the transition for clients using unpatched client libraries. CPU overhead can be around 10% over direct UDS traffic, but it's negligible for low throughput use cases.