### PR TITLE
Fix aws dup hostname

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -200,6 +200,7 @@ func getMeta() *Meta {
 	hostname, _ := os.Hostname()
 	tzname, _ := time.Now().Zone()
 	ec2Hostname, _ := ec2.GetHostname()
+	instanceId, _ := ec2.GetInstanceID()
 
 	m := &Meta{
 		SocketHostname: hostname,
@@ -207,6 +208,7 @@ func getMeta() *Meta {
 		SocketFqdn:     util.Fqdn(hostname),
 		EC2Hostname:    ec2Hostname,
 		HostAliases:    getHostAliases(),
+		InstanceId:     instanceId,
 	}
 
 	// Cache the metadata for use in other payload

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -200,7 +200,7 @@ func getMeta() *Meta {
 	hostname, _ := os.Hostname()
 	tzname, _ := time.Now().Zone()
 	ec2Hostname, _ := ec2.GetHostname()
-	instanceId, _ := ec2.GetInstanceID()
+	instanceID, _ := ec2.GetInstanceID()
 
 	m := &Meta{
 		SocketHostname: hostname,
@@ -208,7 +208,7 @@ func getMeta() *Meta {
 		SocketFqdn:     util.Fqdn(hostname),
 		EC2Hostname:    ec2Hostname,
 		HostAliases:    getHostAliases(),
-		InstanceId:     instanceId,
+		InstanceID:     instanceID,
 	}
 
 	// Cache the metadata for use in other payload

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -25,6 +25,7 @@ type Meta struct {
 	EC2Hostname    string   `json:"ec2-hostname"`
 	Hostname       string   `json:"hostname"`
 	HostAliases    []string `json:"host_aliases"`
+	InstanceId     string   `json:"instance-id"`
 }
 
 type tags struct {

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -25,7 +25,7 @@ type Meta struct {
 	EC2Hostname    string   `json:"ec2-hostname"`
 	Hostname       string   `json:"hostname"`
 	HostAliases    []string `json:"host_aliases"`
-	InstanceId     string   `json:"instance-id"`
+	InstanceID     string   `json:"instance-id"`
 }
 
 type tags struct {


### PR DESCRIPTION
### What does this PR do?

Send additional host metadata. Specifically, send `instance-id` for ec2 instances.

### Motivation

What inspired you to submit this pull request?

When deploying Agent 6 Beta to ec2 instances that are also being monitored by the `aws integration`, the UI shows duplicate hosts.

### Additional Notes
