### PR TITLE
[circleci] bumping builder image to 0.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: jfullaondo/datadog-agent-builder-deb:0.1.1
+      - image: jfullaondo/datadog-agent-builder-deb:0.2.0
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent


### PR DESCRIPTION
### What does this PR do?

Bumps the docker circleCI container.

### Motivation

Updated builder/testing image released with Reno

### Additional Notes

Anything else we should know when reviewing?
