### PR TITLE
[DCA] Event collection from the API server

### DIFF
--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -127,4 +127,4 @@ subjects:
 ```
 
 The ConfigMap to store the `LatestEventToken` has to be deployed in the `default` namespace and be named `eventtokendca`
-Simply running `kubectl create configmap eventtokendca --from-literal="eventToken"="12"`
+Simply running `kubectl create configmap configmaptokendca --from-literal="eventToken"="12"`

--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -80,7 +80,7 @@ This manifest will create a Service Account, a Cluster Role with a restricted sc
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: dca
+  name: datadog-dca
 rules:
 - apiGroups:
   - ""
@@ -100,7 +100,7 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - eventtokendca
+  - configmapdcatoken
   verbs:
   - get
   - update
@@ -108,23 +108,28 @@ rules:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: dca
+  name: datadog-dca
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: dca
+  name: datadog-dca
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: dca
+  name: datadog-dca
 subjects:
 - kind: ServiceAccount
-  name: dca
+  name: datadog-dca
   namespace: default
 ---
 ```
 
-The ConfigMap to store the `LatestEventToken` has to be deployed in the `default` namespace and be named `eventtokendca`
-Simply running `kubectl create configmap configmaptokendca --from-literal="eventToken"="12"`
+The ConfigMap to store the `event.tokenKey` and the `event.tokenTimestamp` has to be deployed in the `default` namespace and be named `configmapdcatoken`
+One can simply run `kubectl create configmap configmapdcatoken --from-literal="event.tokenKey"="0"` .
+NB: you can set any resversion here, make sure it's not set to a value superior to the actual curent resversion.
+
+You can also set the `event.tokenTimestamp`, if not present, it will be automatically set.
+
+

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/DataDog/gohai"
-  packages = [
-    "cpu",
-    "filesystem",
-    "memory",
-    "network",
-    "platform",
-    "processes",
-    "processes/gops"
-  ]
+  packages = ["cpu","filesystem","memory","network","platform","processes","processes/gops"]
   revision = "d80d0f562a71fa2380fbeccc93ba5a2e325606e4"
 
 [[projects]]
@@ -28,16 +20,22 @@
   revision = "2cfb68475274527a10701355c739f31dd404718c"
 
 [[projects]]
+  branch = "1.x"
   name = "github.com/DataDog/zstd"
   packages = ["."]
-  revision = "0727e1752ea5db67e0ede4e0fb7168ddc6ead61b"
-  version = "v1.3.0"
+  revision = "dcab8fb122781db546af7aa75978ae681b6085f5"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
   revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
   version = "v0.4.5"
+
+[[projects]]
+  name = "github.com/Sirupsen/logrus"
+  packages = ["."]
+  revision = "55eb11d21d2a31a3cc93838241d04800f52e823d"
+  version = "v0.7.3"
 
 [[projects]]
   branch = "master"
@@ -47,35 +45,9 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = [
-    "aws",
-    "aws/awserr",
-    "aws/awsutil",
-    "aws/client",
-    "aws/client/metadata",
-    "aws/corehandlers",
-    "aws/credentials",
-    "aws/credentials/ec2rolecreds",
-    "aws/credentials/endpointcreds",
-    "aws/credentials/stscreds",
-    "aws/defaults",
-    "aws/ec2metadata",
-    "aws/endpoints",
-    "aws/request",
-    "aws/session",
-    "aws/signer/v4",
-    "internal/shareddefaults",
-    "private/protocol",
-    "private/protocol/ec2query",
-    "private/protocol/query",
-    "private/protocol/query/queryutil",
-    "private/protocol/rest",
-    "private/protocol/xml/xmlutil",
-    "service/ec2",
-    "service/sts"
-  ]
-  revision = "f62f7b7c5425f2b1a630932617477bdeac6dc371"
-  version = "v1.12.55"
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/sts"]
+  revision = "e63027ac6e05f6d4ae9f97ce0294d7468ca652da"
+  version = "v1.10.33"
 
 [[projects]]
   name = "github.com/beevik/ntp"
@@ -85,8 +57,8 @@
 [[projects]]
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
-  version = "v1.1.0"
+  revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/cihub/seelog"
@@ -96,104 +68,41 @@
 
 [[projects]]
   name = "github.com/coreos/etcd"
-  packages = [
-    "client",
-    "pkg/pathutil",
-    "pkg/types"
-  ]
-  revision = "960f4604bc821241b94906da5fe7f66306a77472"
-  version = "v3.1.11"
+  packages = ["client","pkg/pathutil","pkg/types"]
+  revision = "0520cb9304cb2385f7e72b8bc02d6e4d3257158a"
+  version = "v3.1.10"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = [
-    "digest",
-    "reference"
-  ]
-  revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
-  version = "v2.6.2"
+  packages = ["digestset","reference"]
+  revision = "5cfdfbdce59c0b1854b9d82189e9c6164d54456a"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = [
-    "api/types",
-    "api/types/blkiodev",
-    "api/types/container",
-    "api/types/events",
-    "api/types/filters",
-    "api/types/mount",
-    "api/types/network",
-    "api/types/reference",
-    "api/types/registry",
-    "api/types/strslice",
-    "api/types/swarm",
-    "api/types/time",
-    "api/types/versions",
-    "api/types/volume",
-    "client",
-    "pkg/tlsconfig"
-  ]
+  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = [
-    "nat",
-    "sockets",
-    "tlsconfig"
-  ]
-  revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
-  version = "v0.3.0"
+  packages = ["nat","sockets","tlsconfig"]
+  revision = "e15c02316c12de00874640cd76311849de2aeed5"
 
 [[projects]]
+  branch = "master"
   name = "github.com/docker/go-units"
   packages = ["."]
   revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
-  version = "v0.3.2"
 
 [[projects]]
   name = "github.com/ericchiang/k8s"
-  packages = [
-    ".",
-    "api/resource",
-    "api/unversioned",
-    "api/v1",
-    "apis/apps/v1alpha1",
-    "apis/apps/v1beta1",
-    "apis/authentication/v1",
-    "apis/authentication/v1beta1",
-    "apis/authorization/v1",
-    "apis/authorization/v1beta1",
-    "apis/autoscaling/v1",
-    "apis/autoscaling/v2alpha1",
-    "apis/batch/v1",
-    "apis/batch/v2alpha1",
-    "apis/certificates/v1alpha1",
-    "apis/certificates/v1beta1",
-    "apis/extensions/v1beta1",
-    "apis/imagepolicy/v1alpha1",
-    "apis/meta/v1",
-    "apis/policy/v1alpha1",
-    "apis/policy/v1beta1",
-    "apis/rbac/v1alpha1",
-    "apis/rbac/v1beta1",
-    "apis/settings/v1alpha1",
-    "apis/storage/v1",
-    "apis/storage/v1beta1",
-    "runtime",
-    "runtime/schema",
-    "util/intstr",
-    "watch/versioned"
-  ]
-  revision = "68b0248f880c5967d1ba7166486cb216af849b15"
-  version = "v0.4.0"
+  packages = [".","api/resource","api/unversioned","api/v1","apis/apps/v1alpha1","apis/apps/v1beta1","apis/authentication/v1","apis/authentication/v1beta1","apis/authorization/v1","apis/authorization/v1beta1","apis/autoscaling/v1","apis/autoscaling/v2alpha1","apis/batch/v1","apis/batch/v2alpha1","apis/certificates/v1alpha1","apis/certificates/v1beta1","apis/extensions/v1beta1","apis/imagepolicy/v1alpha1","apis/meta/v1","apis/policy/v1alpha1","apis/policy/v1beta1","apis/rbac/v1alpha1","apis/rbac/v1beta1","apis/settings/v1alpha1","apis/storage/v1","apis/storage/v1beta1","runtime","runtime/schema","util/intstr","watch/versioned"]
+  revision = "fa30591be9ccaacee478995fbba53c648e901483"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -216,33 +125,24 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
+  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
+  version = "v1.28.2"
 
 [[projects]]
   name = "github.com/go-ole/go-ole"
-  packages = [
-    ".",
-    "oleutil"
-  ]
-  revision = "0e87ea779d9deb219633b828a023b32e1244dd57"
-  version = "v1.2.0"
+  packages = [".","oleutil"]
+  revision = "de8695c8edbf8236f30d6e1376e20b198a028d42"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = [
-    "gogoproto",
-    "proto",
-    "protoc-gen-gogo/descriptor"
-  ]
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor"]
+  revision = "909568be09de550ed094403c2bf8a261b5bb730a"
+  version = "v0.3"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
 
 [[projects]]
   branch = "master"
@@ -259,20 +159,19 @@
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
-  version = "v1.6.0"
+  revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/hashicorp/consul"
   packages = ["api"]
-  revision = "b55059fc3d0327c92c41431e57dfd2df3f956b03"
-  version = "v1.0.2"
+  revision = "5473255f9816e2b64d52cc054470d600b007d821"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
-  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
+  revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
 
 [[projects]]
   branch = "master"
@@ -281,34 +180,19 @@
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token"
-  ]
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "7fa7fff964d035e8a162cce3a164b3ad02ad651b"
 
 [[projects]]
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
-  revision = "d6574a5bb1226678d7010325fb6c985db20ee458"
-  version = "v0.8.1"
+  revision = "91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc"
 
 [[projects]]
   branch = "master"
   name = "github.com/hectane/go-acl"
-  packages = [
-    ".",
-    "api"
-  ]
+  packages = [".","api"]
   revision = "7f56832555fc229dad908c67d65ed3ce6156b70c"
 
 [[projects]]
@@ -325,7 +209,8 @@
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "0b12d6b5"
+  revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
+  version = "0.2.2"
 
 [[projects]]
   name = "github.com/k-sone/snmpgo"
@@ -334,16 +219,14 @@
   version = "v3.2.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/kardianos/osext"
   packages = ["."]
-  revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
+  revision = "9d302b58e975387d0b4d9be876622c86cefe64be"
 
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "d419a98cdbed11a922bf76f257b7c4be79b50e73"
-  version = "v1.7.4"
+  revision = "51463bfca2576e06c62a8504b5c0f06d61312647"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -364,46 +247,52 @@
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+  revision = "cc8532a8e9a55ea36402aa21efdf403a60d34096"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
-  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
+  revision = "417edcfd99a4d472c262e58f22b4bfe97580f03e"
+
+[[projects]]
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  revision = "aa2ec055abd10d26d539eb630a92241b781ce4bc"
+  version = "v1.0.0-rc0"
 
 [[projects]]
   name = "github.com/patrickmn/go-cache"
   packages = ["."]
-  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
-  version = "v2.1.0"
+  revision = "1881a9bccb818787f68c52bfba648c6cf34c34fa"
+  version = "v2.0.0"
+
+[[projects]]
+  name = "github.com/pelletier/go-buffruneio"
+  packages = ["."]
+  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
+  version = "v0.2.0"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
-  version = "v1.0.1"
+  revision = "fe206efb84b2bc8e8cfafe6b4c1826622be969e3"
 
 [[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ff09b135c25aae272398c51a07235b90a75aa4f0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
-  version = "v1.0.0"
+  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 
 [[projects]]
-  branch = "master"
   name = "github.com/samuel/go-zookeeper"
   packages = ["zk"]
-  revision = "471cd4e61d7a78ece1791fa5faa0345dc8c7d5a5"
+  revision = "1d7be4effb13d2d908342d349d71a284a7542693"
 
 [[projects]]
   branch = "master"
@@ -413,18 +302,9 @@
 
 [[projects]]
   name = "github.com/shirou/gopsutil"
-  packages = [
-    "cpu",
-    "disk",
-    "host",
-    "internal/common",
-    "load",
-    "mem",
-    "net",
-    "process"
-  ]
-  revision = "7ec06ec280df1dd1f08befc535049d49d63ae18a"
-  version = "v2.17.12"
+  packages = ["cpu","disk","host","internal/common","load","mem","net","process"]
+  revision = "a452de7c734a0fa0f16d2e5725b0fa5934d9fbec"
+  version = "v2.17.08"
 
 [[projects]]
   branch = "master"
@@ -433,13 +313,10 @@
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
+  branch = "master"
   name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem"
-  ]
-  revision = "ec3a3111d1e1bdff38a61e09d5a5f5e974905611"
-  version = "v1.0.1"
+  packages = [".","mem"]
+  revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -450,130 +327,80 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
-  version = "v0.0.1"
+  revision = "7b1b6e8dc027253d45fc029bc269d1c019f83a34"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
+  revision = "fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "f1d95a35e132e8a1868023a08932b14f0b8b8fcb"
 
 [[projects]]
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
-  version = "v1.0.0"
+  revision = "0967fc9aceab2ce9da34061253ac10fb99bba5b2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/stretchr/objx"
   packages = ["."]
-  revision = "74fbc600c03d927552c1888536e49238da904364"
+  revision = "cbeaeb16a013161a98496fad62933b1d21786672"
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = [
-    "assert",
-    "mock",
-    "require",
-    "suite"
-  ]
-  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
-  version = "v1.2.0"
+  packages = ["assert","mock","require","suite"]
+  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
+  version = "v1.1.4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/ugorji/go"
   packages = ["codec"]
-  revision = "ccfe18359b55b97855cee1d3f74e5efbda4869dc"
+  revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
 
 [[projects]]
   name = "github.com/urfave/negroni"
   packages = ["."]
-  revision = "5dbbc83f748fc3ad38585842b0aedab546d0ea1e"
-  version = "v0.3.0"
+  revision = "fde5e16d32adc7ad637e9cd9ad21d4ebc6192535"
+  version = "v0.2.0"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "context/ctxhttp",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "lex/httplex",
-    "proxy"
-  ]
-  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
+  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex","proxy"]
+  revision = "f2499483f923065a842d38eb4c7f1927e6fc6e6d"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows",
-    "windows/registry",
-    "windows/svc",
-    "windows/svc/debug",
-    "windows/svc/eventlog",
-    "windows/svc/mgr"
-  ]
-  revision = "a3f2cbd54cf5dfe3fbaccf76375fdb12f67654c8"
+  packages = ["unix","windows","windows/registry","windows/svc","windows/svc/debug","windows/svc/eventlog","windows/svc/mgr"]
+  revision = "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable"
-  ]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
-  packages = [
-    "go/ast/astutil",
-    "go/buildutil",
-    "go/loader"
-  ]
-  revision = "951512dfed6ce3af7c9c8aa37505a03c9b0c348d"
+  packages = ["go/ast/astutil","go/buildutil","go/loader"]
+  revision = "9badcbe49be523255546b669968041d707ece12e"
 
 [[projects]]
-  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "0e4404da71227dcc02fb1deee803d93e86d08f72"
+  revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
 
 [[projects]]
   name = "gopkg.in/zorkian/go-datadog-api.v2"
   packages = ["."]
-  revision = "2ba72e380572e4d47f66358c875618afe24721ee"
-  version = "v2.7"
+  revision = "659bba33a1626ab76f393d6878dc3e4f13253f6d"
+  version = "v2.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "187102bd7429c9658500ae54996cc1e24d561f8e28ff571d2957d3354c90a3d7"
+  inputs-digest = "c2077c0c76de7e9f127153bfe9b20fb511398a03e7821e713b8cbc841bce9d72"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,15 @@
 [[projects]]
   branch = "master"
   name = "github.com/DataDog/gohai"
-  packages = ["cpu","filesystem","memory","network","platform","processes","processes/gops"]
+  packages = [
+    "cpu",
+    "filesystem",
+    "memory",
+    "network",
+    "platform",
+    "processes",
+    "processes/gops"
+  ]
   revision = "d80d0f562a71fa2380fbeccc93ba5a2e325606e4"
 
 [[projects]]
@@ -20,22 +28,16 @@
   revision = "2cfb68475274527a10701355c739f31dd404718c"
 
 [[projects]]
-  branch = "1.x"
   name = "github.com/DataDog/zstd"
   packages = ["."]
-  revision = "dcab8fb122781db546af7aa75978ae681b6085f5"
+  revision = "0727e1752ea5db67e0ede4e0fb7168ddc6ead61b"
+  version = "v1.3.0"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
   revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
   version = "v0.4.5"
-
-[[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "55eb11d21d2a31a3cc93838241d04800f52e823d"
-  version = "v0.7.3"
 
 [[projects]]
   branch = "master"
@@ -45,9 +47,35 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/sts"]
-  revision = "e63027ac6e05f6d4ae9f97ce0294d7468ca652da"
-  version = "v1.10.33"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ec2",
+    "service/sts"
+  ]
+  revision = "f62f7b7c5425f2b1a630932617477bdeac6dc371"
+  version = "v1.12.55"
 
 [[projects]]
   name = "github.com/beevik/ntp"
@@ -57,8 +85,8 @@
 [[projects]]
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
-  version = "v1.0.0"
+  revision = "61153c768f31ee5f130071d08fc82b85208528de"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/cihub/seelog"
@@ -68,41 +96,104 @@
 
 [[projects]]
   name = "github.com/coreos/etcd"
-  packages = ["client","pkg/pathutil","pkg/types"]
-  revision = "0520cb9304cb2385f7e72b8bc02d6e4d3257158a"
-  version = "v3.1.10"
+  packages = [
+    "client",
+    "pkg/pathutil",
+    "pkg/types"
+  ]
+  revision = "960f4604bc821241b94906da5fe7f66306a77472"
+  version = "v3.1.11"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "6d212800a42e8ab5c146b8ace3490ee17e5225f9"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digestset","reference"]
-  revision = "5cfdfbdce59c0b1854b9d82189e9c6164d54456a"
+  packages = [
+    "digest",
+    "reference"
+  ]
+  revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
+  version = "v2.6.2"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/reference",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "pkg/tlsconfig"
+  ]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = ["nat","sockets","tlsconfig"]
-  revision = "e15c02316c12de00874640cd76311849de2aeed5"
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig"
+  ]
+  revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
+  version = "v0.3.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/docker/go-units"
   packages = ["."]
   revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
+  version = "v0.3.2"
 
 [[projects]]
   name = "github.com/ericchiang/k8s"
-  packages = [".","api/resource","api/unversioned","api/v1","apis/apps/v1alpha1","apis/apps/v1beta1","apis/authentication/v1","apis/authentication/v1beta1","apis/authorization/v1","apis/authorization/v1beta1","apis/autoscaling/v1","apis/autoscaling/v2alpha1","apis/batch/v1","apis/batch/v2alpha1","apis/certificates/v1alpha1","apis/certificates/v1beta1","apis/extensions/v1beta1","apis/imagepolicy/v1alpha1","apis/meta/v1","apis/policy/v1alpha1","apis/policy/v1beta1","apis/rbac/v1alpha1","apis/rbac/v1beta1","apis/settings/v1alpha1","apis/storage/v1","apis/storage/v1beta1","runtime","runtime/schema","util/intstr","watch/versioned"]
-  revision = "fa30591be9ccaacee478995fbba53c648e901483"
+  packages = [
+    ".",
+    "api/resource",
+    "api/unversioned",
+    "api/v1",
+    "apis/apps/v1alpha1",
+    "apis/apps/v1beta1",
+    "apis/authentication/v1",
+    "apis/authentication/v1beta1",
+    "apis/authorization/v1",
+    "apis/authorization/v1beta1",
+    "apis/autoscaling/v1",
+    "apis/autoscaling/v2alpha1",
+    "apis/batch/v1",
+    "apis/batch/v2alpha1",
+    "apis/certificates/v1alpha1",
+    "apis/certificates/v1beta1",
+    "apis/extensions/v1beta1",
+    "apis/imagepolicy/v1alpha1",
+    "apis/meta/v1",
+    "apis/policy/v1alpha1",
+    "apis/policy/v1beta1",
+    "apis/rbac/v1alpha1",
+    "apis/rbac/v1beta1",
+    "apis/settings/v1alpha1",
+    "apis/storage/v1",
+    "apis/storage/v1beta1",
+    "runtime",
+    "runtime/schema",
+    "util/intstr",
+    "watch/versioned"
+  ]
+  revision = "68b0248f880c5967d1ba7166486cb216af849b15"
+  version = "v0.4.0"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -125,24 +216,33 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
-  version = "v1.28.2"
+  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
+  version = "v1.32.0"
 
 [[projects]]
   name = "github.com/go-ole/go-ole"
-  packages = [".","oleutil"]
-  revision = "de8695c8edbf8236f30d6e1376e20b198a028d42"
+  packages = [
+    ".",
+    "oleutil"
+  ]
+  revision = "0e87ea779d9deb219633b828a023b32e1244dd57"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor"]
-  revision = "909568be09de550ed094403c2bf8a261b5bb730a"
-  version = "v0.3"
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor"
+  ]
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
 
 [[projects]]
+  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
@@ -159,19 +259,20 @@
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
-  version = "v1.4.0"
+  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
+  version = "v1.6.0"
 
 [[projects]]
   name = "github.com/hashicorp/consul"
   packages = ["api"]
-  revision = "5473255f9816e2b64d52cc054470d600b007d821"
+  revision = "b55059fc3d0327c92c41431e57dfd2df3f956b03"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
-  revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
+  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
@@ -180,19 +281,34 @@
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
+  branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
-  revision = "7fa7fff964d035e8a162cce3a164b3ad02ad651b"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
-  revision = "91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc"
+  revision = "d6574a5bb1226678d7010325fb6c985db20ee458"
+  version = "v0.8.1"
 
 [[projects]]
   branch = "master"
   name = "github.com/hectane/go-acl"
-  packages = [".","api"]
+  packages = [
+    ".",
+    "api"
+  ]
   revision = "7f56832555fc229dad908c67d65ed3ce6156b70c"
 
 [[projects]]
@@ -209,8 +325,7 @@
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
-  version = "0.2.2"
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/k-sone/snmpgo"
@@ -219,14 +334,16 @@
   version = "v3.2.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/kardianos/osext"
   packages = ["."]
-  revision = "9d302b58e975387d0b4d9be876622c86cefe64be"
+  revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "51463bfca2576e06c62a8504b5c0f06d61312647"
+  revision = "d419a98cdbed11a922bf76f257b7c4be79b50e73"
+  version = "v1.7.4"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -247,52 +364,46 @@
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
+  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "cc8532a8e9a55ea36402aa21efdf403a60d34096"
+  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
+  branch = "master"
   name = "github.com/mitchellh/reflectwalk"
   packages = ["."]
-  revision = "417edcfd99a4d472c262e58f22b4bfe97580f03e"
-
-[[projects]]
-  name = "github.com/opencontainers/go-digest"
-  packages = ["."]
-  revision = "aa2ec055abd10d26d539eb630a92241b781ce4bc"
-  version = "v1.0.0-rc0"
+  revision = "63d60e9d0dbc60cf9164e6510889b0db6683d98c"
 
 [[projects]]
   name = "github.com/patrickmn/go-cache"
   packages = ["."]
-  revision = "1881a9bccb818787f68c52bfba648c6cf34c34fa"
-  version = "v2.0.0"
-
-[[projects]]
-  name = "github.com/pelletier/go-buffruneio"
-  packages = ["."]
-  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
-  version = "v0.2.0"
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
+  version = "v2.1.0"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "fe206efb84b2bc8e8cfafe6b4c1826622be969e3"
+  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "ff09b135c25aae272398c51a07235b90a75aa4f0"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/samuel/go-zookeeper"
   packages = ["zk"]
-  revision = "1d7be4effb13d2d908342d349d71a284a7542693"
+  revision = "471cd4e61d7a78ece1791fa5faa0345dc8c7d5a5"
 
 [[projects]]
   branch = "master"
@@ -302,9 +413,18 @@
 
 [[projects]]
   name = "github.com/shirou/gopsutil"
-  packages = ["cpu","disk","host","internal/common","load","mem","net","process"]
-  revision = "a452de7c734a0fa0f16d2e5725b0fa5934d9fbec"
-  version = "v2.17.08"
+  packages = [
+    "cpu",
+    "disk",
+    "host",
+    "internal/common",
+    "load",
+    "mem",
+    "net",
+    "process"
+  ]
+  revision = "7ec06ec280df1dd1f08befc535049d49d63ae18a"
+  version = "v2.17.12"
 
 [[projects]]
   branch = "master"
@@ -313,10 +433,13 @@
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
-  revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "ec3a3111d1e1bdff38a61e09d5a5f5e974905611"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -327,80 +450,130 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "7b1b6e8dc027253d45fc029bc269d1c019f83a34"
+  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
+  version = "v0.0.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66"
+  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
 
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "f1d95a35e132e8a1868023a08932b14f0b8b8fcb"
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "0967fc9aceab2ce9da34061253ac10fb99bba5b2"
+  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
+  version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/stretchr/objx"
   packages = ["."]
-  revision = "cbeaeb16a013161a98496fad62933b1d21786672"
+  revision = "74fbc600c03d927552c1888536e49238da904364"
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock","require","suite"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  packages = [
+    "assert",
+    "mock",
+    "require",
+    "suite"
+  ]
+  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
+  version = "v1.2.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/ugorji/go"
   packages = ["codec"]
-  revision = "ded73eae5db7e7a0ef6f55aace87a2873c5d2b74"
+  revision = "ccfe18359b55b97855cee1d3f74e5efbda4869dc"
 
 [[projects]]
   name = "github.com/urfave/negroni"
   packages = ["."]
-  revision = "fde5e16d32adc7ad637e9cd9ad21d4ebc6192535"
-  version = "v0.2.0"
+  revision = "5dbbc83f748fc3ad38585842b0aedab546d0ea1e"
+  version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex","proxy"]
-  revision = "f2499483f923065a842d38eb4c7f1927e6fc6e6d"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "lex/httplex",
+    "proxy"
+  ]
+  revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry","windows/svc","windows/svc/debug","windows/svc/eventlog","windows/svc/mgr"]
-  revision = "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9"
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry",
+    "windows/svc",
+    "windows/svc/debug",
+    "windows/svc/eventlog",
+    "windows/svc/mgr"
+  ]
+  revision = "a3f2cbd54cf5dfe3fbaccf76375fdb12f67654c8"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
-  revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
+  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
-  packages = ["go/ast/astutil","go/buildutil","go/loader"]
-  revision = "9badcbe49be523255546b669968041d707ece12e"
+  packages = [
+    "go/ast/astutil",
+    "go/buildutil",
+    "go/loader"
+  ]
+  revision = "951512dfed6ce3af7c9c8aa37505a03c9b0c348d"
 
 [[projects]]
+  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
+  revision = "0e4404da71227dcc02fb1deee803d93e86d08f72"
 
 [[projects]]
   name = "gopkg.in/zorkian/go-datadog-api.v2"
   packages = ["."]
-  revision = "659bba33a1626ab76f393d6878dc3e4f13253f6d"
-  version = "v2.3"
+  revision = "2ba72e380572e4d47f66358c875618afe24721ee"
+  version = "v2.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c2077c0c76de7e9f127153bfe9b20fb511398a03e7821e713b8cbc841bce9d72"
+  inputs-digest = "187102bd7429c9658500ae54996cc1e24d561f8e28ff571d2957d3354c90a3d7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/cluster-agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/cmd/cluster-agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -1,10 +1,15 @@
 init_configs:
 instances:
-  -
-## Tagging
-##
+  - ## Tagging
+    ##
 
-# You can add extra tags to your Kubernetes API Server metrics, events and Service Checks with the tags list option.
-# Example: ["extra_tag", "env:testing"]
-
-#    filtered_event_types: ["MissingClusterDNS"]
+    # You can add extra tags to your Kubernetes API Server metrics, events and Service Checks with the tags list option.
+    #
+    # tags: ["foo:bar"]
+    #
+    # To deactivate the event collection, flip the collect_events option to false.
+    # collect_events: false
+    #
+    # You can specify a filter over the event types you want the check to ignore.
+    # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20
+    # filtered_event_types: ["MissingClusterDNS"]

--- a/cmd/cluster-agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/cmd/cluster-agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -1,10 +1,10 @@
-#init_configs:
-#instances:
-#  -
+init_configs:
+instances:
+  -
 ## Tagging
 ##
 
 # You can add extra tags to your Kubernetes API Server metrics, events and Service Checks with the tags list option.
 # Example: ["extra_tag", "env:testing"]
-#
-#   tags: ["foo"]
+
+#    filtered_event_types: ["MissingClusterDNS"]

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -74,3 +74,9 @@ of the present repo.
 You must sign a CLA before we can accept your contributions. If you submit a PR
 without having signed it, our bot will prompt you to do so. Once signed you will
 be set for all contributions going forward.
+
+## Pre-requisites for the DCA to interact with the API server.
+
+For the DCA to produce events, service checks and run checks one needs to enable it to perform a few actions.
+Please find the minimum RBAC [here](https://hub.docker.com/r/datadog/cluster-agent/) to get the full scope of features.
+This manifest will create a Service Account, a Cluster Role with a restricted scope and actions detailed below and a Cluster Role Binding as well.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/ericchiang/k8s/api/v1"
 	yaml "gopkg.in/yaml.v2"
+	"strconv"
 )
 
 // Covers the Control Plane service check and the in memory pod metadata.
@@ -35,10 +36,10 @@ type KubeASConfig struct {
 // KubeASCheck grabs metrics and events from the API server.
 type KubeASCheck struct {
 	core.CheckBase
-	lastWarnings            []error
-	instance                *KubeASConfig
-	KubeAPIServerHostname   string
-	latest_latestEventToken string
+	lastWarnings          []error
+	instance              *KubeASConfig
+	KubeAPIServerHostname string
+	latestEventToken      int
 }
 
 func (c *KubeASConfig) parse(data []byte) error {
@@ -82,25 +83,33 @@ func (k *KubeASCheck) Run() error {
 		k.Warn("could not collect API Server component status: ", err.Error())
 	}
 
-	newEvents, modifiedEvents, versionToken, err := asclient.LatestEvents(k.latest_latestEventToken)
+	token := strconv.Itoa(k.latestEventToken)
+	if k.latestEventToken == 0 {
+		token = ""
+	}
+
+	newEvents, modifiedEvents, versionToken, err := asclient.LatestEvents(token)
+
 	if err != nil {
 		k.Warn("could not collect events from the api server: ", err.Error())
 	}
 
-	if versionToken != k.latest_latestEventToken {
-		k.latest_latestEventToken = versionToken
-		evToSubmit := k.aggregateEvents(newEvents, false)
+	lastVersion, _ := strconv.Atoi(versionToken)
 
-		// We send the events in 2 steps to make sure the new events are initializing the aggregation keys.
-		for _, ev := range evToSubmit {
-			sender.Event(ev)
+	if lastVersion > k.latestEventToken {
+		k.latestEventToken = lastVersion
+		err := k.aggregateEvents(sender, newEvents, false)
+
+		if err != nil {
+			k.Warnf("Could not submit new event", err.Error())
 		}
 
+		// We send the events in 2 steps to make sure the new events are initializing the aggregation keys and as modified events have a different payload.
 		if len(modifiedEvents) != 0 {
-			modifiedEv := k.aggregateEvents(modifiedEvents, true)
+			err := k.aggregateEvents(sender, modifiedEvents, true)
 
-			for _, ev := range modifiedEv {
-				sender.Event(ev)
+			if err != nil {
+				k.Warnf("Could not submit modified event ", err.Error())
 			}
 		}
 	}
@@ -149,10 +158,9 @@ func (k *KubeASCheck) parseComponentStatus(sender aggregator.Sender, componentsS
 	return nil
 }
 
-func (k *KubeASCheck) aggregateEvents(events []*v1.Event, modified bool) []metrics.Event {
+func (k *KubeASCheck) aggregateEvents(sender aggregator.Sender, events []*v1.Event, modified bool) error {
 	eventsByObject := make(map[string]*kubernetesEventBundle)
 	filteredByType := make(map[string]int)
-	var evs []metrics.Event
 
 ITER_EVENTS:
 	for _, event := range events {
@@ -161,23 +169,31 @@ ITER_EVENTS:
 				filteredByType[action] = filteredByType[action] + 1
 				continue ITER_EVENTS
 			}
-			bundle, found := eventsByObject[*event.InvolvedObject.Name]
-			if found == false {
-				bundle = newKubernetesEventBundler(*event.InvolvedObject.Name, *event.Source.Component)
-				eventsByObject[*event.InvolvedObject.Name] = bundle
-			}
-			bundle.addEvent(event)
 		}
+		bundle, found := eventsByObject[*event.InvolvedObject.Uid]
+		if found == false {
+			bundle = newKubernetesEventBundler(*event.InvolvedObject.Uid, *event.Source.Component)
+			eventsByObject[*event.InvolvedObject.Uid] = bundle
+		}
+		err := bundle.addEvent(event)
+		if err != nil {
+			k.Warnf("Error while bundling events, %s.", err.Error())
+		}
+
 		if len(filteredByType) > 0 {
 			log.Debugf("filtered out the following events: %s", formatStringIntMap(filteredByType))
 		}
 	}
 	for _, bundle := range eventsByObject {
-		datadogEv, _ := bundle.formatEvents(k.KubeAPIServerHostname, modified)
+		datadogEv, err := bundle.formatEvents(k.KubeAPIServerHostname, modified)
+		if err != nil {
+			k.Warnf("Error while formatting bundled events, %s. Not submitting", err.Error())
+			continue
+		}
 		datadogEv.Tags = append(datadogEv.Tags, k.instance.Tags...)
-		evs = append(evs, datadogEv)
+		sender.Event(datadogEv)
 	}
-	return evs
+	return nil
 }
 
 func init() {

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -124,7 +124,7 @@ func (k *KubeASCheck) Run() error {
 		}
 	}
 
-	err := k.processEvents(sender, newEvents, false)
+	err = k.processEvents(sender, newEvents, false)
 	if err != nil {
 		k.Warnf("Could not submit new event %s", err.Error())
 	}
@@ -133,7 +133,7 @@ func (k *KubeASCheck) Run() error {
 	if len(modifiedEvents) == 0 {
 		return nil
 	}
-	err := k.processEvents(sender, modifiedEvents, true)
+	err = k.processEvents(sender, modifiedEvents, true)
 	if err != nil {
 		k.Warnf("Could not submit modified event %s", err.Error())
 	}

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -93,7 +93,7 @@ func (k *KubeASCheck) Run() error {
 		token, found, err := asclient.ConfigMapTokenFetcher(eventTokenKey)
 		if err != nil {
 			k.Warnf("Could not get the LatestEventToken from the eventtokendca ConfigMap: %s", err.Error())
-			token = ""
+			token = "0"
 		}
 		k.configMapAvailable = found
 		k.latestEventToken, err = strconv.Atoi(token)

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -97,7 +97,7 @@ func (k *KubeASCheck) Run() error {
 				k.configMapAvailable = found
 				k.latestEventToken = token
 			case err == collectors.ErrNotFound:
-				token = "0"
+				k.latestEventToken = "0"
 			case err == nil:
 				k.configMapAvailable = found
 				k.latestEventToken = token

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -91,7 +91,7 @@ func (k *KubeASCheck) Run() error {
 	if k.instance.CollectEvent {
 		if k.latestEventToken == "" {
 			// Initialization: Checking if we previously stored the latestEventToken in a configMap
-			token, found, err := asclient.ConfigMapTokenFetcher(eventTokenKey, 60)
+			token, found, err := asclient.GetTokenFromConfigmap(eventTokenKey, 60)
 			switch {
 			case err == collectors.ErrOutdated:
 				k.configMapAvailable = found
@@ -102,7 +102,6 @@ func (k *KubeASCheck) Run() error {
 				k.configMapAvailable = found
 				k.latestEventToken = token
 			}
-
 		}
 
 		newEvents, modifiedEvents, versionToken, err := asclient.LatestEvents(k.latestEventToken)
@@ -114,7 +113,7 @@ func (k *KubeASCheck) Run() error {
 		if len(newEvents)+len(modifiedEvents) > 0 {
 			k.latestEventToken = versionToken
 			if k.configMapAvailable {
-				configMapErr := asclient.ConfigMapTokenSetter(eventTokenKey, versionToken)
+				configMapErr := asclient.UpdateTokenInConfigmap(eventTokenKey, versionToken)
 				if configMapErr != nil {
 					k.Warnf("Could not store the LastEventToken in the ConfigMap: %s", configMapErr.Error())
 				}

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -26,6 +26,7 @@ import (
 const (
 	KubeControlPaneCheck         = "kube_apiserver_controlplane.up"
 	kubernetesAPIServerCheckName = "kubernetes_apiserver"
+	eventTokenKey                = "eventToken"
 )
 
 // KubeASConfig is the config of the API server.
@@ -89,7 +90,7 @@ func (k *KubeASCheck) Run() error {
 
 	if k.latestEventToken == 0 {
 		// Initialization: Checking if we previously stored the latestEventToken in a configMap
-		token, found, err := asclient.EventTokenFetcher()
+		token, found, err := asclient.ConfigMapTokenFetcher(eventTokenKey)
 		if err != nil {
 			k.Warnf("Could not get the LatestEventToken from the eventtokendca ConfigMap: %s", err.Error())
 			token = ""
@@ -115,7 +116,7 @@ func (k *KubeASCheck) Run() error {
 	if lastVersion > k.latestEventToken {
 		k.latestEventToken = lastVersion
 		if k.configMapAvailable {
-			configMapErr := asclient.EventTokenSetter(versionToken)
+			configMapErr := asclient.ConfigMapTokenSetter(eventTokenKey, versionToken)
 			if configMapErr != nil {
 				k.Warnf("Could not store the LastEventToken in the ConfigMap eventtokendca: %s", configMapErr.Error())
 			}

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -26,7 +26,7 @@ import (
 const (
 	KubeControlPaneCheck         = "kube_apiserver_controlplane.up"
 	kubernetesAPIServerCheckName = "kubernetes_apiserver"
-	eventTokenKey                = "eventToken"
+	eventTokenKey                = "eventKey"
 )
 
 // KubeASConfig is the config of the API server.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"time"
 )
 
 func toStr(str string) *string {
@@ -170,7 +171,7 @@ func TestAggregateEvents(t *testing.T) {
 	// 1 Scheduled:
 	newDatadogEvent := metrics.Event{
 		Title:          "Events from the dca-789976f5d7-2ljx6 Pod",
-		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n \n _New events emitted by the default-scheduler seen at 1992-06-27 12:30:00 -0400 EDT_ \n\n %%%",
+		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n \n _New events emitted by the default-scheduler seen at " + time.Unix(709662600, 0).String() + "_ \n\n %%%",
 		Priority:       "normal",
 		Tags:           []string{"test"},
 		AggregationKey: "kubernetes_apiserver:e6417a7f-f566-11e7-9749-0e4863e1cbf4",
@@ -193,7 +194,7 @@ func TestAggregateEvents(t *testing.T) {
 	}
 	newDatadogEvents := metrics.Event{
 		Title:          "Events from the dca-789976f5d7-2ljx6 Pod",
-		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n 3 **Started**: Started container\n \n _New events emitted by the default-scheduler seen at 1992-06-27 12:30:00 -0400 EDT_ \n\n %%%",
+		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n 3 **Started**: Started container\n \n _New events emitted by the default-scheduler seen at " + time.Unix(709662600, 0).String() + "_ \n\n %%%",
 		Priority:       "normal",
 		Tags:           []string{"test"},
 		AggregationKey: "kubernetes_apiserver:e6417a7f-f566-11e7-9749-0e4863e1cbf4",
@@ -220,7 +221,7 @@ func TestAggregateEvents(t *testing.T) {
 	}
 	modifiedNewDatadogEvents := metrics.Event{
 		Title:          "Events from the localhost Node",
-		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at 1992-06-27 16:00:00 -0400 EDT_ \n\n %%%",
+		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at " + time.Unix(709675200, 0).String() + "_ \n\n %%%",
 		Priority:       "normal",
 		Tags:           []string{"test"},
 		AggregationKey: "kubernetes_apiserver:e63e74fa-f566-11e7-9749-0e4863e1cbf4",

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -255,5 +255,4 @@ func TestProcessEvents(t *testing.T) {
 	kubeASCheck.processEvents(mock, filteredKubeEventsBundle, false)
 	mock.AssertNotCalled(t, "Event")
 	mock.AssertExpectations(t)
-
 }

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -147,7 +147,7 @@ func createEvent(count int32, objname, objkind, objuid, component, reason string
 	}
 }
 
-func TestAggregateEvents(t *testing.T) {
+func TestProcessEvents(t *testing.T) {
 	// We want to check if the format of 1 New event, several new events and several modified events creates DD events accordingly
 	// We also want to check that a modified event with an existing key is aggregated (i.e. the key is already known)
 
@@ -182,7 +182,7 @@ func TestAggregateEvents(t *testing.T) {
 		EventType:      "kubernetes_apiserver",
 	}
 	mock.On("Event", newDatadogEvent).Times(1)
-	kubeASCheck.aggregateEvents(mock, newKubeEventBundle, false)
+	kubeASCheck.processEvents(mock, newKubeEventBundle, false)
 	mock.AssertEvent(t, newDatadogEvent, 0)
 	mock.AssertExpectations(t)
 
@@ -208,7 +208,7 @@ func TestAggregateEvents(t *testing.T) {
 	mock = mocksender.NewMockSender(kubeASCheck.ID())
 	mock.On("Event", newDatadogEvents).Times(1)
 
-	kubeASCheck.aggregateEvents(mock, newKubeEventsBundle, false)
+	kubeASCheck.processEvents(mock, newKubeEventsBundle, false)
 	assert.Contains(t, newDatadogEvents.Text, "2 **Scheduled**")
 	assert.Contains(t, newDatadogEvents.Text, "3 **Started**")
 	mock.AssertNumberOfCalls(t, "Event", 1)
@@ -234,7 +234,7 @@ func TestAggregateEvents(t *testing.T) {
 	mock = mocksender.NewMockSender(kubeASCheck.ID())
 	mock.On("Event", modifiedNewDatadogEvents).Times(1)
 
-	kubeASCheck.aggregateEvents(mock, modifiedKubeEventsBundle, true)
+	kubeASCheck.processEvents(mock, modifiedKubeEventsBundle, true)
 
 	mock.AssertEvent(t, modifiedNewDatadogEvents, 0)
 	mock.AssertExpectations(t)
@@ -242,7 +242,7 @@ func TestAggregateEvents(t *testing.T) {
 	// No events
 	empty := []*v1.Event{}
 	mock = mocksender.NewMockSender(kubeASCheck.ID())
-	kubeASCheck.aggregateEvents(mock, empty, false)
+	kubeASCheck.processEvents(mock, empty, false)
 	mock.AssertNotCalled(t, "Event")
 	mock.AssertExpectations(t)
 
@@ -252,7 +252,7 @@ func TestAggregateEvents(t *testing.T) {
 		ev5,
 	}
 	mock = mocksender.NewMockSender(kubeASCheck.ID())
-	kubeASCheck.aggregateEvents(mock, filteredKubeEventsBundle, false)
+	kubeASCheck.processEvents(mock, filteredKubeEventsBundle, false)
 	mock.AssertNotCalled(t, "Event")
 	mock.AssertExpectations(t)
 

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -13,10 +13,11 @@ import (
 	obj "github.com/ericchiang/k8s/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
 
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"time"
 )
 
 func toStr(str string) *string {
@@ -121,8 +122,8 @@ func TestParseComponentStatus(t *testing.T) {
 
 	mock.AssertExpectations(t)
 }
-func createEvent(count int32, objname, objkind, objuid, component, reason string, message string, timestamp int64) *v1.Event {
 
+func createEvent(count int32, objname, objkind, objuid, component, reason string, message string, timestamp int64) *v1.Event {
 	return &v1.Event{
 		Metadata: &obj.ObjectMeta{
 			CreationTimestamp: &obj.Time{

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -120,3 +120,138 @@ func TestParseComponentStatus(t *testing.T) {
 
 	mock.AssertExpectations(t)
 }
+func createEvent(count int32, objname, objkind, objuid, component, reason string, message string, timestamp int64) *v1.Event {
+
+	return &v1.Event{
+		Metadata: &obj.ObjectMeta{
+			CreationTimestamp: &obj.Time{
+				Seconds: &timestamp,
+			},
+		},
+		InvolvedObject: &v1.ObjectReference{
+			Name: &objname,
+			Kind: &objkind,
+			Uid:  &objuid,
+		},
+		Count: &count,
+		Source: &v1.EventSource{
+			Component: &component,
+		},
+		Reason: &reason,
+		LastTimestamp: &obj.Time{
+			Seconds: &timestamp,
+		},
+		Message: &message,
+	}
+}
+
+func TestAggregateEvents(t *testing.T) {
+	// We want to check if the format of 1 New event, several new events and several modified events creates DD events accordingly
+	// We also want to check that a modified event with an existing key is aggregated (i.e. the key is already known)
+
+	ev1 := createEvent(2, "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
+	ev2 := createEvent(3, "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "Started", "Started container", 709662600)
+	ev3 := createEvent(1, "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709662600)
+	ev4 := createEvent(29, "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709675200)
+
+	kubeASCheck := &KubeASCheck{
+		instance: &KubeASConfig{
+			Tags:              []string{"test"},
+			FilteredEventType: []string{"ignored"},
+		},
+		CheckBase:             core.NewCheckBase(kubernetesAPIServerCheckName),
+		KubeAPIServerHostname: "hostname",
+	}
+	mock := mocksender.NewMockSender(kubeASCheck.ID())
+
+	newKubeEventBundle := []*v1.Event{
+		ev1,
+	}
+	// 1 Scheduled:
+	newDatadogEvent := metrics.Event{
+		Title:          "Events from the dca-789976f5d7-2ljx6 Pod",
+		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n \n _New events emitted by the default-scheduler seen at 1992-06-27 12:30:00 -0400 EDT_ \n\n %%%",
+		Priority:       "normal",
+		Tags:           []string{"test"},
+		AggregationKey: "kubernetes_apiserver:e6417a7f-f566-11e7-9749-0e4863e1cbf4",
+		SourceTypeName: "kubernetes",
+		Ts:             709662600,
+		Host:           "hostname",
+		EventType:      "kubernetes_apiserver",
+	}
+	mock.On("Event", newDatadogEvent).Times(1)
+	kubeASCheck.aggregateEvents(mock, newKubeEventBundle, false)
+	mock.AssertEvent(t, newDatadogEvent, 0)
+	mock.AssertExpectations(t)
+
+	// Several new events, testing aggregation
+	// Not testing full match of the event message as the order of the actions in the summary isn't guaranteed
+
+	newKubeEventsBundle := []*v1.Event{
+		ev1,
+		ev2,
+	}
+	newDatadogEvents := metrics.Event{
+		Title:          "Events from the dca-789976f5d7-2ljx6 Pod",
+		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n 3 **Started**: Started container\n \n _New events emitted by the default-scheduler seen at 1992-06-27 12:30:00 -0400 EDT_ \n\n %%%",
+		Priority:       "normal",
+		Tags:           []string{"test"},
+		AggregationKey: "kubernetes_apiserver:e6417a7f-f566-11e7-9749-0e4863e1cbf4",
+		SourceTypeName: "kubernetes",
+		Ts:             709662600,
+		Host:           "hostname",
+		EventType:      "kubernetes_apiserver",
+	}
+
+	mock = mocksender.NewMockSender(kubeASCheck.ID())
+	mock.On("Event", newDatadogEvents).Times(1)
+
+	kubeASCheck.aggregateEvents(mock, newKubeEventsBundle, false)
+	assert.Contains(t, newDatadogEvents.Text, "2 **Scheduled**")
+	assert.Contains(t, newDatadogEvents.Text, "3 **Started**")
+	mock.AssertNumberOfCalls(t, "Event", 1)
+	mock.AssertExpectations(t)
+
+	// Several modified events, timestamp is the latest, event submitted has the correct key and count.
+
+	modifiedKubeEventsBundle := []*v1.Event{
+		ev3,
+		ev4,
+	}
+	modifiedNewDatadogEvents := metrics.Event{
+		Title:          "Events from the localhost Node",
+		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at 1992-06-27 16:00:00 -0400 EDT_ \n\n %%%",
+		Priority:       "normal",
+		Tags:           []string{"test"},
+		AggregationKey: "kubernetes_apiserver:e63e74fa-f566-11e7-9749-0e4863e1cbf4",
+		SourceTypeName: "kubernetes",
+		Ts:             709675200,
+		Host:           "hostname",
+		EventType:      "kubernetes_apiserver",
+	}
+	mock = mocksender.NewMockSender(kubeASCheck.ID())
+	mock.On("Event", modifiedNewDatadogEvents).Times(1)
+
+	kubeASCheck.aggregateEvents(mock, modifiedKubeEventsBundle, true)
+
+	mock.AssertEvent(t, modifiedNewDatadogEvents, 0)
+	mock.AssertExpectations(t)
+
+	// No events
+	empty := []*v1.Event{}
+	mock = mocksender.NewMockSender(kubeASCheck.ID())
+	kubeASCheck.aggregateEvents(mock, empty, false)
+	mock.AssertNotCalled(t, "Event")
+	mock.AssertExpectations(t)
+
+	// Ignored Event
+	ev5 := createEvent(1, "localhost", "Node", "529fe848-e132-11e7-bad4-0e4863e1cbf4", "kubelet", "ignored", "", 709675200)
+	filteredKubeEventsBundle := []*v1.Event{
+		ev5,
+	}
+	mock = mocksender.NewMockSender(kubeASCheck.ID())
+	kubeASCheck.aggregateEvents(mock, filteredKubeEventsBundle, false)
+	mock.AssertNotCalled(t, "Event")
+	mock.AssertExpectations(t)
+
+}

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -52,6 +52,9 @@ func (k *kubernetesEventBundle) addEvent(event *v1.Event) error {
 }
 
 func (k *kubernetesEventBundle) formatEvents(hostname string, modified bool) (metrics.Event, error) {
+	if len(k.events) == 0 {
+		return metrics.Event{}, errors.New("no event to export")
+	}
 	output := metrics.Event{
 		Priority:       metrics.EventPriorityNormal,
 		Host:           hostname,
@@ -59,9 +62,6 @@ func (k *kubernetesEventBundle) formatEvents(hostname string, modified bool) (me
 		EventType:      kubernetesAPIServerCheckName,
 		Ts:             int64(k.timeStamp),
 		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", k.objUid),
-	}
-	if len(k.events) == 0 {
-		return output, errors.New("no event to export")
 	}
 
 	output.Title = fmt.Sprintf("Events from the %s", k.readableKey)

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+// +build kubeapiserver
+
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/ericchiang/k8s/api/v1"
+	"math"
+	"strings"
+	"time"
+)
+
+type kubernetesEventBundle struct {
+	nodeUid       string
+	events        []*v1.Event
+	firstTime     int64
+	lastTime      int64
+	countByAction map[string]int
+}
+
+func newKubernetesEventBundler(nodeUid string) *kubernetesEventBundle {
+	return &kubernetesEventBundle{
+		nodeUid:       nodeUid,
+		events:        []*v1.Event{},
+		countByAction: make(map[string]int),
+	}
+}
+
+func (k *kubernetesEventBundle) addEvent(event *v1.Event) error {
+	if *event.InvolvedObject.Uid != k.nodeUid {
+		return fmt.Errorf("mismatching Node Id name: %s != %s", event.InvolvedObject.Uid, k.nodeUid)
+	}
+	k.events = append(k.events, event)
+	k.countByAction[*event.Reason] += int(*event.Count)
+	k.firstTime = *event.FirstTimestamp.Seconds
+	k.lastTime = int64(math.Max(float64(k.lastTime), float64(*event.LastTimestamp.Seconds)))
+	return nil
+}
+
+func (k *kubernetesEventBundle) formatEvents(hostname string, modified bool) (metrics.Event, error) {
+	output := metrics.Event{
+		Priority:       metrics.EventPriorityNormal,
+		Host:           hostname,
+		SourceTypeName: kubernetesAPIServerCheck,
+		EventType:      kubernetesAPIServerCheck,
+		Ts:             int64(k.lastTime),
+		AggregationKey: fmt.Sprintf("kubernetes_apiserver:%s", k.nodeUid),
+	}
+	if len(k.events) == 0 {
+		return output, errors.New("no event to export")
+	}
+	output.Title = fmt.Sprintf("Events of %s on %s",
+		k.nodeUid,
+		hostname)
+
+	//if k.lastTime != k.firstTime {
+	//	// Modified events
+	//	output.Text = fmt.Sprintf("%s events seen at %s", formatStringIntMap(k.countByAction), time.Unix(k.lastTime,0))
+	//	return output, nil
+	//}
+	output.Text = fmt.Sprintf("%s new events seen at %s", formatStringIntMap(k.countByAction), time.Unix(k.lastTime, 0))
+	return output, nil
+}
+
+func formatStringIntMap(input map[string]int) string {
+	var parts []string
+	for k, v := range input {
+		parts = append(parts, fmt.Sprintf("%d %s", v, k))
+	}
+	return strings.Join(parts, " ")
+}

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -18,13 +18,13 @@ import (
 )
 
 type kubernetesEventBundle struct {
-	objUid        string
-	readableKey   string
-	component     string
-	events        []*v1.Event
-	timeStamp     float64
-	lastTimestamp float64
-	countByAction map[string]int
+	objUid        string         // Unique object Identifier used as the Aggregation key
+	readableKey   string         // Formated key used in the Title in the events
+	component     string         // Used to identify the Kubernetes component which generated the event
+	events        []*v1.Event    // List of events in the bundle
+	timeStamp     float64        // Used for the new events in the bundle to specify when they first occurred
+	lastTimestamp float64        // Used for the modified events in the bundle to specify when they last occurred
+	countByAction map[string]int // Map of count per action to aggregate several events from the same ObjUid in one event
 }
 
 func newKubernetesEventBundler(objUid string, compName string) *kubernetesEventBundle {
@@ -36,6 +36,9 @@ func newKubernetesEventBundler(objUid string, compName string) *kubernetesEventB
 }
 
 func (k *kubernetesEventBundle) addEvent(event *v1.Event) error {
+	if event == nil || event.InvolvedObject == nil {
+		return errors.New("could not retrieve some parent attributes of the event")
+	}
 	if *event.InvolvedObject.Uid != k.objUid {
 		return fmt.Errorf("mismatching Object UIDs: %s != %s", event.InvolvedObject.Uid, k.objUid)
 	}

--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -9,11 +9,12 @@ package cluster
 import (
 	"errors"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/ericchiang/k8s/api/v1"
 	"math"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/ericchiang/k8s/api/v1"
 )
 
 type kubernetesEventBundle struct {

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -20,9 +20,13 @@ type TagInfo struct {
 // CollectionMode informs the Tagger of how to schedule a Collector
 type CollectionMode int
 
-// ErrNotFound is returned by Fetch not collection error occurred but
+// ErrNotFound is returned by Fetch if no collection error occurred but
 // the entity is not found in the source
 var ErrNotFound = errors.New("entity not found")
+
+// ErrOutdated is returned when an entity is found but
+// it's value is outdated compared to the one locally saved
+var ErrOutdated = errors.New("entity is outdated")
 
 // Return values for Collector.Init to inform the Tagger of the scheduling needed
 const (

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -15,6 +15,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/ericchiang/k8s"
+
 	"github.com/ericchiang/k8s/api/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/config"

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"strconv"
 	"time"
 
 	log "github.com/cihub/seelog"

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -119,7 +119,7 @@ func (c *APIClient) ComponentStatuses() (*v1.ComponentStatusList, error) {
 	return c.client.CoreV1().ListComponentStatuses(ctx)
 }
 
-// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configmaptokendca` if its timestamp is less than tokenTimeout old.
+// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap configMapDCAToken if its timestamp is less than tokenTimeout old.
 func (c *APIClient) GetTokenFromConfigmap(token string, tokenTimeout int64) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
@@ -141,8 +141,8 @@ func (c *APIClient) GetTokenFromConfigmap(token string, tokenTimeout int64) (str
 
 	if !set {
 		log.Debugf("Could not find timestamp associated with %s in the ConfigMap %s. Refreshing.", token, configMapDCAToken)
-		// We return tokenValue = "" to reset the tokenValue and its timestamp as token's timestamp was not found.
-		return token, found, collectors.ErrOutdated
+		// We return ErrOutdated to reset the tokenValue and its timestamp as token's timestamp was not found.
+		return tokenValue, found, collectors.ErrOutdated
 	}
 
 	tokenTime, err := time.Parse(time.RFC822, tokenTimeStr)

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -28,7 +28,7 @@ import (
 var globalApiClient *APIClient
 
 const (
-	configMapDCAToken = "configmaptokendca"
+	configMapDCAToken = "configmapdcatoken"
 	defaultNamespace  = "default"
 	tokenTime         = "tokenTimestamp"
 	tokenKey          = "tokenKey"

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -114,8 +114,8 @@ func (c *APIClient) ComponentStatuses() (*v1.ComponentStatusList, error) {
 	return c.client.CoreV1().ListComponentStatuses(ctx)
 }
 
-// EventTokenFetcher returns the value of the token `eventToken` in the ConfigMap `eventtokendca`
-func (c *APIClient) EventTokenFetcher() (string, bool, error) {
+// EventTokenFetcher returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `eventtokendca`
+func (c *APIClient) ConfigMapTokenFetcher(tokenKey string) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 	tokenConfigMap, err := c.client.CoreV1().GetConfigMap(ctx, configMapEventToken, defaultNamespace)
@@ -123,24 +123,25 @@ func (c *APIClient) EventTokenFetcher() (string, bool, error) {
 		return "", false, err
 	}
 	log.Infof("Fetched LatestEventToken from the %s ConfigMap", configMapEventToken)
-	token, found := tokenConfigMap.Data["eventToken"]
+	token, found := tokenConfigMap.Data[tokenKey]
 	log.Debugf("LatestEventToken is %s", token)
 	return token, found, nil
 }
 
-//EventTokenSetter upadtes the value of the token `eventToken` in the ConfigMap `configMapEventToken`
-func (c *APIClient) EventTokenSetter(token string) error {
+//EventTokenSetter upadtes the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configMapEventToken`
+func (c *APIClient) ConfigMapTokenSetter(tokenKey, tokenValue string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 	tokenConfigMap, err := c.client.CoreV1().GetConfigMap(ctx, configMapEventToken, defaultNamespace)
 	if err != nil {
 		return err
 	}
-	tokenConfigMap.Data["eventToken"] = token
+	tokenConfigMap.Data[tokenKey] = tokenValue
+
 	_, err = c.client.CoreV1().UpdateConfigMap(ctx, tokenConfigMap)
 	if err != nil {
 		return err
 	}
-	log.Debugf("Updated LatestEventToken in the %s ConfigMap to %s", configMapEventToken, token)
+	log.Debugf("Updated LatestEventToken in the %s ConfigMap to %s", configMapEventToken, tokenValue)
 	return nil
 }

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -127,11 +127,11 @@ func (c *APIClient) ConfigMapTokenFetcher(tokenKey string) (string, bool, error)
 	}
 	log.Infof("Found the ConfigMap %s", configMapDCAToken)
 
-	token, found := tokenConfigMap.Data[fmt.Sprintf("%s.Key", tokenKey)]
+	token, found := tokenConfigMap.Data[tokenKey]
 	if !found {
 		return "", found, log.Errorf("%s was not found in the ConfigMap %s", tokenKey, configMapDCAToken)
 	}
-	log.Debugf("%s is %s", tokenKey, token)
+	log.Tracef("%s is %s", tokenKey, token)
 
 	tokenTimeStr, set := tokenConfigMap.Data[fmt.Sprintf("%s.%s", tokenKey, tokenTime)] // This is so we can have one timestamp per tokenKey
 
@@ -143,7 +143,7 @@ func (c *APIClient) ConfigMapTokenFetcher(tokenKey string) (string, bool, error)
 		tokenAge := time.Now().Unix() - tokenTime.Unix()
 
 		if tokenAge > tokenTimeout {
-			log.Infof("The event token is outdated, refreshing the events")
+			log.Infof("The token is outdated, refreshing the state")
 			return "", found, nil
 		}
 	}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -154,7 +154,7 @@ func (c *APIClient) ConfigMapTokenFetcher(token string, tokenTimeout int64) (str
 	}
 	log.Debugf("Could not find timestamp associated with %s in the ConfigMap %s. Refreshing.", token, configMapDCAToken)
 	// We return tokenValue = "" to reset the tokenValue and its timestamp as token's timestamp was not found.
-	return "", found, collectors.ErrOutdated
+	return token, found, collectors.ErrOutdated
 }
 
 //EventTokenSetter updates the value of the `tokenValue` from the `tokenKey` and sets its collected timestamp in the ConfigMap `configmaptokendca`

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ericchiang/k8s/api/v1"
 
 	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
@@ -118,8 +119,8 @@ func (c *APIClient) ComponentStatuses() (*v1.ComponentStatusList, error) {
 	return c.client.CoreV1().ListComponentStatuses(ctx)
 }
 
-// ConfigMapTokenFetcher returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configmaptokendca` if its timestamp is less than tokenTimeout old.
-func (c *APIClient) ConfigMapTokenFetcher(token string, tokenTimeout int64) (string, bool, error) {
+// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configmaptokendca` if its timestamp is less than tokenTimeout old.
+func (c *APIClient) GetTokenFromConfigmap(token string, tokenTimeout int64) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 	tokenConfigMap, err := c.client.CoreV1().GetConfigMap(ctx, configMapDCAToken, defaultNamespace)
@@ -157,8 +158,8 @@ func (c *APIClient) ConfigMapTokenFetcher(token string, tokenTimeout int64) (str
 	return token, found, collectors.ErrOutdated
 }
 
-//EventTokenSetter updates the value of the `tokenValue` from the `tokenKey` and sets its collected timestamp in the ConfigMap `configmaptokendca`
-func (c *APIClient) ConfigMapTokenSetter(token, tokenValue string) error {
+// UpdateTokenInConfigmap updates the value of the `tokenValue` from the `tokenKey` and sets its collected timestamp in the ConfigMap `configmaptokendca`
+func (c *APIClient) UpdateTokenInConfigmap(token, tokenValue string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 	tokenConfigMap, err := c.client.CoreV1().GetConfigMap(ctx, configMapDCAToken, defaultNamespace)

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -37,7 +37,6 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 	resVersionCached, cachedResErr := strconv.Atoi(*latestResVersion)
 	if cachedResErr != nil {
 		log.Errorf("The cached event token could not be parsed: %s, pulling events from the API server's cache", cachedResErr.Error())
-		resVersionCached = 0
 	}
 	var sinceOption k8s.Option
 

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -34,7 +34,7 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 	// If `since` is "" strconv.Atoi(*latestResVersion) below will panic as we evaluate the error.
 	// One could chose to use "" instead of 0 to not query the API Server cache.
 	// We decide to only rely on the cache as it avoids crawling everything from the API Server at once.
-	resVersionCached, cachedResErr := strconv.Atoi(*latestResVersion)
+	resVersionCached, cachedResErr := strconv.Atoi(since)
 	if cachedResErr != nil {
 		log.Errorf("The cached event token could not be parsed: %s, pulling events from the API server's cache", cachedResErr.Error())
 	}

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -63,10 +63,14 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 		timeout.Reset(eventReadTimeout)
 
 		if event != nil && event.Metadata != nil && event.Metadata.ResourceVersion != nil {
-			resVersionMetadata, err := strconv.Atoi(*event.Metadata.ResourceVersion)
-			resVersionCached, _ := strconv.Atoi(*latestResVersion)
-			if err != nil {
+			resVersionMetadata, kubeEventErr := strconv.Atoi(*event.Metadata.ResourceVersion)
+			resVersionCached, cachedResErr := strconv.Atoi(*latestResVersion)
+			if kubeEventErr != nil {
 				log.Errorf("The Resource version associated with the event %s is not supported: %s", event.Metadata.Uid, err.Error())
+				continue
+			}
+			if cachedResErr != nil {
+				log.Errorf("The cached event token could not be parsed: ", err.Error())
 				continue
 			}
 			if resVersionMetadata > resVersionCached {

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -64,13 +64,13 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 		meta, event, err := watcher.Next()
 		if err != nil {
 			if err != context.Canceled && err != io.EOF {
-				log.Debugf("stopping event collection, got error: %s", err)
+				log.Debugf("Stopping event collection, got error: %s", err)
 			} // else silently stop
 			break
 		}
 		timeout.Reset(eventReadTimeout)
-		if event != nil || event.Metadata != nil || event.Metadata.ResourceVersion != nil {
-			log.Debugf("skipping invalid event: %v", event)
+		if event == nil || event.Metadata == nil || event.Metadata.ResourceVersion == nil {
+			log.Tracef("Skipping invalid event: %v", event)
 			continue
 		}
 
@@ -85,7 +85,7 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 			resVersionCached = resVersionMetadata
 		}
 
-		if meta != nil || meta.Type != nil {
+		if meta == nil || meta.Type == nil {
 			log.Debugf("skipping invalid event: %v", meta)
 			continue
 		}

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -70,7 +70,7 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 				continue
 			}
 			if cachedResErr != nil {
-				log.Errorf("The cached event token could not be parsed: ", err.Error())
+				log.Errorf("The cached event token could not be parsed: %s", err.Error())
 				continue
 			}
 			if resVersionMetadata > resVersionCached {

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+//// Covered by test/integration/util/kube_apiserver/events_test.go
+
+import (
+	"context"
+	"io"
+	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/ericchiang/k8s"
+	"github.com/ericchiang/k8s/api/v1"
+)
+
+var eventReadTimeout = 100 * time.Millisecond
+
+// LatestEvents retrieves all the cluster events happening after a given token.
+// First slice is the new events, second slice the modified events.
+// If the `since` parameter is empty, we query the apiserver's cache to avoid
+// overloading it.
+// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#watch-list-289
+func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string, error) {
+	var addedEvents, modifiedEvents []*v1.Event
+	latestResVersion := &since
+
+	var sinceOption k8s.Option
+	if len(since) > 0 {
+		sinceOption = k8s.ResourceVersion(since)
+	} else {
+		// Only retrieve what is in the apiserver cache.
+		// Else we'll get one hour worth of events.
+		sinceOption = k8s.ResourceVersion("0")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	watcher, err := c.client.CoreV1().WatchEvents(ctx, "", sinceOption)
+	if err != nil {
+		return addedEvents, modifiedEvents, since, err
+	}
+
+	// Start a timer that will cancel the connection when the watcher is idle.
+	// That allows `watcher.Next()` to return context.Canceled and break the reading loop.
+	timeout := time.AfterFunc(eventReadTimeout, func() { cancel() })
+
+	for {
+		meta, event, err := watcher.Next()
+		if err != nil {
+			if err != context.Canceled && err != io.EOF {
+				log.Debugf("stopping event collection, got error: %s", err)
+			} // else silently stop
+			break
+		}
+		timeout.Reset(eventReadTimeout)
+
+		if event != nil && event.Metadata != nil && event.Metadata.ResourceVersion != nil {
+			latestResVersion = event.Metadata.ResourceVersion
+		} else {
+			log.Debugf("skipping invalid event: %v", event)
+			continue
+		}
+
+		if meta != nil && meta.Type != nil {
+			switch *meta.Type {
+			case k8s.EventAdded:
+				addedEvents = append(addedEvents, event)
+			case k8s.EventModified:
+				modifiedEvents = append(modifiedEvents, event)
+			}
+		} else {
+			log.Debugf("skipping invalid event: %v", meta)
+			continue
+		}
+	}
+
+	watcher.Close()
+	return addedEvents, modifiedEvents, *latestResVersion, nil
+}

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -14,6 +14,7 @@ from .go import fmt, lint, vet, misspell, ineffassign
 from .build_tags import get_default_build_tags
 from .agent import integration_tests as agent_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
+from .cluster_agent import integration_tests as dca_integration_tests
 
 PROFILE_COV = "profile.cov"
 
@@ -132,6 +133,7 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     """
     agent_integration_tests(ctx, install_deps, race, remote_docker)
     dsd_integration_tests(ctx, install_deps, race, remote_docker)
+    dca_integration_tests(ctx, install_deps, race, remote_docker)
 
 
 @task

--- a/test/integration/util/kube_apiserver/common.go
+++ b/test/integration/util/kube_apiserver/common.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+// +build kubeapiserver
+
+package kubernetes
+
+import (
+    "fmt"
+
+    apiv1 "github.com/ericchiang/k8s/api/v1"
+    metav1 "github.com/ericchiang/k8s/apis/meta/v1"
+
+    "github.com/DataDog/datadog-agent/pkg/util/docker"
+    "github.com/DataDog/datadog-agent/test/integration/utils"
+)
+
+// initAPIServerCompose returns a ComposeConf ready to launch
+// with etcd and the apiserver running in the same network
+// namespace as the current process.
+func initAPIServerCompose() (*utils.ComposeConf, error) {
+    var networkMode string
+    du, err := docker.GetDockerUtil()
+    if err != nil {
+        return nil, err
+    }
+
+    // Get container id if containerized and prepare compose
+    co, err := du.InspectSelf()
+    if err != nil {
+        networkMode = "host"
+    } else {
+        networkMode = fmt.Sprintf("container:%s", co.ID)
+    }
+    compose := &utils.ComposeConf{
+        ProjectName: "kube_events",
+        FilePath:    "testdata/apiserver.compose",
+        Variables:   map[string]string{"network_mode": networkMode},
+    }
+    return compose, nil
+}
+
+func createObjectReference(namespace, kind, name string) *apiv1.ObjectReference {
+    return &apiv1.ObjectReference{
+        Namespace: &namespace,
+        Kind:      &kind,
+        Name:      &name,
+    }
+}
+
+func createEvent(namespace, name, reason string, involvedObject *apiv1.ObjectReference) *apiv1.Event {
+    return &apiv1.Event{
+        Metadata: &metav1.ObjectMeta{
+            Namespace: &namespace,
+            Name:      &name,
+        },
+        InvolvedObject: involvedObject,
+        Reason:         &reason,
+    }
+}

--- a/test/integration/util/kube_apiserver/events_test.go
+++ b/test/integration/util/kube_apiserver/events_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build docker
+// +build kubeapiserver
+
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ericchiang/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+func TestKubeEvents(t *testing.T) {
+	// Start compose stack
+	compose, err := initAPIServerCompose()
+	require.Nil(t, err)
+	output, err := compose.Start()
+	defer compose.Stop()
+	require.Nil(t, err, string(output))
+
+	// Init apiclient
+	pwd, err := os.Getwd()
+	require.Nil(t, err)
+	kubeConfigPath := filepath.Join(pwd, "testdata", "kubeconfig.json")
+	config.Datadog.Set("kubernetes_kubeconfig_path", kubeConfigPath)
+	apiclient, err := apiserver.GetAPIClient()
+	require.Nil(t, err)
+
+	// Init own client to write the events
+	var config *k8s.Config
+	config, err = apiserver.ParseKubeConfig(kubeConfigPath)
+	require.Nil(t, err)
+	rawclient, err := k8s.NewClient(config)
+	require.Nil(t, err)
+	core := rawclient.CoreV1()
+	require.NotNil(t, core)
+
+	// Ignore potential startup events
+	_, _, initresversion, err := apiclient.LatestEvents("")
+	require.Nil(t, err)
+
+	// Create started event
+	testReference := createObjectReference("default", "integration_test", "event_test")
+	startedEvent := createEvent("default", "test_started", "started", testReference)
+	_, err = core.CreateEvent(context.Background(), startedEvent)
+	require.Nil(t, err)
+
+	// Test we get the new started event
+	added, modified, resversion, err := apiclient.LatestEvents(initresversion)
+	require.Nil(t, err)
+	assert.Len(t, added, 1)
+	assert.Len(t, modified, 0)
+	assert.Equal(t, "started", *added[0].Reason)
+
+	// Create tick event
+	tickEvent := createEvent("default", "test_tick", "tick", testReference)
+	_, err = core.CreateEvent(context.Background(), tickEvent)
+	require.Nil(t, err)
+
+	// Test we get the new tick event
+	added, modified, resversion, err = apiclient.LatestEvents(resversion)
+	require.Nil(t, err)
+	assert.Len(t, added, 1)
+	assert.Len(t, modified, 0)
+	assert.Equal(t, "tick", *added[0].Reason)
+
+	// Update tick event
+	pointer2 := int32(2)
+	tickEvent2 := added[0]
+	tickEvent2.Count = &pointer2
+	tickEvent3, err := core.UpdateEvent(context.Background(), tickEvent2)
+	require.Nil(t, err)
+
+	// Update tick event a second time
+	pointer3 := int32(3)
+	tickEvent3.Count = &pointer3
+	_, err = core.UpdateEvent(context.Background(), tickEvent3)
+	require.Nil(t, err)
+
+	// Test we get the two modified test events
+	added, modified, resversion, err = apiclient.LatestEvents(resversion)
+	require.Nil(t, err)
+	assert.Len(t, added, 0)
+	assert.Len(t, modified, 2)
+	assert.Equal(t, "tick", *modified[0].Reason)
+	assert.EqualValues(t, 2, *modified[0].Count)
+	assert.Equal(t, "tick", *modified[1].Reason)
+	assert.EqualValues(t, 3, *modified[1].Count)
+	assert.EqualValues(t, *modified[0].Metadata.Uid, *modified[1].Metadata.Uid)
+
+	// We should get nothing new now
+	added, modified, resversion, err = apiclient.LatestEvents(resversion)
+	require.Nil(t, err)
+	assert.Len(t, added, 0)
+	assert.Len(t, modified, 0)
+
+	// We should get 2+0 events from initresversion
+	// apiserver does not send updates to objects if the add is in the same bucket
+	added, modified, resversion, err = apiclient.LatestEvents(initresversion)
+	require.Nil(t, err)
+	assert.Len(t, added, 2)
+	assert.Len(t, modified, 0)
+}

--- a/test/integration/util/kube_apiserver/events_test.go
+++ b/test/integration/util/kube_apiserver/events_test.go
@@ -48,7 +48,7 @@ func TestKubeEvents(t *testing.T) {
 	require.NotNil(t, core)
 
 	// Ignore potential startup events
-	_, _, initresversion, err := apiclient.LatestEvents("")
+	_, _, initresversion, err := apiclient.LatestEvents("0")
 	require.Nil(t, err)
 
 	// Create started event

--- a/test/integration/util/kube_apiserver/testdata/apiserver.compose
+++ b/test/integration/util/kube_apiserver/testdata/apiserver.compose
@@ -1,0 +1,46 @@
+version: '2.3'
+services:
+  etcd:
+    image: "quay.io/coreos/etcd:latest"
+    network_mode: ${network_mode}
+    healthcheck:
+      test: ["CMD", "etcdctl", "--endpoints", "http://127.0.0.1:2379", "cluster-health"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+
+  apiserver:
+    image: "gcr.io/google_containers/kube-apiserver:v1.8.3"
+    command: "/usr/local/bin/kube-apiserver
+        --apiserver-count=1
+        --advertise-address=127.0.0.1
+        --insecure-bind-address=0.0.0.0
+        --insecure-port=8080
+        --allow-privileged=true
+        --service-cluster-ip-range=192.168.1.1/24
+        --admission-control=NamespaceLifecycle,LimitRanger,DefaultStorageClass,ResourceQuota
+        --kubelet-preferred-address-types=InternalIP,LegacyHostIP,ExternalDNS,InternalDNS,Hostname
+        --authorization-mode=AlwaysAllow
+        --anonymous-auth=false
+        --etcd-servers=http://127.0.0.1:2379"
+    network_mode: ${network_mode}
+    depends_on:
+      etcd:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -qO - localhost:8080/healthz | grep ok"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+  pause:
+    #
+    # This pause container is here to wait until the apiserver
+    # is healthy before returning.
+    #
+    image: "gcr.io/google_containers/pause"
+    depends_on:
+      etcd:
+        condition: service_healthy
+      apiserver:
+        condition: service_healthy
+    network_mode: none

--- a/test/integration/util/kube_apiserver/testdata/kubeconfig.json
+++ b/test/integration/util/kube_apiserver/testdata/kubeconfig.json
@@ -1,0 +1,31 @@
+{
+   "apiVersion": "v1",
+   "kind": "Config",
+   "clusters": [
+      {
+         "cluster": {
+            "server": "http://127.0.0.1:8080"
+         },
+         "name": "kubernetes"
+      }
+   ],
+   "contexts": [
+      {
+         "context": {
+            "cluster": "kubernetes",
+            "user": "kubelet"
+         },
+         "name": "kubelet-to-kubernetes"
+      }
+   ],
+   "current-context": "kubelet-to-kubernetes",
+   "users": [
+      {
+         "name": "kubelet",
+         "user": {
+            "password": "some-password",
+            "username": "exp"
+         }
+      }
+   ]
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces the event collection check.

### Motivation

The DCA needs to be able to collect events from the API server.
This introduces:
- [x] A method to connect to the API Server
- [x] A wrapper to collect the events
- [x] Leverage the new/modified outputs
- [x] Cache a map to properly aggregate related events
- [x] Format the events to have be properly processed by the intake
- [x] Map the events with the Human friendly InvolvedObject name
- [x] Flush the cache regularily
- [x] Add filtering
- [x] Add a function to collect and update a `LatestEventToken` (i.e. token of the most up to date version of the events collected by the DCA) from a ConfigMap `eventtokendca`. 
- [x] Add doc in the README.md and Dockerfiles/cluster-agent/README.md

### Testings

- [x] Image publicly available
- [x] Image tested
- [x] Integration tests
- [x] Unit tests

### Additional Notes
🐩 

  