### PR TITLE
Rework autoconfig to unify flow with AD

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -206,16 +206,13 @@ func (ac *AutoConfig) getAllConfigs(withResolve bool) []check.Config {
 			}
 		}
 		if withResolve {
-			resolvedConfigs := []check.Config{}
 			for _, config := range cfgs {
 				rc, err := ac.resolve(config)
 				if err != nil {
 					log.Error(err)
 				}
-				resolvedConfigs = append(resolvedConfigs, rc...)
+				configs = append(configs, rc...)
 			}
-
-			configs = append(configs, resolvedConfigs...)
 		} else {
 			configs = append(configs, cfgs...)
 		}


### PR DESCRIPTION
### What does this PR do?

* Try to simplify and unify the autoconfig ↔️ autodiscovery flow
* Separation of config/check retrieval and scheduling
* Follow-up of #769 