### PR TITLE
[developer_mode] add BC `in_developer_mode` option - always False

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -93,7 +93,18 @@ class AgentCheck(object):
                 False,
                 "DEPRECATION NOTICE: `device_name` is deprecated, please use a `device:` tag in the `tags` list instead",
             ],
+            'in_developer_mode': [
+                False,
+                "DEPRECATION NOTICE: `in_developer_mode` is deprecated, please stop using it.",
+            ],
         }
+
+
+    @property
+    def in_developer_mode(self):
+        self._log_deprecation('in_developer_mode')
+        return False
+
 
     def get_instance_proxy(self, instance, uri):
         proxies = self.proxies.copy()


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

`in_developer_mode` is called by `agent_metrics` in the SDK. It doesn't make an awful lot of sense on agent6 but it does on agent5, so let's just always make it false. 

### Motivation

Hit this testing on `staging`.

### Additional Notes

Anything else we should know when reviewing?
