### PR TITLE
[tagger] cleanup pkg/tagger public api

### DIFF
--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -345,7 +345,7 @@ func (s *DockerService) GetPorts() ([]int, error) {
 // GetTags retrieves tags using the Tagger
 func (s *DockerService) GetTags() ([]string, error) {
 	entity := collectors.DockerEntityName(string(s.ID))
-	tags, err := tagger.DefaultTagger.Tag(entity, true)
+	tags, err := tagger.Tag(entity, true)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
@@ -344,7 +343,7 @@ func (s *DockerService) GetPorts() ([]int, error) {
 
 // GetTags retrieves tags using the Tagger
 func (s *DockerService) GetTags() ([]string, error) {
-	entity := collectors.DockerEntityName(string(s.ID))
+	entity := docker.ContainerIDToEntityName(string(s.ID))
 	tags, err := tagger.Tag(entity, true)
 	if err != nil {
 		return []string{}, err

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -2,11 +2,11 @@
 
 The **Tagger** is the central source of truth for client-side entity tagging. It
 runs **Collector**s that detect entities and collect their tags. Tags are then
-stored in memory (by the **TagStore**) and can be queried by the Tagger.Tag()
-method. Calling once Tagger.Init() after the **config** package is ready is
+stored in memory (by the **TagStore**) and can be queried by the tagger.Tag()
+method. Calling once tagger.Init() after the **config** package is ready is
 needed to enable collection.
 
-The package methods use a common **DefaultTagger** object, but we can create
+The package methods use a common **defaultTagger** object, but we can create
 a custom **Tagger** object for testing.
 
 The package will implement an IPC mechanism (a server and a client) to allow
@@ -42,7 +42,7 @@ The Tagger handles the glue between **Collectors** and **TagStore** and the
 cache miss logic. If the tags from the **TagStore** are missing some sources,
 they will be manually queried in a block way, and the cache will be updated.
 
-For convenience, the package creates a **DefaultTagger** object that is used
+For convenience, the package creates a **defaultTagger** object that is used
 when calling the `tagger.Tag()` method.
 
 

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -28,11 +28,6 @@ const (
 	dockerCollectorName = "docker"
 )
 
-// DockerEntityName returns a prefixed entity name from a container ID
-func DockerEntityName(cid string) string {
-	return fmt.Sprintf("%s%s", DockerEntityPrefix, cid)
-}
-
 // DockerCollector listens to events on the docker socket to get new/dead containers
 // and feed a stram of TagInfo. It requires access to the docker socket.
 // It will also embed DockerExtractor collectors for container tagging.
@@ -103,7 +98,7 @@ func (c *DockerCollector) Stop() error {
 
 // Fetch inspect a given container to get its tags on-demand (cache miss)
 func (c *DockerCollector) Fetch(container string) ([]string, []string, error) {
-	cid := strings.TrimPrefix(container, DockerEntityPrefix)
+	cid := strings.TrimPrefix(container, docker.DockerEntityPrefix)
 	if cid == container {
 		return nil, nil, fmt.Errorf("name is not a docker container: %s", container)
 	}
@@ -116,10 +111,10 @@ func (c *DockerCollector) processEvent(e events.Message) {
 
 	switch e.Action {
 	case "die":
-		out[0] = &TagInfo{Entity: DockerEntityName(cID), Source: dockerCollectorName, DeleteEntity: true}
+		out[0] = &TagInfo{Entity: docker.ContainerIDToEntityName(cID), Source: dockerCollectorName, DeleteEntity: true}
 	case "start":
 		low, high, _ := c.fetchForDockerID(cID)
-		out[0] = &TagInfo{Entity: DockerEntityName(cID), Source: dockerCollectorName, LowCardTags: low, HighCardTags: high}
+		out[0] = &TagInfo{Entity: docker.ContainerIDToEntityName(cID), Source: dockerCollectorName, LowCardTags: low, HighCardTags: high}
 	}
 	c.infoOut <- out
 }

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -5,9 +5,6 @@
 
 package collectors
 
-// DockerEntityPrefix is the entity prefix for docker containers
-const DockerEntityPrefix = "docker://"
-
 // TagInfo holds the tag information for a given entity and source. It's meant
 // to be created from collectors and read by the store.
 type TagInfo struct {

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
-// defaultTagger is the common tagger to be used by all users
+// defaultTagger is the shared tagger instance backing the global Tag and Init functions
 var defaultTagger *Tagger
 
 // Init must be called once config is available, call it in your cmd

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -30,7 +30,7 @@ func Stop() error {
 }
 
 func init() {
-	tagger, err := NewTagger()
+	tagger, err := newTagger()
 	if err != nil {
 		log.Errorf("tagger initialisation failed: %s", err)
 	}

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -11,22 +11,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
-// DefaultTagger is the common tagger to be used by all users
-var DefaultTagger *Tagger
+// defaultTagger is the common tagger to be used by all users
+var defaultTagger *Tagger
 
 // Init must be called once config is available, call it in your cmd
 func Init() error {
-	return DefaultTagger.Init(collectors.DefaultCatalog)
+	return defaultTagger.Init(collectors.DefaultCatalog)
 }
 
 // Tag queries the defaulttagger to get entity tags from cache or sources
 func Tag(entity string, highCard bool) ([]string, error) {
-	return DefaultTagger.Tag(entity, highCard)
+	return defaultTagger.Tag(entity, highCard)
 }
 
 // Stop queues a stop signal to the defaulttagger
 func Stop() error {
-	return DefaultTagger.Stop()
+	return defaultTagger.Stop()
 }
 
 func init() {
@@ -34,5 +34,5 @@ func init() {
 	if err != nil {
 		log.Errorf("tagger initialisation failed: %s", err)
 	}
-	DefaultTagger = tagger
+	defaultTagger = tagger
 }

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -29,11 +29,11 @@ type Tagger struct {
 	stop       chan bool
 }
 
-// NewTagger returns an allocated tagger. You still have to run Init()
+// newTagger returns an allocated tagger. You still have to run Init()
 // once the config package is ready.
-// This is exported for system tests, you are probably looking for
-// tagger.Tag() using the global instance instead of creating your own.
-func NewTagger() (*Tagger, error) {
+// You are probably looking for tagger.Tag() using the global instance
+// instead of creating your own.
+func newTagger() (*Tagger, error) {
 	store, err := newTagStore()
 	if err != nil {
 		return nil, err

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -31,6 +31,8 @@ type Tagger struct {
 
 // NewTagger returns an allocated tagger. You still have to run Init()
 // once the config package is ready.
+// This is exported for system tests, you are probably looking for
+// tagger.Tag() using the global instance instead of creating your own.
 func NewTagger() (*Tagger, error) {
 	store, err := newTagStore()
 	if err != nil {

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -96,7 +96,7 @@ func TestInit(t *testing.T) {
 	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
 	require.Equal(t, 2, len(catalog))
 
-	tagger, err := NewTagger()
+	tagger, err := newTagger()
 	require.Equal(t, nil, err)
 	err = tagger.Init(catalog)
 	require.Equal(t, nil, err)
@@ -118,7 +118,7 @@ func TestFetchAllMiss(t *testing.T) {
 	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
 	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
 	require.Equal(t, 2, len(catalog))
-	tagger, _ := NewTagger()
+	tagger, _ := newTagger()
 	tagger.Init(catalog)
 
 	tags, err := tagger.Tag("entity_name", false)
@@ -136,7 +136,7 @@ func TestFetchAllCached(t *testing.T) {
 	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
 	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
 	require.Equal(t, 2, len(catalog))
-	tagger, _ := NewTagger()
+	tagger, _ := newTagger()
 	tagger.Init(catalog)
 
 	tagger.tagStore.processTagInfo(&collectors.TagInfo{
@@ -164,7 +164,7 @@ func TestFetchOneCached(t *testing.T) {
 	d := &Dummies{&DummyStreamer{}, &DummyPuller{}}
 	catalog := collectors.Catalog{"stream": d.getDummyStreamer, "pull": d.getDummyPuller}
 	require.Equal(t, 2, len(catalog))
-	tagger, _ := NewTagger()
+	tagger, _ := newTagger()
 	tagger.Init(catalog)
 
 	tagger.tagStore.processTagInfo(&collectors.TagInfo{

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -59,6 +59,9 @@ const (
 	ContainerPausedState     string = "paused"
 	ContainerExitedState     string = "exited"
 	ContainerDeadState       string = "dead"
+
+	// DockerEntityPrefix is the entity prefix for docker containers
+	DockerEntityPrefix = "docker://"
 )
 
 // NetworkStat stores network statistics about a Docker container.
@@ -110,6 +113,11 @@ func DefaultGateway() (net.IP, error) {
 		}
 	}
 	return ip, nil
+}
+
+// ContainerIDToEntityName returns a prefixed entity name from a container ID
+func ContainerIDToEntityName(cid string) string {
+	return fmt.Sprintf("%s%s", DockerEntityPrefix, cid)
 }
 
 // IsExcluded returns a bool indicating if the container should be excluded

--- a/pkg/util/docker/events.go
+++ b/pkg/util/docker/events.go
@@ -31,6 +31,11 @@ type ContainerEvent struct {
 	Tags          map[string]string
 }
 
+// ContainerEntityName returns the event's container as a tagger entity name
+func (ev *ContainerEvent) ContainerEntityName() string {
+	return ContainerIDToEntityName(ev.ContainerID)
+}
+
 // openEventChannel just wraps the client.Event call with saner argument types.
 func (d *dockerUtil) openEventChannel(since, until time.Time, filter map[string]string) (<-chan events.Message, <-chan error) {
 	// Event since/until string can be formatted or hold a timestamp,


### PR DESCRIPTION
### What does this PR do?

- Un-export internals from the `tagger` package and move `DockerEntityPrefix` and `DockerEntityName` from docker collector to the `util/docker` package so they can be used by other packages.
- Update using classes

