### PR TITLE
rework agent dockerfile for smaller image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,7 +191,7 @@ agent_rpm-x64:
     paths:
       - $AGENT_OMNIBUS_PACKAGE_DIR
 
-# build windows 
+# build windows
 build_windows_msi_x64:
   before_script:
     - if exist %GOPATH%\src\github.com\DataDog\datadog-agent rd /s/q %GOPATH%\src\github.com\DataDog\datadog-agent
@@ -229,6 +229,15 @@ build_agent6:
     DD_DIND_IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent/agent:$CI_PIPELINE_ID
     DD_DIND_ARTEFACTS: "true"
 
+# build the agent6 jmx image
+build_agent6_jmx:
+  <<: *dind_job_definition
+  variables:
+    DD_DIND_BUILD_CONTEXT: Dockerfiles/agent
+    DD_DIND_IMAGE: &agent_jmx_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent/agent:${CI_PIPELINE_ID}-jmx
+    DD_DIND_BUILD_ARG: "WITH_JMX=true"
+    DD_DIND_ARTEFACTS: "true"
+
 # build the dogstatsd image
 build_dogstatsd:
   <<: *dind_job_definition
@@ -258,6 +267,17 @@ agent6_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent:$CI_COMMIT_TAG
 
+agent6_jmx_docker_hub:
+  <<: *dind_tag_job_definition
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:${CI_COMMIT_TAG}-jmx
+
 agent6_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
@@ -268,6 +288,16 @@ agent6_dev_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent-dev:$CI_COMMIT_REF_SLUG
 
+agent6_jmx_dev_docker_hub:
+  <<: *dind_tag_job_definition
+  when: manual
+  except:
+    - master
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
+
 agent6_dev_docker_hub_master:
   <<: *dind_tag_job_definition
   only:
@@ -276,6 +306,15 @@ agent6_dev_docker_hub_master:
     DD_DIND_TAG_SOURCE: *agent_ecr
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent-dev:$CI_COMMIT_REF_SLUG
+
+agent6_jmx_dev_docker_hub_master:
+  <<: *dind_tag_job_definition
+  only:
+    - master
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
 
 dogstatsd_docker_hub:
   <<: *dind_tag_job_definition

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -1,25 +1,53 @@
+FROM debian:stretch-slim as extract
+ARG WITH_JMX
+COPY datadog-agent*_amd64.deb /
+WORKDIR /output
+
+# Extract and cleanup:
+#   - unused systemd unit
+#   - GPL sources for embedded software
+#   - docs and manpages
+#   - static libraries
+#   - jmxfetch on nojmx build
+RUN dpkg -x /datadog-agent*_amd64.deb . \
+ && rm -rf usr etc/init lib \
+    opt/datadog-agent/sources \
+    opt/datadog-agent/embedded/share/doc \
+    opt/datadog-agent/embedded/share/man \
+ && find opt/datadog-agent/ -iname "*.a" -delete \
+ && if [ -z "$WITH_JMX" ]; then rm -rf opt/datadog-agent/bin/agent/dist/jmx; fi
+
+# Configuration:
+#   - empty config file to remove logline
+#   - enable docker check by default
+#   - enable process agent
+ RUN touch etc/datadog-agent/datadog.yaml \
+ && mv etc/datadog-agent/conf.d/docker.yaml.example etc/datadog-agent/conf.d/docker.yaml.default \
+ && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default
+COPY entrypoint.sh .
+
+
 FROM debian:stretch-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
+ARG WITH_JMX
 ENV DOCKER_DD_AGENT=yes \
-    AGENT_VERSION=1:6.0-1 \
-    DD_AGENT_HOME=/opt/datadog-agent/
+    PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH
 
-# Install the Agent
-COPY datadog-agent*_amd64.deb /datadog-agent*_amd64.deb
+# Install dependencies:
+#   - ca-certificates for ssl connections
+#   - busybox (top+wget) for support - FIXME: remove once our support tooling has improved
+#   - openjdk-8-jre-headless for jmx flavor
 RUN apt-get update \
- && apt-get install --no-install-recommends -y apt-transport-https ca-certificates\
- && dpkg -i datadog-agent*_amd64.deb\
- && apt-get clean\
- && rm -rf agent6.deb /var/lib/apt/lists/* /tmp/* /var/tmp/*\
- && touch /etc/datadog-agent/datadog.yaml\
- && mv /etc/datadog-agent/conf.d/docker.yaml.example /etc/datadog-agent/conf.d/docker.yaml.default
+ && apt-get install --no-install-recommends -y ca-certificates busybox \
+ && if [ -n "$WITH_JMX" ]; then mkdir /usr/share/man/man1 && apt-get install --no-install-recommends -y openjdk-8-jre-headless; fi \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && busybox --install
 
-COPY entrypoint.sh /entrypoint.sh
+COPY --from=extract /output/ /
 
 EXPOSE 8125/udp
-
 ENTRYPOINT ["/entrypoint.sh"]
-
 CMD ["/opt/datadog-agent/bin/agent/agent", "start"]

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -33,14 +33,14 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ARG WITH_JMX
 ENV DOCKER_DD_AGENT=yes \
-    PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH
+    PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
+    SSL_CERT_DIR=/opt/datadog-agent/embedded/ssl
 
 # Install dependencies:
-#   - ca-certificates for ssl connections
 #   - busybox (top+wget) for support - FIXME: remove once our support tooling has improved
 #   - openjdk-8-jre-headless for jmx flavor
 RUN apt-get update \
- && apt-get install --no-install-recommends -y ca-certificates busybox \
+ && apt-get install --no-install-recommends -y busybox \
  && if [ -n "$WITH_JMX" ]; then mkdir /usr/share/man/man1 && apt-get install --no-install-recommends -y openjdk-8-jre-headless; fi \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /output
 
 # Extract and cleanup:
 #   - unused systemd unit
-#   - GPL sources for embedded software
-#   - docs and manpages
-#   - static libraries
+#   - GPL sources for embedded software  # FIXME: move upstream
+#   - docs and manpages                  # FIXME: move upstream
+#   - static libraries                   # FIXME: move upstream
 #   - jmxfetch on nojmx build
 RUN dpkg -x /datadog-agent*_amd64.deb . \
  && rm -rf usr etc/init lib \
@@ -48,6 +48,8 @@ RUN apt-get update \
 
 COPY --from=extract /output/ /
 
-EXPOSE 8125/udp
+# Expose DogStatsD and trace-agent ports
+EXPOSE 8125/udp 8126/tcp
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/opt/datadog-agent/bin/agent/agent", "start"]

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -28,24 +28,20 @@ COPY entrypoint.sh .
 
 
 FROM debian:stretch-slim
-
 LABEL maintainer "Datadog <package@datadoghq.com>"
-
 ARG WITH_JMX
 ENV DOCKER_DD_AGENT=yes \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
     SSL_CERT_DIR=/opt/datadog-agent/embedded/ssl
 
-# Install dependencies:
-#   - busybox (top+wget) for support - FIXME: remove once our support tooling has improved
-#   - openjdk-8-jre-headless for jmx flavor
-RUN apt-get update \
- && apt-get install --no-install-recommends -y busybox \
- && if [ -n "$WITH_JMX" ]; then mkdir /usr/share/man/man1 && apt-get install --no-install-recommends -y openjdk-8-jre-headless; fi \
+# Install openjdk-8-jre-headless on jmx flavor
+RUN if [ -n "$WITH_JMX" ]; then apt-get update \
+ && mkdir /usr/share/man/man1 \
+ && apt-get install --no-install-recommends -y openjdk-8-jre-headless \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
- && busybox --install
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
+# Copy agent from extract stage
 COPY --from=extract /output/ /
 
 # Expose DogStatsD and trace-agent ports

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -28,3 +28,5 @@ To build the image you'll need the agent debian package that can be found on thi
 You'll need to download one of the `datadog-agent*_amd64.deb` package in this directory, it will then be used by the `Dockerfile` and installed within the image.
 
 You can then build the image using `docker build -t datadog/agent:master .`
+
+To build the jmx variant, add `--build-arg WITH_JMX=true` to the build command

--- a/Dockerfiles/agent/entrypoint.sh
+++ b/Dockerfiles/agent/entrypoint.sh
@@ -8,7 +8,7 @@
 
 ##### Core config #####
 
-if [[ -z $DD_API_KEY ]]; then
+if [ -z $DD_API_KEY ]; then
     echo "You must set an DD_API_KEY environment variable to run the Datadog Agent container"
     exit 1
 fi
@@ -33,7 +33,5 @@ fi
 
 
 ##### Starting up #####
-
-export PATH="/opt/datadog-agent/bin/agent/:/opt/datadog-agent/bin/:$PATH"
 
 exec "$@"


### PR DESCRIPTION
### What does this PR do?

![](https://cl.ly/290Z2f003i00/[f18f373c1b1257a4aca3441b1b3a8098]_Image%202017-10-30%20at%2012.47.57%20PM.png)

### Smaller footprint

- use multistage build for agent6 image
- remove unused init, static libs, GPL sources and docs from package
- remove unused apt-transport-https package (debian packages are signed anyway) and ca-certificates (they are shipped in /opt)
- remove jmxfetch if not using the WITH_JMX build arg

### More functionnality
- change PATH to include bin/agent and embedded/bin
- enable process_agent
- expose port 8126 for trace agent

### Add JMX image
- add WITH_JMX build arg to install jre and keep jmxfetch
- build the *-jmx images in the CD pipeline (works with a hardcoded conf, AD seems non-functionnal on both images)
