### PR TITLE
[Docs] Add a note about sysvinit to debian

### DIFF
--- a/docs/beta/known_issues.md
+++ b/docs/beta/known_issues.md
@@ -121,7 +121,7 @@ We do not yet build packages for the full gamut of systems that Agent 5 targets.
 While some will be dropped as unsupported, others are simply not yet supported.
 Beta is currently available on these platforms:
 
-* Debian x86_64 version 7 (wheezy) and above
+* Debian x86_64 version 7 (wheezy) and above (we do not support SysVinit)
 * Ubuntu x86_64 version 12.04 and above
 * RedHat/CentOS x86_64 version 6 and above
 * SUSE Enterprise Linux x86_64 version 11 SP4 and above (we do not support SysVinit)


### PR DESCRIPTION
### What does this PR do?

Debian Wheezy uses sysvinit, which we do not support. This PR adds a note about this to the docs.