### PR TITLE
[subprocess_output] Fix illegitimate partial/empty outputs

### DIFF
--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -170,6 +170,9 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
 	cmd.Start()
 
+	// Wait for the pipes to be closed *before* waiting for the cmd to exit, as per os.exec docs
+	wg.Wait()
+
 	retCode := 0
 	err = cmd.Wait()
 	if exiterr, ok := err.(*exec.ExitError); ok {
@@ -177,7 +180,6 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 			retCode = status.ExitStatus()
 		}
 	}
-	wg.Wait()
 
 	if raise > 0 {
 		// raise on error


### PR DESCRIPTION
### What does this PR do?

Fixes illegitimate partial/empty outputs for `get_subprocess_output`,

### Motivation

Typically, these empty outputs would then raise `SubprocessEmptyOutputError`s
for commands that actually had some output.

Would happen in about 25% of the calls to `get_subprocess_output` on Linux.

### Additional Notes


We need to wait for the pipes to be closed before we wait for the
command to exit, otherwise we may not read the full output of the
command. See `os.exec` docs:

https://golang.org/pkg/os/exec/#Cmd.StdoutPipe
and
https://golang.org/pkg/os/exec/#Cmd.StderrPipe
