### PR TITLE
sets pythonhome to a relative directory path

### DIFF
--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -8,6 +8,7 @@ package py
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
@@ -113,7 +114,15 @@ func Initialize(paths ...string) *python.PyThreadState {
 
 func setPythonPath() {
 	_here, _ := osext.ExecutableFolder()
-	embeddedDirectory := filepath.Join(_here, "..", "..", "embedded")
+
+	var embeddedDirectory string
+	switch os := runtime.GOOS; os {
+	case "windows":
+		embeddedDirectory = _here
+	default: // Should cover Unices (Linux, OSX, FreeBSD,...)
+		embeddedDirectory = filepath.Join(_here, "..", "..", "embedded")
+	}
+
 	pythonLibDir := filepath.Join(embeddedDirectory, "lib", "python2.7")
 	_, err := os.Stat(pythonLibDir)
 	if !os.IsNotExist(err) {


### PR DESCRIPTION
### What does this PR do?

On Windows (and sometimes otherwise) we want to be able to move the install directory around on the system. In that case, we need to set pythonHome dynamically, rather than statically.

This sets it dynamically.

Setting any of these kinds of things dynamically can be problematic, however I think this is a relatively minimal implementation and will solve the problem better than the alternatives, all of which are hacky and dangerous.