### PR TITLE
[docker] Docker labels AD provider

### DIFF
--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -4,3 +4,9 @@
 # Autodiscovery
 listeners:
   - name: docker
+
+config_providers:
+## The docker provider handles templates embedded in container labels, see
+## https://docs.datadoghq.com/guides/autodiscovery/#template-source-docker-label-annotations
+  - name: docker
+    polling: true

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -399,7 +399,7 @@ func (s *DockerService) GetPorts() ([]int, error) {
 // GetTags retrieves tags using the Tagger
 func (s *DockerService) GetTags() ([]string, error) {
 	entity := docker.ContainerIDToEntityName(string(s.ID))
-	tags, err := tagger.Tag(entity, true)
+	tags, err := tagger.Tag(entity, false)
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package providers
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+)
+
+const (
+	dockerLabelFormat = "com.datadoghq.ad."
+)
+
+// DockerConfigProvider implements the ConfigProvider interface for the docker labels.
+type DockerConfigProvider struct {
+	dockerUtil *docker.DockerUtil
+}
+
+// NewDockerConfigProvider returns a new ConfigProvider connected to docker.
+// Connectivity is not checked at this stage to allow for retries, Collect will do it.
+func NewDockerConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	return &DockerConfigProvider{}, nil
+}
+
+func (d *DockerConfigProvider) String() string {
+	return "Docker container labels"
+}
+
+// Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them
+// TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
+func (d *DockerConfigProvider) Collect() ([]check.Config, error) {
+	var err error
+	if d.dockerUtil == nil {
+		d.dockerUtil, err = docker.GetDockerUtil()
+		if err != nil {
+			return []check.Config{}, err
+		}
+	}
+
+	containers, err := d.dockerUtil.AllContainerLabels()
+	if err != nil {
+		return []check.Config{}, err
+	}
+
+	return parseDockerLabels(containers)
+}
+
+func parseDockerLabels(containers map[string]map[string]string) ([]check.Config, error) {
+	var configs []check.Config
+	for cID, labels := range containers {
+		c, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerLabelFormat)
+		switch {
+		case err != nil:
+			log.Errorf("Can't parse template for container %s: %s", cID, err)
+			continue
+		case len(c) == 0:
+			continue
+		default:
+			configs = append(configs, c...)
+
+		}
+	}
+	return configs, nil
+}
+
+func init() {
+	RegisterProvider("docker", NewDockerConfigProvider)
+}

--- a/pkg/collector/providers/docker_test.go
+++ b/pkg/collector/providers/docker_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Only testing parseDockerLabels, lifecycle should be tested in end-to-end test
+
+func TestParseDockerLabels(t *testing.T) {
+
+	containers := map[string]map[string]string{
+		"nolabels": map[string]string{},
+		"3b8efe0c50e8": map[string]string{
+			"com.datadoghq.ad.check_names":  "[\"apache\",\"http_check\"]",
+			"com.datadoghq.ad.init_configs": "[{}, {}]",
+			"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+		},
+	}
+
+	checks, err := parseDockerLabels(containers)
+	assert.Nil(t, err)
+
+	assert.Len(t, checks, 2)
+
+	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[0].ADIdentifiers)
+	assert.Equal(t, "{}", string(checks[0].InitConfig))
+	assert.Len(t, checks[0].Instances, 1)
+	assert.Equal(t, "{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}", string(checks[0].Instances[0]))
+	assert.Equal(t, "apache", checks[0].Name)
+
+	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[1].ADIdentifiers)
+	assert.Equal(t, "{}", string(checks[1].InitConfig))
+	assert.Len(t, checks[1].Instances, 1)
+	assert.Equal(t, "{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}", string(checks[1].Instances[0]))
+	assert.Equal(t, "http_check", checks[1].Name)
+}

--- a/pkg/collector/providers/docker_test.go
+++ b/pkg/collector/providers/docker_test.go
@@ -18,8 +18,8 @@ import (
 func TestParseDockerLabels(t *testing.T) {
 
 	containers := map[string]map[string]string{
-		"nolabels": map[string]string{},
-		"3b8efe0c50e8": map[string]string{
+		"nolabels": {},
+		"3b8efe0c50e8": {
 			"com.datadoghq.ad.check_names":  "[\"apache\",\"http_check\"]",
 			"com.datadoghq.ad.init_configs": "[{}, {}]",
 			"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -26,7 +26,7 @@ api_key:
 # hostname: mymachine.mydomain
 
 # Set the host's tags (optional)
-# tags: 
+# tags:
 #   - mytag
 #   - env:prod
 #   - role:database
@@ -145,6 +145,11 @@ metadata_collectors:
 ## The kubelet provider handles templates embedded in pod annotations, see
 ## https://docs.datadoghq.com/guides/autodiscovery/#template-source-kubernetes-pod-annotations
 #   - name: kubelet
+#     polling: true
+
+## The docker provider handles templates embedded in container labels, see
+## https://docs.datadoghq.com/guides/autodiscovery/#template-source-docker-label-annotations
+#   - name: docker
 #     polling: true
 
 #   - name: etcd

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -475,3 +475,23 @@ func parseContainerHealth(status string) string {
 	}
 	return all[0][1]
 }
+
+// AllContainerLabels retrieves all running containers (`docker ps`) and returns
+// a map mapping containerID to container labels as a map[string]string
+func (d *DockerUtil) AllContainerLabels() (map[string]map[string]string, error) {
+	containers, err := d.cli.ContainerList(context.Background(), types.ContainerListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error listing containers: %s", err)
+	}
+
+	labelMap := make(map[string]map[string]string)
+
+	for _, container := range containers {
+		if len(container.ID) == 0 {
+			continue
+		}
+		labelMap[container.ID] = container.Labels
+	}
+
+	return labelMap, nil
+}


### PR DESCRIPTION
### What does this PR do?

- Add support for AD templates in docker container labels. For now, we get all containers at every `Collect` (10 seconds). Once https://github.com/DataDog/datadog-agent/pull/855 is merged, `DockerConfigProvider` will suscribe to events via a callback and only hit docker if a `start` event as emitted since the last `Collect`

- That provider is enabled by default in the docker image if kubernetes is not set. If it is, users are to use pod annotations instead of docker labels

- Fix `DockerService.GetTags` to only retrieve low-card tags for AD metrics