### PR TITLE
[CCI] pre-compile go deps for faster CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,13 @@ jobs:
     steps:
       - run: *save_sha
       - restore_cache: *restore_source
-      - restore_cache: *restore_vendor
+      #- restore_cache: *restore_vendor
       - run:
           name: grab go deps
           command: invoke deps
       - run:
           name: pre-compile go deps
-          command: inv agent.build -e
+          command: inv agent.build --race --precompile-only
       - save_cache:
           key: v1-govendordeps-{{ checksum "Gopkg.toml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ templates:
           - v1-repo-{{ checksum ".circle-sha" }}
     - restore_cache: &restore_vendor
         keys:
+          # The first match will be used. Doing that so new branches
+          # use master's cache but don't pollute it back.
           - v1-govendordeps-{{ .Branch }}-{{ checksum "Gopkg.toml" }}
           - v1-govendordeps-master-{{ checksum "Gopkg.toml" }}
     - restore_cache: &restore_gobindeps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - restore_cache: *restore_deps
       - run:
           name: run unit tests
-          command: inv -e test --coverage --race
+          command: inv -e test --coverage --race --fail-on-fmt
 
   integration_tests:
     <<: *job_template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,14 @@ jobs:
       - run:
           name: grab go deps
           command: invoke deps
+      - run:
+          name: pre-compile go deps
+          command: inv agent.build -e
       - save_cache:
           key: v1-govendordeps-{{ checksum "Gopkg.toml" }}
           paths:
             - /go/src/github.com/DataDog/datadog-agent/vendor
+            - /go/pkg
       - save_cache:
           key: v1-gobindeps
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,39 +12,33 @@ templates:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent
   step_templates:
-    - run: &save_sha
-        name: save SHA to a file
-        command: echo $CIRCLE_SHA1 > .circle-sha
     - restore_cache: &restore_source
         keys:
-          - v1-repo-{{ checksum ".circle-sha" }}
-    - restore_cache: &restore_vendor
+          # Cache retrieval is faster than full git checkout
+          - v2-repo-{{ .Revision }}
+    - restore_cache: &restore_deps
         keys:
           # The first match will be used. Doing that so new branches
           # use master's cache but don't pollute it back.
-          - v1-govendordeps-{{ .Branch }}-{{ checksum "Gopkg.toml" }}
-          - v1-govendordeps-master-{{ checksum "Gopkg.toml" }}
-    - restore_cache: &restore_gobindeps
-        keys:
-          - v1-gobindeps
+          - v2-godeps-{{ .Branch }}-{{ .Revision }}
+          - v2-godeps-{{ .Branch }}-
+          - v2-godeps-master-
 
 jobs:
   checkout_code:
     <<: *job_template
     steps:
       - checkout
-      - run: *save_sha
       - save_cache:
-          key: v1-repo-{{ checksum ".circle-sha" }}
+          key: v2-repo-{{ .Revision }}
           paths:
             - /go/src/github.com/DataDog/datadog-agent
 
   dependencies:
     <<: *job_template
     steps:
-      - run: *save_sha
       - restore_cache: *restore_source
-      - restore_cache: *restore_vendor
+      - restore_cache: *restore_deps
       - run:
           name: grab go deps
           command: invoke deps
@@ -52,59 +46,48 @@ jobs:
           name: pre-compile go deps
           command: inv agent.build --race --precompile-only
       - save_cache:
-          key: v1-govendordeps-{{ .Branch }}-{{ checksum "Gopkg.toml" }}
+          key: v2-godeps-{{ .Branch }}-{{ .Revision }}
           paths:
             - /go/src/github.com/DataDog/datadog-agent/vendor
             - /go/pkg
-      - save_cache:
-          key: v1-gobindeps
-          paths:
             - /go/bin
 
   unit_tests:
     <<: *job_template
     steps:
-      - run: *save_sha
       - restore_cache: *restore_source
-      - restore_cache: *restore_vendor
-      - restore_cache: *restore_gobindeps
+      - restore_cache: *restore_deps
       - run:
           name: run unit tests
-          command: invoke -e test --coverage --race
+          command: inv -e test --coverage --race
 
   integration_tests:
     <<: *job_template
     steps:
-      - run: *save_sha
       - restore_cache: *restore_source
-      - restore_cache: *restore_vendor
-      - restore_cache: *restore_gobindeps
+      - restore_cache: *restore_deps
       - setup_remote_docker
       - run:
           name: run integration tests
-          command: inv integration-tests --race --install-deps --remote-docker
+          command: inv  -e integration-tests --race --remote-docker
 
   build_binaries:
     <<: *job_template
     steps:
-      - run: *save_sha
       - restore_cache: *restore_source
-      - restore_cache: *restore_vendor
-      - restore_cache: *restore_gobindeps
+      - restore_cache: *restore_deps
       - run:
           name: build dogstatsd
           command: inv -e dogstatsd.build --static
       - run:
           name: build agent
-          command: inv agent.build
+          command: inv -e agent.build
 
   build_puppy:
     <<: *job_template
     steps:
-      - run: *save_sha
       - restore_cache: *restore_source
-      - restore_cache: *restore_vendor
-      - restore_cache: *restore_gobindeps
+      - restore_cache: *restore_deps
       - run:
           name: build puppy
           command: inv agent.build --puppy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ templates:
           - v1-repo-{{ checksum ".circle-sha" }}
     - restore_cache: &restore_vendor
         keys:
-          - v1-govendordeps-{{ checksum "Gopkg.toml" }}
+          - v1-govendordeps-{{ .Branch }}-{{ checksum "Gopkg.toml" }}
+          - v1-govendordeps-master-{{ checksum "Gopkg.toml" }}
     - restore_cache: &restore_gobindeps
         keys:
           - v1-gobindeps
@@ -41,7 +42,7 @@ jobs:
     steps:
       - run: *save_sha
       - restore_cache: *restore_source
-      #- restore_cache: *restore_vendor
+      - restore_cache: *restore_vendor
       - run:
           name: grab go deps
           command: invoke deps
@@ -49,7 +50,7 @@ jobs:
           name: pre-compile go deps
           command: inv agent.build --race --precompile-only
       - save_cache:
-          key: v1-govendordeps-{{ checksum "Gopkg.toml" }}
+          key: v1-govendordeps-{{ .Branch }}-{{ checksum "Gopkg.toml" }}
           paths:
             - /go/src/github.com/DataDog/datadog-agent/vendor
             - /go/pkg
@@ -79,7 +80,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: run integration tests
-          command: inv integration-tests --install-deps --remote-docker
+          command: inv integration-tests --race --install-deps --remote-docker
 
   build_binaries:
     <<: *job_template

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,7 +83,6 @@
 [[constraint]]
   name = "gopkg.in/yaml.v2"
 
-
 [[constraint]]
   name = "gopkg.in/zorkian/go-datadog-api.v2"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -86,6 +86,7 @@
 [[constraint]]
   name = "gopkg.in/zorkian/go-datadog-api.v2"
 
+
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "v1.10.33"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,9 +83,9 @@
 [[constraint]]
   name = "gopkg.in/yaml.v2"
 
+
 [[constraint]]
   name = "gopkg.in/zorkian/go-datadog-api.v2"
-
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,14 @@ install:
   - choco install pkgconfiglite
 
 cache:
-  - '%GOPATH%/pkg/dep'
+  - '%GOPATH%\bin'
+  - '%GOPATH%\pkg'
+  - '%GOPATH%\src\github.com\DataDog\datadog-agent\vendor'
 
 build: off
 
 test_script:
   - cd
   - inv -e deps
-  - inv -e test --coverage --race --fail-on-fmt
+  - inv -e agent.build --race --precompile-only
+  - inv -e test --race --fail-on-fmt

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -22,7 +22,7 @@ AGENT_TAG = "datadog/agent:master"
 
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-          puppy=False, use_embedded_libs=False, development=True):
+          puppy=False, use_embedded_libs=False, development=True, precompile_only=False):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -69,7 +69,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     cmd += "-o {agent_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/agent"
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else "",
+        "build_type": "-a" if rebuild else ("-i" if precompile_only else ""),
         "go_build_tags": " ".join(build_tags),
         "agent_bin": os.path.join(BIN_PATH, bin_name("agent")),
         "gcflags": gcflags,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -146,7 +146,7 @@ def image_build(ctx, base_dir="omnibus"):
 
 
 @task
-def integration_tests(ctx, install_deps=False, remote_docker=False):
+def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     """
     Run integration tests for the Agent
     """
@@ -155,13 +155,14 @@ def integration_tests(ctx, install_deps=False, remote_docker=False):
 
     test_args = {
         "go_build_tags": " ".join(get_default_build_tags()),
+        "race_opt": "-race" if race else "",
         "exec_opts": "",
     }
 
     if remote_docker:
         test_args["exec_opts"] = "-exec \"inv docker.dockerize-test\""
 
-    go_cmd = 'go test -tags "{go_build_tags}" {exec_opts}'.format(**test_args)
+    go_cmd = 'go test {race_opt} -tags "{go_build_tags}" {exec_opts}'.format(**test_args)
 
     prefixes = [
         "./test/integration/config_providers/...",

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -148,22 +148,23 @@ def omnibus_build(ctx):
 
 
 @task
-def integration_tests(ctx, install_deps=False, remote_docker=False):
+def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     """
-    Run integration tests for Dogstatsd
+    Run integration tests for dogstatsd
     """
     if install_deps:
         deps(ctx)
 
     test_args = {
         "go_build_tags": " ".join(get_default_build_tags()),
+        "race_opt": "-race" if race else "",
         "exec_opts": "",
     }
 
     if remote_docker:
         test_args["exec_opts"] = "-exec \"inv docker.dockerize-test\""
 
-    go_cmd = 'go test -tags "{go_build_tags}" {exec_opts}'.format(**test_args)
+    go_cmd = 'go test {race_opt} -tags "{go_build_tags}" {exec_opts}'.format(**test_args)
 
     prefixes = [
         "./test/integration/dogstatsd/...",

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -110,12 +110,13 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
 
 
 @task
-def integration_tests(ctx, install_deps=False, remote_docker=False):
+def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     """
     Run all the available integration tests
     """
-    agent_integration_tests(ctx, install_deps, remote_docker)
-    dsd_integration_tests(ctx, install_deps, remote_docker)
+    agent_integration_tests(ctx, install_deps, race, remote_docker)
+    dsd_integration_tests(ctx, install_deps, race, remote_docker)
+
 
 @task
 def version(ctx):


### PR DESCRIPTION
### What does this PR do?

### CircleCI
- add a `--precompile-only` option to `agent.build` that precompiles the agent's dependencies in `$GOPATH/pkg/` to speed up test compilation. Add that folder to the govendordeps cache
- change the cache key to ` v2-godeps-{{ .Branch }}-{{ .Revision }}`. If not found, will lookup the latest cache for that branch with `v2-godeps-{{ .Branch }}-`, and latest from master if first build of the branch. As [cache entries are immutable](https://circleci.com/docs/2.0/caching/#writing-to-the-cache-in-workflows), the previous stategy got us pinned to the first `inv deps` after moving to CCI2
- enable race detection on integration-tests too, as they are faster with race+cache than before, and cache is only reused if all build flags are the same
-  unify inv invocations in the CCI workflow
- [BUGFIX] make tests fail on gofmt

### Appveyor
- remove cover for speedup (15 to 9 minutes) 
- backport pre-compile logic  (9 to 8 minutes, speedup is mostly erased by slow cache)

### Motivation

Reduce average CCI workflow duration from 12 to 8 minutes.
