### PR TITLE
refactor corecheck boilerplate in CheckBase class

### DIFF
--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -13,13 +13,18 @@ import (
 // ID is the representation of the unique ID of a Check instance
 type ID string
 
-// Identify returns the ID of the check
+// Identify returns a unique ID for a check and its configuration
 func Identify(check Check, instance ConfigData, initConfig ConfigData) ID {
+	return BuildID(check.String(), instance, initConfig)
+}
+
+// BuildID returns a unique ID for a check name and its configuration
+func BuildID(checkName string, instance, initConfig ConfigData) ID {
 	h := fnv.New64()
 	h.Write([]byte(instance))
 	h.Write([]byte(initConfig))
 
-	id := check.String() + ":"
+	id := checkName + ":"
 	id += strconv.FormatUint(h.Sum64(), 16)
 	return ID(id)
 }

--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -6,25 +6,24 @@
 package check
 
 import (
+	"fmt"
 	"hash/fnv"
-	"strconv"
 )
 
 // ID is the representation of the unique ID of a Check instance
 type ID string
 
-// Identify returns a unique ID for a check and its configuration
+// Identify returns an unique ID for a check and its configuration
 func Identify(check Check, instance ConfigData, initConfig ConfigData) ID {
 	return BuildID(check.String(), instance, initConfig)
 }
 
-// BuildID returns a unique ID for a check name and its configuration
+// BuildID returns an unique ID for a check name and its configuration
 func BuildID(checkName string, instance, initConfig ConfigData) ID {
 	h := fnv.New64()
 	h.Write([]byte(instance))
 	h.Write([]byte(initConfig))
 
-	id := checkName + ":"
-	id += strconv.FormatUint(h.Sum64(), 16)
+	id := fmt.Sprintf("%s:%x", checkName, h.Sum64())
 	return ID(id)
 }

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package corechecks
+
+import (
+    "fmt"
+    "time"
+
+    "github.com/DataDog/datadog-agent/pkg/collector/check"
+    "github.com/DataDog/datadog-agent/pkg/aggregator"
+    log "github.com/cihub/seelog"
+)
+
+// CheckBase provides default for most methods required by
+// the check.Check interface to make it easier to bootstrap a
+// new corecheck.
+type CheckBase struct {
+    checkId      string
+    lastWarnings []error
+}
+
+func NewCheckBase(id string) CheckBase {
+    return CheckBase{
+        checkId: id,
+    }
+}
+
+func (c *CheckBase) String() string {
+    return c.checkId
+}
+
+// ID returns the name of the check since there should be only one instance running
+func (c *CheckBase) ID() check.ID {
+    return check.ID(c.String())
+}
+
+// Interval returns the scheduling time for the check
+func (c *CheckBase) Interval() time.Duration {
+    return check.DefaultCheckInterval
+}
+
+// GetWarnings grabs the last warnings from the sender
+func (c *CheckBase) GetWarnings() []error {
+    if len(c.lastWarnings) == 0 {
+        return nil
+    }
+    w := c.lastWarnings
+    c.lastWarnings = []error{}
+    return w
+}
+
+// Warn will log a warning and add it to the warnings
+func (c *CheckBase) warn(v ...interface{}) error {
+    w := log.Warn(v)
+    c.lastWarnings = append(c.lastWarnings, w)
+
+    return w
+}
+
+// Warnf will log a formatted warning and add it to the warnings
+func (c *CheckBase) warnf(format string, params ...interface{}) error {
+    w := log.Warnf(format, params)
+    c.lastWarnings = append(c.lastWarnings, w)
+
+    return w
+}
+
+// GetMetricStats returns the stats from the last run of the check
+func (c *CheckBase) GetMetricStats() (map[string]int64, error) {
+    sender, err := aggregator.GetSender(c.ID())
+    if err != nil {
+        return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
+    }
+    return sender.GetMetricStats(), nil
+}

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	log "github.com/cihub/seelog"
 )
 
 // CheckBase provides default implementations for most of the check.Check

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -9,6 +9,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -17,13 +18,12 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/ericchiang/k8s/api/v1"
 	yaml "gopkg.in/yaml.v2"
-	"time"
 )
 
 // Covers the Control Plane service check and the in memory pod metadata.
 const (
-	KubeControlPaneCheck     = "kube_apiserver_controlplane.up"
-	kubernetesAPIServerCheck = "kubernetes_apiserver"
+	KubeControlPaneCheck         = "kube_apiserver_controlplane.up"
+	kubernetesAPIServerCheckName = "kubernetes_apiserver"
 )
 
 // KubeASConfig is the config of the API server.
@@ -33,14 +33,9 @@ type KubeASConfig struct {
 
 // KubeASCheck grabs metrics and events from the API server.
 type KubeASCheck struct {
-	lastWarnings          []error
+	core.CheckBase
 	instance              *KubeASConfig
 	KubeAPIServerHostname string
-}
-
-// String returns the name of the API Server check.
-func (k *KubeASCheck) String() string {
-	return kubernetesAPIServerCheck
 }
 
 func (c *KubeASConfig) parse(data []byte) error {
@@ -60,31 +55,6 @@ func (k *KubeASCheck) Configure(config, initConfig check.ConfigData) error {
 	return nil
 }
 
-// GetWarnings grabs the last warnings from the sender.
-func (k *KubeASCheck) GetWarnings() []error {
-	w := k.lastWarnings
-	k.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (k *KubeASCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	k.lastWarnings = append(k.lastWarnings, w)
-
-	return w
-}
-
-// ID returns the name of the check since there should be only one instance running.
-func (k *KubeASCheck) ID() check.ID {
-	return check.ID(k.String())
-}
-
-// Interval returns the scheduling time for the check.
-func (k *KubeASCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
 // Run executes the check.
 func (k *KubeASCheck) Run() error {
 	sender, err := aggregator.GetSender(k.ID())
@@ -101,34 +71,23 @@ func (k *KubeASCheck) Run() error {
 
 	componentsStatus, err := asclient.ComponentStatuses()
 	if err != nil {
-		k.warn("could not retrieve the status from the control plane's components", err.Error())
+		k.Warn("could not retrieve the status from the control plane's components", err.Error())
 	}
 
 	err = k.parseComponentStatus(sender, componentsStatus)
 	if err != nil {
-		k.warn("could not collect API Server component status: ", err.Error())
+		k.Warn("could not collect API Server component status: ", err.Error())
 	}
 	sender.Commit()
 	return nil
 }
 
-// Stop does nothing.
-func (k *KubeASCheck) Stop() {}
-
 // KubernetesASFactory is exported for integration testing.
 func KubernetesASFactory() check.Check {
 	return &KubeASCheck{
-		instance: &KubeASConfig{},
+		CheckBase: core.NewCheckBase(kubernetesAPIServerCheckName),
+		instance:  &KubeASConfig{},
 	}
-}
-
-// GetMetricStats returns the stats from the last run of the check.
-func (k *KubeASCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(k.ID())
-	if err != nil {
-		return nil, log.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
 }
 
 func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsStatus *v1.ComponentStatusList) error {
@@ -164,5 +123,5 @@ func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsS
 	return nil
 }
 func init() {
-	core.RegisterCheck("kubernetes_apiserver", KubernetesASFactory)
+	core.RegisterCheck(kubernetesAPIServerCheckName, KubernetesASFactory)
 }

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -7,12 +7,15 @@
 package cluster
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"testing"
+
 	"github.com/ericchiang/k8s/api/v1"
 	obj "github.com/ericchiang/k8s/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func toStr(str string) *string {
@@ -81,11 +84,12 @@ func TestParseComponentStatus(t *testing.T) {
 		Items: nil,
 	}
 
+	// FIXME: use the factory instead
 	kubeASCheck := &KubeASCheck{
-		lastWarnings: []error{},
 		instance: &KubeASConfig{
 			Tags: []string{"test"},
 		},
+		CheckBase:             core.NewCheckBase(kubernetesAPIServerCheckName),
 		KubeAPIServerHostname: "hostname",
 	}
 

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -63,7 +63,7 @@ func (c *DockerConfig) Parse(data []byte) error {
 
 // DockerCheck grabs docker metrics
 type DockerCheck struct {
-	lastWarnings   []error
+	core.CheckBase
 	instance       *DockerConfig
 	lastEventTime  time.Time
 	dockerHostname string
@@ -287,10 +287,6 @@ func (d *DockerCheck) Run() error {
 // Stop does nothing
 func (d *DockerCheck) Stop() {}
 
-func (d *DockerCheck) String() string {
-	return dockerCheckName
-}
-
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 	d.instance.Parse(config)
@@ -307,35 +303,10 @@ func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 	return nil
 }
 
-// Interval returns the scheduling time for the check
-func (d *DockerCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// ID returns the name of the check since there should be only one instance running
-func (d *DockerCheck) ID() check.ID {
-	return check.ID(d.String())
-}
-
-// GetWarnings grabs the last warnings from the sender
-func (d *DockerCheck) GetWarnings() []error {
-	w := d.lastWarnings
-	d.lastWarnings = []error{}
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (d *DockerCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(d.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 // DockerFactory is exported for integration testing
 func DockerFactory() check.Check {
 	return &DockerCheck{
+		CheckBase: core.NewCheckBase(dockerCheckName),
 		instance: &DockerConfig{},
 	}
 }

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -284,9 +284,6 @@ func (d *DockerCheck) Run() error {
 	return nil
 }
 
-// Stop does nothing
-func (d *DockerCheck) Stop() {}
-
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 	d.instance.Parse(config)
@@ -307,7 +304,7 @@ func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 func DockerFactory() check.Check {
 	return &DockerCheck{
 		CheckBase: core.NewCheckBase(dockerCheckName),
-		instance: &DockerConfig{},
+		instance:  &DockerConfig{},
 	}
 }
 

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -9,7 +9,6 @@ import (
 	"expvar"
 	"fmt"
 	"math/rand"
-	"time"
 
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/beevik/ntp"
@@ -21,6 +20,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const ntpCheckName = "ntp"
+
 var (
 	ntpExpVar = expvar.NewFloat("ntpOffset")
 	// for testing purpose
@@ -29,9 +30,8 @@ var (
 
 // NTPCheck only has sender and config
 type NTPCheck struct {
-	id           check.ID
-	lastWarnings []error
-	cfg          *ntpConfig
+	core.CheckBase
+	cfg *ntpConfig
 }
 
 type ntpInstanceConfig struct {
@@ -53,7 +53,7 @@ func (c *NTPCheck) String() string {
 	return "ntp"
 }
 
-func (c *ntpConfig) Parse(data []byte, initData []byte) error {
+func (c *ntpConfig) parse(data []byte, initData []byte) error {
 	var instance ntpInstanceConfig
 	var initConf ntpInitConfig
 	defaultVersion := 3
@@ -93,30 +93,17 @@ func (c *ntpConfig) Parse(data []byte, initData []byte) error {
 // Configure configure the data from the yaml
 func (c *NTPCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
 	cfg := new(ntpConfig)
-	err := cfg.Parse(data, initConfig)
+	err := cfg.parse(data, initConfig)
 	if err != nil {
 		log.Criticalf("Error parsing configuration file: %s", err)
 		return err
 	}
 
-	c.id = check.Identify(c, data, initConfig)
+	c.BuildID(data, initConfig)
 	c.cfg = cfg
 
 	return nil
 }
-
-// ID returns the id of the instance
-func (c *NTPCheck) ID() check.ID {
-	return c.id
-}
-
-// Interval returns the scheduling time for the check
-func (c *NTPCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// Stop does nothing
-func (c *NTPCheck) Stop() {}
 
 // Run runs the check
 func (c *NTPCheck) Run() error {
@@ -154,42 +141,12 @@ func (c *NTPCheck) Run() error {
 	return nil
 }
 
-// GetWarnings grabs the last warnings from the sender
-func (c *NTPCheck) GetWarnings() []error {
-	w := c.lastWarnings
-	c.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (c *NTPCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// Warnf will log a formatted warning and add it to the warnings
-func (c *NTPCheck) warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (c *NTPCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 func ntpFactory() check.Check {
-	return &NTPCheck{}
+	return &NTPCheck{
+		CheckBase: core.NewCheckBase(ntpCheckName),
+	}
 }
 
 func init() {
-	core.RegisterCheck("ntp", ntpFactory)
+	core.RegisterCheck(ntpCheckName, ntpFactory)
 }

--- a/pkg/collector/corechecks/network/snmp_test.go
+++ b/pkg/collector/corechecks/network/snmp_test.go
@@ -140,7 +140,7 @@ func TestIndexTagExtraction(t *testing.T) {
 func TestConfigureV2(t *testing.T) {
 	cfg := new(snmpConfig)
 
-	err := cfg.Parse(bytes.NewBufferString(goodV2Cfg).Bytes(), []byte{})
+	err := cfg.parse(bytes.NewBufferString(goodV2Cfg).Bytes(), []byte{})
 	if err != nil {
 		t.Fatalf("Unable to parse configuration: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestConfigureV2(t *testing.T) {
 func TestConfigureV3(t *testing.T) {
 	cfg := new(snmpConfig)
 
-	err := cfg.Parse(bytes.NewBufferString(goodV3Cfg).Bytes(), []byte{})
+	err := cfg.parse(bytes.NewBufferString(goodV3Cfg).Bytes(), []byte{})
 	if err != nil {
 		t.Fatalf("Unable to parse configuration: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestSubmitSNMP(t *testing.T) {
 
 	mock := mocksender.NewMockSender(snmpCheck.ID())
 
-	if err := cfg.Parse(bytes.NewBufferString(basicCfg).Bytes(), []byte{}); err != nil {
+	if err := cfg.parse(bytes.NewBufferString(basicCfg).Bytes(), []byte{}); err != nil {
 		t.Fatalf("Unable to parse configuration: %v", err)
 	}
 	snmpCheck.cfg = cfg

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -7,7 +7,6 @@ package system
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -17,20 +16,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
+const cpuCheckName = "cpu"
+
 // For testing purpose
 var times = cpu.Times
 var cpuInfo = cpu.Info
 
 // CPUCheck doesn't need additional fields
 type CPUCheck struct {
-	nbCPU        float64
-	lastNbCycle  float64
-	lastWarnings []error
-	lastTimes    cpu.TimesStat
-}
-
-func (c *CPUCheck) String() string {
-	return "cpu"
+	core.CheckBase
+	nbCPU       float64
+	lastNbCycle float64
+	lastTimes   cpu.TimesStat
 }
 
 // Run executes the check
@@ -91,55 +88,12 @@ func (c *CPUCheck) Configure(data check.ConfigData, initConfig check.ConfigData)
 	return nil
 }
 
-// Interval returns the scheduling time for the check
-func (c *CPUCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// ID returns the name of the check since there should be only one instance running
-func (c *CPUCheck) ID() check.ID {
-	return check.ID(c.String())
-}
-
-// Stop does nothing
-func (c *CPUCheck) Stop() {}
-
-// GetWarnings grabs the last warnings from the sender
-func (c *CPUCheck) GetWarnings() []error {
-	w := c.lastWarnings
-	c.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (c *CPUCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// Warnf will log a formatted warning and add it to the warnings
-func (c *CPUCheck) warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (c *CPUCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 func cpuFactory() check.Check {
-	return &CPUCheck{}
+	return &CPUCheck{
+		CheckBase: core.NewCheckBase(cpuCheckName),
+	}
 }
 
 func init() {
-	core.RegisterCheck("cpu", cpuFactory)
+	core.RegisterCheck(cpuCheckName, cpuFactory)
 }

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -6,32 +6,24 @@
 package system
 
 import (
-	"fmt"
 	"regexp"
-	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/shirou/gopsutil/disk"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-
-	log "github.com/cihub/seelog"
-	"github.com/shirou/gopsutil/disk"
-
-	"gopkg.in/yaml.v2"
 )
 
 const (
 	// SectorSize is exported in github.com/shirou/gopsutil/disk (but not working!)
-	SectorSize = 512
-	kB         = (1 << 10)
+	SectorSize       = 512
+	kB               = (1 << 10)
+	iostatsCheckName = "io"
 )
 
 // For testing purpose
 var ioCounters = disk.IOCounters
-
-func (c *IOCheck) String() string {
-	return "io"
-}
 
 // Configure the IOstats check
 func (c *IOCheck) commonConfigure(data check.ConfigData, initConfig check.ConfigData) error {
@@ -51,57 +43,12 @@ func (c *IOCheck) commonConfigure(data check.ConfigData, initConfig check.Config
 	return err
 }
 
-// Interval returns the scheduling time for the check
-func (c *IOCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// ID returns the name of the check since there should be only one instance running
-func (c *IOCheck) ID() check.ID {
-	return check.ID(c.String())
-}
-
-// Stop does nothing
-func (c *IOCheck) Stop() {}
-
-// GetWarnings grabs the last warnings from the sender
-func (c *IOCheck) GetWarnings() []error {
-	w := c.lastWarnings
-	c.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (c *IOCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// Warnf will log a formatted warning and add it to the warnings
-func (c *IOCheck) warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (c *IOCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 func init() {
-	core.RegisterCheck("io", ioFactory)
+	core.RegisterCheck(iostatsCheckName, ioFactory)
 }
 
 func ioFactory() check.Check {
-	log.Debug("IOCheck factory")
-	c := &IOCheck{}
-	return c
+	return &IOCheck{
+		CheckBase: core.NewCheckBase(iostatsCheckName),
+	}
 }

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/xc"
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/disk"
@@ -24,10 +25,10 @@ var hz int64
 
 // IOCheck doesn't need additional fields
 type IOCheck struct {
-	blacklist    *regexp.Regexp
-	lastWarnings []error
-	ts           int64
-	stats        map[string]disk.IOCountersStat
+	core.CheckBase
+	blacklist *regexp.Regexp
+	ts        int64
+	stats     map[string]disk.IOCountersStat
 }
 
 // Configure the IOstats check

--- a/pkg/collector/corechecks/system/iostats_wmi_windows.go
+++ b/pkg/collector/corechecks/system/iostats_wmi_windows.go
@@ -46,9 +46,9 @@ type Win32_PerfRawData_PerfDisk_LogicalDisk struct {
 
 // IOCheck doesn't need additional fields
 type IOCheck struct {
-	blacklist    *regexp.Regexp
-	drivemap     map[string]Win32_PerfRawData_PerfDisk_LogicalDisk
-	lastWarnings []error
+	core.CheckBase
+	blacklist *regexp.Regexp
+	drivemap  map[string]Win32_PerfRawData_PerfDisk_LogicalDisk
 }
 
 // Configure the IOstats check

--- a/pkg/collector/corechecks/system/iostats_wmi_windows.go
+++ b/pkg/collector/corechecks/system/iostats_wmi_windows.go
@@ -12,10 +12,12 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/StackExchange/wmi"
 	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
 
 var (

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -7,7 +7,6 @@ package system
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -16,17 +15,15 @@ import (
 	"github.com/shirou/gopsutil/load"
 )
 
+const loadCheckName = "load"
+
 // For testing purpose
 var loadAvg = load.Avg
 
 // LoadCheck doesn't need additional fields
 type LoadCheck struct {
-	lastWarnings []error
-	nbCPU        int32
-}
-
-func (c *LoadCheck) String() string {
-	return "load"
+	core.CheckBase
+	nbCPU int32
 }
 
 // Run executes the check
@@ -67,55 +64,12 @@ func (c *LoadCheck) Configure(data check.ConfigData, initConfig check.ConfigData
 	return nil
 }
 
-// Interval returns the scheduling time for the check
-func (c *LoadCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// ID returns the name of the check since there should be only one instance running
-func (c *LoadCheck) ID() check.ID {
-	return check.ID(c.String())
-}
-
-// Stop does nothing
-func (c *LoadCheck) Stop() {}
-
-// GetWarnings grabs the last warnings from the sender
-func (c *LoadCheck) GetWarnings() []error {
-	w := c.lastWarnings
-	c.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (c *LoadCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// Warnf will log a formatted warning and add it to the warnings
-func (c *LoadCheck) warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (c *LoadCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 func loadFactory() check.Check {
-	return &LoadCheck{}
+	return &LoadCheck{
+		CheckBase: core.NewCheckBase(loadCheckName),
+	}
 }
 
 func init() {
-	core.RegisterCheck("load", loadFactory)
+	core.RegisterCheck(loadCheckName, loadFactory)
 }

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -8,7 +8,6 @@ package system
 import (
 	"fmt"
 	"runtime"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -18,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
+const memCheckName = "memory"
+
 // For testing purpose
 var virtualMemory = mem.VirtualMemory
 var swapMemory = mem.SwapMemory
@@ -25,11 +26,7 @@ var runtimeOS = runtime.GOOS
 
 // MemoryCheck doesn't need additional fields
 type MemoryCheck struct {
-	lastWarnings []error
-}
-
-func (c *MemoryCheck) String() string {
-	return "memory"
+	core.CheckBase
 }
 
 const mbSize float64 = 1024 * 1024
@@ -113,54 +110,11 @@ func (c *MemoryCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	return nil
 }
 
-// Interval returns the scheduling time for the check
-func (c *MemoryCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// ID returns the name of the check since there should be only one instance running
-func (c *MemoryCheck) ID() check.ID {
-	return check.ID(c.String())
-}
-
-// Stop does nothing
-func (c *MemoryCheck) Stop() {}
-
-// GetWarnings grabs the last warnings from the sender
-func (c *MemoryCheck) GetWarnings() []error {
-	w := c.lastWarnings
-	c.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (c *MemoryCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// Warnf will log a formatted warning and add it to the warnings
-func (c *MemoryCheck) warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (c *MemoryCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 func memFactory() check.Check {
-	return &MemoryCheck{}
+	return &MemoryCheck{
+		CheckBase: core.NewCheckBase(memCheckName),
+	}
 }
 func init() {
-	core.RegisterCheck("memory", memFactory)
+	core.RegisterCheck(memCheckName, memFactory)
 }

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -6,9 +6,6 @@
 package system
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -17,16 +14,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
+const uptimeCheckName = "uptime"
+
 // For testing purpose
 var uptime = host.Uptime
 
 // UptimeCheck doesn't need additional fields
 type UptimeCheck struct {
-	lastWarnings []error
-}
-
-func (c *UptimeCheck) String() string {
-	return "uptime"
+	core.CheckBase
 }
 
 // Run executes the check
@@ -54,55 +49,12 @@ func (c *UptimeCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	return nil
 }
 
-// Interval returns the scheduling time for the check
-func (c *UptimeCheck) Interval() time.Duration {
-	return check.DefaultCheckInterval
-}
-
-// ID returns the name of the check since there should be only one instance running
-func (c *UptimeCheck) ID() check.ID {
-	return check.ID(c.String())
-}
-
-// Stop does nothing
-func (c *UptimeCheck) Stop() {}
-
-// GetWarnings grabs the last warnings from the sender
-func (c *UptimeCheck) GetWarnings() []error {
-	w := c.lastWarnings
-	c.lastWarnings = []error{}
-	return w
-}
-
-// Warn will log a warning and add it to the warnings
-func (c *UptimeCheck) warn(v ...interface{}) error {
-	w := log.Warn(v)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// Warnf will log a formatted warning and add it to the warnings
-func (c *UptimeCheck) warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
-	c.lastWarnings = append(c.lastWarnings, w)
-
-	return w
-}
-
-// GetMetricStats returns the stats from the last run of the check
-func (c *UptimeCheck) GetMetricStats() (map[string]int64, error) {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve a Sender instance: %v", err)
-	}
-	return sender.GetMetricStats(), nil
-}
-
 func uptimeFactory() check.Check {
-	return &UptimeCheck{}
+	return &UptimeCheck{
+		CheckBase: core.NewCheckBase(uptimeCheckName),
+	}
 }
 
 func init() {
-	core.RegisterCheck("uptime", uptimeFactory)
+	core.RegisterCheck(uptimeCheckName, uptimeFactory)
 }


### PR DESCRIPTION
### What does this PR do?

Create a `corecheck.CheckBase` class that corechecks can embed to get sane defaults for most of the `check.Check` interface. This removes lots of non-check-logic from the corecheck files for better readability, and will make changes easier in the future.

Also, this class provides a [different implementation of GetWarnings](https://github.com/DataDog/datadog-agent/blob/500cb7e7064462d09c4872e8eb07bc78373d1979/pkg/collector/corechecks/checkbase.go#L90) that avoids churning the `latestWarnings` array when it's empty.

As a side effect, the `warn`/`warnf` methods become public `Warn`/`Warnf` methods to be used by the embedding class. This made me realise only the `kubernetes_apiserver` uses that mechanism, I'll need to update the `docker` corecheck.

As they might change in the near future, I didn't update the `embed` corechecks, please let me know if that's desirable.

  