### PR TITLE
[ci] Make tools run on `./cmd`

### DIFF
--- a/cmd/agent/app/install_service_windows.go
+++ b/cmd/agent/app/install_service_windows.go
@@ -74,12 +74,14 @@ func exePath() (string, error) {
 	}
 	if filepath.Ext(p) == "" {
 		p += ".exe"
-		fi, err := os.Stat(p)
-		if err == nil {
+		fi, statErr := os.Stat(p)
+		if statErr == nil {
 			if !fi.Mode().IsDir() {
 				return p, nil
 			}
 			err = fmt.Errorf("%s is directory", p)
+		} else {
+			err = statErr
 		}
 	}
 	return "", err

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -6,28 +6,28 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	
+
 	"github.com/hectane/go-acl"
 	"github.com/kardianos/osext"
 	"golang.org/x/sys/windows"
-
 )
+
 var (
-	wellKnownSidStrings = map[string]string {
+	wellKnownSidStrings = map[string]string{
 		"Administrators": "S-1-5-32-544",
-		"System": "S-1-5-18",
-		"Users": "S-1-5-32-545",
+		"System":         "S-1-5-18",
+		"Users":          "S-1-5-32-545",
 	}
 	wellKnownSids = make(map[string]*windows.SID)
 )
 
 func init() {
-	
+
 	for key, val := range wellKnownSidStrings {
 		sid, err := windows.StringToSid(val)
 		if err == nil {
 			wellKnownSids[key] = sid
-		} 
+		}
 	}
 }
 
@@ -53,11 +53,11 @@ func saveAuthToken(token string) error {
 	if err == nil {
 		err = acl.Apply(
 			authTokenPath,
-			true, // replace the file permissions
+			true,  // replace the file permissions
 			false, // don't inherit
 			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["Administrators"]),
 			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["System"]))
-		
+
 	}
 	return err
 }

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -16,8 +16,8 @@ WIN_MODULE_WHITELIST = [
 
 # List of paths to ignore in misspell's output
 MISSPELL_IGNORED_TARGETS = [
-    "cmd/agent/dist/checks/prometheus_check",
-    "cmd/agent/gui/views/private",
+    os.path.join("cmd", "agent", "dist", "checks", "prometheus_check"),
+    os.path.join("cmd", "agent", "gui", "views", "private"),
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Make tools run on `./cmd` by default.

Also, add a couple of exceptions to `misspell` on the `dist`-like paths.

### Motivation

go fmt, lint, vet, etc are interesting to run by default on
the `./cmd` path, so run these tools there.
