### PR TITLE
[runner] [command line] adds check command

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -29,7 +29,6 @@ func init() {
 
 	checkCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to datadog.yaml")
 	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice")
-	checkCmd.Flags().StringVarP(&checkName, "check", "c", "", "check name")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")
 	checkCmd.SetArgs([]string{"checkName"})
 }
@@ -41,7 +40,7 @@ var checkCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
 			checkName = args[0]
-		} else if checkName == "" {
+		} else {
 			cmd.Help()
 			os.Exit(0)
 		}

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -90,6 +90,7 @@ var checkCmd = &cobra.Command{
 				fmt.Println(string(j))
 			}
 		}
+
 		serviceChecks := agg.GetServiceChecks()
 		if len(serviceChecks) != 0 {
 			fmt.Println("Service Checks: ")
@@ -98,22 +99,12 @@ var checkCmd = &cobra.Command{
 				fmt.Println(string(j))
 			}
 		}
+
 		events := agg.GetEvents()
 		if len(events) != 0 {
 			fmt.Println("Events: ")
 			for _, e := range events {
 				j, _ := json.Marshal(e)
-				fmt.Println(string(j))
-			}
-		}
-
-		metricsJSON, _ := agg.GetMetrics(check.ID())
-		metrics := []*aggregator.Serie{}
-		json.Unmarshal(metricsJSON, &metrics)
-		if len(metrics) != 0 {
-			fmt.Println("Metrics: ")
-			for _, m := range metrics {
-				j, _ := json.Marshal(m)
 				fmt.Println(string(j))
 			}
 		}

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	checkRate int
+	checkName string
+)
+
+func init() {
+	AgentCmd.AddCommand(checkCmd)
+
+	checkCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to datadog.yaml")
+	checkCmd.Flags().IntVarP(&checkRate, "check-rate", "r", 0, "check rate")
+	checkCmd.Flags().StringVarP(&checkName, "check", "c", "", "check name")
+	checkCmd.SetArgs([]string{"checkName"})
+}
+
+var checkCmd = &cobra.Command{
+	Use:   "check -c <check_name>",
+	Short: "Run the specified check",
+	Long:  `Use this to run a specific check with a specific rate`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			checkName = args[0]
+		}
+		fmt.Println(checkName)
+	},
+}

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 var checkCmd = &cobra.Command{
-	Use:   "check -c <check_name>",
+	Use:   "check <check_name>",
 	Short: "Run the specified check",
 	Long:  `Use this to run a specific check with a specific rate`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -101,8 +101,7 @@ func StartAgent() {
 	log.Debugf("statsd started")
 
 	// create and setup the Autoconfig instance
-	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
-	common.StartAutoConfig()
+	common.StartAutoConfig(config.Datadog.GetString("confd_path"))
 
 	// setup the metadata collector, this needs a working Python env to function
 	if config.Datadog.GetBool("enable_metadata_collection") {

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -102,6 +102,7 @@ func StartAgent() {
 
 	// create and setup the Autoconfig instance
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
+	common.StartAutoConfig()
 
 	// setup the metadata collector, this needs a working Python env to function
 	if config.Datadog.GetBool("enable_metadata_collection") {

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -49,7 +49,8 @@ func SetupAutoConfig(confdPath string) {
 }
 
 // StartAutoConfig starts the autoconfig polling and loads the configs
-func StartAutoConfig() {
+func StartAutoConfig(confdPath string) {
+	SetupAutoConfig(confdPath)
 	AC.StartPolling()
 	AC.LoadConfigs()
 }

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -48,6 +48,12 @@ func SetupAutoConfig(confdPath string) {
 	}
 }
 
+// StartAutoConfig starts the autoconfig polling and loads the configs
+func StartAutoConfig() {
+	AC.StartPolling()
+	AC.LoadConfigs()
+}
+
 // SetupConfig fires up the configuration system
 func SetupConfig(confFilePath string) {
 	// set the paths where a config file is expected

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -155,6 +155,7 @@ func (agg *BufferedAggregator) GetChannels() (chan *metrics.MetricSample, chan m
 	return agg.dogstatsdIn, agg.eventIn, agg.serviceCheckIn
 }
 
+// SetFlushInterval allows the flush interval to be set
 func (agg *BufferedAggregator) SetFlushInterval(interval int64) {
 	if interval == 0 {
 		agg.TickerChan = nil
@@ -249,6 +250,7 @@ func (agg *BufferedAggregator) addSample(metricSample *metrics.MetricSample, tim
 	}
 }
 
+// GetSeries grabs all the series from the queue and clears the queue
 func (agg *BufferedAggregator) GetSeries() []*Serie {
 	series := agg.sampler.flush(timeNowNano())
 	agg.mu.Lock()
@@ -281,6 +283,7 @@ func (agg *BufferedAggregator) flushSeries() {
 	}()
 }
 
+// GetServiceChecks grabs all the service checks from the queue and clears the queue
 func (agg *BufferedAggregator) GetServiceChecks() []ServiceCheck {
 	// Clear the current service check slice
 	serviceChecks := agg.serviceChecks
@@ -314,6 +317,7 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 	}()
 }
 
+// GetSketches grabs all the sketches from the queue and clears the queue
 func (agg *BufferedAggregator) GetSketches() []*percentile.SketchSeries {
 	return agg.distSampler.flush(timeNowNano())
 }

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -74,6 +74,7 @@ func InitAggregator(f forwarder.Forwarder, hostname string) *BufferedAggregator 
 	return InitAggregatorWithFlushInterval(f, hostname, defaultFlushInterval)
 }
 
+// InitAggregatorWithFlushInterval returns the Singleton instance with a configured flush interval
 func InitAggregatorWithFlushInterval(f forwarder.Forwarder, hostname string, flushInterval int64) *BufferedAggregator {
 	aggregatorInit.Do(func() {
 		aggregatorInstance = NewBufferedAggregator(f, hostname, flushInterval)

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -296,9 +296,7 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 		Status:    metrics.ServiceCheckOK,
 	})
 
-	// Clear the current service check slice
-	serviceChecks := agg.serviceChecks
-	agg.serviceChecks = nil
+	serviceChecks := agg.GetServiceChecks()
 
 	// Serialize and forward in a separate goroutine
 	go func() {

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/metrics/percentile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
@@ -245,7 +246,7 @@ func (agg *BufferedAggregator) addSample(metricSample *metrics.MetricSample, tim
 }
 
 // GetSeries grabs all the series from the queue and clears the queue
-func (agg *BufferedAggregator) GetSeries() []*Serie {
+func (agg *BufferedAggregator) GetSeries() []*metrics.Serie {
 	series := agg.sampler.flush(timeNowNano())
 	agg.mu.Lock()
 	for _, checkSampler := range agg.checkSamplers {
@@ -278,7 +279,7 @@ func (agg *BufferedAggregator) flushSeries() {
 }
 
 // GetServiceChecks grabs all the service checks from the queue and clears the queue
-func (agg *BufferedAggregator) GetServiceChecks() []ServiceCheck {
+func (agg *BufferedAggregator) GetServiceChecks() []metrics.ServiceCheck {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
 	// Clear the current service check slice
@@ -341,7 +342,7 @@ func (agg *BufferedAggregator) flushSketches() {
 }
 
 // GetEvents grabs the events from the queue and clears it
-func (agg *BufferedAggregator) GetEvents() []Event {
+func (agg *BufferedAggregator) GetEvents() []metrics.Event {
 	agg.mu.Lock()
 	defer agg.mu.Unlock()
 	events := agg.events

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -279,6 +279,8 @@ func (agg *BufferedAggregator) flushSeries() {
 
 // GetServiceChecks grabs all the service checks from the queue and clears the queue
 func (agg *BufferedAggregator) GetServiceChecks() []ServiceCheck {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
 	// Clear the current service check slice
 	serviceChecks := agg.serviceChecks
 	agg.serviceChecks = nil
@@ -313,6 +315,8 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 
 // GetSketches grabs all the sketches from the queue and clears the queue
 func (agg *BufferedAggregator) GetSketches() []*percentile.SketchSeries {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
 	return agg.distSampler.flush(timeNowNano())
 }
 
@@ -338,6 +342,8 @@ func (agg *BufferedAggregator) flushSketches() {
 
 // GetEvents grabs the events from the queue and clears it
 func (agg *BufferedAggregator) GetEvents() []Event {
+	agg.mu.Lock()
+	defer agg.mu.Unlock()
 	events := agg.events
 	agg.events = nil
 	return events

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -3,6 +3,7 @@ package autodiscovery
 import (
 	"expvar"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -157,6 +158,23 @@ func (ac *AutoConfig) LoadConfigs() {
 // RunCheck runs a single check
 func (ac *AutoConfig) RunCheck(checkName string) {
 	ac.collectChecks(checkName)
+}
+
+// GetCheck grabs a check from the config
+func (ac *AutoConfig) GetCheck(checkName string) check.Check {
+	titleCheck := fmt.Sprintf("%s%s", strings.Title(checkName), "Check")
+	for _, pd := range ac.providers {
+		configs, _ := ac.collect(pd)
+		for _, config := range configs {
+			// load the check instances and schedule them
+			for _, check := range ac.loadChecks(config) {
+				if checkName == check.String() || titleCheck == check.String() {
+					return check
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (ac *AutoConfig) collectChecks(checkName string) {

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -27,11 +27,13 @@ func (l *MockLoader) Load(config check.Config) ([]check.Check, error) { return [
 
 func TestAddProvider(t *testing.T) {
 	ac := NewAutoConfig(nil)
+	ac.StartPolling()
 	assert.Len(t, ac.providers, 0)
 	mp := &MockProvider{}
 	ac.AddProvider(mp, false)
 	ac.AddProvider(mp, false) // this should be a noop
 	ac.AddProvider(&MockProvider2{}, true)
+	ac.LoadConfigs()
 	require.Len(t, ac.providers, 2)
 	assert.Equal(t, 1, mp.CollectCounter)
 	assert.False(t, ac.providers[0].poll)

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -4,7 +4,7 @@ Collector
   Running Checks
   ==============
 {{- with .RunnerStats -}}
-{{- if not .Runs}}
+{{- if and (not .Runs) (not .Checks)}}
     No checks have run yet
 {{end -}}
 {{- range .Checks}}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -19,8 +19,6 @@ var (
 
 func init() {
 	templateFolder = filepath.Join(here, "dist", "templates")
-	// t := template.New("").Funcs(fmap)
-	// t.New("aggregator.tmpl")
 }
 
 // FormatStatus takes a json bytestring and prints out the formatted statuspage


### PR DESCRIPTION
### What does this PR do?

This adds a check command to the commands list. It attempts to mirror the check command on Agent 5.

1) Agent 5 had a different way of gathering metrics, you could grab them straight from the check. We cannot do this, we have to grab them from the aggregator. To do this, we had to expose a bunch of things that were not previously exposed. However, since most metrics aren't segmented by check, if something like an event or service check is submitted within any of the exposed methods I use, it will grab that as well. We will need to be mindful of this going forward.

1) Agent 5 had a way of collecting metrics from each check that Agent 6 does not. There is no workaround for this. I have displayed a limited status page with the check that allows them to see some metrics. However, metrics like how many metrics they've submitted are, for now, missing. 

We will need to add these to the check status at some point, but it's out of scope for now.
