### PR TITLE
[host-tags] Set tags to empty slice if no tags are configured

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ func init() {
 	Datadog.SetDefault("proxy", "")
 	Datadog.SetDefault("skip_ssl_validation", false)
 	Datadog.SetDefault("hostname", "")
+	Datadog.SetDefault("tags", []string{})
 	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -72,10 +72,18 @@ func TestGetMeta(t *testing.T) {
 
 func TestGetHostTags(t *testing.T) {
 	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
+	defer config.Datadog.Set("tags", nil)
 
 	hostTags := getHostTags()
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, hostTags.System, []string{"tag1:value1", "tag2", "tag3"})
+}
+
+func TestGetEmptyHostTags(t *testing.T) {
+	// getHostTags should never return a nil value under System even when there are no host tags
+	hostTags := getHostTags()
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, hostTags.System, []string{})
 }
 
 func TestBuildKey(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Sets tags to empty slice if no tags are configured instead of setting them to `nil`.

### Motivation

The legacy metadata endpoint drops metadata payloads that have `null`
under ["host-tags"]["system"].
