### PR TITLE
Remove Panics

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -85,5 +85,7 @@ func StartServer() error {
 // StopServer closes the connection and the server
 // stops listening to new commands.
 func StopServer() {
-	listener.Close()
+	if listener != nil {
+		listener.Close()
+	}
 }

--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -31,7 +31,7 @@ var (
 )
 
 // StartServer creates the router and starts the HTTP server
-func StartServer() {
+func StartServer() error {
 	// create the root HTTP router
 	r := mux.NewRouter()
 
@@ -45,7 +45,7 @@ func StartServer() {
 	if err != nil {
 		// we use the listener to handle commands for the Agent, there's
 		// no way we can recover from this error
-		panic(fmt.Sprintf("Unable to create the api server: %v", err))
+		return fmt.Errorf("Unable to create the api server: %v", err)
 	}
 	common.SetAuthToken()
 
@@ -53,8 +53,7 @@ func StartServer() {
 	hosts := []string{"127.0.0.1", "localhost"}
 	_, rootCertPEM, rootKey, err := common.GenerateRootCert(hosts, 2048)
 	if err != nil {
-		stdLog.Fatalf("unable to start TLS server")
-		return
+		return fmt.Errorf("unable to start TLS server")
 	}
 
 	// PEM encode the private key
@@ -65,8 +64,7 @@ func StartServer() {
 	// Create a TLS cert using the private key and certificate
 	rootTLSCert, err := tls.X509KeyPair(rootCertPEM, rootKeyPEM)
 	if err != nil {
-		stdLog.Fatalf("invalid key pair: %v", err)
-		return
+		return fmt.Errorf("invalid key pair: %v", err)
 	}
 
 	tlsConfig := tls.Config{
@@ -81,6 +79,7 @@ func StartServer() {
 	tlsListener := tls.NewListener(listener, &tlsConfig)
 
 	go srv.Serve(tlsListener)
+	return nil
 }
 
 // StopServer closes the connection and the server

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -8,7 +8,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path"
 	"time"
 
@@ -45,9 +44,13 @@ var checkCmd = &cobra.Command{
 	Use:   "check <check_name>",
 	Short: "Run the specified check",
 	Long:  `Use this to run a specific check with a specific rate`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Global Agent configuration
-		common.SetupConfig(confFilePath)
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			fmt.Printf("Cannot setup config, exiting: %v\n", err)
+			return err
+		}
 
 		if logLevel == "" {
 			if confFilePath != "" {
@@ -58,27 +61,25 @@ var checkCmd = &cobra.Command{
 		}
 
 		// Setup logger
-		err := config.SetupLogger("off", "", "", false, false, "")
+		err = config.SetupLogger("off", "", "", false, false, "")
 		if err != nil {
 			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		if len(args) != 0 {
 			checkName = args[0]
 		} else {
 			cmd.Help()
-			os.Exit(0)
+			return nil
 		}
-
-		common.SetupConfig(confFilePath)
 
 		hostname, err := util.GetHostname()
 		key := path.Join(util.AgentCachePrefix, "hostname")
 		util.Cache.Set(key, hostname, util.NoExpiration)
 		if err != nil {
 			fmt.Printf("Cannot get hostname, exiting: %v\n", err)
-			os.Exit(1)
+			return err
 		}
 
 		s := &serializer.Serializer{Forwarder: common.Forwarder}
@@ -87,7 +88,7 @@ var checkCmd = &cobra.Command{
 		cs := common.AC.GetChecksByName(checkName)
 		if len(cs) == 0 {
 			fmt.Println("no check found")
-			os.Exit(1)
+			return fmt.Errorf("no check found")
 		}
 
 		if len(cs) > 1 {
@@ -106,6 +107,7 @@ var checkCmd = &cobra.Command{
 			fmt.Println(string(checkStatus))
 		}
 
+		return nil
 	},
 }
 

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -60,7 +60,8 @@ var checkCmd = &cobra.Command{
 		// Setup logger
 		err := config.SetupLogger("off", "", "", false, false, "")
 		if err != nil {
-			panic(err)
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			os.Exit(1)
 		}
 
 		if len(args) != 0 {
@@ -76,7 +77,8 @@ var checkCmd = &cobra.Command{
 		key := path.Join(util.AgentCachePrefix, "hostname")
 		util.Cache.Set(key, hostname, util.NoExpiration)
 		if err != nil {
-			panic(err)
+			fmt.Printf("Cannot get hostname, exiting: %v\n", err)
+			os.Exit(1)
 		}
 
 		s := &serializer.Serializer{Forwarder: common.Forwarder}

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -37,7 +37,10 @@ var flareCmd = &cobra.Command{
 	Short: "Collect a flare and send it to Datadog",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		common.SetupConfig(confFilePath)
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return err
+		}
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format
 		config.SetupLogger("off", "", "", false, false, "")
 		if customerEmail == "" && caseID == "" {

--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -51,7 +51,10 @@ func doImport(cmd *cobra.Command, args []string) error {
 	}
 
 	// Global Agent configuration
-	common.SetupConfig(confFilePath)
+	err = common.SetupConfig(confFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
 
 	// store the current datadog.yaml path
 	datadogYamlPath := config.Datadog.ConfigFileUsed()

--- a/cmd/agent/app/listchecks.go
+++ b/cmd/agent/app/listchecks.go
@@ -23,7 +23,10 @@ var listCheckCommand = &cobra.Command{
 	Short: "Query the agent for the list of checks running",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		common.SetupConfig(confFilePath)
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
 		return doListChecks()
 	},
 }

--- a/cmd/agent/app/reloadcheck.go
+++ b/cmd/agent/app/reloadcheck.go
@@ -33,7 +33,10 @@ var reloadCheckCommand = &cobra.Command{
 			return fmt.Errorf("missing arguments")
 		}
 
-		common.SetupConfig(confFilePath)
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
 		return doReloadCheck(checkName)
 	},
 }

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
@@ -84,10 +85,14 @@ func start(cmd *cobra.Command, args []string) {
 	for {
 		// Block here until we receive the interrupt signal
 		select {
-		case <-common.Stopper:
+		case <-signals.Stopper:
 			log.Info("Received stop command, shutting down...")
 			StopAgent()
 			return
+		case <-signals.ErrorStopper:
+			log.Info("The Agent has encountered an error, shutting down...")
+			StopAgent()
+			os.Exit(1)
 		case sig := <-signalCh:
 			log.Infof("Received signal '%s', shutting down...", sig)
 			StopAgent()

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -96,7 +96,7 @@ func start(cmd *cobra.Command, args []string) error {
 			log.Info("Received stop command, shutting down...")
 			stopCh <- nil
 		case <-signals.ErrorStopper:
-			log.Info("The Agent has encountered an error, shutting down...")
+			log.Critical("The Agent has encountered an error, shutting down...")
 			stopCh <- fmt.Errorf("shutting down because of an error")
 		case sig := <-signalCh:
 			log.Infof("Received signal '%s', shutting down...", sig)

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -240,12 +240,16 @@ func StopAgent() {
 	if common.DSD != nil {
 		common.DSD.Stop()
 	}
-	common.AC.Stop()
+	if common.AC != nil {
+		common.AC.Stop()
+	}
 	if common.MetadataScheduler != nil {
 		common.MetadataScheduler.Stop()
 	}
 	api.StopServer()
-	common.Forwarder.Stop()
+	if common.Forwarder != nil {
+		common.Forwarder.Stop()
+	}
 	os.Remove(pidfilePath)
 	log.Info("See ya!")
 	log.Flush()

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	apicommon "github.com/DataDog/datadog-agent/cmd/agent/api/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -37,12 +36,16 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Print the current status",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		common.SetupConfig(confFilePath)
-		err := requestStatus()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := common.SetupConfig(confFilePath)
 		if err != nil {
-			os.Exit(1)
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
+		err = requestStatus()
+		if err != nil {
+			return err
+		}
+		return nil
 	},
 }
 

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -8,6 +8,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/spf13/cobra"
@@ -18,7 +20,7 @@ var (
 		Use:   "stop",
 		Short: "Stop the Agent",
 		Long:  ``,
-		Run:   stop,
+		RunE:  stop,
 	}
 )
 
@@ -27,9 +29,13 @@ func init() {
 	AgentCmd.AddCommand(stopCmd)
 }
 
-func stop(*cobra.Command, []string) {
+func stop(*cobra.Command, []string) error {
 	// Global Agent configuration
-	common.SetupConfig("")
+	err := common.SetupConfig("")
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
 	// get an API client
 	signals.Stopper <- true
+	return nil
 }

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -9,6 +9,7 @@ package app
 
 import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/spf13/cobra"
 )
 
@@ -30,5 +31,5 @@ func stop(*cobra.Command, []string) {
 	// Global Agent configuration
 	common.SetupConfig("")
 	// get an API client
-	common.Stopper <- true
+	signals.Stopper <- true
 }

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -31,9 +31,6 @@ var (
 	// Forwarder is the global forwarder instance
 	Forwarder forwarder.Forwarder
 
-	// Stopper is the channel used by other packages to ask for stopping the agent
-	Stopper = make(chan bool)
-
 	// utility variables
 	_here, _ = osext.ExecutableFolder()
 )

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -6,8 +6,10 @@
 package common
 
 import (
-	"fmt"
+	"os"
 	"path/filepath"
+
+	stdLog "log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
@@ -107,6 +109,8 @@ func SetupConfig(confFilePath string) {
 	// load the configuration
 	err := config.Datadog.ReadInConfig()
 	if err != nil {
-		panic(fmt.Errorf("unable to load Datadog config file: %s", err))
+		// if it cannot load the config, the agent must exit
+		stdLog.Fatalf("unable to load Datadog config file: %s", err)
+		os.Exit(1)
 	}
 }

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -6,10 +6,8 @@
 package common
 
 import (
-	"os"
+	"fmt"
 	"path/filepath"
-
-	stdLog "log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
@@ -96,7 +94,7 @@ func StartAutoConfig() {
 }
 
 // SetupConfig fires up the configuration system
-func SetupConfig(confFilePath string) {
+func SetupConfig(confFilePath string) error {
 	// set the paths where a config file is expected
 	if len(confFilePath) != 0 {
 		// if the configuration file path was supplied on the command line,
@@ -109,8 +107,7 @@ func SetupConfig(confFilePath string) {
 	// load the configuration
 	err := config.Datadog.ReadInConfig()
 	if err != nil {
-		// if it cannot load the config, the agent must exit
-		stdLog.Fatalf("unable to load Datadog config file: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}
+	return nil
 }

--- a/cmd/agent/common/signals/signals.go
+++ b/cmd/agent/common/signals/signals.go
@@ -1,0 +1,7 @@
+package signals
+
+// This is a new package in order to avoid cyclical imports
+
+// Stopper is the channel used by other packages to ask for stopping the agent
+var Stopper = make(chan bool)
+var ErrorStopper = make(chan bool)

--- a/cmd/agent/common/signals/signals.go
+++ b/cmd/agent/common/signals/signals.go
@@ -2,6 +2,10 @@ package signals
 
 // This is a new package in order to avoid cyclical imports
 
-// Stopper is the channel used by other packages to ask for stopping the agent
-var Stopper = make(chan bool)
-var ErrorStopper = make(chan bool)
+var (
+	// Stopper is the channel used by other packages to ask for stopping the agent
+	Stopper = make(chan bool)
+
+	// ErrorStopper is the channel used by other packages to ask for stopping the agent because of an error
+	ErrorStopper = make(chan bool)
+)

--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -67,7 +68,7 @@ loop:
 			default:
 				elog.Error(1, fmt.Sprintf("unexpected control request #%d", c))
 			}
-		case <-common.Stopper:
+		case <-signals.Stopper:
 			elog.Info(1, "Received stop command, shutting down...")
 			app.StopAgent()
 			break loop

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -123,12 +123,13 @@ func start(cmd *cobra.Command, args []string) error {
 	var metaScheduler *metadata.Scheduler
 	if config.Datadog.GetBool("enable_metadata_collection") {
 		// start metadata collection
-		metaScheduler := metadata.NewScheduler(s, hname)
+		metaScheduler = metadata.NewScheduler(s, hname)
 
 		// add the host metadata collector
 		err = metaScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
 		if err != nil {
-			panic("Host metadata is supposed to be always available in the catalog!")
+			metaScheduler.Stop()
+			return log.Error("Host metadata is supposed to be always available in the catalog!")
 		}
 	} else {
 		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -8,6 +8,8 @@ package py
 import (
 	"strings"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	log "github.com/cihub/seelog"
 	python "github.com/sbinet/go-python"
 )
 
@@ -54,7 +56,8 @@ func Initialize(paths ...string) *python.PyThreadState {
 		C.Py_Initialize()
 	}
 	if C.Py_IsInitialized() == 0 {
-		panic("python: could not initialize the python interpreter")
+		log.Error("python: could not initialize the python interpreter")
+		signals.ErrorStopper <- true
 	}
 
 	// make sure the Python threading facilities are correctly initialized,
@@ -65,7 +68,8 @@ func Initialize(paths ...string) *python.PyThreadState {
 		C.PyEval_InitThreads()
 	}
 	if C.PyEval_ThreadsInitialized() == 0 {
-		panic("python: could not initialize the GIL")
+		log.Error("python: could not initialize the GIL")
+		signals.ErrorStopper <- true
 	}
 
 	// Set the PYTHONPATH if needed.

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	log "github.com/cihub/seelog"
 )
@@ -68,7 +69,8 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 func (c *Scheduler) firstRun() error {
 	p, found := catalog["host"]
 	if !found {
-		panic("Unable to find 'host' metadata collector in the catalog!")
+		log.Error("Unable to find 'host' metadata collector in the catalog!")
+		signals.ErrorStopper <- true
 	}
 	return p.Send(c.srl)
 }

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"math"
 	"sort"
+
+	log "github.com/cihub/seelog"
 )
 
 // EPSILON represents the accuracy of the sketch.
@@ -149,7 +151,8 @@ func (s GKArray) Compress() GKArray {
 // no need to check Incoming or Compress().
 func (s GKArray) Quantile(q float64) float64 {
 	if q < 0 || q > 1 {
-		panic("Quantile out of bounds")
+		log.Errorf("Quantile out of bounds")
+		return math.NaN()
 	}
 
 	if s.Count == 0 {


### PR DESCRIPTION
### What does this PR do?

We call a handful of manual panics in the agent. Some of these should exit the agent, some should not. This PR will remove all of them, it will also improve cleanup after exiting.

### Motivation

I was annoyed by the panics, and they were not something we wanted to show to users of the beta.

This is not a perfect PR. Maybe the signals could be handled differently. 

Furthermore, we might want to work on catching panics that come from other packages. I am genuinely not sure how to do that when we have multiple goroutines. How do panics bubble up through go routines?