### PR TITLE
[collector/loader] Fix nil dereference when a loader fails initializing

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -25,12 +25,8 @@ func SetupAutoConfig(confdPath string) {
 
 	// add the check loaders
 	for _, loader := range loaders.LoaderCatalog() {
-		if loader != nil {
-			AC.AddLoader(loader)
-			log.Debugf("Added %s to AutoConfig", loader)
-		} else {
-			log.Infof("Failed to instantiate %s", loader)
-		}
+		AC.AddLoader(loader)
+		log.Debugf("Added %s to AutoConfig", loader)
 	}
 
 	// add the configuration providers

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -28,7 +28,7 @@ type JMXCheckLoader struct {
 }
 
 // NewJMXCheckLoader creates a loader for go checks
-func NewJMXCheckLoader() *JMXCheckLoader {
+func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 	basePath := config.Datadog.GetString("jmx_pipe_path")
 	pipeName := config.Datadog.GetString("jmx_pipe_name")
 
@@ -49,15 +49,15 @@ func NewJMXCheckLoader() *JMXCheckLoader {
 	pipe, err := util.GetPipe(pipePath)
 	if err != nil {
 		log.Errorf("Error getting pipe: %v", err)
-		return nil
+		return nil, errors.New("unable to initialize pipe")
 	}
 
 	if err := pipe.Open(); err != nil {
 		log.Errorf("Error opening pipe: %v", err)
-		return nil
+		return nil, errors.New("unable to initialize pipe")
 	}
 
-	return &JMXCheckLoader{ipc: pipe}
+	return &JMXCheckLoader{ipc: pipe}, nil
 }
 
 // Load returns an (empty?) list of checks and nil if it all works out
@@ -112,7 +112,7 @@ func (jl *JMXCheckLoader) String() string {
 }
 
 func init() {
-	factory := func() check.Loader {
+	factory := func() (check.Loader, error) {
 		return NewJMXCheckLoader()
 	}
 

--- a/pkg/collector/corechecks/embed/jmxloader_test.go
+++ b/pkg/collector/corechecks/embed/jmxloader_test.go
@@ -69,7 +69,8 @@ func TestLoadCheckConfig(t *testing.T) {
 
 	config.Datadog.Set("jmx_pipe_path", tmp)
 
-	jl := NewJMXCheckLoader()
+	jl, err := NewJMXCheckLoader()
+	assert.Nil(t, err)
 	assert.NotNil(t, jl)
 
 	f, err := getFile()

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -22,8 +22,8 @@ func RegisterCheck(name string, c checkFactory) {
 type GoCheckLoader struct{}
 
 // NewGoCheckLoader creates a loader for go checks
-func NewGoCheckLoader() *GoCheckLoader {
-	return &GoCheckLoader{}
+func NewGoCheckLoader() (*GoCheckLoader, error) {
+	return &GoCheckLoader{}, nil
 }
 
 // Load returns a list of checks, one for every configuration instance found in `config`
@@ -54,7 +54,7 @@ func (gl *GoCheckLoader) String() string {
 }
 
 func init() {
-	factory := func() check.Loader {
+	factory := func() (check.Loader, error) {
 		return NewGoCheckLoader()
 	}
 

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -19,7 +19,7 @@ func (c *TestCheck) Interval() time.Duration                            { return
 func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
 
 func TestNewGoCheckLoader(t *testing.T) {
-	if NewGoCheckLoader() == nil {
+	if checkLoader, _ := NewGoCheckLoader(); checkLoader == nil {
 		t.Fatal("Expected loader instance, found: nil")
 	}
 }
@@ -45,7 +45,7 @@ func TestLoad(t *testing.T) {
 		check.ConfigData("bar: baz"),
 	}
 	cc := check.Config{Name: "foo", Instances: i}
-	l := NewGoCheckLoader()
+	l, _ := NewGoCheckLoader()
 
 	lst, err := l.Load(cc)
 

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -1,6 +1,7 @@
 package loaders
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -16,14 +17,21 @@ type LoaderTwo struct{}
 
 func (lt LoaderTwo) Load(config check.Config) ([]check.Check, error) { return nil, nil }
 
+type LoaderThree struct{}
+
+func (lt *LoaderThree) Load(config check.Config) ([]check.Check, error) { return nil, nil }
+
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}
-	factory1 := func() check.Loader { return l1 }
+	factory1 := func() (check.Loader, error) { return l1, nil }
 	l2 := LoaderTwo{}
-	factory2 := func() check.Loader { return l2 }
+	factory2 := func() (check.Loader, error) { return l2, nil }
+	var l3 *LoaderThree
+	factory3 := func() (check.Loader, error) { return l3, errors.New("error") }
 
 	RegisterLoader(20, factory1)
 	RegisterLoader(10, factory2)
+	RegisterLoader(30, factory3)
 
 	require.Len(t, LoaderCatalog(), 2)
 	assert.Equal(t, l1, LoaderCatalog()[1])

--- a/pkg/collector/py/loader_test.go
+++ b/pkg/collector/py/loader_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	l := NewPythonCheckLoader()
+	l, _ := NewPythonCheckLoader()
 	config := check.Config{Name: "testcheck"}
 	config.Instances = append(config.Instances, []byte("foo: bar"))
 	config.Instances = append(config.Instances, []byte("bar: baz"))
@@ -38,6 +38,7 @@ func TestLoad(t *testing.T) {
 }
 
 func TestNewPythonCheckLoader(t *testing.T) {
-	loader := NewPythonCheckLoader()
+	loader, err := NewPythonCheckLoader()
+	assert.Nil(t, err)
 	assert.NotNil(t, loader)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a nil dereference when a loader fails initializing.

Since each loader (as returned by `LoaderCatalog()`) is an interface,
it's not `nil` when the underlying concrete loader failed
initializing (and is actually `nil`). Once the loaders are added to
AutoConfig, we assume they're not `nil`, which leads to `nil`
dereferences.

To fix this, make the factory functions return an error when a loader
initialization fails, and skip those loaders.

### Additional Notes

Regression introduced in #346