### PR TITLE
[collector] Increase default number of check runners

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,7 +82,7 @@ func init() {
 	Datadog.SetDefault("cmd_port", 5001)
 	Datadog.SetDefault("default_integration_http_timeout", 9)
 	Datadog.SetDefault("enable_metadata_collection", true)
-	Datadog.SetDefault("check_runners", int64(4))
+	Datadog.SetDefault("check_runners", int64(20))
 	Datadog.SetDefault("expvar_port", "5000")
 	if IsContainerized() {
 		Datadog.SetDefault("container_proc_root", "/host/proc")


### PR DESCRIPTION
### What does this PR do?

Increases default number of check runners to 20.

### Motivation

We need to increase the default number of workers now that we can
expect a lot of agents to run 4 long-running checks (JMX, apm, process,
and logs), otherwise by default no runners would be left for the
"regular" checks.

Increase it to 20, since some testing/benchmarking has shown that 16 runners is a good compromise for most setups + 4 runners aside for the long-running checks.

### Additional Notes

This will be overridden by #559 that makes the number of workers dynamic. But we need a quick stop-gap to fix the issue now.
