### PR TITLE
make TestGetAPIKey set apikey explicitly instead of setdefault

### DIFF
--- a/pkg/metadata/common/common_test.go
+++ b/pkg/metadata/common/common_test.go
@@ -22,7 +22,7 @@ func TestGetPayload(t *testing.T) {
 }
 
 func TestGetAPIKey(t *testing.T) {
-	config.Datadog.SetDefault("api_key", "bar,baz")
+	config.Datadog.Set("api_key", "bar,baz")
 	assert.Equal(t, "bar", getAPIKey())
 	assert.Equal(t, "bar", apiKey)
 	apiKey = "foo"


### PR DESCRIPTION
### What does this PR do?

Make tests work again even if we have a dangling `DD_API_KEY` envvar set.
