### PR TITLE
fix dogstatsd static build and re-enable integration test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,7 +118,6 @@ run_dogstatsd_size_test:
 # run integration tests for deb-x64
 run_docker_integration_tests_deb-x64:
   stage: integration_test
-  allow_failure: true  # FIXME: when we publish the datadog/dogstatsd:master docker image
   dependencies:
     - dogstatsd_static-x64 # Reuse artifact from build stage
   tags:

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -16,7 +16,7 @@ namespace :dogstatsd do
     bin_path = DOGSTATSD_BIN_PATH
     ldflags = get_base_ldflags()
     if static_bin then
-      ldflags << " -s -w -extldflags \"-static\""
+      ldflags << " -s -w -linkmode external -extldflags \"-static\""
       bin_path = STATIC_BIN_PATH
     end
 


### PR DESCRIPTION
Force linking with gcc instead of using go's internal linker. This is necessary for static build to work.
It was used implicitly before now.
