### PR TITLE
embed curl in the datadog-agent package to help support

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -110,6 +110,7 @@ end
 if linux?
   dependency 'procps-ng'
   dependency 'sysstat'
+  dependency 'curl'
 end
 
 # creates required build directories


### PR DESCRIPTION
### What does this PR do?

Add `curl` to the datadog-agent omnibus package. It is compiled with the embedded libssl and the embedded cacerts. It adds ~1MB to the .deb (and the docker image) size.

### Motivation

Lots of support cases are currently diagnosed through `curl` invocations, to pinpoint whether the issue is DNS resolution, IP reachability, traffic filtering (good ol' timeout) or permission issues on the server. Both agent5 images ship `curl` by default.

The alternative would be to install curl from the debian package in the docker image, but it adds 6 MB and will use a different libssl and different cacerts, which (in rare edge cases though) could lead to false negatives.
