### PR TITLE
[py] Clean up `AgentCheck` constants

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -26,12 +26,7 @@ class CheckException(Exception):
     pass
 
 class AgentCheck(object):
-
-    RATE = "rate"
-    GAUGE = "gauge"
-    OK = 0
-    WARNING = 1
-    CRITICAL = 2
+    OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)
 
     def __init__(self, *args, **kwargs):
         # `args` order is `name`, `init_config`, `agentConfig` (deprecated), `instances`


### PR DESCRIPTION
### What does this PR do?

* Add the `UNKNOWN` service check status
* Remove constants that were there only for the agent6-specific checks

### Motivation

🔥 

