### PR TITLE
[Hostname] Fix issue with docker runing on EC2 outside of ecs

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -143,6 +143,9 @@ func GetHostname() (string, error) {
 	// If at this point we don't have a name, bail out
 	if hostName == "" {
 		err = fmt.Errorf("Unable to reliably determine the host name. You can define one in the agent config file or in your hosts file")
+	} else {
+		// we got a hostname, residual errors are irrelevant now
+		err = nil
 	}
 
 	cache.Cache.Set(cacheHostnameKey, hostName, cache.NoExpiration)


### PR DESCRIPTION
error wouldn't be nil, so agent wouldn't start

One can test `datadog/agent-dev:tristan-hostname-jmx` to confirm the behavior is fixed