### PR TITLE
Put shebang on first line of all shell scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,7 @@ agent_deb-x64:
     # Uncomment the following to see debug logs from omnibus, it defaults to info
     # AGENT_OMNIBUS_LOG_LEVEL: debug
   script:
-    - apt-get install -y -qq libpq-dev  # this has to be removed as soon as we upgrade to psycopg2 2.7
+    - apt-get update && apt-get install -y -qq libpq-dev  # this has to be removed as soon as we upgrade to psycopg2 2.7
     - rake agent:omnibus
     - dpkg -c $AGENT_OMNIBUS_PACKAGE_DIR/*.deb
   cache:

--- a/Dockerfiles/agent6/entrypoint.sh
+++ b/Dockerfiles/agent6/entrypoint.sh
@@ -1,10 +1,9 @@
+#!/bin/bash
+
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
-
-#!/bin/bash
-#set -e
 
 
 ##### Core config #####

--- a/Dockerfiles/dogstatsd/alpine/entrypoint.sh
+++ b/Dockerfiles/dogstatsd/alpine/entrypoint.sh
@@ -1,10 +1,9 @@
+#!/bin/sh
+
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
-
-#!/bin/sh
-#set -e
 
 ##### Core config #####
 

--- a/test/integration/config_providers/zookeeper/test.sh
+++ b/test/integration/config_providers/zookeeper/test.sh
@@ -1,9 +1,9 @@
+#!/bin/bash
+
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
-
-#!/bin/bash
 
 set -e
 

--- a/test/integration/docker/dsd_alpine_listening.sh
+++ b/test/integration/docker/dsd_alpine_listening.sh
@@ -1,10 +1,10 @@
+#!/bin/bash
+
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
 
-#!/bin/bash
-#
 # System check for the dsd-alpine image. Runs the image both in UDP and
 # socket mode. With lsof, we test that dogstatsd is running and listening
 # on the right interface
@@ -73,7 +73,7 @@ if [ $TEST_FAIL -eq 0 ]; then
     echo "OK"
 fi
 
-# Cleanup 
+# Cleanup
 
 docker stop $UDP_CO $SOCKET_CO > /dev/null
 

--- a/test/system/python_binding/test.sh
+++ b/test/system/python_binding/test.sh
@@ -1,9 +1,9 @@
+#!/bin/bash
+
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
-
-#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
### What does this PR do?

* Puts shebang on first line of all shell scripts
* In deb build, run `apt-get update` before installing `libpq-dev` (otherwise the install can fail)

### Motivation

Shebangs have to be on the very first line of scripts, before the
license, or they won't work.

The entrypoint script of the alpine image was broken because of this.
(this fixes the static dogstatsd docker integration test that was failing)
