### PR TITLE
When running `import`, silence usage in case of error

### DIFF
--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -21,10 +21,11 @@ import (
 
 var (
 	importCmd = &cobra.Command{
-		Use:   "import <old_configuration_dir> <destination_dir>",
-		Short: "Import and convert configuration files from previous versions of the Agent",
-		Long:  ``,
-		RunE:  doImport,
+		Use:          "import <old_configuration_dir> <destination_dir>",
+		Short:        "Import and convert configuration files from previous versions of the Agent",
+		Long:         ``,
+		RunE:         doImport,
+		SilenceUsage: true,
 	}
 
 	force    = false


### PR DESCRIPTION
<!--
Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/datadog-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.
-->

### What does this PR do?

the `import` command is mainly used within scripts, let's only print the error message, not the command usage in case of error.
