### PR TITLE
CircleCI: bumped go to v.1.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
     IMPORT_PATH: "/home/ubuntu/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-    GIMME_GO_VERSION: 1.7.4
+    GIMME_GO_VERSION: 1.8.3
     PATH: "$PATH:$HOME/bin"
 
   post:


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### Motivation

We fell behind with the go version on circleci

