### PR TITLE
[puppy] fix build + add gitlab ci step

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,15 +65,13 @@ build_dogstatsd_static-deb_x64:
     paths:
       - dogstatsd
 
-# build dogstatsd static for rpm-x64
-build_dogstatsd_static-rpm_x64:
+# build puppy agent for deb-x64, to make sure the build is not broken because of build flags
+build_puppy_agent-deb_x64:
   stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e dogstatsd.build --static
-    - cp $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $CI_PROJECT_DIR
-
+    - inv -e agent.build --puppy
 
 #
 # integration_test
@@ -202,7 +200,7 @@ agent_rpm-x64:
 # package_build
 #
 
-# build windows 
+# build windows
 build_windows_msi_x64:
   before_script:
     - if exist %GOPATH%\src\github.com\DataDog\datadog-agent rd /s/q %GOPATH%\src\github.com\DataDog\datadog-agent

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -12,23 +12,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
-	"time"
 
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/gorilla/mux"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
 // SetupHandlers adds the specific handlers for /agent endpoints
@@ -119,102 +113,6 @@ func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("%s", err.Error())
 		http.Error(w, err.Error(), 404)
 	}
-}
-
-func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
-	var err error
-
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
-
-	var ts int
-	queries := r.URL.Query()
-	if timestamps, ok := queries["timestamp"]; ok {
-		ts, _ = strconv.Atoi(timestamps[0])
-	}
-
-	if int64(ts) > embed.JMXConfigCache.GetModified() {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
-
-	j := map[string]interface{}{}
-	configs := map[string]check.ConfigJSONMap{}
-
-	configItems := embed.JMXConfigCache.Items()
-	for name, config := range configItems {
-		m, ok := config.(map[string]interface{})
-		if !ok {
-			err = fmt.Errorf("wrong type in cache")
-			log.Errorf("%s", err.Error())
-			http.Error(w, err.Error(), 500)
-			return
-		}
-
-		cfg, ok := m["config"].(check.Config)
-		if !ok {
-			err = fmt.Errorf("wrong type for config")
-			log.Errorf("%s", err.Error())
-			http.Error(w, err.Error(), 500)
-			return
-		}
-
-		var rawInitConfig check.ConfigRawMap
-		err = yaml.Unmarshal(cfg.InitConfig, &rawInitConfig)
-		if err != nil {
-			log.Errorf("unable to parse JMX configuration: %s", err)
-			http.Error(w, err.Error(), 500)
-			return
-		}
-
-		c := map[string]interface{}{}
-		c["init_config"] = util.GetJSONSerializableMap(rawInitConfig)
-		instances := []check.ConfigJSONMap{}
-		for _, instance := range cfg.Instances {
-			var rawInstanceConfig check.ConfigJSONMap
-			err = yaml.Unmarshal(instance, &rawInstanceConfig)
-			if err != nil {
-				log.Errorf("unable to parse JMX configuration: %s", err)
-				http.Error(w, err.Error(), 500)
-				return
-			}
-			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(check.ConfigJSONMap))
-		}
-
-		c["instances"] = instances
-		configs[name] = c
-
-	}
-	j["configs"] = configs
-	j["timestamp"] = time.Now().Unix()
-	jsonPayload, err := json.Marshal(util.GetJSONSerializableMap(j))
-	if err != nil {
-		log.Errorf("unable to parse JMX configuration: %s", err)
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	w.Write(jsonPayload)
-}
-
-func setJMXStatus(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
-
-	decoder := json.NewDecoder(r.Body)
-
-	var jmxStatus status.JMXStatus
-	err := decoder.Decode(&jmxStatus)
-	if err != nil {
-		log.Errorf("unable to parse jmx status: %s", err)
-		http.Error(w, err.Error(), 500)
-	}
-
-	status.SetJMXStatus(jmxStatus)
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/api/agent/agent_jmx.go
+++ b/cmd/agent/api/agent/agent_jmx.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// Package agent implements the api endpoints for the `/agent` prefix.
+// This group of endpoints is meant to provide high-level functionalities
+// at the agent level.
+
+// +build jmx
+
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
+	"github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/util"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
+	var err error
+
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+
+	var ts int
+	queries := r.URL.Query()
+	if timestamps, ok := queries["timestamp"]; ok {
+		ts, _ = strconv.Atoi(timestamps[0])
+	}
+
+	if int64(ts) > embed.JMXConfigCache.GetModified() {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
+
+	j := map[string]interface{}{}
+	configs := map[string]check.ConfigJSONMap{}
+
+	configItems := embed.JMXConfigCache.Items()
+	for name, config := range configItems {
+		m, ok := config.(map[string]interface{})
+		if !ok {
+			err = fmt.Errorf("wrong type in cache")
+			log.Errorf("%s", err.Error())
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		cfg, ok := m["config"].(check.Config)
+		if !ok {
+			err = fmt.Errorf("wrong type for config")
+			log.Errorf("%s", err.Error())
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		var rawInitConfig check.ConfigRawMap
+		err = yaml.Unmarshal(cfg.InitConfig, &rawInitConfig)
+		if err != nil {
+			log.Errorf("unable to parse JMX configuration: %s", err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		c := map[string]interface{}{}
+		c["init_config"] = util.GetJSONSerializableMap(rawInitConfig)
+		instances := []check.ConfigJSONMap{}
+		for _, instance := range cfg.Instances {
+			var rawInstanceConfig check.ConfigJSONMap
+			err = yaml.Unmarshal(instance, &rawInstanceConfig)
+			if err != nil {
+				log.Errorf("unable to parse JMX configuration: %s", err)
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(check.ConfigJSONMap))
+		}
+
+		c["instances"] = instances
+		configs[name] = c
+
+	}
+	j["configs"] = configs
+	j["timestamp"] = time.Now().Unix()
+	jsonPayload, err := json.Marshal(util.GetJSONSerializableMap(j))
+	if err != nil {
+		log.Errorf("unable to parse JMX configuration: %s", err)
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	w.Write(jsonPayload)
+}
+
+func setJMXStatus(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+
+	decoder := json.NewDecoder(r.Body)
+
+	var jmxStatus status.JMXStatus
+	err := decoder.Decode(&jmxStatus)
+	if err != nil {
+		log.Errorf("unable to parse jmx status: %s", err)
+		http.Error(w, err.Error(), 500)
+	}
+
+	status.SetJMXStatus(jmxStatus)
+}

--- a/cmd/agent/api/agent/agent_nojmx.go
+++ b/cmd/agent/api/agent/agent_nojmx.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// Package agent implements the api endpoints for the `/agent` prefix.
+// This group of endpoints is meant to provide high-level functionalities
+// at the agent level.
+
+// +build !jmx
+
+package agent
+
+import (
+	"net/http"
+
+	log "github.com/cihub/seelog"
+)
+
+const noJMXErrorString = "jmx is not compiled in this agent"
+
+func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
+	log.Error(noJMXErrorString)
+	http.Error(w, noJMXErrorString, 500)
+}
+
+func setJMXStatus(w http.ResponseWriter, r *http.Request) {
+	log.Error(noJMXErrorString)
+	http.Error(w, noJMXErrorString, 500)
+}


### PR DESCRIPTION
### What does this PR do?

Build flags are great but our current CI pipeline only runs with all flags on. Today, I had to patch a bunch of packages to make the puppy agent build agent.

This PR fixes the last build issue + adds a build step in the gitlab pipeline. It'll need to be added to the circleci pipeline when porting.

Also, removing the unused `build_dogstatsd_static-rpm_x64` step as we don't use that binary anywhere (test nor distribution).

### Motivation

Avoid regressions
