### PR TITLE
[dsd] resolve container id for origin detection

### DIFF
--- a/pkg/dogstatsd/listeners/README.md
+++ b/pkg/dogstatsd/listeners/README.md
@@ -6,8 +6,8 @@ packets to be processed by the `dogstatsd` package.
 ### Packet
 
 `Packet` is a statsd packet that might contain several statsd messages in it's
-`Contents` field. If origin detection is supported and enabled, the `Container`
-field will hold the container id ready for tag resolution. If not, the field hold
+`Contents` field. If origin detection is supported and enabled, the `Origin`
+field will hold the container id ready for tag resolution. If not, the field holds
 an empty `string`.
 
 ### StatsdListener

--- a/pkg/dogstatsd/listeners/types.go
+++ b/pkg/dogstatsd/listeners/types.go
@@ -8,8 +8,8 @@ package listeners
 // Packet reprensents a statsd packet ready to process,
 // with its origin metadata if applicable.
 type Packet struct {
-	Contents  []byte // Contents, might contain several messages
-	Container string // Origin container if identified
+	Contents []byte // Contents, might contain several messages
+	Origin   string // Origin container if identified
 }
 
 // StatsdListener opens a communication channel to get statsd packets in.

--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -3,17 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
-// +build !windows
-// UDS won't work in windows
-
 package listeners
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestNewUDPListener(t *testing.T) {
@@ -25,18 +25,56 @@ func TestNewUDPListener(t *testing.T) {
 }
 
 func TestStartStopUDPListener(t *testing.T) {
+	config.Datadog.Set("dogstatsd_non_local_traffic", false)
 	s, err := NewUDPListener(nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
 	go s.Listen()
-	// Port should be unavailable
+	// Local port should be unavailable
 	address, _ := net.ResolveUDPAddr("udp", "127.0.0.1:8125")
 	_, err = net.ListenUDP("udp", address)
 	assert.NotNil(t, err)
 
 	s.Stop()
 	// Port should be available again
+	conn, err := net.ListenUDP("udp", address)
+	assert.Nil(t, err)
+	conn.Close()
+}
+
+func TestUDPNonLocal(t *testing.T) {
+	config.Datadog.Set("dogstatsd_non_local_traffic", true)
+	s, err := NewUDPListener(nil)
+	go s.Listen()
+	defer s.Stop()
+
+	// Local port should be unavailable
+	address, _ := net.ResolveUDPAddr("udp", "127.0.0.1:8125")
+	_, err = net.ListenUDP("udp", address)
+	assert.NotNil(t, err)
+
+	// External port should be unavailable
+	externalPort := fmt.Sprintf("%s:8125", getLocalIP())
+	address, _ = net.ResolveUDPAddr("udp", externalPort)
+	_, err = net.ListenUDP("udp", address)
+	assert.NotNil(t, err)
+}
+
+func TestUDPLocalOnly(t *testing.T) {
+	config.Datadog.Set("dogstatsd_non_local_traffic", false)
+	s, err := NewUDPListener(nil)
+	go s.Listen()
+	defer s.Stop()
+
+	// Local port should be unavailable
+	address, _ := net.ResolveUDPAddr("udp", "127.0.0.1:8125")
+	_, err = net.ListenUDP("udp", address)
+	assert.NotNil(t, err)
+
+	// External port should be available
+	externalPort := fmt.Sprintf("%s:8125", getLocalIP())
+	address, _ = net.ResolveUDPAddr("udp", externalPort)
 	conn, err := net.ListenUDP("udp", address)
 	assert.Nil(t, err)
 	conn.Close()
@@ -60,9 +98,25 @@ func TestUDPReceive(t *testing.T) {
 	select {
 	case packet := <-packetChannel:
 		assert.NotNil(t, packet)
-		assert.Equal(t, packet.Contents, contents)
-		assert.Equal(t, packet.Container, "")
+		assert.Equal(t, contents, packet.Contents)
+		assert.Equal(t, "", packet.Origin)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
+}
+
+// getLocalIP returns the first non loopback local IPv4 on that host
+func getLocalIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addrs {
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -85,15 +85,14 @@ func (l *UDSListener) Listen() {
 			oob := make([]byte, l.oobSize)
 			var oobn int
 			n, oobn, _, _, err = l.conn.ReadMsgUnix(buf, oob)
-			log.Infof("dogstatsd-uds: n %d oobn %d of %d", n, oobn, l.oobSize) // FIXME remove
 
-			// Extract PID from credentials
+			// Extract container id from credentials
 			container, err := processUDSOrigin(oob[:oobn])
 			if err != nil {
 				log.Warnf("dogstatsd-uds: error processing origin, data will not be tagged : %v", err)
 				socketExpvar.Add("OriginDetectionErrors", 1)
 			} else {
-				packet.Container = container
+				packet.Origin = container
 			}
 		} else {
 			// Read only datagram contents with no credentials

--- a/pkg/dogstatsd/listeners/uds_common_test.go
+++ b/pkg/dogstatsd/listeners/uds_common_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestNewUDSListener(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := ioutil.TempDir("", "dd-test-")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir) // clean up
 	socketPath := filepath.Join(dir, "dsd.socket")
@@ -37,13 +37,13 @@ func TestNewUDSListener(t *testing.T) {
 }
 
 func TestStartStopUDSListener(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := ioutil.TempDir("", "dd-test-")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir) // clean up
 	socketPath := filepath.Join(dir, "dsd.socket")
 
 	config.Datadog.Set("dogstatsd_socket", socketPath)
-
+	config.Datadog.Set("dogstatsd_origin_detection", false)
 	s, err := NewUDSListener(nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
@@ -59,12 +59,14 @@ func TestStartStopUDSListener(t *testing.T) {
 }
 
 func TestUDSReceive(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := ioutil.TempDir("", "dd-test-")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir) // clean up
 	socketPath := filepath.Join(dir, "dsd.socket")
 
 	config.Datadog.Set("dogstatsd_socket", socketPath)
+	config.Datadog.Set("dogstatsd_origin_detection", false)
+
 	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
 	packetChannel := make(chan *Packet)
@@ -83,7 +85,7 @@ func TestUDSReceive(t *testing.T) {
 	case packet := <-packetChannel:
 		assert.NotNil(t, packet)
 		assert.Equal(t, packet.Contents, contents)
-		assert.Equal(t, packet.Container, "")
+		assert.Equal(t, packet.Origin, "")
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}

--- a/pkg/dogstatsd/listeners/uds_linux_test.go
+++ b/pkg/dogstatsd/listeners/uds_linux_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build linux
+// Origin detection is linux-only
+
+// Most of it is tested by test/integration/dogstatsd/origin_detection_test.go
+// that requires a docker environment to run
+
+package listeners
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"golang.org/x/sys/unix"
+)
+
+func TestUDSPassCred(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dd-test-")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir) // clean up
+	socketPath := filepath.Join(dir, "dsd.socket")
+
+	config.Datadog.Set("dogstatsd_socket", socketPath)
+	config.Datadog.Set("dogstatsd_origin_detection", true)
+
+	s, err := NewUDSListener(nil)
+	defer s.Stop()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, s)
+
+	// Test socket has PASSCRED option set to 1
+	f, err := s.conn.File()
+	defer f.Close()
+	assert.Nil(t, err)
+
+	enabled, err := unix.GetsockoptInt(int(f.Fd()), unix.SOL_SOCKET, unix.SO_PASSCRED)
+	assert.Nil(t, err)
+	assert.Equal(t, enabled, 1)
+}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -91,8 +91,8 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 	for {
 		packet := <-s.packetIn
 
-		if packet.Container != "" {
-			log.Debugf("dogstatsd receive from %s: %s", packet.Container, packet.Contents)
+		if packet.Origin != "" {
+			log.Debugf("dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
 		} else {
 			log.Debugf("dogstatsd receive: %s", packet.Contents)
 		}

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -1,0 +1,106 @@
+package docker
+
+// Copied from https://github.com/DataDog/datadog-process-agent/blob/e44b0de7b9eb7f05c96a2dbf91e763e931bf6174/util/docker/cgroup.go
+// FIXME: merge back these utils
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var (
+	containerRe = regexp.MustCompile("[0-9a-f]{64}")
+)
+
+// ContainerIDForPID is a lighter version of CgroupsForPids to only retrieve the
+// container ID for origin detection. Returns container id as a string, empty if
+// the PID is not in a container.
+func ContainerIDForPID(pid int) (string, error) {
+	cgPath := filepath.Join(config.Datadog.GetString("proc_root"), strconv.Itoa(pid), "cgroup")
+	containerID, _, err := readCgroupPaths(cgPath)
+	if err != nil {
+		return "", err
+	}
+	return containerID, nil
+}
+
+// readCgroupPaths reads the cgroups from a /sys/$pid/cgroup path.
+func readCgroupPaths(pidCgroupPath string) (string, map[string]string, error) {
+	f, err := os.Open(pidCgroupPath)
+	if os.IsNotExist(err) {
+		return "", nil, err
+	} else if err != nil {
+		return "", nil, err
+	}
+	defer f.Close()
+	return parseCgroupPaths(f)
+}
+
+// parseCgroupPaths parses out the cgroup paths from a /proc/$pid/cgroup file.
+// The file format will be something like:
+//
+// 11:net_cls:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e
+// 10:freezer:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e
+// 9:cpu,cpuacct:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e
+// 8:memory:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e
+// 7:blkio:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e
+//
+// Returns the common containerID and a mapping of target => path
+// If the first line doesn't have a valid container ID we will return an empty string
+func parseCgroupPaths(r io.Reader) (string, map[string]string, error) {
+	var ok bool
+	var containerID string
+	paths := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		l := scanner.Text()
+		if containerID == "" {
+			// Check if this process running inside a container.
+			containerID, ok = containerIDFromCgroup(l)
+			if !ok {
+				return "", nil, nil
+			}
+		}
+
+		sp := strings.SplitN(l, ":", 3)
+		if len(sp) < 3 {
+			continue
+		}
+		// Target can be comma-separate values like cpu,cpuacct
+		tsp := strings.Split(sp[1], ",")
+		for _, target := range tsp {
+			paths[target] = sp[2]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", nil, err
+	}
+
+	// In Ubuntu Xenial, we've encountered containers with no `cpu`
+	_, cpuok := paths["cpu"]
+	cpuacct, cpuacctok := paths["cpuacct"]
+	if !cpuok && cpuacctok {
+		paths["cpu"] = cpuacct
+	}
+
+	return containerID, paths, nil
+}
+
+func containerIDFromCgroup(cgroup string) (string, bool) {
+	sp := strings.SplitN(cgroup, ":", 3)
+	if len(sp) < 3 {
+		return "", false
+	}
+	match := containerRe.Find([]byte(sp[2]))
+	if match == nil {
+		return "", false
+	}
+	return string(match), true
+}

--- a/pkg/util/docker/cgroup_test.go
+++ b/pkg/util/docker/cgroup_test.go
@@ -1,0 +1,62 @@
+package docker
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestParseCgroupPaths(t *testing.T) {
+	for _, tc := range []struct {
+		contents          []string
+		expectedContainer string
+		expectedPaths     map[string]string
+	}{
+		{
+			contents: []string{
+				"11:net_cls:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"9:cpu,cpuacct:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"8:memory:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"7:blkio:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+			},
+			expectedContainer: "47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+			expectedPaths: map[string]string{
+				"net_cls": "/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"cpu":     "/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"cpuacct": "/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"memory":  "/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"blkio":   "/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+			},
+		},
+		{
+			contents: []string{
+				"",
+				"11:net_cls:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+				"9:cpu,cpuacct:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/47fc31db38b4fa0f4db44b99d0cad10e3cd4d5f142135a7721c1c95c1aadfb2e",
+			},
+			expectedContainer: "",
+			expectedPaths:     nil,
+		},
+		{
+			contents: []string{
+				"6:memory:/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+				"5:cpuacct:/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+				"3:cpuset:/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+			},
+			expectedContainer: "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+			expectedPaths: map[string]string{
+				"memory":  "/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+				"cpuacct": "/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+				"cpuset":  "/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+				// CPU is mising so we will automatically use from cpuacct
+				"cpu": "/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+			},
+		},
+	} {
+		contents := strings.NewReader(strings.Join(tc.contents, "\n"))
+		c, p, err := parseCgroupPaths(contents)
+		assert.NoError(t, err)
+		assert.Equal(t, c, tc.expectedContainer)
+		assert.Equal(t, p, tc.expectedPaths)
+	}
+}

--- a/test/integration/dogstatsd/origin_detection_test.go
+++ b/test/integration/dogstatsd/origin_detection_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build linux
+
+package dogstatsd_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
+)
+
+const (
+	socatImg  string = "datadog/socat-proxy:master"
+	socatName string = "dd-test-socat-proxy"
+)
+
+// FIXME: move as a system test once the runner is able to run them
+
+// TestUDSOriginDetection ensures UDS origin detection works, by submitting
+// a metric from a `socat` container. As we need the origin PID to stay running,
+// we can't just `netcat` to the socket, that's why we keep socat running as
+// UDP->UDS proxy and submit the metric through it.
+//
+// FIXME: this test should be ported to the go docker client
+func TestUDSOriginDetection(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dd-test-")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir) // clean up
+	socketPath := filepath.Join(dir, "dsd.socket")
+	config.Datadog.Set("dogstatsd_socket", socketPath)
+	config.Datadog.Set("dogstatsd_origin_detection", true)
+	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
+
+	// Build proxy docker image
+	buildCmd := exec.Command("docker", "build",
+		"-t", socatImg,
+		"../../../Dockerfiles/dogstatsd/socat-proxy/")
+	output, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Error building docker image: %s", string(output))
+		panic(err)
+	}
+	rmImageCmd := exec.Command("docker", "image", "rm", socatImg)
+	defer rmImageCmd.Run()
+
+	// Start DSD
+	packetChannel := make(chan *listeners.Packet)
+	s, err := listeners.NewUDSListener(packetChannel)
+	if err != nil {
+		panic(err)
+	}
+	go s.Listen()
+	defer s.Stop()
+
+	// Run proxy docker image
+	runCmd := exec.Command("docker", "run", "-d", "--rm",
+		"-v", fmt.Sprintf("%s:/socket/statsd.socket", socketPath),
+		"-p", "8125:8125/udp",
+		socatImg)
+	output, err = runCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Error running docker image: %s", string(output))
+		panic(err)
+	}
+	containerId := strings.Trim(string(output), "\n")
+	assert.Equal(t, 64, len(containerId))
+
+	t.Logf("Running socat container: %s", containerId)
+	stopCmd := exec.Command("docker", "stop", containerId)
+	defer stopCmd.Run()
+
+	// Send test data through proxy via UDP
+	conn, err := net.Dial("udp", "127.0.0.1:8125")
+	assert.Nil(t, err)
+	defer conn.Close()
+	conn.Write(contents)
+
+	select {
+	case packet := <-packetChannel:
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents)
+		assert.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- temporarily copy [process-agent's cgroup.go](https://github.com/DataDog/datadog-process-agent/blob/e44b0de7b9eb7f05c96a2dbf91e763e931bf6174/util/docker/cgroup.go), source will be merged there when stable
- update uds_linux.go, introduced by #463
- create origin_detection_test.go integration test
- improve UDS & UDP test coverage

### Current limitations

- PID -> container resolution is a quick `proc` file parsing away, so we do it synchronously and cache it for 5 minutes in gocache. As detecting processes ending would be costly, we can't invalidate the cache selectively. Best alternative would be to expire entries `x` seconds after the last access (last packet sent from that process), but gocache does not implement that out of the box.
- Although we resolve the container id as soon as possible, there's a possible race condition if the process exits just after submitting the metric. That means submitting with ephemeral processes like `netcat` is not viable.

### Additional Notes

gitlab runner can't run this test, launch by running:

`go test ./test/integration/dogstatsd/origin_detection_test.go` on a docker host
