### PR TITLE
Move default logfile path definition to `cmd/agent`

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -76,8 +77,13 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultLogFile
+	}
+
 	log.Infof("Making a flare")
-	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath)
+	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -65,6 +65,11 @@ func requestFlare(caseID string) error {
 	c := common.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/agent/flare", config.Datadog.GetInt("cmd_port"))
 
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultLogFile
+	}
+
 	// Set session token
 	util.SetAuthToken()
 
@@ -78,7 +83,7 @@ func requestFlare(caseID string) error {
 		}
 		fmt.Println("Initiating flare locally.")
 
-		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath)
+		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -123,6 +123,10 @@ func StartAgent() error {
 	// Setup logger
 	syslogURI := config.GetSyslogURI()
 	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultLogFile
+	}
+
 	if config.Datadog.GetBool("disable_file_logging") {
 		// this will prevent any logging on file
 		logFile = ""

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -9,8 +9,12 @@ import (
 	"path/filepath"
 )
 
-// DefaultConfPath points to the folder containing datadog.yaml
-const DefaultConfPath = "/opt/datadog-agent/etc/datadog-agent"
+const (
+	// DefaultConfPath points to the folder containing datadog.yaml
+	DefaultConfPath = "/opt/datadog-agent/etc/datadog-agent"
+	// DefaultLogFile points to the log file that will be used if not configured
+	DefaultLogFile = "/var/log/datadog/agent.log"
+)
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -11,8 +11,12 @@ import (
 	"path/filepath"
 )
 
-// DefaultConfPath points to the folder containing datadog.yaml
-const DefaultConfPath = "/etc/datadog-agent"
+const (
+	// DefaultConfPath points to the folder containing datadog.yaml
+	DefaultConfPath = "/etc/datadog-agent"
+	// DefaultLogFile points to the log file that will be used if not configured
+	DefaultLogFile = "/var/log/datadog/agent.log"
+)
 
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -28,9 +28,12 @@ var (
 	viewsPath string
 )
 
-// DefaultConfPath points to the folder containing datadog.yaml
-const DefaultConfPath = "c:\\programdata\\datadog"
-const defaultLogPath = "c:\\programdata\\datadog\\logs\\agent.log"
+const (
+	// DefaultConfPath points to the folder containing datadog.yaml
+	DefaultConfPath = "c:\\programdata\\datadog"
+	// DefaultLogFile points to the log file that will be used if not configured
+	DefaultLogFile = "c:\\programdata\\datadog\\logs\\agent.log"
+)
 
 // EnableLoggingToFile -- set up logging to file
 func EnableLoggingToFile() {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -96,10 +96,15 @@ func start(cmd *cobra.Command, args []string) error {
 	// Setup logger
 	syslogURI := config.GetSyslogURI()
 	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = defaultLogFile
+	}
+
 	if config.Datadog.GetBool("disable_file_logging") {
 		// this will prevent any logging on file
 		logFile = ""
 	}
+
 	err := config.SetupLogger(
 		config.Datadog.GetString("log_level"),
 		logFile,

--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -7,4 +7,4 @@
 
 package main
 
-const defaultLogPath = "/var/log/datadog/dogstatsd.log"
+const defaultLogFile = "/var/log/datadog/dogstatsd.log"

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -5,4 +5,4 @@
 
 package main
 
-const defaultLogPath = "c:\\programdata\\datadog\\logs\\dogstatsd.log"
+const defaultLogFile = "c:\\programdata\\datadog\\logs\\dogstatsd.log"

--- a/pkg/collector/corechecks/embed/common.go
+++ b/pkg/collector/corechecks/embed/common.go
@@ -16,7 +16,7 @@ const defaultRetries = 3
 func retryExitError(err error) error {
 	switch err.(type) {
 	case *exec.ExitError: // error type returned when the process exits with non-zero status
-		return check.RetryableError{err}
+		return check.RetryableError{Err: err}
 	default:
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,7 +71,6 @@ func init() {
 	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
-	Datadog.SetDefault("log_file", defaultLogPath)
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("log_to_syslog", false)
 	Datadog.SetDefault("disable_file_logging", false)

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -8,7 +8,6 @@ package config
 const (
 	defaultConfdPath            = "/opt/datadog-agent/etc/conf.d"
 	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
-	defaultLogPath              = "/var/log/datadog/agent.log"
 	defaultJMXPipePath          = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///var/run/syslog"
 )

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -10,7 +10,6 @@ package config
 const (
 	defaultConfdPath            = "/etc/datadog-agent/conf.d"
 	defaultAdditionalChecksPath = "/etc/datadog-agent/checks.d"
-	defaultLogPath              = "/var/log/datadog/agent.log"
 	defaultJMXPipePath          = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///dev/log"
 )

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -9,6 +9,5 @@ const (
 	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
 	defaultJMXPipePath          = "\\\\.\\pipe\\"
-	defaultLogPath              = "c:\\programdata\\datadog\\logs\\agent.log"
 	defaultSyslogURI            = ""
 )

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -19,7 +19,7 @@ func TestCreateArchive(t *testing.T) {
 	config.Datadog.Set("confd_path", "./test/confd")
 	config.Datadog.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := mkFilePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{})
+	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -38,7 +38,7 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 
 	common.SetupConfig("")
 	zipFilePath := mkFilePath()
-	filePath, err := createArchive(zipFilePath, true, SearchPaths{})
+	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)


### PR DESCRIPTION
### What does this PR do?

The `config` package is supposed to be general purpose but some of the defaults provided are agent specific, it's the case of `log_file`. Leave the default log file definition to the specific clients.

### Motivation

Dogstatsd writes to the agent log file if the config file doesn't define `log_file`
