### PR TITLE
[omnibus][macOS] Allow building without signature

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -67,7 +67,9 @@ end
 # OSX .pkg specific flags
 package :pkg do
   identifier 'com.datadoghq.agent'
-  signing_identity 'Developer ID Installer: Datadog, Inc. (JKFCB4CN7C)'
+  unless ENV['SKIP_SIGN_MAC'] == 'true'
+    signing_identity 'Developer ID Installer: Datadog, Inc. (JKFCB4CN7C)'
+  end
 end
 compress :dmg do
   window_bounds '200, 200, 750, 600'

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -180,9 +180,9 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
         ctx.run("{} {}".format(go_cmd, prefix))
 
 
-@task
+@task(help={'skip-sign': "On macOS, use this option to build an unsigned package if you don't have Datadog's developer keys."})
 def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=None,
-                  skip_deps=False):
+                  skip_deps=False, skip_sign=False):
     """
     Build the Agent packages with Omnibus Installer.
     """
@@ -206,6 +206,7 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
         if gem_path:
             cmd += " --path {}".format(gem_path)
         ctx.run(cmd)
+
         omnibus = "bundle exec omnibus.bat" if invoke.platform.WINDOWS else "bundle exec omnibus"
         cmd = "{omnibus} build {project_name} --log-level={log_level} {overrides}"
         args = {
@@ -214,7 +215,10 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
             "log_level": log_level,
             "overrides": overrides_cmd
         }
-        ctx.run(cmd.format(**args))
+        env = {}
+        if skip_sign:
+            env['SKIP_SIGN_MAC'] = 'true'
+        ctx.run(cmd.format(**args), env=env)
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Allows building macOS pkg without Datadog's developer signature.

Can be selected with additional `--skip-sign` option to the agent's omnibus build.

### Motivation

Allowing contributors to build the macOS package.

### Additional Notes

The default is still to require the signature to avoid mistakes when building actual release packages.

cc @CharlyF: you may want to implement the same logic for the DCA build.