### PR TITLE
[ecs] Fix casing of agent detection check

### DIFF
--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -91,7 +91,7 @@ func GetPayload() (metadata.Payload, error) {
 // ECS agent being detected. This is a used as a way to check if is available
 // or if the host is not in an ECS cluster.
 func IsAgentNotDetected(err error) bool {
-	return strings.Contains(err.Error(), "could not detect ECS Agent")
+	return strings.Contains(err.Error(), "could not detect ECS agent")
 }
 
 // detectAgentURL finds a hostname for the ECS-agent either via Docker, if


### PR DESCRIPTION
### What does this PR do?

Fix dumb bug in https://github.com/DataDog/datadog-agent/pull/484 where the `IsAgentNotDetected` does not work due to different casing.

### Motivation

See https://github.com/DataDog/datadog-agent/pull/484

