### PR TITLE
lifecycle: readiness / liveness status

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,6 +67,18 @@
   version = "v3.1.10"
 
 [[projects]]
+  name = "github.com/coreos/go-systemd"
+  packages = ["daemon","util"]
+  revision = "d2196463941895ee908e13531a23a39feb9e1243"
+  version = "v15"
+
+[[projects]]
+  name = "github.com/coreos/pkg"
+  packages = ["dlopen"]
+  revision = "3ac0863d7acf3bc44daf49afef8919af12f704ef"
+  version = "v3"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
@@ -401,6 +413,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d4f29aad1567ef7834793cec163267bd4d9a5a7009784ff2c5844cec8171b16c"
+  inputs-digest = "f168e929dacda51a47767c596f59c64abddf820e5f1b625c8a05b1bbebfbe158"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -42,6 +42,7 @@ import (
 	// register metadata providers
 	_ "github.com/DataDog/datadog-agent/pkg/collector/metadata"
 	_ "github.com/DataDog/datadog-agent/pkg/metadata"
+	"github.com/DataDog/datadog-agent/pkg/lifecycle"
 )
 
 var (
@@ -147,9 +148,11 @@ func StartAgent() error {
 
 	log.Infof("Starting Datadog Agent v%v", version.AgentVersion)
 
+	lifecycle.RecordHealthPath()
+
 	// Setup expvar server
-	var port = config.Datadog.GetString("expvar_port")
-	go http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
+	var httpBind = fmt.Sprintf("127.0.0.1:%s", config.Datadog.GetString("expvar_port"))
+	go http.ListenAndServe(httpBind, http.DefaultServeMux)
 
 	if pidfilePath != "" {
 		err = pidfile.WritePID(pidfilePath)

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/lifecycle"
 	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 
@@ -193,6 +194,7 @@ func start(cmd *cobra.Command, args []string) error {
 }
 
 func main() {
+	lifecycle.RecordHealthPath()
 	// go_expvar server
 	go http.ListenAndServe(
 		fmt.Sprintf("127.0.0.1:%d", config.Datadog.GetInt("dogstatsd_stats_port")),

--- a/pkg/forwarder/worker.go
+++ b/pkg/forwarder/worker.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/lifecycle"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
@@ -32,6 +33,8 @@ type Worker struct {
 
 	stopChan    chan bool
 	blockedList *blockedEndpoints
+
+	life *lifecycle.Lifecycle
 }
 
 // NewWorker returns a new worker to consume Transaction from inputChan
@@ -51,6 +54,7 @@ func NewWorker(highPrioChan <-chan Transaction, lowPrioChan <-chan Transaction, 
 		stopChan:    make(chan bool),
 		Client:      httpClient,
 		blockedList: blocked,
+		life:        lifecycle.GetLifecycle(),
 	}
 }
 
@@ -135,5 +139,6 @@ func (w *Worker) process(ctx context.Context, t Transaction) {
 		log.Errorf("Error while processing transaction: %v", err)
 	} else {
 		w.blockedList.unblock(target)
+		w.life.RefreshHealthStatus()
 	}
 }

--- a/pkg/lifecycle/README.md
+++ b/pkg/lifecycle/README.md
@@ -1,0 +1,107 @@
+# Lifecycle
+
+## Goals
+
+Identify if the datadog-agent is healthy by creating readiness && liveness features.
+
+Expose a HTTP endpoint to allow external services to reach easily the status of the agent.
+If running in a systemd `.service`: notify dbus the readiness of the application.
+
+
+### HTTP Endpoint
+
+Implemented HTTP responses on GET `/health`:
+
+* **200** `{"health":true}`
+* **503** `{"health":false}`
+* **500** `{"health":false}`
+
+Healthy response example from the agent:
+       
+```bash 
+curl -fv 127.0.0.1:5000/health 
+*   Trying 127.0.0.1...
+* TCP_NODELAY set
+* Connected to 127.0.0.1 (127.0.0.1) port 5000 (#0)
+> GET /health HTTP/1.1
+> Host: 127.0.0.1:5000
+> User-Agent: curl/7.52.1
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+< Date: Sun, 26 Nov 2017 17:01:06 GMT
+< Content-Length: 15
+< 
+* Curl_http_done: called premature == 0
+* Connection #0 to host 127.0.0.1 left intact
+{"health":true}
+```
+
+### Notify Systemd
+
+Online documentation: https://www.freedesktop.org/software/systemd/man/systemd-notify.html
+
+##### TL;DR:
+
+> systemd-notify may be called by daemon scripts to notify the init system about status changes
+> Most importantly, it can be used for start-up completion notification.
+
+> Tells the service manager that service startup is finished. This is only used by systemd if the service definition file has Type=notify set.
+
+##### Example of notify service file
+
+```text
+[Unit]
+After=network.target
+
+[Service]
+Type=notify
+Environment=DD_API_KEY=******
+EnvironmentFile=-/etc/datadog-agent-env
+ExecStart=/path/to/datadog-agent start $ARGS
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+##### Behavior 
+
+Start the service:
+
+```bash
+systemctl start datadog-agent.service 
+```
+    
+The Active field will have two states:
+
+* activating (start)
+* active (running)  
+    
+The activating is triggered by the `start` command, the active by the sd_notify(3) call in the agent's code.  
+    
+When active, you can observe systemd PID 1 writing in the logs of `datadog-agent.service` the following entry:
+
+```json
+{        
+    "PRIORITY" : "6",
+    "SYSLOG_FACILITY" : "3",
+    "SYSLOG_IDENTIFIER" : "systemd",
+    "CODE_FILE" : "../src/core/job.c",
+    "CODE_LINE" : "804",
+    "CODE_FUNCTION" : "job_log_status_message",
+    "RESULT" : "done",
+    "_TRANSPORT" : "journal",
+    "_PID" : "1",
+    "_COMM" : "systemd",
+    "_EXE" : "/lib/systemd/systemd",
+    "_CMDLINE" : "/sbin/init splash",
+    "_SYSTEMD_CGROUP" : "/init.scope",
+    "_SYSTEMD_UNIT" : "init.scope",
+    "_SYSTEMD_SLICE" : "-.slice",
+    "UNIT" : "datadog-agent.service",
+    "MESSAGE" : "Started datadog-agent.service."
+}
+```

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/gorilla/mux"
+)
+
+var globalLifecycle = &Lifecycle{}
+
+const expectedRefreshSeconds = 60
+
+// Lifecycle items to handle the readiness and liveness statuses
+type Lifecycle struct {
+	readiness         sync.Once
+	lastHealthRefresh int64
+	m                 sync.RWMutex
+}
+
+type lifecycleResponse struct {
+	Health bool `json:"health"`
+}
+
+// GetLifecycle return the package globalLifecycle struct pointer
+func GetLifecycle() *Lifecycle {
+	return globalLifecycle
+}
+
+// RecordHealthPath add a /health route to the http server
+func RecordHealthPath() {
+	l := GetLifecycle()
+	r := mux.NewRouter()
+	r.HandleFunc("/health", l.healthHandler).Methods("GET")
+	http.Handle("/", r)
+}
+
+// readinessOnce is executed only Once
+// Contain all associated calls to notify the readiness state of the whole application
+func (l *Lifecycle) readinessOnce() {
+	l.readiness.Do(func() {
+		log.Infof("Triggering the readiness stage")
+		notifySystemd()
+	})
+}
+
+// RefreshHealthStatus call readinessOnce and update the timestamp of lastHealthRefresh
+func (l *Lifecycle) RefreshHealthStatus() {
+	l.readinessOnce()
+	l.m.Lock()
+	l.lastHealthRefresh = time.Now().Unix()
+	l.m.Unlock()
+	log.Debugf("Refreshed the healthCheck value")
+}
+
+func (l *Lifecycle) healthHandler(w http.ResponseWriter, r *http.Request) {
+	resp := &lifecycleResponse{}
+	l.m.RLock()
+	resp.Health = l.lastHealthRefresh > time.Now().Unix()-expectedRefreshSeconds
+	l.m.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	byteResp, err := json.Marshal(resp)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Warnf("GET /health %d: fail to marshal response: %s", http.StatusInternalServerError, err)
+		return
+	}
+	if resp.Health {
+		w.WriteHeader(http.StatusOK)
+		log.Debugf("GET /health %d: application is healthy", http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		log.Debugf("GET /health %d: application is unhealthy", http.StatusServiceUnavailable)
+	}
+	w.Write(byteResp)
+}

--- a/pkg/lifecycle/lifecycle_linux.go
+++ b/pkg/lifecycle/lifecycle_linux.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package lifecycle
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/coreos/go-systemd/daemon"
+	systemdutil "github.com/coreos/go-systemd/util"
+)
+
+// notifySystemd call sd_notify(3) if the agent is running on systemd platform and in a systemd service
+func notifySystemd() {
+	if systemdutil.IsRunningSystemd() == false {
+		log.Info("Not running on systemd platform")
+		return
+	}
+
+	inService, err := systemdutil.RunningFromSystemService()
+	if err != nil {
+		log.Errorf("Fail to identify if running in systemd service: %s", err)
+		return
+	}
+	if inService == false {
+		log.Info("Not running in systemd service")
+		return
+	}
+
+	sent, err := daemon.SdNotify(false, "READY=1")
+	if err != nil {
+		log.Errorf("Failed to notify systemd for readiness: %v", err)
+		return
+	}
+	if sent == false {
+		log.Errorf("Forgot to set Type=notify in systemd service file?")
+	}
+}

--- a/pkg/lifecycle/lifecycle_nolinux.go
+++ b/pkg/lifecycle/lifecycle_nolinux.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+//+build !linux
+
+package lifecycle
+
+func notifySystemd() {
+}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertServiceIs(t *testing.T, serverURL string, healthy bool) {
+	r, err := http.Get(fmt.Sprintf("%s/health", serverURL))
+	assert.Nil(t, err)
+	content, err := ioutil.ReadAll(r.Body)
+	assert.Nil(t, err)
+	health := &lifecycleResponse{}
+	err = json.Unmarshal(content, health)
+	assert.Nil(t, err)
+	assert.True(t, health.Health == healthy)
+	if health.Health == true {
+		assert.True(t, r.StatusCode == http.StatusOK)
+	} else {
+		assert.True(t, r.StatusCode == http.StatusServiceUnavailable)
+	}
+}
+
+func TestLifecycle(t *testing.T) {
+	server := httptest.NewServer(nil)
+	defer server.Close()
+
+	RecordHealthPath()
+	assertServiceIs(t, server.URL, false)
+
+	l := GetLifecycle()
+	// Pass the service OK then Unavailable several times
+	for r := 0; r < 5; r++ {
+		l.RefreshHealthStatus()
+		assertServiceIs(t, server.URL, true)
+
+		l.lastHealthRefresh = time.Now().Unix() - (expectedRefreshSeconds + 1)
+		assertServiceIs(t, server.URL, false)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Identify if the datadog-agent is healthy by creating readiness && liveness features.
Expose a HTTP endpoint to allow external services to reach easily the status of the agent.
If running in a systemd `.service`: notify dbus the readiness of the application.

### Motivation

Coming from #846 

### Additional Notes

This is still WIP, it's a simple implementation now.
We need to define where the `RefreshHealthStatus` is call and do we call a `RefreshHealthStatus` by component (forwarder, aggregator, AD, ...) ?