### PR TITLE
agent doc warning for upgrade and logs

### DIFF
--- a/docs/beta/upgrade.md
+++ b/docs/beta/upgrade.md
@@ -12,6 +12,8 @@ filesystem layout.
 
 #### To Upgrade
 
+**Note**: To use the new log collection feature, do a `Fresh install` instead of the upgrade.
+
 In case you have an Agent version 5.17 or later and you want to import the
 existing configuration:
 


### PR DESCRIPTION
90% of log collection issue are linked to the usage of the upgrade script.
We need to add a warning to let users know they should do a fresh install instead for log collection.

### What does this PR do?

We add a note in the upgrade section

### Motivation

90% of support ticket regarding log collection comes from issues with the upgrade script


