### PR TITLE
Move the cache to its own package to be used by package in the util folder

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -8,7 +8,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -18,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/spf13/cobra"
 )
 
@@ -75,8 +75,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		hostname, err := util.GetHostname()
-		key := path.Join(util.AgentCachePrefix, "hostname")
-		util.Cache.Set(key, hostname, util.NoExpiration)
+		cache.Cache.Set(cache.BuildAgentKey("hostname"), hostname, cache.NoExpiration)
 		if err != nil {
 			fmt.Printf("Cannot get hostname, exiting: %v\n", err)
 			return err

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -7,7 +7,6 @@ package app
 
 import (
 	"fmt"
-	"path"
 	"syscall"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
@@ -156,8 +156,7 @@ func StartAgent() error {
 	}
 
 	// store the computed hostname in the global cache
-	key := path.Join(util.AgentCachePrefix, "hostname")
-	util.Cache.Set(key, hostname, util.NoExpiration)
+	cache.Cache.Set(cache.BuildAgentKey("hostname"), hostname, cache.NoExpiration)
 
 	log.Infof("Hostname is: %s", hostname)
 

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -12,13 +12,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
@@ -153,7 +152,7 @@ func init() {
 }
 
 func getHostname() string {
-	hname, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
+	hname, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
 	if found {
 		return hname.(string)
 	}

--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -7,13 +7,12 @@ package agentchecks
 
 import (
 	"encoding/json"
-	"path"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 
 	log "github.com/cihub/seelog"
 )
@@ -24,7 +23,7 @@ func GetPayload() *Payload {
 
 	// Grab the hostname from the cache
 	var hostname string
-	x, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
+	x, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
 	if found {
 		hostname = x.(string)
 	}

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -8,7 +8,6 @@ package runner
 import (
 	"expvar"
 	"fmt"
-	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	log "github.com/cihub/seelog"
 )
 
@@ -232,7 +231,7 @@ func GetCheckStats() map[check.ID]*check.Stats {
 }
 
 func getHostname() string {
-	hname, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
+	hname, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
 	if found {
 		return hname.(string)
 	}

--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -8,10 +8,9 @@ package listeners
 import (
 	"fmt"
 	"net"
-	"path"
 	"strconv"
 
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"golang.org/x/sys/unix"
 )
@@ -72,8 +71,8 @@ func processUDSOrigin(ancillary []byte) (string, error) {
 // As the result is cached and the lookup is really fast (parsing a local file), it can be
 // called from the intake goroutine.
 func getContainerForPID(pid int32) (string, error) {
-	key := path.Join(util.AgentCachePrefix, PIDToContainerKeyPrefix, strconv.Itoa(int(pid)))
-	if x, found := util.Cache.Get(key); found {
+	key := cache.BuildAgentKey(PIDToContainerKeyPrefix, strconv.Itoa(int(pid)))
+	if x, found := cache.Cache.Get(key); found {
 		return x.(string), nil
 	}
 	id, err := docker.ContainerIDForPID(int(pid))
@@ -82,6 +81,6 @@ func getContainerForPID(pid int32) (string, error) {
 	}
 	value := fmt.Sprintf("docker://%s", id)
 
-	util.Cache.Set(key, value, 0)
+	cache.Cache.Set(key, value, 0)
 	return value, err
 }

--- a/pkg/metadata/common/common.go
+++ b/pkg/metadata/common/common.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	log "github.com/cihub/seelog"
@@ -47,7 +47,7 @@ func getAPIKey() string {
 
 func getUUID() string {
 	key := path.Join(CachePrefix, "uuid")
-	if x, found := util.Cache.Get(key); found {
+	if x, found := cache.Cache.Get(key); found {
 		return x.(string)
 	}
 
@@ -57,6 +57,6 @@ func getUUID() string {
 		log.Errorf("failed to retrieve host info: %s", err)
 		return ""
 	}
-	util.Cache.Set(key, info.HostID, util.NoExpiration)
+	cache.Cache.Set(key, info.HostID, cache.NoExpiration)
 	return info.HostID
 }

--- a/pkg/metadata/host.go
+++ b/pkg/metadata/host.go
@@ -7,11 +7,10 @@ package metadata
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/v5"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 )
 
 // HostCollector fills and sends the old metadata payload used in the
@@ -21,7 +20,7 @@ type HostCollector struct{}
 // Send collects the data needed and submits the payload
 func (hp *HostCollector) Send(s *serializer.Serializer) error {
 	var hostname string
-	x, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
+	x, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
 	if found {
 		hostname = x.(string)
 	}

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 
@@ -51,7 +52,7 @@ func GetStatusInformation() *host.InfoStat {
 // if the cache is empty, then it queries the information directly
 func GetMeta() *Meta {
 	key := buildKey("meta")
-	if x, found := util.Cache.Get(key); found {
+	if x, found := cache.Cache.Get(key); found {
 		return x.(*Meta)
 	}
 	return getMeta()
@@ -81,7 +82,7 @@ func getHostTags() *tags {
 func getSystemStats() *systemStats {
 	var stats *systemStats
 	key := buildKey("systemStats")
-	if x, found := util.Cache.Get(key); found {
+	if x, found := cache.Cache.Get(key); found {
 		stats = x.(*systemStats)
 	} else {
 		cpuInfo := getCPUInfo()
@@ -97,7 +98,7 @@ func getSystemStats() *systemStats {
 
 		// fill the platform dependent bits of info
 		fillOsVersion(stats, hostInfo)
-		util.Cache.Set(key, stats, util.NoExpiration)
+		cache.Cache.Set(key, stats, cache.NoExpiration)
 	}
 
 	return stats
@@ -109,8 +110,7 @@ func getSystemStats() *systemStats {
 // using this package without embedding Python.
 func getPythonVersion() string {
 	// retrieve the Python version from the Agent cache
-	key := path.Join(util.AgentCachePrefix, "pythonVersion")
-	if x, found := util.Cache.Get(key); found {
+	if x, found := cache.Cache.Get(cache.BuildAgentKey("pythonVersion")); found {
 		return x.(string)
 	}
 
@@ -120,7 +120,7 @@ func getPythonVersion() string {
 // getCPUInfo returns InfoStat for the first CPU gopsutil found
 func getCPUInfo() *cpu.InfoStat {
 	key := buildKey("cpuInfo")
-	if x, found := util.Cache.Get(key); found {
+	if x, found := cache.Cache.Get(key); found {
 		return x.(*cpu.InfoStat)
 	}
 
@@ -131,13 +131,13 @@ func getCPUInfo() *cpu.InfoStat {
 		return &cpu.InfoStat{}
 	}
 	info := &i[0]
-	util.Cache.Set(key, info, util.NoExpiration)
+	cache.Cache.Set(key, info, cache.NoExpiration)
 	return info
 }
 
 func getHostInfo() *host.InfoStat {
 	key := buildKey("hostInfo")
-	if x, found := util.Cache.Get(key); found {
+	if x, found := cache.Cache.Get(key); found {
 		return x.(*host.InfoStat)
 	}
 
@@ -147,7 +147,7 @@ func getHostInfo() *host.InfoStat {
 		log.Errorf("failed to retrieve host info: %s", err)
 		return &host.InfoStat{}
 	}
-	util.Cache.Set(key, info, util.NoExpiration)
+	cache.Cache.Set(key, info, cache.NoExpiration)
 	return info
 }
 
@@ -195,7 +195,7 @@ func getMeta() *Meta {
 
 	// Cache the metadata for use in other payload
 	key := buildKey("meta")
-	util.Cache.Set(key, m, util.NoExpiration)
+	cache.Cache.Set(key, m, cache.NoExpiration)
 
 	return m
 }

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -6,11 +6,10 @@
 package host
 
 import (
-	"path"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ func TestGetSystemStats(t *testing.T) {
 	assert.NotNil(t, getSystemStats())
 	fakeStats := &systemStats{Machine: "fooMachine"}
 	key := buildKey("systemStats")
-	util.Cache.Set(key, fakeStats, util.NoExpiration)
+	cache.Cache.Set(key, fakeStats, cache.NoExpiration)
 	s := getSystemStats()
 	assert.NotNil(t, s)
 	assert.Equal(t, fakeStats.Machine, s.Machine)
@@ -38,8 +37,8 @@ func TestGetSystemStats(t *testing.T) {
 
 func TestGetPythonVersion(t *testing.T) {
 	require.Equal(t, "n/a", getPythonVersion())
-	key := path.Join(util.AgentCachePrefix, "pythonVersion")
-	util.Cache.Set(key, "Python 2.8", util.NoExpiration)
+	key := cache.BuildAgentKey("pythonVersion")
+	cache.Cache.Set(key, "Python 2.8", cache.NoExpiration)
 	require.Equal(t, "Python 2.8", getPythonVersion())
 }
 
@@ -47,7 +46,7 @@ func TestGetCPUInfo(t *testing.T) {
 	assert.NotNil(t, getCPUInfo())
 	fakeInfo := &cpu.InfoStat{Cores: 42}
 	key := buildKey("cpuInfo")
-	util.Cache.Set(key, fakeInfo, util.NoExpiration)
+	cache.Cache.Set(key, fakeInfo, cache.NoExpiration)
 	info := getCPUInfo()
 	assert.Equal(t, int32(42), info.Cores)
 }
@@ -56,7 +55,7 @@ func TestGetHostInfo(t *testing.T) {
 	assert.NotNil(t, getHostInfo())
 	fakeInfo := &host.InfoStat{HostID: "FOOBAR"}
 	key := buildKey("hostInfo")
-	util.Cache.Set(key, fakeInfo, util.NoExpiration)
+	cache.Cache.Set(key, fakeInfo, cache.NoExpiration)
 	info := getHostInfo()
 	assert.Equal(t, "FOOBAR", info.HostID)
 }

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -7,11 +7,10 @@ package metadata
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 )
 
 // ResourcesCollector sends the old metadata payload used in the
@@ -21,7 +20,7 @@ type ResourcesCollector struct{}
 // Send collects the data needed and submits the payload
 func (rp *ResourcesCollector) Send(s *serializer.Serializer) error {
 	var hostname string
-	x, found := util.Cache.Get(path.Join(util.AgentCachePrefix, "hostname"))
+	x, found := cache.Cache.Get(cache.BuildAgentKey("hostname"))
 	if found {
 		hostname = x.(string)
 	}

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -3,17 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
-package util
+package cache
 
 import (
+	"path"
 	"time"
 
 	cache "github.com/patrickmn/go-cache"
 )
 
 const (
-	defaultCacheExpire = 5 * time.Minute
-	defaultCachePurge  = 30 * time.Second
+	defaultExpire = 5 * time.Minute
+	defaultPurge  = 30 * time.Second
 	// AgentCachePrefix is the common root to use to prefix all the cache
 	// keys for any value regarding the Agent
 	AgentCachePrefix = "agent"
@@ -25,4 +26,12 @@ const (
 )
 
 // Cache provides an in-memory key:value store similar to memcached
-var Cache = cache.New(defaultCacheExpire, defaultCachePurge)
+var Cache = cache.New(defaultExpire, defaultPurge)
+
+// BuildAgentKey creates a cache key by joining the constant AgentCachePrefix
+// and path elements passed as arguments. It is to be used by core agent
+// packages to reuse the prefix constant
+func BuildAgentKey(keys ...string) string {
+	keys = append([]string{AgentCachePrefix}, keys...)
+	return path.Join(keys...)
+}


### PR DESCRIPTION
### What does this PR do?

Move caching to its own package

### Motivation

Caching was needed by modules in the utils folder creating cyclic dependencies,