### PR TITLE
Enable docker listener and make it configurable

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -64,13 +65,23 @@ func SetupAutoConfig(confdPath string) {
 		log.Errorf("Error while reading 'config_providers' settings: %v", err)
 	}
 
-	// Docker listener
-	// docker, err := listeners.NewDockerListener(newService, delService)
-	// if err != nil {
-	// 	log.Errorf("Failed to create a Docker listener. Is Docker accessible by the agent? %s", err)
-	// } else {
-	// 	AC.AddListener(docker)
-	// }
+	// Autodiscovery listeners
+	// for now, no need to implement a registry of available listeners since we
+	// have only docker
+	var Listeners []config.Listeners
+	if err = config.Datadog.UnmarshalKey("listeners", &Listeners); err == nil {
+		for _, l := range Listeners {
+			if l.Name == "docker" {
+				docker, err := listeners.NewDockerListener()
+				if err != nil {
+					log.Errorf("Failed to create a Docker listener. Is Docker accessible by the agent? %s", err)
+				} else {
+					AC.AddListener(docker)
+				}
+				break
+			}
+		}
+	}
 }
 
 // StartAutoConfig starts the autoconfig:

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -210,7 +210,7 @@ func (ac *AutoConfig) AddListener(listener listeners.ServiceListener) {
 	}
 
 	ac.listeners = append(ac.listeners, listener)
-	listener.Listen()
+	listener.Listen(ac.configResolver.newService, ac.configResolver.delService)
 }
 
 // AddLoader adds a new Loader that AutoConfig can use to load a check.

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,8 +36,8 @@ type MockListener struct {
 	stopReceived bool
 }
 
-func (l *MockListener) Listen() { l.ListenCount++ }
-func (l *MockListener) Stop()   { l.stopReceived = true }
+func (l *MockListener) Listen(newSvc, delSvc chan<- listeners.Service) { l.ListenCount++ }
+func (l *MockListener) Stop()                                          { l.stopReceived = true }
 
 func TestAddProvider(t *testing.T) {
 	ac := NewAutoConfig(nil)

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -116,6 +116,11 @@ metadata_collectors:
 #     username:
 #     password:
 
+# Autodiscovery
+#
+listeners:
+  - name: docker
+
 # Logging
 #
 # log_level: info

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -118,8 +118,8 @@ metadata_collectors:
 
 # Autodiscovery
 #
-listeners:
-  - name: docker
+# listeners:
+#   - name: docker
 
 # Logging
 #

--- a/pkg/collector/listeners/types.go
+++ b/pkg/collector/listeners/types.go
@@ -24,6 +24,6 @@ type Service struct {
 // It holds a cache of running services, listens to new/killed services and
 // updates its cache, and the ConfigResolver with these events.
 type ServiceListener interface {
-	Listen()
+	Listen(newSvc, delSvc chan<- Service)
 	Stop()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,11 @@ type ConfigurationProviders struct {
 	KeyFile     string `mapstructure:"key_file"`
 }
 
+// Listeners helps unmarshalling `listeners` config param
+type Listeners struct {
+	Name string `mapstructure:"name"`
+}
+
 func init() {
 	// config identifiers
 	Datadog.SetConfigName("datadog")

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -46,6 +46,13 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 		"histogram_aggregates",
 		"histogram_percentiles",
 		"service_discovery_backend",
+		"sd_config_backend",
+		"sd_backend_host",
+		"sd_backend_port",
+		"sd_backend_username",
+		"sd_backend_password",
+		"sd_template_dir",
+		"consul_token",
 		"use_dogstatsd",
 		"dogstatsd_port",
 		"statsd_metric_namespace",
@@ -92,6 +99,7 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 	config["endpoints"] = "{}"
 	config["version"] = "5.18.0"
 	config["proxy_settings"] = "{'host': 'my-proxy.com', 'password': 'password', 'port': 3128, 'user': 'user'}"
+	config["service_discovery"] = "True"
 
 	return config, nil
 }

--- a/pkg/legacy/tests/datadog.conf
+++ b/pkg/legacy/tests/datadog.conf
@@ -119,24 +119,24 @@ service_discovery_backend: docker
 #
 # Define which key/value store must be used to look for configuration templates.
 # Default is etcd. Consul is also supported.
-# sd_config_backend: etcd
+sd_config_backend: etcd
 #
 # Settings for connecting to the service discovery backend.
-# sd_backend_host: 127.0.0.1
-# sd_backend_port: 4001
+sd_backend_host: 127.0.0.1
+sd_backend_port: 4001
 #
 # If you use etcd, you can set a username and password for auth
 #
-# sd_backend_username:
-# sd_backend_password:
+sd_backend_username:
+sd_backend_password:
 #
 # By default, the agent will look for the configuration templates under the
 # `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
 # and modify its value.
-# sd_template_dir: /datadog/check_configs
+sd_template_dir: /datadog/check_configs
 #
 # If you Consul store requires token authentication for service discovery, you can define that token here.
-# consul_token:
+consul_token:
 #
 # Enable JMX checks for service discovery
 # sd_jmx_enable: False


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

 * Moves the I/O channels from listeners constructors to the `Listen` method to ease initialization
 * Starts the docker listener when the proper configuration parameter is set
 * Adds the conversion from the old configuration flags in `datadog.conf`

### Motivation

That's the core of Autodiscovery
