### PR TITLE
[tooling]  add audit-tag-impact invoke task 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -389,6 +389,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4cef3042b5c8332db9f5aed456dba11604340758f2fdb62347254b0084c3b088"
+  inputs-digest = "620090c6d1189e1943e87f4b9058a8f1694a830fe181ef42c5568aeae9aa3d6f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -19,10 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
 
 	log "github.com/cihub/seelog"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type apmCheckConf struct {
@@ -209,9 +208,4 @@ func init() {
 		}
 	}
 	core.RegisterCheck("apm", factory)
-}
-
-func getHostname() string {
-	hostname, _ := util.GetHostname()
-	return hostname
 }

--- a/pkg/collector/corechecks/embed/common.go
+++ b/pkg/collector/corechecks/embed/common.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 const defaultRetryDuration = 5 * time.Second
@@ -20,4 +21,9 @@ func retryExitError(err error) error {
 	default:
 		return err
 	}
+}
+
+func getHostname() string {
+	hostname, _ := util.GetHostname()
+	return hostname
 }

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -8,7 +8,7 @@ from . import agent, benchmarks, docker, dogstatsd, pylauncher
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
 from .test import test, integration_tests, version
-
+from .build_tags import audit_tag_impact
 
 # the root namespace
 ns = Collection()
@@ -25,6 +25,7 @@ ns.add_task(integration_tests)
 ns.add_task(deps)
 ns.add_task(reset)
 ns.add_task(version)
+ns.add_task(audit_tag_impact)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -20,9 +20,11 @@ from .go import deps
 BIN_PATH = os.path.join(".", "bin", "agent")
 AGENT_TAG = "datadog/agent:master"
 
+
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-          puppy=False, use_embedded_libs=False, development=True, precompile_only=False):
+          puppy=False, use_embedded_libs=False, development=True, precompile_only=False,
+          skip_assets=False):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -78,7 +80,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     }
 
     ctx.run(cmd.format(**args), env=env)
-    refresh_assets(ctx, development=development)
+    if not skip_assets:
+        refresh_assets(ctx, development=development)
 
 
 @task

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -2,7 +2,7 @@
 Utilities to manage build tags
 """
 import invoke
-
+from invoke import task
 
 # ALL_TAGS lists any available build tag
 ALL_TAGS = set([
@@ -53,3 +53,43 @@ def get_build_tags(include, exclude):
     include = ALL_TAGS.intersection(set(include))
     exclude = ALL_TAGS.intersection(set(exclude))
     return list(include - exclude)
+
+
+@task
+def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False):
+    """
+    Measure each tag's contribution to the binary size
+    """
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+
+    tags_to_audit = ALL_TAGS.difference(set(build_exclude)).difference(set(PUPPY_TAGS))
+
+    max_size = _compute_build_size(ctx, build_exclude=','.join(build_exclude), use_embedded_libs=use_embedded_libs)
+    print("size with all tags is {} kB".format(max_size / 1000))
+
+    puppy_size = _compute_build_size(ctx, puppy=True, use_embedded_libs=use_embedded_libs)
+    print("puppy size is {} kB\n".format(puppy_size / 1000))
+
+    report = {"unaccounted": max_size - puppy_size, "puppy": puppy_size}
+
+    for tag in tags_to_audit:
+        exclude_string = ','.join(build_exclude + [tag])
+        size = _compute_build_size(ctx, build_exclude=exclude_string, use_embedded_libs=use_embedded_libs)
+        delta = (max_size - size)
+        print("tag {} adds {} kB (excludes: {})".format(tag, delta / 1000, exclude_string))
+        report[tag] = delta
+        report["unaccounted"] -= delta
+
+    print("\nCSV output in bytes:")
+    for k, v in report.iteritems():
+        print("{};{}".format(k, v))
+
+
+def _compute_build_size(ctx, build_exclude=None, use_embedded_libs=False, puppy=False):
+    import os
+    from .agent import build as agent_build
+    agent_build(ctx, build_exclude=build_exclude, use_embedded_libs=use_embedded_libs,
+                skip_assets=True, puppy=puppy)
+
+    statinfo = os.stat('bin/agent/agent')
+    return statinfo.st_size

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -56,7 +56,7 @@ def get_build_tags(include, exclude):
 
 
 @task
-def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False):
+def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False, csv=False):
     """
     Measure each tag's contribution to the binary size
     """
@@ -80,9 +80,10 @@ def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False):
         report[tag] = delta
         report["unaccounted"] -= delta
 
-    print("\nCSV output in bytes:")
-    for k, v in report.iteritems():
-        print("{};{}".format(k, v))
+    if csv:
+        print("\nCSV output in bytes:")
+        for k, v in report.iteritems():
+            print("{};{}".format(k, v))
 
 
 def _compute_build_size(ctx, build_exclude=None, use_embedded_libs=False, puppy=False):


### PR DESCRIPTION
### What does this PR do?

Iterates over every default tag and builds the agent without it, to compute how much it contributes to the agent binary size. Current results:

![](https://cl.ly/3y0L1O0q193F/Image%202017-11-07%20at%203.04.41%20PM.png)

Also fixes process embed depending on a private method guarded by the apm flag.