### PR TITLE
[metadata] Make macos OS payload a list

### DIFF
--- a/pkg/metadata/host/host_darwin.go
+++ b/pkg/metadata/host/host_darwin.go
@@ -6,16 +6,8 @@ import (
 	"github.com/shirou/gopsutil/host"
 )
 
-type osVersion struct {
-	Release     string    `json:"release"`
-	Versioninfo [3]string `json:"versioninfo"`
-	Machine     string    `json:"machine"`
-}
+type osVersion [3]interface{}
 
 func fillOsVersion(stats *systemStats, info *host.InfoStat) {
-	stats.Macver = osVersion{
-		Release:     info.PlatformVersion,
-		Versioninfo: [3]string{"", "", ""},
-		Machine:     runtime.GOARCH,
-	}
+	stats.Macver = osVersion{info.PlatformVersion, [3]string{"", "", ""}, runtime.GOARCH}
 }

--- a/pkg/metadata/host/host_darwin_test.go
+++ b/pkg/metadata/host/host_darwin_test.go
@@ -11,5 +11,6 @@ func TestFillOsVersion(t *testing.T) {
 	stats := &systemStats{}
 	info, _ := host.Info()
 	fillOsVersion(stats, info)
-	assert.NotEmpty(t, stats.Macver.Release)
+	assert.Len(t, stats.Nixver, 3)
+	assert.NotEmpty(t, stats.Macver[0])
 }

--- a/pkg/metadata/host/host_darwin_test.go
+++ b/pkg/metadata/host/host_darwin_test.go
@@ -11,6 +11,6 @@ func TestFillOsVersion(t *testing.T) {
 	stats := &systemStats{}
 	info, _ := host.Info()
 	fillOsVersion(stats, info)
-	assert.Len(t, stats.Nixver, 3)
+	assert.Len(t, stats.Macver, 3)
 	assert.NotEmpty(t, stats.Macver[0])
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Make macos OS payload a list

### Motivation

It's a list for all the other OS, and it used to be a list in agent5.

### Additional Notes

Anything else we should know when reviewing?