### PR TITLE
adds option to disable gohai metadata collection

### DIFF
--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -62,7 +62,7 @@ api_key:
 # enable_metadata_collection: true
 
 # Enable the gohai collection of systems data
-# enable_gohai: false
+# enable_gohai: true
 
 # Metadata collectors, add or remove from the list to enable or disable collection.
 # Intervals are expressed in seconds.

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -61,7 +61,7 @@ api_key:
 # WARNING: disabling it on every agent will lead to display and billing issues
 # enable_metadata_collection: true
 
-# Disable the gohai collection of systems data
+# Enable the gohai collection of systems data
 # enable_gohai: false
 
 # Metadata collectors, add or remove from the list to enable or disable collection.

--- a/pkg/collector/dist/datadog.yaml
+++ b/pkg/collector/dist/datadog.yaml
@@ -61,6 +61,9 @@ api_key:
 # WARNING: disabling it on every agent will lead to display and billing issues
 # enable_metadata_collection: true
 
+# Disable the gohai collection of systems data
+# enable_gohai: false
+
 # Metadata collectors, add or remove from the list to enable or disable collection.
 # Intervals are expressed in seconds.
 metadata_collectors:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,7 @@ func init() {
 	Datadog.SetDefault("cmd_port", 5001)
 	Datadog.SetDefault("default_integration_http_timeout", 9)
 	Datadog.SetDefault("enable_metadata_collection", true)
+	Datadog.SetDefault("enable_gohai", true)
 	Datadog.SetDefault("check_runners", int64(20))
 	Datadog.SetDefault("expvar_port", "5000")
 	if IsContainerized() {

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -108,6 +108,10 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("enable_metadata_collection", enabled)
 	}
 
+	if enabled, err := isAffirmative(agentConfig["enable_gohai"]); err == nil {
+		config.Datadog.Set("enable_gohai", enabled)
+	}
+
 	return nil
 }
 

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -68,6 +68,7 @@ var (
 		"connection_limit",
 		"resource",
 		"disable_file_logging",
+		"enable_gohai",
 	}
 )
 

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -8,6 +8,7 @@
 package v5
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
@@ -19,12 +20,16 @@ func GetPayload(hostname string) *Payload {
 	cp := common.GetPayload(hostname)
 	hp := host.GetPayload(hostname)
 	rp := resources.GetPayload(hostname)
-	gp := gohai.GetPayload()
 
-	return &Payload{
+	p := &Payload{
 		CommonPayload:    CommonPayload{*cp},
 		HostPayload:      HostPayload{*hp},
 		ResourcesPayload: ResourcesPayload{*rp},
-		GohaiPayload:     GohaiPayload{MarshalledGohaiPayload{*gp}},
 	}
+
+	if config.Datadog.GetBool("enable_gohai") {
+		p.GohaiPayload = GohaiPayload{MarshalledGohaiPayload{*gohai.GetPayload()}}
+	}
+
+	return p
 }


### PR DESCRIPTION
### What does this PR do?

Sometimes customers want to disable gohai metadata collection, but it's currently not possible without removing the binary. It should be possible through a configuration option. This adds a config option, `disable_gohai`, which disables the collection of metadata by the gohai binary. 

This is a sister PR to this one for the dd-agent: https://github.com/DataDog/dd-agent/pull/3572