### PR TITLE
[dsd] use UnixConn.RawCon instead of previous unsupported way

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ currently in Beta. The source code of the stable Datadog Agent 5 is located in t
 ## Getting started
 
 To build the Agent you need:
- * [Go](https://golang.org/doc/install) 1.8.1 or later.
+ * [Go](https://golang.org/doc/install) 1.9.2 or later.
  * Python 2.7 along with development libraries.
  * [Invoke](http://www.pyinvoke.org/installing.html), you can install it via
    `pip install invoke` or via [Homebrew](https://brew.sh) on OSX/macOS with

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -23,7 +23,7 @@ variables (see Invoke docs for more details).
 
 ## Golang
 
-You must install [go](https://golang.org/doc/install) version 1.8 or above. Make
+You must install [go](https://golang.org/doc/install) version 1.9.2 or above. Make
 sure that `$GOPATH/bin` is in your `$PATH` otherwise Invoke cannot use any
 additional tool it might need.
 

--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -30,14 +30,14 @@ func getUDSAncillarySize() int {
 // enableUDSPassCred enables credential passing from the kernel for origin detection.
 // That flag can be ignored if origin dection is disabled.
 func enableUDSPassCred(conn *net.UnixConn) error {
-	f, err := conn.File()
-	defer f.Close()
-
+	rawconn, err := conn.SyscallConn()
 	if err != nil {
 		return err
 	}
-	fd := int(f.Fd())
-	err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_PASSCRED, 1)
+
+	err = rawconn.Control(func(fd uintptr) {
+		unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PASSCRED, 1)
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -35,13 +35,9 @@ func enableUDSPassCred(conn *net.UnixConn) error {
 		return err
 	}
 
-	err = rawconn.Control(func(fd uintptr) {
+	return rawconn.Control(func(fd uintptr) {
 		unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PASSCRED, 1)
 	})
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // processUDSOrigin reads ancillary data to determine a packet's origin,


### PR DESCRIPTION
### What does this PR do?

- Use the new 1.9+ [RawConn](https://golang.org/pkg/net/#UnixConn.SyscallConn) mechanism to setup the underlying file descriptor instead of the previous [File](https://golang.org/pkg/net/#UnixConn.File), which does not have the same safety guarantees.
- Update minimal Go version to 1.9.2

### Motivation

Best practices / maintainability.

### Additional Notes

Integration tests on origin detection confirm it's working as before
