### PR TITLE
[docker] make `util/docker` work out-of-the-box in containers

### DIFF
--- a/Dockerfiles/agent6/Dockerfile
+++ b/Dockerfiles/agent6/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker.yaml /etc/dd-agent/conf.d/
 
 EXPOSE 8125/udp
 

--- a/Dockerfiles/agent6/docker.yaml
+++ b/Dockerfiles/agent6/docker.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - ## Placeholder configuration file to start the docker check by default
+    ## Please see https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/dist/conf.d/docker.yaml.example
+    ## for supported options

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,10 +81,14 @@ func init() {
 	Datadog.SetDefault("enable_metadata_collection", true)
 	Datadog.SetDefault("check_runners", int64(4))
 	if IsContainerized() {
-		Datadog.SetDefault("proc_root", "/host/proc")
+		Datadog.SetDefault("container_proc_root", "/host/proc")
+		Datadog.SetDefault("container_sysfs_root", "/host/sys")
+
 	} else {
-		Datadog.SetDefault("proc_root", "/proc")
+		Datadog.SetDefault("container_proc_root", "/proc")
+		Datadog.SetDefault("container_sysfs_root", "/sys")
 	}
+	Datadog.SetDefault("proc_root", "/proc")
 	// Serializer
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)
@@ -134,6 +138,8 @@ func init() {
 	Datadog.BindEnv("enable_metadata_collection")
 	Datadog.BindEnv("dogstatsd_port")
 	Datadog.BindEnv("proc_root")
+	Datadog.BindEnv("container_proc_root")
+	Datadog.BindEnv("container_sysfs_root")
 	Datadog.BindEnv("dogstatsd_socket")
 	Datadog.BindEnv("dogstatsd_stats_port")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")

--- a/pkg/util/docker/docker_test.go
+++ b/pkg/util/docker/docker_test.go
@@ -26,7 +26,7 @@ func TestFindDockerNetworks(t *testing.T) {
 	dummyProcDir, err := newTempFolder("test-find-docker-networks")
 	assert.Nil(err)
 	defer dummyProcDir.removeAll() // clean up
-	config.Datadog.SetDefault("proc_root", dummyProcDir.RootPath)
+	config.Datadog.SetDefault("container_proc_root", dummyProcDir.RootPath)
 
 	containerID := "test-find-docker-networks"
 	for _, tc := range []struct {

--- a/pkg/util/docker/util.go
+++ b/pkg/util/docker/util.go
@@ -63,7 +63,7 @@ func GetEnv(key string, dfault string, combineWith ...string) string {
 // HostProc returns the location of a host's procfs. This can and will be
 // overriden when running inside a container.
 func HostProc(combineWith ...string) string {
-	parts := append([]string{config.Datadog.GetString("proc_root")}, combineWith...)
+	parts := append([]string{config.Datadog.GetString("container_proc_root")}, combineWith...)
 	return path.Join(parts...)
 }
 
@@ -71,7 +71,8 @@ func HostProc(combineWith ...string) string {
 // when running inside a container.
 // TODO: use config value instead of envvar
 func HostSys(combineWith ...string) string {
-	return GetEnv("HOST_SYS", "/sys", combineWith...)
+	parts := append([]string{config.Datadog.GetString("container_sysfs_root")}, combineWith...)
+	return path.Join(parts...)
 }
 
 // PathExists returns a boolean indicating if the given path exists on the file system.


### PR DESCRIPTION
### What does this PR do?

### Rename `proc_root` option to `container_proc_root`
To keep `proc_root` for the container's own proc folder (for gw detection)

### Cgroup parsing
Instead of getting PIDs from gopsutil and reading
cgroups from that list, directly scrape /{host/}proc
and get all cgroups we can find, via the new
`ScrapeAllCgroups` that replaces `CgroupsForPids`.

gopsutil does the same directory scraping, so we
don't lose any performance. Alternative would be to
set the `HOST_PROC` envvar for gopsutil to catch it
but that's error prone and might interfere with other
usages of gousutil in the same binary.

in the future, we should benchmark inspecting container
on detection, parsing it's root pid's cgroup and caching
instead of scaping everything.

### Add `container_sys_root` config option
Add `container_sys_root` config option with autodetected defaults,
like `container_proc_root` is. cgroup mountpoints out of this path are
ignored, to avoid mixing up the container's cgroup folder from the host's

### Default docker.yaml file
Add default `docker.yaml` conf to the agent6 image