### PR TITLE
[agent] Clean up redundant `signal.Notify`

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -82,7 +82,6 @@ func start(cmd *cobra.Command, args []string) error {
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGINT)
 
 	// Make a channel to exit the function
 	stopCh := make(chan error)


### PR DESCRIPTION
### What does this PR do?

Cleans up a redundant `signal.Notify` line (no functional change)

### Motivation

`os.Interrupt` is an alias for `syscall.SIGINT`, and we already set up
`os.Interrupt` above, so this line is useless (and a bit confusing). (see https://golang.org/pkg/os/#Signal)
