### PR TITLE
allow disabling of copying development folder

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -14,7 +14,7 @@ build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
   # the go deps needs to be installed (invoke dep) before running omnibus
   # TODO: enable omnibus to run invoke deps while building the project
-  command "invoke agent.build --rebuild --use-embedded-libs"
+  command "invoke agent.build --rebuild --use-embedded-libs --no-development"
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/omnibus/config/software/datadog-puppy.rb
+++ b/omnibus/config/software/datadog-puppy.rb
@@ -11,7 +11,7 @@ build do
   ship_license 'https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE'
   # the go deps needs to be installed (invoke dep) before running omnibus
   # TODO: enable omnibus to run invoke deps while building the project
-  command "invoke agent.build --puppy --rebuild --use-embedded-libs"
+  command "invoke agent.build --puppy --rebuild --use-embedded-libs --no-development"
   copy('bin', install_dir)
 
   mkdir "#{install_dir}/run/"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -21,7 +21,7 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-          puppy=False, use_embedded_libs=False):
+          puppy=False, use_embedded_libs=False, development=True):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -69,11 +69,11 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     }
 
     ctx.run(cmd.format(**args), env=env)
-    refresh_assets(ctx)
+    refresh_assets(ctx, development=development)
 
 
 @task
-def refresh_assets(ctx):
+def refresh_assets(ctx, development=True):
     """
     Clean up and refresh Collector's assets and config files
     """
@@ -86,7 +86,8 @@ def refresh_assets(ctx):
         shutil.rmtree(dist_folder)
     copy_tree("./pkg/collector/dist/", dist_folder)
     copy_tree("./pkg/status/dist/", dist_folder)
-    copy_tree("./dev/dist/", dist_folder)
+    if development:
+        copy_tree("./dev/dist/", dist_folder)
     # copy the dd-agent placeholder to the bin folder
     bin_ddagent = os.path.join(BIN_PATH, "dd-agent")
     shutil.move(os.path.join(dist_folder, "dd-agent"), bin_ddagent)


### PR DESCRIPTION
### What does this PR do?

We don't wanna include the Readme.md in the final omnibus built binary, allow it to be disabled, though have it enabled by default.

### Motivation

I saw it in the binary and accidentally sent a build with my datadog.yaml to someone who was showing it to a customer.