### PR TITLE
revamp origin detection integration test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -341,6 +341,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "85926e0b1725c7c85c78cae3ef15f44a0e4f8816c3453a5bbb2c8e4992c81bfc"
+  inputs-digest = "2a9cb517eee74de0d8c17c07c4739d79dbc2ef60f24587486ea52a2fb0f54c90"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/integration/dogstatsd/fixtures/origin_detection/Dockerfile
+++ b/test/integration/dogstatsd/fixtures/origin_detection/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2.7-alpine3.6
+
+# datadog-py has no release with UDS support yet, using a commit hash
+RUN pip install --no-cache-dir https://github.com/DataDog/datadogpy/archive/8b19b0b6e2d5e898dc05800f8257430b68156471.zip
+
+COPY sender.py /sender.py
+
+CMD [ "python", "/sender.py" ]

--- a/test/integration/dogstatsd/fixtures/origin_detection/sender.py
+++ b/test/integration/dogstatsd/fixtures/origin_detection/sender.py
@@ -3,11 +3,7 @@ import time
 
 client = datadog.dogstatsd.base.DogStatsd(socket_path="/dsd.socket")
 
-# Send 10 packets
-for x in xrange(1, 10):
+# Send 4 packets/s until killed
+while True:
     client.increment('custom_counter1')
     time.sleep(0.25)
-
-# Wait until killed
-while True:
-    time.sleep(1)

--- a/test/integration/dogstatsd/fixtures/origin_detection/sender.py
+++ b/test/integration/dogstatsd/fixtures/origin_detection/sender.py
@@ -1,0 +1,13 @@
+import datadog
+import time
+
+client = datadog.dogstatsd.base.DogStatsd(socket_path="/dsd.socket")
+
+# Send 10 packets
+for x in xrange(1, 10):
+    client.increment('custom_counter1')
+    time.sleep(0.25)
+
+# Wait until killed
+while True:
+    time.sleep(1)

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -10,7 +10,6 @@ package dogstatsd
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,20 +22,16 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd/listeners"
-	"github.com/DataDog/datadog-agent/test/integration/utils"
 )
 
 const (
-	socatImg  string = "datadog/socat-proxy:master"
-	socatName string = "dd-test-socat-proxy"
+	senderImg string = "datadog/test-origin-detection-sender:master"
 )
 
-// FIXME: move as a system test once the runner is able to run them
-
 // testUDSOriginDetection ensures UDS origin detection works, by submitting
-// a metric from a `socat` container. As we need the origin PID to stay running,
-// we can't just `netcat` to the socket, that's why we keep socat running as
-// UDP->UDS proxy and submit the metric through it.
+// a metric from a container. As we need the origin PID to stay running,
+// we can't just `netcat` to the socket, that's why we run a custom python
+// script that will stay up after sending packets.
 //
 // FIXME: this test should be ported to the go docker client
 func testUDSOriginDetection(t *testing.T) {
@@ -46,16 +41,15 @@ func testUDSOriginDetection(t *testing.T) {
 	socketPath := filepath.Join(dir, "dsd.socket")
 	config.Datadog.Set("dogstatsd_socket", socketPath)
 	config.Datadog.Set("dogstatsd_origin_detection", true)
-	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
-	// Build proxy docker image
+	// Build sender docker image
 	buildCmd := exec.Command("docker", "build",
-		"-t", socatImg,
-		"../../../Dockerfiles/dogstatsd/socat-proxy/")
+		"-t", senderImg,
+		"fixtures/origin_detection/")
 	output, err := buildCmd.CombinedOutput()
 	require.Nil(t, err)
 
-	rmImageCmd := exec.Command("docker", "image", "rm", socatImg)
+	rmImageCmd := exec.Command("docker", "image", "rm", senderImg)
 	defer rmImageCmd.Run()
 
 	// Start DSD
@@ -66,36 +60,25 @@ func testUDSOriginDetection(t *testing.T) {
 	go s.Listen()
 	defer s.Stop()
 
-	// Run proxy docker image
+	// Run sender docker image
 	runCmd := exec.Command("docker", "run", "-d", "--rm",
-		"-v", fmt.Sprintf("%s:/socket/statsd.socket", socketPath),
-		socatImg)
+		"-v", fmt.Sprintf("%s:/dsd.socket", socketPath),
+		senderImg)
 	output, err = runCmd.CombinedOutput()
 	require.Nil(t, err)
 
 	containerId := strings.Trim(string(output), "\n")
-	assert.Equal(t, 64, len(containerId))
+	require.Equal(t, 64, len(containerId))
 
-	// Get socat's IP
-	socatIp, err := utils.GetContainerIP(containerId)
-	require.Nil(t, err)
-
-	t.Logf("Running socat container: %s on IP %s", containerId, socatIp)
+	t.Logf("Running sender container: %s", containerId)
 	stopCmd := exec.Command("docker", "stop", containerId)
 	defer stopCmd.Run()
 
-	// Send test data through proxy via UDP
-	conn, err := net.Dial("udp", fmt.Sprintf("%s:8125", socatIp))
-	require.Nil(t, err)
-
-	defer conn.Close()
-	conn.Write(contents)
-
 	select {
 	case packet := <-packetChannel:
-		assert.NotNil(t, packet)
-		assert.Equal(t, contents, packet.Contents)
-		assert.Equal(t, fmt.Sprintf("docker://%s", containerId), packet.Origin)
+		require.NotNil(t, packet)
+		require.Equal(t, string(packet.Contents), "custom_counter1:1|c")
+		require.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}

--- a/test/integration/utils/zk.go
+++ b/test/integration/utils/zk.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -48,12 +47,7 @@ func StartZkContainer(imageName string, containerName string) (string, error) {
 	// wait for the container to start
 	err = waitFor(func() bool {
 		res, err := cli.ContainerInspect(ctx, containerName)
-		if err == nil {
-			fmt.Println(res.ContainerJSONBase.State.Health.Status)
-			return res.ContainerJSONBase.State.Health.Status == "healthy"
-		} else {
-			return false
-		}
+		return err == nil && res.ContainerJSONBase.State.Health.Status == "healthy"
 	}, 5*time.Second)
 
 	return containerID, err

--- a/test/integration/utils/zk.go
+++ b/test/integration/utils/zk.go
@@ -48,8 +48,12 @@ func StartZkContainer(imageName string, containerName string) (string, error) {
 	// wait for the container to start
 	err = waitFor(func() bool {
 		res, err := cli.ContainerInspect(ctx, containerName)
-		fmt.Println(res.ContainerJSONBase.State.Health.Status)
-		return err == nil && res.ContainerJSONBase.State.Health.Status == "healthy"
+		if err == nil {
+			fmt.Println(res.ContainerJSONBase.State.Health.Status)
+			return res.ContainerJSONBase.State.Health.Status == "healthy"
+		} else {
+			return false
+		}
 	}, 5*time.Second)
 
 	return containerID, err


### PR DESCRIPTION
### What does this PR do?

Revamp the origin detection integration test to use a custom python sender script instead of a socat proxy image. This will make it simpler and more robust.