### PR TITLE
[py] Add `CheckException` subclass

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -22,6 +22,9 @@ class AgentLogHandler(logging.Handler):
 rootLogger = logging.getLogger()
 rootLogger.addHandler(AgentLogHandler())
 
+class CheckException(Exception):
+    pass
+
 class AgentCheck(object):
 
     RATE = "rate"


### PR DESCRIPTION
### What does this PR do?

Adds the `CheckException` class of exceptions for py checks to import
and use.

### Motivation

Quite a few `integrations-core` checks use this class of exceptions
for some of the exceptions they raise. It makes sense to keep it: it
encourages some level of exception granularity in the checks.

### Additional Notes

If for some reason someone thinks it's better to get rid of this class, it's
possible to modify the `integrations-core` checks instead and declare the
class deprecated.
