### PR TITLE
Add output of coverage tests (profile.tmp) to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor/
 bin/
 /dev/
 
+**/*.tmp
 **/debug.test
 # files
 .DS_Store

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: '{branch}.{build}'
 shallow_clone: false
 platform: x64
+skip_branch_with_pr: true
 
 clone_folder: C:\gopath\src\github.com\DataDog\datadog-agent
 


### PR DESCRIPTION
### What does this PR do?

- Convenience change to .gitignore, to ignore files generated by test runs.
- `Adds skip_branch_with_pr: true` to prevent redundant builds on PRs.