### PR TITLE
Fix branch name detection on CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,4 +213,4 @@ run_benchmarks:
     USE_SYSTEM_LIBS: "1"
   script:
     - rake benchmark:aggregator:build
-    - rake benchmark:aggregator:run
+    - DD_REPO_BRANCH_NAME="${CI_COMMIT_REF_NAME}" rake benchmark:aggregator:run

--- a/rake/benchmarks.rb
+++ b/rake/benchmarks.rb
@@ -22,7 +22,7 @@ namespace :benchmark do
 
     desc "Run the aggregator benchmark"
     task :run do
-      branch = `git rev-parse --abbrev-ref HEAD`.strip()
+      branch = ENV["DD_REPO_BRANCH_NAME"] or `git rev-parse --abbrev-ref HEAD`.strip()
       options = ""
       if ENV["DD_AGENT_API_KEY"]
         options = " -api-key #{ENV["DD_AGENT_API_KEY"]}"

--- a/tasks/benchmarks.py
+++ b/tasks/benchmarks.py
@@ -77,7 +77,8 @@ def aggregator(ctx):
     Run the Aggregator Benchmarks.
     """
     bin_path = os.path.join(BENCHMARKS_BIN_PATH, bin_name("aggregator"))
-    options = "-branch {}".format(get_git_branch_name())
+    branch_name = os.environ.get("DD_REPO_BRANCH_NAME") or get_git_branch_name()
+    options = "-branch {}".format(branch_name)
 
     key = os.environ.get("DD_AGENT_API_KEY")
     if key:


### PR DESCRIPTION
### What does this PR do?

Using gitlab branch name allow us to have better branch name detection.