### PR TITLE
[benchmark] add SubmitV1SketchSeries to forwarderBenchStub

### DIFF
--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -69,6 +69,10 @@ func (f *forwarderBenchStub) SubmitV1CheckRuns(apiKey string, payload *[]byte) e
 	f.computeStats(payload)
 	return nil
 }
+func (f *forwarderBenchStub) SubmitV1SketchSeries(apiKey string, payload *[]byte) error {
+	f.computeStats(payload)
+	return nil
+}
 func (f *forwarderBenchStub) SubmitV2Series(apikey string, payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Add the method SubmitV1SketchSeries to forwardBenchStub

### Motivation

The method is missing from forwardBenchStub and breaks the benchmark testing

### Additional Notes

Anything else we should know when reviewing?
