### PR TITLE
 put the collector/py package behind the cpython tag 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,9 @@ jobs:
       - run:
           name: build puppy
           command: inv agent.build --puppy
+      - run:
+          name: test puppy
+          command: ./bin/agent/agent -c ./bin/agent/dist check cpu
 
 workflows:
   version: 2

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -1,3 +1,5 @@
+// +build cpython
+
 #include "api.h"
 
 PyObject* SubmitMetric(PyObject*, char*, MetricType, char*, float, PyObject*, char*);

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -1,3 +1,5 @@
+// +build cpython
+
 #ifndef _PY_API_H
 #define _PY_API_H
 

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 // NOTICE: See TestMain function in `utils_test.go` for Python initialization
 package py
 

--- a/pkg/collector/py/config.go
+++ b/pkg/collector/py/config.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/config_test.go
+++ b/pkg/collector/py/config_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 // NOTICE: See TestMain function in `utils_test.go` for Python initialization
 package py
 

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -1,3 +1,5 @@
+// +build cpython
+
 #include "datadog_agent.h"
 
 // Functions

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/datadog_agent.h
+++ b/pkg/collector/py/datadog_agent.h
@@ -1,3 +1,5 @@
+// +build cpython
+
 #ifndef DATADOG_HEADER
 #define DATADOG_HEADER
 

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/loader_test.go
+++ b/pkg/collector/py/loader_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 // NOTICE: See TestMain function in `utils_test.go` for Python initialization
 package py
 

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/py_test.go
+++ b/pkg/collector/py/py_test.go
@@ -1,3 +1,5 @@
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (
@@ -39,21 +41,6 @@ import "C"
 type stickyLock struct {
 	gstate python.PyGILState
 	locked uint32 // Flag set to 1 if the lock is locked, 0 otherwise
-}
-
-//PythonStatsEntry are entries for specific object type memory usage
-type PythonStatsEntry struct {
-	Reference string
-	NObjects  int
-	Size      int
-}
-
-//PythonStats contains python memory statistics
-type PythonStats struct {
-	Type     string
-	NObjects int
-	Size     int
-	Entries  []*PythonStatsEntry
 }
 
 const (

--- a/pkg/collector/py/utils_common.go
+++ b/pkg/collector/py/utils_common.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package py
+
+//PythonStatsEntry are entries for specific object type memory usage
+type PythonStatsEntry struct {
+	Reference string
+	NObjects  int
+	Size      int
+}
+
+//PythonStats contains python memory statistics
+type PythonStats struct {
+	Type     string
+	NObjects int
+	Size     int
+	Entries  []*PythonStatsEntry
+}

--- a/pkg/collector/py/utils_nocpython.go
+++ b/pkg/collector/py/utils_nocpython.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build !cpython
+
+package py
+
+import (
+	"errors"
+)
+
+// ErrNotCompiled is returned by methods when cpython is not compiled in
+var ErrNotCompiled = errors.New("cpython is not compiled in")
+
+// GetPythonInterpreterMemoryUsage stub when cpython is not compiled in
+func GetPythonInterpreterMemoryUsage() ([]*PythonStats, error) {
+	return nil, ErrNotCompiled
+}

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build cpython
+
 package py
 
 import (


### PR DESCRIPTION
### What does this PR do?

- Put the `collector/py` package behind the `cpython` tag to restore puppy agent
- Add an `agent check cpu` run in the puppy build stage to make sure puppy can run
