### PR TITLE
[aggregator] Add expvar stats on number of m/sc/events of past flushes

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -22,34 +22,44 @@ import (
 const defaultFlushInterval = 15 // flush interval in seconds
 const bucketSize = 10           // fixed for now
 
-// Stats collect several flush duration allowing computation like median or percentiles
+// Stats stores a statistic from several past flushes allowing computations like median or percentiles
 type Stats struct {
-	FlushTime     [32]int64 // circular buffer of recent run durations
-	FlushIndex    int       // last flush time position in circular buffer
-	LastFlushTime int64     // most recent flush duration, provided for convenience
-	Name          string
-	m             sync.Mutex
+	Flushes    [32]int64 // circular buffer of recent flushes stat
+	FlushIndex int       // last flush position in circular buffer
+	LastFlush  int64     // most recent flush stat, provided for convenience
+	Name       string
+	m          sync.Mutex
 }
 
-func (s *Stats) add(duration int64) {
+func (s *Stats) add(stat int64) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
 	s.FlushIndex = (s.FlushIndex + 1) % 32
-	s.FlushTime[s.FlushIndex] = duration
-	s.LastFlushTime = duration
+	s.Flushes[s.FlushIndex] = stat
+	s.LastFlush = stat
 }
 
-func newStats(name string) {
-	flushStats[name] = &Stats{Name: name, FlushIndex: -1}
+func newFlushTimeStats(name string) {
+	flushTimeStats[name] = &Stats{Name: name, FlushIndex: -1}
 }
 
 func addFlushTime(name string, value int64) {
-	flushStats[name].add(value)
+	flushTimeStats[name].add(value)
 }
 
-func expStats() interface{} {
-	return flushStats
+func newFlushCountStats(name string) {
+	flushCountStats[name] = &Stats{Name: name, FlushIndex: -1}
+}
+
+func addFlushCount(name string, value int64) {
+	flushCountStats[name].add(value)
+}
+
+func expStatsMap(statsMap map[string]*Stats) func() interface{} {
+	return func() interface{} {
+		return statsMap
+	}
 }
 
 func timeNowNano() float64 {
@@ -61,16 +71,23 @@ var (
 	aggregatorInit     sync.Once
 
 	aggregatorExpvar = expvar.NewMap("aggregator")
-	flushStats       = make(map[string]*Stats)
+	flushTimeStats   = make(map[string]*Stats)
+	flushCountStats  = make(map[string]*Stats)
 )
 
 func init() {
-	newStats("ChecksMetricSampleFlushTime")
-	newStats("ServiceCheckFlushTime")
-	newStats("EventFlushTime")
-	newStats("MainFlushTime")
-	newStats("MetricSketchFlushTime")
-	aggregatorExpvar.Set("Flush", expvar.Func(expStats))
+	newFlushTimeStats("ChecksMetricSampleFlushTime")
+	newFlushTimeStats("ServiceCheckFlushTime")
+	newFlushTimeStats("EventFlushTime")
+	newFlushTimeStats("MainFlushTime")
+	newFlushTimeStats("MetricSketchFlushTime")
+	aggregatorExpvar.Set("Flush", expvar.Func(expStatsMap(flushTimeStats)))
+
+	newFlushCountStats("ServiceChecks")
+	newFlushCountStats("Series")
+	newFlushCountStats("Events")
+	newFlushCountStats("Sketches")
+	aggregatorExpvar.Set("FlushCount", expvar.Func(expStatsMap(flushCountStats)))
 }
 
 // InitAggregator returns the Singleton instance
@@ -262,6 +279,7 @@ func (agg *BufferedAggregator) GetSeries() metrics.Series {
 func (agg *BufferedAggregator) flushSeries() {
 	start := time.Now()
 	series := agg.GetSeries()
+	addFlushCount("Series", int64(len(series)))
 
 	if len(series) == 0 {
 		return
@@ -299,6 +317,7 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 	})
 
 	serviceChecks := agg.GetServiceChecks()
+	addFlushCount("ServiceChecks", int64(len(serviceChecks)))
 
 	// Serialize and forward in a separate goroutine
 	go func() {
@@ -324,9 +343,11 @@ func (agg *BufferedAggregator) flushSketches() {
 	// Serialize and forward in a separate goroutine
 	start := time.Now()
 	sketchSeries := agg.GetSketches()
+	addFlushCount("Sketches", int64(len(sketchSeries)))
 	if len(sketchSeries) == 0 {
 		return
 	}
+
 	go func() {
 		log.Debug("Flushing ", len(sketchSeries), " sketches to the forwarder")
 		err := agg.serializer.SendSketch(sketchSeries)
@@ -356,6 +377,7 @@ func (agg *BufferedAggregator) flushEvents() {
 	if len(events) == 0 {
 		return
 	}
+	addFlushCount("Events", int64(len(events)))
 
 	go func() {
 		log.Debug("Flushing ", len(events), " events to the forwarder")

--- a/pkg/collector/dist/conf.d/go_expvar.yaml.default
+++ b/pkg/collector/dist/conf.d/go_expvar.yaml.default
@@ -58,13 +58,23 @@ instances:
         type: rate
 
       # aggregator monitoring
-      - path: aggregator/Flush/ChecksMetricSampleFlushTime/LastFlushTime
+      - path: aggregator/Flush/ChecksMetricSampleFlushTime/LastFlush
         type: gauge
-      - path: aggregator/Flush/ServiceCheckFlushTime/LastFlushTime
+      - path: aggregator/Flush/ServiceCheckFlushTime/LastFlush
         type: gauge
-      - path: aggregator/Flush/EventFlushTime/LastFlushTime
+      - path: aggregator/Flush/EventFlushTime/LastFlush
         type: gauge
-      - path: aggregator/Flush/MainFlushTime/LastFlushTime
+      - path: aggregator/Flush/MetricSketchFlushTime/LastFlush
+        type: gauge
+      - path: aggregator/Flush/MainFlushTime/LastFlush
+        type: gauge
+      - path: aggregator/FlushCount/ServiceChecks/LastFlush
+        type: gauge
+      - path: aggregator/FlushCount/Series/LastFlush
+        type: gauge
+      - path: aggregator/FlushCount/Events/LastFlush
+        type: gauge
+      - path: aggregator/FlushCount/Sketches/LastFlush
         type: gauge
       - path: aggregator/SeriesFlushed
         type: rate

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -80,7 +80,7 @@ func report(agg *aggregator.BufferedAggregator, flush chan time.Time, lastInfo *
 			return nil
 		}
 
-		if lastInfo != nil && lastInfo.Flush[waitingKey].LastFlushTime == stats.Flush[waitingKey].LastFlushTime {
+		if lastInfo != nil && lastInfo.Flush[waitingKey].LastFlush == stats.Flush[waitingKey].LastFlush {
 			log.Info("flush Time is not over, waiting a second")
 			time.Sleep(1 * time.Second)
 			continue

--- a/test/benchmarks/aggregator/metrics.go
+++ b/test/benchmarks/aggregator/metrics.go
@@ -103,8 +103,8 @@ func benchmarkMetrics(agg *aggregator.BufferedAggregator, numberOfSeries []int, 
 					nbSerie, name, nbPoint,
 					float64(genTime)/float64(time.Millisecond),
 					float64(commitTime)/float64(time.Millisecond),
-					float64(info.Flush["FlushTime"].LastFlushTime)/float64(time.Millisecond),
-					float64(info.Flush["ChecksMetricSampleFlushTime"].LastFlushTime)/float64(time.Millisecond))
+					float64(info.Flush["FlushTime"].LastFlush)/float64(time.Millisecond),
+					float64(info.Flush["ChecksMetricSampleFlushTime"].LastFlush)/float64(time.Millisecond))
 
 				plotRes += fmt.Sprintf(" %f", float64(genTime)/float64(time.Millisecond))
 			}
@@ -121,8 +121,8 @@ func benchmarkMetrics(agg *aggregator.BufferedAggregator, numberOfSeries []int, 
 				nbPoint,
 				float64(genTime)/float64(time.Millisecond),
 				float64(commitTime)/float64(time.Millisecond),
-				float64(info.Flush["FlushTime"].LastFlushTime)/float64(time.Millisecond),
-				float64(info.Flush["EventFlushTime"].LastFlushTime)/float64(time.Millisecond))
+				float64(info.Flush["FlushTime"].LastFlush)/float64(time.Millisecond),
+				float64(info.Flush["EventFlushTime"].LastFlush)/float64(time.Millisecond))
 			plotRes += fmt.Sprintf(" %f", float64(genTime)/float64(time.Millisecond))
 		}
 
@@ -137,8 +137,8 @@ func benchmarkMetrics(agg *aggregator.BufferedAggregator, numberOfSeries []int, 
 				nbPoint,
 				float64(genTime)/float64(time.Millisecond),
 				float64(commitTime)/float64(time.Millisecond),
-				float64(info.Flush["FlushTime"].LastFlushTime)/float64(time.Millisecond),
-				float64(info.Flush["ServiceCheckFlushTime"].LastFlushTime)/float64(time.Millisecond))
+				float64(info.Flush["FlushTime"].LastFlush)/float64(time.Millisecond),
+				float64(info.Flush["ServiceCheckFlushTime"].LastFlush)/float64(time.Millisecond))
 			plotRes += fmt.Sprintf(" %f", float64(genTime)/float64(time.Millisecond))
 		}
 


### PR DESCRIPTION
### What does this PR do?

Adds expvar stats on number of m/sc/events of past flushes.
Re-uses (and changes slightly) the existing `Stats` struct in the aggregator pkg.

### Motivation

Interesting information to have exposed through expvar. Also useful
for the info page of the agent5 (running dogstatsd6).

### Additional Notes

If this looks good I'll add it to the status page of the agent6