### PR TITLE
move MockSender to its own package and extend it

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package mocksender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// AssertServiceCheck allows to assert a ServiceCheck was emitted with given parameters.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertServiceCheck(t *testing.T, checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string) bool {
+	return m.Mock.AssertCalled(t, "ServiceCheck", checkName, status, hostname, AssertTagsContain(t, tags), message)
+}
+
+// AssertMetric allows to assert a metric was emitted with given parameters.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertMetric(t *testing.T, method string, metric string, value float64, hostname string, tags []string) bool {
+	return m.Mock.AssertCalled(t, method, metric, value, hostname, AssertTagsContain(t, tags))
+}
+
+// AssertTagsContain is a mock.argumentMatcher builder to be used in asserts.
+// It allows to check if tags are emitted, ignoring unexpected ones and order.
+func AssertTagsContain(t *testing.T, expected []string) interface{} {
+	return mock.MatchedBy(func(actual []string) bool {
+		for _, tag := range expected {
+			if !assert.Contains(t, actual, tag) {
+				return false
+			}
+		}
+		return true
+	})
+}

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -3,30 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
-package aggregator
+package mocksender
 
 import (
-	"github.com/stretchr/testify/mock"
-
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
-
-// NewMockSender initiates the aggregator and returns a
-// functionnal mocked Sender for testing
-func NewMockSender(id check.ID) *MockSender {
-	mockSender := new(MockSender)
-	// The MockSender requires an aggregator
-	InitAggregator(nil, "")
-	SetSender(mockSender, id)
-
-	return mockSender
-}
-
-//MockSender allows mocking of the checks sender for unit testing
-type MockSender struct {
-	mock.Mock
-}
 
 //Rate adds a rate type to the mock calls.
 func (m *MockSender) Rate(metric string, value float64, hostname string, tags []string) {

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package mocksender
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+// NewMockSender initiates the aggregator and returns a
+// functionnal mocked Sender for testing
+func NewMockSender(id check.ID) *MockSender {
+	mockSender := new(MockSender)
+	// The MockSender requires an aggregator
+	aggregator.InitAggregator(nil, "")
+	aggregator.SetSender(mockSender, id)
+
+	return mockSender
+}
+
+//MockSender allows mocking of the checks sender for unit testing
+type MockSender struct {
+	mock.Mock
+}
+
+// SetupAcceptAll sets mock expectations to accept any call in the Sender interface
+func (m *MockSender) SetupAcceptAll() {
+	metricCalls := []string{"Rate", "Count", "MonotonicCount", "Counter", "Histogram", "Historate", "Gauge"}
+	for _, call := range metricCalls {
+		m.On(call, mock.AnythingOfType("string"), mock.AnythingOfType("float64"),
+			mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return()
+	}
+	m.On("ServiceCheck", mock.AnythingOfType("string"), mock.AnythingOfType("metrics.ServiceCheckStatus"),
+		mock.AnythingOfType("string"), mock.AnythingOfType("[]string"),
+		mock.AnythingOfType("string")).Return()
+	m.On("Event", mock.AnythingOfType("metrics.Event")).Return()
+	m.On("GetMetricStats", mock.AnythingOfType("map[string]int64")).Return()
+
+	m.On("Commit").Return()
+}
+
+// ResetCalls makes the mock forget previous calls
+func (m *MockSender) ResetCalls() {
+	m.Mock.Calls = m.Mock.Calls[0:0]
+}

--- a/pkg/collector/corechecks/containers/docker_events_test.go
+++ b/pkg/collector/corechecks/containers/docker_events_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
@@ -22,7 +22,7 @@ func TestReportExitCodes(t *testing.T) {
 	dockerCheck := &DockerCheck{
 		instance: &DockerConfig{},
 	}
-	mockSender := aggregator.NewMockSender(dockerCheck.ID())
+	mockSender := mocksender.NewMockSender(dockerCheck.ID())
 
 	var events []*docker.ContainerEvent
 

--- a/pkg/collector/corechecks/network/ntp_test.go
+++ b/pkg/collector/corechecks/network/ntp_test.go
@@ -8,7 +8,7 @@ package network
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -26,7 +26,7 @@ func TestNTP(t *testing.T) {
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
 
-	mockSender := aggregator.NewMockSender(ntpCheck.ID())
+	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
 	mockSender.On("Gauge", "ntp.offset", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	mockSender.On("ServiceCheck",

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/k-sone/snmpgo"
 )
 
@@ -196,7 +196,7 @@ func TestSubmitSNMP(t *testing.T) {
 
 	initCNetSnmpLib(nil)
 
-	mock := aggregator.NewMockSender(snmpCheck.ID())
+	mock := mocksender.NewMockSender(snmpCheck.ID())
 
 	if err := cfg.Parse(bytes.NewBufferString(basicCfg).Bytes(), []byte{}); err != nil {
 		t.Fatalf("Unable to parse configuration: %v", err)

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -8,7 +8,7 @@ package system
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/shirou/gopsutil/cpu"
 )
 
@@ -78,7 +78,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	cpuCheck := new(CPUCheck)
 	cpuCheck.Configure(nil, nil)
 
-	mock := aggregator.NewMockSender(cpuCheck.ID())
+	mock := mocksender.NewMockSender(cpuCheck.ID())
 
 	sample = firstSample
 	cpuCheck.Run()

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -11,8 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	log "github.com/cihub/seelog"
 )
 
@@ -49,7 +48,7 @@ func TestFhCheckLinux(t *testing.T) {
 	fileHandleCheck := new(fhCheck)
 	fileHandleCheck.Configure(nil, nil)
 
-	mock := aggregator.NewMockSender(fileHandleCheck.ID())
+	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 
 	mock.On("Gauge", "system.fs.file_handles.in_use", 0.008829499990145647, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/shirou/gopsutil/disk"
 )
 
@@ -68,7 +68,7 @@ func TestIOCheck(t *testing.T) {
 	ioCheck := new(IOCheck)
 	ioCheck.Configure(nil, nil)
 
-	mock := aggregator.NewMockSender(ioCheck.ID())
+	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	expectedRates := 2
 	expectedGauges := 0
@@ -131,7 +131,7 @@ func TestIOCheckBlacklist(t *testing.T) {
 	ioCheck := new(IOCheck)
 	ioCheck.Configure(nil, nil)
 
-	mock := aggregator.NewMockSender(ioCheck.ID())
+	mock := mocksender.NewMockSender(ioCheck.ID())
 
 	//set blacklist
 	bl, err := regexp.Compile("sd.*")

--- a/pkg/collector/corechecks/system/load_test.go
+++ b/pkg/collector/corechecks/system/load_test.go
@@ -8,7 +8,7 @@ package system
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/shirou/gopsutil/load"
 )
 
@@ -30,7 +30,7 @@ func TestLoadCheckLinux(t *testing.T) {
 	loadCheck := new(LoadCheck)
 	loadCheck.Configure(nil, nil)
 
-	mock := aggregator.NewMockSender(loadCheck.ID())
+	mock := mocksender.NewMockSender(loadCheck.ID())
 
 	var nbCPU float64
 	info, _ := cpuInfo()

--- a/pkg/collector/corechecks/system/memory_test.go
+++ b/pkg/collector/corechecks/system/memory_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,7 +53,7 @@ func TestMemoryCheckLinux(t *testing.T) {
 	swapMemory = SwapMemory
 	memCheck := new(MemoryCheck)
 
-	mock := aggregator.NewMockSender(memCheck.ID())
+	mock := mocksender.NewMockSender(memCheck.ID())
 
 	runtimeOS = "linux"
 
@@ -85,7 +85,7 @@ func TestMemoryCheckFreebsd(t *testing.T) {
 	swapMemory = SwapMemory
 	memCheck := new(MemoryCheck)
 
-	mock := aggregator.NewMockSender(memCheck.ID())
+	mock := mocksender.NewMockSender(memCheck.ID())
 
 	runtimeOS = "freebsd"
 
@@ -113,7 +113,7 @@ func TestMemoryCheckDarwin(t *testing.T) {
 	swapMemory = SwapMemory
 	memCheck := new(MemoryCheck)
 
-	mock := aggregator.NewMockSender(memCheck.ID())
+	mock := mocksender.NewMockSender(memCheck.ID())
 
 	runtimeOS = "darwin"
 
@@ -140,7 +140,7 @@ func TestMemoryError(t *testing.T) {
 	swapMemory = func() (*mem.SwapMemoryStat, error) { return nil, fmt.Errorf("some error") }
 	memCheck := new(MemoryCheck)
 
-	mock := aggregator.NewMockSender(memCheck.ID())
+	mock := mocksender.NewMockSender(memCheck.ID())
 
 	runtimeOS = "linux"
 
@@ -157,7 +157,7 @@ func TestSwapMemoryError(t *testing.T) {
 	swapMemory = func() (*mem.SwapMemoryStat, error) { return nil, fmt.Errorf("some error") }
 	memCheck := new(MemoryCheck)
 
-	mock := aggregator.NewMockSender(memCheck.ID())
+	mock := mocksender.NewMockSender(memCheck.ID())
 
 	runtimeOS = "linux"
 
@@ -185,7 +185,7 @@ func TestVirtualMemoryError(t *testing.T) {
 	swapMemory = SwapMemory
 	memCheck := new(MemoryCheck)
 
-	mock := aggregator.NewMockSender(memCheck.ID())
+	mock := mocksender.NewMockSender(memCheck.ID())
 
 	runtimeOS = "linux"
 

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -8,7 +8,7 @@ package system
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 )
 
 func uptimeSampler() (uint64, error) {
@@ -20,7 +20,7 @@ func TestUptimeCheckLinux(t *testing.T) {
 	uptimeCheck := new(UptimeCheck)
 	uptimeCheck.Configure(nil, nil)
 
-	mock := aggregator.NewMockSender(uptimeCheck.ID())
+	mock := mocksender.NewMockSender(uptimeCheck.ID())
 
 	mock.On("Gauge", "system.uptime", 555.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	python "github.com/sbinet/go-python"
@@ -134,7 +134,7 @@ func TestInitNoTracebackException(t *testing.T) {
 func TestAggregatorLink(t *testing.T) {
 	check, _ := getCheckInstance("testaggregator", "TestAggregatorCheck")
 
-	mockSender := aggregator.NewMockSender(check.ID())
+	mockSender := mocksender.NewMockSender(check.ID())
 
 	mockSender.On("ServiceCheck",
 		"testservicecheck", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",
@@ -158,7 +158,7 @@ func TestAggregatorLink(t *testing.T) {
 func TestAggregatorLinkTwoRuns(t *testing.T) {
 	check, _ := getCheckInstance("testaggregator", "TestAggregatorCheck")
 
-	mockSender := aggregator.NewMockSender(check.ID())
+	mockSender := mocksender.NewMockSender(check.ID())
 
 	mockSender.On("ServiceCheck",
 		"testservicecheck", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",


### PR DESCRIPTION
### What does this PR do?

Build assertion helpers on top of MockSender, to allow for
asserting calls while being flexible on tags (ignoring excess
tags and order).

Keeping it under the `aggregator` package as it's mocking
an interface defined there.

### Motivation

This will be used by the docker integration tests
