### PR TITLE
Cleans up the status command with newlines and spaces for camelcased …

### DIFF
--- a/pkg/status/dist/templates/aggregator.tmpl
+++ b/pkg/status/dist/templates/aggregator.tmpl
@@ -2,32 +2,32 @@
 DogStatsD
 =========
 {{- if .ChecksMetricSample}}
-  ChecksMetricSample: {{.ChecksMetricSample}}
+  Checks Metric Sample: {{.ChecksMetricSample}}
 {{- end -}}
 {{- if .Event}}
   Event: {{.Event}}
 {{- end -}}
 {{- if .EventsFlushed}}
-  EventsFlushed: {{.EventsFlushed}}
+  Events Flushed: {{.EventsFlushed}}
 {{- end -}}
 {{- if .NumberOfFlush}}
-  NumberOfFlush: {{.NumberOfFlush}}
+  Number Of Flushes: {{.NumberOfFlush}}
 {{- end -}}
 {{- if .SeriesFlushed}}
-  SeriesFlushed: {{.SeriesFlushed}}
+  Series Flushed: {{.SeriesFlushed}}
 {{- end -}}
 {{- if .ServiceCheck}}
-  ServiceCheck: {{.ServiceCheck}}
+  Service Check: {{.ServiceCheck}}
 {{- end -}}
 {{- if .ServiceCheckFlushed}}
-  ServiceCheckFlushed: {{.ServiceCheckFlushed}}
+  Service Checks Flushed: {{.ServiceCheckFlushed}}
 {{- end -}}
 {{- if .SketchesFlushed}}
-  SketchesFlushed: {{.SketchesFlushed}}
+  Sketches Flushed: {{.SketchesFlushed}}
 {{- end -}}
 {{- if .HostnameUpdate}}
-  HostnameUpdate: {{.HostnameUpdate}}
+  Hostname Update: {{.HostnameUpdate}}
 {{- end -}}
 {{- if .DogstatsdMetricSample}}
-  DogstatsdMetricSample: {{.DogstatsdMetricSample}}
+  Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}
 {{- end}}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -1,6 +1,7 @@
 =========
 Collector
 =========
+
   Running Checks
   ==============
 {{- with .RunnerStats -}}
@@ -8,12 +9,13 @@ Collector
     No checks have run yet
 {{end -}}
 {{- range .Checks}}
+
     {{.CheckName}}
     {{printDashes .CheckName "-"}}
       Total Runs: {{.TotalRuns}}
-      Metrics: {{.Metrics}}, TotalMetrics: {{humanize .TotalMetrics}}
-      Events: {{.Events}}, TotalEvents: {{humanize .TotalEvents}}
-      ServiceChecks: {{.ServiceChecks}}, TotalServiceChecks: {{humanize .TotalServiceChecks}}
+      Metrics: {{.Metrics}}, Total Metrics: {{humanize .TotalMetrics}}
+      Events: {{.Events}}, Total Events: {{humanize .TotalEvents}}
+      Service Checks: {{.ServiceChecks}}, Total Service Checks: {{humanize .TotalServiceChecks}}
 {{- if .LastError}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}
@@ -22,6 +24,7 @@ Collector
       Warning: {{.}}
 {{- end -}} {{- end -}} {{- end -}} {{- end -}}
 {{- with .AutoConfigStats -}} {{- if .LoaderErrors}}
+
   Loading Errors
   ==============
 {{- range $checkname, $errors := .LoaderErrors}}

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -5,8 +5,10 @@ Forwarder
 {{- range $key, $value := .TransactionsCreated}}
   {{$key}}: {{$value}}
 {{- end -}}
+
 {{- end}}
 {{- if .APIKeyStatus}}
+
   API Keys status
   ---------------
   {{- range $key, $value := .APIKeyStatus}}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -8,16 +8,19 @@
 {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers -}} {{end}}
   Log Level: {{.config.log_level}}
+
   Paths
   =====
     Config File: {{if .conf_file}}{{.conf_file}}{{else}}There is no config file{{end}}
     conf.d: {{.config.confd_path}}
     checks.d: {{.config.additional_checksd}}
+
   Clocks
   ======
 {{- if .ntpOffset}}
     NTP offset: {{.ntpOffset}} s {{end}}
     System UTC time: {{.time}}
+
   Host Info
   =========
     {{- range $type, $value := .hostinfo -}}
@@ -28,6 +31,7 @@
     {{- $value -}}
     {{- end -}}
     {{end -}} {{end -}} {{end -}} {{- end}}
+
   Hostnames
   =========
     {{- range $type, $value := .metadata.meta -}} {{- if ne $type "timezones" -}} {{- if $value}}

--- a/pkg/status/dist/templates/jmxfetch.tmpl
+++ b/pkg/status/dist/templates/jmxfetch.tmpl
@@ -14,6 +14,7 @@ no JMX status available
 {{- end -}}
 {{- end -}}
 {{- end }}
+
     failed checks:
 {{- if (not .checks.failed_checks)}}
         no failed checks


### PR DESCRIPTION
…names

<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Updates the status command to be a bit cleaner with newlines and spacing. Also cleans up the camelcased names that are hardcoded. 

### Motivation

Make the Status command easier to consume visually, and issue - https://github.com/DataDog/datadog-agent/issues/531

### Additional Notes

Original Status command - https://gist.github.com/nmuesch/7cd39a1a1d955f8ecea2f5f495a308e5
Status command after this PR - https://gist.github.com/nmuesch/3cdd259710b980bc3926f09fe73a9314

Some of the variable names are still camelcased due to the fact that they come from the variable name themselves. ~I believe this can be resolved if we manually hardcode the metadata that we want to include in the output, it just means that if/when new metadata comes in, it would have to also be manually added in the template file. Specifically the hostinfo and forwarder info are still hardcoded~ EDIT: I went down that path a bit, hardcoding values in the template file won't work here since we dynamically build the list, not all keys are always available, so doing this would make the output have empty values. We would have to use something like this library - https://github.com/fatih/camelcase to split out the variable names, and update the keys in the interface{} in the render file. Not sure if we want to add an extra library or not, or if its worth the work :)

Anything else we should know when reviewing?
