### PR TITLE
[Logs] Update parameter sent to logs-agent

### DIFF
--- a/pkg/collector/corechecks/embed/logs-agent.go
+++ b/pkg/collector/corechecks/embed/logs-agent.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -68,11 +69,12 @@ func (c *LogsCheck) Run() error {
 func (c *LogsCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
 	here, _ := osext.ExecutableFolder()
 	confd := config.Datadog.GetString("confd_path")
+	ddcondig := filepath.Clean(filepath.Join(confd, ".."))
 	bin := path.Join(here, "logs-agent")
 
 	c.cmd = exec.Command(
 		bin,
-		fmt.Sprintf("-ddconfig=%s", confd),
+		fmt.Sprintf("-ddconfig=%s", ddcondig),
 	)
 
 	return nil

--- a/pkg/collector/dist/conf.d/logs-agent.yaml.default
+++ b/pkg/collector/dist/conf.d/logs-agent.yaml.default
@@ -1,0 +1,4 @@
+instances:
+- {} # default instance, if you need to customize its configuration, please do so
+     # in the main datadog.yaml
+


### PR DESCRIPTION
As the logs agent expects `confd_path`'s parent directory now

Compatible with the current aplha version of logs-agent