### PR TITLE
Remove race condition on forwarder tests + cosmetics changes to the api

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -89,15 +89,15 @@ type Transaction interface {
 type Forwarder interface {
 	Start() error
 	Stop()
-	SubmitV1Series(payload Payloads, extraHeaders map[string]string) error
-	SubmitV1Intake(payload Payloads, extraHeaders map[string]string) error
-	SubmitV1CheckRuns(payload Payloads, extraHeaders map[string]string) error
-	SubmitSeries(payload Payloads, extraHeaders map[string]string) error
-	SubmitEvents(payload Payloads, extraHeaders map[string]string) error
-	SubmitServiceChecks(payload Payloads, extraHeaders map[string]string) error
-	SubmitSketchSeries(payload Payloads, extraHeaders map[string]string) error
-	SubmitHostMetadata(payload Payloads, extraHeaders map[string]string) error
-	SubmitMetadata(payload Payloads, extraHeaders map[string]string) error
+	SubmitV1Series(payload Payloads, extra http.Header) error
+	SubmitV1Intake(payload Payloads, extra http.Header) error
+	SubmitV1CheckRuns(payload Payloads, extra http.Header) error
+	SubmitSeries(payload Payloads, extra http.Header) error
+	SubmitEvents(payload Payloads, extra http.Header) error
+	SubmitServiceChecks(payload Payloads, extra http.Header) error
+	SubmitSketchSeries(payload Payloads, extra http.Header) error
+	SubmitHostMetadata(payload Payloads, extra http.Header) error
+	SubmitMetadata(payload Payloads, extra http.Header) error
 }
 
 // DefaultForwarder is in charge of receiving transaction payloads and sending them to Datadog backend over HTTP.
@@ -133,14 +133,14 @@ func (v byCreatedTime) Len() int           { return len(v) }
 func (v byCreatedTime) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
 func (v byCreatedTime) Less(i, j int) bool { return v[i].GetCreatedAt().After(v[j].GetCreatedAt()) }
 
-func (f *DefaultForwarder) retryTransactions(tickTime time.Time) {
+func (f *DefaultForwarder) retryTransactions(retryBefore time.Time) {
 	newQueue := []Transaction{}
 	droppedTransaction := 0
 
 	sort.Sort(byCreatedTime(f.retryQueue))
 
 	for _, t := range f.retryQueue {
-		if t.GetNextFlush().Before(tickTime) {
+		if t.GetNextFlush().Before(retryBefore) {
 			f.waitingPipe <- t
 			transactionsCreation.Add("SuccessfullyRetried", 1)
 		} else if len(newQueue) < f.retryQueueLimit {
@@ -246,7 +246,7 @@ func (f *DefaultForwarder) Stop() {
 	log.Info("DefaultForwarder stopped")
 }
 
-func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payloads Payloads, apiKeyInQueryString bool, extraHeaders map[string]string) ([]*HTTPTransaction, error) {
+func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payloads Payloads, apiKeyInQueryString bool, extra http.Header) []*HTTPTransaction {
 	transactions := []*HTTPTransaction{}
 	for _, payload := range payloads {
 		for domain, apiKeys := range f.KeysPerDomains {
@@ -266,14 +266,14 @@ func (f *DefaultForwarder) createHTTPTransactions(endpoint string, payloads Payl
 					t.apiKeyStatusKey += apiKey[len(apiKey)-5:]
 				}
 
-				for k, v := range extraHeaders {
-					t.Headers.Set(k, v)
+				for key := range extra {
+					t.Headers.Set(key, extra.Get(key))
 				}
 				transactions = append(transactions, t)
 			}
 		}
 	}
-	return transactions, nil
+	return transactions
 }
 
 func (f *DefaultForwarder) sendHTTPTransactions(transactions []*HTTPTransaction) error {
@@ -289,100 +289,66 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*HTTPTransaction)
 }
 
 // SubmitSeries will send a series type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitSeries(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(seriesEndpoint, payload, false, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitSeries(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(seriesEndpoint, payload, false, extra)
 	transactionsCreation.Add("Series", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitEvents will send an event type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitEvents(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(eventsEndpoint, payload, false, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(eventsEndpoint, payload, false, extra)
 	transactionsCreation.Add("Events", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitServiceChecks will send a service check type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitServiceChecks(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(serviceChecksEndpoint, payload, false, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitServiceChecks(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(serviceChecksEndpoint, payload, false, extra)
 	transactionsCreation.Add("ServiceChecks", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitSketchSeries will send payloads to Datadog backend - PROTOTYPE FOR PERCENTILE
-func (f *DefaultForwarder) SubmitSketchSeries(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(sketchSeriesEndpoint, payload, true, extraHeaders)
-	if err != nil {
-		return err
-	}
+func (f *DefaultForwarder) SubmitSketchSeries(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(sketchSeriesEndpoint, payload, true, extra)
 	transactionsCreation.Add("SketchSeries", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitHostMetadata will send a host_metadata tag type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitHostMetadata(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(hostMetadataEndpoint, payload, false, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitHostMetadata(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(hostMetadataEndpoint, payload, false, extra)
 	transactionsCreation.Add("HostMetadata", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitMetadata will send a metadata type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitMetadata(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(metadataEndpoint, payload, false, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitMetadata(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(metadataEndpoint, payload, false, extra)
 	transactionsCreation.Add("Metadata", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV1Series will send timeserie to v1 endpoint (this will be remove once
 // the backend handles v2 endpoints).
-func (f *DefaultForwarder) SubmitV1Series(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(v1SeriesEndpoint, payload, true, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitV1Series(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(v1SeriesEndpoint, payload, true, extra)
 	transactionsCreation.Add("TimeseriesV1", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV1CheckRuns will send service checks to v1 endpoint (this will be removed once
 // the backend handles v2 endpoints).
-func (f *DefaultForwarder) SubmitV1CheckRuns(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(v1CheckRunsEndpoint, payload, true, extraHeaders)
-	if err != nil {
-		return err
-	}
-
+func (f *DefaultForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(v1CheckRunsEndpoint, payload, true, extra)
 	transactionsCreation.Add("CheckRunsV1", 1)
 	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitV1Intake will send payloads to the universal `/intake/` endpoint used by Agent v.5
-func (f *DefaultForwarder) SubmitV1Intake(payload Payloads, extraHeaders map[string]string) error {
-	transactions, err := f.createHTTPTransactions(v1IntakeEndpoint, payload, true, extraHeaders)
-	if err != nil {
-		return err
-	}
+func (f *DefaultForwarder) SubmitV1Intake(payload Payloads, extra http.Header) error {
+	transactions := f.createHTTPTransactions(v1IntakeEndpoint, payload, true, extra)
 
 	// the intake endpoint requires the Content-Type header to be set
 	for _, t := range transactions {

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -6,278 +6,153 @@
 package forwarder
 
 import (
-	"encoding/base64"
-	"fmt"
-	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+var (
+	keysPerDomains = map[string][]string{
+		"datadog.foo": []string{"api-key-1", "api-key-2"},
+		"datadog.bar": nil,
+	}
 )
 
 func TestNewDefaultForwarder(t *testing.T) {
-	keysPerDomains := map[string][]string{"domainsA": []string{"key1", "key2"}, "domainsB": nil}
 	forwarder := NewDefaultForwarder(keysPerDomains)
 
 	assert.NotNil(t, forwarder)
 	assert.Equal(t, forwarder.NumberOfWorkers, 4)
 	assert.Equal(t, forwarder.KeysPerDomains, keysPerDomains)
-
 	assert.Nil(t, forwarder.waitingPipe)
 	assert.Nil(t, forwarder.requeuedTransaction)
 	assert.Nil(t, forwarder.stopRetry)
 	assert.Len(t, forwarder.workers, 0)
 	assert.Len(t, forwarder.retryQueue, 0)
 	assert.Equal(t, forwarder.internalState, Stopped)
+	assert.Equal(t, forwarder.State(), forwarder.internalState)
 }
 
-func TestState(t *testing.T) {
+func TestStart(t *testing.T) {
 	forwarder := NewDefaultForwarder(nil)
-
-	assert.NotNil(t, forwarder)
-	assert.Equal(t, forwarder.State(), Stopped)
-	forwarder.internalState = Started
-	assert.Equal(t, forwarder.State(), Started)
-}
-
-func TestForwarderStart(t *testing.T) {
-	forwarder := NewDefaultForwarder(nil)
-
 	err := forwarder.Start()
-	defer forwarder.Stop()
-	assert.Nil(t, err)
 
+	assert.Nil(t, err)
 	require.Len(t, forwarder.retryQueue, 0)
 	assert.Equal(t, forwarder.internalState, Started)
 	assert.NotNil(t, forwarder.waitingPipe)
 	assert.NotNil(t, forwarder.requeuedTransaction)
 	assert.NotNil(t, forwarder.stopRetry)
-
 	assert.NotNil(t, forwarder.Start())
+
+	forwarder.Stop()
 }
 
-func TestSubmitInStopMode(t *testing.T) {
+func TestInit(t *testing.T) {
+	forwarder := NewDefaultForwarder(nil)
+	forwarder.init()
+	assert.Len(t, forwarder.workers, 0)
+	assert.Len(t, forwarder.retryQueue, 0)
+}
+
+func TestStop(t *testing.T) {
+	forwarder := NewDefaultForwarder(nil)
+	forwarder.Stop() // this should be a noop
+	forwarder.Start()
+	forwarder.Stop()
+	assert.Len(t, forwarder.workers, 0)
+	assert.Len(t, forwarder.retryQueue, 0)
+}
+
+func TestSubmitIfStopped(t *testing.T) {
 	forwarder := NewDefaultForwarder(nil)
 
 	assert.NotNil(t, forwarder)
-	assert.NotNil(t, forwarder.SubmitSeries(nil, map[string]string{}))
-	assert.NotNil(t, forwarder.SubmitEvents(nil, map[string]string{}))
-	assert.NotNil(t, forwarder.SubmitServiceChecks(nil, map[string]string{}))
-	assert.NotNil(t, forwarder.SubmitSketchSeries(nil, map[string]string{}))
-	assert.NotNil(t, forwarder.SubmitHostMetadata(nil, map[string]string{}))
-	assert.NotNil(t, forwarder.SubmitMetadata(nil, map[string]string{}))
+	assert.NotNil(t, forwarder.SubmitSeries(nil, make(http.Header)))
+	assert.NotNil(t, forwarder.SubmitEvents(nil, make(http.Header)))
+	assert.NotNil(t, forwarder.SubmitServiceChecks(nil, make(http.Header)))
+	assert.NotNil(t, forwarder.SubmitSketchSeries(nil, make(http.Header)))
+	assert.NotNil(t, forwarder.SubmitHostMetadata(nil, make(http.Header)))
+	assert.NotNil(t, forwarder.SubmitMetadata(nil, make(http.Header)))
 }
 
-func TestSubmit(t *testing.T) {
-	expectedEndpoint := ""
-	expectAPIKeyInQuery := false
-	expectedPayload := []byte{}
-	expectedHeaders := make(http.Header)
-	var payloads []*[]byte
+func TestCreateHTTPTransactions(t *testing.T) {
+	forwarder := NewDefaultForwarder(keysPerDomains)
+	endpoint := "/api/foo"
+	p1 := []byte("A payload")
+	p2 := []byte("Another payload")
+	payloads := Payloads{&p1, &p2}
+	headers := make(http.Header)
+	headers.Set("HTTP-MAGIC", "foo")
 
-	firstKey := "api_key1"
-	secondKey := "api_key2"
-	currentKey := firstKey
-	expectedHeaders.Set(apiHTTPHeaderKey, firstKey)
-	expectedHeaders.Set("Content-Type", "application/unit-test")
+	transactions := forwarder.createHTTPTransactions(endpoint, payloads, false, headers)
+	require.Len(t, transactions, 4)
+	assert.Equal(t, "datadog.foo", transactions[0].Domain)
+	assert.Equal(t, "datadog.foo", transactions[1].Domain)
+	assert.Equal(t, "datadog.foo", transactions[2].Domain)
+	assert.Equal(t, "datadog.foo", transactions[3].Domain)
+	assert.Equal(t, endpoint, transactions[0].Endpoint)
+	assert.Equal(t, endpoint, transactions[1].Endpoint)
+	assert.Equal(t, endpoint, transactions[2].Endpoint)
+	assert.Equal(t, endpoint, transactions[3].Endpoint)
+	assert.Len(t, transactions[0].Headers, 2)
+	assert.Equal(t, p1, *(transactions[0].Payload))
+	assert.Equal(t, p1, *(transactions[1].Payload))
+	assert.Equal(t, p2, *(transactions[2].Payload))
+	assert.Equal(t, p2, *(transactions[3].Payload))
 
-	wait := make(chan bool)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() { wait <- true }()
-		assert.Equal(t, r.Method, "POST")
-		assert.Equal(t, r.URL.Path, expectedEndpoint)
-		if expectAPIKeyInQuery {
-			assert.Equal(t, r.URL.RawQuery, fmt.Sprintf("api_key=%s", currentKey))
-		}
-		for k := range expectedHeaders {
-			assert.Equal(t, expectedHeaders.Get(k), r.Header.Get(k))
-		}
-
-		// We switch expected keys as the forwarder should create one
-		// transaction per keys
-		if expectedHeaders.Get(apiHTTPHeaderKey) == firstKey {
-			currentKey = secondKey
-			expectedHeaders.Set(apiHTTPHeaderKey, secondKey)
-		} else {
-			currentKey = firstKey
-			expectedHeaders.Set(apiHTTPHeaderKey, firstKey)
-		}
-
-		body, err := ioutil.ReadAll(r.Body)
-		assert.Nil(t, err)
-		assert.Equal(t, body, expectedPayload)
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	forwarder := NewDefaultForwarder(map[string][]string{ts.URL: []string{firstKey, secondKey}})
-	// delay next retry cycle so we can inspect retry queue
-	flushInterval = 5 * time.Hour
-	forwarder.NumberOfWorkers = 1
-	forwarder.Start()
-	defer forwarder.Stop()
-
-	expectedPayload = []byte("SubmitSeries payload")
-	expectedEndpoint = "/api/v2/series"
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	// wait for the queries to complete before changing expected value
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitEvents payload")
-	expectedEndpoint = "/api/v2/events"
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitEvents(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitServiceChecks payload")
-	expectedEndpoint = "/api/v2/service_checks"
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitServiceChecks(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitSketchSeries payload")
-	expectedEndpoint = "/api/beta/sketches"
-	expectAPIKeyInQuery = true
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitSketchSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-	expectAPIKeyInQuery = false
-
-	expectedPayload = []byte("SubmitHostMetadata payload")
-	expectedEndpoint = "/api/v2/host_metadata"
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitHostMetadata(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitMetadata payload")
-	expectedEndpoint = "/api/v2/metadata"
-	payloads = []*[]byte{&expectedPayload}
-	assert.Nil(t, forwarder.SubmitMetadata(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitV1Series payload")
-	expectedEndpoint = "/api/v1/series"
-	expectAPIKeyInQuery = true
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitV1Series(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitV1CheckRuns payload")
-	expectedEndpoint = "/api/v1/check_run"
-	expectAPIKeyInQuery = true
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitV1CheckRuns(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
-
-	expectedPayload = []byte("SubmitV1Intake payload")
-	expectedEndpoint = "/intake/"
-	expectedHeaders.Set("Content-type", "application/json")
-	expectAPIKeyInQuery = true
-	payloads = []*[]byte{}
-	payloads = append(payloads, &expectedPayload)
-	assert.Nil(t, forwarder.SubmitV1Intake(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	<-wait
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
+	transactions = forwarder.createHTTPTransactions(endpoint, payloads, true, headers)
+	require.Len(t, transactions, 4)
+	assert.Contains(t, transactions[0].Endpoint, "api_key=api-key-1")
+	assert.Contains(t, transactions[1].Endpoint, "api_key=api-key-2")
+	assert.Contains(t, transactions[2].Endpoint, "api_key=api-key-1")
+	assert.Contains(t, transactions[3].Endpoint, "api_key=api-key-2")
 }
 
-func TestSubmitWithProxy(t *testing.T) {
-	targetURL := "http://test:2121"
-	firstKey := "api_key1"
-	wait := make(chan bool)
+func TestSendHTTPTransactions(t *testing.T) {
+	forwarder := NewDefaultForwarder(keysPerDomains)
+	endpoint := "/api/foo"
+	p1 := []byte("A payload")
+	payloads := Payloads{&p1}
+	headers := make(http.Header)
+	tr := forwarder.createHTTPTransactions(endpoint, payloads, false, headers)
+	err := forwarder.sendHTTPTransactions(tr)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() { wait <- true }()
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, targetURL, fmt.Sprintf("%s://%s", r.URL.Scheme, r.URL.Host))
-		assert.Equal(t, firstKey, r.Header.Get(apiHTTPHeaderKey))
+	// fw is stopped, we should get an error
+	assert.NotNil(t, err)
 
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-	config.Datadog.Set("proxy", map[string]interface{}{"http": ts.URL})
-	defer config.Datadog.Set("proxy", nil)
-
-	forwarder := NewDefaultForwarder(map[string][]string{targetURL: []string{firstKey}})
-	// delay next retry cycle so we can inspect retry queue
-	flushInterval = 5 * time.Hour
-	forwarder.NumberOfWorkers = 1
 	forwarder.Start()
-	defer forwarder.Stop()
-
-	payload := []byte("SubmitSeries payload")
-	payloads := []*[]byte{}
-	payloads = append(payloads, &payload)
-	assert.Nil(t, forwarder.SubmitSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	// wait for the queries to complete before changing expected value
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
+	err = forwarder.sendHTTPTransactions(tr)
+	assert.Nil(t, err)
+	forwarder.Stop()
 }
 
-func TestSubmitWithProxyAndPassword(t *testing.T) {
-	targetURL := "http://test:2121"
-	userInfo := "testuser:password123456"
-	expectedAuth := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(userInfo)))
-	firstKey := "api_key1"
-	wait := make(chan bool)
+func TestRequeueTransaction(t *testing.T) {
+	forwarder := NewDefaultForwarder(nil)
+	tr := NewHTTPTransaction()
+	assert.Len(t, forwarder.retryQueue, 0)
+	forwarder.requeueTransaction(tr)
+	assert.Len(t, forwarder.retryQueue, 1)
+}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() { wait <- true }()
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, targetURL, fmt.Sprintf("%s://%s", r.URL.Scheme, r.URL.Host))
-		assert.Equal(t, firstKey, r.Header.Get(apiHTTPHeaderKey))
-		assert.Equal(t, expectedAuth, r.Header.Get("Proxy-Authorization"))
+func TestRetryTransactions(t *testing.T) {
+	forwarder := NewDefaultForwarder(nil)
+	forwarder.init()
+	forwarder.retryQueueLimit = 1
 
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-	config.Datadog.Set("proxy", map[string]interface{}{"http": fmt.Sprintf("http://%s@%s", userInfo, ts.URL[7:])})
-	defer config.Datadog.Set("proxy", nil)
-
-	forwarder := NewDefaultForwarder(map[string][]string{targetURL: []string{firstKey}})
-	// delay next retry cycle so we can inspect retry queue
-	flushInterval = 5 * time.Hour
-	forwarder.NumberOfWorkers = 1
-	forwarder.Start()
-	defer forwarder.Stop()
-
-	payload := []byte("SubmitSeries payload")
-	payloads := []*[]byte{}
-	payloads = append(payloads, &payload)
-	assert.Nil(t, forwarder.SubmitSeries(payloads, map[string]string{"Content-Type": "application/unit-test"}))
-	// wait for the queries to complete before changing expected value
-	<-wait
-	require.Len(t, forwarder.retryQueue, 0)
+	t1 := NewHTTPTransaction()
+	t1.nextFlush = time.Now().Add(-1 * time.Hour)
+	t2 := NewHTTPTransaction()
+	t2.nextFlush = time.Now().Add(1 * time.Hour)
+	forwarder.requeueTransaction(t2)
+	forwarder.requeueTransaction(t2) // this second one should be dropped
+	forwarder.requeueTransaction(t1) // the queue should be sorted
+	forwarder.retryTransactions(time.Now())
+	assert.Len(t, forwarder.retryQueue, 1)
+	assert.Len(t, forwarder.waitingPipe, 1)
 }
 
 func TestForwarderRetry(t *testing.T) {
@@ -337,32 +212,4 @@ func TestForwarderRetryLifo(t *testing.T) {
 	transaction1.AssertExpectations(t)
 	transaction2.AssertExpectations(t)
 	assert.Len(t, forwarder.retryQueue, 0)
-}
-
-func TestForwarderRetryLimitQueue(t *testing.T) {
-	forwarder := NewDefaultForwarder(nil)
-	forwarder.init()
-
-	forwarder.retryQueueLimit = 1
-
-	transaction1 := newTestTransaction()
-	transaction2 := newTestTransaction()
-
-	forwarder.requeueTransaction(transaction1)
-	forwarder.requeueTransaction(transaction2)
-
-	transaction1.On("GetNextFlush").Return(time.Now().Add(1 * time.Minute)).Times(1)
-	transaction1.On("GetCreatedAt").Return(time.Now()).Times(1)
-
-	transaction2.On("GetNextFlush").Return(time.Now().Add(1 * time.Minute)).Times(1)
-	transaction2.On("GetCreatedAt").Return(time.Now().Add(1 * time.Minute)).Times(1)
-
-	forwarder.retryTransactions(time.Now())
-
-	transaction1.AssertExpectations(t)
-	transaction2.AssertExpectations(t)
-	require.Len(t, forwarder.retryQueue, 1)
-	require.Len(t, forwarder.waitingPipe, 0)
-	// assert that the oldest transaction was dropped
-	assert.Equal(t, transaction2, forwarder.retryQueue[0])
 }

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -61,46 +61,46 @@ func (tf *MockedForwarder) Stop() {
 }
 
 // SubmitV1Series updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1Series(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitV1Series(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitV1Intake updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1Intake(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitV1Intake(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitV1CheckRuns updates the internal mock struct
-func (tf *MockedForwarder) SubmitV1CheckRuns(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitSeries(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitSeries(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitEvents updates the internal mock struct
-func (tf *MockedForwarder) SubmitEvents(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitServiceChecks updates the internal mock struct
-func (tf *MockedForwarder) SubmitServiceChecks(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitServiceChecks(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitSketchSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitSketchSeries(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitSketchSeries(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitHostMetadata updates the internal mock struct
-func (tf *MockedForwarder) SubmitHostMetadata(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitHostMetadata(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }
 
 // SubmitMetadata updates the internal mock struct
-func (tf *MockedForwarder) SubmitMetadata(payload Payloads, extraHeaders map[string]string) error {
-	return tf.Called(payload, extraHeaders).Error(0)
+func (tf *MockedForwarder) SubmitMetadata(payload Payloads, extra http.Header) error {
+	return tf.Called(payload, extra).Error(0)
 }

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -7,6 +7,7 @@ package serializer
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,22 +32,24 @@ func TestInitExtraHeadersNoopCompression(t *testing.T) {
 
 	initExtraHeaders()
 
-	assert.Equal(t, map[string]string{"Content-Type": jsonContentType}, jsonExtraHeaders)
-	assert.Equal(t,
-		map[string]string{
-			payloadVersionHTTPHeader: "",
-			"Content-Type":           protobufContentType,
-		},
-		protobufExtraHeaders)
+	expected := make(http.Header)
+	expected.Set("Content-Type", jsonContentType)
+	assert.Equal(t, expected, jsonExtraHeaders)
+
+	expected = make(http.Header)
+	expected.Set(payloadVersionHTTPHeader, "")
+	expected.Set("Content-Type", protobufContentType)
+	assert.Equal(t, expected, protobufExtraHeaders)
 
 	// No "Content-Encoding" header
-	assert.Equal(t, map[string]string{"Content-Type": jsonContentType}, jsonExtraHeadersWithCompression)
-	assert.Equal(t,
-		map[string]string{
-			payloadVersionHTTPHeader: "",
-			"Content-Type":           protobufContentType,
-		},
-		protobufExtraHeadersWithCompression)
+	expected = make(http.Header)
+	expected.Set("Content-Type", jsonContentType)
+	assert.Equal(t, expected, jsonExtraHeadersWithCompression)
+
+	expected = make(http.Header)
+	expected.Set("Content-Type", protobufContentType)
+	expected.Set(payloadVersionHTTPHeader, "")
+	assert.Equal(t, expected, protobufExtraHeadersWithCompression)
 }
 
 func TestInitExtraHeadersWithCompression(t *testing.T) {
@@ -55,28 +58,26 @@ func TestInitExtraHeadersWithCompression(t *testing.T) {
 
 	initExtraHeaders()
 
-	assert.Equal(t, map[string]string{"Content-Type": jsonContentType}, jsonExtraHeaders)
-	assert.Equal(t,
-		map[string]string{
-			payloadVersionHTTPHeader: "",
-			"Content-Type":           protobufContentType,
-		},
-		protobufExtraHeaders)
+	expected := make(http.Header)
+	expected.Set("Content-Type", jsonContentType)
+	assert.Equal(t, expected, jsonExtraHeaders)
+
+	expected = make(http.Header)
+	expected.Set("Content-Type", protobufContentType)
+	expected.Set(payloadVersionHTTPHeader, "")
+	assert.Equal(t, expected, protobufExtraHeaders)
 
 	// "Content-Encoding" header present with correct value
-	assert.Equal(t,
-		map[string]string{
-			"Content-Type":     jsonContentType,
-			"Content-Encoding": compression.ContentEncoding,
-		},
-		jsonExtraHeadersWithCompression)
-	assert.Equal(t,
-		map[string]string{
-			payloadVersionHTTPHeader: "",
-			"Content-Type":           protobufContentType,
-			"Content-Encoding":       compression.ContentEncoding,
-		},
-		protobufExtraHeadersWithCompression)
+	expected = make(http.Header)
+	expected.Set("Content-Type", jsonContentType)
+	expected.Set("Content-Encoding", compression.ContentEncoding)
+	assert.Equal(t, expected, jsonExtraHeadersWithCompression)
+
+	expected = make(http.Header)
+	expected.Set("Content-Type", protobufContentType)
+	expected.Set("Content-Encoding", compression.ContentEncoding)
+	expected.Set(payloadVersionHTTPHeader, "")
+	assert.Equal(t, expected, protobufExtraHeadersWithCompression)
 }
 
 var (


### PR DESCRIPTION
### What does this PR do?

Changes the approach to unit testing for the Forwarder package

### Motivation

Tests were raising a race condition while accessing the global `config` object. 
In my opinion the old approach was more like an integration test than a set of unit tests so I refactored the code, now there's no need to access the config anymore and the tests are more readable.

### Additional Notes

While at the job, I decided to polish a bit the public interface, this required more work than I would like to do, changes are not functional but the diff is huge.
