### PR TITLE
Add log collection instruction for docker

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -48,15 +48,14 @@ First let’s create two directories on the host that we will later mount on the
 To  run a Docker container which embeds the Datadog Agent to monitor your host use the following command:
 
 ```
-docker run -d --name dd-agent -h `hostname` -e DD_API_KEY=<YOUR_API_KEY>  -e DD_LOG_ENABLED=true -e SD_BACKEND=docker -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/conf.d:/conf.d:ro datadog/agent:6.0.0-beta.6
+docker run -d --name dd-agent -h `hostname` -e DD_API_KEY=<YOUR_API_KEY> -e DD_LOG_ENABLED=true -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/conf.d:/conf.d:ro datadog/agent:latest
 ```
 
 *Important notes*: 
 
-- The Docker integration is enabled by default, as well as [autodiscovery](https://docs.datadoghq.com/guides/servicediscovery/) in auto config mode (remove the `SD_BACKEND` variable to disable it).
+- The Docker integration is enabled by default, as well as [autodiscovery](https://docs.datadoghq.com/guides/servicediscovery/) in auto config mode ((remove the `listeners: -docker` section in `datadog.yaml` to disable it).
 
-- For this example we used the image 6.0.0-beta.6 of the agent. You can find [here](https://hub.docker.com/r/datadog/agent/tags/) the latest available images for agent 6 and we encourage you to always pick the latest version
-
+- You can find [here](https://hub.docker.com/r/datadog/agent/tags/) the list of available images for agent 6 and we encourage you to always pick the latest version.
 
 The parameters specific to log collection are the following:
 

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -30,3 +30,59 @@ You'll need to download one of the `datadog-agent*_amd64.deb` package in this di
 You can then build the image using `docker build -t datadog/agent:master .`
 
 To build the jmx variant, add `--build-arg WITH_JMX=true` to the build command
+
+## How to activate log collection
+
+The Datadog Agent can collect logs from containers starting at the version 6. Two installations are possible:
+ 
+- on the host: where the agent is external to the Docker environment 
+- or by deploying its containerized version in the Docker environment
+
+### Setup
+
+First let’s create two directories on the host that we will later mount on the containerized agent:
+
+- `/opt/datadog-agent/run`: to make sure we do not lose any logs from containers during restarts or network issues we store on the host the last line that was collected for each container in this directory
+- ` /opt/datadog-agent/conf.d`: this is where you will provide your integration instructions. Any configuration file added there will automatically be picked up by the containerized agent when restarted. For more information about this check [here](https://github.com/DataDog/docker-dd-agent#enabling-integrations).
+
+To  run a Docker container which embeds the Datadog Agent to monitor your host use the following command:
+
+```
+docker run -d --name dd-agent -h `hostname` -e DD_API_KEY=<YOUR_API_KEY>  -e DD_LOG_ENABLED=true -e SD_BACKEND=docker -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/conf.d:/conf.d:ro datadog/agent:6.0.0-beta.6
+```
+
+*Important notes*: 
+
+- The Docker integration is enabled by default, as well as [autodiscovery](https://docs.datadoghq.com/guides/servicediscovery/) in auto config mode (remove the `SD_BACKEND` variable to disable it).
+
+- For this example we used the image 6.0.0-beta.6 of the agent. You can find [here](https://hub.docker.com/r/datadog/agent/tags/) the latest available images for agent 6 and we encourage you to always pick the latest version
+
+
+The parameters specific to log collection are the following:
+
+- `-e DD_LOG_ENABLED=true`: this parameter enables the log collection when set to true. The agent now looks for log instructions in configuration files.
+- `-v /opt/datadog-agent/run:/opt/datadog-agent/run:rw` : mount the directory we created to store pointer on each container logs to make sure we do not lose any.
+- `-v /opt/datadog-agent/conf.d:/conf.d:ro` : mount the configuration directory we previously created to the container
+
+### Configuration file example
+
+Now that the agent is ready to collect logs, you need to define which containers you want to follow.
+To start collecting logs for a given container filtered by image or label, you need to update the log section in an integration or custom .yaml file. 
+Add a new yaml file in the conf.d directory with the following parameters:
+
+```
+init_config:
+
+instances:
+    [{}]
+
+#Log section
+
+logs:    
+   - type: docker
+     image: my_image_name    #or label: mylabel
+     service: my_application_name
+     source: java #tells Datadog what integration it is
+     sourcecategory: sourcecode
+```
+For more examples of configuration files or agent capabilities (such as filtering, redacting, multiline, …) read [this documentation](https://docs.datadoghq.com/logs/#filter-logs).


### PR DESCRIPTION
### What does this PR do?
Improve the read.me to include instruction for log collection

### Motivation
Log collection is available in Docker since agent 6, therefore it should be documented.

