### PR TITLE
Add Gitlab steps to push latest docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -346,50 +346,6 @@ build_dogstatsd:
   stage: image_deploy
   script: [ "# noop" ]
 
-agent6_docker_hub:
-  <<: *dind_tag_job_definition
-  when: manual
-  only:
-    - master
-    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
-  variables:
-    DD_DIND_TAG_SOURCE: *agent_ecr
-    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
-    DD_DIND_TAG_DEST: datadog/agent:$CI_COMMIT_TAG
-
-agent6_jmx_docker_hub:
-  <<: *dind_tag_job_definition
-  when: manual
-  only:
-    - master
-    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
-  variables:
-    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
-    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
-    DD_DIND_TAG_DEST: datadog/agent:${CI_COMMIT_TAG}-jmx
-
-agent6_docker_hub_latest:
-  <<: *dind_tag_job_definition
-  when: manual
-  only:
-    - master
-    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
-  variables:
-    DD_DIND_TAG_SOURCE: *agent_ecr
-    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
-    DD_DIND_TAG_DEST: datadog/agent:latest
-
-agent6_jmx_docker_hub_latest:
-  <<: *dind_tag_job_definition
-  when: manual
-  only:
-    - master
-    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
-  variables:
-    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
-    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
-    DD_DIND_TAG_DEST: datadog/agent:latest-jmx
-
 agent6_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual
@@ -427,28 +383,6 @@ agent6_jmx_dev_docker_hub_master:
     DD_DIND_TAG_SOURCE: *agent_jmx_ecr
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
-
-dogstatsd_docker_hub:
-  <<: *dind_tag_job_definition
-  when: manual
-  only:
-    - master
-    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
-  variables:
-    DD_DIND_TAG_SOURCE: *dogstatsd_ecr
-    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
-    DD_DIND_TAG_DEST: datadog/dogstatsd:$CI_COMMIT_TAG
-
-dogstatsd_docker_hub_latest:
-  <<: *dind_tag_job_definition
-  when: manual
-  only:
-    - master
-    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
-  variables:
-    DD_DIND_TAG_SOURCE: *dogstatsd_ecr
-    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
-    DD_DIND_TAG_DEST: datadog/dogstatsd:latest
 
 dogstatsd_dev_docker_hub:
   <<: *dind_tag_job_definition
@@ -571,3 +505,75 @@ deploy_dsd:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
     - export VERSION=$(inv version)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+
+tag_push_agent:
+  <<: *dind_tag_job_definition
+  stage: deploy
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:$CI_COMMIT_TAG
+
+tag_jmx_push_agent:
+  <<: *dind_tag_job_definition
+  stage: deploy
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:${CI_COMMIT_TAG}-jmx
+
+latest_push_agent:
+  <<: *dind_tag_job_definition
+  stage: deploy
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:latest
+
+latest_jmx_push_agent:
+  <<: *dind_tag_job_definition
+  stage: deploy
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:latest-jmx
+
+tag_dsd_push:
+  <<: *dind_tag_job_definition
+  stage: deploy
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *dogstatsd_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/dogstatsd:$CI_COMMIT_TAG
+
+latest_dsd_push:
+  <<: *dind_tag_job_definition
+  stage: deploy
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *dogstatsd_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/dogstatsd:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,6 +368,28 @@ agent6_jmx_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/agent:${CI_COMMIT_TAG}-jmx
 
+agent6_docker_hub_latest:
+  <<: *dind_tag_job_definition
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:latest
+
+agent6_jmx_docker_hub_latest:
+  <<: *dind_tag_job_definition
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *agent_jmx_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/agent:latest-jmx
+
 agent6_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -439,6 +439,17 @@ dogstatsd_docker_hub:
     DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
     DD_DIND_TAG_DEST: datadog/dogstatsd:$CI_COMMIT_TAG
 
+dogstatsd_docker_hub_latest:
+  <<: *dind_tag_job_definition
+  when: manual
+  only:
+    - master
+    - tags # FIXME see https://gitlab.com/gitlab-org/gitlab-ce/issues/37397
+  variables:
+    DD_DIND_TAG_SOURCE: *dogstatsd_ecr
+    DD_DIND_DEST_REGISTRY_TYPE: DOCKER_HUB
+    DD_DIND_TAG_DEST: datadog/dogstatsd:latest
+
 dogstatsd_dev_docker_hub:
   <<: *dind_tag_job_definition
   when: manual


### PR DESCRIPTION
### What does this PR do?

- Adds two steps to manually push latest and latest-jmx tags to docker hub
- Adds a step to manually push latest to docker hub for dogstatsd
- Re-organize steps to move the public pushes to the `deploy` stage.

### Motivation

We should provide a latest tag for people who want to follow upgrades closely.
Plus the default pull fails without a latest tag in the repo.

### Additional Notes

Until the first stable release this tag will follow betas. Once we have a first stable release it will follow those.

Also fixes #949 
