### PR TITLE
Remove distPath from locations where config file is searched by default.

### DIFF
--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -25,7 +25,6 @@ func SetupConfig(confFilePath string) error {
 		}
 	}
 	config.Datadog.AddConfigPath(DefaultConfPath)
-	config.Datadog.AddConfigPath(GetDistPath())
 
 	// load the configuration
 	err := config.Datadog.ReadInConfig()


### PR DESCRIPTION
Creates ambiguity as to which config file is being used, especially on
initial install
