### PR TITLE
[omnibus] Unpin the external agents and integrations-core

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -13,7 +13,7 @@ relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
-default_version '5.19.0'
+default_version 'master'
 
 blacklist = [
   'agent_metrics',

--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -6,7 +6,7 @@
 name "datadog-process-agent"
 always_build true
 
-default_version '5.19.0'
+default_version 'master'
 
 
 build do

--- a/omnibus/config/software/datadog-trace-agent.rb
+++ b/omnibus/config/software/datadog-trace-agent.rb
@@ -8,7 +8,7 @@ require 'pathname'
 
 name "datadog-trace-agent"
 
-default_version "5.19.0"
+default_version "master"
 
 source git: 'https://github.com/DataDog/datadog-trace-agent.git'
 relative_path 'src/github.com/DataDog/datadog-trace-agent'


### PR DESCRIPTION
### What does this PR do?

Unpins the external agents and `integrations-core` in the omnibus build.

### Motivation

On master, we should build with the latest versions of these deps,
otherwise it's hard to synchronize changes that affect both
`datadog-agent` and these other projects.

For now, we can pin them in the beta builds by pinning the deps on the
`beta` branch. If at some point we want to build beta/stable builds
from master we'll have to discuss how to define the pins on these deps.

### Additional notes

Before releasing the next beta (`beta.4`), we will **have to** think about pinning
the deps on the `beta` branch.

Incidentally, this should fix the autoconf issue on the current nightlies, which regard the autoconf yamls as non-templated yamls (because the `integrations-core` version that’s used in the nightly still uses `docker_images` in the autoconf yamls instead of the newer `ad_identifiers`)