### PR TITLE
forwarder: transaction various improvements

### DIFF
--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -130,7 +130,7 @@ func (t *HTTPTransaction) Process(ctx context.Context, client *http.Client) erro
 	loggingFrequency := config.Datadog.GetInt64("logging_frequency")
 
 	if successfulTransactions.Value() == 1 {
-		log.Infof("Successfully posted payload to %q, the agent will only log transaction success every 20 transactions", logURL)
+		log.Infof("Successfully posted payload to %q, the agent will only log transaction success every %d transactions", logURL, loggingFrequency)
 		log.Debugf("Url: %q payload: %s", logURL, string(body))
 		return nil
 	}

--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -99,7 +99,7 @@ func (t *HTTPTransaction) Process(ctx context.Context, client *http.Client) erro
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("fail to read the response Body: %s", err)
+		log.Errorf("Fail to read the response Body: %s", err)
 		return err
 	}
 
@@ -130,16 +130,16 @@ func (t *HTTPTransaction) Process(ctx context.Context, client *http.Client) erro
 	loggingFrequency := config.Datadog.GetInt64("logging_frequency")
 
 	if successfulTransactions.Value() == 1 {
-		log.Infof("successfully posted payload to %q, the agent will only log transaction success every 20 transactions", logURL)
-		log.Debugf("url: %q payload: %s", logURL, string(body))
+		log.Infof("Successfully posted payload to %q, the agent will only log transaction success every 20 transactions", logURL)
+		log.Debugf("Url: %q payload: %s", logURL, string(body))
 		return nil
 	}
 	if successfulTransactions.Value()%loggingFrequency == 0 {
-		log.Infof("successfully posted payload to %q", logURL)
-		log.Debugf("payload: %s", logURL, string(body))
+		log.Infof("Successfully posted payload to %q", logURL)
+		log.Debugf("Payload: %s", logURL, string(body))
 		return nil
 	}
-	log.Debugf("successfully posted payload to %q: %s", logURL, string(body))
+	log.Debugf("Successfully posted payload to %q: %s", logURL, string(body))
 	return nil
 }
 

--- a/pkg/forwarder/transaction_test.go
+++ b/pkg/forwarder/transaction_test.go
@@ -135,7 +135,7 @@ func TestProcessHTTPError(t *testing.T) {
 
 	err := transaction.Process(context.Background(), client)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Error '503 Service Unavailable' while sending transaction")
+	assert.Contains(t, err.Error(), "error \"503 Service Unavailable\" while sending transaction")
 	assert.Equal(t, transaction.ErrorCount, 1)
 
 	errorCode = http.StatusBadRequest


### PR DESCRIPTION
### What does this PR do?

We can observe in the agent's logs some missing fields in the formatting:
```text
2018-01-04 11:53:35 CET | INFO | (transaction.go:128 in Process) | successfully posted payload to 'https://6-0-0-app.agent.datadoghq.com/intake/?api_key=*************************xxxxx', the agent will only log transaction success every 20 transactions%!(EXTRA string=Accepted)
```

I removed the extra parameter (body) as it's present on the debug log

Also refactor various nits inside the same file.

  