### PR TITLE
Remove docker_images settings for AD

### DIFF
--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -144,6 +144,19 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 			continue
 		}
 
+		// Transform if needed AD configuration
+		input, err := ioutil.ReadFile(dst)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to open %s", dst)
+			continue
+		}
+		output := strings.Replace(string(input), "docker_images:", "ad_identifiers:", 1)
+		err = ioutil.WriteFile(dst, []byte(output), 0640)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to write %s", dst)
+			continue
+		}
+
 		fmt.Fprintln(
 			color.Output,
 			fmt.Sprintf("Copied %s over the new %s directory",

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -158,7 +158,6 @@ func getCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 
 type configFormat struct {
 	ADIdentifiers []string    `yaml:"ad_identifiers"`
-	DockerImages  []string    `yaml:"docker_images"`
 	InitConfig    interface{} `yaml:"init_config"`
 	Instances     []check.ConfigRawMap
 }

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -263,5 +263,8 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 		config.MetricConfig = rawMetricConfig
 	}
 
+	// Copy auto discovery identifiers
+	config.ADIdentifiers = cf.ADIdentifiers
+
 	return config, err
 }

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -20,7 +20,6 @@ import (
 
 type configFormat struct {
 	ADIdentifiers []string    `yaml:"ad_identifiers"`
-	DockerImages  []string    `yaml:"docker_images"`
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	Instances     []check.ConfigRawMap
@@ -262,23 +261,6 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 	if cf.MetricConfig != nil {
 		rawMetricConfig, _ := yaml.Marshal(cf.MetricConfig)
 		config.MetricConfig = rawMetricConfig
-	}
-
-	// Read AutoDiscovery data, try to use the old `docker_image` settings
-	// param first
-	if len(cf.DockerImages) > 0 {
-		log.Warnf("'docker_image' section in %s is deprecated and will be eventually removed, use 'ad_identifiers' instead",
-			fpath)
-		config.ADIdentifiers = cf.DockerImages
-	}
-
-	// Override the legacy param with the new one, `ad_identifiers`
-	if len(cf.ADIdentifiers) > 0 {
-		if len(config.ADIdentifiers) > 0 {
-			log.Warnf("Overwriting the deprecated 'docker_image' section from %s in favor of the new 'ad_identifiers' one",
-				fpath)
-		}
-		config.ADIdentifiers = cf.ADIdentifiers
 	}
 
 	return config, err

--- a/pkg/collector/providers/file_test.go
+++ b/pkg/collector/providers/file_test.go
@@ -43,9 +43,6 @@ func TestGetCheckConfig(t *testing.T) {
 	assert.Nil(t, config.MetricConfig)
 
 	// autodiscovery
-	config, err = GetCheckConfigFromFile("foo", "tests/ad_legacy.yaml")
-	require.Nil(t, err)
-	assert.Equal(t, config.ADIdentifiers, []string{"foo", "bar"})
 	config, err = GetCheckConfigFromFile("foo", "tests/ad.yaml")
 	require.Nil(t, err)
 	assert.Equal(t, config.ADIdentifiers, []string{"foo_id", "bar_id"})
@@ -82,7 +79,6 @@ func TestCollect(t *testing.T) {
 
 	// the regular configs
 	assert.Equal(t, 3, len(get("testcheck")))
-	assert.Equal(t, 1, len(get("ad_legacy")))
 	assert.Equal(t, 1, len(get("ad")))
 
 	// default configs must be picked up
@@ -108,7 +104,7 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, 0, len(get("metrics")))
 
 	// total number of configurations found
-	assert.Equal(t, 11, len(configs))
+	assert.Equal(t, 10, len(configs))
 
 	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml)
 	assert.Equal(t, 2, len(provider.Errors))

--- a/pkg/collector/providers/tests/ad.yaml
+++ b/pkg/collector/providers/tests/ad.yaml
@@ -1,7 +1,3 @@
-docker_images:
-  - foo
-  - bar
-
 ad_identifiers:
   - foo_id
   - bar_id

--- a/pkg/collector/providers/tests/ad_legacy.yaml
+++ b/pkg/collector/providers/tests/ad_legacy.yaml
@@ -1,9 +1,0 @@
-docker_images:
-  - foo
-  - bar
-
-init_config:
-
-instances:
-  # No configuration is needed for this check.
-  - foo: bar


### PR DESCRIPTION
### What does this PR do?

* Remove support for `docker_images` settings in auto discovery templates
* Tranforms `docker_images` to `ad_identifiers` in import command

### Additional Notes

The old setting is already deprecated in agent 5.20
