### PR TITLE
[serializer] Add config param to use v2 api

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,9 +50,9 @@ func init() {
 		Datadog.SetDefault("proc_root", "/proc")
 	}
 	// Serializer
-	Datadog.SetDefault("use_v2_endpoint.series", false)
-	Datadog.SetDefault("use_v2_endpoint.events", false)
-	Datadog.SetDefault("use_v2_endpoint.service_checks", false)
+	Datadog.SetDefault("use_v2_api.series", false)
+	Datadog.SetDefault("use_v2_api.events", false)
+	Datadog.SetDefault("use_v2_api.service_checks", false)
 	// Forwarder
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("forwarder_retry_queue_max_size", 30)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,10 @@ func init() {
 	} else {
 		Datadog.SetDefault("proc_root", "/proc")
 	}
+	// Serializer
+	Datadog.SetDefault("use_v2_endpoint.series", false)
+	Datadog.SetDefault("use_v2_endpoint.events", false)
+	Datadog.SetDefault("use_v2_endpoint.service_checks", false)
 	// Forwarder
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("forwarder_retry_queue_max_size", 30)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -59,11 +59,11 @@ type Serializer struct {
 	Forwarder forwarder.Forwarder
 }
 
-func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool, useV1Endpoint bool) (forwarder.Payloads, map[string]string, error) {
+func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool, useV1API bool) (forwarder.Payloads, map[string]string, error) {
 	var marshalType split.MarshalType
 	var extraHeaders map[string]string
 
-	if useV1Endpoint {
+	if useV1API {
 		marshalType = split.MarshalJSON
 		if compress {
 			extraHeaders = jsonExtraHeadersWithCompression
@@ -90,18 +90,18 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 
 // SendEvents serializes a list of event and sends the payload to the forwarder
 func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
-	useV1Endpoint := false
-	if !config.Datadog.GetBool("use_v2_endpoint.events") {
-		useV1Endpoint = true
+	useV1API := false
+	if !config.Datadog.GetBool("use_v2_api.events") {
+		useV1API = true
 	}
 
 	compress := true
-	eventPayloads, extraHeaders, err := s.serializePayload(e, compress, useV1Endpoint)
+	eventPayloads, extraHeaders, err := s.serializePayload(e, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping event payload: %s", err)
 	}
 
-	if useV1Endpoint {
+	if useV1API {
 		return s.Forwarder.SubmitV1Intake(eventPayloads, extraHeaders)
 	}
 	return s.Forwarder.SubmitEvents(eventPayloads, extraHeaders)
@@ -109,18 +109,18 @@ func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
-	useV1Endpoint := false
-	if !config.Datadog.GetBool("use_v2_endpoint.service_checks") {
-		useV1Endpoint = true
+	useV1API := false
+	if !config.Datadog.GetBool("use_v2_api.service_checks") {
+		useV1API = true
 	}
 
 	compress := false
-	serviceCheckPayloads, extraHeaders, err := s.serializePayload(sc, compress, useV1Endpoint)
+	serviceCheckPayloads, extraHeaders, err := s.serializePayload(sc, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping service check payload: %s", err)
 	}
 
-	if useV1Endpoint {
+	if useV1API {
 		return s.Forwarder.SubmitV1CheckRuns(serviceCheckPayloads, extraHeaders)
 	}
 	return s.Forwarder.SubmitServiceChecks(serviceCheckPayloads, extraHeaders)
@@ -128,18 +128,18 @@ func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
-	useV1Endpoint := false
-	if !config.Datadog.GetBool("use_v2_endpoint.series") {
-		useV1Endpoint = true
+	useV1API := false
+	if !config.Datadog.GetBool("use_v2_api.series") {
+		useV1API = true
 	}
 
 	compress := true
-	seriesPayloads, extraHeaders, err := s.serializePayload(series, compress, useV1Endpoint)
+	seriesPayloads, extraHeaders, err := s.serializePayload(series, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping series payload: %s", err)
 	}
 
-	if useV1Endpoint {
+	if useV1API {
 		return s.Forwarder.SubmitV1Series(seriesPayloads, extraHeaders)
 	}
 	return s.Forwarder.SubmitSeries(seriesPayloads, extraHeaders)
@@ -148,8 +148,8 @@ func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder
 func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
 	compress := false
-	useV1Endpoint := false // Sketches only have a v2 endpoint
-	splitSketches, extraHeaders, err := s.serializePayload(sketches, compress, useV1Endpoint)
+	useV1API := false // Sketches only have a v2 endpoint
+	splitSketches, extraHeaders, err := s.serializePayload(sketches, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping sketch payload: %s", err)
 	}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -98,7 +98,7 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 	useV1API := !config.Datadog.GetBool("use_v2_api.events")
 
-	compress := true
+	compress := !useV1API
 	eventPayloads, extraHeaders, err := s.serializePayload(e, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping event payload: %s", err)
@@ -114,7 +114,8 @@ func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 	useV1API := !config.Datadog.GetBool("use_v2_api.service_checks")
 
-	compress := false
+	// FIXME(olivier): zstd compression is supposed to work on this v1 endpoint, we should investigate why it's broken
+	compress := !useV1API
 	serviceCheckPayloads, extraHeaders, err := s.serializePayload(sc, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping service check payload: %s", err)
@@ -130,7 +131,8 @@ func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
 	useV1API := !config.Datadog.GetBool("use_v2_api.series")
 
-	compress := true
+	// FIXME(olivier): zstd compression is supposed to work on this v1 endpoint, we should investigate why it's broken
+	compress := !useV1API
 	seriesPayloads, extraHeaders, err := s.serializePayload(series, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping series payload: %s", err)
@@ -144,7 +146,7 @@ func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
 
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder
 func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
-	compress := false
+	compress := false // TODO: enable compression once the backend supports it on this endpoint
 	useV1API := false // Sketches only have a v2 endpoint
 	splitSketches, extraHeaders, err := s.serializePayload(sketches, compress, useV1API)
 	if err != nil {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -31,6 +31,12 @@ var (
 )
 
 func init() {
+	initExtraHeaders()
+}
+
+// initExtraHeaders initializes the global extraHeaders variables
+// extracted out of the `init` function to ease testing
+func initExtraHeaders() {
 	jsonExtraHeaders = map[string]string{
 		"Content-Type": jsonContentType,
 	}
@@ -90,10 +96,7 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 
 // SendEvents serializes a list of event and sends the payload to the forwarder
 func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
-	useV1API := false
-	if !config.Datadog.GetBool("use_v2_api.events") {
-		useV1API = true
-	}
+	useV1API := !config.Datadog.GetBool("use_v2_api.events")
 
 	compress := true
 	eventPayloads, extraHeaders, err := s.serializePayload(e, compress, useV1API)
@@ -109,10 +112,7 @@ func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
-	useV1API := false
-	if !config.Datadog.GetBool("use_v2_api.service_checks") {
-		useV1API = true
-	}
+	useV1API := !config.Datadog.GetBool("use_v2_api.service_checks")
 
 	compress := false
 	serviceCheckPayloads, extraHeaders, err := s.serializePayload(sc, compress, useV1API)
@@ -128,10 +128,7 @@ func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
-	useV1API := false
-	if !config.Datadog.GetBool("use_v2_api.series") {
-		useV1API = true
-	}
+	useV1API := !config.Datadog.GetBool("use_v2_api.series")
 
 	compress := true
 	seriesPayloads, extraHeaders, err := s.serializePayload(series, compress, useV1API)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -108,8 +108,8 @@ func TestSendEvents(t *testing.T) {
 func TestSendV2Events(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitEvents", protobufPayloads, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	config.Datadog.Set("use_v2_endpoint.events", true)
-	defer config.Datadog.Set("use_v2_endpoint.events", nil)
+	config.Datadog.Set("use_v2_api.events", true)
+	defer config.Datadog.Set("use_v2_api.events", nil)
 
 	s := Serializer{Forwarder: f}
 
@@ -144,8 +144,8 @@ func TestSendV2ServiceChecks(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	payloads, _ := mkPayloads(protobufString, false)
 	f.On("SubmitServiceChecks", payloads, protobufExtraHeaders).Return(nil).Times(1)
-	config.Datadog.Set("use_v2_endpoint.service_checks", true)
-	defer config.Datadog.Set("use_v2_endpoint.service_checks", nil)
+	config.Datadog.Set("use_v2_api.service_checks", true)
+	defer config.Datadog.Set("use_v2_api.service_checks", nil)
 
 	s := Serializer{Forwarder: f}
 
@@ -178,8 +178,8 @@ func TestSendSeries(t *testing.T) {
 func TestSendV2Series(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitSeries", protobufPayloads, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	config.Datadog.Set("use_v2_endpoint.series", true)
-	defer config.Datadog.Set("use_v2_endpoint.series", nil)
+	config.Datadog.Set("use_v2_api.series", true)
+	defer config.Datadog.Set("use_v2_api.series", nil)
 
 	s := Serializer{Forwarder: f}
 

--- a/pkg/util/compression/no_compression.go
+++ b/pkg/util/compression/no_compression.go
@@ -2,9 +2,10 @@
 
 package compression
 
-// ContentEncoding describes the HTTP header value associated with the compression
+// ContentEncoding describes the HTTP header value associated with the compression method
 // empty here since there's no compression
-const ContentEncoding = ""
+// var instead of const to ease testing
+var ContentEncoding = ""
 
 // Compress will not compress anything
 func Compress(dst []byte, src []byte) ([]byte, error) {

--- a/pkg/util/compression/no_compression.go
+++ b/pkg/util/compression/no_compression.go
@@ -2,6 +2,10 @@
 
 package compression
 
+// ContentEncoding describes the HTTP header value associated with the compression
+// empty here since there's no compression
+const ContentEncoding = ""
+
 // Compress will not compress anything
 func Compress(dst []byte, src []byte) ([]byte, error) {
 	dst = src

--- a/pkg/util/compression/zlib.go
+++ b/pkg/util/compression/zlib.go
@@ -7,6 +7,9 @@ import (
 	"compress/zlib"
 )
 
+// CompressionHeaders lists the HTTP headers that should be used with this compression method
+const ContentEncoding = "application/zlib"
+
 // Compress will compress the data with zlib
 func Compress(dst []byte, src []byte) ([]byte, error) {
 	var b bytes.Buffer

--- a/pkg/util/compression/zlib.go
+++ b/pkg/util/compression/zlib.go
@@ -7,8 +7,9 @@ import (
 	"compress/zlib"
 )
 
-// CompressionHeaders lists the HTTP headers that should be used with this compression method
-const ContentEncoding = "application/zlib"
+// ContentEncoding describes the HTTP header value associated with the compression method
+// var instead of const to ease testing
+var ContentEncoding = "deflate"
 
 // Compress will compress the data with zlib
 func Compress(dst []byte, src []byte) ([]byte, error) {

--- a/pkg/util/compression/zstd.go
+++ b/pkg/util/compression/zstd.go
@@ -4,6 +4,9 @@ package compression
 
 import "github.com/DataDog/zstd"
 
+// ContentEncoding describes the HTTP header value associated with the compression
+const ContentEncoding = "application/zstd"
+
 // Compress will compress the data with zstd
 func Compress(dst []byte, src []byte) ([]byte, error) {
 	return zstd.Compress(dst, src)

--- a/pkg/util/compression/zstd.go
+++ b/pkg/util/compression/zstd.go
@@ -4,8 +4,9 @@ package compression
 
 import "github.com/DataDog/zstd"
 
-// ContentEncoding describes the HTTP header value associated with the compression
-const ContentEncoding = "application/zstd"
+// ContentEncoding describes the HTTP header value associated with the compression method
+// var instead of const to ease testing
+var ContentEncoding = "zstd"
 
 // Compress will compress the data with zstd
 func Compress(dst []byte, src []byte) ([]byte, error) {


### PR DESCRIPTION
### What does this PR do?

* Adds a config param to use v2 api, per endpoint
* Adds a `Content-Encoding` header to the payloads when they're compressed

### Motivation

This should allow us to start testing the v2 endpoints one by one. The default endpoints will remain the v1 endpoints until the v2 api is stable.

### Additional Notes

See commit descriptions.

Example config to use the v2 api on the `series` endpoint only:

```yaml
use_v2_endpoint:
  series: true
```

The options are not documented directly in `datadog.yaml` because I don't think customers should be changing them, they're there for our internal testing purposes only (at least for now).

**[update]**

I've disabled compression on the v1 endpoints as we've noticed the agent6 zstd compression doesn't work on the v1 endpoints right now (`400` status code). I've added a card to our backlog to track this, we can spend more time investigating this as part of a separate PR.