### PR TITLE
fix AD DockerListener image name lookup

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -107,7 +107,7 @@ func (d *DockerCheck) countAndWeightImages(sender aggregator.Sender) error {
 
 	if d.instance.CollectImageSize {
 		for _, i := range availableImages {
-			name, tag, err := docker.SplitImageName(i.RepoTags[0])
+			name, _, tag, err := docker.SplitImageName(i.RepoTags[0])
 			if err != nil {
 				log.Errorf("could not parse image name and tag, RepoTag is: %s", i.RepoTags[0])
 				continue

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -230,20 +230,11 @@ func (l *DockerListener) removeService(cID ID) {
 //   1. Long image name
 //   2. Short image name
 func (l *DockerListener) getConfigIDFromPs(co types.Container) []string {
-	// check for an identifier label
-	for l, v := range co.Labels {
-		if l == identifierLabel {
-			return []string{v}
-		}
+	image, err := docker.ResolveImageName(co.Image)
+	if err != nil {
+		log.Warnf("error while resolving image name: %s", err)
 	}
-
-	ids := []string{}
-
-	// use the image name
-	ids = append(ids, co.Image) // TODO: check if it's the sha256
-	// TODO: add the short name with lower priority
-
-	return ids
+	return computeDockerIDs(image, co.Labels)
 }
 
 // getHostsFromPs gets the addresss (for now IP address only) of a container on all its networks.
@@ -291,20 +282,11 @@ func (s *DockerService) GetADIdentifiers() ([]string, error) {
 		if err != nil {
 			return []string{}, err
 		}
-
-		// check for an identifier label
-		for l, v := range cj.Config.Labels {
-			if l == identifierLabel {
-				return []string{v}, nil
-			}
+		image, err := docker.ResolveImageName(cj.Image)
+		if err != nil {
+			log.Warnf("error while resolving image name: %s", err)
 		}
-
-		ids := []string{}
-
-		// use the image name
-		ids = append(ids, cj.Image) // TODO: check if it's the sha256
-		// TODO: add the short name with lower priority
-		s.ADIdentifiers = ids
+		s.ADIdentifiers = computeDockerIDs(image, cj.Config.Labels)
 	}
 
 	return s.ADIdentifiers, nil
@@ -382,4 +364,33 @@ func (s *DockerService) GetPid() (int, error) {
 	}
 
 	return s.Pid, nil
+}
+
+// computeDockerIDs factors in code for getConfigIDFromPs and GetADIdentifiers
+// it assumes the image name's sha is already resolved via docker.ResolveImageName
+func computeDockerIDs(image string, labels map[string]string) []string {
+	var ids []string
+
+	// check for an identifier label
+	for l, v := range labels {
+		if l == identifierLabel {
+			ids = append(ids, v)
+			// Let's not return the image name if we find the label
+			return ids
+		}
+	}
+
+	// add the image names (long then short if different)
+	long, short, _, err := docker.SplitImageName(image)
+	if err != nil {
+		log.Warnf("error while spliting image name: %s", err)
+	}
+	if len(long) > 0 {
+		ids = append(ids, long)
+	}
+	if len(short) > 0 && short != long {
+		ids = append(ids, short)
+	}
+
+	return ids
 }

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -28,8 +28,14 @@ func TestGetConfigIDFromPs(t *testing.T) {
 	dl := DockerListener{}
 
 	ids := dl.getConfigIDFromPs(co)
-	assert.Len(t, ids, 1)
-	assert.Equal(t, "test", ids[0])
+	assert.Equal(t, []string{"test"}, ids)
+
+	prefixCo := types.Container{
+		ID:    "deadbeef",
+		Image: "org/test",
+	}
+	ids = dl.getConfigIDFromPs(prefixCo)
+	assert.Equal(t, []string{"org/test", "test"}, ids)
 
 	labeledCo := types.Container{
 		ID:     "deadbeef",
@@ -37,8 +43,7 @@ func TestGetConfigIDFromPs(t *testing.T) {
 		Labels: map[string]string{"io.datadog.check.id": "w00tw00t"},
 	}
 	ids = dl.getConfigIDFromPs(labeledCo)
-	assert.Len(t, ids, 1)
-	assert.Equal(t, "w00tw00t", ids[0])
+	assert.Equal(t, []string{"w00tw00t"}, ids)
 }
 
 func TestGetHostsFromPs(t *testing.T) {
@@ -95,7 +100,7 @@ func TestGetADIdentifiers(t *testing.T) {
 
 	// Setting mocked data in cache
 	co := types.ContainerJSON{
-		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "test"},
+		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "org/test"},
 		Mounts:            make([]types.MountPoint, 0),
 		Config:            &container.Config{},
 		NetworkSettings:   &types.NetworkSettings{},
@@ -105,8 +110,7 @@ func TestGetADIdentifiers(t *testing.T) {
 
 	ids, err := s.GetADIdentifiers()
 	assert.Nil(t, err)
-	assert.Len(t, ids, 1)
-	assert.Equal(t, "test", ids[0])
+	assert.Equal(t, []string{"org/test", "test"}, ids)
 
 	s = DockerService{ID: ID("deadbeef")}
 	labeledCo := types.ContainerJSON{
@@ -119,8 +123,7 @@ func TestGetADIdentifiers(t *testing.T) {
 
 	ids, err = s.GetADIdentifiers()
 	assert.Nil(t, err)
-	assert.Len(t, ids, 1)
-	assert.Equal(t, "w00tw00t", ids[0])
+	assert.Equal(t, []string{"w00tw00t"}, ids)
 }
 
 func TestGetHosts(t *testing.T) {

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -26,7 +26,7 @@ func (c *DockerCollector) extractFromInspect(co types.ContainerJSON) ([]string, 
 		log.Debugf("error resolving image %s: %s", co.Image, err)
 
 	} else {
-		image_name, image_tag, err := docker.SplitImageName(docker_image)
+		image_name, _, image_tag, err := docker.SplitImageName(docker_image)
 
 		low = append(low, fmt.Sprintf("docker_image:%s", docker_image))
 

--- a/pkg/util/docker/global_test.go
+++ b/pkg/util/docker/global_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitImageName(t *testing.T) {
+	assert := assert.New(t)
+	for nb, tc := range []struct {
+		source     string
+		long_name  string
+		short_name string
+		tag        string
+		err        error
+	}{
+		// Empty
+		{"", "", "", "", fmt.Errorf("empty image name")},
+		// Shortest possibility
+		{"alpine", "alpine", "alpine", "", nil},
+		// Historical docker format
+		{"nginx:latest", "nginx", "nginx", "latest", nil},
+		// Org prefix to be removed for short name
+		{"datadog/docker-dd-agent:latest-jmx",
+			"datadog/docker-dd-agent", "docker-dd-agent", "latest-jmx", nil},
+		// Sha-pinning used by many orchestrators -> empty tag
+		// We should not have this string here as ResolveImageName should
+		// have handled that before, but let's keep it just in case
+		{"redis@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
+			"redis", "redis", "", nil},
+		// Quirky pinning used by swarm
+		{"org/redis:latest@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
+			"org/redis", "redis", "latest", nil},
+		// Custom registry, simple form
+		{"myregistry.local:5000/testing/test-image:version",
+			"myregistry.local:5000/testing/test-image", "test-image", "version", nil},
+		// Custom registry, most insane form possible
+		{"myregistry.local:5000/testing/test-image:version@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
+			"myregistry.local:5000/testing/test-image", "test-image", "version", nil},
+	} {
+		t.Logf("test case %d", nb)
+		long, short, tag, err := SplitImageName(tc.source)
+		assert.Equal(tc.long_name, long)
+		assert.Equal(tc.short_name, short)
+		assert.Equal(tc.tag, tag)
+
+		if tc.err == nil {
+			assert.Nil(err)
+		} else {
+			assert.NotNil(err)
+			assert.Equal(tc.err.Error(), err.Error())
+		}
+	}
+}

--- a/pkg/util/docker/global_test.go
+++ b/pkg/util/docker/global_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestSplitImageName(t *testing.T) {
-	assert := assert.New(t)
 	for nb, tc := range []struct {
 		source     string
 		long_name  string
@@ -47,17 +46,19 @@ func TestSplitImageName(t *testing.T) {
 		{"myregistry.local:5000/testing/test-image:version@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
 			"myregistry.local:5000/testing/test-image", "test-image", "version", nil},
 	} {
-		t.Logf("test case %d", nb)
-		long, short, tag, err := SplitImageName(tc.source)
-		assert.Equal(tc.long_name, long)
-		assert.Equal(tc.short_name, short)
-		assert.Equal(tc.tag, tag)
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {
+			assert := assert.New(t)
+			long, short, tag, err := SplitImageName(tc.source)
+			assert.Equal(tc.long_name, long)
+			assert.Equal(tc.short_name, short)
+			assert.Equal(tc.tag, tag)
 
-		if tc.err == nil {
-			assert.Nil(err)
-		} else {
-			assert.NotNil(err)
-			assert.Equal(tc.err.Error(), err.Error())
-		}
+			if tc.err == nil {
+				assert.Nil(err)
+			} else {
+				assert.NotNil(err)
+				assert.Equal(tc.err.Error(), err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

- resolve sha checksums to real image tag
- if label, not set, send long name AND short name 
- update tests

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
