### PR TITLE
Dev Dist Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Dockerfiles/dogstatsd/alpine/dogstatsd
 
 vendor/
 bin/
+dev/
 .vscode
 
 .DS_Store

--- a/dev/dist/README.md
+++ b/dev/dist/README.md
@@ -1,0 +1,3 @@
+## Developer Dist Directory
+
+This is a directory for developers! Developers can drop their checks and configs in here, ones that they won't want to track in git, but that they want included in their dev build.

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -67,6 +67,7 @@ namespace :agent do
     FileUtils.rm_rf("#{BIN_PATH}/dist")
     FileUtils.cp_r("./pkg/collector/dist/", "#{BIN_PATH}", :remove_destination => true)
     FileUtils.cp_r("./pkg/status/dist/", "#{BIN_PATH}", :remove_destination => true)
+    FileUtils.cp_r("./dev/dist/", "#{BIN_PATH}", :remove_destination => true)
     FileUtils.mv("#{BIN_PATH}/dist/agent", "#{BIN_PATH}/agent")
     FileUtils.chmod(0755, "#{BIN_PATH}/agent")
   end


### PR DESCRIPTION
### What does this PR do?

This adds a dev controlled gitignored dist folder to the build.

### Motivation

A bunch of times, I've added checks or my own datadog.yaml to the build to test things. However, when it's just my own small additions, I do not want to add them to the git build by accident (which I've done a few times and had to `git reset HEAD~1`. This is a better solution, adding a dist folder that's dev controlled so that we can add small customizations here, while keeping git clean.
