### PR TITLE
[tagger] implement collectors.ErrNotFound custom error for better control flow

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -107,7 +107,7 @@ func (c *DockerCollector) Stop() error {
 func (c *DockerCollector) Fetch(container string) ([]string, []string, error) {
 	cid := strings.TrimPrefix(container, docker.DockerEntityPrefix)
 	if cid == container {
-		return nil, nil, fmt.Errorf("name is not a docker container: %s", container)
+		return nil, nil, ErrNotFound
 	}
 	return c.fetchForDockerID(cid)
 }
@@ -129,6 +129,7 @@ func (c *DockerCollector) processEvent(e events.Message) {
 func (c *DockerCollector) fetchForDockerID(cID string) ([]string, []string, error) {
 	co, err := c.client.ContainerInspect(context.Background(), string(cID))
 	if err != nil {
+		// TODO separate "not found" and inspect error
 		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
 		return nil, nil, err
 	}

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -74,7 +74,7 @@ func (c *ECSCollector) Fetch(container string) ([]string, []string, error) {
 		}
 	}
 	// container not found in updates
-	return []string{}, []string{}, fmt.Errorf("entity %s not found in tasklist", container)
+	return []string{}, []string{}, ErrNotFound
 }
 
 func ecsFactory() Collector {

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -8,7 +8,6 @@
 package collectors
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -98,7 +97,7 @@ func (c *KubeletCollector) Fetch(container string) ([]string, []string, error) {
 		}
 	}
 	// container not found in updates
-	return []string{}, []string{}, fmt.Errorf("entity %s not found in podlist", container)
+	return []string{}, []string{}, ErrNotFound
 }
 
 // parseExpires transforms event from the PodWatcher to TagInfo objects

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -5,6 +5,8 @@
 
 package collectors
 
+import "errors"
+
 // TagInfo holds the tag information for a given entity and source. It's meant
 // to be created from collectors and read by the store.
 type TagInfo struct {
@@ -17,6 +19,10 @@ type TagInfo struct {
 
 // CollectionMode informs the Tagger of how to schedule a Collector
 type CollectionMode int
+
+// ErrNotFound is returned by Fetch not collection error occurred but
+// the entity is not found in the source
+var ErrNotFound = errors.New("entity not found")
 
 // Return values for Collector.Init to inform the Tagger of the scheduling needed
 const (


### PR DESCRIPTION
### What does this PR do?

When a collector does not find an entity in its source, but not because of a logic / communication error, it should return the custom `collectors.ErrNoFound` error. The tagger will store empty tags for this entity and no call that collector again. If it's another error, the tagger will retry next time this entity is tagged.

### Motivation

More expressive and resilient code