### PR TITLE
Bump Alpine version for dogstatsd docker images

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 

--- a/Dockerfiles/dogstatsd/socat-proxy/Dockerfile
+++ b/Dockerfiles/dogstatsd/socat-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 


### PR DESCRIPTION
### What does this PR do?

Bump Alpine version for dogstatsd docker images

### Motivation

Use latest minor version of Alpine Linux 

### Additional Notes

Patch notes available here: https://alpinelinux.org/posts/Alpine-3.6.0-released.html
