### PR TITLE
Mfpierre/enable docker listener image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -21,8 +21,8 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 #   - empty config file to remove logline
 #   - enable docker check by default
 #   - enable process agent
- RUN touch etc/datadog-agent/datadog.yaml \
- && mv etc/datadog-agent/conf.d/docker.yaml.example etc/datadog-agent/conf.d/docker.yaml.default \
+COPY datadog.yaml etc/datadog-agent/datadog.yaml
+RUN mv etc/datadog-agent/conf.d/docker.yaml.example etc/datadog-agent/conf.d/docker.yaml.default \
  && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default
 COPY entrypoint.sh .
 

--- a/Dockerfiles/agent/datadog.yaml
+++ b/Dockerfiles/agent/datadog.yaml
@@ -1,0 +1,3 @@
+# Autodiscovery
+listeners:
+  - name: docker

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -151,8 +151,8 @@ func (l *DockerListener) processEvent(e events.Message) {
 		if e.Action == "die" {
 			l.removeService(cID)
 		} else {
-			log.Error("TODO - this shouldn't happen, expected die")
-			signals.ErrorStopper <- true
+			// FIXME sometimes the agent's container's events are picked up twice at startup
+			log.Debugf("Expected die for container %s got %s **skipping event**", cID[:12], e.Action)
 			return
 		}
 	} else {


### PR DESCRIPTION
### What does this PR do?

* Enable docker listener by default in agent image
* Remove fatal error on docker events
