### PR TITLE
[ci][system_tests] Remove py-launcher tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ task :test => %w[fmt lint vet] do
 end
 
 desc "Run every system tests"
-task system_test: %w[dogstatsd:system_test pylauncher:system_test]
+task system_test: %w[dogstatsd:system_test] # FIXME: re-enable pylauncher:system_test once they're fixed
 
 desc "Build allthethings"
 task build: %w[agent:build dogstatsd:build pylauncher:build]


### PR DESCRIPTION
### What does this PR do?

Reverts adding `pylauncher:system_test` to the automated system tests (added in #359)

### Motivation

the tests are broken, see https://gitlab.ddbuild.io/datadog/datadog-agent/builds/915591

### Additional Notes

cc @hush-hush, can you have a look into the failure and try to fix it? :)