### PR TITLE
Changed logs-agent log severity from Error to Info

### DIFF
--- a/pkg/collector/corechecks/embed/logs-agent.go
+++ b/pkg/collector/corechecks/embed/logs-agent.go
@@ -84,7 +84,9 @@ func (c *LogsCheck) run() error {
 	go func() {
 		in := bufio.NewScanner(stderr)
 		for in.Scan() {
-			log.Error(in.Text())
+			// using Info severity because all logs-agent logs are forwarded to stderr
+			// FIXME: fix the severity issue when we merge the repositories
+			log.Info(in.Text())
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Updated the logs-agent check to change the severity of messages coming from stderr.

### Motivation

Before, all logs from logs-agent were in Error, changed the severity to Info.

### Additional Notes

All logs are forward to stderr because we are not using `seelog` in logs-agent. This is a short term fix as we are about to merge the logs-agent repository in the agent repository.
