### PR TITLE
Update the beta config documentation

### DIFF
--- a/docs/beta/config.md
+++ b/docs/beta/config.md
@@ -15,7 +15,7 @@ in any way.
 
 | Old Name | New Name | Notes |
 | --- | --- | --- |
-| `proxy_host`  | `proxy`  | Proxy settings are now expressed as a list of URIs like `http://user:password@proxyurl:port` |
+| `proxy_host`  | `proxy`  | Proxy settings are now expressed as a list of URIs like `http://user:password@proxyurl:port`, one per transport type (see the `proxy` section of [datadog.yaml][datadog-yaml] for more details). |
 | `collect_instance_metadata` | `enable_metadata_collection` | This now enabled the new metadata collection mechanism |
 | `collector_log_file` | `log_file` ||
 | `syslog_host`  | `syslog_uri`  | The Syslog configuration is now expressed as an URI |
@@ -55,4 +55,4 @@ differently from Agent version 5.
 
 
 
-[datadog-yaml]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/pkg/collector/dist/datadog.yaml
+[datadog-yaml]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/pkg/config/config_template.yaml


### PR DESCRIPTION
### What does this PR do?

Link the documentation to `datadog.yaml` to make it more explicit how to use the new proxy setting.
Also fix the `datadog.yaml` link that was broken since we use a template.