### PR TITLE
[subprocess][go] no need to release lock - let caller handle that

### DIFF
--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -121,6 +121,10 @@ func LogMessage(message *C.char, logLevel C.int) *C.PyObject {
 //export GetSubprocessOutput
 func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
+	// IMPORTANT: this is (probably) running in a go routine already locked to
+	//            a thread. No need to do it again, and definitely no need to
+	//            to release it - we can let the caller do that.
+
 	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
 	length := int(argc)
 	subprocessArgs := make([]string, length-1)
@@ -131,8 +135,6 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	}
 	cmd := exec.Command(subprocessCmd, subprocessArgs...)
 
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 	glock := C.PyGILState_Ensure()
 	defer C.PyGILState_Release(glock)
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
-	"runtime"
 	"sync"
 	"syscall"
 	"unsafe"


### PR DESCRIPTION
### What does this PR do?

Avoids unlocking the go routine from the present thread. The check caller will handle that with the stickylock.

### Motivation

The python check calling the C-bindings, and then the SubProcessOutput go function is already locked to a thread, if we unlock it, the rest of the check will run unlocked triggering the race condition and probable crash. 

The previous approach, although stable on a single-core vagrant VM, after being release onto some beefier, more complex hardware, etc... resulted in crashes every 30m - 2h. No sign of the rogue processes so far though, memory looks in check, but with the restarts it's hard to tell.

### Additional Notes

Anything else we should know when reviewing?
