### PR TITLE
[collector] Make sure scheduler is stopped once Stop returns

### DIFF
--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -70,6 +70,7 @@ func NewRunner(numWorkers int) *Runner {
 }
 
 // Stop closes the pending channel so all workers will exit their loop and terminate
+// All publishers to the pending channel need to have stopped before Stop is called
 func (r *Runner) Stop() {
 	if atomic.LoadUint32(&r.running) == 0 {
 		log.Debug("Runner already stopped, nothing to do here...")

--- a/pkg/collector/scheduler/README.md
+++ b/pkg/collector/scheduler/README.md
@@ -9,4 +9,7 @@ and even if this is not a requirement, a use case for multiple schedulers didn't
 A `Scheduler` instance keeps a collection of `time.Ticker`s associated to a list of `check.Check`s: every time the
 ticker fires, all the checks in that list are sent to the execution pipeline. Every queue runs in its own goroutine.
 The `Scheduler` expose an interface based on methods attached to the struct but the implementation makes use of
-channels to synchronize the queues and to talk with the scheduler loop to send commands like `Run`, `Reload`, `Stop`.
+channels to synchronize the queues and to talk with the scheduler loop to send commands like `Run` and `Stop`.
+
+Once a scheduler is stopped, restarting it with `Run` is not expected to work. A new one should be instantiated and
+`Run` instead.

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -18,10 +18,10 @@ import (
 )
 
 const defaultTimeout time.Duration = 5 * time.Second
-const minAllowedInterval time.Duration = 1 * time.Second
 
 var (
-	schedulerStats *expvar.Map
+	minAllowedInterval = 1 * time.Second
+	schedulerStats     *expvar.Map
 )
 
 func init() {
@@ -31,40 +31,39 @@ func init() {
 // Scheduler keeps things rolling.
 // More docs to come...
 type Scheduler struct {
-	checksPipe   chan<- check.Check          // The pipe the Runner pops the checks from, initially set to nil
-	done         chan bool                   // Guard for the main loop
-	halted       chan bool                   // Used to internally communicate all queues are done
-	started      chan bool                   // Used to internally communicate the queues are up
-	jobQueues    map[time.Duration]*jobQueue // We have one scheduling queue for every interval
-	checkToQueue map[check.ID]*jobQueue      // Keep track of what is the queue for any Check
-	mu           sync.Mutex                  // To protect critical sections in struct's fields
-	running      uint32                      // Flag to see if the scheduler is running
+	checksPipe    chan<- check.Check          // The pipe the Runner pops the checks from, initially set to nil
+	done          chan bool                   // Guard for the main loop
+	halted        chan bool                   // Used to internally communicate all queues are done
+	started       chan bool                   // Used to internally communicate the queues are up
+	jobQueues     map[time.Duration]*jobQueue // We have one scheduling queue for every interval
+	checkToQueue  map[check.ID]*jobQueue      // Keep track of what is the queue for any Check
+	mu            sync.Mutex                  // To protect critical sections in struct's fields
+	running       uint32                      // Flag to see if the scheduler is running
+	cancelOneTime chan bool                   // Used to internally communicate a cancel signal to one-time schedule goroutines
+	wgOneTime     sync.WaitGroup              // WaitGroup to track the exit of one-time schedule goroutines
 }
 
 // NewScheduler create a Scheduler and returns a pointer to it.
 func NewScheduler(checksPipe chan<- check.Check) *Scheduler {
 	return &Scheduler{
-		checksPipe:   checksPipe,
-		done:         make(chan bool, 1),
-		halted:       make(chan bool, 1),
-		started:      make(chan bool, 1),
-		jobQueues:    make(map[time.Duration]*jobQueue),
-		checkToQueue: make(map[check.ID]*jobQueue),
-		running:      0,
+		checksPipe:    checksPipe,
+		done:          make(chan bool, 1),
+		halted:        make(chan bool, 1),
+		started:       make(chan bool, 1),
+		jobQueues:     make(map[time.Duration]*jobQueue),
+		checkToQueue:  make(map[check.ID]*jobQueue),
+		running:       0,
+		cancelOneTime: make(chan bool),
+		wgOneTime:     sync.WaitGroup{},
 	}
 }
 
 // Enter schedules a `Check`s for execution accordingly to the `Check.Interval()` value.
 // If the interval is 0, the check is supposed to run only once.
 func (s *Scheduler) Enter(check check.Check) error {
-	// send immediately to the checks Pipe if this is a one-time schedule
-	// do not block, in case the runner has not started
+	// enqueue immediately if this is a one-time schedule
 	if check.Interval() == 0 {
-		log.Infof("Scheduling check %v for one-time execution", check)
-		go func() {
-			s.checksPipe <- check
-		}()
-		schedulerStats.Add("ChecksEntered", 1)
+		s.enqueueOnce(check)
 		return nil
 	}
 
@@ -125,7 +124,9 @@ func (s *Scheduler) Run() {
 	go func() {
 		log.Debug("Starting scheduler loop...")
 
+		s.mu.Lock()
 		s.startQueues()
+		s.mu.Unlock()
 
 		// set internal state
 		atomic.StoreUint32(&s.running, 1)
@@ -138,7 +139,9 @@ func (s *Scheduler) Run() {
 
 		// someone asked to stop
 		log.Debug("Exited Scheduler loop, shutting down queues...")
+		s.mu.Lock()
 		s.stopQueues()
+		s.mu.Unlock()
 		atomic.StoreUint32(&s.running, 0)
 
 		// notify we're done, channel is buffered this doesn't block
@@ -149,8 +152,8 @@ func (s *Scheduler) Run() {
 	<-s.started
 }
 
-// Stop the scheduler, optionally pass an integer to specify
-// the timeout in `time.Duration` format.
+// Stop the scheduler, blocks until the scheduler is fully stopped or the timeout
+// is reached.
 func (s *Scheduler) Stop(timeout ...time.Duration) error {
 	// Stopping when the Scheduler is not running is a noop.
 	if atomic.LoadUint32(&s.running) == 0 {
@@ -166,6 +169,14 @@ func (s *Scheduler) Stop(timeout ...time.Duration) error {
 	// Interrupt the main loop, proceeding to shut down all the queues
 	// `done` is buffered so we can proceed and wait for shutdown (or timeout)
 	s.done <- true
+
+	// Signal an exit to any remaining goroutine still trying to enqueue one-time checks,
+	// and wait for them to exit
+	close(s.cancelOneTime)
+	s.wgOneTime.Wait()
+	s.cancelOneTime = make(chan bool)
+	s.wgOneTime = sync.WaitGroup{}
+
 	log.Debugf("Waiting for the scheduler to shutdown, timeout after %v", to)
 
 	select {
@@ -176,25 +187,16 @@ func (s *Scheduler) Stop(timeout ...time.Duration) error {
 	}
 }
 
-// Reload the scheduler
-func (s *Scheduler) Reload(timeout ...time.Duration) error {
-	log.Debug("Reloading scheduler loop...")
-	if s.Stop(timeout...) == nil {
-		log.Debug("Scheduler stopped, running again...")
-		s.Run()
-		return nil
-	}
-
-	return errors.New("Unable to perform reload")
-}
-
 // stopQueues shuts down the timers for each active queue
 func (s *Scheduler) stopQueues() {
+	log.Debugf("Stopping %v queue(s)", len(s.jobQueues))
 	for _, q := range s.jobQueues {
 		// check that the queue is actually running or this blocks
 		// while posting to the channel
 		if q.running {
 			q.stop <- true
+			<-q.stopped
+			log.Debugf("Stopped queue %v", q.interval)
 			q.running = false
 		}
 	}
@@ -207,10 +209,30 @@ func (s *Scheduler) startQueues() {
 	}
 }
 
-// simple wrapper to have this in just one place
+// startQueue starts a queue if it's not running yet
 func (s *Scheduler) startQueue(q *jobQueue) {
-	q.run(s.checksPipe)
-	q.running = true
+	if !q.running {
+		q.run(s.checksPipe)
+		q.running = true
+	}
+}
+
+// enqueueOnce enqueues a check once to the checksPipe.
+// Do not block, in case the runner has not started yet.
+// The queuing can be cancelled by closing the `cancelOneTime` channel.
+func (s *Scheduler) enqueueOnce(check check.Check) {
+	log.Infof("Scheduling check %v for one-time execution", check)
+	s.wgOneTime.Add(1)
+
+	go func(cancelOneTime <-chan bool) {
+		defer s.wgOneTime.Done()
+		select {
+		case s.checksPipe <- check:
+		case <-s.cancelOneTime:
+		}
+	}(s.cancelOneTime)
+
+	schedulerStats.Add("ChecksEntered", 1)
 }
 
 // expQueues return a function to get the stats for the queues

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -189,7 +189,7 @@ func (s *Scheduler) stopQueues() {
 }
 
 // startQueues loads the timer for each queue
-// Not blocking
+// Should not block, unless there's contention on the internal mutex
 func (s *Scheduler) startQueues() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -199,7 +199,7 @@ func (s *Scheduler) startQueues() {
 	}
 }
 
-// startQueue starts a queue if it's not running yet
+// startQueue starts a queue (non-blocking operation) if it's not running yet
 func (s *Scheduler) startQueue(q *jobQueue) {
 	if !q.running {
 		q.run(s.checksPipe)

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -149,20 +149,6 @@ func TestStopCancelsProducers(t *testing.T) {
 	time.Sleep(time.Millisecond)
 }
 
-func TestStopTimeout(t *testing.T) {
-	s := getScheduler()
-	s.Enter(&TestCheck{intl: 10})
-	s.Run()
-	s.Stop()
-
-	// to trigger the timeout, fake scheduler state to `running`...
-	s.running = uint32(1)
-	// ...now, stopping should trigger the timeout, set it at 1ms
-	err := s.Stop(time.Millisecond)
-
-	assert.NotNil(t, err)
-}
-
 func TestTinyInterval(t *testing.T) {
 	s := getScheduler()
 	err := s.Enter(&TestCheck{intl: 1 * time.Millisecond})

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -25,6 +25,8 @@ func (c *TestCheck) ID() check.ID                                       { return
 func (c *TestCheck) GetWarnings() []error                               { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
 
+var initialMinAllowedInterval = minAllowedInterval
+
 // wait 1s for a predicate function to return true, use polling
 // instead of a giant sleep.
 // predicate f must return true if the desired condition is met
@@ -37,6 +39,10 @@ func consistently(f func() bool) bool {
 	}
 	// condition was not met during the wait period
 	return false
+}
+
+func resetMinAllowedInterval() {
+	minAllowedInterval = initialMinAllowedInterval
 }
 
 func getScheduler() *Scheduler {
@@ -126,6 +132,23 @@ func TestStop(t *testing.T) {
 	assert.Nil(t, s.Stop())
 }
 
+func TestStopCancelsProducers(t *testing.T) {
+	s := getScheduler()
+	minAllowedInterval = time.Millisecond // for the purpose of this test, so that the scheduler actually schedules the checks
+	defer resetMinAllowedInterval()
+
+	s.Enter(&TestCheck{intl: time.Millisecond})
+	s.Run()
+
+	time.Sleep(2 * time.Millisecond) // wait for the scheduler to actually schedule the check
+
+	s.Stop()
+	// once the scheduler is stopped, it should be safe to close this channel. Otherwise, this should panic
+	close(s.checksPipe)
+	// sleep to make the runtime schedule the hanging producer goroutines, if there are any left
+	time.Sleep(time.Millisecond)
+}
+
 func TestStopTimeout(t *testing.T) {
 	s := getScheduler()
 	s.Enter(&TestCheck{intl: 10})
@@ -140,24 +163,28 @@ func TestStopTimeout(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestReload(t *testing.T) {
-	s := getScheduler()
-	s.Enter(&TestCheck{intl: 10 * time.Second})
-	s.Run()
-
-	// add a queue to check the reload picks it up
-	s.Enter(&TestCheck{intl: 1 * time.Second})
-
-	err := s.Reload()
-	assert.Nil(t, err)
-
-	// check the scheduler is up again with the new queue running
-	assert.Equal(t, uint32(1), s.running)
-	assert.True(t, s.jobQueues[1*time.Second].running)
-}
-
 func TestTinyInterval(t *testing.T) {
 	s := getScheduler()
 	err := s.Enter(&TestCheck{intl: 1 * time.Millisecond})
 	assert.NotNil(t, err)
+}
+
+// Test that stopping the scheduler while one-time checks are still being enqueued works
+func TestStopOneTimeSchedule(t *testing.T) {
+	c := &TestCheck{}
+	s := getScheduler()
+
+	// schedule a one-time check
+	c.intl = 0
+	err := s.Enter(c)
+	assert.Nil(t, err)
+	s.Enter(c)
+
+	s.Run()
+
+	s.Stop()
+	// this will panic if we didn't properly cancel all the one-time scheduling goroutines
+	close(s.checksPipe)
+	// sleep to make the runtime schedule the hanging goroutines, if there are any
+	time.Sleep(time.Millisecond)
 }


### PR DESCRIPTION
### What does this PR do?

Makes sure the scheduler is fully stopped once `Scheduler.Stop` returns. This fixes panics that could occur when the collector was stopped (generally during agent shutdown).

### Motivation

The scheduler submits checks to run to the check runner by sending to an unbuffered channel:
`Scheduler.checksPipe` (same channel as`Runner.pending` for the check runner).

When the check runner stops, it closes this channel, so at that point we have to make sure that all producers to the channel have stopped sending to the channel, otherwise we get a `panic: send on closed channel`.

The scheduler (and the collector as a whole) has 2 kinds of producers to this channel:
* one-time check schedulers (for long-running checks)
* the `jobQueue`s (for regular checks)

Unfortunately the scheduler was not stopping properly before. When calling `Scheduler.Stop`:
* the one-time check schedulers, if they hadn't scheduled their check yet, would still try to send to the channel
* the scheduler would send `stop` messages to the `jobQueues`, but it would never actually check that these producers exited correctly/in time, and those that were already blocked on the send to the channel would never listen to the `stop` message

This fixes both issues:
* one-time check schedulers, in the unlikely event they're still trying to enqueue their check when `Stop` is called, now stop trying
* the `jobQueue`s now exit correctly when stop is called, even if they're trying to enqueue checks to the channel

### Additional Notes

Added a couple of tests that cause panics without this fix.

I've removed `Scheduler.Reload` since I don't think it works right now and it's not used anywhere. There are a few things happening in `Scheduler.Stop` that are not reversible (the main thing is that once `jobQueues` are stopped, they can't currently be started up again). If we want `Reload` to work in the future we can spend some time and re-implement it.
