### PR TITLE
Cache the hostname in the GetHostname func

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +75,6 @@ var checkCmd = &cobra.Command{
 		}
 
 		hostname, err := util.GetHostname()
-		cache.Cache.Set(cache.BuildAgentKey("hostname"), hostname, cache.NoExpiration)
 		if err != nil {
 			fmt.Printf("Cannot get hostname, exiting: %v\n", err)
 			return err

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -29,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
@@ -156,10 +155,6 @@ func StartAgent() error {
 	if err != nil {
 		return log.Errorf("Error while getting hostname, exiting: %v", err)
 	}
-
-	// store the computed hostname in the global cache
-	cache.Cache.Set(cache.BuildAgentKey("hostname"), hostname, cache.NoExpiration)
-
 	log.Infof("Hostname is: %s", hostname)
 
 	// start the cmd HTTP server

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util"
 
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
@@ -152,9 +152,6 @@ func init() {
 }
 
 func getHostname() string {
-	hname, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
-	if found {
-		return hname.(string)
-	}
-	return ""
+	hostname, _ := util.GetHostname()
+	return hostname
 }

--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util"
 
 	log "github.com/cihub/seelog"
 )
@@ -20,14 +20,7 @@ import (
 // GetPayload builds a payload of all the agentchecks metadata
 func GetPayload() *Payload {
 	agentChecksPayload := ACPayload{}
-
-	// Grab the hostname from the cache
-	var hostname string
-	x, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
-	if found {
-		hostname = x.(string)
-	}
-
+	hostname, _ := util.GetHostname()
 	checkStats := runner.GetCheckStats()
 
 	for _, stats := range checkStats {

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	log "github.com/cihub/seelog"
 )
 
@@ -231,9 +231,6 @@ func GetCheckStats() map[check.ID]*check.Stats {
 }
 
 func getHostname() string {
-	hname, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
-	if found {
-		return hname.(string)
-	}
-	return ""
+	hostname, _ := util.GetHostname()
+	return hostname
 }

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // HostCollector fills and sends the old metadata payload used in the
@@ -19,11 +19,7 @@ type HostCollector struct{}
 
 // Send collects the data needed and submits the payload
 func (hp *HostCollector) Send(s *serializer.Serializer) error {
-	var hostname string
-	x, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
-	if found {
-		hostname = x.(string)
-	}
+	hostname, _ := util.GetHostname()
 
 	payload := v5.GetPayload(hostname)
 	if err := s.SendMetadata(payload); err != nil {

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // ResourcesCollector sends the old metadata payload used in the
@@ -19,11 +19,7 @@ type ResourcesCollector struct{}
 
 // Send collects the data needed and submits the payload
 func (rp *ResourcesCollector) Send(s *serializer.Serializer) error {
-	var hostname string
-	x, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
-	if found {
-		hostname = x.(string)
-	}
+	hostname, _ := util.GetHostname()
 
 	payload := map[string]interface{}{
 		"resources": resources.GetPayload(hostname),

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
 
@@ -87,6 +88,11 @@ func Fqdn(hostname string) string {
 // * os
 // * EC2
 func GetHostname() (string, error) {
+	cacheHostnameKey := cache.BuildAgentKey("hostname")
+	if cacheHostname, found := cache.Cache.Get(cacheHostnameKey); found {
+		return cacheHostname.(string), nil
+	}
+
 	var hostName string
 	var err error
 
@@ -139,6 +145,7 @@ func GetHostname() (string, error) {
 		err = fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file")
 	}
 
+	cache.Cache.Set(cacheHostnameKey, hostName, cache.NoExpiration)
 	return hostName, err
 }
 


### PR DESCRIPTION
### What does this PR do?

The 'GetHostname' func is called everywhere (including the python
checks), we can cache the value instead.