### PR TITLE
Fix runner stats

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -113,8 +113,8 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats m
 	// store execution times in Milliseconds
 	tms := t.Nanoseconds() / 1e6
 	cs.LastExecutionTime = tms
-	cs.ExecutionTimes[cs.TotalRuns] = tms
-	cs.TotalRuns = (cs.TotalRuns + 1) % 32
+	cs.ExecutionTimes[cs.TotalRuns%uint64(len(cs.ExecutionTimes))] = tms
+	cs.TotalRuns++
 	if err != nil {
 		cs.TotalErrors++
 		cs.LastError = err.Error()


### PR DESCRIPTION
### What does this PR do?

Fixes the `TotalRuns` counter for a check in the runner stats, previously reset every 32 runs.
Also added some cosmetics to `runner.go`
