### PR TITLE
Forwarding 'process_agent_enabled' setting to the process agent.

### DIFF
--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -81,6 +81,7 @@ func (c *ProcessAgentCheck) run() error {
 	env = append(env, fmt.Sprintf("DD_HOSTNAME=%s", getHostname()))
 	env = append(env, fmt.Sprintf("DD_DOGSTATSD_PORT=%s", config.Datadog.GetString("dogstatsd_port")))
 	env = append(env, fmt.Sprintf("DD_LOG_LEVEL=%s", config.Datadog.GetString("log_level")))
+	env = append(env, fmt.Sprintf("DD_PROCESS_AGENT_ENABLED=%t", config.Datadog.GetBool("process_agent_enabled")))
 	cmd.Env = env
 
 	// forward the standard output to the Agent logger

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,6 +189,8 @@ func init() {
 	Datadog.BindEnv("histogram_percentiles")
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 
+	Datadog.BindEnv("process_agent_enabled")
+
 	// Logs
 	BindEnvAndSetDefault("log_enabled", false)
 	BindEnvAndSetDefault("logset", "")


### PR DESCRIPTION
### What does this PR do?

Forwarding 'process_agent_enabled' setting to the process agent. Without is the `process-agent` would not start.