### PR TITLE
[omnibus] Upgrade external agents to latest stable tag

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -13,7 +13,7 @@ relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
-default_version '5.18.1'
+default_version '5.19.0'
 
 blacklist = [
   'agent_metrics',

--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -6,7 +6,7 @@
 name "datadog-process-agent"
 always_build true
 
-default_version '5.18.1'
+default_version '5.19.0'
 
 
 build do

--- a/omnibus/config/software/datadog-trace-agent.rb
+++ b/omnibus/config/software/datadog-trace-agent.rb
@@ -8,7 +8,7 @@ require 'pathname'
 
 name "datadog-trace-agent"
 
-default_version "5.18.1"
+default_version "5.19.0"
 
 source git: 'https://github.com/DataDog/datadog-trace-agent.git'
 relative_path 'src/github.com/DataDog/datadog-trace-agent'


### PR DESCRIPTION
Upgrade external agents and integrations-core to latest stable tag, `5.19.0` (except logs-agent that's not tagged yet).