### PR TITLE
[api] expose JMX configurations via API

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -36,11 +36,11 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/version", getVersion).Methods("GET")
 	r.HandleFunc("/hostname", getHostname).Methods("GET")
 	r.HandleFunc("/flare", makeFlare).Methods("POST")
-	r.HandleFunc("/jmxstatus", setJMXStatus).Methods("POST")
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
-	r.HandleFunc("/jmxconfigs", getJMXConfigs).Methods("GET")
 	r.HandleFunc("/status", getStatus).Methods("GET")
 	r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
+	r.HandleFunc("/{component}/status", componentStatusHandler).Methods("POST")
+	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +93,32 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 	}
 	w.Write([]byte(filePath))
+}
+
+func componentConfigHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	component := vars["component"]
+	switch component {
+	case "jmx":
+		getJMXConfigs(w, r)
+	default:
+		err := fmt.Errorf("bad url or resource does not exist")
+		log.Errorf("%s", err.Error())
+		http.Error(w, err.Error(), 404)
+	}
+}
+
+func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	component := vars["component"]
+	switch component {
+	case "jmx":
+		setJMXStatus(w, r)
+	default:
+		err := fmt.Errorf("bad url or resource does not exist")
+		log.Errorf("%s", err.Error())
+		http.Error(w, err.Error(), 404)
+	}
 }
 
 func getJMXConfigs(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -99,17 +99,11 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	decoder := json.NewDecoder(r.Body)
 
-	var tsjson map[string]interface{}
-	err := decoder.Decode(&tsjson)
-	if err != nil {
-		log.Errorf("unable to parse jmx status: %s", err)
-		http.Error(w, err.Error(), 500)
-		return
-	}
+	queries = r.URL.Query()
+	ts, _ := queries["timestamp"]
 
-	log.Debugf("Getting latest JMX Configs as of: %#v", tsjson["timestamp"])
+	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
 	j := map[string]interface{}{}
 	configs := map[string]check.ConfigJSONMap{}
 	for name, config := range embed.JMXConfigCache {

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -10,6 +10,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -95,6 +96,8 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 }
 
 func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
+	var err error
+
 	if err := apicommon.Validate(w, r); err != nil {
 		return
 	}
@@ -102,9 +105,9 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	var ts int
-	queries = r.URL.Query()
+	queries := r.URL.Query()
 	if timestamps, ok := queries["timestamp"]; ok {
-		ts = strconv.Atoi(timestamps[0])
+		ts, _ = strconv.Atoi(timestamps[0])
 	}
 
 	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
@@ -113,14 +116,16 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	for name, config := range embed.JMXConfigCache {
 		m, ok := config.(map[string]interface{})
 		if !ok {
-			log.Errorf("wrong type in cache: %s", err)
+			err = fmt.Errorf("wrong type in cache")
+			log.Errorf("%s", err.Error())
 			http.Error(w, err.Error(), 500)
 			return
 		}
 
 		cfg, ok := m["config"].(check.Config)
 		if !ok {
-			log.Errorf("wrong type for config: %s", err)
+			err = fmt.Errorf("wrong type for config")
+			log.Errorf("%s", err.Error())
 			http.Error(w, err.Error(), 500)
 			return
 		}

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -145,9 +145,8 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	j := map[string]interface{}{}
 	configs := map[string]check.ConfigJSONMap{}
 
-	keys, vals := embed.JMXConfigCache.Iterator()
-	for name := range keys {
-		config := <-vals // there will be as many vals as keys
+	configItems := embed.JMXConfigCache.Items()
+	for name, config := range configItems {
 		m, ok := config.(map[string]interface{})
 		if !ok {
 			err = fmt.Errorf("wrong type in cache")

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -17,11 +17,15 @@ import (
 	apicommon "github.com/DataDog/datadog-agent/cmd/agent/api/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/gorilla/mux"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 // SetupHandlers adds the specific handlers for /agent endpoints
@@ -101,13 +105,60 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Errorf("unable to parse jmx status: %s", err)
 		http.Error(w, err.Error(), 500)
+		return
 	}
 
 	log.Debugf("Getting latest JMX Configs as of: %v", tsjson["timestamp"])
-	// stub for now...
-	j, _ := json.Marshal(map[string]interface{}{
-		"configurations": map[string]interface{}{}})
-	w.Write(j)
+	j := map[string]interface{}{}
+	configs := map[string]check.ConfigJSONMap{}
+	for name, config := range embed.JMXConfigCache {
+		m, ok := config.(map[string]interface{})
+		if !ok {
+			log.Errorf("wrong type in cache: %s", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		cfg, ok := m["config"].(check.Config)
+		if !ok {
+			log.Errorf("wrong type for config: %s", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		var rawInitConfig check.ConfigRawMap
+		err = yaml.Unmarshal(cfg.InitConfig, &rawInitConfig)
+		if err != nil {
+			log.Errorf("unable to parse JMX configuration: %s", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		c := map[string]interface{}{}
+		c["init_config"] = util.GetJSONSerializableMap(rawInitConfig)
+		instances := []check.ConfigJSONMap{}
+		for _, instance := range cfg.Instances {
+			var rawInstanceConfig check.ConfigJSONMap
+			err = yaml.Unmarshal(instance, &rawInstanceConfig)
+			if err != nil {
+				log.Errorf("unable to parse JMX configuration: %s", err)
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(check.ConfigJSONMap))
+		}
+
+		c["instances"] = instances
+		configs[name] = c
+	}
+	j["configs"] = configs
+	jsonPayload, err := json.Marshal(util.GetJSONSerializableMap(j))
+	if err != nil {
+		log.Errorf("unable to parse JMX configuration: %s", err)
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	w.Write(jsonPayload)
 }
 
 func setJMXStatus(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -110,6 +110,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 
 	if int64(ts) > embed.JMXConfigCache.GetModified() {
 		w.WriteHeader(http.StatusNoContent)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -11,6 +11,7 @@ package agent
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -108,7 +109,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debugf("Getting latest JMX Configs as of: %v", tsjson["timestamp"])
+	log.Debugf("Getting latest JMX Configs as of: %#v", tsjson["timestamp"])
 	j := map[string]interface{}{}
 	configs := map[string]check.ConfigJSONMap{}
 	for name, config := range embed.JMXConfigCache {
@@ -152,6 +153,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 		configs[name] = c
 	}
 	j["configs"] = configs
+	j["timestamp"] = time.Now().Unix()
 	jsonPayload, err := json.Marshal(util.GetJSONSerializableMap(j))
 	if err != nil {
 		log.Errorf("unable to parse JMX configuration: %s", err)

--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -5,9 +5,17 @@
 
 name "jmxfetch"
 
-default_version "0.17.0"
-source :url => "https://dd-jmxfetch.s3.amazonaws.com/jmxfetch-#{version}-jar-with-dependencies.jar",
-       :sha256 => "e4bea1b045a3770736fbc1bc41cb37ebfd3b628d2180985e363b4b9cd8e77f95"
+default_version "0.18.0"
+
+version "0.17.0" do
+  source sha256: "e4bea1b045a3770736fbc1bc41cb37ebfd3b628d2180985e363b4b9cd8e77f95"
+end
+
+version "0.18.0" do
+  source sha256: "a99edc3e2e82f2c08554ba310960e269e534f149b2cb17fd99dc3bfaec891190"
+end
+
+source :url => "https://dd-jmxfetch.s3.amazonaws.com/jmxfetch-#{version}-jar-with-dependencies.jar"
 
 jar_dir = "#{install_dir}/bin/agent/dist/jmx"
 

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -52,6 +52,9 @@ type ConfigData []byte
 // ConfigRawMap is the generic type to hold YAML configurations
 type ConfigRawMap map[interface{}]interface{}
 
+// ConfigJSONMap is the generic type to hold YAML configurations
+type ConfigJSONMap map[string]interface{}
+
 // Config is a generic container for configuration files
 type Config struct {
 	Name          string       // the name of the check

--- a/pkg/collector/corechecks/embed/fixtures/jmx_alt.yaml
+++ b/pkg/collector/corechecks/embed/fixtures/jmx_alt.yaml
@@ -1,0 +1,57 @@
+init_config:
+  is_jmx: true
+  # custom_jar_paths: # Optional, allows specifying custom jars that will be added to the classpath of the agent's JVM, 
+  # BREAKING CHANGE NOTICE : The agent currently supports a string if there is only one custom JAR. In future versions, this will be deprecated and MUST be a list in all cases.
+  #   - /path/to/custom/jarfile.jar
+  #   - /path/to/another/custom/jarfile2.jar
+
+instances:
+  - host: localhost
+    port: 7199
+    user: username
+    password: password
+
+    # If the agent needs to connect to a non-default JMX URL, specify it here instead of a host and a port
+    # If you use this you need to specify a 'name' for the instance, below
+    jmx_url: "service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath"
+
+    process_name_regex: .*process_name.* # Instead of specifying a host and port or jmx_url, the agent can connect using the attach api.
+                                         # This requires the JDK to be installed and the path to tools.jar to be set below.
+    tools_jar_path: /usr/lib/jvm/java-8-oracle/lib/tools.jar # To be set when process_name_regex is set
+
+    name: "jmx_instance"
+    java_bin_path: /usr/bin/java # Optional, should be set if the agent cannot find your java executable
+    java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
+    # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
+    # trust_store_password: password
+    # refresh_beans: 600 # Optional (in seconds), default is 600 seconds. Sets refresh period for refreshing matching MBeans list.
+                       # Decreasing this value may result in increased CPU usage.
+    # tags:
+    #   env: stage
+    #   newTag: test
+
+    # List of metrics to be collected by the integration
+    # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+    conf:
+      - include:
+          domain: my_domain
+          bean:
+            - my_bean
+            - my_second_bean
+          attribute:
+            attribute1:
+              metric_type: counter
+              alias: jmx.my_metric_name
+            attribute2:
+              metric_type: gauge
+              alias: jmx.my2ndattribute
+      # - include:
+      #     domain: 2nd_domain
+      #   exclude:
+      #     bean:
+      #       - excluded_bean
+      # - include:
+      #     domain_regex: regex_on_domain
+        exclude:
+          bean_regex:
+            - regex_on_excluded_bean

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	jmxJarName                        = "jmxfetch-0.17.0-jar-with-dependencies.jar"
+	jmxJarName                        = "jmxfetch-0.18.0-jar-with-dependencies.jar"
 	jmxMainClass                      = "org.datadog.jmxfetch.App"
 	jmxCollectCommand                 = "collect"
 	jvmDefaultMaxMemoryAllocation     = " -Xmx200m"

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -139,10 +139,11 @@ func (c *JMXCheck) Run() error {
 	if !ok {
 		jmxLogLevel = "INFO"
 	}
+	// checks are now enabled via IPC on JMXFetch
 	subprocessArgs = append(subprocessArgs,
 		"-classpath", classpath,
 		jmxMainClass,
-		"--ipc_host", "localhost",
+		"--ipc_host", config.Datadog.GetString("cmd_host"),
 		"--ipc_port", fmt.Sprintf("%v", config.Datadog.GetInt("cmd_port")),
 		"--check_period", fmt.Sprintf("%v", int(check.DefaultCheckInterval/time.Millisecond)), // Period of the main loop of jmxfetch in ms
 		"--conf_directory", jmxConfPath, // Path of the conf directory that will be read by jmxfetch,
@@ -151,14 +152,6 @@ func (c *JMXCheck) Run() error {
 		"--reporter", reporter, // Reporter to use
 		jmxCollectCommand, // Name of the command
 	)
-	if len(c.checks) > 0 {
-		subprocessArgs = append(subprocessArgs, "--check")
-		for c, _ := range c.checks {
-			subprocessArgs = append(subprocessArgs, c)
-		}
-	} else {
-		log.Errorf("No valid JMX configuration found in %s", jmxConfPath)
-	}
 
 	if jmxExitFile != "" {
 		c.ExitFilePath = path.Join(here, "dist", "jmx", jmxExitFile) // FIXME : At some point we should have a `run` folder

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -20,7 +20,6 @@ import (
 
 	api "github.com/DataDog/datadog-agent/cmd/agent/api/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	log "github.com/cihub/seelog"
 	"github.com/kardianos/osext"
@@ -73,8 +72,7 @@ type JMXCheck struct {
 	running            uint32
 }
 
-// singleton for the JMXCheck
-var jmxLauncher *JMXCheck
+var jmxLauncher JMXCheck = JMXCheck{checks: make(map[string]struct{})}
 
 func (c *JMXCheck) String() string {
 	return "JMX Check"
@@ -300,15 +298,4 @@ func (c *JMXCheck) Stop() {
 // GetWarnings does not return anything in JMX
 func (c *JMXCheck) GetWarnings() []error {
 	return []error{}
-}
-
-func init() {
-	factory := func() check.Check {
-		if jmxLauncher != nil {
-			return jmxLauncher
-		}
-		jmxLauncher = &JMXCheck{checks: make(map[string]struct{})}
-		return jmxLauncher
-	}
-	core.RegisterCheck("jmx", factory)
 }

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -72,7 +72,7 @@ type JMXCheck struct {
 	running            uint32
 }
 
-var jmxLauncher JMXCheck = JMXCheck{checks: make(map[string]struct{})}
+var jmxLauncher = JMXCheck{checks: make(map[string]struct{})}
 
 func (c *JMXCheck) String() string {
 	return "JMX Check"

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -125,6 +125,7 @@ func (c *JMXCheck) Run() error {
 	subprocessArgs = append(subprocessArgs,
 		"-classpath", classpath,
 		jmxMainClass,
+		"--ipc_host", "localhost",
 		"--ipc_port", fmt.Sprintf("%v", config.Datadog.GetInt("cmd_port")),
 		"--check_period", fmt.Sprintf("%v", int(check.DefaultCheckInterval/time.Millisecond)), // Period of the main loop of jmxfetch in ms
 		"--conf_directory", jmxConfPath, // Path of the conf directory that will be read by jmxfetch,

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -22,12 +22,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const (
-	windowsToken       = '\\'
-	unixToken          = '/'
-	autoDiscoveryToken = "#### AUTO-DISCOVERY ####\n"
-)
-
 var JMXConfigCache = cache.NewBasicCache()
 
 // JMXCheckLoader is a specific loader for checks living in this package

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -10,13 +10,10 @@ package embed
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	log "github.com/cihub/seelog"
 	yaml "gopkg.in/yaml.v2"

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	log "github.com/cihub/seelog"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -27,7 +28,7 @@ const (
 	autoDiscoveryToken = "#### AUTO-DISCOVERY ####\n"
 )
 
-var JMXConfigCache = map[string]interface{}{}
+var JMXConfigCache = cache.NewBasicCache()
 
 // JMXCheckLoader is a specific loader for checks living in this package
 type JMXCheckLoader struct {
@@ -93,7 +94,7 @@ func (jl *JMXCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		}
 	}
 
-	JMXConfigCache[config.Name] = mapConfig
+	JMXConfigCache.Add(config.Name, mapConfig)
 	jmxLauncher.checks[fmt.Sprintf("%s.yaml", config.Name)] = struct{}{} // exists
 	checks = append(checks, &jmxLauncher)
 	mapConfig["config"] = config

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -37,34 +37,6 @@ type JMXCheckLoader struct {
 
 // NewJMXCheckLoader creates a loader for go checks
 func NewJMXCheckLoader() (*JMXCheckLoader, error) {
-	basePath := config.Datadog.GetString("jmx_pipe_path")
-	pipeName := config.Datadog.GetString("jmx_pipe_name")
-
-	var sep byte
-	var pipePath string
-	if strings.Contains(basePath, string(windowsToken)) {
-		sep = byte(windowsToken)
-	} else {
-		sep = byte(unixToken)
-	}
-
-	if basePath[len(basePath)-1] == sep {
-		pipePath = fmt.Sprintf("%s%s", basePath, pipeName)
-	} else {
-		pipePath = fmt.Sprintf("%s%c%s", basePath, sep, pipeName)
-	}
-
-	pipe, err := util.GetPipe(pipePath)
-	if err != nil {
-		log.Errorf("Error getting pipe: %v", err)
-		return nil, errors.New("unable to initialize pipe")
-	}
-
-	if err := pipe.Open(); err != nil {
-		log.Errorf("Error opening pipe: %v", err)
-		return nil, errors.New("unable to initialize pipe")
-	}
-
 	return &JMXCheckLoader{checks: []string{}}, nil
 }
 

--- a/pkg/collector/corechecks/embed/jmxloader_test.go
+++ b/pkg/collector/corechecks/embed/jmxloader_test.go
@@ -59,7 +59,7 @@ func TestLoadCheckConfig(t *testing.T) {
 	assert.Nil(t, err)
 
 	// should be three valid instances
-	assert.Len(t, cfgs, 3)
+	assert.Len(t, cfgs, 4)
 	for _, cfg := range cfgs {
 		_, err := jl.Load(cfg)
 		assert.Nil(t, err)

--- a/pkg/collector/corechecks/embed/jmxloader_test.go
+++ b/pkg/collector/corechecks/embed/jmxloader_test.go
@@ -16,7 +16,6 @@ import (
 	"runtime"
 	"testing"
 
-	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/providers"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -67,20 +66,9 @@ func TestLoadCheckConfig(t *testing.T) {
 
 	}
 
-	factory := core.GetCheckFactory("jmx")
-	if factory == nil {
-		t.Errorf("Cannot find JMX factory")
-	}
-
-	launcher := factory()
-	j, ok := launcher.(*JMXCheck)
-	if !ok {
-		t.Errorf("factory returned unexpeced checky")
-	}
-
 	for _, cfg := range cfgs {
 		found := false
-		for k, _ := range j.checks {
+		for k, _ := range jmxLauncher.checks {
 			if k == fmt.Sprintf("%s.yaml", cfg.Name) {
 				found = true
 				break

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,7 @@ func init() {
 	Datadog.SetDefault("syslog_rfc", false)
 	Datadog.SetDefault("syslog_tls", false)
 	Datadog.SetDefault("syslog_pem", "")
+	Datadog.SetDefault("cmd_host", "localhost")
 	Datadog.SetDefault("cmd_port", 5001)
 	Datadog.SetDefault("default_integration_http_timeout", 9)
 	Datadog.SetDefault("enable_metadata_collection", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,9 +111,6 @@ func init() {
 	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
 	Datadog.SetDefault("dogstatsd_expiry_seconds", 300)
 	Datadog.SetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
-	// JMX
-	Datadog.SetDefault("jmx_pipe_path", defaultJMXPipePath)
-	Datadog.SetDefault("jmx_pipe_name", "dd-auto_discovery")
 	// Autoconfig
 	Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
 	Datadog.SetDefault("exclude_pause_container", true)

--- a/pkg/util/cache/basic_cache.go
+++ b/pkg/util/cache/basic_cache.go
@@ -41,7 +41,23 @@ func (b *BasicCache) Get(k string) (interface{}, error) {
 	return nil, fmt.Errorf("item not in cache")
 }
 
-// Get gets interface for specified key or error
+// Remove removes an entry from the cache if it exists
+func (b *BasicCache) Remove(k string) {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	delete(b.cache, k)
+}
+
+// Size returns the current size of the cache
+func (b *BasicCache) Size() int {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	return len(b.cache)
+}
+
+// GetModified gets interface for specified key or error
 func (b *BasicCache) GetModified() int64 {
 	b.m.RLock()
 	defer b.m.RUnlock()

--- a/pkg/util/cache/basic_cache.go
+++ b/pkg/util/cache/basic_cache.go
@@ -1,0 +1,73 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// BasicCache is a simple threadsafe cache
+type BasicCache struct {
+	m        sync.RWMutex
+	cache    map[string]interface{}
+	modified int64
+}
+
+// NewBasicCache Creates new BasicCache
+func NewBasicCache() *BasicCache {
+	return &BasicCache{
+		cache: make(map[string]interface{}),
+	}
+}
+
+// Add adds value to cache for specified key
+func (b *BasicCache) Add(k string, v interface{}) {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	b.cache[k] = v
+	b.modified = time.Now().Unix()
+}
+
+// Get gets interface for specified key or error
+func (b *BasicCache) Get(k string) (interface{}, error) {
+	b.m.RLock()
+	defer b.m.RUnlock()
+
+	if v, ok := b.cache[k]; ok {
+		return v, nil
+	}
+
+	return nil, fmt.Errorf("item not in cache")
+}
+
+// Get gets interface for specified key or error
+func (b *BasicCache) GetModified() int64 {
+	b.m.RLock()
+	defer b.m.RUnlock()
+
+	return b.modified
+}
+
+// Iterator returns key and value channels to iterate on
+// Not the most performant implementation - but clean and should be fine
+// given that basic caches should be small
+func (b *BasicCache) Iterator() (<-chan string, <-chan interface{}) {
+	b.m.RLock()
+	defer b.m.RUnlock()
+
+	keyChan := make(chan string, len(b.cache))
+	valueChan := make(chan interface{}, len(b.cache))
+	go func() {
+		b.m.RLock()
+		defer b.m.RUnlock()
+		for k, v := range b.cache {
+			keyChan <- k
+			valueChan <- v
+		}
+		close(keyChan)
+		close(valueChan)
+	}()
+
+	return keyChan, valueChan
+}

--- a/pkg/util/cache/basic_cache.go
+++ b/pkg/util/cache/basic_cache.go
@@ -65,25 +65,15 @@ func (b *BasicCache) GetModified() int64 {
 	return b.modified
 }
 
-// Iterator returns key and value channels to iterate on
-// Not the most performant implementation - but clean and should be fine
-// given that basic caches should be small
-func (b *BasicCache) Iterator() (<-chan string, <-chan interface{}) {
+// Items returns a map with the elements in the cache
+func (b *BasicCache) Items() map[string]interface{} {
+	items := map[string]interface{}{}
+
 	b.m.RLock()
 	defer b.m.RUnlock()
+	for k, v := range b.cache {
+		items[k] = v
+	}
 
-	keyChan := make(chan string, len(b.cache))
-	valueChan := make(chan interface{}, len(b.cache))
-	go func() {
-		b.m.RLock()
-		defer b.m.RUnlock()
-		for k, v := range b.cache {
-			keyChan <- k
-			valueChan <- v
-		}
-		close(keyChan)
-		close(valueChan)
-	}()
-
-	return keyChan, valueChan
+	return items
 }

--- a/pkg/util/cache/basic_cache_test.go
+++ b/pkg/util/cache/basic_cache_test.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicCache(t *testing.T) {
+	m := map[string]interface{}{
+		"a": 1,
+		"b": "dos",
+		"c": struct{}{},
+	}
+
+	c := NewBasicCache()
+	for k, v := range m {
+		c.Add(k, v)
+	}
+	assert.Equal(t, len(m), c.Size())
+
+	for k, v := range m {
+		cached, err := c.Get(k)
+		assert.Nil(t, err)
+		assert.Equal(t, v, cached)
+	}
+
+	_, err := c.Get("notincache")
+	assert.NotNil(t, err)
+
+	keys, vals := c.Iterator()
+	for k := range keys {
+		assert.Equal(t, m[k], <-vals)
+	}
+
+	for k := range m {
+		c.Remove(k)
+	}
+	assert.Equal(t, 0, c.Size())
+}

--- a/pkg/util/cache/basic_cache_test.go
+++ b/pkg/util/cache/basic_cache_test.go
@@ -28,9 +28,9 @@ func TestBasicCache(t *testing.T) {
 	_, err := c.Get("notincache")
 	assert.NotNil(t, err)
 
-	keys, vals := c.Iterator()
-	for k := range keys {
-		assert.Equal(t, m[k], <-vals)
+	items := c.Items()
+	for k, v := range items {
+		assert.Equal(t, m[k], v)
 	}
 
 	for k := range m {

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -1,13 +1,19 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestEmptyProxy(t *testing.T) {
@@ -89,4 +95,41 @@ func TestBadScheme(t *testing.T) {
 	proxyURL, err := proxyFunc(r1)
 	assert.Nil(t, err)
 	assert.Nil(t, proxyURL)
+}
+
+func TestJSONConverter(t *testing.T) {
+
+	checks := []string{
+		"cassandra",
+		"kafka",
+		"jmx",
+		"jmx_alt",
+	}
+
+	cache := map[string]check.ConfigRawMap{}
+	for _, c := range checks {
+		var cf check.ConfigRawMap
+
+		// Read file contents
+		yamlFile, err := ioutil.ReadFile(fmt.Sprintf("../collector/corechecks/embed/fixtures/%s.yaml", c))
+		assert.Nil(t, err)
+
+		// Parse configuration
+		err = yaml.Unmarshal(yamlFile, &cf)
+		assert.Nil(t, err)
+
+		cache[c] = cf
+	}
+
+	//convert
+	j := map[string]interface{}{}
+	c := map[string]interface{}{}
+	for name, config := range cache {
+		c[name] = GetJSONSerializableMap(config)
+	}
+	j["configurations"] = c
+
+	//json encode
+	m, err := json.Marshal(GetJSONSerializableMap(j))
+	assert.Nil(t, err)
 }

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -130,6 +130,6 @@ func TestJSONConverter(t *testing.T) {
 	j["configurations"] = c
 
 	//json encode
-	m, err := json.Marshal(GetJSONSerializableMap(j))
+	_, err := json.Marshal(GetJSONSerializableMap(j))
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
### What does this PR do?

Adds an endpoint to the API (I should probably change it to something cleaner) - `agent/jmxconfigs` where a caller can collect all JMX configurations available after a certain timestamp.

(ie. `GET http://localhost:5001/agent/jmxconfigs?timestamp=<sometimestamp>`)

- Agent log level is now correctly mapped to JMXFetch.
- JMXFetch is now launched bare, with no checks configured, it'll collect the configurations via the endpoint. See https://github.com/DataDog/jmxfetch/pull/156 

It also adds a basic thread-safe cache, mainly because I wanted a clean interface to iterate over the contents of the cache while remaining thread safe without too much lock/unlock management fuss. The current channel based iteration mechanism isn't very performant compared to other alternatives out there - we can always roll those out if necessary - but since this basic cache should be relatively small in general we should be fine, besides having `range` to iterate over keys and values just makes it clean.     

### Motivation

Cleaner interface with JMXFetch, ground work for AutoDiscovery which should now be trivial to complete on the JMXFetch side.
