### PR TITLE
[AD] first draft of the `Resolve` method

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -272,11 +272,16 @@ func (ac *AutoConfig) pollConfigs() {
 					// as removed configurations
 					newConfigs, removedConfigs := ac.collect(pd)
 					for _, config := range newConfigs {
-						if len(config.ADIdentifiers) > 0 { // TODO: move this evaluation in a config.IsTemplate() method
-							// TODO: try to resolve the template
-							// TODO: if success, schedule the check for running
-							// TODO: if failed, notify we couldn't resolve it for now (it might happen later)
-							// store the template in the cache
+						if config.IsTemplate() {
+							// try to resolve the template
+							resolved := ac.configResolver.Resolve(config)
+							if len(resolved) > 0 {
+								// TODO: if success, schedule the check for running
+							} else {
+								// TODO: if failed, notify we couldn't resolve it for now (it might happen later)
+							}
+
+							// store the template in the cache in any case
 							if err := ac.templateCache.Set(config); err != nil {
 								log.Errorf("Unable to process Check configuration: %s", err)
 							}
@@ -287,7 +292,7 @@ func (ac *AutoConfig) pollConfigs() {
 
 					for _, config := range removedConfigs {
 						// TODO: unschedule the checks corresponding to this config
-						if len(config.ADIdentifiers) > 0 {
+						if config.IsTemplate() {
 							// if the config is a template, remove it from the cache
 							ac.templateCache.Del(config)
 						}

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -274,7 +274,7 @@ func (ac *AutoConfig) pollConfigs() {
 					for _, config := range newConfigs {
 						if config.IsTemplate() {
 							// try to resolve the template
-							resolved := ac.configResolver.Resolve(config)
+							resolved := ac.configResolver.ResolveTemplate(config)
 							if len(resolved) > 0 {
 								// TODO: if success, schedule the check for running
 							} else {

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -221,7 +221,8 @@ func (cr *ConfigResolver) Stop() {
 // 	}
 // }
 
-// Resolve attempts to resolve a configuration template.
+// ResolveTemplate attempts to resolve a configuration template using the AD
+// identifiers in the `check.Config` struct to match a Service.
 //
 // The function might return more than one configuration for a single template,
 // for example when the `ad_identifiers` section of a config.yaml file contains
@@ -230,7 +231,7 @@ func (cr *ConfigResolver) Stop() {
 // The function might return an empty list in the case the configuration has a
 // list of Autodiscovery identifiers for services that are unknown to the
 // resolver at this moment.
-func (cr *ConfigResolver) Resolve(tpl check.Config) []check.Config {
+func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 	// use a map to dedupe configurations
 	resolvedSet := map[string]check.Config{}
 	resolved := []check.Config{}

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -133,17 +133,25 @@ func (c *Config) String() string {
 	return yamlBuff.String()
 }
 
-// IsTemplate looks at init config and instance and
-// returns if it finds template variables
+// IsTemplate returns if the config has AD identifiers and template variables
 func (c *Config) IsTemplate() bool {
+	// a template must have at least an AD identifier
+	if len(c.ADIdentifiers) == 0 {
+		return false
+	}
+
+	// init_config containing template tags
 	if tplVarRegex.Match(c.InitConfig) {
 		return true
 	}
+
+	// any of the instances containing template tags
 	for _, inst := range c.Instances {
 		if tplVarRegex.Match(inst) {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -17,16 +17,18 @@ func TestGetConfigIDFromPs(t *testing.T) {
 	}
 	dl := DockerListener{}
 
-	id := dl.getConfigIDFromPs(co)
-	assert.Equal(t, "test", id)
+	ids := dl.getConfigIDFromPs(co)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, "test", ids[0])
 
 	labeledCo := types.Container{
 		ID:     "deadbeef",
 		Image:  "test",
 		Labels: map[string]string{"io.datadog.check.id": "w00tw00t"},
 	}
-	id = dl.getConfigIDFromPs(labeledCo)
-	assert.Equal(t, "w00tw00t", id)
+	ids = dl.getConfigIDFromPs(labeledCo)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, "w00tw00t", ids[0])
 }
 
 func TestGetHostsFromPs(t *testing.T) {
@@ -87,8 +89,9 @@ func TestGetConfigIDFromInspect(t *testing.T) {
 	}
 	dl := DockerListener{}
 
-	id := dl.getConfigIDFromInspect(co)
-	assert.Equal(t, "test", string(id))
+	ids := dl.getConfigIDFromInspect(co)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, "test", ids[0])
 
 	labeledCo := types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "test"},
@@ -96,8 +99,9 @@ func TestGetConfigIDFromInspect(t *testing.T) {
 		Config:            &container.Config{Labels: map[string]string{"io.datadog.check.id": "w00tw00t"}},
 		NetworkSettings:   &types.NetworkSettings{},
 	}
-	id = dl.getConfigIDFromInspect(labeledCo)
-	assert.Equal(t, "w00tw00t", string(id))
+	ids = dl.getConfigIDFromInspect(labeledCo)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, "w00tw00t", ids[0])
 }
 
 func TestGetHostsFromInspect(t *testing.T) {

--- a/pkg/collector/listeners/types.go
+++ b/pkg/collector/listeners/types.go
@@ -1,20 +1,17 @@
 package listeners
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-)
-
-// ID is the representation of the unique ID of a service
+// ID is the representation of the unique ID of a Service
 type ID string
 
 // Service reprensents an application we can run a check against.
-// It should be matched with a check template by the ConfigResolver.
+// It should be matched with a check template by the ConfigResolver using the
+// ADIdentifiers field.
 type Service struct {
-	ID       ID                // unique ID
-	ConfigID check.ID          // key on which templates will be matched
-	Hosts    map[string]string // network --> IP address
-	Ports    []int
-	Tags     []string
+	ID            ID                // unique ID
+	ADIdentifiers []string          // identifiers on which templates will be matched
+	Hosts         map[string]string // network --> IP address
+	Ports         []int
+	Tags          []string
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds a stub for a `Resolve` method in the `ConfigProvider`. The method will be used by `Autoconfig` to change templates into configuration that can be used to load checks.

If we agree on the design, I'll keep un-commenting the parts of the `ConfigResolvers` performing the actual mapping