### PR TITLE
Run dsd integration tests on the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ run_integration_tests_deb-x64:
     # disable global before_script
     - pwd
   script:
-    - docker run --rm --user root --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv agent.integration-tests --install-deps
+    - docker run --rm --user root --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv integration-tests --install-deps
 
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -6,7 +6,7 @@ from invoke import Collection
 from . import agent, benchmarks, docker, dogstatsd, pylauncher
 
 from .go import fmt, lint, vet, deps
-from .test import test
+from .test import test, integration_tests
 
 
 # the root namespace
@@ -17,6 +17,7 @@ ns.add_task(fmt)
 ns.add_task(lint)
 ns.add_task(vet)
 ns.add_task(test)
+ns.add_task(integration_tests)
 ns.add_task(deps)
 
 # add namespaced tasks to the root

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -11,7 +11,7 @@ from invoke.exceptions import Exit
 from .build_tags import get_build_tags
 from .utils import get_ldflags, bin_name, get_root
 from .utils import REPO_PATH
-
+from .go import deps
 
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
@@ -134,3 +134,17 @@ def omnibus_build(ctx):
             "overrides": overrides_cmd
         }
         ctx.run(cmd.format(**args))
+
+@task
+def integration_tests(ctx, install_deps=False):
+    """
+    Run integration tests for the Agent
+    """
+    if install_deps:
+        deps(ctx)
+
+    build_tags = get_build_tags()
+
+    # config_providers
+    cmd = "go test -tags '{}' {}/test/integration/dogstatsd/..."
+    ctx.run(cmd.format(" ".join(build_tags), REPO_PATH))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -11,6 +11,8 @@ from invoke import task
 from .utils import pkg_config_path
 from .go import fmt, lint, vet
 from .build_tags import get_build_tags
+from .agent import integration_tests as agent_integration_tests
+from .dogstatsd import integration_tests as dsd_integration_tests
 
 PROFILE_COV = "profile.cov"
 
@@ -73,3 +75,12 @@ def test(ctx, targets=None, race=False, use_embedded_libs=False):
             os.remove(profile_tmp)
 
     ctx.run("go tool cover -func {}".format(PROFILE_COV))
+
+
+@task
+def integration_tests(ctx, install_deps=False):
+    """
+    Run all the available integration tests
+    """
+    agent_integration_tests(ctx, install_deps)
+    dsd_integration_tests(ctx, install_deps)

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build linux
+
+package dogstatsd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
+)
+
+const (
+	socatImg  string = "datadog/socat-proxy:master"
+	socatName string = "dd-test-socat-proxy"
+)
+
+// FIXME: move as a system test once the runner is able to run them
+
+// TestUDSOriginDetection ensures UDS origin detection works, by submitting
+// a metric from a `socat` container. As we need the origin PID to stay running,
+// we can't just `netcat` to the socket, that's why we keep socat running as
+// UDP->UDS proxy and submit the metric through it.
+//
+// FIXME: this test should be ported to the go docker client
+func testUDSOriginDetection(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dd-test-")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir) // clean up
+	socketPath := filepath.Join(dir, "dsd.socket")
+	config.Datadog.Set("dogstatsd_socket", socketPath)
+	config.Datadog.Set("dogstatsd_origin_detection", true)
+	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
+
+	// Build proxy docker image
+	buildCmd := exec.Command("docker", "build",
+		"-t", socatImg,
+		"../../../Dockerfiles/dogstatsd/socat-proxy/")
+	output, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Error building docker image: %s", string(output))
+		panic(err)
+	}
+	rmImageCmd := exec.Command("docker", "image", "rm", socatImg)
+	defer rmImageCmd.Run()
+
+	// Start DSD
+	packetChannel := make(chan *listeners.Packet)
+	s, err := listeners.NewUDSListener(packetChannel)
+	if err != nil {
+		panic(err)
+	}
+	go s.Listen()
+	defer s.Stop()
+
+	// Run proxy docker image
+	runCmd := exec.Command("docker", "run", "-d", "--rm",
+		"-v", fmt.Sprintf("%s:/socket/statsd.socket", socketPath),
+		"-p", "8125:8125/udp",
+		socatImg)
+	output, err = runCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Error running docker image: %s", string(output))
+		panic(err)
+	}
+	containerId := strings.Trim(string(output), "\n")
+	assert.Equal(t, 64, len(containerId))
+
+	t.Logf("Running socat container: %s", containerId)
+	stopCmd := exec.Command("docker", "stop", containerId)
+	defer stopCmd.Run()
+
+	// Send test data through proxy via UDP
+	conn, err := net.Dial("udp", "127.0.0.1:8125")
+	assert.Nil(t, err)
+	defer conn.Close()
+	conn.Write(contents)
+
+	select {
+	case packet := <-packetChannel:
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents)
+		assert.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+}

--- a/test/integration/dogstatsd/origin_detection_skip.go
+++ b/test/integration/dogstatsd/origin_detection_skip.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build !linux
+
+package dogstatsd
+
+import "testing"
+
+// noop version for unsupported platforms
+func testUDSOriginDetection(t *testing.T) {
+	t.Log("Unsupported platform, skip...")
+}

--- a/test/integration/dogstatsd/origin_detection_test.go
+++ b/test/integration/dogstatsd/origin_detection_test.go
@@ -3,31 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
-// +build linux
+package dogstatsd
 
-package dogstatsd_test
-
-import (
-	"fmt"
-	"io/ioutil"
-	"net"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
-)
-
-const (
-	socatImg  string = "datadog/socat-proxy:master"
-	socatName string = "dd-test-socat-proxy"
-)
+import "testing"
 
 // FIXME: move as a system test once the runner is able to run them
 
@@ -38,64 +16,5 @@ const (
 //
 // FIXME: this test should be ported to the go docker client
 func TestUDSOriginDetection(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dd-test-")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir) // clean up
-	socketPath := filepath.Join(dir, "dsd.socket")
-	config.Datadog.Set("dogstatsd_socket", socketPath)
-	config.Datadog.Set("dogstatsd_origin_detection", true)
-	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
-
-	// Build proxy docker image
-	buildCmd := exec.Command("docker", "build",
-		"-t", socatImg,
-		"../../../Dockerfiles/dogstatsd/socat-proxy/")
-	output, err := buildCmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Error building docker image: %s", string(output))
-		panic(err)
-	}
-	rmImageCmd := exec.Command("docker", "image", "rm", socatImg)
-	defer rmImageCmd.Run()
-
-	// Start DSD
-	packetChannel := make(chan *listeners.Packet)
-	s, err := listeners.NewUDSListener(packetChannel)
-	if err != nil {
-		panic(err)
-	}
-	go s.Listen()
-	defer s.Stop()
-
-	// Run proxy docker image
-	runCmd := exec.Command("docker", "run", "-d", "--rm",
-		"-v", fmt.Sprintf("%s:/socket/statsd.socket", socketPath),
-		"-p", "8125:8125/udp",
-		socatImg)
-	output, err = runCmd.CombinedOutput()
-	if err != nil {
-		t.Logf("Error running docker image: %s", string(output))
-		panic(err)
-	}
-	containerId := strings.Trim(string(output), "\n")
-	assert.Equal(t, 64, len(containerId))
-
-	t.Logf("Running socat container: %s", containerId)
-	stopCmd := exec.Command("docker", "stop", containerId)
-	defer stopCmd.Run()
-
-	// Send test data through proxy via UDP
-	conn, err := net.Dial("udp", "127.0.0.1:8125")
-	assert.Nil(t, err)
-	defer conn.Close()
-	conn.Write(contents)
-
-	select {
-	case packet := <-packetChannel:
-		assert.NotNil(t, packet)
-		assert.Equal(t, packet.Contents, contents)
-		assert.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
-	case <-time.After(2 * time.Second):
-		assert.FailNow(t, "Timeout on receive channel")
-	}
+	testUDSOriginDetection(t)
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

 * adds a global `integration-tests` task to run any integration test we have
 * refactor origin detection test so it's skipped on unsupported platforms

### Motivation

Test coverage++
