### PR TITLE
[compression] Use zlib instead of zstd

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -98,7 +98,7 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 	useV1API := !config.Datadog.GetBool("use_v2_api.events")
 
-	compress := !useV1API
+	compress := true
 	eventPayloads, extraHeaders, err := s.serializePayload(e, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping event payload: %s", err)
@@ -114,8 +114,7 @@ func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 	useV1API := !config.Datadog.GetBool("use_v2_api.service_checks")
 
-	// FIXME(olivier): zstd compression is supposed to work on this v1 endpoint, we should investigate why it's broken
-	compress := !useV1API
+	compress := true
 	serviceCheckPayloads, extraHeaders, err := s.serializePayload(sc, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping service check payload: %s", err)
@@ -131,8 +130,7 @@ func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
 	useV1API := !config.Datadog.GetBool("use_v2_api.series")
 
-	// FIXME(olivier): zstd compression is supposed to work on this v1 endpoint, we should investigate why it's broken
-	compress := !useV1API
+	compress := true
 	seriesPayloads, extraHeaders, err := s.serializePayload(series, compress, useV1API)
 	if err != nil {
 		return fmt.Errorf("dropping series payload: %s", err)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -82,7 +82,7 @@ var (
 )
 
 func init() {
-	jsonPayloads, _ = mkPayloads(jsonString, false)
+	jsonPayloads, _ = mkPayloads(jsonString, true)
 	protobufPayloads, _ = mkPayloads(protobufString, true)
 }
 
@@ -117,7 +117,7 @@ func mkPayloads(payload []byte, compress bool) (forwarder.Payloads, error) {
 
 func TestSendV1Events(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
-	f.On("SubmitV1Intake", jsonPayloads, jsonExtraHeaders).Return(nil).Times(1)
+	f.On("SubmitV1Intake", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := Serializer{Forwarder: f}
 
@@ -151,8 +151,7 @@ func TestSendEvents(t *testing.T) {
 
 func TestSendV1ServiceChecks(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
-	payloads, _ := mkPayloads(jsonString, false)
-	f.On("SubmitV1CheckRuns", payloads, jsonExtraHeaders).Return(nil).Times(1)
+	f.On("SubmitV1CheckRuns", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := Serializer{Forwarder: f}
 
@@ -186,7 +185,7 @@ func TestSendServiceChecks(t *testing.T) {
 
 func TestSendV1Series(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
-	f.On("SubmitV1Series", jsonPayloads, jsonExtraHeaders).Return(nil).Times(1)
+	f.On("SubmitV1Series", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := Serializer{Forwarder: f}
 

--- a/pkg/util/compression/no_compression.go
+++ b/pkg/util/compression/no_compression.go
@@ -12,3 +12,9 @@ func Compress(dst []byte, src []byte) ([]byte, error) {
 	dst = src
 	return dst, nil
 }
+
+// Decompress will not decompress anything
+func Decompress(dst []byte, src []byte) ([]byte, error) {
+	dst = src
+	return dst, nil
+}

--- a/pkg/util/compression/zlib.go
+++ b/pkg/util/compression/zlib.go
@@ -5,6 +5,7 @@ package compression
 import (
 	"bytes"
 	"compress/zlib"
+	"io/ioutil"
 )
 
 // ContentEncoding describes the HTTP header value associated with the compression method
@@ -24,5 +25,20 @@ func Compress(dst []byte, src []byte) ([]byte, error) {
 		return nil, err
 	}
 	dst = b.Bytes()
+	return dst, nil
+}
+
+// Decompress will decompress the data with zlib
+func Decompress(dst []byte, src []byte) ([]byte, error) {
+	r, err := zlib.NewReader(bytes.NewReader(src))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	dst, err = ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
 	return dst, nil
 }

--- a/pkg/util/compression/zstd.go
+++ b/pkg/util/compression/zstd.go
@@ -15,3 +15,8 @@ var ContentEncoding = "zstd"
 func Compress(dst []byte, src []byte) ([]byte, error) {
 	return zstd.Compress(dst, src)
 }
+
+// Decompress will decompress the data with zstd
+func Decompress(dst []byte, src []byte) ([]byte, error) {
+	return zstd.Decompress(dst, src)
+}

--- a/pkg/util/compression/zstd.go
+++ b/pkg/util/compression/zstd.go
@@ -4,6 +4,9 @@ package compression
 
 import "github.com/DataDog/zstd"
 
+// TODO: the intake still uses a pre-v1 (unstable) version of the zstd compression format.
+// The agent shouldn't use zstd compression until the intake supports a stable v1 format.
+
 // ContentEncoding describes the HTTP header value associated with the compression method
 // var instead of const to ease testing
 var ContentEncoding = "zstd"

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -15,7 +15,7 @@ end
 
 # `tags` option
 def go_build_tags
-  build_tags = ENV['tags'] || "zstd snmp etcd zk cpython jmx apm docker ec2 gce process"
+  build_tags = ENV['tags'] || "zlib snmp etcd zk cpython jmx apm docker ec2 gce process"
   build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
 end
 

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -37,7 +37,7 @@ namespace :dogstatsd do
     puts "Starting DogStatsD system tests"
     root = `git rev-parse --show-toplevel`.strip
     bin_path = File.join(root, DOGSTATSD_BIN_PATH, "dogstatsd")
-    sh("DOGSTATSD_BIN=\"#{bin_path}\" go test -v #{REPO_PATH}/test/system/dogstatsd/")
+    sh("DOGSTATSD_BIN=\"#{bin_path}\" go test -tags '#{go_build_tags}' -v #{REPO_PATH}/test/system/dogstatsd/")
   end
 
   desc "Run Dogstatsd size test [skip_rebuild=false]"

--- a/test/system/dogstatsd/receive_and_forward_test.go
+++ b/test/system/dogstatsd/receive_and_forward_test.go
@@ -2,6 +2,7 @@ package dogstatsd_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,8 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/compression"
 )
 
 func testMetadata(t *testing.T, d *dogstatsdTest) {
@@ -52,8 +54,10 @@ func TestReceiveAndForward(t *testing.T) {
 	require.Len(t, requests, 1)
 
 	sc := []metrics.ServiceCheck{}
-	err := json.Unmarshal([]byte(requests[0]), &sc)
-	require.NoError(t, err, "Could not Unmarshal request")
+	decompressedBody, err := compression.Decompress(nil, []byte(requests[0]))
+	require.NoError(t, err, "Could not decompress request body")
+	err = json.Unmarshal(decompressedBody, &sc)
+	require.NoError(t, err, fmt.Sprintf("Could not Unmarshal request body: %s", decompressedBody))
 
 	require.Len(t, sc, 2)
 	assert.Equal(t, sc[0].CheckName, "test.ServiceCheck")


### PR DESCRIPTION
### What does this PR do?

* Uses zlib by default, instead of zstd
* enables compression for the v1 & v2 series/service check/event endpoints (with zlib)

### Motivation

The `zstd` version used in the backend is currently not suitable for use by the agent: it still uses an unstable (pre-v1) version of the compression format.  Let's use `zlib` until the backend makes use of a stable version of the `zstd` compression format.

cc @elijahandrews 
