### PR TITLE
[WIP] add docker corecheck integration tests and fixes

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -17,23 +17,64 @@ import (
 // AssertServiceCheck allows to assert a ServiceCheck was emitted with given parameters.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertServiceCheck(t *testing.T, checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string) bool {
-	return m.Mock.AssertCalled(t, "ServiceCheck", checkName, status, hostname, AssertTagsContain(t, tags), message)
+	return m.Mock.AssertCalled(t, "ServiceCheck", checkName, status, hostname, AssertTagsContains(t, tags), message)
 }
 
 // AssertMetric allows to assert a metric was emitted with given parameters.
 // Additional tags over the ones specified don't make it fail
 func (m *MockSender) AssertMetric(t *testing.T, method string, metric string, value float64, hostname string, tags []string) bool {
-	return m.Mock.AssertCalled(t, method, metric, value, hostname, AssertTagsContain(t, tags))
+	return m.Mock.AssertCalled(t, method, metric, value, hostname, AssertTagsContains(t, tags))
 }
 
-// AssertTagsContain is a mock.argumentMatcher builder to be used in asserts.
+// AssertMetricInRange allows to assert a metric was emitted with given parameters, with a value in a given range.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertMetricInRange(t *testing.T, method string, metric string, min float64, max float64, hostname string, tags []string) bool {
+	return m.Mock.AssertCalled(t, method, metric, AssertFloatInRange(t, min, max), hostname, AssertTagsContains(t, tags))
+}
+
+// AssertMetricTaggedWith allows to assert a metric was emitted with given tags, value and hostname not tested.
+// Additional tags over the ones specified don't make it fail
+func (m *MockSender) AssertMetricTaggedWith(t *testing.T, method string, metric string, tags []string) bool {
+	return m.Mock.AssertCalled(t, method, metric, mock.AnythingOfType("float64"), mock.AnythingOfType("string"), AssertTagsContains(t, tags))
+}
+
+// AssertMetricNotTaggedWith allows to assert tags were never emitted for a metric.
+func (m *MockSender) AssertMetricNotTaggedWith(t *testing.T, method string, metric string, tags []string) bool {
+	return m.Mock.AssertCalled(t, method, metric, mock.AnythingOfType("float64"), mock.AnythingOfType("string"), AssertTagsNotContains(t, tags))
+}
+
+// AssertTagsContains is a mock.argumentMatcher builder to be used in asserts.
 // It allows to check if tags are emitted, ignoring unexpected ones and order.
-func AssertTagsContain(t *testing.T, expected []string) interface{} {
+func AssertTagsContains(t *testing.T, expected []string) interface{} {
 	return mock.MatchedBy(func(actual []string) bool {
 		for _, tag := range expected {
 			if !assert.Contains(t, actual, tag) {
 				return false
 			}
+		}
+		return true
+	})
+}
+
+// AssertTagsNotContains is a mock.argumentMatcher builder to be used in asserts.
+// It allows to check if tags are NOT emitted.
+func AssertTagsNotContains(t *testing.T, expected []string) interface{} {
+	return mock.MatchedBy(func(actual []string) bool {
+		for _, tag := range expected {
+			if !assert.NotContains(t, actual, tag) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// AssertFloatInRange is a mock.argumentMatcher builder to be used in asserts.
+// It allows to check if a metric value is in a given range instead of matching exactly.
+func AssertFloatInRange(t *testing.T, min float64, max float64) interface{} {
+	return mock.MatchedBy(func(actual float64) bool {
+		if actual > max || actual < min {
+			return false
 		}
 		return true
 	})

--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -73,9 +73,6 @@ func AssertTagsNotContains(t *testing.T, expected []string) interface{} {
 // It allows to check if a metric value is in a given range instead of matching exactly.
 func AssertFloatInRange(t *testing.T, min float64, max float64) interface{} {
 	return mock.MatchedBy(func(actual float64) bool {
-		if actual > max || actual < min {
-			return false
-		}
-		return true
+		return actual >= min && actual <= max
 	})
 }

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -129,7 +129,7 @@ func (d *DockerCheck) Run() error {
 
 	containers, err := docker.AllContainers(&docker.ContainerListConfig{IncludeExited: true, FlagExcluded: true})
 	if err != nil {
-		sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckCritical, "", nil, err.Error())
+		sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckCritical, "", d.instance.Tags, err.Error())
 		return err
 	}
 
@@ -206,10 +206,10 @@ func (d *DockerCheck) Run() error {
 
 	if err := d.countAndWeightImages(sender); err != nil {
 		log.Error(err.Error())
-		sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckCritical, "", nil, err.Error())
+		sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckCritical, "", d.instance.Tags, err.Error())
 		return err
 	}
-	sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckOK, "", nil, "")
+	sender.ServiceCheck(DockerServiceUp, metrics.ServiceCheckOK, "", d.instance.Tags, "")
 
 	if d.instance.CollectEvent || d.instance.CollectExitCodes {
 		events, err := d.retrieveEvents()
@@ -321,12 +321,13 @@ func (d *DockerCheck) GetMetricStats() (map[string]int64, error) {
 	return sender.GetMetricStats(), nil
 }
 
-func dockerFactory() check.Check {
+// DockerFactory is exported for integration testing
+func DockerFactory() check.Check {
 	return &DockerCheck{
 		instance: &DockerConfig{},
 	}
 }
 
 func init() {
-	core.RegisterCheck("docker", dockerFactory)
+	core.RegisterCheck("docker", DockerFactory)
 }

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -165,6 +165,7 @@ def integration_tests(ctx, install_deps=False, remote_docker=False):
 
     prefixes = [
         "./test/integration/config_providers/...",
+        "./test/integration/corechecks/...",
         # "./test/integration/listeners/...", ## Hangups
     ]
 

--- a/test/integration/corechecks/docker/base_test.go
+++ b/test/integration/corechecks/docker/base_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func TestServiceCheckOK(t *testing.T) {
+	sender.AssertServiceCheck(t, "docker.service_up", metrics.ServiceCheckOK, "", []string{"integration:test"}, "")
+}
+
+func TestContainerMetricsTagging(t *testing.T) {
+	expectedTags := []string{
+		"integration:test",                                                  // Instance tags
+		"container_name:dockerchecktest_redis_1",                            // Container name
+		"docker_image:redis:latest", "image_name:redis", "image_tag:latest", // Image tags
+		"highcardlabeltag:redishigh", "lowcardlabeltag:redislow", // Labels as tags
+		"highcardenvtag:redishighenv", "lowcardenvtag:redislowenv", // Env as tags
+	}
+
+	expectedMetrics := map[string][]string{
+		"Gauge": []string{"docker.mem.cache", "docker.mem.rss",
+			"docker.container.size_rw", "docker.container.size_rootfs"},
+		"Rate": []string{"docker.cpu.system", "docker.cpu.user", "docker.cpu.usage", "docker.cpu.throttled",
+			"docker.io.read_bytes", "docker.io.write_bytes",
+			"docker.net.bytes_sent", "docker.net.bytes_rcvd"},
+	}
+
+	for method, metrics := range expectedMetrics {
+		for _, metric := range metrics {
+			found := sender.AssertMetricTaggedWith(t, method, metric, expectedTags)
+			if !found {
+				fmt.Printf("Missing %s %s with tags %s\n", method, metric, expectedTags)
+			}
+		}
+	}
+}

--- a/test/integration/corechecks/docker/catalog.go
+++ b/test/integration/corechecks/docker/catalog.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+type catalog struct {
+	composeFiles map[string]string
+}
+
+var defaultCatalog = catalog{
+	composeFiles: make(map[string]string),
+}
+
+func registerComposeFile(name string, filename string) {
+	defaultCatalog.composeFiles[name] = filename
+}

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+var retryDelay = flag.Int("retry-delay", 1, "time to wait between retries (default 1 second)")
+var retryTimeout = flag.Int("retry-timeout", 10, "maximum time before failure (default 10 seconds)")
+var skipCleanup = flag.Bool("skip-cleanup", false, "skip cleanup of the docker containers (for debugging)")
+
+var dockerCfgString = `
+collect_container_size: true
+tags:
+  - integration:test
+`
+
+var datadogCfgString = `
+docker_labels_as_tags:
+    "high.card.label": +highcardlabeltag
+    "low.card.label": lowcardlabeltag
+docker_env_as_tags:
+    "HIGH_CARD_ENV": +highcardenvtag
+    "low_card_env": lowcardenvtag
+`
+
+var sender *mocksender.MockSender
+var dockerCheck check.Check
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	retryTicker := time.NewTicker(time.Duration(*retryDelay) * time.Second)
+	timeoutTicker := time.NewTicker(time.Duration(*retryTimeout) * time.Second)
+	var lastRunResult int
+	var retryCount int
+
+	registerComposeFile("redis container", "redis.compose")
+
+	err := setup(m)
+	if err != nil {
+		fmt.Printf("Test setup failed:\n%s\n", err.Error())
+		tearOffAndExit(1)
+	}
+
+	for {
+		select {
+		case <-retryTicker.C:
+			retryCount++
+			if retryCount > 1 {
+				fmt.Print("\n\n")
+			}
+			fmt.Printf("===== Starting run %d =====\n", retryCount)
+			lastRunResult = doRun(m)
+			if lastRunResult == 0 {
+				tearOffAndExit(lastRunResult)
+			}
+		case <-timeoutTicker.C:
+			fmt.Printf("\n\n===== FAILED after %d retries\n", retryCount)
+			//fmt.Printf("Latest state:\n%s", sender.Mock.Calls)
+			tearOffAndExit(lastRunResult)
+		}
+	}
+}
+
+// Called before for first test run: compose up
+func setup(m *testing.M) error {
+	if docker.NeedInit() {
+		docker.InitDockerUtil(&docker.Config{
+			CollectNetwork: true,
+		})
+	}
+
+	// Setup global conf
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(datadogCfgString))
+	if err != nil {
+		return err
+	}
+
+	// Setup tagger
+	err = tagger.Init()
+	if err != nil {
+		return err
+	}
+
+	// Setup docker check
+	var dockerCfg = []byte(dockerCfgString)
+	var dockerInitCfg = []byte("")
+	dockerCheck = containers.DockerFactory()
+	dockerCheck.Configure(dockerCfg, dockerInitCfg)
+
+	// Setup mock sender
+	sender = mocksender.NewMockSender(dockerCheck.ID())
+	sender.SetupAcceptAll()
+
+	// Start compose recipes
+	for _, file := range defaultCatalog.composeFiles {
+		buildCmd := exec.Command("docker-compose",
+			"--project-name", "dockerchecktest",
+			"--file", fmt.Sprintf("testdata/%s", file),
+			"up", "-d")
+		output, err := buildCmd.CombinedOutput()
+		if err != nil {
+			fmt.Println(string(output))
+			return err
+		}
+	}
+	return nil
+}
+
+// Reset the state and trigger a new run
+func doRun(m *testing.M) int {
+	sender.ResetCalls()
+	dockerCheck.Run()
+	return m.Run()
+}
+
+// Compose down, reset the external states and exit
+func tearOffAndExit(exitcode int) {
+	if *skipCleanup {
+		os.Exit(exitcode)
+	}
+
+	// Stop compose recipes, ignore errors
+	for _, file := range defaultCatalog.composeFiles {
+		stopCmd := exec.Command("docker-compose",
+			"--project-name", "dockerchecktest",
+			"--file", fmt.Sprintf("testdata/%s", file),
+			"stop")
+		output, err := stopCmd.CombinedOutput()
+		if err != nil {
+			fmt.Println(string(output))
+		}
+	}
+	os.Exit(exitcode)
+}

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -19,8 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
-
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/test/integration/utils"
 )
 
 var retryDelay = flag.Int("retry-delay", 1, "time to wait between retries (default 1 second)")
@@ -114,11 +113,11 @@ func setup(m *testing.M) error {
 
 	// Start compose recipes
 	for _, file := range defaultCatalog.composeFiles {
-		buildCmd := exec.Command("docker-compose",
-			"--project-name", "dockerchecktest",
-			"--file", fmt.Sprintf("testdata/%s", file),
-			"up", "-d")
-		output, err := buildCmd.CombinedOutput()
+		compose := &utils.ComposeConf{
+			ProjectName: "dockerchecktest",
+			FilePath:    fmt.Sprintf("testdata/%s", file),
+		}
+		output, err := compose.Start()
 		if err != nil {
 			fmt.Println(string(output))
 			return err
@@ -142,11 +141,11 @@ func tearOffAndExit(exitcode int) {
 
 	// Stop compose recipes, ignore errors
 	for _, file := range defaultCatalog.composeFiles {
-		stopCmd := exec.Command("docker-compose",
-			"--project-name", "dockerchecktest",
-			"--file", fmt.Sprintf("testdata/%s", file),
-			"stop")
-		output, err := stopCmd.CombinedOutput()
+		compose := &utils.ComposeConf{
+			ProjectName: "dockerchecktest",
+			FilePath:    fmt.Sprintf("testdata/%s", file),
+		}
+		output, err := compose.Stop()
 		if err != nil {
 			fmt.Println(string(output))
 		}

--- a/test/integration/corechecks/docker/testdata/redis.compose
+++ b/test/integration/corechecks/docker/testdata/redis.compose
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  redis:
+    image: "redis:latest"
+    labels:
+        low.card.label: "redislow"
+        high.card.label: "redishigh"
+    environment:
+        LOW_CARD_ENV: "redislowenv"
+        HIGH_CARD_ENV: "redishighenv"


### PR DESCRIPTION
### What does this PR do?

- Add an integration test for the docker corecheck with `docker-compose` recipes as fixtures
- Add new asserts to the MockSender class
- Fix issues brought forward by the tests

### Fixes

- add instance tags to service checks

