### PR TITLE
[windows] Fix APM loader to write "Main" section

### DIFF
--- a/cmd/agent/app/dependent_services_windows.go
+++ b/cmd/agent/app/dependent_services_windows.go
@@ -43,7 +43,7 @@ func apmInit() error {
 		iniFile = ini.Empty()
 	}
 	// this will create the section if it's not there
-	main := iniFile.Section("main")
+	main := iniFile.Section("Main")
 	k, err := main.GetKey("api_key")
 	if err != nil {
 		log.Warnf("API key not found in trace-agent.conf, adding")


### PR DESCRIPTION
 (section name is case sensitive).  Make sure API key can be found by APM agent on startup.
