### PR TITLE
Revert "🔥 Kill Rake with fire"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,94 @@
+require_relative './rake/common'
+require_relative './rake/agent'
+require_relative './rake/dogstatsd'
+require_relative './rake/benchmarks'
+require_relative './rake/docker'
+require_relative './rake/py-launcher'
+
+# Only add 'embedded' pkg-config dir to the env's PKG_CONFIG_PATH if the embedded python/libs are used
+# In that case it should be the first path so that the 'embedded' dir takes precedence over the 'system' one
+PKG_CONFIG_EMBEDDED_PATH=File.join(Dir.pwd, "pkg-config", os, "embedded")
+# Always add 'system' pkg-config dir to the env's PKG_CONFIG_PATH
+PKG_CONFIG_PATH=File.join(Dir.pwd, "pkg-config", os, "system")
+ENV["PKG_CONFIG_PATH"] = ENV.has_key?("PKG_CONFIG_PATH") ? "#{PKG_CONFIG_PATH}:#{ENV['PKG_CONFIG_PATH']}" : PKG_CONFIG_PATH
+
+ORG_PATH="github.com/DataDog"
+REPO_PATH="#{ORG_PATH}/datadog-agent"
+TARGETS = %w[./pkg ./cmd]
+
+CLOBBER.include("*.cov")
+
+task default: %w[agent:build]
+
+desc "Setup Go dependencies"
+task :deps do
+  system("go get -u github.com/golang/dep/cmd/dep")
+  system("go get -u github.com/golang/lint/golint")
+  system("dep ensure")
+end
+
+desc "Run go fmt on #{TARGETS}"
+task :fmt do
+  fail_on_mod = ENV["CI"] # only fail on modification when we're running in CI env
+  TARGETS.each do |t|
+    go_fmt(t, fail_on_mod)
+  end
+end
+
+desc "Run golint on #{TARGETS}"
+task :lint do
+  TARGETS.each do |t|
+    go_lint(t)
+  end
+end
+
+desc "Run go vet on #{TARGETS}"
+task :vet do
+  TARGETS.each do |t|
+    go_vet(t)
+  end
+end
+
+desc "Run testsuite [race=false|tags=*|puppy=false]"
+task :test => %w[fmt lint vet] do
+  PROFILE = "profile.cov"  # collect global coverage data in this file
+  `echo "mode: count" > #{PROFILE}`
+  covermode_opt = "-covermode=count"
+
+  # -race option
+  race_opt = ENV['race'] == "true" ? "-race" : ""
+  if race_opt != ""
+    # atomic is quite expensive but it's the only way to run
+    # both the coverage and the race detector at the same time
+    # without getting false positives from the cover counter
+    covermode_opt = "-covermode=atomic"
+  end
+
+  TARGETS.each do |t|
+    Dir.glob("#{t}/**/*").select {|f| File.directory? f }.each do |pkg_folder|  # recursively search for go packages
+      next if Dir.glob(File.join(pkg_folder, "*.go")).length == 0  # folder is a package if contains go modules
+      profile_tmp = "#{pkg_folder}/profile.tmp"  # temp file to collect coverage data
+
+      # Check if we should use Embedded or System Python,
+      # default to the embedded one.
+      env = {}
+      if !ENV["USE_SYSTEM_LIBS"]
+        env["PKG_CONFIG_PATH"] = "#{PKG_CONFIG_EMBEDDED_PATH}:#{ENV["PKG_CONFIG_PATH"]}"
+      end
+
+      system(env, "go test -tags '#{go_build_tags}' #{race_opt} -short #{covermode_opt} -coverprofile=#{profile_tmp} #{pkg_folder}") || exit(1)
+      if File.file?(profile_tmp)
+        `cat #{profile_tmp} | tail -n +2 >> #{PROFILE}`
+        File.delete(profile_tmp)
+      end
+    end
+  end
+
+  sh("go tool cover -func #{PROFILE}")
+end
+
+desc "Run every system tests"
+task system_test: %w[dogstatsd:system_test] # FIXME: re-enable pylauncher:system_test once they're fixed
+
+desc "Build allthethings"
+task build: %w[agent:build dogstatsd:build pylauncher:build]

--- a/rake/agent.rb
+++ b/rake/agent.rb
@@ -1,0 +1,137 @@
+require_relative './common'
+
+
+def agent_bin_name
+  case os
+  when "windows"
+    "agent.exe"
+  else
+    "agent.bin"
+  end
+end
+
+namespace :agent do
+  BIN_PATH="./bin/agent"
+  CLOBBER.include(BIN_PATH)
+  desc "Build the Agent [race=false|incremental=false|tags=*|puppy=false]"
+  task :build do
+    # `race` option
+    race_opt = ENV['race'] == "true" ? "-race" : ""
+    # `incremental` option
+    build_type = ENV['incremental'] == "true" ? "-i" : "-a"
+
+    # Check if we should use Embedded or System Python,
+    # default to the embedded one.
+    env = {}
+    gcflags = []
+    ldflags = get_base_ldflags()
+    if !ENV["USE_SYSTEM_LIBS"]
+      env["PKG_CONFIG_PATH"] = "#{PKG_CONFIG_EMBEDDED_PATH}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+      ENV["PKG_CONFIG_PATH"] = "#{PKG_CONFIG_EMBEDDED_PATH}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+      libdir = `pkg-config --variable=libdir python-2.7`.strip
+      fail "Can't find path to embedded lib directory with pkg-config" if libdir.empty?
+      ldflags << "-r #{libdir}"
+    else
+      if os == "windows"
+        # set PKG_CONFIG_SYSTEM to point to where your local .pc files are. ENV["PKG_CONFIG_PATH"] is already set up, 
+        # and you can't really concatenate onto it.
+        env["PKG_CONFIG_PATH"] = "#{ENV["PKG_CONFIG_SYSTEM"]}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+        ENV["PKG_CONFIG_PATH"] = "#{ENV["PKG_CONFIG_SYSTEM"]}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+        libdir = `pkg-config --variable=libdir python-2.7`.strip
+        fail "Can't find path to embedded lib directory with pkg-config" if libdir.empty?
+        ldflags << "-r #{libdir}"
+      end
+    end
+
+    if os == "windows"
+      # This generates the manifest resource. The manifest resource is necessary for
+      # being able to load the ancient C-runtime that comes along with Python 2.7
+
+      # fixme -- still need to calculate correct *_VER numbers at build time rather than
+      # hard-coded here.
+      command = "windres --define MAJ_VER=6 --define MIN_VER=0 --define PATCH_VER=0 -i cmd/agent/agent.rc --target=pe-x86-64 -O coff -o cmd/agent/rsrc.syso"
+      puts command
+      build_success = system(env, command)
+      fail "Agent build failed with code #{$?.exitstatus}" if !build_success
+    end
+    if ENV["DELVE"]
+      gcflags << "-N" << "-l"
+      if os == "windows"
+        # On windows, need to build with the extra argument -ldflags="-linkmode internal"
+        # if you want to be able to use the delve debugger.
+        ldflags << "-linkmode internal"
+      end
+    end
+
+    command = "go build #{race_opt} #{build_type} -tags \"#{go_build_tags}\" -o #{BIN_PATH}/#{agent_bin_name} -gcflags=\"#{gcflags.join(" ")}\" -ldflags=\"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/agent"
+    puts command
+    build_success = system(env, command)
+    fail "Agent build failed with code #{$?.exitstatus}" if !build_success
+
+    Rake::Task["agent:refresh_assets"].invoke
+  end
+
+  desc "Refresh the build assets"
+  task :refresh_assets do
+    # Collector's assets and config files
+    FileUtils.rm_rf("#{BIN_PATH}/dist")
+    FileUtils.cp_r("./pkg/collector/dist/", "#{BIN_PATH}", :remove_destination => true)
+    FileUtils.cp_r("./pkg/status/dist/", "#{BIN_PATH}", :remove_destination => true)
+    FileUtils.cp_r("./dev/dist/", "#{BIN_PATH}", :remove_destination => true)
+    FileUtils.mv("#{BIN_PATH}/dist/agent", "#{BIN_PATH}/agent")
+    FileUtils.chmod(0755, "#{BIN_PATH}/agent")
+  end
+
+  desc "Run the agent"
+  task :run => %w[agent:build agent:run_lazy]
+
+  desc "Run the agent (no build)"
+  task :run_lazy do
+    abort "Binary unavailable run agent:build or agent:run" if !File.exists? "#{BIN_PATH}/#{agent_bin_name}"
+    sh("#{BIN_PATH}/agent start")
+  end
+
+  desc "Build omnibus installer [puppy=false]"
+  task :omnibus do
+    # omnibus config overrides
+    overrides = []
+
+    # puppy mode option
+    project_name = ENV['puppy'] == "true" ? "puppy" : "datadog-agent6"
+
+    # omnibus log level
+    log_level = ENV["AGENT_OMNIBUS_LOG_LEVEL"] || "info"
+
+    base_dir = ENV["AGENT_OMNIBUS_BASE_DIR"]
+    if base_dir
+      overrides.push("base_dir:#{base_dir}")
+    end
+
+    package_dir = ENV["AGENT_OMNIBUS_PACKAGE_DIR"]
+    if package_dir
+      overrides.push("package_dir:#{package_dir}")
+    end
+
+    overrides_cmd = ""
+    if overrides.size > 0
+      overrides_cmd = "--override=" + overrides.join(" ")
+    end
+
+    Dir.chdir('omnibus') do
+      system("bundle install --without development")
+      case os
+      when "windows"
+        system("bundle exec omnibus.bat build #{project_name} --log-level=#{log_level} #{overrides_cmd}")
+      else
+        system("omnibus build #{project_name} --log-level=#{log_level} #{overrides_cmd}")
+      end
+    end
+
+  end
+
+  desc "Run agent system tests"
+  task :system_test do
+    system("cd #{ENV["GOPATH"]}/src/#{REPO_PATH}/test/integration/config_providers/zookeeper/ && bash ./test.sh") || exit(1)
+  end
+
+end

--- a/rake/benchmarks.rb
+++ b/rake/benchmarks.rb
@@ -1,0 +1,48 @@
+require_relative './common'
+
+namespace :benchmark do
+  BENCHMARK_BIN_PATH="./bin/benchmarks"
+  CLOBBER.include(BENCHMARK_BIN_PATH)
+
+  namespace :aggregator do
+    desc "Build the aggregator benchmark"
+    task :build do
+      # -race option
+      build_type = ENV['incremental'] == "true" ? "-i" : "-a"
+      flags = ""
+
+      if ENV["WINDOWS_DELVE"]
+        # On windows, need to build with the extra arguments -gcflags "-N -l" -ldflags="-linkmode internal"
+        # if you want to be able to use the delve debugger.
+        flags="-gcflags \"-N -l\" -ldflags=\"-linkmode internal\""
+      end
+
+      system("go build #{build_type} -tags '#{go_build_tags}' -o #{BENCHMARK_BIN_PATH}/#{bin_name("aggregator")} #{flags} #{REPO_PATH}/test/benchmarks/aggregator") or exit!(1)
+    end
+
+    desc "Run the aggregator benchmark"
+    task :run do
+      branch = ENV["DD_REPO_BRANCH_NAME"] or `git rev-parse --abbrev-ref HEAD`.strip()
+      options = ""
+      if ENV["DD_AGENT_API_KEY"]
+        options = " -api-key #{ENV["DD_AGENT_API_KEY"]}"
+      end
+
+      system("#{BENCHMARK_BIN_PATH}/#{bin_name("aggregator")} -points 2,10,100,500,1000 -series 10,100,1000 -log-level info -json -branch #{branch} #{options}") or exit!(1)
+    end
+  end
+
+  namespace :dogstatsd do
+    desc "Build Dogstatsd benchmark"
+    task :build do
+      system("go build -tags '#{go_build_tags}' -o #{BENCHMARK_BIN_PATH}/#{bin_name("dogstatsd")} #{REPO_PATH}/test/benchmarks/dogstatsd") or exit!(1)
+    end
+
+    desc "Run Dogstatsd Benchmark"
+    task :run => %w[benchmark:dogstatsd:build] do
+      root = `git rev-parse --show-toplevel`.strip
+      bin_path = File.join(root, BENCHMARK_BIN_PATH, "dogstatsd")
+      system("#{bin_path} -pps=5000 -dur 45 -ser 5 -brk -inc 1000")
+    end
+  end
+end

--- a/rake/common.rb
+++ b/rake/common.rb
@@ -1,0 +1,109 @@
+require 'rake/clean'
+
+def os
+  case RUBY_PLATFORM
+  when /linux/
+    "linux"
+  when /darwin/
+    "darwin"
+  when /x64-mingw32/
+    "windows"
+  else
+    fail 'Unsupported OS'
+  end
+end
+
+# `tags` option
+def go_build_tags
+  build_tags = ENV['tags'] || "zlib snmp etcd zk cpython jmx apm docker ec2 gce process"
+  build_tags = ENV['puppy'] == 'true' ? 'zlib' : build_tags
+end
+
+def get_base_ldflags()
+  # get agent-payload version
+  agent_payload_version = get_payload_version()
+  commit = `git rev-parse --short HEAD`.strip
+
+  ldflags = [
+    "-X #{REPO_PATH}/pkg/version.commit=#{commit}",
+    "-X #{REPO_PATH}/pkg/serializer.AgentPayloadVersion=#{agent_payload_version}",
+  ]
+end
+
+def go_fmt(path, fail_on_mod)
+  out = `go fmt #{path}/...`
+  errors = out.split("\n")
+  if errors.length > 0
+    puts "Reformatted the following files:"
+    puts out
+    fail if fail_on_mod
+  end
+end
+
+def go_lint(path)
+  out = `golint #{path}/...`
+  errors = out.split("\n")
+  puts "#{errors.length} linting issues found in #{path}"
+  if errors.length > 0
+    puts out
+    fail
+  end
+end
+
+def go_vet(path)
+  out = `go vet #{path}/... 2>&1`
+  errors = out.split("\n")
+  puts "vet found #{errors.length} issues in #{path}"
+  if errors.length > 0
+    puts out
+    fail
+  end
+end
+
+def bin_name(name)
+  case os
+  when "windows"
+    "#{name}.exe"
+  else
+    name
+  end
+end
+
+# extract the agent payload version from `Gopkg.toml` without requiring an
+# external package
+def get_payload_version()
+
+  current = {}
+
+  # parse the TOML file line by line
+  File.readlines("Gopkg.lock").each do |line|
+    # skip empty lines and comments
+    if line.length == 0 || line.start_with?("#")
+      next
+    end
+
+    # change the parser "state" when we find a [[projects]] section
+    if line.include? "[[projects]]"
+      # see if the current section is what we're searching for
+      if current.fetch('name', nil) == "github.com/DataDog/agent-payload"
+        return current["version"]
+      end
+
+      # if not, reset the "state" and proceed with the next line
+      current = {}
+      next
+    end
+
+    # search for an assignment, ignore subsequent `=` chars
+    toks = line.split('=', 2)
+    if toks.length == 2
+      # strip whitespaces
+      key = toks.first.strip
+      # strip whitespaces and quotes
+      value = toks.last.tr('"', '').strip
+      current[key] = value
+    end
+  end
+
+  return ""
+end

--- a/rake/docker.rb
+++ b/rake/docker.rb
@@ -1,0 +1,23 @@
+require_relative './common'
+
+namespace :docker do
+  DOGSTATSD_TAG="datadog/dogstatsd:master"
+
+  desc "Build datadog/dogstatsd docker image [skip_rebuild=false]"
+  task :build_dogstatsd do
+    if ENV['skip_rebuild'] != "true" then
+      puts "Building DogStatsD"
+      ENV['static'] = 'true'
+      Rake::Task["dogstatsd:build"].invoke
+    end
+    FileUtils.cp("bin/static/dogstatsd", "Dockerfiles/dogstatsd/alpine/")
+    system("docker build -t #{DOGSTATSD_TAG} Dockerfiles/dogstatsd/alpine/") || exit(1)
+  end
+
+  desc "Run docker integration tests"
+  task :integration_test => %w[docker:build_dogstatsd]  do
+    puts "Starting docker integration tests"
+    system("DOCKER_IMAGE=#{DOGSTATSD_TAG} ./test/integration/docker/dsd_alpine_listening.sh") || exit(1)
+  end
+
+end

--- a/rake/dogstatsd.rb
+++ b/rake/dogstatsd.rb
@@ -1,0 +1,93 @@
+require_relative './common'
+
+
+namespace :dogstatsd do
+  DOGSTATSD_BIN_PATH="./bin/dogstatsd"
+  STATIC_BIN_PATH="./bin/static"
+  CLOBBER.include(DOGSTATSD_BIN_PATH, STATIC_BIN_PATH)
+
+  desc "Build Dogstatsd [race=false|incremental=false|static=false]"
+  task :build do
+    race_opt = ENV['race'] == "true" ? "-race" : ""
+    build_type_opt = ENV['incremental'] == "true" ? "-i" : "-a"
+    static_bin = ENV['static'] == "true"
+    build_tags = ENV['tags'] || "zlib"
+
+    bin_path = DOGSTATSD_BIN_PATH
+    ldflags = get_base_ldflags()
+    if static_bin then
+      ldflags << " -s -w -linkmode external -extldflags \"-static\""
+      bin_path = STATIC_BIN_PATH
+    end
+
+    sh("go build #{race_opt} #{build_type_opt} -tags '#{build_tags}' -o #{bin_path}/#{bin_name("dogstatsd")} -ldflags \"#{ldflags.join(" ")}\" #{REPO_PATH}/cmd/dogstatsd/")
+  end
+
+  desc "Run Dogstatsd"
+  task :run => %w[dogstatsd:build] do
+    system("#{DOGSTATSD_BIN_PATH}/dogstatsd")
+  end
+
+  desc "Run Dogstatsd system tests [skip_rebuild=false]"
+  task :system_test do
+    if ENV['skip_rebuild'] != "true" then
+      puts "Building DogStatsD"
+      Rake::Task["dogstatsd:build"].invoke
+    end
+
+    puts "Starting DogStatsD system tests"
+    root = `git rev-parse --show-toplevel`.strip
+    bin_path = File.join(root, DOGSTATSD_BIN_PATH, "dogstatsd")
+    sh("DOGSTATSD_BIN=\"#{bin_path}\" go test -tags '#{go_build_tags}' -v #{REPO_PATH}/test/system/dogstatsd/")
+  end
+
+  desc "Run Dogstatsd size test [skip_rebuild=false]"
+  task :size_test do
+    if ENV['skip_rebuild'] != "true" then
+      puts "Building DogStatsD"
+      ENV['static'] = "true"
+      Rake::Task["dogstatsd:build"].invoke
+    end
+
+    root = `git rev-parse --show-toplevel`.strip
+    bin_path = File.join(root, STATIC_BIN_PATH, "dogstatsd")
+    size = File.size(bin_path) / 1024
+
+    if size > 15 * 1024 then
+      puts "DogStatsD static build size too big: #{size} kB"
+      puts "This means your PR added big classes or dependencies in the packages dogstatsd uses"
+      exit(1)
+    else
+      puts "DogStatsD static build size OK: #{size} kB"
+    end
+  end
+
+  desc "Build omnibus installer"
+  task :omnibus do
+    # omnibus log level
+    log_level = ENV["AGENT_OMNIBUS_LOG_LEVEL"] || "info"
+
+    # omnibus config overrides
+    overrides_cmd = ""
+    overrides = []
+    base_dir = ENV["AGENT_OMNIBUS_BASE_DIR"]
+    if base_dir
+      overrides.push("base_dir:#{base_dir}")
+    end
+
+    package_dir = ENV["AGENT_OMNIBUS_PACKAGE_DIR"]
+    if package_dir
+      overrides.push("package_dir:#{package_dir}")
+    end
+
+    Dir.chdir('omnibus') do
+      system("bundle install --without development")
+
+      if overrides.size > 0
+        overrides_cmd = "--override=" + overrides.join(" ")
+      end
+
+      system("omnibus build dogstatsd --log-level=#{log_level} #{overrides_cmd}")
+    end
+  end
+end

--- a/rake/py-launcher.rb
+++ b/rake/py-launcher.rb
@@ -1,0 +1,44 @@
+require_relative './common'
+
+namespace :pylauncher do
+  PYLAUNCHER_BIN_PATH="./bin/py-launcher"
+  CLOBBER.include(PYLAUNCHER_BIN_PATH)
+
+  desc "Build py-launcher [incremental=false]"
+  task :build do
+    # Check if we should use Embedded or System Python,
+    # default to the embedded one.
+    env = {}
+    gcflags = []
+    ldflags = []
+
+    if !ENV["USE_SYSTEM_LIBS"]
+      env["PKG_CONFIG_PATH"] = "#{PKG_CONFIG_EMBEDDED_PATH}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+      ENV["PKG_CONFIG_PATH"] = "#{PKG_CONFIG_EMBEDDED_PATH}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+      libdir = `pkg-config --variable=libdir python-2.7`.strip
+      fail "Can't find path to embedded lib directory with pkg-config" if libdir.empty?
+      ldflags << "-r #{libdir}"
+    else
+      if os == "windows"
+        env["PKG_CONFIG_PATH"] = "#{ENV["PKG_CONFIG_SYSTEM"]}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+        ENV["PKG_CONFIG_PATH"] = "#{ENV["PKG_CONFIG_SYSTEM"]}" + File::PATH_SEPARATOR + "#{ENV["PKG_CONFIG_PATH"]}"
+        libdir = `pkg-config --variable=libdir python-2.7`.strip
+        fail "Can't find path to embedded lib directory with pkg-config" if libdir.empty?
+        ldflags << "-r #{libdir}"
+      end
+    end
+    build_type_opt = ENV['incremental'] == "true" ? "-i" : "-a"
+
+    build_tags = go_build_tags
+
+    bin_path = PYLAUNCHER_BIN_PATH
+    sh("go build #{build_type_opt} -tags \"#{go_build_tags}\" -o #{bin_path}/#{bin_name("py-launcher")} #{REPO_PATH}/cmd/py-launcher/")
+  end
+
+  desc "Run system tests with pylauncher"
+  task :system_test => %w[pylauncher:build] do
+    root = `git rev-parse --show-toplevel`.strip
+    bin_path = File.join(root, PYLAUNCHER_BIN_PATH, "py-launcher")
+    sh("cd #{root}/test/system/python_binding/ && PYLAUNCHER_BIN=\"#{bin_path}\" ./test.sh")
+  end
+end


### PR DESCRIPTION
invoke does not work on windows right now. We need to resolve this, until then, we'll have to revert the deprecation of rake.

Reverts DataDog/datadog-agent#499