### PR TITLE
Removing unused option from the import cmd

### DIFF
--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -28,8 +28,7 @@ var (
 		SilenceUsage: true,
 	}
 
-	force    = false
-	destPath = ""
+	force = false
 )
 
 func init() {
@@ -37,7 +36,6 @@ func init() {
 	AgentCmd.AddCommand(importCmd)
 
 	// local flags
-	importCmd.Flags().StringVarP(&destPath, "dest", "d", "", "destination path where to put datadog.yaml")
 	importCmd.Flags().BoolVarP(&force, "force", "f", force, "overwrite existing files")
 }
 


### PR DESCRIPTION
### What does this PR do?

Removing unused `-dest` option from the import command.