### PR TITLE
[omnibus] Sane defaults now that the repo is tagged

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -2,3 +2,6 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https:#www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
+
+# Don't append a timestamp to the package version
+append_timestamp false

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -132,11 +132,7 @@ def get_git_branch_name():
 def query_version(ctx):
     # The string that's passed in will look something like this: 6.0.0-beta.0-1-g4f19118
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
-    try:
-        described_version = ctx.run("git describe --tags", hide=True).stdout.strip()
-    except invoke.exceptions.UnexpectedExit:
-        # FIXME remove this `except` block when we start tagging the repo
-        described_version = "6.0.0"
+    described_version = ctx.run("git describe --tags", hide=True).stdout.strip()
     # For the tag 6.0.0-beta.0, this will match 6.0.0
     version_match = re.findall(r"^v?(\d+\.\d+\.\d+)", described_version)
 


### PR DESCRIPTION
### What does this PR do?

Set sane defaults on the package/binary versions now that the repo is tagged:
* Stop appending timestamps to the package version to have more
  readable/usable versions (see option usage there: https://github.com/DataDog/omnibus-ruby/blob/datadog-5.5.0/lib/omnibus/config.rb#L482-L485)
* Assume that there's always a tag in the tree, so stop using
  a default version in the invoke task that retrieves the version from
  git.

### Motivation

Better versioning pattern