### PR TITLE
Better default dd_url, fixes dsd config file

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -7,6 +7,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -21,6 +22,10 @@ func SetupConfig(confFilePath string) error {
 	}
 	config.Datadog.AddConfigPath(DefaultConfPath)
 	config.Datadog.AddConfigPath(GetDistPath())
+	// If they set a config file directly, let's try to honor that
+	if strings.HasSuffix(confFilePath, ".yaml") {
+		config.Datadog.SetConfigFile(confFilePath)
+	}
 
 	// load the configuration
 	err := config.Datadog.ReadInConfig()

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -19,13 +19,13 @@ func SetupConfig(confFilePath string) error {
 		// if the configuration file path was supplied on the command line,
 		// add that first so it's first in line
 		config.Datadog.AddConfigPath(confFilePath)
+		// If they set a config file directly, let's try to honor that
+		if strings.HasSuffix(confFilePath, ".yaml") {
+			config.Datadog.SetConfigFile(confFilePath)
+		}
 	}
 	config.Datadog.AddConfigPath(DefaultConfPath)
 	config.Datadog.AddConfigPath(GetDistPath())
-	// If they set a config file directly, let's try to honor that
-	if strings.HasSuffix(confFilePath, ".yaml") {
-		config.Datadog.SetConfigFile(confFilePath)
-	}
 
 	// load the configuration
 	err := config.Datadog.ReadInConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,7 +62,7 @@ func init() {
 
 	// Configuration defaults
 	// Agent
-	Datadog.SetDefault("dd_url", "http://localhost:17123")
+	Datadog.SetDefault("dd_url", "https://app.datadoghq.com")
 	Datadog.SetDefault("proxy", nil)
 	Datadog.SetDefault("skip_ssl_validation", false)
 	Datadog.SetDefault("hostname", "")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,7 +17,7 @@ import (
 const targetDomain string = "6-0-0-app.agent"
 
 func TestDefaults(t *testing.T) {
-	assert.Equal(t, Datadog.GetString("dd_url"), "http://localhost:17123")
+	assert.Equal(t, Datadog.GetString("dd_url"), "https://app.datadoghq.com")
 }
 
 func setupViperConf(yamlConfig string) *viper.Viper {


### PR DESCRIPTION
### What does this PR do?

Currently, dsd sets its config file differently from agent6. It should be unified. This will unify it.

Also the dd_url has a bad default to localhost, this changes it to the right url