### PR TITLE
resolves a data race in autoconfig

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -136,7 +136,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 	for _, pd := range ac.providers {
 		if pd.provider == provider {
 			// we already know this configuration provider, don't do anything
-			log.Warnf("Provider %s was already added, skipping...", provider)
+			log.Warn(fmt.Sprintf("Provider %s was already added, skipping...", provider))
 			return
 		}
 	}

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -136,6 +136,9 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 	for _, pd := range ac.providers {
 		if pd.provider == provider {
 			// we already know this configuration provider, don't do anything
+			// this is formatted inline since logging is done on a background thread,
+			// so you can only pass it things to act on if they're thread safe
+			// this is not inherently thread safe
 			log.Warn(fmt.Sprintf("Provider %s was already added, skipping...", provider))
 			return
 		}


### PR DESCRIPTION
### What does this PR do?

Instead of allowing the logger to format a line, it is formatted directly inline.

### Motivation

Logging does not happen inline, it is handed off to a background thread. This is fine, as long as you only pass it objects that are threadsafe. This object is not, we have to use the mutex to ensure safety. Unfortunately, that means that when the log hands it off to another thread to log the line, it creates a data race. This will ensure thread safety with this object.
