### PR TITLE
Prevent logs-agent from stopping when some integration files are misconfigured

### DIFF
--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAvailableIntegrationConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	assert.Equal(t, []string{"integration.yaml", "integration2.yaml", "integration.d/integration3.yaml"}, availableIntegrationConfigs(ddconfdPath))
+	assert.Equal(t, []string{"integration.yaml", "integration2.yaml", "misconfigured_integration.yaml", "integration.d/integration3.yaml"}, availableIntegrationConfigs(ddconfdPath))
 }
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {

--- a/pkg/logs/config/tests/complete/conf.d/misconfigured_integration.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/misconfigured_integration.yaml
@@ -1,0 +1,8 @@
+init_config:
+
+instances:
+  - whatever: anything
+
+logs:
+  - type: udp
+    logset: devteam


### PR DESCRIPTION
Prevent logs-agent from stopping when some integration files are misconfigured but there is at least one well configured.

### What does this PR do?

Updated the integration configuration files parser to just log `errors` when an issue is encountered instead of returning them. Yet, if there is no integration file well configured, we still stop logs-agent.

### Motivation

Keep collecting logs from other sources.
