### PR TITLE
[docker] Move network routing after processing all containers.

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -184,7 +184,6 @@ func (d *dockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*Container, e
 				}
 				d.networkMappings[c.ID] = findDockerNetworks(c.ID, i.State.Pid, c)
 			}
-			resolveDockerNetworks(d.networkMappings)
 			d.Unlock()
 		}
 
@@ -206,6 +205,14 @@ func (d *dockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*Container, e
 			continue
 		}
 		ret = append(ret, container)
+	}
+
+	// Resolve docker networks after we've processed all containers so all
+	// routing maps are available.
+	if d.cfg.CollectNetwork {
+		d.Lock()
+		resolveDockerNetworks(d.networkMappings)
+		d.Unlock()
 	}
 
 	if d.lastInvalidate.Add(invalidationInterval).After(time.Now()) {

--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -146,7 +146,7 @@ func resolveDockerNetworks(containerNetworks map[string][]dockerNetwork) {
 			if cnw, ok := containerNetworks[nw.routingContainerID]; ok {
 				containerNetworks[cid] = cnw
 			} else {
-				log.Debugf("unable resolve network for c:%s that uses namespace of c:%s", cid, nw.routingContainerID)
+				log.Debugf("unable to resolve network for c:%s that uses namespace of c:%s", cid, nw.routingContainerID)
 				containerNetworks[cid] = nil
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Moves the network route resolution after fetching all docker networks in order to be certain that all container-based networks will resolve accurately.

Also fixes a typo in a log message.

### Motivation

Fixes a bug in the process-agent running in K8s with the latest master code.
