### PR TITLE
[wheels] support checks installed to site-packages

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -46,6 +46,7 @@ func GetPythonPaths() []string {
 		GetDistPath(),                                  // common modules are shipped in the dist path directly or under the "checks/" sub-dir
 		filepath.Join(GetDistPath(), "checks.d"),       // custom checks in the "checks.d/" sub-dir of the dist path
 		config.Datadog.GetString("additional_checksd"), // custom checks, have precedence over integrations-core checks
+		PySitePackages,                                 // integrations-core, wheels have precedence over old-school SDK
 		PyChecksPath,                                   // integrations-core checks
 	}
 }

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -15,6 +15,8 @@ const DefaultConfPath = "/opt/datadog-agent/etc/datadog-agent"
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
+	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
+	PySitePackages = filepath.Join(_here, "..", "..", "embedded", "lib", "python2.7", "site-packages")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
 )

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -17,6 +17,8 @@ const DefaultConfPath = "/etc/datadog-agent"
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
+	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
+	PySitePackages = filepath.Join(_here, "..", "..", "embedded", "lib", "python2.7", "site-packages")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
 )

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -23,7 +23,10 @@ import (
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "agent", "checks.d")
-	distPath     string
+	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
+	// FIXME: pretty sure this path is broken on windows
+	PySitePackages = filepath.Join(_here, "..", "..", "embedded", "lib", "python2.7", "site-packages")
+	distPath       string
 	// ViewsPath holds the path to the folder containing the GUI support files
 	viewsPath string
 )

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -24,8 +24,7 @@ var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "agent", "checks.d")
 	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
-	// FIXME: pretty sure this path is broken on windows
-	PySitePackages = filepath.Join(_here, "..", "..", "embedded", "lib", "python2.7", "site-packages")
+	PySitePackages = filepath.Join(_here, "lib", "python2.7", "site-packages")
 	distPath       string
 	// ViewsPath holds the path to the folder containing the GUI support files
 	viewsPath string

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -52,7 +52,7 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 	moduleName := config.Name
-	whlModuleName := fmt.Sprintf("datadog.%s.%s", config.Name, config.Name)
+	whlModuleName := fmt.Sprintf("datadog.%s", config.Name)
 
 	// Looking for wheels first
 	modules := []string{whlModuleName, moduleName}

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -68,17 +68,17 @@ func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		} else {
 			log.Debugf("Unable to load python check as wheel: %v", errors.New(pyErr))
 		}
-	}
 
-	// Looking for regular checks after
-	checkModule := python.PyImport_ImportModule(moduleName)
-	if checkModule == nil {
-		defer glock.unlock()
-		pyErr, err := glock.getPythonError()
-		if err != nil {
-			return nil, fmt.Errorf("An error occurred while loading the python module and couldn't be formatted: %v", err)
+		// Looking for regular checks after
+		checkModule = python.PyImport_ImportModule(moduleName)
+		if checkModule == nil {
+			defer glock.unlock()
+			pyErr, err := glock.getPythonError()
+			if err != nil {
+				return nil, fmt.Errorf("An error occurred while loading the python module and couldn't be formatted: %v", err)
+			}
+			return nil, errors.New(pyErr)
 		}
-		return nil, errors.New(pyErr)
 	}
 
 	// Try to find a class inheriting from AgentCheck within the module

--- a/pkg/collector/py/tests/__init__.py
+++ b/pkg/collector/py/tests/__init__.py
@@ -2,4 +2,3 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
-

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -7,6 +7,8 @@ package py
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -16,7 +18,17 @@ import (
 
 // Setup the test module
 func TestMain(m *testing.M) {
-	state := Initialize(".", "tests", "../dist")
+	rootDir := "."
+	testsDir := "tests"
+	distDir := "../dist"
+
+	// best effort for abs path
+	if _, fileName, _, ok := runtime.Caller(0); ok {
+		rootDir = filepath.Dir(fileName)
+		testsDir = filepath.Join(rootDir, "tests/")
+		distDir = filepath.Join(rootDir, "../dist/")
+	}
+	state := Initialize(rootDir, testsDir, distDir)
 
 	// testing this package needs an inited aggregator
 	// to work properly


### PR DESCRIPTION
### What does this PR do?

This PR adds support for checks installed to `./datadog/<integration>/` site in `site-packages`. It will add support for checks packaged as wheels. 

It should remain completely backward compatible as far as previous functionality goes.

It also sneaks in a small change so that the initialization of python tests attempts to provide absolute paths as opposed to the relative paths currently provided to `sys.path` (PYTHONPATH) for the embedded python interepreter.  

### Motivation

Supporting pip _wheels_ for our integrations.

### Additional Notes

Anything else we should know when reviewing?
