### PR TITLE
Do not delete config files

### DIFF
--- a/omnibus/package-scripts/agent/postrm
+++ b/omnibus/package-scripts/agent/postrm
@@ -28,7 +28,6 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIB
             echo "Force-deleting $INSTALL_DIR"
             rm -rf $INSTALL_DIR
             rm -rf $LOG_DIR
-            rm -rf $CONFIG_DIR
         ;;
         *)
         ;;


### PR DESCRIPTION
### What does this PR do?

Agent 6 should not remove the config dir. The config directory should stay there so that downgrading is easier.
