### PR TITLE
[percentile/forwarder] use v2 endpoint to forward sketch series

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -302,11 +302,12 @@ func (agg *BufferedAggregator) flushSketches() {
 	// Serialize and forward in a separate goroutine
 	go func() {
 		log.Debug("Flushing ", len(sketchSeries), " sketches to the forwarder")
-		payload, err := percentile.MarshalJSONSketchSeries(sketchSeries)
+		// Serialize with Protocol Buffer and use v2 endpoint
+		payload, err := percentile.MarshalSketchSeries(sketchSeries)
 		if err != nil {
 			log.Error("could not serialize sketches, dropping them:", err)
 		}
-		agg.forwarder.SubmitV1SketchSeries(&payload)
+		agg.forwarder.SubmitV2SketchSeries(&payload)
 		addFlushTime("MetricSketchFlushTime", int64(time.Since(start)))
 		aggregatorExpvar.Add("SketchesFlushed", int64(len(sketchSeries)))
 	}()

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -41,6 +41,7 @@ const (
 	seriesEndpoint       = "/api/v2/series"
 	eventsEndpoint       = "/api/v2/events"
 	checkRunsEndpoint    = "/api/v2/check_runs"
+	sketchSeriesEndpoint = "/api/v2/sketches"
 	hostMetadataEndpoint = "/api/v2/host_metadata"
 	metadataEndpoint     = "/api/v2/metadata"
 
@@ -69,12 +70,13 @@ type Forwarder interface {
 	SubmitV1Series(payload *[]byte) error
 	SubmitV1Intake(payload *[]byte) error
 	SubmitV1CheckRuns(payload *[]byte) error
+	SubmitV1SketchSeries(payload *[]byte) error
 	SubmitV2Series(payload *[]byte) error
 	SubmitV2Events(payload *[]byte) error
 	SubmitV2CheckRuns(payload *[]byte) error
+	SubmitV2SketchSeries(payload *[]byte) error
 	SubmitV2HostMeta(payload *[]byte) error
 	SubmitV2GenericMeta(payload *[]byte) error
-	SubmitV1SketchSeries(payload *[]byte) error
 }
 
 // DefaultForwarder is in charge of receiving transaction payloads and sending them to Datadog backend over HTTP.
@@ -286,6 +288,17 @@ func (f *DefaultForwarder) SubmitCheckRun(payload *[]byte) error {
 	return f.sendHTTPTransactions(transactions)
 }
 
+// SubmitSketchSeries will send a SketchSeries type payload to Datadog backend.
+func (f *DefaultForwarder) SubmitSketchSeries(payload *[]byte) error {
+	transactions, err := f.createHTTPTransactions(sketchSeriesEndpoint, payload, true, false)
+	if err != nil {
+		return err
+	}
+
+	transactionsCreation.Add("SketchSeries", 1)
+	return f.sendHTTPTransactions(transactions)
+}
+
 // SubmitHostMetadata will send a host_metadata tag type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitHostMetadata(payload *[]byte) error {
 	transactions, err := f.createHTTPTransactions(hostMetadataEndpoint, payload, true, false)
@@ -354,7 +367,7 @@ func (f *DefaultForwarder) SubmitV1SketchSeries(payload *[]byte) error {
 	if err != nil {
 		return err
 	}
-	transactionsCreation.Add("SketchSeries", 1)
+	transactionsCreation.Add("SketchSeriesV1", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
@@ -371,6 +384,17 @@ func (f *DefaultForwarder) SubmitV2Events(payload *[]byte) error {
 // SubmitV2CheckRuns will send service checks to v2 endpoint - UNIMPLEMENTED
 func (f *DefaultForwarder) SubmitV2CheckRuns(payload *[]byte) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
+}
+
+// SubmitV2SketchSeries will send payloads to v2 endpoint - PROTOTYPE FOR PERCENTILE
+// Prototype for Percentiles. Same as for SubmitV1SketchSeries method.
+func (f *DefaultForwarder) SubmitV2SketchSeries(payload *[]byte) error {
+	transactions, err := f.createHTTPTransactions(sketchSeriesEndpoint, payload, false, true)
+	if err != nil {
+		return err
+	}
+	transactionsCreation.Add("SketchSeriesV2", 1)
+	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV2HostMeta will send host metadata to v2 endpoint - UNIMPLEMENTED

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -63,6 +63,7 @@ func TestSubmitInStopMode(t *testing.T) {
 	assert.NotNil(t, forwarder.SubmitTimeseries(nil))
 	assert.NotNil(t, forwarder.SubmitEvent(nil))
 	assert.NotNil(t, forwarder.SubmitCheckRun(nil))
+	assert.NotNil(t, forwarder.SubmitSketchSeries(nil))
 	assert.NotNil(t, forwarder.SubmitHostMetadata(nil))
 	assert.NotNil(t, forwarder.SubmitMetadata(nil))
 }
@@ -140,6 +141,14 @@ func TestSubmit(t *testing.T) {
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
+	payload = []byte("SubmitSketchSeries payload")
+	expectedPayload, _ = zstd.Compress(nil, payload)
+	expectedEndpoint = "/api/v2/sketches"
+	assert.Nil(t, forwarder.SubmitSketchSeries(&payload))
+	<-wait
+	<-wait
+	assert.Equal(t, len(forwarder.retryQueue), 0)
+
 	payload = []byte("SubmitHostMetadata payload")
 	expectedPayload, _ = zstd.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/host_metadata"
@@ -168,6 +177,14 @@ func TestSubmit(t *testing.T) {
 	expectedEndpoint = "/api/v1/sketches"
 	expectAPIKeyInQuery = true
 	assert.Nil(t, forwarder.SubmitV1SketchSeries(&expectedPayload))
+	<-wait
+	<-wait
+	assert.Equal(t, len(forwarder.retryQueue), 0)
+
+	expectedPayload = []byte("SubmitV2SketchSeries payload")
+	expectedEndpoint = "/api/v2/sketches"
+	expectAPIKeyInQuery = true
+	assert.Nil(t, forwarder.SubmitV2SketchSeries(&expectedPayload))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Uses v2 endpoint to forward sketch series.

### Motivation

Using protobuf serialization for sketch payloads for their smaller size.

### Additional Notes

I am using the exact same logic as the v1 submission for sketch payloads besides the endpoint and serialization. There's no further compression and the api key is passed in the query string. This will be changed to match the v2 submission of other payloads when they are finalized.
