### PR TITLE
[py] Initialize site, and use PYTHONHOME

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -37,9 +37,8 @@ func NewCollector(paths ...string) *Collector {
 	log.Debug("scheduler created")
 	sched.Run()
 
-	// Send the agent startup event
-	// TODO
 	log.Debug("Creating collector")
+	log.Infof("Initializing python interpreter with paths: %v", paths)
 	c := &Collector{
 		scheduler: sched,
 		runner:    run,

--- a/pkg/collector/dist/agent
+++ b/pkg/collector/dist/agent
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-BASEPATH=/opt/datadog-agent6/embedded/lib/python2.7/
+EMBEDDEDPATH=/opt/datadog-agent6/embedded
 DIRPATH=`dirname $0`
-exec env PYTHONPATH=$BASEPATH:$BASEPATH/site-packages/:$BASEPATH/lib-dynload/ $DIRPATH/agent.bin "$@"
+exec env PYTHONHOME=$EMBEDDEDPATH $DIRPATH/agent.bin "$@"

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -127,9 +127,6 @@ func (sl *stickyLock) getPythonError() (string, error) {
 // configure the environment. This function should be called at most once in the
 // Agent lifetime.
 func Initialize(paths ...string) *python.PyThreadState {
-	// Disable Site initialization
-	C.Py_NoSiteFlag = 1
-
 	// Start the interpreter
 	if C.Py_IsInitialized() == 0 {
 		C.Py_Initialize()


### PR DESCRIPTION
### What does this PR do?

* Allows python to automatically initialize `site` when we initialize
the interpreter (see https://docs.python.org/2/library/site.html).
This makes python build its own default `PYTHONPATH` from the
`PYTHONHOME` (so that it can load all the modules: built-ins,
`site-packages` modules, etc).
* Instead of setting `PYTHONPATH` (since we let python build that on
its own), sets `PYTHONHOME`. That'll set up the embedded python's home, and
the rest will be handled by python.

See https://docs.python.org/2/using/cmdline.html#envvar-PYTHONHOME:

>When PYTHONHOME is set to a single directory, its value replaces both prefix and exec_prefix

### Motivation

Disabling site initialization is error-prone. In my case, the installed `supervisor`
module couldn't be imported because without site initialization, python doesn't
take into account the `.pth` files in its `site-packages` directory (and the `supervisor`
module relies on such a file).

Instead, let's enable the default behavior and let the interpreter do everything.

### Additional Notes

This changes the site initialization behavior that was introduced in #15.

Also, sneaked in the addition of a log line that helped me for troubleshooting
(not directly related to the PYTHONPATH change though)