### PR TITLE
Adding invoke task to build the cluster-agent 

### DIFF
--- a/Dockerfiles/clusteragent/.gitignore
+++ b/Dockerfiles/clusteragent/.gitignore
@@ -1,0 +1,1 @@
+datadog-agent*_amd64.deb

--- a/Dockerfiles/clusteragent/Dockerfile
+++ b/Dockerfiles/clusteragent/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:stretch-slim
+
+LABEL maintainer "Datadog <package@datadoghq.com>"
+
+ENV DOCKER_DD_AGENT=yes \
+    AGENT_VERSION=1:7.0-1 \
+    DD_AGENT_HOME=/opt/datadog-agent/
+
+# Install the Agent
+COPY bin/cluster-agent/cluster-agent $DD_AGENT_HOME/bin/cluster-agent/
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y libpython2.7 curl vim apt-transport-https ca-certificates\
+ && apt-get clean
+
+COPY Dockerfiles/clusteragent/entrypoint.sh /entrypoint.sh
+COPY dev/dist/datadog.yaml $DD_AGENT_HOME/dev/dist/
+
+EXPOSE 8125/udp
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/opt/datadog-agent/bin/cluster-agent/cluster-agent", "start"]

--- a/Dockerfiles/clusteragent/README.md
+++ b/Dockerfiles/clusteragent/README.md
@@ -1,0 +1,23 @@
+# Cluster Agent 6 docker image
+
+This is how the official cluster-agent (aka DCA) 6 image available [here](https://hub.docker.com/r/datadog/agent/) is built.
+
+## How to run it
+
+The following environment variables are supported:
+
+- `DD_API_KEY`: your API key (**required**)
+- `DD_HOSTNAME`: hostname to use for metrics
+- 'CMD_PORT': Port you want the DCA to serve
+
+Example usage: `docker run -e DD_API_KEY=your-api-key-here -e CMD_PORT=1234 -it <image-name>`
+
+For a more detailed usage please refer to the official [Docker Hub](https://hub.docker.com/r/datadog/agent/)
+
+## How to build it
+
+### On debian-based systems
+
+You can build your own binary using `inv cluster-agent.build`
+
+Then you can call `inv cluster-agent.image-build` that will take the binary generated above and use it to build the image

--- a/Dockerfiles/clusteragent/docker.yaml
+++ b/Dockerfiles/clusteragent/docker.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - ## Placeholder configuration file to start the docker check by default
+    ## Please see https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/dist/conf.d/docker.yaml.example
+    ## for supported options

--- a/Dockerfiles/clusteragent/entrypoint.sh
+++ b/Dockerfiles/clusteragent/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2017 Datadog, Inc.
+
+
+##### Core config #####
+
+if [[ -z $DD_API_KEY ]]; then
+    echo "You must set an DD_API_KEY environment variable to run the Datadog Agent container"
+    exit 1
+fi
+
+if [ -z $DD_DD_URL ]; then
+    export DD_DD_URL="https://app.datadoghq.com"
+fi
+
+if [[ -z $DCA_CMD_PORT ]]; then
+    export CMD_PORT=$DCA_CMD_PORT
+fi
+
+##### Starting up #####
+
+export PATH="/opt/datadog-agent/bin/cluster-agent/:/opt/datadog-agent/bin/:$PATH"
+
+exec "$@"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  branch = "default"
+  name = "bitbucket.org/ww/goautoneg"
+  packages = ["."]
+  revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+
+[[projects]]
   name = "github.com/DataDog/agent-payload"
   packages = ["gogen"]
   revision = "b0b883b8c68f11698e1eee462d1efa83e76bf14a"
@@ -24,6 +30,24 @@
   packages = ["."]
   revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
   version = "v0.4.5"
+
+[[projects]]
+  name = "github.com/NYTimes/gziphandler"
+  packages = ["."]
+  revision = "d6f46609c7629af3a02d791a4666866eed3cbd3e"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   name = "github.com/Sirupsen/logrus"
@@ -49,6 +73,12 @@
   revision = "cb3dae3a7588ae35829eb5724df611cd75152fba"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
+
+[[projects]]
   name = "github.com/cenkalti/backoff"
   packages = ["."]
   revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
@@ -62,20 +92,26 @@
 
 [[projects]]
   name = "github.com/coreos/etcd"
-  packages = ["client","pkg/pathutil","pkg/types"]
-  revision = "0520cb9304cb2385f7e72b8bc02d6e4d3257158a"
-  version = "v3.1.10"
+  packages = ["auth/authpb","client","clientv3","etcdserver/api/v3rpc/rpctypes","etcdserver/etcdserverpb","mvcc/mvccpb","pkg/pathutil","pkg/srv","pkg/tlsutil","pkg/transport","pkg/types","version"]
+  revision = "1e1dbb23924672c6cd72c62ee0db2b45f778da71"
+  version = "v3.2.11"
+
+[[projects]]
+  name = "github.com/coreos/go-semver"
+  packages = ["semver"]
+  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
+  version = "v0.2.0"
+
+[[projects]]
+  name = "github.com/coreos/go-systemd"
+  packages = ["daemon"]
+  revision = "d2196463941895ee908e13531a23a39feb9e1243"
+  version = "v15"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
-
-[[projects]]
-  name = "github.com/dgrijalva/jwt-go"
-  packages = ["."]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
 
 [[projects]]
   name = "github.com/docker/distribution"
@@ -100,9 +136,33 @@
   revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/elazarl/go-bindata-assetfs"
+  packages = ["."]
+  revision = "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"
+
+[[projects]]
+  name = "github.com/emicklei/go-restful"
+  packages = [".","log"]
+  revision = "5741799b275a3c4a5a9623a993576d7545cf7b5c"
+  version = "v2.4.0"
+
+[[projects]]
+  name = "github.com/emicklei/go-restful-swagger12"
+  packages = ["."]
+  revision = "dcef7f55730566d41eae5db10e7d6981829720f6"
+  version = "1.0.1"
+
+[[projects]]
   name = "github.com/ericchiang/k8s"
   packages = [".","api/resource","api/unversioned","api/v1","apis/apps/v1alpha1","apis/apps/v1beta1","apis/authentication/v1","apis/authentication/v1beta1","apis/authorization/v1","apis/authorization/v1beta1","apis/autoscaling/v1","apis/autoscaling/v2alpha1","apis/batch/v1","apis/batch/v2alpha1","apis/certificates/v1alpha1","apis/certificates/v1beta1","apis/extensions/v1beta1","apis/imagepolicy/v1alpha1","apis/meta/v1","apis/policy/v1alpha1","apis/policy/v1beta1","apis/rbac/v1alpha1","apis/rbac/v1beta1","apis/settings/v1alpha1","apis/storage/v1","apis/storage/v1beta1","runtime","runtime/schema","util/intstr","watch/versioned"]
   revision = "fa30591be9ccaacee478995fbba53c648e901483"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  revision = "944e07253867aacae43c04b2e6a239005443f33a"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -123,6 +183,12 @@
   revision = "854377f11dfb81f04121879829bc53487e377739"
 
 [[projects]]
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
@@ -134,21 +200,64 @@
   revision = "de8695c8edbf8236f30d6e1376e20b198a028d42"
 
 [[projects]]
-  name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor"]
-  revision = "909568be09de550ed094403c2bf8a261b5bb730a"
-  version = "v0.3"
+  branch = "master"
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  revision = "779f45308c19820f1a69e9a4cd965f496e0da10f"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  revision = "36d33bfe519efae5632669801b180bf1a245da3b"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  revision = "01738944bdee0f26bf66420c5b17d54cfdf55341"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  revision = "cf0bdb963811675a4d7e74901cefc7411a1df939"
+
+[[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys"]
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto"]
-  revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
+  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/btree"
+  packages = ["."]
+  revision = "316fb6d3f031ae8f4d457c6c5186b9e3ded70435"
 
 [[projects]]
   branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  name = "github.com/googleapis/gnostic"
+  packages = ["OpenAPIv2","compiler","extensions"]
+  revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
+  version = "v0.1.0"
 
 [[projects]]
   name = "github.com/gorilla/context"
@@ -161,6 +270,12 @@
   packages = ["."]
   revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
   version = "v1.4.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/gregjones/httpcache"
+  packages = [".","diskcache"]
+  revision = "2bcd89a1743fd4b373f7370ce8ddc14dfbd18229"
 
 [[projects]]
   name = "github.com/hashicorp/consul"
@@ -180,6 +295,12 @@
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [".","simplelru"]
+  revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
+
+[[projects]]
   name = "github.com/hashicorp/hcl"
   packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
   revision = "7fa7fff964d035e8a162cce3a164b3ad02ad651b"
@@ -194,6 +315,18 @@
   name = "github.com/hectane/go-acl"
   packages = [".","api"]
   revision = "7f56832555fc229dad908c67d65ed3ce6156b70c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/howeyc/gopass"
+  packages = ["."]
+  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+
+[[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "7fe0c75c13abdee74b09fcacef5ea1c6bba6a874"
+  version = "0.2.4"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -213,6 +346,18 @@
   version = "0.2.2"
 
 [[projects]]
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  revision = "f7279a603edee96fe7764d3de9c6ff8cf9970994"
+  version = "1.0.4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/juju/ratelimit"
+  packages = ["."]
+  revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
+
+[[projects]]
   name = "github.com/k-sone/snmpgo"
   packages = ["."]
   revision = "de09377ff34857b08afdc16ea8c7c2929eb1fc6e"
@@ -224,9 +369,21 @@
   revision = "9d302b58e975387d0b4d9be876622c86cefe64be"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/kubernetes-incubator/custom-metrics-apiserver"
+  packages = ["pkg/apiserver","pkg/apiserver/installer","pkg/cmd/server","pkg/provider","pkg/registry/custom_metrics"]
+  revision = "fae01650d93f5de6151a024e36323344e14427aa"
+
+[[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
   revision = "51463bfca2576e06c62a8504b5c0f06d61312647"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mailru/easyjson"
+  packages = ["buffer","jlexer","jwriter"]
+  revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -239,6 +396,12 @@
   packages = ["."]
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
+
+[[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -257,6 +420,12 @@
   revision = "417edcfd99a4d472c262e58f22b4bfe97580f03e"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mxk/go-flowrate"
+  packages = ["flowrate"]
+  revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
+
+[[projects]]
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
   revision = "aa2ec055abd10d26d539eb630a92241b781ce4bc"
@@ -267,6 +436,12 @@
   packages = ["."]
   revision = "1881a9bccb818787f68c52bfba648c6cf34c34fa"
   version = "v2.0.0"
+
+[[projects]]
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
+  version = "v1.1"
 
 [[projects]]
   name = "github.com/pelletier/go-buffruneio"
@@ -280,6 +455,18 @@
   revision = "fe206efb84b2bc8e8cfafe6b4c1826622be969e3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+
+[[projects]]
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
+  version = "v2.0.1"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "ff09b135c25aae272398c51a07235b90a75aa4f0"
@@ -288,6 +475,30 @@
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = ["prometheus"]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  revision = "2e54d0b93cba2fd133edc32211dcc32c06ef72ca"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [".","xfs"]
+  revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
   name = "github.com/samuel/go-zookeeper"
@@ -367,25 +578,58 @@
   version = "v0.2.0"
 
 [[projects]]
-  name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex","proxy"]
-  revision = "f2499483f923065a842d38eb4c7f1927e6fc6e6d"
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "94eea52f7b742c7cbe0b03b22f0c4c8631ece122"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/net"
+  packages = ["context","context/ctxhttp","html","html/atom","http2","http2/hpack","idna","internal/timeseries","lex/httplex","proxy","trace","websocket"]
+  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows","windows/registry","windows/svc","windows/svc/debug","windows/svc/eventlog","windows/svc/mgr"]
-  revision = "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
+  revision = "1d2aa6dbdea45adaaebb9905d0666e4537563829"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
-  revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
   packages = ["go/ast/astutil","go/buildutil","go/loader"]
   revision = "9badcbe49be523255546b669968041d707ece12e"
+
+[[projects]]
+  branch = "master"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/api/annotations","googleapis/rpc/status"]
+  revision = "a8101f21cf983e773d0c1133ebc5424792003214"
+
+[[projects]]
+  name = "google.golang.org/grpc"
+  packages = [".","balancer","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","health/grpc_health_v1","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  revision = "e687fa4e6424368ece6e4fe727cea2c806a0fcb4"
+  version = "v1.8.2"
+
+[[projects]]
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
+  version = "v0.9.0"
+
+[[projects]]
+  name = "gopkg.in/natefinch/lumberjack.v2"
+  packages = ["."]
+  revision = "a96e63847dc3c67d17befa69c303767e2f84e54f"
+  version = "v2.1"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -398,9 +642,45 @@
   revision = "659bba33a1626ab76f393d6878dc3e4f13253f6d"
   version = "v2.3"
 
+[[projects]]
+  name = "k8s.io/api"
+  packages = ["admissionregistration/v1alpha1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1beta1"]
+  revision = "81aa34336d28aadc3a8e8da7dfd9258c5157e5e4"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[projects]]
+  name = "k8s.io/apimachinery"
+  packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/api/validation","pkg/api/validation/path","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/internalversion","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1/validation","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/conversion/unstructured","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/httpstream","pkg/util/intstr","pkg/util/json","pkg/util/mergepatch","pkg/util/net","pkg/util/proxy","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/strategicpatch","pkg/util/uuid","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/json","third_party/forked/golang/netutil","third_party/forked/golang/reflect"]
+  revision = "3b05bbfa0a45413bfa184edbf9af617e277962fb"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[projects]]
+  name = "k8s.io/apiserver"
+  packages = ["pkg/admission","pkg/admission/initializer","pkg/admission/plugin/namespace/lifecycle","pkg/apis/apiserver","pkg/apis/apiserver/install","pkg/apis/apiserver/v1alpha1","pkg/apis/audit","pkg/apis/audit/install","pkg/apis/audit/v1alpha1","pkg/apis/audit/v1beta1","pkg/apis/audit/validation","pkg/audit","pkg/audit/policy","pkg/authentication/authenticator","pkg/authentication/authenticatorfactory","pkg/authentication/group","pkg/authentication/request/anonymous","pkg/authentication/request/bearertoken","pkg/authentication/request/headerrequest","pkg/authentication/request/union","pkg/authentication/request/websocket","pkg/authentication/request/x509","pkg/authentication/serviceaccount","pkg/authentication/token/tokenfile","pkg/authentication/user","pkg/authorization/authorizer","pkg/authorization/authorizerfactory","pkg/authorization/union","pkg/endpoints","pkg/endpoints/discovery","pkg/endpoints/filters","pkg/endpoints/handlers","pkg/endpoints/handlers/negotiation","pkg/endpoints/handlers/responsewriters","pkg/endpoints/metrics","pkg/endpoints/openapi","pkg/endpoints/request","pkg/features","pkg/registry/generic","pkg/registry/generic/registry","pkg/registry/rest","pkg/server","pkg/server/filters","pkg/server/healthz","pkg/server/httplog","pkg/server/mux","pkg/server/options","pkg/server/routes","pkg/server/routes/data/swagger","pkg/server/storage","pkg/storage","pkg/storage/errors","pkg/storage/etcd","pkg/storage/etcd/metrics","pkg/storage/etcd/util","pkg/storage/etcd3","pkg/storage/etcd3/preflight","pkg/storage/names","pkg/storage/storagebackend","pkg/storage/storagebackend/factory","pkg/storage/value","pkg/util/feature","pkg/util/flag","pkg/util/flushwriter","pkg/util/trace","pkg/util/webhook","pkg/util/wsstream","plugin/pkg/audit/log","plugin/pkg/audit/webhook","plugin/pkg/authenticator/token/webhook","plugin/pkg/authorizer/webhook"]
+  revision = "c1e53d745d0fe45bf7d5d44697e6eface25fceca"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[projects]]
+  name = "k8s.io/client-go"
+  packages = ["discovery","informers","informers/admissionregistration","informers/admissionregistration/v1alpha1","informers/apps","informers/apps/v1beta1","informers/apps/v1beta2","informers/autoscaling","informers/autoscaling/v1","informers/autoscaling/v2beta1","informers/batch","informers/batch/v1","informers/batch/v1beta1","informers/batch/v2alpha1","informers/certificates","informers/certificates/v1beta1","informers/core","informers/core/v1","informers/extensions","informers/extensions/v1beta1","informers/internalinterfaces","informers/networking","informers/networking/v1","informers/policy","informers/policy/v1beta1","informers/rbac","informers/rbac/v1","informers/rbac/v1alpha1","informers/rbac/v1beta1","informers/scheduling","informers/scheduling/v1alpha1","informers/settings","informers/settings/v1alpha1","informers/storage","informers/storage/v1","informers/storage/v1beta1","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","listers/admissionregistration/v1alpha1","listers/apps/v1beta1","listers/apps/v1beta2","listers/autoscaling/v1","listers/autoscaling/v2beta1","listers/batch/v1","listers/batch/v1beta1","listers/batch/v2alpha1","listers/certificates/v1beta1","listers/core/v1","listers/extensions/v1beta1","listers/networking/v1","listers/policy/v1beta1","listers/rbac/v1","listers/rbac/v1alpha1","listers/rbac/v1beta1","listers/scheduling/v1alpha1","listers/settings/v1alpha1","listers/storage/v1","listers/storage/v1beta1","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  revision = "82aa063804cf055e16e8911250f888bc216e8b61"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/kube-openapi"
+  packages = ["pkg/builder","pkg/common","pkg/handler","pkg/util"]
+  revision = "b16ebc07f5cad97831f961e4b5a9cc1caed33b7e"
+
+[[projects]]
+  name = "k8s.io/metrics"
+  packages = ["pkg/apis/custom_metrics","pkg/apis/custom_metrics/install","pkg/apis/custom_metrics/v1beta1"]
+  revision = "4c7ac522b9daf7beeb53f6766722ba78b7e5712d"
+  version = "kubernetes-1.9.0-alpha.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d4f29aad1567ef7834793cec163267bd4d9a5a7009784ff2c5844cec8171b16c"
+  inputs-digest = "260df4b8ec4f635f16ab84d5c6744d0bebc35d60e078148b7ee2840330296bb6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   version = "4.6"
 
 [[projects]]
+  name = "github.com/DataDog/datadog-go"
+  packages = ["statsd"]
+  revision = "0ddda6bee21174ef6c4873647cb0d6ec9cba996f"
+  version = "1.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/DataDog/gohai"
   packages = ["cpu","filesystem","memory","network","platform","processes","processes/gops"]
@@ -62,8 +68,26 @@
   revision = "ea383cf3ba6ec950874b8486cd72356d007c768f"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/armon/circbuf"
+  packages = ["."]
+  revision = "bbbad097214e2918d8543d5201d12bfd7bca254d"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/armon/go-metrics"
+  packages = [".","circonus","datadog"]
+  revision = "7aa49fde808223f8dadfdbfd3a20ff6c19e5f9ec"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/armon/go-radix"
+  packages = ["."]
+  revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
+
+[[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/sts"]
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","awstesting","awstesting/mock","awstesting/unit","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restjson","private/protocol/restxml","private/protocol/xml/xmlutil","private/util","service/dynamodb","service/ec2","service/kinesis","service/route53","service/s3","service/sqs","service/sts"]
   revision = "e63027ac6e05f6d4ae9f97ce0294d7468ca652da"
   version = "v1.10.33"
 
@@ -91,6 +115,24 @@
   version = "v2.6"
 
 [[projects]]
+  name = "github.com/circonus-labs/circonus-gometrics"
+  packages = [".","api","api/config","checkmgr"]
+  revision = "b25d14eeef390159289ad3e8521eff3162c59685"
+  version = "v2.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/circonus-labs/circonusllhist"
+  packages = ["."]
+  revision = "6e85b9352cf0c2bb969831347491388bb3ae9c69"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/cockroachdb/cmux"
+  packages = ["."]
+  revision = "30d10be492927e2dcae0089c374c455d42414fcb"
+
+[[projects]]
   name = "github.com/coreos/etcd"
   packages = ["auth/authpb","client","clientv3","etcdserver/api/v3rpc/rpctypes","etcdserver/etcdserverpb","mvcc/mvccpb","pkg/pathutil","pkg/srv","pkg/tlsutil","pkg/transport","pkg/types","version"]
   revision = "1e1dbb23924672c6cd72c62ee0db2b45f778da71"
@@ -109,18 +151,42 @@
   version = "v15"
 
 [[projects]]
+  name = "github.com/coreos/go-semver"
+  packages = ["semver"]
+  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
+  version = "v0.2.0"
+
+[[projects]]
+  name = "github.com/coreos/go-systemd"
+  packages = ["daemon","journal","util"]
+  revision = "d2196463941895ee908e13531a23a39feb9e1243"
+  version = "v15"
+
+[[projects]]
+  name = "github.com/coreos/pkg"
+  packages = ["capnslog","dlopen"]
+  revision = "3ac0863d7acf3bc44daf49afef8919af12f704ef"
+  version = "v3"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
-  packages = ["spew"]
+  packages = ["spew","spew/testdata"]
   revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
 
 [[projects]]
+  name = "github.com/dgrijalva/jwt-go"
+  packages = ["."]
+  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
+  version = "v3.1.0"
+
+[[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digestset","reference"]
+  packages = ["context","digestset","reference","uuid"]
   revision = "5cfdfbdce59c0b1854b9d82189e9c6164d54456a"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
+  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/ioutils","pkg/longpath","pkg/system","pkg/tlsconfig"]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
@@ -175,6 +241,12 @@
   packages = ["."]
   revision = "629574ca2a5df945712d3079857300b5e4da0236"
   version = "v1.4.2"
+
+[[projects]]
+  name = "github.com/fsouza/go-dockerclient"
+  packages = [".","external/github.com/Sirupsen/logrus","external/github.com/docker/docker/opts","external/github.com/docker/docker/pkg/archive","external/github.com/docker/docker/pkg/fileutils","external/github.com/docker/docker/pkg/homedir","external/github.com/docker/docker/pkg/idtools","external/github.com/docker/docker/pkg/ioutils","external/github.com/docker/docker/pkg/longpath","external/github.com/docker/docker/pkg/pools","external/github.com/docker/docker/pkg/promise","external/github.com/docker/docker/pkg/stdcopy","external/github.com/docker/docker/pkg/system","external/github.com/docker/go-units","external/github.com/hashicorp/go-cleanhttp","external/github.com/opencontainers/runc/libcontainer/user","external/golang.org/x/net/context","external/golang.org/x/sys/unix"]
+  revision = "1d4f4ae73768d3ca16a6fb964694f58dc5eba601"
+  version = "docker-1.9/go-1.4"
 
 [[projects]]
   branch = "master"
@@ -249,6 +321,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/google/btree"
+  packages = ["."]
+  revision = "316fb6d3f031ae8f4d457c6c5186b9e3ded70435"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
@@ -279,14 +357,56 @@
 
 [[projects]]
   name = "github.com/hashicorp/consul"
-  packages = ["api"]
+  packages = ["acl","agent","agent/consul","agent/consul/agent","agent/consul/prepared_query","agent/consul/servers","agent/consul/state","agent/consul/structs","api","command","ipaddr","lib","logger","snapshot","testutil","testutil/retry","tlsutil","types","version","watch"]
   revision = "5473255f9816e2b64d52cc054470d600b007d821"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-checkpoint"
+  packages = ["."]
+  revision = "1545e56e46dec3bba264e41fde2c1e2aa65b5dd4"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
   revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-immutable-radix"
+  packages = ["."]
+  revision = "8aac2701530899b64bdea735a1de8da899815220"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-memdb"
+  packages = ["."]
+  revision = "75ff99613d288868d8888ec87594525906815dbc"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-msgpack"
+  packages = ["codec"]
+  revision = "fa3f63826f7c23912c15263591e65d54d080b458"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  revision = "b7773ae218740a7be65057fc60b366a49b538a44"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  revision = "794af36148bf63c118d6db80eb902a136b907e71"
 
 [[projects]]
   branch = "master"
@@ -302,12 +422,48 @@
 
 [[projects]]
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token","testhelper"]
   revision = "7fa7fff964d035e8a162cce3a164b3ad02ad651b"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hil"
+  packages = [".","ast","parser","scanner"]
+  revision = "fa9f258a92500514cc8e9c67020487709df92432"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/logutils"
+  packages = ["."]
+  revision = "0dc08b1671f34c4250ce212759ebd880f743d883"
+
+[[projects]]
+  name = "github.com/hashicorp/memberlist"
+  packages = ["."]
+  revision = "ce8abaa0c60c2d6bee7219f5ddf500e0a1457b28"
+  version = "v0.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/net-rpc-msgpackrpc"
+  packages = ["."]
+  revision = "a14192a58a694c123d8fe5481d4a4727d6ae82f3"
+
+[[projects]]
+  name = "github.com/hashicorp/raft"
+  packages = ["."]
+  revision = "6d14f0c70869faabd9e60ba7ed88a6cbbd6a661f"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/raft-boltdb"
+  packages = ["."]
+  revision = "6e5ba93211eaf8d9a2ad7e41ffad8c6f160f9fe3"
+
+[[projects]]
   name = "github.com/hashicorp/serf"
-  packages = ["coordinate"]
+  packages = ["coordinate","serf"]
   revision = "91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc"
 
 [[projects]]
@@ -360,6 +516,18 @@
 [[projects]]
   name = "github.com/k-sone/snmpgo"
   packages = ["."]
+  revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
+  version = "v0.1.0"
+
+[[projects]]
+  name = "github.com/jtolds/gls"
+  packages = ["."]
+  revision = "77f18212c9c7edc9bd6a33d383a7b545ce62f064"
+  version = "v4.2.1"
+
+[[projects]]
+  name = "github.com/k-sone/snmpgo"
+  packages = [".","snmptest"]
   revision = "de09377ff34857b08afdc16ea8c7c2929eb1fc6e"
   version = "v3.2.0"
 
@@ -377,7 +545,43 @@
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
+  revision = "a2d62155777b39595c825ed3824279e642a5db3c"
+  version = "v2.0.2"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = [".","assert"]
   revision = "51463bfca2576e06c62a8504b5c0f06d61312647"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
+
+[[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/miekg/dns"
+  packages = ["."]
+  revision = "9271f6595be6734763aaf4b7923f8f1b7a6cc559"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/cli"
+  packages = ["."]
+  revision = "33edc47170b5df54d2588696d590c5e20ee583fe"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/copystructure"
+  packages = ["."]
+  revision = "d23ffcb85de31694d6ccaa23ccb4a03e55c1303f"
 
 [[projects]]
   branch = "master"
@@ -430,6 +634,12 @@
   packages = ["."]
   revision = "aa2ec055abd10d26d539eb630a92241b781ce4bc"
   version = "v1.0.0-rc0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/pascaldekloe/goe"
+  packages = ["verify"]
+  revision = "07ebd1e2481f616a278ab431cf04cc5cf5ab3ebe"
 
 [[projects]]
   name = "github.com/patrickmn/go-cache"
@@ -512,6 +722,12 @@
   revision = "6d13f941744b9332d6ed00dc2cd2722acd79a47e"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/sean-/seed"
+  packages = ["."]
+  revision = "e2103e2c35297fb7e17febb81e49b312087a2372"
+
+[[projects]]
   name = "github.com/shirou/gopsutil"
   packages = ["cpu","disk","host","internal/common","load","mem","net","process"]
   revision = "a452de7c734a0fa0f16d2e5725b0fa5934d9fbec"
@@ -522,6 +738,18 @@
   name = "github.com/shirou/w32"
   packages = ["."]
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
+
+[[projects]]
+  name = "github.com/smartystreets/assertions"
+  packages = [".","internal/go-render/render","internal/oglematchers"]
+  revision = "ff1918e1e5a13a74014644ae7c1e0ba2f791364d"
+  version = "1.8.0"
+
+[[projects]]
+  name = "github.com/smartystreets/goconvey"
+  packages = ["convey","convey/gotest","convey/reporting"]
+  revision = "9e8dc3f972df6c8fcc0375ef492c24d0bb204857"
+  version = "1.6.3"
 
 [[projects]]
   branch = "master"
@@ -562,9 +790,21 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock","require","suite"]
+  packages = ["assert","http","mock","require","suite"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tonnerre/golang-text"
+  packages = ["."]
+  revision = "048ed3d792f7104850acbc8cfc01e5a6070f4c04"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tv42/httpunix"
+  packages = ["."]
+  revision = "b75d8614f926c077e48d85f1f8f7885b758c6225"
 
 [[projects]]
   name = "github.com/ugorji/go"
@@ -600,6 +840,12 @@
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  revision = "6dc17368e09b0e8634d71cac8168d853e869a0c7"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,27 @@
+[[override]]
+  name = "github.com/emicklei/go-restful-swagger12"
+  version = "1.0.1"
+
+[[override]]
+  name = "k8s.io/apimachinery"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[override]]
+  name = "k8s.io/apiserver"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[override]]
+  name = "k8s.io/client-go"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[override]]
+  name = "k8s.io/metrics"
+  version = "kubernetes-1.9.0-alpha.1"
+
+[[override]]
+  name = "k8s.io/api"
+  version = "kubernetes-1.9.0-alpha.1"
+
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
   version = "=4.6.0"
@@ -26,7 +50,7 @@
 
 [[constraint]]
   name = "github.com/coreos/etcd"
-  version = "~3.1.3"
+  version = "~3.2.0"
 
 [[constraint]]
   name = "github.com/docker/docker"

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/dd-go/log"
+	log "github.com/cihub/seelog"
 	"github.com/gorilla/mux"
 )
 

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -57,7 +57,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	av, _ := version.New(version.AgentVersion)
+	av, _ := version.New(version.ClusterAgentVersion)
 	j, _ := json.Marshal(av)
 	w.Write(j)
 }

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -84,7 +85,11 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Infof("Making a flare")
-	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath)
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultLogFile
+	}
+	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -10,28 +10,119 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	log "github.com/cihub/seelog"
-
-	apicommon "github.com/DataDog/datadog-agent/cmd/agent/api/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/flare"
-	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/dd-go/log"
 	"github.com/gorilla/mux"
 )
+
+// EventChecks are checks that send events and are supported by the DCA
+var EventChecks = []string{
+	"kubernetes",
+}
 
 // SetupHandlers adds the specific handlers for cluster agent endpoints
 func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/version", getVersion).Methods("GET")
 	r.HandleFunc("/hostname", getHostname).Methods("GET")
 	r.HandleFunc("/flare", makeFlare).Methods("POST")
-	r.HandleFunc("/jmxstatus", setJMXStatus).Methods("POST")
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
-	r.HandleFunc("/jmxconfigs", getJMXConfigs).Methods("GET")
-	r.HandleFunc("/status", getStatus).Methods("GET")
-	r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
+	// r.HandleFunc("/status", getStatus).Methods("GET")
+	// r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
+	r.HandleFunc("/api/v1/metadata/{host}/{container:[0-9a-z]{64}}", getContainerMetadata).Methods("GET")
+	r.HandleFunc("/api/v1/{check}/events", getCheckLatestEvents).Methods("GET")
+}
+
+// TODO: make sure it works for DCA
+func stopAgent(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+	signals.Stopper <- true
+	w.Header().Set("Content-Type", "application/json")
+	j, _ := json.Marshal("")
+	w.Write(j)
+}
+
+// TODO: make sure it works for DCA
+func getVersion(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	av, _ := version.New(version.AgentVersion)
+	j, _ := json.Marshal(av)
+	w.Write(j)
+}
+
+// TODO: make sure it works for DCA
+func getHostname(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	hname, err := util.GetHostname()
+	if err != nil {
+		log.Warnf("Error getting hostname: %s\n", err) // or something like this
+		hname = ""
+	}
+	j, _ := json.Marshal(hname)
+	w.Write(j)
+}
+
+// TODO: make a special flare for DCA
+func makeFlare(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+
+	log.Infof("Making a flare")
+	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath)
+	if err != nil || filePath == "" {
+		if err != nil {
+			log.Errorf("The flare failed to be created: %s", err)
+		} else {
+			log.Warnf("The flare failed to be created")
+		}
+		http.Error(w, err.Error(), 500)
+	}
+	w.Write([]byte(filePath))
+}
+
+// TODO: complete it
+func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	check := vars["check"]
+	supportedCheck := false
+	for _, c := range EventChecks {
+		if c == check {
+			supportedCheck = true
+			break
+		}
+	}
+	if supportedCheck {
+		// TODO
+		w.Write([]byte("[OK] TODO"))
+	} else {
+		err := fmt.Errorf("[FAIL] TODO")
+		log.Errorf("%s", err.Error())
+		http.Error(w, err.Error(), 404)
+	}
+}
+
+// TODO: complete it
+func getContainerMetadata(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	host := vars["host"]
+	cID := vars["container"]
+	// TODO: check host (in store/ not in store)
+	// then check container
+	w.Write([]byte("host: " + host + ", container: " + cID))
 }

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// Package agent implements the api endpoints for the `/agent` prefix.
+// This group of endpoints is meant to provide high-level functionalities
+// at the agent level.
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+
+	log "github.com/cihub/seelog"
+
+	apicommon "github.com/DataDog/datadog-agent/cmd/agent/api/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/pkg/flare"
+	"github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/gorilla/mux"
+)
+
+// SetupHandlers adds the specific handlers for cluster agent endpoints
+func SetupHandlers(r *mux.Router) {
+	r.HandleFunc("/version", getVersion).Methods("GET")
+	r.HandleFunc("/hostname", getHostname).Methods("GET")
+	r.HandleFunc("/flare", makeFlare).Methods("POST")
+	r.HandleFunc("/jmxstatus", setJMXStatus).Methods("POST")
+	r.HandleFunc("/stop", stopAgent).Methods("POST")
+	r.HandleFunc("/jmxconfigs", getJMXConfigs).Methods("GET")
+	r.HandleFunc("/status", getStatus).Methods("GET")
+	r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
+}

--- a/cmd/cluster-agent/api/listener.go
+++ b/cmd/cluster-agent/api/listener.go
@@ -13,5 +13,5 @@ import (
 
 // getListener returns a listening connection
 func getListener() (net.Listener, error) {
-	return net.Listen("tcp", fmt.Sprintf("localhost:%v", config.Datadog.GetInt("cmd_port")))
+	return net.Listen("tcp", fmt.Sprintf("0.0.0.0:%v", config.Datadog.GetInt("cmd_port")))
 }

--- a/cmd/cluster-agent/api/listener.go
+++ b/cmd/cluster-agent/api/listener.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package api
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"net"
+)
+
+// getListener returns a listening connection
+func getListener() (net.Listener, error) {
+	return net.Listen("tcp", fmt.Sprintf("localhost:%v", config.Datadog.GetInt("cmd_port")))
+}

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+/*
+Package api implements the agent IPC api. Using HTTP
+calls, it's possible to communicate with the agent,
+sending commands and receiving infos.
+*/
+package api
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	stdLog "log"
+	"net"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/agent"
+	"github.com/DataDog/datadog-agent/pkg/api/security"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/gorilla/mux"
+)
+
+var (
+	listener net.Listener
+)
+
+// StartServer creates the router and starts the HTTP server
+func StartServer() error {
+	// create the root HTTP router
+	r := mux.NewRouter()
+
+	// IPC REST API server
+	agent.SetupHandlers(r)
+
+	// get the transport we're going to use under HTTP
+	var err error
+	listener, err = getListener()
+	if err != nil {
+		// we use the listener to handle commands for the agent, there's
+		// no way we can recover from this error
+		return fmt.Errorf("Unable to create the api server: %v", err)
+	}
+	util.SetAuthToken()
+
+	// create cert
+	hosts := []string{"127.0.0.1", "localhost"}
+	_, rootCertPEM, rootKey, err := security.GenerateRootCert(hosts, 2048)
+	if err != nil {
+		return fmt.Errorf("unable to start TLS server")
+	}
+
+	// PEM encode the private key
+	rootKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey),
+	})
+
+	// Create a TLS cert using the private key and certificate
+	rootTLSCert, err := tls.X509KeyPair(rootCertPEM, rootKeyPEM)
+	if err != nil {
+		return fmt.Errorf("invalid key pair: %v", err)
+	}
+
+	tlsConfig := tls.Config{
+		Certificates: []tls.Certificate{rootTLSCert},
+	}
+
+	srv := &http.Server{
+		Handler:   r,
+		ErrorLog:  stdLog.New(&config.ErrorLogWriter{}, "", 0), // log errors to seelog
+		TLSConfig: &tlsConfig,
+	}
+	tlsListener := tls.NewListener(listener, &tlsConfig)
+
+	go srv.Serve(tlsListener)
+	return nil
+
+}
+
+// StopServer closes the connection and the server
+// stops listening to new commands.
+func StopServer() {
+	if listener != nil {
+		listener.Close()
+	}
+}

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -76,8 +76,8 @@ func StartServer() error {
 		TLSConfig: &tlsConfig,
 	}
 	tlsListener := tls.NewListener(listener, &tlsConfig)
-
-	go srv.Serve(tlsListener)
+	fmt.Println(tlsListener)
+	go srv.Serve(listener)
 	return nil
 
 }

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -1,0 +1,37 @@
+package custommetrics
+
+import (
+	"os"
+
+	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd/server"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
+)
+
+var stopCh chan struct{}
+
+// StartServer creates and start a k8s custom metrics API server
+func StartServer() error {
+	options := server.NewCustomMetricsAdapterServerOptions(os.Stdout, os.Stdout) // FIXME: log to seelog
+	config, err := options.Config()
+	if err != nil {
+		return err
+	}
+
+	cmProvider := custommetrics.NewDatadogProvider()
+
+	server, err := config.Complete().New("datadog-custom-metrics-adapter", cmProvider)
+	if err != nil {
+		return err
+	}
+	stopCh = make(chan struct{})
+	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+}
+
+// StopServer closes the connection and the server
+// stops listening to new commands.
+func StopServer() {
+	if stopCh != nil {
+		stopCh <- struct{}{}
+	}
+}

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	_ "expvar" // Blank import used because this isn't directly used in this file
+
+	log "github.com/cihub/seelog"
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/metadata"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+var (
+	clusterAgentCmd = &cobra.Command{
+		Use:   "cluster-agent [command]",
+		Short: "Datadog Cluster Agent at your service.",
+		Long: `
+Datadog Cluster Agent takes care of running checks that need run only once per cluster.
+It also exposes an API for other Datadog agents that provides them with cluster-level
+metadata for their metrics.`,
+	}
+
+	startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "Start the Cluster Agent",
+		Long:  `Runs Datadog Cluster agent in the foreground`,
+		RunE:  start,
+	}
+
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			av, _ := version.New(version.AgentVersion)
+			fmt.Println(fmt.Sprintf("Cluster Agent from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
+		},
+	}
+
+	confPath string
+)
+
+// run the host metadata collector every 14400 seconds (4 hours)
+const hostMetadataCollectorInterval = 14400
+
+func init() {
+	// attach the command to the root
+	clusterAgentCmd.AddCommand(startCmd)
+	clusterAgentCmd.AddCommand(versionCmd)
+
+	// local flags
+	startCmd.Flags().StringVarP(&confPath, "cfgpath", "c", "", "path to datadog.yaml")
+	config.Datadog.BindPFlag("conf_path", startCmd.Flags().Lookup("cfgpath"))
+}
+
+func start(cmd *cobra.Command, args []string) error {
+	config.Datadog.SetConfigFile(config.Datadog.GetString("conf_path"))
+	confErr := config.Datadog.ReadInConfig()
+
+	// Setup logger
+	syslogURI := config.GetSyslogURI()
+	logFile := config.Datadog.GetString("log_file")
+	if config.Datadog.GetBool("disable_file_logging") {
+		// this will prevent any logging on file
+		logFile = ""
+	}
+	err := config.SetupLogger(
+		config.Datadog.GetString("log_level"),
+		logFile,
+		syslogURI,
+		config.Datadog.GetBool("syslog_rfc"),
+		config.Datadog.GetBool("syslog_tls"),
+		config.Datadog.GetString("syslog_pem"),
+	)
+	if err != nil {
+		log.Criticalf("Unable to setup logger: %s", err)
+		return nil
+	}
+
+	if confErr != nil {
+		log.Infof("unable to parse Datadog config file, running with env variables: %s", confErr)
+	}
+
+	if !config.Datadog.IsSet("api_key") {
+		log.Critical("no API key configured, exiting")
+		return nil
+	}
+
+	// get hostname
+	hostname, err := util.GetHostname()
+	if err != nil {
+		return log.Errorf("Error while getting hostname, exiting: %v", err)
+	}
+	log.Infof("Hostname is: %s", hostname)
+
+	// start the cmd HTTP server
+	// if err = api.StartServer(); err != nil {
+	// 	return log.Errorf("Error while starting api server, exiting: %v", err)
+	// }
+
+	// setup the forwarder
+	keysPerDomain, err := config.GetMultipleEndpoints()
+	if err != nil {
+		log.Error("Misconfiguration of agent endpoints: ", err)
+	}
+	f := forwarder.NewDefaultForwarder(keysPerDomain)
+	f.Start()
+	s := &serializer.Serializer{Forwarder: f}
+
+	hname, err := util.GetHostname()
+	if err != nil {
+		log.Warnf("Error getting hostname: %s", err)
+		hname = ""
+	}
+	log.Debugf("Using hostname: %s", hname)
+
+	var metaScheduler *metadata.Scheduler
+	if config.Datadog.GetBool("enable_metadata_collection") {
+		// start metadata collection
+		metaScheduler = metadata.NewScheduler(s, hname)
+
+		// add the host metadata collector
+		// TODO: make it configurable. We shouldn't report them
+		// twice if cluster agent and normal agents are on the same node
+		err = metaScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
+		if err != nil {
+			metaScheduler.Stop()
+			return log.Error("Host metadata is supposed to be always available in the catalog!")
+		}
+	} else {
+		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")
+	}
+
+	aggregatorInstance := aggregator.InitAggregator(s, hname)
+	// TODO: run the actual thing
+	clusterAgent, err := clusteragent.Run(aggregatorInstance.GetChannels())
+
+	// Setup a channel to catch OS signals
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Block here until we receive the interrupt signal
+	<-signalCh
+
+	if metaScheduler != nil {
+		metaScheduler.Stop()
+	}
+	clusterAgent.Stop()
+	log.Info("See ya!")
+	log.Flush()
+	return nil
+
+}
+
+func main() {
+	// go_expvar server
+	go http.ListenAndServe(
+		fmt.Sprintf("127.0.0.1:%d", config.Datadog.GetInt("clusteragent_expvar_port")),
+		http.DefaultServeMux)
+
+	if err := clusterAgentCmd.Execute(); err != nil {
+		log.Error(err)
+		os.Exit(-1)
+	}
+}

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -168,6 +168,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if metaScheduler != nil {
 		metaScheduler.Stop()
 	}
+	custommetrics.StopServer()
 	clusterAgent.Stop()
 	log.Info("See ya!")
 	log.Flush()

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api"
 )
 
 var (
@@ -114,9 +115,9 @@ func start(cmd *cobra.Command, args []string) error {
 	log.Infof("Hostname is: %s", hostname)
 
 	// start the cmd HTTP server
-	// if err = api.StartServer(); err != nil {
-	// 	return log.Errorf("Error while starting api server, exiting: %v", err)
-	// }
+	if err = api.StartServer(); err != nil {
+	 	return log.Errorf("Error while starting api server, exiting: %v", err)
+	 }
 
 	// Start the k8s custom metrics server
 	custommetrics.StartServer()

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -89,6 +90,7 @@ func start(cmd *cobra.Command, args []string) error {
 		config.Datadog.GetBool("syslog_rfc"),
 		config.Datadog.GetBool("syslog_tls"),
 		config.Datadog.GetString("syslog_pem"),
+		config.Datadog.GetBool("log_to_console"),
 	)
 	if err != nil {
 		log.Criticalf("Unable to setup logger: %s", err)
@@ -115,6 +117,9 @@ func start(cmd *cobra.Command, args []string) error {
 	// if err = api.StartServer(); err != nil {
 	// 	return log.Errorf("Error while starting api server, exiting: %v", err)
 	// }
+
+	// Start the k8s custom metrics server
+	custommetrics.StartServer()
 
 	// setup the forwarder
 	keysPerDomain, err := config.GetMultipleEndpoints()

--- a/docs/beta/upgrade.md
+++ b/docs/beta/upgrade.md
@@ -132,7 +132,7 @@ You can either download the DMG package and install it manually, or use the one-
 
 ### Manual installation
 
-1. Download the DMG package of the latest beta version, please use the latest macOS release listed on the (release page)[https://github.com/DataDog/datadog-agent/releases] of the repo
+1. Download the DMG package of the latest beta version, please use the latest macOS release listed on the [release page](https://github.com/DataDog/datadog-agent/releases) of the repo
 2. Install the DMG package
 3. Add your api key to `/opt/datadog-agent/etc/datadog.yaml`
 

--- a/pkg/clusteragent/clusteragent.go
+++ b/pkg/clusteragent/clusteragent.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package clusteragent
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/cmd/clusteragent/api"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// Agent represents a Cluster Agent.
+// It is responsible for running checks that need only run once per cluster.
+// It also exposes
+type Agent struct {
+	metricOut       chan<- *metrics.MetricSample
+	eventout        chan<- metrics.Event
+	serviceCheckOut chan<- metrics.ServiceCheck
+}
+
+// Run returns a running Cluster agent instance
+func Run(mOut chan<- *metrics.MetricSample, eOut chan<- metrics.Event, scOut chan<- metrics.ServiceCheck) (*Agent, error) {
+	a := Agent{
+		metricOut:       mOut,
+		eventout:        eOut,
+		serviceCheckOut: scOut,
+	}
+	log.Infof("Datadog cluster agent is now running.")
+	return &a, nil
+}
+
+// Stop the cluster agent
+func (a *Agent) Stop() {
+	api.StopServer()
+}

--- a/pkg/clusteragent/clusteragent.go
+++ b/pkg/clusteragent/clusteragent.go
@@ -8,7 +8,7 @@ package clusteragent
 import (
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/cmd/clusteragent/api"
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 

--- a/pkg/clusteragent/clusteragent.go
+++ b/pkg/clusteragent/clusteragent.go
@@ -36,3 +36,5 @@ func Run(mOut chan<- *metrics.MetricSample, eOut chan<- metrics.Event, scOut cha
 func (a *Agent) Stop() {
 	api.StopServer()
 }
+
+

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -1,0 +1,153 @@
+package custommetrics
+
+import (
+	"fmt"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/metrics/pkg/apis/custom_metrics"
+
+	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
+)
+
+type datadogProvider struct{}
+
+func NewDatadogProvider() provider.CustomMetricsProvider {
+	return &datadogProvider{}
+}
+
+func (p *datadogProvider) metricFor(value int64, groupResource schema.GroupResource, namespace string, name string, metricName string) (*custom_metrics.MetricValue, error) {
+	return &custom_metrics.MetricValue{
+		DescribedObject: custom_metrics.ObjectReference{
+			APIVersion: groupResource.Group + "/" + runtime.APIVersionInternal,
+			Kind:       "",
+			Name:       name,
+			Namespace:  namespace,
+		},
+		MetricName: metricName,
+		Timestamp:  metav1.Time{time.Now()},
+		Value:      *resource.NewQuantity(value, resource.DecimalSI),
+	}, nil
+}
+
+// func (p *datadogProvider) metricsFor(totalValue int64, groupResource schema.GroupResource, metricName string, list runtime.Object) (*custom_metrics.MetricValueList, error) {
+// 	if !apimeta.IsListType(list) {
+// 		return nil, fmt.Errorf("returned object was not a list")
+// 	}
+
+// 	res := make([]custom_metrics.MetricValue, 0)
+
+// 	err := apimeta.EachListItem(list, func(item runtime.Object) error {
+// 		objMeta := item.(metav1.Object)
+// 		value, err := p.metricFor(0, groupResource, objMeta.GetNamespace(), objMeta.GetName(), metricName)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		res = append(res, *value)
+
+// 		return nil
+// 	})
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	for i := range res {
+// 		res[i].Value = *resource.NewMilliQuantity(100*totalValue/int64(len(res)), resource.DecimalSI)
+// 	}
+
+// 	//return p.metricFor(value, groupResource, "", name, metricName)
+// 	return &custom_metrics.MetricValueList{
+// 		Items: res,
+// 	}, nil
+// }
+
+func (p *datadogProvider) GetRootScopedMetricByName(groupResource schema.GroupResource, name string, metricName string) (*custom_metrics.MetricValue, error) {
+	return nil, fmt.Errorf("Not Implemented")
+}
+
+func (p *datadogProvider) GetRootScopedMetricBySelector(groupResource schema.GroupResource, selector labels.Selector, metricName string) (*custom_metrics.MetricValueList, error) {
+	// // construct a client to list the names of objects matching the label selector
+	// client, err := p.client.ClientForGroupVersionResource(groupResource.WithVersion(""))
+	// if err != nil {
+	// 	glog.Errorf("unable to construct dynamic client to list matching resource names: %v", err)
+	// 	// don't leak implementation details to the user
+	// 	return nil, apierr.NewInternalError(fmt.Errorf("unable to list matching resources"))
+	// }
+
+	// totalValue, err := p.valueFor(groupResource, metricName, false)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// // we can construct a this APIResource ourself, since the dynamic client only uses Name and Namespaced
+	// apiRes := &metav1.APIResource{
+	// 	Name:       groupResource.Resource,
+	// 	Namespaced: false,
+	// }
+
+	// matchingObjectsRaw, err := client.Resource(apiRes, "").
+	// 	List(metav1.ListOptions{LabelSelector: selector.String()})
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// return p.metricsFor(totalValue, groupResource, metricName, matchingObjectsRaw)
+	return nil, fmt.Errorf("Not Implemented")
+}
+
+func (p *datadogProvider) GetNamespacedMetricByName(groupResource schema.GroupResource, namespace string, name string, metricName string) (*custom_metrics.MetricValue, error) {
+	return p.metricFor(10, groupResource, namespace, name, metricName)
+}
+
+func (p *datadogProvider) GetNamespacedMetricBySelector(groupResource schema.GroupResource, namespace string, selector labels.Selector, metricName string) (*custom_metrics.MetricValueList, error) {
+	// // construct a client to list the names of objects matching the label selector
+	// client, err := p.client.ClientForGroupVersionResource(groupResource.WithVersion(""))
+	// if err != nil {
+	// 	glog.Errorf("unable to construct dynamic client to list matching resource names: %v", err)
+	// 	// don't leak implementation details to the user
+	// 	return nil, apierr.NewInternalError(fmt.Errorf("unable to list matching resources"))
+	// }
+
+	// totalValue, err := p.valueFor(groupResource, metricName, true)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// // we can construct a this APIResource ourself, since the dynamic client only uses Name and Namespaced
+	// apiRes := &metav1.APIResource{
+	// 	Name:       groupResource.Resource,
+	// 	Namespaced: true,
+	// }
+
+	// matchingObjectsRaw, err := client.Resource(apiRes, namespace).
+	// 	List(metav1.ListOptions{LabelSelector: selector.String()})
+	// if err != nil {
+	// 	return nil, err
+	// }
+	return nil, fmt.Errorf("Not Implemented")
+}
+
+func (p *datadogProvider) ListAllMetrics() []provider.MetricInfo {
+	// TODO: maybe dynamically generate this?
+	return []provider.MetricInfo{
+		{
+			GroupResource: schema.GroupResource{Group: "", Resource: "pods"},
+			Metric:        "nginx.net.connections",
+			Namespaced:    true,
+		},
+		// {
+		// 	GroupResource: schema.GroupResource{Group: "", Resource: "services"},
+		// 	Metric:        "connections-per-second",
+		// 	Namespaced:    true,
+		// },
+		// {
+		// 	GroupResource: schema.GroupResource{Group: "", Resource: "namespaces"},
+		// 	Metric:        "queue-length",
+		// 	Namespaced:    false,
+		// },
+	}
+}

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,9 @@ func init() {
 	// Kubernetes
 	Datadog.SetDefault("kubernetes_http_kubelet_port", 10255)
 	Datadog.SetDefault("kubernetes_https_kubelet_port", 10250)
+	Datadog.SetDefault("kubernetes_pod_label_to_tag_prefix", "kube_")
+	Datadog.SetDefault("kubernetes_http_custom_metrics_port", 6443)
+
 	// ECS
 	Datadog.SetDefault("ecs_agent_url", "") // Will be autodetected
 
@@ -173,6 +176,8 @@ func init() {
 	Datadog.BindEnv("kubernetes_kubelet_host")
 	Datadog.BindEnv("kubernetes_http_kubelet_port")
 	Datadog.BindEnv("kubernetes_https_kubelet_port")
+	Datadog.BindEnv("kubernetes_pod_label_to_tag_prefix")
+	Datadog.BindEnv("kubernetes_http_custom_metrics_port")
 	Datadog.BindEnv("forwarder_timeout")
 	Datadog.BindEnv("forwarder_retry_queue_max_size")
 	Datadog.BindEnv("cloud_foundry")

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -10,10 +10,17 @@ package version
 // AgentVersion contains the version of the Agent
 var AgentVersion string
 
+// ClusterAgentVersion contains the version of the cluster agent
+var ClusterAgentVersion string
+
 var agentVersionDefault = "6.0.0"
+var clusterAgentVersionDefault = "6.0.0"
 
 func init() {
 	if AgentVersion == "" {
 		AgentVersion = agentVersionDefault
+	}
+	if ClusterAgentVersion == "" {
+		AgentVersion = clusterAgentVersionDefault
 	}
 }

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,7 +4,7 @@ Invoke entrypoint, import here all the tasks we want to make available
 import os
 from invoke import Collection
 
-from . import agent, benchmarks, docker, dogstatsd, pylauncher, logs
+from . import agent, benchmarks, docker, dogstatsd, pylauncher, logs, cluster_agent
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
 from .test import test, integration_tests, version
@@ -29,6 +29,7 @@ ns.add_task(audit_tag_impact)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)
+ns.add_collection(cluster_agent)
 ns.add_collection(benchmarks, name="bench")
 ns.add_collection(docker)
 ns.add_collection(dogstatsd)

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -1,0 +1,70 @@
+"""
+Cluster Agent tasks
+"""
+
+import os
+from invoke import task
+
+from .build_tags import get_build_tags
+from .utils import get_build_flags, bin_name
+from .utils import REPO_PATH
+
+#constants
+BIN_PATH = os.path.join(".", "bin", "cluster-agent")
+AGENT_TAG = "datadog/cluster_agent:master"
+
+@task
+def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False):
+    """
+    Build Cluster Agent
+
+     Example invokation:
+        inv cluster-agent.build
+    """
+
+    build_tags = get_build_tags("all", "snmp")
+
+    ldflags, gcflags = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
+
+    cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
+    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent/"
+    args = {
+        "race_opt": "-race" if race else "",
+        "build_type": "-a" if rebuild else "",
+        "build_tags": " ".join(build_tags),
+        "bin_name": os.path.join(BIN_PATH, bin_name("cluster-agent")),
+        "gcflags": gcflags,
+        "ldflags": ldflags,
+        "REPO_PATH": REPO_PATH,
+    }
+    ctx.run(cmd.format(**args))
+
+@task
+def run(ctx, rebuild=False, race=False, skip_build=False, development=True):
+    """
+    Run the Cluster Agent's binary. Build the binary before executing, unless
+    --skip-build was passed.
+    """
+    if not skip_build:
+        print("Building the Cluster Agent...")
+        build(ctx, rebuild=rebuild, race=race)
+
+    target = os.path.join(BIN_PATH, bin_name("cluster-agent"))
+    cfgPath = ""
+    if development:
+        cfgPath = "-c dev/dist/datadog.yaml"
+
+    ctx.run("{0} start {1}".format(target, cfgPath))
+
+@task
+def clean(ctx):
+    """
+    Remove temporary objects and binary artifacts
+    """
+    # go clean
+    print("Executing go clean")
+    ctx.run("go clean")
+
+    # remove the bin/agent folder
+    print("Remove agent binary folder")
+    ctx.run("rm -rf ./bin/cluster-agent")

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -68,3 +68,4 @@ def clean(ctx):
     # remove the bin/agent folder
     print("Remove agent binary folder")
     ctx.run("rm -rf ./bin/cluster-agent")
+

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -30,7 +30,7 @@ def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False)
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent/"
     args = {
         "race_opt": "-race" if race else "",
-        "build_type": "-a" if rebuild else "",
+        "build_type": "-a" if rebuild else "-i",
         "build_tags": " ".join(build_tags),
         "bin_name": os.path.join(BIN_PATH, bin_name("cluster-agent")),
         "gcflags": gcflags,


### PR DESCRIPTION
### What does this PR do?

Adds invoke to the DCA.
`inv -e cluster-agent.build --use-embedded-libs`
creates a bin in `${PWD}datadog-agent/cluster-agent/cluster-agent`. You can start it with start or you can use `inv agent.run`. This will use the conf file from the `dev/dist/datatog.yaml`. This could be improved later.

### Motivation

Roll out the DCA

### Additional Notes

Anything else we should know when reviewing?
