### PR TITLE
Add the process agent specific bits to the agent config file

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -254,3 +254,33 @@ metadata_collectors:
 # URL where the ECS agent can be found. Standard cases will be autodetected.
 # ecs_agent_url: http://localhost:51678
 {{ end -}}
+{{- if .ProcessAgent }}
+# Process agent specific settings
+#
+# process_config:
+#   enabled: true
+#   The full path to the file where process-agent logs will be written.
+#   log_file:
+#   The interval, in seconds, at which we will run each check. If you want consistent
+#   behavior between real-time you may set the Container/ProcessRT intervals to 10.
+#   Defaults to 10s for normal checks and 2s for others.
+#   intervals:
+#     container:
+#     container_realtime:
+#     process:
+#     process_realtime:
+#   A list of regex patterns that will exclude a process if matched.
+#   blacklist_patterns:
+#   How many check results to buffer in memory when POST fails. The default is usually fine.
+#   queue_size:
+#   The maximum number of file descriptors to open when collecting net connections.
+#   Only change if you are running out of file descriptors from the Agent.
+#   max_proc_fds:
+#   The maximum number of processes or containers per message.
+#   Only change if the defaults are causing issues.
+#   max_per_message:
+#   Overrides the path to the Agent bin used for getting the hostname. The default is usually fine.
+#   dd_agent_bin:
+#   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
+#   dd_agent_env:
+{{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -258,7 +258,8 @@ metadata_collectors:
 # Process agent specific settings
 #
 # process_config:
-#   enabled: true
+#   Note: the Process Agent expects this to be a string
+#   enabled: "true"
 #   The full path to the file where process-agent logs will be written.
 #   log_file:
 #   The interval, in seconds, at which we will run each check. If you want consistent

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -28,6 +28,7 @@ type context struct {
 	DockerTagging     bool
 	KubernetesTagging bool
 	ECS               bool
+	ProcessAgent      bool
 }
 
 func mkContext(buildType string) context {
@@ -47,6 +48,7 @@ func mkContext(buildType string) context {
 			DockerTagging:     true,
 			KubernetesTagging: true,
 			ECS:               true,
+			ProcessAgent:      true,
 		}
 	case "dogstatsd":
 		return context{


### PR DESCRIPTION
### What does this PR do?

The Process Agent can now read the infra agent config file, see https://github.com/DataDog/datadog-process-agent/pull/72

This PR adds the specific bits the Process Agent will search in the config file.

Next step will be removing the specific ini file we currently have in `dist` from the package and invoke the process agent binary passing in the path to `datadog.yaml` (the process agent defaults to `/etc/datadog-agent/datadog.yaml` but since the infra agent accepts overrides, we should forward this info downstream).