### PR TITLE
Remove usage of ListenAndServe which can make the test fail

### DIFF
--- a/pkg/metadata/ecs/ecs_test.go
+++ b/pkg/metadata/ecs/ecs_test.go
@@ -7,6 +7,7 @@ package ecs
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 
 	"testing"
@@ -17,6 +18,7 @@ import (
 
 var nextTestResponse string
 
+// TODO: ideally this test should use the httptest package
 func runServer(t *testing.T, ready chan<- bool, exit <-chan bool) {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Satisfy the initial check of URLs
@@ -29,7 +31,11 @@ func runServer(t *testing.T, ready chan<- bool, exit <-chan bool) {
 	})
 
 	s := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", DefaultAgentPort)}
-	go s.ListenAndServe()
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		t.Fail()
+	}
+	go s.Serve(ln)
 	ready <- true
 	<-exit
 	s.Close()


### PR DESCRIPTION
### What does this PR do?

Remove usage of `ListenAndServe` which can make the test fail
