### PR TITLE
[rancher] add AD and tagger support

### DIFF
--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -263,7 +263,6 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 	}
 }
 
-// TODO support orchestrators
 func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	hosts, err := svc.GetHosts()
 	if err != nil {
@@ -297,8 +296,8 @@ func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 // 		- if we can't find it we fail because we shouldn't try and guess the IP address
 func getFallbackHost(hosts map[string]string) (string, error) {
 	if len(hosts) == 1 {
-		for k := range hosts {
-			return hosts[k], nil
+		for _, host := range hosts {
+			return host, nil
 		}
 	}
 	for k, v := range hosts {

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -487,14 +488,13 @@ func findKubernetesInLabels(labels map[string]string) bool {
 // Rancher 1.x containers don't have docker networks as the orchestrator provides
 // its own CNI. The IP is stored in the `io.rancher.container.ip` label.
 func findRancherIPInLabels(labels map[string]string) (string, bool) {
-	rancherIP, found := labels[rancherIPLabel]
+	cidr, found := labels[rancherIPLabel]
 	if found {
-		parts := strings.SplitN(rancherIP, "/", 2)
-		if len(parts) < 1 || len(parts[0]) == 0 {
-			log.Warnf("error while retrieving Rancher IP: %q is not valid", rancherIP)
-		} else {
-			return parts[0], true
+		ipv4Addr, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			log.Warnf("error while retrieving Rancher IP: %q is not valid", cidr)
 		}
+		return ipv4Addr.String(), true
 	}
 
 	return "", false

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -359,7 +359,9 @@ func (s *DockerService) GetHosts() (map[string]string, error) {
 		return nil, fmt.Errorf("failed to inspect container %s", string(s.ID)[:12])
 	}
 	for net, settings := range cInspect.NetworkSettings.Networks {
-		ips[net] = settings.IPAddress
+		if len(settings.IPAddress) > 0 {
+			ips[net] = settings.IPAddress
+		}
 	}
 
 	// Rancher 1.x containers don't have docker networks as the orchestrator provides

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -204,14 +204,22 @@ func TestGetRancherIP(t *testing.T) {
 		ID:    id,
 		Image: "test",
 	}
+
+	nets := make(map[string]*network.EndpointSettings)
+	nets["none"] = &network.EndpointSettings{}
+
+	networkSettings := types.NetworkSettings{
+		Networks: nets,
+	}
+
 	cj := types.ContainerJSON{
 		ContainerJSONBase: &cBase,
 		Mounts:            make([]types.MountPoint, 0),
 		Config: &container.Config{Labels: map[string]string{
 			"io.datadog.check.id":     "w00tw00t",
-			"io.rancher.container.ip": "192.168.0.6/32",
+			"io.rancher.container.ip": "10.42.90.224/16",
 		}},
-		NetworkSettings: &types.NetworkSettings{},
+		NetworkSettings: &networkSettings,
 	}
 	// add cj to the cache to avoir having to query docker in the test
 	cacheKey := docker.GetInspectCacheKey(id)
@@ -222,7 +230,7 @@ func TestGetRancherIP(t *testing.T) {
 	}
 
 	hosts, _ := svc.GetHosts()
-	assert.Equal(t, "192.168.0.6", hosts["rancher"])
+	assert.Equal(t, "10.42.90.224", hosts["rancher"])
 	assert.Equal(t, 1, len(hosts))
 }
 

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -85,6 +85,36 @@ func TestGetHostsFromPs(t *testing.T) {
 	assert.Equal(t, 2, len(hosts))
 }
 
+func TestGetRancherIPFromPs(t *testing.T) {
+	dl := DockerListener{}
+
+	co := types.Container{
+		ID:    "foo",
+		Image: "test",
+	}
+
+	assert.Empty(t, dl.getHostsFromPs(co))
+
+	nets := make(map[string]*network.EndpointSettings)
+	nets["none"] = &network.EndpointSettings{}
+	networkSettings := types.SummaryNetworkSettings{
+		Networks: nets}
+
+	co = types.Container{
+		ID:              "deadbeef",
+		Image:           "test",
+		NetworkSettings: &networkSettings,
+		Ports:           []types.Port{{PrivatePort: 1337}, {PrivatePort: 42}},
+		Labels: map[string]string{
+			"io.rancher.container.ip": "10.42.90.224/16",
+		},
+	}
+	hosts := dl.getHostsFromPs(co)
+
+	assert.Equal(t, "10.42.90.224", hosts["rancher"])
+	assert.Equal(t, 1, len(hosts))
+}
+
 func TestGetPortsFromPs(t *testing.T) {
 	dl := DockerListener{}
 

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -59,6 +59,14 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 		case "com.docker.swarm.service.name":
 			tags.AddLow("swarm_service", labelValue)
 
+		// Rancher 1.x
+		case "io.rancher.container.name":
+			tags.AddHigh("rancher_container", labelValue)
+		case "io.rancher.stack.name":
+			tags.AddLow("rancher_stack", labelValue)
+		case "io.rancher.stack_service.name":
+			tags.AddLow("rancher_service", labelValue)
+
 		default:
 			if tagName, found := labelsAsTags[strings.ToLower(labelName)]; found {
 				tags.AddAuto(tagName, labelValue)

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -145,6 +145,39 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			expectedLow:  []string{"swarm_service:helloworld", "custom_add_swarm_node:zdtab51ei97djzrpa1y2tz8li"},
 			expectedHigh: []string{"custom_add_task_name:helloworld.1.knk1rz1szius7pvyznn9zolld"},
 		},
+		{
+			testName: "extractRancherLabels",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{"PATH=/bin"},
+					Labels: map[string]string{
+						"io.rancher.cni.network":             "ipsec",
+						"io.rancher.cni.wait":                "true",
+						"io.rancher.container.ip":            "10.42.234.7/16",
+						"io.rancher.container.mac_address":   "02:f1:dd:48:4c:d9",
+						"io.rancher.container.name":          "testAD-redis-1",
+						"io.rancher.container.pull_image":    "always",
+						"io.rancher.container.uuid":          "8e969193-2bc7-4a58-9a54-9eed44b01bb2",
+						"io.rancher.environment.uuid":        "adminProject",
+						"io.rancher.project.name":            "testAD",
+						"io.rancher.project_service.name":    "testAD/redis",
+						"io.rancher.service.deployment.unit": "06c082fc-4b66-4b6c-b098-30dbf29ed204",
+						"io.rancher.service.launch.config":   "io.rancher.service.primary.launch.config",
+						"io.rancher.stack.name":              "testAD",
+						"io.rancher.stack_service.name":      "testAD/redis",
+					},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"rancher_service:testAD/redis",
+				"rancher_stack:testAD",
+			},
+			expectedHigh: []string{
+				"rancher_container:testAD-redis-1",
+			},
+		},
 	}
 
 	dc := &DockerCollector{}

--- a/pkg/util/docker/rancher.go
+++ b/pkg/util/docker/rancher.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+import (
+	"net"
+
+	log "github.com/cihub/seelog"
+)
+
+const rancherIPLabel = "io.rancher.container.ip"
+
+// FindRancherIPInLabels looks for the `io.rancher.container.ip` label and parses it.
+// Rancher 1.x containers don't have docker networks as the orchestrator provides its own CNI.
+func FindRancherIPInLabels(labels map[string]string) (string, bool) {
+	cidr, found := labels[rancherIPLabel]
+	if found {
+		ipv4Addr, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			log.Warnf("error while retrieving Rancher IP: %q is not valid", cidr)
+			return "", false
+		}
+		return ipv4Addr.String(), true
+	}
+
+	return "", false
+}

--- a/pkg/util/docker/rancher_test.go
+++ b/pkg/util/docker/rancher_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindRancherIPInLabels(t *testing.T) {
+	testCases := []struct {
+		labels        map[string]string
+		expectedIP    string
+		expectedFound bool
+	}{
+		{
+			labels:        map[string]string{},
+			expectedIP:    "",
+			expectedFound: false,
+		},
+		{
+			labels: map[string]string{
+				"io.rancher.container.ip": "10.42.90.224/16",
+			},
+			expectedIP:    "10.42.90.224",
+			expectedFound: true,
+		},
+		{
+			labels: map[string]string{
+				"io.rancher.container.ip": "42.90.224/16",
+			},
+			expectedIP:    "",
+			expectedFound: false,
+		},
+		{
+			labels: map[string]string{
+				"io.rancher.container.ip": "10.42.90.224",
+			},
+			expectedIP:    "",
+			expectedFound: false,
+		},
+	}
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("case %d: %v", i, test.labels), func(t *testing.T) {
+			ip, found := FindRancherIPInLabels(test.labels)
+			assert.Equal(t, test.expectedIP, ip)
+			assert.Equal(t, test.expectedFound, found)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- support AD in Rancher 1.x: containers don't have docker networks as the orchestrator provides its own CNI. The IP is stored in the `io.rancher.container.ip` label.
- port docker label extration logic from agent5 into tagger
- update tests for both

As Rancher does not set the `Ports` mapping in the container specs, the `%%port%%` tag does not work and it is required to hardcode the port. Opened a backlog item to handle that by fallback-ing to the `ExposedPorts` map