### PR TITLE
Hardening CIS 5.4.2 - locking system user

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -50,7 +50,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         getent group dd-agent >/dev/null || groupadd -r dd-agent
         getent passwd dd-agent >/dev/null || \
             useradd -r -M -g dd-agent -d $INSTALL_DIR -s /bin/sh \
-                -c "Datadog Agent" dd-agent
+                -c "Datadog Agent" dd-agent && \
+            usermod -L dd-agent
 
         # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
         if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then


### PR DESCRIPTION
### What does this PR do?

Locks dd-agent system user

### Motivation

Hardening dd-agent system user and making it compliant with CIS 5.4.2

### Additional Notes

None
