### PR TITLE
Update ntp tests

### DIFF
--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -21,7 +21,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var ntpExpVar = expvar.NewFloat("ntpOffset")
+var (
+	ntpExpVar = expvar.NewFloat("ntpOffset")
+	// for testing purpose
+	ntpQuery = ntp.Query
+)
 
 // NTPCheck only has sender and config
 type NTPCheck struct {
@@ -126,7 +130,7 @@ func (c *NTPCheck) Run() error {
 	serviceCheckMessage := ""
 	offsetThreshold := c.cfg.instance.OffsetThreshold
 
-	response, err := ntp.Query(c.cfg.instance.Host, c.cfg.instance.Version)
+	response, err := ntpQuery(c.cfg.instance.Host, c.cfg.instance.Version)
 	if err != nil {
 		log.Infof("There was an error querying the ntp host: %s", err)
 		serviceCheckStatus = metrics.ServiceCheckUnknown

--- a/pkg/collector/corechecks/network/ntp_test.go
+++ b/pkg/collector/corechecks/network/ntp_test.go
@@ -6,38 +6,121 @@
 package network
 
 import (
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/beevik/ntp"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/stretchr/testify/mock"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
-var ntpCfgString = `
+var (
+	ntpCfgString = `
 offset_threshold: 60
 port: ntp
 version: 3
 timeout: 5
 `
+	offset = 10
+)
 
-func TestNTP(t *testing.T) {
+func testNTPQueryError(host string, version int) (*ntp.Response, error) {
+	return nil, fmt.Errorf("test error from NTP")
+}
+
+func testNTPQuery(host string, version int) (*ntp.Response, error) {
+	return &ntp.Response{
+		ClockOffset: time.Duration(offset) * time.Second,
+	}, nil
+}
+
+func TestNTPOK(t *testing.T) {
 	var ntpCfg = []byte(ntpCfgString)
 	var ntpInitCfg = []byte("")
+
+	offset = 21
+	ntpQuery = testNTPQuery
+	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
-	mockSender.On("Gauge", "ntp.offset", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
+	mockSender.On("Gauge", "ntp.offset", float64(21), "", []string(nil)).Return().Times(1)
 	mockSender.On("ServiceCheck",
-		"ntp.in_sync", mock.AnythingOfType("metrics.ServiceCheckStatus"), "",
-		[]string(nil), mock.AnythingOfType("string")).Return().Times(1)
+		"ntp.in_sync",
+		metrics.ServiceCheckOK,
+		"",
+		[]string(nil),
+		"").Return().Times(1)
 
 	mockSender.On("Commit").Return().Times(1)
 	ntpCheck.Run()
 
 	mockSender.AssertExpectations(t)
 	mockSender.AssertNumberOfCalls(t, "Gauge", 1)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestNTPCritical(t *testing.T) {
+	var ntpCfg = []byte(ntpCfgString)
+	var ntpInitCfg = []byte("")
+
+	offset = 100
+	ntpQuery = testNTPQuery
+	defer func() { ntpQuery = ntp.Query }()
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+
+	mockSender := mocksender.NewMockSender(ntpCheck.ID())
+
+	mockSender.On("Gauge", "ntp.offset", float64(100), "", []string(nil)).Return().Times(1)
+	mockSender.On("ServiceCheck",
+		"ntp.in_sync",
+		metrics.ServiceCheckCritical,
+		"",
+		[]string(nil),
+		"Offset 100 secs higher than offset threshold (60 secs)").Return().Times(1)
+
+	mockSender.On("Commit").Return().Times(1)
+	ntpCheck.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 1)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestNTPError(t *testing.T) {
+	var ntpCfg = []byte(ntpCfgString)
+	var ntpInitCfg = []byte("")
+
+	ntpQuery = testNTPQueryError
+	defer func() { ntpQuery = ntp.Query }()
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+
+	mockSender := mocksender.NewMockSender(ntpCheck.ID())
+
+	mockSender.On("ServiceCheck",
+		"ntp.in_sync",
+		metrics.ServiceCheckUnknown,
+		"",
+		[]string(nil),
+		mock.AnythingOfType("string")).Return().Times(1)
+
+	mockSender.On("Commit").Return().Times(1)
+	ntpCheck.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 0)
 	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 1)
 	mockSender.AssertNumberOfCalls(t, "Commit", 1)
 }


### PR DESCRIPTION
### What does this PR do?

The tests are now mock to avoid failing when the ntp lib returns an error
(it happens very often on the windows CI). This also allows us to cover
more cases.

### Motivation

Windows CI would fail 50% of the time.