### PR TITLE
[forwarder][expvar] Export retry queue size as a gauge

### DIFF
--- a/pkg/collector/dist/conf.d/go_expvar.yaml.default
+++ b/pkg/collector/dist/conf.d/go_expvar.yaml.default
@@ -29,7 +29,7 @@ instances:
       - path: forwarder/TransactionsCreated/IntakeV1
         type: rate
       - path: forwarder/TransactionsCreated/RetryQueueSize
-        type: rate
+        type: gauge
       - path: forwarder/TransactionsCreated/Requeued
         type: rate
       - path: forwarder/TransactionsCreated/Errors

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -20,11 +20,13 @@ var (
 
 	forwarderExpvar      = expvar.NewMap("forwarder")
 	transactionsCreation = expvar.Map{}
+	retryQueueSize       = expvar.Int{}
 )
 
 func init() {
 	transactionsCreation.Init()
 	forwarderExpvar.Set("TransactionsCreated", &transactionsCreation)
+	transactionsCreation.Set("RetryQueueSize", &retryQueueSize)
 }
 
 const (
@@ -120,7 +122,7 @@ func (f *DefaultForwarder) retryTransactions(tickTime time.Time) {
 		}
 	}
 	f.retryQueue = newQueue
-	transactionsCreation.Add("RetryQueueSize", int64(len(f.retryQueue)))
+	retryQueueSize.Set(int64(len(f.retryQueue)))
 }
 
 func (f *DefaultForwarder) requeueTransaction(t Transaction) {


### PR DESCRIPTION
### What does this PR do?

Exports "retry queue size" as a gauge instead of a rate

### Motivation

Using a rate isn't as interesting as a gauge. A gauge allows knowing
what the actual size of the retry queue is at a given instant, whereas
a rate doesn't.
