### PR TITLE
Migrate CI jobs to new runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,8 +209,8 @@ deploy_deb:
     - master
   tags: [ "runner:main", "size:large" ]
   script:
-    - source /home/jenkins/.rvm/scripts/rvm
-    - rvm use 2.2.2@circleci
+    - source /usr/local/rvm/scripts/rvm
+    - rvm use 2.4
 
     - set +x # make sure we don't output the creds to the build log
     - APT_SIGNING_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_id --with-decryption --query "Parameter.Value" --out text)
@@ -219,8 +219,8 @@ deploy_deb:
     - APT_SIGNING_KEY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
 
     - echo "$APT_SIGNING_KEY_ID"
-    - echo "$APT_SIGNING_PRIVATE_KEY_PART1\n$APT_SIGNING_PRIVATE_KEY_PART2" | gpg --import
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
+    - printf -- "$APT_SIGNING_PRIVATE_KEY_PART1\n$APT_SIGNING_PRIVATE_KEY_PART2\n" | gpg --import --batch
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
 
 # TODO: deploy rpm packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,7 @@ deploy_deb:
     - rvm use 2.2.2@circleci
     - echo "$APT_SIGNING_KEY_ID"
     - echo "$APT_SIGNING_PRIVATE_KEY" | gpg --import
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
 
 # TODO: deploy rpm packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,10 @@ run_benchmarks-deb_x64:
     # make invoke traceback. For now, the workaround is to call the benchmarks
     # manually
     - inv -e bench.build-dogstatsd
+
+    - set +x # make sure we don't output the creds to the build log
+    - DD_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_agent_api_key --with-decryption --query "Parameter.Value" --out text)
+
     - ./bin/benchmarks/dogstatsd -pps=5000 -dur 45 -ser 5 -brk -inc 1000 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
   artifacts:
     expire_in: 2 weeks
@@ -207,8 +211,15 @@ deploy_deb:
   script:
     - source /home/jenkins/.rvm/scripts/rvm
     - rvm use 2.2.2@circleci
+
+    - set +x # make sure we don't output the creds to the build log
+    - APT_SIGNING_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_id --with-decryption --query "Parameter.Value" --out text)
+    - APT_SIGNING_PRIVATE_KEY_PART1=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_private_key_part1 --with-decryption --query "Parameter.Value" --out text)
+    - APT_SIGNING_PRIVATE_KEY_PART2=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_private_key_part2 --with-decryption --query "Parameter.Value" --out text)
+    - APT_SIGNING_KEY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
+
     - echo "$APT_SIGNING_KEY_ID"
-    - echo "$APT_SIGNING_PRIVATE_KEY" | gpg --import
+    - echo "$APT_SIGNING_PRIVATE_KEY_PART1\n$APT_SIGNING_PRIVATE_KEY_PART2" | gpg --import
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty --digest-algo SHA512" --preserve_versions --visibility bucket_owner $AGENT_OMNIBUS_PACKAGE_DIR/*amd64.deb
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,13 +6,7 @@ stages:
   - deploy
 
 variables:
-  DOCKER_REGISTRY: 727006795293.dkr.ecr.us-east-1.amazonaws.com
   SRC_PATH: /src/github.com/DataDog/datadog-agent
-  DEB_X64: $DOCKER_REGISTRY/datadog-agent-builders:deb_x64
-  DEB_X64_TEST: $DOCKER_REGISTRY/datadog-agent-builders:deb_test_x64
-  RPM_X64: $DOCKER_REGISTRY/datadog-agent-builders:rpm_x64
-  RPM_X64_TEST: $DOCKER_REGISTRY/datadog-agent-builders:rpm_test_x64
-  DEPLOY: $DOCKER_REGISTRY/datadog-agent-builders:deploy # For now, just a renamed version of the image datadog/mars-jenkins-scripts
   AGENT_OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
   STATIC_BINARIES_DIR: bin/static
   DEB_S3_BUCKET: apt-agent6.datad0g.com
@@ -35,18 +29,16 @@ before_script:
 # run tests for deb-x64
 run_tests_deb-x64:
   stage: source_test
-  image: $DEB_X64
-  tags:
-    - docker
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
   script:
     - inv -e test --coverage
 
 # run tests for rpm-x64
 run_test_rpm-x64:
   stage: source_test
-  image: $RPM_X64
-  tags:
-    - docker
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
+  tags: [ "runner:main", "size:large" ]
   script:
     - inv -e test --coverage
 
@@ -59,9 +51,8 @@ run_test_rpm-x64:
 # build dogstatsd static for deb-x64
 build_dogstatsd_static-deb_x64:
   stage: binary_build
-  image: $DEB_X64
-  tags:
-    - docker
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
   script:
     - inv -e dogstatsd.build --static
     - cp $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $CI_PROJECT_DIR
@@ -73,9 +64,8 @@ build_dogstatsd_static-deb_x64:
 # build dogstatsd static for rpm-x64
 build_dogstatsd_static-rpm_x64:
   stage: binary_build
-  image: $RPM_X64
-  tags:
-    - docker
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
+  tags: [ "runner:main", "size:large" ]
   script:
     - inv -e dogstatsd.build --static
     - cp $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $CI_PROJECT_DIR
@@ -88,10 +78,9 @@ build_dogstatsd_static-rpm_x64:
 # run benchmarks on deb
 run_benchmarks-deb_x64:
   stage: integration_test
-  image: $DEB_X64
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
-  tags:
-    - docker
+  tags: [ "runner:main", "size:large" ]
   script:
     - inv -e bench.aggregator
     # FIXME: in our docker image, non ascii characters printed by the benchmark
@@ -114,14 +103,13 @@ run_integration_tests_deb-x64:
     # disable global before_script
     - pwd
   script:
-    - docker run --rm --user root --pid=host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64_TEST inv integration-tests --install-deps
+    - docker run --rm --user root --pid=host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA 727006795293.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders:deb_test_x64 inv integration-tests --install-deps
 
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
   stage: integration_test
-  image: $DEB_X64
-  tags:
-    - docker
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
   dependencies:
     - build_dogstatsd_static-deb_x64 # Reuse artifact from build stage
   before_script:
@@ -144,7 +132,7 @@ run_docker_integration_tests_deb-x64:
     - mkdir --parent $STATIC_BINARIES_DIR
     - ln dogstatsd $STATIC_BINARIES_DIR/dogstatsd
   script:
-    - docker run --rm --user root -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$(pwd) --workdir $(pwd) -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA $DEB_X64 inv docker.integration-tests --skip-build 2>&1
+    - docker run --rm --user root -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$(pwd) --workdir $(pwd) -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA 727006795293.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders:deb_x64 inv docker.integration-tests --skip-build 2>&1
 
 
 #
@@ -155,9 +143,8 @@ run_docker_integration_tests_deb-x64:
 # build the package for deb-x64
 agent_deb-x64:
   stage: package_build
-  image: $DEB_X64
-  tags:
-    - docker
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
   variables:
     # Artifacts and cache must live within project directory but we run omnibus from the GOPATH (see above).
     # We then instrument `rake` to invoke `omnibus` with custom parameter, pointing to a gitlab-friendly location.
@@ -180,10 +167,9 @@ agent_deb-x64:
 # build the package for rpm-x64
 agent_rpm-x64:
   stage: package_build
-  image: $RPM_X64
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   allow_failure: true  # FIXME: when we start deploying the rpm package
-  tags:
-    - docker
+  tags: [ "runner:main", "size:large" ]
   variables:
     # Artifacts and cache must live within project directory but we run omnibus from the GOPATH (see above).
     # We then instrument `rake` to invoke `omnibus` with custom parameter, pointing to a gitlab-friendly location.
@@ -212,13 +198,12 @@ agent_rpm-x64:
 # deploy debian packages to apt staging repo
 deploy_deb:
   stage: deploy
-  image: $DEPLOY
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest # For now, just a renamed version of the image datadog/mars-jenkins-scripts
   before_script:
     - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
-  tags:
-    - docker
+  tags: [ "runner:main", "size:large" ]
   script:
     - source /home/jenkins/.rvm/scripts/rvm
     - rvm use 2.2.2@circleci


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

What does this PR do?
---------------------

:wave:

This changes the Gitlab yaml so that jobs run on our new fleet of runners.

- Had to remove the image variables because it made the runners fail for some reason
- Credentials are now stored in SSM, we'll need to update the `deploy` image to include a recent `awscli`. @gmmeyer you're probably best equipped to do that, since I have no state on that one. Maybe it is a good opportunity to have a Dockerfile for it in `datadog-agent-builders`?
- Changed the `deb-s3 upload` command to include `--visibility bucket_owner` since we do cross-account upload now, otherwise the files would be owned by gitlab, not by staging
- These changes depend on a few PRs:
    - https://github.com/DataDog/buildenv/pull/120 (merged)
    - https://github.com/DataDog/cloudops/pull/1548 (merged)
    - https://github.com/DataDog/cloudops/pull/1567 (waiting for review)
    - https://github.com/DataDog/cloudops/pull/1568 (waiting for review)
- For now, I did not migrate the two jobs using raw docker socket access as discussed

The IAM stuff above in particular could use review, I'm not entirely confident on what deb-s3 needs. Or I guess we could merge and iterate.
Anyway, let me know what you think!

Test pipeline: https://gitlab.ddbuild.io/datadog/datadog-agent/pipelines/119660