### PR TITLE
Fix deprecated maintainer in Dockerfiles

### DIFF
--- a/Dockerfiles/agent6/Dockerfile
+++ b/Dockerfiles/agent6/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-MAINTAINER Datadog <package@datadoghq.com>
+LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV DOCKER_DD_AGENT=yes \
     AGENT_VERSION=1:6.0-1 \

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-MAINTAINER Datadog <package@datadoghq.com>
+LABEL maintainer "Datadog <package@datadoghq.com>"
 
 RUN apk add --no-cache ca-certificates
 

--- a/Dockerfiles/dogstatsd/socat-proxy/Dockerfile
+++ b/Dockerfiles/dogstatsd/socat-proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-MAINTAINER Datadog <package@datadoghq.com>
+LABEL maintainer "Datadog <package@datadoghq.com>"
 
 RUN apk add --no-cache socat
 


### PR DESCRIPTION
### What does this PR do?

`MAINTAINER` in Dockerfiles is deprecated since 1.13 (see https://github.com/moby/moby/pull/25466) in favor of `LABEL maintainer`
