### PR TITLE
add send_host_metadata option to disable host metadata collection

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/README.md
+++ b/Dockerfiles/dogstatsd/alpine/README.md
@@ -7,6 +7,7 @@ The following environment variables are supported:
   - `DD_API_KEY`: your API key (**required**)
   - `DD_HOSTNAME`: hostname to use for metrics
   - `DD_DOGSTATSD_SOCKET`: path to the unix socket to use instead of UDP. Must be in a `rw` mounted volume.
+  - `DD_SEND_HOST_METADATA`: whether to send host metadata (default is true, set to false only if running alonside an existing dd-agent)
 
 This is a sample Kubernetes DaemonSet, using the UDS protocol:
 
@@ -31,6 +32,8 @@ spec:
             value: ___value___
           - name: DD_DOGSTATSD_SOCKET
             value: "/socket/statsd.socket"
+          - name: DD_SEND_HOST_METADATA
+            value: false
           - name: DD_HOSTNAME
             valueFrom:
               fieldRef:

--- a/Dockerfiles/dogstatsd/alpine/README.md
+++ b/Dockerfiles/dogstatsd/alpine/README.md
@@ -7,9 +7,9 @@ The following environment variables are supported:
   - `DD_API_KEY`: your API key (**required**)
   - `DD_HOSTNAME`: hostname to use for metrics
   - `DD_DOGSTATSD_SOCKET`: path to the unix socket to use instead of UDP. Must be in a `rw` mounted volume.
-  - `DD_SEND_HOST_METADATA`: whether to send host metadata (default is true, set to false only if running alonside an existing dd-agent)
+  - `DD_ENABLE_METADATA_COLLECTION`: whether to collect metadata (default is true, set to false only if running alonside an existing dd-agent)
 
-This is a sample Kubernetes DaemonSet, using the UDS protocol:
+This is a sample Kubernetes DaemonSet, using the UDS protocol, running alongside an existing agent5:
 
 ```
 apiVersion: extensions/v1beta1
@@ -32,7 +32,7 @@ spec:
             value: ___value___
           - name: DD_DOGSTATSD_SOCKET
             value: "/socket/statsd.socket"
-          - name: DD_SEND_HOST_METADATA
+          - name: DD_ENABLE_METADATA_COLLECTION
             value: false
           - name: DD_HOSTNAME
             valueFrom:

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -104,7 +104,7 @@ func StartAgent() {
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
 	// setup the metadata collector, this needs a working Python env to function
-	if config.Datadog.GetBool("send_host_metadata") {
+	if config.Datadog.GetBool("enable_metadata_collection") {
 		common.MetadataScheduler = metadata.NewScheduler(common.Forwarder, hostname)
 		var C []config.MetadataProviders
 		err = config.Datadog.UnmarshalKey("metadata_providers", &C)
@@ -131,7 +131,7 @@ func StartAgent() {
 			panic("Host metadata is supposed to be always available in the catalog!")
 		}
 	} else {
-		log.Warnf("Host metadata disabled, only do that if another agent/dogstatsd is running on this host\n")
+		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")
 	}
 }
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -104,7 +104,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	var metaScheduler *metadata.Scheduler
-	if config.Datadog.GetBool("send_host_metadata") {
+	if config.Datadog.GetBool("enable_metadata_collection") {
 		// start metadata collection
 		metaScheduler := metadata.NewScheduler(f, hname)
 
@@ -114,7 +114,7 @@ func start(cmd *cobra.Command, args []string) error {
 			panic("Host metadata is supposed to be always available in the catalog!")
 		}
 	} else {
-		log.Warnf("Host metadata disabled, only do that if another agent/dogstatsd is running on this host\n")
+		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")
 	}
 
 	aggregatorInstance := aggregator.InitAggregator(f, hname)

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -103,13 +103,18 @@ func start(cmd *cobra.Command, args []string) error {
 		hname = ""
 	}
 
-	// start metadata collection
-	metaCollector := metadata.NewScheduler(f, hname)
+	var metaScheduler *metadata.Scheduler
+	if config.Datadog.GetBool("send_host_metadata") {
+		// start metadata collection
+		metaScheduler := metadata.NewScheduler(f, hname)
 
-	// add the host metadata collector
-	err = metaCollector.AddCollector("host", hostMetadataCollectorInterval*time.Second)
-	if err != nil {
-		panic("Host metadata is supposed to be always available in the catalog!")
+		// add the host metadata collector
+		err = metaScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
+		if err != nil {
+			panic("Host metadata is supposed to be always available in the catalog!")
+		}
+	} else {
+		log.Warnf("Host metadata disabled, only do that if another agent/dogstatsd is running on this host\n")
 	}
 
 	aggregatorInstance := aggregator.InitAggregator(f, hname)
@@ -126,7 +131,9 @@ func start(cmd *cobra.Command, args []string) error {
 	// Block here until we receive the interrupt signal
 	<-signalCh
 
-	metaCollector.Stop()
+	if metaScheduler != nil {
+		metaScheduler.Stop()
+	}
 	statsd.Stop()
 	log.Info("See ya!")
 	log.Flush()

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -36,13 +36,17 @@ api_key:
 # forwarder_timeout: 20
 
 # Metadata collectors, add or remove from the list to enable or disable collection.
-# The host metadata collector cannot be configured and is enabled by default.
 # Intervals are expressed in seconds.
 metadata_collectors:
   - name: 'resources'
     interval: 60
 #  - name: k8s
 #    interval: 60
+
+# Host metadata collection should always be enabled, except if you are running several
+# agents/dsd instances per host. In that case, only one agent should have it on.
+# WARNING: disabling it on every agent will lead to display and billing issues
+# send_host_metadata: true
 
 # DogStatsd
 #

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -35,6 +35,11 @@ api_key:
 # Forwarder timeout in seconds
 # forwarder_timeout: 20
 
+# Metadata collection should always be enabled, except if you are running several
+# agents/dsd instances per host. In that case, only one agent should have it on.
+# WARNING: disabling it on every agent will lead to display and billing issues
+# enable_metadata_collection: true
+
 # Metadata collectors, add or remove from the list to enable or disable collection.
 # Intervals are expressed in seconds.
 metadata_collectors:
@@ -42,11 +47,6 @@ metadata_collectors:
     interval: 60
 #  - name: k8s
 #    interval: 60
-
-# Host metadata collection should always be enabled, except if you are running several
-# agents/dsd instances per host. In that case, only one agent should have it on.
-# WARNING: disabling it on every agent will lead to display and billing issues
-# send_host_metadata: true
 
 # DogStatsd
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,7 +35,7 @@ func init() {
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	Datadog.SetDefault("default_integration_http_timeout", 9)
-	Datadog.SetDefault("send_host_metadata", true)
+	Datadog.SetDefault("enable_metadata_collection", true)
 	// BUG(massi): make the listener_windows.go module actually use the following:
 	Datadog.SetDefault("cmd_pipe_name", `\\.\pipe\ddagent`)
 	Datadog.SetDefault("check_runners", int64(4))
@@ -63,7 +63,7 @@ func init() {
 	Datadog.BindEnv("hostname")
 	Datadog.BindEnv("cmd_sock")
 	Datadog.BindEnv("conf_path")
-	Datadog.BindEnv("send_host_metadata")
+	Datadog.BindEnv("enable_metadata_collection")
 	Datadog.BindEnv("dogstatsd_socket")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")
 	Datadog.BindEnv("kubernetes_kubelet_host")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ func init() {
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
 	Datadog.SetDefault("default_integration_http_timeout", 9)
+	Datadog.SetDefault("send_host_metadata", true)
 	// BUG(massi): make the listener_windows.go module actually use the following:
 	Datadog.SetDefault("cmd_pipe_name", `\\.\pipe\ddagent`)
 	Datadog.SetDefault("check_runners", int64(4))
@@ -62,6 +63,7 @@ func init() {
 	Datadog.BindEnv("hostname")
 	Datadog.BindEnv("cmd_sock")
 	Datadog.BindEnv("conf_path")
+	Datadog.BindEnv("send_host_metadata")
 	Datadog.BindEnv("dogstatsd_socket")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")
 	Datadog.BindEnv("kubernetes_kubelet_host")


### PR DESCRIPTION
### What does this PR do?

Allow to disable host metadata collection with the `send_host_metadata` option. This is needed if dsd6 is running alongside agent5, and might be needed for agent6 in some edge cases (one agent/pod in openshift, dedicated agent for event collection...), although these cases might be tackled differently.

Please discuss whether the common option for agent is legit or whether that should be a dsd-only option.

Docker image `datadog/dogstatsd:beta` is built with this branch to enable for beta testing.