### PR TITLE
Add support for keywords to the headers() func

### DIFF
--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -102,7 +102,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
 static PyMethodDef datadogAgentMethods[] = {
   {"get_version", GetVersion, METH_VARARGS, "Get the Agent version."},
   {"get_config", get_config, METH_VARARGS, "Get value from the agent configuration."},
-  {"headers", Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {"headers", Headers, METH_VARARGS | METH_KEYWORDS, "Get basic HTTP headers with the right UserAgent."},
   {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
   {"log", log_message, METH_VARARGS, "Log a message through the agent logger."},
   {NULL, NULL}
@@ -113,7 +113,7 @@ static PyMethodDef datadogAgentMethods[] = {
  * deprecated in favor of 'datadog_agent' package.
  */
 static PyMethodDef utilMethods[] = {
-  {"headers", (PyCFunction)Headers, METH_VARARGS, "Get basic HTTP headers with the right UserAgent."},
+  {"headers", (PyCFunction)Headers, METH_VARARGS | METH_KEYWORDS, "Get basic HTTP headers with the right UserAgent."},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
### What does this PR do?

Let Python checks call `util.headers(agentConfig, http_host="example.com"`

### Motivation

Some checks need an extra header and pass keyword args to `headers()`, see php_fpm here: https://github.com/DataDog/integrations-core/blob/master/php_fpm/check.py#L79

I think the best fix would be on the check side (the check could adjust the contents of the headers on its own) but I'm not sure how many other checks are broken - this fix would solve the issue for all of them.

