### PR TITLE
[omnibus] Blacklist ntp check from integrations-core

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -20,6 +20,7 @@ blacklist = [
   'docker_daemon',
   'kubernetes',
   'kubernetes_state',
+  'ntp',  # provided as a go check by the core agent
   'vsphere',
 ]
 


### PR DESCRIPTION
### What does this PR do?

Blacklists ntp check that's in integrations-core so that it's not shipped with agent 6.

### Motivation

We provide it in the core agent as a go check now

