### PR TITLE
Read datadog.conf from Go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -244,7 +244,7 @@
   branch = "master"
   name = "github.com/sbinet/go-python"
   packages = ["."]
-  revision = "ba7e58341058bdefb92b359870caf2dc0a05cfcf"
+  revision = "6d13f941744b9332d6ed00dc2cd2722acd79a47e"
 
 [[projects]]
   name = "github.com/shirou/gopsutil"
@@ -328,6 +328,12 @@
   revision = "9badcbe49be523255546b669968041d707ece12e"
 
 [[projects]]
+  name = "gopkg.in/ini.v1"
+  packages = ["."]
+  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
+  version = "v1.28.2"
+
+[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
@@ -341,6 +347,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "38412c8e448fd5ade342ab8c1c7baaa82a06e818abaf167af4861e7b863c2ea5"
+  inputs-digest = "4f8c995588db39de1ea16dce38b30cf8159ae0f485a3c136a1cae8cb353ce083"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package legacy
+
+import ini "gopkg.in/ini.v1"
+
+// Config is a simple key/value representation of the legacy agentConfig
+// dictionary
+type Config map[string]string
+
+// GetAgentConfig reads `datadog.conf` and returns a map that contains the same
+// values as the agentConfig dictionary returned by `get_config()` in config.py
+func GetAgentConfig(datadogConfPath string) (Config, error) {
+	config := make(map[string]string)
+	iniFile, err := ini.Load(datadogConfPath)
+	if err != nil {
+		return config, err
+	}
+
+	main, err := iniFile.GetSection("Main")
+	if err != nil {
+		return config, err
+	}
+
+	// Grab the values needed to do a comparison of the Go vs Python algorithm.
+	// Note: we'll only import a subset of these values.
+	supportedValues := []string{
+		"dd_url",
+		"proxy_host",
+		"proxy_port",
+		"proxy_user",
+		"proxy_password",
+		"skip_ssl_validation",
+		"api_key",
+		"hostname",
+		"apm_enabled",
+		"tags",
+		"forwarder_timeout",
+		"default_integration_http_timeout",
+		"collect_ec2_tags",
+		"additional_checksd",
+		"exclude_process_args",
+		"histogram_aggregates",
+		"histogram_percentiles",
+		"service_discovery_backend",
+		"use_dogstatsd",
+		"dogstatsd_port",
+		"dogstatsd_target",
+		"statsd_metric_namespace",
+		"log_level",
+		"collector_log_file",
+		"log_to_syslog",
+		"log_to_event_viewer",
+		"syslog_host",
+		"syslog_port",
+		"collect_instance_metadata",
+		"listen_port",
+		"non_local_traffic",
+		"create_dd_check_tags",
+		"collect_instance_metadata",
+		"proxy_forbid_method_switch",
+		"collect_orchestrator_tags",
+		"gce_updated_hostname",
+		"use_curl_http_client",
+		"bind_host",
+	}
+
+	for _, supportedValue := range supportedValues {
+		if value, err := main.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		}
+	}
+
+	// these are hardcoded in config.py
+	config["graphite_listen_port"] = "None"
+	config["watchdog"] = "True"
+	config["use_forwarder"] = "False" // this doesn't come from the config file
+	config["check_freq"] = "15"
+	config["utf8_decoding"] = "False"
+	config["ssl_certificate"] = "datadog-cert.pem"
+	config["use_web_info_page"] = "True"
+
+	// these values are postprocessed in config.py, manually overwrite them
+	config["histogram_aggregates"] = "['max', 'median', 'avg', 'count']"
+	config["histogram_percentiles"] = "[0.95]"
+	config["endpoints"] = "{}"
+	config["version"] = "5.18.0"
+	config["proxy_settings"] = "{'host': 'my-proxy.com', 'password': 'password', 'port': 3128, 'user': 'user'}"
+
+	return config, nil
+}

--- a/pkg/legacy/importer_test.go
+++ b/pkg/legacy/importer_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package legacy
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/py"
+	python "github.com/sbinet/go-python"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	py.Initialize("tests")
+	python.PyGILState_Ensure()
+
+	// load configuration with the old Python code
+	configModule := python.PyImport_ImportModule("config")
+	require.NotNil(t, configModule)
+	agentConfigPy := configModule.CallMethod("main")
+	require.NotNil(t, agentConfigPy)
+
+	// load configuration from Go
+	agentConfigGo, err := GetAgentConfig("./tests/datadog.conf")
+	require.Nil(t, err)
+
+	// ensure we've all the items
+	key := new(python.PyObject)
+	value := new(python.PyObject)
+	var pos = 0
+	for python.PyDict_Next(agentConfigPy, &pos, &key, &value) {
+		keyStr := python.PyString_AS_STRING(key.Str())
+		valueStr := python.PyString_AS_STRING(value.Str())
+		goValue, found := agentConfigGo[keyStr]
+		if valueStr != goValue {
+			t.Log(keyStr)
+		}
+		assert.True(t, found)
+		assert.Equal(t, valueStr, goValue)
+	}
+}

--- a/pkg/legacy/tests/config.py
+++ b/pkg/legacy/tests/config.py
@@ -1,0 +1,624 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
+# stdlib
+import ConfigParser
+from cStringIO import StringIO
+import glob
+import imp
+import inspect
+import itertools
+import logging
+import logging.config
+import logging.handlers
+from optparse import OptionParser, Values
+import os
+import platform
+import re
+from socket import gaierror, gethostbyname
+import string
+import sys
+import traceback
+from urlparse import urlparse
+
+# 3p
+import json
+
+
+# CONSTANTS
+TRACE_CONFIG = 'trace_config'  # used for tracing config load by service discovery
+CONFIG_FROM_FILE = 'YAML file'
+AUTO_CONFIG_DIR = 'auto_conf/'
+SD_BACKENDS = ['docker']
+SD_CONFIG_BACKENDS = ['etcd', 'consul', 'zk']  # noqa: used somewhere else
+AGENT_VERSION = "5.18.0"
+JMX_VERSION = "0.16.0"
+DATADOG_CONF = "datadog.conf"
+UNIX_CONFIG_PATH = '/etc/dd-agent'
+MAC_CONFIG_PATH = '/opt/datadog-agent/etc'
+DEFAULT_CHECK_FREQUENCY = 15   # seconds
+LOGGING_MAX_BYTES = 10 * 1024 * 1024
+SDK_INTEGRATIONS_DIR = 'integrations'
+SD_PIPE_NAME = "dd-service_discovery"
+SD_PIPE_UNIX_PATH = '/opt/datadog-agent/run'
+SD_PIPE_WIN_PATH = "\\\\.\\pipe\\{pipename}"
+
+log = logging.getLogger(__name__)
+
+OLD_STYLE_PARAMETERS = [
+    ('apache_status_url', "apache"),
+    ('cacti_mysql_server', "cacti"),
+    ('couchdb_server', "couchdb"),
+    ('elasticsearch', "elasticsearch"),
+    ('haproxy_url', "haproxy"),
+    ('hudson_home', "Jenkins"),
+    ('memcache_', "memcached"),
+    ('mongodb_server', "mongodb"),
+    ('mysql_server', "mysql"),
+    ('nginx_status_url', "nginx"),
+    ('postgresql_server', "postgres"),
+    ('redis_urls', "redis"),
+    ('varnishstat', "varnish"),
+    ('WMI', "WMI"),
+]
+
+NAGIOS_OLD_CONF_KEYS = [
+    'nagios_log',
+    'nagios_perf_cfg'
+]
+
+LEGACY_DATADOG_URLS = [
+    "app.datadoghq.com",
+    "app.datad0g.com",
+]
+
+JMX_SD_CONF_TEMPLATE = '.jmx.{}.yaml'
+
+# These are unlikely to change, but manifests are versioned,
+# so keeping these as a list just in case we change add stuff.
+MANIFEST_VALIDATION = {
+    'max': ['max_agent_version'],
+    'min': ['min_agent_version']
+}
+
+
+class PathNotFound(Exception):
+    pass
+
+
+def get_version():
+    return AGENT_VERSION
+
+
+def skip_leading_wsp(f):
+    "Works on a file, returns a file-like object"
+    return StringIO("\n".join(map(string.strip, f.readlines())))
+
+
+def _windows_commondata_path():
+    """Return the common appdata path, using ctypes
+    From http://stackoverflow.com/questions/626796/\
+    how-do-i-find-the-windows-common-application-data-folder-using-python
+    """
+    import ctypes
+    from ctypes import wintypes, windll
+
+    CSIDL_COMMON_APPDATA = 35
+
+    _SHGetFolderPath = windll.shell32.SHGetFolderPathW
+    _SHGetFolderPath.argtypes = [wintypes.HWND,
+                                 ctypes.c_int,
+                                 wintypes.HANDLE,
+                                 wintypes.DWORD, wintypes.LPCWSTR]
+
+    path_buf = wintypes.create_unicode_buffer(wintypes.MAX_PATH)
+    _SHGetFolderPath(0, CSIDL_COMMON_APPDATA, 0, 0, path_buf)
+    return path_buf.value
+
+
+def _windows_extra_checksd_path():
+    common_data = _windows_commondata_path()
+    return os.path.join(common_data, 'Datadog', 'checks.d')
+
+
+def _windows_checksd_path():
+    if hasattr(sys, 'frozen'):
+        # we're frozen - from py2exe
+        prog_path = os.path.dirname(sys.executable)
+        return _checksd_path(os.path.normpath(os.path.join(prog_path, '..', 'agent')))
+    else:
+        cur_path = os.path.dirname(__file__)
+        return _checksd_path(cur_path)
+
+
+def _config_path(directory):
+    path = os.path.join(directory, DATADOG_CONF)
+    if os.path.exists(path):
+        return path
+    raise PathNotFound(path)
+
+
+def _confd_path(directory):
+    path = os.path.join(directory, 'conf.d')
+    if os.path.exists(path):
+        return path
+    raise PathNotFound(path)
+
+
+def _checksd_path(directory):
+    path_override = os.environ.get('CHECKSD_OVERRIDE')
+    if path_override and os.path.exists(path_override):
+        return path_override
+
+    # this is deprecated in testing on versions after SDK (5.12.0)
+    path = os.path.join(directory, 'checks.d')
+    if os.path.exists(path):
+        return path
+    raise PathNotFound(path)
+
+
+def _is_affirmative(s):
+    if s is None:
+        return False
+    # int or real bool
+    if isinstance(s, int):
+        return bool(s)
+    # try string cast
+    return s.lower() in ('yes', 'true', '1')
+
+
+def get_config_path(cfg_path="", os_name=None):
+    return os.path.join(cfg_path, "datadog.conf")
+
+
+def get_default_bind_host():
+    try:
+        gethostbyname('localhost')
+    except gaierror:
+        log.warning("localhost seems undefined in your hosts file, using 127.0.0.1 instead")
+        return '127.0.0.1'
+    return 'localhost'
+
+
+def get_histogram_aggregates(configstr=None):
+    if configstr is None:
+        return None
+
+    try:
+        vals = configstr.split(',')
+        valid_values = ['min', 'max', 'median', 'avg', 'sum', 'count']
+        result = []
+
+        for val in vals:
+            val = val.strip()
+            if val not in valid_values:
+                log.warning("Ignored histogram aggregate {0}, invalid".format(val))
+                continue
+            else:
+                result.append(val)
+    except Exception:
+        log.exception("Error when parsing histogram aggregates, skipping")
+        return None
+
+    return result
+
+
+def get_histogram_percentiles(configstr=None):
+    if configstr is None:
+        return None
+
+    result = []
+    try:
+        vals = configstr.split(',')
+        for val in vals:
+            try:
+                val = val.strip()
+                floatval = float(val)
+                if floatval <= 0 or floatval >= 1:
+                    raise ValueError
+                if len(val) > 4:
+                    log.warning("Histogram percentiles are rounded to 2 digits: {0} rounded"
+                                .format(floatval))
+                result.append(float(val[0:4]))
+            except ValueError:
+                log.warning("Bad histogram percentile value {0}, must be float in ]0;1[, skipping"
+                            .format(val))
+    except Exception:
+        log.exception("Error when parsing histogram percentiles, skipping")
+        return None
+
+    return result
+
+
+def clean_dd_url(url):
+    url = url.strip()
+    if not url.startswith('http'):
+        url = 'https://' + url
+    return url[:-1] if url.endswith('/') else url
+
+
+def remove_empty(string_array):
+    return filter(lambda x: x, string_array)
+
+
+def get_config(cfg_path=None, options=None, can_query_registry=True):
+    # General config
+    agentConfig = {
+        'check_freq': DEFAULT_CHECK_FREQUENCY,
+        'collect_orchestrator_tags': True,
+        'dogstatsd_port': 8125,
+        'dogstatsd_target': 'http://localhost:17123',
+        'graphite_listen_port': None,
+        'hostname': None,
+        'listen_port': None,
+        'tags': None,
+        'version': get_version(),
+        'watchdog': True,
+        'additional_checksd': '/etc/dd-agent/checks.d/',
+        'bind_host': get_default_bind_host(),
+        'statsd_metric_namespace': None,
+        'utf8_decoding': False
+    }
+
+    if "darwin" in sys.platform:
+        agentConfig['additional_checksd'] = '/opt/datadog-agent/etc/checks.d'
+    elif "win32" in sys.platform:
+        agentConfig['additional_checksd'] = _windows_extra_checksd_path()
+
+    # Config handling
+    try:
+        # Find the right config file
+        path = os.path.realpath(__file__)
+        path = os.path.dirname(path)
+
+        config_path = get_config_path(path)
+        config = ConfigParser.ConfigParser()
+        config.readfp(skip_leading_wsp(open(config_path)))
+
+        # bulk import
+        for option in config.options('Main'):
+            agentConfig[option] = config.get('Main', option)
+
+        # Store developer mode setting in the agentConfig
+        if config.has_option('Main', 'developer_mode'):
+            agentConfig['developer_mode'] = _is_affirmative(config.get('Main', 'developer_mode'))
+
+        # Allow an override with the --profile option
+        if options is not None and options.profile:
+            agentConfig['developer_mode'] = True
+
+        # Core config
+        #ap
+        if not config.has_option('Main', 'api_key'):
+            log.warning(u"No API key was found. Aborting.")
+            sys.exit(2)
+
+        if not config.has_option('Main', 'dd_url'):
+            log.warning(u"No dd_url was found. Aborting.")
+            sys.exit(2)
+
+        # Endpoints
+        dd_urls = map(clean_dd_url, config.get('Main', 'dd_url').split(','))
+        api_keys = map(lambda el: el.strip(), config.get('Main', 'api_key').split(','))
+
+        # For collector and dogstatsd
+        agentConfig['dd_url'] = dd_urls[0]
+        agentConfig['api_key'] = api_keys[0]
+
+        # Forwarder endpoints logic
+        # endpoints is:
+        # {
+        #    'https://app.datadoghq.com': ['api_key_abc', 'api_key_def'],
+        #    'https://app.example.com': ['api_key_xyz']
+        # }
+        endpoints = {}
+        dd_urls = remove_empty(dd_urls)
+        api_keys = remove_empty(api_keys)
+        if len(dd_urls) == 1:
+            if len(api_keys) > 0:
+                endpoints[dd_urls[0]] = api_keys
+        else:
+            assert len(dd_urls) == len(api_keys), 'Please provide one api_key for each url'
+            for i, dd_url in enumerate(dd_urls):
+                endpoints[dd_url] = endpoints.get(dd_url, []) + [api_keys[i]]
+
+        agentConfig['endpoints'] = endpoints
+
+        # Forwarder or not forwarder
+        agentConfig['use_forwarder'] = options is not None and options.use_forwarder
+        if agentConfig['use_forwarder']:
+            listen_port = 17123
+            if config.has_option('Main', 'listen_port'):
+                listen_port = int(config.get('Main', 'listen_port'))
+            agentConfig['dd_url'] = "http://{}:{}".format(agentConfig['bind_host'], listen_port)
+        # FIXME: Legacy dd_url command line switch
+        elif options is not None and options.dd_url is not None:
+            agentConfig['dd_url'] = options.dd_url
+
+        # Forwarder timeout
+        agentConfig['forwarder_timeout'] = 20
+        if config.has_option('Main', 'forwarder_timeout'):
+            agentConfig['forwarder_timeout'] = int(config.get('Main', 'forwarder_timeout'))
+
+
+        # Extra checks.d path
+        # the linux directory is set by default
+        if config.has_option('Main', 'additional_checksd'):
+            agentConfig['additional_checksd'] = config.get('Main', 'additional_checksd')
+
+        if config.has_option('Main', 'use_dogstatsd'):
+            agentConfig['use_dogstatsd'] = config.get('Main', 'use_dogstatsd').lower() in ("yes", "true")
+        else:
+            agentConfig['use_dogstatsd'] = True
+
+        # Service discovery
+        if config.has_option('Main', 'service_discovery_backend'):
+            try:
+                additional_config = extract_agent_config(config)
+                agentConfig.update(additional_config)
+            except:
+                log.error('Failed to load the agent configuration related to '
+                          'service discovery. It will not be used.')
+
+        # Concerns only Windows
+        if config.has_option('Main', 'use_web_info_page'):
+            agentConfig['use_web_info_page'] = config.get('Main', 'use_web_info_page').lower() in ("yes", "true")
+        else:
+            agentConfig['use_web_info_page'] = True
+
+        # local traffic only? Default to no
+        agentConfig['non_local_traffic'] = False
+        if config.has_option('Main', 'non_local_traffic'):
+            agentConfig['non_local_traffic'] = config.get('Main', 'non_local_traffic').lower() in ("yes", "true")
+
+        # DEPRECATED
+        if config.has_option('Main', 'use_ec2_instance_id'):
+            use_ec2_instance_id = config.get('Main', 'use_ec2_instance_id')
+            # translate yes into True, the rest into False
+            agentConfig['use_ec2_instance_id'] = (use_ec2_instance_id.lower() == 'yes')
+
+        if config.has_option('Main', 'check_freq'):
+            try:
+                agentConfig['check_freq'] = int(config.get('Main', 'check_freq'))
+            except Exception:
+                pass
+
+        # Custom histogram aggregate/percentile metrics
+        if config.has_option('Main', 'histogram_aggregates'):
+            agentConfig['histogram_aggregates'] = get_histogram_aggregates(config.get('Main', 'histogram_aggregates'))
+
+        if config.has_option('Main', 'histogram_percentiles'):
+            agentConfig['histogram_percentiles'] = get_histogram_percentiles(config.get('Main', 'histogram_percentiles'))
+
+        # Disable Watchdog (optionally)
+        if config.has_option('Main', 'watchdog'):
+            if config.get('Main', 'watchdog').lower() in ('no', 'false'):
+                agentConfig['watchdog'] = False
+
+        # Optional graphite listener
+        if config.has_option('Main', 'graphite_listen_port'):
+            agentConfig['graphite_listen_port'] = \
+                int(config.get('Main', 'graphite_listen_port'))
+        else:
+            agentConfig['graphite_listen_port'] = None
+
+        # Dogstatsd config
+        dogstatsd_defaults = {
+            'dogstatsd_port': 8125,
+            'dogstatsd_target': 'http://' + agentConfig['bind_host'] + ':17123',
+        }
+        for key, value in dogstatsd_defaults.iteritems():
+            if config.has_option('Main', key):
+                agentConfig[key] = config.get('Main', key)
+            else:
+                agentConfig[key] = value
+
+        # Create app:xxx tags based on monitored apps
+        agentConfig['create_dd_check_tags'] = config.has_option('Main', 'create_dd_check_tags') and \
+            _is_affirmative(config.get('Main', 'create_dd_check_tags'))
+
+        # Forwarding to external statsd server
+        if config.has_option('Main', 'statsd_forward_host'):
+            agentConfig['statsd_forward_host'] = config.get('Main', 'statsd_forward_host')
+            if config.has_option('Main', 'statsd_forward_port'):
+                agentConfig['statsd_forward_port'] = int(config.get('Main', 'statsd_forward_port'))
+
+        # Optional config
+        # FIXME not the prettiest code ever...
+        if config.has_option('Main', 'use_mount'):
+            agentConfig['use_mount'] = _is_affirmative(config.get('Main', 'use_mount'))
+
+        if options is not None and options.autorestart:
+            agentConfig['autorestart'] = True
+        elif config.has_option('Main', 'autorestart'):
+            agentConfig['autorestart'] = _is_affirmative(config.get('Main', 'autorestart'))
+
+        if config.has_option('Main', 'check_timings'):
+            agentConfig['check_timings'] = _is_affirmative(config.get('Main', 'check_timings'))
+
+        if config.has_option('Main', 'exclude_process_args'):
+            agentConfig['exclude_process_args'] = _is_affirmative(config.get('Main', 'exclude_process_args'))
+
+        try:
+            filter_device_re = config.get('Main', 'device_blacklist_re')
+            agentConfig['device_blacklist_re'] = re.compile(filter_device_re)
+        except ConfigParser.NoOptionError:
+            pass
+
+        # Dogstream config
+        if config.has_option("Main", "dogstream_log"):
+            # Older version, single log support
+            log_path = config.get("Main", "dogstream_log")
+            if config.has_option("Main", "dogstream_line_parser"):
+                agentConfig["dogstreams"] = ':'.join([log_path, config.get("Main", "dogstream_line_parser")])
+            else:
+                agentConfig["dogstreams"] = log_path
+
+        elif config.has_option("Main", "dogstreams"):
+            agentConfig["dogstreams"] = config.get("Main", "dogstreams")
+
+        if config.has_option("Main", "nagios_perf_cfg"):
+            agentConfig["nagios_perf_cfg"] = config.get("Main", "nagios_perf_cfg")
+
+        if config.has_option("Main", "use_curl_http_client"):
+            agentConfig["use_curl_http_client"] = _is_affirmative(config.get("Main", "use_curl_http_client"))
+        else:
+            # Default to False as there are some issues with the curl client and ELB
+            agentConfig["use_curl_http_client"] = False
+
+        if config.has_section('WMI'):
+            agentConfig['WMI'] = {}
+            for key, value in config.items('WMI'):
+                agentConfig['WMI'][key] = value
+
+        if config.has_option("Main", "skip_ssl_validation"):
+            agentConfig["skip_ssl_validation"] = _is_affirmative(config.get("Main", "skip_ssl_validation"))
+
+        agentConfig["collect_instance_metadata"] = True
+        if config.has_option("Main", "collect_instance_metadata"):
+            agentConfig["collect_instance_metadata"] = _is_affirmative(config.get("Main", "collect_instance_metadata"))
+
+        agentConfig["proxy_forbid_method_switch"] = False
+        if config.has_option("Main", "proxy_forbid_method_switch"):
+            agentConfig["proxy_forbid_method_switch"] = _is_affirmative(config.get("Main", "proxy_forbid_method_switch"))
+
+        agentConfig["collect_ec2_tags"] = False
+        if config.has_option("Main", "collect_ec2_tags"):
+            agentConfig["collect_ec2_tags"] = _is_affirmative(config.get("Main", "collect_ec2_tags"))
+
+        agentConfig["collect_orchestrator_tags"] = True
+        if config.has_option("Main", "collect_orchestrator_tags"):
+            agentConfig["collect_orchestrator_tags"] = _is_affirmative(config.get("Main", "collect_orchestrator_tags"))
+
+        agentConfig["utf8_decoding"] = False
+        if config.has_option("Main", "utf8_decoding"):
+            agentConfig["utf8_decoding"] = _is_affirmative(config.get("Main", "utf8_decoding"))
+
+        agentConfig["gce_updated_hostname"] = False
+        if config.has_option("Main", "gce_updated_hostname"):
+            agentConfig["gce_updated_hostname"] = _is_affirmative(config.get("Main", "gce_updated_hostname"))
+
+    except ConfigParser.NoSectionError as e:
+        sys.stderr.write('Config file not found or incorrectly formatted.\n')
+        sys.exit(2)
+
+    except ConfigParser.ParsingError as e:
+        sys.stderr.write('Config file not found or incorrectly formatted.\n')
+        sys.exit(2)
+
+    except ConfigParser.NoOptionError as e:
+        sys.stderr.write('There are some items missing from your config file, but nothing fatal [%s]' % e)
+
+    # Storing proxy settings in the agentConfig
+    agentConfig['proxy_settings'] = get_proxy(agentConfig)
+    if agentConfig.get('ca_certs', None) is None:
+        agentConfig['ssl_certificate'] = 'datadog-cert.pem'
+    else:
+        agentConfig['ssl_certificate'] = agentConfig['ca_certs']
+
+    return agentConfig
+
+
+def extract_agent_config(config):
+    # get merged into the real agentConfig
+    agentConfig = {}
+
+    backend = config.get('Main', 'service_discovery_backend')
+    agentConfig['service_discovery'] = True
+
+    conf_backend = None
+    if config.has_option('Main', 'sd_config_backend'):
+        conf_backend = config.get('Main', 'sd_config_backend')
+
+    if backend not in SD_BACKENDS:
+        log.error("The backend {0} is not supported. "
+                  "Service discovery won't be enabled.".format(backend))
+        agentConfig['service_discovery'] = False
+
+    if conf_backend is None:
+        log.warning('No configuration backend provided for service discovery. '
+                    'Only auto config templates will be used.')
+    elif conf_backend not in SD_CONFIG_BACKENDS:
+        log.error("The config backend {0} is not supported. "
+                  "Only auto config templates will be used.".format(conf_backend))
+        conf_backend = None
+    agentConfig['sd_config_backend'] = conf_backend
+
+    additional_config = extract_sd_config(config)
+    agentConfig.update(additional_config)
+    return agentConfig
+
+
+def extract_sd_config(config):
+    """Extract configuration about service discovery for the agent"""
+    sd_config = {}
+    if config.has_option('Main', 'sd_config_backend'):
+        sd_config['sd_config_backend'] = config.get('Main', 'sd_config_backend')
+    else:
+        sd_config['sd_config_backend'] = None
+    if config.has_option('Main', 'sd_template_dir'):
+        sd_config['sd_template_dir'] = config.get(
+            'Main', 'sd_template_dir')
+    else:
+        sd_config['sd_template_dir'] = SD_TEMPLATE_DIR
+    if config.has_option('Main', 'sd_backend_host'):
+        sd_config['sd_backend_host'] = config.get(
+            'Main', 'sd_backend_host')
+    if config.has_option('Main', 'sd_backend_port'):
+        sd_config['sd_backend_port'] = config.get(
+            'Main', 'sd_backend_port')
+    if config.has_option('Main', 'sd_jmx_enable'):
+        sd_config['sd_jmx_enable'] = config.get(
+            'Main', 'sd_jmx_enable')
+    return sd_config
+
+
+def get_proxy(agentConfig):
+    proxy_settings = {}
+
+    # First we read the proxy configuration from datadog.conf
+    proxy_host = agentConfig.get('proxy_host')
+    if proxy_host is not None:
+        proxy_settings['host'] = proxy_host
+        try:
+            proxy_settings['port'] = int(agentConfig.get('proxy_port', 3128))
+        except ValueError:
+            log.error('Proxy port must be an Integer. Defaulting it to 3128')
+            proxy_settings['port'] = 3128
+
+        proxy_settings['user'] = agentConfig.get('proxy_user')
+        proxy_settings['password'] = agentConfig.get('proxy_password')
+        log.debug("Proxy Settings: %s:*****@%s:%s", proxy_settings['user'],
+                  proxy_settings['host'], proxy_settings['port'])
+        return proxy_settings
+
+    # If no proxy configuration was specified in datadog.conf
+    # We try to read it from the system settings
+    try:
+        proxy = getproxies().get('https')
+        if proxy is not None:
+            parse = urlparse(proxy)
+            proxy_settings['host'] = parse.hostname
+            proxy_settings['port'] = int(parse.port)
+            proxy_settings['user'] = parse.username
+            proxy_settings['password'] = parse.password
+
+            log.debug("Proxy Settings: %s:*****@%s:%s", proxy_settings['user'],
+                      proxy_settings['host'], proxy_settings['port'])
+            return proxy_settings
+
+    except Exception as e:
+        log.debug("Error while trying to fetch proxy settings using urllib %s."
+                  "Proxy is probably not set", str(e))
+
+    return None
+
+
+def main():
+    return get_config()
+
+
+if __name__ == "__main__":
+    print(main())

--- a/pkg/legacy/tests/datadog.conf
+++ b/pkg/legacy/tests/datadog.conf
@@ -1,0 +1,298 @@
+[Main]
+
+# The host of the Datadog intake server to send Agent data to
+dd_url: https://app.datadoghq.com
+
+# If you need a proxy to connect to the Internet, provide the settings here (default: disabled)
+proxy_host: my-proxy.com
+proxy_port: 3128
+proxy_user: user
+proxy_password: password
+# To be used with some proxys that return a 302 which make curl switch from POST to GET
+# See http://stackoverflow.com/questions/8156073/curl-violate-rfc-2616-10-3-2-and-switch-from-post-to-get
+proxy_forbid_method_switch: False
+
+# If you run the agent behind haproxy, you might want to enable this
+skip_ssl_validation: False
+
+# The Datadog api key to associate your Agent's data with your organization.
+# Can be found here:
+# https://app.datadoghq.com/account/settings
+# (default: None, the agent doesn't start without it)
+api_key:
+
+# Force the hostname to whatever you want. (default: auto-detected)
+hostname: mymachine.mydomain
+
+# Enable the trace agent.
+apm_enabled: false
+
+# Set the host's tags (optional)
+tags: mytag, env:prod, role:database
+
+# Collect docker orchestrator name and version as agent tags
+collect_orchestrator_tags: True
+
+# Set timeout in seconds for outgoing requests to Datadog. (default: 20)
+# When a request timeout, it will be retried after some time.
+# It will only be deleted if the forwarder queue becomes too big. (30 MB by default)
+forwarder_timeout: 20
+
+# Set timeout in seconds for integrations that use HTTP to fetch metrics, since
+# unbounded timeouts can potentially block the collector indefinitely and cause
+# problems!
+default_integration_http_timeout: 9
+
+# Add one "dd_check:checkname" tag per running check. It makes it possible to slice
+# and dice per monitored app (= running Agent Check) on Datadog's backend.
+create_dd_check_tags: False
+
+# Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
+collect_ec2_tags: False
+# Incorporate security-groups into tags collected from AWS EC2
+# collect_security_groups: False
+
+# Enable Agent Developer Mode
+# Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance
+# developer_mode: False
+# In developer mode, the number of runs to be included in a single collector profile
+# collector_profile_interval: 20
+# In developer mode, disable profiling altogether, but still collect fine-grained agent metrics
+# allow_profiling: False
+
+# use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
+# when not specified, default: False
+gce_updated_hostname: True
+
+# Set the threshold for accepting points to allow anything
+# within recent_point_threshold seconds (default: 30)
+# recent_point_threshold: 30
+
+# Use mount points instead of volumes to track disk and fs metrics
+# DEPRECATED: use conf.d/disk.yaml instead to configure it
+# use_mount: False
+
+# Forwarder listening port
+listen_port: 17123
+
+# Graphite listener port
+# graphite_listen_port: 17124
+
+# Additional directory to look for Datadog checks (optional)
+additional_checksd: /etc/dd-agent/checks.d/
+
+# Allow non-local traffic to this Agent
+# This is required when using this Agent as a proxy for other Agents
+# that might not have an internet connection
+# For more information, please see
+# https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
+non_local_traffic: False
+
+# Select the Tornado HTTP Client to be used in the Forwarder,
+# between curl client and simple http client (default: simple http client)
+use_curl_http_client: False
+
+# The loopback address the Forwarder and Dogstatsd will bind.
+# Optional, it is mainly used when running the agent on Openshift
+bind_host: localhost
+
+# If enabled the collector will capture a metric for check run times.
+# check_timings: False
+
+# If you want to remove the 'ww' flag from ps catching the arguments of processes
+# for instance for security reasons
+exclude_process_args: False
+
+histogram_aggregates: max, median, avg, count
+histogram_percentiles: 0.95
+
+# ========================================================================== #
+# Service Discovery                                                          #
+# See http://docs.datadoghq.com/guides/servicediscovery/ for details #
+# ========================================================================== #
+#
+# Service discovery allows the agent to look for running services
+# and load a configuration object for the one it recognizes.
+# This feature is disabled by default.
+# Uncomment this line to enable it (works for docker containers only for now).
+service_discovery_backend: docker
+#
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+# sd_config_backend: etcd
+#
+# Settings for connecting to the service discovery backend.
+# sd_backend_host: 127.0.0.1
+# sd_backend_port: 4001
+#
+# If you use etcd, you can set a username and password for auth
+#
+# sd_backend_username:
+# sd_backend_password:
+#
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
+# and modify its value.
+# sd_template_dir: /datadog/check_configs
+#
+# If you Consul store requires token authentication for service discovery, you can define that token here.
+# consul_token:
+#
+# Enable JMX checks for service discovery
+# sd_jmx_enable: False
+#
+# ========================================================================== #
+# Other                                                                      #
+# ========================================================================== #
+#
+# In some environments we may have the procfs file system mounted in a
+# miscellaneous location. The procfs_path configuration paramenter allows
+# us to override the standard default location '/proc'
+# procfs_path: /proc
+
+# ========================================================================== #
+# DogStatsd configuration                                                    #
+# DogStatsd is a small server that aggregates your custom app metrics. For   #
+# usage information, check out http://docs.datadoghq.com/guides/dogstatsd/   #
+# ========================================================================== #
+
+# If you don't want to enable the DogStatsd server, set this option to no
+use_dogstatsd: True
+
+#  Make sure your client is sending to the same port.
+dogstatsd_port: 8125
+
+# By default dogstatsd will post aggregate metrics to the Agent (which handles
+# errors/timeouts/retries/etc). To send directly to the datadog api, set this
+# to https://app.datadoghq.com.
+dogstatsd_target: http://localhost:17123
+
+# If you want to forward every packet received by the dogstatsd server
+# to another statsd server, uncomment these lines.
+# WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,
+# as your other statsd server might not be able to handle them.
+# statsd_forward_host: address_of_own_statsd_server
+# statsd_forward_port: 8125
+
+# you may want all statsd metrics coming from this host to be namespaced
+# in some way; if so, configure your namespace here. a metric that looks
+# like `metric.name` will instead become `namespace.metric.name`
+statsd_metric_namespace:
+
+# By default, dogstatsd supports only plain ASCII packets. However, most
+# (dog)statsd client support UTF8 by encoding packets before sending them
+# this option enables UTF8 decoding in case you need it.
+# However, it comes with a performance overhead of ~10% in the dogstatsd
+# server. This will be taken care of properly in the new gen agent core.
+# utf8_decoding: false
+
+# The number of bytes allocated to the statsd socket receive buffer. By default,
+# this value is set to the value of `/proc/sys/net/core/rmem_default`. If you
+# need to increase the size of this buffer but keep the OS default value the
+# same, you can set dogstats's receive buffer size here. The maximum allowed
+# value is the value of `/proc/sys/net/core/rmem_max`.
+# statsd_so_rcvbuf:
+
+# ========================================================================== #
+# Service-specific configuration                                             #
+# ========================================================================== #
+
+# -------------------------------------------------------------------------- #
+#   Ganglia                                                                  #
+# -------------------------------------------------------------------------- #
+
+# Ganglia host where gmetad is running
+# ganglia_host: localhost
+
+# Ganglia port where gmetad is running
+# ganglia_port: 8651
+
+# -------------------------------------------------------------------------- #
+#  Dogstream (log file parser)												 #
+# -------------------------------------------------------------------------- #
+
+# Comma-separated list of logs to parse and optionally custom parsers to use.
+# The form should look like this:
+#
+#   dogstreams: /path/to/log1:parsers_module:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Or this:
+#
+#   dogstreams: /path/to/log1:/path/to/my/parsers_module.py:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Each entry is a path to a log file and optionally a Python module/function pair
+# separated by colons.
+#
+# Custom parsers should take a 2 parameters, a logger object and
+# a string parameter of the current line to parse. It should return a tuple of
+# the form:
+#   (metric (str), timestamp (unix timestamp), value (float), attributes (dict))
+# where attributes should at least contain the key 'metric_type', specifying
+# whether the given metric is a 'counter' or 'gauge'.
+#
+# Unless parsers are specified with an absolute path, the modules must exist in
+# the Agent's PYTHONPATH. You can set this as an environment variable when
+# starting the Agent. If the name of the custom parser function is not passed,
+# 'parser' is assumed.
+#
+# If this value isn't specified, the default parser assumes this log format:
+#     metric timestamp value key0=val0 key1=val1 ...
+#
+
+# ========================================================================== #
+# Custom Emitters                                                            #
+# ========================================================================== #
+
+# Comma-separated list of emitters to be used in addition to the standard one
+#
+# Expected to be passed as a comma-separated list of colon-delimited
+# name/object pairs.
+#
+# custom_emitters: /usr/local/my-code/emitters/rabbitmq.py:RabbitMQEmitter
+#
+# If the name of the emitter function is not specified, 'emitter' is assumed.
+
+
+# ========================================================================== #
+# Logging
+# ========================================================================== #
+
+log_level: INFO
+
+collector_log_file: /var/log/datadog/collector.log
+# forwarder_log_file: /var/log/datadog/forwarder.log
+# dogstatsd_log_file: /var/log/datadog/dogstatsd.log
+
+# if syslog is enabled but a host and port are not set, a local domain socket
+# connection will be attempted
+#
+log_to_syslog: True
+syslog_host:
+syslog_port:
+collect_instance_metadata: False
+
+# ========================================================================== #
+# Tracing
+# ========================================================================== #
+
+[trace.sampler]
+# Extra global sample rate to apply on all the traces
+# This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
+# From 1 (no extra rate) to 0 (don't sample at all)
+# extra_sample_rate=1
+
+# Maximum number of traces per second to sample.
+# The limit is applied over an average over a few minutes ; much bigger spikes are possible.
+# Set to 0 to disable the limit.
+# max_traces_per_second=10
+
+[trace.receiver]
+# the port that the Receiver should listen on
+# receiver_port=8126
+# how many unique client connections to allow during one 30 second lease period
+# connection_limit=2000
+
+[trace.ignore]
+# a blacklist of regular expressions can be provided to disable certain traces based on their resource name
+# all entries must be surrounded by double quotes and separated by comas
+# resource="GET|POST /healthcheck","GET /V1"


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds the code needed to read the contents of `datadog.conf` into a `map[string]string`.

### Motivation

First step towards converting the old `datadog.conf` into the new format in `datadog.yaml`

### Additional Notes

Tests use the same Python code used in Agent5 to read the ini file. Comparison is not optimal since for the sake of simplicity everything is casted to string, even booleans, thus the minor adjustments I made to the contents of the fixture in `legacy/tests/datadog.conf`
