### PR TITLE
[suprocess][go] fix multiple binding issues - rename module.

### DIFF
--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -19,10 +19,10 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     if isinstance(command, basestring):
         for arg in command.split():
             _args.append(arg)
-    elif hastattr(type(command), '__iter__'):
+    elif hasattr(type(command), '__iter__'):
         for arg in command:
             cmd_args.append(arg)
     else:
-        raise Exception("command must be a sequence or string")
+        raise TypeError("command must be a sequence or string")
 
     return subprocess_output(cmd_args, raise_on_empty_output)

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -6,12 +6,23 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 
-from util import get_subprocess_output as subprocess_output
-from util import SubprocessOutputEmptyError  # noqa
+from _util import get_subprocess_output as subprocess_output
+from _util import SubprocessOutputEmptyError  # noqa
 
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
     Run the given subprocess command and return its output. Raise an Exception
     if an error occurs.
     """
-    return subprocess_output(command, raise_on_empty_output)
+
+    cmd_args = []
+    if isinstance(command, basestring):
+        for arg in command.split():
+            _args.append(arg)
+    elif hastattr(type(command), '__iter__'):
+        for arg in command:
+            cmd_args.append(arg)
+    else:
+        raise Exception("command must be a sequence or string")
+
+    return subprocess_output(cmd_args, raise_on_empty_output)

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -55,20 +55,19 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     cmd_raise_on_empty = NULL;
     if (!PyArg_ParseTuple(args, "O|O:get_subprocess_output", &cmd_args, &cmd_raise_on_empty)) {
         PyGILState_Release(gstate);
-        PyErr_SetString(PyExc_TypeError, "unable to parse arguments");
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     if (!PyList_Check(cmd_args)) {
-        PyGILState_Release(gstate);
         PyErr_SetString(PyExc_TypeError, "command args not a list");
-        Py_RETURN_NONE;
+        PyGILState_Release(gstate);
+        return NULL;
     }
 
     if (cmd_raise_on_empty != NULL && !PyBool_Check(cmd_raise_on_empty)) {
+        PyErr_SetString(PyExc_TypeError, "bad raise_on_empty_argument - should be bool");
         PyGILState_Release(gstate);
-        PyErr_SetString(PyExc_TypeError, "bad raise on empty argument - should be bool");
-        Py_RETURN_NONE;
+        return NULL;
     }
 
     if (cmd_raise_on_empty != NULL) {
@@ -77,9 +76,9 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
 
     subprocess_args_sz = PyList_Size(cmd_args);
     if(!(subprocess_args = (char **)malloc(sizeof(char *)*subprocess_args_sz))) {
-        PyGILState_Release(gstate);
         PyErr_SetString(PyExc_MemoryError, "unable to allocate memory, bailing out");
-        Py_RETURN_NONE;
+        PyGILState_Release(gstate);
+        return NULL;
     }
 
     for (i = 0; i < subprocess_args_sz; i++) {
@@ -117,7 +116,17 @@ static PyMethodDef datadogAgentMethods[] = {
  */
 static PyMethodDef utilMethods[] = {
   {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
-  {"get_subprocess_output", (PyCFunction)get_subprocess_output, METH_VARARGS, "Run subprocess and return its output."},
+  {NULL, NULL}
+};
+
+/*
+ * _Util package is a private module for utility bindings
+ */
+static PyMethodDef _utilMethods[] = {
+  {"get_subprocess_output", (PyCFunction)get_subprocess_output, 
+      METH_VARARGS, "Run subprocess and return its output. "
+                    "This is a private method and should not be called directly. " 
+                    "Please use the utils.get_subprocess_output wrapper."},
   {NULL, NULL}
 };
 
@@ -128,10 +137,11 @@ void initdatadogagent()
 
   PyObject *da = Py_InitModule("datadog_agent", datadogAgentMethods);
   PyObject *util = Py_InitModule("util", utilMethods);
+  PyObject *_util = Py_InitModule("_util", _utilMethods);
 
-  SubprocessOutputEmptyError = PyErr_NewException("util.SubprocessOutputEmptyError", NULL, NULL);
+  SubprocessOutputEmptyError = PyErr_NewException("_util.SubprocessOutputEmptyError", NULL, NULL);
   Py_INCREF(SubprocessOutputEmptyError);
-  PyModule_AddObject(util, "SubprocessOutputEmptyError", SubprocessOutputEmptyError);
+  PyModule_AddObject(_util, "SubprocessOutputEmptyError", SubprocessOutputEmptyError);
 
   PyGILState_Release(gstate);
 }

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -126,7 +126,7 @@ static PyMethodDef _utilMethods[] = {
   {"get_subprocess_output", (PyCFunction)get_subprocess_output, 
       METH_VARARGS, "Run subprocess and return its output. "
                     "This is a private method and should not be called directly. " 
-                    "Please use the utils.get_subprocess_output wrapper."},
+                    "Please use the utils.subprocess_output.get_subprocess_output wrapper."},
   {NULL, NULL}
 };
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -142,7 +142,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 		cErr := C.CString(fmt.Sprintf("internal error creating stdout pipe: %v", err))
 		C.PyErr_SetString(C.PyExc_Exception, cErr)
 		C.free(unsafe.Pointer(cErr))
-		return C._none()
+		return nil
 	}
 
 	var wg sync.WaitGroup
@@ -158,7 +158,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 		cErr := C.CString(fmt.Sprintf("internal error creating stderr pipe: %v", err))
 		C.PyErr_SetString(C.PyExc_Exception, cErr)
 		C.free(unsafe.Pointer(cErr))
-		return C._none()
+		return nil
 	}
 
 	var outputErr []byte
@@ -182,14 +182,11 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	if raise > 0 {
 		// raise on error
 		if len(output) == 0 {
-			cModuleName := C.CString("util")
+			cModuleName := C.CString("_util")
 			utilModule := C.PyImport_ImportModule(cModuleName)
 			C.free(unsafe.Pointer(cModuleName))
 			if utilModule == nil {
-				cErr := C.CString("unable to import subprocess empty output exception")
-				C.PyErr_SetString(C.PyExc_Exception, cErr)
-				C.free(unsafe.Pointer(cErr))
-				return C._none()
+				return nil
 			}
 			defer C.Py_DecRef(utilModule)
 
@@ -197,17 +194,14 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 			excClass := C.PyObject_GetAttrString(utilModule, cExcName)
 			C.free(unsafe.Pointer(cExcName))
 			if excClass == nil {
-				cErr := C.CString("unable to import subprocess empty output exception")
-				C.PyErr_SetString(C.PyExc_Exception, cErr)
-				C.free(unsafe.Pointer(cErr))
-				return C._none()
+				return nil
 			}
 			defer C.Py_DecRef(excClass)
 
 			cErr := C.CString("get_subprocess_output expected output but had none.")
 			C.PyErr_SetString((*C.PyObject)(unsafe.Pointer(excClass)), cErr)
 			C.free(unsafe.Pointer(cErr))
-			return C._none()
+			return nil
 		}
 	}
 

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -79,7 +79,7 @@ func TestSubprocessBindings(t *testing.T) {
 	gstate := newStickyLock()
 	defer gstate.unlock()
 
-	utilModule := python.PyImport_ImportModuleNoBlock("util")
+	utilModule := python.PyImport_ImportModuleNoBlock("_util")
 	assert.NotNil(t, utilModule)
 	defer utilModule.DecRef()
 


### PR DESCRIPTION
### What does this PR do?

Addresses some issues with #843 - mainly exception handling. Renames the module to a private `_util` module instead.

### Motivation

Cleanup after hail-mary merge that didn't go so bad :)

### Additional Notes

We have one more test to add, but will add it tomorrow due to time constraints.
