### PR TITLE
[py] Fix precedence of py paths

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -8,7 +8,10 @@
 package common
 
 import (
+	"path/filepath"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
@@ -34,3 +37,14 @@ var (
 	// utility variables
 	_here, _ = osext.ExecutableFolder()
 )
+
+// GetPythonPaths returns the paths (in order of precedence) from where the agent
+// should load python modules and checks
+func GetPythonPaths() []string {
+	return []string{
+		GetDistPath(),                                  // some common modules are shipped in the dist path directly
+		filepath.Join(GetDistPath(), "checks"),         // other common modules (e.g. `AgentCheck` class)
+		config.Datadog.GetString("additional_checksd"), // custom checks, have precedence over integrations-core checks
+		PyChecksPath,                                   // integrations-core checks
+	}
+}

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -23,10 +23,7 @@ import (
 func SetupAutoConfig(confdPath string) {
 	// create the Collector instance and start all the components
 	// NOTICE: this will also setup the Python environment
-	coll := collector.NewCollector(GetDistPath(),
-		PyChecksPath,
-		filepath.Join(GetDistPath(), "checks"),
-		config.Datadog.GetString("additional_checksd"))
+	coll := collector.NewCollector(GetPythonPaths()...)
 
 	// create the Autoconfig instance
 	AC = autodiscovery.NewAutoConfig(coll)


### PR DESCRIPTION
Fixes the precedence of py paths (regression from #406).

We should load checks first from the custom check directory, and
then from the integrations-core path.

This also extracts out the list of paths to make its ordering
more explicit.
