### PR TITLE
[ipc] Fix client commands' authorization

### DIFF
--- a/cmd/agent/common/doget.go
+++ b/cmd/agent/common/doget.go
@@ -35,7 +35,7 @@ func DoGet(c *http.Client, url string) (body []byte, e error) {
 		return body, e
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Session-Token", common.GetAuthToken())
+	req.Header.Set("Authorization", "Bearer "+common.GetAuthToken())
 
 	r, e := c.Do(req)
 	if e != nil {
@@ -60,7 +60,7 @@ func DoPost(c *http.Client, url string, contentType string, body io.Reader) (res
 		return resp, e
 	}
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Session-Token", common.GetAuthToken())
+	req.Header.Set("Authorization", "Bearer "+common.GetAuthToken())
 
 	r, e := c.Do(req)
 	if e != nil {


### PR DESCRIPTION
### What does this PR do?

Fixes client commands' authorization.

### Motivation

All the client commands were broken since https://github.com/DataDog/datadog-agent/pull/560
The client commands weren't using the correct header to provide
the token.

### Additional Notes

We really need to add integration tests for all these commands. It's not the first time we're breaking agent commands.