### PR TITLE
[tagger] add support for FetchOnlyCollection and rework unit tests

### DIFF
--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -20,9 +20,11 @@ type CollectionMode int
 
 // Return values for Collector.Init to inform the Tagger of the scheduling needed
 const (
-	NoCollection     CollectionMode = iota // Not available
-	PullCollection                         // Call regularly via the Pull methof
-	StreamCollection                       // Will continuously feed updates on the channel from Steam() to Stop()
+	NoCollection        CollectionMode = iota // Not available
+	PullCollection                            // Call regularly via the Pull method
+	StreamCollection                          // Will continuously feed updates on the channel from Steam() to Stop()
+	FetchOnlyCollection                       // Only call Fetch() on cache misses
+
 )
 
 // Collector retrieve entity tags from a given source and feeds

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -84,6 +84,13 @@ func (t *Tagger) Init(catalog collectors.Catalog) error {
 			} else {
 				log.Errorf("error initialising collector %s: does not implement stream", name)
 			}
+		case collectors.FetchOnlyCollection:
+			fetch, ok := collector.(collectors.Fetcher)
+			if ok {
+				t.fetchers[name] = fetch
+			} else {
+				log.Errorf("error initialising collector %s: does not implement fetch", name)
+			}
 		}
 	}
 	t.Unlock()


### PR DESCRIPTION
### What does this PR do?

The ECS tag collector will only be called on cache misses, as there's no way to do partial lookups on the ecs-agent. This does not fit into either the `Steamer` nor `Puller` interfaces. Adding support for directly using the `Fetcher` interface.

Tests were rewriten using `testify/mock` instead of homegrown mocking.
