### PR TITLE
fixes ntp offset in template

### DIFF
--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -16,7 +16,7 @@
   Clocks
   ======
 {{- if .ntpOffset}}
-    NTP offset: {{.ntpOffset}}s {{end}}
+    NTP offset: {{.ntpOffset}} s {{end}}
     System UTC time: {{.time}}
   Host Info
   =========

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -15,7 +15,8 @@
     checks.d: {{.config.additional_checksd}}
   Clocks
   ======
-    NTP offset: 7850.7797 s
+{{- if .ntpOffset}}
+    NTP offset: {{.ntpOffset}}s {{end}}
     System UTC time: {{.time}}
   Host Info
   =========


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

It fixes the ntp offset in the template. I had mistakenly forgotten to put the variable into the template when I made the original PR.

### Motivation

The original number was quite high and @olivielpeau  got freaked out over it, thinking it was real.

### Additional Notes

Anything else we should know when reviewing?
