### PR TITLE
Charly/ecs enhanced metadatacollector

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -371,6 +371,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "88fbb6eaf256010ccf07d121d7762c748ba461196596b0fd7c102fd35c406160"
+  inputs-digest = "9190d3ef893267b22070182c970797c4c9cf014fc53312ed7d2defffaad4f8f5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -28,7 +28,7 @@ updates to the store though, by keeping an internal state of the latest
 revision.
 
 #### FetchOnly
-The **ECSCollector** will not push the updates to the Store. It is not meant to run in standalone. DockerCollector will trigger deletions in the store.
+The **ECSCollector** does not push updates to the Store by itself, but is only triggered on cache misses. As tasks don't change after creation, there's no need for periodic pulling. It is designed to run alongside DockerCollector, that will trigger deletions in the store.
 
 ### TagStore
 The **TagStore** reads **TagInfo** structs and stores them in a in-memory

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -16,17 +16,19 @@ in their process. Switch between local and client mode will be done via a build 
 ### Collector
 A **Collector** connects to a single information source and pushes **TagInfo**
 structs to a channel, towards the **Tagger**. It can either run in streaming
-mode or pull mode, depending of what's most efficient for the data source:
+mode, pull or fetchonly mode, depending of what's most efficient for the data source:
 
 #### Streamer
 The **DockerCollector** runs in stream mode as it collects events from the docker
 daemon and reacts to them, sending updates incrementally.
 
 #### Puller
-The **KubernetesCollector** and **ECSCollector** will run in pull mode as they
-need to query and filter a full entity list every time. They will only push
+The **KubernetesCollector** will run in pull mode as it needs to query and filter a full entity list every time. It will only push
 updates to the store though, by keeping an internal state of the latest
 revision.
+
+#### FetchOnly
+The **ECSCollector** will not push the updates to the Store. It is not meant to run in standalone. DockerCollector will trigger deletions in the store.
 
 ### TagStore
 The **TagStore** reads **TagInfo** structs and stores them in a in-memory

--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -8,21 +8,23 @@
 package collectors
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
-	"time"
 )
 
 func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInfo, error) {
 	var output []*TagInfo
 	now := time.Now()
 	for _, task := range tasks_list.Tasks {
-		// We only want to collect tasks without a STOPPED status
+		// We only want to collect tasks without a STOPPED status.
 		if task.KnownStatus == "STOPPED" {
 			continue
 		}
 		for _, container := range task.Containers {
+			// We only want to collect the tags from new containers.
 			if c.expire.Update(container.DockerID, now) {
 				tags := utils.NewTagList()
 				tags.AddLow("task_version", task.Version)

--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -10,8 +10,8 @@ package collectors
 import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	"time"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"time"
 )
 
 func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInfo, error) {
@@ -19,21 +19,21 @@ func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInf
 	now := time.Now()
 	for _, task := range tasks_list.Tasks {
 		for _, container := range task.Containers {
-            if c.expire.Update(container.DockerID, now) {
-                tags := utils.NewTagList()
-                tags.AddLow("task_version", task.Version)
-                tags.AddLow("task_name", task.Family)
+			if c.expire.Update(container.DockerID, now) {
+				tags := utils.NewTagList()
+				tags.AddLow("task_version", task.Version)
+				tags.AddLow("task_name", task.Family)
 
-                low, high := tags.Compute()
+				low, high := tags.Compute()
 
-                info := &TagInfo{
-                    Source:       ecsCollectorName,
-                    Entity:       docker.ContainerIDToEntityName(container.DockerID),
-                    HighCardTags: high,
-                    LowCardTags:  low,
-                }
-                output = append(output, info)
-            }
+				info := &TagInfo{
+					Source:       ecsCollectorName,
+					Entity:       docker.ContainerIDToEntityName(container.DockerID),
+					HighCardTags: high,
+					LowCardTags:  low,
+				}
+				output = append(output, info)
+			}
 		}
 	}
 	return output, nil

--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -19,7 +19,7 @@ func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInf
 	now := time.Now()
 	for _, task := range tasks_list.Tasks {
 		// We only want to collect tasks without a STOPPED status
-		if task.KnownStatus == "STOPPED"{
+		if task.KnownStatus == "STOPPED" {
 			continue
 		}
 		for _, container := range task.Containers {

--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -18,6 +18,10 @@ func (c *ECSCollector) parseTasks(tasks_list ecsutil.TasksV1Response) ([]*TagInf
 	var output []*TagInfo
 	now := time.Now()
 	for _, task := range tasks_list.Tasks {
+		// We only want to collect tasks without a STOPPED status
+		if task.KnownStatus == "STOPPED"{
+			continue
+		}
 		for _, container := range task.Containers {
 			if c.expire.Update(container.DockerID, now) {
 				tags := utils.NewTagList()

--- a/pkg/tagger/collectors/ecs_extract_test.go
+++ b/pkg/tagger/collectors/ecs_extract_test.go
@@ -9,7 +9,9 @@ package collectors
 
 import (
 	"testing"
+	"time"
 
+	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +19,11 @@ import (
 
 func TestECSMetadata(t *testing.T) {
 	assert := assert.New(t)
-	ecsCollector := &ECSCollector{}
+	ecsExpireFreq := 5 * time.Minute
+	expiretest, _ := taggerutil.NewExpire(ecsExpireFreq)
+	ecsCollector := &ECSCollector{
+		expire: expiretest,
+	}
 
 	for nb, tc := range []struct {
 		input    ecsutil.TasksV1Response

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -54,7 +54,6 @@ func (c *ECSCollector) Fetch(container string) ([]string, []string, error) {
 		return []string{}, []string{}, err
 	}
 	c.infoOut <- updates
-
 	if time.Now().Sub(c.lastExpire) >= c.expireFreq {
 		go c.expire.ExpireContainers()
 		c.lastExpire = time.Now()

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -9,9 +9,10 @@ package collectors
 
 import (
 	"fmt"
+	"time"
+
 	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
-	"time"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 )
 
 // ECSCollector listen to the ECS agent to get ECS metadata.
-// And feed a stream of TagInfo.
+// Relies on the DockerCollector to trigger deletions, it's not intended to run standalone
 type ECSCollector struct {
 	infoOut    chan<- []*TagInfo
 	expire     *taggerutil.Expire
@@ -28,13 +29,19 @@ type ECSCollector struct {
 	expireFreq time.Duration
 }
 
-// Detect tries to connect to the ecs agent
+// Detect tries to connect to the ECS agent
 func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
+	var err error
 	if ecsutil.IsInstance() {
 		c.infoOut = out
 		c.lastExpire = time.Now()
 		c.expireFreq = ecsExpireFreq
-		c.expire, _ = taggerutil.NewExpire(ecsExpireFreq)
+
+		c.expire, err = taggerutil.NewExpire(ecsExpireFreq)
+
+		if err != nil {
+			return FetchOnlyCollection, fmt.Errorf("Failed to instanciate the container expiring process")
+		}
 		return FetchOnlyCollection, nil
 	} else {
 		return NoCollection, fmt.Errorf("Failed to connect to ecs, ECS tagging will not work")
@@ -54,8 +61,12 @@ func (c *ECSCollector) Fetch(container string) ([]string, []string, error) {
 		return []string{}, []string{}, err
 	}
 	c.infoOut <- updates
+
+	// Only run the expire process with the most up to date tasks parsed.
+	// Using a go routine as the expire process can be done asynchronously.
+	// We do not use the output as the ECSCollector is not meant run in standalone.
 	if time.Now().Sub(c.lastExpire) >= c.expireFreq {
-		go c.expire.ExpireContainers()
+		go c.expire.ComputeExpires()
 		c.lastExpire = time.Now()
 	}
 

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -9,24 +9,24 @@ package collectors
 
 import (
 	"fmt"
-	"time"
-	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
+	"time"
 )
 
 const (
 	ecsCollectorName = "ecs"
-    ecsExpireFreq    = 5 * time.Minute
+	ecsExpireFreq    = 5 * time.Minute
 )
 
 // ECSCollector listen to the ECS agent to get ECS metadata.
 // And feed a stream of TagInfo.
 
 type ECSCollector struct {
-	infoOut chan<- []*TagInfo
-	expire 			*taggerutil.Expire
-	lastExpire		time.Time
-	expireFreq		time.Duration
+	infoOut    chan<- []*TagInfo
+	expire     *taggerutil.Expire
+	lastExpire time.Time
+	expireFreq time.Duration
 }
 
 // Detect tries to connect to the ecs agent

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -44,7 +44,7 @@ func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 		}
 		return FetchOnlyCollection, nil
 	} else {
-		return NoCollection, fmt.Errorf("Failed to connect to ecs, ECS tagging will not work")
+		return NoCollection, fmt.Errorf("Failed to connect to ECS, ECS tagging will not work")
 	}
 
 }

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -21,7 +21,6 @@ const (
 
 // ECSCollector listen to the ECS agent to get ECS metadata.
 // And feed a stream of TagInfo.
-
 type ECSCollector struct {
 	infoOut    chan<- []*TagInfo
 	expire     *taggerutil.Expire

--- a/pkg/tagger/utils/expiry.go
+++ b/pkg/tagger/utils/expiry.go
@@ -6,34 +6,34 @@
 package utils
 
 import (
-
-    "time"
-    "sync"
-    "errors"
+	"errors"
+	"sync"
+	"time"
 )
 
 type Expire struct {
-    sync.Mutex
-    expiryDuration   time.Duration
-    lastSeen         map[string]time.Time
+	sync.Mutex
+	expiryDuration time.Duration
+	lastSeen       map[string]time.Time
 }
-func NewExpire(expiryDuration time.Duration) (*Expire, error){
-    if expiryDuration <= 0 {
-        return nil, errors.New("expiryDuration must be above 0")
-    }
-    return &Expire{
-        expiryDuration: expiryDuration,
-        lastSeen: make(map[string]time.Time),
-    }, nil
+
+func NewExpire(expiryDuration time.Duration) (*Expire, error) {
+	if expiryDuration <= 0 {
+		return nil, errors.New("expiryDuration must be above 0")
+	}
+	return &Expire{
+		expiryDuration: expiryDuration,
+		lastSeen:       make(map[string]time.Time),
+	}, nil
 }
 
 func (e *Expire) Update(container string, ts time.Time) bool {
 
-    e.Lock()
-    _, found := e.lastSeen[container]
-    e.lastSeen[container] = ts
-    e.Unlock()
-    return !found
+	e.Lock()
+	_, found := e.lastSeen[container]
+	e.lastSeen[container] = ts
+	e.Unlock()
+	return !found
 }
 
 // ExpireContainers returns a list of container id for containers
@@ -41,15 +41,15 @@ func (e *Expire) Update(container string, ts time.Time) bool {
 // immediately after a PullChanges or a Fetch.
 
 func (e *Expire) ExpireContainers() ([]string, error) {
-    now := time.Now()
-    var expiredContainers []string
-    e.Lock()
-    for id, seen := range e.lastSeen {
-        if now.Sub(seen) > e.expiryDuration {
-            expiredContainers = append(expiredContainers, id)
-            delete(e.lastSeen, id)
-        }
-    }
-    e.Unlock()
-    return expiredContainers, nil
+	now := time.Now()
+	var expiredContainers []string
+	e.Lock()
+	for id, seen := range e.lastSeen {
+		if now.Sub(seen) > e.expiryDuration {
+			expiredContainers = append(expiredContainers, id)
+			delete(e.lastSeen, id)
+		}
+	}
+	e.Unlock()
+	return expiredContainers, nil
 }

--- a/pkg/tagger/utils/expiry.go
+++ b/pkg/tagger/utils/expiry.go
@@ -31,6 +31,7 @@ func NewExpire(expiryDuration time.Duration) (*Expire, error) {
 		lastSeen:       make(map[string]time.Time),
 	}, nil
 }
+
 // Update will update the map of the Expire obect with the elements and the time they reported.
 // Will return True if the element passed (container) is not found in the current lastseen map.
 func (e *Expire) Update(container string, ts time.Time) bool {

--- a/pkg/tagger/utils/expiry.go
+++ b/pkg/tagger/utils/expiry.go
@@ -35,9 +35,14 @@ func (e *Expire) Update(container string, ts time.Time) bool {
     e.Unlock()
     return !found
 }
-func (e *Expire) ExpireContainers() []string {
-    var expiredContainers []string
+
+// ExpireContainers returns a list of container id for containers
+// that are not listed in the podlist/tasklist anymore. It must be called
+// immediately after a PullChanges or a Fetch.
+
+func (e *Expire) ExpireContainers() ([]string, error) {
     now := time.Now()
+    var expiredContainers []string
     e.Lock()
     for id, seen := range e.lastSeen {
         if now.Sub(seen) > e.expiryDuration {
@@ -46,5 +51,5 @@ func (e *Expire) ExpireContainers() []string {
         }
     }
     e.Unlock()
-    return expiredContainers
+    return expiredContainers, nil
 }

--- a/pkg/tagger/utils/expiry.go
+++ b/pkg/tagger/utils/expiry.go
@@ -42,7 +42,7 @@ func (e *Expire) Update(container string, ts time.Time) bool {
 	return !found
 }
 
-// Make sure you recently called Updates before computing.
+// ComputeExpires should be called right after an Update.
 func (e *Expire) ComputeExpires() ([]string, error) {
 	now := time.Now()
 	var expiredContainers []string

--- a/pkg/tagger/utils/expiry.go
+++ b/pkg/tagger/utils/expiry.go
@@ -11,12 +11,17 @@ import (
 	"time"
 )
 
+// Expire regularly pools the source keeping the elements reporting.
+// Currently only used for ECSCollector and active containers.
+// It keeps an internal state to only send the updated elements (only used for containers to start with).
 type Expire struct {
 	sync.Mutex
 	expiryDuration time.Duration
 	lastSeen       map[string]time.Time
 }
 
+// NewExpire creates a new Expire object. Called when a Collector is started.
+// Only used for the ECS collector to start with.
 func NewExpire(expiryDuration time.Duration) (*Expire, error) {
 	if expiryDuration <= 0 {
 		return nil, errors.New("expiryDuration must be above 0")
@@ -26,7 +31,8 @@ func NewExpire(expiryDuration time.Duration) (*Expire, error) {
 		lastSeen:       make(map[string]time.Time),
 	}, nil
 }
-
+// Update will update the map of the Expire obect with the elements and the time they reported.
+// Will return True if the element passed (container) is not found in the current lastseen map.
 func (e *Expire) Update(container string, ts time.Time) bool {
 
 	e.Lock()
@@ -39,7 +45,6 @@ func (e *Expire) Update(container string, ts time.Time) bool {
 // ExpireContainers returns a list of container id for containers
 // that are not listed in the podlist/tasklist anymore. It must be called
 // immediately after a PullChanges or a Fetch.
-
 func (e *Expire) ExpireContainers() ([]string, error) {
 	now := time.Now()
 	var expiredContainers []string

--- a/pkg/tagger/utils/expiry.go
+++ b/pkg/tagger/utils/expiry.go
@@ -42,9 +42,7 @@ func (e *Expire) Update(container string, ts time.Time) bool {
 	return !found
 }
 
-// ComputeExpires returns a list of container id for containers
-// that are not listed in the podlist/tasklist anymore. It must be called
-// immediately after a PullChanges or a Fetch.
+// Make sure you recently called Updates before computing.
 func (e *Expire) ComputeExpires() ([]string, error) {
 	now := time.Now()
 	var expiredContainers []string

--- a/pkg/tagger/utils/expiry_test.go
+++ b/pkg/tagger/utils/expiry_test.go
@@ -22,6 +22,9 @@ func TestUpdate(t *testing.T) {
 	now := time.Now()
 	twoMinutesAgo := now.Add(-2 * time.Minute)
 
+	// Checking we initialyze the map with nothing.
+	require.Len(t, expire.lastSeen, 0)
+
 	// Inserting container, we expect True as it's not in the lastseen map.
 	found := expire.Update(testContainerID, twoMinutesAgo)
 	require.True(t, found)

--- a/pkg/tagger/utils/expiry_test.go
+++ b/pkg/tagger/utils/expiry_test.go
@@ -6,71 +6,67 @@
 package utils
 
 import (
-
-    "time"
-    "testing"
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
 )
 
-
 func TestUpdate(t *testing.T) {
-    expire := &Expire{
-        expiryDuration: 5 * time.Minute,
-        lastSeen: make(map[string]time.Time),
-    }
-    testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+	expire := &Expire{
+		expiryDuration: 5 * time.Minute,
+		lastSeen:       make(map[string]time.Time),
+	}
+	testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
 
-    now := time.Now()
-    twoMinutesAgo := now.Add(-2 * time.Minute)
+	now := time.Now()
+	twoMinutesAgo := now.Add(-2 * time.Minute)
 
-    // Inserting container
-    found := expire.Update(testContainerID, twoMinutesAgo)
-    require.True(t, found)
-    require.Len(t, expire.lastSeen, 1)
-    require.Equal(t, expire.lastSeen[testContainerID], twoMinutesAgo)
+	// Inserting container
+	found := expire.Update(testContainerID, twoMinutesAgo)
+	require.True(t, found)
+	require.Len(t, expire.lastSeen, 1)
+	require.Equal(t, expire.lastSeen[testContainerID], twoMinutesAgo)
 
-    // Updating container
-    found = expire.Update(testContainerID, now)
-    require.False(t, found)
-    require.Len(t, expire.lastSeen, 1)
-    require.Equal(t, expire.lastSeen[testContainerID], now)
-
+	// Updating container
+	found = expire.Update(testContainerID, now)
+	require.False(t, found)
+	require.Len(t, expire.lastSeen, 1)
+	require.Equal(t, expire.lastSeen[testContainerID], now)
 
 }
 
 func TestExpireContainers(t *testing.T) {
 
-    testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
-    testContainerID2 := "asf234ijrwada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+	testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+	testContainerID2 := "asf234ijrwada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
 
-    now := time.Now()
-    twoMinutesAgo := now.Add(-2 * time.Minute)
+	now := time.Now()
+	twoMinutesAgo := now.Add(-2 * time.Minute)
 
-    expire := &Expire{
-        expiryDuration: 5 * time.Minute,
-        lastSeen: make(map[string]time.Time),
-    }
+	expire := &Expire{
+		expiryDuration: 5 * time.Minute,
+		lastSeen:       make(map[string]time.Time),
+	}
 
-    expire.Update(testContainerID, now)
-    expire.Update(testContainerID2, twoMinutesAgo)
+	expire.Update(testContainerID, now)
+	expire.Update(testContainerID2, twoMinutesAgo)
 
-    expirelist, err := expire.ExpireContainers()
-    require.Nil(t, err)
-    require.Len(t, expirelist, 0)
+	expirelist, err := expire.ExpireContainers()
+	require.Nil(t, err)
+	require.Len(t, expirelist, 0)
 
+	// 4 minutes should NOT be enough to expire
+	expire.lastSeen[testContainerID] = expire.lastSeen[testContainerID].Add(-4 * time.Minute)
 
-    // 4 minutes should NOT be enough to expire
-    expire.lastSeen[testContainerID] = expire.lastSeen[testContainerID].Add(-4 * time.Minute)
+	expirelist, err = expire.ExpireContainers()
+	require.Nil(t, err)
+	require.Len(t, expirelist, 0)
 
-    expirelist, err = expire.ExpireContainers()
-    require.Nil(t, err)
-    require.Len(t, expirelist, 0)
-
-    // 6 minutes should be enough to expire
-    expire.lastSeen[testContainerID2] = expire.lastSeen[testContainerID2].Add(-6 * time.Minute)
-    expirelist, err = expire.ExpireContainers()
-    require.Nil(t, err)
-    require.Len(t, expirelist, 1)
-    require.Equal(t, testContainerID2, expirelist[0])
-    require.Len(t, expire.lastSeen, 1)
+	// 6 minutes should be enough to expire
+	expire.lastSeen[testContainerID2] = expire.lastSeen[testContainerID2].Add(-6 * time.Minute)
+	expirelist, err = expire.ExpireContainers()
+	require.Nil(t, err)
+	require.Len(t, expirelist, 1)
+	require.Equal(t, testContainerID2, expirelist[0])
+	require.Len(t, expire.lastSeen, 1)
 }

--- a/pkg/tagger/utils/expiry_test.go
+++ b/pkg/tagger/utils/expiry_test.go
@@ -21,13 +21,13 @@ func TestUpdate(t *testing.T) {
 	now := time.Now()
 	twoMinutesAgo := now.Add(-2 * time.Minute)
 
-	// Inserting container
+	// Inserting container, we expect True as it's not in the lastseen map.
 	found := expire.Update(testContainerID, twoMinutesAgo)
 	require.True(t, found)
 	require.Len(t, expire.lastSeen, 1)
 	require.Equal(t, expire.lastSeen[testContainerID], twoMinutesAgo)
 
-	// Updating container
+	// Updating container, we expect false as it already exists. We also expect the timestamp to be correct.
 	found = expire.Update(testContainerID, now)
 	require.False(t, found)
 	require.Len(t, expire.lastSeen, 1)
@@ -38,7 +38,7 @@ func TestUpdate(t *testing.T) {
 func TestExpireContainers(t *testing.T) {
 
 	testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
-	testContainerID2 := "asf234ijrwada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+	testContainerID2 := "asf234ijrwada35e083c78029fesfs789s7w0sx99ffs107e2ede87a9ce7bf50"
 
 	now := time.Now()
 	twoMinutesAgo := now.Add(-2 * time.Minute)
@@ -48,21 +48,24 @@ func TestExpireContainers(t *testing.T) {
 		lastSeen:       make(map[string]time.Time),
 	}
 
+	// We add the two containers to the lastseen list with different timestamps.
 	expire.Update(testContainerID, now)
 	expire.Update(testContainerID2, twoMinutesAgo)
 
+	// First we check that given the passed timestamps (inferior to the expire threshold)
+	// the list of expired containers is empty
 	expirelist, err := expire.ExpireContainers()
 	require.Nil(t, err)
 	require.Len(t, expirelist, 0)
 
-	// 4 minutes should NOT be enough to expire
+	// We update one container's timestamp, 4 minutes should NOT be enough to expire
 	expire.lastSeen[testContainerID] = expire.lastSeen[testContainerID].Add(-4 * time.Minute)
 
 	expirelist, err = expire.ExpireContainers()
 	require.Nil(t, err)
 	require.Len(t, expirelist, 0)
 
-	// 6 minutes should be enough to expire
+	// We update the other container's timestamp, 6 minutes should be enough to expire
 	expire.lastSeen[testContainerID2] = expire.lastSeen[testContainerID2].Add(-6 * time.Minute)
 	expirelist, err = expire.ExpireContainers()
 	require.Nil(t, err)

--- a/pkg/tagger/utils/expiry_test.go
+++ b/pkg/tagger/utils/expiry_test.go
@@ -49,6 +49,9 @@ func TestComputeExpires(t *testing.T) {
 		lastSeen:       make(map[string]time.Time),
 	}
 
+	// Checking we initialyze the map with nothing.
+	require.Len(t, expire.lastSeen, 0)
+
 	// We add the two containers to the lastseen list with different timestamps.
 	expire.Update(testContainerID, now)
 	expire.Update(testContainerID2, twoMinutesAgo)
@@ -67,7 +70,6 @@ func TestComputeExpires(t *testing.T) {
 	require.Len(t, expirelist, 0)
 
 	// We update the other container's timestamp, 6 minutes should be enough to expire
-	require.Len(t, expire.lastSeen, 0)
 	expire.lastSeen[testContainerID2] = expire.lastSeen[testContainerID2].Add(-6 * time.Minute)
 	expirelist, err = expire.ComputeExpires()
 	require.Nil(t, err)

--- a/pkg/tagger/utils/expiry_test.go
+++ b/pkg/tagger/utils/expiry_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package utils
+
+import (
+
+    "time"
+    "testing"
+    "github.com/stretchr/testify/require"
+)
+
+
+func TestUpdate(t *testing.T) {
+    expire := &Expire{
+        expiryDuration: 5 * time.Minute,
+        lastSeen: make(map[string]time.Time),
+    }
+    testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+
+    now := time.Now()
+    twoMinutesAgo := now.Add(-2 * time.Minute)
+
+    // Inserting container
+    found := expire.Update(testContainerID, twoMinutesAgo)
+    require.True(t, found)
+    require.Len(t, expire.lastSeen, 1)
+    require.Equal(t, expire.lastSeen[testContainerID], twoMinutesAgo)
+
+    // Updating container
+    found = expire.Update(testContainerID, now)
+    require.False(t, found)
+    require.Len(t, expire.lastSeen, 1)
+    require.Equal(t, expire.lastSeen[testContainerID], now)
+
+
+}
+
+func TestExpireContainers(t *testing.T) {
+
+    testContainerID := "b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+    testContainerID2 := "asf234ijrwada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
+
+    now := time.Now()
+    twoMinutesAgo := now.Add(-2 * time.Minute)
+
+    expire := &Expire{
+        expiryDuration: 5 * time.Minute,
+        lastSeen: make(map[string]time.Time),
+    }
+
+    expire.Update(testContainerID, now)
+    expire.Update(testContainerID2, twoMinutesAgo)
+
+    expirelist, err := expire.ExpireContainers()
+    require.Nil(t, err)
+    require.Len(t, expirelist, 0)
+
+
+    // 4 minutes should NOT be enough to expire
+    expire.lastSeen[testContainerID] = expire.lastSeen[testContainerID].Add(-4 * time.Minute)
+
+    expirelist, err = expire.ExpireContainers()
+    require.Nil(t, err)
+    require.Len(t, expirelist, 0)
+
+    // 6 minutes should be enough to expire
+    expire.lastSeen[testContainerID2] = expire.lastSeen[testContainerID2].Add(-6 * time.Minute)
+    expirelist, err = expire.ExpireContainers()
+    require.Nil(t, err)
+    require.Len(t, expirelist, 1)
+    require.Equal(t, testContainerID2, expirelist[0])
+    require.Len(t, expire.lastSeen, 1)
+}


### PR DESCRIPTION
### What does this PR do?

Sister PR of https://github.com/DataDog/datadog-agent/pull/719.
Introduces a method to update and expire the list of seen container if they were not in the latest fetch and have been in the list for more than 5 minutes.

### Motivation

Enhance the ECS Metadata collector

## Testing

Tested on ECS, added temp logs at the relevant lines:

 - [x] Message from Tagger, the containers started:
```
2017-10-25 13:27:19 UTC | DEBUG | (tagger.go:121 in run) | listener message: [%!s(*collectors.TagInfo=&{docker docker://431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26 [container_name:ecs-haissam-nginx-redis-1-nginx-8af193ad84e186c7b601 container_id:431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26] [docker_image:nginx:latest image_name:nginx image_tag:latest] false})]
```

- [x] Updating and first insert:
```
2017-10-25 13:27:33 UTC | WARN | (expiry.go:42 in Update) | Updating 431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26 which was %!s(bool=false) found

2017-10-25 13:27:33 UTC | WARN | (ecs_extract.go:28 in parseTasks) | inserted 431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26 at 2017-10-25 13:27:33.39649488 +0000 UTC
```

- [x] Updating and found:
```
2017-10-25 13:27:33 UTC | WARN | (expiry.go:42 in Update) | Updating 431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26 which was %!s(bool=true) found
```

- [x] Killed the task:
```
2017-10-25 13:29:03 UTC | DEBUG | (sender.go:260 in Event) | Event submitted: redis:latest 1 kill 1 die 1 stop on ip-10-0-0-9 for hostname: ip-10-0-0-9 tags: [docker_image:redis:latest image_name:redis image_tag:latest container_name:ecs-haissam-nginx-redis-1-redis-c282bc97d388f0feb901 container_id:9f77cb72c24d6d2d2b123326cc86f01fd8d972627de077370610c7e21b953722]
```

- [x] Tasked Stopped and ignored:
```
2017-10-25 13:30:03 UTC | WARN | (ecs_extract.go:23 in parseTasks) | The task arn:aws:ecs:us-east-1:172597598159:task/05088c3a-5a27-4602-9167-774d2a20ee24 is STOPPED, skipping these [{431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26 ecs-haissam-nginx-redis-1-nginx-8af193ad84e186c7b601 nginx} {9f77cb72c24d6d2d2b123326cc86f01fd8d972627de077370610c7e21b953722 ecs-haissam-nginx-redis-1-redis-c282bc97d388f0feb901 redis}]
```

- [x] Expiring:
```
2017-10-25 13:30:03 UTC | WARN | (expiry.go:58 in ExpireContainers) | Expiring 431f091abf3f3c15ec9843aa5f831039eff7b1e505e16a626b05df9285f31f26
2017-10-25 13:30:03 UTC | WARN | (expiry.go:58 in ExpireContainers) | Expiring 9f77cb72c24d6d2d2b123326cc86f01fd8d972627de077370610c7e21b953722
```