### PR TITLE
[CI] extend the expiration date of the key

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -440,6 +440,9 @@ deploy_deb:
     - echo "$APT_SIGNING_KEY_DEPRECATED_ID"
     - printf -- "$APT_SIGNING_PRIVATE_KEY_DEPRECATED" | gpg --import --batch
 
+    # grab the updated public key to extend the expiration date
+    - gpg --keyserver hkp://keyserver.ubuntu.com:80 --receive-keys "$APT_SIGNING_KEY_DEPRECATED_ID"
+
     # FIXME: remove this once we move to the new apt repo on our staging and production environments
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET_DEPRECATED -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET_DEPRECATED -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*amd64.deb


### PR DESCRIPTION
### What does this PR do?

The private key is expired. If we import the public key, which has an extended expiration date, it properly extends the expiration date so that packages can be signed properly.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
