### PR TITLE
[percentile] Modifying GKArray for better efficiency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -346,12 +346,6 @@
   revision = "9badcbe49be523255546b669968041d707ece12e"
 
 [[projects]]
-  name = "gopkg.in/ini.v1"
-  packages = ["."]
-  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
-  version = "v1.28.2"
-
-[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
@@ -365,6 +359,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7243e6edc31a07d257320a8ac404a038fbfcdcccc7a84970a187cab6e707aaa6"
+  inputs-digest = "07bfe7b77493c407ebc1392034e1b30f0146ed6b40b7a68fa922c64150b3fe90"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/DataDog/agent-payload"
   packages = ["gogen"]
-  revision = "878e17eb68c0ab47f62a702158bf01c7d6e1452b"
-  version = "4.4"
+  revision = "d6a2f74c00f08246bc0ca160ffa9d28756968065"
+  version = "4.5"
 
 [[projects]]
   branch = "master"
@@ -346,6 +346,12 @@
   revision = "9badcbe49be523255546b669968041d707ece12e"
 
 [[projects]]
+  name = "gopkg.in/ini.v1"
+  packages = ["."]
+  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
+  version = "v1.28.2"
+
+[[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
@@ -359,6 +365,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0ba778132ba6d07909d1bc2be5fcdf2ee51cd1aa7196a32e0435cbc1beb6cd1f"
+  inputs-digest = "7243e6edc31a07d257320a8ac404a038fbfcdcccc7a84970a187cab6e707aaa6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
-  version = "=4.4.0"
+  version = "=4.5.0"
 
 [[constraint]]
   name = "github.com/DataDog/gohai"

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -31,10 +31,27 @@ func (slice Entries) Less(i, j int) bool { return slice[i].V < slice[j].V }
 func (slice Entries) Swap(i, j int)      { slice[i], slice[j] = slice[j], slice[i] }
 
 // GKArray is a version of GK with a buffer for the incoming values.
+// The expected usage is that Add() is called in the agent, while Merge() and
+// Quantile() are called in the backend; in other words, values are added to
+// the sketch in the agent, sketches are sent to the backend where they are
+// merged with other sketches, and quantile queries are made to the merged
+// sketches only. This allows us to ignore the Incoming buffer once the
+// sketch goes through a Merge.
+// In addition, the size of the sketch can be optimized if Incoming is
+// compressed only when Count > 1/EPSILON. GKArray therefore has three versions
+// of compress:
+// 1. compressWithIncoming(incomingEntries []Entry) is used during Merge(), and sets
+//	Incoming to nil after compressing so that merged sketches do not allocate
+//	unnecessary storage.
+// 2. compressAndAllocateBuf() is used during Add(), and allocates Incoming after
+//	compressing for further addition of values to the sketch.
+// 3. Compress() is the exported function, and is meant to be called before the
+//	sketch is sent to the backend. It calls compressAndAllocateBuf(), but only when
+//	Count > 1/EPSILON.
 type GKArray struct {
 	// the last item of Entries will always be the max inserted value
-	Entries  Entries `json:"entries"`
-	incoming []float64
+	Entries  Entries   `json:"entries"`
+	Incoming []float64 `json:"buf"`
 	// TODO[Charles]: incorporate min in entries so that we can get rid of the field.
 	Min   float64 `json:"min"`
 	Max   float64 `json:"max"`
@@ -84,7 +101,7 @@ func (e *Entry) UnmarshalJSON(b []byte) error {
 func NewGKArray() GKArray {
 	return GKArray{
 		// preallocate the incoming array for better insert throughput (5% faster)
-		incoming: make([]float64, 0, int(1/EPSILON)),
+		Incoming: make([]float64, 0, int(1/EPSILON)),
 		Min:      math.Inf(1),
 		Max:      math.Inf(-1),
 	}
@@ -95,7 +112,7 @@ func (s GKArray) Add(v float64) GKArray {
 	s.Count++
 	s.Sum += v
 	s.Avg += (v - s.Avg) / float64(s.Count)
-	s.incoming = append(s.incoming, v)
+	s.Incoming = append(s.Incoming, v)
 	if v < s.Min {
 		s.Min = v
 	}
@@ -103,16 +120,33 @@ func (s GKArray) Add(v float64) GKArray {
 		s.Max = v
 	}
 	if s.Count%int64(1/EPSILON) == 0 {
-		return s.compress(nil)
+		return s.compressAndAllocateBuf()
 	}
 
 	return s
 }
 
+// compressAndAllocateBuf compresses Incoming into Entries, then allocates
+// an empty Incoming for futher addition of values.
+func (s GKArray) compressAndAllocateBuf() GKArray {
+	s = s.compressWithIncoming(nil)
+	// allocate Incoming
+	s.Incoming = make([]float64, 0, int(1/EPSILON))
+	return s
+}
+
+// Compress merges the Incoming buffer into Entries and compresses it, but
+// only if Count > 1/EPSILON.
+func (s GKArray) Compress() GKArray {
+	if len(s.Incoming) == 0 || s.Count <= int64(1/EPSILON) {
+		return s
+	}
+	return s.compressAndAllocateBuf()
+}
+
 // Quantile returns an epsilon estimate of the element at quantile q.
-// If calling Quantile() repeatedly on the same sketch, it would be more
-// efficient to Compress() the sketch beforehand since each Quantile()
-// calls Compress() if incoming is not empty.
+// The incoming buffer is empty during the quantile query phase, so there's
+// no need to check Incoming or Compress().
 func (s GKArray) Quantile(q float64) float64 {
 	if q < 0 || q > 1 {
 		panic("Quantile out of bounds")
@@ -125,15 +159,6 @@ func (s GKArray) Quantile(q float64) float64 {
 	// Interpolate the quantile when there are only a few values.
 	if s.Count < int64(1/EPSILON) {
 		return s.interpolatedQuantile(q)
-	}
-
-	if len(s.Entries) == 0 {
-		sort.Float64s(s.incoming)
-		return s.incoming[int(q*float64(s.Count-1))]
-	}
-
-	if len(s.incoming) > 0 {
-		s = s.compress(nil)
 	}
 
 	rank := int64(q * float64(s.Count-1))
@@ -155,7 +180,8 @@ func (s GKArray) Quantile(q float64) float64 {
 
 // interpolatedQuantile returns an estimate of the element at quantile q,
 // but interpolates between the lower and higher elements when Count is
-// less than 1/EPSILON
+// less than 1/EPSILON.
+// Again, the incoming buffer is empty during the quantile query phase.
 func (s GKArray) interpolatedQuantile(q float64) float64 {
 	rank := q * float64(s.Count-1)
 	indexBelow := int64(rank)
@@ -166,9 +192,6 @@ func (s GKArray) interpolatedQuantile(q float64) float64 {
 	weightAbove := rank - float64(indexBelow)
 	weightBelow := 1.0 - weightAbove
 
-	if len(s.incoming) > 0 {
-		s = s.compress(nil)
-	}
 	// When Count is less than 1/EPSILON, all the entries will have G = 1, Delta = 0.
 	return weightBelow*s.Entries[indexBelow].V + weightAbove*s.Entries[indexAbove].V
 }
@@ -176,12 +199,12 @@ func (s GKArray) interpolatedQuantile(q float64) float64 {
 // Merge another GKArray into this in-place.
 func (s GKArray) Merge(o GKArray) GKArray {
 	if o.Count == 0 {
-		return s.compress(nil)
+		return s.compressWithIncoming(nil)
 	}
 	if s.Count == 0 {
-		return o.compress(nil)
+		return o.compressWithIncoming(nil)
 	}
-	o = o.compress(nil)
+	o = o.compressWithIncoming(nil)
 	spread := uint32(EPSILON * float64(o.Count-1))
 
 	/*
@@ -197,22 +220,22 @@ func (s GKArray) Merge(o GKArray) GKArray {
 			can notice that each of the quantiles that are queried from o is a v of one of the entry of o. Instead of actually
 			querying for those quantiles, we can count the number of times each v will be returned (when querying the quantiles
 		        i/(o.valCount-1)); we end up with the values n below. Then instead of successively inserting each v n times, we can
-			actually directly append them to s.incoming as new entries where g = n. This is possible because the values of n
+			actually directly append them to s.Incoming as new entries where g = n. This is possible because the values of n
 			will never violate the condition n <= int(s.eps * (s.Count+o.Count-1)). Also, we need to make sure that
-			compress() can handle entries in incoming where g > 1.
+			compress() can handle entries in Incoming where g > 1.
 	*/
 
-	incomingEntries := make([]Entry, 0, len(o.Entries))
+	IncomingEntries := make([]Entry, 0, len(o.Entries))
 	if n := o.Entries[0].G + o.Entries[0].Delta - spread - 1; n > 0 {
-		incomingEntries = append(incomingEntries, Entry{V: o.Min, G: n, Delta: 0})
+		IncomingEntries = append(IncomingEntries, Entry{V: o.Min, G: n, Delta: 0})
 	}
 	for i := 0; i < len(o.Entries)-1; i++ {
 		if n := o.Entries[i+1].G + o.Entries[i+1].Delta - o.Entries[i].Delta; n > 0 { // TODO[Charles]: is the check necessary?
-			incomingEntries = append(incomingEntries, Entry{V: o.Entries[i].V, G: n, Delta: 0})
+			IncomingEntries = append(IncomingEntries, Entry{V: o.Entries[i].V, G: n, Delta: 0})
 		}
 	}
 	if n := spread + 1 - o.Entries[len(o.Entries)-1].Delta; n > 0 { // TODO[Charles]: is the check necessary?
-		incomingEntries = append(incomingEntries, Entry{V: o.Entries[len(o.Entries)-1].V, G: n, Delta: 0})
+		IncomingEntries = append(IncomingEntries, Entry{V: o.Entries[len(o.Entries)-1].V, G: n, Delta: 0})
 	}
 
 	s.Count += o.Count
@@ -224,21 +247,15 @@ func (s GKArray) Merge(o GKArray) GKArray {
 	if o.Max > s.Max {
 		s.Max = o.Max
 	}
-	return s.compress(incomingEntries)
+	return s.compressWithIncoming(IncomingEntries)
 }
 
-// Compress merges the incoming buffer into entries and compresses it.
-func (s GKArray) Compress() GKArray {
-	if len(s.incoming) == 0 {
-		return s
-	}
-	return s.compress(nil)
-}
+// compressWithIncoming merges an optional incomingEntries and Incoming buffer into
+// Entries and compresses. Incoming buffer is set to nil after compressing.
+func (s GKArray) compressWithIncoming(incomingEntries Entries) GKArray {
 
-func (s GKArray) compress(incomingEntries Entries) GKArray {
-
-	// TODO[Charles]: use s.incoming and incomingEntries directly instead of merging them prior to compressing
-	for _, v := range s.incoming {
+	// TODO[Charles]: use s.Incoming and incomingEntries directly instead of merging them prior to compressing
+	for _, v := range s.Incoming {
 		incomingEntries = append(incomingEntries, Entry{V: v, G: 1, Delta: 0})
 	}
 	sort.Sort(incomingEntries)
@@ -251,7 +268,7 @@ func (s GKArray) compress(incomingEntries Entries) GKArray {
 	i, j := 0, 0
 	for i < len(incomingEntries) || j < len(s.Entries) {
 		if i == len(incomingEntries) {
-			// done with incoming; now only considering the sketch
+			// done with Incoming; now only considering the sketch
 			if j+1 < len(s.Entries) &&
 				s.Entries[j].G+s.Entries[j+1].G+s.Entries[j+1].Delta <= removalThreshold {
 				// removable from sketch
@@ -261,10 +278,10 @@ func (s GKArray) compress(incomingEntries Entries) GKArray {
 			}
 			j++
 		} else if j == len(s.Entries) {
-			// done with sketch; now only considering incoming
+			// done with sketch; now only considering Incoming
 			if i+1 < len(incomingEntries) &&
 				incomingEntries[i].G+incomingEntries[i+1].G+incomingEntries[i+1].Delta <= removalThreshold {
-				// removable from incoming
+				// removable from Incoming
 				incomingEntries[i+1].G += incomingEntries[i].G
 			} else {
 				merged = append(merged, incomingEntries[i])
@@ -272,7 +289,7 @@ func (s GKArray) compress(incomingEntries Entries) GKArray {
 			i++
 		} else if incomingEntries[i].V < s.Entries[j].V {
 			if incomingEntries[i].G+s.Entries[j].G+s.Entries[j].Delta <= removalThreshold {
-				// removable from incoming
+				// removable from Incoming
 				s.Entries[j].G += incomingEntries[i].G
 			} else {
 				incomingEntries[i].Delta = s.Entries[j].G + s.Entries[j].Delta - incomingEntries[i].G
@@ -291,6 +308,7 @@ func (s GKArray) compress(incomingEntries Entries) GKArray {
 		}
 	}
 	s.Entries = merged
-	s.incoming = make([]float64, 0, int(1/EPSILON))
+	// set Incoming to nil, since it is not used after merge
+	s.Incoming = nil
 	return s
 }

--- a/pkg/metrics/percentile/gk_array_test.go
+++ b/pkg/metrics/percentile/gk_array_test.go
@@ -97,7 +97,8 @@ func EvaluateSketch(t *testing.T, n int, gen Generator) {
 		s = s.Add(value)
 		d.Add(value)
 	}
-	s = s.Compress()
+	// Need to compress before querying for quantiles
+	s = s.compressWithIncoming(nil)
 	eps := float64(1.0e-6)
 	for _, q := range testQuantiles {
 		assert.InDelta(t, d.Quantile(q), s.Quantile(q), EPSILON*(float64(n)))
@@ -125,7 +126,8 @@ func TestConstant(t *testing.T) {
 			s = s.Add(value)
 			d.Add(value)
 		}
-		s = s.Compress()
+		// Need to compress before querying for quantiles
+		s = s.compressWithIncoming(nil)
 		for _, q := range testQuantiles {
 			assert.Equal(t, 42.0, s.Quantile(q))
 		}
@@ -210,7 +212,7 @@ func TestMergeNormal(t *testing.T) {
 			assert.InEpsilon(t, d.Avg(), s1.Avg, eps)
 			assert.InEpsilon(t, d.Sum(), s1.Sum, eps)
 			assert.InEpsilon(t, d.Count, s1.Count, eps)
-			assert.Equal(t, 0, len(s1.incoming))
+			assert.Equal(t, 0, len(s1.Incoming))
 		}
 	}
 }
@@ -236,7 +238,7 @@ func TestMergeEmpty(t *testing.T) {
 			assert.InEpsilon(t, d.Avg(), s1.Avg, eps)
 			assert.InEpsilon(t, d.Sum(), s1.Sum, eps)
 			assert.InEpsilon(t, d.Count, s1.Count, eps)
-			assert.Equal(t, 0, len(s1.incoming))
+			assert.Equal(t, 0, len(s1.Incoming))
 		}
 
 		// Merge an empty sketch to a non-empty sketch
@@ -249,7 +251,7 @@ func TestMergeEmpty(t *testing.T) {
 			assert.InEpsilon(t, d.Avg(), s2.Avg, eps)
 			assert.InEpsilon(t, d.Sum(), s2.Sum, eps)
 			assert.InEpsilon(t, d.Count, s2.Count, eps)
-			assert.Equal(t, 0, len(s2.incoming))
+			assert.Equal(t, 0, len(s2.Incoming))
 		}
 	}
 }
@@ -289,7 +291,7 @@ func TestMergeMixed(t *testing.T) {
 			assert.InEpsilon(t, d.Avg(), s1.Avg, eps)
 			assert.InEpsilon(t, d.Sum(), s1.Sum, eps)
 			assert.InEpsilon(t, d.Count, s1.Count, eps)
-			assert.Equal(t, 0, len(s1.incoming))
+			assert.Equal(t, 0, len(s1.Incoming))
 		}
 	}
 }
@@ -301,7 +303,7 @@ func TestInterpolatedQuantile(t *testing.T) {
 			for i := 0; i < n; i++ {
 				s = s.Add(float64(i))
 			}
-			s = s.Compress()
+			s = s.compressWithIncoming(nil)
 			for _, q := range testQuantiles {
 				expected := q * (float64(n) - 1)
 				assert.Equal(t, expected, s.Quantile(q))

--- a/pkg/metrics/percentile/sketch_series.go
+++ b/pkg/metrics/percentile/sketch_series.go
@@ -99,7 +99,7 @@ func unmarshalSketches(payloadSketches []agentpayload.SketchPayload_Sketch_Distr
 						Avg:      s.Avg,
 						Sum:      s.Sum,
 						Entries:  unmarshalEntries(s.V, s.G, s.Delta),
-						incoming: make([]float64, 0, int(1/EPSILON))}},
+						Incoming: s.Buf}},
 			})
 	}
 	return sketches
@@ -132,6 +132,7 @@ func marshalSketches(sketches []Sketch) []agentpayload.SketchPayload_Sketch_Dist
 				V:     v,
 				G:     g,
 				Delta: delta,
+				Buf:   s.Sketch.Incoming,
 			})
 	}
 	return sketchesPayload


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Modifies GKArray so that 1. the Incoming buffer is not allocated after Merge, 2. the sketch is not compressed before sending if number of values < 1/epsilon. These changes will help the sketch be more efficient on the backend as well as its transmission to the backend.

### Motivation

The sketch is smaller if not compressed before number of values > 1/epsilon. Also, since no new values will be added in the backend, there is no need for the incoming buffer once the sketches have been merged.

### Additional Notes

Anything else we should know when reviewing?
