### PR TITLE
[kube] scaffold apiserver package and add config option

### DIFF
--- a/pkg/collector/corechecks/containers/kubernetes_events.go
+++ b/pkg/collector/corechecks/containers/kubernetes_events.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package containers
+
+import (
+	_ "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,10 @@ func init() {
 	// Kubernetes
 	Datadog.SetDefault("kubernetes_http_kubelet_port", 10255)
 	Datadog.SetDefault("kubernetes_https_kubelet_port", 10250)
+
+	// Kube ApiServer
+	Datadog.SetDefault("kubernetes_kubeconfig_path", "")
+
 	// ECS
 	Datadog.SetDefault("ecs_agent_url", "") // Will be autodetected
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,12 +177,14 @@ func init() {
 	Datadog.BindEnv("kubernetes_kubelet_host")
 	Datadog.BindEnv("kubernetes_http_kubelet_port")
 	Datadog.BindEnv("kubernetes_https_kubelet_port")
+
 	Datadog.BindEnv("forwarder_timeout")
 	Datadog.BindEnv("forwarder_retry_queue_max_size")
 	Datadog.BindEnv("cloud_foundry")
 	Datadog.BindEnv("bosh_id")
 	Datadog.BindEnv("histogram_aggregates")
 	Datadog.BindEnv("histogram_percentiles")
+	Datadog.BindEnv("kubernetes_kubeconfig_path")
 
 	// Logs
 	BindEnvAndSetDefault("log_enabled", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -276,7 +276,20 @@ metadata_collectors:
 #
 # URL where the ECS agent can be found. Standard cases will be autodetected.
 # ecs_agent_url: http://localhost:51678
+#
 {{ end -}}
+{{- if .KubeApiServer }}
+# Kubernetes apiserver integration
+#
+# When running in a pod, the agent will automatically use the pod's serviceaccount
+# to authenticate with the apiserver. If you wish to install the agent out of a pod
+# or customise connection parameters, you can provide the path to a KubeConfig file
+# see https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
+#
+# kubernetes_kubeconfig_path: /path/to/file
+#
+{{ end -}}
+
 {{- if .ProcessAgent }}
 # Process agent specific settings
 #

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -29,6 +29,7 @@ type context struct {
 	KubernetesTagging bool
 	ECS               bool
 	ProcessAgent      bool
+	KubeApiServer     bool
 }
 
 func mkContext(buildType string) context {
@@ -58,6 +59,12 @@ func mkContext(buildType string) context {
 			Logging:           true,
 			KubernetesTagging: true,
 			ECS:               true,
+		}
+	case "dca":
+		return context{
+			Common:        true,
+			Logging:       true,
+			KubeApiServer: true,
 		}
 	}
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -3,28 +3,91 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build kubeapiserver
+
 package apiserver
 
 import (
 	"context"
-	"fmt"
+	"io/ioutil"
+	"time"
 
+	log "github.com/cihub/seelog"
 	"github.com/ericchiang/k8s"
-	"github.com/ericchiang/k8s/api/v1"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
-// GetGlobalPodList returns the list of pods running on the cluster where this pod is running
-// This function queries the API server which could put heavy load on it so use with caution
-func GetGlobalPodList() ([]*v1.Pod, error) {
-	client, err := k8s.NewInClusterClient()
+var globalApiClient *ApiClient
+
+// ApiClient provides authenticated access to the
+// apiserver endpoints. Use the shared instance via GetApiClient.
+type ApiClient struct {
+	retry.Retrier
+	client *k8s.Client
+}
+
+// GetApiClient returns the shared ApiClient instance.
+func GetApiClient() (*ApiClient, error) {
+
+	if globalApiClient == nil {
+		globalApiClient = &ApiClient{}
+		globalApiClient.SetupRetrier(&retry.Config{
+			Name:          "apiserver",
+			AttemptMethod: globalApiClient.connect,
+			Strategy:      retry.RetryCount,
+			RetryCount:    10,
+			RetryDelay:    30 * time.Second,
+		})
+	}
+	err := globalApiClient.TriggerRetry()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get client: %s", err)
+		log.Debugf("init error: %s", err)
+		return nil, err
+	}
+	return globalApiClient, nil
+}
+
+func (c *ApiClient) connect() error {
+	if c.client == nil {
+		var err error
+		cfgPath := config.Datadog.GetString("kubernetes_kubeconfig_path")
+		if cfgPath == "" {
+			// Autoconfiguration
+			log.Debugf("using autoconfiguration")
+			c.client, err = k8s.NewInClusterClient()
+		} else {
+			// Kubeconfig provided by conf
+			log.Debugf("using credentials from %s", cfgPath)
+			var config *k8s.Config
+			config, err = parseKubeConfig(cfgPath)
+			if err != nil {
+				return err
+			}
+			c.client, err = k8s.NewClient(config)
+		}
+		if err != nil {
+			return err
+		}
 	}
 
-	pods, err := client.CoreV1().ListPods(context.Background(), "")
+	// Try to get apiserver version to confim connectivity
+	version, err := c.client.Discovery().Version(context.TODO())
+	if err == nil {
+		log.Debugf("connected to apiserver, version %s", version.GitVersion)
+	}
+	return err
+}
+
+func parseKubeConfig(fpath string) (*k8s.Config, error) {
+	yamlFile, err := ioutil.ReadFile(fpath)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get pods: %s", err)
+		return nil, err
 	}
 
-	return pods.GetItems(), nil
+	config := &k8s.Config{}
+	err = yaml.Unmarshal(yamlFile, config)
+	return config, err
 }

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -20,20 +20,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
-var globalApiClient *ApiClient
+var globalApiClient *APIClient
 
 // ApiClient provides authenticated access to the
 // apiserver endpoints. Use the shared instance via GetApiClient.
-type ApiClient struct {
+type APIClient struct {
 	retry.Retrier
 	client *k8s.Client
 }
 
-// GetApiClient returns the shared ApiClient instance.
-func GetApiClient() (*ApiClient, error) {
+// GetAPIClient returns the shared ApiClient instance.
+func GetAPIClient() (*APIClient, error) {
 
 	if globalApiClient == nil {
-		globalApiClient = &ApiClient{}
+		globalApiClient = &APIClient{}
 		globalApiClient.SetupRetrier(&retry.Config{
 			Name:          "apiserver",
 			AttemptMethod: globalApiClient.connect,
@@ -50,7 +50,7 @@ func GetApiClient() (*ApiClient, error) {
 	return globalApiClient, nil
 }
 
-func (c *ApiClient) connect() error {
+func (c *APIClient) connect() error {
 	if c.client == nil {
 		var err error
 		cfgPath := config.Datadog.GetString("kubernetes_kubeconfig_path")

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -17,7 +17,7 @@ var (
 	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
 )
 
-// GetApiClient returns the shared ApiClient instance.
-func GetApiClient() (*ApiClient, error) {
+// GetAPIClient returns the shared ApiClient instance.
+func GetAPIClient() (*ApiClient, error) {
 	return nil, ErrNotCompiled
 }

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build !kubeapiserver
+
+package apiserver
+
+import (
+	"errors"
+)
+
+var (
+	// ErrNotCompiled is returned if kubernetes apiserver support is not compiled in.
+	// User classes should handle that case as gracefully as possible.
+	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
+)
+
+// GetApiClient returns the shared ApiClient instance.
+func GetApiClient() (*ApiClient, error) {
+	return nil, ErrNotCompiled
+}

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -16,8 +16,3 @@ var (
 	// User classes should handle that case as gracefully as possible.
 	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
 )
-
-// GetAPIClient returns the shared ApiClient instance.
-func GetAPIClient() (*ApiClient, error) {
-	return nil, ErrNotCompiled
-}

--- a/pkg/util/kubernetes/apiserver/diagnosis.go
+++ b/pkg/util/kubernetes/apiserver/diagnosis.go
@@ -3,21 +3,23 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017 Datadog, Inc.
 
+// +build kubeapiserver
+
 package apiserver
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	log "github.com/cihub/seelog"
-	"github.com/ericchiang/k8s"
+
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 )
 
 func init() {
-	diagnosis.Register("K8s API Server availability", diagnose)
+	diagnosis.Register("Kubernetes API Server availability", diagnose)
 }
 
-// diagnosee the API server availability
+// diagnose the API server availability
 func diagnose() error {
-	_, err := k8s.NewInClusterClient()
+	_, err := GetApiClient()
 	if err != nil {
 		log.Error(err)
 	}

--- a/pkg/util/kubernetes/apiserver/diagnosis.go
+++ b/pkg/util/kubernetes/apiserver/diagnosis.go
@@ -19,7 +19,7 @@ func init() {
 
 // diagnose the API server availability
 func diagnose() error {
-	_, err := GetApiClient()
+	_, err := GetAPIClient()
 	if err != nil {
 		log.Error(err)
 	}

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -19,6 +19,22 @@ from .go import deps
 #constants
 BIN_PATH = os.path.join(".", "bin", "agent")
 AGENT_TAG = "datadog/agent:master"
+DEFAULT_BUILD_TAGS = [
+    "apm",
+    "consul",
+    "cpython",
+    "docker",
+    "ec2",
+    "etcd",
+    "gce",
+    "jmx",
+    "kubelet",
+    "log",
+    "process",
+    "snmp",
+    "zk",
+    "zlib",
+]
 
 
 @task
@@ -32,7 +48,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     Example invokation:
         inv agent.build --build-exclude=snmp
     """
-    build_include = ALL_TAGS if build_include is None else build_include.split(",")
+    build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     env = {
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -20,6 +20,7 @@ ALL_TAGS = set([
     "snmp",
     "zk",
     "zlib",
+    "kubeapiserver",
 ])
 
 # PUPPY_TAGS lists the tags needed when building the Puppy Agent
@@ -36,7 +37,7 @@ def get_default_build_tags(puppy=False):
         return PUPPY_TAGS
 
     include = ["all"]
-    exclude = ["docker", "kubelet"] if invoke.platform.WINDOWS else []
+    exclude = ["docker", "kubelet", "kubeapiserver"] if invoke.platform.WINDOWS else []
     return get_build_tags(include, exclude)
 
 


### PR DESCRIPTION
### What does this PR do?

Scaffold the `kubernetes/apiserver` package and add the `kubeapiserver` build tag, not used by the agent. This build tag will be used by the DCA.
