### PR TITLE
fix agent check cmd by reducing aggregator flush interval

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -79,7 +79,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		s := &serializer.Serializer{Forwarder: common.Forwarder}
-		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, 10000000000)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, 1000000000)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 		cs := common.AC.GetChecksByName(checkName)
 		if len(cs) == 0 {


### PR DESCRIPTION
### What does this PR do?

To avoid sending metrics, the `agent check` command initialises the aggregator with a flush interval of `1e10` seconds. This caused the command to fail with `panic: non-positive interval for NewTicker` since Friday.

This is because [`Duration`s](https://golang.org/pkg/time/#Duration) are stored in `int64` nanoseconds. 1e10*1e9 = **1e19 > 2^63 = 9.22e18** -> int64 overflow 🙀

This is the perfect example of one bug hiding another as this was working OK since [this commit](https://github.com/DataDog/datadog-agent/commit/87c532a910c678726a89969bcc6198cee4ec3fab) caused the aggregator to actually use the value passed to it instead of the default 15 seconds value.


BTW, should we keep this mechanism of setting a high flush interval, instead of having a "don't flush" option?

