### PR TITLE
Mfpierre/implement get pid

### DIFF
--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -8,6 +8,7 @@ package autodiscovery
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"sync"
 	"unicode"
 
@@ -17,7 +18,7 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-type variableGetter func(key []byte, tpl check.Config, svc listeners.Service) []byte
+type variableGetter func(key []byte, svc listeners.Service) []byte
 
 var (
 	templateVariables = map[string]variableGetter{
@@ -138,7 +139,7 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 	for _, v := range vars {
 		name, key := parseTemplateVar(v)
 		if f, ok := templateVariables[string(name)]; ok {
-			resolvedVar := f(key, tpl, svc)
+			resolvedVar := f(key, svc)
 			if resolvedVar != nil {
 				tpl.InitConfig = bytes.Replace(tpl.InitConfig, v, resolvedVar, -1)
 				tpl.Instances[0] = bytes.Replace(tpl.Instances[0], v, resolvedVar, -1)
@@ -158,14 +159,19 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 	defer cr.m.Unlock()
 
 	// in any case, register the service
-	cr.services[svc.ID] = svc
-	cr.serviceToChecks[svc.ID] = make([]check.ID, 0)
+	cr.services[svc.GetID()] = svc
+	cr.serviceToChecks[svc.GetID()] = make([]check.ID, 0)
 
 	// get all the templates matching service identifiers
 	templates := []check.Config{}
-	for _, adID := range svc.ADIdentifiers {
+	ADIdentifiers, err := svc.GetADIdentifiers()
+	if err != nil {
+		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetID(), err)
+		return
+	}
+	for _, adID := range ADIdentifiers {
 		// map the AD identifier to this service for reverse lookup
-		cr.adIDToServices[adID] = append(cr.adIDToServices[adID], svc.ID)
+		cr.adIDToServices[adID] = append(cr.adIDToServices[adID], svc.GetID())
 		tpls, err := cr.templates.Get(adID)
 		if err != nil {
 			log.Errorf("Unable to fetch templates from the cache: %v", err)
@@ -198,7 +204,7 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 			// add the check to the list of checks running against the service
 			// this is used when a template or a service is removed
 			// and we want to stop their related checks
-			cr.serviceToChecks[svc.ID] = append(cr.serviceToChecks[svc.ID], id)
+			cr.serviceToChecks[svc.GetID()] = append(cr.serviceToChecks[svc.GetID()], id)
 		}
 	}
 }
@@ -208,7 +214,7 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 	cr.m.Lock()
 	defer cr.m.Unlock()
 
-	if checks, ok := cr.serviceToChecks[svc.ID]; ok {
+	if checks, ok := cr.serviceToChecks[svc.GetID()]; ok {
 		stopped := map[check.ID]struct{}{}
 		for _, id := range checks {
 			err := cr.collector.StopCheck(id)
@@ -219,45 +225,50 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 		}
 
 		// remove the entry from `serviceToChecks`
-		if len(stopped) == len(cr.serviceToChecks[svc.ID]) {
+		if len(stopped) == len(cr.serviceToChecks[svc.GetID()]) {
 			// we managed to stop all the checks for this config
-			delete(cr.serviceToChecks, svc.ID)
+			delete(cr.serviceToChecks, svc.GetID())
 		} else {
 			// keep the checks we failed to stop in `serviceToChecks[svc.ID]`
 			dangling := []check.ID{}
-			for _, id := range cr.serviceToChecks[svc.ID] {
+			for _, id := range cr.serviceToChecks[svc.GetID()] {
 				if _, found := stopped[id]; !found {
 					dangling = append(dangling, id)
 				}
 			}
-			cr.serviceToChecks[svc.ID] = dangling
+			cr.serviceToChecks[svc.GetID()] = dangling
 		}
 	}
 }
 
 // TODO (use svc.Hosts)
-func getHost(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+func getHost(tplVar []byte, svc listeners.Service) []byte {
 	return []byte("127.0.0.1")
 }
 
 // TODO (use svc.Ports)
-func getPort(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+func getPort(tplVar []byte, svc listeners.Service) []byte {
 	return []byte("80")
 }
 
-// TODO
-func getPid(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
-	return []byte("1")
+// getPid returns the process identifier of the service
+func getPid(tplVar []byte, svc listeners.Service) []byte {
+	pid, err := svc.GetPid()
+	if err != nil {
+		log.Errorf("Failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
+		return nil
+	}
+	return []byte(strconv.Itoa(pid))
 }
 
 // TODO
-func getContainerName(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+func getContainerName(tplVar []byte, svc listeners.Service) []byte {
 	return []byte("test-container-name")
 }
 
 // getTags returns tags that are appended by default to all metrics.
 // TODO (use svc.Tags)
-func getTags(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+func getTags(tplVar []byte, svc listeners.Service) []byte {
 	return []byte("[\"tag:foo\", \"tag:bar\"]")
 }
 
@@ -265,7 +276,7 @@ func getTags(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
 // This is generally reserved to high-cardinality tags that we want to provide,
 // but not by default.
 // TODO
-func getOptTags(tplVar []byte, tpl check.Config, svc listeners.Service) []byte {
+func getOptTags(tplVar []byte, svc listeners.Service) []byte {
 	return []byte("[\"opt:tag1\", \"opt:tag2\"]")
 }
 

--- a/pkg/collector/listeners/types.go
+++ b/pkg/collector/listeners/types.go
@@ -8,15 +8,26 @@ package listeners
 // ID is the representation of the unique ID of a Service
 type ID string
 
-// Service reprensents an application we can run a check against.
-// It should be matched with a check template by the ConfigResolver using the
-// ADIdentifiers field.
-type Service struct {
+// DockerService implements and store results from the Service interface
+type DockerService struct {
 	ID            ID                // unique ID
 	ADIdentifiers []string          // identifiers on which templates will be matched
 	Hosts         map[string]string // network --> IP address
 	Ports         []int
 	Tags          []string
+	Pid           int // Process identifier
+}
+
+// Service represents an application we can run a check against.
+// It should be matched with a check template by the ConfigResolver using the
+// ADIdentifiers field.
+type Service interface {
+	GetID() ID
+	GetADIdentifiers() ([]string, error)
+	GetHosts() (map[string]string, error)
+	GetPorts() ([]int, error)
+	GetTags() ([]string, error)
+	GetPid() (int, error)
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/test/integration/listeners/docker_listener_test.go
+++ b/test/integration/listeners/docker_listener_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -16,6 +17,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/test/integration/utils"
 )
 
@@ -36,22 +39,21 @@ func NewDockerListenerTestSuite(redisVersion, containerName string) *DockerListe
 	return &DockerListenerTestSuite{
 		containerName: containerName,
 		redisImage:    "redis:" + redisVersion,
-		stop:          make(chan struct{}, 1),
 	}
 }
 
 func (suite *DockerListenerTestSuite) SetupSuite() {
+	docker.InitDockerUtil(&docker.Config{
+		CacheDuration:  10 * time.Second,
+		CollectNetwork: true,
+		Whitelist:      config.Datadog.GetStringSlice("ac_include"),
+		Blacklist:      config.Datadog.GetStringSlice("ac_exclude"),
+	})
 	utils.PullImage(suite.redisImage)
 }
 
 func (suite *DockerListenerTestSuite) SetupTest() {
-	suite.m.Lock()
-	defer suite.m.Unlock()
-
-	suite.newSvc = make(chan listeners.Service)
-	suite.delSvc = make(chan listeners.Service)
-
-	dl, err := listeners.NewDockerListener(suite.newSvc, suite.delSvc)
+	dl, err := listeners.NewDockerListener()
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +64,6 @@ func (suite *DockerListenerTestSuite) SetupTest() {
 func (suite *DockerListenerTestSuite) TearDownTest() {
 	suite.listener = nil
 	suite.containerID = ""
-	suite.stop <- struct{}{}
 }
 
 func (suite *DockerListenerTestSuite) containerStart() {
@@ -83,38 +84,46 @@ func (suite *DockerListenerTestSuite) containerRemove() {
 	cli.ContainerRemove(ctx, suite.containerName, types.ContainerRemoveOptions{Force: true})
 }
 
-func (suite *DockerListenerTestSuite) TestInit() {
-	// Init sends to the newSvc channel, grab the messages so we don't
-	// block the test
-	go func() {
-		suite.m.RLock()
-		defer suite.m.RUnlock()
-
-		for {
-			select {
-			case <-suite.stop:
-				return
-			case <-suite.newSvc:
-			}
-		}
-	}()
-
-	suite.listener.Init()
-	services := suite.listener.GetServices()
-	// services might contain other, unrelated containers running on the host,
-	// we specifically search for our redis container
-	assert.NotContains(suite.T(), services, suite.containerID)
+// this tests init
+func (suite *DockerListenerTestSuite) TestListenWithInit() {
+	suite.m.RLock()
+	defer suite.m.RUnlock()
 
 	suite.containerStart()
 
-	suite.listener.Init()
-	services = suite.listener.GetServices()
+	suite.newSvc = make(chan listeners.Service, 1) // buffered channel to avoid blocking
+	suite.delSvc = make(chan listeners.Service)
+
+	suite.listener.Listen(suite.newSvc, suite.delSvc)
+
+	// the listener should have posted the new service at this point
+	createdSvc := <-suite.newSvc
+
+	services := suite.listener.GetServices()
+	assert.Len(suite.T(), services, 1)
 	service, found := services[suite.containerID]
 	assert.True(suite.T(), found)
-	assert.Len(suite.T(), service.Hosts, 1)
-	assert.Len(suite.T(), service.Tags, 0)
+	pid, _ := service.GetPid()
+	assert.True(suite.T(), pid > 0)
+	hosts, _ := service.GetHosts()
+	assert.Len(suite.T(), hosts, 1)
+	ports, _ := service.GetPorts()
+	assert.Len(suite.T(), ports, 1)
+	tags, _ := service.GetTags()
+	assert.Len(suite.T(), tags, 0)
+	assert.Equal(suite.T(), createdSvc, services[suite.containerID])
+	assert.Equal(suite.T(), suite.containerID, createdSvc.GetID())
 
 	suite.containerRemove()
+
+	// the listener should have put the service in the delSvc channel at
+	// this point, grab it
+	oldSvc := <-suite.delSvc
+
+	services = suite.listener.GetServices()
+
+	assert.Len(suite.T(), services, 0)
+	assert.Equal(suite.T(), oldSvc, createdSvc)
 }
 
 // this tests processEvent, createService and removeService as well
@@ -122,7 +131,10 @@ func (suite *DockerListenerTestSuite) TestListen() {
 	suite.m.RLock()
 	defer suite.m.RUnlock()
 
-	suite.listener.Listen()
+	suite.newSvc = make(chan listeners.Service)
+	suite.delSvc = make(chan listeners.Service)
+
+	suite.listener.Listen(suite.newSvc, suite.delSvc)
 
 	suite.containerStart()
 
@@ -131,8 +143,18 @@ func (suite *DockerListenerTestSuite) TestListen() {
 
 	services := suite.listener.GetServices()
 	assert.Len(suite.T(), services, 1)
+	service, found := services[suite.containerID]
+	assert.True(suite.T(), found)
+	pid, _ := service.GetPid()
+	assert.True(suite.T(), pid > 0)
+	hosts, _ := service.GetHosts()
+	assert.Len(suite.T(), hosts, 0)
+	ports, _ := service.GetPorts()
+	assert.Len(suite.T(), ports, 0)
+	tags, _ := service.GetTags()
+	assert.Len(suite.T(), tags, 0)
 	assert.Equal(suite.T(), createdSvc, services[suite.containerID])
-	assert.Equal(suite.T(), suite.containerID, createdSvc.ID)
+	assert.Equal(suite.T(), suite.containerID, createdSvc.GetID())
 
 	suite.containerRemove()
 


### PR DESCRIPTION
### What does this PR do?

* Services are now an interface, and a new `DockerService` implements it
* If the config resolver need some specific info that is only available in inspect, the cache-enabled container inspect is called (see #671) all `*GetFromInspect` methods are deprecated
* `getConfigIDFromInspect` is refactored into `getADIdentifiers`
* `GetPid` is implemented for AD
* Fix integration test that were broken since last refactor
