### PR TITLE
[cmd api] Listen on localhost only

### DIFF
--- a/cmd/agent/api/listener.go
+++ b/cmd/agent/api/listener.go
@@ -13,5 +13,5 @@ import (
 
 // getListener returns a listening connection
 func getListener() (net.Listener, error) {
-	return net.Listen("tcp", fmt.Sprintf(":%v", config.Datadog.GetInt("cmd_port")))
+	return net.Listen("tcp", fmt.Sprintf("localhost:%v", config.Datadog.GetInt("cmd_port")))
 }


### PR DESCRIPTION
### What does this PR do?

Make the cmd HTTP api server listen on localhost only

### Motivation

Technically we could make the command API listen on all network
interfaces, but since there are no use cases for it yet, let's stay safe
and listen on localhost only.

We need to audit the security of our cmd api thoroughly before listening
on public network interfaces.