### PR TITLE
Generate the config template to datadog.yaml for Windows too

### DIFF
--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+//go:generate go run ../../pkg/config/render_config.go agent ../../pkg/config/config_template.yaml ./dist/datadog.yaml
+
 package main
 
 import (


### PR DESCRIPTION
### What does this PR do?

Windows has its specific `main` module, I forgot to add the config file generation there.
