### PR TITLE
[pidfile] Log PID and PIDfile path

### DIFF
--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -43,14 +43,6 @@ const hostMetadataCollectorInterval = 14400
 
 // StartAgent Initializes the agent process
 func StartAgent() {
-
-	if pidfilePath != "" {
-		err := pidfile.WritePID(pidfilePath)
-		if err != nil {
-			panic(err)
-		}
-	}
-
 	// Global Agent configuration
 	common.SetupConfig(confFilePath)
 
@@ -58,6 +50,16 @@ func StartAgent() {
 	err := config.SetupLogger(config.Datadog.GetString("log_level"), config.Datadog.GetString("log_file"))
 	if err != nil {
 		panic(err)
+	}
+
+	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
+
+	if pidfilePath != "" {
+		err := pidfile.WritePID(pidfilePath)
+		if err != nil {
+			panic(err)
+		}
+		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), pidfilePath)
 	}
 
 	hostname, err := util.GetHostname()
@@ -69,7 +71,6 @@ func StartAgent() {
 	key := path.Join(util.AgentCachePrefix, "hostname")
 	util.Cache.Set(key, hostname, util.NoExpiration)
 
-	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
 	log.Infof("Hostname is: %s", hostname)
 
 	// start the cmd HTTP server


### PR DESCRIPTION
### What does this PR do?

* Adds log entries for pid and pidfile path
* Moves the pidfile write to after the config and logging setup (so that we can actually log stuff)
* Move the "Agent starting" entry to a bit earlier in the setup

### Motivation

More helpful logs when debugging

