### PR TITLE
Revert "Changed logs-agent logs severity from Error to Info"

### DIFF
--- a/pkg/collector/corechecks/embed/logs-agent.go
+++ b/pkg/collector/corechecks/embed/logs-agent.go
@@ -84,9 +84,7 @@ func (c *LogsCheck) run() error {
 	go func() {
 		in := bufio.NewScanner(stderr)
 		for in.Scan() {
-			// using Info severity because all logs-agent logs are forwarded to stderr
-			// FIXME: fix the severity issue when we merge the repositories
-			log.Info(in.Text())
+			log.Error(in.Text())
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

This reverts commit 591a09dd428860fad1c33f301b19998e0fa3066a.
Fixed the issue changing logs format in logs-agent.

Cannot be merged before merging:
https://github.com/DataDog/datadog-log-agent/pull/10