### PR TITLE
Fix status cmd

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -12,11 +12,13 @@ package api
 
 import (
 	"fmt"
+	stdLog "log"
 	"net"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/agent"
 	"github.com/DataDog/datadog-agent/cmd/agent/api/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/gorilla/mux"
 )
 
@@ -42,7 +44,12 @@ func StartServer() {
 		panic(fmt.Sprintf("Unable to create the api server: %v", err))
 	}
 
-	go http.Serve(listener, r)
+	server := &http.Server{
+		Handler:  r,
+		ErrorLog: stdLog.New(&config.ErrorLogWriter{}, "", 0), // log errors to seelog
+	}
+
+	go server.Serve(listener)
 }
 
 // StopServer closes the connection and the server

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -37,3 +37,12 @@ func SetupLogger(logLevel, logFile string) error {
 	log.ReplaceLogger(logger)
 	return nil
 }
+
+// ErrorLogWriter is a Writer that logs all written messages with the global seelog logger
+// at an error level
+type ErrorLogWriter struct{}
+
+func (s *ErrorLogWriter) Write(p []byte) (n int, err error) {
+	log.Error(string(p))
+	return len(p), nil
+}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -18,10 +18,10 @@ Collector
 {{- if .LastWarnings}} {{- range .LastWarnings }}
       Warning: {{.}}
 {{- end -}} {{- end -}} {{- end -}} {{- end -}}
-{{- with .LoaderStats -}} {{- if .Errors}}
+{{- with .AutoConfigStats -}} {{- if .LoaderErrors}}
   Loading Errors
   ==============
-{{- range $checkname, $errors := .Errors}}
+{{- range $checkname, $errors := .LoaderErrors}}
     {{$checkname}}
     {{printDashes $checkname "-"}}
 {{- range $kind, $err := $errors -}}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -34,12 +34,12 @@ func FormatStatus(data []byte) (string, error) {
 	json.Unmarshal(data, &stats)
 	forwarderStats := stats["forwarderStats"]
 	runnerStats := stats["runnerStats"]
-	loaderStats := stats["loaderStats"]
+	autoConfigStats := stats["autoConfigStats"]
 	aggregatorStats := stats["aggregatorStats"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, loaderStats, "")
+	renderChecksStats(b, runnerStats, autoConfigStats, "")
 	renderForwarderStatus(b, forwarderStats)
 	renderAggregatorStatus(b, aggregatorStats)
 
@@ -70,10 +70,10 @@ func renderForwarderStatus(w io.Writer, forwarderStats interface{}) {
 	}
 }
 
-func renderChecksStats(w io.Writer, runnerStats interface{}, loaderStats interface{}, onlyCheck string) {
+func renderChecksStats(w io.Writer, runnerStats interface{}, autoConfigStats interface{}, onlyCheck string) {
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
-	checkStats["LoaderStats"] = loaderStats
+	checkStats["AutoConfigStats"] = autoConfigStats
 	checkStats["OnlyCheck"] = onlyCheck
 	t := template.Must(template.New("collector.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "collector.tmpl")))
 
@@ -89,8 +89,8 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	stats := make(map[string]interface{})
 	json.Unmarshal(data, &stats)
 	runnerStats := stats["runnerStats"]
-	loaderStats := stats["loaderStats"]
-	renderChecksStats(b, runnerStats, loaderStats, checkName)
+	autoConfigStats := stats["autoConfigStats"]
+	renderChecksStats(b, runnerStats, autoConfigStats, checkName)
 
 	return b.String(), nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -40,7 +40,7 @@ func GetStatus() (map[string]interface{}, error) {
 		stats["metadata"] = host.GetPayload(hostname)
 	}
 
-	stats["config"] = getConfig()
+	stats["config"] = getPartialConfig()
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 
 	platformPayload, err := new(platform.Platform).Collect()
@@ -98,15 +98,14 @@ func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
 	return []byte(st), nil
 }
 
-func getConfig() map[string]interface{} {
-	var conf = config.Datadog.AllSettings()
-	newConf := make(map[string]interface{})
-	for k, v := range conf {
-		if k != "api_key" && k != "metadata_collectors" {
-			newConf[k] = v
-		}
-	}
-	return newConf
+// getPartialConfig returns config parameters of interest for the status page
+func getPartialConfig() map[string]string {
+	conf := make(map[string]string)
+	conf["log_file"] = config.Datadog.GetString("log_file")
+	conf["log_level"] = config.Datadog.GetString("log_level")
+	conf["confd_path"] = config.Datadog.GetString("confd_path")
+	conf["additional_checksd"] = config.Datadog.GetString("additional_checksd")
+	return conf
 }
 
 func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
@@ -121,10 +120,10 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	json.Unmarshal(runnerStatsJSON, &runnerStats)
 	stats["runnerStats"] = runnerStats
 
-	loaderStatsJSON := []byte(expvar.Get("loader").String())
-	loaderStats := make(map[string]interface{})
-	json.Unmarshal(loaderStatsJSON, &loaderStats)
-	stats["loaderStats"] = loaderStats
+	autoConfigStatsJSON := []byte(expvar.Get("autoconfig").String())
+	autoConfigStats := make(map[string]interface{})
+	json.Unmarshal(autoConfigStatsJSON, &autoConfigStats)
+	stats["autoConfigStats"] = autoConfigStats
 
 	aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
 	aggregatorStats := make(map[string]interface{})


### PR DESCRIPTION
### What does this PR do?

* Fixes the status command
* Makes the api server log unexpected errors (`panic`s for example)

### Motivation

Fixing stuff, and having more visibility in the logs as to why an agent command has failed.

### Additional notes

See commit messages for more details.

More details on the api server logging change:
1. see the docs on `http.Server`: https://golang.org/pkg/net/http/#Server (`ErrorLog` field)
2. the `ErrorLog` field only accepts a `*log.Logger` struct
3. so we create a `log.Logger` that writes to our `ErrorLogWriter`
4. `ErrorLogWriter` forwards all the messages to seelog