### PR TITLE
Add ECS metadata collection

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -220,3 +220,8 @@ metadata_collectors:
 #
 # kubernetes_pod_label_to_tag_prefix: "kube_"
 #
+
+# ECS integration
+#
+# URL where the ECS agent can be found. Standard cases will be autodetected.
+# ecs_agent_url: http://localhost:51678

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,6 +121,8 @@ func init() {
 	Datadog.SetDefault("kubernetes_http_kubelet_port", 10255)
 	Datadog.SetDefault("kubernetes_https_kubelet_port", 10250)
 	Datadog.SetDefault("kubernetes_pod_label_to_tag_prefix", "kube_")
+	// ECS
+	Datadog.SetDefault("ecs_agent_url", "")	// Will be autodetected
 
 	// Cloud Foundry
 	Datadog.SetDefault("cloud_foundry", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,7 +122,7 @@ func init() {
 	Datadog.SetDefault("kubernetes_https_kubelet_port", 10250)
 	Datadog.SetDefault("kubernetes_pod_label_to_tag_prefix", "kube_")
 	// ECS
-	Datadog.SetDefault("ecs_agent_url", "")	// Will be autodetected
+	Datadog.SetDefault("ecs_agent_url", "") // Will be autodetected
 
 	// Cloud Foundry
 	Datadog.SetDefault("cloud_foundry", false)

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -18,6 +18,9 @@ import (
 // the local ECS agent.
 func GetPayload() (metadata.Payload, error) {
 	resp, err := ecsutil.ExtractPayload()
+	if err != nil {
+		return nil, err
+	}
 	return parseTaskResponse(resp), nil
 }
 

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -8,18 +8,8 @@
 package ecs
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
-	"strings"
-	"time"
-
 	payload "github.com/DataDog/agent-payload/gogen"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
-	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
-	"github.com/docker/docker/client"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
 
@@ -28,7 +18,7 @@ import (
 // the local ECS agent.
 func GetPayload() (metadata.Payload, error) {
 	resp, err := ecsutil.ExtractPayload()
-	parseTaskResponse(resp)
+	return parseTaskResponse(resp), nil
 }
 
 

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -20,152 +20,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/docker/docker/client"
-)
-
-const (
-	// DefaultAgentPort is the default port used by the ECS Agent.
-	DefaultAgentPort = 51678
-	// DefaultECSContainer is the default container used by ECS.
-	DefaultECSContainer = "amazon-ecs-agent"
-)
-
-// DetectedAgentURL stores the URL of the ECS agent. After the first call to
-// getHostname this will be detected and used as-is going forward. It will only
-// be re-detected if getHostname is called again.
-var detectedAgentURL string
-
-type (
-	// CommandsV1Response is the format of a response from the ECS-agent on the root.
-	CommandsV1Response struct {
-		AvailableCommands []string `json:"AvailableCommands"`
-	}
-
-	// TasksV1Response is the format of a response from the ECS tasks API.
-	// See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
-	TasksV1Response struct {
-		Tasks []TaskV1 `json:"tasks"`
-	}
-
-	// TaskV1 is the format of a Task in the ECS tasks API.
-	TaskV1 struct {
-		Arn           string        `json:"Arn"`
-		DesiredStatus string        `json:"DesiredStatus"`
-		KnownStatus   string        `json:"KnownStatus"`
-		Family        string        `json:"Family"`
-		Version       string        `json:"Version"`
-		Containers    []ContainerV1 `json:"containers"`
-	}
-
-	// ContainerV1 is the format of a Container in the ECS tasks API.
-	ContainerV1 struct {
-		DockerID   string `json:"DockerId"`
-		DockerName string `json:"DockerName"`
-		Name       string `json:"Name"`
-	}
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
 
 // GetPayload returns a payload.ECSMetadataPayload with metadat about the state
 // of the local ECS containers running on this node. This data is provided via
 // the local ECS agent.
 func GetPayload() (metadata.Payload, error) {
-	if detectedAgentURL == "" {
-		url, err := detectAgentURL()
-		if err != nil {
-			return nil, err
-		}
-		detectedAgentURL = url
-	}
-
-	r, err := http.Get(fmt.Sprintf("%sv1/tasks", detectedAgentURL))
-	if err != nil {
-		return nil, err
-	}
-	defer r.Body.Close()
-
-	var resp TasksV1Response
-	if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-		return nil, err
-	}
-	return parseTaskResponse(resp), nil
+	resp, err := ecsutil.ExtractPayload()
+	parseTaskResponse(resp)
 }
 
-// IsAgentNotDetected indicates if an error from GetPayload was about no
-// ECS agent being detected. This is a used as a way to check if is available
-// or if the host is not in an ECS cluster.
-func IsAgentNotDetected(err error) bool {
-	return strings.Contains(err.Error(), "could not detect ECS agent")
-}
 
-// detectAgentURL finds a hostname for the ECS-agent either via Docker, if
-// running inside of a container, or just defaulting to localhost.
-func detectAgentURL() (string, error) {
-	urls := make([]string, 0, 3)
-	if config.IsContainerized() {
-		cli, err := dockerutil.ConnectToDocker()
-		if err != nil {
-			return "", err
-		}
-		defer cli.Close()
-
-		// Try all networks available on the ecs container.
-		ecsConfig, err := cli.ContainerInspect(context.TODO(), DefaultECSContainer)
-		if client.IsErrContainerNotFound(err) {
-			return "", fmt.Errorf("could not detect ECS agent, missing %s container", DefaultECSContainer)
-		} else if err != nil {
-			return "", err
-		}
-		for _, network := range ecsConfig.NetworkSettings.Networks {
-			ip := network.IPAddress
-			if ip != "" {
-				urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
-			}
-		}
-
-		// Try the default gateway
-		gw, err := dockerutil.DefaultGateway()
-		if err != nil {
-			// "expected" errors are handled in DefaultGateway so only
-			// unexpected errors are bubbled up, so we keep bubbling.
-			return "", err
-		}
-		if gw != nil {
-			urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))
-		}
-	}
-
-	// Always try the localhost URL.
-	urls = append(urls, fmt.Sprintf("http://localhost:%d/", DefaultAgentPort))
-	detected := testURLs(urls, 1*time.Second)
-	if detected != "" {
-		return detected, nil
-	}
-	return "", fmt.Errorf("could not detect ECS agent, tried URLs: %s", urls)
-}
-
-// testURLs trys a set of URLs and returns the first one that succeeds.
-func testURLs(urls []string, timeout time.Duration) string {
-	client := &http.Client{Timeout: timeout}
-	for _, url := range urls {
-		r, err := client.Get(url)
-		if err != nil {
-			continue
-		}
-		if r.StatusCode != http.StatusOK {
-			continue
-		}
-		var resp CommandsV1Response
-		if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-			fmt.Printf("decode err: %s\n", err)
-			continue
-		}
-		if len(resp.AvailableCommands) > 0 {
-			return url
-		}
-	}
-	return ""
-}
-
-func parseTaskResponse(resp TasksV1Response) *payload.ECSMetadataPayload {
+func parseTaskResponse(resp ecsutil.TasksV1Response) *payload.ECSMetadataPayload {
 	tasks := make([]*payload.ECSMetadataPayload_Task, 0, len(resp.Tasks))
 	for _, t := range resp.Tasks {
 		containers := make([]*payload.ECSMetadataPayload_Container, 0, len(t.Containers))

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -17,7 +17,7 @@ import (
 // of the local ECS containers running on this node. This data is provided via
 // the local ECS agent.
 func GetPayload() (metadata.Payload, error) {
-	resp, err := ecsutil.ExtractPayload()
+	resp, err := ecsutil.GetTasks()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metadata/ecs/ecs.go
+++ b/pkg/metadata/ecs/ecs.go
@@ -21,7 +21,6 @@ func GetPayload() (metadata.Payload, error) {
 	return parseTaskResponse(resp), nil
 }
 
-
 func parseTaskResponse(resp ecsutil.TasksV1Response) *payload.ECSMetadataPayload {
 	tasks := make([]*payload.ECSMetadataPayload_Task, 0, len(resp.Tasks))
 	for _, t := range resp.Tasks {

--- a/pkg/metadata/ecs/ecs_test.go
+++ b/pkg/metadata/ecs/ecs_test.go
@@ -8,82 +8,51 @@
 package ecs
 
 import (
-	"fmt"
-	"net"
-	"net/http"
-
 	"testing"
 
 	payload "github.com/DataDog/agent-payload/gogen"
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/stretchr/testify/assert"
 )
 
-var nextTestResponse string
+var nextTestResponse ecsutil.TasksV1Response
 
-// TODO: ideally this test should use the httptest package
-func runServer(t *testing.T, ready chan<- bool, exit <-chan bool) {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// Satisfy the initial check of URLs
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("{\"AvailableCommands\":[\"/license\",\"/v1/metadata\",\"/v1/tasks\"]}"))
-	})
-	http.HandleFunc("/v1/tasks", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(nextTestResponse))
-	})
-
-	s := &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", DefaultAgentPort)}
-	ln, err := net.Listen("tcp", s.Addr)
-	if err != nil {
-		t.Fail()
-	}
-	go s.Serve(ln)
-	ready <- true
-	<-exit
-	s.Close()
-}
-
-func TestGetPayload(t *testing.T) {
+func TestParseTaskResponse(t *testing.T) {
 	assert := assert.New(t)
-	exit := make(chan bool, 1)
-	ready := make(chan bool, 1)
-	go runServer(t, ready, exit)
-	<-ready
-	for _, tc := range []struct {
-		input    string
+	for nb, tc := range []struct {
+		input    ecsutil.TasksV1Response
 		expected *payload.ECSMetadataPayload
-		hasError bool
 	}{
 		{
-			input: `{}`,
+			input: ecsutil.TasksV1Response{},
 			expected: &payload.ECSMetadataPayload{
 				Tasks: []*payload.ECSMetadataPayload_Task{},
 			},
 		},
 		{
-			input: `{
-			  "Tasks": [
-			    {
-			      "Arn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
-			      "DesiredStatus": "RUNNING",
-			      "KnownStatus": "RUNNING",
-			      "Family": "hello_world",
-			      "Version": "8",
-			      "Containers": [
-			        {
-			          "DockerId": "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
-			          "DockerName": "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
-			          "Name": "mysql"
-			        },
-			        {
-			          "DockerId": "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
-			          "DockerName": "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
-			          "Name": "wordpress"
-			        }
-			      ]
-			    }
-			  ]
-			}`,
+			input: ecsutil.TasksV1Response{
+				Tasks: []ecsutil.TaskV1{
+					ecsutil.TaskV1{
+						Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+						DesiredStatus: "RUNNING",
+						KnownStatus:   "RUNNING",
+						Family:        "hello_world",
+						Version:       "8",
+						Containers: []ecsutil.ContainerV1{
+							ecsutil.ContainerV1{
+								DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+								DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+								Name:       "mysql",
+							},
+							ecsutil.ContainerV1{
+								DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+								DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+								Name:       "wordpress",
+							},
+						},
+					},
+				},
+			},
 			expected: &payload.ECSMetadataPayload{
 				Tasks: []*payload.ECSMetadataPayload_Task{
 					&payload.ECSMetadataPayload_Task{
@@ -109,10 +78,9 @@ func TestGetPayload(t *testing.T) {
 			},
 		},
 	} {
+		t.Logf("test case %d", nb)
 		nextTestResponse = tc.input
-		p, err := GetPayload()
-		assert.NoError(err)
+		p := parseTaskResponse(nextTestResponse)
 		assert.Equal(tc.expected, p)
 	}
-	exit <- true
 }

--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -18,7 +18,6 @@ func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInf
 	for _, task := range tasks_list.Tasks {
 		for _, container := range task.Containers {
 			tags := utils.NewTagList()
-			tags.AddHigh("ecs_arn", task.Arn)
 			tags.AddLow("task_version", task.Version)
 			tags.AddLow("task_name", task.Family)
 

--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package collectors
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
+)
+
+func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInfo, error) {
+	var output []*TagInfo
+	for _, task := range tasks_list.Tasks {
+		for _, container := range task.Containers {
+			tags := utils.NewTagList()
+			tags.AddHigh("ecs_arn", task.Arn)
+			tags.AddLow("task_version", task.Version)
+			tags.AddLow("task_name", task.Family)
+
+			low, high := tags.Compute()
+
+			info := &TagInfo{
+				Source:       ecsCollectorName,
+				Entity:       docker.ContainerIDToEntityName(container.DockerID),
+				HighCardTags: high,
+				LowCardTags:  low,
+			}
+			output = append(output, info)
+		}
+	}
+	return output, nil
+}

--- a/pkg/tagger/collectors/ecs_extract_test.go
+++ b/pkg/tagger/collectors/ecs_extract_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package collectors
+
+import (
+	"testing"
+
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestECSMetadata(t *testing.T) {
+	assert := assert.New(t)
+	ecsCollector := &ECSCollector{}
+
+	for nb, tc := range []struct {
+		input    ecsutil.TasksV1Response
+		expected []*TagInfo
+		err      error
+	}{
+		{
+			input:    ecsutil.TasksV1Response{},
+			expected: []*TagInfo{},
+			err:      nil,
+		},
+		{
+			input: ecsutil.TasksV1Response{
+				Tasks: []ecsutil.TaskV1{
+					ecsutil.TaskV1{
+						Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+						DesiredStatus: "RUNNING",
+						KnownStatus:   "RUNNING",
+						Family:        "hello_world",
+						Version:       "8",
+						Containers: []ecsutil.ContainerV1{
+							ecsutil.ContainerV1{
+								DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+								DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+								Name:       "mysql",
+							},
+							ecsutil.ContainerV1{
+								DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+								DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+								Name:       "wordpress",
+							},
+						},
+					},
+				},
+			},
+			expected: []*TagInfo{
+				&TagInfo{
+					Source:       "ecs",
+					Entity:       "docker://9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+					HighCardTags: []string{"ecs_arn:arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example"},
+					LowCardTags:  []string{"task_version:8", "task_name:hello_world"},
+				},
+				&TagInfo{
+					Source:       "ecs",
+					Entity:       "docker://bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+					HighCardTags: []string{"ecs_arn:arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example"},
+					LowCardTags:  []string{"task_version:8", "task_name:hello_world"},
+				},
+			},
+			err: nil,
+		},
+	} {
+		t.Logf("test case %d", nb)
+		infos, err := ecsCollector.parseTasks(tc.input)
+		if len(infos) > 0 {
+			require.Len(t, infos, 2)
+		}
+		for _, item := range infos {
+			t.Logf("testing entity %s", item.Entity)
+			require.True(t, requireMatchInfo(t, tc.expected, item))
+			require.Contains(t, item.LowCardTags, "task_version:8")
+		}
+		if tc.err == nil {
+			assert.Nil(err)
+		} else {
+			assert.NotNil(err)
+			assert.Equal(tc.err.Error(), err.Error())
+		}
+	}
+}

--- a/pkg/tagger/collectors/ecs_extract_test.go
+++ b/pkg/tagger/collectors/ecs_extract_test.go
@@ -78,7 +78,6 @@ func TestECSMetadata(t *testing.T) {
 		for _, item := range infos {
 			t.Logf("testing entity %s", item.Entity)
 			require.True(t, requireMatchInfo(t, tc.expected, item))
-			require.Contains(t, item.LowCardTags, "task_version:8")
 		}
 		if tc.err == nil {
 			assert.Nil(err)

--- a/pkg/tagger/collectors/ecs_extract_test.go
+++ b/pkg/tagger/collectors/ecs_extract_test.go
@@ -57,13 +57,13 @@ func TestECSMetadata(t *testing.T) {
 				&TagInfo{
 					Source:       "ecs",
 					Entity:       "docker://9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
-					HighCardTags: []string{"ecs_arn:arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example"},
+					HighCardTags: []string{},
 					LowCardTags:  []string{"task_version:8", "task_name:hello_world"},
 				},
 				&TagInfo{
 					Source:       "ecs",
 					Entity:       "docker://bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
-					HighCardTags: []string{"ecs_arn:arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example"},
+					HighCardTags: []string{},
 					LowCardTags:  []string{"task_version:8", "task_name:hello_world"},
 				},
 			},

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -27,17 +27,11 @@ type ECSCollector struct {
 func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 	if ecsutil.IsInstance() {
 		c.infoOut = out
-		return PullCollection, nil
+		return FetchOnlyCollection, nil
 	} else {
 		return NoCollection, fmt.Errorf("Failed to connect to ecs, ECS tagging will not work")
 	}
 
-}
-
-// No need to use the Pull for ECS, metadata collection relies on Fetch.
-// Implementing for compliance with tagger interface.
-func (c *ECSCollector) Pull() error {
-	return nil
 }
 
 // Fetch fetches ECS tags

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package collectors
+
+import (
+	"fmt"
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
+)
+
+const (
+	ecsCollectorName = "ecs"
+)
+
+// ECSCollector listen to the ECS agent to get ECS metadata.
+// And feed a stream of TagInfo.
+
+type ECSCollector struct {
+	infoOut chan<- []*TagInfo
+}
+
+// Detect tries to connect to the ecs agent
+func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
+	if ecsutil.IsInstance() {
+		c.infoOut = out
+		return PullCollection, nil
+	} else {
+		return NoCollection, fmt.Errorf("Failed to connect to ecs, ECS tagging will not work")
+	}
+
+}
+
+// No need to use the Pull for ECS, metadata collection relies on Fetch.
+// Implementing for compliance with tagger interface.
+func (c *ECSCollector) Pull() error {
+	return nil
+}
+
+// Fetch fetches ECS tags
+func (c *ECSCollector) Fetch(container string) ([]string, []string, error) {
+
+	tasks_list, err := ecsutil.GetTasks()
+	if err != nil {
+		return []string{}, []string{}, err
+	}
+	updates, err := c.parseTasks(tasks_list)
+	if err != nil {
+		return []string{}, []string{}, err
+	}
+	c.infoOut <- updates
+
+	for _, info := range updates {
+		if info.Entity == container {
+			return info.LowCardTags, info.HighCardTags, nil
+		}
+	}
+	// container not found in updates
+	return []string{}, []string{}, fmt.Errorf("entity %s not found in tasklist", container)
+}
+
+func ecsFactory() Collector {
+	return &ECSCollector{}
+}
+
+func init() {
+	registerCollector(ecsCollectorName, ecsFactory)
+}

--- a/pkg/util/docker/storage_test.go
+++ b/pkg/util/docker/storage_test.go
@@ -254,8 +254,9 @@ func TestParseDiskQuantity(t *testing.T) {
 		assert.Equal(tc.bytes, val)
 
 		if tc.err == nil {
-			assert.Nil(tc.err)
+			assert.Nil(err)
 		} else {
+			assert.NotNil(err)
 			assert.Equal(tc.err.Error(), err.Error())
 		}
 	}

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -8,23 +8,23 @@
 package ecs
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
-    "github.com/DataDog/datadog-agent/pkg/config"
-    dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
-    "github.com/docker/docker/client"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/docker/docker/client"
 )
 
 const (
-    // DefaultAgentPort is the default port used by the ECS Agent.
-    DefaultAgentPort = 51678
-    // DefaultECSContainer is the default container used by ECS.
-    DefaultECSContainer = "amazon-ecs-agent"
+	// DefaultAgentPort is the default port used by the ECS Agent.
+	DefaultAgentPort = 51678
+	// DefaultECSContainer is the default container used by ECS.
+	DefaultECSContainer = "amazon-ecs-agent"
 )
 
 // DetectedAgentURL stores the URL of the ECS agent. After the first call to
@@ -33,52 +33,52 @@ const (
 var detectedAgentURL string
 
 type (
-    // CommandsV1Response is the format of a response from the ECS-agent on the root.
-    CommandsV1Response struct {
-        AvailableCommands []string `json:"AvailableCommands"`
-    }
+	// CommandsV1Response is the format of a response from the ECS-agent on the root.
+	CommandsV1Response struct {
+		AvailableCommands []string `json:"AvailableCommands"`
+	}
 
-    // TasksV1Response is the format of a response from the ECS tasks API.
-    // See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
-    TasksV1Response struct {
-        Tasks []TaskV1 `json:"tasks"`
-    }
+	// TasksV1Response is the format of a response from the ECS tasks API.
+	// See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
+	TasksV1Response struct {
+		Tasks []TaskV1 `json:"tasks"`
+	}
 
-    // TaskV1 is the format of a Task in the ECS tasks API.
-    TaskV1 struct {
-        Arn           string        `json:"Arn"`
-        DesiredStatus string        `json:"DesiredStatus"`
-        KnownStatus   string        `json:"KnownStatus"`
-        Family        string        `json:"Family"`
-        Version       string        `json:"Version"`
-        Containers    []ContainerV1 `json:"containers"`
-    }
+	// TaskV1 is the format of a Task in the ECS tasks API.
+	TaskV1 struct {
+		Arn           string        `json:"Arn"`
+		DesiredStatus string        `json:"DesiredStatus"`
+		KnownStatus   string        `json:"KnownStatus"`
+		Family        string        `json:"Family"`
+		Version       string        `json:"Version"`
+		Containers    []ContainerV1 `json:"containers"`
+	}
 
-    // ContainerV1 is the format of a Container in the ECS tasks API.
-    ContainerV1 struct {
-        DockerID   string `json:"DockerId"`
-        DockerName string `json:"DockerName"`
-        Name       string `json:"Name"`
-    }
+	// ContainerV1 is the format of a Container in the ECS tasks API.
+	ContainerV1 struct {
+		DockerID   string `json:"DockerId"`
+		DockerName string `json:"DockerName"`
+		Name       string `json:"Name"`
+	}
 )
 
 // IsInstance returns whether this host is part of an ECS cluster
 func IsInstance() bool {
-    if detectedAgentURL == "" {
-        _, err := detectAgentURL()
-        if err != nil {
-            return false
-        }
-        return true
-    }
-    return true
+	if detectedAgentURL == "" {
+		_, err := detectAgentURL()
+		if err != nil {
+			return false
+		}
+		return true
+	}
+	return true
 }
 
 // IsAgentNotDetected indicates if an error from ExtractPayload was about no
 // ECS agent being detected. This is a used as a way to check if is available
 // or if the host is not in an ECS cluster.
 func IsAgentNotDetected(err error) bool {
-    return strings.Contains(err.Error(), "could not detect ECS agent")
+	return strings.Contains(err.Error(), "could not detect ECS agent")
 }
 
 // ExtractPayload returns a TasksV1Response containing information about the state
@@ -86,93 +86,93 @@ func IsAgentNotDetected(err error) bool {
 // the local ECS agent.
 func ExtractPayload() (TasksV1Response, error) {
 
-    var resp TasksV1Response
-    if detectedAgentURL == "" {
-        url, err := detectAgentURL()
-        if err != nil {
-            return resp, err
-        }
-        detectedAgentURL = url
-    }
-    // TODO: Use IsAgentNotDetected ?
+	var resp TasksV1Response
+	if detectedAgentURL == "" {
+		url, err := detectAgentURL()
+		if err != nil {
+			return resp, err
+		}
+		detectedAgentURL = url
+	}
+	// TODO: Use IsAgentNotDetected ?
 
-    r, err := http.Get(fmt.Sprintf("%sv1/tasks", detectedAgentURL))
-    if err != nil {
-        return resp, err
-    }
-    defer r.Body.Close()
+	r, err := http.Get(fmt.Sprintf("%sv1/tasks", detectedAgentURL))
+	if err != nil {
+		return resp, err
+	}
+	defer r.Body.Close()
 
-    if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-        return resp, err
-    }
-    return resp, nil
+	if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+		return resp, err
+	}
+	return resp, nil
 }
 
 // detectAgentURL finds a hostname for the ECS-agent either via Docker, if
 // running inside of a container, or just defaulting to localhost.
 func detectAgentURL() (string, error) {
-    urls := make([]string, 0, 3)
-    if config.IsContainerized() {
-        cli, err := dockerutil.ConnectToDocker()
-        if err != nil {
-            return "", err
-        }
-        defer cli.Close()
+	urls := make([]string, 0, 3)
+	if config.IsContainerized() {
+		cli, err := dockerutil.ConnectToDocker()
+		if err != nil {
+			return "", err
+		}
+		defer cli.Close()
 
-        // Try all networks available on the ecs container.
-        ecsConfig, err := cli.ContainerInspect(context.TODO(), DefaultECSContainer)
-        if client.IsErrContainerNotFound(err) {
-            return "", fmt.Errorf("could not detect ECS agent, missing %s container", DefaultECSContainer)
-        } else if err != nil {
-            return "", err
-        }
-        for _, network := range ecsConfig.NetworkSettings.Networks {
-            ip := network.IPAddress
-            if ip != "" {
-                urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
-            }
-        }
+		// Try all networks available on the ecs container.
+		ecsConfig, err := cli.ContainerInspect(context.TODO(), DefaultECSContainer)
+		if client.IsErrContainerNotFound(err) {
+			return "", fmt.Errorf("could not detect ECS agent, missing %s container", DefaultECSContainer)
+		} else if err != nil {
+			return "", err
+		}
+		for _, network := range ecsConfig.NetworkSettings.Networks {
+			ip := network.IPAddress
+			if ip != "" {
+				urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
+			}
+		}
 
-        // Try the default gateway
-        gw, err := dockerutil.DefaultGateway()
-        if err != nil {
-            // "expected" errors are handled in DefaultGateway so only
-            // unexpected errors are bubbled up, so we keep bubbling.
-            return "", err
-        }
-        if gw != nil {
-            urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))
-        }
-    }
+		// Try the default gateway
+		gw, err := dockerutil.DefaultGateway()
+		if err != nil {
+			// "expected" errors are handled in DefaultGateway so only
+			// unexpected errors are bubbled up, so we keep bubbling.
+			return "", err
+		}
+		if gw != nil {
+			urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))
+		}
+	}
 
-    // Always try the localhost URL.
-    urls = append(urls, fmt.Sprintf("http://localhost:%d/", DefaultAgentPort))
-    detected := testURLs(urls, 1*time.Second)
-    if detected != "" {
-        return detected, nil
-    }
-    return "", fmt.Errorf("could not detect ECS agent, tried URLs: %s", urls)
+	// Always try the localhost URL.
+	urls = append(urls, fmt.Sprintf("http://localhost:%d/", DefaultAgentPort))
+	detected := testURLs(urls, 1*time.Second)
+	if detected != "" {
+		return detected, nil
+	}
+	return "", fmt.Errorf("could not detect ECS agent, tried URLs: %s", urls)
 }
 
 // testURLs trys a set of URLs and returns the first one that succeeds.
 func testURLs(urls []string, timeout time.Duration) string {
-    client := &http.Client{Timeout: timeout}
-    for _, url := range urls {
-        r, err := client.Get(url)
-        if err != nil {
-            continue
-        }
-        if r.StatusCode != http.StatusOK {
-            continue
-        }
-        var resp CommandsV1Response
-        if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-            fmt.Printf("decode err: %s\n", err)
-            continue
-        }
-        if len(resp.AvailableCommands) > 0 {
-            return url
-        }
-    }
-    return ""
+	client := &http.Client{Timeout: timeout}
+	for _, url := range urls {
+		r, err := client.Get(url)
+		if err != nil {
+			continue
+		}
+		if r.StatusCode != http.StatusOK {
+			continue
+		}
+		var resp CommandsV1Response
+		if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+			fmt.Printf("decode err: %s\n", err)
+			continue
+		}
+		if len(resp.AvailableCommands) > 0 {
+			return url
+		}
+	}
+	return ""
 }

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -3,10 +3,176 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build docker
+
 package ecs
 
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "strings"
+    "time"
+
+    payload "github.com/DataDog/agent-payload/gogen"
+    "github.com/DataDog/datadog-agent/pkg/config"
+    "github.com/DataDog/datadog-agent/pkg/metadata"
+    dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
+    "github.com/docker/docker/client"
+)
+
+const (
+    // DefaultAgentPort is the default port used by the ECS Agent.
+    DefaultAgentPort = 51678
+    // DefaultECSContainer is the default container used by ECS.
+    DefaultECSContainer = "amazon-ecs-agent"
+)
+
+// DetectedAgentURL stores the URL of the ECS agent. After the first call to
+// getHostname this will be detected and used as-is going forward. It will only
+// be re-detected if getHostname is called again.
+var detectedAgentURL string
+
+type (
+    // CommandsV1Response is the format of a response from the ECS-agent on the root.
+    CommandsV1Response struct {
+        AvailableCommands []string `json:"AvailableCommands"`
+    }
+
+    // TasksV1Response is the format of a response from the ECS tasks API.
+    // See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
+    TasksV1Response struct {
+        Tasks []TaskV1 `json:"tasks"`
+    }
+
+    // TaskV1 is the format of a Task in the ECS tasks API.
+    TaskV1 struct {
+        Arn           string        `json:"Arn"`
+        DesiredStatus string        `json:"DesiredStatus"`
+        KnownStatus   string        `json:"KnownStatus"`
+        Family        string        `json:"Family"`
+        Version       string        `json:"Version"`
+        Containers    []ContainerV1 `json:"containers"`
+    }
+
+    // ContainerV1 is the format of a Container in the ECS tasks API.
+    ContainerV1 struct {
+        DockerID   string `json:"DockerId"`
+        DockerName string `json:"DockerName"`
+        Name       string `json:"Name"`
+    }
+)
+
 // IsInstance returns whether this host is part of an ECS cluster
-// BUG(massi) TODO
 func IsInstance() bool {
-	return false
+    if detectedAgentURL == "" {
+        url, err := detectAgentURL()
+        if err != nil {
+            return false
+        }
+        return true
+    }
+    return true
+}
+
+// IsAgentNotDetected indicates if an error from GetPayload was about no
+// ECS agent being detected. This is a used as a way to check if is available
+// or if the host is not in an ECS cluster.
+func IsAgentNotDetected(err error) bool {
+    return strings.Contains(err.Error(), "could not detect ECS agent")
+}
+
+// GetPayload returns a payload.ECSMetadataPayload with metadata about the state
+// of the local ECS containers running on this node. This data is provided via
+// the local ECS agent.
+func ExtractPayload() (metadata.Payload, error) {
+    if detectedAgentURL == "" {
+        url, err := detectAgentURL()
+        if err != nil {
+            return nil, err
+        }
+        detectedAgentURL = url
+    }
+
+    r, err := http.Get(fmt.Sprintf("%sv1/tasks", detectedAgentURL))
+    if err != nil {
+        return nil, err
+    }
+    defer r.Body.Close()
+
+    var resp TasksV1Response
+    if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+        return nil, err
+    }
+    return parseTaskResponse(resp), nil
+}
+
+// detectAgentURL finds a hostname for the ECS-agent either via Docker, if
+// running inside of a container, or just defaulting to localhost.
+func detectAgentURL() (string, error) {
+    urls := make([]string, 0, 3)
+    if config.IsContainerized() {
+        cli, err := dockerutil.ConnectToDocker()
+        if err != nil {
+            return "", err
+        }
+        defer cli.Close()
+
+        // Try all networks available on the ecs container.
+        ecsConfig, err := cli.ContainerInspect(context.TODO(), DefaultECSContainer)
+        if client.IsErrContainerNotFound(err) {
+            return "", fmt.Errorf("could not detect ECS agent, missing %s container", DefaultECSContainer)
+        } else if err != nil {
+            return "", err
+        }
+        for _, network := range ecsConfig.NetworkSettings.Networks {
+            ip := network.IPAddress
+            if ip != "" {
+                urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
+            }
+        }
+
+        // Try the default gateway
+        gw, err := dockerutil.DefaultGateway()
+        if err != nil {
+            // "expected" errors are handled in DefaultGateway so only
+            // unexpected errors are bubbled up, so we keep bubbling.
+            return "", err
+        }
+        if gw != nil {
+            urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))
+        }
+    }
+
+    // Always try the localhost URL.
+    urls = append(urls, fmt.Sprintf("http://localhost:%d/", DefaultAgentPort))
+    detected := testURLs(urls, 1*time.Second)
+    if detected != "" {
+        return detected, nil
+    }
+    return "", fmt.Errorf("could not detect ECS agent, tried URLs: %s", urls)
+}
+
+// testURLs trys a set of URLs and returns the first one that succeeds.
+func testURLs(urls []string, timeout time.Duration) string {
+    client := &http.Client{Timeout: timeout}
+    for _, url := range urls {
+        r, err := client.Get(url)
+        if err != nil {
+            continue
+        }
+        if r.StatusCode != http.StatusOK {
+            continue
+        }
+        var resp CommandsV1Response
+        if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+            fmt.Printf("decode err: %s\n", err)
+            continue
+        }
+        if len(resp.AvailableCommands) > 0 {
+            return url
+        }
+    }
+    return ""
 }

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -65,7 +65,7 @@ type (
 // IsInstance returns whether this host is part of an ECS cluster
 func IsInstance() bool {
     if detectedAgentURL == "" {
-        url, err := detectAgentURL()
+        _, err := detectAgentURL()
         if err != nil {
             return false
         }
@@ -84,11 +84,13 @@ func IsAgentNotDetected(err error) bool {
 // ExtractPayload returns a TasksV1Response containing information about the state
 // of the local ECS containers running on this node. This data is provided via
 // the local ECS agent.
-func ExtractPayload() (resp TasksV1Response, error) {
+func ExtractPayload() (TasksV1Response, error) {
+
+    var resp TasksV1Response
     if detectedAgentURL == "" {
         url, err := detectAgentURL()
         if err != nil {
-            return nil, err
+            return resp, err
         }
         detectedAgentURL = url
     }
@@ -96,13 +98,12 @@ func ExtractPayload() (resp TasksV1Response, error) {
 
     r, err := http.Get(fmt.Sprintf("%sv1/tasks", detectedAgentURL))
     if err != nil {
-        return nil, err
+        return resp, err
     }
     defer r.Body.Close()
 
-    var resp TasksV1Response
     if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
-        return nil, err
+        return resp, err
     }
     return resp, nil
 }

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -24,7 +24,7 @@ const (
 	// DefaultAgentPort is the default port used by the ECS Agent.
 	DefaultAgentPort = 51678
 	// DefaultECSContainer is the default container used by ECS.
-	DefaultECSContainer = "amazon-ecs-agent"
+	DefaultECSContainer = "ecs-agent"
 )
 
 // DetectedAgentURL stores the URL of the ECS agent. After the first call to

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -74,14 +74,14 @@ func IsInstance() bool {
 	return true
 }
 
-// IsAgentNotDetected indicates if an error from ExtractPayload was about no
+// IsAgentNotDetected indicates if an error from GetTasks was about no
 // ECS agent being detected. This is a used as a way to check if is available
 // or if the host is not in an ECS cluster.
 func IsAgentNotDetected(err error) bool {
 	return strings.Contains(err.Error(), "could not detect ECS agent")
 }
 
-// ExtractPayload returns a TasksV1Response containing information about the state
+// GetTasks returns a TasksV1Response containing information about the state
 // of the local ECS containers running on this node. This data is provided via
 // the local ECS agent.
 func GetTasks() (TasksV1Response, error) {

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package ecs
+
+import (
+    "net/http/httptest"
+    "testing"
+    "net/url"
+    "fmt"
+    "errors"
+    "strconv"
+    "net/http"
+
+    "github.com/stretchr/testify/require"
+    "time"
+    "github.com/DataDog/datadog-agent/pkg/config"
+    "github.com/stretchr/testify/assert"
+)
+// dummyECS allows tests to mock a ECS's responses
+type dummyECS struct {
+    Requests chan *http.Request
+    TaskListJSON string
+}
+
+func newDummyECS() (*dummyECS, error) {
+    return &dummyECS{Requests: make(chan *http.Request, 3)}, nil
+}
+
+func (d *dummyECS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    fmt.Printf("dummyECS received %s on %s", r.Method, r.URL.Path)
+    d.Requests <- r
+    switch r.URL.Path {
+    case "/":
+        w.Write([]byte(`{"AvailableCommands":["/v1/metadata","/v1/tasks","/license"]}`))
+    case "/v1/tasks":
+        w.Write([]byte(d.TaskListJSON))
+    default:
+        w.WriteHeader(http.StatusNotFound)
+    }
+}
+func (d *dummyECS) Start() (*httptest.Server, int, error) {
+    ts := httptest.NewServer(d)
+    ecs_agent_url, err := url.Parse(ts.URL)
+    if err != nil {
+        return nil, 0, err
+    }
+    ecs_agent_port, err := strconv.Atoi(ecs_agent_url.Port())
+    if err != nil {
+        return nil, 0, err
+    }
+    return ts, ecs_agent_port, nil
+}
+func TestLocateECSHTTP(t *testing.T) {
+    assert := assert.New(t)
+    ecsinterface, err := newDummyECS()
+    require.Nil(t, err)
+    ts, ecs_agent_port, err := ecsinterface.Start()
+    defer ts.Close()
+    require.Nil(t, err)
+
+    config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecs_agent_port))
+
+    isInstance := IsInstance()
+    assert.True(isInstance)
+    select {
+    case r := <-ecsinterface.Requests:
+        assert.Equal("GET", r.Method)
+        assert.Equal("/", r.URL.Path)
+    case <-time.After(2 * time.Second):
+        require.FailNow(t, "Timeout on receive channel")
+    }
+    for nb, tc := range []struct {
+        input string
+        expected TasksV1Response
+        err   error
+    }{
+        {
+            input: "",
+            expected: TasksV1Response{},
+            err: errors.New("EOF"),
+        },
+        {
+            input: `{
+            "Tasks": [
+                {
+                  "Arn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+                  "DesiredStatus": "RUNNING",
+                  "KnownStatus": "RUNNING",
+                  "Family": "hello_world",
+                  "Version": "8",
+                  "Containers": [
+                    {
+                      "DockerId": "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+                      "DockerName": "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+                      "Name": "mysql"
+                    },
+                    {
+                      "DockerId": "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+                      "DockerName": "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+                      "Name": "wordpress"
+                    }
+                  ]
+                }
+              ]
+            }`,
+            expected: TasksV1Response{
+                Tasks: []TaskV1{
+                    TaskV1{
+                        Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+                        DesiredStatus: "RUNNING",
+                        KnownStatus:   "RUNNING",
+                        Family:        "hello_world",
+                        Version:       "8",
+                        Containers: []ContainerV1{
+                            ContainerV1{
+                                DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+                                DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+                                Name:       "mysql",
+                            },
+                            ContainerV1{
+                                DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+                                DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+                                Name:       "wordpress",
+                            },
+                        },
+                    },
+                },
+            },
+            err: nil,
+        },
+    } {
+        t.Logf("test case %d", nb)
+        ecsinterface.TaskListJSON = tc.input
+        tasks, err := GetTasks()
+        assert.Equal(tc.expected, tasks)
+        if tc.err == nil {
+            assert.Nil(err)
+        } else {
+            assert.NotNil(err)
+            assert.Equal(tc.err.Error(), err.Error())
+        }
+    }
+    select {
+    case r := <-ecsinterface.Requests:
+        assert.Equal("GET", r.Method)
+        assert.Equal("/v1/tasks", r.URL.Path)
+    case <-time.After(2 * time.Second):
+        assert.FailNow("Timeout on receive channel")
+    }
+}

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -8,84 +8,85 @@
 package ecs
 
 import (
-    "net/http/httptest"
-    "testing"
-    "net/url"
-    "fmt"
-    "errors"
-    "strconv"
-    "net/http"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
 
-    "github.com/stretchr/testify/require"
-    "time"
-    "github.com/DataDog/datadog-agent/pkg/config"
-    "github.com/stretchr/testify/assert"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"time"
 )
+
 // dummyECS allows tests to mock a ECS's responses
 type dummyECS struct {
-    Requests chan *http.Request
-    TaskListJSON string
+	Requests     chan *http.Request
+	TaskListJSON string
 }
 
 func newDummyECS() (*dummyECS, error) {
-    return &dummyECS{Requests: make(chan *http.Request, 3)}, nil
+	return &dummyECS{Requests: make(chan *http.Request, 3)}, nil
 }
 
 func (d *dummyECS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-    fmt.Printf("dummyECS received %s on %s", r.Method, r.URL.Path)
-    d.Requests <- r
-    switch r.URL.Path {
-    case "/":
-        w.Write([]byte(`{"AvailableCommands":["/v1/metadata","/v1/tasks","/license"]}`))
-    case "/v1/tasks":
-        w.Write([]byte(d.TaskListJSON))
-    default:
-        w.WriteHeader(http.StatusNotFound)
-    }
+	fmt.Printf("dummyECS received %s on %s", r.Method, r.URL.Path)
+	d.Requests <- r
+	switch r.URL.Path {
+	case "/":
+		w.Write([]byte(`{"AvailableCommands":["/v1/metadata","/v1/tasks","/license"]}`))
+	case "/v1/tasks":
+		w.Write([]byte(d.TaskListJSON))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
 }
 func (d *dummyECS) Start() (*httptest.Server, int, error) {
-    ts := httptest.NewServer(d)
-    ecs_agent_url, err := url.Parse(ts.URL)
-    if err != nil {
-        return nil, 0, err
-    }
-    ecs_agent_port, err := strconv.Atoi(ecs_agent_url.Port())
-    if err != nil {
-        return nil, 0, err
-    }
-    return ts, ecs_agent_port, nil
+	ts := httptest.NewServer(d)
+	ecs_agent_url, err := url.Parse(ts.URL)
+	if err != nil {
+		return nil, 0, err
+	}
+	ecs_agent_port, err := strconv.Atoi(ecs_agent_url.Port())
+	if err != nil {
+		return nil, 0, err
+	}
+	return ts, ecs_agent_port, nil
 }
 func TestLocateECSHTTP(t *testing.T) {
-    assert := assert.New(t)
-    ecsinterface, err := newDummyECS()
-    require.Nil(t, err)
-    ts, ecs_agent_port, err := ecsinterface.Start()
-    defer ts.Close()
-    require.Nil(t, err)
+	assert := assert.New(t)
+	ecsinterface, err := newDummyECS()
+	require.Nil(t, err)
+	ts, ecs_agent_port, err := ecsinterface.Start()
+	defer ts.Close()
+	require.Nil(t, err)
 
-    config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecs_agent_port))
+	config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecs_agent_port))
 
-    isInstance := IsInstance()
-    assert.True(isInstance)
-    select {
-    case r := <-ecsinterface.Requests:
-        assert.Equal("GET", r.Method)
-        assert.Equal("/", r.URL.Path)
-    case <-time.After(2 * time.Second):
-        require.FailNow(t, "Timeout on receive channel")
-    }
-    for nb, tc := range []struct {
-        input string
-        expected TasksV1Response
-        err   error
-    }{
-        {
-            input: "",
-            expected: TasksV1Response{},
-            err: errors.New("EOF"),
-        },
-        {
-            input: `{
+	isInstance := IsInstance()
+	assert.True(isInstance)
+	select {
+	case r := <-ecsinterface.Requests:
+		assert.Equal("GET", r.Method)
+		assert.Equal("/", r.URL.Path)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "Timeout on receive channel")
+	}
+	for nb, tc := range []struct {
+		input    string
+		expected TasksV1Response
+		err      error
+	}{
+		{
+			input:    "",
+			expected: TasksV1Response{},
+			err:      errors.New("EOF"),
+		},
+		{
+			input: `{
             "Tasks": [
                 {
                   "Arn": "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
@@ -108,48 +109,48 @@ func TestLocateECSHTTP(t *testing.T) {
                 }
               ]
             }`,
-            expected: TasksV1Response{
-                Tasks: []TaskV1{
-                    TaskV1{
-                        Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
-                        DesiredStatus: "RUNNING",
-                        KnownStatus:   "RUNNING",
-                        Family:        "hello_world",
-                        Version:       "8",
-                        Containers: []ContainerV1{
-                            ContainerV1{
-                                DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
-                                DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
-                                Name:       "mysql",
-                            },
-                            ContainerV1{
-                                DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
-                                DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
-                                Name:       "wordpress",
-                            },
-                        },
-                    },
-                },
-            },
-            err: nil,
-        },
-    } {
-        t.Logf("test case %d", nb)
-        ecsinterface.TaskListJSON = tc.input
-        tasks, err := GetTasks()
-        assert.Equal(tc.expected, tasks)
-        if tc.err == nil {
-            assert.Nil(err)
-        } else {
-            assert.NotNil(err)
-            assert.Equal(tc.err.Error(), err.Error())
-        }
-    }
-    select {
-    case r := <-ecsinterface.Requests:
-        assert.Equal("GET", r.Method)
-        assert.Equal("/v1/tasks", r.URL.Path)
-    case <-time.After(2 * time.Second):
-        assert.FailNow("Timeout on receive channel")
-    }
+			expected: TasksV1Response{
+				Tasks: []TaskV1{
+					TaskV1{
+						Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+						DesiredStatus: "RUNNING",
+						KnownStatus:   "RUNNING",
+						Family:        "hello_world",
+						Version:       "8",
+						Containers: []ContainerV1{
+							ContainerV1{
+								DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+								DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+								Name:       "mysql",
+							},
+							ContainerV1{
+								DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+								DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+								Name:       "wordpress",
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	} {
+		t.Logf("test case %d", nb)
+		ecsinterface.TaskListJSON = tc.input
+		tasks, err := GetTasks()
+		assert.Equal(tc.expected, tasks)
+		if tc.err == nil {
+			assert.Nil(err)
+		} else {
+			assert.NotNil(err)
+			assert.Equal(tc.err.Error(), err.Error())
+		}
+	}
+	select {
+	case r := <-ecsinterface.Requests:
+		assert.Equal("GET", r.Method)
+		assert.Equal("/v1/tasks", r.URL.Path)
+	case <-time.After(2 * time.Second):
+		assert.FailNow("Timeout on receive channel")
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Add ECS metadata collection in the tags.

- [x] Refactor detection & task retrieval logic from metadata collector into a shared `util/ecs`
- [x] Create change detection logic to only send new containers on Fetch (keep the existing container ID and expire them, like kubelet?)
- [x] Implement a PullCollector for `pkg/tagger`, that only queries the task list on cache miss (Fetch) and returns empty on Pull
- [x] Add unit tests to this class (see kubelet PR for unit tests with jsons fixtures)



### Motivation

Get all the metadata from ECS with the A6.

### Additional Notes

This should not impact @DataDog/burrito but I'd need thumbs up from all stakeholders.
Pushed for review - Will run tests now

- [x] Tested on ECS 