### PR TITLE
normalize the checknames of the go checks

### DIFF
--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -41,7 +41,7 @@ type ntpConfig struct {
 }
 
 func (c *NTPCheck) String() string {
-	return "NTPCheck"
+	return "ntp"
 }
 
 func (c *ntpConfig) Parse(data []byte, initData []byte) error {

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -103,7 +103,7 @@ type SNMPCheck struct {
 }
 
 func (c *SNMPCheck) String() string {
-	return "SNMPCheck"
+	return "snmp"
 }
 
 func initCNetSnmpLib(cfg *snmpInitCfg) (err error) {

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -25,7 +25,7 @@ type CPUCheck struct {
 }
 
 func (c *CPUCheck) String() string {
-	return "CPUCheck"
+	return "cpu"
 }
 
 // Run executes the check

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (c *IOCheck) String() string {
-	return "IOCheck"
+	return "io"
 }
 
 // Configure the IOstats check

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -22,7 +22,7 @@ type LoadCheck struct {
 }
 
 func (c *LoadCheck) String() string {
-	return "LoadCheck"
+	return "load"
 }
 
 // Run executes the check

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -24,7 +24,7 @@ type MemoryCheck struct {
 }
 
 func (c *MemoryCheck) String() string {
-	return "MemoryCheck"
+	return "memory"
 }
 
 const mbSize float64 = 1024 * 1024

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -20,7 +20,7 @@ type UptimeCheck struct {
 }
 
 func (c *UptimeCheck) String() string {
-	return "UptimeCheck"
+	return "uptime"
 }
 
 // Run executes the check


### PR DESCRIPTION
### What does this PR do?

The internal go check names should match the names of the other checks and the configuration files. This will normalize them.

### Motivation

They were confusingly named and it would not make sense to normalize them externally, naming them consistently makes much more sense.