### PR TITLE
[cmd][version] Display meta only when populated

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -23,6 +23,10 @@ var versionCmd = &cobra.Command{
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		av, _ := version.New(version.AgentVersion)
-		fmt.Println(fmt.Sprintf("Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumberAndPre(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
+		meta := ""
+		if av.Meta != "" {
+			meta = fmt.Sprintf("- Meta: %s ", av.Meta)
+		}
+		fmt.Println(fmt.Sprintf("Agent %s %s- Commit: %s - Serialization version: %s", av.GetNumberAndPre(), meta, av.Commit, serializer.AgentPayloadVersion))
 	},
 }


### PR DESCRIPTION
### What does this PR do?

In the `version` command:
* Displays the `Meta` version field only when it's populated
* Renames it from `Codename`

### Motivation

On tagged builds `Meta` is not populated, so we would display a weird empty value.

Now we output:
```
Agent 6.0.0-alpha.1 - Commit: 92fcf5d8 - Serialization version: 4.5  # tagged build
# or
Agent 6.0.0-alpha.1 - Meta: git.1.d6d0ee73 - Commit: d6d0ee73 - Serialization version: 4.5  # untagged build
```