### PR TITLE
[packaging][linux] Fix missing `dd-agent` script after upgrade

### DIFF
--- a/omnibus/package-scripts/agent/postrm
+++ b/omnibus/package-scripts/agent/postrm
@@ -14,7 +14,6 @@ CONFIG_DIR=/etc/datadog-agent
 
 # Remove the symlink to the binary.
 rm -f "/usr/bin/datadog-agent"
-rm -f "/usr/bin/dd-agent"
 
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     set -e


### PR DESCRIPTION
### What does this PR do?

Fixes missing `dd-agent` script after upgrade from any datadog-agent 6 version `<= 6.0.0~beta.7`.

That script is there to display a message to the user (see #548). (Linux only)

### Motivation

On upgrade, the postrm script would remove the `dd-agent` script from
`/usr/bin/` because it still assumed it was a symlink that would be
re-created in the postinst script, whereas now it's an actual file
that's listed in the package's file list (and as such, we shouldn't
to handle it in the install scripts, it gets installed/changed/removed
automatically).

### Additional Notes

One caveat of this fix is that any upgrade _from_ any agent 6 version already released (i.e. up to `beta.7`) will continue to remove the `dd-agent` script. We could introduce workarounds in the `preinst`script to mitigate this, but I'd rather avoid adding more complexity in these scripts.
  