### PR TITLE
[docker] port capped_metrics option

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -125,7 +125,7 @@ func (d *DockerCheck) countAndWeightImages(sender aggregator.Sender) error {
 
 // Run executes the check
 func (d *DockerCheck) Run() error {
-	sender, err := d.updateCappedSender()
+	sender, err := d.GetSender()
 
 	containers, err := docker.AllContainers(&docker.ContainerListConfig{IncludeExited: true, FlagExcluded: true})
 	if err != nil {

--- a/pkg/collector/corechecks/containers/docker_rate_capping.go
+++ b/pkg/collector/corechecks/containers/docker_rate_capping.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+// cappedSender wraps around the standard Sender and overrides
+// the Rate method to implement rate capping
+type cappedSender struct {
+	aggregator.Sender
+	previousRateValues map[string]float64
+	rateCaps           map[string]float64
+}
+
+// Rate checks the rate value against the `capped_metrics` configuration
+// to filter out buggy spikes coming for cgroup cpu accounting
+func (s *cappedSender) Rate(metric string, value float64, hostname string, tags []string) {
+	capValue, found := s.rateCaps[metric]
+	if !found { // Metric not capped
+		s.Sender.Rate(metric, value, hostname, tags)
+		return
+	}
+	previousValue, found := s.previousRateValues[metric]
+	if !found { // First submit of the rate
+		s.previousRateValues[metric] = value
+		s.Sender.Rate(metric, value, hostname, tags)
+		return
+	}
+	delta := value - previousValue
+	if delta < capValue { // Under cap
+		s.previousRateValues[metric] = value
+		s.Sender.Rate(metric, value, hostname, tags)
+		return
+	}
+	// Over cap
+	log.Debugf("Dropped latest value %.0f (raw sample: %.0f) of metric %s as it was above the cap for this metric.", delta, value, metric)
+	s.previousRateValues[metric] = value
+
+	return
+}
+
+func (d *DockerCheck) updateCappedSender() (aggregator.Sender, error) {
+	sender, err := aggregator.GetSender(d.ID())
+	if err != nil {
+		return sender, err
+	}
+
+	if d.cappedSender == nil {
+		d.cappedSender = &cappedSender{
+			Sender:             sender,
+			previousRateValues: make(map[string]float64),
+			rateCaps:           d.instance.CappedMetrics,
+		}
+	} else {
+		// always refresh the base sender reference (not guaranteed to be constant)
+		d.cappedSender.Sender = sender
+	}
+
+	return d.cappedSender, nil
+}

--- a/pkg/collector/corechecks/containers/docker_rate_capping.go
+++ b/pkg/collector/corechecks/containers/docker_rate_capping.go
@@ -8,6 +8,8 @@
 package containers
 
 import (
+	"time"
+
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -18,49 +20,68 @@ import (
 type cappedSender struct {
 	aggregator.Sender
 	previousRateValues map[string]float64
+	previousTimes      map[string]time.Time
 	rateCaps           map[string]float64
+	timestamp          time.Time // Current time at check Run()
 }
 
 // Rate checks the rate value against the `capped_metrics` configuration
 // to filter out buggy spikes coming for cgroup cpu accounting
 func (s *cappedSender) Rate(metric string, value float64, hostname string, tags []string) {
 	capValue, found := s.rateCaps[metric]
-	if !found { // Metric not capped
+	if !found { // Metric not capped, skip capping system
 		s.Sender.Rate(metric, value, hostname, tags)
 		return
 	}
 	previousValue, found := s.previousRateValues[metric]
 	if !found { // First submit of the rate
-		s.previousRateValues[metric] = value
-		s.Sender.Rate(metric, value, hostname, tags)
+		s.doRate(metric, value, hostname, tags)
 		return
 	}
-	delta := value - previousValue
-	if delta < capValue { // Under cap
-		s.previousRateValues[metric] = value
-		s.Sender.Rate(metric, value, hostname, tags)
+	timeDelta := s.timestamp.Sub(s.previousTimes[metric]).Seconds()
+	if timeDelta == 0 {
+		s.doRate(metric, value, hostname, tags)
 		return
 	}
-	// Over cap
-	log.Debugf("Dropped latest value %.0f (raw sample: %.0f) of metric %s as it was above the cap for this metric.", delta, value, metric)
+	rate := (value - previousValue) / timeDelta
+	if rate < capValue { // Under cap
+		s.doRate(metric, value, hostname, tags)
+		return
+	}
+	// Over cap, skipping
+	log.Debugf("Dropped latest value %.0f (raw sample: %.0f) of metric %s as it was above the cap for this metric.", rate, value, metric)
 	s.previousRateValues[metric] = value
+	s.previousTimes[metric] = s.timestamp
 
 	return
 }
 
-func (d *DockerCheck) updateCappedSender() (aggregator.Sender, error) {
+func (s *cappedSender) doRate(metric string, value float64, hostname string, tags []string) {
+	s.previousRateValues[metric] = value
+	s.previousTimes[metric] = s.timestamp
+	s.Sender.Rate(metric, value, hostname, tags)
+}
+
+func (d *DockerCheck) GetSender() (aggregator.Sender, error) {
 	sender, err := aggregator.GetSender(d.ID())
 	if err != nil {
 		return sender, err
+	}
+	if len(d.instance.CappedMetrics) == 0 {
+		// No cap set, using a bare sender
+		return sender, nil
 	}
 
 	if d.cappedSender == nil {
 		d.cappedSender = &cappedSender{
 			Sender:             sender,
 			previousRateValues: make(map[string]float64),
+			previousTimes:      make(map[string]time.Time),
 			rateCaps:           d.instance.CappedMetrics,
+			timestamp:          time.Now(),
 		}
 	} else {
+		d.cappedSender.timestamp = time.Now()
 		// always refresh the base sender reference (not guaranteed to be constant)
 		d.cappedSender.Sender = sender
 	}

--- a/pkg/collector/corechecks/containers/docker_rate_capping_test.go
+++ b/pkg/collector/corechecks/containers/docker_rate_capping_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 )
 
 type dockerRateCappingSuite struct {
 	suite.Suite
-	mockSender   *aggregator.MockSender
+	mockSender   *mocksender.MockSender
 	cappedSender *cappedSender
 }
 
@@ -31,7 +31,7 @@ func (s *dockerRateCappingSuite) tick() {
 
 // Put configuration back in a known state before each test
 func (s *dockerRateCappingSuite) SetupTest() {
-	s.mockSender = aggregator.NewMockSender("rateTest")
+	s.mockSender = mocksender.NewMockSender("rateTest")
 	s.mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 	s.cappedSender = &cappedSender{

--- a/pkg/collector/corechecks/containers/docker_rate_capping_test.go
+++ b/pkg/collector/corechecks/containers/docker_rate_capping_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+func TestCappedSender(t *testing.T) {
+	mockSender := aggregator.NewMockSender("rateTest")
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	cappedSender := &cappedSender{
+		Sender:             mockSender,
+		previousRateValues: make(map[string]float64),
+		rateCaps: map[string]float64{
+			"capped.at.100": 100,
+		},
+	}
+
+	// Unfiltered metric
+	cappedSender.Rate("non.capped", 200, "", nil)
+	cappedSender.Rate("non.capped", 2000, "", nil)
+	cappedSender.Rate("non.capped", 20000, "", nil)
+	mockSender.AssertNumberOfCalls(t, "Rate", 3)
+
+	// Filtered rate under the cap is transmitted
+	mockSender.ResetCalls()
+	cappedSender.Rate("capped.at.100", 200, "", nil)
+	cappedSender.Rate("capped.at.100", 250, "", nil)
+	mockSender.AssertNumberOfCalls(t, "Rate", 2)
+
+	// Updates over the rate are ignored
+	mockSender.ResetCalls()
+	cappedSender.Rate("capped.at.100", 1000, "", nil)
+	cappedSender.Rate("capped.at.100", 2000, "", nil)
+	mockSender.AssertNumberOfCalls(t, "Rate", 0)
+
+	// Back under the cap, should be transmitted
+	mockSender.ResetCalls()
+	cappedSender.Rate("capped.at.100", 2050, "", nil)
+	mockSender.AssertNumberOfCalls(t, "Rate", 1)
+}

--- a/pkg/collector/dist/conf.d/docker.yaml.example
+++ b/pkg/collector/dist/conf.d/docker.yaml.example
@@ -58,6 +58,12 @@ instances:
     #
     # collect_exit_codes: true
 
+    # Allows ad-hoc spike filtering if the system reports incorrect metrics.
+    # This will drop points if the computed rate is higher than the cap value
+    # capped_metrics:
+    #   docker.cpu.user: 1000
+    #   docker.cpu.system: 1000
+
     ## Tagging
     ##
 

--- a/pkg/legacy/docker_test.go
+++ b/pkg/legacy/docker_test.go
@@ -67,6 +67,9 @@ filtered_event_types:
 - top
 - exec_start
 - exec_create
+capped_metrics:
+  docker.cpu.system: 1000
+  docker.cpu.user: 1000
 `
 )
 


### PR DESCRIPTION
### What does this PR do?

- wrap aggregator.Sender in a custom cappedSender
- implement configurable rate limiting on metrics
- update dist and tests

### Motivation

See https://github.com/DataDog/integrations-core/pull/412 for original implementation reasons

### Testing

Unit test coverage for the capping logic, plus local testing with two cpuburn containers running at 1 core and 2 cores. Cap was 150, 250 then 150. We see metrics reporting for the 2 core containers only in the middle

![](https://cl.ly/3o36390o1p3Y/Image%202017-10-25%20at%202.21.53%20PM.png)