### PR TITLE
[AD] add a cache for templates and use it in autoconfig

### DIFF
--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -9,16 +9,18 @@ import (
 
 // TemplateCache is a data structure to store configuration templates
 type TemplateCache struct {
-	id2templates map[string][]check.Config
-	template2ids map[string][]string
-	m            sync.RWMutex
+	id2digests      map[string][]string     // map an AD identifier to the all the configs that have it
+	digest2ids      map[string][]string     // map a config to the list of AD identifiers it has
+	digest2template map[string]check.Config // map a digest to the corresponding config object
+	m               sync.RWMutex
 }
 
 // NewTemplateCache creates a new cache
 func NewTemplateCache() *TemplateCache {
 	return &TemplateCache{
-		id2templates: make(map[string][]check.Config, 0),
-		template2ids: make(map[string][]string, 0),
+		id2digests:      make(map[string][]string, 0),
+		digest2ids:      make(map[string][]string, 0),
+		digest2template: make(map[string]check.Config, 0),
 	}
 }
 
@@ -32,14 +34,19 @@ func (cache *TemplateCache) Set(tpl check.Config) error {
 	cache.m.Lock()
 	defer cache.m.Unlock()
 
+	// compute the template digest once
+	d := tpl.Digest()
+
 	// do nothing if the template is already in cache
-	if _, found := cache.template2ids[tpl.Digest()]; found {
+	if _, found := cache.digest2ids[d]; found {
 		return nil
 	}
 
-	cache.template2ids[tpl.Digest()] = tpl.ADIdentifiers
+	// store the template
+	cache.digest2template[d] = tpl
+	cache.digest2ids[d] = tpl.ADIdentifiers
 	for _, id := range tpl.ADIdentifiers {
-		cache.id2templates[id] = append(cache.id2templates[id], tpl)
+		cache.id2digests[id] = append(cache.id2digests[id], d)
 	}
 
 	return nil
@@ -50,7 +57,11 @@ func (cache *TemplateCache) Get(adID string) ([]check.Config, error) {
 	cache.m.RLock()
 	defer cache.m.RUnlock()
 
-	if templates, found := cache.id2templates[adID]; found {
+	if digests, found := cache.id2digests[adID]; found {
+		templates := make([]check.Config, len(digests))
+		for _, digest := range digests {
+			templates = append(templates, cache.digest2template[digest])
+		}
 		return templates, nil
 	}
 
@@ -60,26 +71,27 @@ func (cache *TemplateCache) Get(adID string) ([]check.Config, error) {
 // Del removes a template from the cache
 func (cache *TemplateCache) Del(tpl check.Config) error {
 	// compute the digest once
-	tplDigest := tpl.Digest()
+	d := tpl.Digest()
 
 	cache.m.Lock()
 	defer cache.m.Unlock()
 
 	// returns an error in case the template isn't there
-	if _, found := cache.template2ids[tplDigest]; !found {
+	if _, found := cache.digest2ids[d]; !found {
 		return fmt.Errorf("template not found in cache")
 	}
 
-	// remove the template from template2ids
-	delete(cache.template2ids, tplDigest)
+	// remove the template
+	delete(cache.digest2ids, d)
+	delete(cache.digest2template, d)
 
 	// iterate through the AD identifiers for this config
 	for _, id := range tpl.ADIdentifiers {
-		tpls := cache.id2templates[id]
+		digests := cache.id2digests[id]
 		// remove the template from id2templates
-		for i, template := range tpls {
-			if template.Equal(&tpl) {
-				cache.id2templates[id] = append(tpls[:i], tpls[i+1:]...)
+		for i, digest := range digests {
+			if digest == d {
+				cache.id2digests[id] = append(digests[:i], digests[i+1:]...)
 				break
 			}
 		}

--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -1,0 +1,89 @@
+package autodiscovery
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+// TemplateCache is a data structure to store configuration templates
+type TemplateCache struct {
+	id2templates map[string][]check.Config
+	template2ids map[check.ID][]string
+	m            sync.RWMutex
+}
+
+// NewTemplateCache creates a new cache
+func NewTemplateCache() *TemplateCache {
+	return &TemplateCache{
+		id2templates: make(map[string][]check.Config, 0),
+		template2ids: make(map[check.ID][]string, 0),
+	}
+}
+
+// Set stores or updates a template in the cache
+func (cache *TemplateCache) Set(tpl check.Config) error {
+	// return an error if configuration has no AD identifiers
+	if len(tpl.ADIdentifiers) == 0 {
+		return fmt.Errorf("template has no AD identifiers, unable to store it in the cache")
+	}
+
+	cache.m.Lock()
+	defer cache.m.Unlock()
+
+	// do nothing if the template is already in cache
+	if _, found := cache.template2ids[tpl.Digest()]; found {
+		return nil
+	}
+
+	cache.template2ids[tpl.Digest()] = tpl.ADIdentifiers
+	for _, id := range tpl.ADIdentifiers {
+		cache.id2templates[id] = append(cache.id2templates[id], tpl)
+	}
+
+	return nil
+}
+
+// Get retrieves a template from the cache
+func (cache *TemplateCache) Get(adID string) ([]check.Config, error) {
+	cache.m.RLock()
+	defer cache.m.RUnlock()
+
+	if templates, found := cache.id2templates[adID]; found {
+		return templates, nil
+	}
+
+	return nil, fmt.Errorf("Autodiscovery id not found in cache")
+}
+
+// Del removes a template from the cache
+func (cache *TemplateCache) Del(tpl check.Config) error {
+	// compute the digest once
+	tplDigest := tpl.Digest()
+
+	cache.m.Lock()
+	defer cache.m.Unlock()
+
+	// returns an error in case the template isn't there
+	if _, found := cache.template2ids[tplDigest]; !found {
+		return fmt.Errorf("template not found in cache")
+	}
+
+	// remove the template from template2ids
+	delete(cache.template2ids, tplDigest)
+
+	// iterate through the AD identifiers for this config
+	for _, id := range tpl.ADIdentifiers {
+		tpls := cache.id2templates[id]
+		// remove the template from id2templates
+		for i, template := range tpls {
+			if template.Equal(&tpl) {
+				cache.id2templates[id] = append(tpls[:i], tpls[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -10,7 +10,7 @@ import (
 // TemplateCache is a data structure to store configuration templates
 type TemplateCache struct {
 	id2templates map[string][]check.Config
-	template2ids map[check.ID][]string
+	template2ids map[string][]string
 	m            sync.RWMutex
 }
 
@@ -18,7 +18,7 @@ type TemplateCache struct {
 func NewTemplateCache() *TemplateCache {
 	return &TemplateCache{
 		id2templates: make(map[string][]check.Config, 0),
-		template2ids: make(map[check.ID][]string, 0),
+		template2ids: make(map[string][]string, 0),
 	}
 }
 

--- a/pkg/collector/autodiscovery/templatecache_test.go
+++ b/pkg/collector/autodiscovery/templatecache_test.go
@@ -1,0 +1,52 @@
+package autodiscovery
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	cache := NewTemplateCache()
+	assert.Len(t, cache.id2templates, 0)
+	assert.Len(t, cache.template2ids, 0)
+}
+
+func TestSet(t *testing.T) {
+	cache := NewTemplateCache()
+
+	tpl1 := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	err := cache.Set(tpl1)
+
+	require.Nil(t, err)
+	assert.Len(t, cache.id2templates, 2)
+	assert.Len(t, cache.id2templates["foo"], 1)
+	assert.Len(t, cache.id2templates["bar"], 1)
+	assert.Len(t, cache.template2ids, 1)
+
+	tpl2 := check.Config{ADIdentifiers: []string{"foo"}}
+	err = cache.Set(tpl2)
+
+	require.Nil(t, err)
+	assert.Len(t, cache.id2templates, 2)
+	assert.Len(t, cache.id2templates["foo"], 2)
+	assert.Len(t, cache.id2templates["bar"], 1)
+	assert.Len(t, cache.template2ids, 2)
+}
+
+func TestDel(t *testing.T) {
+	cache := NewTemplateCache()
+	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	err := cache.Set(tpl)
+	require.Nil(t, err)
+
+	err = cache.Del(tpl)
+	require.Nil(t, err)
+
+	require.Len(t, cache.id2templates, 2)
+	assert.Len(t, cache.id2templates["foo"], 0)
+	assert.Len(t, cache.id2templates["bar"], 0)
+	assert.Len(t, cache.template2ids, 0)
+}

--- a/pkg/collector/autodiscovery/templatecache_test.go
+++ b/pkg/collector/autodiscovery/templatecache_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestNew(t *testing.T) {
 	cache := NewTemplateCache()
-	assert.Len(t, cache.id2templates, 0)
-	assert.Len(t, cache.template2ids, 0)
+	assert.Len(t, cache.id2digests, 0)
+	assert.Len(t, cache.digest2ids, 0)
+	assert.Len(t, cache.digest2template, 0)
 }
 
 func TestSet(t *testing.T) {
@@ -21,19 +22,21 @@ func TestSet(t *testing.T) {
 	err := cache.Set(tpl1)
 
 	require.Nil(t, err)
-	assert.Len(t, cache.id2templates, 2)
-	assert.Len(t, cache.id2templates["foo"], 1)
-	assert.Len(t, cache.id2templates["bar"], 1)
-	assert.Len(t, cache.template2ids, 1)
+	assert.Len(t, cache.id2digests, 2)
+	assert.Len(t, cache.id2digests["foo"], 1)
+	assert.Len(t, cache.id2digests["bar"], 1)
+	assert.Len(t, cache.digest2ids, 1)
+	assert.Len(t, cache.digest2template, 1)
 
 	tpl2 := check.Config{ADIdentifiers: []string{"foo"}}
 	err = cache.Set(tpl2)
 
 	require.Nil(t, err)
-	assert.Len(t, cache.id2templates, 2)
-	assert.Len(t, cache.id2templates["foo"], 2)
-	assert.Len(t, cache.id2templates["bar"], 1)
-	assert.Len(t, cache.template2ids, 2)
+	assert.Len(t, cache.id2digests, 2)
+	assert.Len(t, cache.id2digests["foo"], 2)
+	assert.Len(t, cache.id2digests["bar"], 1)
+	assert.Len(t, cache.digest2ids, 2)
+	assert.Len(t, cache.digest2template, 2)
 }
 
 func TestDel(t *testing.T) {
@@ -45,8 +48,9 @@ func TestDel(t *testing.T) {
 	err = cache.Del(tpl)
 	require.Nil(t, err)
 
-	require.Len(t, cache.id2templates, 2)
-	assert.Len(t, cache.id2templates["foo"], 0)
-	assert.Len(t, cache.id2templates["bar"], 0)
-	assert.Len(t, cache.template2ids, 0)
+	require.Len(t, cache.id2digests, 2)
+	assert.Len(t, cache.id2digests["foo"], 0)
+	assert.Len(t, cache.id2digests["bar"], 0)
+	assert.Len(t, cache.digest2ids, 0)
+	assert.Len(t, cache.digest2template, 0)
 }

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -2,6 +2,8 @@ package check
 
 import (
 	"bytes"
+	"hash/fnv"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -81,35 +83,7 @@ func (c *Config) Equal(config *Config) bool {
 		return false
 	}
 
-	if c.Name != config.Name {
-		return false
-	}
-
-	if len(c.Instances) != len(config.Instances) {
-		return false
-	}
-
-	for i := range c.Instances {
-		if !bytes.Equal(c.Instances[i], config.Instances[i]) {
-			return false
-		}
-	}
-
-	if !bytes.Equal(c.InitConfig, config.InitConfig) {
-		return false
-	}
-
-	if len(c.ADIdentifiers) != len(config.ADIdentifiers) {
-		return false
-	}
-
-	for i, id := range c.ADIdentifiers {
-		if id != config.ADIdentifiers[i] {
-			return false
-		}
-	}
-
-	return true
+	return c.Digest() == config.Digest()
 }
 
 // String YAML representation of the config
@@ -143,4 +117,19 @@ func (c *Config) String() string {
 	}
 
 	return yamlBuff.String()
+}
+
+// Digest returns an hash value representing the data stored in this configuration
+func (c *Config) Digest() ID {
+	h := fnv.New64()
+	h.Write([]byte(c.Name))
+	for _, i := range c.Instances {
+		h.Write([]byte(i))
+	}
+	h.Write([]byte(c.InitConfig))
+	for _, i := range c.ADIdentifiers {
+		h.Write([]byte(i))
+	}
+
+	return ID(strconv.FormatUint(h.Sum64(), 16))
 }

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -120,7 +120,7 @@ func (c *Config) String() string {
 }
 
 // Digest returns an hash value representing the data stored in this configuration
-func (c *Config) Digest() ID {
+func (c *Config) Digest() string {
 	h := fnv.New64()
 	h.Write([]byte(c.Name))
 	for _, i := range c.Instances {
@@ -131,5 +131,5 @@ func (c *Config) Digest() ID {
 		h.Write([]byte(i))
 	}
 
-	return ID(strconv.FormatUint(h.Sum64(), 16))
+	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -59,10 +59,10 @@ func TestDigest(t *testing.T) {
 }
 
 // this is here to prevent compiler optimization on the benchmarking code
-var result ID
+var result string
 
 func BenchmarkID(b *testing.B) {
-	var id ID // store ID() return value to avoid the compiler to strip the function call
+	var id string // store return value to avoid the compiler to strip the function call
 	config := &Config{}
 	config.InitConfig = make([]byte, 32000)
 	rand.Read(config.InitConfig)

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,4 +51,23 @@ instances:
 - justFoo
 `
 	assert.Equal(t, config.String(), expected)
+}
+
+func TestDigest(t *testing.T) {
+	config := &Config{}
+	assert.Equal(t, 16, len(config.Digest()))
+}
+
+// this is here to prevent compiler optimization on the benchmarking code
+var result ID
+
+func BenchmarkID(b *testing.B) {
+	var id ID // store ID() return value to avoid the compiler to strip the function call
+	config := &Config{}
+	config.InitConfig = make([]byte, 32000)
+	rand.Read(config.InitConfig)
+	for n := 0; n < b.N; n++ {
+		id = config.Digest()
+	}
+	result = id
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds a data structure to store configuration templates.

### Motivation

Needed by Autodiscovery, it will access the cache and try to render the templates it finds there.

### Additional Notes

We need a way to identify configuration templates, so the `Digest` method was added. The computational cost of the digesting is negligible in our use case, a benchmark function was added to see how the function performs.
The `Equal` method was rewritten to use the digest, a little slower now but way more consistent.
