### PR TITLE
Update histogram to use float instead of integer

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -76,11 +76,11 @@ metadata_collectors:
 #
 # histogram_aggregates: ["max", "median", "avg", "count"]
 #
-# Configure which percentiles will be computed. Must be a list of integer
-# between 1 and 100.
+# Configure which percentiles will be computed. Must be a list of float
+# between 0 and 1.
 # Warning: percentiles must be specified as yaml strings
 #
-# histogram_percentiles: ["95"]
+# histogram_percentiles: ["0.95"]
 
 # DogStatsd
 #

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,7 @@ func init() {
 	}
 	Datadog.SetDefault("proc_root", "/proc")
 	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
-	Datadog.SetDefault("histogram_percentiles", []string{"95"})
+	Datadog.SetDefault("histogram_percentiles", []string{"0.95"})
 	// Serializer
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -108,7 +108,7 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 
 	// these values are postprocessed in config.py, manually overwrite them
 	config["histogram_aggregates"] = "['max', 'median', 'avg', 'count']"
-	config["histogram_percentiles"] = "[0.95]"
+	config["histogram_percentiles"] = "['0.95']"
 	config["endpoints"] = "{}"
 	config["version"] = "5.18.0"
 	config["proxy_settings"] = "{'host': 'my-proxy.com', 'password': 'password', 'port': 3128, 'user': 'user'}"

--- a/pkg/legacy/importer_test.go
+++ b/pkg/legacy/importer_test.go
@@ -39,7 +39,18 @@ func TestGetAgentConfig(t *testing.T) {
 	var pos = 0
 	for python.PyDict_Next(agentConfigPy, &pos, &key, &value) {
 		keyStr := python.PyString_AS_STRING(key.Str())
+
 		valueStr := python.PyString_AS_STRING(value.Str())
+
+		// histogram_percentiles were converted from string to float
+		// by the config module in agent5. In agent6 this is now the
+		// responsibility of the histogram class.
+		// The value is overwritten anyway: we're just testing the
+		// default value.
+		if keyStr == "histogram_percentiles" {
+			valueStr = "['0.95']"
+		}
+
 		goValue, found := agentConfigGo[keyStr]
 		if valueStr != goValue {
 			t.Log(keyStr)

--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -57,16 +57,19 @@ type histogramPercentilesConfig struct {
 func (h *histogramPercentilesConfig) percentiles() []int {
 	res := []int{}
 	for _, p := range h.Percentiles {
-		i, err := strconv.Atoi(p)
+		i, err := strconv.ParseFloat(p, 64)
 		if err != nil {
 			log.Errorf("Could not parse '%s' from 'histogram_percentiles' (skipping): %s", p, err)
 			continue
 		}
-		if i < 1 || i > 100 {
-			log.Errorf("histogram_percentiles must be between 1 and 100: skipping %d", i)
+		if i < 0 || i > 1 {
+			log.Errorf("histogram_percentiles must be between 0 and 1: skipping %f", i)
 			continue
 		}
-		res = append(res, i)
+		// in some cases the '*100' will lower the number resulting in
+		// an int lower by 1 from what is expected (ex: 0.29 would
+		// become 28). As a workaround we add 0.5 before casting.
+		res = append(res, int(i*100+0.5))
 	}
 	return res
 }

--- a/pkg/metrics/histogram_test.go
+++ b/pkg/metrics/histogram_test.go
@@ -19,12 +19,12 @@ import (
 )
 
 func TestHistogramConf(t *testing.T) {
-	h := histogramPercentilesConfig{Percentiles: []string{"95", "96"}}
-	assert.Equal(t, []int{95, 96}, h.percentiles())
+	h := histogramPercentilesConfig{Percentiles: []string{"0.95", "0.96", "0.28", "0.57", "0.58"}}
+	assert.Equal(t, []int{95, 96, 28, 57, 58}, h.percentiles())
 }
 
 func TestHistogramConfError(t *testing.T) {
-	h := histogramPercentilesConfig{Percentiles: []string{"95", "12test", "22", "200", "-50"}}
+	h := histogramPercentilesConfig{Percentiles: []string{"0.95", "test", "0.12test", "0.22", "200", "-50"}}
 	assert.Equal(t, []int{95, 22}, h.percentiles())
 }
 
@@ -53,7 +53,7 @@ func TestConfigure(t *testing.T) {
 	defaultPercentiles = nil
 	aggregates := []string{"max", "min", "test"}
 	config.Datadog.Set("histogram_aggregates", aggregates)
-	config.Datadog.Set("histogram_percentiles", []string{"50", "30", "98"})
+	config.Datadog.Set("histogram_percentiles", []string{"0.50", "0.30", "0.98"})
 
 	hist := NewHistogram(10)
 	assert.Equal(t, aggregates, hist.aggregates)


### PR DESCRIPTION
### What does this PR do?

Update histogram to use float instead of integer. Agent5 use to work with float, no need to break compatibility.
This also change histogram_percentiles in the legacy config importer

### Motivation

Don't introduce a breaking change.