### PR TITLE
[LOGS] Added a wildcard support on file paths in integration files for logs-agent

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -35,7 +35,8 @@ func Start() {
 	l := listener.New(config.GetLogsSources(), pp)
 	l.Start()
 
-	s := tailer.New(config.GetLogsSources(), pp, a)
+	tailingLimit := config.LogsAgent.GetInt("log_open_files_limit")
+	s := tailer.New(config.GetLogsSources(), tailingLimit, pp, a)
 	s.Start()
 
 	c := container.New(config.GetLogsSources(), pp, a)

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -25,8 +25,10 @@ func BuildLogsAgentConfig(ddconfigPath, ddconfdPath string) error {
 }
 
 func buildMainConfig(config *viper.Viper, ddconfigPath, ddconfdPath string) error {
-
 	config.SetConfigFile(ddconfigPath)
+
+	// default values
+	config.SetDefault("log_open_files_limit", DefaultTailingLimit)
 
 	err := config.ReadInConfig()
 	if err != nil {

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -31,6 +31,7 @@ func TestBuildConfigWithCompleteFile(t *testing.T) {
 	assert.Equal(t, 10516, testConfig.GetInt("log_dd_port"))
 	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
 	assert.Equal(t, true, testConfig.GetBool("log_enabled"))
+	assert.Equal(t, 123, testConfig.GetInt("log_open_files_limit"))
 }
 
 func TestDDConfigDefaultValues(t *testing.T) {
@@ -44,6 +45,7 @@ func TestDDConfigDefaultValues(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "incomplete", "conf.d")
 	buildMainConfig(ddconfig.Datadog, ddconfigPath, ddconfdPath)
 	assert.Equal(t, hostname, ddconfig.Datadog.GetString("hostname"))
+	assert.Equal(t, 100, ddconfig.Datadog.GetInt("log_open_files_limit"))
 }
 
 func TestComputeConfigWithMisconfiguredFile(t *testing.T) {

--- a/pkg/logs/config/constants.go
+++ b/pkg/logs/config/constants.go
@@ -11,6 +11,11 @@ const (
 	NumberOfPipelines = int32(4)
 )
 
+// Default open files limit
+const (
+	DefaultTailingLimit = 100
+)
+
 // Date and time format
 const (
 	DateFormat = "2006-01-02T15:04:05.000000000Z"

--- a/pkg/logs/config/tests/complete/datadog_test.yaml
+++ b/pkg/logs/config/tests/complete/datadog_test.yaml
@@ -5,3 +5,4 @@ logset: playground
 api_key: "helloworld"
 hostname: "my.host"
 log_enabled: true
+log_open_files_limit: 123

--- a/pkg/logs/input/tailer/file_provider.go
+++ b/pkg/logs/input/tailer/file_provider.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build !windows
+
+package tailer
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+)
+
+// File represents a file to tail
+type File struct {
+	Path   string
+	Source *config.IntegrationConfigLogSource
+}
+
+// NewFile returns a new File
+func NewFile(path string, source *config.IntegrationConfigLogSource) *File {
+	return &File{
+		Path:   path,
+		Source: source,
+	}
+}
+
+// FileProvider implements the logic to retrieve at most filesLimit Files defined in sources
+type FileProvider struct {
+	sources    []*config.IntegrationConfigLogSource
+	filesLimit int
+}
+
+// NewFileProvider returns a new FileProvider
+func NewFileProvider(sources []*config.IntegrationConfigLogSource, filesLimit int) *FileProvider {
+	return &FileProvider{
+		sources:    sources,
+		filesLimit: filesLimit,
+	}
+}
+
+// FilesToTail returns all the Files matching paths in sources,
+// it cannot return more than filesLimit Files.
+// For now, there is no way to prioritize specific Files over others,
+// they are just returned in alphabetical order
+func (r *FileProvider) FilesToTail() []*File {
+	filesToTail := []*File{}
+	for _, source := range r.sources {
+		// search all files matching pattern and append them all until filesLimit is reached
+		pattern := source.Path
+		paths, err := filepath.Glob(pattern)
+		if err != nil {
+			log.Println("Malformed pattern, could not find any file:", pattern)
+			continue
+		}
+		for _, path := range paths {
+			if len(filesToTail) == r.filesLimit {
+				log.Println("Reached the limit on the maximum number of files in use:", r.filesLimit)
+				return filesToTail
+			}
+			filesToTail = append(filesToTail, NewFile(path, source))
+		}
+	}
+	return filesToTail
+}

--- a/pkg/logs/input/tailer/file_provider_test.go
+++ b/pkg/logs/input/tailer/file_provider_test.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build !windows
+
+package tailer
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+)
+
+type FileProviderTestSuite struct {
+	suite.Suite
+	testDir    string
+	filesLimit int
+}
+
+// newFileProvider returns a new FileProvider initialized with the right configuration
+func (suite *FileProviderTestSuite) newFileProvider(path string) *FileProvider {
+	sources := []*config.IntegrationConfigLogSource{{Type: config.FileType, Path: path}}
+	return NewFileProvider(sources, suite.filesLimit)
+}
+
+func (suite *FileProviderTestSuite) SetupTest() {
+	suite.filesLimit = 3
+
+	// Create temporary directory
+	var err error
+	suite.testDir, err = ioutil.TempDir("", "log-file_provider-test-")
+	suite.Nil(err)
+
+	// Create directory tree:
+	path := fmt.Sprintf("%s/1", suite.testDir)
+	err = os.Mkdir(path, os.ModePerm)
+	suite.Nil(err)
+
+	path = fmt.Sprintf("%s/1/1.log", suite.testDir)
+	_, err = os.Create(path)
+	suite.Nil(err)
+
+	path = fmt.Sprintf("%s/1/2.log", suite.testDir)
+	_, err = os.Create(path)
+	suite.Nil(err)
+
+	path = fmt.Sprintf("%s/2", suite.testDir)
+	err = os.Mkdir(path, os.ModePerm)
+	suite.Nil(err)
+
+	path = fmt.Sprintf("%s/2/1.log", suite.testDir)
+	_, err = os.Create(path)
+	suite.Nil(err)
+
+	path = fmt.Sprintf("%s/2/2.log", suite.testDir)
+	_, err = os.Create(path)
+	suite.Nil(err)
+}
+
+func (suite *FileProviderTestSuite) TearDownTest() {
+	os.Remove(suite.testDir)
+}
+
+func (suite *FileProviderTestSuite) TestFilesToTailReturnSpecificFile() {
+	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
+	fileProvider := suite.newFileProvider(path)
+	files := fileProvider.FilesToTail()
+
+	suite.Equal(len(files), 1)
+	suite.Equal(files[0].Path, fmt.Sprintf("%s/1/1.log", suite.testDir))
+}
+
+func (suite *FileProviderTestSuite) TestFilesToTailReturnAllFilesInDirectory() {
+	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
+	fileProvider := suite.newFileProvider(path)
+	files := fileProvider.FilesToTail()
+
+	suite.Equal(len(files), 2)
+	suite.Equal(files[0].Path, fmt.Sprintf("%s/1/1.log", suite.testDir))
+	suite.Equal(files[1].Path, fmt.Sprintf("%s/1/2.log", suite.testDir))
+}
+
+func (suite *FileProviderTestSuite) TestFilesToTailReturnAllFilesInAnyDirectory() {
+	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
+	fileProvider := suite.newFileProvider(path)
+	files := fileProvider.FilesToTail()
+
+	suite.Equal(len(files), 2)
+	suite.Equal(files[0].Path, fmt.Sprintf("%s/1/1.log", suite.testDir))
+	suite.Equal(files[1].Path, fmt.Sprintf("%s/2/1.log", suite.testDir))
+}
+
+func (suite *FileProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
+	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
+	fileProvider := suite.newFileProvider(path)
+	files := fileProvider.FilesToTail()
+
+	suite.Equal(len(files), suite.filesLimit)
+}
+
+func TestFileProviderTestSuite(t *testing.T) {
+	suite.Run(t, new(FileProviderTestSuite))
+}

--- a/pkg/logs/input/tailer/scanner.go
+++ b/pkg/logs/input/tailer/scanner.go
@@ -19,18 +19,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 )
 
+// scanPeriod represents the period of scanning
 const scanPeriod = 10 * time.Second
 
-// Scanner checks all files metadata and updates its tailers if needed
+// Scanner checks all files provided by fileProvider and create new tailers
+// or update the old ones if needed
 type Scanner struct {
-	sources []*config.IntegrationConfigLogSource
-	pp      pipeline.Provider
-	tailers map[string]*Tailer
-	auditor *auditor.Auditor
+	pp           pipeline.Provider
+	tailingLimit int
+	fileProvider *FileProvider
+	tailers      map[string]*Tailer
+	auditor      *auditor.Auditor
 }
 
 // New returns an initialized Scanner
-func New(sources []*config.IntegrationConfigLogSource, pp pipeline.Provider, auditor *auditor.Auditor) *Scanner {
+func New(sources []*config.IntegrationConfigLogSource, tailingLimit int, pp pipeline.Provider, auditor *auditor.Auditor) *Scanner {
 	tailSources := []*config.IntegrationConfigLogSource{}
 	for _, source := range sources {
 		switch source.Type {
@@ -40,27 +43,32 @@ func New(sources []*config.IntegrationConfigLogSource, pp pipeline.Provider, aud
 		}
 	}
 	return &Scanner{
-		sources: tailSources,
-		pp:      pp,
-		tailers: make(map[string]*Tailer),
-		auditor: auditor,
+		pp:           pp,
+		tailingLimit: tailingLimit,
+		fileProvider: NewFileProvider(tailSources, tailingLimit),
+		tailers:      make(map[string]*Tailer),
+		auditor:      auditor,
 	}
 }
 
 // setup sets all tailers
 func (s *Scanner) setup() {
-	for _, source := range s.sources {
-		if _, ok := s.tailers[source.Path]; ok {
-			log.Println("Can't tail file twice:", source.Path)
+	files := s.fileProvider.FilesToTail()
+	for _, file := range files {
+		if len(s.tailers) == s.tailingLimit {
+			return
+		}
+		if _, ok := s.tailers[file.Path]; ok {
+			log.Println("Can't tail file twice:", file.Path)
 		} else {
-			s.setupTailer(source, false, s.pp.NextPipelineChan())
+			s.setupTailer(file, false, s.pp.NextPipelineChan())
 		}
 	}
 }
 
 // setupTailer sets one tailer, making it tail from the beginning or the end
-func (s *Scanner) setupTailer(source *config.IntegrationConfigLogSource, tailFromBeginning bool, outputChan chan message.Message) {
-	t := NewTailer(outputChan, source)
+func (s *Scanner) setupTailer(file *File, tailFromBeginning bool, outputChan chan message.Message) {
+	t := NewTailer(outputChan, file.Source, file.Path)
 	var err error
 	if tailFromBeginning {
 		err = t.tailFromBeginning()
@@ -71,7 +79,7 @@ func (s *Scanner) setupTailer(source *config.IntegrationConfigLogSource, tailFro
 	if err != nil {
 		log.Println(err)
 	}
-	s.tailers[source.Path] = t
+	s.tailers[file.Path] = t
 }
 
 // Start starts the Scanner
@@ -96,36 +104,81 @@ func (s *Scanner) run() {
 // The Scanner needs to stop that previous tailer,
 // and start a new one for the new file.
 func (s *Scanner) scan() {
-	for _, source := range s.sources {
-		tailer := s.tailers[source.Path]
-		f, err := os.Open(source.Path)
-		if err != nil {
-			continue
-		}
-		stat1, err := f.Stat()
-		if err != nil {
-			continue
-		}
-		stat2, err := tailer.file.Stat()
-		if err != nil {
-			s.onFileRotation(tailer, source)
-			continue
-		}
-		if inode(stat1) != inode(stat2) {
-			s.onFileRotation(tailer, source)
+	files := s.fileProvider.FilesToTail()
+	filesTailed := make(map[string]bool)
+	tailersLen := len(s.tailers)
+
+	for _, file := range files {
+		tailer, exists := s.tailers[file.Path]
+		if !exists && tailersLen >= s.tailingLimit {
+			// can't create new tailer because tailingLimit is reached
 			continue
 		}
 
-		if stat1.Size() < tailer.GetReadOffset() {
-			s.onFileRotation(tailer, source)
+		if !exists && tailersLen < s.tailingLimit {
+			// create new tailer for file
+			s.setupTailer(file, false, s.pp.NextPipelineChan())
+			tailersLen++
+			filesTailed[file.Path] = true
+			continue
+		}
+
+		didRotate, err := s.didFileRotate(file, tailer)
+		if err != nil {
+			continue
+		}
+
+		if didRotate {
+			// update tailer because of file-rotation on file
+			s.onFileRotation(tailer, file)
+		}
+
+		filesTailed[file.Path] = true
+	}
+
+	for path, tailer := range s.tailers {
+		// stop all tailers which have not been selected
+		_, shouldTail := filesTailed[path]
+		if !shouldTail {
+			s.stopTailer(tailer)
 		}
 	}
 }
 
-func (s *Scanner) onFileRotation(tailer *Tailer, source *config.IntegrationConfigLogSource) {
+// didFileRotate returns true if a file-rotation happened to file
+// since tailer has been set up, otherwise returns false
+func (s *Scanner) didFileRotate(file *File, tailer *Tailer) (bool, error) {
+	f, err := os.Open(file.Path)
+	if err != nil {
+		return false, err
+	}
+
+	stat1, err := f.Stat()
+	if err != nil {
+		return false, err
+	}
+
+	stat2, err := tailer.file.Stat()
+	if err != nil {
+		return true, nil
+	}
+
+	return inode(stat1) != inode(stat2) || stat1.Size() < tailer.GetReadOffset(), nil
+}
+
+// onFileRotation safely stops tailer and setup a new one
+func (s *Scanner) onFileRotation(tailer *Tailer, file *File) {
+	log.Println("Log rotation happened to", tailer.path)
 	shouldTrackOffset := false
 	tailer.Stop(shouldTrackOffset)
-	s.setupTailer(source, true, tailer.outputChan)
+	s.setupTailer(file, true, tailer.outputChan)
+}
+
+// stopTailer safely stops tailer and remove its reference from tailers
+func (s *Scanner) stopTailer(tailer *Tailer) {
+	shouldTrackOffset := false
+	tailer.Stop(shouldTrackOffset)
+	delete(s.tailers, tailer.path)
 }
 
 // Stop stops the Scanner and its tailers

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -49,9 +49,9 @@ type Tailer struct {
 }
 
 // NewTailer returns an initialized Tailer
-func NewTailer(outputChan chan message.Message, source *config.IntegrationConfigLogSource) *Tailer {
+func NewTailer(outputChan chan message.Message, source *config.IntegrationConfigLogSource, path string) *Tailer {
 	return &Tailer{
-		path:       source.Path,
+		path:       path,
 		outputChan: outputChan,
 		d:          decoder.InitializeDecoder(source),
 		source:     source,
@@ -69,7 +69,7 @@ func NewTailer(outputChan chan message.Message, source *config.IntegrationConfig
 
 // Identifier returns a string that uniquely identifies a source
 func (t *Tailer) Identifier() string {
-	return fmt.Sprintf("file:%s", t.source.Path)
+	return fmt.Sprintf("file:%s", t.path)
 }
 
 // recoverTailing starts the tailing from the last log line processed, or now

--- a/pkg/logs/input/tailer/tailer_test.go
+++ b/pkg/logs/input/tailer/tailer_test.go
@@ -49,7 +49,7 @@ func (suite *TailerTestSuite) SetupTest() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	}
-	suite.tl = NewTailer(suite.outputChan, suite.source)
+	suite.tl = NewTailer(suite.outputChan, suite.source, suite.testPath)
 	suite.tl.sleepDuration = 10 * time.Millisecond
 }
 
@@ -154,7 +154,7 @@ func (suite *TailerTestSuite) TestTailerIsTooSlowAndClosed() {
 	testPath := fmt.Sprintf("%s/tailer2.log", suite.testDir)
 	testFile, _ := os.Create(testPath)
 	defer testFile.Close()
-	tl := NewTailer(nil, &config.IntegrationConfigLogSource{Type: config.FileType, Path: testPath})
+	tl := NewTailer(nil, &config.IntegrationConfigLogSource{Type: config.FileType, Path: testPath}, testPath)
 	tl.sleepDuration = 50 * time.Millisecond
 	tl.closeTimeout = 2 * time.Millisecond
 


### PR DESCRIPTION
Added a wild card support on file paths in integration files for logs-agent

### What does this PR do?

Updated file `Scanner` to support wildcards in file paths using `filepath.Glob`.

### Motivation

Be able to use wildcard in logs integration configuration files, for example:
```
 - type: file
   path: /var/*/*.log
```

### Additional Notes

Added a logic to:
- create new tailers for new files that are created after the agent has launched
- remove old tailers for files erased on the fly