### PR TITLE
[gitlab] Disable race detector in tests that run on Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ run_tests_deb-x64:
   tags:
     - docker
   script:
-    - inv test --race
+    - inv test
 
 # run tests for rpm-x64
 run_test_rpm-x64:
@@ -48,7 +48,7 @@ run_test_rpm-x64:
   tags:
     - docker
   script:
-    - inv test --race
+    - inv test
 
 
 #


### PR DESCRIPTION
### What does this PR do?

Disables race detector in tests that run on Gitlab

### Motivation

Enabling the race detector considerably slows down the tests on Gitlab.
They're still enabled on CircleCI