### PR TITLE
Adding reno to the repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,16 @@ jobs:
           name: run integration tests
           command: inv  -e integration-tests --race --remote-docker
 
+  reno_linting:
+    <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - restore_cache: *restore_deps
+      - setup_remote_docker
+      - run:
+          name: run reno linting
+          command: inv -e lint-releasenote
+
   docker_integration_tests:
     <<: *job_template
     steps:
@@ -123,6 +133,9 @@ workflows:
           requires:
             - dependencies
       - integration_tests:
+          requires:
+            - dependencies
+      - reno_linting:
           requires:
             - dependencies
       - docker_integration_tests:

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -25,6 +25,7 @@ when submitting your PR:
   * preferably make sure that all tests pass locally.
   * summarize your PR with an explanatory title and a message describing your
     changes, cross-referencing any related bugs/PRs.
+  * Use [Reno](#reno) to create a releasenote.
 
 Your pull request must pass all CI tests before we will merge it. If you're seeing
 an error and don't think it's your fault, it may not be! [Join us on Slack][slack]
@@ -54,6 +55,25 @@ body to skip the build and give that slot to someone else who does need it.
 Please rebase your changes on `master` and squash your commits whenever possible,
 it keeps history cleaner and it's easier to revert things. It also makes developers
 happier!
+
+### Reno
+
+To install reno: `pip install reno`
+
+We use `Reno` to create our CHANGELOG. Reno is a pretty simple
+[tool](https://docs.openstack.org/reno/latest/user/usage.html).
+
+Ultra quick `Reno` HOWTO:
+
+```bash
+$> reno new <topic-of-my-pr> --edit
+[...]
+# Remove unused section and fill the relevant ones
+# Reno will create a new file in releasenotes/notes
+[...]
+```
+
+Then just add and commit the new releasenote (located in `releasenotes/notes/`) with your PR.
 
 ## Integrations
 

--- a/releasenotes/notes/add-reno-linting-to-test-23f722e6856fb1d8.yaml
+++ b/releasenotes/notes/add-reno-linting-to-test-23f722e6856fb1d8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    We now handle release notes with Reno.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,7 +7,7 @@ from invoke import Collection
 from . import agent, benchmarks, docker, dogstatsd, pylauncher, logs, cluster_agent
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
-from .test import test, integration_tests, version
+from .test import test, integration_tests, version, lint_releasenote
 from .build_tags import audit_tag_impact
 
 # the root namespace
@@ -25,6 +25,7 @@ ns.add_task(integration_tests)
 ns.add_task(deps)
 ns.add_task(reset)
 ns.add_task(version)
+ns.add_task(lint_releasenote)
 ns.add_task(audit_tag_impact)
 
 # add namespaced tasks to the root

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -118,6 +118,12 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
     if coverage:
         ctx.run("go tool cover -func {}".format(PROFILE_COV))
 
+@task
+def lint_releasenote(ctx):
+    """
+    Lint release notes with Reno
+    """
+    ctx.run("reno lint")
 
 @task
 def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):


### PR DESCRIPTION
### What does this PR do?

From now on Reno will be used to handle our changelog and we will lint
every PR to make.