### PR TITLE
Add token authentication for consul

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -108,6 +108,7 @@ metadata_collectors:
 #     key_file:
 #     username:
 #     password:
+#     token:
 
 #   - name: zookeeper
 #     polling: true

--- a/pkg/collector/providers/consul.go
+++ b/pkg/collector/providers/consul.go
@@ -59,6 +59,7 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 	clientCfg := consul.DefaultConfig()
 	clientCfg.Address = consulURL.Host
 	clientCfg.Address = consulURL.Scheme
+	clientCfg.Token = config.Token
 
 	if consulURL.Scheme == "https" {
 		clientCfg.TLSConfig = consul.TLSConfig{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type ConfigurationProviders struct {
 	CAPath      string `mapstructure:"ca_path"`
 	CertFile    string `mapstructure:"cert_file"`
 	KeyFile     string `mapstructure:"key_file"`
+	Token       string `mapstructure:"token"`
 }
 
 // Listeners helps unmarshalling `listeners` config param

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -182,7 +182,7 @@ func buildConfigProviders(agentConfig Config) ([]config.ConfigurationProviders, 
 		cp.Name = "etcd"
 	case "consul":
 		cp.Name = "consul"
-		// what to do with "consul_token" ?
+		cp.Token = agentConfig["consul_token"]
 	case "zk":
 		cp.Name = "zookeeper" // name is different in v6
 	}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

 * let users specify a per-request token to use in the Consul client
 * import the old `consul_token` config parameter from datadog.conf
