### PR TITLE
Nick/windows link msi doc

### DIFF
--- a/docs/beta/changes.md
+++ b/docs/beta/changes.md
@@ -66,6 +66,7 @@ There are a few major changes
 * The configuration GUI is now a browser based configuration application.  
 
 The agent has a new set of command-line options:
+
 | Command         | Notes
 | --------------- | -------------------------------------------------------------------------- |
 | check           | Run the specified check |

--- a/docs/beta/changes.md
+++ b/docs/beta/changes.md
@@ -58,6 +58,36 @@ For example, for an Agent installed on Ubuntu, the differences are as follows:
 * on `upstart`-based systems: `sudo start/stop/restart datadog-agent`
 * on `systemd`-based systems: `sudo systemctl start/stop/restart datadog-agent`
 
+### Windows 
+
+There are a few major changes
+* the main executable name is now `agent.exe` (it was `ddagent.exe` previously)
+* Commands should be run with the command line `c:\program files\datadog\datadog-agent\embedded\agent.exe <command>`
+* The configuration GUI is now a browser based configuration application.  
+
+The agent has a new set of command-line options:
+| Command         | Notes
+| --------------- | -------------------------------------------------------------------------- |
+| check           | Run the specified check |
+| diagnose        | Execute some connectivity diagnosis on your system |
+| flare           | Collect a flare and send it to Datadog |
+| help            | Help about any command |
+| hostname        | Print the hostname used by the Agent |
+| import          | Import and convert configuration files from previous versions of the Agent |
+| installservice  | Installs the agent within the service control manager |
+| launch-gui      | starts the Datadog Agent GUI |
+| regimport       | Import the registry settings into datadog.yaml |
+| remove-service  | Removes the agent from the service control manager |
+| restart-service | restarts the agent within the service control manager |
+| start           | Start the Agent |
+| start-service   | starts the agent within the service control manager |
+| status          | Print the current status |
+| stopservice     | stops the agent within the service control manager |
+| version         | Print the version info |
+
+#### Gui
+* The browser session must be restarted each time the Agent service is restarted.  This will be fixed in an upcoming beta.
+
 ### MacOS
 
 * the _lifecycle commands_ (former `datadog-agent start`/`stop`/`restart`/`status` on the Agent 5) are replaced by `launchctl` commands on the `com.datadoghq.agent` service, and should be run under the logged-in user. For these commands, you can also use the Datadog Agent systray app

--- a/docs/beta/changes.md
+++ b/docs/beta/changes.md
@@ -110,7 +110,7 @@ A few examples:
 
 ## Logs
 
-The Agent logs are still located in the `/var/log/datadog/` directory.
+The Agent logs are still located in the `/var/log/datadog/` directory.  On Windows, the logs are still located in the `c:\programdata\Datadog\logs` directory.
 
 Prior releases were logging to multiple files in that directory (`collector.log`,
 `forwarder.log`, `dogstatsd.log`, etc). Starting with 6.0 the Agent logs to a single log file, `agent.log`.

--- a/docs/beta/downgrade.md
+++ b/docs/beta/downgrade.md
@@ -78,7 +78,7 @@ sudo -u dd-agent -- rm -rf /etc/datadog-agent/
 
 ## Windows
 
-Coming soon.
+Run the agent5 installer package.
 
 ## MacOS
 

--- a/docs/beta/upgrade.md
+++ b/docs/beta/upgrade.md
@@ -123,7 +123,7 @@ sudo restart datadog-agent
 
 ## Windows
 
-Run the agent6 installation package.
+Run the agent6 installation package.  Download the MSI package of the latest beta version, please use the latest Windows release listed on the [release page](https://github.com/DataDog/datadog-agent/releases)
 
 
 ## MacOS

--- a/docs/beta/upgrade.md
+++ b/docs/beta/upgrade.md
@@ -123,7 +123,7 @@ sudo restart datadog-agent
 
 ## Windows
 
-Coming soon.
+Run the agent6 installation package.
 
 
 ## MacOS


### PR DESCRIPTION
### What does this PR do?

Added a link to the release page under the Windows Upgrade Instructions in the beta docs.

### Motivation

Less confusion about where to go to install Agent 6 on Windows. This also keeps the instructions in line with The Mac OS Instructions.

### Additional Notes

Anything else we should know when reviewing?
