### PR TITLE
[Config] Logs - Add default logs related parameters

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,6 +170,19 @@ func init() {
 	Datadog.BindEnv("bosh_id")
 	Datadog.BindEnv("histogram_aggregates")
 	Datadog.BindEnv("histogram_percentiles")
+
+	// Logs
+	BindEnvAndSetDefault("log_enabled", false)
+	BindEnvAndSetDefault("logset", "")
+	BindEnvAndSetDefault("log_dd_url", "intake.logs.datadoghq.com")
+	BindEnvAndSetDefault("log_dd_port", 10516)
+	BindEnvAndSetDefault("run_path", defaultRunPath)
+}
+
+// BindEnvAndSetDefault sets the default value for a config parameter, and adds an env binding
+func BindEnvAndSetDefault(key string, val interface{}) {
+	Datadog.SetDefault(key, val)
+	Datadog.BindEnv(key)
 }
 
 var (

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -8,6 +8,6 @@ package config
 const (
 	defaultConfdPath            = "/opt/datadog-agent/etc/conf.d"
 	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
-	defaultJMXPipePath          = "/opt/datadog-agent/run"
+	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///var/run/syslog"
 )

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -10,6 +10,6 @@ package config
 const (
 	defaultConfdPath            = "/etc/datadog-agent/conf.d"
 	defaultAdditionalChecksPath = "/etc/datadog-agent/checks.d"
-	defaultJMXPipePath          = "/opt/datadog-agent/run"
+	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///dev/log"
 )

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -8,6 +8,6 @@ package config
 const (
 	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
-	defaultJMXPipePath          = "\\\\.\\pipe\\"
+	defaultRunPath              = ""
 	defaultSyslogURI            = ""
 )


### PR DESCRIPTION
So we play well with config files and env variables (docker)

Notes:

- only `log_enable` is an official parameter. Other parameters are for internal usage, and are not documented
- `run_path` is not great, doesn't work on all platforms, etc. This is a temporary workaround for logs,  which are linux only. We will make this platform agnostic when we work on windows support. Also, this is used only because we need a path on filesystem to store a file. If there is an existing configuration parameter we can use, please let me know. Alternative would be to rename `defaultJMXPipePath` to something more generic

I'll add a link to related log-agent PR when ready