### PR TITLE
[percentile] Add max, avg and sum to GKArray

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 53f3397071741b3e934291d6186d55d94b4c85607fc54efafe27457c20e64d98
-updated: 2017-06-29T16:03:56.41071368-04:00
+hash: 730d35370e1cc6eb3c1c439c34a1cb626717ff10b2f535708888f017bc08e5c6
+updated: 2017-07-05T14:46:24.245647215-04:00
 imports:
 - name: github.com/beevik/ntp
   version: cb3dae3a7588ae35829eb5724df611cd75152fba
@@ -12,7 +12,7 @@ imports:
   - pkg/pathutil
   - pkg/types
 - name: github.com/DataDog/agent-payload
-  version: 81c6e466836dfc706380e4f060062836ce7197a6
+  version: 480a98b258fa6ee55641d7a9c3729770e5b2ba34
   subpackages:
   - gogen
 - name: github.com/DataDog/datadog-go
@@ -168,7 +168,7 @@ imports:
 - name: github.com/sbinet/go-python
   version: ba7e58341058bdefb92b359870caf2dc0a05cfcf
 - name: github.com/shirou/gopsutil
-  version: e30b7839cd6161b2fbef5f187377a345157abe04
+  version: aa0a3bce9d1f4efc710ed812f19f77851da2eedd
   subpackages:
   - cpu
   - disk

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,7 +42,7 @@ import:
   - gogoproto
   - proto
 - package: github.com/DataDog/agent-payload
-  version: ^4.2
+  version: ^4.3
 - package: github.com/patrickmn/go-cache
   version: ^2.0.0
 - package: github.com/k-sone/snmpgo

--- a/pkg/aggregator/distribution_test.go
+++ b/pkg/aggregator/distribution_test.go
@@ -32,6 +32,7 @@ func TestDistributionSampling(t *testing.T) {
 	expectedSketch.Compress()
 	expectedSeries := &percentile.SketchSeries{
 		Sketches: []percentile.Sketch{{Timestamp: int64(15), Sketch: expectedSketch}}}
+
 	AssertSketchSeriesEqual(t, expectedSeries, sketchSeries)
 
 	// Global histogram is reset after a flush

--- a/pkg/aggregator/percentile/sketch_series.go
+++ b/pkg/aggregator/percentile/sketch_series.go
@@ -51,8 +51,11 @@ func marshalSketches(sketches []Sketch) []agentpayload.SketchPayload_Summary_Ske
 		sketchesPayload = append(sketchesPayload,
 			agentpayload.SketchPayload_Summary_Sketch{
 				Ts:      s.Timestamp,
-				N:       int64(s.Sketch.ValCount),
+				N:       int64(s.Sketch.Count),
 				Min:     s.Sketch.Min,
+				Max:     s.Sketch.Max,
+				Avg:     s.Sketch.Avg,
+				Sum:     s.Sketch.Sum,
 				Entries: marshalEntries(s.Sketch.Entries),
 			})
 	}
@@ -67,7 +70,10 @@ func unmarshalSketches(summarySketches []agentpayload.SketchPayload_Summary_Sket
 				Timestamp: s.Ts,
 				Sketch: QSketch{
 					GKArray{Min: s.Min,
-						ValCount: int(s.N),
+						Count:    int(s.N),
+						Max:      s.Max,
+						Avg:      s.Avg,
+						Sum:      s.Sum,
 						Entries:  unmarshalEntries(s.Entries),
 						incoming: make([]float64, 0, int(1/EPSILON))}},
 			})

--- a/pkg/aggregator/percentile/sketch_series_test.go
+++ b/pkg/aggregator/percentile/sketch_series_test.go
@@ -12,12 +12,12 @@ func TestMarshalSketches(t *testing.T) {
 	sketch1 := QSketch{
 		GKArray{
 			Entries: []Entry{{1, 1, 0}},
-			Min:     1, ValCount: 1,
+			Min:     1, Count: 1, Sum: 1, Avg: 1, Max: 1,
 			incoming: make([]float64, 0, int(1/EPSILON))}}
 	sketch2 := QSketch{
 		GKArray{
 			Entries: []Entry{{10, 1, 0}, {14, 3, 0}, {21, 2, 0}},
-			Min:     10, ValCount: 6,
+			Min:     10, Count: 6, Sum: 96, Avg: 16, Max: 21,
 			incoming: make([]float64, 0, int(1/EPSILON))}}
 	series := []*SketchSeries{{
 		ContextKey: "test_context",
@@ -48,11 +48,11 @@ func TestMarshalJSONSketchSeries(t *testing.T) {
 	sketch1 := QSketch{
 		GKArray{
 			Entries: []Entry{{1, 1, 0}},
-			Min:     1, ValCount: 1}}
+			Min:     1, Count: 1, Sum: 1, Avg: 1, Max: 1}}
 	sketch2 := QSketch{
 		GKArray{
 			Entries: []Entry{{10, 1, 0}, {14, 3, 0}, {21, 2, 0}},
-			Min:     10, ValCount: 6}}
+			Min:     10, Count: 6, Sum: 96, Avg: 16, Max: 21}}
 	series := []*SketchSeries{{
 		ContextKey: "test_context",
 		Sketches:   []Sketch{{int64(12345), sketch1}, {int64(67890), sketch2}},
@@ -65,17 +65,17 @@ func TestMarshalJSONSketchSeries(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
 
-	expectedPayload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"n\":1}},{\"timestamp\":67890,\"qsketch\":{\"entries\":[[10,1,0],[14,3,0],[21,2,0]],\"min\":10,\"n\":6}}]}]}\n")
+	expectedPayload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"max\":1,\"n\":1,\"sum\":1,\"avg\":1}},{\"timestamp\":67890,\"qsketch\":{\"entries\":[[10,1,0],[14,3,0],[21,2,0]],\"min\":10,\"max\":21,\"n\":6,\"sum\":96,\"avg\":16}}]}]}\n")
 	assert.Equal(t, payload, []byte(expectedPayload))
 }
 
 func TestUnmarshalJSONSketchSeries(t *testing.T) {
 
-	payload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"n\":1}}]}]}\n")
+	payload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"max\":1,\"n\":1,\"sum\":1,\"avg\":1}}]}]}\n")
 
 	sketch := QSketch{
 		GKArray{Entries: []Entry{{1, 1, 0}},
-			Min: 1, ValCount: 1},
+			Min: 1, Count: 1, Sum: 1, Avg: 1, Max: 1},
 	}
 
 	data, err := UnmarshalJSONSketchSeries(payload)


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds the Max, Sum and Avg fields to GKArray

### Motivation

These are needed in order to compute the .cnt .sum .avg .min and .max metrics

### Additional Notes

The dependency to `agent-payload` has been updated to 4.3 to keep the payload consistent.