### PR TITLE
Check the apiKey length before slicing.

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -259,7 +259,12 @@ func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payloads Payl
 				t.Endpoint = transactionEndpoint
 				t.Payload = payload
 				t.Headers.Set(apiHTTPHeaderKey, apiKey)
-				t.apiKeyStatusKey = fmt.Sprintf("%s,%s", domain, fmt.Sprintf("*************************%s", apiKey[len(apiKey)-5:]))
+
+				t.apiKeyStatusKey = fmt.Sprintf("%s,*************************", domain)
+				if len(apiKey) > 5 {
+					t.apiKeyStatusKey += apiKey[len(apiKey)-5:]
+				}
+
 				for k, v := range extraHeaders {
 					t.Headers.Set(k, v)
 				}


### PR DESCRIPTION
### What does this PR do?

When the user set an erroneous api_key (too short), the agent would panic.
If the key is to short we don't show the 5 last characters.