### PR TITLE
[gui] Write token to run directory

### DIFF
--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -45,8 +45,8 @@ func launchGui(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("GUI not enabled: to enable, please set an appropriate port in your datadog.yaml file")
 	}
 
-	// Read the authentication token: can only be done if user can read from datadog.yaml
-	authToken, err := ioutil.ReadFile(filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), gui.AuthTokenName))
+	// Read the authentication token: can only be done if user has access to run directory
+	authToken, err := ioutil.ReadFile(filepath.Join(config.Datadog.GetString("run_path"), gui.AuthTokenName))
 	if err != nil {
 		return fmt.Errorf("unable to access GUI authentication token: " + err.Error())
 	}

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -99,7 +99,7 @@ func createCSRFToken() error {
 // Fetches the authentication token from the auth token file, creates one if it doesn't exist
 func fetchAuthToken() error {
 	// Check if the auth token file already exists
-	authTokenPath := filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), AuthTokenName)
+	authTokenPath := filepath.Join(config.Datadog.GetString("run_path"), AuthTokenName)
 
 	// Create a new token if there's an error with the current file/if it doesn't exist
 	if _, e := os.Stat(authTokenPath); e != nil {


### PR DESCRIPTION
### What does this PR do?

The agent user doesn't necessarily have write access to the conf
directory, so writing the auth token there can fail.

Let's write the token to the `run` path, which is a path where
(by definition) the agent user should have write access. The read
permissions on this directory should be as limited as the conf
directory.

The run path is `/opt/datadog-agent/run` on Linux and macOS.
That's where the agent writes its PID file for example.

### Motivation

Right now the agent user on mac (which is actually the logged-in user)
doesn't have write access to the conf directory, so the GUI doesn't work.

In general I don't think we can expect the agent user to have _write_ access
to the conf directory.

### Additional Notes

Currently it appears that the agent6 on Windows doesn't have a run directory (see https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_windows.go#L11).
@derekwbrown could we set one up, or is there a reason we shouldn't have one on Windows? (the agent 5 on windows has one, in `<install_dir>/run/`)