### PR TITLE
[AC] Schedule checks after polling config providers

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -249,7 +249,7 @@ func (ac *AutoConfig) pollConfigs() {
 							// try to resolve the template
 							resolvedConfigs := ac.configResolver.ResolveTemplate(config)
 							if len(resolvedConfigs) == 0 {
-								log.Infof("Couldn't resolve the template for %s, adding to the template cache...", config.Name)
+								log.Infof("Can't resolve the template for %s at this moment.", config.Name)
 								continue
 							}
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -151,7 +151,7 @@ func (c *Collector) StopCheck(id check.ID) error {
 		return fmt.Errorf("an error occurred while cancelling the check schedule: %s", err)
 	}
 
-	// stop the instance
+	// stop the instance, this might time out
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

While polling the config providers, a bunch of new check configurations might come, as well as configurations already processed might disappear.
Now `Autoconfig` reacts properly, scheduling and unscheduling checks accordingly.

### Additional Notes

Another PR will be dedicated to provide integration tests to ensure the agent behaves correctly
