### PR TITLE
separate python sender per check

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -48,7 +48,6 @@ type Check interface {
 	Stop()                                         // stop the check if it's running
 	String() string                                // provide a printable version of the check name
 	Configure(config, initConfig ConfigData) error // configure the check from the outside
-	InitSender()                                   // initialize what's needed to send data to the aggregator
 	Interval() time.Duration                       // return the interval time for the check
 	ID() ID                                        // provide a unique identifier for every check instance
 }

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -13,7 +13,6 @@ type TestCheck struct{}
 func (c *TestCheck) String() string                         { return "TestCheck" }
 func (c *TestCheck) Stop()                                  {}
 func (c *TestCheck) Configure(ConfigData, ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                            {}
 func (c *TestCheck) Interval() time.Duration                { return 1 }
 func (c *TestCheck) Run() error                             { return nil }
 func (c *TestCheck) ID() ID                                 { return ID(c.String()) }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -17,7 +17,6 @@ type TestCheck struct {
 func (c *TestCheck) String() string                        { return "TestCheck" }
 func (c *TestCheck) Stop()                                 { c.stop <- true }
 func (c *TestCheck) Configure(a, b check.ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                           {}
 func (c *TestCheck) Interval() time.Duration               { return 1 * time.Minute }
 func (c *TestCheck) Run() error                            { <-c.stop; return nil }
 func (c *TestCheck) ID() check.ID                          { return check.ID(c.String()) }

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -106,9 +106,6 @@ func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData)
 	return nil
 }
 
-// InitSender initializes a sender but we don't need any
-func (c *APMCheck) InitSender() {}
-
 // Interval returns the scheduling time for the check, this will be scheduled only once
 // since `Run` won't return, thus implementing a long running check.
 func (c *APMCheck) Interval() time.Duration {

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -350,9 +350,6 @@ func (c *JMXCheck) Configure(data, initConfig check.ConfigData) error {
 	return nil
 }
 
-// InitSender initializes a sender but we don't need any
-func (c *JMXCheck) InitSender() {}
-
 // Interval returns the scheduling time for the check, this will be scheduled only once
 // since `Run` won't return, thus implementing a long running check.
 func (c *JMXCheck) Interval() time.Duration {

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -42,7 +42,6 @@ func (gl *GoCheckLoader) Load(config check.Config) ([]check.Check, error) {
 			log.Errorf("core.loader: could not configure check %s: %s", newCheck, err)
 			continue
 		}
-		newCheck.InitSender()
 		checks = append(checks, newCheck)
 	}
 

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -12,7 +12,6 @@ type TestCheck struct{}
 
 func (c *TestCheck) String() string                                     { return "TestCheck" }
 func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                                        {}
 func (c *TestCheck) Run() error                                         { return nil }
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) Interval() time.Duration                            { return 1 }

--- a/pkg/collector/corechecks/network/common_test.go
+++ b/pkg/collector/corechecks/network/common_test.go
@@ -3,8 +3,14 @@ package network
 import (
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
+
+func init() {
+	// The MockSender requires an aggregator
+	aggregator.InitAggregator(nil, "")
+}
 
 //MockSender allows mocking of the checks sender
 type MockSender struct {

--- a/pkg/collector/corechecks/network/ntp_test.go
+++ b/pkg/collector/corechecks/network/ntp_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -21,7 +22,7 @@ func TestNTP(t *testing.T) {
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
 
 	mockSender := new(MockSender)
-	ntpCheck.sender = mockSender
+	aggregator.SetSender(mockSender, ntpCheck.ID())
 
 	mockSender.On("Gauge", "ntp.offset", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	mockSender.On("ServiceCheck",

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/k-sone/snmpgo"
 )
 
@@ -191,7 +192,7 @@ func TestSubmitSNMP(t *testing.T) {
 	initCNetSnmpLib(nil)
 
 	mock := new(MockSender)
-	snmpCheck.sender = mock
+	aggregator.SetSender(mock, snmpCheck.ID())
 
 	if err := cfg.Parse(bytes.NewBufferString(basicCfg).Bytes(), []byte{}); err != nil {
 		t.Fatalf("Unable to parse configuration: %v", err)

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/shirou/gopsutil/cpu"
 )
 
@@ -73,7 +74,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	cpuCheck.Configure(nil, nil)
 
 	mock := new(MockSender)
-	cpuCheck.sender = mock
+	aggregator.SetSender(mock, cpuCheck.ID())
 	sample = firstSample
 	cpuCheck.Run()
 

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -9,7 +9,6 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"gopkg.in/yaml.v2"
 )
 
@@ -35,17 +34,6 @@ func (c *IOCheck) commonConfigure(data check.ConfigData, initConfig check.Config
 		}
 	}
 	return err
-}
-
-// InitSender initializes a sender
-func (c *IOCheck) InitSender() {
-	s, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	c.sender = s
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -7,11 +7,10 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/disk"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 /*
@@ -35,7 +34,6 @@ const (
 
 // IOCheck doesn't need additional fields
 type IOCheck struct {
-	sender    aggregator.Sender
 	blacklist *regexp.Regexp
 	ts        int64
 	stats     map[string]disk.IOCountersStat
@@ -47,6 +45,10 @@ func (c *IOCheck) Configure(data check.ConfigData, initConfig check.ConfigData) 
 	return err
 }
 func (c *IOCheck) nixIO() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
 	// See: https://www.xaprb.com/blog/2010/01/09/how-linux-iostat-computes-its-results/
 	//      https://www.kernel.org/doc/Documentation/iostats.txt
 	iomap, err := ioCounters()
@@ -69,10 +71,10 @@ func (c *IOCheck) nixIO() error {
 		tagbuff.WriteString(device)
 		tags := []string{tagbuff.String()}
 
-		c.sender.Rate("system.io.r_s", float64(ioStats.ReadCount), "", tags)
-		c.sender.Rate("system.io.w_s", float64(ioStats.WriteCount), "", tags)
-		c.sender.Rate("system.io.rrqm_s", float64(ioStats.MergedReadCount), "", tags)
-		c.sender.Rate("system.io.wrqm_s", float64(ioStats.MergedWriteCount), "", tags)
+		sender.Rate("system.io.r_s", float64(ioStats.ReadCount), "", tags)
+		sender.Rate("system.io.w_s", float64(ioStats.WriteCount), "", tags)
+		sender.Rate("system.io.rrqm_s", float64(ioStats.MergedReadCount), "", tags)
+		sender.Rate("system.io.wrqm_s", float64(ioStats.MergedWriteCount), "", tags)
 
 		if c.ts == 0 {
 			continue
@@ -118,21 +120,21 @@ func (c *IOCheck) nixIO() error {
 			svctime = util / tput
 		}
 
-		c.sender.Gauge("system.io.rkb_s", rkbs/delta, "", tags)
-		c.sender.Gauge("system.io.wkb_s", wkbs/delta, "", tags)
-		c.sender.Gauge("system.io.avg_rq_sz", avgrqsz/delta, "", tags)
-		c.sender.Gauge("system.io.await", aWait/delta, "", tags)
-		c.sender.Gauge("system.io.r_await", rAwait/delta, "", tags)
-		c.sender.Gauge("system.io.w_await", wAwait/delta, "", tags)
-		c.sender.Gauge("system.io.avg_q_sz", avgqusz/delta, "", tags)
+		sender.Gauge("system.io.rkb_s", rkbs/delta, "", tags)
+		sender.Gauge("system.io.wkb_s", wkbs/delta, "", tags)
+		sender.Gauge("system.io.avg_rq_sz", avgrqsz/delta, "", tags)
+		sender.Gauge("system.io.await", aWait/delta, "", tags)
+		sender.Gauge("system.io.r_await", rAwait/delta, "", tags)
+		sender.Gauge("system.io.w_await", wAwait/delta, "", tags)
+		sender.Gauge("system.io.avg_q_sz", avgqusz/delta, "", tags)
 		if hz > 0 { // only send if we were able to collect HZ
-			c.sender.Gauge("system.io.svctm", svctime/delta, "", tags)
+			sender.Gauge("system.io.svctm", svctime/delta, "", tags)
 		}
 
 		// Stats should be per device no device groups.
 		// If device groups ever become a thing - util / 10.0 / n_devs_in_group
 		// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
-		c.sender.Gauge("system.io.util", (util / 10.0 / delta), "", tags)
+		sender.Gauge("system.io.util", (util / 10.0 / delta), "", tags)
 
 	}
 
@@ -143,11 +145,14 @@ func (c *IOCheck) nixIO() error {
 
 // Run executes the check
 func (c *IOCheck) Run() error {
-	var err error
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
 	err = c.nixIO()
 
 	if err == nil {
-		c.sender.Commit()
+		sender.Commit()
 	}
 	return err
 }

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/shirou/gopsutil/disk"
 )
 
@@ -62,7 +63,7 @@ func TestIOCheck(t *testing.T) {
 	ioCheck.Configure(nil, nil)
 
 	mock := new(MockSender)
-	ioCheck.sender = mock
+	aggregator.SetSender(mock, ioCheck.ID())
 
 	expectedRates := 2
 	expectedGauges := 0
@@ -126,7 +127,7 @@ func TestIOCheckBlacklist(t *testing.T) {
 	ioCheck.Configure(nil, nil)
 
 	mock := new(MockSender)
-	ioCheck.sender = mock
+	aggregator.SetSender(mock, ioCheck.ID())
 
 	//set blacklist
 	bl, err := regexp.Compile("sd.*")

--- a/pkg/collector/corechecks/system/load_test.go
+++ b/pkg/collector/corechecks/system/load_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/shirou/gopsutil/load"
 )
 
@@ -25,7 +26,7 @@ func TestLoadCheckLinux(t *testing.T) {
 	loadCheck.Configure(nil, nil)
 
 	mock := new(MockSender)
-	loadCheck.sender = mock
+	aggregator.SetSender(mock, loadCheck.ID())
 
 	var nbCPU float64
 	info, _ := cpuInfo()

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -19,9 +19,7 @@ var swapMemory = mem.SwapMemory
 var runtimeOS = runtime.GOOS
 
 // MemoryCheck doesn't need additional fields
-type MemoryCheck struct {
-	sender aggregator.Sender
-}
+type MemoryCheck struct{}
 
 func (c *MemoryCheck) String() string {
 	return "memory"
@@ -29,34 +27,56 @@ func (c *MemoryCheck) String() string {
 
 const mbSize float64 = 1024 * 1024
 
-func (c *MemoryCheck) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) {
-	c.sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
-	c.sender.Gauge("system.mem.shared", float64(v.Shared)/mbSize, "", nil)
-	c.sender.Gauge("system.mem.slab", float64(v.Slab)/mbSize, "", nil)
-	c.sender.Gauge("system.mem.page_tables", float64(v.PageTables)/mbSize, "", nil)
-	c.sender.Gauge("system.swap.cached", float64(v.SwapCached)/mbSize, "", nil)
+func (c *MemoryCheck) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
+	sender.Gauge("system.mem.shared", float64(v.Shared)/mbSize, "", nil)
+	sender.Gauge("system.mem.slab", float64(v.Slab)/mbSize, "", nil)
+	sender.Gauge("system.mem.page_tables", float64(v.PageTables)/mbSize, "", nil)
+	sender.Gauge("system.swap.cached", float64(v.SwapCached)/mbSize, "", nil)
+	return nil
 }
 
-func (c *MemoryCheck) freebsdSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) {
-	c.sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
+func (c *MemoryCheck) freebsdSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
+	return nil
 }
 
 // Run executes the check
 func (c *MemoryCheck) Run() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
 
 	v, errVirt := virtualMemory()
 	if errVirt == nil {
-		c.sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
-		c.sender.Gauge("system.mem.free", float64(v.Free)/mbSize, "", nil)
-		c.sender.Gauge("system.mem.used", float64(v.Total-v.Free)/mbSize, "", nil)
-		c.sender.Gauge("system.mem.usable", float64(v.Available)/mbSize, "", nil)
-		c.sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
+		sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
+		sender.Gauge("system.mem.free", float64(v.Free)/mbSize, "", nil)
+		sender.Gauge("system.mem.used", float64(v.Total-v.Free)/mbSize, "", nil)
+		sender.Gauge("system.mem.usable", float64(v.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
 
 		switch runtimeOS {
 		case "linux":
-			c.linuxSpecificVirtualMemoryCheck(v)
+			e := c.linuxSpecificVirtualMemoryCheck(v)
+			if e != nil {
+				return e
+			}
 		case "freebsd":
-			c.freebsdSpecificVirtualMemoryCheck(v)
+			e := c.freebsdSpecificVirtualMemoryCheck(v)
+			if e != nil {
+				return e
+			}
 		}
 	} else {
 		log.Errorf("system.MemoryCheck: could not retrieve virtual memory stats: %s", errVirt)
@@ -64,10 +84,10 @@ func (c *MemoryCheck) Run() error {
 
 	s, errSwap := swapMemory()
 	if errSwap == nil {
-		c.sender.Gauge("system.swap.total", float64(s.Total)/mbSize, "", nil)
-		c.sender.Gauge("system.swap.free", float64(s.Free)/mbSize, "", nil)
-		c.sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
-		c.sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
+		sender.Gauge("system.swap.total", float64(s.Total)/mbSize, "", nil)
+		sender.Gauge("system.swap.free", float64(s.Free)/mbSize, "", nil)
+		sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
+		sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
 	} else {
 		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
 	}
@@ -76,7 +96,7 @@ func (c *MemoryCheck) Run() error {
 		return fmt.Errorf("failed to gather any memory information")
 	}
 
-	c.sender.Commit()
+	sender.Commit()
 	return nil
 }
 
@@ -84,17 +104,6 @@ func (c *MemoryCheck) Run() error {
 func (c *MemoryCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
 	// do nothing
 	return nil
-}
-
-// InitSender initializes a sender
-func (c *MemoryCheck) InitSender() {
-	s, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	c.sender = s
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/corechecks/system/memory_test.go
+++ b/pkg/collector/corechecks/system/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func TestMemoryCheckLinux(t *testing.T) {
 	memCheck := new(MemoryCheck)
 
 	mock := new(MockSender)
-	memCheck.sender = mock
+	aggregator.SetSender(mock, memCheck.ID())
 	runtimeOS = "linux"
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -80,7 +81,7 @@ func TestMemoryCheckFreebsd(t *testing.T) {
 	memCheck := new(MemoryCheck)
 
 	mock := new(MockSender)
-	memCheck.sender = mock
+	aggregator.SetSender(mock, memCheck.ID())
 	runtimeOS = "freebsd"
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -108,7 +109,7 @@ func TestMemoryCheckDarwin(t *testing.T) {
 	memCheck := new(MemoryCheck)
 
 	mock := new(MockSender)
-	memCheck.sender = mock
+	aggregator.SetSender(mock, memCheck.ID())
 	runtimeOS = "darwin"
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -135,7 +136,7 @@ func TestMemoryError(t *testing.T) {
 	memCheck := new(MemoryCheck)
 
 	mock := new(MockSender)
-	memCheck.sender = mock
+	aggregator.SetSender(mock, memCheck.ID())
 	runtimeOS = "linux"
 
 	err := memCheck.Run()
@@ -152,7 +153,7 @@ func TestSwapMemoryError(t *testing.T) {
 	memCheck := new(MemoryCheck)
 
 	mock := new(MockSender)
-	memCheck.sender = mock
+	aggregator.SetSender(mock, memCheck.ID())
 	runtimeOS = "linux"
 
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -180,7 +181,7 @@ func TestVirtualMemoryError(t *testing.T) {
 	memCheck := new(MemoryCheck)
 
 	mock := new(MockSender)
-	memCheck.sender = mock
+	aggregator.SetSender(mock, memCheck.ID())
 	runtimeOS = "linux"
 
 	mock.On("Gauge", "system.swap.total", 100000.0/mbSize, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -15,9 +15,7 @@ import (
 var uptime = host.Uptime
 
 // UptimeCheck doesn't need additional fields
-type UptimeCheck struct {
-	sender aggregator.Sender
-}
+type UptimeCheck struct{}
 
 func (c *UptimeCheck) String() string {
 	return "uptime"
@@ -25,14 +23,19 @@ func (c *UptimeCheck) String() string {
 
 // Run executes the check
 func (c *UptimeCheck) Run() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
 	t, err := uptime()
 	if err != nil {
 		log.Errorf("system.UptimeCheck: could not retrieve uptime: %s", err)
 		return err
 	}
 
-	c.sender.Gauge("system.uptime", float64(t), "", nil)
-	c.sender.Commit()
+	sender.Gauge("system.uptime", float64(t), "", nil)
+	sender.Commit()
 
 	return nil
 }
@@ -41,17 +44,6 @@ func (c *UptimeCheck) Run() error {
 func (c *UptimeCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
 	// do nothing
 	return nil
-}
-
-// InitSender initializes a sender
-func (c *UptimeCheck) InitSender() {
-	s, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	c.sender = s
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -2,6 +2,8 @@ package system
 
 import (
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 func uptimeSampler() (uint64, error) {
@@ -14,7 +16,7 @@ func TestUptimeCheckLinux(t *testing.T) {
 	uptimeCheck.Configure(nil, nil)
 
 	mock := new(MockSender)
-	uptimeCheck.sender = mock
+	aggregator.SetSender(mock, uptimeCheck.ID())
 
 	mock.On("Gauge", "system.uptime", 555.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)

--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -81,7 +81,7 @@ class AgentCheck(object):
         if hostname is None:
             hostname = ""
 
-        aggregator.submit_metric(self, mtype, name, value, tags, hostname)
+        aggregator.submit_metric(self, self.check_id, mtype, name, value, tags, hostname)
 
     def gauge(self, name, value, tags=None, hostname=None, device_name=None):
         self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)
@@ -119,7 +119,7 @@ class AgentCheck(object):
 
     def service_check(self, name, status, tags=None, message=""):
         tags = self._normalize_tags_type(tags)
-        aggregator.submit_service_check(self, name, status, tags, message)
+        aggregator.submit_service_check(self, self.check_id, name, status, tags, message)
 
     def event(self, event):
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream
@@ -137,11 +137,11 @@ class AgentCheck(object):
             event['timestamp'] = int(event['timestamp'])
         if event.get('aggregation_key'):
             event['aggregation_key'] = str(event['aggregation_key'])
-        aggregator.submit_event(self, event)
+        aggregator.submit_event(self, self.check_id, event)
 
     def increment(self, name, value, tags=None):
         pass
-        
+
     def check(self, instance):
         raise NotImplementedError
 

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -1,8 +1,8 @@
 #include "api.h"
 
-PyObject* SubmitMetric(PyObject*, MetricType, char*, float, PyObject*, char*);
-PyObject* SubmitServiceCheck(PyObject*, char*, int, PyObject*, char*);
-PyObject* SubmitEvent(PyObject*, PyObject*);
+PyObject* SubmitMetric(PyObject*, char*, MetricType, char*, float, PyObject*, char*);
+PyObject* SubmitServiceCheck(PyObject*, char*, char*, int, PyObject*, char*);
+PyObject* SubmitEvent(PyObject*, char*, PyObject*);
 
 // _must_ be in the same order as the MetricType enum
 char* MetricTypeNames[] = {
@@ -21,18 +21,19 @@ static PyObject *submit_metric(PyObject *self, PyObject *args) {
     float value;
     PyObject *tags = NULL;
     char *hostname;
+    char *check_id;
 
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    // aggregator.submit_metric(self, aggregator.metric_type.GAUGE, name, value, tags, hostname)
-    if (!PyArg_ParseTuple(args, "OisfOs", &check, &mt, &name, &value, &tags, &hostname)) {
+    // aggregator.submit_metric(self, check_id, aggregator.metric_type.GAUGE, name, value, tags, hostname)
+    if (!PyArg_ParseTuple(args, "OsisfOs", &check, &check_id, &mt, &name, &value, &tags, &hostname)) {
       PyGILState_Release(gstate);
       return NULL;
     }
 
     PyGILState_Release(gstate);
-    return SubmitMetric(check, mt, name, value, tags, hostname);
+    return SubmitMetric(check, check_id, mt, name, value, tags, hostname);
 }
 
 static PyObject *submit_service_check(PyObject *self, PyObject *args) {
@@ -41,35 +42,37 @@ static PyObject *submit_service_check(PyObject *self, PyObject *args) {
     int status;
     PyObject *tags = NULL;
     char *message = NULL;
+    char *check_id;
 
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    // aggregator.submit_service_check(self, name, status, tags, message)
-    if (!PyArg_ParseTuple(args, "OsiOs", &check, &name, &status, &tags, &message)) {
+    // aggregator.submit_service_check(self, check_id, name, status, tags, message)
+    if (!PyArg_ParseTuple(args, "OssiOs", &check, &check_id, &name, &status, &tags, &message)) {
       PyGILState_Release(gstate);
       return NULL;
     }
 
     PyGILState_Release(gstate);
-    return SubmitServiceCheck(check, name, status, tags, message);
+    return SubmitServiceCheck(check, check_id, name, status, tags, message);
 }
 
 static PyObject *submit_event(PyObject *self, PyObject *args) {
     PyObject *check = NULL;
     PyObject *event = NULL;
+    char *check_id;
 
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    // aggregator.submit_event(self, event)
-    if (!PyArg_ParseTuple(args, "OO", &check, &event)) {
+    // aggregator.submit_event(self, check_id, event)
+    if (!PyArg_ParseTuple(args, "OsO", &check, &check_id, &event)) {
       PyGILState_Release(gstate);
       return NULL;
     }
 
     PyGILState_Release(gstate);
-    return SubmitEvent(check, event);
+    return SubmitEvent(check, check_id, event);
 }
 
 static PyMethodDef AggMethods[] = {

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"unsafe"
 
+	chk "github.com/DataDog/datadog-agent/pkg/collector/check"
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -18,10 +19,15 @@ import "C"
 
 // SubmitMetric is the method exposed to Python scripts to submit metrics
 //export SubmitMetric
-func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject, hostname *C.char) *C.PyObject {
+func SubmitMetric(check *C.PyObject, checkID *C.char, mt C.MetricType, name *C.char, value C.float, tags *C.PyObject, hostname *C.char) *C.PyObject {
 
-	sender, err := aggregator.GetDefaultSender()
-	if err != nil {
+	goCheckID := C.GoString(checkID)
+	var sender aggregator.Sender
+	var err error
+
+	sender, err = aggregator.GetSender(chk.ID(goCheckID))
+
+	if err != nil || sender == nil {
 		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return C._none()
 	}
@@ -55,11 +61,16 @@ func SubmitMetric(check *C.PyObject, mt C.MetricType, name *C.char, value C.floa
 
 // SubmitServiceCheck is the method exposed to Python scripts to submit service checks
 //export SubmitServiceCheck
-func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.PyObject, message *C.char) *C.PyObject {
+func SubmitServiceCheck(check *C.PyObject, checkID *C.char, name *C.char, status C.int, tags *C.PyObject, message *C.char) *C.PyObject {
 
-	sender, err := aggregator.GetDefaultSender()
-	if err != nil {
-		log.Errorf("Error submitting service check to the Sender: %v", err)
+	goCheckID := C.GoString(checkID)
+	var sender aggregator.Sender
+	var err error
+
+	sender, err = aggregator.GetSender(chk.ID(goCheckID))
+
+	if err != nil || sender == nil {
+		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return C._none()
 	}
 
@@ -79,11 +90,16 @@ func SubmitServiceCheck(check *C.PyObject, name *C.char, status C.int, tags *C.P
 
 // SubmitEvent is the method exposed to Python scripts to submit events
 //export SubmitEvent
-func SubmitEvent(check *C.PyObject, event *C.PyObject) *C.PyObject {
+func SubmitEvent(check *C.PyObject, checkID *C.char, event *C.PyObject) *C.PyObject {
 
-	sender, err := aggregator.GetDefaultSender()
-	if err != nil {
-		log.Errorf("Error submitting event to the Sender: %v", err)
+	goCheckID := C.GoString(checkID)
+	var sender aggregator.Sender
+	var err error
+
+	sender, err = aggregator.GetSender(chk.ID(goCheckID))
+
+	if err != nil || sender == nil {
+		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return C._none()
 	}
 

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -56,7 +56,7 @@ func (c *PythonCheck) Run() error {
 		return errors.New(pyErr)
 	}
 
-	s, err := aggregator.GetDefaultSender()
+	s, err := aggregator.GetSender(c.ID())
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
 	}
@@ -184,13 +184,15 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	}
 	log.Debugf("python check configure done %s", c.ModuleName)
 
+	// The Check ID is set in Python so that the python check
+	// can use it afterwards to submit to the proper sender in the aggregator
+	pyID := python.PyString_FromString(string(c.ID()))
+	instance.SetAttrString("check_id", pyID)
+
 	c.Instance = instance
 	c.Config = kwargs
-	return nil
-}
 
-// InitSender does nothing here because all python checks use the default sender
-func (c *PythonCheck) InitSender() {
+	return nil
 }
 
 // Interval returns the scheduling time for the check

--- a/pkg/collector/py/common_test.go
+++ b/pkg/collector/py/common_test.go
@@ -1,4 +1,4 @@
-package system
+package py
 
 import (
 	"github.com/stretchr/testify/mock"

--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from checks import AgentCheck
+
+
+class TestAggregatorCheck(AgentCheck):
+    def check(self, instance):
+        """
+        Do not interact with the Aggregator during
+        unit tests. Doing anything is ok here.
+        """
+        self.service_check("testservicecheck", AgentCheck.OK, tags=None, message="")
+        # _send_metric is not used in tests, so it should not be used to test it.
+        # Instead call gauge, which is the one that checks will be using
+        self.gauge("testmetric", 0, tags=None)
+        self.event({
+            "event_type": "new.event",
+            "msg_title": "new test event",
+            "aggregation_key": "test.event",
+            "msg_text": "test event test event",
+            "tags": None
+        })

--- a/pkg/collector/py/tests/testaggregator.yaml
+++ b/pkg/collector/py/tests/testaggregator.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - foo: bar
+    baz: bar
+  - bar: baz

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -18,7 +18,6 @@ type TestCheck struct {
 func (c *TestCheck) String() string                                     { return "TestCheck" }
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                                        {}
 func (c *TestCheck) Interval() time.Duration                            { return 1 }
 func (c *TestCheck) Run() error {
 	if c.doErr {

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -13,7 +13,6 @@ type TestCheck struct{ intl time.Duration }
 
 func (c *TestCheck) String() string                                     { return "TestCheck" }
 func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
-func (c *TestCheck) InitSender()                                        {}
 func (c *TestCheck) Interval() time.Duration                            { return c.intl }
 func (c *TestCheck) Run() error                                         { return nil }
 func (c *TestCheck) Stop()                                              {}


### PR DESCRIPTION
### What does this PR do?

Each python check needs its own sender, otherwise python checks will stomp on each others rates.

I've created a sender pool in the aggregator. It does not expose this directly, instead just using the same GetSender function that we used before.

I then call this in `api.go`, with the check name from each check as the Check ID. (I have to do some type conversion in order to make this go smoothly.) Instead of using the check name, it might be better to use the Check ID itself. This would require a few extra steps and I think the current mechanism copies what happened in Agent5, where each check object got its own aggregator, pretty well.

I have tested this and the Python checks work and send metrics and such up to DataDog.

### Additional Notes

My C is a bit rusty, but I think this works fine
