### PR TITLE
make tagger.Tag error if entity ID is empty

### DIFF
--- a/pkg/collector/autodiscovery/configresolver_test.go
+++ b/pkg/collector/autodiscovery/configresolver_test.go
@@ -36,6 +36,7 @@ func TestResolveTemplate(t *testing.T) {
 	assert.Len(t, res, 0)
 
 	service := listeners.DockerService{
+		ID:            "a5901276aed16ae9ea11660a41fecd674da47e8f5d8d5bce0080a611feed2be9",
 		ADIdentifiers: []string{"redis"},
 	}
 	cr.processNewService(&service)
@@ -66,6 +67,7 @@ func TestParseTemplateVar(t *testing.T) {
 func TestResolve(t *testing.T) {
 	cr := newConfigResolver(nil, nil, NewTemplateCache())
 	service := listeners.DockerService{
+		ID:            "a5901276aed16ae9ea11660a41fecd674da47e8f5d8d5bce0080a611feed2be9",
 		ADIdentifiers: []string{"redis"},
 		Pid:           1337,
 	}

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -6,6 +6,7 @@
 package tagger
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -147,6 +148,9 @@ func (t *Tagger) Stop() error {
 // Tag returns tags for a given entity. If highCard is false, high
 // cardinality tags are left out.
 func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
+	if entity == "" {
+		return nil, errors.New("empty entity ID")
+	}
 	cachedTags, sources, err := t.tagStore.lookup(entity, highCard)
 	if err != nil {
 		return nil, err

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -185,3 +185,22 @@ func TestFetchOneCached(t *testing.T) {
 	puller.AssertCalled(t, "Fetch", "entity_name")
 	fetcher.AssertCalled(t, "Fetch", "entity_name")
 }
+
+func TestEmptyEntity(t *testing.T) {
+	catalog := collectors.Catalog{
+		"fetcher": NewDummyFetcher,
+	}
+	tagger, _ := newTagger()
+	tagger.Init(catalog)
+
+	tagger.tagStore.processTagInfo(&collectors.TagInfo{
+		Entity:      "entity_name",
+		Source:      "stream",
+		LowCardTags: []string{"low1"},
+	})
+
+	tags, err := tagger.Tag("", true)
+	assert.Nil(t, tags)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "empty entity ID")
+}


### PR DESCRIPTION
As a follow-up to https://github.com/DataDog/datadog-agent/pull/726#discussion_r146245017 , make tagger exit if the entity ID is empty, instead of going through the lookup logic
