### PR TITLE
[omnibus] Use embedded libs for agent omnibus build

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -14,7 +14,7 @@ build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
   # the go deps needs to be installed (invoke dep) before running omnibus
   # TODO: enable omnibus to run invoke deps while building the project
-  command "invoke agent.build -r"
+  command "invoke agent.build --rebuild --use-embedded-libs"
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/omnibus/config/software/datadog-puppy.rb
+++ b/omnibus/config/software/datadog-puppy.rb
@@ -11,7 +11,7 @@ build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
   # the go deps needs to be installed (invoke dep) before running omnibus
   # TODO: enable omnibus to run invoke deps while building the project
-  command "invoke agent.build -p -r"
+  command "invoke agent.build --puppy --rebuild --use-embedded-libs"
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/omnibus/config/software/dogstatsd.rb
+++ b/omnibus/config/software/dogstatsd.rb
@@ -8,7 +8,7 @@ build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
   # the go deps needs to be installed (invoke dep) before running omnibus
   # TODO: enable omnibus to run invoke deps while building the project
-  command 'invoke dogstatsd.build -r'
+  command 'invoke dogstatsd.build --rebuild --use-embedded-libs'
   copy('bin', install_dir)
 
   if debian?

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -29,10 +29,12 @@ ns.add_collection(docker)
 ns.add_collection(dogstatsd)
 ns.add_collection(pylauncher)
 
-# workaround waiting for a fix being merged on Invoke,
-# see https://github.com/pyinvoke/invoke/pull/407
 ns.configure({
     'run': {
+        # by default, always echo commands as they're run
+        'echo': True,
+        # workaround waiting for a fix being merged on Invoke,
+        # see https://github.com/pyinvoke/invoke/pull/407
         'shell': os.environ.get('COMSPEC', os.environ.get('SHELL'))
     }
 })

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -9,7 +9,7 @@ from distutils.dir_util import copy_tree
 import invoke
 from invoke import task
 
-from .utils import bin_name, get_ldflags, pkg_config_path
+from .utils import bin_name, get_build_flags, pkg_config_path
 from .utils import REPO_PATH
 from .build_tags import get_build_tags, get_puppy_build_tags
 from .go import deps
@@ -35,7 +35,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         build_tags = get_puppy_build_tags()
     else:
         build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags = get_ldflags(ctx)
+    ldflags, gcflags = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
 
     env = {
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -9,7 +9,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .build_tags import get_build_tags
-from .utils import get_ldflags, bin_name, get_root
+from .utils import get_build_flags, bin_name, get_root
 from .utils import REPO_PATH
 
 from .go import deps
@@ -20,14 +20,14 @@ STATIC_BIN_PATH = os.path.join(".", "bin", "static")
 MAX_BINARY_SIZE = 15 * 1024
 
 @task
-def build(ctx, rebuild=False, race=False, static=False, build_include=None, build_exclude=None):
+def build(ctx, rebuild=False, race=False, static=False, build_include=None, build_exclude=None, use_embedded_libs=False):
     """
     Build Dogstatsd
     """
     build_include = ctx.dogstatsd.build_include if build_include is None else build_include.split(",")
     build_exclude = ctx.dogstatsd.build_exclude if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags = get_ldflags(ctx, static=static)
+    ldflags, gcflags = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
     bin_path = DOGSTATSD_BIN_PATH
 
     if static:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -44,7 +44,7 @@ def pkg_config_path(use_embedded_libs):
     return retval
 
 
-def get_ldflags(ctx, static=False):
+def get_build_flags(ctx, static=False, use_embedded_libs=False):
     """
     Build the common value for both ldflags and gcflags.
 
@@ -59,6 +59,11 @@ def get_ldflags(ctx, static=False):
     ldflags += "-X {}/pkg/serializer.AgentPayloadVersion={} ".format(REPO_PATH, payload_v)
     if static:
         ldflags += "-s -w -linkmode external -extldflags '-static' "
+    elif use_embedded_libs:
+        embedded_lib_path = ctx.run(
+                "pkg-config --variable=libdir python-2.7", env={"PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)}, hide=True
+            ).stdout.strip()
+        ldflags += "-r {} ".format(embedded_lib_path)
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"
@@ -110,6 +115,7 @@ def get_root():
     Get the root of the Go project
     """
     return check_output(['git', 'rev-parse', '--show-toplevel']).strip()
+
 
 def get_git_branch_name():
     """


### PR DESCRIPTION
* Fix build task to make agent binary load embedded libs.
  By adding rpath (`-r`) param to the ldflags.
* Use embedded libs for agent omnibus build.
  Otherwise we build the omnibus agent against the system libs, which is obviously not what we want.
* Always `echo` commands as they're run (by default).
  Helps to understand what the tasks actually do