### PR TITLE
[log] Nicer log format for omnibus-built agent

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -61,7 +61,7 @@ func SetupLogger(logLevel, logFile, uri string, rfc, tls bool, pem string) error
 	}
 	configTemplate += `</outputs>
     <formats>
-        <format id="common" format="%%Date(%s) | %%LEVEL | (%%RelFile:%%Line) | %%Msg%%n"/>`
+        <format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n"/>`
 	if syslog {
 		if rfc {
 			configTemplate += `<format id="syslog" format="%%CustomSyslogHeader(20,true) %%LEVEL | (%%RelFile:%%Line) | %%Msg%%n" />`


### PR DESCRIPTION
### What does this PR do?

Currently the omnibus-built agent logs entries with this format:

```
2017-09-27 16:54:03 UTC | INFO | (/builds/datadog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:208) | Done running check load
```

which is ugly.

For now let's use a different format (removing absolute path to go file):

```
2017-09-27 16:54:03 UTC | INFO | (runner.go:208 in work) | Done running check load
```

which gives a bit less info but is still good enough.

### Additional Notes

When we have time let's revisit this to have the package path in the log entries (custom seelog formatter?)
