### PR TITLE
[deploy] Fix rvm source in deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ deploy_deb:
   tags:
     - docker
   script:
-    - source ~/.rvm/scripts/rvm
+    - source /home/jenkins/.rvm/scripts/rvm
     - rvm use 2.2.2@circleci
     - echo "$APT_SIGNING_KEY_ID"
     - echo "$APT_SIGNING_PRIVATE_KEY" | gpg --import


### PR DESCRIPTION
### What does this PR do?

Fixes the deploy step. The user in the container is `root` instead of `jenkins`, let's use the correct path to source the rvm env.

### Additional Notes

Was broken since the gitlab migration yesterday
