### PR TITLE
[omnibus] Make 4xx & 5xx http statuses fail the build

### DIFF
--- a/omnibus/config/software/datadog-logs-agent.rb
+++ b/omnibus/config/software/datadog-logs-agent.rb
@@ -10,7 +10,7 @@ build do
   logs_agent_version = "alpha"
   binary = "logagent"
   url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
-  command "curl #{url} -o #{binary}"
+  command "curl -f #{url} -o #{binary}"
   command "chmod +x #{binary}"
   command "mv #{binary} #{install_dir}/bin/agent/logs-agent"
 end

--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -16,7 +16,7 @@ build do
   binary_url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
 
   # fetch the binary and move to install_dir
-  command "curl #{binary_url} -o #{binary}"
+  command "curl -f #{binary_url} -o #{binary}"
   command "chmod +x #{binary}"
   move binary, "#{install_dir}/embedded/bin/process-agent"
 end


### PR DESCRIPTION
When downloading the process agent/logs agent binaries.

### What does this PR do?

Make 4xx & 5xx http statuses fail the build when downloading the process agent/logs agent binaries.

### Motivation

Same thing as https://github.com/DataDog/dd-agent-omnibus/pull/205

