### PR TITLE
Add a CLI command to import the old datadog.conf file

### DIFF
--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -31,6 +31,9 @@ monitoring and performance data.`,
 
 	// flags variables
 	sockname string
+	// confFilePath holds the path to the folder containing the configuration
+	// file, to allow overrides from the command line
+	confFilePath string
 )
 
 func init() {
@@ -42,4 +45,5 @@ func init() {
 		defaultSockName = strings.SplitAfter(config.Datadog.GetString("cmd_sock"), "tmp/")[1]
 	}
 	AgentCmd.Flags().StringVarP(&sockname, "name", "n", defaultSockName, "name of socket/pipe")
+	startCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to directory containing datadog.yaml")
 }

--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -78,7 +78,9 @@ func doImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal config to YAML: %v", err)
 	}
-	if err = ioutil.WriteFile(datadogYamlPath, b, 0644); err != nil {
+	// file permissions will be used only to create the file if doesn't exist,
+	// please note on Windows such permissions have no effect.
+	if err = ioutil.WriteFile(datadogYamlPath, b, 0640); err != nil {
 		return fmt.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
 	}
 

--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/legacy"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	importCmd = &cobra.Command{
+		Use:   "import <path_to_datadog.conf>",
+		Short: "Import the old datadog.conf and convert to the new format",
+		Long:  ``,
+		RunE:  doImport,
+	}
+)
+
+func init() {
+	// attach the command to the root
+	AgentCmd.AddCommand(importCmd)
+}
+
+func doImport(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("please provide the path to datadog.conf")
+	}
+
+	datadogConfPath := args[0]
+
+	// read the old configuration in memory
+	fmt.Println("Reading config data from:", datadogConfPath)
+	agentConfig, err := legacy.GetAgentConfig(datadogConfPath)
+	if err != nil {
+		return fmt.Errorf("unable to read data from %s: %v", datadogConfPath, err)
+	}
+
+	// overwrite curren agent configuration with the converted data
+	err = legacy.FromAgentConfig(agentConfig)
+	if err != nil {
+		return fmt.Errorf("unable to convert configuration data from %s: %v", datadogConfPath, err)
+	}
+
+	// backup the original datadog.yaml to datadog.yaml.bak
+	var datadogYaml string
+	if len(confFilePath) != 0 {
+		// the configuration file path was supplied on the command line
+		datadogYaml = filepath.Join(confFilePath, "datadog.yaml")
+		// config.Datadog.AddConfigPath(confFilePath)
+	} else {
+		datadogYaml = filepath.Join(common.DefaultConfPath, "datadog.yaml")
+	}
+	err = os.Rename(datadogYaml, datadogYaml+".bak")
+	if err != nil {
+		return fmt.Errorf("unable to create a backup for the existing file: %s", datadogYaml)
+	}
+
+	// dump the current configuration to datadog.yaml
+	b, err := yaml.Marshal(config.Datadog.AllSettings())
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal config to YAML: %v", err)
+	}
+	fmt.Println("Writing new configuration file to:", datadogYaml)
+	if err = ioutil.WriteFile(datadogYaml, b, 0644); err != nil {
+		return fmt.Errorf("unable to unmarshal config to %s: %v", datadogYaml, err)
+	}
+
+	return nil
+}

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -55,9 +55,6 @@ var (
 	runForeground bool
 	pidfilePath   string
 	confdPath     string
-	// ConfFilePath holds the path to the folder containing the configuration
-	// file, for override from the command line
-	confFilePath string
 )
 
 // run the host metadata collector every 14400 seconds (4 hours)
@@ -73,7 +70,6 @@ func init() {
 	// local flags
 	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
 	startCmd.Flags().StringVarP(&confdPath, "confd", "c", "", "path to the confd folder")
-	startCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to directory containing datadog.yaml")
 	config.Datadog.BindPFlag("confd_path", startCmd.Flags().Lookup("confd"))
 }
 

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -9,7 +9,8 @@ import (
 	"path/filepath"
 )
 
-const defaultConfPath = "/opt/datadog-agent6/etc"
+// DefaultConfPath points to the folder containing datadog.yaml
+const DefaultConfPath = "/opt/datadog-agent/etc"
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -11,7 +11,8 @@ import (
 	"path/filepath"
 )
 
-const defaultConfPath = "/etc/dd-agent"
+// DefaultConfPath points to the folder containing datadog.yaml
+const DefaultConfPath = "/etc/dd-agent"
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -18,7 +18,8 @@ var (
 	distPath     string
 )
 
-const defaultConfPath = "c:\\programdata\\datadog"
+// DefaultConfPath points to the folder containing datadog.yaml
+const DefaultConfPath = "c:\\programdata\\datadog"
 const defaultLogPath = "c:\\programdata\\datadog\\logs\\agent.log"
 
 // EnableLoggingToFile -- set up logging to file

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -101,7 +101,7 @@ func SetupConfig(confFilePath string) {
 		// add that first so it's first in line
 		config.Datadog.AddConfigPath(confFilePath)
 	}
-	config.Datadog.AddConfigPath(defaultConfPath)
+	config.Datadog.AddConfigPath(DefaultConfPath)
 	config.Datadog.AddConfigPath(GetDistPath())
 
 	// load the configuration

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
@@ -17,7 +16,6 @@ import (
 func main() {
 	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

adds this command to the CLI:
```
./bin/agent/agent.bin import /path/to/datadog.conf
```
Note the script would refuse to proceed if `datadog.yaml` contains an api_key, in that case to proceed you need to pass the `--force` flag.

### Motivation

Better support upgrade transitions
