### PR TITLE
fixes socket error

### DIFF
--- a/cmd/agent/api/listener_nix.go
+++ b/cmd/agent/api/listener_nix.go
@@ -8,21 +8,76 @@
 package api
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+
+	log "github.com/cihub/seelog"
 )
 
 // getListener returns a listening connection to a Unix socket
 // on non-windows platforms.
 func getListener() (net.Listener, error) {
-	return net.Listen("unix", config.Datadog.GetString("cmd_sock"))
+	listener, err := net.Listen("unix", config.Datadog.GetString("cmd_sock"))
+	if err != nil {
+		up, e := checkIfUp()
+		if e != nil {
+			log.Info("here it is")
+			return listener, err
+		}
+		if !up {
+			e := os.Remove(config.Datadog.GetString("cmd_sock"))
+			if e != nil {
+				log.Infof("cannot remove cmd_sock: %v", e)
+				return listener, e
+			}
+			listener, e = net.Listen("unix", config.Datadog.GetString("cmd_sock"))
+			if e != nil {
+				return listener, e
+			}
+		}
+	}
+	return listener, nil
 }
 
 // HTTP doesn't need anything from TCP so we can use a Unix socket to dial
 func fakeDial(proto, addr string) (conn net.Conn, err error) {
-	return net.Dial("unix", config.Datadog.GetString("cmd_sock"))
+	sockname := "/tmp/" + addr
+	sockname = strings.Split(sockname, ":")[0]
+
+	return net.Dial("unix", sockname)
+}
+
+func checkIfUp() (bool, error) {
+	c := GetClient()
+	url := "http://" + strings.SplitAfter(config.Datadog.GetString("cmd_sock"), "tmp/")[1] + "/agent/version"
+	r, e := c.Get(url)
+	if e != nil {
+		if strings.Contains(e.Error(), "connection refused") {
+			return false, nil
+		}
+		return false, e
+	}
+	body, e := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	// if it returns an error, it's probably not up
+	if e != nil {
+		return false, e
+	}
+	// if it returns a status code, it's up
+	if r.StatusCode >= 1 {
+		return true, fmt.Errorf("Status code too high")
+	}
+	// if it doesn't return a body, it's probably not up
+	if string(body) == "" {
+		return false, e
+	}
+	return true, nil
 }
 
 // GetClient is a convenience function returning an http

--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -11,15 +11,17 @@ sending commands and receiving infos.
 package api
 
 import (
-	"fmt"
 	stdLog "log"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/agent"
 	"github.com/DataDog/datadog-agent/cmd/agent/api/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/gorilla/mux"
+
+	log "github.com/cihub/seelog"
 )
 
 var (
@@ -41,7 +43,8 @@ func StartServer() {
 	if err != nil {
 		// we use the listener to handle commands for the Agent, there's
 		// no way we can recover from this error
-		panic(fmt.Sprintf("Unable to create the api server: %v", err))
+		log.Errorf("Unable to create the api server: %v", err)
+		os.Exit(1)
 	}
 
 	server := &http.Server{


### PR DESCRIPTION
### What does this PR do?

If the agent crashes or exits early, it will not properly remove the socket. This will ensure that the socket is removed on agent start if it wasn't when the agent exited.

### Motivation

This is the most annoying agent bug during development and I've lost probably a few hours to this while developing (if you count up all the time I've spent).