### PR TITLE
[subprocess_output] Fix exception raised on empty output + string cmd

### DIFF
--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -29,8 +29,8 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     else:
         raise TypeError("command must be a sequence or string")
 
-    log.debug("Running get_subprocess_output with cmd: '%s'", cmd_args)
+    log.debug("Running get_subprocess_output with cmd: %s", cmd_args)
     out, err, returncode = subprocess_output(cmd_args, raise_on_empty_output)
-    log.debug("get_subprocess_output returned with len(out) '%d' ; len(err) '%d' ; returncode '%d'", len(out), len(err), returncode)
+    log.debug("get_subprocess_output with cmd %s returned (len(out): %d ; len(err): %d ; returncode: %d)", cmd_args, len(out), len(err), returncode)
 
     return (out, err, returncode)

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -6,8 +6,12 @@
 # (C) Datadog, Inc. 2010-2017
 # All rights reserved
 
+import logging
+
 from _util import get_subprocess_output as subprocess_output
 from _util import SubprocessOutputEmptyError  # noqa
+
+log = logging.getLogger(__name__)
 
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
@@ -25,4 +29,8 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     else:
         raise TypeError("command must be a sequence or string")
 
-    return subprocess_output(cmd_args, raise_on_empty_output)
+    log.debug("Running get_subprocess_output with cmd: '%s'", cmd_args)
+    out, err, returncode = subprocess_output(cmd_args, raise_on_empty_output)
+    log.debug("get_subprocess_output returned with len(out) '%d' ; len(err) '%d' ; returncode '%d'", len(out), len(err), returncode)
+
+    return (out, err, returncode)

--- a/cmd/agent/dist/utils/subprocess_output.py
+++ b/cmd/agent/dist/utils/subprocess_output.py
@@ -18,7 +18,7 @@ def get_subprocess_output(command, log, raise_on_empty_output=True):
     cmd_args = []
     if isinstance(command, basestring):
         for arg in command.split():
-            _args.append(arg)
+            cmd_args.append(arg)
     elif hasattr(type(command), '__iter__'):
         for arg in command:
             cmd_args.append(arg)

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -1,6 +1,6 @@
 #include "datadog_agent.h"
 
-// Functions 
+// Functions
 PyObject* GetVersion(PyObject *self, PyObject *args);
 PyObject* Headers(PyObject *self, PyObject *args);
 PyObject* GetHostname(PyObject *self, PyObject *args);
@@ -44,7 +44,7 @@ static PyObject *log_message(PyObject *self, PyObject *args) {
 }
 
 static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
-    PyObject *cmd_args, *cmd_raise_on_empty; 
+    PyObject *cmd_args, *cmd_raise_on_empty;
     int raise = 1, i=0;
     int subprocess_args_sz;
     char ** subprocess_args, * subprocess_arg;
@@ -86,7 +86,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
         if (subprocess_arg == NULL) {
             PyErr_SetString(PyExc_Exception, "unable to parse arguments to cgo/go-land");
             free(subprocess_args);
-            Py_RETURN_NONE;
+            return NULL;
         }
         subprocess_args[i] = subprocess_arg;
     }
@@ -95,9 +95,6 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     py_result = GetSubprocessOutput(subprocess_args, subprocess_args_sz, raise);
     free(subprocess_args);
 
-    if (py_result == NULL) {
-        Py_RETURN_NONE;
-    }
     return py_result;
 }
 
@@ -123,9 +120,9 @@ static PyMethodDef utilMethods[] = {
  * _Util package is a private module for utility bindings
  */
 static PyMethodDef _utilMethods[] = {
-  {"get_subprocess_output", (PyCFunction)get_subprocess_output, 
+  {"get_subprocess_output", (PyCFunction)get_subprocess_output,
       METH_VARARGS, "Run subprocess and return its output. "
-                    "This is a private method and should not be called directly. " 
+                    "This is a private method and should not be called directly. "
                     "Please use the utils.subprocess_output.get_subprocess_output wrapper."},
   {NULL, NULL}
 };

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -19,7 +19,7 @@ static PyObject *get_config(PyObject *self, PyObject *args) {
 
     if (!PyArg_ParseTuple(args, "s", &key)) {
       PyGILState_Release(gstate);
-      Py_RETURN_NONE;
+      return NULL;
     }
 
     PyGILState_Release(gstate);
@@ -36,7 +36,7 @@ static PyObject *log_message(PyObject *self, PyObject *args) {
     // datadog_agent.log(message, log_level)
     if (!PyArg_ParseTuple(args, "si", &message, &log_level)) {
       PyGILState_Release(gstate);
-      Py_RETURN_NONE;
+      return NULL;
     }
 
     PyGILState_Release(gstate);
@@ -48,7 +48,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     int raise = 1, i=0;
     int subprocess_args_sz;
     char ** subprocess_args, * subprocess_arg;
-    PyObject * py_result = Py_None;
+    PyObject *py_result;
 
     PyGILState_STATE gstate = PyGILState_Ensure();
 
@@ -86,6 +86,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
         if (subprocess_arg == NULL) {
             PyErr_SetString(PyExc_Exception, "unable to parse arguments to cgo/go-land");
             free(subprocess_args);
+            PyGILState_Release(gstate);
             return NULL;
         }
         subprocess_args[i] = subprocess_arg;


### PR DESCRIPTION
### What does this PR do?

Without this fix, `_util.get_subprocess_output` wouldn't raise an exception
on empty output, and would instead return `None` (which would then raise
a `TypeError` since we try to use `None` as a tuple).

Fix that.

Also, fix typo for the string cmd logic.
