### PR TITLE
[agg] move contextKeys to 128bit Murmur3 hashes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "d80d0f562a71fa2380fbeccc93ba5a2e325606e4"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/DataDog/mmh3"
+  packages = ["."]
+  revision = "2cfb68475274527a10701355c739f31dd404718c"
+
+[[projects]]
   branch = "1.x"
   name = "github.com/DataDog/zstd"
   packages = ["."]
@@ -70,12 +76,6 @@
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
-
-[[projects]]
-  name = "github.com/dgrijalva/jwt-go"
-  packages = ["."]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
 
 [[projects]]
   name = "github.com/docker/distribution"
@@ -401,6 +401,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d4f29aad1567ef7834793cec163267bd4d9a5a7009784ff2c5844cec8171b16c"
+  inputs-digest = "c2077c0c76de7e9f127153bfe9b20fb511398a03e7821e713b8cbc841bce9d72"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package ckey
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/DataDog/mmh3"
+)
+
+const byteSize = 16
+
+// ContextKey is a non-cryptographic hash that allows to
+// aggregate metrics from a same context together.
+//
+// This implementation has been designed to remove all heap
+// allocations from the intake to reduce GC pressure on high
+// volumes.
+//
+// It uses the 128bit murmur3 hash, that is already successfully
+// used on other products. 128bit is probably overkill for avoiding
+// collisions, but it's better to err on the safe side, as we do not
+// have a collision mitigation mechanism.
+type ContextKey [byteSize]byte
+
+// hashPool is a reusable pool of murmur hasher objects
+// to avoid allocating
+var hashPool = sync.Pool{
+	New: func() interface{} {
+		return &mmh3.HashWriter128{}
+	},
+}
+
+// Generate returns the ContextKey hash for the given parameters.
+// The tags array is sorted in place to avoid heap allocations.
+func Generate(name, hostname string, tags []string) ContextKey {
+	mmh := hashPool.Get().(*mmh3.HashWriter128)
+	mmh.Reset()
+	defer hashPool.Put(mmh)
+
+	// Sort the tags in place. For typical tag slices, we use
+	// the in-place section sort to avoid heap allocations.
+	// We default to stdlib's sort package for longer slices.
+	if len(tags) < 20 {
+		selectionSort(tags)
+	} else {
+		sort.Strings(tags)
+	}
+
+	mmh.WriteString(name)
+	mmh.WriteString(",")
+	for _, t := range tags {
+		mmh.WriteString(t)
+		mmh.WriteString(",")
+	}
+	mmh.WriteString(hostname)
+
+	var hash [byteSize]byte
+	mmh.Sum(hash[0:0])
+	return hash
+}
+
+// Compare returns an integer comparing two strings lexicographically.
+// The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
+func Compare(a, b ContextKey) int {
+	for i := 0; i < byteSize; i++ {
+		switch {
+		case a[i] > b[i]:
+			return 1
+		case a[i] < b[i]:
+			return -1
+		default: // equality, compare next byte
+			continue
+		}
+	}
+	return 0
+}
+
+// IsZero returns true if the key is at zero value
+func (k ContextKey) IsZero() bool {
+	for _, b := range k {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// String returns the hexadecimal representation of the key
+func (k ContextKey) String() string {
+	return hex.EncodeToString(k[:])
+}
+
+// Parse returns a ContextKey instanciated with the value decoded as hexa
+func Parse(src string) (ContextKey, error) {
+	if hex.DecodedLen(len(src)) != byteSize {
+		return ContextKey{}, fmt.Errorf("invalid source length, expected %d bytes", byteSize)
+	}
+	var key ContextKey
+	_, err := hex.Decode(key[:], []byte(src))
+	return key, err
+}

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package ckey
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsZero(t *testing.T) {
+	var k ContextKey
+	assert.True(t, k.IsZero())
+}
+
+func TestGenerateReproductible(t *testing.T) {
+	name := "metric.name"
+	hostname := "hostname"
+	tags := []string{"bar", "foo", "key:value", "key:value2"}
+
+	firstKey := Generate(name, hostname, tags)
+	assert.Equal(t, "10c490eb35462b5a1e39489fe3944be7", firstKey.String())
+
+	for n := 0; n < 10; n++ {
+		t.Run(fmt.Sprintf("iteration %d:", n), func(t *testing.T) {
+			key := Generate(name, hostname, tags)
+			assert.Equal(t, firstKey, key)
+		})
+	}
+
+	otherKey := Generate("othername", hostname, tags)
+	assert.NotEqual(t, firstKey, otherKey)
+	assert.Equal(t, "cd3bca32c0520309fbb533e63ac0d40f", otherKey.String())
+}
+
+func TestCompare(t *testing.T) {
+	base, _ := Parse("cd3bca32c0520309fbb533e63ac0d40f")
+	veryHigh, _ := Parse("ff3bca32c0520309fbb533e63ac0d40f")
+	littleHigh, _ := Parse("ff3bca32c0520309fbb533e63ac0d4ff")
+	veryLow, _ := Parse("003bca32c0520309fbb533e63ac0d40f")
+
+	assert.Equal(t, 0, Compare(base, base))
+	assert.Equal(t, 1, Compare(veryHigh, base))
+	assert.Equal(t, 1, Compare(littleHigh, base))
+	assert.Equal(t, -1, Compare(veryLow, base))
+}
+
+// This benchmark is here to make sure we have
+// zero heap allocation for ContextKey generation
+//
+// run with `go test -bench=. -benchmem ./pkg/aggregator/ckey/`
+func BenchmarkGenerateNoAlloc(b *testing.B) {
+	name := "testname"
+	host := "myhost"
+	tags := []string{"foo", "bar"}
+	for n := 0; n < b.N; n++ {
+		Generate(name, host, tags)
+	}
+}

--- a/pkg/aggregator/ckey/sort.go
+++ b/pkg/aggregator/ckey/sort.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package ckey
+
+// selectionSort is a in-place sorting algorithm used as
+// an alternative to the sort package to avoid heap allocations
+// in the metric intake section. It is benchmarked faster than
+// sort.Strings up to 20 elements
+func selectionSort(array []string) {
+	var min int
+	var tmp string
+
+	for i := 0; i < len(array); i++ {
+		min = i
+		for j := i + 1; j < len(array); j++ {
+			if array[j] < array[min] {
+				min = j
+			}
+		}
+
+		tmp = array[i]
+		array[i] = array[min]
+		array[min] = tmp
+	}
+}

--- a/pkg/aggregator/ckey/sort_test.go
+++ b/pkg/aggregator/ckey/sort_test.go
@@ -1,0 +1,83 @@
+package ckey
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper function
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func generateRandomTags(tagSize, listSize int) []string {
+	var tags []string
+	for i := 0; i < listSize; i++ {
+		t := make([]byte, tagSize)
+		for i := range t {
+			t[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+		}
+		tags = append(tags, string(t))
+	}
+	return tags
+}
+
+// Unit testing: compare selection sort with stdlib on random slices
+
+func TestSortOK(t *testing.T) {
+	for n := 0; n < 10; n++ {
+		t.Run(fmt.Sprintf("iteration %d:", n), func(t *testing.T) {
+			toSort := generateRandomTags(20, 10)
+			selSort := make([]string, len(toSort))
+			copy(selSort, toSort)
+			stdSort := make([]string, len(toSort))
+			copy(stdSort, toSort)
+
+			selectionSort(selSort)
+			sort.Strings(stdSort)
+
+			assert.Equal(t, stdSort, selSort)
+		})
+	}
+
+}
+
+// Benchmark selection sort vs stdlib
+// Run with `go test -bench=. -benchmem ./pkg/aggregator/ckey/`
+
+var benchmarkTags []string
+
+func init() {
+	listSize, err := strconv.Atoi(os.Getenv("LISTSIZE"))
+	if err != nil {
+		listSize = 19
+	}
+	tagSize, err := strconv.Atoi(os.Getenv("TAGSIZE"))
+	if err != nil {
+		tagSize = 20
+	}
+	benchmarkTags = generateRandomTags(tagSize, listSize)
+}
+
+func BenchmarkSelectionSort(b *testing.B) {
+	t := make([]string, len(benchmarkTags))
+
+	for n := 0; n < b.N; n++ {
+		copy(t, benchmarkTags)
+		selectionSort(t)
+	}
+}
+
+func BenchmarkStdlibSort(b *testing.B) {
+	t := make([]string, len(benchmarkTags))
+
+	for n := 0; n < b.N; n++ {
+		copy(t, benchmarkTags)
+		sort.Strings(t)
+	}
+}

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -7,13 +7,12 @@ package aggregator
 
 import (
 	// stdlib
-	"bytes"
 	"fmt"
-	"sort"
 
 	// 3p
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
@@ -26,42 +25,24 @@ type Context struct {
 
 // ContextResolver allows tracking and expiring contexts
 type ContextResolver struct {
-	contextsByKey map[string]*Context
-	lastSeenByKey map[string]float64
+	contextsByKey map[ckey.ContextKey]*Context
+	lastSeenByKey map[ckey.ContextKey]float64
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
-func generateContextKey(metricSample *metrics.MetricSample) string {
-	// Pre-compute the size of the buffer we'll need, and allocate a buffer of that size
-	bufferSize := len(metricSample.Name) + 1
-	for k := range metricSample.Tags {
-		bufferSize += len(metricSample.Tags[k]) + 1
-	}
-	bufferSize += len(metricSample.Host)
-	buffer := bytes.NewBuffer(make([]byte, 0, bufferSize))
-
-	sort.Strings(metricSample.Tags)
-	// write the context items to the buffer, and return it as a string
-	buffer.WriteString(metricSample.Name)
-	buffer.WriteString(",")
-	for k := range metricSample.Tags {
-		buffer.WriteString(metricSample.Tags[k])
-		buffer.WriteString(",")
-	}
-	buffer.WriteString(metricSample.Host)
-
-	return buffer.String()
+func generateContextKey(metricSample *metrics.MetricSample) ckey.ContextKey {
+	return ckey.Generate(metricSample.Name, metricSample.Host, metricSample.Tags)
 }
 
 func newContextResolver() *ContextResolver {
 	return &ContextResolver{
-		contextsByKey: make(map[string]*Context),
-		lastSeenByKey: make(map[string]float64),
+		contextsByKey: make(map[ckey.ContextKey]*Context),
+		lastSeenByKey: make(map[ckey.ContextKey]float64),
 	}
 }
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *ContextResolver) trackContext(metricSample *metrics.MetricSample, currentTimestamp float64) string {
+func (cr *ContextResolver) trackContext(metricSample *metrics.MetricSample, currentTimestamp float64) ckey.ContextKey {
 	contextKey := generateContextKey(metricSample)
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		cr.contextsByKey[contextKey] = &Context{
@@ -76,7 +57,7 @@ func (cr *ContextResolver) trackContext(metricSample *metrics.MetricSample, curr
 }
 
 // updateTrackedContext updates the last seen timestamp on a given context key
-func (cr *ContextResolver) updateTrackedContext(contextKey string, timestamp float64) error {
+func (cr *ContextResolver) updateTrackedContext(contextKey ckey.ContextKey, timestamp float64) error {
 	if _, ok := cr.lastSeenByKey[contextKey]; ok && cr.lastSeenByKey[contextKey] < timestamp {
 		cr.lastSeenByKey[contextKey] = timestamp
 	} else if !ok {
@@ -88,8 +69,8 @@ func (cr *ContextResolver) updateTrackedContext(contextKey string, timestamp flo
 
 // expireContexts cleans up the contexts that haven't been tracked since the given timestamp
 // and returns the associated contextKeys
-func (cr *ContextResolver) expireContexts(expireTimestamp float64) []string {
-	var expiredContextKeys []string
+func (cr *ContextResolver) expireContexts(expireTimestamp float64) []ckey.ContextKey {
+	var expiredContextKeys []ckey.ContextKey
 
 	// Find expired context keys
 	for contextKey, lastSeen := range cr.lastSeenByKey {

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -12,6 +12,7 @@ import (
 	// 3p
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
@@ -26,7 +27,7 @@ func TestGenerateContextKey(t *testing.T) {
 	}
 
 	contextKey := generateContextKey(&mSample)
-	assert.Equal(t, "my.metric.name,bar,foo,metric-hostname", contextKey)
+	assert.Equal(t, "f15c7df5722489dd29b6dbcd0cafda62", contextKey.String())
 }
 
 func TestTrackContext(t *testing.T) {
@@ -83,7 +84,8 @@ func TestTrackContext(t *testing.T) {
 	assert.Equal(t, expectedContext3, *context3)
 
 	// Looking for a missing context key returns an error
-	_, ok := contextResolver.contextsByKey["missingContextKey"]
+	unknownContextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
+	_, ok := contextResolver.contextsByKey[unknownContextKey]
 	assert.False(t, ok)
 }
 

--- a/pkg/aggregator/dist_sampler.go
+++ b/pkg/aggregator/dist_sampler.go
@@ -8,6 +8,7 @@
 package aggregator
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metrics/percentile"
 
@@ -57,7 +58,7 @@ func (d *DistSampler) addSample(metricSample *metrics.MetricSample, timestamp fl
 func (d *DistSampler) flush(timestamp float64) percentile.SketchSeriesList {
 	var result []*percentile.SketchSeries
 
-	sketchesByContext := make(map[string]*percentile.SketchSeries)
+	sketchesByContext := make(map[ckey.ContextKey]*percentile.SketchSeries)
 
 	cutoffTime := d.calculateBucketStart(timestamp)
 	for bucketTimestamp, ctxSketch := range d.sketchesByTimestamp {

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	// project
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
@@ -27,7 +28,7 @@ func (os OrderedSeries) Len() int {
 }
 
 func (os OrderedSeries) Less(i, j int) bool {
-	return os.series[i].ContextKey < os.series[j].ContextKey
+	return ckey.Compare(os.series[i].ContextKey, os.series[j].ContextKey) == -1
 }
 
 func (os OrderedSeries) Swap(i, j int) {
@@ -118,18 +119,18 @@ func TestContextSampling(t *testing.T) {
 		Interval: 10,
 	}
 	expectedSerie2 := &metrics.Serie{
-		Name:     "my.metric.name2",
-		Points:   []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
-		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
-		MType:    metrics.APIGaugeType,
-		Interval: 10,
-	}
-	expectedSerie3 := &metrics.Serie{
 		Name:     "my.metric.name3",
 		Points:   []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
 		Tags:     []string{"bar", "foo"},
 		Host:     "metric-hostname",
+		MType:    metrics.APIGaugeType,
+		Interval: 10,
+	}
+	expectedSerie3 := &metrics.Serie{
+		Name:     "my.metric.name2",
+		Points:   []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
+		Tags:     []string{"bar", "foo"},
+		Host:     "default-hostname",
 		MType:    metrics.APIGaugeType,
 		Interval: 10,
 	}
@@ -150,7 +151,7 @@ func TestCounterExpirySeconds(t *testing.T) {
 		Tags:       []string{"foo", "bar"},
 		SampleRate: 1,
 	}
-	contextCounter1 := "my.counter1,bar,foo,"
+	contextCounter1 := generateContextKey(sampleCounter1)
 
 	sampleCounter2 := &metrics.MetricSample{
 		Name:       "my.counter2",
@@ -159,7 +160,7 @@ func TestCounterExpirySeconds(t *testing.T) {
 		Tags:       []string{"foo", "bar"},
 		SampleRate: 1,
 	}
-	contextCounter2 := "my.counter2,bar,foo,"
+	contextCounter2 := generateContextKey(sampleCounter2)
 
 	sampleGauge3 := &metrics.MetricSample{
 		Name:       "my.gauge",

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -8,20 +8,24 @@ package metrics
 import (
 	"math"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	log "github.com/cihub/seelog"
 )
 
+// ContextKey is a non-cryptographic hash unique to a context
+type ContextKey [16]byte
+
 // ContextMetrics stores all the metrics by context key
-type ContextMetrics map[string]Metric
+type ContextMetrics map[ckey.ContextKey]Metric
 
 // MakeContextMetrics returns a new ContextMetrics
 func MakeContextMetrics() ContextMetrics {
-	return ContextMetrics(make(map[string]Metric))
+	return ContextMetrics(make(map[ckey.ContextKey]Metric))
 }
 
 // AddSample add a sample to the current ContextMetrics and initialize a new metrics if needed.
 // TODO: Pass a reference to *MetricSample instead
-func (m ContextMetrics) AddSample(contextKey string, sample *MetricSample, timestamp float64, interval int64) {
+func (m ContextMetrics) AddSample(contextKey ckey.ContextKey, sample *MetricSample, timestamp float64, interval int64) {
 	if math.IsInf(sample.Value, 0) {
 		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
 		return

--- a/pkg/metrics/context_metrics_test.go
+++ b/pkg/metrics/context_metrics_test.go
@@ -11,13 +11,14 @@ import (
 	"testing"
 
 	// 3p
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestContextMetricsGaugeSampling(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 	mSample := MetricSample{
 		Value: 1,
 		Mtype: GaugeType,
@@ -42,7 +43,7 @@ func TestContextMetricsGaugeSampling(t *testing.T) {
 // Important for check metrics aggregation
 func TestContextMetricsGaugeSamplingNoSample(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 	mSample := MetricSample{
 		Value: 1,
 		Mtype: GaugeType,
@@ -61,8 +62,8 @@ func TestContextMetricsGaugeSamplingNoSample(t *testing.T) {
 // No series should be flushed when the samples have values of +Inf/-Inf
 func TestContextMetricsGaugeSamplingInfinity(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey1 := "context_key1"
-	contextKey2 := "context_key2"
+	contextKey1, _ := ckey.Parse("aaffffffffffffffffffffffffffffff")
+	contextKey2, _ := ckey.Parse("bbffffffffffffffffffffffffffffff")
 	mSample1 := MetricSample{
 		Value: math.Inf(1),
 		Mtype: GaugeType,
@@ -83,7 +84,7 @@ func TestContextMetricsGaugeSamplingInfinity(t *testing.T) {
 // Important for check metrics aggregation
 func TestContextMetricsRateSampling(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	metrics.AddSample(contextKey, &MetricSample{Mtype: RateType, Value: 1}, 12340, 10)
 	series := metrics.Flush(12345)
@@ -107,7 +108,7 @@ func TestContextMetricsRateSampling(t *testing.T) {
 
 func TestContextMetricsCountSampling(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	metrics.AddSample(contextKey, &MetricSample{Mtype: CountType, Value: 1}, 12340, 10)
 	metrics.AddSample(contextKey, &MetricSample{Mtype: CountType, Value: 5}, 12345, 10)
@@ -126,7 +127,7 @@ func TestContextMetricsCountSampling(t *testing.T) {
 
 func TestContextMetricsMonotonicCountSampling(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	metrics.AddSample(contextKey, &MetricSample{Mtype: MonotonicCountType, Value: 1}, 12340, 10)
 	metrics.AddSample(contextKey, &MetricSample{Mtype: MonotonicCountType, Value: 5}, 12345, 10)
@@ -145,7 +146,7 @@ func TestContextMetricsMonotonicCountSampling(t *testing.T) {
 
 func TestContextMetricsHistogramSampling(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	metrics.AddSample(contextKey, &MetricSample{Mtype: HistogramType, Value: 1}, 12340, 10)
 	metrics.AddSample(contextKey, &MetricSample{Mtype: HistogramType, Value: 2}, 12342, 10)
@@ -195,7 +196,7 @@ func TestContextMetricsHistogramSampling(t *testing.T) {
 
 func TestContextMetricsHistorateSampling(t *testing.T) {
 	metrics := MakeContextMetrics()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	metrics.AddSample(contextKey, &MetricSample{Mtype: HistorateType, Value: 1}, 12340, 10)
 	metrics.AddSample(contextKey, &MetricSample{Mtype: HistorateType, Value: 2}, 12341, 10)

--- a/pkg/metrics/context_sketch.go
+++ b/pkg/metrics/context_sketch.go
@@ -10,6 +10,7 @@ package metrics
 import (
 	"math"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics/percentile"
 
 	log "github.com/cihub/seelog"
@@ -19,15 +20,15 @@ import (
 // the logic.
 
 // ContextSketch stores the distributions by context key
-type ContextSketch map[string]DistributionMetric
+type ContextSketch map[ckey.ContextKey]DistributionMetric
 
 // MakeContextSketch returns a new ContextSketch
 func MakeContextSketch() ContextSketch {
-	return ContextSketch(make(map[string]DistributionMetric))
+	return ContextSketch(make(map[ckey.ContextKey]DistributionMetric))
 }
 
 // AddSample adds a sample to the ContextSketch
-func (c ContextSketch) AddSample(contextKey string, sample *MetricSample, timestamp float64, interval int64) {
+func (c ContextSketch) AddSample(contextKey ckey.ContextKey, sample *MetricSample, timestamp float64, interval int64) {
 	if math.IsInf(sample.Value, 0) {
 		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
 		return

--- a/pkg/metrics/context_sketch_test.go
+++ b/pkg/metrics/context_sketch_test.go
@@ -9,13 +9,14 @@ import (
 	"math"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics/percentile"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContextSketchSampling(t *testing.T) {
 	ctxSketch := MakeContextSketch()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("aaffffffffffffffffffffffffffffff")
 
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: 1, Mtype: DistributionType}, 1, 10)
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: 5, Mtype: DistributionType}, 3, 10)
@@ -40,7 +41,7 @@ func TestContextSketchSampling(t *testing.T) {
 
 	// KLL
 	ctxSketch = MakeContextSketch()
-	contextKey = "context_key"
+	contextKey, _ = ckey.Parse("bbffffffffffffffffffffffffffffff")
 
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: 1, Mtype: DistributionKType}, 1, 10)
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: 5, Mtype: DistributionKType}, 3, 10)
@@ -62,7 +63,7 @@ func TestContextSketchSampling(t *testing.T) {
 // The sketches ignore sample values of +Inf/-Inf
 func TestContextSketchSamplingInfinity(t *testing.T) {
 	ctxSketch := MakeContextSketch()
-	contextKey := "context_key"
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: math.Inf(1), Mtype: DistributionType}, 1, 10)
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: math.Inf(-1), Mtype: DistributionType}, 2, 10)

--- a/pkg/metrics/percentile/sketch_series.go
+++ b/pkg/metrics/percentile/sketch_series.go
@@ -14,6 +14,7 @@ import (
 	"expvar"
 
 	agentpayload "github.com/DataDog/agent-payload/gogen"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/gogo/protobuf/proto"
 
@@ -54,13 +55,13 @@ func (s SketchType) String() string {
 
 // SketchSeries holds an array of sketches.
 type SketchSeries struct {
-	Name       string     `json:"metric"`
-	Tags       []string   `json:"tags"`
-	Host       string     `json:"host"`
-	Interval   int64      `json:"interval"`
-	Sketches   []Sketch   `json:"sketches"`
-	SketchType SketchType `json:"sketch_type"`
-	ContextKey string     `json:"-"`
+	Name       string          `json:"metric"`
+	Tags       []string        `json:"tags"`
+	Host       string          `json:"host"`
+	Interval   int64           `json:"interval"`
+	Sketches   []Sketch        `json:"sketches"`
+	SketchType SketchType      `json:"sketch_type"`
+	ContextKey ckey.ContextKey `json:"-"`
 }
 
 // SketchSeriesList represents a list of SketchSeries ready to be serialized

--- a/pkg/metrics/percentile/sketch_series_test.go
+++ b/pkg/metrics/percentile/sketch_series_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 )
 
 func createSketchSeries() []*SketchSeries {
@@ -23,8 +25,9 @@ func createSketchSeries() []*SketchSeries {
 		Entries:  []Entry{{V: 10, G: 1, Delta: 0}, {V: 14, G: 3, Delta: 0}, {V: 21, G: 2, Delta: 0}},
 		Incoming: []float64{},
 		Min:      10, Count: 6, Sum: 96, Avg: 16, Max: 21}
+	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 	series := []*SketchSeries{{
-		ContextKey: "test_context",
+		ContextKey: contextKey,
 		Sketches:   []Sketch{{Timestamp: int64(12345), Sketch: sketch1}, {Timestamp: int64(67890), Sketch: sketch2}},
 		Name:       "test.metrics",
 		Host:       "localhost",
@@ -48,22 +51,26 @@ func createMultiSketchSeries() []*SketchSeries {
 		Values: []float64{2, 8},
 		Min:    2, Count: 2, Sum: 10, Avg: 5, Max: 8,
 	}
+	contextKey1, _ := ckey.Parse("aaffffffffffffffffffffffffffffff")
+	contextKey2, _ := ckey.Parse("bbffffffffffffffffffffffffffffff")
+	contextKey3, _ := ckey.Parse("ccffffffffffffffffffffffffffffff")
+
 	series := []*SketchSeries{{
-		ContextKey: "test_context1",
+		ContextKey: contextKey1,
 		Sketches:   []Sketch{{Timestamp: int64(12345), Sketch: sketch1}},
 		Name:       "test.metrics1",
 		Host:       "localhost",
 		Tags:       []string{"tag1", "tag2:yes"},
 		SketchType: SketchGK,
 	}, {
-		ContextKey: "test_context2",
+		ContextKey: contextKey2,
 		Sketches:   []Sketch{{Timestamp: int64(12345), Sketch: sketch2}},
 		Name:       "test.metrics2",
 		Host:       "localhost",
 		Tags:       []string{"tag2:yes"},
 		SketchType: SketchKLL,
 	}, {
-		ContextKey: "test_context3",
+		ContextKey: contextKey3,
 		Sketches:   []Sketch{{Timestamp: int64(12345), Sketch: sketch3}},
 		Name:       "test.metrics3",
 		Host:       "localhost",

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	agentpayload "github.com/DataDog/agent-payload/gogen"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
@@ -34,16 +35,16 @@ func (p *Point) MarshalJSON() ([]byte, error) {
 
 // Serie holds a timeseries (w/ json serialization to DD API format)
 type Serie struct {
-	Name           string        `json:"metric"`
-	Points         []Point       `json:"points"`
-	Tags           []string      `json:"tags"`
-	Host           string        `json:"host"`
-	Device         string        `json:"device,omitempty"` // FIXME(olivier): remove as soon as the v1 API can handle `device` as a regular tag
-	MType          APIMetricType `json:"type"`
-	Interval       int64         `json:"interval"`
-	SourceTypeName string        `json:"source_type_name,omitempty"`
-	ContextKey     string        `json:"-"`
-	NameSuffix     string        `json:"-"`
+	Name           string          `json:"metric"`
+	Points         []Point         `json:"points"`
+	Tags           []string        `json:"tags"`
+	Host           string          `json:"host"`
+	Device         string          `json:"device,omitempty"` // FIXME(olivier): remove as soon as the v1 API can handle `device` as a regular tag
+	MType          APIMetricType   `json:"type"`
+	Interval       int64           `json:"interval"`
+	SourceTypeName string          `json:"source_type_name,omitempty"`
+	ContextKey     ckey.ContextKey `json:"-"`
+	NameSuffix     string          `json:"-"`
 }
 
 // Series represents a list of Serie ready to be serialize

--- a/pkg/metrics/test_helper.go
+++ b/pkg/metrics/test_helper.go
@@ -46,7 +46,7 @@ func AssertSerieEqual(t *testing.T, expected, actual *Serie) {
 	assert.Equal(t, expected.MType, actual.MType)
 	assert.Equal(t, expected.Interval, actual.Interval)
 	assert.Equal(t, expected.SourceTypeName, actual.SourceTypeName)
-	if expected.ContextKey != "" {
+	if !expected.ContextKey.IsZero() {
 		// Only test the contextKey if it's set in the expected Serie
 		assert.Equal(t, expected.ContextKey, actual.ContextKey)
 	}
@@ -64,7 +64,7 @@ func AssertSketchSeriesEqual(t *testing.T, expected, actual *percentile.SketchSe
 	assert.Equal(t, expected.Host, actual.Host)
 	assert.Equal(t, expected.Interval, actual.Interval)
 	assert.Equal(t, expected.SketchType, actual.SketchType)
-	if expected.ContextKey != "" {
+	if !expected.ContextKey.IsZero() {
 		assert.Equal(t, expected.ContextKey, actual.ContextKey)
 	}
 	if expected.Sketches != nil {


### PR DESCRIPTION
### What does this PR do?

Transition aggregator context keys from joined strings to [Murmur3 hashes](https://en.wikipedia.org/wiki/MurmurHash). This allows:
- one more step towards a `zero heap allocation dsd intake` goal for better scalability
- faster intake as the hash computation is ~40% faster than string operations
- (marginally) lower memory requirements

### Changes

#### Use murmur3 128bit hash

This hash has proven reliable in other Datadog projects and has a no-heap implementation. I also benchmarked the 64bit XXHASH64, but gains are not that great to take the risk on a non-battle-tested hash:

```
goos: darwin
goarch: amd64
BenchmarkCurrent-4       3000000	       433 ns/op	     560 B/op	       4 allocs/op
BenchmarkMurmur-4   	 5000000	       302 ns/op	       0 B/op	       0 allocs/op
BenchmarkXXHash-4        5000000	       291 ns/op	       0 B/op	       0 allocs/op
```
I was afraid that using `[16]byte` as map keys would lead to slow lookups, but it's not that's bad:
```
goos: darwin
goarch: amd64
BenchmarkStringLookup-4   	50000000	        23.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkCKeyLookup-4     	50000000	        29.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkInt64Lookup-4    	100000000	16.2 ns/op	       0 B/op	       0 allocs/op
```

Our current implementation computes the contextkey for every lookup, so we can compare the `compute + lookup` cost for the three solutions:

|                | Compute | Lookup | Total | Total (base 100) |
|----------------|---------|--------|-------|----------|
| Current        | 433     | 24     | 457   | 138      |
| Murmur3 128bit | 302     | 30     | 332   | 100      |
| XXHash64 64bit | 291     | 16     | 307   | 92       |

#### Sort tags with in-place selection sort

The current implementation of `sort.Strings` uses [quicksort](https://en.wikipedia.org/wiki/Quicksort), which is fast for medium-to-big arrays, but:
- is slower than [selection sort](https://en.wikipedia.org/wiki/Selection_sort) on small (<20) arrays
- allocates a new list for the result

Selection sort works in-place, which enables 0 heap allocation.

For ContextKey generation, if set the algorithm to use selection sort `if len(tags) < 20`, or fallback to `sort.Strings` for longer arrays (edge case though).

#### Update all user classes and test cases

By moving from `string` to a specific `ckey.ContextKey` type, we can later decide to change the underlying hash size/algorithm without breaking user classes.

### Motivation

Scalability on high data volumes. Local benchmarks show a ~10 % decrease in CPU usage (both from the faster contextkey generation and less GC runs).
