### PR TITLE
[jmx] Remove conf fields from instance struct

### DIFF
--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -48,21 +48,13 @@ var (
 	}
 )
 
+// checkInstanceCfg lists the config options on the instance against which we make some sanity checks
+// on how they're configured. All the other options should be checked on JMXFetch's side.
 type checkInstanceCfg struct {
-	Host               string            `yaml:"host,omitempty"`
-	Port               int               `yaml:"port,omitempty"`
-	User               string            `yaml:"user,omitempty"`
-	Password           string            `yaml:"password,omitempty"`
-	JMXUrl             string            `yaml:"jmx_url,omitempty"`
-	Name               string            `yaml:"name,omitempty"`
-	JavaBinPath        string            `yaml:"java_bin_path,omitempty"`
-	JavaOptions        string            `yaml:"java_options,omitempty"`
-	ToolsJarPath       string            `yaml:"tools_jar_path,omitempty"`
-	TrustStorePath     string            `yaml:"trust_store_path,omitempty"`
-	TrustStorePassword string            `yaml:"trust_store_password,omitempty"`
-	ProcessNameRegex   string            `yaml:"process_name_regex,omitempty"`
-	RefreshBeans       int               `yaml:"refresh_beans,omitempty"`
-	Tags               map[string]string `yaml:"tags,omitempty"`
+	JavaBinPath      string `yaml:"java_bin_path,omitempty"`
+	JavaOptions      string `yaml:"java_options,omitempty"`
+	ToolsJarPath     string `yaml:"tools_jar_path,omitempty"`
+	ProcessNameRegex string `yaml:"process_name_regex,omitempty"`
 }
 
 type checkInitCfg struct {


### PR DESCRIPTION
### What does this PR do?

Removes unused conf fields from instance struct.

### Motivation

These fields aren't used anywhere and can cause type mismatches between
what's in the conf instances and the types defined in the struct
fields, even when, downstream, JMXFetch can accommodate different types
for some fields. (These mismatches make the jmx check throw errors)

Actual example: `Tags` is supported by JMXFetch as either a list of strings or
a hash (with string keys and string values), but the former makes the check fail.

### Additional Notes

If we want to introduce more agent-side validation of the jmx configs
we can re-discuss this (intuitively though I'd say most of the validation
should be done by JMXFetch itself).
