### PR TITLE
Fix the benchmarks build and add them to the ci pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,22 @@ dogstatsd_static-x64:
     paths:
       - dogstatsd
 
+# build benchmarks
+benchmarks-x64:
+  stage: binary_build
+  image: $DEB_X64
+  tags:
+    - docker
+  variables:
+    USE_SYSTEM_LIBS: "1"
+  script:
+    - rake benchmark:aggregator:build
+    - rake benchmark:dogstatsd:build
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - benchmarks
+
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -92,9 +92,9 @@ func main() {
 
 	config.SetupLogger("error", "")
 	f := forwarder.NewDefaultForwarder(map[string][]string{})
-	s := &serializer.Serializer{forwarder: f}
+	s := &serializer.Serializer{Forwarder: f}
 
-	agg := aggregator.NewBufferedAggregator(s, "benchmark")
+	agg := aggregator.InitAggregator(s, "hostname")
 	flush := make(chan time.Time)
 	agg.TickerChan = flush
 

--- a/test/benchmarks/aggregator/metrics.go
+++ b/test/benchmarks/aggregator/metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 var gnuplotHeader = `# set terminal png truecolor
@@ -37,14 +38,14 @@ func generateMetrics(numberOfSeries int, pointPerSeries int, senderMetric sender
 func generateEvent(numberOfEvent int, sender aggregator.Sender) time.Duration {
 	start := time.Now()
 	for i := 0; i < numberOfEvent; i++ {
-		sender.Event(aggregator.Event{
+		sender.Event(metrics.Event{
 			Title:          "Event title",
 			Text:           "some text",
 			Ts:             21,
-			Priority:       aggregator.EventPriorityNormal,
+			Priority:       metrics.EventPriorityNormal,
 			Host:           "localhost",
 			Tags:           []string{"a", "b:21", "c"},
-			AlertType:      aggregator.EventAlertTypeWarning,
+			AlertType:      metrics.EventAlertTypeWarning,
 			AggregationKey: "",
 			SourceTypeName: "",
 			EventType:      "",
@@ -56,7 +57,7 @@ func generateEvent(numberOfEvent int, sender aggregator.Sender) time.Duration {
 func generateServiceCheck(numberOfSC int, sender aggregator.Sender) time.Duration {
 	start := time.Now()
 	for i := 0; i < numberOfSC; i++ {
-		sender.ServiceCheck("benchmark.ServiceCheck."+strconv.Itoa(i), aggregator.ServiceCheckOK, "localhost", []string{"a", "b:21", "c"}, "some message")
+		sender.ServiceCheck("benchmark.ServiceCheck."+strconv.Itoa(i), metrics.ServiceCheckOK, "localhost", []string{"a", "b:21", "c"}, "some message")
 	}
 	return time.Since(start)
 }

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -189,7 +189,7 @@ func main() {
 
 	config.Datadog.Set("dogstatsd_stats_enable", true)
 	config.Datadog.Set("dogstatsd_stats_buffer", 100)
-	s := &serializer.Serializer{forwarder: f}
+	s := &serializer.Serializer{Forwarder: f}
 	aggr := aggregator.InitAggregator(s, "localhost")
 	statsd, err := dogstatsd.NewServer(aggr.GetChannels())
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Fix the benchmarks build and add them to the ci pipeline (build step only)

### Motivation

This would avoid the benchmark code getting out of sync from the agent packages.