### PR TITLE
[invoke] Set boolean default values on params that should be bools

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,25 +1,9 @@
 targets: [./pkg, ./cmd]
-use_system_libs: true
-
-test:
-  race: false
 
 agent:
-  puppy: false
-  incremental: true
-  race: false
   build_include: [all]
   build_exclude: []
 
-benchmarks:
-  incremental: false
-
 dogstatsd:
-  incremental: false
-  race: false
-  static: false
   build_include: [zlib]
   build_exclude: []
-
-pylauncher:
-  incremental: false

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -18,8 +18,8 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 
 
 @task
-def build(ctx, incremental=None, race=None, build_include=None, build_exclude=None,
-          puppy=None, use_system_libs=None):
+def build(ctx, incremental=True, race=False, build_include=None, build_exclude=None,
+          puppy=False, use_system_libs=True):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -27,12 +27,8 @@ def build(ctx, incremental=None, race=None, build_include=None, build_exclude=No
     Example invokation:
         inv agent.build --build-exclude=snmp
     """
-    incremental = incremental or ctx.agent.incremental
-    race = race or ctx.agent.race
     build_include = ctx.agent.build_include if build_include is None else build_include.split(",")
     build_exclude = ctx.agent.build_exclude if build_exclude is None else build_exclude.split(",")
-    puppy = puppy or ctx.agent.puppy
-    use_system_libs = use_system_libs or ctx.use_system_libs
 
     if puppy:
         build_tags = get_puppy_build_tags()
@@ -93,8 +89,8 @@ def refresh_assets(ctx):
 
 
 @task
-def run(ctx, incremental=None, race=None, build_include=None, build_exclude=None,
-        puppy=None, skip_build=False):
+def run(ctx, incremental=True, race=False, build_include=None, build_exclude=None,
+        puppy=False, skip_build=False):
     """
     Execute the agent binary.
 
@@ -119,12 +115,10 @@ def system_tests(ctx):
 
 
 @task
-def omnibus_build(ctx, puppy=None):
+def omnibus_build(ctx, puppy=False):
     """
     Build the Agent packages with Omnibus Installer.
     """
-    puppy = puppy or ctx.agent.puppy
-
     # omnibus config overrides
     overrides = []
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -19,7 +19,7 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 
 @task
 def build(ctx, incremental=True, race=False, build_include=None, build_exclude=None,
-          puppy=False, use_system_libs=True):
+          puppy=False, use_embedded_libs=False):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -37,7 +37,7 @@ def build(ctx, incremental=True, race=False, build_include=None, build_exclude=N
     ldflags, gcflags = get_ldflags(ctx)
 
     env = {
-        "PKG_CONFIG_PATH": pkg_config_path(use_system_libs)
+        "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)
     }
 
     if invoke.platform.WINDOWS:

--- a/tasks/benchmarks.py
+++ b/tasks/benchmarks.py
@@ -17,11 +17,10 @@ BENCHMARKS_BIN_PATH = os.path.join(".", "bin", "benchmarks")
 
 
 @task
-def build_aggregator(ctx, incremental=None):
+def build_aggregator(ctx, incremental=False):
     """
     Build the Aggregator benchmarks.
     """
-    incremental = incremental or ctx.benchmarks.incremental
     build_tags = get_build_tags()  # pass all the build flags
 
     ldflags = ""

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -19,13 +19,10 @@ STATIC_BIN_PATH = os.path.join(".", "bin", "static")
 MAX_BINARY_SIZE = 15 * 1024
 
 @task
-def build(ctx, incremental=None, race=False, static=False, build_include=None, build_exclude=None):
+def build(ctx, incremental=False, race=False, static=False, build_include=None, build_exclude=None):
     """
     Build Dogstatsd
     """
-    incremental = incremental or ctx.dogstatsd.incremental
-    race = race or ctx.dogstatsd.race
-    static = static or ctx.dogstatsd.static
     build_include = ctx.dogstatsd.build_include if build_include is None else build_include.split(",")
     build_exclude = ctx.dogstatsd.build_exclude if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
@@ -51,7 +48,7 @@ def build(ctx, incremental=None, race=False, static=False, build_include=None, b
 
 
 @task
-def run(ctx, incremental=None, race=None, build_include=None, build_exclude=None,
+def run(ctx, incremental=False, race=False, build_include=None, build_exclude=None,
         skip_build=False):
     """
     Run Dogstatsd binary. Build the binary before executing, unless
@@ -59,7 +56,7 @@ def run(ctx, incremental=None, race=None, build_include=None, build_exclude=None
     """
     if not skip_build:
         print("Building dogstatsd...")
-        build(ctx, incremental, race, build_include, build_exclude)
+        build(ctx, incremental=incremental, race=race, build_include=build_include, build_exclude=build_exclude)
 
     target = os.path.join(DOGSTATSD_BIN_PATH, bin_name("dogstatsd"))
     ctx.run("{} start".format(target))

--- a/tasks/pylauncher.py
+++ b/tasks/pylauncher.py
@@ -14,11 +14,10 @@ from .utils import REPO_PATH, bin_name, get_root
 PYLAUNCHER_BIN_PATH = os.path.join(get_root(), "bin", "pylauncher")
 
 @task
-def build(ctx, incremental=None):
+def build(ctx, incremental=False):
     """
     Build the pylauncher executable
     """
-    incremental = incremental or ctx.pylauncher.incremental
     build_tags = get_build_tags()  # pass all the build flags
 
     cmd = "go build {build_type} -tags \"{build_tags}\" -o {bin_name} {REPO_PATH}/cmd/py-launcher/"

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -16,7 +16,7 @@ PROFILE_COV = "profile.cov"
 
 
 @task()
-def test(ctx, targets=None, race=False):
+def test(ctx, targets=None, race=False, use_system_libs=True):
     """
     Run all the tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -25,7 +25,6 @@ def test(ctx, targets=None, race=False):
         inv test --targets=./pkg/collector/check,./pkg/aggregator --race
     """
     targets_list = ctx.targets if targets is None else targets.split(',')
-    race = race or ctx.test.race
     build_tags = get_build_tags()  # pass all the build flags for tests
 
     # explicitly run these tasks instead of using pre-tasks so we can
@@ -38,7 +37,7 @@ def test(ctx, targets=None, race=False):
         f_cov.write("mode: count")
 
     env = {
-        "PKG_CONFIG_PATH": pkg_config_path(ctx.use_system_libs)
+        "PKG_CONFIG_PATH": pkg_config_path(use_system_libs)
     }
 
     if race:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -16,7 +16,7 @@ PROFILE_COV = "profile.cov"
 
 
 @task()
-def test(ctx, targets=None, race=False, use_system_libs=True):
+def test(ctx, targets=None, race=False, use_embedded_libs=False):
     """
     Run all the tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -37,7 +37,7 @@ def test(ctx, targets=None, race=False, use_system_libs=True):
         f_cov.write("mode: count")
 
     env = {
-        "PKG_CONFIG_PATH": pkg_config_path(use_system_libs)
+        "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)
     }
 
     if race:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -24,7 +24,7 @@ def bin_name(name):
     return "{}.bin".format(name)
 
 
-def pkg_config_path(use_system_libs):
+def pkg_config_path(use_embedded_libs):
     """
     Prepend the full path to either the `system` or `embedded` pkg-config
     folders provided by the agent to the existing value of `PKG_CONFIG_PATH`
@@ -33,10 +33,10 @@ def pkg_config_path(use_system_libs):
     retval = ""
 
     base = os.path.join(os.path.dirname("."), "pkg-config", platform.system().lower())
-    if use_system_libs:
-        retval = os.path.abspath(os.path.join(base, "system"))
-    else:
+    if use_embedded_libs:
         retval = os.path.abspath(os.path.join(base, "embedded"))
+    else:
+        retval = os.path.abspath(os.path.join(base, "system"))
 
     # append the system wide value of PKG_CONFIG_PATH
     retval += ":{}".format(os.environ.get("PKG_CONFIG_PATH", ""))


### PR DESCRIPTION
### What does this PR do?

Another take on what #479 fixes, this time using default boolean values (`False` for almost all) on boolean parameters.

See discussion on #479.

### Motivation

Fix boolean parameter override through CLI options.

### Additional Notes

All boolean params are `False` by default, except `incremental` (`False` by default on every task except the dogstatsd ones).

Supersedes #479
