### PR TITLE
[omnibus] Pin (or upgrade) external Datadog deps

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -13,7 +13,7 @@ relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
-default_version 'master'
+default_version '5.18.1'
 
 blacklist = [
   'agent_metrics',
@@ -33,7 +33,6 @@ build do
   mkdir conf_dir
   mkdir "#{conf_dir}/auto_conf"
 
-  
 
   # Copy the checks and generate the global requirements file
   block do

--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -6,7 +6,7 @@
 name "datadog-process-agent"
 always_build true
 
-default_version 'master'
+default_version '5.18.1'
 
 
 build do

--- a/omnibus/config/software/datadog-trace-agent.rb
+++ b/omnibus/config/software/datadog-trace-agent.rb
@@ -8,7 +8,7 @@ require 'pathname'
 
 name "datadog-trace-agent"
 
-default_version "5.17.1"
+default_version "5.18.1"
 
 source git: 'https://github.com/DataDog/datadog-trace-agent.git'
 relative_path 'src/github.com/DataDog/datadog-trace-agent'


### PR DESCRIPTION
### What does this PR do?

Pin/Upgrade them to their latest stable versions.

logs-agent is not pinned because it's not versioned yet.

### Motivation

Better to have these pinned to versions we know work now that we ship beta builds.
