### PR TITLE
build dogstatsd with docker by default

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -5,5 +5,5 @@ agent:
   build_exclude: []
 
 dogstatsd:
-  build_include: [zlib]
+  build_include: [zlib, docker]
   build_exclude: []


### PR DESCRIPTION
### What does this PR do?

Add `docker` default build tag to dogstatsd taget. This adds ~600kb to the static binary and we import a very small portion of the client library. 

### Motivation

Required for out-of-the-box origin detection support.
