### PR TITLE
[py] support get_instance_proxy()

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -98,7 +98,8 @@ class AgentCheck(object):
     def get_instance_proxy(self, instance, uri):
         proxies = self.proxies.copy()
 
-        return config_proxy_skip(proxies, uri, _is_affirmative(instance.get('no_proxy', False)))
+        skip = _is_affirmative(instance.get('no_proxy', not self._use_agent_proxy))
+        return config_proxy_skip(proxies, uri, skip)
 
     def _submit_metric(self, mtype, name, value, tags=None, hostname=None, device_name=None):
         if value is None:

--- a/pkg/collector/dist/checks/wmi_check.py
+++ b/pkg/collector/dist/checks/wmi_check.py
@@ -317,6 +317,7 @@ def from_time(year=None, month=None, day=None, hours=None, minutes=None, seconds
 
     return wmi_time
 
+
 def to_time(wmi_time):
     """Convenience wrapper to take a WMI datetime string of the form
     yyyymmddHHMMSS.mmmmmm+UUU and return a 9-tuple containing the

--- a/pkg/collector/dist/config.py
+++ b/pkg/collector/dist/config.py
@@ -3,9 +3,30 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
 
+import logging
+
+log_level_map = {
+    'CRIT': logging.CRITICAL,
+    'CRITICAL': logging.CRITICAL,
+    'ERR':  logging.ERROR,
+    'ERROR':  logging.ERROR,
+    'WARN': logging.WARNING,
+    'WARNING': logging.WARNING,
+    'INFO': logging.INFO,
+    'DEBUG': logging.DEBUG,
+    'TRACE': logging.DEBUG,
+}
+
+
 def _is_affirmative(s):
     # int or real bool
     if isinstance(s, int):
         return bool(s)
     # try string cast
     return s.lower() in ('yes', 'true', '1')
+
+
+def _get_py_loglevel(l):
+    if not l:
+        l = 'INFO'
+    return log_level_map.get(l.upper(), logging.DEBUG)

--- a/pkg/collector/dist/utils/proxy.py
+++ b/pkg/collector/dist/utils/proxy.py
@@ -26,6 +26,8 @@ def get_requests_proxy(agentConfig):
 
     # First we read the proxy configuration from datadog.conf
     proxies = config.get('proxy', datadog_agent.get_config('proxy'))
+    if proxies:
+        proxies = proxies.copy()
 
     # requests compliant dict
     if proxies and 'no_proxy' in proxies:

--- a/pkg/collector/dist/utils/proxy.py
+++ b/pkg/collector/dist/utils/proxy.py
@@ -1,0 +1,68 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+
+import logging
+from urlparse import urlparse
+
+import datadog_agent
+
+
+log = logging.getLogger(__name__)
+
+
+def get_requests_proxy(agentConfig):
+    no_proxy_settings = {
+        "http": None,
+        "https": None,
+        "no": [],
+    }
+
+    config = {} if agentConfig is None else agentConfig
+
+    # First we read the proxy configuration from datadog.conf
+    proxies = config.get('proxy', datadog_agent.get_config('proxy'))
+
+    # requests compliant dict
+    if proxies and 'no_proxy' in proxies:
+        proxies['no'] = proxies.pop('no_proxy')
+
+    return proxies if proxies else no_proxy_settings
+
+
+def config_proxy_skip(proxies, uri, skip_proxy=False):
+    """
+    Returns an amended copy of the proxies dictionary - used by `requests`,
+    it will disable the proxy if the uri provided is to be reached directly.
+
+    Keyword Arguments:
+        proxies -- dict with existing proxies: 'https', 'http', 'no' as pontential keys
+        uri -- uri to determine if proxy is necessary or not.
+        skip_proxy -- if True, the proxy dictionary returned will disable all proxies
+    """
+    parsed_uri = urlparse(uri)
+
+    # disable proxy if necessary
+    if skip_proxy:
+        if 'http' in proxies:
+            proxies.pop('http')
+        if 'https' in proxies:
+            proxies.pop('https')
+    elif proxies.get('no'):
+        urls = []
+        if isinstance(proxies['no'], basestring):
+            urls = proxies['no'].replace(';', ',').split(",")
+        elif isinstance(proxies['no'], list):
+            urls = proxies['no']
+        for url in urls:
+            if url in parsed_uri.netloc:
+                if 'http' in proxies:
+                    proxies.pop('http')
+                if 'https' in proxies:
+                    proxies.pop('https')
+
+    return proxies


### PR DESCRIPTION
### What does this PR do?

Adds support for the proxy resolution necessary by some of the checks (`http_check` being a great example).

This also sneaks in a small fix for setting the log level for the check logging.

### Motivation

Support necessary in Agent6.

### Additional Notes

Python side changes only, nothing was necessary on the go-side.
