### PR TITLE
[check.Config] fix equality check

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -99,6 +99,16 @@ func (c *Config) Equal(config *Config) bool {
 		return false
 	}
 
+	if len(c.ADIdentifiers) != len(config.ADIdentifiers) {
+		return false
+	}
+
+	for i, id := range c.ADIdentifiers {
+		if id != config.ADIdentifiers[i] {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -27,6 +27,13 @@ func TestConfigEqual(t *testing.T) {
 	assert.False(t, config.Equal(another))
 	config.Instances = another.Instances
 	assert.True(t, config.Equal(another))
+
+	config.ADIdentifiers = []string{"foo", "bar"}
+	assert.False(t, config.Equal(another))
+	another.ADIdentifiers = []string{"foo", "bar"}
+	assert.True(t, config.Equal(another))
+	another.ADIdentifiers = []string{"bar", "foo"}
+	assert.False(t, config.Equal(another))
 }
 
 func TestString(t *testing.T) {


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Fix the equality check between check configurations taking into account also what it comes from `docker_images` or `ad_identifiers`

### Motivation

Should have been in #429 

NOTE: the equality check returns `false` if the AD identifiers are the same but in a different order. I think for now, being the AD feature under development, is better to keep it simple
