### PR TITLE
[macOS] Give write access to agent user on whole conf dir

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -156,8 +156,7 @@ else
     fi
 
     echo "# Setting correct rights on conf"
-    chown -v $INSTALL_USER:admin $CONF_DIR/datadog.yaml
-    chown -vR $INSTALL_USER:admin $CONF_DIR/conf.d $CONF_DIR/checks.d
+    chown -vR $INSTALL_USER:admin $CONF_DIR
 
     # `datadog-agent` command line
     mkdir -vp /usr/local/bin


### PR DESCRIPTION

### What does this PR do?

On macOS, gives write access to agent user on whole conf dir

### Motivation

Allows agent to write gui auth token. Having these write permissions
is also a pre-requisite for the GUI to fully work (since the GUI allows
changing the conf files).

### Additional Notes

Follow-up to #897