### PR TITLE
[test] Disable test coverage by default for dev env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ run_tests_deb-x64:
   tags:
     - docker
   script:
-    - inv -e test
+    - inv -e test --coverage
 
 # run tests for rpm-x64
 run_test_rpm-x64:
@@ -48,7 +48,7 @@ run_test_rpm-x64:
   tags:
     - docker
   script:
-    - inv -e test
+    - inv -e test --coverage
 
 
 #

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
 
 test:
   override:
-    - cd "$IMPORT_PATH" && eval "$(gimme)" && inv deps && inv test --race --fail-on-fmt
+    - cd "$IMPORT_PATH" && eval "$(gimme)" && inv deps && inv test --coverage --race --fail-on-fmt
 
   post:
     - cd "$IMPORT_PATH" && eval "$(gimme)" && go tool cover -html=profile.cov -o $CIRCLE_ARTIFACTS/coverage.html


### PR DESCRIPTION
### What does this PR do?

Disables test coverage by default for dev env. We keep the coverage info in the CI (with the new `--coverage` option).

### Motivation

Makes the tests way faster in the dev env.

On my dev machine, it reduces the duration of the `test` command from ~10min to ~1m30sec:
```sh
$ time inv test --coverage  # with test coverage
# [...]
real    9m49.644s
user    17m41.573s
sys 3m48.833s
$ time inv test  # without test coverage
# [...]
real    1m30.062s
user    3m7.858s
sys 0m53.553s
```