### PR TITLE
[omnibus] blacklist checks + cleanup package

### DIFF
--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -14,7 +14,7 @@ const DefaultConfPath = "/opt/datadog-agent/etc/datadog-agent"
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
-	PyChecksPath = filepath.Join(_here, "..", "..", "agent", "checks.d")
+	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
 )

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -16,7 +16,7 @@ const DefaultConfPath = "/etc/datadog-agent"
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
-	PyChecksPath = filepath.Join(_here, "..", "..", "agent", "checks.d")
+	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
 )

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
-	PyChecksPath = filepath.Join(_here, "..", "agent", "checks.d")
+	PyChecksPath = filepath.Join(_here, "..", "checks.d")
 	distPath     string
 )
 

--- a/docs/beta/known_issues.md
+++ b/docs/beta/known_issues.md
@@ -10,9 +10,10 @@ by [integrations-core](https://github.com/DataDog/integrations-core) are not qui
 ready yet. This is the list of checks that are expected to fail if run within the
 beta Agent:
 
+* agent_metrics
+* docker_daemon
 * kubernetes
 * kubernetes_state
-* docker_daemon
 * vsphere
 
 The Docker and Kubernetes checks in particular are being rewritten in Go to take

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -6,6 +6,8 @@
 # This software definition doesn"t build anything, it"s the place where we create
 # files outside the omnibus installation directory, so that we can add them to
 # the package manifest using `extra_package_file` in the project definition.
+require './lib/ostools.rb'
+
 name "datadog-agent-finalize"
 description "steps required to finalize the build"
 default_version "1.0.0"
@@ -21,11 +23,17 @@ build do
     move "#{install_dir}/etc/datadog-agent/trace-agent.conf", "/etc/datadog-agent"
     move "#{install_dir}/etc/datadog-agent/process-agent.conf", "/etc/datadog-agent"
     move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent"
-    move "#{install_dir}/agent/checks.d", "/etc/datadog-agent"
+    move "#{install_dir}/bin/agent/dist/conf.d/*", "/etc/datadog-agent/conf.d"
+    move "#{install_dir}/agent/checks.d", "#{install_dir}/checks.d"
 
     # Move system service files
     mkdir "/etc/init"
     move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
     mkdir "/lib/systemd/system"
     move "#{install_dir}/scripts/datadog-agent.service", "/lib/systemd/system"
+
+    # cleanup clutter
+    delete "#{install_dir}/etc" if !osx?
+    delete "#{install_dir}/sources"
+    delete "#{install_dir}/bin/agent/dist/conf.d"
 end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -20,8 +20,8 @@ build do
     # Move checks and configuration files
     mkdir "/etc/datadog-agent"
     move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
-    move "#{install_dir}/etc/datadog-agent/trace-agent.conf", "/etc/datadog-agent"
-    move "#{install_dir}/etc/datadog-agent/process-agent.conf", "/etc/datadog-agent"
+    move "#{install_dir}/etc/datadog-agent/trace-agent.conf", "/etc/datadog-agent/trace-agent.conf.example"
+    move "#{install_dir}/etc/datadog-agent/process-agent.conf", "/etc/datadog-agent/process-agent.conf.example"
     move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent"
     move "#{install_dir}/bin/agent/dist/conf.d/*", "/etc/datadog-agent/conf.d"
     move "#{install_dir}/agent/checks.d", "#{install_dir}/checks.d"
@@ -34,6 +34,8 @@ build do
 
     # cleanup clutter
     delete "#{install_dir}/etc" if !osx?
-    delete "#{install_dir}/sources"
     delete "#{install_dir}/bin/agent/dist/conf.d"
+    delete "#{install_dir}/bin/agent/dist/*.conf"
+    delete "#{install_dir}/bin/agent/dist/*.yaml"
+
 end

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -3,7 +3,7 @@
 # This product includes software developed at Datadog (https:#www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
 
-require "./lib/ostools.rb"
+require './lib/ostools.rb'
 
 name 'datadog-agent-integrations'
 
@@ -43,7 +43,9 @@ build do
     all_reqs_file = File.open("#{project_dir}/check_requirements.txt", 'w+')
 
     Dir.glob("#{project_dir}/*").each do |check_dir|
-      next if blacklist.include? check_dir
+      check = check_dir.split('/').last
+
+      next if blacklist.include? check
       # Check the manifest to be sure that this check is enabled on this system
       # or skip this iteration
       manifest_file_path = "#{check_dir}/manifest.json"
@@ -54,8 +56,6 @@ build do
 
       manifest = JSON.parse(File.read(manifest_file_path))
       manifest['supported_os'].include?(os) || next
-
-      check = check_dir.split('/').last
 
       # Copy the checks over
       if File.exist? "#{check_dir}/check.py"

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -15,6 +15,14 @@ whitelist_file "embedded/lib/python2.7"
 source git: 'https://github.com/DataDog/integrations-core.git'
 default_version 'master'
 
+blacklist = [
+  'agent_metrics',
+  'docker_daemon',
+  'kubernetes',
+  'kubernetes_state',
+  'vsphere',
+]
+
 build do
   # The checks
   checks_dir = "#{install_dir}/agent/checks.d"
@@ -35,6 +43,7 @@ build do
     all_reqs_file = File.open("#{project_dir}/check_requirements.txt", 'w+')
 
     Dir.glob("#{project_dir}/*").each do |check_dir|
+      next if blacklist.include? check_dir
       # Check the manifest to be sure that this check is enabled on this system
       # or skip this iteration
       manifest_file_path = "#{check_dir}/manifest.json"


### PR DESCRIPTION
### What does this PR do?

Blacklists unsupported SDK packages so we do not ship them.

Additional cleanup:
- ships checks in `/opt/datadog-agent/checks.d`
- removes `/opt/datadog-agent/etc` on linux
- removes some clutter from `/opt/datadog-agent/bin/agent/dist`
- we no longer ship the sources tarball.
- we actually copy the default config files to `/etc/datadog-agent/conf.d`
- we remove unneeded `/etc/datadog-agent/bin/agent/dist/conf.d`


### Motivation

Some final package cleanup so we can minimize the number of changes moving forward.

