### PR TITLE
keep configs in one place, removing the yaml config file

### DIFF
--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,9 +1,0 @@
-targets: [./pkg, ./cmd]
-
-agent:
-  build_include: [all]
-  build_exclude: []
-
-dogstatsd:
-  build_include: [zlib, docker]
-  build_exclude: []

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -13,7 +13,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, pkg_config_path, get_version_numeric_only
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags
+from .build_tags import get_build_tags, get_default_build_tags, ALL_TAGS
 from .go import deps
 
 #constants
@@ -30,8 +30,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     Example invokation:
         inv agent.build --build-exclude=snmp
     """
-    build_include = ctx.agent.build_include if build_include is None else build_include.split(",")
-    build_exclude = ctx.agent.build_exclude if build_exclude is None else build_exclude.split(",")
+    build_include = ALL_TAGS if build_include is None else build_include.split(",")
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
     env = {
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)
     }

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -20,14 +20,20 @@ DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
 MAX_BINARY_SIZE = 15 * 1024
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
+DEFAULT_BUILD_TAGS = [
+    "zlib",
+    "docker",
+]
+
 
 @task
-def build(ctx, rebuild=False, race=False, static=False, build_include=None, build_exclude=None, use_embedded_libs=False):
+def build(ctx, rebuild=False, race=False, static=False, build_include=None,
+          build_exclude=None, use_embedded_libs=False):
     """
     Build Dogstatsd
     """
-    build_include = ctx.dogstatsd.build_include if build_include is None else build_include.split(",")
-    build_exclude = ctx.dogstatsd.build_exclude if build_exclude is None else build_exclude.split(",")
+    build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
     ldflags, gcflags = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
     bin_path = DOGSTATSD_BIN_PATH
@@ -59,7 +65,8 @@ def run(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
     """
     if not skip_build:
         print("Building dogstatsd...")
-        build(ctx, rebuild=rebuild, race=race, build_include=build_include, build_exclude=build_exclude)
+        build(ctx, rebuild=rebuild, race=race, build_include=build_include,
+              build_exclude=build_exclude)
 
     target = os.path.join(DOGSTATSD_BIN_PATH, bin_name("dogstatsd"))
     ctx.run("{} start".format(target))
@@ -153,6 +160,7 @@ def integration_tests(ctx, install_deps=False):
     # config_providers
     cmd = "go test -tags '{}' {}/test/integration/dogstatsd/..."
     ctx.run(cmd.format(" ".join(build_tags), REPO_PATH))
+
 
 @task
 def image_build(ctx, skip_build=False):

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -15,18 +15,20 @@ WIN_MODULE_WHITELIST = [
 
 
 @task
-def fmt(ctx, targets=None, fail_on_fmt=False):
+def fmt(ctx, targets, fail_on_fmt=False):
     """
-    Run go fmt on targets. If targets are not specified,
-    the value from `invoke.yaml` will be used.
+    Run go fmt on targets.
 
     Example invokation:
         inv fmt --targets=./pkg/collector/check,./pkg/aggregator
     """
-    targets_list = ctx.targets if targets is None else targets.split(',')
+    if isinstance(targets, basestring):
+        # when this function is called from the command line, targets are passed
+        # as comma separated tokens in a string
+        targets = targets.split(',')
 
     # add the /... suffix to the targets
-    args = ["{}/...".format(t) for t in targets_list]
+    args = ["{}/...".format(t) for t in targets]
     result = ctx.run("go fmt " + " ".join(args))
     if result.stdout:
         files = {x for x in result.stdout.split("\n") if x}
@@ -38,7 +40,7 @@ def fmt(ctx, targets=None, fail_on_fmt=False):
 
 
 @task
-def lint(ctx, targets=None):
+def lint(ctx, targets):
     """
     Run golint on targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -46,9 +48,13 @@ def lint(ctx, targets=None):
     Example invokation:
         inv lint --targets=./pkg/collector/check,./pkg/aggregator
     """
-    targets_list = ctx.targets if targets is None else targets.split(',')
+    if isinstance(targets, basestring):
+        # when this function is called from the command line, targets are passed
+        # as comma separated tokens in a string
+        targets = targets.split(',')
+
     # add the /... suffix to the targets
-    targets_list = ["{}/...".format(t) for t in targets_list]
+    targets_list = ["{}/...".format(t) for t in targets]
     result = ctx.run("golint {}".format(' '.join(targets_list)))
     if result.stdout:
         files = []
@@ -72,18 +78,20 @@ def lint(ctx, targets=None):
 
 
 @task
-def vet(ctx, targets=None):
+def vet(ctx, targets):
     """
-    Run go vet on targets. If targets are not specified,
-    the value from `invoke.yaml` will be used.
+    Run go vet on targets.
 
     Example invokation:
         inv vet --targets=./pkg/collector/check,./pkg/aggregator
     """
-    targets_list = ctx.targets if targets is None else targets.split(',')
+    if isinstance(targets, basestring):
+        # when this function is called from the command line, targets are passed
+        # as comma separated tokens in a string
+        targets = targets.split(',')
 
     # add the /... suffix to the targets
-    args = ["{}/...".format(t) for t in targets_list]
+    args = ["{}/...".format(t) for t in targets]
     ctx.run("go vet " + " ".join(args))
     # go vet exits with status 1 when it finds an issue, if we're here
     # everything went smooth

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -22,6 +22,10 @@ WIN_PKG_BLACKLIST = [
     "./pkg\\util\\xc",
 ]
 
+DEFAULT_TARGETS = [
+    "./pkg",
+]
+
 
 @task()
 def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False, fail_on_fmt=False):
@@ -32,7 +36,13 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
     Example invokation:
         inv test --targets=./pkg/collector/check,./pkg/aggregator --race
     """
-    targets_list = ctx.targets if targets is None else targets.split(',')
+    if isinstance(targets, basestring):
+        # when this function is called from the command line, targets are passed
+        # as comma separated tokens in a string
+        targets = targets.split(',')
+    elif targets is None:
+        targets = DEFAULT_TARGETS
+
     build_tags = get_default_build_tags()
 
     # explicitly run these tasks instead of using pre-tasks so we can
@@ -64,12 +74,12 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
 
     if race or coverage:
         matches = []
-        for target in targets_list:
+        for target in targets:
             for root, _, filenames in os.walk(target):
                 if fnmatch.filter(filenames, "*.go"):
                     matches.append(root)
     else:
-        matches = ["{}/...".format(t) for t in targets_list]
+        matches = ["{}/...".format(t) for t in targets]
 
     for match in matches:
         if invoke.platform.WINDOWS:


### PR DESCRIPTION
### What does this PR do?

Move defaults out from `invoke.yaml` to relevant Python modules.
Task functions might be called programmatically, perform a type check to make it easier to read.

### Motivation

We had defaults stored in different places and one of these was a yaml file, difficult to get if you don't know `invoke` well.

### Additional Notes

Also avoid running tests on `cmd` since we have no tests there (yet). This saves about 3 minutes from the tests running time.
