### PR TITLE
[k8s] Re-use singleton client after first GetPayload() call.

### DIFF
--- a/pkg/metadata/kubernetes/kubernetes.go
+++ b/pkg/metadata/kubernetes/kubernetes.go
@@ -16,6 +16,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 )
 
+var client *k8s.Client
+
 const (
 	createdByKey = "kubernetes.io/created-by"
 
@@ -32,9 +34,12 @@ const (
 // metrics and other services in the backend.
 func GetPayload() (metadata.Payload, error) {
 	ctx := context.Background()
-	client, err := k8s.NewInClusterClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve config: %s", err)
+	if client == nil {
+		var err error
+		client, err = k8s.NewInClusterClient()
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve config: %s", err)
+		}
 	}
 
 	dr, err := client.AppsV1Beta1().ListDeployments(ctx, "")


### PR DESCRIPTION
### What does this PR do?

Only on the first call to Kubernetes `GetPayload` do we initialize a new `k8s.Client`. After that calls will use a global, singleton client.

### Motivation

In the process-agent we were seeing a memory leak caused by constantly re-initializing this client. Unfortunately they provide no `Close()` functionality but this should give us better performance anyway.
