### PR TITLE
check the length of the bearer token

### DIFF
--- a/cmd/agent/api/common/common.go
+++ b/cmd/agent/api/common/common.go
@@ -49,7 +49,7 @@ func Validate(w http.ResponseWriter, r *http.Request) (err error) {
 		return
 	}
 
-	if tok[1] != GetAuthToken() {
+	if len(tok) < 2 || tok[1] != GetAuthToken() {
 		err = fmt.Errorf("invalid session token")
 		http.Error(w, err.Error(), 403)
 	}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Prevent potential crashes by adding a length check

### Motivation

Sending an auth header containing: `Authorization: Bearer` would cause a panic
