### PR TITLE
[dsd] reduce heap allocations in listeners

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -11,6 +11,7 @@ import (
 	_ "expvar"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"

--- a/pkg/dogstatsd/listeners/packet_pool.go
+++ b/pkg/dogstatsd/listeners/packet_pool.go
@@ -37,12 +37,12 @@ func NewPacketPool(bufferSize int) *PacketPool {
 	}
 }
 
-// Get gets a packet object read for use.
+// Get gets a Packet object read for use.
 func (p *PacketPool) Get() *Packet {
 	return p.pool.Get().(*Packet)
 }
 
-// Put resets the packet origin and puts it back in the pool.
+// Put resets the Packet origin and puts it back in the pool.
 func (p *PacketPool) Put(packet *Packet) {
 	if packet.Origin != NoOrigin {
 		packet.Origin = NoOrigin

--- a/pkg/dogstatsd/listeners/packet_pool.go
+++ b/pkg/dogstatsd/listeners/packet_pool.go
@@ -9,6 +9,14 @@ import "sync"
 
 // PacketPool wraps the sync.Pool class for *Packet type.
 // It allows to avoid allocating one object per packet.
+//
+// Caution: as objects get reused, byte slices extracted from
+// packet.Contents will change when the object is reused. You
+// need to hold on to the object until you extracted all the
+// information and parsed it into strings/float/int.
+//
+// Strings extracted with `string(Contents[n:m]) don't share the
+// origin []byte storage, so they will be unaffected.
 type PacketPool struct {
 	pool sync.Pool
 }

--- a/pkg/dogstatsd/listeners/packet_pool.go
+++ b/pkg/dogstatsd/listeners/packet_pool.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package listeners
+
+import "sync"
+
+// PacketPool wraps the sync.Pool class for *Packet type.
+// It allows to avoid allocating one object per packet.
+type PacketPool struct {
+	pool sync.Pool
+}
+
+// NewPacketPool creates a new pool with a specified buffer size
+func NewPacketPool(bufferSize int) *PacketPool {
+	return &PacketPool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				packet := &Packet{
+					buffer: make([]byte, bufferSize),
+					Origin: NoOrigin,
+				}
+				packet.Contents = packet.buffer[0:0]
+				return packet
+			},
+		},
+	}
+}
+
+// Get gets a packet object read for use.
+func (p *PacketPool) Get() *Packet {
+	return p.pool.Get().(*Packet)
+}
+
+// Put resets the packet origin and puts it back in the pool.
+func (p *PacketPool) Put(packet *Packet) {
+	if packet.Origin != NoOrigin {
+		packet.Origin = NoOrigin
+	}
+	p.pool.Put(packet)
+}

--- a/pkg/dogstatsd/listeners/types.go
+++ b/pkg/dogstatsd/listeners/types.go
@@ -5,7 +5,7 @@
 
 package listeners
 
-// Packet reprensents a statsd packet ready to process,
+// Packet represents a statsd packet ready to process,
 // with its origin metadata if applicable.
 //
 // As the Packet object is reused in a sync.Pool, we keep the

--- a/pkg/dogstatsd/listeners/types.go
+++ b/pkg/dogstatsd/listeners/types.go
@@ -7,8 +7,13 @@ package listeners
 
 // Packet reprensents a statsd packet ready to process,
 // with its origin metadata if applicable.
+//
+// As the Packet object is reused in a sync.Pool, we keep the
+// underlying buffer reference to avoid re-sizing the slice
+// before reading
 type Packet struct {
 	Contents []byte // Contents, might contain several messages
+	buffer   []byte // Underlying buffer for data read
 	Origin   string // Origin container if identified
 }
 
@@ -17,3 +22,6 @@ type StatsdListener interface {
 	Listen()
 	Stop()
 }
+
+// NoOrigin is returned if origin detection is off or failed.
+const NoOrigin = ""

--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -19,8 +19,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+var packetPoolUDP = NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
+
 func TestNewUDPListener(t *testing.T) {
-	s, err := NewUDPListener(nil)
+	s, err := NewUDPListener(nil, packetPoolUDP)
 	require.NotNil(t, s)
 	assert.Nil(t, err)
 
@@ -32,7 +34,7 @@ func TestStartStopUDPListener(t *testing.T) {
 	require.Nil(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	s, err := NewUDPListener(nil)
+	s, err := NewUDPListener(nil, packetPoolUDP)
 	require.NotNil(t, s)
 
 	assert.Nil(t, err)
@@ -57,7 +59,7 @@ func TestUDPNonLocal(t *testing.T) {
 	require.Nil(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_non_local_traffic", true)
-	s, err := NewUDPListener(nil)
+	s, err := NewUDPListener(nil, packetPoolUDP)
 	assert.Nil(t, err)
 	require.NotNil(t, s)
 
@@ -81,7 +83,7 @@ func TestUDPLocalOnly(t *testing.T) {
 	require.Nil(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 	config.Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	s, err := NewUDPListener(nil)
+	s, err := NewUDPListener(nil, packetPoolUDP)
 	assert.Nil(t, err)
 	require.NotNil(t, s)
 
@@ -110,7 +112,7 @@ func TestUDPReceive(t *testing.T) {
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
 	packetChannel := make(chan *Packet)
-	s, err := NewUDPListener(packetChannel)
+	s, err := NewUDPListener(packetChannel, packetPoolUDP)
 	require.NotNil(t, s)
 	assert.Nil(t, err)
 

--- a/pkg/dogstatsd/listeners/uds_common_test.go
+++ b/pkg/dogstatsd/listeners/uds_common_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+var packetPoolUDS = NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
+
 func TestNewUDSListener(t *testing.T) {
 	dir, err := ioutil.TempDir("", "dd-test-")
 	assert.Nil(t, err)
@@ -29,7 +31,7 @@ func TestNewUDSListener(t *testing.T) {
 
 	config.Datadog.Set("dogstatsd_socket", socketPath)
 
-	s, err := NewUDSListener(nil)
+	s, err := NewUDSListener(nil, packetPoolUDS)
 	defer s.Stop()
 
 	assert.Nil(t, err)
@@ -44,7 +46,7 @@ func TestStartStopUDSListener(t *testing.T) {
 
 	config.Datadog.Set("dogstatsd_socket", socketPath)
 	config.Datadog.Set("dogstatsd_origin_detection", false)
-	s, err := NewUDSListener(nil)
+	s, err := NewUDSListener(nil, packetPoolUDS)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
@@ -70,7 +72,7 @@ func TestUDSReceive(t *testing.T) {
 	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
 	packetChannel := make(chan *Packet)
-	s, err := NewUDSListener(packetChannel)
+	s, err := NewUDSListener(packetChannel, packetPoolUDS)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 

--- a/pkg/dogstatsd/listeners/uds_linux_test.go
+++ b/pkg/dogstatsd/listeners/uds_linux_test.go
@@ -32,7 +32,8 @@ func TestUDSPassCred(t *testing.T) {
 	config.Datadog.Set("dogstatsd_socket", socketPath)
 	config.Datadog.Set("dogstatsd_origin_detection", true)
 
-	s, err := NewUDSListener(nil)
+	packetPoolUDS := NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
+	s, err := NewUDSListener(nil, packetPoolUDS)
 	defer s.Stop()
 
 	assert.Nil(t, err)

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -23,21 +23,21 @@ const epsilon = 0.1
 
 func TestParseEmptyDatagram(t *testing.T) {
 	emptyDatagram := []byte("")
-	pkt := nextPacket(&emptyDatagram)
+	pkt := nextMessage(&emptyDatagram)
 
 	assert.Nil(t, pkt)
 }
 
 func TestParseOneLineDatagram(t *testing.T) {
 	datagram := []byte("daemon:666|g")
-	pkt := nextPacket(&datagram)
+	pkt := nextMessage(&datagram)
 
 	assert.NotNil(t, pkt)
 	assert.Equal(t, 0, len(datagram))
 
 	// With trailing newline
 	datagram = []byte("daemon:666|g\n")
-	pkt = nextPacket(&datagram)
+	pkt = nextMessage(&datagram)
 
 	assert.NotNil(t, pkt)
 	assert.Equal(t, 0, len(datagram))
@@ -47,15 +47,15 @@ func TestParseMultipleLineDatagram(t *testing.T) {
 	datagram := []byte("daemon:666|g\ndaemon:667|g")
 
 	// First packet
-	pkt := nextPacket(&datagram)
+	pkt := nextMessage(&datagram)
 	assert.Equal(t, []byte("daemon:666|g"), pkt)
 
 	// Second packet
-	pkt = nextPacket(&datagram)
+	pkt = nextMessage(&datagram)
 	assert.Equal(t, []byte("daemon:667|g"), pkt)
 
 	// Nore more packet
-	pkt = nextPacket(&datagram)
+	pkt = nextMessage(&datagram)
 	assert.Nil(t, pkt)
 	assert.Equal(t, 0, len(datagram))
 }
@@ -65,7 +65,7 @@ func TestGaugePacketCounter(t *testing.T) {
 }
 
 func TestParseGauge(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:666|g"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"))
 
 	assert.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestParseGauge(t *testing.T) {
 }
 
 func TestParseCounter(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:21|c"))
+	parsed, err := parseMetricMessage([]byte("daemon:21|c"))
 
 	assert.NoError(t, err)
 
@@ -90,7 +90,7 @@ func TestParseCounter(t *testing.T) {
 }
 
 func TestParseHistogram(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:21|h"))
+	parsed, err := parseMetricMessage([]byte("daemon:21|h"))
 
 	assert.NoError(t, err)
 
@@ -102,7 +102,7 @@ func TestParseHistogram(t *testing.T) {
 }
 
 func TestParseTimer(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:21|ms"))
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"))
 
 	assert.NoError(t, err)
 
@@ -114,7 +114,7 @@ func TestParseTimer(t *testing.T) {
 }
 
 func TestParseSet(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:abc|s"))
+	parsed, err := parseMetricMessage([]byte("daemon:abc|s"))
 
 	assert.NoError(t, err)
 
@@ -126,7 +126,7 @@ func TestParseSet(t *testing.T) {
 }
 
 func TestParseDistribution(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:3.5|d"))
+	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"))
 
 	assert.NoError(t, err)
 
@@ -137,7 +137,7 @@ func TestParseDistribution(t *testing.T) {
 }
 
 func TestParseSetUnicode(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:♬†øU†øU¥ºuT0♪|s"))
+	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"))
 
 	assert.NoError(t, err)
 
@@ -149,7 +149,7 @@ func TestParseSetUnicode(t *testing.T) {
 }
 
 func TestParseGaugeWithTags(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 
 	assert.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"))
 
 	assert.NoError(t, err)
 
@@ -178,7 +178,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithSampleRate(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:666|g|@0.21"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"))
 
 	assert.NoError(t, err)
 
@@ -190,7 +190,7 @@ func TestParseGaugeWithSampleRate(t *testing.T) {
 }
 
 func TestParseGaugeWithPoundOnly(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("daemon:666|g|#"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"))
 
 	assert.NoError(t, err)
 
@@ -202,7 +202,7 @@ func TestParseGaugeWithPoundOnly(t *testing.T) {
 }
 
 func TestParseGaugeWithUnicode(t *testing.T) {
-	parsed, err := parseMetricPacket([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"))
+	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"))
 
 	assert.NoError(t, err)
 
@@ -216,41 +216,41 @@ func TestParseGaugeWithUnicode(t *testing.T) {
 
 func TestParseMetricError(t *testing.T) {
 	// not enough information
-	_, err := parseMetricPacket([]byte("daemon:666"))
+	_, err := parseMetricMessage([]byte("daemon:666"))
 	assert.Error(t, err)
 
-	_, err = parseMetricPacket([]byte("daemon:666|"))
+	_, err = parseMetricMessage([]byte("daemon:666|"))
 	assert.Error(t, err)
 
-	_, err = parseMetricPacket([]byte("daemon:|g"))
+	_, err = parseMetricMessage([]byte("daemon:|g"))
 	assert.Error(t, err)
 
-	_, err = parseMetricPacket([]byte(":666|g"))
+	_, err = parseMetricMessage([]byte(":666|g"))
 	assert.Error(t, err)
 
 	// too many value
-	_, err = parseMetricPacket([]byte("daemon:666:777|g"))
+	_, err = parseMetricMessage([]byte("daemon:666:777|g"))
 	assert.Error(t, err)
 
 	// unknown metadata prefix
-	_, err = parseMetricPacket([]byte("daemon:666|g|m:test"))
+	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"))
 	assert.NoError(t, err)
 
 	// invalid value
-	_, err = parseMetricPacket([]byte("daemon:abc|g"))
+	_, err = parseMetricMessage([]byte("daemon:abc|g"))
 	assert.Error(t, err)
 
 	// invalid metric type
-	_, err = parseMetricPacket([]byte("daemon:666|unknown"))
+	_, err = parseMetricMessage([]byte("daemon:666|unknown"))
 	assert.Error(t, err)
 
 	// invalid sample rate
-	_, err = parseMetricPacket([]byte("daemon:666|g|@abc"))
+	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"))
 	assert.Error(t, err)
 }
 
 func TestParseMonokeyBatching(t *testing.T) {
-	// parsed, err := parseMetricPacket([]byte("test_gauge:1.5|g|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g"))
+	// parsed, err := parseMetricMessage([]byte("test_gauge:1.5|g|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g"))
 
 	// TODO: implement test
 }
@@ -272,7 +272,7 @@ func TestPacketStringEndings(t *testing.T) {
 }
 
 func TestServiceCheckMinimal(t *testing.T) {
-	sc, err := parseServiceCheckPacket([]byte("_sc|agent.up|0"))
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0"))
 
 	assert.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -285,31 +285,31 @@ func TestServiceCheckMinimal(t *testing.T) {
 
 func TestServiceCheckError(t *testing.T) {
 	// not enough information
-	_, err := parseServiceCheckPacket([]byte("_sc|agent.up"))
+	_, err := parseServiceCheckMessage([]byte("_sc|agent.up"))
 	assert.Error(t, err)
 
-	_, err = parseServiceCheckPacket([]byte("_sc|agent.up|"))
+	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|"))
 	assert.Error(t, err)
 
 	// not invalid status
-	_, err = parseServiceCheckPacket([]byte("_sc|agent.up|OK"))
+	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|OK"))
 	assert.Error(t, err)
 
 	// not unknown status
-	_, err = parseServiceCheckPacket([]byte("_sc|agent.up|21"))
+	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|21"))
 	assert.Error(t, err)
 
 	// invalid timestamp
-	_, err = parseServiceCheckPacket([]byte("_sc|agent.up|0|d:some_time"))
+	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|0|d:some_time"))
 	assert.NoError(t, err)
 
 	// unknown metadata
-	_, err = parseServiceCheckPacket([]byte("_sc|agent.up|0|u:unknown"))
+	_, err = parseServiceCheckMessage([]byte("_sc|agent.up|0|u:unknown"))
 	assert.NoError(t, err)
 }
 
 func TestServiceCheckMetadataTimestamp(t *testing.T) {
-	sc, err := parseServiceCheckPacket([]byte("_sc|agent.up|0|d:21"))
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|d:21"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -321,7 +321,7 @@ func TestServiceCheckMetadataTimestamp(t *testing.T) {
 }
 
 func TestServiceCheckMetadataHostname(t *testing.T) {
-	sc, err := parseServiceCheckPacket([]byte("_sc|agent.up|0|h:localhost"))
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|h:localhost"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -333,7 +333,7 @@ func TestServiceCheckMetadataHostname(t *testing.T) {
 }
 
 func TestServiceCheckMetadataTags(t *testing.T) {
-	sc, err := parseServiceCheckPacket([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"))
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -345,7 +345,7 @@ func TestServiceCheckMetadataTags(t *testing.T) {
 }
 
 func TestServiceCheckMetadataMessage(t *testing.T) {
-	sc, err := parseServiceCheckPacket([]byte("_sc|agent.up|0|m:this is fine"))
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|m:this is fine"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -358,7 +358,7 @@ func TestServiceCheckMetadataMessage(t *testing.T) {
 
 func TestServiceCheckMetadataMultiple(t *testing.T) {
 	// all type
-	sc, err := parseServiceCheckPacket([]byte("_sc|agent.up|0|d:21|h:localhost|#tag1:test,tag2|m:this is fine"))
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|d:21|h:localhost|#tag1:test,tag2|m:this is fine"))
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
 	assert.Equal(t, "localhost", sc.Host)
@@ -368,7 +368,7 @@ func TestServiceCheckMetadataMultiple(t *testing.T) {
 	assert.Equal(t, []string{"tag1:test", "tag2"}, sc.Tags)
 
 	// multiple time the same tag
-	sc, err = parseServiceCheckPacket([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"))
+	sc, err = parseServiceCheckMessage([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"))
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
 	assert.Equal(t, "localhost2", sc.Host)
@@ -379,7 +379,7 @@ func TestServiceCheckMetadataMultiple(t *testing.T) {
 }
 
 func TestEventMinimal(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -395,7 +395,7 @@ func TestEventMinimal(t *testing.T) {
 }
 
 func TestEventMultilinesText(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,24}:test title|test\\line1\\nline2\\nline3"))
+	e, err := parseEventMessage([]byte("_e{10,24}:test title|test\\line1\\nline2\\nline3"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -411,7 +411,7 @@ func TestEventMultilinesText(t *testing.T) {
 }
 
 func TestEventPipeInTitle(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"))
+	e, err := parseEventMessage([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test|title", e.Title)
@@ -428,71 +428,71 @@ func TestEventPipeInTitle(t *testing.T) {
 
 func TestEventError(t *testing.T) {
 	// missing length header
-	_, err := parseEventPacket([]byte("_e:title|text"))
+	_, err := parseEventMessage([]byte("_e:title|text"))
 	assert.Error(t, err)
 
 	// greater length than packet
-	_, err = parseEventPacket([]byte("_e{10,10}:title|text"))
+	_, err = parseEventMessage([]byte("_e{10,10}:title|text"))
 	assert.Error(t, err)
 
 	// zero length
-	_, err = parseEventPacket([]byte("_e{0,0}:a|a"))
+	_, err = parseEventMessage([]byte("_e{0,0}:a|a"))
 	assert.Error(t, err)
 
 	// missing title or text length
-	_, err = parseEventPacket([]byte("_e{5555:title|text"))
+	_, err = parseEventMessage([]byte("_e{5555:title|text"))
 	assert.Error(t, err)
 
 	// missing wrong len format
-	_, err = parseEventPacket([]byte("_e{a,1}:title|text"))
+	_, err = parseEventMessage([]byte("_e{a,1}:title|text"))
 	assert.Error(t, err)
 
-	_, err = parseEventPacket([]byte("_e{1,a}:title|text"))
+	_, err = parseEventMessage([]byte("_e{1,a}:title|text"))
 	assert.Error(t, err)
 
 	// missing title or text length
-	_, err = parseEventPacket([]byte("_e{5,}:title|text"))
+	_, err = parseEventMessage([]byte("_e{5,}:title|text"))
 	assert.Error(t, err)
 
-	_, err = parseEventPacket([]byte("_e{,4}:title|text"))
+	_, err = parseEventMessage([]byte("_e{,4}:title|text"))
 	assert.Error(t, err)
 
-	_, err = parseEventPacket([]byte("_e{}:title|text"))
+	_, err = parseEventMessage([]byte("_e{}:title|text"))
 	assert.Error(t, err)
 
-	_, err = parseEventPacket([]byte("_e{,}:title|text"))
+	_, err = parseEventMessage([]byte("_e{,}:title|text"))
 	assert.Error(t, err)
 
 	// not enough information
-	_, err = parseEventPacket([]byte("_e|text"))
+	_, err = parseEventMessage([]byte("_e|text"))
 	assert.Error(t, err)
 
-	_, err = parseEventPacket([]byte("_e:|text"))
+	_, err = parseEventMessage([]byte("_e:|text"))
 	assert.Error(t, err)
 
 	// invalid timestamp
-	_, err = parseEventPacket([]byte("_e{5,4}:title|text|d:abc"))
+	_, err = parseEventMessage([]byte("_e{5,4}:title|text|d:abc"))
 	assert.NoError(t, err)
 
 	// invalid priority
-	_, err = parseEventPacket([]byte("_e{5,4}:title|text|p:urgent"))
+	_, err = parseEventMessage([]byte("_e{5,4}:title|text|p:urgent"))
 	assert.NoError(t, err)
 
 	// invalid priority
-	_, err = parseEventPacket([]byte("_e{5,4}:title|text|p:urgent"))
+	_, err = parseEventMessage([]byte("_e{5,4}:title|text|p:urgent"))
 	assert.NoError(t, err)
 
 	// invalid alert type
-	_, err = parseEventPacket([]byte("_e{5,4}:title|text|t:test"))
+	_, err = parseEventMessage([]byte("_e{5,4}:title|text|t:test"))
 	assert.NoError(t, err)
 
 	// unknown metadata
-	_, err = parseEventPacket([]byte("_e{5,4}:title|text|x:1234"))
+	_, err = parseEventMessage([]byte("_e{5,4}:title|text|x:1234"))
 	assert.NoError(t, err)
 }
 
 func TestEventMetadataTimestamp(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|d:21"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|d:21"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -508,7 +508,7 @@ func TestEventMetadataTimestamp(t *testing.T) {
 }
 
 func TestEventMetadataPriority(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|p:low"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|p:low"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -524,7 +524,7 @@ func TestEventMetadataPriority(t *testing.T) {
 }
 
 func TestEventMetadataHostname(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|h:localhost"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|h:localhost"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -540,7 +540,7 @@ func TestEventMetadataHostname(t *testing.T) {
 }
 
 func TestEventMetadataAlertType(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|t:warning"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|t:warning"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -556,7 +556,7 @@ func TestEventMetadataAlertType(t *testing.T) {
 }
 
 func TestEventMetadataAggregatioKey(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|k:some aggregation key"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|k:some aggregation key"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -572,7 +572,7 @@ func TestEventMetadataAggregatioKey(t *testing.T) {
 }
 
 func TestEventMetadataSourceType(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|s:this is the source"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|s:this is the source"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -588,7 +588,7 @@ func TestEventMetadataSourceType(t *testing.T) {
 }
 
 func TestEventMetadataTags(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|#tag1,tag2:test"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#tag1,tag2:test"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -604,7 +604,7 @@ func TestEventMetadataTags(t *testing.T) {
 }
 
 func TestEventMetadataMultiple(t *testing.T) {
-	e, err := parseEventPacket([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -111,8 +111,8 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 
 		go func() {
 			for {
-				packet := nextPacket(&packet.Contents)
-				if packet == nil {
+				message := nextMessage(&packet.Contents)
+				if message == nil {
 					break
 				}
 
@@ -120,8 +120,8 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 					s.Statistics.StatEvent(1)
 				}
 
-				if bytes.HasPrefix(packet, []byte("_sc")) {
-					serviceCheck, err := parseServiceCheckPacket(packet)
+				if bytes.HasPrefix(message, []byte("_sc")) {
+					serviceCheck, err := parseServiceCheckMessage(message)
 					if err != nil {
 						log.Errorf("dogstatsd: error parsing service check: %s", err)
 						dogstatsdExpvar.Add("ServiceCheckParseErrors", 1)
@@ -132,8 +132,8 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 					}
 					dogstatsdExpvar.Add("ServiceCheckPackets", 1)
 					serviceCheckOut <- *serviceCheck
-				} else if bytes.HasPrefix(packet, []byte("_e")) {
-					event, err := parseEventPacket(packet)
+				} else if bytes.HasPrefix(message, []byte("_e")) {
+					event, err := parseEventMessage(message)
 					if err != nil {
 						log.Errorf("dogstatsd: error parsing event: %s", err)
 						dogstatsdExpvar.Add("EventParseErrors", 1)
@@ -145,7 +145,7 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 					dogstatsdExpvar.Add("EventPackets", 1)
 					eventOut <- *event
 				} else {
-					sample, err := parseMetricPacket(packet)
+					sample, err := parseMetricMessage(message)
 					if err != nil {
 						log.Errorf("dogstatsd: error parsing metrics: %s", err)
 						dogstatsdExpvar.Add("MetricParseErrors", 1)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	packetIn   chan *listeners.Packet // Unbuffered channel as packets processing is done in goroutines
 	Statistics *util.Stats
 	Started    bool
+	packetPool *listeners.PacketPool
 }
 
 // NewServer returns a running Dogstatsd server
@@ -44,11 +45,12 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 	}
 
 	packetChannel := make(chan *listeners.Packet)
+	packetPool := listeners.NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
 	tmpListeners := make([]listeners.StatsdListener, 0, 2)
 
 	socketPath := config.Datadog.GetString("dogstatsd_socket")
 	if len(socketPath) > 0 {
-		unixListener, err := listeners.NewUDSListener(packetChannel)
+		unixListener, err := listeners.NewUDSListener(packetChannel, packetPool)
 		if err != nil {
 			log.Errorf(err.Error())
 		} else {
@@ -56,7 +58,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		}
 	}
 	if config.Datadog.GetInt("dogstatsd_port") > 0 {
-		udpListener, err := listeners.NewUDPListener(packetChannel)
+		udpListener, err := listeners.NewUDPListener(packetChannel, packetPool)
 		if err != nil {
 			log.Errorf(err.Error())
 		} else {
@@ -73,6 +75,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		Statistics: stats,
 		packetIn:   packetChannel,
 		listeners:  tmpListeners,
+		packetPool: packetPool,
 	}
 	go s.handleMessages(metricOut, eventOut, serviceCheckOut)
 
@@ -93,7 +96,7 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 		packet := <-s.packetIn
 		var originTags []string
 
-		if packet.Origin != "" {
+		if packet.Origin != listeners.NoOrigin {
 			var err error
 			log.Debugf("dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
 			originTags, err = tagger.Tag(packet.Origin, false)
@@ -155,6 +158,8 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 					metricOut <- sample
 				}
 			}
+			// Return the packet object back to the object pool for reuse
+			s.packetPool.Put(packet)
 		}()
 	}
 }

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -107,7 +107,7 @@ func (c *DockerCollector) Stop() error {
 // Fetch inspect a given container to get its tags on-demand (cache miss)
 func (c *DockerCollector) Fetch(container string) ([]string, []string, error) {
 	cid := strings.TrimPrefix(container, docker.DockerEntityPrefix)
-	if cid == container {
+	if cid == container || len(cid) == 0 {
 		return nil, nil, ErrNotFound
 	}
 	return c.fetchForDockerID(cid)


### PR DESCRIPTION
### What does this PR do?

We used to allocate a 8kB buffer for every incoming UDP/UDS packet, then garbage-collect it when parsed. When receiving thousands of packets/sec that accounted to several MB/s of heap trash being generated.

This PR uses the `sync.Pool` shared object pool to reuse `Packet` objects instead of allocating new ones everytime. This will help with scaling to higher throughputs.

As indicated in the `PacketPool` comment: 
```
// Caution: as objects get reused, byte slices extracted from
// packet.Contents will change when the object is reused. You
// need to hold on to the object until you extracted all the
// information and parsed it into strings/float/int.
```
I audited `parse.go` and confirmed we are not bleeding out any naked `[]byte` that would be affected by that. We release the Packet object after parsing it entirely. 

### Other changes:

- enable `pprof` on the 5000 port
- rename *Packet to *Message in `parser.go` and users, now a network `Packet` contains `Messages` (second isolated commit)