### PR TITLE
[packaging] Remove references to sock file

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -7,7 +7,6 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStartPre=/bin/rm -f /tmp/agent.sock
 ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
 
 [Install]

--- a/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
@@ -19,5 +19,4 @@ end script
 
 post-stop script
   rm -f <%= install_dir %>/run/agent.pid
-  rm -f /tmp/agent.sock
 end script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -28,5 +28,4 @@ end script
 
 post-stop script
   rm -f <%= install_dir %>/run/agent.pid
-  rm -f /tmp/agent.sock
 end script

--- a/omnibus/config/templates/datadog-puppy/systemd.service.erb
+++ b/omnibus/config/templates/datadog-puppy/systemd.service.erb
@@ -7,7 +7,6 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStartPre=/bin/rm -f /tmp/agent.sock
 ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
 
 [Install]

--- a/omnibus/config/templates/datadog-puppy/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-puppy/upstart.conf.erb
@@ -14,5 +14,4 @@ end script
 
 post-stop script
  rm -f <%= install_dir %>/run/agent.pid
- rm -f /tmp/agent.sock
 end script

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -62,11 +62,8 @@ api_key:
 # Setting 'GUI_port: -1' turns off the GUI completely
 # GUI_port: -1
 
-# The path to the Unix Socket where the IPC api listens on *nix
-# cmd_sock: /tmp/agent.sock
-
-# The path of the Named Pipe the IPC api uses on Windows
-# cmd_pipe_name: \\.\pipe\ddagent
+# The port on which the IPC api listens
+# cmd_port: 5001
 
 # How many workers will be used to run the check (if not specified, is automatically
 # determined based on number of checks running)


### PR DESCRIPTION

### What does this PR do?

Removes references to sock file.

In the conf file, replace references to it with the new `cmd_port`
option.

### Motivation

It's not used by the agent anymore.

Follow-up to https://github.com/DataDog/datadog-agent/pull/808#discussion_r151139730
