### PR TITLE
fix nil pointer error when using MockSender

### DIFF
--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -6,6 +6,8 @@
 package mocksender
 
 import (
+	"time"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -16,8 +18,8 @@ import (
 // functional mocked Sender for testing
 func NewMockSender(id check.ID) *MockSender {
 	mockSender := new(MockSender)
-	// The MockSender requires an aggregator
-	aggregator.InitAggregator(nil, "")
+	// The MockSender will be injected in the corecheck via the aggregator
+	aggregator.InitAggregatorWithFlushInterval(nil, "", 1*time.Hour)
 	aggregator.SetSender(mockSender, id)
 
 	return mockSender


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky docker corecheck integration tests, that sometimes failed if running for more than 15 seconds.

The inject the `MockSender` in the corecheck via the `aggregator` package, hence the need to initialise it. Because we mock every call in the `Sender` interface, no metric actually gets into the aggregator. However, the aggregator itself adds a `datadog.agent.up` service check in every bucket before sending it to the serializer, which is a nil pointer in our case.

This PR changes the flush interval of the aggregator from 15 seconds to an hour when using `MockSender`, so a flush can't happen during an integration test's lifetime.

Fixes https://github.com/DataDog/datadog-agent/issues/807