### PR TITLE
[Windows] Fix restart.  When command line arguments come in (like res…

### DIFF
--- a/cmd/agent/main_windows.go
+++ b/cmd/agent/main_windows.go
@@ -47,14 +47,19 @@ func setupLogger(logLevel string) error {
 }
 
 func main() {
-	isIntSess, err := svc.IsAnInteractiveSession()
-	if err != nil {
-		fmt.Printf("failed to determine if we are running in an interactive session: %v", err)
-	}
-	if !isIntSess {
-		common.EnableLoggingToFile()
-		runService(false)
-		return
+	// if command line arguments are supplied, even in a non interactive session,
+	// then just execute that.  Used when the service is executing the executable,
+	// for instance to trigger a restart.
+	if len(os.Args) == 1 {
+		isIntSess, err := svc.IsAnInteractiveSession()
+		if err != nil {
+			fmt.Printf("failed to determine if we are running in an interactive session: %v", err)
+		}
+		if !isIntSess {
+			common.EnableLoggingToFile()
+			runService(false)
+			return
+		}
 	}
 	defer log.Flush()
 


### PR DESCRIPTION
…tart-service), they were being ignored when running as a non-interactive session (i.e. running as a service). So the 2nd instance executed to restart the main daemon was being ignored
