### PR TITLE
[subprocess][go] run the subprocesses from go-land

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: jfullaondo/datadog-agent-builder-deb:0.1.0
+      - image: jfullaondo/datadog-agent-builder-deb:0.1.1
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: jfullaondo/datadog-agent-builder-deb:0.0.4
+      - image: jfullaondo/datadog-agent-builder-deb:0.1.0
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -4,7 +4,7 @@ RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
     && sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list \
     && sed -i 's/main/main contrib non-free/' /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y python2.7-dev autoconf autogen intltool
+RUN apt-get update && apt-get install -y python2.7-dev autoconf autogen intltool libssl1.0-dev
 RUN apt-get install -y libsnmp-base libsnmp-dev libpq-dev snmp-mibs-downloader
 
 # Ruby,,,
@@ -27,7 +27,6 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
-        libssl-dev \
 		ruby \
 	' \
 	&& apt-get update \

--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.9.1
 
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
     && sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list \
@@ -14,9 +14,9 @@ RUN mkdir -p /usr/local/etc \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
-ENV RUBY_MAJOR 2.3
-ENV RUBY_VERSION 2.3.4
-ENV RUBY_DOWNLOAD_SHA256 341cd9032e9fd17c452ed8562a8d43f7e45bfe05e411d0d7d627751dd82c578c
+ENV RUBY_MAJOR 2.4
+ENV RUBY_VERSION 2.4.2
+ENV RUBY_DOWNLOAD_SHA256 748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
 ENV RUBYGEMS_VERSION 2.6.12
 
 # some of ruby's build scripts are written in ruby
@@ -27,6 +27,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+        libssl-dev \
 		ruby \
 	' \
 	&& apt-get update \
@@ -57,14 +58,14 @@ RUN set -ex \
 		--build="$gnuArch" \
 		--disable-install-doc \
 		--enable-shared \
+        --with-openssl=/usr/lib/ssl \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.3
 

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -141,6 +141,8 @@ func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
 	switch component {
 	case "jmx":
 		setJMXStatus(w, r)
+	case "py":
+		setPythonStatus(w, r)
 	default:
 		err := fmt.Errorf("bad url or resource does not exist")
 		log.Errorf("%s", err.Error())

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -141,8 +141,6 @@ func componentStatusHandler(w http.ResponseWriter, r *http.Request) {
 	switch component {
 	case "jmx":
 		setJMXStatus(w, r)
-	case "py":
-		setPythonStatus(w, r)
 	default:
 		err := fmt.Errorf("bad url or resource does not exist")
 		log.Errorf("%s", err.Error())

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -6,7 +6,7 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 
-from utils import get_subprocess_output as subprocess_output
+from util import get_subprocess_output as subprocess_output
 
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
@@ -14,20 +14,3 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     if an error occurs.
     """
     return subprocess_output(command, raise_on_empty_output)
-
-
-def log_subprocess(func):
-    """
-    Wrapper around subprocess to log.debug commands.
-    """
-    @wraps(func)
-    def wrapper(*params, **kwargs):
-        fc = "%s(%s)" % (func.__name__, ', '.join(
-            [a.__repr__() for a in params] +
-            ["%s = %s" % (a, b) for a, b in kwargs.items()]
-        ))
-        log.debug("%s called" % fc)
-        return func(*params, **kwargs)
-    return wrapper
-
-subprocess.Popen = log_subprocess(subprocess.Popen)

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -22,6 +22,15 @@ else:
     import subprocess
 
 
+if os.name == 'posix' and sys.version_info[0] < 3:
+    try:
+        import subprocess32 as subprocess
+    except ImportError:
+        import subprocess
+else:
+    import subprocess
+
+
 log = logging.getLogger(__name__)
 
 

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -6,59 +6,14 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 
-# stdlib
-from functools import wraps
-import logging
-import tempfile
-import os
-import sys
-
-if os.name == 'posix' and sys.version_info[0] < 3:
-    try:
-        import subprocess32 as subprocess
-    except ImportError:
-        import subprocess
-else:
-    import subprocess
-
-
-log = logging.getLogger(__name__)
-
-
-class SubprocessOutputEmptyError(Exception):
-    pass
-
+from utils import get_subprocess_output as subprocess_output
 
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
     Run the given subprocess command and return its output. Raise an Exception
     if an error occurs.
     """
-
-    # Use tempfile, allowing a larger amount of memory. The subprocess.Popen
-    # docs warn that the data read is buffered in memory. They suggest not to
-    # use subprocess.PIPE if the data size is large or unlimited.
-    with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
-        proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
-        pid = proc.pid
-        log.debug("running process: {0} with pid: {1}".format(" ".join(command), pid))
-
-        retcode = proc.wait()
-        if retcode != 0:
-            log.debug("Error while running {0} with pid: {1}. It returned with code {2}".format(" ".join(command), pid, retcode))
-
-        stderr_f.seek(0)
-        err = stderr_f.read()
-        if err:
-            log.debug("Error while running {0} : {1}".format(" ".join(command), err))
-
-        stdout_f.seek(0)
-        output = stdout_f.read()
-
-    if not output and raise_on_empty_output:
-        raise SubprocessOutputEmptyError("get_subprocess_output expected output but had none.")
-
-    return (output, err, proc.returncode)
+    return subprocess_output(command, raise_on_empty_output)
 
 
 def log_subprocess(func):

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -7,6 +7,7 @@
 # All rights reserved
 
 from util import get_subprocess_output as subprocess_output
+from util import SubprocessOutputEmptyError  # noqa
 
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -22,15 +22,6 @@ else:
     import subprocess
 
 
-if os.name == 'posix' and sys.version_info[0] < 3:
-    try:
-        import subprocess32 as subprocess
-    except ImportError:
-        import subprocess
-else:
-    import subprocess
-
-
 log = logging.getLogger(__name__)
 
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -90,7 +90,6 @@ build do
     # Manually add "core" dependencies that are not listed in the checks requirements
     all_reqs_file.puts "requests==2.11.1"
     all_reqs_file.puts "pympler==0.5"
-    all_reqs_file.puts "subprocess32==3.2.7" if os != 'windows'
 
     all_reqs_file.close
   end

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -50,8 +50,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     char ** subprocess_args, * subprocess_arg;
     PyObject * py_result = Py_None;
 
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
+    PyGILState_STATE gstate = PyGILState_Ensure();
 
 	cmd_raise_on_empty = NULL;
     if (!PyArg_ParseTuple(args, "O|O:get_subprocess_output", &cmd_args, &cmd_raise_on_empty)) {

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -45,7 +45,7 @@ static PyObject *log_message(PyObject *self, PyObject *args) {
 
 static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
 	PyObject *cmd_args, *cmd_raise_on_empty; 
-    int raise = 1;
+    int raise = 1, i=0;
     int subprocess_args_sz;
     char ** subprocess_args, * subprocess_arg;
     PyObject * py_result = Py_None;
@@ -82,7 +82,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
         Py_RETURN_NONE;
     }
 
-	for (int i = 0; i < subprocess_args_sz; i++) {
+	for (i = 0; i < subprocess_args_sz; i++) {
 		subprocess_arg = PyString_AsString(PyList_GetItem(cmd_args, i));
 		if (subprocess_arg == NULL) {
 			PyErr_SetString(PyExc_Exception, "unable to parse arguments to cgo/go-land");

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -97,6 +97,9 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     py_result = GetSubprocessOutput(subprocess_args, subprocess_args_sz, raise);
     free(subprocess_args);
 
+    if (py_result == NULL) {
+        Py_RETURN_NONE;
+	}
     return py_result;
 }
 

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -8,9 +8,6 @@ PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 PyObject* GetSubprocessOutput(char **args, int argc, int raise);
 
-// Exceptions
-PyObject* SubprocessOutputEmptyError;
-
 static PyObject *get_config(PyObject *self, PyObject *args) {
     char *key;
 
@@ -44,7 +41,7 @@ static PyObject *log_message(PyObject *self, PyObject *args) {
 }
 
 static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
-	PyObject *cmd_args, *cmd_log, *cmd_raise_on_empty; //cmd_log is BC
+	PyObject *cmd_args, *cmd_raise_on_empty; 
     int raise = 1;
     int subprocess_args_sz;
     char ** subprocess_args, * subprocess_arg;
@@ -54,7 +51,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     gstate = PyGILState_Ensure();
 
 	cmd_raise_on_empty = NULL;
-    if (!PyArg_ParseTuple(args, "OO|O:get_subprocess_output", &cmd_args, &cmd_log, &cmd_raise_on_empty)) {
+    if (!PyArg_ParseTuple(args, "O|O:get_subprocess_output", &cmd_args, &cmd_raise_on_empty)) {
         PyGILState_Release(gstate);
         PyErr_SetString(PyExc_TypeError, "unable to parse arguments");
         Py_RETURN_NONE;

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -44,7 +44,7 @@ static PyObject *log_message(PyObject *self, PyObject *args) {
 }
 
 static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
-	PyObject *cmd_args, *cmd_raise_on_empty; 
+    PyObject *cmd_args, *cmd_raise_on_empty; 
     int raise = 1, i=0;
     int subprocess_args_sz;
     char ** subprocess_args, * subprocess_arg;
@@ -52,7 +52,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
 
     PyGILState_STATE gstate = PyGILState_Ensure();
 
-	cmd_raise_on_empty = NULL;
+    cmd_raise_on_empty = NULL;
     if (!PyArg_ParseTuple(args, "O|O:get_subprocess_output", &cmd_args, &cmd_raise_on_empty)) {
         PyGILState_Release(gstate);
         PyErr_SetString(PyExc_TypeError, "unable to parse arguments");
@@ -71,9 +71,9 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
         Py_RETURN_NONE;
     }
 
-	if (cmd_raise_on_empty != NULL) {
-		raise = (int)(cmd_raise_on_empty == Py_True);
-	}
+    if (cmd_raise_on_empty != NULL) {
+        raise = (int)(cmd_raise_on_empty == Py_True);
+    }
 
     subprocess_args_sz = PyList_Size(cmd_args);
     if(!(subprocess_args = (char **)malloc(sizeof(char *)*subprocess_args_sz))) {
@@ -82,15 +82,15 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
         Py_RETURN_NONE;
     }
 
-	for (i = 0; i < subprocess_args_sz; i++) {
-		subprocess_arg = PyString_AsString(PyList_GetItem(cmd_args, i));
-		if (subprocess_arg == NULL) {
-			PyErr_SetString(PyExc_Exception, "unable to parse arguments to cgo/go-land");
+    for (i = 0; i < subprocess_args_sz; i++) {
+        subprocess_arg = PyString_AsString(PyList_GetItem(cmd_args, i));
+        if (subprocess_arg == NULL) {
+            PyErr_SetString(PyExc_Exception, "unable to parse arguments to cgo/go-land");
             free(subprocess_args);
             Py_RETURN_NONE;
-		}
+        }
         subprocess_args[i] = subprocess_arg;
-	}
+    }
 
     PyGILState_Release(gstate);
     py_result = GetSubprocessOutput(subprocess_args, subprocess_args_sz, raise);
@@ -98,7 +98,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
 
     if (py_result == NULL) {
         Py_RETURN_NONE;
-	}
+    }
     return py_result;
 }
 

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -3,6 +3,7 @@
 PyObject* GetVersion(PyObject *self, PyObject *args);
 PyObject* Headers(PyObject *self, PyObject *args);
 PyObject* GetHostname(PyObject *self, PyObject *args);
+PyObject* GetSubprocessOutput(PyObject *self, PyObject *args);
 PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 
@@ -53,6 +54,7 @@ static PyMethodDef datadogAgentMethods[] = {
  */
 static PyMethodDef utilMethods[] = {
   {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {"get_subprocess_output", (PyCFunction)GetSubprocessOutput, METH_VARARGS, "Run subprocess and return its output."},
   {NULL, NULL}
 };
 

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -8,6 +8,9 @@ PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 PyObject* GetSubprocessOutput(char **args, int argc, int raise);
 
+// Exceptions
+PyObject* SubprocessOutputEmptyError;
+
 static PyObject *get_config(PyObject *self, PyObject *args) {
     char *key;
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -212,16 +212,12 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
 	cOutput := C.CString(string(output[:]))
 	pyOutput := C.PyString_FromString(cOutput)
-	defer C.Py_DecRef(pyOutput)
 	C.free(unsafe.Pointer(cOutput))
 	cOutputErr := C.CString(string(outputErr[:]))
 	pyOutputErr := C.PyString_FromString(cOutputErr)
-	defer C.Py_DecRef(pyOutputErr)
 	C.free(unsafe.Pointer(cOutputErr))
 	pyRetCode := C.PyInt_FromLong(C.long(retCode))
-	defer C.Py_DecRef(pyRetCode)
 
-	// Don't decref as we're returning this
 	pyResult := C.PyTuple_New(3)
 	C.PyTuple_SetItem(pyResult, 0, pyOutput)
 	C.PyTuple_SetItem(pyResult, 1, pyOutputErr)

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -139,6 +139,10 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 		C.free(unsafe.Pointer(cErr))
 		return C._none()
 	}
+	var output []byte
+	go func() {
+		output, _ = ioutil.ReadAll(stdout)
+	}()
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
@@ -147,6 +151,10 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 		C.free(unsafe.Pointer(cErr))
 		return C._none()
 	}
+	var outputErr []byte
+	go func() {
+		outputErr, _ = ioutil.ReadAll(stderr)
+	}()
 
 	cmd.Start()
 
@@ -158,21 +166,21 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 		}
 	}
 
-	output, err := ioutil.ReadAll(stdout)
-	if err != nil {
-		cErr := C.CString(fmt.Sprintf("unable to read command stdout: %v", err))
-		C.PyErr_SetString(C.PyExc_Exception, cErr)
-		C.free(unsafe.Pointer(cErr))
-		return C._none()
-	}
+	// output, err := ioutil.ReadAll(stdout)
+	// if err != nil {
+	// 	cErr := C.CString(fmt.Sprintf("unable to read command stdout: %v", err))
+	// 	C.PyErr_SetString(C.PyExc_Exception, cErr)
+	// 	C.free(unsafe.Pointer(cErr))
+	// 	return C._none()
+	// }
 
-	outputErr, err := ioutil.ReadAll(stderr)
-	if err != nil {
-		cErr := C.CString(fmt.Sprintf("unable to read command stderr: %v", err))
-		C.PyErr_SetString(C.PyExc_Exception, cErr)
-		C.free(unsafe.Pointer(cErr))
-		return C._none()
-	}
+	// outputErr, err := ioutil.ReadAll(stderr)
+	// if err != nil {
+	// 	cErr := C.CString(fmt.Sprintf("unable to read command stderr: %v", err))
+	// 	C.PyErr_SetString(C.PyExc_Exception, cErr)
+	// 	C.free(unsafe.Pointer(cErr))
+	// 	return C._none()
+	// }
 
 	if raise > 0 {
 		// raise on error

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -183,6 +183,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 				C.free(unsafe.Pointer(cErr))
 				return nil
 			}
+			defer C.Py_DecRef(utilModule)
 
 			cExcName := C.CString("SubprocessOutputEmptyError")
 			excClass := C.PyObject_GetAttrString(utilModule, cExcName)
@@ -193,6 +194,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 				C.free(unsafe.Pointer(cErr))
 				return nil
 			}
+			defer C.Py_DecRef(excClass)
 
 			cErr := C.CString("get_subprocess_output expected output but had none.")
 			C.PyErr_SetString((*C.PyObject)(unsafe.Pointer(excClass)), cErr)
@@ -212,8 +214,8 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	pyRetCode := C.PyInt_FromLong(C.long(retCode))
 	defer C.Py_DecRef(pyRetCode)
 
+	// Don't decref as we're returning this
 	pyResult := C.PyTuple_New(3)
-	defer C.Py_DecRef(pyResult) // I'm returning this so probably shouldn't do this
 	C.PyTuple_SetItem(pyResult, 0, pyOutput)
 	C.PyTuple_SetItem(pyResult, 1, pyOutputErr)
 	C.PyTuple_SetItem(pyResult, 2, pyRetCode)

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -120,9 +120,9 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
 	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
 	length := int(argc)
-	cmdSlice := (*[1 << 30]*C.char)(unsafe.Pointer(argv))[:length:length]
 	subprocessArgs := make([]string, length)
-	subprocessCmd = cmdSlice[0]
+	cmdSlice := (*[1 << 30]*C.char)(unsafe.Pointer(argv))[:length:length]
+	subprocessCmd = C.GoString(cmdSlice[0])
 	for i := 0; i < length; i++ {
 		subprocessArgs[i] = C.GoString(cmdSlice[i])
 	}
@@ -157,7 +157,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	output, err := ioutil.ReadAll(stdout)
 	if err != nil {
 		cErr := C.CString(fmt.Printf("unable to read command stdout: %v", err))
-		C.PyErr_SetString(C.PyExc_Exception)
+		C.PyErr_SetString(C.PyExc_Exception, cErr)
 		C.free(unsafe.Pointer(cErr))
 		return nil
 	}

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"runtime"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -130,6 +131,8 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	}
 	cmd := exec.Command(subprocessCmd, subprocessArgs...)
 
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	glock := C.PyGILState_Ensure()
 	defer C.PyGILState_Release(glock)
 

--- a/pkg/collector/py/datadog_agent.h
+++ b/pkg/collector/py/datadog_agent.h
@@ -3,6 +3,7 @@
 
 #include <Python.h>
 
+
 void initdatadogagent();
 
 #endif /* DATADOG_HEADER */


### PR DESCRIPTION
### What does this PR do?

Runs the subprocess from go-land as opposed to forking from within the python interpreter. This should hopefully address memory leak issues we have experienced, as well as resolve the zombie fork issue (triggered by an obscure race-condition) we have experienced.

### Motivation

The `subprocess32` approach in #830 has helped with the memory leak, but wasn't a truly satisfactory fix as it didn't quite fix the issue on windows. The alternative, setting a global lock on windows would likely be less desirable than a pure-go cross-platform fix. Hopefully this addresses that.

### Additional Notes

I've been unable to get the tests to fly on gitlab, they seem fine locally. Let's see what happens on CircleCI. Let's be thorough with the GIL, reference count during the review 😅 