### PR TITLE
[IPC API] Replace API key with authentication token

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -48,9 +48,12 @@ func StartServer() error {
 		// no way we can recover from this error
 		return fmt.Errorf("Unable to create the api server: %v", err)
 	}
-	util.SetAuthToken()
 
-	//
+	err = util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
 	hosts := []string{"127.0.0.1", "localhost"}
 	_, rootCertPEM, rootKey, err := security.GenerateRootCert(hosts, 2048)
 	if err != nil {

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -62,7 +62,7 @@ var flareCmd = &cobra.Command{
 func requestFlare(caseID string) error {
 	fmt.Println("Asking the agent to build the flare archive.")
 	var e error
-	c := common.GetClient(false) // FIX: get certificates right then make this true
+	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/agent/flare", config.Datadog.GetInt("cmd_port"))
 
 	logFile := config.Datadog.GetString("log_file")
@@ -71,9 +71,12 @@ func requestFlare(caseID string) error {
 	}
 
 	// Set session token
-	util.SetAuthToken()
+	e = util.SetAuthToken()
+	if e != nil {
+		return e
+	}
 
-	r, e := common.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
 	var filePath string
 	if e != nil {
 		if r != nil && string(r) != "" {

--- a/cmd/agent/app/listchecks.go
+++ b/cmd/agent/app/listchecks.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -33,10 +34,10 @@ var listCheckCommand = &cobra.Command{
 
 // query for the version
 func doListChecks() error {
-	c := common.GetClient(false) // FIX: get certificates right then make this true
+	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/check/", config.Datadog.GetInt("cmd_port"))
 
-	body, e := common.DoGet(c, urlstr)
+	body, e := util.DoGet(c, urlstr)
 	if e != nil {
 		fmt.Printf("Error getting version string: %s\n", e)
 		return e

--- a/cmd/agent/app/reloadcheck.go
+++ b/cmd/agent/app/reloadcheck.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -47,12 +48,12 @@ func doReloadCheck(checkName string) error {
 		return fmt.Errorf("Must supply a check name to query")
 	}
 
-	c := common.GetClient(false) // FIX: get certificates right then make this true
+	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/check/%s/reload", config.Datadog.GetInt("cmd_port"), checkName)
 
 	postbody := ""
 
-	body, e := common.DoPost(c, urlstr, "application/json", strings.NewReader(postbody))
+	body, e := util.DoPost(c, urlstr, "application/json", strings.NewReader(postbody))
 	if e != nil {
 		return fmt.Errorf("error getting check status for check %s: %v", checkName, e)
 	}

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -52,13 +52,16 @@ func requestStatus() error {
 	fmt.Printf("Getting the status from the agent.\n\n")
 	var e error
 	var s string
-	c := common.GetClient(false) // FIX: get certificates right then make this true
+	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/agent/status", config.Datadog.GetInt("cmd_port"))
 
 	// Set session token
-	util.SetAuthToken()
+	e = util.SetAuthToken()
+	if e != nil {
+		return e
+	}
 
-	r, e := common.DoGet(c, urlstr)
+	r, e := util.DoGet(c, urlstr)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, errMap)

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -34,14 +34,17 @@ func init() {
 func stop(*cobra.Command, []string) error {
 	// Global Agent configuration
 	common.SetupConfig("")
-	c := common.GetClient(false) // FIX: get certificates right then make this true
+	c := util.GetClient(false) // FIX: get certificates right then make this true
 
 	// Set session token
-	util.SetAuthToken()
+	e := util.SetAuthToken()
+	if e != nil {
+		return e
+	}
 
 	urlstr := fmt.Sprintf("https://localhost:%v/agent/stop", config.Datadog.GetInt("cmd_port"))
 
-	_, e := common.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	_, e = util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
 	if e != nil {
 		return fmt.Errorf("Error stopping the agent: %v", e)
 	}

--- a/cmd/agent/gui/platform_darwin.go
+++ b/cmd/agent/gui/platform_darwin.go
@@ -2,10 +2,6 @@ package gui
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func restartEnabled() bool {
@@ -14,12 +10,4 @@ func restartEnabled() bool {
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
-}
-
-// writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(token, tokenPath string) error {
-	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
-	permissions := confFile.Mode()
-
-	return ioutil.WriteFile(tokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_nix.go
+++ b/cmd/agent/gui/platform_nix.go
@@ -4,10 +4,6 @@ package gui
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func restartEnabled() bool {
@@ -16,12 +12,4 @@ func restartEnabled() bool {
 
 func restart() error {
 	return fmt.Errorf("restarting the agent is not implemented on non-windows platforms")
-}
-
-// writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(token, tokenPath string) error {
-	confFile, _ := os.Stat(config.Datadog.GetString("conf_path"))
-	permissions := confFile.Mode()
-
-	return ioutil.WriteFile(tokenPath, []byte(token), permissions)
 }

--- a/cmd/agent/gui/platform_windows.go
+++ b/cmd/agent/gui/platform_windows.go
@@ -2,34 +2,12 @@ package gui
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
-	"github.com/hectane/go-acl"
-	"golang.org/x/sys/windows"
 )
-
-var (
-	wellKnownSidStrings = map[string]string{
-		"Administrators": "S-1-5-32-544",
-		"System":         "S-1-5-18",
-		"Users":          "S-1-5-32-545",
-	}
-	wellKnownSids = make(map[string]*windows.SID)
-)
-
-func init() {
-
-	for key, val := range wellKnownSidStrings {
-		sid, err := windows.StringToSid(val)
-		if err == nil {
-			wellKnownSids[key] = sid
-		}
-	}
-}
 
 func restartEnabled() bool {
 	return true
@@ -48,20 +26,4 @@ func restart() error {
 	}
 
 	return nil
-}
-
-// writes auth token(s) to a file with the same permissions as datadog.yaml
-func saveAuthToken(token, tokenPath string) error {
-
-	err := ioutil.WriteFile(tokenPath, []byte(token), 0755)
-	if err == nil {
-		err = acl.Apply(
-			tokenPath,
-			true,  // replace the file permissions
-			false, // don't inherit
-			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["Administrators"]),
-			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["System"]))
-
-	}
-	return err
 }

--- a/pkg/api/security/platform_darwin.go
+++ b/pkg/api/security/platform_darwin.go
@@ -1,0 +1,16 @@
+package security
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// writes auth token(s) to a file with the same permissions as datadog.yaml
+func saveAuthToken(token, tokenPath string) error {
+	confFile, _ := os.Stat(config.Datadog.ConfigFileUsed())
+	permissions := confFile.Mode()
+
+	return ioutil.WriteFile(tokenPath, []byte(token), permissions)
+}

--- a/pkg/api/security/platform_nix.go
+++ b/pkg/api/security/platform_nix.go
@@ -1,0 +1,18 @@
+// +build freebsd netbsd openbsd solaris dragonfly linux
+
+package security
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// writes auth token(s) to a file with the same permissions as datadog.yaml
+func saveAuthToken(token, tokenPath string) error {
+	confFile, _ := os.Stat(config.Datadog.ConfigFileUsed())
+	permissions := confFile.Mode()
+
+	return ioutil.WriteFile(tokenPath, []byte(token), permissions)
+}

--- a/pkg/api/security/platform_windows.go
+++ b/pkg/api/security/platform_windows.go
@@ -1,0 +1,40 @@
+package security
+
+import (
+	"io/ioutil"
+
+	acl "github.com/hectane/go-acl"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	wellKnownSidStrings = map[string]string{
+		"Administrators": "S-1-5-32-544",
+		"System":         "S-1-5-18",
+		"Users":          "S-1-5-32-545",
+	}
+	wellKnownSids = make(map[string]*windows.SID)
+)
+
+func init() {
+	for key, val := range wellKnownSidStrings {
+		sid, err := windows.StringToSid(val)
+		if err == nil {
+			wellKnownSids[key] = sid
+		}
+	}
+}
+
+// writes auth token(s) to a file with the same permissions as datadog.yaml
+func saveAuthToken(token, tokenPath string) error {
+	err := ioutil.WriteFile(tokenPath, []byte(token), 0755)
+	if err == nil {
+		err = acl.Apply(
+			tokenPath,
+			true,  // replace the file permissions
+			false, // don't inherit
+			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["Administrators"]),
+			acl.GrantSid(windows.GENERIC_ALL, wellKnownSids["System"]))
+	}
+	return err
+}

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
-package common
+package util
 
 import (
 	"crypto/tls"
@@ -11,8 +11,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-
-	"github.com/DataDog/datadog-agent/pkg/api/util"
 )
 
 // GetClient is a convenience function returning an http client
@@ -35,7 +33,7 @@ func DoGet(c *http.Client, url string) (body []byte, e error) {
 		return body, e
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+util.GetAuthToken())
+	req.Header.Set("Authorization", "Bearer "+GetAuthToken())
 
 	r, e := c.Do(req)
 	if e != nil {
@@ -60,7 +58,7 @@ func DoPost(c *http.Client, url string, contentType string, body io.Reader) (res
 		return resp, e
 	}
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("Authorization", "Bearer "+util.GetAuthToken())
+	req.Header.Set("Authorization", "Bearer "+GetAuthToken())
 
 	r, e := c.Do(req)
 	if e != nil {

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -10,20 +10,23 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/api/security"
 )
 
 var token string
 
 // SetAuthToken sets the session token
+// Requires that the config has been set up before calling
 func SetAuthToken() error {
+	// Noop if token is already set
 	if token != "" {
-		return fmt.Errorf("session token already set")
+		return nil
 	}
 
 	// token is only set once, no need to mutex protect
-	token = config.Datadog.GetString("api_key") // FIXME: encode this into JWT?
-	return nil
+	var err error
+	token, err = security.FetchAuthToken()
+	return err
 }
 
 // GetAuthToken gets the session token


### PR DESCRIPTION
### What does this PR do?

Moves the authentication token logic out of the `gui` package and into the `security` package so that the same token can be used for authentication in the IPC API. This replaces the use of the API key as an authentication token.

Other changes:
- moved the functions relating the HTTP Client (GetClient, DoGet, DoPost) to the `util` package because it makes more sense for them to be there (the API is the only thing that uses these) and it prevents an import cycle

### Motivation

Prior to this, if the API key wasn't set users wouldn't be able to use the CLI.

### Additional Notes

Anything else we should know when reviewing?
