### PR TITLE
[pkg scripts] [centos] Make logic to stop service work on up/downgrades

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -62,21 +62,21 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     chown -R dd-agent:dd-agent ${LOG_DIR}
     chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
-    # Only supports systemd and upstart
-    echo "Enabling service $SERVICE_NAME"
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl enable $SERVICE_NAME
-    elif command -v initctl >/dev/null 2>&1; then
-        # start/stop policy is already defined in the upstart job file
-        :
-    else
-        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-        exit 1
-    fi
-
-    # Restart the agent here on Debian platforms
-    # On RHEL, the restart is done in the posttrans script
+    # Enable and restart the agent service here on Debian platforms
+    # On RHEL, this is done in the posttrans script
     if [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
+        # Only supports systemd and upstart
+        echo "Enabling service $SERVICE_NAME"
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl enable $SERVICE_NAME
+        elif command -v initctl >/dev/null 2>&1; then
+            # Nothing to do, this is defined directly in the upstart job file
+            :
+        else
+            echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+            exit 1
+        fi
+
         # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
         # and avoid restarting when a check conf is invalid
         if [ -f "$CONFIG_DIR/datadog.yaml" ]; then

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -14,6 +14,17 @@ SERVICE_NAME=datadog-agent
 # Create a symlink to the agent's binary
 ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
 
+echo "Enabling service $SERVICE_NAME"
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable $SERVICE_NAME
+elif command -v initctl >/dev/null 2>&1; then
+    # start/stop policy is already defined in the upstart job file
+    :
+else
+    echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+    exit 1
+fi
+
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid
 if [ -f "$CONFIG_DIR/datadog.yaml" ]; then

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -40,6 +40,12 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         :
         #DEBHELPER#
     elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
+        # RPM Agents < 5.18.0 expect the preinst script of the _new_ package to stop the agent service on upgrade (which is defined with an init.d script on Agent 5)
+        # So let's stop the Agent 5 service here until we don't want to support upgrades from Agents < 5.18.0 anymore
+        if [ -f "/etc/init.d/datadog-agent" ]; then
+            /etc/init.d/datadog-agent stop || true
+        fi
+
         # Set up `dd-agent` user and group
         getent group dd-agent >/dev/null || groupadd -r dd-agent
         getent passwd dd-agent >/dev/null || \

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -54,11 +54,12 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIB
     deregister_agent
     remove_py_compiled_files
 elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
+    stop_agent
+    deregister_agent
+
     case "$*" in
         0)
             # We're uninstalling.
-            stop_agent
-            deregister_agent
             remove_py_compiled_files
         ;;
         1)


### PR DESCRIPTION
### What does this PR do?

* Makes logic to stop agent service work on up/downgrades from/to agent5
* Also improves the logic to register/deregister the agent service on upgrade

### Motivation

See related PR on dd-agent-omnibus, which has a detailed description of the stop issue:
https://github.com/DataDog/dd-agent-omnibus/pull/200

The change on the registering/deregistering of the service is just a way to make sure that on upgrade we disable the old service and then enable the new service.