### PR TITLE
[py] Ignore metric samples with `None` values

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -83,6 +83,10 @@ class AgentCheck(object):
         return {}
 
     def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
+        if value is None:
+            # ignore metric sample
+            return
+
         tags = self._normalize_tags(tags, device_name)
         if hostname is None:
             hostname = ""

--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -18,6 +18,7 @@ class TestAggregatorCheck(AgentCheck):
         # _send_metric is not used in tests, so it should not be used to test it.
         # Instead call gauge, which is the one that checks will be using
         self.gauge("testmetric", 0, tags=None)
+        self.gauge("testmetricnonevalue", None) # metrics with None values should be ignored by AgentCheck
         self.event({
             "event_type": "new.event",
             "msg_title": "new test event",


### PR DESCRIPTION
### What does this PR do?

Makes `AgentCheck` ignore metric samples with `None` values.

New behavior is similar to the agent5 behavior: the sample submission
succeeds but the sample is ignored.

Without this change the aggregator would throw an exception on None
values.

### Motivation

The postgres check is failing with the Agent 6 on staging because of this (it sometimes submits `None` values).
