### PR TITLE
[gitlab] Run deploy jobs when tags are pushed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,6 +209,7 @@ deploy_deb:
     - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
+    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -253,6 +254,7 @@ deploy_rpm:
     - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
+    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm


### PR DESCRIPTION
### What does this PR do?

Runs deploy jobs when tags are pushed

### Motivation

When we push tags, we generally want the resulting packages
to be pushed to the repos, so we should run the deploy jobs.

### Additional Notes

See gitlab docs:
https://docs.gitlab.com/ee/ci/yaml/#only-and-except-simplified

