### PR TITLE
[metadata] Add ECS metadata provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,7 @@
 [[projects]]
   name = "github.com/DataDog/agent-payload"
   packages = ["gogen"]
-  revision = "480a98b258fa6ee55641d7a9c3729770e5b2ba34"
+  revision = "fb25fcedf155de94e762080a914adb5436d45b9c"
   version = "4.3"
 
 [[projects]]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -43,6 +44,11 @@ func init() {
 	// BUG(massi): make the listener_windows.go module actually use the following:
 	Datadog.SetDefault("cmd_pipe_name", `\\.\pipe\ddagent`)
 	Datadog.SetDefault("check_runners", int64(4))
+	if IsContainerized() {
+		Datadog.SetDefault("proc_root", "/host/proc")
+	} else {
+		Datadog.SetDefault("proc_root", "/proc")
+	}
 	// Forwarder
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("forwarder_retry_queue_max_size", 30)
@@ -70,6 +76,7 @@ func init() {
 	Datadog.BindEnv("cmd_sock")
 	Datadog.BindEnv("conf_path")
 	Datadog.BindEnv("enable_metadata_collection")
+	Datadog.BindEnv("proc_root")
 	Datadog.BindEnv("dogstatsd_socket")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")
 	Datadog.BindEnv("kubernetes_kubelet_host")
@@ -168,4 +175,9 @@ func getMultipleEndpoints(config *viper.Viper) (map[string][]string, error) {
 	}
 
 	return keysPerDomain, nil
+}
+
+// IsContainerized returns whether the Agent is running on a Docker container
+func IsContainerized() bool {
+	return os.Getenv("DOCKER_DD_AGENT") == "yes"
 }

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -1,0 +1,179 @@
+package ecs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	payload "github.com/DataDog/agent-payload/gogen"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata"
+	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/docker/docker/client"
+)
+
+const (
+	// DefaultAgentPort is the default port used by the ECS Agent.
+	DefaultAgentPort = 51678
+)
+
+// DetectedAgentURL stores the URL of the ECS agent. After the first call to
+// getHostname this will be detected and used as-is going forward. It will only
+// be re-detected if getHostname is called again.
+var detectedAgentURL string
+
+type (
+	// CommandsV1Response is the format of a response from the ECS-agent on the root.
+	CommandsV1Response struct {
+		AvailableCommands []string `json:"AvailableCommands"`
+	}
+
+	// TasksV1Response is the format of a response from the ECS tasks API.
+	// See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
+	TasksV1Response struct {
+		Tasks []TaskV1 `json:"tasks"`
+	}
+
+	// TaskV1 is the format of a Task in the ECS tasks API.
+	TaskV1 struct {
+		Arn           string        `json:"Arn"`
+		DesiredStatus string        `json:"DesiredStatus"`
+		KnownStatus   string        `json:"KnownStatus"`
+		Family        string        `json:"Family"`
+		Version       string        `json:"Version"`
+		Containers    []ContainerV1 `json:"containers"`
+	}
+
+	// ContainerV1 is the format of a Container in the ECS tasks API.
+	ContainerV1 struct {
+		DockerID   string `json:"DockerId"`
+		DockerName string `json:"DockerName"`
+		Name       string `json:"Name"`
+	}
+)
+
+// GetPayload returns a payload.ECSMetadataPayload with metadat about the state
+// of the local ECS containers running on this node. This data is provided via
+// the local ECS agent.
+func GetPayload() (metadata.Payload, error) {
+	if detectedAgentURL == "" {
+		url, err := detectAgentURL()
+		if err != nil {
+			return nil, err
+		}
+		detectedAgentURL = url
+	}
+
+	r, err := http.Get(fmt.Sprintf("%sv1/tasks", detectedAgentURL))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	var resp TasksV1Response
+	if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+	return parseTaskResponse(resp), nil
+}
+
+// IsAgentNotDetected indicates if an error from GetPayload was about no
+// ECS agent being detected. This is a used as a way to check if is available
+// or if the host is not in an ECS cluster.
+func IsAgentNotDetected(err error) bool {
+	return strings.Contains(err.Error(), "could not detect Agent URL")
+}
+
+// detectAgentURL finds a hostname for the ECS-agent either via Docker, if
+// running inside of a container, or just defaulting to localhost.
+func detectAgentURL() (string, error) {
+	urls := make([]string, 0, 3)
+	if config.IsContainerized() {
+		client, err := client.NewEnvClient()
+		if err != nil {
+			return "", err
+		}
+		defer client.Close()
+
+		// Try all networks available on the ecs container.
+		ecsConfig, err := client.ContainerInspect(context.TODO(), "amazon-ecs-agent")
+		if err != nil {
+			return "", err
+		}
+		for _, network := range ecsConfig.NetworkSettings.Networks {
+			ip := network.IPAddress
+			if ip != "" {
+				urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
+			}
+		}
+
+		// Try the default gateway
+		gw, err := dockerutil.DefaultGateway()
+		if err != nil {
+			// "expected" errors are handled in DefaultGateway so only
+			// unexpected errors are bubbled up, so we keep bubbling.
+			return "", err
+		}
+		if gw != nil {
+			urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))
+		}
+	}
+
+	// Always try the localhost URL.
+	urls = append(urls, fmt.Sprintf("http://localhost:%d/", DefaultAgentPort))
+	detected := testURLs(urls, 1*time.Second)
+	if detected != "" {
+		return detected, nil
+	}
+	return "", fmt.Errorf("could not detect Agent URL, tried: %s", urls)
+}
+
+// testURLs trys a set of URLs and returns the first one that succeeds.
+func testURLs(urls []string, timeout time.Duration) string {
+	client := &http.Client{Timeout: timeout}
+	for _, url := range urls {
+		r, err := client.Get(url)
+		if err != nil {
+			continue
+		}
+		if r.StatusCode != http.StatusOK {
+			continue
+		}
+		var resp CommandsV1Response
+		if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+			fmt.Printf("decode err: %s\n", err)
+			continue
+		}
+		if len(resp.AvailableCommands) > 0 {
+			return url
+		}
+	}
+	return ""
+}
+
+func parseTaskResponse(resp TasksV1Response) *payload.ECSMetadataPayload {
+	tasks := make([]*payload.ECSMetadataPayload_Task, 0, len(resp.Tasks))
+	for _, t := range resp.Tasks {
+		containers := make([]*payload.ECSMetadataPayload_Container, 0, len(t.Containers))
+		for _, c := range t.Containers {
+			containers = append(containers, &payload.ECSMetadataPayload_Container{
+				DockerId:   c.DockerID,
+				DockerName: c.DockerName,
+				Name:       c.Name,
+			})
+		}
+
+		tasks = append(tasks, &payload.ECSMetadataPayload_Task{
+			Arn:           t.Arn,
+			DesiredStatus: t.DesiredStatus,
+			KnownStatus:   t.KnownStatus,
+			Family:        t.Family,
+			Version:       t.Version,
+			Containers:    containers,
+		})
+	}
+	return &payload.ECSMetadataPayload{Tasks: tasks}
+}

--- a/pkg/metadata/ecs/ecs_test.go
+++ b/pkg/metadata/ecs/ecs_test.go
@@ -1,0 +1,101 @@
+package ecs
+
+import (
+	"fmt"
+	"net/http"
+
+	payload "github.com/DataDog/agent-payload/gogen"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var nextTestResponse string
+
+func runServer(t *testing.T, exit chan bool) {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Satisfy the initial check of URLs
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"AvailableCommands\":[\"/license\",\"/v1/metadata\",\"/v1/tasks\"]}"))
+	})
+	http.HandleFunc("/v1/tasks", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(nextTestResponse))
+	})
+
+	s := &http.Server{Addr: fmt.Sprintf(":%d", DefaultAgentPort)}
+	go s.ListenAndServe()
+	<-exit
+	s.Close()
+}
+
+func TestGetPayload(t *testing.T) {
+	assert := assert.New(t)
+	exit := make(chan bool)
+	go runServer(t, exit)
+	for _, tc := range []struct {
+		input    string
+		expected *payload.ECSMetadataPayload
+		hasError bool
+	}{
+		{
+			input: `{}`,
+			expected: &payload.ECSMetadataPayload{
+				Tasks: []*payload.ECSMetadataPayload_Task{},
+			},
+		},
+		{
+			input: `{
+			  "Tasks": [
+			    {
+			      "Arn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+			      "DesiredStatus": "RUNNING",
+			      "KnownStatus": "RUNNING",
+			      "Family": "hello_world",
+			      "Version": "8",
+			      "Containers": [
+			        {
+			          "DockerId": "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+			          "DockerName": "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+			          "Name": "mysql"
+			        },
+			        {
+			          "DockerId": "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+			          "DockerName": "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+			          "Name": "wordpress"
+			        }
+			      ]
+			    }
+			  ]
+			}`,
+			expected: &payload.ECSMetadataPayload{
+				Tasks: []*payload.ECSMetadataPayload_Task{
+					&payload.ECSMetadataPayload_Task{
+						Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+						DesiredStatus: "RUNNING",
+						KnownStatus:   "RUNNING",
+						Family:        "hello_world",
+						Version:       "8",
+						Containers: []*payload.ECSMetadataPayload_Container{
+							&payload.ECSMetadataPayload_Container{
+								DockerId:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+								DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+								Name:       "mysql",
+							},
+							&payload.ECSMetadataPayload_Container{
+								DockerId:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+								DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+								Name:       "wordpress",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		nextTestResponse = tc.input
+		p, err := GetPayload()
+		assert.NoError(err)
+		assert.Equal(tc.expected, p)
+	}
+	exit <- true
+}

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -1,9 +1,18 @@
 package docker
 
 import (
+	"bufio"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+	log "github.com/cihub/seelog"
 	"github.com/docker/docker/client"
 )
 
@@ -13,6 +22,7 @@ func GetHostname() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer client.Close()
 
 	info, err := client.Info(context.Background())
 	if err != nil {
@@ -25,4 +35,34 @@ func GetHostname() (string, error) {
 // HostnameProvider docker implementation for the hostname provider
 func HostnameProvider(hostName string) (string, error) {
 	return GetHostname()
+}
+
+// DefaultGateway returns the default Docker gateway.
+func DefaultGateway() (net.IP, error) {
+	procRoot := config.Datadog.GetString("proc_root")
+	netRouteFile := filepath.Join(procRoot, "net", "route")
+	f, err := os.Open(netRouteFile)
+	if os.IsNotExist(err) || os.IsPermission(err) {
+		log.Errorf("unable to open %s: %s", netRouteFile, err)
+		return nil, nil
+	} else if err != nil {
+		// Unknown error types will bubble up for handling.
+		return nil, err
+	}
+	defer f.Close()
+
+	ip := make(net.IP, 4)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 3 && fields[1] == "00000000" {
+			ipInt, err := strconv.ParseInt(fields[2], 16, 32)
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse ip %s, from %s: %s", fields[2], netRouteFile, err)
+			}
+			binary.LittleEndian.PutUint32(ip, uint32(ipInt))
+			break
+		}
+	}
+	return ip, nil
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -137,11 +137,6 @@ func GetHostname() (string, error) {
 	return hostName, err
 }
 
-// IsContainerized returns whether the Agent is running on a Docker container
-func isContainerized() bool {
-	return os.Getenv("DOCKER_DD_AGENT") == "yes"
-}
-
 // IsKubernetes returns whether the Agent is running on a kubernetes cluster
 func isKubernetes() bool {
 	return os.Getenv("KUBERNETES_PORT") != ""

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -5,13 +5,14 @@
 package util
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	log "github.com/cihub/seelog"
 )
 
 func getContainerHostname() (bool, string) {
 	var name string
-	if isContainerized() {
+	if config.IsContainerized() {
 		// Docker
 		log.Debug("GetHostname trying Docker API...")
 		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {


### PR DESCRIPTION
### What does this PR do?

Simply collecting metadata from the local agent provided by the API. See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html

### Motivation

https://trello.com/c/tad5fiho/357-agent-collect-ecs-metadata

### Additional notes

Depends on https://github.com/DataDog/agent-payload/pull/10 and will require a version bump in glide.lock before merge.
