### PR TITLE
[docker] fix cgroup parsing to support rancherOS cgroup hierarchy

### DIFF
--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -597,9 +597,9 @@ func containerIDFromCgroup(cgroup string) (string, bool) {
 	if len(sp) < 3 {
 		return "", false
 	}
-	match := containerRe.Find([]byte(sp[2]))
-	if match == nil {
+	matches := containerRe.FindAllString(sp[2], -1)
+	if matches == nil {
 		return "", false
 	}
-	return string(match), true
+	return matches[len(matches)-1], true
 }

--- a/pkg/util/docker/cgroup_test.go
+++ b/pkg/util/docker/cgroup_test.go
@@ -324,3 +324,24 @@ func TestParseCgroupPaths(t *testing.T) {
 		assert.Equal(t, p, tc.expectedPaths)
 	}
 }
+
+func TestContainerIDFromCgroup(t *testing.T) {
+	for _, tc := range []string{
+		// Kubernetes < 1.6
+		"1:kube1.6:/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+		// New CoreOS / most systems
+		"2:classic:/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+		// Rancher
+		"3:rancher:/docker/864daa0a0b19aa4703231b6c76f85c6f369b2452a5a7f777f0c9101c0fd5772a/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+		// Kubernetes 1.7+
+		"4:kube1.7:/kubepods/besteffort/pod2baa3444-4d37-11e7-bd2f-080027d2bf10/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419",
+		// Legacy CoreOS 7xx
+		"5:coreos_7xx:/system.slice/docker-a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
+		// Legacy systems
+		"6:legacy:a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
+	} {
+		c, err := containerIDFromCgroup(tc)
+		assert.True(t, err)
+		assert.Equal(t, c, "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

As per support ticket, support rancherOS's custom cgroup hierarchy:
- add unit tests for cgroup -> cid parsing
- fix `containerIDFromCgroup` logic to select last match instead of first
- use `regexp.FindAllString` instead of `regexp.FindAll` to avoid `[]bytes` and `string` allocations. This method returns a slice of the source string.
