### PR TITLE
Add process-agent as a check in Agent 6

### DIFF
--- a/omnibus/config/projects/datadog-agent6.rb
+++ b/omnibus/config/projects/datadog-agent6.rb
@@ -140,6 +140,7 @@ dependency 'jmxfetch'
 
 unless windows?
   dependency 'datadog-trace-agent'
+  dependency 'datadog-process-agent'
 end
 
 if windows?

--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -1,0 +1,18 @@
+name "datadog-process-agent"
+always_build true
+
+process_agent_branch = ENV['PROCESS_AGENT_BRANCH']
+if process_agent_branch.nil? || process_agent_branch.empty?
+    process_agent_branch = "master"
+end
+default_version process_agent_branch
+
+
+build do
+  ship_license "https://raw.githubusercontent.com/DataDog/datadog-trace-agent/#{version}/LICENSE"
+  binary = "process-agent-amd64-#{version}"
+  url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
+  command "curl #{url} -o #{binary}"
+  command "chmod +x #{binary}"
+  command "mv #{binary} #{install_dir}/embedded/bin/process-agent"
+end 

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -1,0 +1,166 @@
+// +build process
+
+package embed
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+
+	log "github.com/cihub/seelog"
+	"github.com/kardianos/osext"
+	"gopkg.in/yaml.v2"
+)
+
+type processAgentInitConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+}
+
+type processAgentCheckConf struct {
+	BinPath  string `yaml:"bin_path,omitempty"`
+	ConfPath string `yaml:"conf_path,omitempty"`
+}
+
+// ProcessAgentCheck keeps track of the running command
+type ProcessAgentCheck struct {
+	enabled bool
+	cmd     *exec.Cmd
+}
+
+func (c *ProcessAgentCheck) String() string {
+	return "Process Agent"
+}
+
+// Run executes the check
+func (c *ProcessAgentCheck) Run() error {
+	if !c.enabled {
+		log.Info("Not running process_agent because 'enabled' is false in init_config")
+		return nil
+	}
+
+	// forward the standard output to the Agent logger
+	stdout, err := c.cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		in := bufio.NewScanner(stdout)
+		for in.Scan() {
+			log.Info(in.Text())
+		}
+	}()
+
+	// forward the standard error to the Agent logger
+	stderr, err := c.cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		in := bufio.NewScanner(stderr)
+		for in.Scan() {
+			log.Error(in.Text())
+		}
+	}()
+
+	if err = c.cmd.Start(); err != nil {
+		return err
+	}
+
+	return c.cmd.Wait()
+}
+
+// Configure the ProcessAgentCheck
+func (c *ProcessAgentCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	var initConf processAgentInitConfig
+	if err := yaml.Unmarshal(initConfig, &initConf); err != nil {
+		return err
+	}
+	c.enabled = initConf.Enabled
+
+	var checkConf processAgentCheckConf
+	if err := yaml.Unmarshal(data, &checkConf); err != nil {
+		return err
+	}
+
+	binPath := ""
+	defaultBinPath, defaultBinPathErr := getProcessAgentDefaultBinPath()
+	if checkConf.BinPath != "" {
+		if _, err := os.Stat(checkConf.BinPath); err == nil {
+			binPath = checkConf.BinPath
+		} else {
+			log.Warnf("Can't access process-agent binary at %s, falling back to default path at %s", checkConf.BinPath, defaultBinPath)
+		}
+	}
+
+	if binPath == "" {
+		if defaultBinPathErr != nil {
+			return defaultBinPathErr
+		}
+		binPath = defaultBinPath
+	}
+
+	// let the process-agent use its own default config file if we haven't explicitly configured one
+	ddConfigOption := ""
+	if checkConf.ConfPath != "" {
+		ddConfigOption = fmt.Sprintf("-ddconfig=%s", checkConf.ConfPath)
+	}
+
+	c.cmd = exec.Command(binPath, ddConfigOption)
+
+	env := os.Environ()
+	env = append(env,
+		fmt.Sprintf("DD_HOSTNAME=%s", getHostname()),
+		"DD_PROCESS_AGENT_ENABLED=true",
+	)
+	c.cmd.Env = env
+
+	return nil
+}
+
+// InitSender initializes a sender but we don't need any
+func (c *ProcessAgentCheck) InitSender() {}
+
+// Interval returns the scheduling time for the check, this will be scheduled only once
+// since `Run` won't return, thus implementing a long running check.
+func (c *ProcessAgentCheck) Interval() time.Duration {
+	return 0
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (c *ProcessAgentCheck) ID() check.ID {
+	return "PROCESS_AGENT"
+}
+
+// Stop sends a termination signal to the process-agent process
+func (c *ProcessAgentCheck) Stop() {
+	if !c.enabled {
+		return
+	}
+
+	err := c.cmd.Process.Signal(os.Kill)
+	if err != nil {
+		log.Errorf("unable to stop process-agent check: %s", err)
+	}
+}
+
+func init() {
+	factory := func() check.Check {
+		return &ProcessAgentCheck{}
+	}
+	core.RegisterCheck("process_agent", factory)
+}
+
+func getProcessAgentDefaultBinPath() (string, error) {
+	here, _ := osext.ExecutableFolder()
+	binPath := path.Join(here, "..", "..", "embedded", "bin", "process-agent")
+	if _, err := os.Stat(binPath); err == nil {
+		return binPath, nil
+	}
+	return binPath, fmt.Errorf("Can't access the default process-agent binary at %s", binPath)
+}

--- a/pkg/collector/dist/conf.d/process_agent.yaml.default
+++ b/pkg/collector/dist/conf.d/process_agent.yaml.default
@@ -1,0 +1,12 @@
+init_config:
+  enabled: false
+
+instances:
+- {} # default instance, if you need to customize its configuration, please comment out this instance
+     # and customize the configuration options on the instance below
+
+#   # path to process agent binary, defaults to `embedded/bin/process-agent` in agent installation dir
+# - bin_path: /opt/datadog-agent/embedded/bin/process-agent
+
+#   # Path to classic agent configuration, defaults to `/etc/dd-agent/datadog.conf`
+#   conf_path: /etc/dd-agent/datadog.conf

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -15,7 +15,7 @@ end
 
 # `tags` option
 def go_build_tags
-  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm docker ec2 gce"
+  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm docker ec2 gce process"
   build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
 end
 


### PR DESCRIPTION
### What does this PR do?

Adding process-agent as a long-running check following the style of the APM check. The omnibus portion comes from the dd-agent-omnibus repo.

The only difference is this check has an `enabled` flag in the process_agent config with a default of false since we're not (yet) rolling this out by default.

### Motivation

As croissant continues moving staging to Agent 6 we want the process-agent to keep running without having to maintain the old `dd-process-agent` package.

### Additional Notes

We eventually need to support having additional config in datadog.yaml