### PR TITLE
[py] Define `service_metadata` method in AgentCheck class

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -145,7 +145,8 @@ class AgentCheck(object):
             event['aggregation_key'] = str(event['aggregation_key'])
         aggregator.submit_event(self, self.check_id, event)
 
-    def increment(self, name, value, tags=None):
+    # TODO(olivier): implement service_metadata if it's worth it
+    def service_metadata(self, meta_name, value):
         pass
 
     def check(self, instance):


### PR DESCRIPTION
### What does this PR do?

Defines a `service_metadata` method in the AgentCheck class.

Doesn't do anything for now. I've created a card in the backlog to discuss if it's worth actually
implementing service metadata in agent6.

Also, removed a wrong duplicate of the `increment` method.

### Motivation

Some existing core checks (`redisdb`, `elastic`, `postgres`, `mysql`) use this method and error out if it's not defined.