### PR TITLE
[tagger] add caching to entityTags to avoid joining arrays for every lookup

### DIFF
--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -221,10 +221,8 @@ func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
 	if entity == "" {
 		return nil, errors.New("empty entity ID")
 	}
-	cachedTags, sources, err := t.tagStore.lookup(entity, highCard)
-	if err != nil {
-		return nil, err
-	}
+	cachedTags, sources := t.tagStore.lookup(entity, highCard)
+
 	if len(sources) == len(t.fetchers) {
 		// All sources sent data to cache
 		return cachedTags, nil

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -131,7 +131,7 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 	// Cache miss
 	var arrays [][]string
 	var sources []string
-	var lowCardCount int
+	lowCardCount := 0
 
 	for source, tags := range e.lowCardTags {
 		arrays = append(arrays, tags)

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -59,10 +59,8 @@ func (s *StoreTestSuite) TestLookup() {
 		LowCardTags: []string{"tag"},
 	})
 
-	tagsHigh, sourcesHigh, err := s.store.lookup("test", true)
-	assert.Nil(s.T(), err)
-	tagsLow, sourcesLow, err := s.store.lookup("test", false)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh := s.store.lookup("test", true)
+	tagsLow, sourcesLow := s.store.lookup("test", false)
 
 	assert.Len(s.T(), tagsHigh, 3)
 	assert.Len(s.T(), tagsLow, 2)
@@ -77,8 +75,7 @@ func (s *StoreTestSuite) TestLookup() {
 }
 
 func (s *StoreTestSuite) TestLookupNotPresent() {
-	tags, sources, err := s.store.lookup("test", false)
-	assert.Nil(s.T(), err)
+	tags, sources := s.store.lookup("test", false)
 	assert.Nil(s.T(), tags)
 	assert.Nil(s.T(), sources)
 }
@@ -119,12 +116,10 @@ func (s *StoreTestSuite) TestPrune() {
 	s.store.toDeleteMutex.RUnlock()
 
 	// Data should still be in the store
-	tagsHigh, sourcesHigh, err := s.store.lookup("test1", true)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh := s.store.lookup("test1", true)
 	assert.Len(s.T(), tagsHigh, 3)
 	assert.Len(s.T(), sourcesHigh, 2)
-	tagsHigh, sourcesHigh, err = s.store.lookup("test2", true)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh = s.store.lookup("test2", true)
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
 
@@ -136,25 +131,21 @@ func (s *StoreTestSuite) TestPrune() {
 	s.store.toDeleteMutex.RUnlock()
 
 	// test1 should be removed, test2 still present
-	tagsHigh, sourcesHigh, err = s.store.lookup("test1", true)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh = s.store.lookup("test1", true)
 	assert.Nil(s.T(), tagsHigh)
 	assert.Nil(s.T(), sourcesHigh)
-	tagsHigh, sourcesHigh, err = s.store.lookup("test2", true)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh = s.store.lookup("test2", true)
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
 
-	err = s.store.prune()
+	err := s.store.prune()
 	assert.Nil(s.T(), err)
 
 	// No impact if nothing is queued
-	tagsHigh, sourcesHigh, err = s.store.lookup("test1", true)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh = s.store.lookup("test1", true)
 	assert.Nil(s.T(), tagsHigh)
 	assert.Nil(s.T(), sourcesHigh)
-	tagsHigh, sourcesHigh, err = s.store.lookup("test2", true)
-	assert.Nil(s.T(), err)
+	tagsHigh, sourcesHigh = s.store.lookup("test2", true)
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
 


### PR DESCRIPTION
### What does this PR do?

Store the result of tag concatenation from several sources inside the `entityTags` object for reuse in the next lookup. Cache is invalidated in write, and re-computed on the following read.

As we are storing `[]string`s, memory cost is pretty small (references). `cachedLow` is a slice of `cachedAll` (which stores low card tags + high card tags).
### Motivation

Optimise dsd for higher throughputs