### PR TITLE
Use `exec` in script that starts the agent

### DIFF
--- a/pkg/collector/dist/agent
+++ b/pkg/collector/dist/agent
@@ -2,4 +2,4 @@
 
 BASEPATH=/opt/datadog-agent6/embedded/lib/python2.7/
 DIRPATH=`dirname $0`
-PYTHONPATH=$BASEPATH:$BASEPATH/site-packages/:$BASEPATH/lib-dynload/ $DIRPATH/agent.bin "$@"
+exec env PYTHONPATH=$BASEPATH:$BASEPATH/site-packages/:$BASEPATH/lib-dynload/ $DIRPATH/agent.bin "$@"


### PR DESCRIPTION
### What does this PR do?

Uses `exec` in script that starts the agent.

Resolves #363

### Motivation

Using `exec` makes the agent process replace the shell script's
process instead of starting the agent process as a child process
of the shell script's process.

This is desirable for init systems that can't really track the actual
agent process' PID otherwise (like upstart, see #363),and can then
fail to track the agent process properly.
