### PR TITLE
[Testing] multirunner testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,26 +41,49 @@ before_script:
 
 
 # run tests for deb-x64
-run_tests_deb-x64:
+run_tests_deb_pkg_0-x64:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --coverage
+    - inv -e test --coverage --number=0
 
-# run tests for rpm-x64
-run_test_rpm-x64:
+# run tests for deb-x64
+run_tests_deb_pkg_1-x64:
   stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --coverage
+    - inv -e test --coverage --number=1
+
+# run tests for deb-x64
+run_tests_deb_pkg_2-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --coverage --number=2
+
+# run tests for deb-x64
+run_tests_deb_pkg_3-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --coverage --number=3
+
+# run tests for deb-x64
+run_tests_deb_others-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --coverage --targets=./test,./cmd
 
 
 #
 # binary_build
 #
-
 
 # build dogstatsd static for deb-x64
 build_dogstatsd_static-deb_x64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,14 +72,6 @@ run_tests_deb_pkg_3-x64:
   script:
     - inv -e test --coverage --number=3
 
-# run tests for deb-x64
-run_tests_deb_others-x64:
-  stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e test --coverage --targets=./test,./cmd
-
 
 #
 # binary_build

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -33,7 +33,7 @@ DEFAULT_TEST_TARGETS = [
 
 
 @task()
-def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False, fail_on_fmt=False):
+def test(ctx, targets=None, number=None, max_number=3, coverage=False, race=False, use_embedded_libs=False, fail_on_fmt=False):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -50,6 +50,22 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
         test_targets = DEFAULT_TEST_TARGETS
     else:
         tool_targets = test_targets = targets
+
+
+    if number is not None:
+        number = int(number)
+        max_number = int(max_number)
+        directories = []
+        idx = 0
+        for f in os.listdir("./pkg"):
+            if idx % max_number == number:
+                if os.path.isdir(os.path.join("./pkg", f)):
+                    directories.append(os.path.join("./pkg", f))
+            idx += 1
+
+        tool_targets = test_targets = directories
+
+        print(directories)
 
     build_tags = get_default_build_tags()
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -65,7 +65,8 @@ def test(ctx, targets=None, number=None, max_number=3, coverage=False, race=Fals
 
         tool_targets = test_targets = directories
 
-        print(directories)
+        if number == 0:
+            tool_targets += "./cmd"
 
     build_tags = get_default_build_tags()
 


### PR DESCRIPTION
### What does this PR do?

Running the same tests twice does not seem to be useful any longer. We should only run the tests twice if we need to. This divides up the tests between multiple runners, so we can take advantage of the concurrency.

### Motivation

The tests now take a long time to run, so this was something we should do anyway.

### Additional Notes

Not sure this is a great idea, open to suggestions about it