### PR TITLE
[pct] change endpoint to api/beta/sketches

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -57,7 +57,7 @@ const (
 	seriesEndpoint        = "/api/v2/series"
 	eventsEndpoint        = "/api/v2/events"
 	serviceChecksEndpoint = "/api/v2/service_checks"
-	sketchSeriesEndpoint  = "/api/v2/sketches"
+	sketchSeriesEndpoint  = "/api/beta/sketches"
 	hostMetadataEndpoint  = "/api/v2/host_metadata"
 	metadataEndpoint      = "/api/v2/metadata"
 
@@ -90,7 +90,6 @@ type Forwarder interface {
 	SubmitV1Series(payload Payloads, extraHeaders map[string]string) error
 	SubmitV1Intake(payload Payloads, extraHeaders map[string]string) error
 	SubmitV1CheckRuns(payload Payloads, extraHeaders map[string]string) error
-	SubmitV1SketchSeries(payload Payloads, extraHeaders map[string]string) error
 	SubmitSeries(payload Payloads, extraHeaders map[string]string) error
 	SubmitEvents(payload Payloads, extraHeaders map[string]string) error
 	SubmitServiceChecks(payload Payloads, extraHeaders map[string]string) error
@@ -316,17 +315,6 @@ func (f *DefaultForwarder) SubmitServiceChecks(payload Payloads, extraHeaders ma
 	return f.sendHTTPTransactions(transactions)
 }
 
-// SubmitSketchSeries will send payloads to v2 endpoint - PROTOTYPE FOR PERCENTILE
-// Prototype for Percentiles: same as for SubmitV1SketchSeries method for now.
-func (f *DefaultForwarder) SubmitSketchSeries(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(sketchSeriesEndpoint, payload, true, extraHeaders)
-	if err != nil {
-		return err
-	}
-	transactionsCreation.Add("SketchSeries", 1)
-	return f.sendHTTPTransactions(transactions)
-}
-
 // SubmitHostMetadata will send a host_metadata tag type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitHostMetadata(payload Payloads, extraHeaders map[string]string) error {
 	transactions, err := f.createHTTPTransactions(hostMetadataEndpoint, payload, false, extraHeaders)
@@ -386,15 +374,5 @@ func (f *DefaultForwarder) SubmitV1Intake(payload Payloads, extraHeaders map[str
 	}
 
 	transactionsCreation.Add("IntakeV1", 1)
-	return f.sendHTTPTransactions(transactions)
-}
-
-// SubmitV1SketchSeries will send payloads to v1 endpoint
-func (f *DefaultForwarder) SubmitV1SketchSeries(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(v1SketchSeriesEndpoint, payload, true, extraHeaders)
-	if err != nil {
-		return err
-	}
-	transactionsCreation.Add("SketchSeriesV1", 1)
 	return f.sendHTTPTransactions(transactions)
 }

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -315,6 +315,16 @@ func (f *DefaultForwarder) SubmitServiceChecks(payload Payloads, extraHeaders ma
 	return f.sendHTTPTransactions(transactions)
 }
 
+// SubmitSketchSeries will send payloads to Datadog backend - PROTOTYPE FOR PERCENTILE
+func (f *DefaultForwarder) SubmitSketchSeries(payload Payloads, extraHeaders map[string]string) error {
+	transactions, err := f.createHTTPTransactions(sketchSeriesEndpoint, payload, true, extraHeaders)
+	if err != nil {
+		return err
+	}
+	transactionsCreation.Add("SketchSeries", 1)
+	return f.sendHTTPTransactions(transactions)
+}
+
 // SubmitHostMetadata will send a host_metadata tag type payload to Datadog backend.
 func (f *DefaultForwarder) SubmitHostMetadata(payload Payloads, extraHeaders map[string]string) error {
 	transactions, err := f.createHTTPTransactions(hostMetadataEndpoint, payload, false, extraHeaders)

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -152,7 +152,7 @@ func TestSubmit(t *testing.T) {
 	require.Len(t, forwarder.retryQueue, 0)
 
 	expectedPayload = []byte("SubmitSketchSeries payload")
-	expectedEndpoint = "/api/v2/sketches"
+	expectedEndpoint = "/api/beta/sketches"
 	expectAPIKeyInQuery = true
 	payloads = []*[]byte{}
 	payloads = append(payloads, &expectedPayload)
@@ -185,16 +185,6 @@ func TestSubmit(t *testing.T) {
 	payloads = []*[]byte{}
 	payloads = append(payloads, &expectedPayload)
 	assert.Nil(t, forwarder.SubmitV1Series(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitV1SketchSeries payload")
-	expectedEndpoint = "/api/v1/sketches"
-	expectAPIKeyInQuery = true
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitV1SketchSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
 	<-wait
 	<-wait
 	require.Len(t, forwarder.retryQueue, 0)

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -75,11 +75,6 @@ func (tf *MockedForwarder) SubmitV1CheckRuns(payload Payloads, extraHeaders map[
 	return tf.Called(payload, extraHeaders).Error(0)
 }
 
-// SubmitV1SketchSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1SketchSeries(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
-}
-
 // SubmitSeries updates the internal mock struct
 func (tf *MockedForwarder) SubmitSeries(payload Payloads, extraHeaders map[string]string) error {
 	return tf.Called(payload, extraHeaders).Error(0)

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -81,10 +81,6 @@ func (f *forwarderBenchStub) SubmitV1CheckRuns(payloads forwarder.Payloads, extr
 	f.computeStats(payloads)
 	return nil
 }
-func (f *forwarderBenchStub) SubmitV1SketchSeries(payloads forwarder.Payloads, extraHeaders map[string]string) error {
-	f.computeStats(payloads)
-	return nil
-}
 func (f *forwarderBenchStub) SubmitSeries(payload forwarder.Payloads, extraHeaders map[string]string) error {
 	return fmt.Errorf("v2 endpoint submission unimplemented")
 }


### PR DESCRIPTION
#metrics-intake team is more comfortable releasing percentiles without a v1 or v2 version tag.