### PR TITLE
Import trace-agent specific configs

### DIFF
--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -154,11 +154,7 @@ func doImport(cmd *cobra.Command, args []string) error {
 	}
 
 	// Extract trace-agent specific info and dump it to its own config file.
-	// Overwrite is safe at this point, if the script was run by mistake, we'd
-	// have already been returned. On the other side, we cannot really know if
-	// we're overwriting the default config file shipped with the package or a
-	// customized version. Worst case, we have a backup file.
-	if err := processTraceAgent(datadogConfPath, traceAgentConfPath, true); err != nil {
+	if err := processTraceAgent(datadogConfPath, traceAgentConfPath, force); err != nil {
 		return fmt.Errorf("failed to import Trace Agent specific settings: %v", err)
 	}
 	fmt.Printf("Copied Trace Agent specific settings to %s\n", traceAgentConfPath)

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -113,6 +113,8 @@ func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData)
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("DD_API_KEY=%s", config.Datadog.GetString("api_key")))
 	env = append(env, fmt.Sprintf("DD_HOSTNAME=%s", getHostname()))
+	env = append(env, fmt.Sprintf("DD_DOGSTATSD_PORT=%s", config.Datadog.GetString("dogstatsd_port")))
+	env = append(env, fmt.Sprintf("DD_LOG_LEVEL=%s", config.Datadog.GetString("log_level")))
 	c.cmd.Env = env
 
 	return nil

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -108,7 +108,14 @@ func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData)
 		configFile = path.Join(config.FileUsedDir(), "trace-agent.conf")
 	}
 
-	c.cmd = exec.Command(binPath, fmt.Sprintf("-ddconfig=%s", configFile))
+	commandOpts := []string{}
+
+	// if the trace-agent.conf file is available, use it
+	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
+		commandOpts = append(commandOpts, fmt.Sprintf("-ddconfig=%s", configFile))
+	}
+
+	c.cmd = exec.Command(binPath, commandOpts...)
 
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("DD_API_KEY=%s", config.Datadog.GetString("api_key")))

--- a/pkg/legacy/trace-agent.go
+++ b/pkg/legacy/trace-agent.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	// whitelist the sections we want to import
 	traceAgentSections = map[string]struct{}{
 		"DEFAULT":        struct{}{}, // removing this section would mess up the ini file
 		"trace.sampler":  struct{}{},
@@ -36,8 +37,8 @@ func ImportTraceAgentConfig(datadogConfPath, traceAgentConfPath string) error {
 		}
 	}
 
-	// only dump the file if we have Sections
-	if len(iniFile.SectionStrings()) > 0 {
+	// only write the file if we have other Sections than DEFAULT
+	if len(iniFile.SectionStrings()) > 1 {
 		return iniFile.SaveTo(traceAgentConfPath)
 	}
 

--- a/pkg/legacy/trace-agent.go
+++ b/pkg/legacy/trace-agent.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package legacy
+
+import (
+	"fmt"
+
+	"github.com/go-ini/ini"
+)
+
+var (
+	traceAgentSections = map[string]struct{}{
+		"DEFAULT":        struct{}{}, // removing this section would mess up the ini file
+		"trace.sampler":  struct{}{},
+		"trace.receiver": struct{}{},
+		"trace.ignore":   struct{}{},
+	}
+)
+
+// ImportTraceAgentConfig reads `datadog.conf` and returns an ini config object,
+// ready to be dumped to a .ini file.
+func ImportTraceAgentConfig(datadogConfPath, traceAgentConfPath string) error {
+	// read datadog.conf
+	iniFile, err := ini.Load(datadogConfPath)
+	if err != nil {
+		return err
+	}
+
+	// remove any section that's not trace-agent specific
+	for _, section := range iniFile.SectionStrings() {
+		if _, found := traceAgentSections[section]; !found {
+			iniFile.DeleteSection(section)
+		}
+	}
+
+	// only dump the file if we have Sections
+	if len(iniFile.SectionStrings()) > 0 {
+		return iniFile.SaveTo(traceAgentConfPath)
+	}
+
+	return fmt.Errorf("nothing to import")
+}


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

When importing `datadog.conf`, copy trace agent specific settings to its own config file
