### PR TITLE
Created a new configuration parameter to skip ssl in dev mode

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -22,7 +22,7 @@ func Start() {
 	cm := sender.NewConnectionManager(
 		config.LogsAgent.GetString("log_dd_url"),
 		config.LogsAgent.GetInt("log_dd_port"),
-		config.LogsAgent.GetBool("skip_ssl_validation"),
+		config.LogsAgent.GetBool("dev_mode_no_ssl"),
 	)
 
 	auditorChan := make(chan message.Message, config.ChanSizes)

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -29,7 +29,7 @@ func TestBuildConfigWithCompleteFile(t *testing.T) {
 	assert.Equal(t, "playground", testConfig.GetString("logset"))
 	assert.Equal(t, "my.url", testConfig.GetString("log_dd_url"))
 	assert.Equal(t, 10516, testConfig.GetInt("log_dd_port"))
-	assert.Equal(t, true, testConfig.GetBool("skip_ssl_validation"))
+	assert.Equal(t, true, testConfig.GetBool("dev_mode_no_ssl"))
 	assert.Equal(t, true, testConfig.GetBool("log_enabled"))
 }
 
@@ -38,6 +38,7 @@ func TestDDConfigDefaultValues(t *testing.T) {
 	assert.Equal(t, "intake.logs.datadoghq.com", ddconfig.Datadog.GetString("log_dd_url"))
 	assert.Equal(t, 10516, ddconfig.Datadog.GetInt("log_dd_port"))
 	assert.Equal(t, false, ddconfig.Datadog.GetBool("skip_ssl_validation"))
+	assert.Equal(t, false, ddconfig.Datadog.GetBool("dev_mode_no_ssl"))
 	assert.Equal(t, false, ddconfig.Datadog.GetBool("log_enabled"))
 	hostname, _ := util.GetHostname()
 	ddconfigPath := filepath.Join(testsPath, "incomplete", "datadog_test.yaml")

--- a/pkg/logs/config/tests/complete/datadog_test.yaml
+++ b/pkg/logs/config/tests/complete/datadog_test.yaml
@@ -1,6 +1,6 @@
 log_dd_url: "my.url"
 log_dd_port: 10516
-skip_ssl_validation: true
+dev_mode_no_ssl: true
 logset: playground
 api_key: "helloworld"
 hostname: "my.host"

--- a/pkg/logs/sender/connection_manager.go
+++ b/pkg/logs/sender/connection_manager.go
@@ -23,9 +23,9 @@ const (
 
 // A ConnectionManager manages connections
 type ConnectionManager struct {
-	connectionString  string
-	serverName        string
-	skipSSLValidation bool
+	connectionString string
+	serverName       string
+	devModeNoSSL     bool
 
 	mutex   sync.Mutex
 	retries int
@@ -34,11 +34,11 @@ type ConnectionManager struct {
 }
 
 // NewConnectionManager returns an initialized ConnectionManager
-func NewConnectionManager(ddURL string, ddPort int, skipSSLValidation bool) *ConnectionManager {
+func NewConnectionManager(ddURL string, ddPort int, devModeNoSSL bool) *ConnectionManager {
 	return &ConnectionManager{
-		connectionString:  fmt.Sprintf("%s:%d", ddURL, ddPort),
-		serverName:        ddURL,
-		skipSSLValidation: skipSSLValidation,
+		connectionString: fmt.Sprintf("%s:%d", ddURL, ddPort),
+		serverName:       ddURL,
+		devModeNoSSL:     devModeNoSSL,
 
 		mutex: sync.Mutex{},
 
@@ -54,7 +54,7 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 
 	for {
 		if cm.firstConn {
-			log.Println("Connecting to the backend:", cm.connectionString, "- skip_ssl_validation:", cm.skipSSLValidation)
+			log.Println("Connecting to the backend:", cm.connectionString)
 			cm.firstConn = false
 		}
 
@@ -66,7 +66,7 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 			continue
 		}
 
-		if !cm.skipSSLValidation {
+		if !cm.devModeNoSSL {
 			config := &tls.Config{
 				ServerName: cm.serverName,
 			}


### PR DESCRIPTION
### What does this PR do?

Replaced `skip_ssl_validation` flag with `dev_mode_no_ssl` in connection manager.

### Motivation

Security

### Additional Notes

For more context, see https://github.com/DataDog/croissant-issues/issues/13
