### PR TITLE
[Windows] make sure exampleconfig directory is created, otherwise build

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -46,6 +46,7 @@ build do
   end
 
   if windows?
+    mkdir "../../extra_package_files/EXAMPLECONFSLOCATION"
     copy "pkg/collector/dist/conf.d/*", "../../extra_package_files/EXAMPLECONFSLOCATION"
   end
 


### PR DESCRIPTION
fails (happens on clean build system)

