### PR TITLE
Reworking aggregator benchmark to be graphed using datadog

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - integration_test
   - package_build
   - deploy
+  - statistics
 
 variables:
   DOCKER_REGISTRY: 727006795293.dkr.ecr.us-east-1.amazonaws.com
@@ -201,3 +202,15 @@ deploy_deb:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
 
 # TODO: deploy rpm packages
+
+# run benchmarks on master and push result to DataDog
+run_benchmarks:
+  stage: statistics
+  image: $DEB_X64
+  tags:
+    - docker
+  variables:
+    USE_SYSTEM_LIBS: "1"
+  script:
+    - rake benchmark:aggregator:build
+    - rake benchmark:aggregator:run

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -43,6 +43,12 @@
   revision = "cb3dae3a7588ae35829eb5724df611cd75152fba"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/cihub/seelog"
   packages = ["."]
   revision = "d2c6e5aa9fbfdd1c624e140287063c7730654115"
@@ -326,9 +332,15 @@
   packages = ["."]
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
 
+[[projects]]
+  name = "gopkg.in/zorkian/go-datadog-api.v2"
+  packages = ["."]
+  revision = "659bba33a1626ab76f393d6878dc3e4f13253f6d"
+  version = "v2.3"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d62b0eff218ba491d085ef7c1bd436b28f5c416fc267a81f1f96d845100dc41f"
+  inputs-digest = "85926e0b1725c7c85c78cae3ef15f44a0e4f8816c3453a5bbb2c8e4992c81bfc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -78,3 +78,6 @@
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"
+
+[[constraint]]
+  name = "gopkg.in/zorkian/go-datadog-api.v2"

--- a/rake/benchmarks.rb
+++ b/rake/benchmarks.rb
@@ -19,6 +19,17 @@ namespace :benchmark do
 
       system("go build #{build_type} -tags '#{go_build_tags}' -o #{BENCHMARK_BIN_PATH}/#{bin_name("aggregator")} #{flags} #{REPO_PATH}/test/benchmarks/aggregator") or exit!(1)
     end
+
+    desc "Run the aggregator benchmark"
+    task :run do
+      branch = `git rev-parse --abbrev-ref HEAD`.strip()
+      options = ""
+      if ENV["DD_AGENT_API_KEY"]
+        options = " -api-key #{ENV["DD_AGENT_API_KEY"]}"
+      end
+
+      system("#{BENCHMARK_BIN_PATH}/#{bin_name("aggregator")} -points 2,10,100,500,1000 -series 10,100,1000 -log-level info -json -branch #{branch} #{options}") or exit!(1)
+    end
   end
 
   namespace :dogstatsd do

--- a/tasks/benchmarks.py
+++ b/tasks/benchmarks.py
@@ -9,6 +9,7 @@ from invoke import task
 
 from .build_tags import get_build_tags
 from .utils import bin_name
+from .utils import get_git_branch_name
 from .utils import REPO_PATH
 
 
@@ -70,3 +71,17 @@ def dogstastd(ctx):
     """
     bin_path = os.path.join(BENCHMARKS_BIN_PATH, bin_name("dogstatsd"))
     ctx.run("{} -pps=5000 -dur 45 -ser 5 -brk -inc 1000".format(bin_path))
+
+@task(pre=[build_aggregator])
+def aggregator(ctx):
+    """
+    Run the Aggregator Benchmarks.
+    """
+    bin_path = os.path.join(BENCHMARKS_BIN_PATH, bin_name("aggregator"))
+    options = "-branch {}".format(get_git_branch_name())
+
+    key = os.environ.get("DD_AGENT_API_KEY")
+    if key:
+      options +=" -api-key {}".format(key)
+
+    ctx.run("{} -points 2,10,100,500,1000 -series 10,100,1000 -log-level info -json {}".format(bin_path, options))

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -110,3 +110,9 @@ def get_root():
     Get the root of the Go project
     """
     return check_output(['git', 'rev-parse', '--show-toplevel']).strip()
+
+def get_git_branch_name():
+    """
+    Return the name of the current git branch
+    """
+    return check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()

--- a/test/benchmarks/aggregator/metrics.go
+++ b/test/benchmarks/aggregator/metrics.go
@@ -11,25 +11,16 @@ import (
 	"strconv"
 	"time"
 
+	log "github.com/cihub/seelog"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-var gnuplotHeader = `# set terminal png truecolor
-# set autoscale
-# set style data linespoints
-# set xlabel "Number of points per serie"
-# set ylabel "Time in Ms"
-# set grid
-# set key autotitle columnhead
-#
-# plot for [i=2:%d] "%s" u 1:i
-
-`
-
 type senderFunc func(string, float64, string, []string)
 
-func generateMetrics(numberOfSeries int, pointPerSeries int, senderMetric senderFunc) time.Duration {
+func generateMetrics(numberOfSeries int, pointPerSeries int, senderMetric senderFunc) float64 {
 	start := time.Now()
 	for s := 0; s < numberOfSeries; s++ {
 		serieName := "benchmark.metric." + strconv.Itoa(s)
@@ -37,10 +28,11 @@ func generateMetrics(numberOfSeries int, pointPerSeries int, senderMetric sender
 			senderMetric(serieName, float64(rand.Intn(1024)), "localhost", []string{"a", "b:21", "c"})
 		}
 	}
-	return time.Since(start)
+	waitForAggregatorEmptyQueue()
+	return float64(time.Since(start)) / float64(time.Millisecond)
 }
 
-func generateEvent(numberOfEvent int, sender aggregator.Sender) time.Duration {
+func generateEvent(numberOfEvent int, sender aggregator.Sender) float64 {
 	start := time.Now()
 	for i := 0; i < numberOfEvent; i++ {
 		sender.Event(metrics.Event{
@@ -56,18 +48,18 @@ func generateEvent(numberOfEvent int, sender aggregator.Sender) time.Duration {
 			EventType:      "",
 		})
 	}
-	return time.Since(start)
+	return float64(time.Since(start)) / float64(time.Millisecond)
 }
 
-func generateServiceCheck(numberOfSC int, sender aggregator.Sender) time.Duration {
+func generateServiceCheck(numberOfSC int, sender aggregator.Sender) float64 {
 	start := time.Now()
 	for i := 0; i < numberOfSC; i++ {
 		sender.ServiceCheck("benchmark.ServiceCheck."+strconv.Itoa(i), metrics.ServiceCheckOK, "localhost", []string{"a", "b:21", "c"}, "some message")
 	}
-	return time.Since(start)
+	return float64(time.Since(start)) / float64(time.Millisecond)
 }
 
-func benchmarkMetrics(agg *aggregator.BufferedAggregator, numberOfSeries []int, nbPoints []int, sender aggregator.Sender, flush chan time.Time, info *aggregatorStats) string {
+func benchmarkMetrics(numberOfSeries []int, nbPoints []int, sender aggregator.Sender, info *aggregatorStats, branchName string) []datadog.Metric {
 	metrics := map[string]senderFunc{"Gauge": sender.Gauge,
 		"Rate":           sender.Rate,
 		"Count":          sender.Count,
@@ -78,71 +70,83 @@ func benchmarkMetrics(agg *aggregator.BufferedAggregator, numberOfSeries []int, 
 	// this is here to keep the same order between the header and metric
 	metricTypes := []string{"Gauge", "Rate", "Count", "MonotonicCount", "Histogram", "Historate"}
 
-	// add plot header
-	plotRes := fmt.Sprintf(gnuplotHeader, len(metricTypes)*len(numberOfSeries)+2, *plotFile)
-	plotRes += "nbPoint"
-	for _, name := range metricTypes {
-		for _, s := range numberOfSeries {
-			plotRes += fmt.Sprintf(" %d-serie-%s", s, name)
-		}
-	}
-	plotRes += " Event ServiceCheck"
-
-	for _, nbPoint := range nbPoints {
-		plotRes += fmt.Sprintf("\n%d", nbPoint)
-		fmt.Printf("-- Series of %d points ---\n", nbPoint)
+	t := time.Now().Unix()
+	results := []datadog.Metric{}
+	for _, nbSerie := range numberOfSeries {
+		log.Infof("-- Series of %d points ---\n", nbSerie)
 		for _, name := range metricTypes {
-			for _, nbSerie := range numberOfSeries {
+			for _, nbPoint := range nbPoints {
+				tags := []string{
+					fmt.Sprintf("branch:%s", branchName),
+					fmt.Sprintf("nb_point:%d", nbPoint),
+					fmt.Sprintf("nb_serie:%d", nbSerie),
+					fmt.Sprintf("type:%s", name),
+				}
+
 				genTime := generateMetrics(nbSerie, nbPoint, metrics[name])
 				start := time.Now()
 				sender.Commit()
-				commitTime := time.Since(start)
-				info = report(agg, flush, info, "ChecksMetricSampleFlushTime")
+				commitTime := float64(time.Since(start)) / float64(time.Millisecond)
 
-				fmt.Printf("sent %d %s series of %d poins in %f and commited in %f flush in %f serialize in %f\n",
-					nbSerie, name, nbPoint,
-					float64(genTime)/float64(time.Millisecond),
-					float64(commitTime)/float64(time.Millisecond),
-					float64(info.Flush["FlushTime"].LastFlush)/float64(time.Millisecond),
-					float64(info.Flush["ChecksMetricSampleFlushTime"].LastFlush)/float64(time.Millisecond))
+				info = report(info, "ChecksMetricSampleFlushTime")
+				flushTime := float64(info.Flush["ChecksMetricSampleFlushTime"].LastFlush) / float64(time.Millisecond)
 
-				plotRes += fmt.Sprintf(" %f", float64(genTime)/float64(time.Millisecond))
+				genRes := createMetric(genTime, tags, "benchmark.aggregator.gen", t)
+				commitRes := createMetric(commitTime, tags, "benchmark.aggregator.commit", t)
+				flushRes := createMetric(flushTime, tags, "benchmark.aggregator.flush", t)
+
+				log.Infof("[%d %s] [%d point] sent %f | commit time: %f | flush time: %f", nbSerie, name, nbPoint, genTime, commitTime, flushTime)
+
+				results = append(results, genRes)
+				results = append(results, commitRes)
+				results = append(results, flushRes)
 			}
 		}
-
-		fmt.Printf("-- %d Events ---\n", nbPoint)
-		for _, nbPoint := range nbPoints {
-			genTime := generateEvent(nbPoint, sender)
-			start := time.Now()
-			sender.Commit()
-			commitTime := time.Since(start)
-			info = report(agg, flush, info, "EventFlushTime")
-			fmt.Printf("sent %d Events in %f and commited in %f flush in %f serialize in %f\n",
-				nbPoint,
-				float64(genTime)/float64(time.Millisecond),
-				float64(commitTime)/float64(time.Millisecond),
-				float64(info.Flush["FlushTime"].LastFlush)/float64(time.Millisecond),
-				float64(info.Flush["EventFlushTime"].LastFlush)/float64(time.Millisecond))
-			plotRes += fmt.Sprintf(" %f", float64(genTime)/float64(time.Millisecond))
-		}
-
-		fmt.Printf("-- %d ServiceChecks ---\n", nbPoint)
-		for _, nbPoint := range nbPoints {
-			genTime := generateServiceCheck(nbPoint, sender)
-			start := time.Now()
-			sender.Commit()
-			commitTime := time.Since(start)
-			info = report(agg, flush, info, "ServiceCheckFlushTime")
-			fmt.Printf("sent %d Service Checks in %f and commited in %f flush in %f serialize in %f\n",
-				nbPoint,
-				float64(genTime)/float64(time.Millisecond),
-				float64(commitTime)/float64(time.Millisecond),
-				float64(info.Flush["FlushTime"].LastFlush)/float64(time.Millisecond),
-				float64(info.Flush["ServiceCheckFlushTime"].LastFlush)/float64(time.Millisecond))
-			plotRes += fmt.Sprintf(" %f", float64(genTime)/float64(time.Millisecond))
-		}
-
 	}
 
-	return plotRes
+	log.Infof("-- Events ---")
+	for _, nbSerie := range numberOfSeries {
+		tags := []string{fmt.Sprintf("nb_serie:%d", nbSerie), fmt.Sprintf("branch:%s", branchName), "type:event"}
+
+		genTime := generateEvent(nbSerie, sender)
+		start := time.Now()
+		sender.Commit()
+		commitTime := float64(time.Since(start)) / float64(time.Millisecond)
+
+		info := report(info, "EventFlushTime")
+		flushTime := float64(info.Flush["EventFlushTime"].LastFlush) / float64(time.Millisecond)
+
+		genRes := createMetric(genTime, tags, "benchmark.aggregator.gen", t)
+		commitRes := createMetric(commitTime, tags, "benchmark.aggregator.commit", t)
+		flushRes := createMetric(flushTime, tags, "benchmark.aggregator.flush", t)
+
+		results = append(results, genRes)
+		results = append(results, commitRes)
+		results = append(results, flushRes)
+		log.Infof("[%d Event] sent %f | commit time: %f | flush time: %f", nbSerie, genTime, commitTime, flushTime)
+	}
+
+	log.Infof("-- ServiceChecks ---")
+	for _, nbSerie := range numberOfSeries {
+		tags := []string{fmt.Sprintf("nb_serie:%d", nbSerie), fmt.Sprintf("branch:%s", branchName), "type:service_check"}
+
+		genTime := generateServiceCheck(nbSerie, sender)
+		start := time.Now()
+		sender.Commit()
+		commitTime := float64(time.Since(start)) / float64(time.Millisecond)
+
+		info := report(info, "ServiceCheckFlushTime")
+		flushTime := float64(info.Flush["ServiceCheckFlushTime"].LastFlush) / float64(time.Millisecond)
+
+		genRes := createMetric(genTime, tags, "benchmark.aggregator.gen", t)
+		commitRes := createMetric(commitTime, tags, "benchmark.aggregator.commit", t)
+		flushRes := createMetric(flushTime, tags, "benchmark.aggregator.flush", t)
+
+		results = append(results, genRes)
+		results = append(results, commitRes)
+		results = append(results, flushRes)
+		log.Infof("[%d ServiceCheck] sent %f | commit time: %f | flush time: %f", nbSerie, genTime, commitTime, flushTime)
+	}
+
+	return results
 }

--- a/test/benchmarks/aggregator/push_metric.go
+++ b/test/benchmarks/aggregator/push_metric.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package main
+
+import (
+	"os"
+
+	log "github.com/cihub/seelog"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+)
+
+func createMetric(value float64, tags []string, name string, t int64) datadog.Metric {
+	unit := "millisecond"
+	metricType := "gauge"
+	hostname, _ := os.Hostname()
+
+	return datadog.Metric{
+		Metric: &name,
+		Points: []datadog.DataPoint{{float64(t), value}},
+		Type:   &metricType,
+		Host:   &hostname,
+		Tags:   tags,
+		Unit:   &unit,
+	}
+}
+
+func pushMetricsToDatadog(apiKey string, results []datadog.Metric) {
+	client := datadog.NewClient(apiKey, "")
+	err := client.PostMetrics(results)
+	if err != nil {
+		log.Errorf("Could not post metrics: %s", err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- We now can send metrics to Datadog backend when merging on master
- Display the metrics in json
- Add a step in gitlab pipeline to run the benchmarks (on every branch for now, we will limit it to master later).