### PR TITLE
Added net-snmp-5.7.3.pc for darwin

### DIFF
--- a/pkg-config/darwin/embedded/net-snmp-5.7.3.pc
+++ b/pkg-config/darwin/embedded/net-snmp-5.7.3.pc
@@ -1,10 +1,10 @@
-# net-snmp doesn't provide support for pkg-config, this file is provided for
-# convenience but some adjustments might be needed to match what's in your
-# system.
-prefix=/usr/local/Cellar/net-snmp/5.7.3
+prefix=/opt/datadog-agent6/embedded
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
+# HACK: the agent6 pkg doesn't ship the net-snmp headers (pkg size concerns)
+# let's use the system ones as backup
+backup_libdir=/usr/include/net-snmp/library
 
 Name: Net-SNMP
 Description: net-snmp library

--- a/pkg-config/linux/system/net-snmp-5.7.3.pc
+++ b/pkg-config/linux/system/net-snmp-5.7.3.pc
@@ -1,3 +1,6 @@
+# net-snmp doesn't provide support for pkg-config, this file is provided for
+# convenience but some adjustments might be needed to match what's in your
+# system.
 prefix=/usr/include/net-snmp
 exec_prefix=${prefix}
 includedir=${prefix}/library


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Adds the .pc file so net-snmp can be linked used pkg-config on Mac, otherwise embedded builds fall back to using the version provided by the system.
