### PR TITLE
Pretty print metrics for the check command

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -26,6 +26,7 @@ var (
 	checkRate  bool
 	checkName  string
 	checkDelay int
+	logLevel   string
 )
 
 const checkCmdFlushInterval = 10000000000
@@ -33,8 +34,9 @@ const checkCmdFlushInterval = 10000000000
 func init() {
 	AgentCmd.AddCommand(checkCmd)
 
-	checkCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to datadog.yaml")
+	checkCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to directory containing datadog.yaml")
 	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice")
+	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")
 	checkCmd.SetArgs([]string{"checkName"})
 }
@@ -44,15 +46,29 @@ var checkCmd = &cobra.Command{
 	Short: "Run the specified check",
 	Long:  `Use this to run a specific check with a specific rate`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Global Agent configuration
+		common.SetupConfig(confFilePath)
+
+		if logLevel == "" {
+			if confFilePath != "" {
+				logLevel = config.Datadog.GetString("log_level")
+			} else {
+				logLevel = "off"
+			}
+		}
+
+		// Setup logger
+		err := config.SetupLogger(logLevel, "")
+		if err != nil {
+			panic(err)
+		}
+
 		if len(args) != 0 {
 			checkName = args[0]
 		} else {
 			cmd.Help()
 			os.Exit(0)
 		}
-		config.SetupLogger("off", "")
-
-		common.SetupConfig(confFilePath)
 
 		hostname, err := util.GetHostname()
 		key := path.Join(util.AgentCachePrefix, "hostname")
@@ -111,36 +127,28 @@ func getMetrics(agg *aggregator.BufferedAggregator) {
 	series := agg.GetSeries()
 	if len(series) != 0 {
 		fmt.Println("Series: ")
-		for _, s := range series {
-			j, _ := json.Marshal(s)
-			fmt.Println(string(j))
-		}
+		j, _ := json.MarshalIndent(series, "", "  ")
+		fmt.Println(string(j))
 	}
 
 	sketches := agg.GetSketches()
 	if len(sketches) != 0 {
 		fmt.Println("Sketches: ")
-		for _, s := range sketches {
-			j, _ := json.Marshal(s)
-			fmt.Println(string(j))
-		}
+		j, _ := json.MarshalIndent(sketches, "", "  ")
+		fmt.Println(string(j))
 	}
 
 	serviceChecks := agg.GetServiceChecks()
 	if len(serviceChecks) != 0 {
 		fmt.Println("Service Checks: ")
-		for _, s := range serviceChecks {
-			j, _ := json.Marshal(s)
-			fmt.Println(string(j))
-		}
+		j, _ := json.MarshalIndent(serviceChecks, "", "  ")
+		fmt.Println(string(j))
 	}
 
 	events := agg.GetEvents()
 	if len(events) != 0 {
 		fmt.Println("Events: ")
-		for _, e := range events {
-			j, _ := json.Marshal(e)
-			fmt.Println(string(j))
-		}
+		j, _ := json.MarshalIndent(events, "", "  ")
+		fmt.Println(string(j))
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Pretty print metrics for the check command.
Allow to have the logs output as the same time, to ease working on integration.
This also fix the help for the '-f' option.

### Motivation

This makes the `check` command output much easier to read.

we go from:

```
[{ "check":"docker.service_up","host_name":"maxime","timestamp":1505313615,"status": 0,"message":"","tags": null}]
```

to:

```
[
  {
    "check": "docker.service_up",
    "host_name": "maxime",
    "timestamp": 1505313615,
    "status": 0,
    "message": "",
    "tags": null
  }
]
```