### PR TITLE
[omnibus] Add packaging metric files

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -71,6 +71,12 @@ build do
         copy "#{check_dir}/conf.yaml.default", "#{check_conf_dir}/"
       end
 
+      # Copy the metric file, if it exists
+      if File.exist? "#{check_dir}/metrics.yaml"
+        mkdir check_conf_dir unless File.exists? (check_conf_dir)
+        copy "#{check_dir}/metrics.yaml", "#{check_conf_dir}/"
+      end
+
       # We don't have auto_conf on windows yet
       if os != 'windows'
         if File.exist? "#{check_dir}/auto_conf.yaml"


### PR DESCRIPTION
### What does this PR do?

Modifies omnibus so thats `metrics.yaml` files  (if they exist) are packaged with Agent 6

### Motivation

https://github.com/DataDog/integrations-core/pull/863 Added `metrics.yaml` files for JMX checks

### Additional Notes

Anything else we should know when reviewing?
