### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,22 +6,8 @@
 # PRs should still be peer-reviewed by the team opening the PR
 
 # See https://help.github.com/articles/about-codeowners/ for syntax
-# Rules are matched top-to-bottom, so one team can own subdirectories
+# Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
-
-/pkg/metadata/kubernetes/               @DataDog/burrito
-/pkg/metadata/ecs/                      @DataDog/burrito
-
-/pkg/metrics/percentile/                @DataDog/sandwich
-
-/Dockerfiles/                           @DataDog/kenafeh
-/pkg/collector/autodiscovery/           @DataDog/kenafeh @DataDog/croissant
-/pkg/collector/corechecks/containers/   @DataDog/kenafeh
-/pkg/collector/listeners/docker*        @DataDog/kenafeh
-/pkg/tagger/                            @DataDog/kenafeh
-/pkg/util/docker/                       @DataDog/kenafeh @DataDog/burrito
-/pkg/util/ecs/                          @DataDog/kenafeh @DataDog/burrito
-/pkg/util/kubernetes/                   @DataDog/kenafeh @DataDog/burrito
 
 /cmd/                                   @DataDog/croissant
 /pkg/aggregator/                        @DataDog/croissant
@@ -32,3 +18,17 @@
 /pkg/serializer/                        @DataDog/croissant
 /pkg/status/                            @DataDog/croissant
 /pkg/version/                           @DataDog/croissant
+
+/Dockerfiles/                           @DataDog/kenafeh
+/pkg/collector/autodiscovery/           @DataDog/kenafeh @DataDog/croissant
+/pkg/collector/corechecks/containers/   @DataDog/kenafeh
+/pkg/collector/listeners/docker*        @DataDog/kenafeh
+/pkg/tagger/                            @DataDog/kenafeh
+/pkg/util/docker/                       @DataDog/kenafeh @DataDog/burrito
+/pkg/util/ecs/                          @DataDog/kenafeh @DataDog/burrito
+/pkg/util/kubernetes/                   @DataDog/kenafeh @DataDog/burrito
+
+/pkg/metrics/percentile/                @DataDog/sandwich
+
+/pkg/metadata/ecs/                      @DataDog/burrito
+/pkg/metadata/kubernetes/               @DataDog/burrito

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 # and another the rest of the directory.
 
 /cmd/                                   @DataDog/croissant
+/omnibus/                               @DataDog/croissant
 /pkg/aggregator/                        @DataDog/croissant
 /pkg/collector/                         @DataDog/croissant
 /pkg/forwarder/                         @DataDog/croissant

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,8 @@
 # PRs should still be peer-reviewed by the team opening the PR
 
 # See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched top-to-bottom, so one team can own subdirectories
+# and another the rest of the directory.
 
 /pkg/metadata/kubernetes/               @DataDog/burrito
 /pkg/metadata/ecs/                      @DataDog/burrito
@@ -13,12 +15,13 @@
 /pkg/metrics/percentile/                @DataDog/sandwich
 
 /Dockerfiles/                           @DataDog/kenafeh
+/pkg/collector/autodiscovery/           @DataDog/kenafeh @DataDog/croissant
+/pkg/collector/corechecks/containers/   @DataDog/kenafeh
+/pkg/collector/listeners/docker*        @DataDog/kenafeh
 /pkg/tagger/                            @DataDog/kenafeh
 /pkg/util/docker/                       @DataDog/kenafeh @DataDog/burrito
 /pkg/util/ecs/                          @DataDog/kenafeh @DataDog/burrito
 /pkg/util/kubernetes/                   @DataDog/kenafeh @DataDog/burrito
-/pkg/collector/listeners/docker*        @DataDog/kenafeh
-/pkg/collector/corechecks/containers/   @DataDog/kenafeh
 
 /cmd/                                   @DataDog/croissant
 /pkg/aggregator/                        @DataDog/croissant

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# Package code owners
+
+# The listed owners will be automatically added as reviewers for PRs,
+# to ensure code quality and consistency of the package, and identify
+# possible side effects.
+# PRs should still be peer-reviewed by the team opening the PR
+
+# See https://help.github.com/articles/about-codeowners/ for syntax
+
+/pkg/metadata/kubernetes/               @DataDog/burrito
+/pkg/metadata/ecs/                      @DataDog/burrito
+
+/pkg/metrics/percentile/                @DataDog/sandwich
+
+/Dockerfiles/                           @DataDog/kenafeh
+/pkg/tagger/                            @DataDog/kenafeh
+/pkg/util/docker/                       @DataDog/kenafeh @DataDog/burrito
+/pkg/util/ecs/                          @DataDog/kenafeh @DataDog/burrito
+/pkg/util/kubernetes/                   @DataDog/kenafeh @DataDog/burrito
+/pkg/collector/listeners/docker*        @DataDog/kenafeh
+/pkg/collector/corechecks/containers/   @DataDog/kenafeh
+
+/cmd/                                   @DataDog/croissant
+/pkg/aggregator/                        @DataDog/croissant
+/pkg/collector/                         @DataDog/croissant
+/pkg/forwarder/                         @DataDog/croissant
+/pkg/metadata/                          @DataDog/croissant
+/pkg/metrics/                           @DataDog/croissant
+/pkg/serializer/                        @DataDog/croissant
+/pkg/status/                            @DataDog/croissant
+/pkg/version/                           @DataDog/croissant


### PR DESCRIPTION
As an experiment, add [code owners](https://help.github.com/articles/about-codeowners/) for several packages. +# These owners will be automatically added as reviewers for PRs, to ensure code quality and consistency of the package, and identify possible side effects.

PRs should still be peer-reviewed by the team opening the PR.

See https://github.com/DataDog/datadog-agent/pull/794 for an example. **Note:** code owners are added after the PR is created, not suggested in the PR creation form.

Please feel free to push on the branch to add/remove packages for your team, or open a review.

