### PR TITLE
[WIP] [Logs] Added a logs section to agent status

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -10,10 +10,13 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	log "github.com/cihub/seelog"
 	"github.com/spf13/viper"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 // LogsAgent is the global configuration object
@@ -42,6 +45,7 @@ const (
 )
 
 const logsRules = "LogsRules"
+const logsIntegrationsStatus = "LogsIntegrationsStatus"
 
 // LogsProcessingRule defines an exclusion or a masking rule to
 // be applied on log lines
@@ -88,6 +92,19 @@ func getLogsSources(config *viper.Viper) []*IntegrationConfigLogSource {
 	return config.Get(logsRules).([]*IntegrationConfigLogSource)
 }
 
+// GetIntegrationsStatus returns all the integrations status
+// if not set returns nil
+func GetIntegrationsStatus() []status.Integration {
+	return getIntegrationsStatus(LogsAgent)
+}
+
+func getIntegrationsStatus(config *viper.Viper) []status.Integration {
+	if config.Get(logsIntegrationsStatus) != nil {
+		return config.Get(logsIntegrationsStatus).([]status.Integration)
+	}
+	return nil
+}
+
 // BuildLogsAgentIntegrationsConfigs looks for all yml configs in the ddconfdPath directory,
 // and initializes the LogsAgent integrations configs
 func BuildLogsAgentIntegrationsConfigs() error {
@@ -98,19 +115,29 @@ func buildLogsAgentIntegrationsConfig(config *viper.Viper, ddconfdPath string) e
 
 	integrationConfigFiles := availableIntegrationConfigs(ddconfdPath)
 	logsSourceConfigs := []*IntegrationConfigLogSource{}
+	integrationsStatus := []status.Integration{}
 
 	for _, file := range integrationConfigFiles {
 		var integrationConfig IntegrationConfig
 		var viperCfg = viper.New()
+
+		integrationName := strings.TrimSuffix(file, filepath.Ext(file))
+		integrationSources := []status.Source{}
+		integrationErrors := []status.Error{}
+
 		viperCfg.SetConfigFile(filepath.Join(ddconfdPath, file))
 		err := viperCfg.ReadInConfig()
 		if err != nil {
 			log.Error(err)
+			integrationErrors = append(integrationErrors, status.Error{err.Error()})
+			integrationsStatus = append(integrationsStatus, status.Integration{Name: integrationName, Errors: integrationErrors})
 			continue
 		}
 		err = viperCfg.Unmarshal(&integrationConfig)
 		if err != nil {
 			log.Error(err)
+			integrationErrors = append(integrationErrors, status.Error{err.Error()})
+			integrationsStatus = append(integrationsStatus, status.Integration{Name: integrationName, Errors: integrationErrors})
 			continue
 		}
 
@@ -119,12 +146,14 @@ func buildLogsAgentIntegrationsConfig(config *viper.Viper, ddconfdPath string) e
 			err = validateSource(logSourceConfig)
 			if err != nil {
 				log.Error(err)
+				integrationErrors = append(integrationErrors, status.Error{err.Error()})
 				continue
 			}
 
 			rules, err := validateProcessingRules(logSourceConfig.ProcessingRules)
 			if err != nil {
 				log.Error(err)
+				integrationErrors = append(integrationErrors, status.Error{err.Error()})
 				continue
 			}
 			logSourceConfig.ProcessingRules = rules
@@ -132,14 +161,21 @@ func buildLogsAgentIntegrationsConfig(config *viper.Viper, ddconfdPath string) e
 			logSourceConfig.TagsPayload = BuildTagsPayload(logSourceConfig.Tags, logSourceConfig.Source, logSourceConfig.SourceCategory)
 
 			logsSourceConfigs = append(logsSourceConfigs, &logSourceConfig)
+			integrationSources = append(integrationSources, buildSourceStatus(logSourceConfig))
 		}
+
+		integrationsStatus = append(integrationsStatus, status.Integration{Name: integrationName, Sources: integrationSources, Errors: integrationErrors})
 	}
+
+	// save the integrations status for further status queries
+	config.Set(logsIntegrationsStatus, integrationsStatus)
 
 	if len(logsSourceConfigs) == 0 {
 		return fmt.Errorf("Could not find any valid logs integration configuration file in %s", ddconfdPath)
 	}
 
 	config.Set(logsRules, logsSourceConfigs)
+
 	return nil
 }
 
@@ -253,4 +289,18 @@ func BuildTagsPayload(configTags, source, sourceCategory string) []byte {
 	}
 
 	return tagsPayload
+}
+
+// buildSourceStatus returns the status of source
+func buildSourceStatus(source IntegrationConfigLogSource) status.Source {
+	var info string
+	switch source.Type {
+	case FileType:
+		info = fmt.Sprintf("tailing file(s) matching %s", source.Path)
+	case DockerType:
+		info = fmt.Sprintf("tailing docker image %s", source.Image)
+	case TCPType, UDPType:
+		info = fmt.Sprintf("listenning on port %d", source.Port)
+	}
+	return status.Source{Type: source.Type, Info: info}
 }

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -171,7 +171,7 @@ func buildLogsAgentIntegrationsConfig(config *viper.Viper, ddconfdPath string) e
 	config.Set(logsIntegrationsStatus, integrationsStatus)
 
 	if len(logsSourceConfigs) == 0 {
-		return fmt.Errorf("Could not find any valid logs integration configuration file in %s", ddconfdPath)
+		return fmt.Errorf("Could not find any valid logs configuration file in %s", ddconfdPath)
 	}
 
 	config.Set(logsRules, logsSourceConfigs)
@@ -239,7 +239,10 @@ func validateSource(config IntegrationConfigLogSource) error {
 func validateProcessingRules(rules []LogsProcessingRule) ([]LogsProcessingRule, error) {
 	for i, rule := range rules {
 		if rule.Name == "" {
-			return nil, fmt.Errorf("LogsAgent misconfigured: all log processing rules need a name")
+			return nil, fmt.Errorf("logs-agent misconfigured: all logs processing rules must have a name")
+		}
+		if rule.Pattern == "" {
+			return nil, fmt.Errorf("logs-agent misconfigured: all logs processing rules must have a pattern")
 		}
 		switch rule.Type {
 		case ExcludeAtMatch:
@@ -253,9 +256,9 @@ func validateProcessingRules(rules []LogsProcessingRule) ([]LogsProcessingRule, 
 			rules[i].Reg = regexp.MustCompile("^" + rule.Pattern)
 		default:
 			if rule.Type == "" {
-				return nil, fmt.Errorf("LogsAgent misconfigured: type must be set for log processing rule `%s`", rule.Name)
+				return nil, fmt.Errorf("logs-agent misconfigured: type must be set for logs processing rule `%s`", rule.Name)
 			}
-			return nil, fmt.Errorf("LogsAgent misconfigured: type %s is unsupported for log processing rule `%s`", rule.Type, rule.Name)
+			return nil, fmt.Errorf("logs-agent misconfigured: type %s is not supported for logs processing rule `%s`", rule.Type, rule.Name)
 		}
 	}
 	return rules, nil

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -116,4 +117,62 @@ func TestLogsAgentDefaultValues(t *testing.T) {
 	assert.Equal(t, false, LogsAgent.GetBool("dev_mode_no_ssl"))
 	assert.Equal(t, false, LogsAgent.GetBool("log_enabled"))
 	assert.Equal(t, 100, LogsAgent.GetInt("log_open_files_limit"))
+}
+
+func TestIntegrationsStatus(t *testing.T) {
+	var testConfig = viper.New()
+	var ddconfdPath string
+	var integrationsStatus []status.Integration
+
+	ddconfdPath = filepath.Join(testsPath, "complete", "conf.d")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 4, len(integrationsStatus))
+
+	var integration status.Integration
+
+	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 1, len(integrationsStatus))
+	integration = integrationsStatus[0]
+	assert.Equal(t, "integration", integration.Name)
+	assert.Equal(t, 1, len(integration.Errors))
+
+	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 1, len(integrationsStatus))
+	integration = integrationsStatus[0]
+	assert.Equal(t, "integration", integration.Name)
+	assert.Equal(t, 1, len(integration.Errors))
+
+	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 1, len(integrationsStatus))
+	integration = integrationsStatus[0]
+	assert.Equal(t, "integration", integration.Name)
+	assert.Equal(t, 1, len(integration.Errors))
+
+	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 1, len(integrationsStatus))
+	integration = integrationsStatus[0]
+	assert.Equal(t, "integration", integration.Name)
+	assert.Equal(t, 1, len(integration.Errors))
+
+	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 1, len(integrationsStatus))
+	integration = integrationsStatus[0]
+	assert.Equal(t, "integration", integration.Name)
+	assert.Equal(t, 1, len(integration.Errors))
+
+	ddconfdPath = filepath.Join(testsPath, "does_not_exist")
+	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	integrationsStatus = getIntegrationsStatus(testConfig)
+	assert.Equal(t, 0, len(integrationsStatus))
 }

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 // Start starts logs-agent
@@ -52,4 +53,12 @@ func run() {
 
 	c := container.New(config.GetLogsSources(), pp, a)
 	c.Start()
+}
+
+// GetStatus returns the status of logs-agent
+func GetStatus() status.Status {
+	return status.Status{
+		IsEnabled:    config.LogsAgent.GetBool("log_enabled"),
+		Integrations: config.GetIntegrationsStatus(),
+	}
 }

--- a/pkg/logs/logs_windows.go
+++ b/pkg/logs/logs_windows.go
@@ -7,6 +7,8 @@ package logs
 
 import (
 	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 // Start returns an error because logs-agent is not supported on windows yet
@@ -16,3 +18,8 @@ func Start() error {
 
 // Stop does nothing at the moment
 func Stop() {}
+
+// GetStatus returns an empty status at the moment
+func GetStatus() status.Status {
+	return status.Status{}
+}

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package status
+
+// Error provides some information about an error that occurred when parsing a logs integration file
+type Error struct {
+	Message string `json:"message"`
+}
+
+// Source provides some information about a logs source from an integration file
+type Source struct {
+	Type string `json:"type"`
+	Info string `json:"info"`
+}
+
+// Integration provides some information about a logs integration file
+type Integration struct {
+	Name    string   `json:"name"`
+	Sources []Source `json:"sources"`
+	Errors  []Error  `json:"errors"`
+}
+
+// Status provides some information about logs-agent
+type Status struct {
+	IsEnabled    bool          `json:"is_enabled"`
+	Integrations []Integration `json:"integrations"`
+}

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -1,9 +1,14 @@
 ==========
 Logs-agent
 ==========
-{{ if (not .is_enabled) }}
+
+  Status
+  ======
+{{- if (not .is_enabled) }}
   logs-agent is disabled
 {{ else }}
+  logs-agent is active
+
   Configuration
   =============
   {{- if (not .integrations) }}

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -1,0 +1,26 @@
+==========
+Logs-agent
+==========
+{{ if (not .is_enabled) }}
+  logs-agent is disabled
+{{ else }}
+  Configuration
+  =============
+  {{- if (not .integrations) }}
+    no integrations
+  {{- end }}
+  {{- range .integrations }}
+    {{ .name }}
+    {{printDashes .name "-"}}
+    {{- range .sources }}
+      Type: {{ .type }}
+      Info: {{ .info }}
+    {{- end }}
+    {{- if .errors }}
+      Errors:
+      {{- range .errors }}
+        {{ .message }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{ end }}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -38,12 +38,14 @@ func FormatStatus(data []byte) (string, error) {
 	autoConfigStats := stats["autoConfigStats"]
 	aggregatorStats := stats["aggregatorStats"]
 	jmxStats := stats["JMXStatus"]
+	logsStats := stats["logsStats"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
 	renderChecksStats(b, runnerStats, autoConfigStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
+	renderLogsStatus(b, logsStats)
 	renderDogstatsdStatus(b, aggregatorStats)
 
 	return b.String(), nil
@@ -104,6 +106,14 @@ func renderJMXFetchStatus(w io.Writer, jmxStats interface{}) {
 	t := template.Must(template.New("jmxfetch.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "jmxfetch.tmpl")))
 
 	err := t.Execute(w, stats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderLogsStatus(w io.Writer, logsStats interface{}) {
+	t := template.Must(template.New("logsagent.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "logsagent.tmpl")))
+	err := t.Execute(w, logsStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -54,6 +55,8 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["time"] = now.Format(timeFormat)
 
 	stats["JMXStatus"] = GetJMXStatus()
+
+	stats["logsStats"] = logs.GetStatus()
 
 	return stats, nil
 }


### PR DESCRIPTION
### What does this PR do?

Added a logs section to the agent status to report meaningful information about `logs-agent` configuration.

### Motivation

Report logs-agent config information when using the command `status`.

### Additional Notes

Output example:
```
=========
Forwarder
=========

...

==========
Logs-agent
==========

  Configuration
  =============
    logs-integrations
    -----------------
      Type: docker
      Info: tailing docker image redis
      Errors:
        A file source must have a path

=========
DogStatsD
=========

...
```  