### PR TITLE
[GUI] Added restart alert

### DIFF
--- a/cmd/agent/gui/views/private/js/javascript.js
+++ b/cmd/agent/gui/views/private/js/javascript.js
@@ -641,7 +641,11 @@ function restartAgent() {
       if (data != "Success") {
         $("#general_status").css("display", "block");
         $('#general_status').html("<span class='center'>Error restarting agent: " + data + "</span>");
-      } else loadStatus("general");
+      } else {
+        alert("The agent has restarted. You must restart the GUI using the launch-gui command.\n(Beta only)")
+        window.close();
+      }
+
     }, 2000);
   }, function() {
     $(".loading_spinner").remove();


### PR DESCRIPTION
### What does this PR do?

Adds an alert that upon agent restart that the `launch-gui` command has to be executed once again, and then closes the window.

### Motivation

Restarting makes the current GUI session token invalid.

### Additional Notes

Anything else we should know when reviewing?
