### PR TITLE
[py] Add NetworkCheck class

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -63,6 +63,8 @@ class AgentCheck(object):
         # FIXME: get the log level from the agent global config and apply it to the python one.
         self.log.setLevel(logging.DEBUG)
 
+        self.default_integration_http_timeout = float(self.agentConfig.get('default_integration_http_timeout', 9))
+
         self._deprecations = {
             'increment' : [
                 False,
@@ -74,6 +76,10 @@ class AgentCheck(object):
                 "DEPRECATION NOTICE: `device_name` is deprecated, please use a `device:` tag in the `tags` list instead",
             ],
         }
+
+    # FIXME(olivier): implement this method
+    def get_instance_proxy(self, instance, uri):
+        return {}
 
     def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
         tags = self._normalize_tags(tags, device_name)

--- a/pkg/collector/dist/checks/network_checks.py
+++ b/pkg/collector/dist/checks/network_checks.py
@@ -8,7 +8,7 @@ class Status:
     UP = "UP"
 
 
-# Deprecated since we don't reporting statuses as events anymore
+# Deprecated since we aren't reporting statuses as events anymore
 # Keep the class here so that imports don't fail
 class EventType:
     pass
@@ -17,6 +17,8 @@ class EventType:
 class NetworkCheck(AgentCheck):
     """
     This class should never be directly instantiated.
+    This class is deprecated, please make your checks inherit from the
+    `AgentCheck` class directly.
     """
 
     STATUS_TO_SERVICE_CHECK = {

--- a/pkg/collector/dist/checks/network_checks.py
+++ b/pkg/collector/dist/checks/network_checks.py
@@ -1,0 +1,53 @@
+from checks import AgentCheck
+
+
+class Status:
+    DOWN = "DOWN"
+    WARNING = "WARNING"
+    CRITICAL = "CRITICAL"
+    UP = "UP"
+
+
+# Deprecated since we don't reporting statuses as events anymore
+# Keep the class here so that imports don't fail
+class EventType:
+    pass
+
+
+class NetworkCheck(AgentCheck):
+    """
+    This class should never be directly instantiated.
+    """
+
+    STATUS_TO_SERVICE_CHECK = {
+        Status.UP: AgentCheck.OK,
+        Status.WARNING: AgentCheck.WARNING,
+        Status.CRITICAL: AgentCheck.CRITICAL,
+        Status.DOWN: AgentCheck.CRITICAL,
+    }
+
+    def check(self, instance):
+        try:
+            statuses = self._check(instance)
+        except Exception:
+            self.log.exception(
+                u"Failed to run instance '%s'.", instance.get('name', u"")
+            )
+        else:
+            if isinstance(statuses, tuple):
+                # Assume the check only returns one service check
+                status, msg = statuses
+                self.report_as_service_check(None, status, instance, msg)
+
+            elif isinstance(statuses, list):
+                for status in statuses:
+                    sc_name, status, msg = status
+                    self.report_as_service_check(sc_name, status, instance, msg)
+
+    def _check(self, instance):
+        """This function should be implemented by inherited classes"""
+        raise NotImplementedError
+
+    def report_as_service_check(self, sc_name, status, instance, msg=None):
+        """This function should be implemented by inherited classes"""
+        raise NotImplementedError

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ func init() {
 	Datadog.SetDefault("log_file", defaultLogPath)
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("cmd_sock", "/tmp/agent.sock")
+	Datadog.SetDefault("default_integration_http_timeout", 9)
 	// BUG(massi): make the listener_windows.go module actually use the following:
 	Datadog.SetDefault("cmd_pipe_name", `\\.\pipe\ddagent`)
 	Datadog.SetDefault("check_runners", int64(4))


### PR DESCRIPTION
### What does this PR do?

Adds a thin `NetworkCheck` class that allows running the integrations-core's
`NetworkCheck`s out of the box.

Also, added the `default_integration_http_timeout` config parameter
and `AgentCheck` attribute that some checks use.

### Motivation

Make `NetworkCheck`s work

### Additional Notes

* I got rid of the handling of events (deprecated `skip_event` option) since that's been deprecated since agent 5.3
* I've tested this with the `http_check`, and it works fine ; different instances can be run in parallel by multiple check runners
* we should add some logic in the collector to determine a "good" number of check runners depending on the number of check instances configured. The need for this becomes clear when you have tens of `http_check` instances configured. I'll add that to our backlog
