### PR TITLE
Parse config if provided on diagnosis command

### DIFF
--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -6,8 +6,10 @@
 package app
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 
 	"github.com/fatih/color"
@@ -26,6 +28,14 @@ var diagnoseCommand = &cobra.Command{
 }
 
 func doDiagnose(cmd *cobra.Command, args []string) {
+	// Global config setup
+	if confFilePath != "" {
+		if err := common.SetupConfig(confFilePath); err != nil {
+			fmt.Println("Cannot setup config, exiting:", err)
+			panic(err)
+		}
+	}
+
 	if flagNoColor {
 		color.NoColor = true
 	}


### PR DESCRIPTION
### What does this PR do?

Small PR to setup global config on for the diagnose command if `confFilePath ` is provided.

### Motivation

The diagnose command allows for config file path flag to be passed in but doesn't ever set it up.