### PR TITLE
[py] Cast metric values to floats

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -91,7 +91,7 @@ class AgentCheck(object):
         if hostname is None:
             hostname = ""
 
-        aggregator.submit_metric(self, self.check_id, mtype, name, value, tags, hostname)
+        aggregator.submit_metric(self, self.check_id, mtype, name, float(value), tags, hostname)
 
     def gauge(self, name, value, tags=None, hostname=None, device_name=None):
         self._submit_metric(aggregator.GAUGE, name, value, tags=tags, hostname=hostname, device_name=device_name)

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -142,6 +142,7 @@ func TestAggregatorLink(t *testing.T) {
 		"testservicecheckwithhostname", mock.AnythingOfType("metrics.ServiceCheckStatus"), "testhostname",
 		[]string{"foo", "bar"}, "a message").Return().Times(1)
 	mockSender.On("Gauge", "testmetric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
+	mockSender.On("Gauge", "testmetricstringvalue", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	mockSender.On("Event", mock.AnythingOfType("metrics.Event")).Return().Times(1)
 	mockSender.On("Commit").Return().Times(1)
 
@@ -164,6 +165,7 @@ func TestAggregatorLinkTwoRuns(t *testing.T) {
 		"testservicecheckwithhostname", mock.AnythingOfType("metrics.ServiceCheckStatus"), "testhostname",
 		[]string{"foo", "bar"}, "a message").Return().Times(2)
 	mockSender.On("Gauge", "testmetric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(2)
+	mockSender.On("Gauge", "testmetricstringvalue", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(2)
 	mockSender.On("Event", mock.AnythingOfType("metrics.Event")).Return().Times(2)
 	mockSender.On("Commit").Return().Times(2)
 

--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -15,10 +15,19 @@ class TestAggregatorCheck(AgentCheck):
         """
         self.service_check("testservicecheck", AgentCheck.OK, tags=None, message="")
         self.service_check("testservicecheckwithhostname", AgentCheck.OK, tags=["foo", "bar"], hostname="testhostname", message="a message")
+
         # _send_metric is not used in tests, so it should not be used to test it.
         # Instead call gauge, which is the one that checks will be using
         self.gauge("testmetric", 0, tags=None)
         self.gauge("testmetricnonevalue", None) # metrics with None values should be ignored by AgentCheck
+        self.gauge("testmetricstringvalue", "2") # string values should be cast to floats
+        try:
+            self.gauge("testmetricstringvalue", "notcastabletofloat") # values not castable to floats should raise an exception
+        except ValueError:
+            pass
+        else:
+            raise Exception("Expected gauge to raise ValueError")
+
         self.event({
             "event_type": "new.event",
             "msg_title": "new test event",


### PR DESCRIPTION
### What does this PR do?

Makes `AgentCheck` always cast metric values to floats.

### Motivation

The python bindings can already handle casting `int`,
`decimal.Decimal`, etc, to floats, but some other types currently
throw exceptions, for example `string`s (and yes, some checks
do send numeric values as strings).

To address this, explicitly cast values to floats in the `AgentCheck`
class. This will still (rightfully) raise exceptions when the value
is not castable to a float, but it should make the behavior of
Agent6 closer to Agent5's.
