### PR TITLE
adds *.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dev/
 *.swp
 *.exe
 *.syso
+
+*.log


### PR DESCRIPTION
### What does this PR do?

We should ignore logs in the repo.

### Motivation

I sometimes move the logfile to the repo for easier access.
