### PR TITLE
Integration-tests: cover the global metrics in corecheck docker

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -75,6 +75,14 @@ func MatchTagsContains(expected []string) interface{} {
 	})
 }
 
+// IsGreaterOrEqual is a mock.argumentMatcher builder to be used in asserts.
+// actual have to be greater or equal expectedMin
+func IsGreaterOrEqual(expectedMin float64) interface{} {
+	return mock.MatchedBy(func(actual float64) bool {
+		return expectedMin <= actual
+	})
+}
+
 // AssertTagsNotContains is a mock.argumentMatcher builder to be used in asserts.
 // It allows to check if tags are NOT emitted.
 func AssertTagsNotContains(expected []string) interface{} {

--- a/pkg/aggregator/mocksender/asserts_test.go
+++ b/pkg/aggregator/mocksender/asserts_test.go
@@ -18,35 +18,49 @@ type unittestMock struct {
 	mock.Mock
 }
 
-// Test the behavior of AnythingBut
+// A dummy Method to be called
+func (u *unittestMock) dummyMethod(s interface{}) {
+	u.Called(s)
+}
+
 // In this method we could observe an intend failure of "AssertNotCalled" tied to the localTester
-// Method returns the failure state of the localTester
-func (u *unittestMock) assertAnythingBut(t *testing.T, s string) bool {
-	u.Mock.AssertCalled(t, "dummyMethod", mock.AnythingOfType("string"))
+func TestAnythingBut(t *testing.T) {
+	m := &unittestMock{}
+	m.On("dummyMethod", mock.AnythingOfType("string")).Return()
+
+	m.dummyMethod("ok")
+	m.AssertCalled(t, "dummyMethod", mock.AnythingOfType("string"))
+
+	m.dummyMethod("ko")
+	m.AssertCalled(t, "dummyMethod", mock.AnythingOfType("string"))
 
 	// Create a local testing.T just for the following AssertNotCalled
 	localTester := &testing.T{}
 	// Pass the [localTester *testing.T] instead of [t *testing.T]
-	u.Mock.AssertNotCalled(localTester, "dummyMethod", AnythingBut(s))
-	return localTester.Failed()
+	m.AssertNotCalled(localTester, "dummyMethod", AnythingBut("ok"))
+	// Expected a failure on localTester
+	assert.True(t, localTester.Failed())
 }
 
-// A dummy Method to be called
-func (u *unittestMock) dummyMethod(s string) {
-	u.Called(s)
-}
-
-func TestAnythingBut(t *testing.T) {
+// In this method we could observe an intend failure of "AssertNotCalled" tied to the localTester
+func TestIsGreaterOrEqual(t *testing.T) {
 	m := &unittestMock{}
-	m.On("dummyMethod", mock.AnythingOfType("string")).Return()
-	m.dummyMethod("ok")
+	m.On("dummyMethod", mock.AnythingOfType("float64")).Return()
 
-	result := m.assertAnythingBut(t, "ok")
-	assert.False(t, result)
+	const dummyValue = 3.0
+	m.dummyMethod(dummyValue)
 
-	m.dummyMethod("ko")
-	result = m.assertAnythingBut(t, "ok")
-	assert.True(t, result)
+	for i := 0.0; i < dummyValue+1; i++ {
+		m.AssertCalled(t, "dummyMethod", IsGreaterOrEqual(i))
+	}
+	m.AssertNotCalled(t, "dummyMethod", IsGreaterOrEqual(dummyValue+1))
+
+	// Create a local testing.T just for the following AssertCalled
+	localTester := &testing.T{}
+	// Pass the [localTester *testing.T] instead of [t *testing.T]
+	m.AssertCalled(localTester, "dummyMethod", IsGreaterOrEqual(dummyValue+1))
+	// Expected a failure on localTester
+	assert.True(t, localTester.Failed())
 }
 
 func TestExpectedInActual(t *testing.T) {

--- a/test/integration/corechecks/docker/globalmetrics_test.go
+++ b/test/integration/corechecks/docker/globalmetrics_test.go
@@ -9,28 +9,21 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/stretchr/testify/mock"
 )
 
 func init() {
 	registerComposeFile("globalmetrics.compose")
 }
 
-func isGreaterOrEqual(atLeast float64) interface{} {
-	return mock.MatchedBy(func(actual float64) bool {
-		return atLeast <= actual
-	})
-}
-
 func TestGlobalMetrics(t *testing.T) {
 	expectedTags := []string{instanceTag}
 
-	sender.AssertCalled(t, "Gauge", "docker.images.available", isGreaterOrEqual(2), "", mocksender.MatchTagsContains(expectedTags))
-	sender.AssertCalled(t, "Gauge", "docker.images.intermediate", isGreaterOrEqual(0), "", mocksender.MatchTagsContains(expectedTags))
+	sender.AssertCalled(t, "Gauge", "docker.images.available", mocksender.IsGreaterOrEqual(2), "", mocksender.MatchTagsContains(expectedTags))
+	sender.AssertCalled(t, "Gauge", "docker.images.intermediate", mocksender.IsGreaterOrEqual(0), "", mocksender.MatchTagsContains(expectedTags))
 
 	redisTags := append(expectedTags, []string{"docker_image:redis:latest", "image_name:redis", "image_tag:latest"}...)
-	sender.AssertCalled(t, "Gauge", "docker.containers.running", isGreaterOrEqual(1), "", mocksender.MatchTagsContains(redisTags))
+	sender.AssertCalled(t, "Gauge", "docker.containers.running", mocksender.IsGreaterOrEqual(1), "", mocksender.MatchTagsContains(redisTags))
 
 	buxyboxTags := append(expectedTags, []string{"docker_image:busybox:latest", "image_name:busybox", "image_tag:latest"}...)
-	sender.AssertCalled(t, "Gauge", "docker.containers.stopped", isGreaterOrEqual(1), "", mocksender.MatchTagsContains(buxyboxTags))
+	sender.AssertCalled(t, "Gauge", "docker.containers.stopped", mocksender.IsGreaterOrEqual(1), "", mocksender.MatchTagsContains(buxyboxTags))
 }

--- a/test/integration/corechecks/docker/globalmetrics_test.go
+++ b/test/integration/corechecks/docker/globalmetrics_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/stretchr/testify/mock"
+)
+
+func init() {
+	registerComposeFile("globalmetrics.compose")
+}
+
+func isGreaterOrEqual(atLeast float64) interface{} {
+	return mock.MatchedBy(func(actual float64) bool {
+		return atLeast <= actual
+	})
+}
+
+func TestGlobalMetrics(t *testing.T) {
+	expectedTags := []string{instanceTag}
+
+	sender.AssertCalled(t, "Gauge", "docker.images.available", isGreaterOrEqual(2), "", mocksender.MatchTagsContains(expectedTags))
+	sender.AssertCalled(t, "Gauge", "docker.images.intermediate", isGreaterOrEqual(0), "", mocksender.MatchTagsContains(expectedTags))
+
+	redisTags := append(expectedTags, []string{"docker_image:redis:latest", "image_name:redis", "image_tag:latest"}...)
+	sender.AssertCalled(t, "Gauge", "docker.containers.running", isGreaterOrEqual(1), "", mocksender.MatchTagsContains(redisTags))
+
+	buxyboxTags := append(expectedTags, []string{"docker_image:busybox:latest", "image_name:busybox", "image_tag:latest"}...)
+	sender.AssertCalled(t, "Gauge", "docker.containers.stopped", isGreaterOrEqual(1), "", mocksender.MatchTagsContains(buxyboxTags))
+}

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -32,6 +32,7 @@ const instanceTag = "instanceTag:MustBeHere"
 var dockerCfgString = `
 collect_events: true
 collect_container_size: true
+collect_images_stats: true
 collect_exit_codes: true
 tags:
   - instanceTag:MustBeHere

--- a/test/integration/corechecks/docker/testdata/globalmetrics.compose
+++ b/test/integration/corechecks/docker/testdata/globalmetrics.compose
@@ -1,0 +1,18 @@
+# This file uses YAML anchors to deduplicate steps
+# see https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
+# and https://learnxinyminutes.com/docs/yaml/
+
+version: '2'
+services:
+  globalmetrics0: &globalmetrics_base
+    image: "redis:latest"
+    labels:
+        low.card.label: "globalmetricslow"
+        high.card.label: "globalmetricshigh"
+    environment:
+        LOW_CARD_ENV: "globalmetricslowenv"
+        HIGH_CARD_ENV: "globalmetricshighenv"
+  globalmetrics1:
+    <<: *globalmetrics_base
+    image: "busybox:latest"
+    command: /bin/echo


### PR DESCRIPTION
### What does this PR do?

Integration-tests: Cover the global metrics in corecheck docker by checking if the `docker.images` and `docker.containers` are correct.
