### PR TITLE
Import command rework

### DIFF
--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -29,5 +29,5 @@ monitoring and performance data.`,
 )
 
 func init() {
-	startCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to directory containing datadog.yaml")
+	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
 }

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -33,7 +33,6 @@ const checkCmdFlushInterval = 10000000000
 func init() {
 	AgentCmd.AddCommand(checkCmd)
 
-	checkCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to directory containing datadog.yaml")
 	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice")
 	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -26,9 +26,8 @@ func init() {
 	AgentCmd.AddCommand(flareCmd)
 
 	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
-	flareCmd.Flags().StringVarP(&caseID, "case-id", "c", "", "Your case ID")
-	flareCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to datadog.yaml")
-	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation")
+	flareCmd.Flags().StringVarP(&caseID, "case-id", "i", "", "Your case ID")
+	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
 	flareCmd.SetArgs([]string{"caseID"})
 }
 

--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -7,10 +7,11 @@ package app
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/legacy"
 	yaml "gopkg.in/yaml.v2"
@@ -20,13 +21,14 @@ import (
 
 var (
 	importCmd = &cobra.Command{
-		Use:   "import <path_to_datadog.conf>",
-		Short: "Import the old datadog.conf and convert to the new format",
+		Use:   "import <old_configuration_dir> <destination_dir>",
+		Short: "Import and convert configuration files from previous versions of the Agent",
 		Long:  ``,
 		RunE:  doImport,
 	}
 
-	force = false
+	force    = false
+	destPath = ""
 )
 
 func init() {
@@ -34,15 +36,23 @@ func init() {
 	AgentCmd.AddCommand(importCmd)
 
 	// local flags
+	importCmd.Flags().StringVarP(&destPath, "dest", "d", "", "destination path where to put datadog.yaml")
 	importCmd.Flags().BoolVarP(&force, "force", "f", force, "force the creation of the yaml file")
 }
 
 func doImport(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("please provide the path to datadog.conf")
+	if len(args) != 2 {
+		return fmt.Errorf("please provide all the required arguments")
 	}
 
-	datadogConfPath := args[0]
+	if confFilePath != "" {
+		fmt.Fprintf(os.Stderr, "Please note configdir option has no effect\n")
+	}
+
+	oldConfigDir := args[0]
+	newConfigDir := args[1]
+	datadogConfPath := filepath.Join(oldConfigDir, "datadog.conf")
+	datadogYamlPath := filepath.Join(newConfigDir, "datadog.yaml")
 
 	// read the old configuration in memory
 	agentConfig, err := legacy.GetAgentConfig(datadogConfPath)
@@ -50,21 +60,29 @@ func doImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to read data from %s: %v", datadogConfPath, err)
 	}
 
-	// Global Agent configuration
-	err = common.SetupConfig(confFilePath)
-	if err != nil {
-		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	// the new config file might not exist, create it
+	if _, err := os.Stat(datadogYamlPath); os.IsNotExist(err) {
+		f, err := os.Create(datadogYamlPath)
+		if err != nil {
+			return fmt.Errorf("error creating %s: %v", datadogYamlPath, err)
+		}
+		f.Close()
 	}
 
-	// store the current datadog.yaml path
-	datadogYamlPath := config.Datadog.ConfigFileUsed()
+	// setup the configuration system
+	config.Datadog.AddConfigPath(newConfigDir)
+	err = config.Datadog.ReadInConfig()
+	if err != nil {
+		return fmt.Errorf("unable to load Datadog config file: %s", err)
+	}
 
+	// we won't overwrite the conf file if it contains a valid api_key
 	if config.Datadog.GetString("api_key") != "" && !force {
 		return fmt.Errorf("%s seems to contain a valid configuration, run the command again with --force or -f to overwrite it",
 			datadogYamlPath)
 	}
 
-	// overwrite current agent configuration with the converted data
+	// merge current agent configuration with the converted data
 	err = legacy.FromAgentConfig(agentConfig)
 	if err != nil {
 		return fmt.Errorf("unable to convert configuration data from %s: %v", datadogConfPath, err)
@@ -76,11 +94,13 @@ func doImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to create a backup for the existing file: %s", datadogYamlPath)
 	}
 
-	// dump the current configuration to datadog.yaml
+	// marshal the config object to YAML
 	b, err := yaml.Marshal(config.Datadog.AllSettings())
 	if err != nil {
 		return fmt.Errorf("unable to unmarshal config to YAML: %v", err)
 	}
+
+	// dump the current configuration to datadog.yaml
 	// file permissions will be used only to create the file if doesn't exist,
 	// please note on Windows such permissions have no effect.
 	if err = ioutil.WriteFile(datadogYamlPath, b, 0640); err != nil {
@@ -89,5 +109,71 @@ func doImport(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Successfully imported the contents of %s into %s\n", datadogConfPath, datadogYamlPath)
 
+	// move existing config files to the new configuration directory
+	files, err := ioutil.ReadDir(filepath.Join(oldConfigDir, "conf.d"))
+	if err != nil {
+		return fmt.Errorf("unable to list config files from %s: %v", oldConfigDir, err)
+	}
+
+	for _, f := range files {
+		if f.IsDir() || filepath.Ext(f.Name()) != ".yaml" {
+			continue
+		}
+
+		src := filepath.Join(oldConfigDir, "conf.d", f.Name())
+		dst := filepath.Join(newConfigDir, "conf.d", f.Name())
+
+		if err := copyFile(src, dst); err != nil {
+			fmt.Fprintf(os.Stderr, "unable to copy %s to %s: %v\n", src, dst, err)
+			continue
+		}
+
+		fmt.Printf("Copied %s over the new conf.d directory\n", f.Name())
+	}
+
+	autoConfFiles, err := ioutil.ReadDir(filepath.Join(oldConfigDir, "conf.d", "auto_conf"))
+	if err != nil {
+		return fmt.Errorf("unable to list auto_conf files from %s: %v", oldConfigDir, err)
+	}
+
+	for _, f := range autoConfFiles {
+		if f.IsDir() || filepath.Ext(f.Name()) != ".yaml" {
+			continue
+		}
+
+		src := filepath.Join(oldConfigDir, "conf.d", "auto_conf", f.Name())
+		dst := filepath.Join(newConfigDir, "conf.d", "auto_conf", f.Name())
+
+		if err := copyFile(src, dst); err != nil {
+			fmt.Fprintf(os.Stderr, "unable to copy %s to %s: %v\n", src, dst, err)
+			continue
+		}
+
+		fmt.Printf("Copied %s over the new auto_conf directory\n", f.Name())
+	}
+
 	return nil
+}
+
+// Copy the src file to dst.
+// Any existing file will be overwritten.
+// File attributes won't be copied.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return out.Close()
 }

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -57,7 +57,6 @@ var (
 	// flags variables
 	runForeground bool
 	pidfilePath   string
-	confdPath     string
 )
 
 // run the host metadata collector every 14400 seconds (4 hours)
@@ -72,8 +71,6 @@ func init() {
 
 	// local flags
 	startCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
-	startCmd.Flags().StringVarP(&confdPath, "confd", "c", "", "path to the confd folder")
-	config.Datadog.BindPFlag("confd_path", startCmd.Flags().Lookup("confd"))
 }
 
 // Start the main loop

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -26,7 +26,6 @@ var (
 
 func init() {
 	AgentCmd.AddCommand(statusCmd)
-	statusCmd.Flags().StringVarP(&confFilePath, "cfgpath", "f", "", "path to folder containing datadog.yaml")
 	statusCmd.Flags().BoolVarP(&jsonStatus, "json", "j", false, "print out raw json")
 	statusCmd.Flags().BoolVarP(&prettyPrintJSON, "pretty-json", "p", false, "pretty print JSON")
 	statusCmd.Flags().StringVarP(&statusFilePath, "file", "o", "", "Output the status command to a file")

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -70,7 +70,7 @@ func init() {
 	dogstatsdCmd.AddCommand(versionCmd)
 
 	// local flags
-	startCmd.Flags().StringVarP(&confPath, "cfgpath", "f", "", "path to datadog.yaml")
+	startCmd.Flags().StringVarP(&confPath, "cfgpath", "c", "", "path to datadog.yaml")
 	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath"))
 	startCmd.Flags().StringVarP(&socketPath, "socket", "s", "", "listen to this socket instead of UDP")
 	config.Datadog.BindPFlag("dogstatsd_socket", startCmd.Flags().Lookup("socket"))


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Copies over config files for check from the old config dir to the new one, while converting the old configuration file to the new one.

The CLI changed a bit to address a chicken/egg issue about reading the agent config file to run the import command, which in turn tries to update the same config file. Now the command accepts two arguments, the old config dir and the new one:
```
agent import <old_configuration_dir> <destination_dir> [flags]
```

### Additional Notes

The `cfgpath` was supposed to be global but it wasn't, this PR fixes that. Ironically, `import` doesn't need that flag but it still makes sense to have it global.
