### PR TITLE
[percentile] change GKArray methods to value receivers

### DIFF
--- a/pkg/aggregator/context_sketch_test.go
+++ b/pkg/aggregator/context_sketch_test.go
@@ -18,9 +18,9 @@ func TestContextSketchSampling(t *testing.T) {
 	resultSeries := ctxSketch.flush(12345.0)
 
 	expectedSketch := percentile.NewQSketch()
-	expectedSketch.Add(1)
-	expectedSketch.Add(5)
-	expectedSketch.Compress()
+	expectedSketch = expectedSketch.Add(1)
+	expectedSketch = expectedSketch.Add(5)
+	expectedSketch = expectedSketch.Compress()
 	expectedSeries := &percentile.SketchSeries{
 		ContextKey: contextKey,
 		Sketches:   []percentile.Sketch{{Timestamp: int64(12345), Sketch: expectedSketch}}}
@@ -57,15 +57,15 @@ func TestContextSketchSamplingMultiContexts(t *testing.T) {
 	sort.Sort(orderedSketchSeries)
 
 	expectedSketch1 := percentile.NewQSketch()
-	expectedSketch1.Add(1)
-	expectedSketch1.Add(3)
-	expectedSketch1.Compress()
+	expectedSketch1 = expectedSketch1.Add(1)
+	expectedSketch1 = expectedSketch1.Add(3)
+	expectedSketch1 = expectedSketch1.Compress()
 	expectedSeries1 := &percentile.SketchSeries{
 		ContextKey: contextKey1,
 		Sketches:   []percentile.Sketch{{Timestamp: int64(12345), Sketch: expectedSketch1}}}
 	expectedSketch2 := percentile.NewQSketch()
-	expectedSketch2.Add(1)
-	expectedSketch2.Compress()
+	expectedSketch2 = expectedSketch2.Add(1)
+	expectedSketch2 = expectedSketch2.Compress()
 	expectedSeries2 := &percentile.SketchSeries{
 		ContextKey: contextKey2,
 		Sketches:   []percentile.Sketch{{Timestamp: int64(12345), Sketch: expectedSketch2}}}

--- a/pkg/aggregator/dist_sampler_test.go
+++ b/pkg/aggregator/dist_sampler_test.go
@@ -95,9 +95,9 @@ func TestDistSamplerBucketSampling(t *testing.T) {
 	sketchSeries := distSampler.flush(10020.0)
 
 	expectedSketch := percentile.NewQSketch()
-	expectedSketch.Add(1)
-	expectedSketch.Add(2)
-	expectedSketch.Compress()
+	expectedSketch = expectedSketch.Add(1)
+	expectedSketch = expectedSketch.Add(2)
+	expectedSketch = expectedSketch.Compress()
 	expectedSeries := &percentile.SketchSeries{
 		Name:     "test.metric.name",
 		Tags:     []string{"a", "b"},
@@ -140,8 +140,8 @@ func TestDistSamplerContextSampling(t *testing.T) {
 	sketchSeries := orderedSketchSeries.sketchSeries
 
 	expectedSketch := percentile.NewQSketch()
-	expectedSketch.Add(1)
-	expectedSketch.Compress()
+	expectedSketch = expectedSketch.Add(1)
+	expectedSketch = expectedSketch.Compress()
 	expectedSeries1 := &percentile.SketchSeries{
 		Name:     "test.metric.name1",
 		Tags:     []string{"a", "b"},

--- a/pkg/aggregator/distribution.go
+++ b/pkg/aggregator/distribution.go
@@ -18,7 +18,7 @@ func NewDistribution() *Distribution {
 
 func (d *Distribution) addSample(sample *MetricSample, timestamp float64) {
 	// Insert sample value into the sketch
-	d.sketch.Add(sample.Value)
+	d.sketch = d.sketch.Add(sample.Value)
 	d.count++
 }
 
@@ -27,7 +27,7 @@ func (d *Distribution) flush(timestamp float64) (*percentile.SketchSeries, error
 		return &percentile.SketchSeries{}, percentile.NoSketchError{}
 	}
 	// compress the sketch before flushing
-	d.sketch.Compress()
+	d.sketch = d.sketch.Compress()
 	sketch := &percentile.SketchSeries{
 		Sketches: []percentile.Sketch{{Timestamp: int64(timestamp),
 			Sketch: d.sketch}},

--- a/pkg/aggregator/distribution_test.go
+++ b/pkg/aggregator/distribution_test.go
@@ -26,10 +26,10 @@ func TestDistributionSampling(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedSketch := percentile.NewQSketch()
-	expectedSketch.Add(1)
-	expectedSketch.Add(10)
-	expectedSketch.Add(5)
-	expectedSketch.Compress()
+	expectedSketch = expectedSketch.Add(1)
+	expectedSketch = expectedSketch.Add(10)
+	expectedSketch = expectedSketch.Add(5)
+	expectedSketch = expectedSketch.Compress()
 	expectedSeries := &percentile.SketchSeries{
 		Sketches: []percentile.Sketch{{Timestamp: int64(15), Sketch: expectedSketch}}}
 

--- a/pkg/aggregator/percentile/gk_array_test.go
+++ b/pkg/aggregator/percentile/gk_array_test.go
@@ -89,7 +89,7 @@ func EvaluateSketch(t *testing.T, n int, gen Generator) {
 	d := NewDataset()
 	for i := 0; i < n; i++ {
 		value := gen.Generate()
-		s.Add(value)
+		s = s.Add(value)
 		d.Add(value)
 	}
 	eps := float64(1.0e-6)
@@ -116,7 +116,7 @@ func TestConstant(t *testing.T) {
 		d := NewDataset()
 		for i := 0; i < n; i++ {
 			value := constantGenerator.Generate()
-			s.Add(value)
+			s = s.Add(value)
 			d.Add(value)
 		}
 		for _, q := range testQuantiles {
@@ -162,25 +162,25 @@ func TestMerge(t *testing.T) {
 		generator1 := NewNormal(35, 1)
 		for i := 0; i < n; i += 3 {
 			value := generator1.Generate()
-			s1.Add(value)
+			s1 = s1.Add(value)
 			d.Add(value)
 		}
 		s2 := NewGKArray()
 		generator2 := NewNormal(50, 2)
 		for i := 1; i < n; i += 3 {
 			value := generator2.Generate()
-			s2.Add(value)
+			s2 = s2.Add(value)
 			d.Add(value)
 		}
-		s1.Merge(s2)
+		s1 = s1.Merge(s2)
 		s3 := NewGKArray()
 		generator3 := NewNormal(40, 0.5)
 		for i := 2; i < n; i += 3 {
 			value := generator3.Generate()
-			s3.Add(value)
+			s3 = s3.Add(value)
 			d.Add(value)
 		}
-		s1.Merge(s3)
+		s1 = s1.Merge(s3)
 
 		eps := float64(1e-6)
 		for _, q := range testQuantiles {
@@ -199,7 +199,7 @@ func TestInterpolatedQuantile(t *testing.T) {
 		if n < int(1/EPSILON) {
 			s := NewGKArray()
 			for i := 0; i < n; i++ {
-				s.Add(float64(i))
+				s = s.Add(float64(i))
 			}
 			for _, q := range testQuantiles {
 				expected := q * (float64(n) - 1)

--- a/pkg/aggregator/percentile/sketch_series.go
+++ b/pkg/aggregator/percentile/sketch_series.go
@@ -36,6 +36,16 @@ func NewQSketch() QSketch {
 	return QSketch{NewGKArray()}
 }
 
+// Add a value to the qsketch
+func (q QSketch) Add(v float64) QSketch {
+	return QSketch{GKArray: q.GKArray.Add(v)}
+}
+
+// Compress the qsketch
+func (q QSketch) Compress() QSketch {
+	return QSketch{GKArray: q.GKArray.Compress()}
+}
+
 // NoSketchError is the error returned when not enough samples have been
 //submitted to generate a sketch
 type NoSketchError struct{}
@@ -79,7 +89,6 @@ func unmarshalSketches(summarySketches []agentpayload.SketchPayload_Summary_Sket
 			})
 	}
 	return sketches
-
 }
 
 // MarshalSketchSeries serializes sketch series using protocol buffers


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Changes the methods of GKArray to value receivers.

### Motivation

In order to make the sketches more efficient by reducing GC overhead.

### Additional Notes

Anything else we should know when reviewing?
