### PR TITLE
Add instance tags to docker.containers metrics.

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -199,8 +199,8 @@ func (d *DockerCheck) Run() error {
 	}
 
 	for _, image := range images {
-		sender.Gauge("docker.containers.running", float64(image.running), "", image.tags)
-		sender.Gauge("docker.containers.stopped", float64(image.stopped), "", image.tags)
+		sender.Gauge("docker.containers.running", float64(image.running), "", append(d.instance.Tags, image.tags...))
+		sender.Gauge("docker.containers.stopped", float64(image.stopped), "", append(d.instance.Tags, image.tags...))
 	}
 
 	if err := d.countAndWeightImages(sender); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR add instance tags (tags define in the docker check configuration) to the tags for `docker.containers.*` metrics.