### PR TITLE
[py] use subprocess32 for all things subprocess + python intepreter stats

### DIFF
--- a/cmd/agent/dist/utils/py_mem.py
+++ b/cmd/agent/dist/utils/py_mem.py
@@ -1,0 +1,23 @@
+from pympler import tracker
+
+
+def get_mem_stats():
+    memory_tracker = tracker.SummaryTracker()
+    summary = memory_tracker.create_summary()
+
+    stats = {}
+    for entry in summary:
+        ref, n, sz = entry
+        entry_type = ref.split(' ')[0]
+
+        stat = stats.get(entry_type, {})
+        stat['n'] = stat.get('n', 0) + n
+        stat['sz'] = stat.get('sz', 0) + n*sz
+
+        entries = stat.get('entries', [])
+        entries.append([ref, n, sz])
+        stat['entries'] = entries
+
+        stats[entry_type] = stat
+
+    return stats

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -10,6 +10,8 @@
 from functools import wraps
 import logging
 import tempfile
+import os
+import sys
 
 if os.name == 'posix' and sys.version_info[0] < 3:
     try:

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -9,8 +9,16 @@
 # stdlib
 from functools import wraps
 import logging
-import subprocess
 import tempfile
+
+if os.name == 'posix' and sys.version_info[0] < 3:
+    try:
+        import subprocess32 as subprocess
+    except ImportError:
+        import subprocess
+else:
+    import subprocess
+
 
 log = logging.getLogger(__name__)
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -89,6 +89,7 @@ build do
 
     # Manually add "core" dependencies that are not listed in the checks requirements
     all_reqs_file.puts "requests==2.11.1"
+    all_reqs_file.puts "subprocess32==3.2.7" if os != 'windows'
 
     all_reqs_file.close
   end

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -89,6 +89,7 @@ build do
 
     # Manually add "core" dependencies that are not listed in the checks requirements
     all_reqs_file.puts "requests==2.11.1"
+    all_reqs_file.puts "pympler==0.5"
     all_reqs_file.puts "subprocess32==3.2.7" if os != 'windows'
 
     all_reqs_file.close


### PR DESCRIPTION
### What does this PR do?

This PR will default to `subprocess32` if available (we'll make it available in the package).

It also adds the ability to collect memory usage statistics from the python interpreter. These should provide a nice tool to identify potential sources of leakage in (cgo)python-land. We have encountered leaks that are pretty much untraceable with the go `pprof` tools, so we're hoping these might provide some additional insight.

### Motivation

Memory leak investigation.

### Additional Notes

We might want to lock down the python memory stats REST api endpoint - but I would probably leave it open for the beta.
