### PR TITLE
[docker] support Amazon Linux hosts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,11 +82,11 @@ func init() {
 	Datadog.SetDefault("check_runners", int64(4))
 	if IsContainerized() {
 		Datadog.SetDefault("container_proc_root", "/host/proc")
-		Datadog.SetDefault("container_sysfs_root", "/host/sys")
+		Datadog.SetDefault("container_cgroup_root", "/host/sys/fs/cgroup/")
 
 	} else {
 		Datadog.SetDefault("container_proc_root", "/proc")
-		Datadog.SetDefault("container_sysfs_root", "/sys")
+		Datadog.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")
 	}
 	Datadog.SetDefault("proc_root", "/proc")
 	// Serializer
@@ -139,7 +139,7 @@ func init() {
 	Datadog.BindEnv("dogstatsd_port")
 	Datadog.BindEnv("proc_root")
 	Datadog.BindEnv("container_proc_root")
-	Datadog.BindEnv("container_sysfs_root")
+	Datadog.BindEnv("container_cgroup_root")
 	Datadog.BindEnv("dogstatsd_socket")
 	Datadog.BindEnv("dogstatsd_stats_port")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 
 	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
@@ -437,7 +439,7 @@ func cgroupMountPoints() (map[string]string, error) {
 }
 
 func parseCgroupMountPoints(r io.Reader) map[string]string {
-
+	cgroupRoot := config.Datadog.GetString("container_cgroup_root")
 	mountPoints := make(map[string]string)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -447,7 +449,7 @@ func parseCgroupMountPoints(r io.Reader) map[string]string {
 			cgroupPath := tokens[1]
 
 			// Ignore mountpoints not mounted under /{host/}sys
-			if !strings.HasPrefix(cgroupPath, HostSys()) {
+			if !strings.HasPrefix(cgroupPath, cgroupRoot) {
 				continue
 			}
 

--- a/pkg/util/docker/util.go
+++ b/pkg/util/docker/util.go
@@ -67,14 +67,6 @@ func HostProc(combineWith ...string) string {
 	return path.Join(parts...)
 }
 
-// HostSys returns the location of a host's /sys. This can and will be overriden
-// when running inside a container.
-// TODO: use config value instead of envvar
-func HostSys(combineWith ...string) string {
-	parts := append([]string{config.Datadog.GetString("container_sysfs_root")}, combineWith...)
-	return path.Join(parts...)
-}
-
 // PathExists returns a boolean indicating if the given path exists on the file system.
 func PathExists(filename string) bool {
 	if _, err := os.Stat(filename); err == nil {


### PR DESCRIPTION
Amazon Linux mounts cgroups in `/cgroup/*`, which can not be
addressed by `c_sysfs_root`, moving to directly specify the
cgroup path with `c_cgroup_root`

running `DD_CONTAINER_CGROUP_ROOT=/cgroup agent` on a ECS host works