### PR TITLE
adds some logging to help debug subprocess output

### DIFF
--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -30,7 +30,13 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     # use subprocess.PIPE if the data size is large or unlimited.
     with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
         proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
-        proc.wait()
+        pid = proc.pid
+        log.debug("running process: {0} with pid: {1}".format(" ".join(command), ppid))
+
+        retcode = proc.wait()
+        if retcode != 0:
+            log.debug("Error while running {0} with pid: {1}. It returned with code {2}".format(" ".join(command), pid, retcode))
+
         stderr_f.seek(0)
         err = stderr_f.read()
         if err:

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -31,7 +31,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
         proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
         pid = proc.pid
-        log.debug("running process: {0} with pid: {1}".format(" ".join(command), ppid))
+        log.debug("running process: {0} with pid: {1}".format(" ".join(command), pid))
 
         retcode = proc.wait()
         if retcode != 0:


### PR DESCRIPTION
### What does this PR do?

The pids are weird in the orphaned processes. This should help us debug some stuff about them.

If we need more debugging we should use the following code instead of waiting:

```python
while proc.poll() is None:
    log.debug("...something...")
    # sleep
```


