### PR TITLE
[AD] make the file provider aware of AD identifiers in yaml files

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -19,10 +19,11 @@ type ConfigRawMap map[interface{}]interface{}
 
 // Config is a generic container for configuration files
 type Config struct {
-	ID         ID           // the resource this Config applies to. Can be empty
-	Name       string       // the name of the check
-	Instances  []ConfigData // array of Yaml configurations
-	InitConfig ConfigData   // the init_config in Yaml (python check only)
+	ID            ID           // the unique ID for this config
+	Name          string       // the name of the check
+	Instances     []ConfigData // array of Yaml configurations
+	InitConfig    ConfigData   // the init_config in Yaml (python check only)
+	ADIdentifiers []string     // the list of AutoDiscovery identifiers (optional)
 }
 
 // Check is an interface for types capable to run checks

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -187,14 +187,16 @@ func getCheckConfig(name, fpath string) (check.Config, error) {
 	// Read AutoDiscovery data, try to use the old `docker_image` settings
 	// param first
 	if len(cf.DockerImages) > 0 {
-		log.Warn("'docker_image' section is deprecated and will be eventually removed, use 'ad_identifiers' instead")
+		log.Warnf("'docker_image' section in %s is deprecated and will be eventually removed, use 'ad_identifiers' instead",
+			fpath)
 		config.ADIdentifiers = cf.DockerImages
 	}
 
 	// Override the legacy param with the new one, `ad_identifiers`
 	if len(cf.ADIdentifiers) > 0 {
 		if len(config.ADIdentifiers) > 0 {
-			log.Warn("Overwriting the deprecated 'docker_image' section in favor of the new 'ad_identifiers' one")
+			log.Warnf("Overwriting the deprecated 'docker_image' section from %s in favor of the new 'ad_identifiers' one",
+				fpath)
 		}
 		config.ADIdentifiers = cf.ADIdentifiers
 	}

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -13,8 +13,10 @@ import (
 )
 
 type configFormat struct {
-	InitConfig interface{} `yaml:"init_config"`
-	Instances  []check.ConfigRawMap
+	ADIdentifiers []string    `yaml:"ad_identifiers"`
+	DockerImages  []string    `yaml:"docker_images"`
+	InitConfig    interface{} `yaml:"init_config"`
+	Instances     []check.ConfigRawMap
 }
 
 // FileConfigProvider collect configuration files from disk
@@ -180,6 +182,17 @@ func getCheckConfig(name, fpath string) (check.Config, error) {
 		// at this point the Yaml was already parsed, no need to check the error
 		rawConf, _ := yaml.Marshal(instance)
 		config.Instances = append(config.Instances, rawConf)
+	}
+
+	// Read AutoDiscovery data, try to use the old `docker_image` settings
+	// param first
+	if len(cf.DockerImages) > 0 {
+		config.ADIdentifiers = cf.DockerImages
+	}
+
+	// Override the legacy param with the new one, `ad_identifiers`
+	if len(cf.ADIdentifiers) > 0 {
+		config.ADIdentifiers = cf.ADIdentifiers
 	}
 
 	return config, err

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -187,11 +187,15 @@ func getCheckConfig(name, fpath string) (check.Config, error) {
 	// Read AutoDiscovery data, try to use the old `docker_image` settings
 	// param first
 	if len(cf.DockerImages) > 0 {
+		log.Warn("'docker_image' section is deprecated and will be eventually removed, use 'ad_identifiers' instead")
 		config.ADIdentifiers = cf.DockerImages
 	}
 
 	// Override the legacy param with the new one, `ad_identifiers`
 	if len(cf.ADIdentifiers) > 0 {
+		if len(config.ADIdentifiers) > 0 {
+			log.Warn("Overwriting the deprecated 'docker_image' section in favor of the new 'ad_identifiers' one")
+		}
 		config.ADIdentifiers = cf.ADIdentifiers
 	}
 

--- a/pkg/collector/providers/file_test.go
+++ b/pkg/collector/providers/file_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCheckConfig(t *testing.T) {
@@ -23,11 +24,20 @@ func TestGetCheckConfig(t *testing.T) {
 
 	// valid configuration file
 	config, err = getCheckConfig("foo", "tests/testcheck.yaml")
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, config.Name, "foo")
 	assert.Equal(t, []byte(config.InitConfig), []byte("- test: 21\n"))
 	assert.Equal(t, len(config.Instances), 1)
 	assert.Equal(t, []byte(config.Instances[0]), []byte("foo: bar\n"))
+	assert.Len(t, config.ADIdentifiers, 0)
+
+	// autodiscovery
+	config, err = getCheckConfig("foo", "tests/ad_legacy.yaml")
+	require.Nil(t, err)
+	assert.Equal(t, config.ADIdentifiers, []string{"foo", "bar"})
+	config, err = getCheckConfig("foo", "tests/ad.yaml")
+	require.Nil(t, err)
+	assert.Equal(t, config.ADIdentifiers, []string{"foo_id", "bar_id"})
 }
 
 func TestNewYamlConfigProvider(t *testing.T) {

--- a/pkg/collector/providers/file_test.go
+++ b/pkg/collector/providers/file_test.go
@@ -57,7 +57,7 @@ func TestCollect(t *testing.T) {
 
 	assert.Nil(t, err)
 	// total number of configurations found
-	assert.Equal(t, 6, len(configs))
+	assert.Equal(t, 8, len(configs))
 
 	// count how many configs were found for a given check
 	get := func(name string) []check.Config {

--- a/pkg/collector/providers/tests/ad.yaml
+++ b/pkg/collector/providers/tests/ad.yaml
@@ -1,0 +1,13 @@
+docker_images:
+  - foo
+  - bar
+
+ad_identifiers:
+  - foo_id
+  - bar_id
+
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar

--- a/pkg/collector/providers/tests/ad_legacy.yaml
+++ b/pkg/collector/providers/tests/ad_legacy.yaml
@@ -1,0 +1,9 @@
+docker_images:
+  - foo
+  - bar
+
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar


### PR DESCRIPTION
### What does this PR do?

Read the `docker_images` section of check config files.
Also changed the name of the config param to `ad_identifiers` for clarity while still supporting the old one.

### Motivation

Need this for AD
