### PR TITLE
Use the same function to connect to docker everywhere in the agent.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -359,6 +359,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2aff2c76538a08462ca01fa0b24fc8da07c64591e0b01c97298782fae56a8235"
+  inputs-digest = "e78a12cab3c909b8e056b9beaeb92af835c8104ecf052ec82c97114579b7aede"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
 
 [[constraint]]
   name = "github.com/docker/docker"
-  version = "1.13.1-rc1"
+  version = "1.13.1"
 
 [[constraint]]
   name = "github.com/ericchiang/k8s"

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
@@ -40,7 +41,7 @@ type DockerListener struct {
 // NewDockerListener creates a client connection to Docker and instanciate a DockerListener with it
 // TODO: TLS support
 func NewDockerListener() (*DockerListener, error) {
-	c, err := client.NewEnvClient()
+	c, err := docker.ConnectToDocker()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to Docker, auto discovery will not work: %s", err)
 	}

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -99,7 +99,7 @@ func IsAgentNotDetected(err error) bool {
 func detectAgentURL() (string, error) {
 	urls := make([]string, 0, 3)
 	if config.IsContainerized() {
-		cli, err := client.NewEnvClient()
+		cli, err := dockerutil.ConnectToDocker()
 		if err != nil {
 			return "", err
 		}

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -47,7 +47,7 @@ type DockerCollector struct {
 // Detect tries to connect to the docker socket and returns success
 func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 	// TODO: refactor with collector.listeners.DockerListener
-	client, err := client.NewEnvClient()
+	client, err := docker.ConnectToDocker()
 	if err != nil {
 		return NoCollection, fmt.Errorf("Failed to connect to Docker, docker tagging will not work: %s", err)
 	}


### PR DESCRIPTION
### What does this PR do?

This allows the tagger and metadata to connect in the same way to
docker. We also use the lowest version between docker server and
client. In the end we leave the internal docker code handle environment
variables like `DOCKER_API_VERSION`.

### Motivation

This allow us to run on older version of docker.