### PR TITLE
[docker] fix nil pointer error on DockerCheck init

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -265,7 +265,9 @@ func (d *DockerCheck) GetMetricStats() (map[string]int64, error) {
 }
 
 func dockerFactory() check.Check {
-	return &DockerCheck{}
+	return &DockerCheck{
+		instance: &DockerConfig{},
+	}
 }
 
 func init() {


### PR DESCRIPTION
### What does this PR do?

Fix `docker` corecheck, that fails with

>panic: runtime error: invalid memory address or nil pointer dereference
>[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xde73e6] 
> 
> goroutine 1 [running]:
> github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers.(*DockerConfig).Parse(0x0, 0xc4204578a0, 0x20, 0x20, 0x50, 0x10b83e0)
> 	/home/ubuntu/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/docker.go:63 +0x26
> github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers.(*DockerCheck).Configure(0xc4200104b0, 0xc4204578a0, 0x20, 0x20, 0xc420504118, 0x5, 0x8, 0xc420503788, 0x7c74a9)