### PR TITLE
Fixed logs.build invoke task

### DIFF
--- a/omnibus/config/software/datadog-logs-agent.rb
+++ b/omnibus/config/software/datadog-logs-agent.rb
@@ -3,6 +3,8 @@
 # This product includes software developed at Datadog (https:#www.datadoghq.com/).
 # Copyright 2017 Datadog, Inc.
 
+require 'pathname'
+
 name "datadog-logs-agent"
 always_build true
 
@@ -11,8 +13,17 @@ binary = "bin/logs/#{binary_name}"
 log_agent_binary_name = "logs-agent"
 log_agent_binary = "#{install_dir}/bin/agent/#{log_agent_binary_name}"
 
+source path: '..'
+relative_path 'src/github.com/DataDog/datadog-agent'
+
 build do
-  command "invoke logs.build"
+  # set GOPATH on the omnibus source dir for this software
+  gopath = Pathname.new(project_dir) + '../../../..'
+  env = {
+    'GOPATH' => gopath.to_path,
+    'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+  }
+  command "invoke logs.build", env: env
   command "chmod +x #{binary}"
   move binary, log_agent_binary
 end

--- a/tasks/logs.py
+++ b/tasks/logs.py
@@ -24,7 +24,7 @@ def build(ctx):
     Build Logs Agent
     """    
     build_tags = get_default_build_tags()
-    cmd = "go build -tags {build_tags} -o {bin_name} {REPO_PATH}/cmd/logs/"
+    cmd = "go build -tags \"{build_tags}\" -o {bin_name} {REPO_PATH}/cmd/logs/"
     args = {
         "build_tags": " ".join(build_tags),
         "bin_name": LOGS_BIN_NAME,


### PR DESCRIPTION
### What does this PR do?

Fixed logs.build invoke task adding quotes to build tags.

### Motivation

Gitlab pipeline is broken since logs-agent code has been merged to `master`:
https://gitlab.ddbuild.io/datadog/datadog-agent/-/jobs/2543564

### Additional Notes

Added missing environment variables to logs-agent omnibus build.