### PR TITLE
Tagger: Add the Docker swarm label

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -49,10 +49,20 @@ func dockerExtractImage(tags *utils.TagList, dockerImage string) {
 	tags.AddLow("image_tag", imageTag)
 }
 
+// dockerExtractLabels contain hard-coded labels from:
+// - Docker swarm
 func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string, labelsAsTags map[string]string) {
+
 	for labelName, labelValue := range containerLabels {
-		if tagName, found := labelsAsTags[strings.ToLower(labelName)]; found {
-			tags.AddAuto(tagName, labelValue)
+		switch labelName {
+		// Docker swarm
+		case "com.docker.swarm.service.name":
+			tags.AddLow("swarm_service", labelValue)
+
+		default:
+			if tagName, found := labelsAsTags[strings.ToLower(labelName)]; found {
+				tags.AddAuto(tagName, labelValue)
+			}
 		}
 	}
 }

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -101,6 +101,50 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			},
 			expectedHigh: []string{"mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"},
 		},
+		{
+			testName: "extractSwarmLabels",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{"PATH=/bin"},
+					Labels: map[string]string{
+						"com.docker.swarm.node.id":      "zdtab51ei97djzrpa1y2tz8li",
+						"com.docker.swarm.service.id":   "tef96xrdmlj82c7nt57jdntl8",
+						"com.docker.swarm.service.name": "helloworld",
+						"com.docker.swarm.task":         "",
+						"com.docker.swarm.task.id":      "knk1rz1szius7pvyznn9zolld",
+						"com.docker.swarm.task.name":    "helloworld.1.knk1rz1szius7pvyznn9zolld",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow:          []string{"swarm_service:helloworld"},
+			expectedHigh:         []string{},
+		},
+		{
+			testName: "extractSwarmLabelsWithCustomLabelsAdds",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{"PATH=/bin"},
+					Labels: map[string]string{
+						"com.docker.swarm.node.id":      "zdtab51ei97djzrpa1y2tz8li",
+						"com.docker.swarm.service.id":   "tef96xrdmlj82c7nt57jdntl8",
+						"com.docker.swarm.service.name": "helloworld",
+						"com.docker.swarm.task":         "",
+						"com.docker.swarm.task.id":      "knk1rz1szius7pvyznn9zolld",
+						"com.docker.swarm.task.name":    "helloworld.1.knk1rz1szius7pvyznn9zolld",
+					},
+				},
+			},
+			toRecordEnvAsTags: map[string]string{},
+			toRecordLabelsAsTags: map[string]string{
+				// Add some uncovered swarm labels to be extracted
+				"com.docker.swarm.node.id":   "custom_add_swarm_node",
+				"com.docker.swarm.task.name": "+custom_add_task_name",
+			},
+			expectedLow:  []string{"swarm_service:helloworld", "custom_add_swarm_node:zdtab51ei97djzrpa1y2tz8li"},
+			expectedHigh: []string{"custom_add_task_name:helloworld.1.knk1rz1szius7pvyznn9zolld"},
+		},
 	}
 
 	dc := &DockerCollector{}


### PR DESCRIPTION
### What does this PR do?

Add the Docker swarm label extractor in the tagger.
The wanted label is hard-coded in the code.

The equivalent in the agent5 is [here](https://github.com/DataDog/dd-agent/blob/1a128371acaa83116fe7fde098a5591cefddb6f4/utils/service_discovery/sd_docker_backend.py#L336)