### PR TITLE
DSD Binary Deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,10 +430,8 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - rsync -azr --delete ./ $SRC_PATH
     - cd $SRC_PATH
     - pip install invoke
-    - inv -e deps
     # - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
@@ -443,7 +441,7 @@ deploy_dsd:
   script:
     - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd
     - pip install invoke
-    - VERSION=$(inv version)
+    - export VERSION=$(inv version)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,7 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - cd $SRC_PATH
+    - ls
     - pip install invoke
     # - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ before_script:
 
 
 # run tests for deb-x64
-run_tests_deb-x64:
+.run_tests_deb-x64:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -45,7 +45,7 @@ run_tests_deb-x64:
     - inv -e test --coverage
 
 # run tests for rpm-x64
-run_test_rpm-x64:
+.run_test_rpm-x64:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -155,7 +155,7 @@ run_docker_integration_tests_deb-x64:
 
 
 # build the package for deb-x64
-agent_deb-x64:
+.agent_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -177,7 +177,7 @@ agent_deb-x64:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
 # build the package for rpm-x64
-agent_rpm-x64:
+.agent_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -203,7 +203,7 @@ agent_rpm-x64:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
 # build windows
-build_windows_msi_x64:
+.build_windows_msi_x64:
   before_script:
     - if exist %GOPATH%\src\github.com\DataDog\datadog-agent rd /s/q %GOPATH%\src\github.com\DataDog\datadog-agent
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
@@ -438,6 +438,7 @@ deploy_dsd:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd
+    - pip install invoke
     - VERSION=$(inv version)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,6 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - pip install invoke
     - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -425,7 +425,7 @@ deploy_rpm:
     - aws s3 sync ./rpmrepo/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy rpm packages to yum staging repo
-deploy_dsd_static:
+deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,11 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - ls $AGENT_OMNIBUS_PACKAGE_DIR
+    - rsync -azr --delete ./ $SRC_PATH
+    - cd $SRC_PATH
+    - pip install invoke
+    - inv -e deps
+    # - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,7 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - ls
+    - apt-get install git
     - pip install invoke
     # - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
@@ -440,7 +440,6 @@ deploy_dsd:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd
-    - pip install invoke
     - export VERSION=$(inv version)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ variables:
   AGENT_OMNIBUS_BASE_DIR: $CI_PROJECT_DIR/.omnibus/
   AGENT_OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
   STATIC_BINARIES_DIR: bin/static
+  DOGSTATSD_BINARIES_DIR: bin/static
   DEB_S3_BUCKET_DEPRECATED: apt-agent6.datad0g.com
   DEB_S3_BUCKET: apt.datad0g.com
   RPM_S3_BUCKET: yum.datad0g.com
@@ -63,7 +64,7 @@ build_dogstatsd_static-deb_x64:
   tags: [ "runner:main", "size:large" ]
   script:
     - inv -e dogstatsd.build --static
-    - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_SCRATCH_URI/dogstatsd
+    - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_SCRATCH_URI/static/dogstatsd
 
 # build puppy agent for deb-x64, to make sure the build is not broken because of build flags
 build_puppy_agent-deb_x64:
@@ -72,6 +73,15 @@ build_puppy_agent-deb_x64:
   tags: [ "runner:main", "size:large" ]
   script:
     - inv -e agent.build --puppy
+
+# build dogstatsd for deb-x64
+build_dogstatsd-deb_x64:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e dogstatsd.build
+    - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_SCRATCH_URI/dogstatsd/dogstatsd
 
 #
 # integration_test
@@ -120,7 +130,7 @@ run_dogstatsd_size_test:
   before_script:
     # Disable global before_script
     - mkdir -p $STATIC_BINARIES_DIR
-    - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+    - $S3_CP_CMD $S3_SCRATCH_URI/static/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
   script:
     - inv -e dogstatsd.size-test --skip-build
 
@@ -133,7 +143,7 @@ run_docker_integration_tests_deb-x64:
   before_script:
     # Disable global before_script
     - mkdir --parent $STATIC_BINARIES_DIR
-    - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+    - $S3_CP_CMD $S3_SCRATCH_URI/static/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
   script:
     - docker run --rm --user root -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):$(pwd) --workdir $(pwd) -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA 727006795293.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders:deb_x64 inv docker.integration-tests --skip-build 2>&1
 
@@ -208,7 +218,6 @@ build_windows_msi_x64:
     expire_in: 2 weeks
     paths:
     - .omnibus/pkg
-
 
 
 #
@@ -426,9 +435,9 @@ deploy_dsd_static:
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
-    - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+    - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd
     - VERSION=$(inv version)
-    - $S3_CP_CMD $STATIC_BINARIES_DIR/dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION
+    - $S3_CP_CMD ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 
 # TODO: deploy and build SUSE packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -434,6 +434,7 @@ deploy_dsd:
   only:
     - master
     - tags
+    - greg/dsd6-build
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ before_script:
 
 
 # run tests for deb-x64
-.run_tests_deb-x64:
+run_tests_deb-x64:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -45,7 +45,7 @@ before_script:
     - inv -e test --coverage
 
 # run tests for rpm-x64
-.run_test_rpm-x64:
+run_test_rpm-x64:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -89,7 +89,7 @@ build_dogstatsd-deb_x64:
 #
 
 # run benchmarks on deb
-.run_benchmarks-deb_x64:
+run_benchmarks-deb_x64:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
@@ -112,7 +112,7 @@ build_dogstatsd-deb_x64:
       - benchmarks
 
 # run integration tests on the test image for deb-x64
-.run_integration_tests_deb-x64:
+run_integration_tests_deb-x64:
   stage: integration_test
   allow_failure: true  # FIXME when the root-user related issues are fixed on gitlab
   tags:
@@ -124,7 +124,7 @@ build_dogstatsd-deb_x64:
     - docker run --rm --user root --pid=host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA 727006795293.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders:deb_test_x64 inv integration-tests --install-deps
 
 # check the size of the static dogstatsd binary
-.run_dogstatsd_size_test:
+run_dogstatsd_size_test:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -136,7 +136,7 @@ build_dogstatsd-deb_x64:
     - inv -e dogstatsd.size-test --skip-build
 
 # run integration tests for deb-x64
-.run_docker_integration_tests_deb-x64:
+run_docker_integration_tests_deb-x64:
   stage: integration_test
   allow_failure: true  # FIXME when the root-user related issues are fixed on gitlab
   tags:
@@ -155,7 +155,7 @@ build_dogstatsd-deb_x64:
 
 
 # build the package for deb-x64
-.agent_deb-x64:
+agent_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -177,7 +177,7 @@ build_dogstatsd-deb_x64:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
 # build the package for rpm-x64
-.agent_rpm-x64:
+agent_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -203,7 +203,7 @@ build_dogstatsd-deb_x64:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
 # build windows
-.build_windows_msi_x64:
+build_windows_msi_x64:
   before_script:
     - if exist %GOPATH%\src\github.com\DataDog\datadog-agent rd /s/q %GOPATH%\src\github.com\DataDog\datadog-agent
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
@@ -232,7 +232,7 @@ build_dogstatsd-deb_x64:
   script: [ "# noop" ]
 
 # build the agent6 image
-.build_agent6:
+build_agent6:
   <<: *dind_job_definition
   variables:
     DD_DIND_BUILD_CONTEXT: Dockerfiles/agent
@@ -240,7 +240,7 @@ build_dogstatsd-deb_x64:
     DD_DIND_ARTEFACTS: "true"
 
 # build the agent6 jmx image
-.build_agent6_jmx:
+build_agent6_jmx:
   <<: *dind_job_definition
   variables:
     DD_DIND_BUILD_CONTEXT: Dockerfiles/agent
@@ -249,7 +249,7 @@ build_dogstatsd-deb_x64:
     DD_DIND_ARTEFACTS: "true"
 
 # build the dogstatsd image
-.build_dogstatsd:
+build_dogstatsd:
   <<: *dind_job_definition
   variables:
     DD_DIND_BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
@@ -288,7 +288,7 @@ agent6_jmx_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent:${CI_COMMIT_TAG}-jmx
 
-.agent6_dev_docker_hub:
+agent6_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
   except:
@@ -298,7 +298,7 @@ agent6_jmx_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent-dev:$CI_COMMIT_REF_SLUG
 
-.agent6_jmx_dev_docker_hub:
+agent6_jmx_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
   except:
@@ -337,7 +337,7 @@ dogstatsd_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/dogstatsd:$CI_COMMIT_TAG
 
-.dogstatsd_dev_docker_hub:
+dogstatsd_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
   except:
@@ -430,13 +430,11 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - apt-get install -y git
     - pip install invoke
-    # - ls $AGENT_OMNIBUS_PACKAGE_DIR
+    - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:
     - master
     - tags
-    - greg/dsd6-build
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,7 +232,7 @@ build_dogstatsd-deb_x64:
   script: [ "# noop" ]
 
 # build the agent6 image
-build_agent6:
+.build_agent6:
   <<: *dind_job_definition
   variables:
     DD_DIND_BUILD_CONTEXT: Dockerfiles/agent
@@ -240,7 +240,7 @@ build_agent6:
     DD_DIND_ARTEFACTS: "true"
 
 # build the agent6 jmx image
-build_agent6_jmx:
+.build_agent6_jmx:
   <<: *dind_job_definition
   variables:
     DD_DIND_BUILD_CONTEXT: Dockerfiles/agent
@@ -249,7 +249,7 @@ build_agent6_jmx:
     DD_DIND_ARTEFACTS: "true"
 
 # build the dogstatsd image
-build_dogstatsd:
+.build_dogstatsd:
   <<: *dind_job_definition
   variables:
     DD_DIND_BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
@@ -288,7 +288,7 @@ agent6_jmx_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent:${CI_COMMIT_TAG}-jmx
 
-agent6_dev_docker_hub:
+.agent6_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
   except:
@@ -298,7 +298,7 @@ agent6_dev_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent-dev:$CI_COMMIT_REF_SLUG
 
-agent6_jmx_dev_docker_hub:
+.agent6_jmx_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
   except:
@@ -337,7 +337,7 @@ dogstatsd_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/dogstatsd:$CI_COMMIT_TAG
 
-dogstatsd_dev_docker_hub:
+.dogstatsd_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ build_dogstatsd-deb_x64:
 #
 
 # run benchmarks on deb
-run_benchmarks-deb_x64:
+.run_benchmarks-deb_x64:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
@@ -112,7 +112,7 @@ run_benchmarks-deb_x64:
       - benchmarks
 
 # run integration tests on the test image for deb-x64
-run_integration_tests_deb-x64:
+.run_integration_tests_deb-x64:
   stage: integration_test
   allow_failure: true  # FIXME when the root-user related issues are fixed on gitlab
   tags:
@@ -124,7 +124,7 @@ run_integration_tests_deb-x64:
     - docker run --rm --user root --pid=host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp -v $(pwd):$SRC_PATH --workdir $SRC_PATH -e CI_PIPELINE_ID=$CI_PIPELINE_ID -e CI_COMMIT_SHA=$CI_COMMIT_SHA 727006795293.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders:deb_test_x64 inv integration-tests --install-deps
 
 # check the size of the static dogstatsd binary
-run_dogstatsd_size_test:
+.run_dogstatsd_size_test:
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -136,7 +136,7 @@ run_dogstatsd_size_test:
     - inv -e dogstatsd.size-test --skip-build
 
 # run integration tests for deb-x64
-run_docker_integration_tests_deb-x64:
+.run_docker_integration_tests_deb-x64:
   stage: integration_test
   allow_failure: true  # FIXME when the root-user related issues are fixed on gitlab
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -415,5 +415,20 @@ deploy_rpm:
     - createrepo --update -v --checksum sha ./rpmrepo/x86_64
     - aws s3 sync ./rpmrepo/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
+# deploy rpm packages to yum staging repo
+deploy_dsd_static:
+  stage: deploy
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
+  before_script:
+    - ls $AGENT_OMNIBUS_PACKAGE_DIR
+  only:
+    - master
+    - tags
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+    - VERSION=$(inv version)
+    - $S3_CP_CMD $STATIC_BINARIES_DIR/dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION
+
 
 # TODO: deploy and build SUSE packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
   AGENT_OMNIBUS_BASE_DIR: $CI_PROJECT_DIR/.omnibus/
   AGENT_OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
   STATIC_BINARIES_DIR: bin/static
-  DOGSTATSD_BINARIES_DIR: bin/static
+  DOGSTATSD_BINARIES_DIR: bin/dogstatsd
   DEB_S3_BUCKET_DEPRECATED: apt-agent6.datad0g.com
   DEB_S3_BUCKET: apt.datad0g.com
   RPM_S3_BUCKET: yum.datad0g.com
@@ -20,6 +20,7 @@ variables:
   DD_REPO_BRANCH_NAME: $CI_COMMIT_REF_NAME
   S3_CP_CMD: aws s3 cp --only-show-errors --region us-east-1 --sse AES256
   S3_SCRATCH_URI: s3://dd-scratch-space-build-stable/$CI_PROJECT_NAME/$CI_PIPELINE_ID
+  S3_DSD6_URI: s3://dsd6-staging/linux
 
 before_script:
   # We need to install go deps from within the GOPATH, which we set to / on builder images; that's because pointing
@@ -424,7 +425,7 @@ deploy_rpm:
     - createrepo --update -v --checksum sha ./rpmrepo/x86_64
     - aws s3 sync ./rpmrepo/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# deploy rpm packages to yum staging repo
+# deploy dsd binary to staging bucket
 deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
@@ -437,7 +438,7 @@ deploy_dsd:
   script:
     - $S3_CP_CMD $S3_SCRATCH_URI/dogstatsd/dogstatsd ./dogstatsd
     - VERSION=$(inv version)
-    - $S3_CP_CMD ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 
 # TODO: deploy and build SUSE packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,7 @@ deploy_dsd:
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deploy:latest
   before_script:
-    - apt-get install git
+    - apt-get install -y git
     - pip install invoke
     # - ls $AGENT_OMNIBUS_PACKAGE_DIR
   only:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,7 +7,7 @@ from invoke import Collection
 from . import agent, benchmarks, docker, dogstatsd, pylauncher
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
-from .test import test, integration_tests
+from .test import test, integration_tests, version
 
 
 # the root namespace
@@ -24,6 +24,7 @@ ns.add_task(test)
 ns.add_task(integration_tests)
 ns.add_task(deps)
 ns.add_task(reset)
+ns.add_task(version)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -9,7 +9,7 @@ import fnmatch
 import invoke
 from invoke import task
 
-from .utils import pkg_config_path
+from .utils import pkg_config_path, get_version
 from .go import fmt, lint, vet
 from .build_tags import get_default_build_tags
 from .agent import integration_tests as agent_integration_tests
@@ -116,3 +116,7 @@ def integration_tests(ctx, install_deps=False, remote_docker=False):
     """
     agent_integration_tests(ctx, install_deps, remote_docker)
     dsd_integration_tests(ctx, install_deps, remote_docker)
+
+@task
+def version(ctx):
+    print(get_version(ctx, include_git=True))


### PR DESCRIPTION
### What does this PR do?

We want to release dsd6 as a binary. We may also want to release it as a package, but that's for another day. This will just build the binary and put it into an s3 bucket. We can then pluck it from that bucket and put it into another s3 bucket that will contain it as a production artifact.

### Motivation

This is for the Datadog Cloud Foundry Buildpack to integrate DSD into CF apps to collect metrics.
