### PR TITLE
Silence OSX firewall when running tests locally

### DIFF
--- a/pkg/metadata/ecs/ecs_test.go
+++ b/pkg/metadata/ecs/ecs_test.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"net/http"
 
+	"testing"
+
 	payload "github.com/DataDog/agent-payload/gogen"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var nextTestResponse string
@@ -27,7 +28,7 @@ func runServer(t *testing.T, exit chan bool) {
 		w.Write([]byte(nextTestResponse))
 	})
 
-	s := &http.Server{Addr: fmt.Sprintf(":%d", DefaultAgentPort)}
+	s := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", DefaultAgentPort)}
 	go s.ListenAndServe()
 	<-exit
 	s.Close()


### PR DESCRIPTION


<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Explicitly listen to 127.0.0.1 so the firewall will stop complaining

