### PR TITLE
[gitlab] dogstatsd should not be benchmarked in gitlab - just validated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,8 @@ run_benchmarks-deb_x64:
     - set +x # make sure we don't output the creds to the build log
     - DD_AGENT_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_agent_api_key --with-decryption --query "Parameter.Value" --out text)
 
-    - ./bin/benchmarks/dogstatsd -pps=5000 -dur 45 -ser 5 -brk -inc 1000 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
+    # dogstatsd validation - not really benchmarking: gitlab isn't the right place to do this.
+    - ./bin/benchmarks/dogstatsd -pps=20000 -dur 30 -ser 5 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
### What does this PR do?

Removes the full dogstatsd benchmarking from gitlab. Gitlab isn't the right environment for these tests, they're also inconsistent due to the nature of the beast (concurrent gitlab worker load, scheduling, etc). To benchmark dsd6 we need to be more precise. The test however is still very helpful and valid to check all is more or less fine on dsd6. Also bumped the rate to 20000 pps - which is a reasonable load, and dropped the test duration to 30 seconds. 

### Motivation
Speed up our gitlab pipeline, remove useless benchmarking.