### PR TITLE
[docker] add docker_network tag to net metrics

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -180,7 +180,7 @@ func (d *DockerCheck) Run() error {
 		sender.Rate("docker.io.write_bytes", float64(c.IO.WriteBytes), "", tags)
 
 		if c.Network != nil {
-			for _, netStat := range c.Network.Stats {
+			for _, netStat := range c.Network {
 				if netStat.NetworkName == "" {
 					log.Debugf("ignore network stat with empty name for container %s: %s", c.ID[:12], netStat)
 					continue

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -41,7 +41,7 @@ var (
 		CPU:     &CgroupTimesStat{},
 		Memory:  &CgroupMemStat{},
 		IO:      &CgroupIOStat{},
-		Network: new(ContainerNetStats),
+		Network: ContainerNetStats{},
 	}
 )
 
@@ -88,7 +88,7 @@ type Container struct {
 	CPU            *CgroupTimesStat
 	Memory         *CgroupMemStat
 	IO             *CgroupIOStat
-	Network        *ContainerNetStats
+	Network        ContainerNetStats
 	StartedAt      int64
 
 	// For internal use only

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -41,7 +41,7 @@ var (
 		CPU:     &CgroupTimesStat{},
 		Memory:  &CgroupMemStat{},
 		IO:      &CgroupIOStat{},
-		Network: &NetworkStat{},
+		Network: new(ContainerNetStats),
 	}
 )
 
@@ -88,7 +88,7 @@ type Container struct {
 	CPU            *CgroupTimesStat
 	Memory         *CgroupMemStat
 	IO             *CgroupIOStat
-	Network        *NetworkStat
+	Network        *ContainerNetStats
 	StartedAt      int64
 
 	// For internal use only

--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -70,8 +70,8 @@ func findDockerNetworks(containerID string, pid int, netSettings *types.SummaryN
 			}
 		}
 
-		// Convert IP to int64 for comparison to network routes.
-		dockerGateways[netName] = int64(binary.BigEndian.Uint32(ip.To4()))
+		// Convert IP to little endian int64 for comparison to network routes.
+		dockerGateways[netName] = int64(binary.LittleEndian.Uint32(ip.To4()))
 	}
 
 	// Read contents of file. Handle missing or unreadable file in case container was stopped.
@@ -96,7 +96,7 @@ func findDockerNetworks(containerID string, pid int, netSettings *types.SummaryN
 		if len(fields) < 8 {
 			continue
 		}
-		if fields[0] == "00000000" {
+		if fields[1] == "00000000" {
 			continue
 		}
 		dest, _ := strconv.ParseInt(fields[1], 16, 32)

--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -33,7 +33,7 @@ func TestFindDockerNetworks(t *testing.T) {
 		settings    *types.SummaryNetworkSettings
 		routes, dev string
 		networks    []dockerNetwork
-		stat        *NetworkStat
+		stat        *ContainerNetStats
 	}{
 		{
 			pid: 1245,
@@ -57,11 +57,16 @@ func TestFindDockerNetworks(t *testing.T) {
                     lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
             `),
 			networks: []dockerNetwork{dockerNetwork{iface: "eth0", dockerName: "eth0"}},
-			stat: &NetworkStat{
-				BytesRcvd:   1296,
-				PacketsRcvd: 16,
-				BytesSent:   0,
-				PacketsSent: 0,
+			stat: &ContainerNetStats{
+				Stats: []*InterfaceNetStats{
+					&InterfaceNetStats{
+						NetworkName: "eth0",
+						BytesRcvd:   1296,
+						PacketsRcvd: 16,
+						BytesSent:   0,
+						PacketsSent: 0,
+					},
+				},
 			},
 		},
 		{
@@ -92,11 +97,16 @@ func TestFindDockerNetworks(t *testing.T) {
 				dockerNetwork{iface: "eth0", dockerName: "eth0"},
 				dockerNetwork{iface: "eth0", dockerName: "isolated_nw"},
 			},
-			stat: &NetworkStat{
-				BytesRcvd:   1111,
-				PacketsRcvd: 2,
-				BytesSent:   1024,
-				PacketsSent: 80,
+			stat: &ContainerNetStats{
+				Stats: []*InterfaceNetStats{
+					&InterfaceNetStats{
+						NetworkName: "isolated_nw",
+						BytesRcvd:   1111,
+						PacketsRcvd: 2,
+						BytesSent:   1024,
+						PacketsSent: 80,
+					},
+				},
 			},
 		},
 		// Dumb error case to make sure we don't panic
@@ -120,7 +130,7 @@ func TestFindDockerNetworks(t *testing.T) {
                   eth0:    1111       2    0    0    0     0          0         0     1024      80    0    0    0     0       0          0
                     lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
             `),
-			stat: &NetworkStat{},
+			stat: &ContainerNetStats{},
 		},
 	} {
 		// Create temporary files on disk with the routes and stats.

--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -34,20 +34,20 @@ func TestFindDockerNetworks(t *testing.T) {
 		routes, dev string
 		networks    []dockerNetwork
 		stat        *ContainerNetStats
+		summedStat  *InterfaceNetStats
 	}{
 		{
 			pid: 1245,
 			settings: &types.SummaryNetworkSettings{
 				Networks: map[string]*dockernetwork.EndpointSettings{
 					"eth0": &dockernetwork.EndpointSettings{
-						Gateway: "172.0.0.1/24",
+						Gateway: "172.17.0.1/24",
 					},
 				},
 			},
 			routes: detab(`
                 Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
                 eth0    00000000    010011AC    0003    0   0   0   00000000    0   0   0
-
                 eth0    000011AC    00000000    0001    0   0   0   0000FFFF    0   0   0
             `),
 			dev: detab(`
@@ -68,47 +68,115 @@ func TestFindDockerNetworks(t *testing.T) {
 					},
 				},
 			},
+			summedStat: &InterfaceNetStats{
+				BytesRcvd:   1296,
+				PacketsRcvd: 16,
+				BytesSent:   0,
+				PacketsSent: 0,
+			},
 		},
+		// Multiple docker networks
 		{
-			pid: 5152,
+			pid: 5153,
 			settings: &types.SummaryNetworkSettings{
 				Networks: map[string]*dockernetwork.EndpointSettings{
-					"isolated_nw": &dockernetwork.EndpointSettings{
-						Gateway: "172.18.0.1",
+					"bridge": &dockernetwork.EndpointSettings{
+						Gateway: "172.17.0.1",
 					},
-					"eth0": &dockernetwork.EndpointSettings{
-						Gateway: "172.0.0.4/24",
+					"test": &dockernetwork.EndpointSettings{
+						Gateway: "172.18.0.1",
 					},
 				},
 			},
 			routes: detab(`
-                Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
-                eth0    00000000    010012AC    0003    0   0   0   00000000    0   0   0
-
-                eth0    000012AC    00000000    0001    0   0   0   0000FFFF    0   0   0
+				Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+				eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0
+				eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+				eth1	000012AC	00000000	0001	0	0	0	0000FFFF	0	0	0
             `),
 			dev: detab(`
-                Inter-|   Receive                                                |  Transmit
-                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
-                  eth0:    1111       2    0    0    0     0          0         0     1024      80    0    0    0     0       0          0
-                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
-            `),
+				Inter-|   Receive                                                |  Transmit
+				 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+				    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+				  eth0:     648       8    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+				  eth1:    1478      19    0    0    0     0          0         0      182       3    0    0    0     0       0          0`),
 			networks: []dockerNetwork{
-				dockerNetwork{iface: "eth0", dockerName: "eth0"},
-				dockerNetwork{iface: "eth0", dockerName: "isolated_nw"},
+				dockerNetwork{iface: "eth0", dockerName: "bridge"},
+				dockerNetwork{iface: "eth1", dockerName: "test"},
 			},
 			stat: &ContainerNetStats{
 				Stats: []*InterfaceNetStats{
 					&InterfaceNetStats{
-						NetworkName: "isolated_nw",
+						NetworkName: "bridge",
+						BytesRcvd:   648,
+						PacketsRcvd: 8,
+						BytesSent:   0,
+						PacketsSent: 0,
+					},
+					&InterfaceNetStats{
+						NetworkName: "test",
+						BytesRcvd:   1478,
+						PacketsRcvd: 19,
+						BytesSent:   182,
+						PacketsSent: 3,
+					},
+				},
+			},
+			summedStat: &InterfaceNetStats{
+				BytesRcvd:   2126,
+				PacketsRcvd: 27,
+				BytesSent:   182,
+				PacketsSent: 3,
+			},
+		},
+		/* TODO: where is this example from?
+				{
+					pid: 5152,
+					settings: &types.SummaryNetworkSettings{
+						Networks: map[string]*dockernetwork.EndpointSettings{
+							"isolated_nw": &dockernetwork.EndpointSettings{
+								Gateway: "172.18.0.1",
+							},
+							"eth0": &dockernetwork.EndpointSettings{
+								Gateway: "172.0.0.4/24",
+							},
+						},
+					},
+					routes: detab(`
+		                Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
+		                eth0    00000000    010012AC    0003    0   0   0   00000000    0   0   0
+
+		                eth0    000012AC    00000000    0001    0   0   0   0000FFFF    0   0   0
+		            `),
+					dev: detab(`
+		                Inter-|   Receive                                                |  Transmit
+		                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+		                  eth0:    1111       2    0    0    0     0          0         0     1024      80    0    0    0     0       0          0
+		                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+		            `),
+					networks: []dockerNetwork{
+						dockerNetwork{iface: "eth0", dockerName: "eth0"},
+						dockerNetwork{iface: "eth0", dockerName: "isolated_nw"},
+					},
+					stat: &ContainerNetStats{
+						Stats: []*InterfaceNetStats{
+							&InterfaceNetStats{
+								NetworkName: "isolated_nw",
+								BytesRcvd:   1111,
+								PacketsRcvd: 2,
+								BytesSent:   1024,
+								PacketsSent: 80,
+							},
+						},
+					},
+					summedStat: &InterfaceNetStats{
 						BytesRcvd:   1111,
 						PacketsRcvd: 2,
 						BytesSent:   1024,
 						PacketsSent: 80,
 					},
 				},
-			},
-		},
+		*/
 		// Dumb error case to make sure we don't panic
 		{
 			pid: 5157,
@@ -130,7 +198,8 @@ func TestFindDockerNetworks(t *testing.T) {
                   eth0:    1111       2    0    0    0     0          0         0     1024      80    0    0    0     0       0          0
                     lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
             `),
-			stat: &ContainerNetStats{},
+			stat:       &ContainerNetStats{},
+			summedStat: &InterfaceNetStats{},
 		},
 	} {
 		// Create temporary files on disk with the routes and stats.
@@ -147,5 +216,7 @@ func TestFindDockerNetworks(t *testing.T) {
 		stat, err := collectNetworkStats(containerID, tc.pid, networks)
 		assert.NoError(err)
 		assert.Equal(tc.stat, stat)
+		assert.Equal(tc.summedStat, stat.SumInterfaces())
+
 	}
 }

--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -33,7 +33,7 @@ func TestFindDockerNetworks(t *testing.T) {
 		settings    *types.SummaryNetworkSettings
 		routes, dev string
 		networks    []dockerNetwork
-		stat        *ContainerNetStats
+		stat        ContainerNetStats
 		summedStat  *InterfaceNetStats
 	}{
 		{
@@ -57,15 +57,13 @@ func TestFindDockerNetworks(t *testing.T) {
                     lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
             `),
 			networks: []dockerNetwork{dockerNetwork{iface: "eth0", dockerName: "eth0"}},
-			stat: &ContainerNetStats{
-				Stats: []*InterfaceNetStats{
-					&InterfaceNetStats{
-						NetworkName: "eth0",
-						BytesRcvd:   1296,
-						PacketsRcvd: 16,
-						BytesSent:   0,
-						PacketsSent: 0,
-					},
+			stat: ContainerNetStats{
+				&InterfaceNetStats{
+					NetworkName: "eth0",
+					BytesRcvd:   1296,
+					PacketsRcvd: 16,
+					BytesSent:   0,
+					PacketsSent: 0,
 				},
 			},
 			summedStat: &InterfaceNetStats{
@@ -104,22 +102,20 @@ func TestFindDockerNetworks(t *testing.T) {
 				dockerNetwork{iface: "eth0", dockerName: "bridge"},
 				dockerNetwork{iface: "eth1", dockerName: "test"},
 			},
-			stat: &ContainerNetStats{
-				Stats: []*InterfaceNetStats{
-					&InterfaceNetStats{
-						NetworkName: "bridge",
-						BytesRcvd:   648,
-						PacketsRcvd: 8,
-						BytesSent:   0,
-						PacketsSent: 0,
-					},
-					&InterfaceNetStats{
-						NetworkName: "test",
-						BytesRcvd:   1478,
-						PacketsRcvd: 19,
-						BytesSent:   182,
-						PacketsSent: 3,
-					},
+			stat: ContainerNetStats{
+				&InterfaceNetStats{
+					NetworkName: "bridge",
+					BytesRcvd:   648,
+					PacketsRcvd: 8,
+					BytesSent:   0,
+					PacketsSent: 0,
+				},
+				&InterfaceNetStats{
+					NetworkName: "test",
+					BytesRcvd:   1478,
+					PacketsRcvd: 19,
+					BytesSent:   182,
+					PacketsSent: 3,
 				},
 			},
 			summedStat: &InterfaceNetStats{
@@ -198,7 +194,7 @@ func TestFindDockerNetworks(t *testing.T) {
                   eth0:    1111       2    0    0    0     0          0         0     1024      80    0    0    0     0       0          0
                     lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
             `),
-			stat:       &ContainerNetStats{},
+			stat:       ContainerNetStats{},
 			summedStat: &InterfaceNetStats{},
 		},
 	} {


### PR DESCRIPTION
### What does this PR do?

Port the `docker_network` tag to docker network metrics:

- change `NetworkStat` struct to `ContainerNetStats`, holding a list of `InterfaceNetStats`
- add ContainerNetStats.SumInterfaces() for retro-compatibility
- fix the network matching logic and update tests
- update the docker check to use that
