### PR TITLE
Adding fake script to replace dd-agent.

### DIFF
--- a/omnibus/package-scripts/datadog-agent6/postinst
+++ b/omnibus/package-scripts/datadog-agent6/postinst
@@ -48,6 +48,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
                 # Create symlink to the agent's binary
                 ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
+                ln -sf $INSTALL_DIR/bin/agent/dd-agent /usr/bin/dd-agent
             ;;
             abort-upgrade|abort-remove|abort-deconfigure)
             ;;

--- a/omnibus/package-scripts/datadog-agent6/postrm
+++ b/omnibus/package-scripts/datadog-agent6/postrm
@@ -13,6 +13,7 @@ CONFIG_DIR=/etc/dd-agent
 
 # Remove the symlink to the binary.
 rm -f "/usr/bin/datadog-agent"
+rm -f "/usr/bin/dd-agent"
 
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     set -e

--- a/omnibus/package-scripts/datadog-agent6/posttrans
+++ b/omnibus/package-scripts/datadog-agent6/posttrans
@@ -9,6 +9,7 @@ SERVICE_NAME=datadog-agent6
 
 # Create symlink to the agent's binary
 ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
+ln -sf $INSTALL_DIR/bin/agent/dd-agent /usr/bin/dd-agent
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid

--- a/pkg/collector/dist/dd-agent
+++ b/pkg/collector/dist/dd-agent
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "The deprecated binary 'dd-agent' is no longer provided. Please use the 'datadog-agent' binary instead."
+exit 1

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -86,6 +86,8 @@ def refresh_assets(ctx):
 
     bin_agent = os.path.join(BIN_PATH, "agent")
     shutil.move(os.path.join(dist_folder, "agent"), bin_agent)
+    bin_ddagent = os.path.join(BIN_PATH, "dd-agent")
+    shutil.move(os.path.join(dist_folder, "dd-agent"), bin_ddagent)
     os.chmod(bin_agent, 0755)
 
 


### PR DESCRIPTION
### What does this PR do?

The 'dd-agent' binary has been deprecated for a while now. In agent6, 'dd-agent' will simply print a warning.