### PR TITLE
Log Panics to File

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -80,9 +80,6 @@ func init() {
 // Start the main loop
 func start(cmd *cobra.Command, args []string) error {
 	defer func() {
-		if r := recover(); r != nil {
-			log.Infof("Recovered from a panic: %v", r)
-		}
 		StopAgent()
 	}()
 

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -80,6 +80,9 @@ func init() {
 // Start the main loop
 func start(cmd *cobra.Command, args []string) error {
 	defer func() {
+		if r := recover(); r != nil {
+			log.Infof("Recovered from a panic: %v", r)
+		}
 		StopAgent()
 	}()
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -33,7 +33,7 @@ build do
       erb source: "upstart.conf.erb",
           dest: "/etc/init/datadog-agent6.conf",
           mode: 0755,
-          vars: { install_dir: install_dir }
+          vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
     end
 
     mkdir "/lib/systemd/system/"
@@ -41,7 +41,7 @@ build do
       erb source: "systemd.service.erb",
           dest: "/lib/systemd/system/datadog-agent6.service",
           mode: 0755,
-          vars: { install_dir: install_dir }
+          vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
     end
   end
 

--- a/omnibus/config/software/datadog-puppy.rb
+++ b/omnibus/config/software/datadog-puppy.rb
@@ -26,14 +26,14 @@ build do
       erb source: "upstart.conf.erb",
           dest: "/etc/init/datadog-agent6.conf",
           mode: 0755,
-          vars: { install_dir: install_dir }
+          vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
     end
 
     if redhat? || debian?
       erb source: "systemd.service.erb",
           dest: "/lib/systemd/system/datadog-agent6.service",
           mode: 0755,
-          vars: { install_dir: install_dir }
+          vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
     end
   end
 

--- a/omnibus/config/software/dogstatsd.rb
+++ b/omnibus/config/software/dogstatsd.rb
@@ -15,18 +15,18 @@ build do
     erb source: "upstart.conf.erb",
         dest: "/etc/init/dogstatsd.conf",
         mode: 0755,
-        vars: { install_dir: install_dir }
+        vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
     erb source: "systemd.service.erb",
         dest: "/lib/systemd/system/dogstatsd.service",
         mode: 0755,
-        vars: { install_dir: install_dir }
+        vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
   end
 
   if redhat?
     erb source: "systemd.service.erb",
         dest: "/lib/systemd/system/dogstatsd.service",
         mode: 0755,
-        vars: { install_dir: install_dir }
+        vars: { install_dir: install_dir, log_dir: "/var/log/datadog" }
   end
 
   # The file below is touched by software builds that don't put anything in the installation

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -7,8 +7,8 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStartPre=/bin/rm -f /tmp/agent.sock
-ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+ExecStartPre=/bin/rm -f /tmp/agent.sock; if test $(sed -n '$=' <%= log_dir %>/agent.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1; end
+ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid 2>> <%= log_dir %>/agent.stderr.log
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -7,7 +7,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStartPre=/bin/rm -f /tmp/agent.sock; if test $(sed -n '$=' <%= log_dir %>/agent.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1; end
+ExecStartPre=/bin/rm -f /tmp/agent.sock; if test $(sed -n '$=' <%= log_dir %>/agent.stderr.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.stderr.log.1; end
 ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid 2>> <%= log_dir %>/agent.stderr.log
 
 [Install]

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -7,10 +7,17 @@ respawn
 
 console none
 
+pre-start script
+  lines=$(sed -n '$=' <%= log_dir %>/agent.log)
+  if test $lines -ge 100; then
+   mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1;
+  end
+end script
+
 script
   # setuid is not available in versions of upstart before 1.4. CentOS/RHEL6 use an earlier version of upstart.
   # This is the best way to set the user in the absence of setuid.
-  exec su -s /bin/sh -c 'exec "$0" "$@"' dd-agent -- <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+  exec su -s /bin/sh -c 'exec "$0" "$@"' dd-agent -- <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid 2>> <%= log_dir %>/agent.stderr.log
 end script
 
 post-stop script

--- a/omnibus/config/templates/datadog-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart.conf.erb
@@ -8,9 +8,9 @@ respawn
 console none
 
 pre-start script
-  lines=$(sed -n '$=' <%= log_dir %>/agent.log)
+  lines=$(sed -n '$=' <%= log_dir %>/agent.stderr.log)
   if test $lines -ge 100; then
-   mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1;
+   mv <%= log_dir %>/agent.stderr.log <%= log_dir %>/agent.stderr.log.1;
   end
 end script
 

--- a/omnibus/config/templates/datadog-puppy/systemd.service.erb
+++ b/omnibus/config/templates/datadog-puppy/systemd.service.erb
@@ -7,8 +7,8 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStartPre=/bin/rm -f /tmp/agent.sock
-ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+ExecStartPre=/bin/rm -f /tmp/agent.sock; if test $(sed -n '$=' <%= log_dir %>/agent.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1; end
+ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid 2>> <%= log_dir %>/agent.stderr.log
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-puppy/systemd.service.erb
+++ b/omnibus/config/templates/datadog-puppy/systemd.service.erb
@@ -7,7 +7,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStartPre=/bin/rm -f /tmp/agent.sock; if test $(sed -n '$=' <%= log_dir %>/agent.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1; end
+ExecStartPre=/bin/rm -f /tmp/agent.sock; if test $(sed -n '$=' <%= log_dir %>/agent.stderr.log) -ge 100; then mv <%= log_dir %>/agent.stderr.log <%= log_dir %>/agent.stderr.log.1; end
 ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid 2>> <%= log_dir %>/agent.stderr.log
 
 [Install]

--- a/omnibus/config/templates/datadog-puppy/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-puppy/upstart.conf.erb
@@ -9,9 +9,9 @@ setuid dd-agent
 console none
 
 pre-start script
-  lines=$(sed -n '$=' <%= log_dir %>/agent.log)
+  lines=$(sed -n '$=' <%= log_dir %>/agent.stderr.log)
   if test $lines -ge 100; then
-   mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1;
+   mv <%= log_dir %>/agent.stderr.log <%= log_dir %>/agent.stderr.log.1;
   end
 end script
 

--- a/omnibus/config/templates/datadog-puppy/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-puppy/upstart.conf.erb
@@ -8,8 +8,15 @@ respawn
 setuid dd-agent
 console none
 
+pre-start script
+  lines=$(sed -n '$=' <%= log_dir %>/agent.log)
+  if test $lines -ge 100; then
+   mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1;
+  end
+end script
+
 script
-  exec <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+  exec <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid 2>> <%= log_dir %>/agent.stderr.log
 end script
 
 post-stop script

--- a/omnibus/config/templates/dogstatsd/systemd.service.erb
+++ b/omnibus/config/templates/dogstatsd/systemd.service.erb
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=root
 Restart=on-failure
-ExecStartPre=if test $(sed -n '$=' <%= log_dir %>/agent.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1; end
+ExecStartPre=if test $(sed -n '$=' <%= log_dir %>/agent.stderr.log) -ge 100; then mv <%= log_dir %>/agent.stderr.log <%= log_dir %>/agent.stderr.log.1; end
 ExecStart=<%= install_dir %>/bin/dogstatsd/dogstatsd 2>> <%= log_dir %>/agent.stderr.log
 
 [Install]

--- a/omnibus/config/templates/dogstatsd/systemd.service.erb
+++ b/omnibus/config/templates/dogstatsd/systemd.service.erb
@@ -6,7 +6,8 @@ After=network.target
 Type=simple
 User=root
 Restart=on-failure
-ExecStart=<%= install_dir %>/bin/dogstatsd/dogstatsd
+ExecStartPre=if test $(sed -n '$=' <%= log_dir %>/agent.log) -ge 100; then mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1; end
+ExecStart=<%= install_dir %>/bin/dogstatsd/dogstatsd 2>> <%= log_dir %>/agent.stderr.log
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/dogstatsd/upstart.conf.erb
+++ b/omnibus/config/templates/dogstatsd/upstart.conf.erb
@@ -8,9 +8,9 @@ respawn
 console log  # redirect daemon's outputs to `/var/log/upstart/dogstatsd.log`
 
 pre-start script
-  lines=$(sed -n '$=' <%= log_dir %>/agent.log)
+  lines=$(sed -n '$=' <%= log_dir %>/agent.stderr.log)
   if test $lines -ge 100; then
-  mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1;
+  mv <%= log_dir %>/agent.stderr.log <%= log_dir %>/agent.stderr.log.1;
   end
 end script
 

--- a/omnibus/config/templates/dogstatsd/upstart.conf.erb
+++ b/omnibus/config/templates/dogstatsd/upstart.conf.erb
@@ -7,6 +7,13 @@ respawn
 
 console log  # redirect daemon's outputs to `/var/log/upstart/dogstatsd.log`
 
+pre-start script
+  lines=$(sed -n '$=' <%= log_dir %>/agent.log)
+  if test $lines -ge 100; then
+  mv <%= log_dir %>/agent.log <%= log_dir %>/agent.log.1;
+  end
+end script
+
 script
-  exec <%= install_dir %>/bin/dogstatsd/dogstatsd
+  exec <%= install_dir %>/bin/dogstatsd/dogstatsd 2>> <%= log_dir %>/agent.stderr.log
 end script


### PR DESCRIPTION
### What does this PR do?

This PR logs panics (it logs all stderr output) to a file in both upstart and systemd

This PR is not great, it has its issues. However, this is the only way to do this. You cannot recover from a panicking goroutine that's not the goroutine the function is currently on. So:

1. we cannot trust the log function to log this.
1. We cannot recover from almost any panics unless they are adjacent to the panicking code. 

Therefore, any solution must be outside of the agent proper. The only way to do this is to do it in the daemon manager--upstart and systemd. 

@derekwbrown I don't know what to do for Windows. I looked over what you do for the service manager, but I do not know if that has the ability to do what I'm asking for here. 😕 
