### PR TITLE
[dogstatsd] Log packet contents with `trace` level

### DIFF
--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -172,7 +172,7 @@ func (s *checkSender) SendRawMetricSample(sample *metrics.MetricSample) {
 }
 
 func (s *checkSender) sendMetricSample(metric string, value float64, hostname string, tags []string, mType metrics.MetricType) {
-	log.Debug(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+	log.Trace(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
 
 	metricSample := &metrics.MetricSample{
 		Name:       metric,
@@ -238,7 +238,7 @@ func (s *checkSender) SendRawServiceCheck(sc *metrics.ServiceCheck) {
 
 // ServiceCheck submits a service check
 func (s *checkSender) ServiceCheck(checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string) {
-	log.Debug("Service check submitted: ", checkName, ": ", status.String(), " for hostname: ", hostname, " tags: ", tags)
+	log.Trace("Service check submitted: ", checkName, ": ", status.String(), " for hostname: ", hostname, " tags: ", tags)
 	serviceCheck := metrics.ServiceCheck{
 		CheckName: checkName,
 		Status:    status,
@@ -257,7 +257,7 @@ func (s *checkSender) ServiceCheck(checkName string, status metrics.ServiceCheck
 
 // Event submits an event
 func (s *checkSender) Event(e metrics.Event) {
-	log.Debug("Event submitted: ", e.Title, " for hostname: ", e.Host, " tags: ", e.Tags)
+	log.Trace("Event submitted: ", e.Title, " for hostname: ", e.Host, " tags: ", e.Tags)
 
 	s.eventOut <- e
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -120,14 +120,14 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 
 		if packet.Origin != listeners.NoOrigin {
 			var err error
-			log.Debugf("dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
+			log.Tracef("dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
 			originTags, err = tagger.Tag(packet.Origin, false)
 			if err != nil {
 				log.Errorf(err.Error())
 			}
-			log.Debugf("tags for %s: %s", packet.Origin, originTags)
+			log.Tracef("tags for %s: %s", packet.Origin, originTags)
 		} else {
-			log.Debugf("dogstatsd receive: %s", packet.Contents)
+			log.Tracef("dogstatsd receive: %s", packet.Contents)
 		}
 
 		for {


### PR DESCRIPTION
### What does this PR do?

Lowers log level of packet logging in dogstatsd to `trace`.

### Motivation

Logging so much stuff with the `debug`-level in the hot loop of dogstatsd:

- makes the logs extremely verbose
- has a significant performance impact (typically, on a reasonably busy node dogstatsd-wise I found on prod, the agent can spend 10% of its CPU time in the logging library).

as soon as dogstatsd receives a significant amount of packets

### Additional Notes

Ideally I'd like to remove these entries altogether (I don't see any point in logging the contents of every packet, dogstatsd is stable enough now)

### Update

Did the same thing for the sample logging in the aggregator