### PR TITLE
We need to deploy on tags as well as on master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,6 +209,8 @@ deploy_deb:
     - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
+    - /^6\.0\..+-alpha\..+/
+    - /^6\.0\..+-beta\..+/
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -253,6 +255,8 @@ deploy_rpm:
     - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
+    - /^6\.0\..+-alpha\..+/
+    - /^6\.0\..+-beta\..+/
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm


### PR DESCRIPTION
### What does this PR do?

I don't wanna get too in the weeds here, but if you look at the pipeline where @olivielpeau pushed the alpha, it didn't push it out, instead using the bad version of the nightly. We need it to push it out.
