### PR TITLE
Remove requirement install in the CI since we don't use nose anymore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ before_script:
   # So we copy the agent sources to / and bootstrap from there the vendor dependencies before running any job.
   - rsync -azr --delete ./ $SRC_PATH
   - cd $SRC_PATH
-  - rake deps && pip install -r test/requirements-test.txt
+  - rake deps
 
 # run tests for deb-x64
 run_tests_deb-x64:


### PR DESCRIPTION
### What does this PR do?

The file test/requirements-test.txt no longer exists.