### PR TITLE
Add kubelet tag for dogstatsd

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -23,6 +23,7 @@ DOGSTATSD_TAG = "datadog/dogstatsd:master"
 DEFAULT_BUILD_TAGS = [
     "zlib",
     "docker",
+    "kubelet",
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Add the `kubelet` tag for dogstatsd builds