### PR TITLE
[check cmd] Fix discrepancy in stats displayed by check cmd

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -95,10 +95,10 @@ var checkCmd = &cobra.Command{
 		for _, c := range cs {
 			s := runCheck(c, agg)
 
-			// Without a small delay some of the metrics will not show up
+			// Sleep for a while to allow the aggregator to finish ingesting all the metrics/events/sc
 			time.Sleep(time.Duration(checkDelay) * time.Millisecond)
 
-			getMetrics(agg)
+			printMetrics(agg)
 
 			checkStatus, _ := status.GetCheckStatus(c, s)
 			fmt.Println(string(checkStatus))
@@ -127,7 +127,7 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 	return s
 }
 
-func getMetrics(agg *aggregator.BufferedAggregator) {
+func printMetrics(agg *aggregator.BufferedAggregator) {
 	series := agg.GetSeries()
 	if len(series) != 0 {
 		fmt.Println("Series: ")

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -137,7 +137,7 @@ func GetDefaultSender() (Sender, error) {
 // Should be called at the end of every check run
 func (s *checkSender) Commit() {
 	s.smsOut <- senderMetricSample{s.id, &metrics.MetricSample{}, true}
-	go s.cyclemetricStats()
+	s.cyclemetricStats()
 }
 
 func (s *checkSender) GetMetricStats() map[string]int64 {


### PR DESCRIPTION
### What does this PR do?

Fixes discrepancy in stats displayed by check cmd. Fixes #955

### Motivation

When the check `Commit`s its metrics/service checks/events, in the
sender we should simply "rotate" the stats structs sequentially so we
know they're up-to-date as soon as the `Commit` is done. I don't see
any benefit of doing that in a separate goroutine.

### Additional Notes

See 1st commit for actual fix.

Also, one thing that's still a bit misleading is that the number of `Metrics` that's shown under each check here and in the `status` command is actually the number of metric _samples_ submitted from the check, not the number of metrics (i.e. individual timeseries) after aggregation. We should probably make that clearer (maybe by renaming it `MetricSamples`).