### PR TITLE
[py] Allow specifying hostname in `AgentCheck.service_check`

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -123,9 +123,12 @@ class AgentCheck(object):
             self.log.warning(self._deprecations[deprecation_key][1])
             self._deprecations[deprecation_key][0] = True
 
-    def service_check(self, name, status, tags=None, message=""):
+    def service_check(self, name, status, tags=None, hostname=None, message=""):
         tags = self._normalize_tags_type(tags)
-        aggregator.submit_service_check(self, self.check_id, name, status, tags, message)
+        if hostname is None:
+            hostname = ""
+
+        aggregator.submit_service_check(self, self.check_id, name, status, tags, hostname, message)
 
     def event(self, event):
         # Enforce types of some fields, considerably facilitates handling in go bindings downstream

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -1,7 +1,7 @@
 #include "api.h"
 
 PyObject* SubmitMetric(PyObject*, char*, MetricType, char*, float, PyObject*, char*);
-PyObject* SubmitServiceCheck(PyObject*, char*, char*, int, PyObject*, char*);
+PyObject* SubmitServiceCheck(PyObject*, char*, char*, int, PyObject*, char*, char*);
 PyObject* SubmitEvent(PyObject*, char*, PyObject*);
 
 // _must_ be in the same order as the MetricType enum
@@ -41,20 +41,21 @@ static PyObject *submit_service_check(PyObject *self, PyObject *args) {
     char *name;
     int status;
     PyObject *tags = NULL;
+    char *hostname;
     char *message = NULL;
     char *check_id;
 
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
 
-    // aggregator.submit_service_check(self, check_id, name, status, tags, message)
-    if (!PyArg_ParseTuple(args, "OssiOs", &check, &check_id, &name, &status, &tags, &message)) {
+    // aggregator.submit_service_check(self, check_id, name, status, tags, hostname, message)
+    if (!PyArg_ParseTuple(args, "OssiOss", &check, &check_id, &name, &status, &tags, &hostname, &message)) {
       PyGILState_Release(gstate);
       return NULL;
     }
 
     PyGILState_Release(gstate);
-    return SubmitServiceCheck(check, check_id, name, status, tags, message);
+    return SubmitServiceCheck(check, check_id, name, status, tags, hostname, message);
 }
 
 static PyObject *submit_event(PyObject *self, PyObject *args) {

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -66,7 +66,7 @@ func SubmitMetric(check *C.PyObject, checkID *C.char, mt C.MetricType, name *C.c
 
 // SubmitServiceCheck is the method exposed to Python scripts to submit service checks
 //export SubmitServiceCheck
-func SubmitServiceCheck(check *C.PyObject, checkID *C.char, name *C.char, status C.int, tags *C.PyObject, message *C.char) *C.PyObject {
+func SubmitServiceCheck(check *C.PyObject, checkID *C.char, name *C.char, status C.int, tags *C.PyObject, hostname *C.char, message *C.char) *C.PyObject {
 
 	goCheckID := C.GoString(checkID)
 	var sender aggregator.Sender
@@ -86,9 +86,10 @@ func SubmitServiceCheck(check *C.PyObject, checkID *C.char, name *C.char, status
 		log.Error(err)
 		return nil
 	}
+	_hostname := C.GoString(hostname)
 	_message := C.GoString(message)
 
-	sender.ServiceCheck(_name, _status, "", _tags, _message)
+	sender.ServiceCheck(_name, _status, _hostname, _tags, _message)
 
 	return C._none()
 }

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -138,6 +138,9 @@ func TestAggregatorLink(t *testing.T) {
 	mockSender.On("ServiceCheck",
 		"testservicecheck", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",
 		[]string(nil), mock.AnythingOfType("string")).Return().Times(1)
+	mockSender.On("ServiceCheck",
+		"testservicecheckwithhostname", mock.AnythingOfType("metrics.ServiceCheckStatus"), "testhostname",
+		[]string{"foo", "bar"}, "a message").Return().Times(1)
 	mockSender.On("Gauge", "testmetric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	mockSender.On("Event", mock.AnythingOfType("metrics.Event")).Return().Times(1)
 	mockSender.On("Commit").Return().Times(1)
@@ -157,6 +160,9 @@ func TestAggregatorLinkTwoRuns(t *testing.T) {
 	mockSender.On("ServiceCheck",
 		"testservicecheck", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",
 		[]string(nil), mock.AnythingOfType("string")).Return().Times(2)
+	mockSender.On("ServiceCheck",
+		"testservicecheckwithhostname", mock.AnythingOfType("metrics.ServiceCheckStatus"), "testhostname",
+		[]string{"foo", "bar"}, "a message").Return().Times(2)
 	mockSender.On("Gauge", "testmetric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(2)
 	mockSender.On("Event", mock.AnythingOfType("metrics.Event")).Return().Times(2)
 	mockSender.On("Commit").Return().Times(2)

--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -14,6 +14,7 @@ class TestAggregatorCheck(AgentCheck):
         unit tests. Doing anything is ok here.
         """
         self.service_check("testservicecheck", AgentCheck.OK, tags=None, message="")
+        self.service_check("testservicecheckwithhostname", AgentCheck.OK, tags=["foo", "bar"], hostname="testhostname", message="a message")
         # _send_metric is not used in tests, so it should not be used to test it.
         # Instead call gauge, which is the one that checks will be using
         self.gauge("testmetric", 0, tags=None)


### PR DESCRIPTION
### What does this PR do?

Allow specifying hostname in `AgentCheck.service_check`

### Motivation

Currently supported in Agent5, and used in the haproxy check.
Added test case.

