### PR TITLE
[aggregator] Improve performance of context key generation

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -2,8 +2,8 @@ package aggregator
 
 import (
 	// stdlib
+	"bytes"
 	"sort"
-	"strings"
 
 	// 3p
 	log "github.com/cihub/seelog"
@@ -26,14 +26,25 @@ type ContextResolver struct {
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
 func generateContextKey(metricSample *metrics.MetricSample) string {
-	var contextFields []string
+	// Pre-compute the size of the buffer we'll need, and allocate a buffer of that size
+	bufferSize := len(metricSample.Name) + 1
+	for k := range metricSample.Tags {
+		bufferSize += len(metricSample.Tags[k]) + 1
+	}
+	bufferSize += len(metricSample.Host)
+	buffer := bytes.NewBuffer(make([]byte, 0, bufferSize))
 
-	contextFields = append(contextFields, metricSample.Name)
 	sort.Strings(metricSample.Tags)
-	contextFields = append(contextFields, metricSample.Tags...)
-	contextFields = append(contextFields, metricSample.Host)
+	// write the context items to the buffer, and return it as a string
+	buffer.WriteString(metricSample.Name)
+	buffer.WriteString(",")
+	for k := range metricSample.Tags {
+		buffer.WriteString(metricSample.Tags[k])
+		buffer.WriteString(",")
+	}
+	buffer.WriteString(metricSample.Host)
 
-	return strings.Join(contextFields, ",")
+	return buffer.String()
 }
 
 func newContextResolver() *ContextResolver {


### PR DESCRIPTION
### What does this PR do?

Improves the performance of the context key generation.

(we allocate a buffer with the right size once now)

### Motivation

On a typical benchmark with many samples sent per second on the same
contexts, this function would take 50% of the total time needed by
`BufferedAggregator.AddSample()` (did some CPU profiling on the aggregator).

This change typically divides the execution time of the `generateContextKey`
function by a factor of 3, and improves `AddSample` performance by ~30%
