### PR TITLE
Jeerim/percentile update pb payload

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/DataDog/agent-payload"
   packages = ["gogen"]
-  revision = "fb25fcedf155de94e762080a914adb5436d45b9c"
-  version = "4.3"
+  revision = "878e17eb68c0ab47f62a702158bf01c7d6e1452b"
+  version = "4.4"
 
 [[projects]]
   name = "github.com/DataDog/gohai"
@@ -329,6 +329,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b18546f75ac0ff366a31fb13bc0bddf7ac59213c66c49833c7bc8972517b182e"
+  inputs-digest = "6cd25394231af3d7cfd1655a983b925cc30f6c0b94acafb8dba2e13c1b8cd01e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
-  version = "=4.3.0"
+  version = "=4.4.0"
 
 [[constraint]]
   name = "github.com/DataDog/gohai"

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -95,6 +95,9 @@ func (s GKArray) Add(v float64) GKArray {
 }
 
 // Quantile returns an epsilon estimate of the element at quantile q.
+// If calling Quantile() repeatedly on the same sketch, it would be more
+// efficient to Compress() the sketch beforehand since each Quantile()
+// calls Compress() if incoming is not empty.
 func (s GKArray) Quantile(q float64) float64 {
 	if q < 0 || q > 1 {
 		panic("Quantile out of bounds")
@@ -158,17 +161,10 @@ func (s GKArray) interpolatedQuantile(q float64) float64 {
 // Merge another GKArray into this in-place.
 func (s GKArray) Merge(o GKArray) GKArray {
 	if o.Count == 0 {
-		return s
+		return s.compress(nil)
 	}
 	if s.Count == 0 {
-		s.Entries = o.Entries
-		s.Count = o.Count
-		s.incoming = o.incoming
-		s.Min = o.Min
-		s.Max = o.Max
-		s.Sum = o.Sum
-		s.Avg = o.Avg
-		return s
+		return o.compress(nil)
 	}
 	o = o.compress(nil)
 	spread := int(EPSILON * float64(o.Count-1))

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-
-	agentpayload "github.com/DataDog/agent-payload/gogen"
 )
 
 // EPSILON represents the accuracy of the sketch.
@@ -16,8 +14,8 @@ const EPSILON float64 = 0.01
 // http://infolab.stanford.edu/~datar/courses/cs361a/papers/quantiles.pdf
 type Entry struct {
 	V     float64 `json:"v"`
-	G     int     `json:"g"`
-	Delta int     `json:"d"`
+	G     uint32  `json:"g"`
+	Delta uint32  `json:"d"`
 }
 
 //Entries is a slice of Entry
@@ -35,15 +33,27 @@ type GKArray struct {
 	// TODO[Charles]: incorporate min in entries so that we can get rid of the field.
 	Min   float64 `json:"min"`
 	Max   float64 `json:"max"`
-	Count int     `json:"n"`
+	Count int64   `json:"cnt"`
 	Sum   float64 `json:"sum"`
 	Avg   float64 `json:"avg"`
 }
 
-func unmarshalEntries(sketchEntries []agentpayload.SketchPayload_Summary_Sketch_Entry) Entries {
-	entries := Entries{}
-	for _, e := range sketchEntries {
-		entries = append(entries, Entry{V: e.V, G: int(e.G), Delta: int(e.Delta)})
+func marshalEntries(entries Entries) ([]float64, []uint32, []uint32) {
+	v := make([]float64, 0, len(entries))
+	g := make([]uint32, 0, len(entries))
+	delta := make([]uint32, 0, len(entries))
+	for _, e := range entries {
+		v = append(v, e.V)
+		g = append(g, e.G)
+		delta = append(delta, e.Delta)
+	}
+	return v, g, delta
+}
+
+func unmarshalEntries(v []float64, g []uint32, delta []uint32) Entries {
+	entries := make(Entries, 0, len(v))
+	for i := 0; i < len(v); i++ {
+		entries = append(entries, Entry{V: v[i], G: g[i], Delta: delta[i]})
 	}
 	return entries
 }
@@ -60,8 +70,8 @@ func (e *Entry) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	e.V = values[0]
-	e.G = int(values[1])
-	e.Delta = int(values[2])
+	e.G = uint32(values[1])
+	e.Delta = uint32(values[2])
 	return nil
 }
 
@@ -87,7 +97,7 @@ func (s GKArray) Add(v float64) GKArray {
 	if v > s.Max {
 		s.Max = v
 	}
-	if s.Count%int(1/EPSILON) == 0 {
+	if s.Count%int64(1/EPSILON) == 0 {
 		return s.compress(nil)
 	}
 
@@ -108,7 +118,7 @@ func (s GKArray) Quantile(q float64) float64 {
 	}
 
 	// Interpolate the quantile when there are only a few values.
-	if s.Count < int(1/EPSILON) {
+	if s.Count < int64(1/EPSILON) {
 		return s.interpolatedQuantile(q)
 	}
 
@@ -121,14 +131,14 @@ func (s GKArray) Quantile(q float64) float64 {
 		s = s.compress(nil)
 	}
 
-	rank := int(q * float64(s.Count-1))
-	spread := int(EPSILON * float64(s.Count-1))
-	gSum := 0
+	rank := int64(q * float64(s.Count-1))
+	spread := int64(EPSILON * float64(s.Count-1))
+	gSum := int64(0)
 	i := 0
 	for ; i < len(s.Entries); i++ {
-		gSum += s.Entries[i].G
+		gSum += int64(s.Entries[i].G)
 		// mininum rank is 0 but gSum starts from 1, hence the -1.
-		if gSum+s.Entries[i].Delta-1 > rank+spread {
+		if gSum+int64(s.Entries[i].Delta)-1 > rank+spread {
 			break
 		}
 	}
@@ -143,7 +153,7 @@ func (s GKArray) Quantile(q float64) float64 {
 // less than 1/EPSILON
 func (s GKArray) interpolatedQuantile(q float64) float64 {
 	rank := q * float64(s.Count-1)
-	indexBelow := int(rank)
+	indexBelow := int64(rank)
 	indexAbove := indexBelow + 1
 	if indexAbove > s.Count-1 {
 		indexAbove = s.Count - 1
@@ -167,7 +177,7 @@ func (s GKArray) Merge(o GKArray) GKArray {
 		return o.compress(nil)
 	}
 	o = o.compress(nil)
-	spread := int(EPSILON * float64(o.Count-1))
+	spread := uint32(EPSILON * float64(o.Count-1))
 
 	/*
 			Here is one way to merge summaries so that the sketch is one-way mergeable: we extract an epsilon-approximate
@@ -228,7 +238,7 @@ func (s GKArray) compress(incomingEntries Entries) GKArray {
 	}
 	sort.Sort(incomingEntries)
 
-	removalThreshold := 2 * int(EPSILON*float64(s.Count-1))
+	removalThreshold := 2 * uint32(EPSILON*float64(s.Count-1))
 	merged := make([]Entry, 0, len(s.Entries)+len(incomingEntries))
 
 	// TODO[Charles]: The compression algo might not be optimal. We need to revisit it if we need to improve space

--- a/pkg/metrics/percentile/gk_array_test.go
+++ b/pkg/metrics/percentile/gk_array_test.go
@@ -15,7 +15,7 @@ type Generator interface {
 
 type Dataset struct {
 	Values []float64
-	Count  int
+	Count  int64
 	sorted bool
 }
 
@@ -36,7 +36,7 @@ func (d *Dataset) Quantile(q float64) float64 {
 	}
 
 	rank := q * float64(d.Count-1)
-	indexBelow := int(rank)
+	indexBelow := int64(rank)
 	indexAbove := indexBelow + 1
 	if indexAbove > d.Count-1 {
 		indexAbove = d.Count - 1
@@ -44,7 +44,7 @@ func (d *Dataset) Quantile(q float64) float64 {
 	weightAbove := rank - float64(indexBelow)
 	weightBelow := 1.0 - weightAbove
 
-	if d.Count < int(1/EPSILON) {
+	if d.Count < int64(1/EPSILON) {
 		return weightBelow*d.Values[indexBelow] + weightAbove*d.Values[indexAbove]
 	}
 	return d.Values[indexBelow]

--- a/pkg/metrics/percentile/gk_array_test.go
+++ b/pkg/metrics/percentile/gk_array_test.go
@@ -92,6 +92,7 @@ func EvaluateSketch(t *testing.T, n int, gen Generator) {
 		s = s.Add(value)
 		d.Add(value)
 	}
+	s = s.Compress()
 	eps := float64(1.0e-6)
 	for _, q := range testQuantiles {
 		assert.InDelta(t, d.Quantile(q), s.Quantile(q), EPSILON*(float64(n)))
@@ -119,6 +120,7 @@ func TestConstant(t *testing.T) {
 			s = s.Add(value)
 			d.Add(value)
 		}
+		s = s.Compress()
 		for _, q := range testQuantiles {
 			assert.Equal(t, 42.0, s.Quantile(q))
 		}
@@ -155,7 +157,20 @@ func TestNormal(t *testing.T) {
 	}
 }
 
-func TestMerge(t *testing.T) {
+// Exponential distribution
+type Exponential struct{ rate float64 }
+
+func NewExponential(rate float64) *Exponential { return &Exponential{rate: rate} }
+func (g *Exponential) Generate() float64       { return rand.ExpFloat64() / g.rate }
+
+func TestExponential(t *testing.T) {
+	for _, n := range testSizes {
+		expGenerator := NewExponential(2)
+		EvaluateSketch(t, n, expGenerator)
+	}
+}
+
+func TestMergeNormal(t *testing.T) {
 	for _, n := range testSizes {
 		d := NewDataset()
 		s1 := NewGKArray()
@@ -190,6 +205,86 @@ func TestMerge(t *testing.T) {
 			assert.InEpsilon(t, d.Avg(), s1.Avg, eps)
 			assert.InEpsilon(t, d.Sum(), s1.Sum, eps)
 			assert.InEpsilon(t, d.Count, s1.Count, eps)
+			assert.Equal(t, 0, len(s1.incoming))
+		}
+	}
+}
+
+func TestMergeEmpty(t *testing.T) {
+	for _, n := range testSizes {
+		d := NewDataset()
+		// Merge a non-empty sketch to an empty sketch
+		s1 := NewGKArray()
+		s2 := NewGKArray()
+		generator := NewExponential(5)
+		for i := 0; i < 30; i++ {
+			value := generator.Generate()
+			s2 = s2.Add(value)
+			d.Add(value)
+		}
+		s1 = s1.Merge(s2)
+		eps := float64(1e-6)
+		for _, q := range testQuantiles {
+			assert.InDelta(t, d.Quantile(q), s1.Quantile(q), 2*EPSILON*float64(n))
+			assert.InEpsilon(t, d.Min(), s1.Min, eps)
+			assert.InEpsilon(t, d.Max(), s1.Max, eps)
+			assert.InEpsilon(t, d.Avg(), s1.Avg, eps)
+			assert.InEpsilon(t, d.Sum(), s1.Sum, eps)
+			assert.InEpsilon(t, d.Count, s1.Count, eps)
+			assert.Equal(t, 0, len(s1.incoming))
+		}
+
+		// Merge an empty sketch to a non-empty sketch
+		s3 := NewGKArray()
+		s2 = s2.Merge(s3)
+		for _, q := range testQuantiles {
+			assert.InDelta(t, d.Quantile(q), s2.Quantile(q), 2*EPSILON*float64(n))
+			assert.InEpsilon(t, d.Min(), s2.Min, eps)
+			assert.InEpsilon(t, d.Max(), s2.Max, eps)
+			assert.InEpsilon(t, d.Avg(), s2.Avg, eps)
+			assert.InEpsilon(t, d.Sum(), s2.Sum, eps)
+			assert.InEpsilon(t, d.Count, s2.Count, eps)
+			assert.Equal(t, 0, len(s2.incoming))
+		}
+	}
+}
+
+func TestMergeMixed(t *testing.T) {
+	for _, n := range testSizes {
+		d := NewDataset()
+		s1 := NewGKArray()
+		generator1 := NewNormal(100, 1)
+		for i := 0; i < n; i += 3 {
+			value := generator1.Generate()
+			s1 = s1.Add(value)
+			d.Add(value)
+		}
+		s2 := NewGKArray()
+		generator2 := NewExponential(5)
+		for i := 1; i < n; i += 3 {
+			value := generator2.Generate()
+			s2 = s2.Add(value)
+			d.Add(value)
+		}
+		s1 = s1.Merge(s2)
+		s3 := NewGKArray()
+		generator3 := NewExponential(0.1)
+		for i := 2; i < n; i += 3 {
+			value := generator3.Generate()
+			s3 = s3.Add(value)
+			d.Add(value)
+		}
+		s1 = s1.Merge(s3)
+
+		eps := float64(1e-6)
+		for _, q := range testQuantiles {
+			assert.InDelta(t, d.Quantile(q), s1.Quantile(q), 2*EPSILON*float64(n))
+			assert.InEpsilon(t, d.Min(), s1.Min, eps)
+			assert.InEpsilon(t, d.Max(), s1.Max, eps)
+			assert.InEpsilon(t, d.Avg(), s1.Avg, eps)
+			assert.InEpsilon(t, d.Sum(), s1.Sum, eps)
+			assert.InEpsilon(t, d.Count, s1.Count, eps)
+			assert.Equal(t, 0, len(s1.incoming))
 		}
 	}
 }
@@ -201,6 +296,7 @@ func TestInterpolatedQuantile(t *testing.T) {
 			for i := 0; i < n; i++ {
 				s = s.Add(float64(i))
 			}
+			s = s.Compress()
 			for _, q := range testQuantiles {
 				expected := q * (float64(n) - 1)
 				assert.Equal(t, expected, s.Quantile(q))

--- a/pkg/metrics/percentile/sketch_series_test.go
+++ b/pkg/metrics/percentile/sketch_series_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUnmarshalJSONSketchSeries(t *testing.T) {
 
-	payload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"max\":1,\"n\":1,\"sum\":1,\"avg\":1}}]}]}\n")
+	payload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"max\":1,\"cnt\":1,\"sum\":1,\"avg\":1}}]}]}\n")
 
 	sketch := QSketch{
 		GKArray{Entries: []Entry{{1, 1, 0}},
@@ -60,48 +60,50 @@ func TestMarshal(t *testing.T) {
 	err = proto.Unmarshal(payload, decodedPayload)
 	assert.Nil(t, err)
 
-	require.Len(t, decodedPayload.Summaries, 1)
+	require.Len(t, decodedPayload.Sketches, 1)
 	assert.Equal(t, agentpayload.CommonMetadata{}, decodedPayload.Metadata)
-	assert.Equal(t, "test.metrics", decodedPayload.Summaries[0].Metric)
-	assert.Equal(t, "tag1", decodedPayload.Summaries[0].Tags[0])
-	assert.Equal(t, "tag2:yes", decodedPayload.Summaries[0].Tags[1])
-	assert.Equal(t, "localHost", decodedPayload.Summaries[0].Host)
+	assert.Equal(t, "test.metrics", decodedPayload.Sketches[0].Metric)
+	assert.Equal(t, "tag1", decodedPayload.Sketches[0].Tags[0])
+	assert.Equal(t, "tag2:yes", decodedPayload.Sketches[0].Tags[1])
+	assert.Equal(t, "localHost", decodedPayload.Sketches[0].Host)
 
-	require.Len(t, decodedPayload.Summaries[0].Sketches, 2)
+	require.Len(t, decodedPayload.Sketches[0].Distributions, 2)
 
 	// first sketch
-	assert.Equal(t, int64(12345), decodedPayload.Summaries[0].Sketches[0].Ts)
-	assert.Equal(t, int64(1), decodedPayload.Summaries[0].Sketches[0].N)
-	assert.Equal(t, float64(1), decodedPayload.Summaries[0].Sketches[0].Min)
-	assert.Equal(t, float64(1), decodedPayload.Summaries[0].Sketches[0].Max)
-	assert.Equal(t, float64(1), decodedPayload.Summaries[0].Sketches[0].Avg)
-	assert.Equal(t, float64(1), decodedPayload.Summaries[0].Sketches[0].Sum)
+	assert.Equal(t, int64(12345), decodedPayload.Sketches[0].Distributions[0].Ts)
+	assert.Equal(t, int64(1), decodedPayload.Sketches[0].Distributions[0].Cnt)
+	assert.Equal(t, float64(1), decodedPayload.Sketches[0].Distributions[0].Min)
+	assert.Equal(t, float64(1), decodedPayload.Sketches[0].Distributions[0].Max)
+	assert.Equal(t, float64(1), decodedPayload.Sketches[0].Distributions[0].Avg)
+	assert.Equal(t, float64(1), decodedPayload.Sketches[0].Distributions[0].Sum)
 
-	require.Len(t, decodedPayload.Summaries[0].Sketches[0].Entries, 1)
-	assert.Equal(t, float64(1), decodedPayload.Summaries[0].Sketches[0].Entries[0].V)
-	assert.Equal(t, int64(1), decodedPayload.Summaries[0].Sketches[0].Entries[0].G)
-	assert.Equal(t, int64(0), decodedPayload.Summaries[0].Sketches[0].Entries[0].Delta)
+	require.Len(t, decodedPayload.Sketches[0].Distributions[0].V, 1)
+	require.Len(t, decodedPayload.Sketches[0].Distributions[0].G, 1)
+	require.Len(t, decodedPayload.Sketches[0].Distributions[0].Delta, 1)
+	assert.Equal(t, float64(1), decodedPayload.Sketches[0].Distributions[0].V[0])
+	assert.Equal(t, uint32(1), decodedPayload.Sketches[0].Distributions[0].G[0])
+	assert.Equal(t, uint32(0), decodedPayload.Sketches[0].Distributions[0].Delta[0])
 
 	// second sketch
-	assert.Equal(t, int64(67890), decodedPayload.Summaries[0].Sketches[1].Ts)
-	assert.Equal(t, int64(6), decodedPayload.Summaries[0].Sketches[1].N)
-	assert.Equal(t, float64(10), decodedPayload.Summaries[0].Sketches[1].Min)
-	assert.Equal(t, float64(21), decodedPayload.Summaries[0].Sketches[1].Max)
-	assert.Equal(t, float64(16), decodedPayload.Summaries[0].Sketches[1].Avg)
-	assert.Equal(t, float64(96), decodedPayload.Summaries[0].Sketches[1].Sum)
+	assert.Equal(t, int64(67890), decodedPayload.Sketches[0].Distributions[1].Ts)
+	assert.Equal(t, int64(6), decodedPayload.Sketches[0].Distributions[1].Cnt)
+	assert.Equal(t, float64(10), decodedPayload.Sketches[0].Distributions[1].Min)
+	assert.Equal(t, float64(21), decodedPayload.Sketches[0].Distributions[1].Max)
+	assert.Equal(t, float64(16), decodedPayload.Sketches[0].Distributions[1].Avg)
+	assert.Equal(t, float64(96), decodedPayload.Sketches[0].Distributions[1].Sum)
 
-	require.Len(t, decodedPayload.Summaries[0].Sketches[1].Entries, 3)
-	assert.Equal(t, float64(10), decodedPayload.Summaries[0].Sketches[1].Entries[0].V)
-	assert.Equal(t, int64(1), decodedPayload.Summaries[0].Sketches[1].Entries[0].G)
-	assert.Equal(t, int64(0), decodedPayload.Summaries[0].Sketches[1].Entries[0].Delta)
-
-	assert.Equal(t, float64(14), decodedPayload.Summaries[0].Sketches[1].Entries[1].V)
-	assert.Equal(t, int64(3), decodedPayload.Summaries[0].Sketches[1].Entries[1].G)
-	assert.Equal(t, int64(0), decodedPayload.Summaries[0].Sketches[1].Entries[1].Delta)
-
-	assert.Equal(t, float64(21), decodedPayload.Summaries[0].Sketches[1].Entries[2].V)
-	assert.Equal(t, int64(2), decodedPayload.Summaries[0].Sketches[1].Entries[2].G)
-	assert.Equal(t, int64(0), decodedPayload.Summaries[0].Sketches[1].Entries[2].Delta)
+	require.Len(t, decodedPayload.Sketches[0].Distributions[1].V, 3)
+	require.Len(t, decodedPayload.Sketches[0].Distributions[1].G, 3)
+	require.Len(t, decodedPayload.Sketches[0].Distributions[1].Delta, 3)
+	assert.Equal(t, float64(10), decodedPayload.Sketches[0].Distributions[1].V[0])
+	assert.Equal(t, uint32(1), decodedPayload.Sketches[0].Distributions[1].G[0])
+	assert.Equal(t, uint32(0), decodedPayload.Sketches[0].Distributions[1].Delta[0])
+	assert.Equal(t, float64(14), decodedPayload.Sketches[0].Distributions[1].V[1])
+	assert.Equal(t, uint32(3), decodedPayload.Sketches[0].Distributions[1].G[1])
+	assert.Equal(t, uint32(0), decodedPayload.Sketches[0].Distributions[1].Delta[1])
+	assert.Equal(t, float64(21), decodedPayload.Sketches[0].Distributions[1].V[2])
+	assert.Equal(t, uint32(2), decodedPayload.Sketches[0].Distributions[1].G[2])
+	assert.Equal(t, uint32(0), decodedPayload.Sketches[0].Distributions[1].Delta[2])
 }
 
 func TestMarshalJSON(t *testing.T) {
@@ -111,6 +113,6 @@ func TestMarshalJSON(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
 
-	expectedPayload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"max\":1,\"n\":1,\"sum\":1,\"avg\":1}},{\"timestamp\":67890,\"qsketch\":{\"entries\":[[10,1,0],[14,3,0],[21,2,0]],\"min\":10,\"max\":21,\"n\":6,\"sum\":96,\"avg\":16}}]}]}\n")
+	expectedPayload := []byte("{\"sketch_series\":[{\"metric\":\"test.metrics\",\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"interval\":0,\"sketches\":[{\"timestamp\":12345,\"qsketch\":{\"entries\":[[1,1,0]],\"min\":1,\"max\":1,\"cnt\":1,\"sum\":1,\"avg\":1}},{\"timestamp\":67890,\"qsketch\":{\"entries\":[[10,1,0],[14,3,0],[21,2,0]],\"min\":10,\"max\":21,\"cnt\":6,\"sum\":96,\"avg\":16}}]}]}\n")
 	assert.Equal(t, payload, []byte(expectedPayload))
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Changes `gk_array` and `sketch_series` to match a more efficient `SketchPayload` in the `agent-payload` repo

* update `Gopkg.toml` to the new version of `agent-payload`
* change `gk_array` and `sketch_series` to match the new payload
* change data types of `gk_array`

Also, changes the `merge()` method of `GKArray` so that it always returns a compressed sketch.

### Motivation

Making the sketch payload more efficient.

### Additional Notes

Anything else we should know when reviewing?
