### PR TITLE
Make tests fail if code is not properly formatted

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
 
 test:
   override:
-    - cd "$IMPORT_PATH" && eval "$(gimme)" && inv deps && inv test --race
+    - cd "$IMPORT_PATH" && eval "$(gimme)" && inv deps && inv test --race --fail-on-fmt
 
   post:
     - cd "$IMPORT_PATH" && eval "$(gimme)" && go tool cover -html=profile.cov -o $CIRCLE_ARTIFACTS/coverage.html

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -8,7 +8,7 @@ from invoke.exceptions import Exit
 
 
 @task
-def fmt(ctx, targets=None, fail_on_mod=False):
+def fmt(ctx, targets=None, fail_on_fmt=False):
     """
     Run go fmt on targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -24,7 +24,7 @@ def fmt(ctx, targets=None, fail_on_mod=False):
     if result.stdout:
         files = {x for x in result.stdout.split("\n") if x}
         print("Reformatted the following files: {}".format(','.join(files)))
-        if fail_on_mod:
+        if fail_on_fmt:
             print("Code was not properly formatted, exiting...")
             raise Exit(1)
     print("go fmt found no issues")

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -18,7 +18,7 @@ PROFILE_COV = "profile.cov"
 
 
 @task()
-def test(ctx, targets=None, race=False, use_embedded_libs=False):
+def test(ctx, targets=None, race=False, use_embedded_libs=False, fail_on_fmt=False):
     """
     Run all the tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -31,7 +31,7 @@ def test(ctx, targets=None, race=False, use_embedded_libs=False):
 
     # explicitly run these tasks instead of using pre-tasks so we can
     # pass the `target` param (pre-tasks are invoked without parameters)
-    fmt(ctx, targets=targets)
+    fmt(ctx, targets=targets, fail_on_fmt=fail_on_fmt)
     lint(ctx, targets=targets)
     vet(ctx, targets=targets)
 


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds a flag to invoke so that tests will fail if `go fmt` finds something to reformat.

### Motivation

Avoid checking in badly formatted code
