### PR TITLE
Add a retry policies for endpoints with a lot of errors.

### DIFF
--- a/pkg/forwarder/blocked_endpoints.go
+++ b/pkg/forwarder/blocked_endpoints.go
@@ -1,0 +1,63 @@
+package forwarder
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	blockInterval    time.Duration = 5 * time.Second
+	maxBlockInterval time.Duration = 30 * time.Second
+)
+
+type block struct {
+	nbError int
+	until   time.Time
+}
+
+type blockedEndpoints struct {
+	errorPerEndpoint map[string]*block
+	m                sync.RWMutex
+}
+
+func newBlockedEndpoints() *blockedEndpoints {
+	return &blockedEndpoints{errorPerEndpoint: make(map[string]*block)}
+}
+
+func (e *blockedEndpoints) block(endpointName string) {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	var b *block
+	if knownBlock, ok := e.errorPerEndpoint[endpointName]; ok {
+		b = knownBlock
+	} else {
+		b = &block{}
+	}
+	b.nbError++
+
+	newInterval := time.Duration(b.nbError) * blockInterval
+	if newInterval > maxRetryInterval {
+		newInterval = maxBlockInterval
+	}
+	b.until = time.Now().Add(newInterval)
+
+	e.errorPerEndpoint[endpointName] = b
+}
+
+func (e *blockedEndpoints) unblock(endpoint string) {
+	e.m.Lock()
+	defer e.m.Unlock()
+
+	delete(e.errorPerEndpoint, endpoint)
+}
+
+func (e *blockedEndpoints) isBlock(endpoint string) bool {
+	e.m.RLock()
+	defer e.m.RUnlock()
+
+	if b, ok := e.errorPerEndpoint[endpoint]; ok && time.Now().Before(b.until) {
+		return true
+	}
+	return false
+}

--- a/pkg/forwarder/blocked_endpoints_test.go
+++ b/pkg/forwarder/blocked_endpoints_test.go
@@ -1,0 +1,80 @@
+package forwarder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlock(t *testing.T) {
+	e := newBlockedEndpoints()
+
+	before := time.Now()
+	e.block("test")
+	after := time.Now()
+	assert.Contains(t, e.errorPerEndpoint, "test")
+	assert.True(t, before.Add(blockInterval).Before(e.errorPerEndpoint["test"].until))
+	assert.True(t, after.Add(blockInterval).After(e.errorPerEndpoint["test"].until))
+}
+
+func TestMaxBlock(t *testing.T) {
+	e := newBlockedEndpoints()
+	e.block("test")
+	e.errorPerEndpoint["test"].nbError = 100
+
+	before := time.Now()
+	e.block("test")
+	after := time.Now()
+	assert.Contains(t, e.errorPerEndpoint, "test")
+	assert.True(t, before.Add(maxBlockInterval).Before(e.errorPerEndpoint["test"].until))
+	assert.True(t, after.Add(maxBlockInterval).After(e.errorPerEndpoint["test"].until))
+}
+
+func TestUnblock(t *testing.T) {
+	e := newBlockedEndpoints()
+
+	e.block("test")
+	require.Contains(t, e.errorPerEndpoint, "test")
+
+	e.unblock("test")
+	assert.NotContains(t, e.errorPerEndpoint, "test")
+}
+
+func TestUnblockUnknown(t *testing.T) {
+	e := newBlockedEndpoints()
+
+	e.unblock("test")
+	assert.NotContains(t, e.errorPerEndpoint, "test")
+}
+
+func TestIsBlock(t *testing.T) {
+	e := newBlockedEndpoints()
+
+	assert.False(t, e.isBlock("test"))
+
+	e.block("test")
+	assert.True(t, e.isBlock("test"))
+
+	e.unblock("test")
+	assert.False(t, e.isBlock("test"))
+}
+
+func TestIsBlockTiming(t *testing.T) {
+	e := newBlockedEndpoints()
+
+	// setting an old block
+	e.errorPerEndpoint["test"] = &block{nbError: 1, until: time.Now().Add(-time.Duration(30 * time.Second))}
+	assert.False(t, e.isBlock("test"))
+
+	// setting an new block
+	e.errorPerEndpoint["test"] = &block{nbError: 1, until: time.Now().Add(time.Duration(30 * time.Second))}
+	assert.True(t, e.isBlock("test"))
+}
+
+func TestIsblockUnknown(t *testing.T) {
+	e := newBlockedEndpoints()
+
+	assert.False(t, e.isBlock("test"))
+}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -72,6 +72,7 @@ type Transaction interface {
 	Reschedule()
 	GetNextFlush() time.Time
 	GetCreatedAt() time.Time
+	GetTarget() string
 }
 
 // Forwarder implements basic interface - useful for testing
@@ -188,8 +189,9 @@ func (f *DefaultForwarder) Start() error {
 	// reset internal state to purge transactions from past starts
 	f.init()
 
+	blockedList := newBlockedEndpoints()
 	for i := 0; i < f.NumberOfWorkers; i++ {
-		w := NewWorker(f.waitingPipe, f.requeuedTransaction)
+		w := NewWorker(f.waitingPipe, f.requeuedTransaction, blockedList)
 		w.Start()
 		f.workers = append(f.workers, w)
 	}

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -280,6 +280,7 @@ func TestForwarderRetry(t *testing.T) {
 	assert.Equal(t, len(forwarder.retryQueue), 2)
 
 	ready.On("Process", forwarder.workers[0].Client).Return(nil).Times(1)
+	ready.On("GetTarget").Return("").Times(1)
 	ready.On("GetNextFlush").Return(time.Now()).Times(1)
 	ready.On("GetCreatedAt").Return(time.Now()).Times(1)
 	notReady.On("GetNextFlush").Return(time.Now().Add(10 * time.Minute)).Times(1)
@@ -291,6 +292,7 @@ func TestForwarderRetry(t *testing.T) {
 	ready.AssertExpectations(t)
 	notReady.AssertExpectations(t)
 	notReady.AssertNumberOfCalls(t, "Process", 0)
+	notReady.AssertNumberOfCalls(t, "GetTarget", 0)
 	assert.Equal(t, len(forwarder.retryQueue), 1)
 	assert.Equal(t, forwarder.retryQueue[0], notReady)
 }

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -35,6 +35,10 @@ func (t *testTransaction) Reschedule() {
 	t.Called()
 }
 
+func (t *testTransaction) GetTarget() string {
+	return t.Called().Get(0).(string)
+}
+
 // MockedForwarder a mocked forwarder to be use in other module to test their dependencies with the forwarder
 type MockedForwarder struct {
 	mock.Mock

--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -57,6 +57,12 @@ func (t *HTTPTransaction) GetCreatedAt() time.Time {
 	return t.createdAt
 }
 
+// GetTarget return the url used by the transaction
+func (t *HTTPTransaction) GetTarget() string {
+	url := t.Domain + t.Endpoint
+	return apiKeyRegExp.ReplaceAllString(url, apiKeyReplacement) // sanitized url that can be logged
+}
+
 // Process sends the Payload of the transaction to the right Endpoint and Domain.
 func (t *HTTPTransaction) Process(client *http.Client) error {
 	reader := bytes.NewReader(*t.Payload)
@@ -74,7 +80,7 @@ func (t *HTTPTransaction) Process(client *http.Client) error {
 	if err != nil {
 		t.ErrorCount++
 		transactionsCreation.Add("Errors", 1)
-		return fmt.Errorf("Error while sending transaction to '%s', rescheduling it: %s", logURL, err)
+		return fmt.Errorf("Error while sending transaction, rescheduling it: %s", apiKeyRegExp.ReplaceAllString(err.Error(), apiKeyReplacement))
 	}
 	defer resp.Body.Close()
 

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -14,7 +14,7 @@ func TestNewWorker(t *testing.T) {
 	input := make(chan Transaction)
 	requeue := make(chan Transaction)
 
-	w := NewWorker(input, requeue)
+	w := NewWorker(input, requeue, newBlockedEndpoints())
 	assert.NotNil(t, w)
 	assert.Equal(t, w.Client.Timeout, config.Datadog.GetDuration("forwarder_timeout")*time.Second)
 }
@@ -26,17 +26,18 @@ func TestNewNoSSLWorker(t *testing.T) {
 	config.Datadog.Set("skip_ssl_validation", true)
 	defer config.Datadog.Set("skip_ssl_validation", false)
 
-	w := NewWorker(input, requeue)
+	w := NewWorker(input, requeue, newBlockedEndpoints())
 	assert.True(t, w.Client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 }
 
 func TestWorkerStart(t *testing.T) {
 	input := make(chan Transaction)
 	requeue := make(chan Transaction, 1)
-	w := NewWorker(input, requeue)
+	w := NewWorker(input, requeue, newBlockedEndpoints())
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client).Return(nil).Times(1)
+	mock.On("GetTarget").Return("").Times(1)
 
 	w.Start()
 	input <- mock
@@ -49,11 +50,12 @@ func TestWorkerStart(t *testing.T) {
 func TestWorkerRetry(t *testing.T) {
 	input := make(chan Transaction)
 	requeue := make(chan Transaction, 1)
-	w := NewWorker(input, requeue)
+	w := NewWorker(input, requeue, newBlockedEndpoints())
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client).Return(fmt.Errorf("some kind of error")).Times(1)
 	mock.On("Reschedule").Return(nil).Times(1)
+	mock.On("GetTarget").Return("error_url").Times(1)
 
 	w.Start()
 	input <- mock
@@ -61,6 +63,29 @@ func TestWorkerRetry(t *testing.T) {
 	w.Stop()
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Process", 1)
+	mock.AssertNumberOfCalls(t, "GetTarget", 1)
+	mock.AssertNumberOfCalls(t, "Reschedule", 1)
+	assert.Equal(t, mock, retryTransaction)
+	assert.True(t, w.blockedList.isBlock("error_url"))
+}
+
+func TestWorkerRetryBlockedTransaction(t *testing.T) {
+	input := make(chan Transaction)
+	requeue := make(chan Transaction, 1)
+	w := NewWorker(input, requeue, newBlockedEndpoints())
+
+	mock := newTestTransaction()
+	mock.On("Reschedule").Return(nil).Times(1)
+	mock.On("GetTarget").Return("error_url").Times(1)
+
+	w.blockedList.block("error_url")
+	w.Start()
+	input <- mock
+	retryTransaction := <-requeue
+	w.Stop()
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Process", 0)
+	mock.AssertNumberOfCalls(t, "GetTarget", 1)
 	mock.AssertNumberOfCalls(t, "Reschedule", 1)
 	assert.Equal(t, mock, retryTransaction)
 }


### PR DESCRIPTION
### What does this PR do?

We block an endpoint for some time if it produces too many errors. This leave more "worker time" for other endpoints.

### Motivation

When an endpoint is down (taken to much time to answer for example) we would retry it for every transaction related to it. This would prevent other endpoint to receive their transaction first.