### PR TITLE
[gui] Made authentication token persists across restarts

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -38,6 +39,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/{component}/status", componentStatusGetterHandler).Methods("GET")
 	r.HandleFunc("/{component}/status", componentStatusHandler).Methods("POST")
 	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
+	r.HandleFunc("/gui_csrf_token", getCSRFToken).Methods("GET")
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
@@ -190,4 +192,11 @@ func getFormattedStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(s)
+}
+
+func getCSRFToken(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+	w.Write([]byte(gui.CsrfToken))
 }

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -39,7 +39,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/{component}/status", componentStatusGetterHandler).Methods("GET")
 	r.HandleFunc("/{component}/status", componentStatusHandler).Methods("POST")
 	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
-	r.HandleFunc("/gui_csrf_token", getCSRFToken).Methods("GET")
+	r.HandleFunc("/gui/csrf-token", getCSRFToken).Methods("GET")
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -6,11 +6,13 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
@@ -50,8 +52,23 @@ func launchGui(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to access GUI authentication token: " + err.Error())
 	}
 
+	// Get the CSRF token
+	c := common.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/gui_csrf_token", config.Datadog.GetInt("cmd_port"))
+	util.SetAuthToken()
+	csrfToken, e := common.DoGet(c, urlstr)
+	if e != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(csrfToken, errMap)
+		if err, found := errMap["error"]; found {
+			e = fmt.Errorf(err)
+		}
+		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before attempting to open the GUI.\n", e)
+		return e
+	}
+
 	// Open the GUI in a browser, passing the authorization tokens as parameters
-	err = open("http://127.0.0.1:" + guiPort + string(authToken))
+	err = open("http://127.0.0.1:" + guiPort + "/authenticate?authToken=" + string(authToken) + ";csrf=" + string(csrfToken))
 	if err != nil {
 		log.Warnf("error opening GUI: " + err.Error())
 		return fmt.Errorf("error opening GUI: " + err.Error())

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 )
 
@@ -42,19 +42,18 @@ func launchGui(cmd *cobra.Command, args []string) error {
 
 	guiPort := config.Datadog.GetString("GUI_port")
 	if guiPort == "-1" {
-		log.Warnf("GUI not enabled: to enable, please set an appropriate port in your datadog.yaml file")
 		return fmt.Errorf("GUI not enabled: to enable, please set an appropriate port in your datadog.yaml file")
 	}
 
 	// Read the authentication token: can only be done if user can read from datadog.yaml
-	authToken, err := ioutil.ReadFile(filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), "gui_auth_token"))
+	authToken, err := ioutil.ReadFile(filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), gui.AuthTokenName))
 	if err != nil {
 		return fmt.Errorf("unable to access GUI authentication token: " + err.Error())
 	}
 
 	// Get the CSRF token
 	c := common.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/agent/gui_csrf_token", config.Datadog.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/gui/csrf-token", config.Datadog.GetInt("cmd_port"))
 	util.SetAuthToken()
 	csrfToken, e := common.DoGet(c, urlstr)
 	if e != nil {
@@ -70,10 +69,9 @@ func launchGui(cmd *cobra.Command, args []string) error {
 	// Open the GUI in a browser, passing the authorization tokens as parameters
 	err = open("http://127.0.0.1:" + guiPort + "/authenticate?authToken=" + string(authToken) + ";csrf=" + string(csrfToken))
 	if err != nil {
-		log.Warnf("error opening GUI: " + err.Error())
 		return fmt.Errorf("error opening GUI: " + err.Error())
 	}
 
-	log.Infof("GUI opened at 127.0.0.1:" + guiPort)
+	fmt.Printf("GUI opened at 127.0.0.1:" + guiPort + "\n")
 	return nil
 }

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -2,7 +2,6 @@ package gui
 
 import (
 	"crypto/rand"
-	"crypto/rsa"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -16,19 +15,18 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
-
 	log "github.com/cihub/seelog"
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 	"github.com/urfave/negroni"
 )
 
 var (
 	listener      net.Listener
-	privateKey    *rsa.PrivateKey
-	publicKey     *rsa.PublicKey
-	csrfToken     string
+	authToken     string
 	authTokenPath string
+
+	// CsrfToken is a session-specific token passed to the GUI's authentication endpoint by app.launchGui
+	CsrfToken string
 )
 
 // Payload struct is for the JSON messages received from a client POST request
@@ -43,11 +41,6 @@ func StopGUIServer() {
 	if listener != nil {
 		listener.Close()
 	}
-
-	err := os.Remove(authTokenPath)
-	if err != nil {
-		log.Infof("error deleting gui_auth_token file: " + err.Error())
-	}
 }
 
 // StartGUIServer creates the router, starts the HTTP server & generates the authentication token for access
@@ -59,7 +52,7 @@ func StartGUIServer(port string) error {
 	router.HandleFunc("/authenticate", generateAuthEndpoint)
 
 	// Serve the (secured) index page on the default endpoint
-	router.Handle("/", authorizeAccess(http.FileServer(http.Dir(filepath.Join(common.GetViewsPath(), "private")))))
+	router.Handle("/", authorizeAccess(http.HandlerFunc(generateIndex)))
 
 	// Mount our (secured) filesystem at the view/{path} route
 	router.PathPrefix("/view/").Handler(http.StripPrefix("/view/", authorizeAccess(http.FileServer(http.Dir(filepath.Join(common.GetViewsPath(), "private"))))))
@@ -80,39 +73,62 @@ func StartGUIServer(port string) error {
 		return e
 	}
 	go http.Serve(listener, router)
+	log.Infof("GUI server is listening at 127.0.0.1:" + port)
 
-	return createAuthToken()
-}
-
-// Generates a JWT & CSRF token, then saves them both to a file with the same permissions as datadog.yaml
-func createAuthToken() error {
-	// Generate a pair of RSA keys
-	privateKey, e := rsa.GenerateKey(rand.Reader, 2048)
-	if e != nil {
-		return fmt.Errorf("error generating RSA key: " + e.Error())
-	}
-	publicKey = &privateKey.PublicKey
-
-	// Create a JWT signed with the private key
-	JWT := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
-		"admin": true,
-		"name":  "Datadog Agent Manager",
-	})
-	jwtString, e := JWT.SignedString(privateKey)
-	if e != nil {
-		return fmt.Errorf("error creating JWT: " + e.Error())
-	}
-
-	// Create a CSRF token
+	// Create a CSRF token (unique to each session)
 	key := make([]byte, 32)
 	_, e = rand.Read(key)
 	if e != nil {
 		return fmt.Errorf("error creating CSRF token: " + e.Error())
 	}
-	csrfToken = hex.EncodeToString(key)
+	CsrfToken = hex.EncodeToString(key)
 
+	return fetchAuthToken()
+}
+
+// Fetches the authentication token from the auth token file, creates one if it doesn't exist
+func fetchAuthToken() error {
+	// Check if the auth token file already exists
 	authTokenPath = filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), "gui_auth_token")
-	return saveAuthToken("/authenticate?jwt=" + jwtString + ";csrf=" + csrfToken)
+
+	// Create a new token if there's an error with the current file/if it doesn't exist
+	if _, e := os.Stat(authTokenPath); e != nil {
+		key := make([]byte, 32)
+		_, e = rand.Read(key)
+		if e != nil {
+			return fmt.Errorf("error creating CSRF token: " + e.Error())
+		}
+		authToken = hex.EncodeToString(key)
+
+		// Write the auth token to the auth token file (platform-specific)
+		e := saveAuthToken()
+		if e == nil {
+			log.Infof("Saved a new GUI authentication token to " + authTokenPath)
+		}
+		return e
+	}
+
+	// Read the token
+	authTokenRaw, e := ioutil.ReadFile(authTokenPath)
+	if e != nil {
+		return fmt.Errorf("unable to access GUI authentication token: " + e.Error())
+	}
+	authToken = string(authTokenRaw)
+	return nil
+}
+
+func generateIndex(w http.ResponseWriter, r *http.Request) {
+	t, e := template.New("index.tmpl").ParseFiles(filepath.Join(common.GetViewsPath(), "templates/index.tmpl"))
+	if e != nil {
+		http.Error(w, e.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	e = t.Execute(w, map[string]bool{"restartEnabled": restartEnabled()})
+	if e != nil {
+		http.Error(w, e.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 func generateAuthEndpoint(w http.ResponseWriter, r *http.Request) {
@@ -122,7 +138,7 @@ func generateAuthEndpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	e = t.Execute(w, map[string]interface{}{"csrf": csrfToken})
+	e = t.Execute(w, map[string]interface{}{"csrf": CsrfToken})
 	if e != nil {
 		http.Error(w, e.Error(), http.StatusInternalServerError)
 		return
@@ -135,15 +151,16 @@ func authorizeAccess(h http.Handler) http.Handler {
 		// Disable caching
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
-		cookie, _ := r.Cookie("jwt")
+		cookie, _ := r.Cookie("authToken")
 		if cookie == nil {
 			w.WriteHeader(http.StatusUnauthorized)
 			http.Error(w, "no authorization token", 401)
 			return
 		}
 
-		e := verifyJWT(w, cookie.Value)
-		if e != nil {
+		if cookie.Value != authToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			http.Error(w, "invalid authorization token", 401)
 			return
 		}
 
@@ -161,30 +178,14 @@ func authorizePOST(w http.ResponseWriter, r *http.Request, next http.HandlerFunc
 		return
 	}
 
-	e := verifyJWT(w, strings.Split(authHeader[0], " ")[1])
-	if e != nil {
+	token := strings.Split(authHeader[0], " ")[1]
+	if token != authToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		http.Error(w, "invalid authorization token", 401)
 		return
 	}
 
 	next(w, r)
-}
-
-func verifyJWT(w http.ResponseWriter, tokenString string) error {
-	// Use public key to verify the token
-	token, e := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		return publicKey, nil
-	})
-
-	if e != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		http.Error(w, "token validation error: "+e.Error(), 500)
-	} else if !token.Valid {
-		w.WriteHeader(http.StatusUnauthorized)
-		http.Error(w, "invalid authorization token", 401)
-		e = fmt.Errorf("invalid authorization token")
-	}
-
-	return e
 }
 
 // Helper function which unmarshals a POST requests data into a Payload object

--- a/cmd/agent/gui/platform_darwin.go
+++ b/cmd/agent/gui/platform_darwin.go
@@ -8,14 +8,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+func restartEnabled() bool {
+	return false
+}
+
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(token string) error {
+func saveAuthToken() error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
 
-	return ioutil.WriteFile(authTokenPath, []byte(token), permissions)
+	return ioutil.WriteFile(authTokenPath, []byte(authToken), permissions)
 }

--- a/cmd/agent/gui/platform_darwin.go
+++ b/cmd/agent/gui/platform_darwin.go
@@ -17,9 +17,9 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken() error {
+func saveAuthToken(token, tokenPath string) error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
 
-	return ioutil.WriteFile(authTokenPath, []byte(authToken), permissions)
+	return ioutil.WriteFile(tokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_nix.go
+++ b/cmd/agent/gui/platform_nix.go
@@ -19,9 +19,9 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken() error {
+func saveAuthToken(token, tokenPath string) error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
 
-	return ioutil.WriteFile(authTokenPath, []byte(authToken), permissions)
+	return ioutil.WriteFile(tokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_nix.go
+++ b/cmd/agent/gui/platform_nix.go
@@ -10,14 +10,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+func restartEnabled() bool {
+	return false
+}
+
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(token string) error {
+func saveAuthToken() error {
 	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
 	permissions := confFile.Mode()
 
-	return ioutil.WriteFile(authTokenPath, []byte(token), permissions)
+	return ioutil.WriteFile(authTokenPath, []byte(authToken), permissions)
 }

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -32,6 +32,10 @@ func init() {
 	}
 }
 
+func restartEnabled() bool {
+	return true
+}
+
 // restarts the agent using the windows service manager
 func restart() error {
 	here, _ := executable.Folder()
@@ -48,9 +52,9 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(token string) error {
+func saveAuthToken() error {
 
-	err := ioutil.WriteFile(authTokenPath, []byte(token), 0755)
+	err := ioutil.WriteFile(authTokenPath, []byte(authToken), 0755)
 	if err == nil {
 		err = acl.Apply(
 			authTokenPath,

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -7,10 +7,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/hectane/go-acl"
 	"golang.org/x/sys/windows"
-
-	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
 var (
@@ -52,12 +51,12 @@ func restart() error {
 }
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken() error {
+func saveAuthToken(token, tokenPath string) error {
 
-	err := ioutil.WriteFile(authTokenPath, []byte(authToken), 0755)
+	err := ioutil.WriteFile(tokenPath, []byte(token), 0755)
 	if err == nil {
 		err = acl.Apply(
-			authTokenPath,
+			tokenPath,
 			true,  // replace the file permissions
 			false, // don't inherit
 			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["Administrators"]),

--- a/cmd/agent/gui/views/private/js/javascript.js
+++ b/cmd/agent/gui/views/private/js/javascript.js
@@ -8,8 +8,8 @@ function getAuthToken() {
   for (var i = 0; i < cookies.length; i++) {
       var c = cookies[i];
       while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-      if (c.indexOf("jwt=") == 0) {
-        return c.substring(4, c.length);
+      if (c.indexOf("authToken=") == 0) {
+        return c.substring(10, c.length);
       }
   }
   return null;

--- a/cmd/agent/gui/views/templates/auth.tmpl
+++ b/cmd/agent/gui/views/templates/auth.tmpl
@@ -12,7 +12,7 @@
   // Decode the url parameters
   var token = urlParam[0].substring(10);   // trim "authToken="
   var csrf = urlParam[1].substring(5);     // trim "csrf="
-
+  
   if (csrf == "{{ .csrf }}") {
     // Save auth token as a cookie
     document.cookie = "authToken=" + token + "; path=/";

--- a/cmd/agent/gui/views/templates/auth.tmpl
+++ b/cmd/agent/gui/views/templates/auth.tmpl
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,12 +10,12 @@
   urlParam = urlParam.split(";");
 
   // Decode the url parameters
-  var jwt = urlParam[0].substring(4);
-  var csrf = urlParam[1].substring(5);
+  var token = urlParam[0].substring(10);   // trim "authToken="
+  var csrf = urlParam[1].substring(5);     // trim "csrf="
 
   if (csrf == "{{ .csrf }}") {
-    // Save JWT as a cookie
-    document.cookie = "jwt=" + jwt + "; path=/";
+    // Save auth token as a cookie
+    document.cookie = "authToken=" + token + "; path=/";
   }
 
   // Redirect to the GUI

--- a/cmd/agent/gui/views/templates/index.tmpl
+++ b/cmd/agent/gui/views/templates/index.tmpl
@@ -47,10 +47,12 @@
         <i class="fa fa-flag fa-fw"> </i>&nbsp;
         Flare
       </li>
+      {{- if .restartEnabled }}
       <li id="restart_button" class="nav_item no-active">
         <i class="fa fa-power-off fa-fw"> </i>&nbsp;
         Restart Agent
       </li>
+      {{ end }}
     </ul>
   </div>
   <div class="top_bar">


### PR DESCRIPTION
### What does this PR do?

The authentication token is no longer deleted at the end of the agent's lifetime; when the agent starts up it attempts to fetch the token, and only if it can't does it create a new one. This way the token persists across agent restarts.

Other changes:
- added an endpoint to the IPC API for fetching the CSRF token, which is still session-specific, so that the `launch-gui` command can access the token & pass it to the browser
- made `index.html` into a template in order to remove the "Restart" button for platforms where it is not implemented

### Motivation

Restarting the agent rendered the GUI's authentication token obsolete, forcing a manual re-launch of the GUI.

### Additional Notes

Anything else we should know when reviewing?
