### PR TITLE
[AC] extend stats with scheduling errors

### DIFF
--- a/pkg/collector/autodiscovery/stats.go
+++ b/pkg/collector/autodiscovery/stats.go
@@ -5,53 +5,58 @@
 
 package autodiscovery
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
 
 // LoaderErrors is just an alias for a loader->error map
 type LoaderErrors map[string]string
 
 // loaderErrorStats holds the error objects
-type loaderErrorStats struct {
-	errors map[string]LoaderErrors
+type acErrorStats struct {
+	loader map[string]LoaderErrors // check name -> LoaderErrors
+	run    map[check.ID]string     // check ID -> error
 	m      sync.RWMutex
 }
 
-// newLoaderErrorStats returns an instance holding loader errors stats
-func newLoaderErrorStats() *loaderErrorStats {
-	return &loaderErrorStats{
-		errors: make(map[string]LoaderErrors),
+// newAcErrorStats returns an instance holding autoconfig errors stats
+func newAcErrorStats() *acErrorStats {
+	return &acErrorStats{
+		loader: make(map[string]LoaderErrors),
 	}
 }
 
-// setError will safely set the error for that check and loader to the LoaderErrorStats
-func (les *loaderErrorStats) setError(checkName string, loaderName string, err string) {
-	les.m.Lock()
-	defer les.m.Unlock()
+// setLoaderError will safely set the error for that check and loader to the LoaderErrorStats
+func (es *acErrorStats) setLoaderError(checkName string, loaderName string, err string) {
+	es.m.Lock()
+	defer es.m.Unlock()
 
-	_, found := les.errors[checkName]
+	_, found := es.loader[checkName]
 	if !found {
-		les.errors[checkName] = make(LoaderErrors)
+		es.loader[checkName] = make(LoaderErrors)
 	}
 
-	les.errors[checkName][loaderName] = err
+	es.loader[checkName][loaderName] = err
 }
 
-// removeCheckErrors removes the errors for a check (usually when successfully loaded)
-func (les *loaderErrorStats) removeCheckErrors(checkName string) {
-	les.m.Lock()
-	defer les.m.Unlock()
+// removeLoaderErrors removes the errors for a check (usually when successfully loaded)
+func (es *acErrorStats) removeLoaderErrors(checkName string) {
+	es.m.Lock()
+	defer es.m.Unlock()
 
-	delete(les.errors, checkName)
+	delete(es.loader, checkName)
 }
 
-// GetErrors will safely get the errors from a LoaderErrorStats object
-func (les *loaderErrorStats) getErrors() map[string]LoaderErrors {
-	les.m.RLock()
-	defer les.m.RUnlock()
+// getLoaderErrors will safely get the errors regarding loaders
+func (es *acErrorStats) getLoaderErrors() map[string]LoaderErrors {
+	es.m.RLock()
+	defer es.m.RUnlock()
 
 	errorsCopy := make(map[string]LoaderErrors)
 
-	for check, loaderErrors := range les.errors {
+	for check, loaderErrors := range es.loader {
 		errorsCopy[check] = make(LoaderErrors)
 		for loader, loaderError := range loaderErrors {
 			errorsCopy[check][loader] = loaderError
@@ -59,4 +64,30 @@ func (les *loaderErrorStats) getErrors() map[string]LoaderErrors {
 	}
 
 	return errorsCopy
+}
+
+func (es *acErrorStats) setRunError(checkID check.ID, err string) {
+	es.m.Lock()
+	defer es.m.Unlock()
+
+	es.run[checkID] = err
+}
+
+func (es *acErrorStats) removeRunError(checkID check.ID) {
+	es.m.Lock()
+	defer es.m.Unlock()
+
+	delete(es.run, checkID)
+}
+
+func (es *acErrorStats) getRunErrors() map[check.ID]string {
+	es.m.RLock()
+	defer es.m.RUnlock()
+
+	runCopy := make(map[check.ID]string)
+	for k, v := range es.run {
+		runCopy[k] = v
+	}
+
+	return runCopy
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

As per suggestion in #459 we should publish Run/Stop errors that happen in Autoconfig as ExpVars.

### Motivation

It might be helpful to diagnose agent issues

### Notes

I re-used the existing struct but I had to change its name to reflect the fact that now is generic and serves for multiple kinds of errors.