### PR TITLE
Use unittests to save a dependency

### DIFF
--- a/tasks/pylauncher.py
+++ b/tasks/pylauncher.py
@@ -37,6 +37,7 @@ def system_tests(ctx, skip_build=False):
     Run the system testsuite.
     """
     if not skip_build:
+        print("Building pylauncher...")
         build(ctx)
 
     env = {

--- a/test/system/python_binding/datadog_agent.py
+++ b/test/system/python_binding/datadog_agent.py
@@ -2,26 +2,26 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
-
+import unittest
 import sys
 import socket
-import nose
-from nose.tools import assert_equals
 import datadog_agent
 
 
-def test_agent_verion():
-    assert_equals(datadog_agent.get_version(), "6.0.0")
+class TestAgent(unittest.TestCase):
 
-def test_get_config():
-    assert_equals(datadog_agent.get_config('dd_url'), "https://test.datadoghq.com")
+    def test_agent_version(self):
+        self.assertEqual(datadog_agent.get_version(), "6.0.0")
 
-def test_headers():
-    assert_equals(datadog_agent.headers(), {'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'text/html, */*', 'User-Agent': 'Datadog Agent/6.0.0'})
+    def test_get_config(self):
+        self.assertEqual(datadog_agent.get_config('dd_url'), "https://test.datadoghq.com")
 
-def test_get_hostname():
-    assert_equals(datadog_agent.get_hostname(), "test.hostname")
+    def test_headers(self):
+        self.assertEqual(datadog_agent.headers(), {'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'text/html, */*', 'User-Agent': 'Datadog Agent/6.0.0'})
+
+    def test_get_hostname(self):
+        self.assertEqual(datadog_agent.get_hostname(), "test.hostname")
+
 
 if __name__ == '__main__':
-    if not nose.run(defaultTest=__name__):
-        sys.exit(1)
+    unittest.main()

--- a/test/system/python_binding/test.sh
+++ b/test/system/python_binding/test.sh
@@ -9,4 +9,4 @@ set -e
 
 current_dir=`dirname "${BASH_SOURCE[0]}"`
 
-$PYLAUNCHER_BIN -conf datadog.yaml -py datadog_agent.py -- -v -s
+$PYLAUNCHER_BIN -conf datadog.yaml -py datadog_agent.py -- -v


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Uses `unittests` instead of `nose` for the Python system tests

### Motivation

Ease onboarding and keep docs simple.
The test is simple and we're not using any nose plugin, we can use `unittests` instead and avoid to make users install an external dependency.

