### PR TITLE
[docker] add conf copy to entrypoint + healthcheck

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -47,5 +47,9 @@ COPY --from=extract /output/ /
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 
+# Placeholder healthcheck, to be improved
+HEALTHCHECK --interval=5m --timeout=20s --retries=1 \
+  CMD ["/opt/datadog-agent/bin/agent/agent", "status"]
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/opt/datadog-agent/bin/agent/agent", "start"]

--- a/Dockerfiles/agent/entrypoint.sh
+++ b/Dockerfiles/agent/entrypoint.sh
@@ -31,6 +31,11 @@ else
     fi
 fi
 
+# Copy custom confs
+
+find /conf.d -name '*.yaml' -exec cp --parents {} /etc/datadog-agent/ \;
+
+find /checks.d -name '*.py' -exec cp --parents {} /etc/datadog-agent/ \;
 
 ##### Starting up #####
 


### PR DESCRIPTION
### What does this PR do?

- Add a healthcheck to the image. For now, we run `agent status`, that returns 1 if it can't connect to the agent. Although if the agent is not running the container is not running either. But it can detect a process freeze though. Later, we need to determine what a `healthy` agent is (collector runs, forwarder forwards successfully...) and add a `agent status --healthcheck` or `agent healthcheck` command 

- Add logic in the entrypoint to copy `/conf.d` and `/checks.d` to `/etc/datadog-agent` on start.
