### PR TITLE
splits test images from build images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ before_script:
 # run tests for deb-x64
 run_tests_deb-x64:
   stage: source_test
-  image: $DEB_TEST_X64
+  image: $DEB_X64
   tags:
     - docker
   variables:
@@ -43,7 +43,7 @@ run_tests_deb-x64:
 # run tests for rpm-x64
 run_test_rpm-x64:
   stage: source_test
-  image: $RPM_TEST_X64
+  image: $RPM_X64
   tags:
     - docker
   variables:
@@ -106,7 +106,7 @@ benchmarks-x64:
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test
-  image: $DEB_TEST_X64
+  image: $DEB_X64
   tags:
     - docker
   dependencies:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,8 @@ variables:
   SRC_PATH: /src/github.com/DataDog/datadog-agent
   DEB_X64: $DOCKER_REGISTRY/datadog-agent-builders:deb_x64
   RPM_X64: $DOCKER_REGISTRY/datadog-agent-builders:rpm_x64
+  DEB_TEST_X64: $DOCKER_REGISTRY/datadog-agent-builders:deb_test_x64
+  RPM_TEST_X64: $DOCKER_REGISTRY/datadog-agent-builders:rpm_test_x64
   DEPLOY: $DOCKER_REGISTRY/datadog-agent-builders:deploy # For now, just a renamed version of the image datadog/mars-jenkins-scripts
   AGENT_OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
   STATIC_BINARIES_DIR: bin/static
@@ -27,7 +29,7 @@ before_script:
 # run tests for deb-x64
 run_tests_deb-x64:
   stage: source_test
-  image: $DEB_X64
+  image: $DEB_TEST_X64
   tags:
     - docker
   variables:
@@ -41,7 +43,7 @@ run_tests_deb-x64:
 # run tests for rpm-x64
 run_test_rpm-x64:
   stage: source_test
-  image: $RPM_X64
+  image: $RPM_TEST_X64
   tags:
     - docker
   variables:
@@ -54,7 +56,7 @@ run_test_rpm-x64:
 # run system tests for deb-x64
 run_system_tests_deb-x64:
   stage: source_test
-  image: $DEB_X64
+  image: $DEB_TEST_X64
   tags:
     - docker
   variables:
@@ -104,7 +106,7 @@ benchmarks-x64:
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test
-  image: $DEB_X64
+  image: $DEB_TEST_X64
   tags:
     - docker
   dependencies:


### PR DESCRIPTION
### What does this PR do?

There's no reason to build the agent on the same dockerfile as we test the agent. It would be easier if we build and tested them on separate dockerfiles.

This PR will split them. It will require this PR to be merged prior to merging this: https://github.com/DataDog/datadog-agent-builders/pull/12


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
