### PR TITLE
Fix invoke run on windows

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,6 +1,7 @@
 """
 Invoke entrypoint, import here all the tasks we want to make available
 """
+import os
 from invoke import Collection
 
 from . import agent, benchmarks, docker, dogstatsd, pylauncher
@@ -27,3 +28,11 @@ ns.add_collection(benchmarks, name="bench")
 ns.add_collection(docker)
 ns.add_collection(dogstatsd)
 ns.add_collection(pylauncher)
+
+# workaround waiting for a fix being merged on Invoke,
+# see https://github.com/pyinvoke/invoke/pull/407
+ns.configure({
+    'run': {
+        'shell': os.environ.get('COMSPEC', os.environ.get('SHELL'))
+    }
+})


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds a workaround for an issue Invoke has on Windows platforms, see https://github.com/pyinvoke/invoke/pull/407

### Motivation

Couldn't `ctx.run()` anything on Windows

