### PR TITLE
[docker] add storage metrics

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -32,12 +32,12 @@ type DockerConfig struct {
 	CollectExitCodes     bool     `yaml:"collect_exit_codes"`
 	CollectImagesStats   bool     `yaml:"collect_images_stats"`
 	CollectImageSize     bool     `yaml:"collect_image_size"`
+	CollectDiskStats     bool     `yaml:"collect_disk_stats"`
 	Tags                 []string `yaml:"tags"`
 	CollectEvent         bool     `yaml:"collect_events"`
 	FilteredEventType    []string `yaml:"filtered_event_types"`
 	//CustomCGroup           bool               `yaml:"custom_cgroups"`
 	//CollectVolumeCount      bool               `yaml:"collect_volume_count"`
-	//CollectDiskStats       bool               `yaml:"collect_disk_stats"`
 	//CappedMetrics          map[string]float64 `yaml:"capped_metrics"`
 }
 
@@ -225,6 +225,33 @@ func (d *DockerCheck) Run() error {
 				err = d.reportExitCodes(events, sender)
 				if err != nil {
 					log.Warn(err.Error())
+				}
+			}
+		}
+	}
+
+	if d.instance.CollectDiskStats {
+		stats, err := docker.GetStorageStats()
+		if err != nil {
+			log.Errorf("Failed to get disk stats: %s", err)
+		} else {
+			for _, stat := range stats {
+				if stat.Name != docker.DataStorageName && stat.Name != docker.MetadataStorageName {
+					log.Debugf("ignoring unknown disk stats: %s", stat)
+					continue
+				}
+				if stat.Free != nil {
+					sender.Gauge(fmt.Sprintf("docker.%s.free", stat.Name), float64(*stat.Free), "", d.instance.Tags)
+				}
+				if stat.Used != nil {
+					sender.Gauge(fmt.Sprintf("docker.%s.used", stat.Name), float64(*stat.Used), "", d.instance.Tags)
+				}
+				if stat.Total != nil {
+					sender.Gauge(fmt.Sprintf("docker.%s.total", stat.Name), float64(*stat.Total), "", d.instance.Tags)
+				}
+				percent := stat.GetPercentUsed()
+				if !math.IsNaN(percent) {
+					sender.Gauge(fmt.Sprintf("docker.%s.percent", stat.Name), percent, "", d.instance.Tags)
 				}
 			}
 		}

--- a/pkg/collector/dist/conf.d/docker.yaml.example
+++ b/pkg/collector/dist/conf.d/docker.yaml.example
@@ -42,6 +42,16 @@ instances:
     #
     # collect_image_size: true
 
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
     # Monitor exiting containers and send service checks based on exit code value
     # (OK if 0, CRITICAL otherwise)
     # Defaults to false.

--- a/pkg/legacy/docker_test.go
+++ b/pkg/legacy/docker_test.go
@@ -50,6 +50,7 @@ instances:
 collect_exit_codes: true
 collect_images_stats: false
 collect_image_size: true
+collect_disk_stats: true
 tags:
 - tag:value
 - value

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -228,6 +228,15 @@ func GetHostname() (string, error) {
 	return globalDockerUtil.getHostname()
 }
 
+// GetStorageStats returns the docker global storage stats if available
+// or ErrStorageStatsNotAvailable
+func GetStorageStats() ([]*StorageStats, error) {
+	if globalDockerUtil == nil {
+		return nil, ErrDockerNotAvailable
+	}
+	return globalDockerUtil.getStorageStats()
+}
+
 // IsContainerized returns True if we're running in the docker-dd-agent container.
 func IsContainerized() bool {
 	return os.Getenv("DOCKER_DD_AGENT") == "yes"

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -325,6 +325,14 @@ func (d *dockerUtil) getHostname() (string, error) {
 	return info.Name, nil
 }
 
+func (d *dockerUtil) getStorageStats() ([]*StorageStats, error) {
+	info, err := d.cli.Info(context.Background())
+	if err != nil {
+		return []*StorageStats{}, fmt.Errorf("unable to get Docker info: %s", err)
+	}
+	return parseStorageStatsFromInfo(info)
+}
+
 // extractImageName will resolve sha image name to their user-friendly name.
 // For non-sha names we will just return the name as-is.
 func (d *dockerUtil) extractImageName(image string) string {

--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -28,7 +28,7 @@ func TestFindDockerNetworks(t *testing.T) {
 	config.Datadog.SetDefault("container_proc_root", dummyProcDir.RootPath)
 
 	containerID := "test-find-docker-networks"
-	for _, tc := range []struct {
+	for nb, tc := range []struct {
 		pid         int
 		settings    *types.SummaryNetworkSettings
 		routes, dev string
@@ -198,6 +198,7 @@ func TestFindDockerNetworks(t *testing.T) {
 			summedStat: &InterfaceNetStats{},
 		},
 	} {
+		t.Logf("test case %d", nb)
 		// Create temporary files on disk with the routes and stats.
 		err = dummyProcDir.add(filepath.Join(strconv.Itoa(int(tc.pid)), "net", "route"), tc.routes)
 		assert.NoError(err)

--- a/pkg/util/docker/storage.go
+++ b/pkg/util/docker/storage.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+
+	log "github.com/cihub/seelog"
+	"github.com/docker/docker/api/types"
+)
+
+var (
+	// ErrStorageStatsNotAvailable is returned if the storage stats are not in the docker info.
+	ErrStorageStatsNotAvailable = errors.New("docker storage stats not available")
+	diskBytesRe                 = regexp.MustCompile("([0-9.]+)\\s?([a-zA-Z]+)")
+	diskUnits                   = map[string]uint64{
+		"b":  1,
+		"kb": 1000,
+		"mb": 1000000,
+		"gb": 1000000000,
+		"tb": 1000000000000,
+	}
+)
+
+const (
+	// DataStorageName represent diskmapper data stats
+	DataStorageName = "data"
+	// MetadataStorageName represent diskmapper metadata stats
+	MetadataStorageName = "metadata"
+)
+
+// StorageStats holds the available stats for a given storage type.
+// Non available stats will result in nil pointer, user has to check
+// for nil before using the value.
+type StorageStats struct {
+	Name  string
+	Free  *uint64
+	Used  *uint64
+	Total *uint64
+}
+
+// GetPercentUsed computes the used percent (from 0 to 100), even if
+// only two of three stats are available. If only one is available
+// or total is 0, Nan is returned.
+func (s *StorageStats) GetPercentUsed() float64 {
+	total := s.Total
+	if s.Total != nil && s.Used != nil && s.Free != nil {
+		if *s.Total < *s.Used+*s.Free {
+			log.Debugf("total lower than free+used, re-computing total")
+			totalValue := *s.Used + *s.Free
+			total = &totalValue
+		}
+	}
+
+	if s.Used != nil && total != nil {
+		return (100.0 * float64(*s.Used) / float64(*total))
+	}
+	if s.Free != nil && total != nil {
+		return 100.0 - (100.0 * float64(*s.Free) / float64(*total))
+	}
+	if s.Used != nil && s.Free != nil {
+		return (100.0 * float64(*s.Used) / float64(*s.Used+*s.Free))
+	}
+	return math.NaN()
+}
+
+// parseStorageStatsFromInfo converts the [][2]string DriverStatus from docker
+// info into a reliable StorageStats struct. It only supports DeviceMapper
+// stats for now.
+func parseStorageStatsFromInfo(info types.Info) ([]*StorageStats, error) {
+	statsArray := []*StorageStats{}
+	statsPerName := make(map[string]*StorageStats)
+
+	if len(info.DriverStatus) == 0 {
+		return statsArray, ErrStorageStatsNotAvailable
+	}
+	for _, entry := range info.DriverStatus {
+		key := entry[0]
+		valueString := entry[1]
+		fields := strings.Fields(key)
+		if len(fields) != 3 || strings.ToLower(fields[1]) != "space" {
+			log.Debugf("ignoring invalid storage stat: %s", key)
+			continue
+		}
+		valueInt, err := parseDiskQuantity(valueString)
+		if err != nil {
+			log.Debugf("ignoring invalid value %s for stat %s: %s", valueString, key, err)
+			continue
+		}
+		storageType := strings.ToLower(fields[0])
+		stats, found := statsPerName[storageType]
+		if !found {
+			stats = &StorageStats{
+				Name: storageType,
+			}
+			statsPerName[storageType] = stats
+			statsArray = append(statsArray, stats)
+		}
+
+		switch strings.ToLower(fields[2]) {
+		case "available":
+			stats.Free = &valueInt
+		case "used":
+			stats.Used = &valueInt
+		case "total":
+			stats.Total = &valueInt
+		}
+	}
+
+	return statsArray, nil
+}
+
+// parseDiskQuantity parses a string from docker into a bytes quantity,
+func parseDiskQuantity(text string) (uint64, error) {
+	match := diskBytesRe.FindStringSubmatch(text)
+	if match == nil {
+		return 0, fmt.Errorf("parsing error: invalid format")
+	}
+	multi, found := diskUnits[strings.ToLower(match[2])]
+	if !found {
+		return 0, fmt.Errorf("parsing error: unknown unit %s", match[2])
+	}
+	value, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing error: %s", err)
+	}
+
+	return uint64(value * float64(multi)), nil
+}

--- a/pkg/util/docker/storage_test.go
+++ b/pkg/util/docker/storage_test.go
@@ -1,0 +1,262 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func createIntPointer(value float64) *uint64 {
+	val := uint64(value)
+	return &val
+}
+
+func TestParseStorageStats(t *testing.T) {
+	assert := assert.New(t)
+	for nb, tc := range []struct {
+		source   [][2]string
+		values   []*StorageStats
+		percents map[string]float64
+		err      error
+	}{
+		{
+			// Return standardized error if no info, to print an integration warning
+			source: [][2]string{},
+			values: []*StorageStats{},
+			err:    ErrStorageStatsNotAvailable,
+		},
+		{
+			// Nominal case
+			source: [][2]string{
+				{"Data Space Used", "1 GB"},
+				{"Data Space Available", "9 GB"},
+				{"Data Space Total", "10 GB"},
+				{"Metadata Space Used", "1 MB"},
+				{"Metadata Space Available", "9 MB"},
+				{"Metadata Space Total", "10 MB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  DataStorageName,
+					Free:  createIntPointer(9e9),
+					Used:  createIntPointer(1e9),
+					Total: createIntPointer(10e9),
+				},
+				&StorageStats{
+					Name:  MetadataStorageName,
+					Free:  createIntPointer(9e6),
+					Used:  createIntPointer(1e6),
+					Total: createIntPointer(10e6),
+				},
+			},
+			percents: map[string]float64{
+				DataStorageName:     10,
+				MetadataStorageName: 10,
+			},
+			err: nil,
+		},
+		{
+			// Only metadata, mixed case to test unit lowercasing
+			source: [][2]string{
+				{"Metadata Space Used", "1 kb"},
+				{"Metadata Space Available", "9 KB"},
+				{"Metadata Space Total", "10 kB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  MetadataStorageName,
+					Free:  createIntPointer(9e3),
+					Used:  createIntPointer(1e3),
+					Total: createIntPointer(10e3),
+				},
+			},
+			percents: map[string]float64{
+				MetadataStorageName: 10,
+			},
+			err: nil,
+		},
+		{
+			// Only metadata, decimal values
+			source: [][2]string{
+				{"Metadata Space Used", "0.100 Mb"},
+				{"Metadata Space Available", "0.9 MB"},
+				{"Metadata Space Total", "1 MB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  MetadataStorageName,
+					Free:  createIntPointer(9e5),
+					Used:  createIntPointer(1e5),
+					Total: createIntPointer(1e6),
+				},
+			},
+			percents: map[string]float64{
+				MetadataStorageName: 10,
+			},
+			err: nil,
+		},
+		{
+			// Missing one line: percentages should still be computed
+			source: [][2]string{
+				{"NoUsed Space Available", "9 GB"},
+				{"NoUsed Space Total", "10 GB"},
+				{"NoFree Space Used", "9 MB"},
+				{"NoFree Space Total", "10 MB"},
+				{"NoTotal Space Available", "2 MB"},
+				{"NoTotal Space Used", "8 MB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  "noused",
+					Free:  createIntPointer(9e9),
+					Used:  nil,
+					Total: createIntPointer(10e9),
+				},
+				&StorageStats{
+					Name:  "nofree",
+					Free:  nil,
+					Used:  createIntPointer(9e6),
+					Total: createIntPointer(10e6),
+				},
+				&StorageStats{
+					Name:  "nototal",
+					Free:  createIntPointer(2e6),
+					Used:  createIntPointer(8e6),
+					Total: nil,
+				},
+			},
+			percents: map[string]float64{
+				"noused":  10,
+				"nofree":  90,
+				"nototal": 80,
+			},
+			err: nil,
+		},
+		{
+			// All zeroes
+			source: [][2]string{
+				{"Data Space Available", "0 GB"},
+				{"Data Space Total", "0 GB"},
+				{"Data Space Used", "0 GB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  DataStorageName,
+					Free:  createIntPointer(0.0),
+					Used:  createIntPointer(0.0),
+					Total: createIntPointer(0.0),
+				},
+			},
+			percents: map[string]float64{
+				DataStorageName: math.NaN(),
+			},
+			err: nil,
+		},
+		{
+			// Invalid total, percent will be computed from used/used+free
+			source: [][2]string{
+				{"Data Space Available", "9 GB"},
+				{"Data Space Total", "10 GB"},
+				{"Data Space Used", "11 GB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  DataStorageName,
+					Free:  createIntPointer(9e9),
+					Used:  createIntPointer(11e9),
+					Total: createIntPointer(10e9),
+				},
+			},
+			percents: map[string]float64{
+				DataStorageName: 55,
+			},
+			err: nil,
+		},
+		{
+			// Only metadata, no spaces before units
+			source: [][2]string{
+				{"Metadata Space Used", "1kb"},
+				{"Metadata Space Available", "19KB"},
+				{"Metadata Space Total", "20kB"},
+			},
+			values: []*StorageStats{
+				&StorageStats{
+					Name:  MetadataStorageName,
+					Free:  createIntPointer(19e3),
+					Used:  createIntPointer(1e3),
+					Total: createIntPointer(20e3),
+				},
+			},
+			percents: map[string]float64{
+				MetadataStorageName: 5,
+			},
+			err: nil,
+		},
+		{
+			// Invalid formats
+			source: [][2]string{
+				{"Metadata Space Used", "1"},
+				{"Metadata pace Available", "19KB"},
+				{"Metadata Total", "20kB"},
+			},
+			values:   []*StorageStats{},
+			percents: map[string]float64{},
+			err:      nil,
+		},
+	} {
+		t.Logf("test case %d", nb)
+		info := types.Info{
+			DriverStatus: tc.source,
+		}
+		stat, err := parseStorageStatsFromInfo(info)
+		assert.Equal(tc.err, err)
+		assert.Equal(tc.values, stat)
+		for _, val := range stat {
+			expected := tc.percents[val.Name]
+			if math.IsNaN(expected) {
+				assert.True(math.IsNaN(val.GetPercentUsed()))
+			} else {
+				assert.Equal(tc.percents[val.Name], val.GetPercentUsed())
+			}
+		}
+	}
+}
+
+func TestParseDiskQuantity(t *testing.T) {
+	assert := assert.New(t)
+	for nb, tc := range []struct {
+		text  string
+		bytes uint64
+		err   error
+	}{
+		// Nominal cases
+		{"10 b", 10, nil},
+		{"521kb", 521000, nil},
+		{"0 MB", 0, nil},
+		// Unknown unit
+		{"10 AB", 0, fmt.Errorf("parsing error: unknown unit AB")},
+		// Parsing error
+		{"10", 0, fmt.Errorf("parsing error: invalid format")},
+		{"MB 10", 0, fmt.Errorf("parsing error: invalid format")},
+	} {
+		t.Logf("test case %d", nb)
+		val, err := parseDiskQuantity(tc.text)
+		assert.Equal(tc.bytes, val)
+
+		if tc.err == nil {
+			assert.Nil(tc.err)
+		} else {
+			assert.Equal(tc.err.Error(), err.Error())
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Port `collect_disk_stats` in agent6. Like agent5, it's only supported for diskmapper backend, as it's the only one exporting stats.

Tests are ported from https://github.com/DataDog/integrations-core/blob/master/docker_daemon/test_docker_daemon.py#L105
Logic is ported from https://github.com/DataDog/integrations-core/blob/master/docker_daemon/check.py#L895

