### PR TITLE
Don't store metric files as valid configs

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -194,17 +194,24 @@ func (ac *AutoConfig) getAllConfigs() []check.Config {
 				errorStats.setConfigError(name, e)
 			}
 
+			var goodConfs []check.Config
 			for _, cfg := range cfgs {
 				// JMX checks can have 2 YAML files: one containing the metrics to collect, one containing the
 				// instance configuration
 				// If the file provider finds any of these metric YAMLs, we store them in a map for future access
 				if cfg.MetricConfig != nil {
 					ac.name2jmxmetrics[cfg.Name] = cfg.MetricConfig
+					// We don't want to save metric files, it's enough to store them in the map
+					continue
 				}
+
+				goodConfs = append(goodConfs, cfg)
 
 				// Clear any old errors if a valid config file is found
 				errorStats.removeConfigError(cfg.Name)
 			}
+
+			cfgs = goodConfs
 		}
 		rawConfigs = append(rawConfigs, cfgs...)
 	}


### PR DESCRIPTION
### What does this PR do?

Discards `metrics.yaml` files after saving them in the `name2jmxmetrics` map.

### Motivation

The JMX loader was attempting to run the metric files as checks because `check.IsConfigJMX` was returning true here https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/corechecks/embed/jmxloader.go#L40.
There is no need for the metric files to be kept further once they've been stored in the map, and discarding them is the simplest way to stop the JMX loader from attempting to run them.

### Additional Notes

Anything else we should know when reviewing?
