### PR TITLE
Split Payloads that are too big

### DIFF
--- a/pkg/collector/dist/conf.d/go_expvar.yaml.default
+++ b/pkg/collector/dist/conf.d/go_expvar.yaml.default
@@ -96,3 +96,11 @@ instances:
         alias: scheduler.queues.interval
       - path: scheduler/QueuesCount
         type: gauge
+
+      # Payload monitoring
+      - path: splitter/NotTooBig
+        type: rate
+      - path: splitter/TooBig
+        type: rate
+      - path: splitter/TotalLoops
+        type: rate

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/compression"
 )
 
 func TestNewDefaultForwarder(t *testing.T) {
@@ -73,6 +72,7 @@ func TestSubmit(t *testing.T) {
 	expectAPIKeyInQuery := false
 	expectedPayload := []byte{}
 	expectedHeaders := make(http.Header)
+	var payloads []*[]byte
 
 	firstKey := "api_key1"
 	secondKey := "api_key2"
@@ -117,53 +117,58 @@ func TestSubmit(t *testing.T) {
 	forwarder.Start()
 	defer forwarder.Stop()
 
-	payload := []byte("SubmitSeries payload")
-	expectedPayload, _ = compression.Compress(nil, payload)
+	expectedPayload = []byte("SubmitSeries payload")
 	expectedEndpoint = "/api/v2/series"
-	assert.Nil(t, forwarder.SubmitSeries(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	payload = []byte("SubmitEvents payload")
-	expectedPayload, _ = compression.Compress(nil, payload)
+	expectedPayload = []byte("SubmitEvents payload")
 	expectedEndpoint = "/api/v2/events"
-	assert.Nil(t, forwarder.SubmitEvents(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitEvents(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	payload = []byte("SubmitServiceChecks payload")
-	expectedPayload, _ = compression.Compress(nil, payload)
+	expectedPayload = []byte("SubmitServiceChecks payload")
 	expectedEndpoint = "/api/v2/service_checks"
-	assert.Nil(t, forwarder.SubmitServiceChecks(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitServiceChecks(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
 	expectedPayload = []byte("SubmitSketchSeries payload")
-	// for now, no compression and api key in query
 	expectedEndpoint = "/api/v2/sketches"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitSketchSeries(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitSketchSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 	expectAPIKeyInQuery = false
 
-	payload = []byte("SubmitHostMetadata payload")
-	expectedPayload, _ = compression.Compress(nil, payload)
+	expectedPayload = []byte("SubmitHostMetadata payload")
 	expectedEndpoint = "/api/v2/host_metadata"
-	assert.Nil(t, forwarder.SubmitHostMetadata(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitHostMetadata(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
 
-	payload = []byte("SubmitMetadata payload")
-	expectedPayload, _ = compression.Compress(nil, payload)
+	expectedPayload = []byte("SubmitMetadata payload")
 	expectedEndpoint = "/api/v2/metadata"
-	assert.Nil(t, forwarder.SubmitMetadata(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{&expectedPayload}
+	assert.Nil(t, forwarder.SubmitMetadata(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -171,7 +176,9 @@ func TestSubmit(t *testing.T) {
 	expectedPayload = []byte("SubmitV1Series payload")
 	expectedEndpoint = "/api/v1/series"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1Series(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitV1Series(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -179,7 +186,9 @@ func TestSubmit(t *testing.T) {
 	expectedPayload = []byte("SubmitV1SketchSeries payload")
 	expectedEndpoint = "/api/v1/sketches"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1SketchSeries(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitV1SketchSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -187,7 +196,9 @@ func TestSubmit(t *testing.T) {
 	expectedPayload = []byte("SubmitV1CheckRuns payload")
 	expectedEndpoint = "/api/v1/check_run"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1CheckRuns(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitV1CheckRuns(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -196,7 +207,9 @@ func TestSubmit(t *testing.T) {
 	expectedEndpoint = "/intake/"
 	expectedHeaders.Set("Content-type", "application/json")
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1Intake(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads = []*[]byte{}
+	payloads = append(payloads, &expectedPayload)
+	assert.Nil(t, forwarder.SubmitV1Intake(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -227,7 +240,9 @@ func TestSubmitWithProxy(t *testing.T) {
 	defer forwarder.Stop()
 
 	payload := []byte("SubmitSeries payload")
-	assert.Nil(t, forwarder.SubmitSeries(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads := []*[]byte{}
+	payloads = append(payloads, &payload)
+	assert.Nil(t, forwarder.SubmitSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	assert.Equal(t, 0, len(forwarder.retryQueue))
@@ -261,7 +276,9 @@ func TestSubmitWithProxyAndPassword(t *testing.T) {
 	defer forwarder.Stop()
 
 	payload := []byte("SubmitSeries payload")
-	assert.Nil(t, forwarder.SubmitSeries(&payload, map[string]string{"Content-Type": "application/unit-test"}))
+	payloads := []*[]byte{}
+	payloads = append(payloads, &payload)
+	assert.Nil(t, forwarder.SubmitSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	assert.Equal(t, 0, len(forwarder.retryQueue))

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -51,51 +51,51 @@ func (tf *MockedForwarder) Stop() {
 }
 
 // SubmitV1Series updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1Series(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitV1Series(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitV1Intake updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1Intake(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitV1Intake(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitV1CheckRuns updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1CheckRuns(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitV1CheckRuns(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitV1SketchSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1SketchSeries(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitV1SketchSeries(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitSeries(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitSeries(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitEvents updates the internal mock struct
-func (tf *MockedForwarder) SubmitEvents(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitEvents(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitServiceChecks updates the internal mock struct
-func (tf *MockedForwarder) SubmitServiceChecks(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitServiceChecks(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitSketchSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitSketchSeries(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitSketchSeries(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitHostMetadata updates the internal mock struct
-func (tf *MockedForwarder) SubmitHostMetadata(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitHostMetadata(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
 // SubmitMetadata updates the internal mock struct
-func (tf *MockedForwarder) SubmitMetadata(payload *[]byte, extraHeaders map[string]string) error {
+func (tf *MockedForwarder) SubmitMetadata(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)
 }

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
 // GohaiPayload wraps Payload from the gohai package
@@ -72,4 +73,10 @@ func (p *Payload) MarshalJSON() ([]byte, error) {
 // Marshal not implemented
 func (p *Payload) Marshal() ([]byte, error) {
 	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
+}
+
+// SplitPayload breaks the payload into times number of pieces
+func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+	// Metadata payloads are analyzed as a whole, so they cannot be split
+	return nil, fmt.Errorf("V5 Payload splitting is not implemented")
 }

--- a/pkg/metrics/event_test.go
+++ b/pkg/metrics/event_test.go
@@ -88,3 +88,29 @@ func TestMarshalJSONOmittedFields(t *testing.T) {
 	// These optional fields are not present in the serialized payload, and a default source type name is used
 	assert.Equal(t, payload, []byte("{\"apiKey\":\"\",\"events\":{\"api\":[{\"msg_title\":\"An event occurred\",\"msg_text\":\"event description\",\"timestamp\":12345,\"host\":\"my-hostname\"}]},\"internalHostname\":\"test-hostname\"}\n"))
 }
+
+func TestSplitEvents(t *testing.T) {
+	var events = Events{}
+	for i := 0; i < 2; i++ {
+		e := Event{
+			Title:          "An event occurred",
+			Text:           "event description",
+			Ts:             12345,
+			Priority:       EventPriorityNormal,
+			Host:           "my-hostname",
+			Tags:           []string{"tag1", "tag2:yes"},
+			AlertType:      EventAlertTypeError,
+			AggregationKey: "my_agg_key",
+			SourceTypeName: "custom_source_type",
+		}
+		events = append(events, &e)
+	}
+
+	newEvents, err := events.SplitPayload(2)
+	require.Nil(t, err)
+	require.Len(t, newEvents, 2)
+
+	newEvents, err = events.SplitPayload(3)
+	require.Nil(t, err)
+	require.Len(t, newEvents, 2)
+}

--- a/pkg/metrics/metric.go
+++ b/pkg/metrics/metric.go
@@ -1,8 +1,6 @@
 package metrics
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // APIMetricType represents an API metric type
 type APIMetricType int
@@ -37,6 +35,20 @@ func (a APIMetricType) MarshalText() ([]byte, error) {
 	}
 
 	return []byte(str), nil
+}
+
+// UnmarshalText is a custom unmarshaller for APIMetricType (used for testing)
+func (a APIMetricType) UnmarshalText(buf []byte) error {
+	tmp := string(buf)
+	switch tmp {
+	case "gauge":
+		a = APIGaugeType
+	case "rate":
+		a = APIRateType
+	case "count":
+		a = APICountType
+	}
+	return nil
 }
 
 // Metric is the interface of all metric types

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -87,4 +88,99 @@ func TestMarshalJSONSeries(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
 	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device\":\"/dev/sda1\",\"type\":\"gauge\",\"interval\":0,\"source_type_name\":\"System\"}]}\n"))
+}
+
+func TestSplitSeries(t *testing.T) {
+	var series = Series{}
+	for i := 0; i < 2; i++ {
+		s := Serie{
+			Points: []Point{
+				{Ts: 12345.0, Value: float64(21.21)},
+				{Ts: 67890.0, Value: float64(12.12)},
+			},
+			MType: APIGaugeType,
+			Name:  "test.metrics",
+			Host:  "localHost",
+			Tags:  []string{"tag1", "tag2:yes"},
+		}
+		series = append(series, &s)
+	}
+
+	newSeries, err := series.SplitPayload(2)
+	require.Nil(t, err)
+	require.Len(t, newSeries, 2)
+	newSeries, err = series.SplitPayload(3)
+	require.Nil(t, err)
+	require.Len(t, newSeries, 2)
+
+	series = Series{{
+		Points: []Point{
+			{Ts: 12345.0, Value: float64(21.21)},
+			{Ts: 67890.0, Value: float64(12.12)},
+		},
+		MType: APIGaugeType,
+		Name:  "test.metrics",
+		Host:  "localHost",
+		Tags:  []string{"tag1", "tag2:yes"},
+	}}
+	newSeries, err = series.SplitPayload(2)
+	require.Nil(t, err)
+	require.Len(t, newSeries, 2)
+	for _, s := range newSeries {
+		ser := s.(Series)
+		require.Len(t, ser[0].Points, 1)
+	}
+	newSeries, err = series.SplitPayload(3)
+	require.Nil(t, err)
+	require.Len(t, newSeries, 2)
+	for _, s := range newSeries {
+		ser := s.(Series)
+		require.Len(t, ser[0].Points, 1)
+	}
+}
+
+func TestUnmarshalSeriesJSON(t *testing.T) {
+	// Test one for each value of the API Type
+	series := Series{{
+		Points: []Point{
+			{Ts: 12345.0, Value: float64(21.21)},
+			{Ts: 67890.0, Value: float64(12.12)},
+		},
+		MType:    APIGaugeType,
+		Name:     "test.metrics",
+		Interval: 1,
+		Host:     "localHost",
+		Tags:     []string{"tag1", "tag2:yes"},
+	}, {
+		Points: []Point{
+			{Ts: 12345.0, Value: float64(21.21)},
+			{Ts: 67890.0, Value: float64(12.12)},
+		},
+		MType:    APIRateType,
+		Name:     "test.metrics",
+		Interval: 1,
+		Host:     "localHost",
+		Tags:     []string{"tag1", "tag2:yes"},
+	}, {
+		Points: []Point{
+			{Ts: 12345.0, Value: float64(21.21)},
+			{Ts: 67890.0, Value: float64(12.12)},
+		},
+		MType:    APICountType,
+		Name:     "test.metrics",
+		Interval: 1,
+		Host:     "localHost",
+		Tags:     []string{"tag1", "tag2:yes"},
+	}}
+
+	seriesJSON, err := series.MarshalJSON()
+	require.Nil(t, err)
+	var newSeries map[string]Series
+	err = json.Unmarshal(seriesJSON, &newSeries)
+	require.Nil(t, err)
+
+	badPointJSON := []byte(`[12345,21.21,1]`)
+	var badPoint Point
+	err = json.Unmarshal(badPointJSON, &badPoint)
+	require.NotNil(t, err)
 }

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -3,11 +3,13 @@ package metrics
 import (
 	"bytes"
 	"encoding/json"
+	"expvar"
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
 
 	agentpayload "github.com/DataDog/agent-payload/gogen"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
 // ServiceCheckStatus represents the status associated with a service check
@@ -20,6 +22,8 @@ const (
 	ServiceCheckCritical ServiceCheckStatus = 2
 	ServiceCheckUnknown  ServiceCheckStatus = 3
 )
+
+var serviceCheckExpvar = expvar.NewMap("ServiceCheck")
 
 // GetServiceCheckStatus returns the ServiceCheckStatus from and integer value
 func GetServiceCheckStatus(val int) (ServiceCheckStatus, error) {
@@ -97,4 +101,30 @@ func (sc ServiceChecks) MarshalJSON() ([]byte, error) {
 	reqBody := &bytes.Buffer{}
 	err := json.NewEncoder(reqBody).Encode(ServiceChecksAlias(sc))
 	return reqBody.Bytes(), err
+}
+
+// SplitPayload breaks the payload into times number of pieces
+func (sc ServiceChecks) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+	serviceCheckExpvar.Add("TimesSplit", 1)
+	// only split it up as much as possible
+	if len(sc) < times {
+		serviceCheckExpvar.Add("ServiceChecksShorter", 1)
+		times = len(sc)
+	}
+	splitPayloads := make([]marshaler.Marshaler, times)
+	batchSize := len(sc) / times
+	n := 0
+	for i := 0; i < times; i++ {
+		var end int
+		// the batch size will not be perfect, only split it as much as possible
+		if i < times-1 {
+			end = n + batchSize
+		} else {
+			end = len(sc)
+		}
+		newSC := ServiceChecks(sc[n:end])
+		splitPayloads[i] = newSC
+		n += batchSize
+	}
+	return splitPayloads, nil
 }

--- a/pkg/metrics/service_check_test.go
+++ b/pkg/metrics/service_check_test.go
@@ -54,3 +54,27 @@ func TestMarshalJSONServiceChecks(t *testing.T) {
 	assert.NotNil(t, payload)
 	assert.Equal(t, payload, []byte("[{\"check\":\"my_service.can_connect\",\"host_name\":\"my-hostname\",\"timestamp\":12345,\"status\":0,\"message\":\"my_service is up\",\"tags\":[\"tag1\",\"tag2:yes\"]}]\n"))
 }
+
+func TestSplitServiceChecks(t *testing.T) {
+	var serviceChecks = ServiceChecks{}
+	for i := 0; i < 2; i++ {
+		sc := ServiceCheck{
+			CheckName: "test.check",
+			Host:      "test.localhost",
+			Ts:        1000,
+			Status:    ServiceCheckOK,
+			Message:   "this is fine",
+			Tags:      []string{"tag1", "tag2:yes"},
+		}
+		serviceChecks = append(serviceChecks, &sc)
+	}
+
+	newSC, err := serviceChecks.SplitPayload(2)
+	require.Nil(t, err)
+	require.Len(t, newSC, 2)
+	require.Equal(t, 2, len(newSC))
+
+	newSC, err = serviceChecks.SplitPayload(3)
+	require.Nil(t, err)
+	require.Len(t, newSC, 2)
+}

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -1,0 +1,8 @@
+package marshaler
+
+// Marshaler is an interface for metrics that are able to serialize themselves to JSON and protobuf
+type Marshaler interface {
+	MarshalJSON() ([]byte, error)
+	Marshal() ([]byte, error)
+	SplitPayload(int) ([]Marshaler, error)
+}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/serializer/split"
+
 	log "github.com/cihub/seelog"
 )
 
 const (
-	protobufContentType = "application/x-protobuf"
-	jsonContentType     = "application/json"
-
+	protobufContentType      = "application/x-protobuf"
+	jsonContentType          = "application/json"
 	payloadVersionHTTPHeader = "DD-Agent-Payload"
 )
 
@@ -35,61 +37,62 @@ func init() {
 	}
 }
 
-// Marshaler is an interface for metrics that are able to serialize themselves to JSON and protobuf
-type Marshaler interface {
-	MarshalJSON() ([]byte, error)
-	Marshal() ([]byte, error)
-}
-
 // Serializer serializes metrics to the correct format and routes the payloads to the correct endpoint in the Forwarder
 type Serializer struct {
 	Forwarder forwarder.Forwarder
 }
 
 // SendEvents serializes a list of event and sends the payload to the forwarder
-func (s *Serializer) SendEvents(e Marshaler) error {
-	payload, err := e.MarshalJSON()
+func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
+	compress := true
+	events, err := split.Payloads(e, compress, split.MarshalJSON)
 	if err != nil {
-		return fmt.Errorf("could not serialize events, %s", err)
+		return fmt.Errorf("could not split events into small enough chunks, dropping: %s", err)
 	}
-	return s.Forwarder.SubmitV1Intake(&payload, jsonExtraHeaders)
+	return s.Forwarder.SubmitV1Intake(events, jsonExtraHeaders)
 }
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
-func (s *Serializer) SendServiceChecks(sc Marshaler) error {
-	payload, err := sc.MarshalJSON()
+func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
+	compress := false
+	serviceChecks, err := split.Payloads(sc, compress, split.MarshalJSON)
 	if err != nil {
-		return fmt.Errorf("could not serialize service checks, %s", err)
+		return fmt.Errorf("could not split service checks into small enough chunks, dropping: %s", err)
 	}
-	return s.Forwarder.SubmitV1CheckRuns(&payload, jsonExtraHeaders)
+	return s.Forwarder.SubmitV1CheckRuns(serviceChecks, jsonExtraHeaders)
 }
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder
-func (s *Serializer) SendSeries(series Marshaler) error {
-	payload, err := series.MarshalJSON()
+func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
+	compress := true
+
+	splitSeries, err := split.Payloads(series, compress, split.MarshalJSON)
 	if err != nil {
-		return fmt.Errorf("could not serialize series: %s", err)
+		return fmt.Errorf("could not split series into small enough chunks, dropping: %s", err)
 	}
-	return s.Forwarder.SubmitV1Series(&payload, jsonExtraHeaders)
+	return s.Forwarder.SubmitV1Series(splitSeries, jsonExtraHeaders)
 }
 
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder
-func (s *Serializer) SendSketch(sketches Marshaler) error {
-	payload, err := sketches.Marshal()
+func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
+	compress := false
+	splitSketches, err := split.Payloads(sketches, compress, split.Marshal)
 	if err != nil {
-		return fmt.Errorf("could not serialize sketches: %s", err)
+		return fmt.Errorf("could not split sketches into small enough chunks, dropping: %s", err)
 	}
-	return s.Forwarder.SubmitSketchSeries(&payload, protobufExtraHeaders)
+	return s.Forwarder.SubmitSketchSeries(splitSketches, protobufExtraHeaders)
 }
 
 // SendMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendMetadata(m Marshaler) error {
-	payload, err := m.MarshalJSON()
+func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
+	smallEnough, payload, err := split.CheckSizeAndSerialize(m, false, split.MarshalJSON)
 	if err != nil {
-		return fmt.Errorf("could not serialize metadata payload: %s", err)
+		return fmt.Errorf("could not determine size of metadata payload: %s", err)
+	} else if !smallEnough {
+		return fmt.Errorf("metadata payload was too big to send, metadata payloads cannot be split")
 	}
 
-	if err := s.Forwarder.SubmitV1Intake(&payload, jsonExtraHeaders); err != nil {
+	if err := s.Forwarder.SubmitV1Intake(forwarder.Payloads{&payload}, jsonExtraHeaders); err != nil {
 		return err
 	}
 
@@ -105,13 +108,11 @@ func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize v1 payload: %s", err)
 	}
-
-	if err := s.Forwarder.SubmitV1Intake(&payload, jsonExtraHeaders); err != nil {
+	if err := s.Forwarder.SubmitV1Intake(forwarder.Payloads{&payload}, jsonExtraHeaders); err != nil {
 		return err
 	}
 
 	log.Infof("Sent processes metadata payload, size: %d bytes.", len(payload))
 	log.Debugf("Sent processes metadata payload, content: %v", string(payload))
 	return nil
-
 }

--- a/pkg/serializer/split/split.go
+++ b/pkg/serializer/split/split.go
@@ -1,0 +1,148 @@
+package split
+
+import (
+	"expvar"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/util/compression"
+
+	log "github.com/cihub/seelog"
+)
+
+// the backend accepts payloads up to 3MB, but being conservative is okay
+var maxPayloadSize = 2 * 1024 * 1024
+
+// MarshalType is the type of marshaler to use
+type MarshalType int
+
+// Enumeration of the existing marshal types
+const (
+	MarshalJSON MarshalType = iota
+	Marshal
+)
+
+var splitterExpvar = expvar.NewMap("splitter")
+
+// CheckSizeAndSerialize Check the size of a payload and marshall it (optionally compress it)
+// The dual role makes sense as you will never serialize without checking the size of the payload
+func CheckSizeAndSerialize(m marshaler.Marshaler, compress bool, mType MarshalType) (bool, []byte, error) {
+	payload, _, err := serializeMarshaller(m, compress, mType)
+	if err != nil {
+		return false, nil, err
+	}
+	return checkSize(payload), payload, nil
+}
+
+// Payloads serializes a metadata payload and sends it to the forwarder
+func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarder.Payloads, error) {
+	marshallers := []marshaler.Marshaler{m}
+	smallEnoughPayloads := forwarder.Payloads{}
+	nottoobig, payload, err := CheckSizeAndSerialize(m, compress, mType)
+	if err != nil {
+		return smallEnoughPayloads, err
+	}
+	// If the payload's size is fine, just return it
+	if nottoobig {
+		log.Debug("The payload was not too big, returning the full payload")
+		splitterExpvar.Add("NotTooBig", 1)
+		smallEnoughPayloads = append(smallEnoughPayloads, &payload)
+		return smallEnoughPayloads, nil
+	}
+	splitterExpvar.Add("TooBig", 1)
+	toobig := !nottoobig
+	loops := 0
+	// Do not attempt to split payloads forever, if a payload cannot be split then abandon the task
+	// the function will return all the payloads that were able to be split
+	for toobig && loops < 3 {
+		splitterExpvar.Add("TotalLoops", 1)
+		// create a temporary slice, the other array will be reused to keep track of the payloads that have yet to be split
+		tempSlice := make([]marshaler.Marshaler, len(marshallers))
+		copy(tempSlice, marshallers)
+		marshallers = []marshaler.Marshaler{}
+		for _, toSplit := range tempSlice {
+			var e error
+			// we have to do this every time to get the proper payload
+			payload, compressedPayload, e := serializeMarshaller(toSplit, compress, mType)
+			if e != nil {
+				return smallEnoughPayloads, e
+			}
+			payloadSize := len(payload)
+			compressedSize := len(compressedPayload)
+			// Attempt to account for the compression when estimating the number of chunks that will be needed
+			// This is the same function used in dd-agent
+			compressionRatio := float64(payloadSize) / float64(compressedSize)
+			numChunks := compressedSize/maxPayloadSize + 1 + int(compressionRatio/2)
+			log.Debugf("split the payload into into %f chunks", numChunks)
+			chunks, err := toSplit.SplitPayload(numChunks)
+			log.Debugf("payload was split into %f chunks", len(chunks))
+			if err != nil {
+				return smallEnoughPayloads, err
+			}
+			// after the payload has been split, loop through the chunks
+			for _, chunk := range chunks {
+				// serialize the payload
+				smallEnough, payload, err := CheckSizeAndSerialize(chunk, compress, mType)
+				if err != nil {
+					log.Debugf("Error serializing a chunk: %s", err)
+					continue
+				}
+				if smallEnough {
+					// if the payload is small enough, return it straight away
+					smallEnoughPayloads = append(smallEnoughPayloads, &payload)
+					log.Debugf("chunk was small enough: %v, smallEnoughPayloads are of length: %v", len(payload), len(smallEnoughPayloads))
+				} else {
+					// if it is not, append it to the list of payloads
+					marshallers = append(marshallers, chunk)
+					log.Debugf("chunk was not small enough: %v, marshallers are of length: %v", len(payload), len(marshallers))
+				}
+			}
+		}
+		if len(marshallers) == 0 {
+			log.Debug("marshallers was empty, breaking out of the loop")
+			toobig = false
+		} else {
+			log.Debug("marshallers was not empty, running around the loop again")
+			loops++
+		}
+	}
+
+	return smallEnoughPayloads, nil
+}
+
+// serializeMarshaller serializes the marshaller and returns both the compressed and uncompressed payloads
+func serializeMarshaller(m marshaler.Marshaler, compress bool, mType MarshalType) ([]byte, []byte, error) {
+	var payload []byte
+	var compressedPayload []byte
+	var err error
+	payload, err = marshal(m, mType)
+	compressedPayload = payload
+	if err != nil {
+		return nil, nil, err
+	}
+	if compress {
+		compressedPayload, err = compression.Compress(nil, payload)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return compressedPayload, payload, nil
+}
+
+func checkSize(payload []byte) bool {
+	if len(payload) >= maxPayloadSize {
+		return false
+	}
+	return true
+}
+
+func marshal(m marshaler.Marshaler, mType MarshalType) ([]byte, error) {
+	switch mType {
+	case MarshalJSON:
+		return m.MarshalJSON()
+	case Marshal:
+		return m.Marshal()
+	default:
+		return m.MarshalJSON()
+	}
+}

--- a/pkg/serializer/split/split_test.go
+++ b/pkg/serializer/split/split_test.go
@@ -1,0 +1,122 @@
+package split
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPayloadsSeries(t *testing.T) {
+	testSeries := metrics.Series{}
+	for i := 0; i < 30000; i++ {
+		point := metrics.Serie{
+			Points: []metrics.Point{
+				{Ts: 12345.0, Value: float64(21.21)},
+				{Ts: 67890.0, Value: float64(12.12)},
+				{Ts: 2222.0, Value: float64(22.12)},
+				{Ts: 333.0, Value: float64(32.12)},
+				{Ts: 444444.0, Value: float64(42.12)},
+				{Ts: 882787.0, Value: float64(52.12)},
+				{Ts: 99990.0, Value: float64(62.12)},
+				{Ts: 121212.0, Value: float64(72.12)},
+				{Ts: 222227.0, Value: float64(82.12)},
+				{Ts: 808080.0, Value: float64(92.12)},
+				{Ts: 9090.0, Value: float64(13.12)},
+			},
+			MType:    metrics.APIGaugeType,
+			Name:     "test.metrics",
+			Interval: 1,
+			Host:     "localHost",
+			Tags:     []string{"tag1", "tag2:yes"},
+		}
+		testSeries = append(testSeries, &point)
+	}
+
+	originalLength := len(testSeries)
+	payloads, err := Payloads(testSeries, false, MarshalJSON)
+	require.Nil(t, err)
+	var splitSeries = []metrics.Series{}
+	for _, payload := range payloads {
+		var s = map[string]metrics.Series{}
+		err = json.Unmarshal(*payload, &s)
+		require.Nil(t, err)
+		splitSeries = append(splitSeries, s["series"])
+	}
+
+	unrolledSeries := metrics.Series{}
+	for _, series := range splitSeries {
+		for _, s := range series {
+			unrolledSeries = append(unrolledSeries, s)
+		}
+	}
+
+	newLength := len(unrolledSeries)
+	require.Equal(t, originalLength, newLength)
+}
+
+func TestSplitPayloadsEvents(t *testing.T) {
+	testEvent := metrics.Events{}
+	for i := 0; i < 30000; i++ {
+		event := metrics.Event{
+			Title:          "test title",
+			Text:           "test text",
+			Ts:             12345,
+			Host:           "test.localhost",
+			Tags:           []string{"tag1", "tag2:yes"},
+			AggregationKey: "test aggregation",
+			SourceTypeName: "test source",
+		}
+		testEvent = append(testEvent, &event)
+	}
+
+	originalLength := len(testEvent)
+	payloads, err := Payloads(testEvent, false, MarshalJSON)
+	require.Nil(t, err)
+	unrolledEvents := []interface{}{}
+	for _, payload := range payloads {
+		var s map[string]interface{}
+		err = json.Unmarshal(*payload, &s)
+		require.Nil(t, err)
+		for _, events := range s["events"].(map[string]interface{}) {
+			for _, evt := range events.([]interface{}) {
+				unrolledEvents = append(unrolledEvents, &evt)
+			}
+		}
+	}
+
+	newLength := len(unrolledEvents)
+	require.Equal(t, originalLength, newLength)
+}
+
+func TestSplitPayloadsServiceChecks(t *testing.T) {
+	testServiceChecks := metrics.ServiceChecks{}
+	for i := 0; i < 30000; i++ {
+		sc := metrics.ServiceCheck{
+			CheckName: "test.check",
+			Host:      "test.localhost",
+			Ts:        1000,
+			Status:    metrics.ServiceCheckOK,
+			Message:   "this is fine",
+			Tags:      []string{"tag1", "tag2:yes"},
+		}
+		testServiceChecks = append(testServiceChecks, &sc)
+	}
+
+	originalLength := len(testServiceChecks)
+	payloads, err := Payloads(testServiceChecks, false, MarshalJSON)
+	require.Nil(t, err)
+	unrolledServiceChecks := []interface{}{}
+	for _, payload := range payloads {
+		var s []interface{}
+		err = json.Unmarshal(*payload, &s)
+		require.Nil(t, err)
+		for _, sc := range s {
+			unrolledServiceChecks = append(unrolledServiceChecks, &sc)
+		}
+	}
+
+	newLength := len(testServiceChecks)
+	require.Equal(t, originalLength, newLength)
+}


### PR DESCRIPTION
### What does this PR do?

Payloads that are too big should be split up on the client, rather than simply rejected.

This adds a split method to the marshallers. It also splits out the Marshaller definition into its own package and the split into its own package. This is to avoid circular dependencies (which would happen otherwise).

It provides an estimation of the necessary size of the payload, it estimates it by using a function that @olivielpeau designed in the [dd-agent version of this](https://github.com/DataDog/dd-agent/pull/3454/files#diff-e1eb4058d174ea4583324176fa473dd5R172). In addition, it adds tests for both the splitting functions in the marshallers and the split package.

### Additional Notes

I did not add any tests for sketching because, honestly, I don't really understand the format. If someone could take some time to help me write them, I will, otherwise, we can leave it untested.