### PR TITLE
[Core] Harden is_affirmative to return false if value doesn't exist

### DIFF
--- a/cmd/agent/dist/config.py
+++ b/cmd/agent/dist/config.py
@@ -19,6 +19,8 @@ log_level_map = {
 
 
 def _is_affirmative(s):
+    if s is None:
+        return False
     # int or real bool
     if isinstance(s, int):
         return bool(s)


### PR DESCRIPTION
### What does this PR do?

Makes is_affirmative immediately return false if passed a None value.

### Motivation

Integrations like [Mongo](https://github.com/DataDog/integrations-core/blob/master/mongo/check.py#L927) rely on this function to check if a yaml provided argument is true/false. These integrations can pass along None and assume to get False returned. This keeps the function consistent with Agent 5. 

Currently you get an error that NoneType has no attribute lower()

### Additional Notes

Anything else we should know when reviewing?
