### PR TITLE
[Logs] Let the agent run logs-agent

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -127,6 +127,7 @@ dependency 'jmxfetch'
 dependency 'datadog-trace-agent'
 unless windows?
   dependency 'datadog-process-agent'
+  dependency 'datadog-logs-agent'
 end
 
 # Remove pyc/pyo files from package

--- a/omnibus/config/software/datadog-logs-agent.rb
+++ b/omnibus/config/software/datadog-logs-agent.rb
@@ -1,0 +1,20 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https:#www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
+name "datadog-logs-agent"
+always_build true
+
+logs_agent_version = ENV['logs_agent_version']
+if logs_agent_version.nil? || logs_agent_version.empty?
+    logs_agent_version = "alpha"
+end
+
+build do
+  binary = "logagent"
+  url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
+  command "curl #{url} -o #{binary}"
+  command "chmod +x #{binary}"
+  command "mv #{binary} #{install_dir}/bin/agent/logs-agent"
+end

--- a/omnibus/config/software/datadog-logs-agent.rb
+++ b/omnibus/config/software/datadog-logs-agent.rb
@@ -6,12 +6,8 @@
 name "datadog-logs-agent"
 always_build true
 
-logs_agent_version = ENV['logs_agent_version']
-if logs_agent_version.nil? || logs_agent_version.empty?
-    logs_agent_version = "alpha"
-end
-
 build do
+  logs_agent_version = "alpha"
   binary = "logagent"
   url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
   command "curl #{url} -o #{binary}"

--- a/pkg/collector/corechecks/embed/logs-agent.go
+++ b/pkg/collector/corechecks/embed/logs-agent.go
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build process
+
+package embed
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	log "github.com/cihub/seelog"
+	"github.com/kardianos/osext"
+)
+
+// LogsCheck keeps track of the running command
+type LogsCheck struct {
+	cmd *exec.Cmd
+}
+
+func (c *LogsCheck) String() string {
+	return "Logs Agent"
+}
+
+// Run executes the check
+func (c *LogsCheck) Run() error {
+	// forward the standard output to the Agent logger
+	stdout, err := c.cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		in := bufio.NewScanner(stdout)
+		for in.Scan() {
+			log.Info(in.Text())
+		}
+	}()
+
+	// forward the standard error to the Agent logger
+	stderr, err := c.cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		in := bufio.NewScanner(stderr)
+		for in.Scan() {
+			log.Error(in.Text())
+		}
+	}()
+
+	if err = c.cmd.Start(); err != nil {
+		return err
+	}
+
+	return c.cmd.Wait()
+}
+
+// Configure the LogsCheck
+func (c *LogsCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+	here, _ := osext.ExecutableFolder()
+	confd := config.Datadog.GetString("confd_path")
+	bin := path.Join(here, "logs-agent")
+
+	c.cmd = exec.Command(
+		bin,
+		fmt.Sprintf("-ddconfig=%s", confd),
+	)
+
+	return nil
+}
+
+// InitSender initializes a sender but we don't need any
+func (c *LogsCheck) InitSender() {}
+
+// Interval returns the scheduling time for the check, this will be scheduled only once
+// since `Run` won't return, thus implementing a long running check.
+func (c *LogsCheck) Interval() time.Duration {
+	return 0
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (c *LogsCheck) ID() check.ID {
+	return "LOGS_AGENT"
+}
+
+// Stop sends a termination signal to the Logs process
+func (c *LogsCheck) Stop() {
+	err := c.cmd.Process.Signal(os.Kill)
+	if err != nil {
+		log.Errorf("unable to stop Logs check: %s", err)
+	}
+}
+
+func init() {
+	factory := func() check.Check {
+		return &LogsCheck{}
+	}
+	core.RegisterCheck("logs-agent", factory)
+}
+
+// GetWarnings does not return anything
+func (c *LogsCheck) GetWarnings() []error {
+	return []error{}
+}
+
+// GetMetricStats returns the stats from the last run of the check, but there aren't any yet
+func (c *LogsCheck) GetMetricStats() (map[string]int64, error) {
+	return make(map[string]int64), nil
+}


### PR DESCRIPTION
### What does this PR do?

- Add logs-agent binary on linux
- Add a logs-agent check that starts the logs agent

### Motivation

We'd like to include the logs-agent as part of agent 6 to dogfood it and for beta customers.

### Additional Notes

#### Related PRs

agent 5 PR - https://github.com/DataDog/dd-agent/pull/3520

#### Notes

The logs-agent is available for linux only. I am not sure what's the status of windows support for datadog-agent, thus haven't tested this scenario.

#### Tests

- gitlab build: [119045](https://gitlab.ddbuild.io/datadog/datadog-agent/pipelines/119045) contains updated builds. I set the [artifact](https://gitlab.ddbuild.io/datadog/datadog-agent/-/jobs/1639040/artifacts/file/.omnibus/pkg/datadog-agent6_0.0.0.20170915130649-1_amd64.deb) to be kept for a longer period

##### Tests the logs-agent included but disabled on a vm

- provision a `ubuntu/trusty64` vagrant box
- download the deb package, found at 
- configure the datadog-agent: in `/etc/datadog-agent/datadog.yaml`
  ```
  dd_url: https://app.datadoghq.com
  api_key: <api_key>
  confd_path: "/etc/datadog-agent/conf.d"
  ```
- install the package: `sudo dpkg -i datadog-agent6_0.0.0.20170915130649-1_amd64.deb`
- assert it reports metrics in datadog
- assert logs-agent is not running: `grep logs-agent /var/log/datadog/agent.log`

##### Tests the logs-agent included and enabled on a vm

- start from previous step
- setup proper configuration for the logs agent. See [internal doc](https://docs.google.com/document/d/1CNQg2hNaIn0WNJT9kTXuQAnhUO7qaeepaxpLclzBtfg/edit#heading=h.do7z5blfmc73) or ping #ramen. You should setup `/etc/datadog-agent/conf.d/logs-agent.yaml` and `/etc/datadog-agent/conf.d/logs-integrations.yaml`
  `/etc/datadog-agent/conf.d/logs-agent.yaml`
  ```
  init_config:

  instances:
    - whatever: anything

  log_dd_url: "intake.logs.datadoghq.com"
  logset: playground2
  api_key: <api_key>
  hostname: "tristan-host"
  ```
  `/etc/datadog-agent/conf.d/logs-integration.yaml`
  ```
  init_config:

  instances:
    - whatever: anything

  logs:
    - type: file
      path: /home/vagrant/test.log
      appname: bench-logs-agent
      source: bench-logs-agent
      logset: playground2
    - type: tcp
      logset: playground2
      source: java
      port: 10514
  ```
- restart dd-agent: `sudo service datadog-agent6 restart`
- assert logs-agent is up and running: `grep 'Starting logs-agent' /var/log/datadog/agent.log`
- assert that it works as expected by submitting logs lines:
  ```
  echo "hello" >> test.log
  grep 'Connecting' /var/log/datadog/agent.log
  2017/09/15 08:07:30 Connecting to the backend: intake.sheepdog.datad0g.com:10514 - skip_ssl_validation: true
  ```
  assert the log line appears in your logset

