### PR TITLE
[apm] Allow configuration of path to binary and conf

### DIFF
--- a/omnibus/config/software/datadog-trace-agent.rb
+++ b/omnibus/config/software/datadog-trace-agent.rb
@@ -38,15 +38,11 @@ build do
    command "go get -d github.com/Masterminds/glide", :env => env, :cwd => agent_cache_dir
 
    # Pin build deps to known versions
+   command "git reset --hard v0.12.3", :env => env, :cwd => glide_cache_dir
    command "go install github.com/Masterminds/glide", :env => env, :cwd => glide_cache_dir
 
    # Build datadog-trace-agent
    command "$GOPATH/bin/glide install", :env => env, :cwd => agent_cache_dir
-   if rhel? # temporary workaround for RHEL 5 build issue with the regular `build -a` command
-     command "rake install", :env => env, :cwd => agent_cache_dir
-     command "mv $GOPATH/bin/trace-agent #{install_dir}/embedded/bin/", :env => env, :cwd => agent_cache_dir
-   else
-     command "rake build", :env => env, :cwd => agent_cache_dir
-     command "mv ./trace-agent #{install_dir}/embedded/bin/", :env => env, :cwd => agent_cache_dir
-   end
+   command "rake build", :env => env, :cwd => agent_cache_dir
+   command "mv ./trace-agent #{install_dir}/embedded/bin/", :env => env, :cwd => agent_cache_dir
 end

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -72,18 +72,20 @@ func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData)
 	}
 
 	binPath := ""
+	defaultBinPath, defaultBinPathErr := getAPMAgentDefaultBinPath()
 	if checkConf.BinPath != "" {
 		if _, err := os.Stat(checkConf.BinPath); err == nil {
 			binPath = checkConf.BinPath
 		} else {
-			log.Infof("Can't access apm binary at %s, falling back to default", checkConf.BinPath)
+			log.Warnf("Can't access apm binary at %s, falling back to default path at %s", checkConf.BinPath, defaultBinPath)
 		}
 	}
+
 	if binPath == "" {
-		defaultBinPath, err := getAPMAgentDefaultBinPath()
-		if err != nil {
-			return err
+		if defaultBinPathErr != nil {
+			return defaultBinPathErr
 		}
+
 		binPath = defaultBinPath
 	}
 
@@ -145,5 +147,5 @@ func getAPMAgentDefaultBinPath() (string, error) {
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}
-	return "", fmt.Errorf("Can't access apm binary at %s", binPath)
+	return binPath, fmt.Errorf("Can't access the default apm binary at %s", binPath)
 }

--- a/pkg/collector/dist/conf.d/apm.yaml.default
+++ b/pkg/collector/dist/conf.d/apm.yaml.default
@@ -1,5 +1,6 @@
 instances:
-- {} # default instance, if you need to customize its configuration, please use the configuration options below
+- {} # default instance, if you need to customize its configuration, please comment out this instance
+     # and customize the configuration options on the instance below
 
 #   # path to trace agent binary, defaults to `embedded/bin/trace-agent` in agent installation dir
 # - bin_path: /opt/datadog-agent/embedded/bin/trace-agent

--- a/pkg/collector/dist/conf.d/apm.yaml.default
+++ b/pkg/collector/dist/conf.d/apm.yaml.default
@@ -1,0 +1,8 @@
+instances:
+- {} # default instance, if you need to customize its configuration, please use the configuration options below
+
+#   # path to trace agent binary, defaults to `embedded/bin/trace-agent` in agent installation dir
+# - bin_path: /opt/datadog-agent/embedded/bin/trace-agent
+
+#   # Path to classic agent configuration, defaults to `/etc/dd-agent/datadog.conf`
+#   conf_path: /etc/dd-agent/datadog.conf

--- a/pkg/collector/dist/conf.d/apm.yaml.example
+++ b/pkg/collector/dist/conf.d/apm.yaml.example
@@ -1,2 +1,0 @@
-instances:
-  - foo: bar


### PR DESCRIPTION
### What does this PR do?

Use a default path to the binary if none is provided (the default
path should work for packaged agents).

The config file is still expected to be in agent5 format.

Also, update the omnibus software definition so that it's on-par
with the one in `dd-agent-omnibus`.

### Motivation

Allow running the trace-agent with the apm check on staging. 

### Additional Notes

At some point in the future we'll have to tackle supporting the new `datadog.yaml` format in the trace-agent.