### PR TITLE
[metadata/gohai] Marshal value twice to comply with v5 format

### DIFF
--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -10,8 +10,44 @@ import (
 )
 
 // GohaiPayload wraps Payload from the gohai package
+// As weird as it sounds, in the v5 payload the value of the "gohai" field
+// is a JSON-formatted string. So this struct contains a MarshalledGohaiPayload
+// which will be marshalled as a JSON-formatted string.
 type GohaiPayload struct {
-	gohai.Payload
+	Marshalled MarshalledGohaiPayload `json:"gohai"`
+}
+
+// MarshalledGohaiPayload contains the marshalled payload
+type MarshalledGohaiPayload struct {
+	gohai gohai.Payload
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// It marshals the gohai struct twice (to a string) to comply with
+// the v5 payload format
+func (m MarshalledGohaiPayload) MarshalJSON() ([]byte, error) {
+	marshalledPayload, err := json.Marshal(m.gohai.Gohai)
+	if err != nil {
+		return []byte(""), err
+	}
+	doubleMarshalledPayload, err := json.Marshal(string(marshalledPayload))
+	if err != nil {
+		return []byte(""), err
+	}
+	return doubleMarshalledPayload, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// Unmarshals the passed bytes twice (first to a string, then to gohai.Gohai)
+func (m *MarshalledGohaiPayload) UnmarshalJSON(bytes []byte) error {
+	firstUnmarshall := ""
+	err := json.Unmarshal(bytes, &firstUnmarshall)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal([]byte(firstUnmarshall), &(m.gohai.Gohai))
+	return err
 }
 
 // Payload handles the JSON unmarshalling of the metadata payload

--- a/pkg/metadata/v5/payload_gohai_test.go
+++ b/pkg/metadata/v5/payload_gohai_test.go
@@ -1,0 +1,22 @@
+// +build linux windows darwin
+
+package v5
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGohaiPayloadMarshalling(t *testing.T) {
+	gp := gohai.GetPayload()
+	payload := GohaiPayload{MarshalledGohaiPayload{*gp}}
+	marshalled, err := json.Marshal(payload)
+	require.Nil(t, err)
+
+	var gohaiPayload GohaiPayload
+	err = json.Unmarshal(marshalled, &gohaiPayload)
+	require.Nil(t, err)
+}

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -19,6 +19,6 @@ func GetPayload(hostname string) *Payload {
 		CommonPayload:    CommonPayload{*cp},
 		HostPayload:      HostPayload{*hp},
 		ResourcesPayload: ResourcesPayload{*rp},
-		GohaiPayload:     GohaiPayload{*gp},
+		GohaiPayload:     GohaiPayload{MarshalledGohaiPayload{*gp}},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Marshals the gohai field twice to comply with v5 format.

### Motivation

The v5 metadata format expects the `gohai` field value to be a string that
contains a marshalled JSON object. As weird as it sounds that's how we send
this field in the agent 5, and how the backend expects it.

### Additional Notes

The implementation is ugly, but I kept things in the `v5` package (so that we can
hopefully get rid of all this entirely once the v2 metadata endpoint is available)
