### PR TITLE
Fix agent version stored in binary

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -58,7 +58,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	av, _ := version.New(version.ClusterAgentVersion)
+	av, _ := version.New(version.AgentVersion)
 	j, _ := json.Marshal(av)
 	w.Write(j)
 }

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -10,17 +10,10 @@ package version
 // AgentVersion contains the version of the Agent
 var AgentVersion string
 
-// ClusterAgentVersion contains the version of the cluster agent
-var ClusterAgentVersion string
-
 var agentVersionDefault = "6.0.0"
-var clusterAgentVersionDefault = "6.0.0"
 
 func init() {
 	if AgentVersion == "" {
 		AgentVersion = agentVersionDefault
-	}
-	if ClusterAgentVersion == "" {
-		AgentVersion = clusterAgentVersionDefault
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the agent version stored in the binary.

Regression introduced in #960.

### Motivation

The agent would always display `6.0.0` as its version.

### Additional Notes

The agent version was being overriden by `clusterAgentVersionDefault`.

Let's use one `AgentVersion` variable for all the different flavors
of the Agent we might build. The build flag that populates it is always
set to use `pkg/version.AgentVersion` anyway.
