### PR TITLE
[aggregator] Normalize histogram's `.count` by the interval

### DIFF
--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -32,9 +32,9 @@ func (m ContextMetrics) AddSample(contextKey string, sample *MetricSample, times
 		case MonotonicCountType:
 			m[contextKey] = &MonotonicCount{}
 		case HistogramType:
-			m[contextKey] = &Histogram{} // default histogram configuration for now
+			m[contextKey] = NewHistogram(interval) // default histogram configuration (no call to `configure`) for now
 		case HistorateType:
-			m[contextKey] = &Historate{} // internal histogram have the configuration for now
+			m[contextKey] = NewHistorate(interval) // internal histogram has the configuration for now
 		case SetType:
 			m[contextKey] = NewSet()
 		case CounterType:

--- a/pkg/metrics/context_metrics_test.go
+++ b/pkg/metrics/context_metrics_test.go
@@ -169,7 +169,7 @@ func TestContextMetricsHistogramSampling(t *testing.T) {
 		},
 		&Serie{
 			ContextKey: contextKey,
-			Points:     []Point{{12351.0, 4.}},
+			Points:     []Point{{12351.0, 0.4}},
 			MType:      APIRateType,
 			NameSuffix: ".count",
 		},
@@ -229,7 +229,7 @@ func TestContextMetricsHistorateSampling(t *testing.T) {
 	AssertSerieEqual(t,
 		&Serie{
 			ContextKey: contextKey,
-			Points:     []Point{{12351.0, 3.}},
+			Points:     []Point{{12351.0, 0.3}},
 			MType:      APIRateType,
 			NameSuffix: ".count",
 		},

--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -23,6 +23,7 @@ func (w weightSamples) Swap(i, j int)      { w[i], w[j] = w[j], w[i] }
 type Histogram struct {
 	aggregates  []string // aggregates configured on this histogram
 	percentiles []int    // percentiles configured on this histogram, each in the 1-100 range
+	interval    int64    // interval over which the `count` value is normalized (bucket interval for Dogstatsd, 1 otherwise)
 	samples     weightSamples
 	configured  bool
 	sum         float64
@@ -37,6 +38,13 @@ const (
 	sumAgg    = "sum"
 	countAgg  = "count"
 )
+
+// NewHistogram returns a newly initialized histogram
+func NewHistogram(interval int64) *Histogram {
+	return &Histogram{
+		interval: interval,
+	}
+}
 
 func (h *Histogram) configure(aggregates []string, percentiles []int) {
 	h.configured = true
@@ -94,7 +102,7 @@ func (h *Histogram) flush(timestamp float64) ([]*Serie, error) {
 		case sumAgg:
 			value = h.sum
 		case countAgg:
-			value = float64(h.count)
+			value = float64(h.count) / float64(h.interval)
 			mType = APIRateType
 		default:
 			log.Infof("Configured aggregate '%s' is not implemented, skipping", aggregate)

--- a/pkg/metrics/historate.go
+++ b/pkg/metrics/historate.go
@@ -10,6 +10,13 @@ type Historate struct {
 	sampled           bool
 }
 
+// NewHistorate returns a newly-initialized historate
+func NewHistorate(interval int64) *Historate {
+	return &Historate{
+		histogram: *NewHistogram(interval),
+	}
+}
+
 func (h *Historate) addSample(sample *MetricSample, timestamp float64) {
 	if h.previousTimestamp != 0 {
 		v := (sample.Value - h.previousSample) / (timestamp - h.previousTimestamp)

--- a/pkg/metrics/historate_test.go
+++ b/pkg/metrics/historate_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestHistorateEmptyFlush(t *testing.T) {
-	h := Historate{}
+	h := NewHistorate(1)
 
 	// Flush w/o samples: error
 	_, err := h.flush(50)
@@ -16,7 +16,7 @@ func TestHistorateEmptyFlush(t *testing.T) {
 }
 
 func TestHistorateAddSampleOnce(t *testing.T) {
-	h := Historate{}
+	h := NewHistorate(1)
 	h.addSample(&MetricSample{Value: 1}, 50)
 
 	// Flush one sample: error
@@ -25,7 +25,7 @@ func TestHistorateAddSampleOnce(t *testing.T) {
 }
 
 func TestHistorateAddSample(t *testing.T) {
-	h := Historate{}
+	h := NewHistorate(1)
 
 	h.addSample(&MetricSample{Value: 1}, 50)
 	h.addSample(&MetricSample{Value: 2}, 51)


### PR DESCRIPTION
### What does this PR do?

Normalizes histogram's `.count` by the interval.

The default interval is 10 for dogstatsd (bucket interval), 1 for checks.

### Motivation

The normalization is done in the agent5. We should do the same thing
on the agent6, otherwise the histogram's `.count` metrics from
dogstatsd are 10 times higher on agent6 than agent5.
