### PR TITLE
[dsd] alpine image: delete socket if existing

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/README.md
+++ b/Dockerfiles/dogstatsd/alpine/README.md
@@ -6,7 +6,7 @@ The following environment variables are supported:
 
   - `DD_API_KEY`: your API key (**required**)
   - `DD_HOSTNAME`: hostname to use for metrics
-  - `DD_DOGSTATSD_SOCKET`: path to the unix socket to use instead of UDP
+  - `DD_DOGSTATSD_SOCKET`: path to the unix socket to use instead of UDP. Must be in a `rw` mounted volume.
 
 This is a sample Kubernetes DaemonSet, using the UDS protocol:
 

--- a/Dockerfiles/dogstatsd/alpine/entrypoint.sh
+++ b/Dockerfiles/dogstatsd/alpine/entrypoint.sh
@@ -3,17 +3,27 @@
 
 ##### Core config #####
 
-if [[ -z $DD_API_KEY ]]; then
+if [ -z $DD_API_KEY ]; then
 	echo "You must set DD_API_KEY environment variable to run the Datadog Agent container"
 	exit 1
 fi
 
-if [[ -z $DD_DD_URL ]]; then
+if [ -z $DD_DD_URL ]; then
     export DD_DD_URL="https://app.datadoghq.com"
 fi
 
 if [ -z $DD_DOGSTATSD_SOCKET ]; then
     export DD_DOGSTATSD_NON_LOCAL_TRAFFIC=1
+else
+    if [ -e $DD_DOGSTATSD_SOCKET ]; then
+        if [ -S $DD_DOGSTATSD_SOCKET ]; then
+            echo "Deleting existing socket at ${DD_DOGSTATSD_SOCKET}"
+            rm $DD_DOGSTATSD_SOCKET
+        else
+            echo "${DD_DOGSTATSD_SOCKET} exists and is not a socket, please check your volume options"
+            exit 1
+        fi
+    fi
 fi
 
 ##### Starting up dogstatsd #####


### PR DESCRIPTION
### What does this PR do?

Modify entrypoint to detect whether the socket path is already existing, and:
  - delete it if it's indeed a socket (previous instance got killed)
  - fail if not, and print an error message

### Motivation

Resilience in case the dsd6 process segfaults during beta stage
