### PR TITLE
[Docker] Add container self inspect to the flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/jhoonb/archivex"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -73,31 +72,13 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths) 
 	if err != nil {
 		return "", err
 	}
-
-	err = zipDockerSelfInspect(zipFile, hostname)
-	if err != nil {
-		return "", err
+	if config.IsContainerized(){
+		err = zipDockerSelfInspect(zipFile, hostname)
+		if err != nil {
+			return "", err
+		}
 	}
-
 	return zipFilePath, nil
-}
-
-func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error{
-
-	co, err := docker.ContainerSelfInspect()
-	if err != nil {
-		return err
-	}
-	// Clean it up
-	cleaned, err := credentialsCleanerBytes(co)
-	if err != nil {
-		return err
-	}
-	err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), cleaned)
-	if err != nil {
-		return err
-	}
-	return err
 }
 
 func zipStatusFile(zipFile *archivex.ZipFile, hostname string) error {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -8,16 +8,16 @@ package flare
 import (
 	"encoding/json"
 	"expvar"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
-	"time"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/jhoonb/archivex"
 	yaml "gopkg.in/yaml.v2"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
 )
 
 // SearchPaths is just an alias for a map of strings
@@ -72,7 +72,7 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths) 
 	if err != nil {
 		return "", err
 	}
-	if config.IsContainerized(){
+	if config.IsContainerized() {
 		err = zipDockerSelfInspect(zipFile, hostname)
 		if err != nil {
 			return "", err

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -9,12 +9,10 @@ import (
 	"encoding/json"
 	"expvar"
 	"os"
-	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -90,7 +88,12 @@ func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error{
 	if err != nil {
 		return err
 	}
-	err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), co)
+	// Clean it up
+	cleaned, err := credentialsCleanerBytes(co)
+	if err != nil {
+		return err
+	}
+	err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), cleaned)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -7,28 +7,26 @@
 
 package flare
 
-
 import (
-    "path/filepath"
-    "github.com/DataDog/datadog-agent/pkg/util/docker"
-    "github.com/jhoonb/archivex"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/jhoonb/archivex"
+	"path/filepath"
 )
 
+func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error {
 
-func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error{
-
-    co, err := docker.ContainerSelfInspect()
-    if err != nil {
-        return err
-    }
-    // Clean it up
-    cleaned, err := credentialsCleanerBytes(co)
-    if err != nil {
-        return err
-    }
-    err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), cleaned)
-    if err != nil {
-        return err
-    }
-    return err
+	co, err := docker.ContainerSelfInspect()
+	if err != nil {
+		return err
+	}
+	// Clean it up
+	cleaned, err := credentialsCleanerBytes(co)
+	if err != nil {
+		return err
+	}
+	err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), cleaned)
+	if err != nil {
+		return err
+	}
+	return err
 }

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package flare
+
+
+import (
+    "path/filepath"
+    "github.com/DataDog/datadog-agent/pkg/util/docker"
+    "github.com/jhoonb/archivex"
+)
+
+
+func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error{
+
+    co, err := docker.ContainerSelfInspect()
+    if err != nil {
+        return err
+    }
+    // Clean it up
+    cleaned, err := credentialsCleanerBytes(co)
+    if err != nil {
+        return err
+    }
+    err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), cleaned)
+    if err != nil {
+        return err
+    }
+    return err
+}

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/jhoonb/archivex"
 	"path/filepath"
-    "regexp"
+	"regexp"
 )
 
 func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error {
@@ -28,10 +28,10 @@ func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error {
 
 	imageSha := regexp.MustCompile(`\"Image\": \"sha256:\w+"`)
 	cleaned = imageSha.ReplaceAllFunc(cleaned, func(s []byte) []byte {
-        m := string(s[10 : len(s)-1])
-        shaResolvedInspect, _ := docker.ResolveImageName(m)
-        return []byte(shaResolvedInspect)
-    })
+		m := string(s[10 : len(s)-1])
+		shaResolvedInspect, _ := docker.ResolveImageName(m)
+		return []byte(shaResolvedInspect)
+	})
 
 	err = zipFile.Add(filepath.Join(hostname, "docker_inspect.log"), cleaned)
 	if err != nil {

--- a/pkg/flare/archive_nodocker.go
+++ b/pkg/flare/archive_nodocker.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build !docker
+
+package flare
+
+import (
+    "path"
+    "path/filepath"
+    "strings"
+    "github.com/jhoonb/archivex"
+)
+
+
+func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error{
+    return nil
+}

--- a/pkg/flare/archive_nodocker.go
+++ b/pkg/flare/archive_nodocker.go
@@ -8,13 +8,12 @@
 package flare
 
 import (
-    "path"
-    "path/filepath"
-    "strings"
-    "github.com/jhoonb/archivex"
+	"github.com/jhoonb/archivex"
+	"path"
+	"path/filepath"
+	"strings"
 )
 
-
-func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error{
-    return nil
+func zipDockerSelfInspect(zipFile *archivex.ZipFile, hostname string) error {
+	return nil
 }

--- a/pkg/flare/strip.go
+++ b/pkg/flare/strip.go
@@ -19,7 +19,7 @@ type replacer struct {
 	replFunc func(b []byte) []byte
 }
 
-var apiKeyReplacer, dockerApiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer replacer
+var apiKeyReplacer, dockerAPIKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer replacer
 var commentRegex = regexp.MustCompile(`^\s*#.*$`)
 var blankRegex = regexp.MustCompile(`^\s*$`)
 
@@ -34,7 +34,7 @@ func init() {
 			return []byte(replacement)
 		},
 	}
-	dockerApiKeyReplacer = replacer{
+	dockerAPIKeyReplacer = replacer{
 		regex: regexp.MustCompile(`DD_API_KEY=\w+`),
 		replFunc: func(b []byte) []byte {
 			s := string(b)
@@ -58,7 +58,7 @@ func init() {
 		regex: regexp.MustCompile(`^(\s*community_string:) *.+$`),
 		repl:  []byte(`$1 ********`),
 	}
-	replacers = []replacer{apiKeyReplacer, dockerApiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer}
+	replacers = []replacer{apiKeyReplacer, dockerAPIKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer}
 }
 
 func credentialsCleanerFile(filePath string) ([]byte, error) {

--- a/pkg/flare/strip.go
+++ b/pkg/flare/strip.go
@@ -19,7 +19,7 @@ type replacer struct {
 	replFunc func(b []byte) []byte
 }
 
-var apiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer replacer
+var apiKeyReplacer, dockerApiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer replacer
 var commentRegex = regexp.MustCompile(`^\s*#.*$`)
 var blankRegex = regexp.MustCompile(`^\s*$`)
 
@@ -31,6 +31,14 @@ func init() {
 		replFunc: func(b []byte) []byte {
 			s := string(b)
 			replacement := "api_key: **************************" + s[len(s)-5:]
+			return []byte(replacement)
+		},
+	}
+	dockerApiKeyReplacer = replacer{
+		regex: regexp.MustCompile(`DD_API_KEY=\w+`),
+		replFunc: func(b []byte) []byte {
+			s := string(b)
+			replacement := "DD_API_KEY=**************************" + s[len(s)-5:]
 			return []byte(replacement)
 		},
 	}
@@ -50,7 +58,7 @@ func init() {
 		regex: regexp.MustCompile(`^(\s*community_string:) *.+$`),
 		repl:  []byte(`$1 ********`),
 	}
-	replacers = []replacer{apiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer}
+	replacers = []replacer{apiKeyReplacer, dockerApiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer}
 }
 
 func credentialsCleanerFile(filePath string) ([]byte, error) {

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -8,11 +8,11 @@
 package docker
 
 import (
-	"encoding/json"
-	"bytes"
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -25,6 +25,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"


### PR DESCRIPTION
### What does this PR do?

Adding the docker self inspect to the flare and redacts the API key.

### Motivation

This will help to investigate for support cases or general investigations.

### Additional Notes

For instance:

```
> docker run -ti --rm -e DD_API_KEY=123123123123123 -v /var/run/docker.sock:/var/run/docker.sock:ro -v $PWD/bin/agent/agent:/opt/datadog-agent6/bin/agent/agent -v $PWD/tmp/:/tmp agent6 /opt/datadog-agent6/bin/agent/agent flare
> unzip datadog-agent-2017-09-19-16-46-53.zip -d .
> less ./unknown/docker_inspect.log
```

```
{
        "Id": "5880e1223712f2edbf226ca717afba6837f33abbc6ead047a34f219a6ef2f649",
        "Created": "2017-09-19T16:46:51.124139271Z",
        "Path": "/entrypoint.sh",
        "Args": [
                "/opt/datadog-agent6/bin/agent/agent",
                "flare"
        ],
        "State": {
                "Status": "running",
                "Running": true,
[...]
                "Env": [
                        "DD_API_KEY=**************************23123",
                        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                        "DOCKER_DD_AGENT=yes",
                        "AGENT_VERSION=1:6.0-1",
                        "DD_AGENT_HOME=/opt/datadog-agent6/"
```

This was tested in a dockerized agent 6.
