### PR TITLE
Let the Python check loader ignore classes that have been derived

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,15 +10,10 @@ reflect the current state of the Beta.
 ## Developer Guide
 
 New users and contributors are encouraged to build the Datadog Agent themselves
-and should start reading the [Developer Guide][developer-guide]
-
-
-## Check Guide
-
-To learn how to write new checks for the Agent please read the [Check Guide][checks-api].
-
+and should start reading the [Developer Guide][developer-guide]. The guide also
+contains a detailed explanation of how [Checks work][checks].
 
 
 [developer-guide]: dev/README.md
-[checks-api]: dev/checks/README.md
+[checks]: dev/checks/README.md
 [beta]: beta/README.md

--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -1,13 +1,14 @@
 # Developer Guide for Checks
 
-This guide will help you to develop new checks (also known as integrations) in Python or Go.
+This section of the docs will help you understanding how checks work and how to
+provide custom or new ones.
 
-For existing integrations go to [integrations-core](https://github.com/DataDog/integrations-core) and [integrations-extras](https://github.com/DataDog/integrations-extras).
+Existing checks live in the [integrations-core](https://github.com/DataDog/integrations-core) and [integrations-extras](https://github.com/DataDog/integrations-extras) repositories.
 
 ## Configuration
 
-Every check has its own YAML configuration file. The file has one mandatory key
-`instances` and one optional `init_config`.
+Every check has its own YAML configuration file. The file has one mandatory key,
+`instances` and one optional, `init_config`.
 
 ### init_config
 
@@ -52,11 +53,17 @@ run at different intervals.
 
 ### API
 
-Read more about the [API](python/check_api.md) to write Python checks.
+Read more about the [Python Checks API](python/check_api.md).
 
-### Agent's Python packages
+### Built-in packages
 
-The Agent offers a list of python packages that bind features from the Go world to Python checks.
+The Agent provides a set of python packages that are built-in and only available
+within the embedded CPython interpreter:
 
 - [aggregator](python/aggregator.md)
 - [datadog-agent](python/datadog_agent.md)
+
+
+## Core Checks (or Go Checks)
+
+TODO

--- a/pkg/collector/py/loader_test.go
+++ b/pkg/collector/py/loader_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {
@@ -20,8 +21,8 @@ func TestLoad(t *testing.T) {
 	config.Instances = append(config.Instances, []byte("bar: baz"))
 
 	instances, err := l.Load(config)
-	assert.Nil(t, err)
-	assert.Equal(t, len(instances), 2)
+	require.Nil(t, err)
+	assert.Equal(t, 2, len(instances))
 
 	// the python module doesn't exist
 	config = check.Config{Name: "doesntexist"}

--- a/pkg/collector/py/tests/testcheck_multi.py
+++ b/pkg/collector/py/tests/testcheck_multi.py
@@ -1,0 +1,9 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+from testcheck_multi_base import AnIntermediateClass
+
+
+class DerivedCheck(AnIntermediateClass):
+    pass

--- a/pkg/collector/py/tests/testcheck_multi_base.py
+++ b/pkg/collector/py/tests/testcheck_multi_base.py
@@ -1,0 +1,18 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
+
+class BaseClass(object):
+    """
+    Think about this as the AgentCheck base class
+    """
+    pass
+
+
+class AnIntermediateClass(BaseClass):
+    """
+    Think about this as the WinWMICheck class
+    """
+    pass

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -150,7 +150,9 @@ func (sl *stickyLock) getPythonError() (string, error) {
 }
 
 // Search in module for a class deriving from baseClass and return the first match if any.
-// Notice: the passed `stickyLock` must be locked
+// Notice: classes that have been derived will be ignored, i.e. this function only
+// returns leaves of the hierarchy tree.
+// Notice: the passed `stickyLock` must be locked.
 func findSubclassOf(base, module *python.PyObject, gstate *stickyLock) (*python.PyObject, error) {
 	if base == nil || module == nil {
 		return nil, fmt.Errorf("both base class and module must be not nil")
@@ -177,24 +179,52 @@ func findSubclassOf(base, module *python.PyObject, gstate *stickyLock) (*python.
 			pyErr, err := gstate.getPythonError()
 
 			if err != nil {
-				return nil, fmt.Errorf("An error occurred while searching for the AgentCheck class and couldn't be formatted: %v", err)
+				return nil, fmt.Errorf("An error occurred while searching for the base class and couldn't be formatted: %v", err)
 			}
 			return nil, errors.New(pyErr)
 		}
 
+		// not a class, ignore
 		if !python.PyType_Check(class) {
-			// ignore this item
 			class.DecRef()
 			continue
 		}
 
-		// IsSubclass returns success if class is the same, we need to go deeper
-		if class.IsSubclass(base) == 1 && class.RichCompareBool(base, python.Py_EQ) != 1 {
-			return class, nil
+		// this is an unrelated class, ignore
+		if class.IsSubclass(base) != 1 {
+			class.DecRef()
+			continue
 		}
+
+		// `class` is actually `base` itself, ignore
+		if class.RichCompareBool(base, python.Py_EQ) == 1 {
+			class.DecRef()
+			continue
+		}
+
+		// does `class` have subclasses?
+		subclasses := class.CallMethod("__subclasses__")
+		if subclasses == nil {
+			pyErr, err := gstate.getPythonError()
+
+			if err != nil {
+				return nil, fmt.Errorf("An error occurred while checking for subclasses and couldn't be formatted: %v", err)
+			}
+			return nil, errors.New(pyErr)
+		}
+
+		// `class` has subclasses but checks are supposed to have none, ignore
+		if python.PyList_GET_SIZE(subclasses) > 0 {
+			class.DecRef()
+			continue
+		}
+
+		// got it, return the check class
+		return class, nil
 	}
+
 	return nil, fmt.Errorf("cannot find a subclass of %s in module %s",
-		python.PyString_AS_STRING(base.Str()), python.PyString_AS_STRING(base.Str()))
+		python.PyString_AS_STRING(base.Str()), python.PyString_AS_STRING(module.Str()))
 }
 
 // Get the rightmost component of a module path like foo.bar.baz

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -213,8 +213,11 @@ func findSubclassOf(base, module *python.PyObject, gstate *stickyLock) (*python.
 			return nil, errors.New(pyErr)
 		}
 
+		subclassesCount := python.PyList_GET_SIZE(subclasses)
+		subclasses.DecRef()
+
 		// `class` has subclasses but checks are supposed to have none, ignore
-		if python.PyList_GET_SIZE(subclasses) > 0 {
+		if subclassesCount > 0 {
 			class.DecRef()
 			continue
 		}

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Setup the test module
@@ -71,8 +72,17 @@ func TestFindSubclassOf(t *testing.T) {
 
 	// Foo in bar module, get Bar
 	sclass, err = findSubclassOf(fooClass, barModule, gstate)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, 1, sclass.RichCompareBool(barClass, python.Py_EQ))
+
+	// Multiple inheritance test
+	multiBaseModule := python.PyImport_ImportModuleNoBlock("testcheck_multi_base")
+	baseCheckClass := multiBaseModule.GetAttrString("BaseClass")
+	multiModule := python.PyImport_ImportModuleNoBlock("testcheck_multi")
+	derivedCheckClass := multiModule.GetAttrString("DerivedCheck")
+	sclass, err = findSubclassOf(baseCheckClass, multiModule, gstate)
+	require.Nil(t, err)
+	assert.Equal(t, 1, sclass.RichCompareBool(derivedCheckClass, python.Py_EQ))
 }
 
 func TestSubprocessBindings(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

When determining if a class is a subclass of another, only take into consideration the leaves of the hierarchy tree.

### Motivation

Despite the generic name, `findSubclassOf` is only used to determine if a Python class is a Check by following the rule: "if it derives from `AgentCheck`, that's a check".

Some of the core checks don't derive directly from `AgentCheck` but from a subclass of it - while searching a module or package for a subclass of `AgentCheck`, depending on the position in the objects' `__dict__`, the intermediate class might be returned instead of the actual check.

With this PR the rule becomes: "if it derives from `AgentCheck` and nothing derives from it, that's a check". A bit arbitrary but it works.

### Additional Notes

Added a note about this to the docs that were revamped on the occasion.
