### PR TITLE
[docker] port exit codes service check

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -28,23 +28,16 @@ import (
 const dockerCheckName = "docker"
 
 type DockerConfig struct {
-	//Url                    string             `yaml:"url"`
 	CollectContainerSize bool     `yaml:"collect_container_size"`
+	CollectExitCodes     bool     `yaml:"collect_exit_codes"`
 	CollectImagesStats   bool     `yaml:"collect_images_stats"`
 	CollectImageSize     bool     `yaml:"collect_image_size"`
 	Tags                 []string `yaml:"tags"`
 	CollectEvent         bool     `yaml:"collect_events"`
 	FilteredEventType    []string `yaml:"filtered_event_types"`
 	//CustomCGroup           bool               `yaml:"custom_cgroups"`
-	//HealthServiceWhitelist []string           `yaml:"health_service_check_whitelist"`
-	//CollectContainerCount  bool               `yaml:"collect_container_count"`
-	//CollectVolumCount      bool               `yaml:"collect_volume_count"`
-	//CollectDistStats       bool               `yaml:"collect_disk_stats"`
-	//CollectExitCodes       bool               `yaml:"collect_exit_codes"`
-	//ECSTags                []string           `yaml:"ecs_tags"`
-	//PerformanceTags        []string           `yaml:"performance_tags"`
-	//ContainrTags           []string           `yaml:"container_tags"`
-	//EventAttributesAsTags  []string           `yaml:"event_attributes_as_tags"`
+	//CollectVolumeCount      bool               `yaml:"collect_volume_count"`
+	//CollectDiskStats       bool               `yaml:"collect_disk_stats"`
 	//CappedMetrics          map[string]float64 `yaml:"capped_metrics"`
 }
 

--- a/pkg/collector/corechecks/containers/docker_eventbundle.go
+++ b/pkg/collector/corechecks/containers/docker_eventbundle.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+// dockerEventBundle holds a list of ContainerEvent
+// identified as coming from the same image. It holds
+// the conversion logic to Datadog events for submission
+type dockerEventBundle struct {
+	imageName     string
+	events        []*docker.ContainerEvent
+	maxTimestamp  time.Time
+	countByAction map[string]int
+}
+
+func newDockerEventBundler(imageName string) *dockerEventBundle {
+	return &dockerEventBundle{
+		imageName:     imageName,
+		events:        []*docker.ContainerEvent{},
+		countByAction: make(map[string]int),
+	}
+}
+
+func (b *dockerEventBundle) addEvent(event *docker.ContainerEvent) error {
+	if event.ImageName != b.imageName {
+		return fmt.Errorf("mismatching image name: %s != %s", event.ImageName, b.imageName)
+	}
+	b.events = append(b.events, event)
+	if event.Timestamp.After(b.maxTimestamp) {
+		b.maxTimestamp = event.Timestamp
+	}
+	b.countByAction[event.Action] = b.countByAction[event.Action] + 1
+
+	return nil
+}
+
+func (b *dockerEventBundle) toDatadogEvent(hostname string) (metrics.Event, error) {
+	output := metrics.Event{
+		Priority:       metrics.EventPriorityNormal,
+		Host:           hostname,
+		SourceTypeName: dockerCheckName,
+		EventType:      dockerCheckName,
+		Ts:             b.maxTimestamp.Unix(),
+		AggregationKey: fmt.Sprintf("docker:%s", b.imageName),
+	}
+	if len(b.events) == 0 {
+		return output, errors.New("no event to export")
+	}
+	output.Title = fmt.Sprintf("%s %s on %s",
+		b.imageName,
+		formatStringIntMap(b.countByAction),
+		hostname)
+
+	seenContainers := make(map[string]bool)
+	textLines := []string{"%%% ", output.Title, "```"}
+
+	for _, ev := range b.events {
+		textLines = append(textLines, fmt.Sprintf("%s\t%s", strings.ToUpper(ev.Action), ev.ContainerName))
+		seenContainers[ev.ContainerID] = true // Emulating a set with a map
+	}
+	textLines = append(textLines, "```", " %%%")
+	output.Text = strings.Join(textLines, "\n")
+
+	for cid, _ := range seenContainers {
+		tags, err := tagger.Tag(fmt.Sprintf("docker://%s", cid), true)
+		if err != nil {
+			log.Debugf("no tags for %s: %s", cid, err)
+		} else {
+			output.Tags = append(output.Tags, tags...)
+		}
+	}
+
+	if b.countByAction["oom"]+b.countByAction["kill"] > 0 {
+		output.AlertType = "error"
+	}
+
+	return output, nil
+}

--- a/pkg/collector/corechecks/containers/docker_eventbundle.go
+++ b/pkg/collector/corechecks/containers/docker_eventbundle.go
@@ -79,7 +79,7 @@ func (b *dockerEventBundle) toDatadogEvent(hostname string) (metrics.Event, erro
 	output.Text = strings.Join(textLines, "\n")
 
 	for cid, _ := range seenContainers {
-		tags, err := tagger.Tag(fmt.Sprintf("docker://%s", cid), true)
+		tags, err := tagger.Tag(docker.ContainerIDToEntityName(cid), true)
 		if err != nil {
 			log.Debugf("no tags for %s: %s", cid, err)
 		} else {

--- a/pkg/collector/corechecks/containers/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker_events.go
@@ -8,7 +8,6 @@
 package containers
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,85 +15,8 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
-
-// dockerEventBundle holds a list of ContainerEvent
-// identified as coming from the same image. It holds
-// the conversion logic to Datadog events for submission
-type dockerEventBundle struct {
-	imageName     string
-	events        []*docker.ContainerEvent
-	maxTimestamp  time.Time
-	countByAction map[string]int
-}
-
-//
-func newDockerEventBundler(imageName string) *dockerEventBundle {
-	return &dockerEventBundle{
-		imageName:     imageName,
-		events:        []*docker.ContainerEvent{},
-		countByAction: make(map[string]int),
-	}
-}
-
-func (b *dockerEventBundle) addEvent(event *docker.ContainerEvent) error {
-	if event.ImageName != b.imageName {
-		return fmt.Errorf("mismatching image name: %s != %s", event.ImageName, b.imageName)
-	}
-	b.events = append(b.events, event)
-	if event.Timestamp.After(b.maxTimestamp) {
-		b.maxTimestamp = event.Timestamp
-	}
-	b.countByAction[event.Action] = b.countByAction[event.Action] + 1
-
-	return nil
-}
-
-func (b *dockerEventBundle) toDatadogEvent(hostname string) (metrics.Event, error) {
-	output := metrics.Event{
-		Priority:       metrics.EventPriorityNormal,
-		Host:           hostname,
-		SourceTypeName: dockerCheckName,
-		EventType:      dockerCheckName,
-		Ts:             b.maxTimestamp.Unix(),
-		AggregationKey: fmt.Sprintf("docker:%s", b.imageName),
-	}
-	if len(b.events) == 0 {
-		return output, errors.New("no event to export")
-	}
-	output.Title = fmt.Sprintf("%s %s on %s",
-		b.imageName,
-		formatStringIntMap(b.countByAction),
-		hostname)
-
-	seenContainers := make(map[string]bool)
-	textLines := []string{"%%% ", output.Title, "```"}
-
-	for _, ev := range b.events {
-		textLines = append(textLines, fmt.Sprintf("%s\t%s", strings.ToUpper(ev.Action), ev.ContainerName))
-		seenContainers[ev.ContainerID] = true // Emulating a set with a map
-	}
-	textLines = append(textLines, "```", " %%%")
-	output.Text = strings.Join(textLines, "\n")
-
-	for cid, _ := range seenContainers {
-		tags, err := tagger.Tag(fmt.Sprintf("docker://%s", cid), true)
-		if err != nil {
-			log.Debugf("no tags for %s: %s", cid, err)
-		} else {
-			output.Tags = append(output.Tags, tags...)
-		}
-	}
-
-	if b.countByAction["oom"]+b.countByAction["kill"] > 0 {
-		output.AlertType = "error"
-	}
-
-	return output, nil
-}
 
 // reportEvents is the check's entrypoint to retrieve, aggregate and send events
 func (d *DockerCheck) reportEvents(sender aggregator.Sender) error {

--- a/pkg/collector/corechecks/containers/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker_events.go
@@ -63,6 +63,7 @@ func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender ag
 			status = metrics.ServiceCheckCritical
 		}
 		tags, err := tagger.Tag(ev.ContainerEntityName(), true)
+		tags = append(tags, d.instance.Tags...)
 		if err != nil {
 			log.Debugf("no tags for %s: %s", ev.ContainerID, err)
 		}

--- a/pkg/collector/corechecks/containers/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker_events.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -61,7 +62,11 @@ func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender ag
 		if exitCodeInt != 0 {
 			status = metrics.ServiceCheckCritical
 		}
-		sender.ServiceCheck(DockerExit, status, "", nil, message)
+		tags, err := tagger.Tag(ev.ContainerEntityName(), true)
+		if err != nil {
+			log.Debugf("no tags for %s: %s", ev.ContainerID, err)
+		}
+		sender.ServiceCheck(DockerExit, status, "", tags, message)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/containers/docker_events_test.go
+++ b/pkg/collector/corechecks/containers/docker_events_test.go
@@ -19,7 +19,9 @@ import (
 )
 
 func TestReportExitCodes(t *testing.T) {
-	dockerCheck := new(DockerCheck)
+	dockerCheck := &DockerCheck{
+		instance: &DockerConfig{},
+	}
 	mockSender := aggregator.NewMockSender(dockerCheck.ID())
 
 	var events []*docker.ContainerEvent

--- a/pkg/collector/corechecks/containers/docker_events_test.go
+++ b/pkg/collector/corechecks/containers/docker_events_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+func TestReportExitCodes(t *testing.T) {
+	dockerCheck := new(DockerCheck)
+	mockSender := aggregator.NewMockSender(dockerCheck.ID())
+
+	var events []*docker.ContainerEvent
+
+	// Don't fail on empty event array
+	err := dockerCheck.reportExitCodes(events, mockSender)
+	assert.Nil(t, err)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 0)
+
+	// Gracefully skip invalid events
+	events = append(events, &docker.ContainerEvent{})
+	events = append(events, &docker.ContainerEvent{
+		Action: "die",
+	})
+	events = append(events, &docker.ContainerEvent{
+		Action:     "die",
+		Attributes: map[string]string{"exitCode": "nonNumeric"},
+	})
+	err = dockerCheck.reportExitCodes(events, mockSender)
+	assert.Nil(t, err)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 0)
+
+	// Reset event array
+	events = events[0:0]
+
+	// Valid exit 0 event
+	events = append(events, &docker.ContainerEvent{
+		Action:        "die",
+		Attributes:    map[string]string{"exitCode": "0"},
+		ContainerID:   "fcc487ac70446287ae0dc79fb72368d824ff6198cd1166a405bc5a7fc111d3a8",
+		ContainerName: "goodOne",
+	})
+	mockSender.On("ServiceCheck", "docker.exit", metrics.ServiceCheckOK, "",
+		mock.AnythingOfType("[]string"), "Container goodOne exited with 0")
+
+	// Valid exit 1 event
+	events = append(events, &docker.ContainerEvent{
+		Action:        "die",
+		Attributes:    map[string]string{"exitCode": "1"},
+		ContainerID:   "fcc487ac70446287ae0dc79fb72368d824ff6198cd1166a405bc5a7fc111d3a8",
+		ContainerName: "badOne",
+	})
+	mockSender.On("ServiceCheck", "docker.exit", metrics.ServiceCheckCritical, "",
+		mock.AnythingOfType("[]string"), "Container badOne exited with 1")
+
+	err = dockerCheck.reportExitCodes(events, mockSender)
+	assert.Nil(t, err)
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 2)
+}

--- a/pkg/collector/dist/conf.d/docker.yaml.example
+++ b/pkg/collector/dist/conf.d/docker.yaml.example
@@ -42,7 +42,8 @@ instances:
     #
     # collect_image_size: true
 
-    # Monitor containers exit codes and send critical service checks when exit code is not 0
+    # Monitor exiting containers and send service checks based on exit code value
+    # (OK if 0, CRITICAL otherwise)
     # Defaults to false.
     #
     # collect_exit_codes: true

--- a/pkg/collector/dist/conf.d/docker.yaml.example
+++ b/pkg/collector/dist/conf.d/docker.yaml.example
@@ -42,6 +42,11 @@ instances:
     #
     # collect_image_size: true
 
+    # Monitor containers exit codes and send critical service checks when exit code is not 0
+    # Defaults to false.
+    #
+    # collect_exit_codes: true
+
     ## Tagging
     ##
 

--- a/pkg/legacy/docker_test.go
+++ b/pkg/legacy/docker_test.go
@@ -47,6 +47,7 @@ instances:
 `
 
 	dockerNewConf string = `collect_container_size: true
+collect_exit_codes: true
 collect_images_stats: false
 collect_image_size: true
 tags:

--- a/pkg/util/docker/events.go
+++ b/pkg/util/docker/events.go
@@ -28,7 +28,7 @@ type ContainerEvent struct {
 	ImageName     string
 	Action        string
 	Timestamp     time.Time
-	Tags          map[string]string
+	Attributes    map[string]string
 }
 
 // ContainerEntityName returns the event's container as a tagger entity name
@@ -94,7 +94,7 @@ func (d *dockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 		ImageName:     imageName,
 		Action:        msg.Action,
 		Timestamp:     time.Unix(msg.Time, ns),
-		Tags:          msg.Actor.Attributes,
+		Attributes:    msg.Actor.Attributes,
 	}
 
 	return event, nil


### PR DESCRIPTION
### What does this PR do?

- Port the optional feature to report container exit codes as service checks. 
- Move the `dockerEventBundle` type to its own file for readability