### PR TITLE
[task] Fix agent version command

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -47,7 +47,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         # being able to load the ancient C-runtime that comes along with Python 2.7
         #command = "rsrc -arch amd64 -manifest cmd/agent/agent.exe.manifest -o cmd/agent/rsrc.syso"
 
-        build_maj, build_min, build_patch = get_version().split(".")
+        build_maj, build_min, build_patch = get_version(ctx).split(".")
         command = "windres --define MAJ_VER={build_maj} --define MIN_VER={build_min} --define PATCH_VER={build_patch} ".format(
             build_maj=build_maj,
             build_min=build_min,

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -134,7 +134,7 @@ def query_version(ctx):
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
     try:
         described_version = ctx.run("git describe --tags", hide=True).stdout.strip()
-    except UnexpectedExit:
+    except invoke.exceptions.UnexpectedExit:
         # FIXME remove this `except` block when we start tagging the repo
         described_version = "6.0.0"
     # For the tag 6.0.0-beta.0, this will match 6.0.0


### PR DESCRIPTION
### What does this PR do?

Fixes the retrieval of the agent version from git tags.

The issue was that the catch-all `except` was catching an error that should
not have been catched (a missing import). Change the try/except block
and make it run in the invoke context to be consistent with other
commands.

### Motivation

Fix stuff. Once this is merged we should be able to start tagging the repo and get tagged packages and binaries.
