### PR TITLE
[GUI] Fix authentication

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -190,6 +190,12 @@
   revision = "91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hectane/go-acl"
+  packages = [".","api"]
+  revision = "7f56832555fc229dad908c67d65ed3ce6156b70c"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -395,6 +401,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fd679af3f6762946b9e7588cfc03f0003f223523e97751a17fc211beb6db8c6a"
+  inputs-digest = "d4f29aad1567ef7834793cec163267bd4d9a5a7009784ff2c5844cec8171b16c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -45,7 +45,7 @@ func launchGui(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read the authentication token: can only be done if user can read from datadog.yaml
-	authToken, err := ioutil.ReadFile(filepath.Join(common.GetDistPath(), "gui_auth_token"))
+	authToken, err := ioutil.ReadFile(filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), "gui_auth_token"))
 	if err != nil {
 		return fmt.Errorf("unable to access GUI authentication token: " + err.Error())
 	}

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/gui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	launchCmd = &cobra.Command{
+		Use:          "launchgui",
+		Short:        "starts the Datadog Agent GUI",
+		Long:         ``,
+		RunE:         launchGui,
+		SilenceUsage: true,
+	}
+
+)
+
+func init() {
+	// attach the command to the root
+	AgentCmd.AddCommand(launchCmd)
+
+}
+
+func launchGui(cmd *cobra.Command, args []string) error {
+	err := common.SetupConfig(confFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
+
+	return gui.LaunchGui()
+}

--- a/cmd/agent/app/open_browser_darwin.go
+++ b/cmd/agent/app/open_browser_darwin.go
@@ -1,0 +1,8 @@
+package app
+
+import "os/exec"
+
+// opens a browser window at the specified URL
+func open(url string) error {
+	return exec.Command("open", url).Start()
+}

--- a/cmd/agent/app/open_browser_unix.go
+++ b/cmd/agent/app/open_browser_unix.go
@@ -1,0 +1,10 @@
+// +build freebsd netbsd openbsd solaris dragonfly linux
+
+package app
+
+// opens a browser window at the specified URL
+import "os/exec"
+
+func open(url string) error {
+	return exec.Command("xdg-open", url).Start()
+}

--- a/cmd/agent/app/open_browser_windows.go
+++ b/cmd/agent/app/open_browser_windows.go
@@ -1,0 +1,8 @@
+package app
+
+import "os/exec"
+
+// opens a browser window at the specified URL
+func open(url string) error {
+	return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+}

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -174,7 +174,7 @@ func StartAgent() error {
 	guiPort := config.Datadog.GetString("GUI_port")
 	if guiPort == "-1" {
 		log.Infof("GUI server port -1 specified: not starting the GUI.")
-	} else if err = gui.StartGUI(guiPort); err != nil {
+	} else if err = gui.StartGUIServer(guiPort); err != nil {
 		log.Errorf("Error while starting GUI: %v", err)
 	}
 

--- a/cmd/agent/gui/README.md
+++ b/cmd/agent/gui/README.md
@@ -1,16 +1,18 @@
 ## DataDog Agent 6 GUI
-A cross-platform GUI served on ```localhost:8080``` (by default) for interacting with DataDog Agent 6.
+A cross-platform GUI for interacting with DataDog Agent 6.
+
+#### Using the GUI
+1. Configure a GUI port in your `datadog.yaml` file (i.e. `8080`)
+  - Setting the port to -1 disables the GUI all together (this is the default state)
+2. Restart the DataDog agent
+3. Use the `datadog-agent launch-gui` command to launch the GUI within your default web browser
 
 #### Requirements
-1. Cookies must be enabled in your browser. Upon initially accessing the GUI, you will be asked once to enter your API key; after that, the key is saved as a cookie and is used for authenticating all communications with the GUI server.  
+1. Cookies must be enabled in your browser. The GUI generates and saves a token in your browser which is used for authenticating all communications with the GUI server.
 
-2. The GUI allows you to edit your configuration (yaml) files. Therefore it is necessary for you to ensure that the user running the DataDog Agent has the correct permissions for writing to these files - generally this means that the user must be the owner.
+2. The GUI will only be launched if the user launching it has the correct user permissions: if you are able to open `datadog.yaml`, you are able to use the GUI.
 
 3. For security reasons, the GUI can **only** be accessed from the local network interface (```localhost```/```127.0.0.1```), so you must be on the same host that the agent is running to use it. In other words, you can't run the agent on a VM and access it from the host machine.
 
-#### Disabling the GUI
-The GUI can be disabled altogether by setting its port to -1 in your datadog.yaml file.
-
 #### In development
 - The 'Restart Agent' feature is not yet implemented for non-windows platforms
-- A more robust authentication system is in progress

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+
 	log "github.com/cihub/seelog"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
@@ -41,6 +43,17 @@ func StopGUIServer() {
 	}
 }
 
+// LaunchGui authenticates that the user can read from datadog.yaml, creates the
+// authentication token, and then starts the gui
+func LaunchGui() error {
+
+	guiPort := config.Datadog.GetString("GUI_port")
+	if guiPort == "-1" {
+		log.Warnf("GUI not enabled")
+		return fmt.Errorf("GUI not enabled")
+	}
+	return open("http://127.0.0.1:" + guiPort)
+}
 // StartGUI creates the router, starts the HTTP server and opens the GUI in a browser
 func StartGUI(port string) error {
 	// Instantiate the gorilla/mux router

--- a/cmd/agent/gui/platform_darwin.go
+++ b/cmd/agent/gui/platform_darwin.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -15,10 +13,9 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(jwt, csrf string) error {
+func saveAuthToken(token string) error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
-	path := filepath.Join(common.GetDistPath(), "gui_auth_token")
 
-	return ioutil.WriteFile(path, []byte("/authenticate?jwt="+jwt+";csrf="+csrf), permissions)
+	return ioutil.WriteFile(authTokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_darwin.go
+++ b/cmd/agent/gui/platform_darwin.go
@@ -2,14 +2,23 @@ package gui
 
 import (
 	"fmt"
-	"os/exec"
-)
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
-// opens a browser window at the specified URL
-func open(url string) error {
-	return exec.Command("open", url).Start()
-}
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
+}
+
+// writes auth token(s) to a file with the same permissions as datadog.yaml
+func saveAuthToken(jwt, csrf string) error {
+	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
+	permissions := confFile.Mode()
+	path := filepath.Join(common.GetDistPath(), "gui_auth_token")
+
+	return ioutil.WriteFile(path, []byte("/authenticate?jwt="+jwt+";csrf="+csrf), permissions)
 }

--- a/cmd/agent/gui/platform_nix.go
+++ b/cmd/agent/gui/platform_nix.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -17,10 +15,9 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(jwt, csrf string) error {
+func saveAuthToken(token string) error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
-	path := filepath.Join(common.GetDistPath(), "gui_auth_token")
 
-	return ioutil.WriteFile(path, []byte("/authenticate?jwt="+jwt+";csrf="+csrf), permissions)
+	return ioutil.WriteFile(authTokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_nix.go
+++ b/cmd/agent/gui/platform_nix.go
@@ -4,14 +4,23 @@ package gui
 
 import (
 	"fmt"
-	"os/exec"
-)
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
-// opens a browser window at the specified URL
-func open(url string) error {
-	return exec.Command("xdg-open", url).Start()
-}
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
+}
+
+// writes auth token(s) to a file with the same permissions as datadog.yaml
+func saveAuthToken(jwt, csrf string) error {
+	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
+	permissions := confFile.Mode()
+	path := filepath.Join(common.GetDistPath(), "gui_auth_token")
+
+	return ioutil.WriteFile(path, []byte("/authenticate?jwt="+jwt+";csrf="+csrf), permissions)
 }

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/kardianos/osext"
 )
@@ -28,10 +27,9 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(jwt, csrf string) error {
+func saveAuthToken(token string) error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
-	path := filepath.Join(common.GetDistPath(), "gui_auth_token")
 
-	return ioutil.WriteFile(path, []byte("/authenticate?jwt="+jwt+";csrf="+csrf), permissions)
+	return ioutil.WriteFile(authTokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -2,17 +2,15 @@ package gui
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/kardianos/osext"
 )
-
-// opens a browser window at the specified URL
-func open(url string) error {
-	return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-}
 
 // restarts the agent using the windows service manager
 func restart() error {
@@ -27,4 +25,13 @@ func restart() error {
 	}
 
 	return nil
+}
+
+// writes auth token(s) to a file with the same permissions as datadog.yaml
+func saveAuthToken(jwt, csrf string) error {
+	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
+	permissions := confFile.Mode()
+	path := filepath.Join(common.GetDistPath(), "gui_auth_token")
+
+	return ioutil.WriteFile(path, []byte("/authenticate?jwt="+jwt+";csrf="+csrf), permissions)
 }


### PR DESCRIPTION
### What does this PR do?

Adds the `launch-gui` command for a user to run when they want to open the GUI in their browser. When the GUI server is created, it saves its generated authentication token into a file with the same permissions as `datadog.yaml`. When the `launch-gui` command is run, it attempts to read the token from this file - thus we add user access control to the GUI. If the token is successfully read, then a browser window is opened and the token is passed as a parameter (same way as before).

### Motivation

When the agent is responsible for launching the GUI on startup, there is 2 problems:
1. If the agent runs as a service, it can't actually open a browser window
2. Because the agent runs with root permissions, we can't check whether or not this user should actually be able to open the GUI

Decoupling the GUI launch process from the main agent process fixes both of these problems.

### Additional Notes
