### PR TITLE
[py] Make service check message empty when None is passed

### DIFF
--- a/pkg/collector/dist/checks/__init__.py
+++ b/pkg/collector/dist/checks/__init__.py
@@ -157,10 +157,12 @@ class AgentCheck(object):
             self.log.warning(self._deprecations[deprecation_key][1])
             self._deprecations[deprecation_key][0] = True
 
-    def service_check(self, name, status, tags=None, hostname=None, message=""):
+    def service_check(self, name, status, tags=None, hostname=None, message=None):
         tags = self._normalize_tags_type(tags)
         if hostname is None:
             hostname = ""
+        if message is None:
+            message = ""
 
         aggregator.submit_service_check(self, self.check_id, name, status, tags, hostname, message)
 

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -142,6 +142,9 @@ func TestAggregatorLink(t *testing.T) {
 	mockSender.On("ServiceCheck",
 		"testservicecheckwithhostname", mock.AnythingOfType("metrics.ServiceCheckStatus"), "testhostname",
 		[]string{"foo", "bar"}, "a message").Return().Times(1)
+	mockSender.On("ServiceCheck",
+		"testservicecheckwithnonemessage", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",
+		[]string(nil), "").Return().Times(1)
 	mockSender.On("Gauge", "testmetric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	mockSender.On("Gauge", "testmetricstringvalue", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
 	mockSender.On("Counter", "test.increment", 1., "", []string{"foo", "bar"}).Return().Times(1)
@@ -166,6 +169,9 @@ func TestAggregatorLinkTwoRuns(t *testing.T) {
 	mockSender.On("ServiceCheck",
 		"testservicecheckwithhostname", mock.AnythingOfType("metrics.ServiceCheckStatus"), "testhostname",
 		[]string{"foo", "bar"}, "a message").Return().Times(2)
+	mockSender.On("ServiceCheck",
+		"testservicecheckwithnonemessage", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",
+		[]string(nil), "").Return().Times(2)
 	mockSender.On("Gauge", "testmetric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(2)
 	mockSender.On("Gauge", "testmetricstringvalue", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(2)
 	mockSender.On("Counter", "test.increment", 1., "", []string{"foo", "bar"}).Return().Times(2)

--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -15,6 +15,7 @@ class TestAggregatorCheck(AgentCheck):
         """
         self.service_check("testservicecheck", AgentCheck.OK, tags=None, message="")
         self.service_check("testservicecheckwithhostname", AgentCheck.OK, tags=["foo", "bar"], hostname="testhostname", message="a message")
+        self.service_check("testservicecheckwithnonemessage", AgentCheck.OK, message=None)
 
         # _send_metric is not used in tests, so it should not be used to test it.
         # Instead call gauge, which is the one that checks will be using


### PR DESCRIPTION
### What does this PR do?

Make the service check message empty when `None` is explicitly passed from a python check.

### Motivation

Otherwise we reject the service check with a type error.

Fixes the underlying issue of https://github.com/DataDog/integrations-core/pull/852
(we could still merge that PR though)
