### PR TITLE
[go_expvar] Don't run check by default

### DIFF
--- a/pkg/collector/dist/conf.d/go_expvar.yaml.example
+++ b/pkg/collector/dist/conf.d/go_expvar.yaml.example
@@ -1,22 +1,51 @@
 init_config:
 instances:
-  - expvar_url: http://localhost:5000/debug/vars
-    tags:
-      - check_type:python
-    metrics:
-      - path: memstats/PauseTotalNs
-        alias: go_expvar.gc.pause_time_in_ns
-        type: rate                  # default is a gauge
-      - path: memstats/Alloc        # will be reported as go_expvar.memstats.alloc
-      - path: points_processed
-        type: rate
+  # Most memstats metrics are exported by default
+  # See http://godoc.org/runtime#MemStats for their explanation
+  # Note that you can specify a `type` for the metrics. One of:
+  #  * counter
+  #  * gauge (the default)
+  #  * rate (note that this will show up as a gauge in Datadog that is meant to be seen as a "per second rate")
 
-      # forwarder monitoring
-      - path: forwarder/TransactionsCreated/Timeseries
+  # - expvar_url: http://localhost:8080
+  #   namespace: examplenamespace         # The default metric namespace is 'go_expvar', define your own
+  #   tags:
+  #     - "application_name:myapp"
+  #     - "optionaltag2"
+  #   metrics:
+  #     # These metrics are just here as examples.
+  #     # Most memstats metrics are collected by default without configuration needed.
+  #     - path: memstats/PauseTotalNs
+  #       alias: go_expvar.gc.pause_time_in_ns
+  #       type: rate
+  #       tags:
+  #         - "metric_tag1:tag_value1"
+  #         - "metric_tag2:tag_value2"
+  #     - path: memstats/Alloc            # metric will be reported as a gauge by default
+  #     - path: memstats/Lookups
+  #       type: rate                      # metric should be reported as a rate instead of the default gauge
+  #     - path: memstats/Mallocs          # with no name specified, the metric name will default to a path based name
+  #       type: counter                   # report as a counter instead of the default gauge
+  #     - path: memstats/Frees
+  #       type: rate
+  #     - path: memstats/BySize/1/Mallocs # You can get nested values by separating them with "/"
+  #     - path: myvariable
+  #       alias: go_expvar.my_custom_name
+  #       type: gauge
+  #     - path: routes/get_.*/count       # You can use a regex when you want to report for all elements matching a certain pattern
+
+
+  # The following instance pulls the go_expvar metrics of the running datadog-agent
+  # Feel free to comment out the instance if you're not interested in these metrics
+  - expvar_url: http://localhost:5000/debug/vars  # if you've defined `expvar_port` in datadog.yaml, change the port here to that value
+    namespace: datadog
+    metrics:
+      # datadog-agent forwarder monitoring
+      - path: forwarder/TransactionsCreated/Series
         type: rate
-      - path: forwarder/TransactionsCreated/Event
+      - path: forwarder/TransactionsCreated/Events
         type: rate
-      - path: forwarder/TransactionsCreated/CheckRuns
+      - path: forwarder/TransactionsCreated/ServiceChecks
         type: rate
       - path: forwarder/TransactionsCreated/HostMetadata
         type: rate
@@ -31,18 +60,19 @@ instances:
       - path: forwarder/TransactionsCreated/Dropped
         type: rate
       - path: forwarder/TransactionsCreated/RetryQueueSize
-        type: gauge
       - path: forwarder/TransactionsCreated/Requeued
         type: rate
       - path: forwarder/TransactionsCreated/Errors
         type: rate
-      - path: forwarder/TransactionsCreated/Dropped
-        type: rate
       - path: forwarder/TransactionsCreated/Success
         type: rate
 
-      # dogstatsd monitoring
-      - path: dogstatsd/PacketReadingErrors
+      # datadog-agent dogstatsd monitoring
+      - path: dogstatsd-udp/PacketReadingErrors
+        type: rate
+      - path: dogstatsd-uds/PacketReadingErrors
+        type: rate
+      - path: dogstatsd-uds/OriginDetectionErrors
         type: rate
       - path: dogstatsd/ServiceCheckParseErrors
         type: rate
@@ -57,25 +87,16 @@ instances:
       - path: dogstatsd/MetricPackets
         type: rate
 
-      # aggregator monitoring
+      # datadog-agent aggregator monitoring
       - path: aggregator/Flush/ChecksMetricSampleFlushTime/LastFlush
-        type: gauge
       - path: aggregator/Flush/ServiceCheckFlushTime/LastFlush
-        type: gauge
       - path: aggregator/Flush/EventFlushTime/LastFlush
-        type: gauge
       - path: aggregator/Flush/MetricSketchFlushTime/LastFlush
-        type: gauge
       - path: aggregator/Flush/MainFlushTime/LastFlush
-        type: gauge
       - path: aggregator/FlushCount/ServiceChecks/LastFlush
-        type: gauge
       - path: aggregator/FlushCount/Series/LastFlush
-        type: gauge
       - path: aggregator/FlushCount/Events/LastFlush
-        type: gauge
       - path: aggregator/FlushCount/Sketches/LastFlush
-        type: gauge
       - path: aggregator/SeriesFlushed
         type: rate
       - path: aggregator/ServiceCheckFlushed
@@ -95,19 +116,15 @@ instances:
       - path: aggregator/HostnameUpdate
         type: rate
 
-      # scheduler monitoring
+      # datadog-agent scheduler monitoring
       - path: scheduler/ChecksEntered
-        type: gauge
       - path: scheduler/Queues/.*/Size
-        type: gauge
         alias: scheduler.queues.size
       - path: scheduler/Queues/.*/Interval
-        type: gauge
         alias: scheduler.queues.interval
       - path: scheduler/QueuesCount
-        type: gauge
 
-      # Payload monitoring
+      # datadog-agent serializer monitoring
       - path: splitter/NotTooBig
         type: rate
       - path: splitter/TooBig


### PR DESCRIPTION
### What does this PR do?

Removes `go_expvar` default config to stop running the check by default

### Motivation

It creates a lot of metrics that we don't want to collect by default.

Keep the yaml as an example file that we can easily enable if needed by
just moving the file (and once agent6 is GA this could become the example file
of the check in integrations-core).

### Additional Notes

I've also updated the expvar metrics which names have changed.
