### PR TITLE
[py] `DecRef` all owned references to `PyObject`s

### DIFF
--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -53,6 +53,7 @@ func (c *PythonCheck) Run() error {
 	// call run function, it takes no args so we pass an empty tuple
 	log.Debugf("Running python check %s %s", c.ModuleName, c.id)
 	emptyTuple := python.PyTuple_New(0)
+	defer emptyTuple.DecRef()
 	result := c.Instance.CallMethod("run", emptyTuple)
 	log.Debugf("Run returned for %s %s", c.ModuleName, c.id)
 	if result == nil {
@@ -62,6 +63,7 @@ func (c *PythonCheck) Run() error {
 		}
 		return errors.New(pyErr)
 	}
+	defer result.DecRef()
 
 	s, err := aggregator.GetSender(c.ID())
 	if err != nil {
@@ -103,6 +105,7 @@ func (c *PythonCheck) getPythonWarnings(gstate *stickyLock) []error {
 	**/
 	warnings := []error{}
 	emptyTuple := python.PyTuple_New(0)
+	defer emptyTuple.DecRef()
 	ws := c.Instance.CallMethod("get_warnings", emptyTuple)
 	if ws == nil {
 		pyErr, err := gstate.getPythonError()
@@ -112,6 +115,7 @@ func (c *PythonCheck) getPythonWarnings(gstate *stickyLock) []error {
 		log.Infof("Python error: %v", pyErr)
 		return warnings
 	}
+	defer ws.DecRef()
 	numWarnings := python.PyList_Size(ws)
 	idx := 0
 	for idx < numWarnings {

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -63,7 +63,7 @@ func TestNewPythonCheck(t *testing.T) {
 	tuple := python.PyTuple_New(0)
 	res := NewPythonCheck("FooBar", tuple)
 
-	assert.Equal(t, tuple, res.Class)
+	assert.Equal(t, tuple, res.class)
 	assert.Equal(t, "FooBar", res.ModuleName)
 }
 

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -70,6 +71,16 @@ func TestRun(t *testing.T) {
 	check, _ := getCheckInstance("testcheck", "TestCheck")
 	err := check.Run()
 	assert.Nil(t, err)
+}
+
+func TestWarning(t *testing.T) {
+	check, _ := getCheckInstance("testwarnings", "TestCheck")
+	err := check.Run()
+	assert.Nil(t, err)
+
+	warnings := check.GetWarnings()
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "The cake is a lie", warnings[0].Error())
 }
 
 func TestStr(t *testing.T) {

--- a/pkg/collector/py/config.go
+++ b/pkg/collector/py/config.go
@@ -46,12 +46,14 @@ func (w *walker) Primitive(v reflect.Value) error {
 
 // push the old container to the stack and start using the new one
 // Notice: the GIL must be acquired before calling this method
+// push steals the reference to the passed *PyObject
 func (w *walker) push(newc *python.PyObject) {
 	// special case: init
 	if w.result == nil {
 		w.containersStack = append(w.containersStack, newc)
 		w.currentContainer = newc
 		w.result = newc
+		newc.IncRef() // the first assignment steals the ref, we need to IncRef for the 2nd assignment
 		return
 	}
 
@@ -59,9 +61,10 @@ func (w *walker) push(newc *python.PyObject) {
 	// we can safely assume it's either a `list` or a `dict`
 	if python.PyDict_Check(w.currentContainer) {
 		k := python.PyString_FromString(w.lastKey)
-		python.PyDict_SetItem(w.currentContainer, k, newc)
+		defer k.DecRef()
+		python.PyDict_SetItem(w.currentContainer, k, newc) // steal the ref, no IncRef
 	} else {
-		python.PyList_Append(w.currentContainer, newc)
+		python.PyList_Append(w.currentContainer, newc) // steal the ref, no IncRef
 	}
 
 	// push it like there's no tomorrow
@@ -74,6 +77,7 @@ func (w *walker) push(newc *python.PyObject) {
 func (w *walker) pop() {
 	l := len(w.containersStack)
 	if l > 0 {
+		w.currentContainer.DecRef()
 		w.currentContainer = w.containersStack[l-1]
 		w.containersStack = w.containersStack[:l-1]
 	}
@@ -168,10 +172,12 @@ func (w *walker) MapElem(m, k, v reflect.Value) error {
 
 	w.lastKey = k.Interface().(string)
 	dictKey := python.PyString_FromString(w.lastKey)
+	defer dictKey.DecRef()
 
 	// set the converted value in the Python dict
 	pyval := ifToPy(v)
 	if pyval != nil {
+		defer pyval.DecRef()
 		python.PyDict_SetItem(w.currentContainer, dictKey, pyval)
 	}
 
@@ -186,6 +192,7 @@ func (w *walker) SliceElem(i int, v reflect.Value) error {
 
 	pyval := ifToPy(v)
 	if pyval != nil {
+		defer pyval.DecRef()
 		python.PyList_Append(w.currentContainer, pyval)
 	}
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -56,10 +56,12 @@ func Headers(self *C.PyObject, args *C.PyObject) *C.PyObject {
 	for k, v := range h {
 		cKey := C.CString(k)
 		pyKey := C.PyString_FromString(cKey)
+		defer C.Py_DecRef(pyKey)
 		C.free(unsafe.Pointer(cKey))
 
 		cVal := C.CString(v)
 		pyVal := C.PyString_FromString(cVal)
+		defer C.Py_DecRef(pyVal)
 		C.free(unsafe.Pointer(cVal))
 
 		C.PyDict_SetItem(dict, pyKey, pyVal)

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -36,8 +36,9 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 		log.Errorf("Unable to import Python module: %s", agentCheckModuleName)
 		return nil, fmt.Errorf("unable to initialize AgentCheck module")
 	}
+	defer agentCheckModule.DecRef()
 
-	agentCheckClass := agentCheckModule.GetAttrString(agentCheckClassName)
+	agentCheckClass := agentCheckModule.GetAttrString(agentCheckClassName) // don't `DecRef` for now since we keep the ref around in the returned PythonCheckLoader
 	if agentCheckClass == nil {
 		log.Errorf("Unable to import %s class from Python module: %s", agentCheckClassName, agentCheckModuleName)
 		return nil, errors.New("unable to initialize AgentCheck class")
@@ -65,8 +66,10 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		}
 		return nil, errors.New(pyErr)
 	}
+
 	// Try to find a class inheriting from AgentCheck within the module
-	checkClass, err := findSubclassOf(cl.agentCheckClass, checkModule)
+	checkClass, err := findSubclassOf(cl.agentCheckClass, checkModule, glock) // FIXME: the reference to checkClass is currently leaked
+	checkModule.DecRef()
 	glock.unlock()
 	if err != nil {
 		msg := fmt.Sprintf("Unable to find a check class in the module: %v", err)

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -68,7 +68,7 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	}
 
 	// Try to find a class inheriting from AgentCheck within the module
-	checkClass, err := findSubclassOf(cl.agentCheckClass, checkModule, glock) // FIXME: the reference to checkClass is currently leaked
+	checkClass, err := findSubclassOf(cl.agentCheckClass, checkModule, glock)
 	checkModule.DecRef()
 	glock.unlock()
 	if err != nil {
@@ -86,6 +86,10 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		}
 		checks = append(checks, check)
 	}
+	glock = newStickyLock()
+	defer glock.unlock()
+	checkClass.DecRef()
+
 	log.Debugf("python loader: done loading check %s", moduleName)
 	return checks, nil
 }

--- a/pkg/collector/py/tests/testwarnings.py
+++ b/pkg/collector/py/tests/testwarnings.py
@@ -1,0 +1,10 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
+from checks import AgentCheck
+
+class TestCheck(AgentCheck):
+    def check(self, instance):
+        self.warning("The cake is a lie")

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -51,25 +51,25 @@ func TestFindSubclassOf(t *testing.T) {
 	barClass := barModule.GetAttrString("Bar")
 
 	// invalid input
-	sclass, err := findSubclassOf(nil, nil)
+	sclass, err := findSubclassOf(nil, nil, gstate)
 	assert.NotNil(t, err)
 
 	// pass something that's not a Type
-	sclass, err = findSubclassOf(python.PyTuple_New(0), fooModule)
+	sclass, err = findSubclassOf(python.PyTuple_New(0), fooModule, gstate)
 	assert.NotNil(t, err)
-	sclass, err = findSubclassOf(fooClass, python.PyTuple_New(0))
+	sclass, err = findSubclassOf(fooClass, python.PyTuple_New(0), gstate)
 	assert.NotNil(t, err)
 
 	// Foo in foo module, only Foo itself found
-	sclass, err = findSubclassOf(fooClass, fooModule)
+	sclass, err = findSubclassOf(fooClass, fooModule, gstate)
 	assert.NotNil(t, err)
 
 	// Bar in foo module, no class found
-	sclass, err = findSubclassOf(barClass, fooModule)
+	sclass, err = findSubclassOf(barClass, fooModule, gstate)
 	assert.NotNil(t, err)
 
 	// Foo in bar module, get Bar
-	sclass, err = findSubclassOf(fooClass, barModule)
+	sclass, err = findSubclassOf(fooClass, barModule, gstate)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, sclass.RichCompareBool(barClass, python.Py_EQ))
 }

--- a/rake/py-launcher.rb
+++ b/rake/py-launcher.rb
@@ -29,7 +29,7 @@ namespace :pylauncher do
     end
     build_type_opt = ENV['incremental'] == "true" ? "-i" : "-a"
 
-    build_tags = go_build_tags added_tags: 'checks'
+    build_tags = go_build_tags
 
     bin_path = PYLAUNCHER_BIN_PATH
     sh("go build #{build_type_opt} -tags \"#{go_build_tags}\" -o #{bin_path}/#{bin_name("py-launcher")} #{REPO_PATH}/cmd/py-launcher/")


### PR DESCRIPTION
### What does this PR do?

* `DecRef`s all owned references to `PyObject`s in py's `Check.Run()` method
* Add a test on `AgentCheck.warning` (not directly related to the 1st change)

### Motivation

Since we added `warning` to `AgentCheck` in #396 there's a pretty significant memory leak which (I think) comes from not properly decreasing the reference count on the result of `c.Instance.CallMethod("get_warnings", emptyTuple)` (a list) that is owned by the caller.

### Additional Notes

More information on reference count and ownership of references when using the python C API: https://docs.python.org/2/c-api/intro.html#objects-types-and-reference-counts

### PR Updated

I went through all our python C API calls and added `DecRef`/`IncRef` wherever needed, except for 2 tricky cases that I've documented.

I've also removed `getPythonError` (copy/paste of `stickyLock.getPythonError` which should be preferred).