### PR TITLE
Import datadog.conf and merge into agent config object

### DIFF
--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
 	log "github.com/cihub/seelog"
@@ -73,6 +74,11 @@ func (c *APMCheck) Run() error {
 
 // Configure the APMCheck
 func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	// handle the case when apm agent is disabled via the old `datadog.conf` file
+	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
+		return fmt.Errorf("APM agent disabled through main configuration file")
+	}
+
 	var checkConf apmCheckConf
 	if err := yaml.Unmarshal(data, &checkConf); err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,7 +99,8 @@ func init() {
 	// Cloud Foundry
 	Datadog.SetDefault("cloud_foundry", false)
 	Datadog.SetDefault("bosh_id", "")
-
+	// APM
+	Datadog.SetDefault("apm_enabled", true) // this is to support the transition to the new config file
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -113,8 +113,10 @@ func buildProxySettings(agentConfig Config) (string, error) {
 		return "", nil
 	}
 
-	u, err := url.Parse(agentConfig["proxy_host"])
-	if err != nil {
+	var err error
+	var u *url.URL
+
+	if u, err = url.Parse(agentConfig["proxy_host"]); err != nil {
 		return "", fmt.Errorf("unable to import value of settings 'proxy_host': %v", err)
 	}
 
@@ -122,10 +124,8 @@ func buildProxySettings(agentConfig Config) (string, error) {
 		u.Host = u.Host + ":" + agentConfig["proxy_port"]
 	}
 
-	user := agentConfig["proxy_user"]
-	pass := agentConfig["proxy_password"]
-	if user != "" {
-		if pass != "" {
+	if user := agentConfig["proxy_user"]; user != "" {
+		if pass := agentConfig["proxy_password"]; pass != "" {
 			u.User = url.UserPassword(user, pass)
 		} else {
 			u.User = url.User(user)

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package legacy
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// FromAgentConfig reads the old agentConfig configuration, converts and merges
+// the values into the current config.Datadog object
+func FromAgentConfig(agentConfig Config) error {
+	config.Datadog.Set("dd_url", agentConfig["dd_url"])
+
+	proxy, err := buildProxySettings(agentConfig)
+	if err == nil {
+		config.Datadog.Set("proxy", proxy)
+	}
+
+	enabled, err := isAffirmative(agentConfig["skip_ssl_validation"])
+	if err == nil {
+		config.Datadog.Set("skip_ssl_validation", enabled)
+	}
+
+	config.Datadog.Set("api_key", agentConfig["api_key"])
+	config.Datadog.Set("hostname", agentConfig["hostname"])
+
+	enabled, err = isAffirmative(agentConfig["apm_enabled"])
+	if err == nil && !enabled {
+		// apm is enabled by default through the check config file
+		// TODO: disable APM check
+	}
+
+	config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))
+
+	value, err := strconv.Atoi(agentConfig["forwarder_timeout"])
+	if err == nil {
+		config.Datadog.Set("forwarder_timeout", value)
+	}
+
+	// TODO: default_integration_http_timeout
+	// TODO: collect_ec2_tags
+
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["additional_checksd"] != "" {
+		config.Datadog.Set("additional_checksd", agentConfig["additional_checksd"])
+	}
+
+	// TODO: exclude_process_args
+	// TODO: histogram_aggregates
+	// TODO: histogram_percentiles
+
+	if agentConfig["service_discovery_backend"] == "docker" {
+		// this means SD is enabled on the old config
+		// TODO: enable Autodiscovery
+	}
+
+	enabled, err = isAffirmative(agentConfig["use_dogstatsd"])
+	if err == nil {
+		config.Datadog.Set("use_dogstatsd", enabled)
+	}
+
+	value, err = strconv.Atoi(agentConfig["dogstatsd_port"])
+	if err == nil {
+		config.Datadog.Set("dogstatsd_port", value)
+	}
+
+	// TODO: statsd_metric_namespace
+
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["log_level"] != "" {
+		config.Datadog.Set("log_level", agentConfig["log_level"])
+	}
+
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["collector_log_file"] != "" {
+		config.Datadog.Set("log_file", agentConfig["collector_log_file"])
+	}
+
+	enabled, err = isAffirmative(agentConfig["log_to_syslog"])
+	if err == nil {
+		config.Datadog.Set("log_to_syslog", enabled)
+	}
+	config.Datadog.Set("syslog_uri", buildSyslogURI(agentConfig))
+
+	enabled, err = isAffirmative(agentConfig["collect_instance_metadata"])
+	if err == nil {
+		config.Datadog.Set("enable_metadata_collection", enabled)
+	}
+
+	return nil
+}
+
+func isAffirmative(value string) (bool, error) {
+	if value == "" {
+		return false, fmt.Errorf("value is empty")
+	}
+
+	v := strings.ToLower(value)
+	return v == "true" || v == "yes" || v == "1", nil
+}
+
+func buildProxySettings(agentConfig Config) (string, error) {
+	if agentConfig["proxy_host"] == "" {
+		// this is expected, not an error
+		return "", nil
+	}
+
+	u, err := url.Parse(agentConfig["proxy_host"])
+	if err != nil {
+		return "", fmt.Errorf("unable to import value of settings 'proxy_host': %v", err)
+	}
+
+	if agentConfig["proxy_port"] != "" {
+		u.Host = u.Host + ":" + agentConfig["proxy_port"]
+	}
+
+	user := agentConfig["proxy_user"]
+	pass := agentConfig["proxy_password"]
+	if user != "" {
+		if pass != "" {
+			u.User = url.UserPassword(user, pass)
+		} else {
+			u.User = url.User(user)
+		}
+	}
+
+	return u.String(), nil
+}
+
+func buildSyslogURI(agentConfig Config) string {
+	host := agentConfig["syslog_host"]
+
+	if host == "" {
+		// this is expected, not an error
+		return ""
+	}
+
+	if agentConfig["syslog_port"] != "" {
+		host = host + ":" + agentConfig["syslog_port"]
+	}
+
+	return host
+}

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -34,8 +34,8 @@ func FromAgentConfig(agentConfig Config) error {
 
 	enabled, err = isAffirmative(agentConfig["apm_enabled"])
 	if err == nil && !enabled {
-		// apm is enabled by default through the check config file
-		// TODO: disable APM check
+		// apm is enabled by default through the check config file `apm.yaml.default`
+		config.Datadog.Set("apm_enabled", false)
 	}
 
 	config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))

--- a/pkg/legacy/converter_test.go
+++ b/pkg/legacy/converter_test.go
@@ -1,0 +1,82 @@
+package legacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAffirmative(t *testing.T) {
+	value, err := isAffirmative("yes")
+	assert.Nil(t, err)
+	assert.True(t, value)
+
+	value, err = isAffirmative("True")
+	assert.Nil(t, err)
+	assert.True(t, value)
+
+	value, err = isAffirmative("1")
+	assert.Nil(t, err)
+	assert.True(t, value)
+
+	value, err = isAffirmative("")
+	assert.NotNil(t, err)
+
+	value, err = isAffirmative("ok")
+	assert.Nil(t, err)
+	assert.False(t, value)
+}
+
+func TestBuildProxySettings(t *testing.T) {
+	agentConfig := make(Config)
+
+	value, err := buildProxySettings(agentConfig)
+	assert.Nil(t, err)
+	assert.Empty(t, value)
+
+	// malformed url
+	agentConfig["proxy_host"] = "http://notanurl{}"
+	_, err = buildProxySettings(agentConfig)
+	assert.NotNil(t, err)
+
+	agentConfig["proxy_host"] = "http://foobar.baz"
+
+	value, err = buildProxySettings(agentConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://foobar.baz", value)
+
+	agentConfig["proxy_port"] = "8080"
+
+	value, err = buildProxySettings(agentConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://foobar.baz:8080", value)
+
+	// the password alone should not be considered without an user
+	agentConfig["proxy_password"] = "mypass"
+	value, err = buildProxySettings(agentConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://foobar.baz:8080", value)
+
+	// the user alone is ok
+	agentConfig["proxy_password"] = ""
+	agentConfig["proxy_user"] = "myuser"
+	value, err = buildProxySettings(agentConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://myuser@foobar.baz:8080", value)
+
+	agentConfig["proxy_password"] = "mypass"
+	agentConfig["proxy_user"] = "myuser"
+	value, err = buildProxySettings(agentConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://myuser:mypass@foobar.baz:8080", value)
+}
+
+func TestBuildSyslogURI(t *testing.T) {
+	agentConfig := make(Config)
+
+	assert.Empty(t, buildSyslogURI(agentConfig))
+
+	agentConfig["syslog_host"] = "127.0.0.1"
+	agentConfig["syslog_port"] = "1234"
+	assert.Equal(t, "127.0.0.1:1234", buildSyslogURI(agentConfig))
+}

--- a/pkg/legacy/converter_test.go
+++ b/pkg/legacy/converter_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
 package legacy
 
 import (

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -48,29 +48,32 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 		"service_discovery_backend",
 		"use_dogstatsd",
 		"dogstatsd_port",
-		"dogstatsd_target",
 		"statsd_metric_namespace",
 		"log_level",
 		"collector_log_file",
 		"log_to_syslog",
-		"log_to_event_viewer",
+		"log_to_event_viewer", // maybe deprecated, ignore for now
 		"syslog_host",
 		"syslog_port",
 		"collect_instance_metadata",
-		"listen_port",
-		"non_local_traffic",
-		"create_dd_check_tags",
-		"collect_instance_metadata",
-		"proxy_forbid_method_switch",
-		"collect_orchestrator_tags",
-		"gce_updated_hostname",
-		"use_curl_http_client",
-		"bind_host",
+		"listen_port",                // not for 6.0, ignore for now
+		"non_local_traffic",          // not for 6.0, ignore for now
+		"create_dd_check_tags",       // not for 6.0, ignore for now
+		"bind_host",                  // not for 6.0, ignore for now
+		"proxy_forbid_method_switch", // deprecated
+		"collect_orchestrator_tags",  // deprecated
+		"use_curl_http_client",       // deprecated
+		"dogstatsd_target",           // deprecated
+		"gce_updated_hostname",       // deprecated
 	}
 
 	for _, supportedValue := range supportedValues {
 		if value, err := main.GetKey(supportedValue); err == nil {
 			config[supportedValue] = value.String()
+		} else {
+			// provide an empty default value so we don't need to check for
+			// key existence when browsing the old configuration
+			config[supportedValue] = ""
 		}
 	}
 

--- a/pkg/legacy/importer_test.go
+++ b/pkg/legacy/importer_test.go
@@ -6,6 +6,7 @@
 package legacy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
@@ -20,6 +21,10 @@ func TestLoadConfig(t *testing.T) {
 
 	// load configuration with the old Python code
 	configModule := python.PyImport_ImportModule("config")
+	if configModule == nil {
+		_, err, _ := python.PyErr_Fetch()
+		fmt.Println(python.PyString_AsString(err.Str()))
+	}
 	require.NotNil(t, configModule)
 	agentConfigPy := configModule.CallMethod("main")
 	require.NotNil(t, agentConfigPy)

--- a/pkg/legacy/importer_test.go
+++ b/pkg/legacy/importer_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadConfig(t *testing.T) {
+func TestGetAgentConfig(t *testing.T) {
 	py.Initialize("tests")
 	python.PyGILState_Ensure()
 


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Import and convert when needed the values coming from `datadog.conf`

### Motivation

This is the second step needed for the config conversion tool
