### PR TITLE
[Windows] fix invoke task for windows.  omnibus needs to be executed

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -161,7 +161,7 @@ def omnibus_build(ctx, puppy=False):
 
     with ctx.cd("omnibus"):
         ctx.run("bundle install")
-        omnibus = "omnibus.bat" if invoke.platform.WINDOWS else "omnibus"
+        omnibus = "bundle exec omnibus.bat" if invoke.platform.WINDOWS else "omnibus"
         cmd = "{omnibus} build {project_name} --log-level={log_level} {overrides}"
         args = {
             "omnibus": omnibus,


### PR DESCRIPTION
from within bundle in order for all of the bundles to be detected
properly
