### PR TITLE
Initial tagger package implementation

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -123,6 +124,14 @@ func start(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")
+	}
+
+	// container tagging initialisation if origin detection is on
+	if config.Datadog.GetBool("dogstatsd_origin_detection") {
+		err = tagger.Init()
+		if err != nil {
+			log.Criticalf("Unable to start tagging system: %s", err)
+		}
 	}
 
 	aggregatorInstance := aggregator.InitAggregator(s, hname)

--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -65,7 +65,7 @@ func processUDSOrigin(ancillary []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("docker://%s", container), nil
+	return container, nil
 }
 
 // getContainerForPID returns the docker container id and caches the value for future lookups
@@ -76,10 +76,12 @@ func getContainerForPID(pid int32) (string, error) {
 	if x, found := util.Cache.Get(key); found {
 		return x.(string), nil
 	}
-	value, err := docker.ContainerIDForPID(int(pid))
+	id, err := docker.ContainerIDForPID(int(pid))
 	if err != nil {
 		return "", err
 	}
+	value := fmt.Sprintf("docker://%s", id)
+
 	util.Cache.Set(key, value, 0)
 	return value, err
 }

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -1,0 +1,61 @@
+## package `tagger`
+
+The **Tagger** is the central source of truth for client-side entity tagging. It
+runs **Collector**s that detect entities and collect their tags. Tags are then
+stored in memory (by the **TagStore**) and can be queried by the Tagger.Tag()
+method. Calling once Tagger.Init() after the **config** package is ready is
+needed to enable collection.
+
+The package methods use a common **DefaultTagger** object, but we can create
+a custom **Tagger** object for testing.
+
+The package will implement an IPC mechanism (a server and a client) to allow
+other agents to query the **DefaultTagger** and avoid duplicating the information
+in their process. Switch between local and client mode will be done via a build flag.
+
+### Collector
+A **Collector** connects to a single information source and pushes **TagInfo**
+structs to a channel, towards the **Tagger**. It can either run in streaming
+mode or pull mode, depending of what's most efficient for the data source:
+
+#### Streamer
+The **DockerCollector** runs in stream mode as it collects events from the docker
+daemon and reacts to them, sending updates incrementally.
+
+#### Puller
+The **KubernetesCollector** and **ECSCollector** will run in pull mode as they
+need to query and filter a full entity list every time. They will only push
+updates to the store though, by keeping an internal state of the latest
+revision.
+
+### TagStore
+The **TagStore** reads **TagInfo** structs and stores them in a in-memory
+cache. Cache invalidation is triggered by the collectors (or source) by either:
+
+  - sending new tags for the same `Entity`, all the tags from this `Source`
+  will be removed and replaced by the new tags
+  - sending a **TagInfo** with **DeleteEntity** set, all the entries for this
+  entity (including from other sources) will be deleted
+
+### Tagger
+The Tagger handles the glue between **Collectors** and **TagStore** and the
+cache miss logic. If the tags from the **TagStore** are missing some sources,
+they will be manually queried in a block way, and the cache will be updated.
+
+For convenience, the package creates a **DefaultTagger** object that is used
+when calling the `tagger.Tag()` method.
+
+
+                   +-----------+
+                   | Collector |
+                   +---+-------+
+                       |
+                       |
+    +--------+      +--+-------+       +-------------+
+    |  User  <------+  Tagger  +-------> IPC handler |
+    |packages|      +--+-----^-+       +-------------+
+    +--------+         |     |
+                       |     |
+                    +--v-----+-+
+                    | TagStore |
+                    +----------+

--- a/pkg/tagger/collectors/catalog.go
+++ b/pkg/tagger/collectors/catalog.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package collectors
+
+// CollectorFactory is functions that return a Collector
+type CollectorFactory func() Collector
+
+// Catalog holds available collectors for detection and usage
+type Catalog map[string]CollectorFactory
+
+// DefaultCatalog holds every compiled-in collector
+var DefaultCatalog = make(Catalog)
+
+// registerCollector is to be called by collectors to be added to the default catalog
+func registerCollector(name string, c CollectorFactory) {
+	DefaultCatalog[name] = c
+}

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package collectors
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+)
+
+// ExtractFromInspect extract tags for a container inspect JSON
+func (c *DockerCollector) ExtractFromInspect(co types.ContainerJSON) ([]string, []string, error) {
+	var low, high []string
+	// TODO: to be completed once docker utils are merged
+	low = append(low, "low:test")
+	high = append(high, fmt.Sprintf("container_name:%s", co.ID))
+	return low, high, nil
+}

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+)
+
+const (
+	dockerCollectorName = "docker"
+)
+
+// DockerEntityName returns a prefixed entity name from a container ID
+func DockerEntityName(cid string) string {
+	return fmt.Sprintf("%s%s", DockerEntityPrefix, cid)
+}
+
+// DockerCollector listens to events on the docker socket to get new/dead containers
+// and feed a stram of TagInfo. It requires access to the docker socket.
+// It will also embed DockerExtractor collectors for container tagging.
+type DockerCollector struct {
+	Client  *client.Client
+	stop    chan bool
+	infoOut chan<- []*TagInfo
+}
+
+// Detect tries to connect to the docker socket and returns success
+func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
+	// TODO: refactor with collector.listeners.DockerListener
+	client, err := client.NewEnvClient()
+	if err != nil {
+		return NoCollection, fmt.Errorf("Failed to connect to Docker, docker tagging will not work: %s", err)
+	}
+	c.Client = client
+	c.stop = make(chan bool)
+	c.infoOut = out
+
+	// TODO: list and inspect existing containers once docker utils are merged
+
+	return StreamCollection, nil
+}
+
+// Stream runs the continuous event watching loop and sends new info
+// to the channel. But be called in a goroutine.
+func (c *DockerCollector) Stream() error {
+	// TODO: refactor with collector.listeners.DockerListener
+	// filters only match start/stop container events
+	filters := filters.NewArgs()
+	filters.Add("type", "container")
+	filters.Add("event", "start")
+	filters.Add("event", "die")
+	eventOptions := types.EventsOptions{
+		Since:   fmt.Sprintf("%d", time.Now().Unix()),
+		Filters: filters,
+	}
+
+	messages, errs := c.Client.Events(context.Background(), eventOptions)
+
+	for {
+		select {
+		case <-c.stop:
+			return nil
+		case msg := <-messages:
+			c.processEvent(msg)
+		case err := <-errs:
+			if err != nil && err != io.EOF {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
+// Stop queues a shutdown of DockerListener
+func (c *DockerCollector) Stop() error {
+	c.stop <- true
+	return nil
+}
+
+// Fetch inspect a given container to get its tags on-demand (cache miss)
+func (c *DockerCollector) Fetch(entity string) ([]string, []string, error) {
+	cid := strings.TrimPrefix(entity, DockerEntityPrefix)
+	if cid == entity {
+		return nil, nil, fmt.Errorf("entity name is not a docker container: %s", entity)
+	}
+	return c.fetchForDockerID(cid)
+}
+
+func (c *DockerCollector) processEvent(e events.Message) {
+	cID := e.Actor.ID
+	out := make([]*TagInfo, 1)
+
+	switch e.Action {
+	case "die":
+		out[0] = &TagInfo{Entity: DockerEntityName(cID), Source: dockerCollectorName, DeleteEntity: true}
+	case "start":
+		low, high, _ := c.fetchForDockerID(cID)
+		out[0] = &TagInfo{Entity: DockerEntityName(cID), Source: dockerCollectorName, LowCardTags: low, HighCardTags: high}
+	}
+	c.infoOut <- out
+}
+
+func (c *DockerCollector) fetchForDockerID(cID string) ([]string, []string, error) {
+	co, err := c.Client.ContainerInspect(context.Background(), string(cID))
+	if err != nil {
+		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
+		return nil, nil, err
+	}
+	return c.ExtractFromInspect(co)
+}
+
+func dockerFactory() Collector {
+	return &DockerCollector{}
+}
+
+func init() {
+	registerCollector(dockerCollectorName, dockerFactory)
+}

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package collectors
+
+// DockerEntityPrefix is the entity prefix for docker containers
+const DockerEntityPrefix = "docker://"
+
+// TagInfo holds the tag information for a given entity and source. It's meant
+// to be created from collectors and read by the store.
+type TagInfo struct {
+	Source       string   // source collector's name
+	Entity       string   // entity name ready for lookup
+	HighCardTags []string // high cardinality tags that can create a lot of contexts
+	LowCardTags  []string // low cardinality tags safe for every pipeline
+	DeleteEntity bool     // true if the entity is to be deleted from the store
+}
+
+// CollectionMode informs the Tagger of how to schedule a Collector
+type CollectionMode int
+
+// Return values for Collector.Init to inform the Tagger of the scheduling needed
+const (
+	NoCollection     CollectionMode = iota // Not available
+	PullCollection                         // Call regularly via the Pull methof
+	StreamCollection                       // Will continuously feed updates on the channel from Steam() to Stop()
+)
+
+// Collector retrieve entity tags from a given source and feeds
+// updates via the TagInfo channel
+type Collector interface {
+	Detect(chan<- []*TagInfo) (CollectionMode, error)
+}
+
+// Fetcher allows to fetch tags on-demand in case of cache miss
+type Fetcher interface {
+	Fetch(string) ([]string, []string, error)
+}
+
+// Streamer feeds back TagInfo when detecting changes
+type Streamer interface {
+	Fetcher
+	Stream() error
+	Stop() error
+}
+
+// Puller has to be triggered regularly
+type Puller interface {
+	Fetcher
+	Pull() error
+}

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package tagger
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
+// DefaultTagger is the common tagger to be used by all users
+var DefaultTagger *Tagger
+
+// Init must be called once config is available, call it in your cmd
+func Init() error {
+	return DefaultTagger.Init(collectors.DefaultCatalog)
+}
+
+// Tag queries the defaulttagger to get entity tags from cache or sources
+func Tag(entity string, highCard bool) ([]string, error) {
+	return DefaultTagger.Tag(entity, highCard)
+}
+
+// Stop queues a stop signal to the defaulttagger
+func Stop() error {
+	return DefaultTagger.Stop()
+}
+
+func init() {
+	tagger, err := NewTagger()
+	if err != nil {
+		log.Errorf("tagger initialisation failed: %s", err)
+	}
+	DefaultTagger = tagger
+}

--- a/pkg/tagger/store.go
+++ b/pkg/tagger/store.go
@@ -1,0 +1,107 @@
+package tagger
+
+import (
+	"fmt"
+	"sync"
+
+	//log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+)
+
+// entityTags holds the tag information for a given entity
+type entityTags struct {
+	sync.RWMutex
+	lowCardTags  map[string][]string
+	highCardTags map[string][]string
+}
+
+// tagStore stores entity tags in memory and handles search and collation.
+// Queries should go through the Tagger for cache-miss handling
+type tagStore struct {
+	sync.RWMutex
+	store map[string]*entityTags
+}
+
+func newTagStore() (*tagStore, error) {
+	t := &tagStore{
+		store: make(map[string]*entityTags),
+	}
+	return t, nil
+}
+
+// TODO: allow batch writes
+func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
+	if info.Entity == "" {
+		return fmt.Errorf("empty entity name, skipping message")
+	}
+	if info.Source == "" {
+		return fmt.Errorf("empty source name, skipping message")
+	}
+	if info.DeleteEntity {
+		// FIXME batch requests
+		s.Lock()
+		delete(s.store, info.Entity)
+		s.Unlock()
+		return nil
+	}
+
+	// TODO: check if real change
+	s.RLock()
+	storedTags, exist := s.store[info.Entity]
+	s.RUnlock()
+	if exist == false {
+		storedTags = &entityTags{
+			lowCardTags:  make(map[string][]string),
+			highCardTags: make(map[string][]string),
+		}
+	}
+
+	storedTags.Lock()
+	storedTags.lowCardTags[info.Source] = info.LowCardTags
+	storedTags.highCardTags[info.Source] = info.HighCardTags
+	storedTags.Unlock()
+
+	if exist == false {
+		s.Lock()
+		s.store[info.Entity] = storedTags
+		s.Unlock()
+	}
+
+	return nil
+}
+
+// lookup gets tags from the store and returns them concatenated in a []string
+// array. It returns the source names in the second []string to allow the
+// client to trigger manual lookups on missing sources.
+func (s *tagStore) lookup(entity string, highCard bool) ([]string, []string, error) {
+	s.RLock()
+	storedTags, present := s.store[entity]
+	s.RUnlock()
+
+	if present == false {
+		//return nil, nil, fmt.Errorf("entity not in memory store")
+		return nil, nil, nil
+	}
+
+	var arrays [][]string
+	var sources []string
+
+	// TODO: the concatenated array could be pre-computed
+	// in entityTags on first read and invalidated on write
+	storedTags.RLock()
+	for source, tags := range storedTags.lowCardTags {
+		arrays = append(arrays, tags)
+		sources = append(sources, source)
+	}
+	if highCard {
+		for _, tags := range storedTags.highCardTags {
+			arrays = append(arrays, tags)
+		}
+	}
+	tags := utils.ConcatenateTags(arrays)
+	storedTags.RUnlock()
+
+	return tags, sources, nil
+}

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package tagger
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+)
+
+// Tagger is the entry class for entity tagging. It holds collectors, memory store
+// and handles the query logic. One can use the package methods to use the default
+// tagger instead of instanciating one.
+type Tagger struct {
+	tagStore  *tagStore
+	pullers   map[string]collectors.Puller
+	streamers map[string]collectors.Streamer
+	fetchers  map[string]collectors.Fetcher
+	infoIn    chan []*collectors.TagInfo
+	stop      chan bool
+}
+
+// NewTagger returns an allocated tagger. You still have to run Init()
+// once the config package is ready.
+func NewTagger() (*Tagger, error) {
+	store, err := newTagStore()
+	if err != nil {
+		return nil, err
+	}
+	t := &Tagger{
+		tagStore:  store,
+		pullers:   make(map[string]collectors.Puller),
+		streamers: make(map[string]collectors.Streamer),
+		fetchers:  make(map[string]collectors.Fetcher),
+		infoIn:    make(chan []*collectors.TagInfo),
+		stop:      make(chan bool),
+	}
+
+	return t, nil
+}
+
+// Init goes through a catalog and tries to detect which are relevant
+// for this host. It then starts the collection logic and is ready for
+// requests.
+func (t *Tagger) Init(catalog collectors.Catalog) error {
+	for name, factory := range catalog {
+		log.Debugf("initialising tag collector %s", name)
+
+		collector := factory()
+		mode, err := collector.Detect(t.infoIn)
+		if err != nil {
+			log.Errorf("error initialising collector %s: %s", name, err)
+			continue
+		}
+		switch mode {
+		case collectors.PullCollection:
+			pull, ok := collector.(collectors.Puller)
+			if ok {
+				t.pullers[name] = pull
+				// TODO: schedule pulling
+				t.fetchers[name] = pull
+			} else {
+				log.Errorf("error initialising collector %s: does not implement pull", name)
+			}
+		case collectors.StreamCollection:
+			stream, ok := collector.(collectors.Streamer)
+			if ok {
+				t.streamers[name] = stream
+				t.fetchers[name] = stream
+				go stream.Stream()
+			} else {
+				log.Errorf("error initialising collector %s: does not implement stream", name)
+			}
+		}
+	}
+	go t.run()
+
+	return nil
+}
+
+func (t *Tagger) run() error {
+	// TODO: handle pulling and stopping
+	for {
+		select {
+		case <-t.stop:
+			for name, collector := range t.streamers {
+				err := collector.Stop()
+				if err != nil {
+					log.Warnf("error stopping %s: %s", name, err)
+				}
+			}
+			return nil
+		case msg := <-t.infoIn:
+			log.Infof("listener message: %s", msg)
+			for _, info := range msg {
+				t.tagStore.processTagInfo(info)
+			}
+		}
+	}
+}
+
+// Stop queues a shutdown of Tagger
+func (t *Tagger) Stop() error {
+	t.stop <- true
+	return nil
+}
+
+// Tag returns tags for a given entity. If highCard is false, high
+// cardinality tags are left out.
+func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
+	cachedTags, sources, err := t.tagStore.lookup(entity, highCard)
+	if err != nil {
+		return nil, err
+	}
+	if len(sources) == len(t.fetchers) {
+		// All sources sent data to cache
+		log.Debugf("all %d sources are in cache", len(sources))
+		return cachedTags, nil
+	}
+	// Else, partial cache miss, query missing data
+	tagArrays := [][]string{cachedTags}
+
+ITER_COLLECTORS:
+	for name, collector := range t.fetchers {
+		for _, s := range sources {
+			if s == name {
+				continue ITER_COLLECTORS // source was in cache, don't lookup again
+			}
+		}
+		log.Debugf("cache miss for %s, collecting", name)
+		low, high, err := collector.Fetch(entity)
+		if err != nil {
+			log.Warnf("error collecting from %s: %s", name, err)
+			continue
+		}
+		tagArrays = append(tagArrays, low)
+		if highCard {
+			tagArrays = append(tagArrays, high)
+		}
+		// Submit to cache for next lookup
+		t.tagStore.processTagInfo(&collectors.TagInfo{
+			Entity:       entity,
+			Source:       name,
+			LowCardTags:  low,
+			HighCardTags: high,
+		})
+	}
+
+	return utils.ConcatenateTags(tagArrays), nil
+}

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package tagger
+
+import (
+	// stdlib
+	"sort"
+	"sync"
+	"testing"
+
+	// 3p
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
+/////////////////////////////// Dummy collectors for mock testing ///////////////////////////////
+
+type DummyStreamer struct {
+	sync.Mutex
+	Inited      int
+	Started     int
+	Stopped     int
+	Fetched     int
+	FetchedWith string
+}
+
+func (c *DummyStreamer) Detect(out chan<- []*collectors.TagInfo) (collectors.CollectionMode, error) {
+	c.Inited++
+	return collectors.StreamCollection, nil
+}
+func (c *DummyStreamer) Fetch(entity string) ([]string, []string, error) {
+	c.Fetched++
+	c.FetchedWith = entity
+	return []string{"low"}, []string{"high"}, nil
+}
+
+func (c *DummyStreamer) Stream() error {
+	c.Lock()
+	c.Started++
+	c.Unlock()
+	return nil
+}
+func (c *DummyStreamer) Stop() error {
+	c.Lock()
+	c.Stopped++
+	c.Unlock()
+	return nil
+}
+
+type DummyPuller struct {
+	sync.Mutex
+	Inited      int
+	Pulled      int
+	Fetched     int
+	FetchedWith string
+}
+
+func (c *DummyPuller) Detect(out chan<- []*collectors.TagInfo) (collectors.CollectionMode, error) {
+	c.Inited++
+	return collectors.PullCollection, nil
+}
+func (c *DummyPuller) Fetch(entity string) ([]string, []string, error) {
+	c.Fetched++
+	c.FetchedWith = entity
+	return []string{"low2"}, []string{}, nil
+}
+
+func (c *DummyPuller) Pull() error {
+	c.Lock()
+	c.Pulled++
+	c.Unlock()
+	return nil
+}
+
+type Dummies struct {
+	Streamer *DummyStreamer
+	Puller   *DummyPuller
+}
+
+func (d *Dummies) getDummyStreamer() collectors.Collector {
+	return d.Streamer
+}
+
+func (d *Dummies) getDummyPuller() collectors.Collector {
+	return d.Puller
+}
+
+/////////////////////////////// Test functions ///////////////////////////////
+
+func TestInit(t *testing.T) {
+	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
+	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
+	require.Equal(t, 2, len(catalog))
+
+	tagger, err := NewTagger()
+	require.Equal(t, nil, err)
+	err = tagger.Init(catalog)
+	require.Equal(t, nil, err)
+
+	require.Equal(t, 2, len(tagger.fetchers))
+	require.Equal(t, 1, len(tagger.streamers))
+	require.Equal(t, 1, len(tagger.pullers))
+
+	require.Equal(t, 1, d.Streamer.Inited)
+	require.Equal(t, 1, d.Streamer.Inited)
+	require.Equal(t, 0, d.Streamer.Stopped)
+	require.Equal(t, 0, d.Streamer.Fetched)
+
+	require.Equal(t, 1, d.Puller.Inited)
+	require.Equal(t, 0, d.Puller.Fetched)
+}
+
+func TestFetchAllMiss(t *testing.T) {
+	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
+	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
+	require.Equal(t, 2, len(catalog))
+	tagger, _ := NewTagger()
+	tagger.Init(catalog)
+
+	tags, err := tagger.Tag("entity_name", false)
+	require.Equal(t, 1, d.Streamer.Fetched)
+	require.Equal(t, "entity_name", d.Streamer.FetchedWith)
+	require.Equal(t, 1, d.Puller.Fetched)
+	require.Equal(t, "entity_name", d.Puller.FetchedWith)
+
+	require.Equal(t, nil, err)
+	sort.Strings(tags)
+	require.Equal(t, []string{"low", "low2"}, tags)
+}
+
+func TestFetchAllCached(t *testing.T) {
+	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
+	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
+	require.Equal(t, 2, len(catalog))
+	tagger, _ := NewTagger()
+	tagger.Init(catalog)
+
+	tagger.tagStore.processTagInfo(&collectors.TagInfo{
+		Entity:       "entity_name",
+		Source:       "stream",
+		LowCardTags:  []string{"low"},
+		HighCardTags: []string{"high"},
+	})
+	tagger.tagStore.processTagInfo(&collectors.TagInfo{
+		Entity:      "entity_name",
+		Source:      "pull",
+		LowCardTags: []string{"low2"},
+	})
+
+	tags, err := tagger.Tag("entity_name", true)
+	require.Equal(t, 0, d.Streamer.Fetched)
+	require.Equal(t, 0, d.Puller.Fetched)
+
+	require.Equal(t, nil, err)
+	sort.Strings(tags)
+	require.Equal(t, []string{"high", "low", "low2"}, tags)
+}
+
+func TestFetchOneCached(t *testing.T) {
+	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
+	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
+	require.Equal(t, 2, len(catalog))
+	tagger, _ := NewTagger()
+	tagger.Init(catalog)
+
+	tagger.tagStore.processTagInfo(&collectors.TagInfo{
+		Entity:      "entity_name",
+		Source:      "stream",
+		LowCardTags: []string{"low"},
+	})
+
+	tags, err := tagger.Tag("entity_name", false)
+	require.Equal(t, 0, d.Streamer.Fetched)
+	require.Equal(t, 1, d.Puller.Fetched)
+
+	require.Equal(t, nil, err)
+	sort.Strings(tags)
+	require.Equal(t, []string{"low", "low2"}, tags)
+}

--- a/pkg/tagger/utils/concat.go
+++ b/pkg/tagger/utils/concat.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package utils
+
+// ConcatenateTags is a fast way to concatenate multiple tag
+// arrays in a single one.
+func ConcatenateTags(slices [][]string) []string {
+	if len(slices) == 1 {
+		return slices[0]
+	}
+	var totalLen int
+	for _, s := range slices {
+		totalLen += len(s)
+	}
+	result := make([]string, totalLen)
+	var i int
+	for _, s := range slices {
+		i += copy(result[i:], s)
+	}
+	return result
+}

--- a/pkg/tagger/utils/concat_test.go
+++ b/pkg/tagger/utils/concat_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package utils
+
+import (
+	// stdlib
+	"testing"
+
+	// 3p
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptyArray(t *testing.T) {
+	source := make([][]string, 0)
+	result := ConcatenateTags(source)
+	require.Equal(t, []string{}, result)
+}
+
+func TestOneArray(t *testing.T) {
+	source := make([][]string, 1)
+	source[0] = []string{"one", "two"}
+	result := ConcatenateTags(source)
+	require.Equal(t, []string{"one", "two"}, result)
+}
+
+func TestThreeArrays(t *testing.T) {
+	source := make([][]string, 3)
+	source[0] = []string{"one", "two"}
+	source[1] = []string{}
+	source[2] = []string{"4", "5", "6"}
+
+	result := ConcatenateTags(source)
+	require.Equal(t, []string{"one", "two", "4", "5", "6"}, result)
+}


### PR DESCRIPTION
### What does this PR do?

Scaffold the `tagger` package to be used by dogstatsd origin detection, agent6 container checks, autodiscovery, and other agents via an IPC interface.

See:
  - [the package README](https://github.com/DataDog/datadog-agent/blob/xvello/pkg_tagger/pkg/tagger/README.md)
  - the initial RFC in the architecture repo

Lots to code is still missing (pull mode, force collection despite initial error, proper tagging in dsd... see TODOs), but the main structure is here.

### What's to do before merging?

- [x] unit and system tests with a dummy collector
- [x] proper tag injection in the metricseries
- [x] cleanup

### What's to do after?
- [ ] optimizations (see todos)
- [ ] merge docker utils from process-agent
- [ ] implement docker image name and labels extraction logic
- [ ] implement docker listing and inspecting containers on start
- [ ] implement ECS and Kube collectors
- [ ] implement Mesos/Nomad/Rancher/Swarm extractors
- [ ] add IPC interface server and client
