### PR TITLE
Point to the right cgroup root dir on Amazon Linux

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,8 @@ func init() {
 	} else {
 		Datadog.SetDefault("container_proc_root", "/proc")
 		// for amazon linux the cgroup directory on host is /cgroup/
-		if _, err := os.Stat("/cgroup/"); err == nil {
+		// we pick memory.stat to make sure it exists and not empty
+		if _, err := os.Stat("/cgroup/memory/memory.stat"); !os.IsNotExist(err) {
 			Datadog.SetDefault("container_cgroup_root", "/cgroup/")
 		} else {
 			Datadog.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,7 +94,12 @@ func init() {
 
 	} else {
 		Datadog.SetDefault("container_proc_root", "/proc")
-		Datadog.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")
+		// for amazon linux the cgroup directory on host is /cgroup
+		if _, err := os.Stat("/cgroup/"); err == nil {
+			Datadog.SetDefault("container_cgroup_root", "/cgroup/")
+		} else {
+			Datadog.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")
+		}
 	}
 	Datadog.SetDefault("proc_root", "/proc")
 	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,7 +94,7 @@ func init() {
 
 	} else {
 		Datadog.SetDefault("container_proc_root", "/proc")
-		// for amazon linux the cgroup directory on host is /cgroup
+		// for amazon linux the cgroup directory on host is /cgroup/
 		if _, err := os.Stat("/cgroup/"); err == nil {
 			Datadog.SetDefault("container_cgroup_root", "/cgroup/")
 		} else {

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -464,6 +464,7 @@ func parseCgroupMountPoints(r io.Reader) map[string]string {
 			}
 		}
 	}
+	log.Warnf("current cgroup root is: %s", cgroupRoot)
 	return mountPoints
 }
 

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -464,7 +464,9 @@ func parseCgroupMountPoints(r io.Reader) map[string]string {
 			}
 		}
 	}
-	log.Warnf("current cgroup root is: %s", cgroupRoot)
+	if len(mountPoints) == 0 {
+		log.Warnf("No mountPoints were detected, current cgroup root is: %s", cgroupRoot)
+	}
 	return mountPoints
 }
 


### PR DESCRIPTION
### What does this PR do?
For agents running on amazon linux, the cgroup mount directory is at `/cgroup/`. This PR sets the variable `container_cgroup_root` to that as the default value.

### Motivation
Amazon linux.