### PR TITLE
Fixed incremental build, added zookeeper build tag

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -19,7 +19,7 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 
 
 @task
-def build(ctx, incremental=True, race=False, build_include=None, build_exclude=None,
+def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
           puppy=False, use_embedded_libs=False):
     """
     Build the agent. If the bits to include in the build are not specified,
@@ -56,7 +56,7 @@ def build(ctx, incremental=True, race=False, build_include=None, build_exclude=N
     cmd += "-o {agent_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/agent"
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-i" if incremental else "-a",
+        "build_type": "-a" if rebuild else "",
         "go_build_tags": " ".join(build_tags),
         "agent_bin": os.path.join(BIN_PATH, bin_name("agent")),
         "gcflags": gcflags,
@@ -90,7 +90,7 @@ def refresh_assets(ctx):
 
 
 @task
-def run(ctx, incremental=True, race=False, build_include=None, build_exclude=None,
+def run(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
         puppy=False, skip_build=False):
     """
     Execute the agent binary.
@@ -99,7 +99,7 @@ def run(ctx, incremental=True, race=False, build_include=None, build_exclude=Non
     passed. It accepts the same set of options as agent.build.
     """
     if not skip_build:
-        build(ctx, incremental, race, build_include, build_exclude, puppy)
+        build(ctx, rebuild, race, build_include, build_exclude, puppy)
 
     ctx.run(os.path.join(BIN_PATH, bin_name("agent")))
 

--- a/tasks/benchmarks.py
+++ b/tasks/benchmarks.py
@@ -18,7 +18,7 @@ BENCHMARKS_BIN_PATH = os.path.join(".", "bin", "benchmarks")
 
 
 @task
-def build_aggregator(ctx, incremental=False):
+def build_aggregator(ctx, rebuild=False):
     """
     Build the Aggregator benchmarks.
     """
@@ -37,7 +37,7 @@ def build_aggregator(ctx, incremental=False):
     cmd = "go build {build_type} -tags \"{build_tags}\" -o {bin_name} "
     cmd += "{ldflags} {gcflags} {REPO_PATH}/test/benchmarks/aggregator"
     args = {
-        "build_type": "-i" if incremental else "-a",
+        "build_type": "-a" if rebuild else "",
         "build_tags": " ".join(build_tags),
         "bin_name": os.path.join(BENCHMARKS_BIN_PATH, bin_name("aggregator")),
         "ldflags": ldflags,

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -15,6 +15,7 @@ ALL_TAGS = set([
     "ec2",
     "gce",
     "process",
+    "zk",
 ])
 
 

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -20,7 +20,7 @@ STATIC_BIN_PATH = os.path.join(".", "bin", "static")
 MAX_BINARY_SIZE = 15 * 1024
 
 @task
-def build(ctx, incremental=False, race=False, static=False, build_include=None, build_exclude=None):
+def build(ctx, rebuild=False, race=False, static=False, build_include=None, build_exclude=None):
     """
     Build Dogstatsd
     """
@@ -37,7 +37,7 @@ def build(ctx, incremental=False, race=False, static=False, build_include=None, 
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd/"
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-i" if incremental else "-a",
+        "build_type": "-a" if rebuild else "",
         "build_tags": " ".join(build_tags),
         "bin_name": os.path.join(bin_path, bin_name("dogstatsd")),
         "gcflags": gcflags,
@@ -49,7 +49,7 @@ def build(ctx, incremental=False, race=False, static=False, build_include=None, 
 
 
 @task
-def run(ctx, incremental=False, race=False, build_include=None, build_exclude=None,
+def run(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
         skip_build=False):
     """
     Run Dogstatsd binary. Build the binary before executing, unless
@@ -57,7 +57,7 @@ def run(ctx, incremental=False, race=False, build_include=None, build_exclude=No
     """
     if not skip_build:
         print("Building dogstatsd...")
-        build(ctx, incremental=incremental, race=race, build_include=build_include, build_exclude=build_exclude)
+        build(ctx, rebuild=rebuild, race=race, build_include=build_include, build_exclude=build_exclude)
 
     target = os.path.join(DOGSTATSD_BIN_PATH, bin_name("dogstatsd"))
     ctx.run("{} start".format(target))

--- a/tasks/pylauncher.py
+++ b/tasks/pylauncher.py
@@ -14,7 +14,7 @@ from .utils import REPO_PATH, bin_name, get_root
 PYLAUNCHER_BIN_PATH = os.path.join(get_root(), "bin", "pylauncher")
 
 @task
-def build(ctx, incremental=False):
+def build(ctx, rebuild=False):
     """
     Build the pylauncher executable
     """
@@ -22,7 +22,7 @@ def build(ctx, incremental=False):
 
     cmd = "go build {build_type} -tags \"{build_tags}\" -o {bin_name} {REPO_PATH}/cmd/py-launcher/"
     args = {
-        "build_type": "-i" if incremental else "-a",
+        "build_type": "-a" if rebuild else "",
         "build_tags": " ".join(build_tags),
         "bin_name": os.path.join(PYLAUNCHER_BIN_PATH, bin_name("pylauncher")),
         "REPO_PATH": REPO_PATH,


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Fixes a couple of flaws in the invoke tasks. 
Precisely, we were not including `zookeeper` build tag and we were misusing the `-i` flag for `go build` since the incremental build is on unless `-a` is passed.

