### PR TITLE
[aggregator] Use `time.Duration` type for the flush interval

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -28,7 +28,7 @@ var (
 )
 
 // Make the check cmd aggregator never flush by setting a very high interval
-const checkCmdFlushInterval = 1000000000 * time.Second
+const checkCmdFlushInterval = time.Hour
 
 func init() {
 	AgentCmd.AddCommand(checkCmd)

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -27,7 +27,8 @@ var (
 	logLevel   string
 )
 
-const checkCmdFlushInterval = 10000000000
+// Make the check cmd aggregator never flush by setting a very high interval
+const checkCmdFlushInterval = 1000000000 * time.Second
 
 func init() {
 	AgentCmd.AddCommand(checkCmd)
@@ -79,7 +80,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		s := &serializer.Serializer{Forwarder: common.Forwarder}
-		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, 1000000000)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, checkCmdFlushInterval)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 		cs := common.AC.GetChecksByName(checkName)
 		if len(cs) == 0 {

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -66,7 +66,7 @@ var (
 		"duration per second.")
 
 	flushIval = flag.Int64("flush_ival",
-		aggregator.DefaultFlushInterval,
+		int64(aggregator.DefaultFlushInterval/time.Second),
 		"Flush interval for aggregator, in seconds")
 
 	agg   *aggregator.BufferedAggregator
@@ -211,7 +211,7 @@ func main() {
 	f := &forwarderBenchStub{}
 	s := &serializer.Serializer{Forwarder: f}
 
-	agg = aggregator.InitAggregatorWithFlushInterval(s, "hostname", *flushIval*time.Second)
+	agg = aggregator.InitAggregatorWithFlushInterval(s, "hostname", time.Duration(*flushIval)*time.Second)
 
 	aggregator.SetDefaultAggregator(agg)
 	sender, err := aggregator.GetSender(check.ID("benchmark check"))

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -67,7 +67,7 @@ var (
 
 	flushIval = flag.Int64("flush_ival",
 		aggregator.DefaultFlushInterval,
-		"Flush interval for aggregator")
+		"Flush interval for aggregator, in seconds")
 
 	agg   *aggregator.BufferedAggregator
 	flush = make(chan time.Time)
@@ -211,7 +211,7 @@ func main() {
 	f := &forwarderBenchStub{}
 	s := &serializer.Serializer{Forwarder: f}
 
-	agg = aggregator.InitAggregatorWithFlushInterval(s, "hostname", *flushIval)
+	agg = aggregator.InitAggregatorWithFlushInterval(s, "hostname", *flushIval*time.Second)
 
 	aggregator.SetDefaultAggregator(agg)
 	sender, err := aggregator.GetSender(check.ID("benchmark check"))


### PR DESCRIPTION
### What does this PR do?

Use `time.Duration` for the aggregator flush interval

### Motivation

Better than using raw integers
