### PR TITLE
Collects the number of metrics (&c) each check emits

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -100,7 +100,8 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 		t0 := time.Now()
 		err := c.Run()
 		warnings := c.GetWarnings()
-		s.Add(time.Since(t0), err, warnings)
+		mStats, _ := c.GetMetricStats()
+		s.Add(time.Since(t0), err, warnings, mStats)
 		i++
 	}
 

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -172,11 +172,9 @@ func (s *checkSender) sendMetricSample(metric string, value float64, hostname st
 
 	s.smsOut <- senderMetricSample{s.id, metricSample, false}
 
-	go func() {
-		s.metricStats.Lock.Lock()
-		s.metricStats.Metrics++
-		s.metricStats.Lock.Unlock()
-	}()
+	s.metricStats.Lock.Lock()
+	s.metricStats.Metrics++
+	s.metricStats.Lock.Unlock()
 }
 
 // Gauge should be used to send a simple gauge value to the aggregator. Only the last value sampled is kept at commit time.
@@ -225,11 +223,9 @@ func (s *checkSender) ServiceCheck(checkName string, status metrics.ServiceCheck
 
 	s.serviceCheckOut <- serviceCheck
 
-	go func() {
-		s.metricStats.Lock.Lock()
-		s.metricStats.ServiceChecks++
-		s.metricStats.Lock.Unlock()
-	}()
+	s.metricStats.Lock.Lock()
+	s.metricStats.ServiceChecks++
+	s.metricStats.Lock.Unlock()
 }
 
 // Event submits an event
@@ -238,11 +234,9 @@ func (s *checkSender) Event(e metrics.Event) {
 
 	s.eventOut <- e
 
-	go func() {
-		s.metricStats.Lock.Lock()
-		s.metricStats.Events++
-		s.metricStats.Lock.Unlock()
-	}()
+	s.metricStats.Lock.Lock()
+	s.metricStats.Events++
+	s.metricStats.Lock.Unlock()
 }
 
 func (sp *checkSenderPool) getSender(id check.ID) (Sender, error) {

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -68,21 +68,28 @@ type Check interface {
 	Interval() time.Duration                       // return the interval time for the check
 	ID() ID                                        // provide a unique identifier for every check instance
 	GetWarnings() []error                          // return the last warning registered by the check
+	GetMetricStats() (map[string]int64, error)     // get metric stats from the sender
 }
 
 // Stats holds basic runtime statistics about check instances
 type Stats struct {
-	CheckName         string
-	CheckID           ID
-	TotalRuns         uint64
-	TotalErrors       uint64
-	TotalWarnings     uint64
-	ExecutionTimes    [32]int64 // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
-	LastExecutionTime int64     // most recent run duration, provided for convenience
-	LastError         string    // error that occured in the last run, if any
-	LastWarnings      []string  // warnings that occured in the last run, if any
-	UpdateTimestamp   int64     // latest update to this instance, unix timestamp in seconds
-	m                 sync.Mutex
+	CheckName          string
+	CheckID            ID
+	TotalRuns          uint64
+	TotalErrors        uint64
+	TotalWarnings      uint64
+	Metrics            int64
+	Events             int64
+	ServiceChecks      int64
+	TotalMetrics       int64
+	TotalEvents        int64
+	TotalServiceChecks int64
+	ExecutionTimes     [32]int64 // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
+	LastExecutionTime  int64     // most recent run duration, provided for convenience
+	LastError          string    // error that occured in the last run, if any
+	LastWarnings       []string  // warnings that occured in the last run, if any
+	UpdateTimestamp    int64     // latest update to this instance, unix timestamp in seconds
+	m                  sync.Mutex
 }
 
 // NewStats returns a new check stats instance
@@ -94,7 +101,7 @@ func NewStats(c Check) *Stats {
 }
 
 // Add tracks a new execution time
-func (cs *Stats) Add(t time.Duration, err error, warnings []error) {
+func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats map[string]int64) {
 	cs.m.Lock()
 	defer cs.m.Unlock()
 
@@ -117,6 +124,19 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error) {
 		}
 	}
 	cs.UpdateTimestamp = time.Now().Unix()
+
+	if m, ok := metricStats["Metrics"]; ok {
+		cs.Metrics = m
+		cs.TotalMetrics += m
+	}
+	if ev, ok := metricStats["Events"]; ok {
+		cs.Events = ev
+		cs.TotalEvents += ev
+	}
+	if sc, ok := metricStats["ServiceChecks"]; ok {
+		cs.ServiceChecks = sc
+		cs.TotalServiceChecks += sc
+	}
 }
 
 // Equal determines whether the passed config is the same

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -127,15 +127,21 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats m
 
 	if m, ok := metricStats["Metrics"]; ok {
 		cs.Metrics = m
-		cs.TotalMetrics += m
+		if cs.TotalMetrics <= 1000001 {
+			cs.TotalMetrics += m
+		}
 	}
 	if ev, ok := metricStats["Events"]; ok {
 		cs.Events = ev
-		cs.TotalEvents += ev
+		if cs.TotalEvents <= 1000001 {
+			cs.TotalEvents += ev
+		}
 	}
 	if sc, ok := metricStats["ServiceChecks"]; ok {
 		cs.ServiceChecks = sc
-		cs.TotalServiceChecks += sc
+		if cs.TotalServiceChecks <= 1000001 {
+			cs.TotalServiceChecks += sc
+		}
 	}
 }
 

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -15,13 +15,14 @@ import (
 // FIXTURE
 type TestCheck struct{}
 
-func (c *TestCheck) String() string                         { return "TestCheck" }
-func (c *TestCheck) Stop()                                  {}
-func (c *TestCheck) Configure(ConfigData, ConfigData) error { return nil }
-func (c *TestCheck) Interval() time.Duration                { return 1 }
-func (c *TestCheck) Run() error                             { return nil }
-func (c *TestCheck) ID() ID                                 { return ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                   { return []error{} }
+func (c *TestCheck) String() string                            { return "TestCheck" }
+func (c *TestCheck) Stop()                                     {}
+func (c *TestCheck) Configure(ConfigData, ConfigData) error    { return nil }
+func (c *TestCheck) Interval() time.Duration                   { return 1 }
+func (c *TestCheck) Run() error                                { return nil }
+func (c *TestCheck) ID() ID                                    { return ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                      { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
 
 func TestIdentify(t *testing.T) {
 	testCheck := &TestCheck{}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -19,13 +19,14 @@ type TestCheck struct {
 	stop chan bool
 }
 
-func (c *TestCheck) String() string                        { return "TestCheck" }
-func (c *TestCheck) Stop()                                 { c.stop <- true }
-func (c *TestCheck) Configure(a, b check.ConfigData) error { return nil }
-func (c *TestCheck) Interval() time.Duration               { return 1 * time.Minute }
-func (c *TestCheck) Run() error                            { <-c.stop; return nil }
-func (c *TestCheck) ID() check.ID                          { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                  { return []error{} }
+func (c *TestCheck) String() string                            { return "TestCheck" }
+func (c *TestCheck) Stop()                                     { c.stop <- true }
+func (c *TestCheck) Configure(a, b check.ConfigData) error     { return nil }
+func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
+func (c *TestCheck) Run() error                                { <-c.stop; return nil }
+func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                      { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
 
 func NewCheck() *TestCheck { return &TestCheck{stop: make(chan bool)} }
 

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -140,6 +140,11 @@ func (c *APMCheck) GetWarnings() []error {
 	return []error{}
 }
 
+// GetMetricStats returns the stats from the last run of the check, but there aren't any
+func (c *APMCheck) GetMetricStats() (map[string]int64, error) {
+	return make(map[string]int64), nil
+}
+
 func init() {
 	factory := func() check.Check {
 		return &APMCheck{}

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -270,6 +270,11 @@ func (c *JMXCheck) ID() check.ID {
 	return "JMX_Check"
 }
 
+// GetMetricStats returns the stats from the last run of the check, but there aren't any yet
+func (c *JMXCheck) GetMetricStats() (map[string]int64, error) {
+	return make(map[string]int64), nil
+}
+
 // Stop sends a termination signal to the JMXFetch process
 func (c *JMXCheck) Stop() {
 	if jmxExitFile == "" {

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -154,6 +154,11 @@ func (c *ProcessAgentCheck) Stop() {
 	}
 }
 
+// GetMetricStats returns the stats from the last run of the check, but there aren't any yet
+func (c *ProcessAgentCheck) GetMetricStats() (map[string]int64, error) {
+	return make(map[string]int64), nil
+}
+
 func init() {
 	factory := func() check.Check {
 		return &ProcessAgentCheck{}

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -22,6 +22,7 @@ func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) Interval() time.Duration                            { return 1 }
 func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
 func (c *TestCheck) GetWarnings() []error                               { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
 
 func TestNewGoCheckLoader(t *testing.T) {
 	if checkLoader, _ := NewGoCheckLoader(); checkLoader == nil {

--- a/pkg/collector/corechecks/network/common_test.go
+++ b/pkg/collector/corechecks/network/common_test.go
@@ -66,3 +66,9 @@ func (m *MockSender) Event(e metrics.Event) {
 func (m *MockSender) Commit() {
 	m.Called()
 }
+
+//GetMetricStats enables the get metric stats mock call.
+func (m *MockSender) GetMetricStats() map[string]int64 {
+	m.Called()
+	return make(map[string]int64)
+}

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -173,6 +173,15 @@ func (c *NTPCheck) warnf(format string, params ...interface{}) error {
 	return w
 }
 
+// GetMetricStats returns the stats from the last run of the check
+func (c *NTPCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
 func ntpFactory() check.Check {
 	return &NTPCheck{}
 }

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -728,6 +728,15 @@ func (c *SNMPCheck) ID() check.ID {
 	return c.id
 }
 
+// GetMetricStats returns the stats from the last run of the check
+func (c *SNMPCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
 // Stop does nothing
 func (c *SNMPCheck) Stop() {}
 

--- a/pkg/collector/corechecks/system/common_test.go
+++ b/pkg/collector/corechecks/system/common_test.go
@@ -66,3 +66,9 @@ func (m *MockSender) Event(e metrics.Event) {
 func (m *MockSender) Commit() {
 	m.Called()
 }
+
+//GetMetricStats enables the get metric stats mock call.
+func (m *MockSender) GetMetricStats() map[string]int64 {
+	m.Called()
+	return make(map[string]int64)
+}

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -127,6 +127,15 @@ func (c *CPUCheck) warnf(format string, params ...interface{}) error {
 	return w
 }
 
+// GetMetricStats returns the stats from the last run of the check
+func (c *CPUCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
 func cpuFactory() check.Check {
 	return &CPUCheck{}
 }

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -6,9 +6,11 @@
 package system
 
 import (
+	"fmt"
 	"regexp"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 
@@ -75,6 +77,15 @@ func (c *IOCheck) warnf(format string, params ...interface{}) error {
 	c.lastWarnings = append(c.lastWarnings, w)
 
 	return w
+}
+
+// GetMetricStats returns the stats from the last run of the check
+func (c *IOCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
 }
 
 func init() {

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -103,6 +103,15 @@ func (c *LoadCheck) warnf(format string, params ...interface{}) error {
 	return w
 }
 
+// GetMetricStats returns the stats from the last run of the check
+func (c *LoadCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
 func loadFactory() check.Check {
 	return &LoadCheck{}
 }

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -149,6 +149,15 @@ func (c *MemoryCheck) warnf(format string, params ...interface{}) error {
 	return w
 }
 
+// GetMetricStats returns the stats from the last run of the check
+func (c *MemoryCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
 func memFactory() check.Check {
 	return &MemoryCheck{}
 }

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -6,6 +6,7 @@
 package system
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -87,6 +88,15 @@ func (c *UptimeCheck) warnf(format string, params ...interface{}) error {
 	c.lastWarnings = append(c.lastWarnings, w)
 
 	return w
+}
+
+// GetMetricStats returns the stats from the last run of the check
+func (c *UptimeCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
 }
 
 func uptimeFactory() check.Check {

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -252,6 +252,15 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	return nil
 }
 
+// GetMetricStats returns the stats from the last run of the check
+func (c *PythonCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
 // Interval returns the scheduling time for the check
 func (c *PythonCheck) Interval() time.Duration {
 	return c.interval

--- a/pkg/collector/py/common_test.go
+++ b/pkg/collector/py/common_test.go
@@ -66,3 +66,8 @@ func (m *MockSender) Event(e metrics.Event) {
 func (m *MockSender) Commit() {
 	m.Called()
 }
+
+func (m *MockSender) GetMetricStats() map[string]int64 {
+	m.Called()
+	return map[string]int64{}
+}

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -195,7 +195,8 @@ func (r *Runner) work() {
 		// publish statistics about this run
 		runnerStats.Add("RunningChecks", -1)
 		runnerStats.Add("Runs", 1)
-		addWorkStats(check, time.Since(t0), err, warnings)
+		mStats, _ := check.GetMetricStats()
+		addWorkStats(check, time.Since(t0), err, warnings, mStats)
 
 		log.Infof("Done running check %s", check)
 	}
@@ -203,7 +204,7 @@ func (r *Runner) work() {
 	log.Debug("Finished processing checks.")
 }
 
-func addWorkStats(c check.Check, execTime time.Duration, err error, warnings []error) {
+func addWorkStats(c check.Check, execTime time.Duration, err error, warnings []error, mStats map[string]int64) {
 	var s *check.Stats
 	var found bool
 
@@ -215,7 +216,7 @@ func addWorkStats(c check.Check, execTime time.Duration, err error, warnings []e
 	}
 	checkStats.M.Unlock()
 
-	s.Add(execTime, err, warnings)
+	s.Add(execTime, err, warnings, mStats)
 }
 
 func expCheckStats() interface{} {

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -157,13 +157,10 @@ func (r *Runner) work() {
 		err := check.Run()
 		warnings := check.GetWarnings()
 
-		sender, e := aggregator.GetSender(check.ID())
+		// use the default sender for the service checks
+		sender, e := aggregator.GetDefaultSender()
 		if e != nil {
-			log.Debugf("Error getting sender: %v for check %s. trying to get default sender", e, check)
-			sender, e = aggregator.GetDefaultSender()
-			if e != nil {
-				log.Errorf("Error getting default sender: %v. Not sending status check for %s", e, check)
-			}
+			log.Errorf("Error getting default sender: %v. Not sending status check for %s", e, check)
 		}
 		serviceCheckTags := []string{fmt.Sprintf("check:%s", check.String())}
 		serviceCheckStatus := metrics.ServiceCheckOK

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -32,8 +32,9 @@ func (c *TestCheck) Run() error {
 	c.hasRun = true
 	return nil
 }
-func (c *TestCheck) ID() check.ID         { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error { return nil }
+func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                      { return nil }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
 
 func TestNewRunner(t *testing.T) {
 	r := NewRunner(1)

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -23,6 +23,7 @@ func (c *TestCheck) Run() error                                         { return
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
 func (c *TestCheck) GetWarnings() []error                               { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
 
 // wait 1s for a predicate function to return true, use polling
 // instead of a giant sleep.

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -11,6 +11,9 @@ Collector
     {{.CheckName}}
     {{printDashes .CheckName "-"}}
       Total Runs: {{.TotalRuns}}
+      Metrics: {{.Metrics}}, TotalMetrics: {{.TotalMetrics}}
+      Events: {{.Events}}, TotalEvents: {{.TotalEvents}}
+      ServiceChecks: {{.ServiceChecks}}, TotalServiceChecks: {{.TotalServiceChecks}}
 {{- if .LastError}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -11,9 +11,9 @@ Collector
     {{.CheckName}}
     {{printDashes .CheckName "-"}}
       Total Runs: {{.TotalRuns}}
-      Metrics: {{.Metrics}}, TotalMetrics: {{.TotalMetrics}}
-      Events: {{.Events}}, TotalEvents: {{.TotalEvents}}
-      ServiceChecks: {{.ServiceChecks}}, TotalServiceChecks: {{.TotalServiceChecks}}
+      Metrics: {{.Metrics}}, TotalMetrics: {{mkHuman .TotalMetrics}}
+      Events: {{.Events}}, TotalEvents: {{mkHuman .TotalEvents}}
+      ServiceChecks: {{.ServiceChecks}}, TotalServiceChecks: {{mkHuman .TotalServiceChecks}}
 {{- if .LastError}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -11,9 +11,9 @@ Collector
     {{.CheckName}}
     {{printDashes .CheckName "-"}}
       Total Runs: {{.TotalRuns}}
-      Metrics: {{.Metrics}}, TotalMetrics: {{mkHuman .TotalMetrics}}
-      Events: {{.Events}}, TotalEvents: {{mkHuman .TotalEvents}}
-      ServiceChecks: {{.ServiceChecks}}, TotalServiceChecks: {{mkHuman .TotalServiceChecks}}
+      Metrics: {{.Metrics}}, TotalMetrics: {{humanize .TotalMetrics}}
+      Events: {{.Events}}, TotalEvents: {{humanize .TotalEvents}}
+      ServiceChecks: {{.ServiceChecks}}, TotalServiceChecks: {{humanize .TotalServiceChecks}}
 {{- if .LastError}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -25,6 +25,7 @@ func init() {
 		"pythonLoaderError":  pythonLoaderError,
 		"printDashes":        printDashes,
 		"formatUnixTime":     formatUnixTime,
+		"humanize":           mkHuman,
 	}
 }
 
@@ -92,6 +93,16 @@ func printDashes(s string, dash string) string {
 		dashes += dash
 	}
 	return dashes
+}
+
+func mkHuman(i int64) string {
+	if i > 100000 {
+		return "over 100K"
+	} else if i > 1000000 {
+		return "over 1M"
+	} else {
+		return string(i)
+	}
 }
 
 func stringLength(s string) int {

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -107,9 +105,7 @@ func mkHuman(f float64) string {
 		str = "over 100K"
 	}
 
-	log.Infof("printing this int: %d with this string: %s", i, str)
-
-	return fmt.Sprintf("%d", i)
+	return str
 }
 
 func stringLength(s string) int {

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/cihub/seelog"
+
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -95,14 +97,19 @@ func printDashes(s string, dash string) string {
 	return dashes
 }
 
-func mkHuman(i int64) string {
-	if i > 100000 {
-		return "over 100K"
-	} else if i > 1000000 {
-		return "over 1M"
-	} else {
-		return string(i)
+func mkHuman(f float64) string {
+	i := int64(f)
+	str := fmt.Sprintf("%d", i)
+
+	if i > 1000000 {
+		str = "over 1M"
+	} else if i > 100000 {
+		str = "over 100K"
 	}
+
+	log.Infof("printing this int: %d with this string: %s", i, str)
+
+	return fmt.Sprintf("%d", i)
 }
 
 func stringLength(s string) int {


### PR DESCRIPTION
### What does this PR do?

Each check emits metrics. This Pull Request collects stats on the number of metrics, service checks and events that each check emits. The infopage now has check stats similar to what we used to have in agent5.

### Motivation

We needed it

### Additional Notes

I am not sure that the strategy I used here is the right one. There's essentially two issues. First, the total metrics/total service checks/total events might be bad metrics. It addresses a concern we've had for a long time, though, that it's hard to determine metric evolution over runs. 

Second, I am not sure if this belongs in the sender. But, I am not sure it could go anywhere else.

Third, I think that there's a possibility this is a bad way of doing it. The main issue I have is that it blocks the sender when updating the metrics (I'm not sure how else you could do it other than by updating the metrics in their own goroutines). Update: I have wrapped them in go routines so this never happens.

Finally, I think that the total metrics might be a bad idea. For some checks they could get very large, especially if left running for a long time. I think they're valuable for events, and if you have it for them, it seems expected you would have it for the others. However, you just send so many metrics in many checks that it might be a very bad idea.