### PR TITLE
[Logs] Trim spaces from single lines

### DIFF
--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -130,6 +130,5 @@ func (d *Decoder) sendLine() {
 	content := make([]byte, d.lineBuffer.Len())
 	copy(content, d.lineBuffer.Bytes())
 	d.lineBuffer.Reset()
-	newLine := NewLine(content)
-	d.lineHandler.Handle(newLine)
+	d.lineHandler.Handle(content)
 }

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -6,6 +6,7 @@
 package decoder
 
 import (
+	"bytes"
 	"regexp"
 	"sync"
 	"time"
@@ -19,16 +20,16 @@ type Line struct {
 	content []byte
 }
 
-// NewLine returns a new Line
-func NewLine(content []byte) *Line {
+// newLine returns a new Line
+func newLine(content []byte) *Line {
 	return &Line{
 		content: content,
 	}
 }
 
-// LineHandler handles Lines to form output
+// LineHandler handles byte slices to form line output
 type LineHandler interface {
-	Handle(line *Line)
+	Handle(content []byte)
 	Stop()
 }
 
@@ -50,9 +51,10 @@ func NewSingleLineHandler(outputChan chan *Output) *SingleLineHandler {
 	return &lineHandler
 }
 
-// Handle forward lines to lineChan to process them
-func (lh *SingleLineHandler) Handle(line *Line) {
-	lh.lineChan <- line
+// Handle trims leading and trailing whitespaces from content,
+// and sends it as a new Line to lineChan.
+func (lh *SingleLineHandler) Handle(content []byte) {
+	lh.lineChan <- newLine(bytes.TrimSpace(content))
 }
 
 // Stop stops the handler from processing new lines
@@ -130,8 +132,8 @@ func NewMultiLineLineHandler(outputChan chan *Output, newContentRe *regexp.Regex
 }
 
 // Handle forward lines to lineChan to process them
-func (lh *MultiLineLineHandler) Handle(line *Line) {
-	lh.lineChan <- line
+func (lh *MultiLineLineHandler) Handle(content []byte) {
+	lh.lineChan <- newLine(content)
 }
 
 // Stop stops the lineHandler from processing lines

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package decoder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimSingleLine(t *testing.T) {
+	outChan := make(chan *Output, 10)
+	h := NewSingleLineHandler(outChan)
+
+	var out *Output
+
+	// All valid whitespace characters
+	whitespace := "\t\n\v\f\r\u0085\u00a0 "
+
+	// All leading and trailing whitespace characters should be trimmed
+	h.Handle([]byte(whitespace + "foo" + whitespace + "bar" + whitespace))
+	out = <-outChan
+	assert.Equal(t, "foo"+whitespace+"bar", string(out.Content))
+
+	// With line break
+	h.Handle([]byte(" foo \n bar "))
+	out = <-outChan
+	assert.Equal(t, "foo \n bar", string(out.Content))
+
+}


### PR DESCRIPTION
### What does this PR do?

This PR trims leading and trailing space characters from logs when tailing in single line mode.
For latin characters, this will remove the following characters: 
> '\t', '\n', '\v', '\f', '\r', ' ', U+0085 (NEL), U+00A0 (NBSP)

### Motivation

Some applications tend to log a lot of blank lines, we'd like to avoid sending and storing them.

