### PR TITLE
Exposing docker labels to docker.Container

### DIFF
--- a/pkg/util/docker/container.go
+++ b/pkg/util/docker/container.go
@@ -24,6 +24,7 @@ type Container struct {
 	ID       string
 	EntityID string
 	Name     string
+	Labels   map[string]string
 	Image    string
 	ImageID  string
 	Created  int64

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -203,6 +203,7 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*Container, e
 			ID:       entityID[9:],
 			EntityID: entityID,
 			Name:     c.Names[0],
+			Labels:   c.Labels,
 			Image:    image,
 			ImageID:  c.ImageID,
 			Created:  c.Created,

--- a/pkg/util/docker/global.go
+++ b/pkg/util/docker/global.go
@@ -26,6 +26,7 @@ var (
 	// If new sub-structs are added to Container this must
 	// be updated.
 	NullContainer = &Container{
+		Labels:  make(map[string]string),
 		CPU:     &CgroupTimesStat{},
 		Memory:  &CgroupMemStat{},
 		IO:      &CgroupIOStat{},

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -74,6 +74,7 @@ func GetContainers() ([]*docker.Container, error) {
 			ID:       c.DockerID,
 			EntityID: entityID,
 			Name:     c.DockerName,
+			Labels:   c.Labels,
 			Image:    c.Image,
 			ImageID:  c.ImageID,
 		}


### PR DESCRIPTION
### What does this PR do?

Exposing the docker labels from `ecs.Container` & `types.Container` to `docker.Container`

### Motivation

We'll be ingesting docker labels via the [datadog-process-agent](https://github.com/DataDog/datadog-process-agent) soon. I'm basing this PR against `haissam/new-ecs-listener` since it's a small change + the process agent is currently pinned to it (via https://github.com/DataDog/datadog-process-agent/pull/79).