### PR TITLE
[metadata] [checks] check status reported in status command and in metadata 

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -94,7 +94,8 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 	for i < times {
 		t0 := time.Now()
 		err := c.Run()
-		s.Add(time.Since(t0), err)
+		warnings := c.GetWarnings()
+		s.Add(time.Since(t0), err, warnings)
 		i++
 	}
 

--- a/cmd/agent/app/runloop.go
+++ b/cmd/agent/app/runloop.go
@@ -42,6 +42,9 @@ var (
 // run the host metadata collector every 14400 seconds (4 hours)
 const hostMetadataCollectorInterval = 14400
 
+// run the agent checks metadata collector every 600 seconds (10 minutes)
+const agentChecksMetadataCollectorInterval = 600
+
 // StartAgent Initializes the agent process
 func StartAgent() {
 	// Global Agent configuration
@@ -113,7 +116,7 @@ func StartAgent() {
 		if err == nil {
 			log.Debugf("Adding configured providers to the metadata collector")
 			for _, c := range C {
-				if c.Name == "host" {
+				if c.Name == "host" || c.Name == "agent_checks" {
 					continue
 				}
 				intl := c.Interval * time.Second
@@ -131,6 +134,10 @@ func StartAgent() {
 		err = common.MetadataScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
 		if err != nil {
 			panic("Host metadata is supposed to be always available in the catalog!")
+		}
+		err = common.MetadataScheduler.AddCollector("agent_checks", agentChecksMetadataCollectorInterval*time.Second)
+		if err != nil {
+			panic("Agent Checks metadata is supposed to be always available in the catalog!")
 		}
 	} else {
 		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -396,3 +396,8 @@ func (pd *providerDescriptor) contains(c *check.Config) bool {
 func expLoaderErrors() interface{} {
 	return loaderErrors.GetErrors()
 }
+
+// GetLoaderErrors gets the errors from the loaderErrors struct
+func GetLoaderErrors() map[string]map[string]string {
+	return loaderErrors.GetErrors()
+}

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -16,6 +16,7 @@ func (c *TestCheck) Configure(ConfigData, ConfigData) error { return nil }
 func (c *TestCheck) Interval() time.Duration                { return 1 }
 func (c *TestCheck) Run() error                             { return nil }
 func (c *TestCheck) ID() ID                                 { return ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                   { return []error{} }
 
 func TestIdentify(t *testing.T) {
 	testCheck := &TestCheck{}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -20,6 +20,7 @@ func (c *TestCheck) Configure(a, b check.ConfigData) error { return nil }
 func (c *TestCheck) Interval() time.Duration               { return 1 * time.Minute }
 func (c *TestCheck) Run() error                            { <-c.stop; return nil }
 func (c *TestCheck) ID() check.ID                          { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                  { return []error{} }
 
 func NewCheck() *TestCheck { return &TestCheck{stop: make(chan bool)} }
 

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -125,6 +125,11 @@ func (c *APMCheck) Stop() {
 	}
 }
 
+// GetWarnings does not return anything in APM
+func (c *APMCheck) GetWarnings() []error {
+	return []error{}
+}
+
 func init() {
 	factory := func() check.Check {
 		return &APMCheck{}

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -375,6 +375,11 @@ func (c *JMXCheck) Stop() {
 	}
 }
 
+// GetWarnings does not return anything in JMX
+func (c *JMXCheck) GetWarnings() []error {
+	return []error{}
+}
+
 func init() {
 	factory := func() check.Check {
 		return &JMXCheck{}

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -16,6 +16,7 @@ func (c *TestCheck) Run() error                                         { return
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) Interval() time.Duration                            { return 1 }
 func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                               { return []error{} }
 
 func TestNewGoCheckLoader(t *testing.T) {
 	if checkLoader, _ := NewGoCheckLoader(); checkLoader == nil {

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -20,8 +20,9 @@ var ntpExpVar = expvar.NewFloat("ntpOffset")
 
 // NTPCheck only has sender and config
 type NTPCheck struct {
-	id  check.ID
-	cfg *ntpConfig
+	id           check.ID
+	lastWarnings []error
+	cfg          *ntpConfig
 }
 
 type ntpInstanceConfig struct {
@@ -142,6 +143,29 @@ func (c *NTPCheck) Run() error {
 	sender.Commit()
 
 	return nil
+}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *NTPCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *NTPCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *NTPCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
 }
 
 func ntpFactory() check.Check {

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -97,8 +97,9 @@ type snmpConfig struct {
 
 // SNMPCheck grabs SNMP metrics
 type SNMPCheck struct {
-	id  check.ID
-	cfg *snmpConfig
+	id           check.ID
+	lastWarnings []error
+	cfg          *snmpConfig
 }
 
 func (c *SNMPCheck) String() string {
@@ -730,6 +731,29 @@ func (c *SNMPCheck) Run() error {
 	}
 
 	return nil
+}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *SNMPCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *SNMPCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *SNMPCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
 }
 
 func snmpFactory() check.Check {

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -18,9 +18,10 @@ var cpuInfo = cpu.Info
 
 // CPUCheck doesn't need additional fields
 type CPUCheck struct {
-	nbCPU       float64
-	lastNbCycle float64
-	lastTimes   cpu.TimesStat
+	nbCPU        float64
+	lastNbCycle  float64
+	lastWarnings []error
+	lastTimes    cpu.TimesStat
 }
 
 func (c *CPUCheck) String() string {
@@ -97,6 +98,29 @@ func (c *CPUCheck) ID() check.ID {
 
 // Stop does nothing
 func (c *CPUCheck) Stop() {}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *CPUCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *CPUCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *CPUCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
 
 func cpuFactory() check.Check {
 	return &CPUCheck{}

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -49,6 +49,29 @@ func (c *IOCheck) ID() check.ID {
 // Stop does nothing
 func (c *IOCheck) Stop() {}
 
+// GetWarnings grabs the last warnings from the sender
+func (c *IOCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *IOCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *IOCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
 func init() {
 	core.RegisterCheck("io", ioFactory)
 }

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -34,9 +34,10 @@ const (
 
 // IOCheck doesn't need additional fields
 type IOCheck struct {
-	blacklist *regexp.Regexp
-	ts        int64
-	stats     map[string]disk.IOCountersStat
+	blacklist    *regexp.Regexp
+	lastWarnings []error
+	ts           int64
+	stats        map[string]disk.IOCountersStat
 }
 
 // Configure the IOstats check

--- a/pkg/collector/corechecks/system/iostats_wmi_windows.go
+++ b/pkg/collector/corechecks/system/iostats_wmi_windows.go
@@ -41,8 +41,9 @@ type Win32_PerfRawData_PerfDisk_LogicalDisk struct {
 
 // IOCheck doesn't need additional fields
 type IOCheck struct {
-	blacklist *regexp.Regexp
-	drivemap  map[string]Win32_PerfRawData_PerfDisk_LogicalDisk
+	blacklist    *regexp.Regexp
+	drivemap     map[string]Win32_PerfRawData_PerfDisk_LogicalDisk
+	lastWarnings []error
 }
 
 // Configure the IOstats check

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -16,7 +16,8 @@ var loadAvg = load.Avg
 
 // LoadCheck doesn't need additional fields
 type LoadCheck struct {
-	nbCPU int32
+	lastWarnings []error
+	nbCPU        int32
 }
 
 func (c *LoadCheck) String() string {
@@ -73,6 +74,29 @@ func (c *LoadCheck) ID() check.ID {
 
 // Stop does nothing
 func (c *LoadCheck) Stop() {}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *LoadCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *LoadCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *LoadCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
 
 func loadFactory() check.Check {
 	return &LoadCheck{}

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -19,7 +19,9 @@ var swapMemory = mem.SwapMemory
 var runtimeOS = runtime.GOOS
 
 // MemoryCheck doesn't need additional fields
-type MemoryCheck struct{}
+type MemoryCheck struct {
+	lastWarnings []error
+}
 
 func (c *MemoryCheck) String() string {
 	return "memory"
@@ -118,6 +120,29 @@ func (c *MemoryCheck) ID() check.ID {
 
 // Stop does nothing
 func (c *MemoryCheck) Stop() {}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *MemoryCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *MemoryCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *MemoryCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
 
 func memFactory() check.Check {
 	return &MemoryCheck{}

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -15,7 +15,9 @@ import (
 var uptime = host.Uptime
 
 // UptimeCheck doesn't need additional fields
-type UptimeCheck struct{}
+type UptimeCheck struct {
+	lastWarnings []error
+}
 
 func (c *UptimeCheck) String() string {
 	return "uptime"
@@ -58,6 +60,29 @@ func (c *UptimeCheck) ID() check.ID {
 
 // Stop does nothing
 func (c *UptimeCheck) Stop() {}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *UptimeCheck) GetWarnings() []error {
+	w := c.lastWarnings
+	c.lastWarnings = []error{}
+	return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *UptimeCheck) warn(v ...interface{}) error {
+	w := log.Warn(v)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *UptimeCheck) warnf(format string, params ...interface{}) error {
+	w := log.Warnf(format, params)
+	c.lastWarnings = append(c.lastWarnings, w)
+
+	return w
+}
 
 func uptimeFactory() check.Check {
 	return &UptimeCheck{}

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -37,6 +37,7 @@ class AgentCheck(object):
         self.name = kwargs.get('name', '')
         self.init_config = kwargs.get('init_config', {})
         self.agentConfig = kwargs.get('agentConfig', {})
+        self.warnings = []
 
         if len(args) > 0:
             self.name = args[0]
@@ -237,10 +238,17 @@ class AgentCheck(object):
         return normalized_tags
 
     def warning(self, warning_message):
-        # TODO: add the warning message to the info page, and send the warning as a service check
-        # to DD so that it shows up on the infrastructure page
         warning_message = str(warning_message)
         self.log.warning(warning_message)
+        self.warnings.append(warning_message)
+
+    def get_warnings(self):
+        """
+        Return the list of warnings messages to be displayed in the info page
+        """
+        warnings = self.warnings
+        self.warnings = []
+        return warnings
 
     def run(self):
         try:

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -27,7 +27,8 @@ func (c *TestCheck) Run() error {
 	c.hasRun = true
 	return nil
 }
-func (c *TestCheck) ID() check.ID { return check.ID(c.String()) }
+func (c *TestCheck) ID() check.ID         { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error { return nil }
 
 func TestNewRunner(t *testing.T) {
 	r := NewRunner(1)

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -17,6 +17,7 @@ func (c *TestCheck) Interval() time.Duration                            { return
 func (c *TestCheck) Run() error                                         { return nil }
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                               { return []error{} }
 
 // wait 1s for a predicate function to return true, use polling
 // instead of a giant sleep.

--- a/pkg/metadata/agentchecks.go
+++ b/pkg/metadata/agentchecks.go
@@ -1,0 +1,27 @@
+// +build checks
+
+package metadata
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/metadata/agentchecks"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+)
+
+// AgentChecksCollector fills and sends the old metadata payload used in the
+// Agent v5 for agent check status
+type AgentChecksCollector struct{}
+
+// Send collects the data needed and submits the payload
+func (hp *AgentChecksCollector) Send(s *serializer.Serializer) error {
+	payload := agentchecks.GetPayload()
+	if err := s.SendMetadata(payload); err != nil {
+		return fmt.Errorf("unable to submit host metadata payload, %s", err)
+	}
+	return nil
+}
+
+func init() {
+	catalog["agent_checks"] = new(AgentChecksCollector)
+}

--- a/pkg/metadata/agentchecks/agentchecks.go
+++ b/pkg/metadata/agentchecks/agentchecks.go
@@ -1,0 +1,46 @@
+package agentchecks
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/collector/runner"
+	"github.com/cihub/seelog"
+)
+
+// GetPayload builds a payload of all the agentchecks metadata
+func GetPayload() *Payload {
+	seelog.Info("I got here!!!!")
+	payload := &Payload{
+		AgentChecks: []interface{}{},
+	}
+
+	checkStats := runner.GetCheckStats()
+
+	for check, stats := range checkStats {
+		var status []interface{}
+		if stats.LastError != "" {
+			status = []interface{}{
+				check, "", stats.CheckID, stats.LastError, "ERROR", "",
+			}
+		} else if len(stats.LastWarnings) != 0 {
+			status = []interface{}{
+				check, "", stats.CheckID, stats.LastWarnings, "WARNING", "",
+			}
+		} else {
+			status = []interface{}{
+				check, "", stats.CheckID, stats.LastWarnings, "OK", "",
+			}
+		}
+		payload.AgentChecks = append(payload.AgentChecks, status)
+	}
+
+	loaderErrors := autodiscovery.GetLoaderErrors()
+
+	for check, errs := range loaderErrors {
+		status := []interface{}{
+			check, "", "initialization", "ERROR", errs,
+		}
+		payload.AgentChecks = append(payload.AgentChecks, status)
+	}
+
+	return payload
+}

--- a/pkg/metadata/agentchecks/payload.go
+++ b/pkg/metadata/agentchecks/payload.go
@@ -1,0 +1,24 @@
+package agentchecks
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	AgentChecks []interface{} `json:"agent_checks"`
+}
+
+// MarshalJSON serialization a Payload to JSON
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	// use an alias to avoid infinit recursion while serializing
+	type PayloadAlias Payload
+
+	return json.Marshal((*PayloadAlias)(p))
+}
+
+// Marshal not implemented
+func (p *Payload) Marshal() ([]byte, error) {
+	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
+}

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -59,7 +59,6 @@ type Payload struct {
 	// TODO: host-tags
 	// TODO: external_host_tags
 	GohaiPayload
-	// TODO: agent_checks
 }
 
 // SplitPayload breaks the payload into times number of pieces

--- a/pkg/metadata/v5/payload_other.go
+++ b/pkg/metadata/v5/payload_other.go
@@ -10,5 +10,4 @@ type Payload struct {
 	// TODO: host-tags
 	// TODO: external_host_tags
 	// TODO: gohai alternative (or fix gohai)
-	// TODO: agent_checks
 }

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -14,7 +14,10 @@ Collector
 {{- if .LastError}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}
-{{- end -}} {{- end -}} {{- end -}}
+{{- end -}}
+{{- if .LastWarnings}} {{- range .LastWarnings }}
+      Warning: {{.}}
+{{- end -}} {{- end -}} {{- end -}} {{- end -}}
 {{- with .LoaderStats -}} {{- if .Errors}}
   Loading Errors
   ==============

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -60,7 +60,9 @@ namespace :agent do
       end
     end
 
-    command = "go build #{race_opt} #{build_type} -tags \"#{go_build_tags}\" -o #{BIN_PATH}/#{agent_bin_name} -gcflags=\"#{gcflags.join(" ")}\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent"
+    build_tags = go_build_tags added_tags: 'checks'
+
+    command = "go build #{race_opt} #{build_type} -tags \"#{build_tags}\" -o #{BIN_PATH}/#{agent_bin_name} -gcflags=\"#{gcflags.join(" ")}\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent"
     puts command
     build_success = system(env, command)
     fail "Agent build failed with code #{$?.exitstatus}" if !build_success

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -14,9 +14,11 @@ def os
 end
 
 # `tags` option
-def go_build_tags
+def go_build_tags(tags: '', added_tags: '')
   build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm docker ec2 gce process"
   build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
+  build_tags = tags ? tags : build_tags
+  build_tags = added_tags ? build_tags + ' ' + added_tags : build_tags
 end
 
 def get_base_ldflags()

--- a/rake/py-launcher.rb
+++ b/rake/py-launcher.rb
@@ -8,8 +8,10 @@ namespace :pylauncher do
   task :build do
     build_type_opt = ENV['incremental'] == "true" ? "-i" : "-a"
 
+    build_tags = go_build_tags added_tags: 'checks'
+
     bin_path = PYLAUNCHER_BIN_PATH
-    sh("go build #{build_type_opt} -tags '#{go_build_tags}' -o #{bin_path}/#{bin_name("py-launcher")} #{REPO_PATH}/cmd/py-launcher/")
+    sh("go build #{build_type_opt} -tags '#{build_tags}' -o #{bin_path}/#{bin_name("py-launcher")} #{REPO_PATH}/cmd/py-launcher/")
   end
 
   desc "Run system tests with pylauncher"


### PR DESCRIPTION
### What does this PR do?

In the Agent5, we track the check status after every check run. We track if it finished successfully, if there was a warning, or if there was an error. 

We report this on the info page. 

And, we also report this to the Datadog Platform twice:

First with a [service check](https://github.com/DataDog/dd-agent/blob/6f107f8ed7f55f4ffa1724b81916cafb64d91614/checks/collector.py#L446-L452). 

Second with a [metadata upload](https://github.com/DataDog/dd-agent/blob/master/checks/collector.py#L708-L734).

The service check is only used in the same way that any service check is used. The metadata upload is what's used on the infrastructure page to report on check status and print out check errors or warnings.

I agree that it seems odd to duplicate check status like this, and we should see if we can dedupe it at some point. However, at the same time, it probably saves a bit of bandwidth by not sending the errors and warnings on every run, but instead only every 10 minutes. So, it's also likely a minor optimization. And, because of the way the pipeline is structured, the inclusion of this in the metadata instead of in a service check does make sense.

### Additional Notes

I discussed some of these features with @olivielpeau while I was writing it. For example, we put the Warn in the sender to make it clear that this is not just a logging shim of some sort, it's also sending the warning to Datadog.