### PR TITLE
[config] Fix paths to agent install dir

### DIFF
--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 )
 
-const defaultConfPath = "/opt/datadog-agent/etc"
+const defaultConfPath = "/opt/datadog-agent6/etc"
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent

--- a/pkg/collector/dist/conf.d/apm.yaml.default
+++ b/pkg/collector/dist/conf.d/apm.yaml.default
@@ -3,7 +3,7 @@ instances:
      # and customize the configuration options on the instance below
 
 #   # path to trace agent binary, defaults to `embedded/bin/trace-agent` in agent installation dir
-# - bin_path: /opt/datadog-agent/embedded/bin/trace-agent
+# - bin_path: /opt/datadog-agent6/embedded/bin/trace-agent
 
 #   # Path to classic agent configuration, defaults to `/etc/dd-agent/datadog.conf`
 #   conf_path: /etc/dd-agent/datadog.conf

--- a/pkg/collector/dist/conf.d/process_agent.yaml.default
+++ b/pkg/collector/dist/conf.d/process_agent.yaml.default
@@ -6,7 +6,7 @@ instances:
      # and customize the configuration options on the instance below
 
 #   # path to process agent binary, defaults to `embedded/bin/process-agent` in agent installation dir
-# - bin_path: /opt/datadog-agent/embedded/bin/process-agent
+# - bin_path: /opt/datadog-agent6/embedded/bin/process-agent
 
 #   # Path to classic agent configuration, defaults to `/etc/dd-agent/datadog.conf`
 #   conf_path: /etc/dd-agent/datadog.conf

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -6,8 +6,8 @@
 package config
 
 const (
-	defaultConfdPath            = "/opt/datadog-agent/etc/conf.d"
-	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
+	defaultConfdPath            = "/opt/datadog-agent6/etc/conf.d"
+	defaultAdditionalChecksPath = "/opt/datadog-agent6/etc/checks.d"
 	defaultLogPath              = "/var/log/datadog/agent.log"
-	defaultJMXPipePath          = "/opt/datadog-agent/run"
+	defaultJMXPipePath          = "/opt/datadog-agent6/run"
 )

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -11,5 +11,5 @@ const (
 	defaultConfdPath            = "/etc/dd-agent/conf.d"
 	defaultAdditionalChecksPath = "/etc/dd-agent/checks.d"
 	defaultLogPath              = "/var/log/datadog/agent.log"
-	defaultJMXPipePath          = "/opt/datadog-agent/run"
+	defaultJMXPipePath          = "/opt/datadog-agent6/run"
 )


### PR DESCRIPTION
### What does this PR do?

Fixes the paths to the agent install dir in the code: currently the correct path is `/opt/datadog-agent6`. We can update these constants back to `/opt/datadog-agent` when we make the change in the package.

### Motivation

The jmxloader currently can't create the pipe in `/opt/datadog-agent/run` and fails, unless the directory is there as a leftover of  agent5 installation.
