### PR TITLE
Added logs to valid config formats to prevent errors to raise

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -61,6 +61,7 @@ type Config struct {
 	Instances     []ConfigData // array of Yaml configurations
 	InitConfig    ConfigData   // the init_config in Yaml (python check only)
 	MetricConfig  ConfigData   // the metric config in Yaml (jmx check only)
+	LogsConfig    ConfigData   // the logs config in Yaml (logs-agent only)
 	ADIdentifiers []string     // the list of AutoDiscovery identifiers (optional)
 }
 

--- a/pkg/collector/providers/file_test.go
+++ b/pkg/collector/providers/file_test.go
@@ -32,6 +32,11 @@ func TestGetCheckConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, config.MetricConfig)
 
+	// valid logs-agent file
+	config, err = GetCheckConfigFromFile("foo", "tests/logs-agent_only.yaml")
+	assert.Nil(t, err)
+	assert.NotNil(t, config.LogsConfig)
+
 	// valid configuration file
 	config, err = GetCheckConfigFromFile("foo", "tests/testcheck.yaml")
 	require.Nil(t, err)
@@ -104,7 +109,7 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, 0, len(get("metrics")))
 
 	// total number of configurations found
-	assert.Equal(t, 10, len(configs))
+	assert.Equal(t, 11, len(configs))
 
 	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml)
 	assert.Equal(t, 2, len(provider.Errors))

--- a/pkg/collector/providers/tests/logs-agent_only.yaml
+++ b/pkg/collector/providers/tests/logs-agent_only.yaml
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+
+logs:
+  - type: file
+    name: /foo/bar/*.log

--- a/pkg/collector/providers/tests/logs-agent_with_instances.yaml
+++ b/pkg/collector/providers/tests/logs-agent_with_instances.yaml
@@ -1,0 +1,8 @@
+init_config:
+
+instances:
+  [{}]
+
+logs:
+  - type: file
+    name: /foo/bar/*.log


### PR DESCRIPTION
### What does this PR do?

Added a support for logs configuration files in `pkg/collector/providers` and `pkg/collector/check` packages. Skip them at the moment as we are already fetching them in `pkg/logs/config`.

### Motivation

Prevent check loading errors to occur and to be reported in `agent status`: https://cl.ly/0Y2m0T1e3W3I

### Additional Notes

Logs-agent should use autoconfig in the future
