### PR TITLE
Disable GUI by default

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -36,8 +36,8 @@ api_key:
 # expvar_port: 5000
 
 # The port for the browser GUI to be served
-# Setting 'GUI_port: -1' turns off the GUI completely 
-# GUI_port: 8080
+# Setting 'GUI_port: -1' turns off the GUI completely
+# GUI_port: -1
 
 # The path to the Unix Socket where the IPC api listens on *nix
 # cmd_sock: /tmp/agent.sock

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,7 +130,7 @@ func init() {
 	// Go_expvar server port
 	Datadog.SetDefault("expvar_port", "5000")
 	// Agent GUI access port
-	Datadog.SetDefault("GUI_port", "8080")
+	Datadog.SetDefault("GUI_port", "-1")
 	// Proess Agent
 	Datadog.SetDefault("process_agent_enabled", true) // this is to support the transition to the new config file
 


### PR DESCRIPTION
### What does this PR do?

See PR title

### Motivation

GUI should be enabled by default only on Win, for now let's change the default behaviour for any platform.