### PR TITLE
[gitlab] Allow failures on benchmark job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,7 @@ build_dogstatsd_static-rpm_x64:
 run_benchmarks-deb_x64:
   stage: integration_test
   image: $DEB_X64
+  allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
   tags:
     - docker
   script:


### PR DESCRIPTION
### What does this PR do?

Allows failures on benchmark job

### Motivation

Job is failing and blocking the whole pipeline
