### PR TITLE
add tag collectors init retry and rework logging

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -50,7 +50,7 @@ func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) 
 
 	du, err := docker.GetDockerUtil()
 	if err != nil {
-		return NoCollection, fmt.Errorf("failed to connect to Docker, docker tagging will not work: %s", err)
+		return NoCollection, err
 	}
 	c.dockerUtil = du
 	c.client = client

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -43,10 +43,8 @@ func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 			return NoCollection, err
 		}
 		return FetchOnlyCollection, nil
-	} else {
-		return NoCollection, fmt.Errorf("can't find ECS agent")
 	}
-
+	return NoCollection, fmt.Errorf("cannot find ECS agent")
 }
 
 // Fetch fetches ECS tags

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -40,11 +40,11 @@ func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 		c.expire, err = taggerutil.NewExpire(ecsExpireFreq)
 
 		if err != nil {
-			return FetchOnlyCollection, fmt.Errorf("Failed to instantiate the container expiring process")
+			return NoCollection, err
 		}
 		return FetchOnlyCollection, nil
 	} else {
-		return NoCollection, fmt.Errorf("Failed to connect to ECS, ECS tagging will not work")
+		return NoCollection, fmt.Errorf("can't find ECS agent")
 	}
 
 }

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -35,7 +35,7 @@ type KubeletCollector struct {
 func (c *KubeletCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 	watcher, err := kubelet.NewPodWatcher()
 	if err != nil {
-		return NoCollection, fmt.Errorf("Failed to connect to kubelet, Kubernetes tagging will not work: %s", err)
+		return NoCollection, err
 	}
 	c.watcher = watcher
 	c.infoOut = out

--- a/pkg/util/retry/retrier.go
+++ b/pkg/util/retry/retrier.go
@@ -108,7 +108,7 @@ func (r *Retrier) doTry() *Error {
 				r.status = PermaFail
 			} else {
 				r.status = FailWillRetry
-				r.nextTry = time.Now().Add(r.cfg.RetryDelay)
+				r.nextTry = time.Now().Add(r.cfg.RetryDelay - 100*time.Millisecond)
 			}
 		}
 	}

--- a/pkg/util/retry/retrier_test.go
+++ b/pkg/util/retry/retrier_test.go
@@ -133,7 +133,7 @@ func TestRetryCount(t *testing.T) {
 		AttemptMethod: mocked.Attempt,
 		Strategy:      RetryCount,
 		RetryCount:    5,
-		RetryDelay:    1 * time.Nanosecond,
+		RetryDelay:    100 * time.Nanosecond,
 	}
 	err := mocked.SetupRetrier(config)
 	assert.Nil(t, err)
@@ -170,7 +170,7 @@ func TestRetryDelayNotElapsed(t *testing.T) {
 	assert.True(t, IsErrWillRetry(err))
 
 	// Testing the NextRetry value is within 1ms
-	expectedNext := time.Now().Add(retryDelay)
+	expectedNext := time.Now().Add(retryDelay - 100*time.Millisecond)
 	assert.WithinDuration(t, expectedNext, mocked.NextRetry(), time.Millisecond)
 
 	// Second call should skip
@@ -188,7 +188,7 @@ func TestRetryDelayRecover(t *testing.T) {
 		AttemptMethod: mocked.Attempt,
 		Strategy:      RetryCount,
 		RetryCount:    5,
-		RetryDelay:    1 * time.Nanosecond,
+		RetryDelay:    100 * time.Millisecond,
 	}
 	err := mocked.SetupRetrier(config)
 	assert.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

- handle collectors returning a `FailWillRetry` and retry them until they `PermaFail`. This will allow the agent to start before its sources (if installed on the host and starting before the kubelet).
- modify KubeletCollector to pass the error from `PodWatcher` instead of a custom error
- modify `retry.Retrier` to set the `nextTry` timestamp 100ms before configured to account for tickers not all being synced
- rework loggging to move most of it to debug (only show success as info) to avoid log spamming

### Testing

On a pure-docker host:
  - docker inits OK
  - ECS fails without retry (does not implement Retrier)
  - kubelet fails after 5 minutes, as configured

```
$ ./bin/agent/agent -c dev/dist/ start|grep tagger.go
2017-11-28 13:24:00 UTC | INFO | (tagger.go:81 in Init) | starting the tagging system
2017-11-28 13:24:00 UTC | INFO | (tagger.go:154 in tryCollectors) | docker tag collector successfully started
2017-11-28 13:24:00 UTC | DEBUG | (tagger.go:152 in tryCollectors) | ecs tag collector cannot start: cannot find ECS agent
2017-11-28 13:24:00 UTC | DEBUG | (tagger.go:148 in tryCollectors) | will retry kubelet later: temporary failure in kubeutil, will retry later: Could not find a method to connect to kubelet
...
2017-11-28 13:28:29 UTC | DEBUG | (tagger.go:148 in tryCollectors) | will retry kubelet later: temporary failure in kubeutil, will retry later: Could not find a method to connect to kubelet
2017-11-28 13:28:59 UTC | DEBUG | (tagger.go:152 in tryCollectors) | kubelet tag collector cannot start: permanent failure in kubeutil: Could not find a method to connect to kubelet
2017-11-28 13:28:59 UTC | DEBUG | (tagger.go:130 in startCollectors) | candidate list empty, stopping detection
```


On a GKE host:
```
$ kubectl logs agent6-xvello|grep tagger
2017-11-28 13:27:18 UTC | INFO | (tagger.go:81 in Init) | starting the tagging system
2017-11-28 13:27:18 UTC | INFO | (tagger.go:154 in tryCollectors) | kubelet tag collector successfully started
2017-11-28 13:27:18 UTC | INFO | (tagger.go:154 in tryCollectors) | docker tag collector successfully started
2017-11-28 13:27:18 UTC | DEBUG | (tagger.go:152 in tryCollectors) | ecs tag collector cannot start: cannot find ECS agent
2017-11-28 13:27:18 UTC | DEBUG | (tagger.go:130 in startCollectors) | candidate list empty, stopping detection
```