### PR TITLE
Add docker check

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/cobra"
 
 	// register core checks
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system"

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -36,7 +37,7 @@ type dockerConfig struct {
 	//CollectExitCodes       bool               `yaml:"collect_exit_codes"`
 	//ExcludeContainers      []string           `yaml:"exclude"`
 	//IncludeContainers      []string           `yaml:"include"`
-	//Tags                   []string           `yaml:"tags"`
+	Tags []string `yaml:"tags"`
 	//ECSTags                []string           `yaml:"ecs_tags"`
 	//PerformanceTags        []string           `yaml:"performance_tags"`
 	//ContainrTags           []string           `yaml:"container_tags"`
@@ -68,7 +69,13 @@ func (d *DockerCheck) Run() error {
 	}
 
 	for _, c := range containers {
-		tags := []string{fmt.Sprintf("image:%s", c.Image), fmt.Sprintf("image_id:%s", c.ImageID)}
+		tags, err := tagger.Tag(c.EntityID, true)
+		if err != nil {
+			log.Errorf("Could not collect tags for container %s: %s", c.ID[:12], err)
+			tags = []string{}
+		}
+		tags = append(tags, d.instance.Tags...)
+
 		sender.Rate("docker.cpu.system", float64(c.CPU.System), "", tags)
 		sender.Rate("docker.cpu.user", float64(c.CPU.User), "", tags)
 		sender.Rate("docker.cpu.usage", c.CPU.UsageTotal, "", tags)

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -15,14 +15,47 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
+type dockerConfig struct {
+	//Url                    string             `yaml:"url"`
+	//CollectEvent           bool               `yaml:"collect_events"`
+	//FilteredEventType      []string           `yaml:"filtered_event_types"`
+	CollectContainerSize bool `yaml:"collect_container_size"`
+	//CustomCGroup           bool               `yaml:"custom_cgroups"`
+	//HealthServiceWhitelist []string           `yaml:"health_service_check_whitelist"`
+	//CollectContainerCount  bool               `yaml:"collect_container_count"`
+	//CollectVolumCount      bool               `yaml:"collect_volume_count"`
+	//CollectImagesStats     bool               `yaml:"collect_images_stats"`
+	//CollectImageSize       bool               `yaml:"collect_image_size"`
+	//CollectDistStats       bool               `yaml:"collect_disk_stats"`
+	//CollectExitCodes       bool               `yaml:"collect_exit_codes"`
+	//ExcludeContainers      []string           `yaml:"exclude"`
+	//IncludeContainers      []string           `yaml:"include"`
+	//Tags                   []string           `yaml:"tags"`
+	//ECSTags                []string           `yaml:"ecs_tags"`
+	//PerformanceTags        []string           `yaml:"performance_tags"`
+	//ContainrTags           []string           `yaml:"container_tags"`
+	//EventAttributesAsTags  []string           `yaml:"event_attributes_as_tags"`
+	//CappedMetrics          map[string]float64 `yaml:"capped_metrics"`
+}
+
+func (c *dockerConfig) Parse(data []byte) error {
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DockerCheck grabs docker metrics
 type DockerCheck struct {
 	lastWarnings []error
+	instance     *dockerConfig
 }
 
 // Run executes the check
@@ -82,6 +115,8 @@ func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 		CacheDuration:  10 * time.Second,
 		CollectNetwork: false,
 	})
+	d.instance = &dockerConfig{}
+	d.instance.Parse(config)
 	return nil
 }
 

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+// DockerCheck grabs docker metrics
+type DockerCheck struct {
+	lastWarnings []error
+}
+
+// Run executes the check
+func (d *DockerCheck) Run() error {
+	log.Error("Running the docker go check !!!!")
+	sender, err := aggregator.GetSender(d.ID())
+
+	containers, err := docker.AllContainers()
+	if err != nil {
+		return fmt.Errorf("Could not list containers: %s", err)
+	}
+
+	for _, c := range containers {
+		tags := []string{fmt.Sprintf("image:%s", c.Image), fmt.Sprintf("image_id:%s", c.ImageID)}
+		sender.Rate("docker.cpu.system", float64(c.CPU.System), "", tags)
+		sender.Rate("docker.cpu.user", float64(c.CPU.User), "", tags)
+		sender.Rate("docker.cpu.usage", c.CPU.UsageTotal, "", tags)
+		sender.Rate("docker.cpu.throttled", float64(c.CPUNrThrottled), "", tags)
+		sender.Gauge("docker.mem.cache", float64(c.Memory.Cache), "", tags)
+		sender.Gauge("docker.mem.rss", float64(c.Memory.RSS), "", tags)
+		if C.Memory.SwapPresent == true {
+			sender.Gauge("docker.mem.swap", float64(c.Memory.Swap), "", tags)
+		}
+
+		if c.Memory.HierarchicalMemoryLimit > 0 && c.Memory.HierarchicalMemoryLimit < uint64(math.Pow(2, 60)) {
+			sender.Gauge("docker.mem.limit", float64(c.Memory.HierarchicalMemoryLimit), "", tags)
+			if c.Memory.HierarchicalMemoryLimit != 0 {
+				sender.Gauge("docker.mem.in_use", float64(c.Memory.RSS/c.Memory.HierarchicalMemoryLimit), "", tags)
+			}
+		}
+
+		if c.Memory.HierarchicalMemSWLimit > 0 && c.Memory.HierarchicalMemSWLimit < uint64(math.Pow(2, 60)) {
+			sender.Gauge("docker.mem.sw_limit", float64(c.Memory.HierarchicalMemSWLimit), "", tags)
+			if c.Memory.HierarchicalMemSWLimit != 0 {
+				sender.Gauge("docker.mem.sw_in_use",
+					float64((c.Memory.Swap+c.Memory.RSS)/c.Memory.HierarchicalMemSWLimit), "", tags)
+			}
+		}
+
+		sender.Rate("docker.io.read_bytes", float64(c.IO.ReadBytes), "", tags)
+		sender.Rate("docker.io.write_bytes", float64(c.IO.WriteBytes), "", tags)
+	}
+	sender.Commit()
+	return nil
+}
+
+// Stop does nothing
+func (d *DockerCheck) Stop() {}
+
+func (d *DockerCheck) String() string {
+	return "docker"
+}
+
+// Configure parses the check configuration and init the check
+func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
+	docker.InitDockerUtil(&docker.Config{
+		CacheDuration:  10 * time.Second,
+		CollectNetwork: false,
+	})
+	return nil
+}
+
+// Interval returns the scheduling time for the check
+func (d *DockerCheck) Interval() time.Duration {
+	return check.DefaultCheckInterval
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (d *DockerCheck) ID() check.ID {
+	return check.ID(d.String())
+}
+
+// GetWarnings grabs the last warnings from the sender
+func (d *DockerCheck) GetWarnings() []error {
+	w := d.lastWarnings
+	d.lastWarnings = []error{}
+	return w
+}
+
+// GetMetricStats returns the stats from the last run of the check
+func (d *DockerCheck) GetMetricStats() (map[string]int64, error) {
+	sender, err := aggregator.GetSender(d.ID())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+	}
+	return sender.GetMetricStats(), nil
+}
+
+func dockerFactory() check.Check {
+	return &DockerCheck{}
+}
+
+func init() {
+	core.RegisterCheck("docker", dockerFactory)
+}

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -12,12 +12,12 @@ import (
 	"math"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -60,7 +60,6 @@ type DockerCheck struct {
 
 // Run executes the check
 func (d *DockerCheck) Run() error {
-	log.Error("Running the docker go check !!!!")
 	sender, err := aggregator.GetSender(d.ID())
 
 	containers, err := docker.AllContainers()
@@ -76,7 +75,7 @@ func (d *DockerCheck) Run() error {
 		sender.Rate("docker.cpu.throttled", float64(c.CPUNrThrottled), "", tags)
 		sender.Gauge("docker.mem.cache", float64(c.Memory.Cache), "", tags)
 		sender.Gauge("docker.mem.rss", float64(c.Memory.RSS), "", tags)
-		if C.Memory.SwapPresent == true {
+		if c.Memory.SwapPresent == true {
 			sender.Gauge("docker.mem.swap", float64(c.Memory.Swap), "", tags)
 		}
 
@@ -97,6 +96,21 @@ func (d *DockerCheck) Run() error {
 
 		sender.Rate("docker.io.read_bytes", float64(c.IO.ReadBytes), "", tags)
 		sender.Rate("docker.io.write_bytes", float64(c.IO.WriteBytes), "", tags)
+
+		sender.Rate("docker.net.bytes_sent", float64(c.Network.BytesSent), "", tags)
+		sender.Rate("docker.net.bytes_rcvd", float64(c.Network.BytesRcvd), "", tags)
+
+		if d.instance.CollectContainerSize {
+			info, err := c.Inspect(true)
+			if err != nil {
+				log.Errorf("Failed to inspect container %s - %s", c.ID[:12], err)
+			} else if info.SizeRw == nil || info.SizeRootFs == nil {
+				log.Warnf("Docker inspect did not return the container size: %s", c.ID[:12])
+			} else {
+				sender.Gauge("docker.container.size_rw", float64(*info.SizeRw), "", tags)
+				sender.Gauge("docker.container.size_rootfs", float64(*info.SizeRootFs), "", tags)
+			}
+		}
 	}
 	sender.Commit()
 	return nil
@@ -113,7 +127,7 @@ func (d *DockerCheck) String() string {
 func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 	docker.InitDockerUtil(&docker.Config{
 		CacheDuration:  10 * time.Second,
-		CollectNetwork: false,
+		CollectNetwork: true,
 	})
 	d.instance = &dockerConfig{}
 	d.instance.Parse(config)

--- a/pkg/collector/dist/conf.d/docker.yaml.example
+++ b/pkg/collector/dist/conf.d/docker.yaml.example
@@ -1,0 +1,203 @@
+init_config:
+  # Change the root directory to look at to get cgroup statistics. Useful when running inside a
+  # container with host directories mounted on a different folder. Default: /.
+  # Example for the docker-dd-agent container:
+  # docker_root: /host
+
+  # Timeout in seconds for the connection to the docker daemon
+  # Default: 5 seconds
+  #
+  # timeout: 10
+
+  # The version of the API the client will use. Specify 'auto' to use the API version provided by the server.
+  # api_version: auto
+
+  # Use TLS encryption while communicating with the Docker API
+  #
+  # tls: False
+  # tls_client_cert: /path/to/client-cert.pem
+  # tls_client_key: /path/to/client-key.pem
+  # tls_cacert: /path/to/ca.pem
+  # tls_verify: True
+
+  # Initialization retries
+  #
+  # if the agent is expected to start before Docker,
+  # use these settings to configure the retry policy.
+  #
+  # init_retry_interval defines how long (in seconds) the docker client
+  # will wait before retrying initialization.
+  # Defaults to 0.
+  #
+  # init_retry_interval: 20
+  #
+  # init_retries configures how many retries are made before failing permanently.
+  # Defaults to 0.
+  #
+  # init_retries: 5
+
+instances:
+  - ## Daemon and system configuration
+    ##
+
+    # URL of the Docker daemon socket to reach the Docker API. HTTP/HTTPS also works.
+    # Warning: if that's a non-local daemon, we won't be able to collect performance metrics.
+    #
+    url: "unix://var/run/docker.sock"
+
+    ## Data collection
+    ##
+
+    # Create events whenever a container status change.
+    # Defaults to true.
+    #
+    # collect_events: false
+
+    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create'].
+    # Here can be added additional statuses to be filtered. 
+    # List of available statuses can be found here https://docs.docker.com/engine/reference/commandline/events/#object-types
+    # filtered_event_types:
+    #    - 'top'
+    #    - 'exec_start'
+    #    - 'exec_create'
+
+    # Collect disk usage per container with docker.container.size_rw and
+    # docker.container.size_rootfs metrics.
+    # Warning: This might take time for Docker daemon to generate,
+    # ensure that `docker ps -a -q` run fast before enabling it.
+    # Defaults to false.
+    #
+    # collect_container_size: true
+
+    # Do you use custom cgroups for this particular instance?
+    # Note: enabling this option modifies the way in which we inspect the containers and causes
+    #       some overhead - if you run a high volume of containers we may timeout.
+    #
+    # custom_cgroups: false
+
+    # Report docker container healthcheck events as service checks
+    # Note: enabling this option modifies the way in which we inspect the containers and causes
+    #       some overhead - if you run a high volume of containers we may timeout.
+    #       Container Healthchecks are available starting with docker 1.12, enabling with older
+    #       versions will result in an UNKNOWN state for the service check.
+    #
+    # You must whitelist the containers you wish to submit health service checks for.
+    # Use the same mechanism as the tagging system (see Tag:performance_tags section).
+    # Example: ["docker_image:tomcat", "container_name:web_front_nginx"]
+    #
+    # health_service_check_whitelist: []
+
+    # Collect the container count tagged by state (running, paused, exited, dead)
+    # Defaults to false.
+    #
+    # collect_container_count: true
+
+    # Collect the volume count for attached and dangling volumes.
+    # Defaults to false.
+    #
+    # collect_volume_count: true
+
+    # Collect images stats
+    # Number of available active images and intermediate images as gauges.
+    # Defaults to false.
+    #
+    # collect_images_stats: true
+
+    # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
+    # The check gets this size with the `docker images` command.
+    # Requires collect_images_stats to be enabled.
+    # Defaults to false.
+    #
+    # collect_image_size: true
+
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
+    # Collect containers exit codes and send service checks critical when exit code is not 0
+    # Defaults to false.
+    #
+    # collect_exit_codes: true
+
+
+    # Exclude containers based on their tags
+    # An excluded container will not get any individual container metric reported for it.
+    # However it will still appear in the container count since ignoring it here would give
+    # a wrong impression about the docker daemon load.
+    #
+    # The rule is a regex on the tags.
+    #
+    # How it works: exclude first.
+    # If a tag matches an exclude rule, it won't be included unless it also matches an include rule.
+    # Examples:
+    # exclude all, except ubuntu and debian.
+    # exclude: [".*"]
+    # include: ["docker_image:ubuntu", "docker_image:debian"]
+    #
+    # include all, except ubuntu and Kubernetes pause containers.
+    # exclude: ["docker_image:ubuntu", "image_name:gcr.io/google_containers/pause.*", "image_name:openshift/origin-pod"]
+    # include: []
+    #
+    # Default: include all containers except for Kubernetes pause containers.
+    # Warning: pause containers exclusion works only if you deploy the agent the recommended way (in a pod).
+    # To customize this default behavior, override exclude.
+    # If you do so, default exclusion patterns won't apply anymore and will need to be added explicitly.
+
+
+
+    ## Tagging
+    ##
+
+    # You can add extra tags to your Docker metrics with the tags list option.
+    # Example: ["extra_tag", "env:testing"]
+    #
+    # tags: []
+
+    # If the agent is running in an Amazon ECS task, tags container metrics with the ECS task name and version.
+    # Default: true
+    #
+    # ecs_tags: false
+
+    # Custom metrics tagging
+    # Define which Docker tags to apply on metrics.
+    # Since it impacts the aggregation, modify it carefully (only if you really need it).
+    #
+    # Tags for performance metrics.
+    # Available:
+    #   - image_name: Name of the image (example: "nginx")
+    #   - image_tag: Tag of the image (example: "latest")
+    #   - docker_image: LEGACY. The full image name:tag string (example: "nginx:latest")
+    #   - container_name: Name of the container (example: "boring_euclid")
+    #   - container_command: Command ran by the container (example: "echo 1")
+    #   - container_id: Id of the container
+    #
+    # performance_tags: ["container_name", "image_name", "image_tag", "docker_image"]
+
+    # Tags for containers count metrics.
+    # Available: ["image_name", "image_tag", "docker_image", "container_command"]
+    #
+    # container_tags: ["image_name", "image_tag", "docker_image"]
+
+    # List of container label names that should be collected and sent as tags.
+    # Default to None
+    # Example:
+    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]
+    # List of docker event attributes to add as tags of the datadog events
+    # Defaults to None.
+    #
+    # event_attributes_as_tags: ["signal"]
+
+    ## Rate Filtering
+    ##
+
+    # Allows ad-hoc spike filtering if the system reports incorrect metrics.
+    # This will drop points if the computed rate is higher than the cap value
+    # capped_metrics:
+    #   docker.cpu.user: 1000
+    #   docker.cpu.system: 1000


### PR DESCRIPTION
### What does this PR do?

Adding a first and basic version of the docker check based on the one from integration-core. The main difference is that we heavily rely on the internal `tagger` and docker util package within the agent.

### Additional Notes

This is based on #585 and #586, you can skip the `pkg/util` and `pkg/tagger` folders from your review.
