### PR TITLE
Make clear windows won't be available for beta1

### DIFF
--- a/docs/beta/downgrade.md
+++ b/docs/beta/downgrade.md
@@ -109,12 +109,6 @@ sudo -u dd-agent -- rm -rf /etc/datadog-agent/
 
 ## Windows
 
-### Download the [Datadog Installer](https://s3.amazonaws.com/ddagent-windows-test/ddagent-cli-latest.msi)
-
-### In a cmd.exe shell in the directory you downloaded the installer, run:
-
-```shell
-msiexec /qn /i ddagent-cli-beta-latest.msi APIKEY="your_api_key" HOSTNAME="my_hostname" TAGS="mytag1,mytag2"
-```
+Coming soon.
 
 [upgrade-guide]: upgrade.md

--- a/docs/beta/known_issues.md
+++ b/docs/beta/known_issues.md
@@ -78,4 +78,6 @@ Beta is currently available on these platforms:
 * Debian x86_64 version 7 (wheezy) and above
 * Ubuntu x86_64 version 12.04 and above
 * RedHat/CentOS x86_64 version 6 and above
+
+Next on the pipeline but still unavailable:
 * Windows 64-bit

--- a/docs/beta/upgrade.md
+++ b/docs/beta/upgrade.md
@@ -103,10 +103,4 @@ sudo restart datadog-agent
 
 ## Windows
 
-### Download the [Datadog Installer](https://s3.amazonaws.com/ddagent-windows-test/ddagent-cli-beta-latest.msi)
-
-### In a cmd.exe shell in the directory you downloaded the installer, run:
-
-```shell
-msiexec /qn /i ddagent-cli-beta-latest.msi APIKEY="your_api_key" HOSTNAME="my_hostname" TAGS="mytag1,mytag2"
-```
+Coming soon.


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

Remove statements from the docs that might make users think we have a beta1 package for Win
