### PR TITLE
[py] Remove `dist/checks` directory from python path

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -8,6 +8,8 @@
 package common
 
 import (
+	"path/filepath"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
@@ -37,7 +39,8 @@ var (
 // should load python modules and checks
 func GetPythonPaths() []string {
 	return []string{
-		GetDistPath(),                                  // common modules are shipped in the dist path directly or under "checks" of the dist path
+		GetDistPath(),                                  // common modules are shipped in the dist path directly or under the "checks/" sub-dir
+		filepath.Join(GetDistPath(), "checks.d"),       // custom checks in the "checks.d/" sub-dir of the dist path
 		config.Datadog.GetString("additional_checksd"), // custom checks, have precedence over integrations-core checks
 		PyChecksPath,                                   // integrations-core checks
 	}

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -42,8 +42,7 @@ var (
 // should load python modules and checks
 func GetPythonPaths() []string {
 	return []string{
-		GetDistPath(),                                  // some common modules are shipped in the dist path directly
-		filepath.Join(GetDistPath(), "checks"),         // other common modules (e.g. `AgentCheck` class)
+		GetDistPath(),                                  // common modules are shipped in the dist path directly or under "checks" of the dist path
 		config.Datadog.GetString("additional_checksd"), // custom checks, have precedence over integrations-core checks
 		PyChecksPath,                                   // integrations-core checks
 	}

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -8,8 +8,6 @@
 package common
 
 import (
-	"path/filepath"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

`dist/` is already in the python path, so all the modules in
`dist/checks` can and should be imported with
`import checks.my_module` instead of `import my_module`.
This prevents potential module name collisions.

From what I've checked the agent6 core py code already accounts for
the `checks.` prefix when it loads the AgentCheck class for example,
so everything should still work.
