### PR TITLE
[expvar] make port configurable

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -109,7 +109,7 @@ func StartAgent() {
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
 
 	// Setup expvar server
-        var port = config.Datadog.GetString("expvar_port")
+        var port = config.Datadog.GetString("expvar_server")
         go http.ListenAndServe(port, http.DefaultServeMux)
 
 	if pidfilePath != "" {

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -12,7 +12,7 @@ import (
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
 	"net/http"
-        _ "net/http/pprof" // Blank import used because this isn't directly used in this file
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"os"
 	"os/signal"
@@ -109,8 +109,8 @@ func StartAgent() {
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
 
 	// Setup expvar server
-        var port = config.Datadog.GetString("expvar_server")
-        go http.ListenAndServe(port, http.DefaultServeMux)
+	var port = config.Datadog.GetString("expvar_port")
+	go http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
 
 	if pidfilePath != "" {
 		err := pidfile.WritePID(pidfilePath)

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -10,6 +10,10 @@ import (
 	"syscall"
 	"time"
 
+	_ "expvar" // Blank import used because this isn't directly used in this file
+	"net/http"
+        _ "net/http/pprof" // Blank import used because this isn't directly used in this file
+
 	"os"
 	"os/signal"
 
@@ -103,6 +107,10 @@ func StartAgent() {
 	}
 
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
+
+	// Setup expvar server
+        var port = config.Datadog.GetString("expvar_port")
+        go http.ListenAndServe(port, http.DefaultServeMux)
 
 	if pidfilePath != "" {
 		err := pidfile.WritePID(pidfilePath)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
 )
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -21,4 +21,3 @@ func main() {
 		os.Exit(-1)
 	}
 }
-

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,22 +8,18 @@
 package main
 
 import (
-	_ "expvar"
 	"fmt"
-	"net/http"
-	_ "net/http/pprof"
 	"os"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
 )
 
 func main() {
-	// go_expvar server
-	go http.ListenAndServe("127.0.0.1:5000", http.DefaultServeMux)
-
 	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
 }
+

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -24,7 +24,7 @@ api_key:
 # additional_checksd:
 
 # The port for the go_expvar server
-# expvar_server: 127.0.0.1:5000
+# expvar_port: 5000
 
 # The path to the Unix Socket where the IPC api listens on *nix
 # cmd_sock: /tmp/agent.sock

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -23,8 +23,8 @@ api_key:
 # By default, uses the checks.d folder located in the agent configuration folder.
 # additional_checksd:
 
-# The port for _expvar server
-# expvar_port: 127.0.0.1:5000
+# The port for the go_expvar server
+# expvar_server: 127.0.0.1:5000
 
 # The path to the Unix Socket where the IPC api listens on *nix
 # cmd_sock: /tmp/agent.sock

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -23,6 +23,9 @@ api_key:
 # By default, uses the checks.d folder located in the agent configuration folder.
 # additional_checksd:
 
+# The port for _expvar server
+# expvar_port: 127.0.0.1:5000
+
 # The path to the Unix Socket where the IPC api listens on *nix
 # cmd_sock: /tmp/agent.sock
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,6 +107,9 @@ func init() {
 	Datadog.SetDefault("bosh_id", "")
 	// APM
 	Datadog.SetDefault("apm_enabled", true) // this is to support the transition to the new config file
+	// Go_expvar server port
+        Datadog.SetDefault("expvar_port", "127.0.0.1:5000")
+
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,7 @@ func init() {
 	// APM
 	Datadog.SetDefault("apm_enabled", true) // this is to support the transition to the new config file
 	// Go_expvar server port
-        Datadog.SetDefault("expvar_port", "127.0.0.1:5000")
+        Datadog.SetDefault("expvar_server", "127.0.0.1:5000")
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,7 @@ func init() {
 	// APM
 	Datadog.SetDefault("apm_enabled", true) // this is to support the transition to the new config file
 	// Go_expvar server port
-        Datadog.SetDefault("expvar_server", "127.0.0.1:5000")
+	Datadog.SetDefault("expvar_port", "5000")
 
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Fixes issue #330 by making the expvar server port configurable.

### Motivation

"Currently it's on localhost:5000, but it should be able to be configured to be anything.
5000 is also the default rails port, and a default port for a lot of stuff, so this will definitely overlap with something."

### Additional Notes

Anything else we should know when reviewing?
