### PR TITLE
[docker] retrive events in check

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -235,13 +235,14 @@ func (d *DockerCheck) String() string {
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 	d.instance = &dockerConfig{
+		// Default conf values
 		ExcludePauseContainer: true,
+		CollectEvent:          true,
 	}
 	d.instance.Parse(config)
 
 	docker.InitDockerUtil(&docker.Config{
 		CacheDuration:  10 * time.Second,
-		CollectEvent:   true,
 		CollectNetwork: true,
 		Whitelist:      d.instance.Include,
 		Blacklist:      d.instance.Exclude,

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
+const dockerCheckName = "docker"
+
 type dockerConfig struct {
 	//Url                    string             `yaml:"url"`
 	CollectContainerSize  bool     `yaml:"collect_container_size"`
@@ -34,8 +36,8 @@ type dockerConfig struct {
 	Include               []string `yaml:"include"`
 	ExcludePauseContainer bool     `yaml:"exclude_pause_container"`
 	Tags                  []string `yaml:"tags"`
-	//CollectEvent           bool               `yaml:"collect_events"`
-	//FilteredEventType      []string           `yaml:"filtered_event_types"`
+	CollectEvent          bool     `yaml:"collect_events"`
+	FilteredEventType     []string `yaml:"filtered_event_types"`
 	//CustomCGroup           bool               `yaml:"custom_cgroups"`
 	//HealthServiceWhitelist []string           `yaml:"health_service_check_whitelist"`
 	//CollectContainerCount  bool               `yaml:"collect_container_count"`
@@ -63,8 +65,14 @@ type containerPerImage struct {
 }
 
 func (c *dockerConfig) Parse(data []byte) error {
+	// Default values
+	c.CollectEvent = true
+
 	if err := yaml.Unmarshal(data, c); err != nil {
 		return err
+	}
+	if len(c.FilteredEventType) == 0 {
+		c.FilteredEventType = []string{"top", "exec_create", "exec_start"}
 	}
 
 	if c.ExcludePauseContainer {
@@ -75,8 +83,10 @@ func (c *dockerConfig) Parse(data []byte) error {
 
 // DockerCheck grabs docker metrics
 type DockerCheck struct {
-	lastWarnings []error
-	instance     *dockerConfig
+	lastWarnings   []error
+	instance       *dockerConfig
+	lastEventTime  time.Time
+	dockerHostname string
 }
 
 func updateContainerRunningCount(images map[string]*containerPerImage, c *docker.Container) {
@@ -210,6 +220,10 @@ func (d *DockerCheck) Run() error {
 	}
 	sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckOK, "", nil, "")
 
+	if d.instance.CollectEvent {
+		d.reportEvents(sender)
+	}
+
 	sender.Commit()
 	return nil
 }
@@ -218,7 +232,7 @@ func (d *DockerCheck) Run() error {
 func (d *DockerCheck) Stop() {}
 
 func (d *DockerCheck) String() string {
-	return "docker"
+	return dockerCheckName
 }
 
 // Configure parses the check configuration and init the check
@@ -234,6 +248,12 @@ func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 		Whitelist:      d.instance.Include,
 		Blacklist:      d.instance.Exclude,
 	})
+
+	var err error
+	d.dockerHostname, err = docker.GetHostname()
+	if err != nil {
+		log.Warnf("can't get hostname from docker, events will not have it: %s", err)
+	}
 	return nil
 }
 

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -65,9 +65,6 @@ type containerPerImage struct {
 }
 
 func (c *dockerConfig) Parse(data []byte) error {
-	// Default values
-	c.CollectEvent = true
-
 	if err := yaml.Unmarshal(data, c); err != nil {
 		return err
 	}
@@ -244,6 +241,7 @@ func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 
 	docker.InitDockerUtil(&docker.Config{
 		CacheDuration:  10 * time.Second,
+		CollectEvent:   true,
 		CollectNetwork: true,
 		Whitelist:      d.instance.Include,
 		Blacklist:      d.instance.Exclude,

--- a/pkg/collector/corechecks/containers/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker_events.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+// dockerEventBundle holds a list of ContainerEvent
+// identified as coming from the same image. It holds
+// the conversion logic to Datadog events for submission
+type dockerEventBundle struct {
+	imageName     string
+	events        []*docker.ContainerEvent
+	maxTimestamp  time.Time
+	countByAction map[string]int
+}
+
+func (b *dockerEventBundle) addEvent(event *docker.ContainerEvent) error {
+	if len(b.events) == 0 {
+		b.imageName = event.ImageName
+		b.events = []*docker.ContainerEvent{}
+	} else if event.ImageName != b.imageName {
+		return fmt.Errorf("mismatching image name: %s != %s", event.ImageName, b.imageName)
+	}
+	b.events = append(b.events, event)
+	if event.Timestamp.After(b.maxTimestamp) {
+		b.maxTimestamp = event.Timestamp
+	}
+	if b.countByAction == nil {
+		b.countByAction = make(map[string]int)
+	}
+	b.countByAction[event.Action] = b.countByAction[event.Action] + 1
+
+	return nil
+}
+
+func (b *dockerEventBundle) toDatadogEvent(hostname string) (metrics.Event, error) {
+	output := metrics.Event{
+		Priority:       metrics.EventPriorityNormal,
+		Host:           hostname,
+		SourceTypeName: dockerCheckName,
+		EventType:      dockerCheckName,
+		Ts:             b.maxTimestamp.Unix(),
+		AggregationKey: fmt.Sprintf("docker:%s", b.imageName),
+	}
+	if len(b.events) == 0 {
+		return output, errors.New("no event to export")
+	}
+	output.Title = fmt.Sprintf("%s %s on %s",
+		b.imageName,
+		formatStringIntMap(b.countByAction),
+		hostname)
+
+	seenContainers := make(map[string]bool)
+	textLines := []string{"%%% ", output.Title, "```"}
+
+	for _, ev := range b.events {
+		textLines = append(textLines, fmt.Sprintf("%s\t%s", strings.ToUpper(ev.Action), ev.ContainerName))
+		seenContainers[ev.ContainerID] = true // Emulating a set with a map
+	}
+	textLines = append(textLines, "```", " %%%")
+	output.Text = strings.Join(textLines, "\n")
+
+	for cid, _ := range seenContainers {
+		tags, err := tagger.Tag(fmt.Sprintf("docker://%s", cid), true)
+		if err != nil {
+			log.Debugf("no tags for %s: %s", cid, err)
+		}
+		output.Tags = append(output.Tags, tags...)
+	}
+
+	if b.countByAction["oom"]+b.countByAction["kill"] > 0 {
+		output.AlertType = "error"
+	}
+
+	return output, nil
+}
+
+// reportEvents is the check's entrypoint to retrieve, aggregate and send events
+func (d *DockerCheck) reportEvents(sender aggregator.Sender) error {
+	if d.lastEventTime.IsZero() {
+		d.lastEventTime = time.Now().Add(-60 * time.Second)
+	}
+	events, latest, err := docker.LatestContainerEvents(d.lastEventTime)
+
+	if err != nil {
+		return err
+	}
+	if latest.IsZero() == false {
+		d.lastEventTime = latest.Add(1 * time.Nanosecond)
+	}
+	bundles, err := d.aggregateEvents(events)
+
+	for _, bundle := range bundles {
+		ev, err := bundle.toDatadogEvent(d.dockerHostname)
+		ev.Tags = append(ev.Tags, d.instance.Tags...)
+
+		if err != nil {
+			log.Warnf("can't submit event: %s", err)
+		} else {
+			sender.Event(ev)
+		}
+	}
+	return nil
+}
+
+// aggregateEvents converts a bunch of ContainerEvent to bundles aggregated by
+// image name. It also filters out unwanted event types.
+func (d *DockerCheck) aggregateEvents(events []*docker.ContainerEvent) (map[string]*dockerEventBundle, error) {
+	// Pre-aggregate container events by image
+	eventsByImage := make(map[string]*dockerEventBundle)
+	filteredByType := make(map[string]int)
+
+ITER_EVENT:
+	for _, event := range events {
+		for _, action := range d.instance.FilteredEventType {
+			if event.Action == action {
+				filteredByType[action] = filteredByType[action] + 1
+				continue ITER_EVENT
+			}
+		}
+		bundle, found := eventsByImage[event.ImageName]
+		if found == false {
+			bundle = &dockerEventBundle{}
+			eventsByImage[event.ImageName] = bundle
+		}
+		bundle.addEvent(event)
+	}
+
+	if len(filteredByType) > 0 {
+		log.Debugf("filtered out the following events: %s", formatStringIntMap(filteredByType))
+	}
+	return eventsByImage, nil
+}
+
+func formatStringIntMap(input map[string]int) string {
+	var parts []string
+	for k, v := range input {
+		parts = append(parts, fmt.Sprintf("%d %s", v, k))
+	}
+	return strings.Join(parts, " ")
+}

--- a/pkg/collector/corechecks/containers/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker_events.go
@@ -33,8 +33,9 @@ type dockerEventBundle struct {
 
 func NewDockerEventBundler(imageName string) *dockerEventBundle {
 	return &dockerEventBundle{
-		imageName: imageName,
-		events:    []*docker.ContainerEvent{},
+		imageName:     imageName,
+		events:        []*docker.ContainerEvent{},
+		countByAction: make(map[string]int),
 	}
 }
 
@@ -45,9 +46,6 @@ func (b *dockerEventBundle) addEvent(event *docker.ContainerEvent) error {
 	b.events = append(b.events, event)
 	if event.Timestamp.After(b.maxTimestamp) {
 		b.maxTimestamp = event.Timestamp
-	}
-	if b.countByAction == nil {
-		b.countByAction = make(map[string]int)
 	}
 	b.countByAction[event.Action] = b.countByAction[event.Action] + 1
 

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -66,7 +66,7 @@ func (c *DockerCollector) extractFromInspect(co types.ContainerJSON) ([]string, 
 		}
 	}
 
-	high = append(high, fmt.Sprintf("container_name:%s", co.Name))
+	high = append(high, fmt.Sprintf("container_name:%s", strings.TrimPrefix(co.Name, "/")))
 	high = append(high, fmt.Sprintf("container_id:%s", co.ID))
 
 	return low, high, nil

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -108,7 +108,7 @@ func (t *Tagger) run() error {
 			t.pullTicker.Stop()
 			return nil
 		case msg := <-t.infoIn:
-			log.Infof("listener message: %s", msg)
+			log.Debugf("listener message: %s", msg)
 			for _, info := range msg {
 				t.tagStore.processTagInfo(info)
 			}
@@ -144,7 +144,6 @@ func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
 	}
 	if len(sources) == len(t.fetchers) {
 		// All sources sent data to cache
-		log.Debugf("all %d sources are in cache", len(sources))
 		return cachedTags, nil
 	}
 	// Else, partial cache miss, query missing data

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -161,19 +161,23 @@ func parseFilters(filters []string) (imageFilters, nameFilters []*regexp.Regexp,
 // IsExcluded returns a bool indicating if the container should be excluded
 // based on the filters in the containerFilter instance.
 func (cf containerFilter) IsExcluded(container *Container) bool {
+	return cf.computeIsExcluded(container.Name, container.Image)
+}
+
+func (cf containerFilter) computeIsExcluded(containerName, containerImage string) bool {
 	if !cf.Enabled {
 		return false
 	}
 
 	var excluded bool
 	for _, r := range cf.ImageBlacklist {
-		if r.MatchString(container.Image) {
+		if r.MatchString(containerImage) {
 			excluded = true
 			break
 		}
 	}
 	for _, r := range cf.NameBlacklist {
-		if r.MatchString(container.Name) {
+		if r.MatchString(containerName) {
 			excluded = true
 			break
 		}
@@ -182,12 +186,12 @@ func (cf containerFilter) IsExcluded(container *Container) bool {
 	// Any excluded container could be whitelisted.
 	if excluded {
 		for _, r := range cf.ImageWhitelist {
-			if r.MatchString(container.Image) {
+			if r.MatchString(containerImage) {
 				return false
 			}
 		}
 		for _, r := range cf.NameWhitelist {
-			if r.MatchString(container.Name) {
+			if r.MatchString(containerName) {
 				return false
 			}
 		}

--- a/pkg/util/docker/events.go
+++ b/pkg/util/docker/events.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+)
+
+type ContainerEvent struct {
+	ContainerID   string
+	ContainerName string
+	ImageName     string
+	Action        string
+	Timestamp     time.Time
+	Tags          map[string]string
+}
+
+// pullEvents just wraps the client.Event call with saner argument types. Channels have to be closed by caller.
+func (d *dockerUtil) openEventChannel(since, until time.Time, filter map[string]string) (<-chan events.Message, <-chan error) {
+	// Event since/until string can be formatted or hold a timestamp,
+	// see https://github.com/moby/moby/blob/7cbbbb95097f065757d38bcccdb1bbef81d10ddb/api/types/time/timestamp.go#L95
+	queryFilter := filters.NewArgs()
+	for k, v := range filter {
+		queryFilter.Add(k, v)
+	}
+	options := types.EventsOptions{
+		Since:   fmt.Sprintf("%d.%09d", since.Unix(), int64(since.Nanosecond())),
+		Until:   fmt.Sprintf("%d.%09d", until.Unix(), int64(until.Nanosecond())),
+		Filters: queryFilter,
+	}
+
+	return d.cli.Events(context.Background(), options)
+}
+
+func (d *dockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent, error) {
+	// Type filtering
+	if msg.Type != "container" {
+		return nil, nil
+	}
+
+	// Container filtering
+	containerName, found := msg.Actor.Attributes["name"]
+	if found == false {
+		// TODO: inspect?
+		return nil, fmt.Errorf("missing container name in event %s", msg)
+	}
+	imageName, found := msg.Actor.Attributes["image"]
+	if found == false {
+		// TODO: inspect?
+		return nil, fmt.Errorf("missing image name in event %s", msg)
+	}
+	if strings.HasPrefix(imageName, "sha256") {
+		imageName = d.extractImageName(imageName)
+	}
+	if d.cfg.filter.computeIsExcluded(containerName, imageName) {
+		return nil, nil
+	}
+
+	ns := msg.TimeNano
+	if ns > 1e10 {
+		ns = ns - msg.Time*1e9
+	}
+
+	// Not filtered, return event
+	event := &ContainerEvent{
+		ContainerID:   msg.Actor.ID,
+		ContainerName: containerName,
+		ImageName:     imageName,
+		Action:        msg.Action,
+		Timestamp:     time.Unix(msg.Time, ns),
+		Tags:          msg.Actor.Attributes,
+	}
+
+	return event, nil
+}
+
+// LatestEvents returns events matching the filter that occured after the time passed. It returns the latest
+// event timestamp in the slice for the user to store and pass again in the next call.
+func (d *dockerUtil) LatestContainerEvents(since time.Time) ([]*ContainerEvent, time.Time, error) {
+	var events []*ContainerEvent
+	filters := map[string]string{"type": "container"}
+
+	msgChan, errorChan := d.openEventChannel(since, time.Now(), filters)
+
+	var maxTimestamp time.Time
+
+	for {
+		select {
+		case msg := <-msgChan:
+			event, err := d.processContainerEvent(msg)
+			if err != nil {
+				log.Warnf("error parsing docker message: %s", err)
+				continue
+			} else if event == nil {
+				continue
+			}
+			events = append(events, event)
+			if event.Timestamp.After(maxTimestamp) {
+				maxTimestamp = event.Timestamp
+			}
+		case err := <-errorChan:
+			if err == io.EOF {
+				break
+			} else {
+				return events, maxTimestamp, err
+			}
+		case <-time.After(2 * time.Second):
+			log.Warnf("timeout on event receive channel")
+			return events, maxTimestamp, errors.New("timeout on event receive channel")
+		}
+	}
+	return events, maxTimestamp, nil
+}
+
+// AllContainers returns a slice of all running containers.
+func LatestContainerEvents(since time.Time) ([]*ContainerEvent, time.Time, error) {
+	if globalDockerUtil != nil {
+		return globalDockerUtil.LatestContainerEvents(since)
+	}
+	return []*ContainerEvent{}, time.Now(), errors.New("dockerutil not initialised")
+}

--- a/pkg/util/docker/events.go
+++ b/pkg/util/docker/events.go
@@ -72,6 +72,11 @@ func (d *dockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 		return nil, nil
 	}
 
+	// msg.TimeNano does not hold the nanosecond portion of the timestamp
+	// like it's usual to do in Go, but the whole timestamp value as ns value
+	// We need to substract the second value to get only the nanoseconds.
+	// Keeping that behind a value test in case docker developers fix that
+	// inconsistency in the future.
 	ns := msg.TimeNano
 	if ns > 1e10 {
 		ns = ns - msg.Time*1e9
@@ -133,5 +138,5 @@ func LatestContainerEvents(since time.Time) ([]*ContainerEvent, time.Time, error
 	if globalDockerUtil != nil {
 		return globalDockerUtil.LatestContainerEvents(since)
 	}
-	return []*ContainerEvent{}, time.Now(), errors.New("dockerutil not initialised")
+	return nil, time.Now(), errors.New("dockerutil not initialised")
 }


### PR DESCRIPTION
### What does this PR do?

Add docker event submission to agent6, porting the agent5 logic:
  - on-demand event pooling via `util/docker/docker_events.go`
  - event type filtering
  - ignored containers filtering
  - pre-aggregation on image name
  - event tagging with mentionned containers' tags
  - submission

Testing:
  - agent5 on top
  - agent6 on bottom

![](https://cl.ly/0K0P3W0a0Z2S/Image%202017-09-25%20at%201.43.42%20PM.png)