### PR TITLE
[docker] add events to integration test

### DIFF
--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -82,6 +82,15 @@ type Event struct {
 	EventType      string         `json:"event_type,omitempty"`
 }
 
+// Return a JSON string or "" in case of error during the Marshaling
+func (e *Event) String() string {
+	s, err := json.Marshal(e)
+	if err != nil {
+		return ""
+	}
+	return string(s)
+}
+
 // Events represents a list of events ready to be serialize
 type Events []*Event
 

--- a/test/integration/corechecks/docker/events_test.go
+++ b/test/integration/corechecks/docker/events_test.go
@@ -26,15 +26,7 @@ func TestEvents(t *testing.T) {
 		"lowcardenvtag:eventlowenv",
 	}
 
-	sender.AssertEvent(t, metrics.Event{
-		Ts:             nowTimestamp,
-		EventType:      "docker",
-		Tags:           expectedTags,
-		AggregationKey: "docker:busybox:latest",
-		SourceTypeName: "docker",
-		Priority:       metrics.EventPriorityNormal,
-	}, time.Minute)
-	sender.AssertEvent(t, metrics.Event{
+	expectedBusyboxEvent := metrics.Event{
 		Ts:        nowTimestamp,
 		EventType: "docker",
 		Tags: append(expectedTags, []string{
@@ -47,7 +39,8 @@ func TestEvents(t *testing.T) {
 		AggregationKey: "docker:busybox:latest",
 		SourceTypeName: "docker",
 		Priority:       metrics.EventPriorityNormal,
-	}, time.Minute)
+	}
+	sender.AssertEvent(t, expectedBusyboxEvent, time.Minute)
 
 	expectedRedisEvent := metrics.Event{
 		Ts:        nowTimestamp,

--- a/test/integration/corechecks/docker/events_test.go
+++ b/test/integration/corechecks/docker/events_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func init() {
+	registerComposeFile("events.compose")
+}
+
+func TestEvents(t *testing.T) {
+	nowTimestamp := time.Now().Unix()
+	expectedTags := []string{
+		instanceTag,
+		"highcardlabeltag:eventhigh",
+		"lowcardlabeltag:eventlow",
+		"highcardenvtag:eventhighenv",
+		"lowcardenvtag:eventlowenv",
+	}
+
+	sender.AssertEvent(t, metrics.Event{
+		Ts:             nowTimestamp,
+		EventType:      "docker",
+		Tags:           expectedTags,
+		AggregationKey: "docker:busybox:latest",
+		SourceTypeName: "docker",
+		Priority:       metrics.EventPriorityNormal,
+	}, time.Minute)
+	sender.AssertEvent(t, metrics.Event{
+		Ts:        nowTimestamp,
+		EventType: "docker",
+		Tags: append(expectedTags, []string{
+			"docker_image:busybox:latest",
+			"image_name:busybox",
+			"image_tag:latest",
+			"container_name:events_recordingevent0_1",
+			"container_name:events_recordingevent1_1",
+		}...),
+		AggregationKey: "docker:busybox:latest",
+		SourceTypeName: "docker",
+		Priority:       metrics.EventPriorityNormal,
+	}, time.Minute)
+
+	expectedRedisEvent := metrics.Event{
+		Ts:        nowTimestamp,
+		EventType: "docker",
+		Tags: append(expectedTags, []string{
+			"docker_image:redis:latest",
+			"image_name:redis",
+			"image_tag:latest",
+			"container_name:events_recordingevent2_1",
+		}...),
+		AggregationKey: "docker:redis:latest",
+		SourceTypeName: "docker",
+		Priority:       metrics.EventPriorityNormal,
+	}
+	sender.AssertEvent(t, expectedRedisEvent, time.Minute)
+
+	// Put the expected expectedRedisEvent event in the future
+	expectedRedisEvent.Ts = time.Now().Unix() + 60
+	sender.AssertEventMissing(t, expectedRedisEvent, time.Second) // Allow a delta of 1 second
+}

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -30,6 +30,7 @@ var skipCleanup = flag.Bool("skip-cleanup", false, "skip cleanup of the docker c
 const instanceTag = "instanceTag:MustBeHere"
 
 var dockerCfgString = `
+collect_events: true
 collect_container_size: true
 collect_exit_codes: true
 tags:

--- a/test/integration/corechecks/docker/testdata/events.compose
+++ b/test/integration/corechecks/docker/testdata/events.compose
@@ -8,11 +8,11 @@ services:
     image: "busybox:latest"
     entrypoint: /bin/true
     labels:
-        low.card.label: &lowcardlabel "eventlow"
-        high.card.label: &highcardlabel "eventhigh"
+        low.card.label: "eventlow"
+        high.card.label: "eventhigh"
     environment:
-        LOW_CARD_ENV: &lowcardenv "eventlowenv"
-        HIGH_CARD_ENV: &highcardenv "eventhighenv"
+        LOW_CARD_ENV: "eventlowenv"
+        HIGH_CARD_ENV: "eventhighenv"
   recordingevent1:
     <<: *event_base
   recordingevent2:

--- a/test/integration/corechecks/docker/testdata/events.compose
+++ b/test/integration/corechecks/docker/testdata/events.compose
@@ -1,0 +1,21 @@
+# This file uses YAML anchors to deduplicate steps
+# see https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
+# and https://learnxinyminutes.com/docs/yaml/
+
+version: '2'
+services:
+  recordingevent0: &event_base
+    image: "busybox:latest"
+    entrypoint: /bin/true
+    labels:
+        low.card.label: &lowcardlabel "eventlow"
+        high.card.label: &highcardlabel "eventhigh"
+    environment:
+        LOW_CARD_ENV: &lowcardenv "eventlowenv"
+        HIGH_CARD_ENV: &highcardenv "eventhighenv"
+  recordingevent1:
+    <<: *event_base
+  recordingevent2:
+    <<: *event_base
+    image: "redis:latest"
+  


### PR DESCRIPTION
### What does this PR do?

Inside the integration-tests, under the docker corecheck, this PR adds a testing suite for the Events.
This PR brings new asserts in mocksender package to easily work with Events.


### Additional Notes

This PR follows #813 with the same goal