### PR TITLE
[kube] support AD on k8s containers + templates in annotations

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -35,7 +35,7 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 #   - empty config file to remove logline
 #   - enable docker check by default
 #   - enable process agent
-COPY datadog.yaml etc/datadog-agent/datadog.yaml
+COPY datadog*.yaml etc/datadog-agent/
 RUN mv etc/datadog-agent/conf.d/docker.d/conf.yaml.example etc/datadog-agent/conf.d/docker.d/conf.yaml.default \
  && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default
 COPY entrypoint.sh .

--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -1,0 +1,6 @@
+## Provides autodetected defaults, for non-kubernetes environments,
+## please see datadog.yaml.example for all supported options
+
+# Autodiscovery
+listeners:
+  - name: docker

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -1,3 +1,6 @@
+## Provides autodetected defaults, for kubernetes environments,
+## please see datadog.yaml.example for all supported options
+
 # Autodiscovery
 listeners:
   - name: docker

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -1,0 +1,9 @@
+# Autodiscovery
+listeners:
+  - name: docker
+
+config_providers:
+# The kubelet provider handles templates embedded in pod annotations, see
+# https://docs.datadoghq.com/guides/autodiscovery/#template-source-kubernetes-pod-annotations
+  - name: kubelet
+    polling: true

--- a/Dockerfiles/agent/datadog.yaml
+++ b/Dockerfiles/agent/datadog.yaml
@@ -1,3 +1,0 @@
-# Autodiscovery
-listeners:
-  - name: docker

--- a/Dockerfiles/agent/entrypoint.sh
+++ b/Dockerfiles/agent/entrypoint.sh
@@ -31,6 +31,17 @@ else
     fi
 fi
 
+if [ $KUBERNETES_SERVICE_PORT ]; then
+    export KUBERNETES="yes"
+fi
+
+# Install default datadog.yaml
+if [ $KUBERNETES ]; then
+    ln -s /etc/datadog-agent/datadog-kubernetes.yaml /etc/datadog-agent/datadog.yaml
+else
+    ln -s /etc/datadog-agent/datadog-docker.yaml /etc/datadog-agent/datadog.yaml
+fi
+
 # Copy custom confs
 
 find /conf.d -name '*.yaml' -exec cp --parents {} /etc/datadog-agent/ \;

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -49,6 +49,7 @@ func SetupAutoConfig(confdPath string) {
 		filepath.Join(GetDistPath(), "conf.d"),
 	}
 	AC.AddProvider(providers.NewFileConfigProvider(confSearchPaths), false)
+	AC.AddProvider(providers.NewKubeletConfigProvider(), true)
 
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -49,7 +49,6 @@ func SetupAutoConfig(confdPath string) {
 		filepath.Join(GetDistPath(), "conf.d"),
 	}
 	AC.AddProvider(providers.NewFileConfigProvider(confSearchPaths), false)
-	AC.AddProvider(providers.NewKubeletConfigProvider(), true)
 
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -23,6 +23,10 @@ func (p *MockProvider) Collect() ([]check.Config, error) {
 	return []check.Config{}, nil
 }
 
+func (p *MockProvider) String() string {
+	return "mocked"
+}
+
 type MockProvider2 struct {
 	MockProvider
 }

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -117,7 +117,7 @@ func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 			if err == nil {
 				resolvedSet[config.Digest()] = config
 			} else {
-				log.Debugf("Error resolving template %s for service %s: %v",
+				log.Warnf("Error resolving template %s for service %s: %v",
 					config.Name, serviceID, err)
 			}
 		}
@@ -255,7 +255,7 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	hosts, err := svc.GetHosts()
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract IP address for container %s, ignoring it", svc.GetID())
+		return nil, fmt.Errorf("failed to extract IP address for container %s, ignoring it. Source error: %s", svc.GetID(), err)
 	}
 	if len(hosts) == 0 {
 		return nil, fmt.Errorf("no network found for container %s, ignoring it", svc.GetID())
@@ -272,7 +272,7 @@ func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	// otherwise use fallback policy
 	ip, err := getFallbackHost(hosts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve IP address for container %s, ignoring it. Err: %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to resolve IP address for container %s, ignoring it. Source error: %s", svc.GetID(), err)
 	}
 
 	return []byte(ip), nil
@@ -301,7 +301,7 @@ func getFallbackHost(hosts map[string]string) (string, error) {
 func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	ports, err := svc.GetPorts()
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract port list for container %s, ignoring it", svc.GetID())
+		return nil, fmt.Errorf("failed to extract port list for container %s, ignoring it. Source error: %s", svc.GetID(), err)
 	} else if len(ports) == 0 {
 		return nil, fmt.Errorf("no port found for container %s - ignoring it", svc.GetID())
 	}

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -137,6 +137,7 @@ func (l *DockerListener) init() {
 				DockerService: DockerService{
 					ID:            id,
 					ADIdentifiers: l.getConfigIDFromPs(co),
+					// Host and Ports will be looked up when needed
 				},
 			}
 		} else {

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -408,5 +408,6 @@ func computeDockerIDs(cid string, image string, labels map[string]string) []stri
 		ids = append(ids, short)
 	}
 
+	log.Warnf("IDS %s", ids)
 	return ids
 }

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -435,7 +435,6 @@ func computeDockerIDs(cid string, image string, labels map[string]string) []stri
 		ids = append(ids, short)
 	}
 
-	log.Warnf("IDS %s", ids)
 	return ids
 }
 

--- a/pkg/collector/listeners/docker_kubelet.go
+++ b/pkg/collector/listeners/docker_kubelet.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+// +build kubelet
+
+package listeners
+
+// This files handles Host & Port lookup from the kubelet's pod status
+// If needed for other orchestrators, we should introduce pluggable
+// sources instead of adding yet another special case.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+// DockerKubeletService overrides some methods when a container is
+// running in kubernetes
+type DockerKubeletService struct {
+	DockerService
+}
+
+var dockerListenerKubeUtil *kubelet.KubeUtil
+
+func (s *DockerKubeletService) getPod() (*kubelet.Pod, error) {
+	if dockerListenerKubeUtil == nil {
+		var err error
+		dockerListenerKubeUtil, err = kubelet.GetKubeUtil()
+		if err != nil {
+			return nil, err
+		}
+	}
+	searchedId := docker.ContainerIDToEntityName(string(s.GetID()))
+	return dockerListenerKubeUtil.GetPodForContainerID(searchedId)
+}
+
+func (s *DockerKubeletService) GetHosts() (map[string]string, error) {
+	pod, err := s.getPod()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"pod": pod.Status.PodIP}, nil
+
+}
+
+func (s *DockerKubeletService) GetPorts() ([]int, error) {
+	pod, err := s.getPod()
+	if err != nil {
+		return nil, err
+	}
+	searchedId := string(s.GetID())
+	var searchedContainerName string
+	for _, container := range pod.Status.Containers {
+		if strings.HasSuffix(container.ID, searchedId) {
+			searchedContainerName = container.Name
+		}
+	}
+	if searchedContainerName == "" {
+		return nil, fmt.Errorf("can't find container %s in pod %s", searchedId, pod.Metadata.Name)
+	}
+	var ports []int
+	for _, container := range pod.Spec.Containers {
+		if container.Name == searchedContainerName {
+			for _, port := range container.Ports {
+				ports = append(ports, port.ContainerPort)
+			}
+		}
+	}
+
+	return ports, nil
+}

--- a/pkg/collector/listeners/docker_nokubelet.go
+++ b/pkg/collector/listeners/docker_nokubelet.go
@@ -3,14 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
-// +build docker
-// +build !kubelet
+// +build docker,!kubelet
 
 package listeners
 
-// DockerKubeletService overrides some methods when a container is
-// running in kubernetes. The overrides are defined in docker_kubelet.go
-// when the kubelet build tag is provided.
+// DockerKubeletService is not compiled if the kubelet tag is not here.
+// Revert to all DockerService methods, that might probably fail though.
 type DockerKubeletService struct {
 	DockerService
 }

--- a/pkg/collector/listeners/docker_nokubelet.go
+++ b/pkg/collector/listeners/docker_nokubelet.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+// +build !kubelet
+
+package listeners
+
+// DockerKubeletService overrides some methods when a container is
+// running in kubernetes. The overrides are defined in docker_kubelet.go
+// when the kubelet build tag is provided.
+type DockerKubeletService struct {
+	DockerService
+}

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -28,14 +28,14 @@ func TestGetConfigIDFromPs(t *testing.T) {
 	dl := DockerListener{}
 
 	ids := dl.getConfigIDFromPs(co)
-	assert.Equal(t, []string{"test"}, ids)
+	assert.Equal(t, []string{"docker://deadbeef", "test"}, ids)
 
 	prefixCo := types.Container{
 		ID:    "deadbeef",
 		Image: "org/test",
 	}
 	ids = dl.getConfigIDFromPs(prefixCo)
-	assert.Equal(t, []string{"org/test", "test"}, ids)
+	assert.Equal(t, []string{"docker://deadbeef", "org/test", "test"}, ids)
 
 	labeledCo := types.Container{
 		ID:     "deadbeef",
@@ -110,7 +110,7 @@ func TestGetADIdentifiers(t *testing.T) {
 
 	ids, err := s.GetADIdentifiers()
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"org/test", "test"}, ids)
+	assert.Equal(t, []string{"docker://deadbeef", "org/test", "test"}, ids)
 
 	s = DockerService{ID: ID("deadbeef")}
 	labeledCo := types.ContainerJSON{

--- a/pkg/collector/providers/consul.go
+++ b/pkg/collector/providers/consul.go
@@ -99,6 +99,10 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 
 }
 
+func (p *ConsulConfigProvider) String() string {
+	return "consul Configuration Provider"
+}
+
 // Collect retrieves templates from consul, builds Config objects and returns them
 func (p *ConsulConfigProvider) Collect() ([]check.Config, error) {
 	var templates []check.Config

--- a/pkg/collector/providers/consul_test.go
+++ b/pkg/collector/providers/consul_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build consul
+
 package providers
 
 import (

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubelet
+
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+const (
+	podAnnotationFormat = "service-discovery.datadoghq.com/%s."
+)
+
+// KubeletConfigProvider implements the ConfigProvider interface for the kubelet.
+type KubeletConfigProvider struct {
+	kubelet *kubelet.KubeUtil
+}
+
+// NewKubeletConfigProvider returns a new ConfigProvider connected to kubelet.
+func NewKubeletConfigProvider() (ConfigProvider, error) {
+	return &KubeletConfigProvider{}, nil
+}
+
+func (k *KubeletConfigProvider) String() string {
+	return "Kubernetes pod annotation"
+}
+
+// Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them
+// TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
+func (k *KubeletConfigProvider) Collect() ([]check.Config, error) {
+	var err error
+	if k.kubelet == nil {
+		k.kubelet, err = kubelet.GetKubeUtil()
+		if err != nil {
+			return []check.Config{}, err
+		}
+	}
+
+	pods, err := k.kubelet.GetLocalPodList()
+	if err != nil {
+		return []check.Config{}, err
+	}
+
+	return parseKubeletPodlist(pods)
+}
+
+func parseKubeletPodlist(podlist []*kubelet.Pod) ([]check.Config, error) {
+	var configs []check.Config
+	for _, pod := range podlist {
+		// Filter out pods with no AD annotation
+		var hasAD bool
+		for name := range pod.Metadata.Annotations {
+			if strings.HasPrefix(name, "service-discovery.datadoghq.com/") {
+				hasAD = true
+				break
+			}
+		}
+		if hasAD == false {
+			continue
+		}
+
+		for _, container := range pod.Status.Containers {
+			c, err := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
+				fmt.Sprintf(podAnnotationFormat, container.Name))
+			switch {
+			case err != nil:
+				log.Errorf("Can't parse template for pod %s: %s", pod.Metadata.Name, err)
+				continue
+			case len(c) == 0:
+				continue
+			default:
+				configs = append(configs, c...)
+
+			}
+		}
+	}
+	return configs, nil
+}

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -27,8 +27,8 @@ type KubeletConfigProvider struct {
 }
 
 // NewKubeletConfigProvider returns a new ConfigProvider connected to kubelet.
-func NewKubeletConfigProvider() (ConfigProvider, error) {
-	return &KubeletConfigProvider{}, nil
+func NewKubeletConfigProvider() ConfigProvider {
+	return &KubeletConfigProvider{}
 }
 
 func (k *KubeletConfigProvider) String() string {
@@ -84,5 +84,6 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]check.Config, error) {
 			}
 		}
 	}
+	log.Warnf("Collected templates: %s", configs)
 	return configs, nil
 }

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -67,7 +67,7 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]check.Config, error) {
 				break
 			}
 		}
-		if hasAD == false {
+		if !hasAD {
 			continue
 		}
 

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -27,8 +28,9 @@ type KubeletConfigProvider struct {
 }
 
 // NewKubeletConfigProvider returns a new ConfigProvider connected to kubelet.
-func NewKubeletConfigProvider() ConfigProvider {
-	return &KubeletConfigProvider{}
+// Connectivity is not checked at this stage to allow for retries, Collect will do it.
+func NewKubeletConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	return &KubeletConfigProvider{}, nil
 }
 
 func (k *KubeletConfigProvider) String() string {
@@ -86,4 +88,8 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]check.Config, error) {
 	}
 	log.Warnf("Collected templates: %s", configs)
 	return configs, nil
+}
+
+func init() {
+	RegisterProvider("kubelet", NewKubeletConfigProvider)
 }

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -86,7 +86,6 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]check.Config, error) {
 			}
 		}
 	}
-	log.Warnf("Collected templates: %s", configs)
 	return configs, nil
 }
 

--- a/pkg/collector/providers/kubelet_test.go
+++ b/pkg/collector/providers/kubelet_test.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubelet
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+// Only testing parseKubeletPodlist, lifecycle should be tested in end-to-end test
+
+func TestParseKubeletPodlist(t *testing.T) {
+	podlist := []*kubelet.Pod{
+		{
+			Status: kubelet.Status{
+				Containers: []kubelet.ContainerStatus{
+					{
+						Name: "testName",
+						ID:   "testID",
+					},
+				},
+			},
+		},
+		{
+			Metadata: kubelet.PodMetadata{
+				Annotations: map[string]string{
+					"service-discovery.datadoghq.com/apache.check_names":  "[\"apache\",\"http_check\"]",
+					"service-discovery.datadoghq.com/apache.init_configs": "[{},{}]",
+					"service-discovery.datadoghq.com/apache.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+				},
+			},
+			Status: kubelet.Status{
+				Containers: []kubelet.ContainerStatus{
+					{
+						Name: "apache",
+						ID:   "docker://3b8efe0c50e8",
+					},
+					{
+						Name: "testName",
+						ID:   "testID",
+					},
+				},
+			},
+		},
+	}
+
+	checks, err := parseKubeletPodlist(podlist)
+	assert.Nil(t, err)
+
+	assert.Len(t, checks, 2)
+
+	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[0].ADIdentifiers)
+	assert.Equal(t, "{}", string(checks[0].InitConfig))
+	assert.Len(t, checks[0].Instances, 1)
+	assert.Equal(t, "{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}", string(checks[0].Instances[0]))
+	assert.Equal(t, "apache", checks[0].Name)
+
+	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[1].ADIdentifiers)
+	assert.Equal(t, "{}", string(checks[1].InitConfig))
+	assert.Len(t, checks[1].Instances, 1)
+	assert.Equal(t, "{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}", string(checks[1].Instances[0]))
+	assert.Equal(t, "http_check", checks[1].Name)
+}

--- a/pkg/collector/providers/providers.go
+++ b/pkg/collector/providers/providers.go
@@ -31,4 +31,5 @@ type ConfigProviderFactory func(cfg config.ConfigurationProviders) (ConfigProvid
 // or data needed to access the resource providing the configuration.
 type ConfigProvider interface {
 	Collect() ([]check.Config, error)
+	String() string
 }

--- a/pkg/collector/providers/utils.go
+++ b/pkg/collector/providers/utils.go
@@ -107,7 +107,6 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []ch
 // extractTemplatesFromMap looks for autodiscovery configurations in a given map
 // (either docker labels or kubernetes annotations) and returns them if found.
 func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]check.Config, error) {
-	log.Warn(prefix + checkNamePath)
 	value, found := input[prefix+checkNamePath]
 	if !found {
 		return []check.Config{}, nil

--- a/pkg/collector/providers/utils_test.go
+++ b/pkg/collector/providers/utils_test.go
@@ -6,6 +6,8 @@
 package providers
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +114,106 @@ func TestBuildTemplates(t *testing.T) {
 	assert.Equal(t, res[1].Name, "b")
 	assert.Equal(t, res[1].InitConfig, check.ConfigData("{}"))
 	assert.Equal(t, res[1].Instances, []check.ConfigData{check.ConfigData("{1:2}")})
+}
+
+func TestExtractTemplatesFromMap(t *testing.T) {
+	for nb, tc := range []struct {
+		source       map[string]string
+		adIdentifier string
+		prefix       string
+		output       []check.Config
+		err          error
+	}{
+		{
+			// Nominal case with two templates
+			source: map[string]string{
+				"prefix.check_names":  "[\"apache\",\"http_check\"]",
+				"prefix.init_configs": "[{},{}]",
+				"prefix.instances":    "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"},{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output: []check.Config{
+				{
+					Name:          "apache",
+					Instances:     []check.ConfigData{check.ConfigData("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    check.ConfigData("{}"),
+					ADIdentifiers: []string{"id"},
+				},
+				{
+					Name:          "http_check",
+					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    check.ConfigData("{}"),
+					ADIdentifiers: []string{"id"},
+				},
+			},
+		},
+		{
+			// Take one, ignore one
+			source: map[string]string{
+				"prefix.check_names":   "[\"apache\"]",
+				"prefix.init_configs":  "[{}]",
+				"prefix.instances":     "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}]",
+				"prefix2.check_names":  "[\"apache\"]",
+				"prefix2.init_configs": "[{}]",
+				"prefix2.instances":    "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output: []check.Config{
+				{
+					Name:          "apache",
+					Instances:     []check.ConfigData{check.ConfigData("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    check.ConfigData("{}"),
+					ADIdentifiers: []string{"id"},
+				},
+			},
+		},
+		{
+			// Missing check_names, silently ignore map
+			source: map[string]string{
+				"prefix.init_configs": "[{}]",
+				"prefix.instances":    "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output:       []check.Config{},
+		},
+		{
+			// Missing init_configs, error out
+			source: map[string]string{
+				"prefix.check_names": "[\"apache\"]",
+				"prefix.instances":   "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output:       []check.Config{},
+			err:          errors.New("missing init_configs key"),
+		},
+		{
+			// Invalid instances json
+			source: map[string]string{
+				"prefix.check_names":  "[\"apache\"]",
+				"prefix.init_configs": "[{}]",
+				"prefix.instances":    "[{\"apache_status_url\" \"http://%%host%%/server-status?auto\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output:       []check.Config{},
+			err:          errors.New("in instances: Failed to unmarshal JSON"),
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {
+			assert := assert.New(t)
+			configs, err := extractTemplatesFromMap(tc.adIdentifier, tc.source, tc.prefix)
+			assert.EqualValues(tc.output, configs)
+
+			if tc.err == nil {
+				assert.Nil(err)
+			} else {
+				assert.NotNil(err)
+				assert.Contains(err.Error(), tc.err.Error())
+			}
+		})
+	}
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -141,6 +141,12 @@ metadata_collectors:
 # Please note the File Configuration Provider is enabled by default and cannot
 # be configured.
 # config_providers:
+
+## The kubelet provider handles templates embedded in pod annotations, see
+## https://docs.datadoghq.com/guides/autodiscovery/#template-source-kubernetes-pod-annotations
+#   - name: kubelet
+#     polling: true
+
 #   - name: etcd
 #     polling: true
 #     template_dir: /datadog/check_configs

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -52,6 +52,7 @@ func GetKubeUtil() (*KubeUtil, error) {
 	}
 	err := globalKubeUtil.TriggerRetry()
 	if err != nil {
+		log.Debugf("init error: %s", err)
 		return nil, err
 	}
 	return globalKubeUtil, nil
@@ -61,6 +62,7 @@ func (ku *KubeUtil) locateKubelet() error {
 	url, err := locateKubelet()
 	if err == nil {
 		ku.kubeletAPIURL = url
+		return nil
 	}
 	return err
 }

--- a/pkg/util/kubernetes/kubelet/kubelet_common.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package kubelet
+
+import (
+	"errors"
+)
+
+var (
+	// ErrNotCompiled is returned if kubelet support is not compiled in.
+	// User classes should handle that case as gracefully as possible.
+	ErrNotCompiled = errors.New("kubelet support not compiled in")
+)

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -28,7 +28,7 @@ type PodWatcher struct {
 // NewPodWatcher creates a new watcher. User call must then trigger PullChanges
 // and ExpireContainers when needed.
 func NewPodWatcher() (*PodWatcher, error) {
-	kubeutil, err := NewKubeUtil()
+	kubeutil, err := GetKubeUtil()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -14,18 +14,27 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestPodWatcherComputeChanges(t *testing.T) {
+type PodwatcherTestSuite struct {
+	suite.Suite
+}
+
+// Make sure globalKubeUtil is deleted before each test
+func (suite *PodwatcherTestSuite) SetupTest() {
+	globalKubeUtil = nil
+}
+
+func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 	raw, err := ioutil.ReadFile("./test/podlist_1.6.json")
-	require.Nil(t, err)
+	require.Nil(suite.T(), err)
 	var podlist PodList
 	json.Unmarshal(raw, &podlist)
 	sourcePods := podlist.Items
-	require.Len(t, sourcePods, 4)
+	require.Len(suite.T(), sourcePods, 4)
 
 	threePods := sourcePods[0:3]
 	fourthPod := sourcePods[3:4]
@@ -37,48 +46,48 @@ func TestPodWatcherComputeChanges(t *testing.T) {
 	}
 
 	changes, err := watcher.computechanges(threePods)
-	require.Nil(t, err)
-	require.Len(t, changes, 3)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 3)
 
 	// Same list should detect no change
 	changes, err = watcher.computechanges(threePods)
-	require.Nil(t, err)
-	require.Len(t, changes, 0)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 0)
 
 	// A pod with new containers should be sent
 	fourthPod[0].Metadata.ResVersion = fmt.Sprintf("%d", watcher.latestResVersion-1)
 	changes, err = watcher.computechanges(fourthPod)
-	require.Nil(t, err)
-	require.Len(t, changes, 1)
-	require.Equal(t, changes[0].Metadata.UID, fourthPod[0].Metadata.UID)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+	require.Equal(suite.T(), changes[0].Metadata.UID, fourthPod[0].Metadata.UID)
 
 	// A newer resversion should be computed
 	fourthPod[0].Metadata.ResVersion = fmt.Sprintf("%d", watcher.latestResVersion+1)
 	changes, err = watcher.computechanges(fourthPod)
-	require.Nil(t, err)
-	require.Len(t, changes, 1)
-	require.Equal(t, changes[0].Metadata.UID, fourthPod[0].Metadata.UID)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+	require.Equal(suite.T(), changes[0].Metadata.UID, fourthPod[0].Metadata.UID)
 
 	// A new container ID in an existing pod should trigger
 	fourthPod[0].Status.Containers[0].ID = "testNewID"
 	changes, err = watcher.computechanges(fourthPod)
-	require.Nil(t, err)
-	require.Len(t, changes, 1)
-	require.Equal(t, changes[0].Metadata.UID, fourthPod[0].Metadata.UID)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+	require.Equal(suite.T(), changes[0].Metadata.UID, fourthPod[0].Metadata.UID)
 
 	// Sending the same pod again with no change
 	changes, err = watcher.computechanges(fourthPod)
-	require.Nil(t, err)
-	require.Len(t, changes, 0)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 0)
 }
 
-func TestPodWatcherExpireContainers(t *testing.T) {
+func (suite *PodwatcherTestSuite) TestPodWatcherExpireContainers() {
 	raw, err := ioutil.ReadFile("./test/podlist_1.6.json")
-	require.Nil(t, err)
+	require.Nil(suite.T(), err)
 	var podlist PodList
 	json.Unmarshal(raw, &podlist)
 	sourcePods := podlist.Items
-	require.Len(t, sourcePods, 4)
+	require.Len(suite.T(), sourcePods, 4)
 
 	watcher := &PodWatcher{
 		latestResVersion: -1,
@@ -87,47 +96,51 @@ func TestPodWatcherExpireContainers(t *testing.T) {
 	}
 
 	_, err = watcher.computechanges(sourcePods)
-	require.Nil(t, err)
-	require.Len(t, watcher.lastSeen, 5)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), watcher.lastSeen, 5)
 
 	expire, err := watcher.ExpireContainers()
-	require.Nil(t, err)
-	require.Len(t, expire, 0)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), expire, 0)
 
 	testContainerID := "docker://b2beae57bb2ada35e083c78029fe6a742848ff021d839107e2ede87a9ce7bf50"
 
 	// 4 minutes should NOT be enough to expire
 	watcher.lastSeen[testContainerID] = watcher.lastSeen[testContainerID].Add(-4 * time.Minute)
 	expire, err = watcher.ExpireContainers()
-	require.Nil(t, err)
-	require.Len(t, expire, 0)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), expire, 0)
 
 	// 6 minutes should be enough to expire
 	watcher.lastSeen[testContainerID] = watcher.lastSeen[testContainerID].Add(-6 * time.Minute)
 	expire, err = watcher.ExpireContainers()
-	require.Nil(t, err)
-	require.Len(t, expire, 1)
-	require.Equal(t, testContainerID, expire[0])
-	require.Len(t, watcher.lastSeen, 4)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), expire, 1)
+	require.Equal(suite.T(), testContainerID, expire[0])
+	require.Len(suite.T(), watcher.lastSeen, 4)
 }
 
-func TestPullChanges(t *testing.T) {
+func (suite *PodwatcherTestSuite) TestPullChanges() {
 	kubelet, err := newDummyKubelet("./test/podlist_1.6.json")
-	require.Nil(t, err)
+	require.Nil(suite.T(), err)
 	ts, kubeletPort, err := kubelet.Start()
 	defer ts.Close()
-	require.Nil(t, err)
+	require.Nil(suite.T(), err)
 
 	config.Datadog.SetDefault("kubernetes_kubelet_host", "localhost")
 	config.Datadog.SetDefault("kubernetes_http_kubelet_port", kubeletPort)
 
 	watcher, err := NewPodWatcher()
-	require.Nil(t, err)
-	require.NotNil(t, watcher)
+	require.Nil(suite.T(), err)
+	require.NotNil(suite.T(), watcher)
 	<-kubelet.Requests // Throwing away /healthz GET
 
 	pods, err := watcher.PullChanges()
 	<-kubelet.Requests // Throwing away /pods GET
-	require.Nil(t, err)
-	require.Len(t, pods, 4)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), pods, 4)
+}
+
+func TestPodwatcherTestSuite(t *testing.T) {
+	suite.Run(t, new(PodwatcherTestSuite))
 }

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -39,9 +39,25 @@ type PodOwner struct {
 
 // Spec contains fields for unmarshalling a Pod.Spec
 type Spec struct {
-	HostNetwork bool   `json:"hostNetwork,omitempty"`
-	Hostname    string `json:"hostname,omitempty"` // TODO: does it exist?
-	NodeName    string `json:"nodeName,omitempty"`
+	HostNetwork bool            `json:"hostNetwork,omitempty"`
+	Hostname    string          `json:"hostname,omitempty"` // TODO: does it exist?
+	NodeName    string          `json:"nodeName,omitempty"`
+	Containers  []ContainerSpec `json:"containers,omitempty"`
+}
+
+// ContainerSpec contains fields for unmarshalling a Pod.Spec.Containers
+type ContainerSpec struct {
+	Name  string              `json:"name"`
+	Image string              `json:"image,omitempty"`
+	Ports []ContainerPortSpec `json:"ports,omitempty"`
+}
+
+// ContainerSpec contains fields for unmarshalling a Pod.Spec.Containers.Ports
+type ContainerPortSpec struct {
+	ContainerPort int    `json:"containerPort"`
+	HostPort      int    `json:"hostPort"`
+	Name          string `json:"name"`
+	Protocol      string `json:"protocol"`
 }
 
 // Status contains fields for unmarshalling a Pod.Status

--- a/pkg/util/retry/retrier.go
+++ b/pkg/util/retry/retrier.go
@@ -93,17 +93,18 @@ func (r *Retrier) doTry() *Error {
 	r.Lock()
 	if err == nil {
 		r.status = OK
-	}
-	switch r.cfg.Strategy {
-	case OneTry:
-		r.status = PermaFail
-	case RetryCount:
-		r.tryCount++
-		if r.tryCount >= r.cfg.RetryCount {
+	} else {
+		switch r.cfg.Strategy {
+		case OneTry:
 			r.status = PermaFail
-		} else {
-			r.status = FailWillRetry
-			r.nextTry = time.Now().Add(r.cfg.RetryDelay)
+		case RetryCount:
+			r.tryCount++
+			if r.tryCount >= r.cfg.RetryCount {
+				r.status = PermaFail
+			} else {
+				r.status = FailWillRetry
+				r.nextTry = time.Now().Add(r.cfg.RetryDelay)
+			}
 		}
 	}
 	r.Unlock()

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -36,7 +36,7 @@ def get_default_build_tags(puppy=False):
         return PUPPY_TAGS
 
     include = ["all"]
-    exclude = ["docker"] if invoke.platform.WINDOWS else []
+    exclude = ["docker", "kubelet"] if invoke.platform.WINDOWS else []
     return get_build_tags(include, exclude)
 
 


### PR DESCRIPTION
### What does this PR do?

Port the templates-in-pod-annotations feature, and makes several changes to get it functional:

- improve configresolver.go logging
- wrap `DockerService` in a `DockerKubeletService` if a k8s-related container label is found, to override the `GetHosts` and `GetPorts` methods without adding lots of `if k8s` in DockerListener
- add `docker://$cid` AD identifier to docker containers to enable matching. Same ID will be used for templates-in-container-labels
- new `KubeletConfigProvider` that pools and parses the podlist to find AD templates. Most of the logic is in `extractTemplatesFromMap` so it can be reused for docker labels (in another PR)
- add `retry.Retrier` logic to `KubeUtil` and `PodWatcher` objects, and update test suites
- extend `kubelet.Pod` with needed fields for AD

# Notes
- `WIP` until I commit test coverage
- checks often get re-loaded because `check.Equals` is flaky

