### PR TITLE
add hostname retrieval to docker diag

### DIFF
--- a/pkg/util/docker/diagnosis.go
+++ b/pkg/util/docker/diagnosis.go
@@ -22,6 +22,16 @@ func diagnose() error {
 	_, err := ConnectToDocker()
 	if err != nil {
 		log.Error(err)
+	} else {
+		log.Info("Successfully connected to docker")
+	}
+
+	hostname, err := HostnameProvider("")
+	if err != nil {
+		log.Error(err)
+		log.Infof("docker returned hostname %q with error", hostname)
+	} else {
+		log.Infof("Successfully got hostname %q from docker", hostname)
 	}
 	return err
 }

--- a/pkg/util/docker/diagnosis.go
+++ b/pkg/util/docker/diagnosis.go
@@ -23,15 +23,14 @@ func diagnose() error {
 	if err != nil {
 		log.Error(err)
 	} else {
-		log.Info("Successfully connected to docker")
+		log.Info("successfully connected to docker")
 	}
 
 	hostname, err := HostnameProvider("")
 	if err != nil {
-		log.Error(err)
-		log.Infof("docker returned hostname %q with error", hostname)
+		log.Errorf("returned hostname %q with error: %s", hostname, err)
 	} else {
-		log.Infof("Successfully got hostname %q from docker", hostname)
+		log.Infof("successfully got hostname %q from docker", hostname)
 	}
 	return err
 }


### PR DESCRIPTION
### What does this PR do?

Add a call to `docker.HostnameProvider` to the docker diagnose as that can cause the agent not to boot
