### PR TITLE
Move implementation of serializer.Marshal to common v5/payload.

### DIFF
--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -1,6 +1,9 @@
 package v5
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
@@ -19,4 +22,17 @@ type HostPayload struct {
 // ResourcesPayload wraps Payload from the resources package
 type ResourcesPayload struct {
 	resources.Payload `json:"resources"`
+}
+
+// MarshalJSON serialization a Payload to JSON
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	// use an alias to avoid infinit recursion while serializing
+	type PayloadAlias Payload
+
+	return json.Marshal((*PayloadAlias)(p))
+}
+
+// Marshal not implemented
+func (p *Payload) Marshal() ([]byte, error) {
+	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
 }

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -62,19 +62,6 @@ type Payload struct {
 	// TODO: agent_checks
 }
 
-// MarshalJSON serialization a Payload to JSON
-func (p *Payload) MarshalJSON() ([]byte, error) {
-	// use an alias to avoid infinit recursion while serializing
-	type PayloadAlias Payload
-
-	return json.Marshal((*PayloadAlias)(p))
-}
-
-// Marshal not implemented
-func (p *Payload) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
-}
-
 // SplitPayload breaks the payload into times number of pieces
 func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
 	// Metadata payloads are analyzed as a whole, so they cannot be split


### PR DESCRIPTION
### What does this PR do?

Move implementation of serializer.Marshal to common v5/payload. This will allow this code to build on freebsd and other architectures that are not covered by the build tags in `payload_gohai.go`.

### Motivation

I was trying to get the process-agent working on freebsd and the build was blocked on error with the `serializer.Marshal` interface not being implemented. I don't know the context here so there certainly may be a better approach. Let me know if so.

