### PR TITLE
fix windows issue in docker event test

### DIFF
--- a/pkg/util/docker/events_test.go
+++ b/pkg/util/docker/events_test.go
@@ -20,7 +20,7 @@ func TestProcessContainerEvent(t *testing.T) {
 	assert := assert.New(t)
 
 	// Dummy timestamp for events
-	timestamp := time.Now()
+	timestamp := time.Now().Truncate(10 * time.Millisecond)
 
 	// Container filter
 	filter, err := newContainerFilter([]string{},


### PR DESCRIPTION
error was:
- Timestamr: (time.Time) 2017-10-23 19:47:04.4247859 +0000 GMT m=+0.040001000,
+ Timestamp: (time.Time) 2017-10-23 19:47:04.4247859 +0000 GMT,