### PR TITLE
Make flare cmdline compatible with v5

### DIFF
--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	customerEmail string
-	caseID        string
 	autoconfirm   bool
 )
 
@@ -26,7 +25,6 @@ func init() {
 	AgentCmd.AddCommand(flareCmd)
 
 	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
-	flareCmd.Flags().StringVarP(&caseID, "case-id", "i", "", "Your case ID")
 	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
 	flareCmd.SetArgs([]string{"caseID"})
 }
@@ -40,9 +38,15 @@ var flareCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		caseID := ""
+		if len(args) > 0 {
+			caseID = args[0]
+		}
+
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format
 		config.SetupLogger("off", "", "", false, false, "")
-		if customerEmail == "" && caseID == "" {
+		if customerEmail == "" {
 			var err error
 			customerEmail, err = flare.AskForEmail()
 			if err != nil {
@@ -50,11 +54,12 @@ var flareCmd = &cobra.Command{
 				return err
 			}
 		}
-		return requestFlare()
+
+		return requestFlare(caseID)
 	},
 }
 
-func requestFlare() error {
+func requestFlare(caseID string) error {
 	fmt.Println("Asking the agent to build the flare archive.")
 	var e error
 	c := common.GetClient(false) // FIX: get certificates right then make this true

--- a/pkg/flare/flare_test.go
+++ b/pkg/flare/flare_test.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package flare
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMkURL(t *testing.T) {
+	common.SetupConfig("./test")
+	config.Datadog.Set("dd_url", "https://example.com")
+	config.Datadog.Set("api_key", "123456")
+	assert.Equal(t, "https://example.com/support/flare/999?api_key=123456", mkURL("999"))
+	assert.Equal(t, "https://example.com/support/flare?api_key=123456", mkURL(""))
+}


### PR DESCRIPTION
### What does this PR do?

Change the flare command interface from:
`datadog-agent flare -i 1234`
to
`datadog-agent flare 1234`
so it's the same we had in agent 5

### Motivation

Users expect to invoke the flare command as before
