### PR TITLE
Maxime/forwarder deadlock

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -137,7 +137,7 @@ func (v byCreatedTime) Less(i, j int) bool { return v[i].GetCreatedAt().After(v[
 func (f *DefaultForwarder) retryTransactions(retryBefore time.Time) {
 	newQueue := []Transaction{}
 	droppedRetryQueueFull := 0
-	droppedWorkerBussy := 0
+	droppedWorkerBusy := 0
 
 	sort.Sort(byCreatedTime(f.retryQueue))
 
@@ -147,7 +147,7 @@ func (f *DefaultForwarder) retryTransactions(retryBefore time.Time) {
 			case f.lowPrio <- t:
 				transactionsExpvar.Add("Retried", 1)
 			default:
-				droppedWorkerBussy++
+				droppedWorkerBusy++
 				transactionsExpvar.Add("Dropped", 1)
 			}
 		} else if len(newQueue) < f.retryQueueLimit {
@@ -162,9 +162,9 @@ func (f *DefaultForwarder) retryTransactions(retryBefore time.Time) {
 	f.retryQueue = newQueue
 	retryQueueSize.Set(int64(len(f.retryQueue)))
 
-	if droppedRetryQueueFull+droppedWorkerBussy > 0 {
+	if droppedRetryQueueFull+droppedWorkerBusy > 0 {
 		log.Errorf("Dropped %d transactions in this retry attempt: %d for exceeding the retry queue size limit of %d, %d because the workers are too busy",
-			droppedRetryQueueFull+droppedWorkerBussy, droppedRetryQueueFull, f.retryQueueLimit, droppedWorkerBussy)
+			droppedRetryQueueFull+droppedWorkerBusy, droppedRetryQueueFull, f.retryQueueLimit, droppedWorkerBusy)
 	}
 }
 

--- a/pkg/forwarder/worker.go
+++ b/pkg/forwarder/worker.go
@@ -7,6 +7,7 @@ package forwarder
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -22,8 +23,10 @@ import (
 type Worker struct {
 	// Client the http client used to processed transactions.
 	Client *http.Client
-	// InputChan is the channel used to receive transaction from the Forwarder.
-	InputChan <-chan Transaction
+	// HighPrio is the channel used to receive high priority transaction from the Forwarder.
+	HighPrio <-chan Transaction
+	// LowPrio is the channel used to receive low priority transaction from the Forwarder.
+	LowPrio <-chan Transaction
 	// RequeueChan is the channel used to send failed transaction back to the Forwarder.
 	RequeueChan chan<- Transaction
 
@@ -33,8 +36,7 @@ type Worker struct {
 
 // NewWorker returns a new worker to consume Transaction from inputChan
 // and push back erroneous ones into requeueChan.
-func NewWorker(inputChan chan Transaction, requeueChan chan Transaction, blocked *blockedEndpoints) *Worker {
-
+func NewWorker(highPrioChan <-chan Transaction, lowPrioChan <-chan Transaction, requeueChan chan<- Transaction, blocked *blockedEndpoints) *Worker {
 	transport := util.CreateHTTPTransport()
 
 	httpClient := &http.Client{
@@ -43,7 +45,8 @@ func NewWorker(inputChan chan Transaction, requeueChan chan Transaction, blocked
 	}
 
 	return &Worker{
-		InputChan:   inputChan,
+		HighPrio:    highPrioChan,
+		LowPrio:     lowPrioChan,
 		RequeueChan: requeueChan,
 		stopChan:    make(chan bool),
 		Client:      httpClient,
@@ -60,30 +63,55 @@ func (w *Worker) Stop() {
 func (w *Worker) Start() {
 	go func() {
 		for {
+			// handling high priority transactions first
 			select {
-			case t := <-w.InputChan:
-				ctx, cancel := context.WithCancel(context.Background())
+			case t := <-w.HighPrio:
+				if w.callProcess(t) == nil {
+					continue
+				}
+				return
+			case <-w.stopChan:
+				return
+			default:
+			}
 
-				done := make(chan interface{})
-				go func() {
-					w.process(ctx, t)
-					done <- nil
-				}()
-
-				select {
-				case <-done:
-					// wait for the Transaction process to be over
-				case <-w.stopChan:
-					// cancel current Transaction if we need to stop the worker
-					cancel()
+			select {
+			case t := <-w.HighPrio:
+				if w.callProcess(t) != nil {
 					return
 				}
-				cancel()
+			case t := <-w.LowPrio:
+				if w.callProcess(t) != nil {
+					return
+				}
 			case <-w.stopChan:
 				return
 			}
 		}
 	}()
+}
+
+// callProcess will process a transaction and cancel it if we need to stop the
+// worker.
+func (w *Worker) callProcess(t Transaction) error {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan interface{})
+	go func() {
+		w.process(ctx, t)
+		done <- nil
+	}()
+
+	select {
+	case <-done:
+		// wait for the Transaction process to be over
+	case <-w.stopChan:
+		// cancel current Transaction if we need to stop the worker
+		cancel()
+		return fmt.Errorf("Worker was requested to stop")
+	}
+	cancel()
+	return nil
 }
 
 func (w *Worker) process(ctx context.Context, t Transaction) {

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -57,7 +57,7 @@ func TestWorkerStart(t *testing.T) {
 	w.Start()
 
 	highPrio <- mock
-	// since highPrio orlowPrio have no buffering the worker won't take another Transaction until it has processed the first one
+	// since highPrio and lowPrio have no buffering the worker won't take another Transaction until it has processed the first one
 	highPrio <- dummy
 
 	mock.AssertExpectations(t)

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -16,53 +16,69 @@ import (
 )
 
 func TestNewWorker(t *testing.T) {
-	input := make(chan Transaction)
+	highPrio := make(chan Transaction)
+	lowPrio := make(chan Transaction)
 	requeue := make(chan Transaction)
 
-	w := NewWorker(input, requeue, newBlockedEndpoints())
+	w := NewWorker(highPrio, lowPrio, requeue, newBlockedEndpoints())
 	assert.NotNil(t, w)
 	assert.Equal(t, w.Client.Timeout, config.Datadog.GetDuration("forwarder_timeout")*time.Second)
 }
 
 func TestNewNoSSLWorker(t *testing.T) {
-	input := make(chan Transaction)
+	highPrio := make(chan Transaction)
+	lowPrio := make(chan Transaction)
 	requeue := make(chan Transaction)
 
 	config.Datadog.Set("skip_ssl_validation", true)
 	defer config.Datadog.Set("skip_ssl_validation", false)
 
-	w := NewWorker(input, requeue, newBlockedEndpoints())
+	w := NewWorker(highPrio, lowPrio, requeue, newBlockedEndpoints())
 	assert.True(t, w.Client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
 }
 
 func TestWorkerStart(t *testing.T) {
-	input := make(chan Transaction)
+	highPrio := make(chan Transaction)
+	lowPrio := make(chan Transaction)
 	requeue := make(chan Transaction, 1)
-	w := NewWorker(input, requeue, newBlockedEndpoints())
+	w := NewWorker(highPrio, lowPrio, requeue, newBlockedEndpoints())
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client).Return(nil).Times(1)
 	mock.On("GetTarget").Return("").Times(1)
+	mock2 := newTestTransaction()
+	mock2.On("Process", w.Client).Return(nil).Times(1)
+	mock2.On("GetTarget").Return("").Times(1)
 
 	dummy := newTestTransaction()
-	dummy.On("Process", w.Client).Return(nil).Times(1)
-	dummy.On("GetTarget").Return("").Times(1)
+	dummy.On("Process", w.Client).Return(nil).Times(2)
+	dummy.On("GetTarget").Return("").Times(2)
 
 	w.Start()
-	input <- mock
-	// since input has no buffering the worker won't take another Transaction until it has processed the first one
-	input <- dummy
-	w.Stop()
+
+	highPrio <- mock
+	// since highPrio orlowPrio have no buffering the worker won't take another Transaction until it has processed the first one
+	highPrio <- dummy
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Process", 1)
 	mock.AssertNumberOfCalls(t, "Reschedule", 0)
+
+	lowPrio <- mock2
+	lowPrio <- dummy
+
+	mock2.AssertExpectations(t)
+	mock2.AssertNumberOfCalls(t, "Process", 1)
+	mock2.AssertNumberOfCalls(t, "Reschedule", 0)
+
+	w.Stop()
 }
 
 func TestWorkerRetry(t *testing.T) {
-	input := make(chan Transaction)
+	highPrio := make(chan Transaction)
+	lowPrio := make(chan Transaction)
 	requeue := make(chan Transaction, 1)
-	w := NewWorker(input, requeue, newBlockedEndpoints())
+	w := NewWorker(highPrio, lowPrio, requeue, newBlockedEndpoints())
 
 	mock := newTestTransaction()
 	mock.On("Process", w.Client).Return(fmt.Errorf("some kind of error")).Times(1)
@@ -70,7 +86,7 @@ func TestWorkerRetry(t *testing.T) {
 	mock.On("GetTarget").Return("error_url").Times(1)
 
 	w.Start()
-	input <- mock
+	highPrio <- mock
 	retryTransaction := <-requeue
 	w.Stop()
 	mock.AssertExpectations(t)
@@ -82,9 +98,10 @@ func TestWorkerRetry(t *testing.T) {
 }
 
 func TestWorkerRetryBlockedTransaction(t *testing.T) {
-	input := make(chan Transaction)
+	highPrio := make(chan Transaction)
+	lowPrio := make(chan Transaction)
 	requeue := make(chan Transaction, 1)
-	w := NewWorker(input, requeue, newBlockedEndpoints())
+	w := NewWorker(highPrio, lowPrio, requeue, newBlockedEndpoints())
 
 	mock := newTestTransaction()
 	mock.On("Reschedule").Return(nil).Times(1)
@@ -92,7 +109,7 @@ func TestWorkerRetryBlockedTransaction(t *testing.T) {
 
 	w.blockedList.block("error_url")
 	w.Start()
-	input <- mock
+	highPrio <- mock
 	retryTransaction := <-requeue
 	w.Stop()
 	mock.AssertExpectations(t)
@@ -100,4 +117,5 @@ func TestWorkerRetryBlockedTransaction(t *testing.T) {
 	mock.AssertNumberOfCalls(t, "GetTarget", 1)
 	mock.AssertNumberOfCalls(t, "Reschedule", 1)
 	assert.Equal(t, mock, retryTransaction)
+	assert.True(t, w.blockedList.isBlock("error_url"))
 }


### PR DESCRIPTION
### What does this PR do?

- Force the forwarder to drop transaction if queues are full
- Split new transactions and retried transactions into two different queues
This always gives priority to new transactions.