### PR TITLE
Resolve symlinks to executable consistently across platforms

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
-	"github.com/kardianos/osext"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 var (
@@ -36,7 +36,7 @@ var (
 	Forwarder forwarder.Forwarder
 
 	// utility variables
-	_here, _ = osext.ExecutableFolder()
+	_here, _ = executable.Folder()
 )
 
 // GetPythonPaths returns the paths (in order of precedence) from where the agent

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 
 	"github.com/hectane/go-acl"
-	"github.com/kardianos/osext"
 	"golang.org/x/sys/windows"
+
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 var (
@@ -33,7 +34,7 @@ func init() {
 
 // restarts the agent using the windows service manager
 func restart() error {
-	here, _ := osext.ExecutableFolder()
+	here, _ := executable.Folder()
 	cmd := exec.Command(filepath.Join(here, "agent"), "restart-service")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/collector/corechecks/embed/apm_nix.go
+++ b/pkg/collector/corechecks/embed/apm_nix.go
@@ -13,13 +13,13 @@ import (
 	"os"
 	"path"
 
-	"github.com/kardianos/osext"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 const apm_binary_name = "trace-agent"
 
 func getAPMAgentDefaultBinPath() (string, error) {
-	here, _ := osext.ExecutableFolder()
+	here, _ := executable.Folder()
 	binPath := path.Join(here, "..", "..", "embedded", "bin", apm_binary_name)
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil

--- a/pkg/collector/corechecks/embed/apm_windows.go
+++ b/pkg/collector/corechecks/embed/apm_windows.go
@@ -14,13 +14,14 @@ import (
 	"path/filepath"
 
 	log "github.com/cihub/seelog"
-	"github.com/kardianos/osext"
+
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 const apm_binary_name = "trace-agent.exe"
 
 func getAPMAgentDefaultBinPath() (string, error) {
-	here, _ := osext.ExecutableFolder()
+	here, _ := executable.Folder()
 	binPath := filepath.Join(here, "bin", apm_binary_name)
 	if _, err := os.Stat(binPath); err == nil {
 		log.Debug("Found APM binary path at %s", binPath)

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -21,8 +21,8 @@ import (
 	api "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	log "github.com/cihub/seelog"
-	"github.com/kardianos/osext"
 	"gopkg.in/yaml.v2"
 )
 
@@ -247,7 +247,7 @@ func (c *JMXCheck) Stop() {
 }
 
 func (c *JMXCheck) start() error {
-	here, _ := osext.ExecutableFolder()
+	here, _ := executable.Folder()
 	jmxConfPath := config.Datadog.GetString("confd_path")
 	classpath := path.Join(here, "dist", "jmx", jmxJarName)
 	if c.javaToolsJarPath != "" {

--- a/pkg/collector/corechecks/embed/logs-agent.go
+++ b/pkg/collector/corechecks/embed/logs-agent.go
@@ -19,8 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	log "github.com/cihub/seelog"
-	"github.com/kardianos/osext"
 )
 
 // LogsCheck keeps track of the running command
@@ -55,7 +55,7 @@ func (c *LogsCheck) run() error {
 	default:
 	}
 
-	here, _ := osext.ExecutableFolder()
+	here, _ := executable.Folder()
 	bin := path.Join(here, "logs-agent")
 
 	cmd := exec.Command(

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -19,9 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 
 	log "github.com/cihub/seelog"
-	"github.com/kardianos/osext"
 	"gopkg.in/yaml.v2"
 )
 
@@ -225,7 +225,7 @@ func init() {
 }
 
 func getProcessAgentDefaultBinPath() (string, error) {
-	here, _ := osext.ExecutableFolder()
+	here, _ := executable.Folder()
 	binPath := path.Join(here, "..", "..", "embedded", "bin", "process-agent")
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
+
 	log "github.com/cihub/seelog"
-	"github.com/kardianos/osext"
 	python "github.com/sbinet/go-python"
 )
 
@@ -113,7 +114,7 @@ func Initialize(paths ...string) *python.PyThreadState {
 }
 
 func setPythonHome() {
-	_here, _ := osext.ExecutableFolder()
+	_here, _ := executable.Folder()
 
 	if pythonHome == "" {
 		// don't do anything if not set, to support system python builds

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -14,11 +14,11 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/kardianos/osext"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 var (
-	here, _        = osext.ExecutableFolder()
+	here, _        = executable.Folder()
 	fmap           template.FuncMap
 	templateFolder string
 )

--- a/pkg/util/executable/executable.go
+++ b/pkg/util/executable/executable.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// Package executable provides information on the executable that started the process
+package executable
+
+import (
+	"path/filepath"
+
+	// TODO: Use the built-in "os" package as soon as it implements `Executable()`
+	// consistently across all platforms
+	"github.com/kardianos/osext"
+)
+
+func path() (string, error) {
+	here, err := osext.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.EvalSymlinks(here)
+}
+
+// Folder returns the folder under which the executable is located,
+// after having resolved all symlinks to the executable.
+// Unlike os.Executable and osext.ExecutableFolder, Folder will
+// resolve the symlinks across all platforms.
+func Folder() (string, error) {
+	p, err := path()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(p), nil
+}


### PR DESCRIPTION
### What does this PR do?

Resolves the symlinks to the `datadog-agent` executable consistently across platforms.

### Motivation

This fixes the `datadog-agent` command in the `PATH` on macOS:

On macOS `os.Executable()` and `osext.ExecutableFolder()` don't resolve symlinks to the executable (so for instance, when running `datadog-agent` from the PATH, the resolved folder would be the directory in the PATH instead of `/opt/datadog-agent/[...]`).

This makes things consistent across platforms by always trying to resolve symlinks.

### Additional Notes

I've isolated the function in a new tiny package, and consolidated all imports to `osext` to that pkg.