### PR TITLE
[omnibus] actual link fix for centos

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -45,6 +45,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                     usermod -g dd-agent dd-agent
                 fi
 
+                # Create a symlink to the agent's binary
+                ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
             ;;
             abort-upgrade|abort-remove|abort-deconfigure)
             ;;
@@ -54,9 +56,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         esac
         #DEBHELPER#
     fi
-
-    # Create a symlink to the agent's binary
-    ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
 
     # Set proper rights to the dd-agent user
     chown -R dd-agent:dd-agent ${CONFIG_DIR}

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -7,6 +7,7 @@
 # .deb: n/a
 # .rpm: STEP 6 of 6
 
+INSTALL_DIR=/opt/datadog-agent
 CONFIG_DIR=/etc/datadog-agent
 SERVICE_NAME=datadog-agent
 


### PR DESCRIPTION
### What does this PR do?

The link should indeed be in the `posttrans` on centOS just set the right variable.

### Motivation

Other link was still getting overridden by the broken one in `posttrans`. 

