### PR TITLE
[docs] Add `metadata` clean when downgrading to agent 5 on RHEL

### DIFF
--- a/docs/beta/downgrade.md
+++ b/docs/beta/downgrade.md
@@ -43,7 +43,7 @@ rm /etc/yum.repos.d/datadog-beta.repo
 
 ##### Update your local yum cache and downgrade the agent
 ```shell
-sudo yum clean expire-cache
+sudo yum clean expire-cache metadata
 sudo yum check-update
 sudo yum remove datadog-agent
 sudo yum install datadog-agent


### PR DESCRIPTION
Without a `clean` of the `metadata` yum (at least on RHEL 7) keeps the repo metadata of the `beta` channel of the repo because it's more recent than the metadata of the stable `rpm` channel, and still tries to install agent 6 even when a downgrade to agent 5 is desired.

Let's add this to make sure yum refreshes the metadata.