### PR TITLE
[aggregator][benchmark] enable memory benchmarking.

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
-const defaultFlushInterval = 15 // flush interval in seconds
+const DefaultFlushInterval = 15 // flush interval in seconds
 const bucketSize = 10           // fixed for now
 
 // Stats stores a statistic from several past flushes allowing computations like median or percentiles
@@ -92,7 +92,7 @@ func init() {
 
 // InitAggregator returns the Singleton instance
 func InitAggregator(s *serializer.Serializer, hostname string) *BufferedAggregator {
-	return InitAggregatorWithFlushInterval(s, hostname, defaultFlushInterval)
+	return InitAggregatorWithFlushInterval(s, hostname, DefaultFlushInterval)
 }
 
 // InitAggregatorWithFlushInterval returns the Singleton instance with a configured flush interval
@@ -142,7 +142,7 @@ func NewBufferedAggregator(s *serializer.Serializer, hostname string, flushInter
 		sampler:            *NewTimeSampler(bucketSize, hostname),
 		checkSamplers:      make(map[check.ID]*CheckSampler),
 		distSampler:        *NewDistSampler(bucketSize, hostname),
-		flushInterval:      defaultFlushInterval,
+		flushInterval:      flushInterval,
 		serializer:         s,
 		hostname:           hostname,
 		hostnameUpdate:     make(chan string),

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
+// DefaultFlushInterval aggregator default flush interval
 const DefaultFlushInterval = 15 // flush interval in seconds
 const bucketSize = 10           // fixed for now
 

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -43,6 +43,12 @@ type metricStats struct {
 	Lock          sync.RWMutex
 }
 
+type RawSender interface {
+	SendRawMetricSample(sample *metrics.MetricSample)
+	SendRawServiceCheck(sc *metrics.ServiceCheck)
+	Event(e metrics.Event)
+}
+
 // checkSender implements Sender
 type checkSender struct {
 	id               check.ID
@@ -158,6 +164,12 @@ func (s *checkSender) cyclemetricStats() {
 	s.priormetricStats.Lock.Unlock()
 }
 
+// SendRawMetricSample sends the raw sample
+// Useful for testing - submitting precomputed samples.
+func (s *checkSender) SendRawMetricSample(sample *metrics.MetricSample) {
+	s.smsOut <- senderMetricSample{s.id, sample, false}
+}
+
 func (s *checkSender) sendMetricSample(metric string, value float64, hostname string, tags []string, mType metrics.MetricType) {
 	log.Debug(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
 
@@ -215,6 +227,12 @@ func (s *checkSender) Histogram(metric string, value float64, hostname string, t
 // Warning this doesn't use the harmonic mean, beware of what it means when using it.
 func (s *checkSender) Historate(metric string, value float64, hostname string, tags []string) {
 	s.sendMetricSample(metric, value, hostname, tags, metrics.HistorateType)
+}
+
+// SendRawServiceCheck sends the raw service check
+// Useful for testing - submitting precomputed service check.
+func (s *checkSender) SendRawServiceCheck(sc *metrics.ServiceCheck) {
+	s.serviceCheckOut <- *sc
 }
 
 // ServiceCheck submits a service check

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -43,6 +43,7 @@ type metricStats struct {
 	Lock          sync.RWMutex
 }
 
+// RawSender interface to submit samples to aggregator directly
 type RawSender interface {
 	SendRawMetricSample(sample *metrics.MetricSample)
 	SendRawServiceCheck(sc *metrics.ServiceCheck)

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -22,7 +22,7 @@ type ServiceCheckStatus int
 
 // Enumeration of the existing service check statuses, and their values
 const (
-	ServiceCheckOK       ServiceCheckStatus = 0
+	ServiceCheckOK       ServiceCheckStatus = iota
 	ServiceCheckWarning  ServiceCheckStatus = 1
 	ServiceCheckCritical ServiceCheckStatus = 2
 	ServiceCheckUnknown  ServiceCheckStatus = 3

--- a/tasks/benchmarks.py
+++ b/tasks/benchmarks.py
@@ -92,3 +92,4 @@ def aggregator(ctx):
       options +=" -api-key {}".format(key)
 
     ctx.run("{} -points 2,10,100,500,1000 -series 10,100,1000 -log-level info -json {}".format(bin_path, options))
+    ctx.run("{} -points 2,10,100,500,1000 -series 10,100,1000 -log-level info -json -memory -duration 10 {}".format(bin_path, options))

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/test/util"
 )
 
 var (
@@ -200,11 +201,14 @@ func main() {
 		fmt.Printf("could not set loggger: %s", err)
 		return
 	}
+	defer log.Flush()
 
 	if *branchName == "" {
 		log.Criticalf("Error: '-branch' parameter is mandatory")
 		return
 	}
+
+	util.SetHostname("foo")
 
 	f := &forwarderBenchStub{}
 	s := &serializer.Serializer{Forwarder: f}
@@ -237,8 +241,9 @@ func main() {
 		nbSeries = append(nbSeries, res)
 	}
 
+	var plotRes string
 	if *memory {
-		benchmarkMemory(agg, sender, nbPoints, nbSeries, *memips, *duration)
+		plotRes = benchmarkMemory(agg, sender, nbPoints, nbSeries, *memips, *duration)
 	} else {
 		agg.TickerChan = flush
 

--- a/test/benchmarks/aggregator/memory.go
+++ b/test/benchmarks/aggregator/memory.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"expvar"
+	"math/rand"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/test/util"
+	log "github.com/cihub/seelog"
+)
+
+func preAllocateMetrics(n int) map[string][]*metrics.MetricSample {
+
+	metricMap := make(map[string][]*metrics.MetricSample)
+	metricTemplate := "benchmark.metric." + util.RandomString(7)
+
+	for mType := metrics.GaugeType; mType <= metrics.DistributionType; mType++ {
+		metricName := metricTemplate + "_" + metrics.MetricType(mType).String()
+		samples := make([]*metrics.MetricSample, n)
+
+		for i, _ := range samples {
+			value := float64(rand.Intn(1024))
+			s := &metrics.MetricSample{
+				Name:       metricName,
+				Value:      value,
+				Mtype:      mType,
+				Tags:       []string{"a", "b:21", "c"},
+				Host:       "localhost",
+				SampleRate: 1,
+				Timestamp:  util.TimeNowNano(),
+			}
+			samples[i] = s
+		}
+		metricType := metrics.MetricType(mType).String()
+		metricMap[metricType] = samples
+	}
+
+	return metricMap
+}
+
+func preAllocateEvents(n int) []*metrics.Event {
+	events := make([]*metrics.Event, n)
+
+	for i, _ := range events {
+		event := &metrics.Event{
+			Title:          "Event title",
+			Text:           "some text",
+			Ts:             21,
+			Priority:       metrics.EventPriorityNormal,
+			Host:           "localhost",
+			Tags:           []string{"a", "b:21", "c"},
+			AlertType:      metrics.EventAlertTypeWarning,
+			AggregationKey: "",
+			SourceTypeName: "",
+			EventType:      "",
+		}
+		events[i] = event
+	}
+
+	return events
+}
+
+func preAllocateServiceChecks(n int) []*metrics.ServiceCheck {
+	scs := make([]*metrics.ServiceCheck, n)
+
+	for i, _ := range scs {
+		sc := &metrics.ServiceCheck{
+			CheckName: "benchmark.sc." + util.RandomString(4),
+			Status:    metrics.ServiceCheckOK,
+			Host:      "localhost",
+			Ts:        time.Now().Unix(),
+			Tags:      []string{"a", "b:21", "c"},
+			Message:   "foo",
+		}
+		scs[i] = sc
+	}
+
+	return scs
+}
+
+func benchmarkMemory(agg *aggregator.BufferedAggregator, sender aggregator.Sender, series, points []int, ips, dur int) {
+	defer log.Flush()
+
+	var wg sync.WaitGroup
+	ticker := time.NewTicker(time.Second / time.Duration(ips))
+
+	// Get raw sender
+	rawSender, ok := sender.(aggregator.RawSender)
+	if !ok {
+		log.Error("[aggregator] sender not RawSender - cannot continue with benchmark")
+		return
+	}
+
+	// Get memory stats from expvar:
+	memstatsFunc := expvar.Get("memstats").(expvar.Func)
+	memstats := memstatsFunc().(runtime.MemStats)
+
+	quitGenerator := make(chan bool)
+
+	for _, s := range series {
+		for _, p := range points {
+			// pre-allocate for operational memory usage benchmarking
+			metrics := make([]map[string][]*metrics.MetricSample, s)
+			for i := range metrics {
+				metrics[i] = preAllocateMetrics(p)
+			}
+			scs := preAllocateServiceChecks(p)
+			events := preAllocateEvents(p)
+			sent := 0
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				i := 0
+				for _ = range ticker.C {
+					i += 1
+					i = i % p
+					select {
+					case <-quitGenerator:
+						return
+					default:
+						// Submit Metrics
+						for _, m := range metrics {
+							for _, generated := range m {
+								rawSender.SendRawMetricSample(generated[i])
+								sent += 1
+							}
+						}
+
+						// Submit ServiceCheck
+						rawSender.SendRawServiceCheck(scs[i])
+						sent += 1
+
+						// Submit Event
+						rawSender.Event(*events[i])
+						sent += 1
+					}
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				log.Infof("[aggregator] starting memory statter")
+				initial := memstats.Alloc
+				tickChan := time.NewTicker(time.Second).C
+				defer wg.Done()
+
+				secs := 0
+				for _ = range tickChan {
+					current := memstats.Alloc
+					log.Infof("[aggregator] allocated: %v delta: %v mallocs: %v ", current, current-initial, memstats.Mallocs)
+					if secs == dur {
+						quitGenerator <- true
+						return
+					} else {
+						secs += 1
+					}
+				}
+			}()
+
+			wg.Wait()
+			log.Infof("[aggregator] benchmark concluded at a rate of %v pps (avg over %v secs)", sent/dur, dur)
+
+		}
+	}
+}

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/test/util"
 	log "github.com/cihub/seelog"
 )
 
@@ -266,7 +267,7 @@ func main() {
 				if !(*rnd) {
 					packets = make([]string, *ser)
 					for i := range packets {
-						packets[i] = buildPayload("foo.bar", rand.Int63n(1000), []byte("|g"), []string{randomString(*pad)}, 1)
+						packets[i] = buildPayload("foo.bar", rand.Int63n(1000), []byte("|g"), []string{util.RandomString(*pad)}, 1)
 					}
 				}
 
@@ -281,9 +282,9 @@ func main() {
 						if *rnd {
 							buf.Reset()
 							buf.WriteString("foo.")
-							buf.WriteString(randomString(*ser))
+							buf.WriteString(util.RandomString(*ser))
 
-							err = submitPacket([]byte(buildPayload(buf.String(), rand.Int63n(1000), []byte("|g"), []string{randomString(*pad)}, 2)), generator)
+							err = submitPacket([]byte(buildPayload(buf.String(), rand.Int63n(1000), []byte("|g"), []string{util.RandomString(*pad)}, 2)), generator)
 						} else {
 							err = submitPacket([]byte(packets[rand.Int63n(int64(*ser))]), generator)
 						}

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -207,7 +207,7 @@ func createMetric(value float64, tags []string, name string, t int64) datadog.Me
 }
 
 func main() {
-	if err := initLogging(); err != nil {
+	if err := util.InitLogging("info"); err != nil {
 		log.Infof("Unable to replace logger, default logging will apply (highly verbose): %s", err)
 	}
 	defer log.Flush()

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"time"
+
+	"math/rand"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandomString(size int) string {
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func TimeNowNano() float64 {
+	return float64(time.Now().UnixNano()) / float64(time.Second) // Unix time with nanosecond precision
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -23,7 +23,7 @@ func TimeNowNano() float64 {
 }
 
 func InitLogging(level string) error {
-	err := config.SetupLogger(level, "")
+	err := config.SetupLogger(level, "", "", false, false, "")
 	if err != nil {
 		return fmt.Errorf("Unable to initiate logger: %s", err)
 	}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"fmt"
+	"math/rand"
 	"time"
 
-	"math/rand"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -18,4 +20,17 @@ func RandomString(size int) string {
 
 func TimeNowNano() float64 {
 	return float64(time.Now().UnixNano()) / float64(time.Second) // Unix time with nanosecond precision
+}
+
+func InitLogging(level string) error {
+	err := config.SetupLogger(level, "")
+	if err != nil {
+		return fmt.Errorf("Unable to initiate logger: %s", err)
+	}
+
+	return nil
+}
+
+func SetHostname(hostname string) {
+	config.Datadog.Set("hostname", hostname)
 }


### PR DESCRIPTION
### What does this PR do?

This PR enables memory benchmarking for the aggregator.

The PR does two things:
 - collects usage stats over time for each iteration.
 - collects usage stats with respect to the rates (but just for the final iteration).

The most important value here is definitely the delta between packets submitted and the evolution of memory usage over time. Because we preallocate memory for the samples (metrics, service checks and events) it's obvious that the process memory bloats up proportionally (as do the number of live objects) with the number of samples. For this reason only the deltas and mallocs between iterations are of real interest.

We should perhaps consider if we want fuller `rate vs memory` statistics - maybe computing the average delta at a particular, rate, etc. 

```
./bin/benchmarks/aggregator --duration 20 -flush_ival 15 -ips 2 -memory -series "1,10" -points "1000,5000,50000" -plot test.plot
```

A `-plot filename` flag is available to generate a gnuplot script to visualize the metrics.


### Motivation

Understand aggregator memory usage.

