### PR TITLE
[testing] fix flaky dsd test

### DIFF
--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -13,23 +13,25 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestNewUDPListener(t *testing.T) {
 	s, err := NewUDPListener(nil)
-	defer s.Stop()
-
+	require.NotNil(t, s)
 	assert.Nil(t, err)
-	assert.NotNil(t, s)
+
+	s.Stop()
 }
 
 func TestStartStopUDPListener(t *testing.T) {
 	config.Datadog.Set("dogstatsd_non_local_traffic", false)
 	s, err := NewUDPListener(nil)
+	require.NotNil(t, s)
+
 	assert.Nil(t, err)
-	assert.NotNil(t, s)
 
 	go s.Listen()
 	// Local port should be unavailable
@@ -40,6 +42,8 @@ func TestStartStopUDPListener(t *testing.T) {
 	s.Stop()
 	// Port should be available again
 	conn, err := net.ListenUDP("udp", address)
+	require.NotNil(t, conn)
+
 	assert.Nil(t, err)
 	conn.Close()
 }
@@ -47,6 +51,8 @@ func TestStartStopUDPListener(t *testing.T) {
 func TestUDPNonLocal(t *testing.T) {
 	config.Datadog.Set("dogstatsd_non_local_traffic", true)
 	s, err := NewUDPListener(nil)
+	require.NotNil(t, s)
+
 	go s.Listen()
 	defer s.Stop()
 
@@ -65,6 +71,8 @@ func TestUDPNonLocal(t *testing.T) {
 func TestUDPLocalOnly(t *testing.T) {
 	config.Datadog.Set("dogstatsd_non_local_traffic", false)
 	s, err := NewUDPListener(nil)
+	require.NotNil(t, s)
+
 	go s.Listen()
 	defer s.Stop()
 
@@ -77,6 +85,7 @@ func TestUDPLocalOnly(t *testing.T) {
 	externalPort := fmt.Sprintf("%s:8125", getLocalIP())
 	address, _ = net.ResolveUDPAddr("udp", externalPort)
 	conn, err := net.ListenUDP("udp", address)
+	require.NotNil(t, conn)
 	assert.Nil(t, err)
 	conn.Close()
 }
@@ -86,12 +95,13 @@ func TestUDPReceive(t *testing.T) {
 
 	packetChannel := make(chan *Packet)
 	s, err := NewUDPListener(packetChannel)
+	require.NotNil(t, s)
 	assert.Nil(t, err)
-	assert.NotNil(t, s)
 
 	go s.Listen()
 	defer s.Stop()
 	conn, err := net.Dial("udp", "127.0.0.1:8125")
+	require.NotNil(t, conn)
 	assert.Nil(t, err)
 	defer conn.Close()
 	conn.Write(contents)

--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -144,7 +144,7 @@ func getAvailableUDPPort() (int, error) {
 	}
 	portInt, err := strconv.Atoi(portString)
 	if err != nil {
-		return -1, fmt.Errorf("can't find an available udp port: %s", err)
+		return -1, fmt.Errorf("can't convert udp port: %s", err)
 	}
 
 	return portInt, nil


### PR DESCRIPTION
### What does this PR do?

dogstatsd udp listening goroutines collided on port 8125, causing a flaky test. This is fixed by:
  - using `require` instead of `assert` to check dsd initialised correctly, to avoid null pointer errors
  - randomising used port to make sure goroutines don't race over the port.
