### PR TITLE
add a regex to remove the api key from the serializer package

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
@@ -23,6 +24,7 @@ const (
 	protobufContentType      = "application/x-protobuf"
 	jsonContentType          = "application/json"
 	payloadVersionHTTPHeader = "DD-Agent-Payload"
+	apiKeyReplacement        = "\"apiKey\":\"*************************$1"
 )
 
 var (
@@ -35,6 +37,8 @@ var (
 	jsonExtraHeadersWithCompression     http.Header
 	protobufExtraHeadersWithCompression http.Header
 )
+
+var apiKeyRegExp = regexp.MustCompile("\"apiKey\":\"*\\w+(\\w{5})")
 
 func init() {
 	initExtraHeaders()
@@ -174,7 +178,7 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 	}
 
 	log.Infof("Sent host metadata payload, size: %d bytes.", len(payload))
-	log.Debugf("Sent host metadata payload, content: %v", string(payload))
+	log.Debugf("Sent host metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
 	return nil
 }
 
@@ -190,6 +194,6 @@ func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
 	}
 
 	log.Infof("Sent processes metadata payload, size: %d bytes.", len(payload))
-	log.Debugf("Sent processes metadata payload, content: %v", string(payload))
+	log.Debugf("Sent processes metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Will use a regex to obfuscate the API key from a debug line that prints the request payload.

### Motivation
It was brought up internally via an escalation card. 
