### PR TITLE
Resolve AD config file templates at startup

### DIFF
--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -155,7 +155,7 @@ func (l *DockerListener) processEvent(e events.Message) {
 			l.removeService(cID)
 		} else {
 			// FIXME sometimes the agent's container's events are picked up twice at startup
-			log.Debugf("Expected die for container %s got %s **skipping event**", cID[:12], e.Action)
+			log.Debugf("Expected die for container %s got %s: skipping event", cID[:12], e.Action)
 			return
 		}
 	} else {


### PR DESCRIPTION
### What does this PR do?

* The autoconfig was only resolving templates when polling config, the thing is the file config provider is for the moment not polled and only called once resulting in skipping all files AD templates
* and two little fix (vet + log)