### PR TITLE
Restart long running checks when they exit

### DIFF
--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -249,7 +249,7 @@ func getHostname() string {
 	return ""
 }
 
-func retry(startupTime time.Duration, retries int, callback func() error) (err error) {
+func retry(retryDuration time.Duration, retries int, callback func() error) (err error) {
 	attempts := 0
 
 	for {
@@ -260,12 +260,12 @@ func retry(startupTime time.Duration, retries int, callback func() error) (err e
 		}
 
 		// how much did the callback run?
-		execTime := time.Now().Sub(t0)
-		if execTime < startupTime {
+		execDuration := time.Now().Sub(t0)
+		if execDuration < retryDuration {
 			// the callback failed too soon, retry but increment the counter
 			attempts++
 		} else {
-			// the callback failed after the startupTime, reset the counter
+			// the callback failed after the retryDuration, reset the counter
 			attempts = 0
 		}
 


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

wraps the call to `Run()` for long running checks, so that if returns an error, `Run` is called again.
To avoid having a worker stuck retrying `Run` indefinitely, if the error occurs within the specified time interval, a counter is incremented. If the counter reaches a certain value, the wrapper gives up.

### Motivation

We use one-time checks as long-running checks: if something happens to a long running check, there's no way to restart it other than restart the agent. 

In this way, if a long running check dies, it can be restarted. If dies too many times within a certain timeframe, it won't be restarted anymore.
