### PR TITLE
Add agent-payload version to the HTTP headers

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,6 @@ var versionCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		av, _ := version.New(version.AgentVersion)
-		fmt.Println(fmt.Sprintf("Agent %s - Codename: %s - Commit: %s", av.GetNumber(), av.Meta, av.Commit))
+		fmt.Println(fmt.Sprintf("Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
 	},
 }

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -47,7 +47,7 @@ extensions for special Datadog features.`,
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			av, _ := version.New(version.AgentVersion)
-			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s", av.GetNumber(), av.Meta, av.Commit))
+			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
 		},
 	}
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,7 +42,8 @@ import:
   - gogoproto
   - proto
 - package: github.com/DataDog/agent-payload
-  version: ^4.3
+  # version for agent-payload has to be exact since it's used in the forwarder payload
+  version: 4.3
 - package: github.com/patrickmn/go-cache
   version: ^2.0.0
 - package: github.com/k-sone/snmpgo

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -60,12 +60,12 @@ func TestSubmitInStopMode(t *testing.T) {
 	forwarder := NewDefaultForwarder(nil)
 
 	assert.NotNil(t, forwarder)
-	assert.NotNil(t, forwarder.SubmitSeries(nil, ""))
-	assert.NotNil(t, forwarder.SubmitEvents(nil, ""))
-	assert.NotNil(t, forwarder.SubmitServiceChecks(nil, ""))
-	assert.NotNil(t, forwarder.SubmitSketchSeries(nil, ""))
-	assert.NotNil(t, forwarder.SubmitHostMetadata(nil, ""))
-	assert.NotNil(t, forwarder.SubmitMetadata(nil, ""))
+	assert.NotNil(t, forwarder.SubmitSeries(nil, map[string]string{}))
+	assert.NotNil(t, forwarder.SubmitEvents(nil, map[string]string{}))
+	assert.NotNil(t, forwarder.SubmitServiceChecks(nil, map[string]string{}))
+	assert.NotNil(t, forwarder.SubmitSketchSeries(nil, map[string]string{}))
+	assert.NotNil(t, forwarder.SubmitHostMetadata(nil, map[string]string{}))
+	assert.NotNil(t, forwarder.SubmitMetadata(nil, map[string]string{}))
 }
 
 func TestSubmit(t *testing.T) {
@@ -120,7 +120,7 @@ func TestSubmit(t *testing.T) {
 	payload := []byte("SubmitSeries payload")
 	expectedPayload, _ = compression.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/series"
-	assert.Nil(t, forwarder.SubmitSeries(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitSeries(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	<-wait
@@ -129,7 +129,7 @@ func TestSubmit(t *testing.T) {
 	payload = []byte("SubmitEvents payload")
 	expectedPayload, _ = compression.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/events"
-	assert.Nil(t, forwarder.SubmitEvents(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitEvents(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -137,7 +137,7 @@ func TestSubmit(t *testing.T) {
 	payload = []byte("SubmitServiceChecks payload")
 	expectedPayload, _ = compression.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/service_checks"
-	assert.Nil(t, forwarder.SubmitServiceChecks(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitServiceChecks(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -146,7 +146,7 @@ func TestSubmit(t *testing.T) {
 	// for now, no compression and api key in query
 	expectedEndpoint = "/api/v2/sketches"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitSketchSeries(&expectedPayload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitSketchSeries(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -155,7 +155,7 @@ func TestSubmit(t *testing.T) {
 	payload = []byte("SubmitHostMetadata payload")
 	expectedPayload, _ = compression.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/host_metadata"
-	assert.Nil(t, forwarder.SubmitHostMetadata(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitHostMetadata(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -163,7 +163,7 @@ func TestSubmit(t *testing.T) {
 	payload = []byte("SubmitMetadata payload")
 	expectedPayload, _ = compression.Compress(nil, payload)
 	expectedEndpoint = "/api/v2/metadata"
-	assert.Nil(t, forwarder.SubmitMetadata(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitMetadata(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -171,7 +171,7 @@ func TestSubmit(t *testing.T) {
 	expectedPayload = []byte("SubmitV1Series payload")
 	expectedEndpoint = "/api/v1/series"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1Series(&expectedPayload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitV1Series(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -179,7 +179,7 @@ func TestSubmit(t *testing.T) {
 	expectedPayload = []byte("SubmitV1SketchSeries payload")
 	expectedEndpoint = "/api/v1/sketches"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1SketchSeries(&expectedPayload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitV1SketchSeries(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -187,7 +187,7 @@ func TestSubmit(t *testing.T) {
 	expectedPayload = []byte("SubmitV1CheckRuns payload")
 	expectedEndpoint = "/api/v1/check_run"
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1CheckRuns(&expectedPayload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitV1CheckRuns(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -196,7 +196,7 @@ func TestSubmit(t *testing.T) {
 	expectedEndpoint = "/intake/"
 	expectedHeaders.Set("Content-type", "application/json")
 	expectAPIKeyInQuery = true
-	assert.Nil(t, forwarder.SubmitV1Intake(&expectedPayload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitV1Intake(&expectedPayload, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	assert.Equal(t, len(forwarder.retryQueue), 0)
@@ -227,7 +227,7 @@ func TestSubmitWithProxy(t *testing.T) {
 	defer forwarder.Stop()
 
 	payload := []byte("SubmitSeries payload")
-	assert.Nil(t, forwarder.SubmitSeries(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitSeries(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	assert.Equal(t, 0, len(forwarder.retryQueue))
@@ -261,7 +261,7 @@ func TestSubmitWithProxyAndPassword(t *testing.T) {
 	defer forwarder.Stop()
 
 	payload := []byte("SubmitSeries payload")
-	assert.Nil(t, forwarder.SubmitSeries(&payload, "application/unit-test"))
+	assert.Nil(t, forwarder.SubmitSeries(&payload, map[string]string{"Content-Type": "application/unit-test"}))
 	// wait for the queries to complete before changing expected value
 	<-wait
 	assert.Equal(t, 0, len(forwarder.retryQueue))

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -34,3 +34,68 @@ func (t *testTransaction) Process(client *http.Client) error {
 func (t *testTransaction) Reschedule() {
 	t.Called()
 }
+
+// MockedForwarder a mocked forwarder to be use in other module to test their dependencies with the forwarder
+type MockedForwarder struct {
+	mock.Mock
+}
+
+// Start updates the internal mock struct
+func (tf *MockedForwarder) Start() error {
+	return tf.Called().Error(0)
+}
+
+// Stop updates the internal mock struct
+func (tf *MockedForwarder) Stop() {
+	tf.Called()
+}
+
+// SubmitV1Series updates the internal mock struct
+func (tf *MockedForwarder) SubmitV1Series(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitV1Intake updates the internal mock struct
+func (tf *MockedForwarder) SubmitV1Intake(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitV1CheckRuns updates the internal mock struct
+func (tf *MockedForwarder) SubmitV1CheckRuns(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitV1SketchSeries updates the internal mock struct
+func (tf *MockedForwarder) SubmitV1SketchSeries(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitSeries updates the internal mock struct
+func (tf *MockedForwarder) SubmitSeries(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitEvents updates the internal mock struct
+func (tf *MockedForwarder) SubmitEvents(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitServiceChecks updates the internal mock struct
+func (tf *MockedForwarder) SubmitServiceChecks(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitSketchSeries updates the internal mock struct
+func (tf *MockedForwarder) SubmitSketchSeries(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitHostMetadata updates the internal mock struct
+func (tf *MockedForwarder) SubmitHostMetadata(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}
+
+// SubmitMetadata updates the internal mock struct
+func (tf *MockedForwarder) SubmitMetadata(payload *[]byte, extraHeaders map[string]string) error {
+	return tf.Called(payload, extraHeaders).Error(0)
+}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -11,7 +11,29 @@ import (
 const (
 	protobufContentType = "application/x-protobuf"
 	jsonContentType     = "application/json"
+
+	payloadVersionHTTPHeader = "DD-Agent-Payload"
 )
+
+var (
+	// AgentPayloadVersion is the versions of the agent-payload repository
+	// used to serialize to protobuf
+	AgentPayloadVersion string
+
+	jsonExtraHeaders     map[string]string
+	protobufExtraHeaders map[string]string
+)
+
+func init() {
+	jsonExtraHeaders = map[string]string{
+		"Content-Type": jsonContentType,
+	}
+
+	protobufExtraHeaders = map[string]string{
+		"Content-Type":           protobufContentType,
+		payloadVersionHTTPHeader: AgentPayloadVersion,
+	}
+}
 
 // Marshaler is an interface for metrics that are able to serialize themselves to JSON and protobuf
 type Marshaler interface {
@@ -30,7 +52,7 @@ func (s *Serializer) SendEvents(e Marshaler) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize events, %s", err)
 	}
-	return s.Forwarder.SubmitV1Intake(&payload, jsonContentType)
+	return s.Forwarder.SubmitV1Intake(&payload, jsonExtraHeaders)
 }
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
@@ -39,7 +61,7 @@ func (s *Serializer) SendServiceChecks(sc Marshaler) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize service checks, %s", err)
 	}
-	return s.Forwarder.SubmitV1CheckRuns(&payload, jsonContentType)
+	return s.Forwarder.SubmitV1CheckRuns(&payload, jsonExtraHeaders)
 }
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder
@@ -48,7 +70,7 @@ func (s *Serializer) SendSeries(series Marshaler) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize series: %s", err)
 	}
-	return s.Forwarder.SubmitV1Series(&payload, jsonContentType)
+	return s.Forwarder.SubmitV1Series(&payload, jsonExtraHeaders)
 }
 
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder
@@ -57,7 +79,7 @@ func (s *Serializer) SendSketch(sketches Marshaler) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize sketches: %s", err)
 	}
-	return s.Forwarder.SubmitSketchSeries(&payload, protobufContentType)
+	return s.Forwarder.SubmitSketchSeries(&payload, protobufExtraHeaders)
 }
 
 // SendMetadata serializes a metadata payload and sends it to the forwarder
@@ -67,7 +89,7 @@ func (s *Serializer) SendMetadata(m Marshaler) error {
 		return fmt.Errorf("could not serialize metadata payload: %s", err)
 	}
 
-	if err := s.Forwarder.SubmitV1Intake(&payload, jsonContentType); err != nil {
+	if err := s.Forwarder.SubmitV1Intake(&payload, jsonExtraHeaders); err != nil {
 		return err
 	}
 
@@ -84,7 +106,7 @@ func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
 		return fmt.Errorf("could not serialize v1 payload: %s", err)
 	}
 
-	if err := s.Forwarder.SubmitV1Intake(&payload, jsonContentType); err != nil {
+	if err := s.Forwarder.SubmitV1Intake(&payload, jsonExtraHeaders); err != nil {
 		return err
 	}
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -1,0 +1,143 @@
+package serializer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+)
+
+func TestInit(t *testing.T) {
+	assert.Equal(t, map[string]string{"Content-Type": jsonContentType}, jsonExtraHeaders)
+
+	assert.Equal(t,
+		map[string]string{
+			payloadVersionHTTPHeader: "",
+			"Content-Type":           protobufContentType,
+		},
+		protobufExtraHeaders)
+}
+
+var (
+	jsonString     = []byte("TO JSON")
+	protobufString = []byte("TO PROTOBUF")
+)
+
+type testPayload struct{}
+
+func (p *testPayload) MarshalJSON() ([]byte, error) { return jsonString, nil }
+func (p *testPayload) Marshal() ([]byte, error)     { return protobufString, nil }
+
+type testErrorPayload struct{}
+
+func (p *testErrorPayload) MarshalJSON() ([]byte, error) { return nil, fmt.Errorf("some error") }
+func (p *testErrorPayload) Marshal() ([]byte, error)     { return nil, fmt.Errorf("some error") }
+
+func TestSendEvents(t *testing.T) {
+	f := &forwarder.MockedForwarder{}
+	f.On("SubmitV1Intake", &jsonString, jsonExtraHeaders).Return(nil).Times(1)
+
+	s := Serializer{Forwarder: f}
+
+	payload := &testPayload{}
+	err := s.SendEvents(payload)
+	require.Nil(t, err)
+	f.AssertExpectations(t)
+
+	errPayload := &testErrorPayload{}
+	err = s.SendEvents(errPayload)
+	require.NotNil(t, err)
+}
+
+func TestSendServiceChecks(t *testing.T) {
+	f := &forwarder.MockedForwarder{}
+	f.On("SubmitV1CheckRuns", &jsonString, jsonExtraHeaders).Return(nil).Times(1)
+
+	s := Serializer{Forwarder: f}
+
+	payload := &testPayload{}
+	err := s.SendServiceChecks(payload)
+	require.Nil(t, err)
+	f.AssertExpectations(t)
+
+	errPayload := &testErrorPayload{}
+	err = s.SendServiceChecks(errPayload)
+	require.NotNil(t, err)
+}
+
+func TestSendSeries(t *testing.T) {
+	f := &forwarder.MockedForwarder{}
+	f.On("SubmitV1Series", &jsonString, jsonExtraHeaders).Return(nil).Times(1)
+
+	s := Serializer{Forwarder: f}
+
+	payload := &testPayload{}
+	err := s.SendSeries(payload)
+	require.Nil(t, err)
+	f.AssertExpectations(t)
+
+	errPayload := &testErrorPayload{}
+	err = s.SendSeries(errPayload)
+	require.NotNil(t, err)
+}
+
+func TestSendSketch(t *testing.T) {
+	f := &forwarder.MockedForwarder{}
+	f.On("SubmitSketchSeries", &protobufString, protobufExtraHeaders).Return(nil).Times(1)
+
+	s := Serializer{Forwarder: f}
+
+	payload := &testPayload{}
+	err := s.SendSketch(payload)
+	require.Nil(t, err)
+	f.AssertExpectations(t)
+
+	errPayload := &testErrorPayload{}
+	err = s.SendSketch(errPayload)
+	require.NotNil(t, err)
+}
+
+func TestSendMetadata(t *testing.T) {
+	f := &forwarder.MockedForwarder{}
+	f.On("SubmitV1Intake", &jsonString, jsonExtraHeaders).Return(nil).Times(1)
+
+	s := Serializer{Forwarder: f}
+
+	payload := &testPayload{}
+	err := s.SendMetadata(payload)
+	require.Nil(t, err)
+	f.AssertExpectations(t)
+
+	f.On("SubmitV1Intake", &jsonString, jsonExtraHeaders).Return(fmt.Errorf("some error")).Times(1)
+	err = s.SendMetadata(payload)
+	require.NotNil(t, err)
+	f.AssertExpectations(t)
+
+	errPayload := &testErrorPayload{}
+	err = s.SendMetadata(errPayload)
+	require.NotNil(t, err)
+}
+
+func TestSendJSONToV1Intake(t *testing.T) {
+	f := &forwarder.MockedForwarder{}
+	payload := []byte("\"test\"")
+	f.On("SubmitV1Intake", &payload, jsonExtraHeaders).Return(nil).Times(1)
+
+	s := Serializer{Forwarder: f}
+
+	err := s.SendJSONToV1Intake("test")
+	require.Nil(t, err)
+	f.AssertExpectations(t)
+
+	f.On("SubmitV1Intake", &payload, jsonExtraHeaders).Return(fmt.Errorf("some error")).Times(1)
+	err = s.SendJSONToV1Intake("test")
+	require.NotNil(t, err)
+	f.AssertExpectations(t)
+
+	errPayload := &testErrorPayload{}
+	err = s.SendJSONToV1Intake(errPayload)
+	require.NotNil(t, err)
+}

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -24,7 +24,7 @@ namespace :agent do
     # default to the embedded one.
     env = {}
     gcflags = []
-    ldflags = []
+    ldflags = get_base_ldflags()
     if !ENV["USE_SYSTEM_LIBS"]
       if os == "windows"
         env["PKG_CONFIG_PATH"] = "#{PKG_CONFIG_EMBEDDED_PATH}"
@@ -51,8 +51,6 @@ namespace :agent do
       build_success = system(env, command)
       fail "Agent build failed with code #{$?.exitstatus}" if !build_success
     end
-    commit = `git rev-parse --short HEAD`.strip
-    ldflags << "-X #{REPO_PATH}/pkg/version.commit=#{commit}"
     if ENV["DELVE"]
       gcflags << "-N" << "-l"
       if os == "windows"

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -1,4 +1,5 @@
 require 'rake/clean'
+require 'yaml'
 
 def os
   case RUBY_PLATFORM
@@ -17,6 +18,17 @@ end
 def go_build_tags
   build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm docker ec2 gce"
   build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
+end
+
+def get_base_ldflags()
+  # get agent-payload version
+  agent_payload_version = YAML.load_file("glide.yaml")["import"].find {|p| p["package"] == "github.com/DataDog/agent-payload"}["version"]
+  commit = `git rev-parse --short HEAD`.strip
+
+  ldflags = [
+    "-X #{REPO_PATH}/pkg/version.commit=#{commit}",
+    "-X #{REPO_PATH}/pkg/serializer.AgentPayloadVersion=#{agent_payload_version}",
+  ]
 end
 
 def go_fmt(path, fail_on_mod)

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -13,14 +13,13 @@ namespace :dogstatsd do
     static_bin = ENV['static'] == "true"
 
     bin_path = DOGSTATSD_BIN_PATH
-    commit = `git rev-parse --short HEAD`.strip
-    ldflags = "-X #{REPO_PATH}/pkg/version.commit=#{commit}"
+    ldflags = get_base_ldflags()
     if static_bin then
-      ldflags += " -s -w -extldflags \"-static\""
+      ldflags << " -s -w -extldflags \"-static\""
       bin_path = STATIC_BIN_PATH
     end
 
-    sh("go build #{race_opt} #{build_type_opt} -tags '#{go_build_tags}' -o #{bin_path}/#{bin_name("dogstatsd")} -ldflags \"#{ldflags}\" #{REPO_PATH}/cmd/dogstatsd/")
+    sh("go build #{race_opt} #{build_type_opt} -tags '#{go_build_tags}' -o #{bin_path}/#{bin_name("dogstatsd")} -ldflags \"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/dogstatsd/")
   end
 
   desc "Run Dogstatsd"

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -58,38 +58,38 @@ func (f *forwarderBenchStub) Start() error {
 func (f *forwarderBenchStub) Stop() {
 	return
 }
-func (f *forwarderBenchStub) SubmitV1Series(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitV1Series(payload *[]byte, extraHeaders map[string]string) error {
 	f.computeStats(payload)
 	return nil
 }
-func (f *forwarderBenchStub) SubmitV1Intake(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitV1Intake(payload *[]byte, extraHeaders map[string]string) error {
 	f.computeStats(payload)
 	return nil
 }
-func (f *forwarderBenchStub) SubmitV1CheckRuns(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitV1CheckRuns(payload *[]byte, extraHeaders map[string]string) error {
 	f.computeStats(payload)
 	return nil
 }
-func (f *forwarderBenchStub) SubmitV1SketchSeries(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitV1SketchSeries(payload *[]byte, extraHeaders map[string]string) error {
 	f.computeStats(payload)
 	return nil
 }
-func (f *forwarderBenchStub) SubmitSeries(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitSeries(payload *[]byte, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
-func (f *forwarderBenchStub) SubmitEvents(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitEvents(payload *[]byte, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
-func (f *forwarderBenchStub) SubmitServiceChecks(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitServiceChecks(payload *[]byte, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
-func (f *forwarderBenchStub) SubmitSketchSeries(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitSketchSeries(payload *[]byte, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
-func (f *forwarderBenchStub) SubmitHostMetadata(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitHostMetadata(payload *[]byte, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
-func (f *forwarderBenchStub) SubmitMetadata(payload *[]byte, contentType string) error {
+func (f *forwarderBenchStub) SubmitMetadata(payload *[]byte, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }
 


### PR DESCRIPTION
### What does this PR do?

In order to let the backend have specific endpoint per agent-payload we send the version of agent-payload in the headers. This commit also make it available in the 'version' command for the agent and dogstatsd.