### PR TITLE
[Windows] Remove second instantiation of expvar server. 

### DIFF
--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -56,8 +56,6 @@ func main() {
 		return
 	}
 	defer log.Flush()
-	// go_expvar server
-	go http.ListenAndServe("127.0.0.1:5000", http.DefaultServeMux)
 
 	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {


### PR DESCRIPTION
 Had been moved to AgentStart() in previous commit
