### PR TITLE
[forwarder] Drop transaction when reponse is 404

### DIFF
--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -78,7 +78,7 @@ func (t *HTTPTransaction) Process(client *http.Client) error {
 	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)
-	if resp.StatusCode == 400 || resp.StatusCode == 413 {
+	if resp.StatusCode == 400 || resp.StatusCode == 404 || resp.StatusCode == 413 {
 		log.Errorf("Error code '%s' received while sending transaction to '%s': %s, dropping it", resp.Status, logURL, string(body))
 		transactionsCreation.Add("Dropped", 1)
 		return nil

--- a/pkg/forwarder/transaction_test.go
+++ b/pkg/forwarder/transaction_test.go
@@ -113,7 +113,7 @@ func TestProcessNetworkError(t *testing.T) {
 }
 
 func TestProcessHTTPError(t *testing.T) {
-	errorCode := http.StatusNotFound
+	errorCode := http.StatusServiceUnavailable
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(errorCode)
@@ -130,7 +130,7 @@ func TestProcessHTTPError(t *testing.T) {
 
 	err := transaction.Process(client)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Error '404 Not Found' while sending transaction")
+	assert.Contains(t, err.Error(), "Error '503 Service Unavailable' while sending transaction")
 	assert.Equal(t, transaction.ErrorCount, 1)
 
 	errorCode = http.StatusBadRequest


### PR DESCRIPTION
### What does this PR do?

Like the 400 and 413 http codes, 404 means that the backend is healthy
but the request endpoint is invalid. It makes sense to drop the transaction in
that case.

### Motivation

Useful in particular for endpoints that are not implemented on all the
accounts/environments, and agents with multiple domains/keys
configured. Dropping the 404 transactions allows not filling up the
retry queue with these transactions.
