### PR TITLE
[py] Add `AgentCheck.hostname`

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -58,6 +58,8 @@ class AgentCheck(object):
                 # new-style init: the 3rd argument is `instances`
                 self.instances = args[2]
 
+        self.hostname = datadog_agent.get_hostname()  # `self.hostname` is deprecated, use `datadog_agent.get_hostname()` instead
+
         # the agent5 'AgentCheck' setup a log attribute.
         self.log = logging.getLogger('%s.%s' % (__name__, self.name))
         # let every log pass through and let the Go logger filter them.


### PR DESCRIPTION
### What does this PR do?

Adds `AgentCheck.hostname`

### Motivation

Still widely-used by integrations-core checks (including some we run on our infra).

### Additional Notes

* We may want to have a clearer path towards deprecating `self.hostname`. We have a dedicated card to tackle that though.
* this uses `util.GetHostname` behind the scenes. Currently that function does not cache its result, which is not good given how widespread its usage is. I've created a separate card to fix this.