### PR TITLE
Fix ip detection + run Dsd integration tests on the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ run_integration_tests_deb-x64:
     # disable global before_script
     - pwd
   script:
-    - docker run --rm --user root --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv integration-tests --install-deps
+    - docker run --rm --user root --pid=host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv integration-tests --install-deps
 
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ run_integration_tests_deb-x64:
     # disable global before_script
     - pwd
   script:
-    - docker run --rm --user root --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv agent.integration-tests --install-deps
+    - docker run --rm --user root --net=host -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv integration-tests --install-deps
 
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:

--- a/docs/dev/agent_tests.md
+++ b/docs/dev/agent_tests.md
@@ -34,7 +34,8 @@ only testing single functions.
 
 System tests cover any use case that doesn't fit an integration test, like executing
 a special binary built using a subset of packages and validate specific operations,
-answering simple questions like _is dogstatsd correctly forwarding metrics_?
+answering simple questions like _is dogstatsd correctly forwarding metrics?_ or
+_are the Python bindings working?_.
 
 System Tests might contain Go code, Python or shell scripts but to ease maintenance
 and keep the execution environment simple, it's preferable to keep the number of

--- a/docs/dev/agent_tests.md
+++ b/docs/dev/agent_tests.md
@@ -1,15 +1,22 @@
 # Testing the Agent
 
-The Agent has a good coverage of code but unit tests validate each package in a
-quick but incomplete way, specially because in go mocking is not always effective.
-For this reason the Agent test suite also includes _system tests_,
+The Agent has a good code coverage but unit tests validate each package in a
+quick and incomplete way, specially because mocking with go is not always effective.
+For this reason, the Agent test suite also includes _system tests_,
 _integration tests_ and _E2E (End to End) tests_.
 
 ## Integration tests
 
-Integration tests are executed using the go test framework. These tests require
-more context than Unit tests, like a third party service up and running.
-Integration tests are run at every commit through the CI.
+Integration tests validates one of more functions using the go test framework -
+the difference with unit tests is that these tests require more context to complete,
+like a third party service up and running. Integration tests are run at every
+commit through the CI so the following requirements must be met:
+
+  * tests must be implemented using the `testing` package from the standard lib.
+  * tests must work both when invoked locally and when invoked from the CI.
+  * tests must work on any supported platform or skipped in a clean way.
+  * execution time matters and it has to be as short as possible.
+
 
 ## E2E tests
 
@@ -20,18 +27,15 @@ Test Kitchen from Chef on the supported platforms.
 
 ## System tests
 
-System Tests are in between Unit and E2E tests. The Agent consists of several
-moving parts running together and sometimes it's useful to validate how such
-components interact with each other, something that might be tricky to implement
-only using a test framework.
+System Tests are in between Unit/Integration and E2E tests. The Agent consists of
+several moving parts running together and sometimes it's useful to validate how such
+components interact with each other, something that might be tricky to achieve by
+only testing single functions.
 
-System tests execute a special binary built using a subset of packages and validate
-specific operations, answering simple questions like _is dogstatsd correctly
-forwarding metrics_?
+System tests cover any use case that doesn't fit an integration test, like executing
+a special binary built using a subset of packages and validate specific operations,
+answering simple questions like _is dogstatsd correctly forwarding metrics_?
 
-System Tests are supposed to be quite fast and are executed along with unit tests
-at every commit through the CI.
-
-To ease maintenance, it's preferable that system tests don't require external
-dependencies so they should be written in either Go, Python or as shell scripts,
-anything that can be invoked in the CI.
+System Tests might contain Go code, Python or shell scripts but to ease maintenance
+and keep the execution environment simple, it's preferable to keep the number of
+external dependencies as low as possible.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -6,7 +6,7 @@ from invoke import Collection
 from . import agent, benchmarks, docker, dogstatsd, pylauncher
 
 from .go import fmt, lint, vet, deps
-from .test import test
+from .test import test, integration_tests
 
 
 # the root namespace
@@ -17,6 +17,7 @@ ns.add_task(fmt)
 ns.add_task(lint)
 ns.add_task(vet)
 ns.add_task(test)
+ns.add_task(integration_tests)
 ns.add_task(deps)
 
 # add namespaced tasks to the root

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -12,6 +12,7 @@ from .build_tags import get_build_tags
 from .utils import get_ldflags, bin_name, get_root
 from .utils import REPO_PATH
 
+from .go import deps
 
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
@@ -81,6 +82,7 @@ def system_tests(ctx, skip_build=False):
     }
     ctx.run(cmd.format(**args), env=env)
 
+
 @task
 def size_test(ctx, skip_build=False):
     """
@@ -134,3 +136,18 @@ def omnibus_build(ctx):
             "overrides": overrides_cmd
         }
         ctx.run(cmd.format(**args))
+
+
+@task
+def integration_tests(ctx, install_deps=False):
+    """
+    Run integration tests for the Agent
+    """
+    if install_deps:
+        deps(ctx)
+
+    build_tags = get_build_tags()
+
+    # config_providers
+    cmd = "go test -tags '{}' {}/test/integration/dogstatsd/..."
+    ctx.run(cmd.format(" ".join(build_tags), REPO_PATH))

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -11,6 +11,8 @@ from invoke import task
 from .utils import pkg_config_path
 from .go import fmt, lint, vet
 from .build_tags import get_build_tags
+from .agent import integration_tests as agent_integration_tests
+from .dogstatsd import integration_tests as dsd_integration_tests
 
 PROFILE_COV = "profile.cov"
 
@@ -73,3 +75,12 @@ def test(ctx, targets=None, race=False, use_embedded_libs=False):
             os.remove(profile_tmp)
 
     ctx.run("go tool cover -func {}".format(PROFILE_COV))
+
+
+@task
+def integration_tests(ctx, install_deps=False):
+    """
+    Run all the available integration tests
+    """
+    agent_integration_tests(ctx, install_deps)
+    dsd_integration_tests(ctx, install_deps)

--- a/test/integration/config_providers/zookeeper/zookeeper_provider_test.go
+++ b/test/integration/config_providers/zookeeper/zookeeper_provider_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/samuel/go-zookeeper/zk"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -144,26 +143,26 @@ func (suite *ZkTestSuite) TestCollect() {
 
 	templates, err := zk.Collect()
 
-	assert.Nil(suite.T(), err)
-	assert.Len(suite.T(), templates, 3)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), templates, 3)
 
-	// FIXME: assert.Equal(suite.T(), "/datadog/check_configs/nginx", templates[0].Digest())
-	assert.Equal(suite.T(), "nginx_a", templates[0].Name)
-	assert.Equal(suite.T(), "{}", string(templates[0].InitConfig))
+	// FIXME: require.Equal(suite.T(), "/datadog/check_configs/nginx", templates[0].Digest())
+	require.Equal(suite.T(), "nginx_a", templates[0].Name)
+	require.Equal(suite.T(), "{}", string(templates[0].InitConfig))
 	require.Len(suite.T(), templates[0].Instances, 1)
-	assert.Equal(suite.T(), "{\"key\":2}", string(templates[0].Instances[0]))
+	require.Equal(suite.T(), "{\"key\":2}", string(templates[0].Instances[0]))
 
-	// FIXME: assert.Equal(suite.T(), check.ID("/datadog/check_configs/nginx"), templates[1].ID)
-	assert.Equal(suite.T(), "nginx_b", templates[1].Name)
-	assert.Equal(suite.T(), "{\"key\":3}", string(templates[1].InitConfig))
+	// FIXME: require.Equal(suite.T(), check.ID("/datadog/check_configs/nginx"), templates[1].ID)
+	require.Equal(suite.T(), "nginx_b", templates[1].Name)
+	require.Equal(suite.T(), "{\"key\":3}", string(templates[1].InitConfig))
 	require.Len(suite.T(), templates[1].Instances, 1)
-	assert.Equal(suite.T(), "{}", string(templates[1].Instances[0]))
+	require.Equal(suite.T(), "{}", string(templates[1].Instances[0]))
 
-	// FIXME: assert.Equal(suite.T(), check.ID("/datadog/check_configs/redis"), templates[2].ID)
-	assert.Equal(suite.T(), "redis_a", templates[2].Name)
-	assert.Equal(suite.T(), "{}", string(templates[2].InitConfig))
+	// FIXME: require.Equal(suite.T(), check.ID("/datadog/check_configs/redis"), templates[2].ID)
+	require.Equal(suite.T(), "redis_a", templates[2].Name)
+	require.Equal(suite.T(), "{}", string(templates[2].InitConfig))
 	require.Len(suite.T(), templates[2].Instances, 1)
-	assert.Equal(suite.T(), "{}", string(templates[2].Instances[0]))
+	require.Equal(suite.T(), "{}", string(templates[2].Instances[0]))
 }
 
 func TestZkSuite(t *testing.T) {

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build linux
+
+package dogstatsd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
+	"github.com/DataDog/datadog-agent/test/integration/utils"
+)
+
+const (
+	socatImg  string = "datadog/socat-proxy:master"
+	socatName string = "dd-test-socat-proxy"
+)
+
+// FIXME: move as a system test once the runner is able to run them
+
+// testUDSOriginDetection ensures UDS origin detection works, by submitting
+// a metric from a `socat` container. As we need the origin PID to stay running,
+// we can't just `netcat` to the socket, that's why we keep socat running as
+// UDP->UDS proxy and submit the metric through it.
+//
+// FIXME: this test should be ported to the go docker client
+func testUDSOriginDetection(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dd-test-")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir) // clean up
+	socketPath := filepath.Join(dir, "dsd.socket")
+	config.Datadog.Set("dogstatsd_socket", socketPath)
+	config.Datadog.Set("dogstatsd_origin_detection", true)
+	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
+
+	// Build proxy docker image
+	buildCmd := exec.Command("docker", "build",
+		"-t", socatImg,
+		"../../../Dockerfiles/dogstatsd/socat-proxy/")
+	output, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Error building docker image: %s", string(output))
+		panic(err)
+	}
+	rmImageCmd := exec.Command("docker", "image", "rm", socatImg)
+	defer rmImageCmd.Run()
+
+	// Start DSD
+	packetChannel := make(chan *listeners.Packet)
+	s, err := listeners.NewUDSListener(packetChannel)
+	if err != nil {
+		panic(err)
+	}
+	go s.Listen()
+	defer s.Stop()
+
+	// Run proxy docker image
+	runCmd := exec.Command("docker", "run", "-d", "--rm",
+		"-v", fmt.Sprintf("%s:/socket/statsd.socket", socketPath),
+		socatImg)
+	output, err = runCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Error running docker image: %s", string(output))
+		panic(err)
+	}
+	containerId := strings.Trim(string(output), "\n")
+	assert.Equal(t, 64, len(containerId))
+
+	// Get socat's IP
+	socatIp, err := utils.GetContainerIP(containerId)
+	if err != nil {
+		t.Logf("Error getting socat's IP: %s", string(output))
+		panic(err)
+	}
+
+	t.Logf("Running socat container: %s on IP %s", containerId, socatIp)
+	stopCmd := exec.Command("docker", "stop", containerId)
+	defer stopCmd.Run()
+
+	// Send test data through proxy via UDP
+	conn, err := net.Dial("udp", fmt.Sprintf("%s:8125", socatIp))
+	assert.Nil(t, err)
+	defer conn.Close()
+	conn.Write(contents)
+
+	select {
+	case packet := <-packetChannel:
+		assert.NotNil(t, packet)
+		assert.Equal(t, packet.Contents, contents)
+		assert.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
+	case <-time.After(2 * time.Second):
+		assert.FailNow(t, "Timeout on receive channel")
+	}
+}

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -100,8 +100,8 @@ func testUDSOriginDetection(t *testing.T) {
 	select {
 	case packet := <-packetChannel:
 		assert.NotNil(t, packet)
-		assert.Equal(t, packet.Contents, contents)
-		assert.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
+		assert.Equal(t, contents, packet.Contents)
+		assert.Equal(t, fmt.Sprintf("docker://%s", containerId), packet.Origin)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}

--- a/test/integration/dogstatsd/origin_detection_skip.go
+++ b/test/integration/dogstatsd/origin_detection_skip.go
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build !linux
+
 package dogstatsd
 
 import "testing"
 
-func TestUDSOriginDetection(t *testing.T) {
-	testUDSOriginDetection(t)
+// noop version for unsupported platforms
+func testUDSOriginDetection(t *testing.T) {
+	t.Log("Unsupported platform, skip...")
 }

--- a/test/integration/utils/etcd.go
+++ b/test/integration/utils/etcd.go
@@ -10,7 +10,7 @@ import (
 )
 
 // StartEtcdContainer starts an Etcd container and waits for the healthcheck
-func StartEtcdContainer(imageName string, containerName string) error {
+func StartEtcdContainer(imageName string, containerName string) (string, error) {
 	healthCheck := &container.HealthConfig{
 		Test:     []string{"CMD", "wget", "--spider", "http://localhost:2379/health"},
 		Interval: 1 * time.Second,
@@ -35,17 +35,17 @@ func StartEtcdContainer(imageName string, containerName string) error {
 
 	err := PullImage(imageName)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	_, err = StartContainer(containerName, containerConfig, hostConfig)
+	id, err := StartContainer(containerName, containerConfig, hostConfig)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cli, err := client.NewEnvClient()
 	if err != nil {
-		return err
+		return "", err
 	}
 	ctx := context.Background()
 
@@ -55,5 +55,5 @@ func StartEtcdContainer(imageName string, containerName string) error {
 		return err == nil && res.ContainerJSONBase.State.Health.Status == "healthy"
 	}, 5*time.Second)
 
-	return err
+	return id, err
 }

--- a/test/integration/utils/utils.go
+++ b/test/integration/utils/utils.go
@@ -107,3 +107,26 @@ func StartContainer(containerName string, containerConfig *container.Config,
 
 	return string(resp.ID), nil
 }
+
+// StartContainer with given image, name and configuration
+func GetContainerIP(containerID string) (string, error) {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return "", err
+	}
+	ctx := context.Background()
+
+	resp, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error inspecting container %s: %s\n", containerID, err)
+		return "", err
+	}
+
+	for _, network := range resp.NetworkSettings.Networks {
+		// return first network's IP
+		return network.IPAddress, nil
+	}
+
+	// No network found
+	return "", fmt.Errorf("no IP found for container %s", containerID)
+}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

 * adds a global `integration-tests` task to run any integration test we have
 * refactor origin detection test so it's skipped on unsupported platforms

### Motivation

Test coverage++
