### PR TITLE
fail dockerutil before docker client to enable retry mechanism

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -42,16 +42,17 @@ type DockerCollector struct {
 
 // Detect tries to connect to the docker socket and returns success
 func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
+	du, err := docker.GetDockerUtil()
+	if err != nil {
+		return NoCollection, err
+	}
+
 	// TODO: refactor with collector.listeners.DockerListener
 	client, err := docker.ConnectToDocker()
 	if err != nil {
 		return NoCollection, fmt.Errorf("Failed to connect to Docker, docker tagging will not work: %s", err)
 	}
 
-	du, err := docker.GetDockerUtil()
-	if err != nil {
-		return NoCollection, err
-	}
 	c.dockerUtil = du
 	c.client = client
 	c.stop = make(chan bool)


### PR DESCRIPTION
### What does this PR do?

While waiting for `DockerCollector` to ditch the docker client and only use `dockerutil`, move `dockerutil` init and failure before, so we get the `FailWillRetry` and `PermaFail` errors from `dockerutil`'s retrier and enable the retry mechanism introduced in https://github.com/DataDog/datadog-agent/pull/861

### Test, docker stopped, then started at 10:17

./bin/agent/agent -c dev/dist/ start|grep tagger.go
2017-11-29 10:15:44 UTC | INFO | (tagger.go:80 in Init) | starting the tagging system
2017-11-29 10:15:44 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry docker later: temporary failure in dockerutil, will retry later: docker not available
2017-11-29 10:15:44 UTC | DEBUG | (tagger.go:151 in tryCollectors) | ecs tag collector cannot start: cannot find ECS agent
2017-11-29 10:15:44 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry kubelet later: temporary failure in kubeutil, will retry later: unable to get hostname from docker, please set the kubernetes_kubelet_host option: temporary failure in dockerutil, will retry later: try delay not elapsed yet
2017-11-29 10:16:13 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry kubelet later: temporary failure in kubeutil, will retry later: try delay not elapsed yet
2017-11-29 10:16:13 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry docker later: temporary failure in dockerutil, will retry later: try delay not elapsed yet
2017-11-29 10:16:43 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry kubelet later: temporary failure in kubeutil, will retry later: unable to get hostname from docker, please set the kubernetes_kubelet_host option: temporary failure in dockerutil, will retry later: try delay not elapsed yet
2017-11-29 10:16:43 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry docker later: temporary failure in dockerutil, will retry later: try delay not elapsed yet
2017-11-29 10:17:13 UTC | INFO | (tagger.go:153 in tryCollectors) | docker tag collector successfully started
2017-11-29 10:17:13 UTC | DEBUG | (tagger.go:147 in tryCollectors) | will retry kubelet later: temporary failure in kubeutil, will retry later: Could not find a method to connect to kubelet
