### PR TITLE
[docker]  multiplex all docker event subscribers in one connection 

### DIFF
--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -158,7 +158,8 @@ func formatTitle(title string) string {
 
 	// Split camel case words
 	var words []string
-	l := 0
+	var l int
+
 	for s := title; s != ""; s = s[l:] {
 		l = strings.IndexFunc(s[1:], unicode.IsUpper) + 1
 		if l <= 0 {

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -50,7 +50,7 @@ type DockerUtil struct {
 	// image sha mapping cache
 	imageNameBySha map[string]string
 	// event subscribers and state
-	eventState eventStreamState
+	eventState *eventStreamState
 }
 
 func detectServerAPIVersion() (string, error) {
@@ -104,8 +104,10 @@ func (d *DockerUtil) init() error {
 	d.networkMappings = make(map[string][]dockerNetwork)
 	d.imageNameBySha = make(map[string]string)
 	d.lastInvalidate = time.Now()
-	d.eventState.subscribers = make(map[string]*eventSubscriber)
-	d.eventState.cancelChan = make(chan struct{})
+	d.eventState = &eventStreamState{
+		subscribers: make(map[string]*eventSubscriber),
+		cancelChan:  make(chan struct{}),
+	}
 
 	return nil
 }

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -104,10 +104,7 @@ func (d *DockerUtil) init() error {
 	d.networkMappings = make(map[string][]dockerNetwork)
 	d.imageNameBySha = make(map[string]string)
 	d.lastInvalidate = time.Now()
-	d.eventState = &eventStreamState{
-		subscribers: make(map[string]*eventSubscriber),
-		cancelChan:  make(chan struct{}),
-	}
+	d.eventState = newEventStreamState()
 
 	return nil
 }

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -37,6 +37,22 @@ func (d *DockerUtil) ContainerList(ctx context.Context, options types.ContainerL
 	return d.cli.ContainerList(ctx, options)
 }
 
+// DockerUtil wraps interactions with a local docker API.
+type DockerUtil struct {
+	retry.Retrier
+	sync.Mutex
+	cfg *Config
+	cli *client.Client
+	// tracks the last time we invalidate our internal caches
+	lastInvalidate time.Time
+	// networkMappings by container id
+	networkMappings map[string][]dockerNetwork
+	// image sha mapping cache
+	imageNameBySha map[string]string
+	// event subscribers and state
+	eventState eventStreamState
+}
+
 func detectServerAPIVersion() (string, error) {
 	host := os.Getenv("DOCKER_HOST")
 	if host == "" {
@@ -87,8 +103,9 @@ func (d *DockerUtil) init() error {
 	d.cli = cli
 	d.networkMappings = make(map[string][]dockerNetwork)
 	d.imageNameBySha = make(map[string]string)
-	d.eventSubscribers = make(map[string]*eventSubscriber)
 	d.lastInvalidate = time.Now()
+	d.eventState.subscribers = make(map[string]*eventSubscriber)
+	d.eventState.cancelChan = make(chan struct{})
 
 	return nil
 }
@@ -132,22 +149,6 @@ func ConnectToDocker() (*client.Client, error) {
 		cli.UpdateClientVersion(serverVersion)
 	}
 	return cli, nil
-}
-
-// DockerUtil wraps interactions with a local docker API.
-type DockerUtil struct {
-	retry.Retrier
-	sync.Mutex
-	cfg *Config
-	cli *client.Client
-	// tracks the last time we invalidate our internal caches
-	lastInvalidate time.Time
-	// networkMappings by container id
-	networkMappings map[string][]dockerNetwork
-	// image sha mapping cache
-	imageNameBySha map[string]string
-	// event subscribers
-	eventSubscribers map[string]*eventSubscriber
 }
 
 // Images returns a slice of all images.

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2017 Datadog, Inc.
+// Copyright 2018 Datadog, Inc.
 
 // +build docker
 

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2018 Datadog, Inc.
+// Copyright 2017 Datadog, Inc.
 
 // +build docker
 
@@ -9,7 +9,6 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strconv"
 	"time"
@@ -22,64 +21,64 @@ import (
 //// Can't be unit tested, covered by the listeners/docker
 //// and dogstatsd/origin_detection integration tests.
 
-// eventSubscriber holds the state for a subscriber
-type eventSubscriber struct {
-	name       string
-	eventChan  chan *ContainerEvent
-	errorChan  chan error
-	cancelChan chan struct{}
-}
+const eventSendTimeout = 100 * time.Millisecond
 
 // SubscribeToContainerEvents allows a package to subscribe to events from the event stream.
-// An unique subscriber name should be provided.
+// A unique subscriber name should be provided.
 func (d *DockerUtil) SubscribeToContainerEvents(name string) (<-chan *ContainerEvent, <-chan error, error) {
-	d.RLock()
-	if _, found := d.eventSubscribers[name]; found {
-		d.RUnlock()
-		return nil, nil, errors.New("already subscribed")
+	d.eventState.RLock()
+	if _, found := d.eventState.subscribers[name]; found {
+		d.eventState.RUnlock()
+		return nil, nil, ErrAlreadySubscribed
 	}
-	d.RUnlock()
+	d.eventState.RUnlock()
 
 	sub := &eventSubscriber{
-		name:       name,
-		eventChan:  make(chan *ContainerEvent, 5),
-		errorChan:  make(chan error, 5),
-		cancelChan: make(chan struct{}),
+		name:      name,
+		eventChan: make(chan *ContainerEvent, 5),
+		errorChan: make(chan error, 1),
 	}
-	d.Lock()
-	d.eventSubscribers[name] = sub
-	d.Unlock()
+	d.eventState.Lock()
+	d.eventState.subscribers[name] = sub
+	if !d.eventState.running {
+		d.eventState.running = true
+		go d.dispatchEvents()
+	}
+	d.eventState.Unlock()
 
-	go d.streamEvents(sub.eventChan, sub.cancelChan)
 	return sub.eventChan, sub.errorChan, nil
 }
 
 // UnsubscribeFromContainerEvents allows a package to unsubscribe.
 // The call is blocking until the request is processed.
 func (d *DockerUtil) UnsubscribeFromContainerEvents(name string) error {
-	d.Lock()
-	sub, found := d.eventSubscribers[name]
+	d.eventState.Lock()
+	sub, found := d.eventState.subscribers[name]
 	if !found {
-		d.Unlock()
-		return errors.New("not subscribed")
+		d.eventState.Unlock()
+		return ErrNotSubscribed
 	}
-	delete(d.eventSubscribers, name)
-	d.Unlock()
 
-	// Block until the goroutine exits, then close all chans
-	sub.cancelChan <- struct{}{}
-	close(sub.cancelChan)
+	// Remove subscriber
 	close(sub.errorChan)
 	close(sub.eventChan)
+	delete(d.eventState.subscribers, name)
 
+	// Stop dispatch if no subs remaining
+	if d.eventState.running && len(d.eventState.subscribers) == 0 {
+		d.eventState.cancelChan <- struct{}{}
+	}
+	d.eventState.Unlock()
 	return nil
 }
 
-func (d *DockerUtil) streamEvents(dataChan chan<- *ContainerEvent, cancelChan <-chan struct{}) {
+func (d *DockerUtil) dispatchEvents() {
 	fltrs := filters.NewArgs()
 	fltrs.Add("type", "container")
 	fltrs.Add("event", "start")
 	fltrs.Add("event", "die")
+
+	badSubs := make(map[*eventSubscriber]error)
 
 	// Outer loop handles re-connecting in case the docker daemon closes the connection
 CONNECT:
@@ -95,16 +94,9 @@ CONNECT:
 		// Inner loop iterates over elements in the channel
 		for {
 			select {
-			case <-cancelChan:
+			case <-d.eventState.cancelChan:
 				cancel()
 				return
-			case msg := <-messages:
-				event, err := d.processContainerEvent(msg)
-				if err != nil {
-					log.Debugf("skipping event: %s", err)
-					continue
-				}
-				dataChan <- event
 			case err := <-errs:
 				if err == io.EOF {
 					// Silently ignore io.EOF that happens on http connection reset
@@ -114,7 +106,49 @@ CONNECT:
 				}
 				cancel()
 				continue CONNECT // Re-connect to docker
+			case msg := <-messages:
+				event, err := d.processContainerEvent(msg)
+				if err != nil {
+					log.Debugf("skipping event: %s", err)
+					continue
+				}
+
+				d.eventState.RLock()
+				for _, sub := range d.eventState.subscribers {
+					err := sub.sendEvent(event)
+					if err != nil {
+						badSubs[sub] = err
+					}
+				}
+				d.eventState.RUnlock()
+
+				if len(badSubs) > 0 {
+					for sub, err := range badSubs {
+						log.Infof("forcefully unsuscribing %s from: %s", sub.name, err)
+						sub.sendError(err)
+						d.UnsubscribeFromContainerEvents(sub.name)
+					}
+					badSubs = make(map[*eventSubscriber]error)
+				}
 			}
 		}
+	}
+}
+
+func (s *eventSubscriber) sendEvent(ev *ContainerEvent) error {
+	select {
+	case s.eventChan <- ev:
+		return nil
+	case <-time.After(eventSendTimeout):
+		return ErrEventTimeout
+	}
+}
+
+func (s *eventSubscriber) sendError(err error) error {
+	select {
+	case s.errorChan <- err:
+		return nil
+	case <-time.After(eventSendTimeout):
+		return ErrEventTimeout
 	}
 }

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -126,7 +126,7 @@ CONNECT:
 			case err := <-errs:
 				if err == io.EOF {
 					// Silently ignore io.EOF that happens on http connection reset
-					log.Debug("got EOF, re-connecting")
+					log.Debug("Got EOF, re-connecting")
 				} else {
 					log.Warnf("error getting docker events: %s", err)
 				}
@@ -135,14 +135,13 @@ CONNECT:
 			case msg := <-messages:
 				event, err := d.processContainerEvent(msg)
 				if err != nil {
-					log.Debugf("skipping event: %s", err)
+					log.Debugf("Skipping event: %s", err)
 					continue
 				}
+
 				badSubs := d.eventState.dispatch(event)
-				if len(badSubs) > 0 {
-					for _, sub := range badSubs {
-						d.UnsubscribeFromContainerEvents(sub.name)
-					}
+				for _, sub := range badSubs {
+					d.UnsubscribeFromContainerEvents(sub.name)
 				}
 			}
 		}

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -81,9 +81,10 @@ func (d *DockerUtil) UnsubscribeFromContainerEvents(name string) error {
 func (e *eventStreamState) unsubscribe(name string) (error, bool) {
 	var shouldStop bool
 	e.Lock()
+	defer e.Unlock()
+
 	sub, found := e.subscribers[name]
 	if !found {
-		e.Unlock()
 		return ErrNotSubscribed, false
 	}
 
@@ -96,7 +97,6 @@ func (e *eventStreamState) unsubscribe(name string) (error, bool) {
 	if e.running && len(e.subscribers) == 0 {
 		shouldStop = true
 	}
-	e.Unlock()
 	return nil, shouldStop
 }
 

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -26,8 +26,11 @@ const eventSendBuffer = 5
 
 // SubscribeToContainerEvents allows a package to subscribe to events from the event stream.
 // A unique subscriber name should be provided.
+//
+// Attention: events sent through the channel are references to objects shared between subscribers,
+// subscribers should NOT modify them.
 func (d *DockerUtil) SubscribeToContainerEvents(name string) (<-chan *ContainerEvent, <-chan error, error) {
-	c1, c2, err, shouldStart := d.eventState.subscribe(name)
+	eventChan, errorChan, err, shouldStart := d.eventState.subscribe(name)
 
 	if shouldStart {
 		d.eventState.Lock()
@@ -36,7 +39,7 @@ func (d *DockerUtil) SubscribeToContainerEvents(name string) (<-chan *ContainerE
 		d.eventState.Unlock()
 	}
 
-	return c1, c2, err
+	return eventChan, errorChan, err
 }
 
 func (e *eventStreamState) subscribe(name string) (<-chan *ContainerEvent, <-chan error, error, bool) {

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -18,10 +18,11 @@ import (
 	"github.com/docker/docker/api/types/filters"
 )
 
-//// Can't be unit tested, covered by the listeners/docker
-//// and dogstatsd/origin_detection integration tests.
+//// eventStreamState logic unit tested in event_stream_test.go
+//// DockerUtil logic covered by the listeners/docker and dogstatsd/origin_detection integration tests.
 
 const eventSendTimeout = 100 * time.Millisecond
+const eventSendBuffer = 5
 
 // SubscribeToContainerEvents allows a package to subscribe to events from the event stream.
 // A unique subscriber name should be provided.
@@ -49,7 +50,7 @@ func (e *eventStreamState) subscribe(name string) (<-chan *ContainerEvent, <-cha
 
 	sub := &eventSubscriber{
 		name:      name,
-		eventChan: make(chan *ContainerEvent, 5),
+		eventChan: make(chan *ContainerEvent, eventSendBuffer),
 		errorChan: make(chan error, 1),
 	}
 	e.Lock()

--- a/pkg/util/docker/event_stream_test.go
+++ b/pkg/util/docker/event_stream_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTwoSubs(t *testing.T) {
+	state := newEventStreamState()
+
+	outData1, outErr1, err, shouldStart := state.subscribe("listener1")
+	assert.Nil(t, err)
+	assert.True(t, shouldStart)
+	state.running = true
+
+	outData2, outErr2, err, shouldStart := state.subscribe("listener2")
+	assert.Nil(t, err)
+	assert.False(t, shouldStart)
+
+	ev := &ContainerEvent{}
+	state.dispatch(ev)
+	received1 := <-outData1
+	assert.Equal(t, ev, received1)
+	received2 := <-outData2
+	assert.Equal(t, ev, received2)
+
+	select {
+	case err := <-outErr1:
+		assert.FailNow(t, "should not have received an error, received %s", err)
+	case err := <-outErr2:
+		assert.FailNow(t, "should not have received an error, received %s", err)
+	case <-time.After(time.Millisecond):
+		break
+	}
+}
+
+func TestSendTimeout(t *testing.T) {
+	state := newEventStreamState()
+
+	_, outErr, err, _ := state.subscribe("listener1")
+	assert.Nil(t, err)
+
+	ev := &ContainerEvent{}
+
+	// First sends should be OK
+	for i := 0; i < eventSendBuffer; i++ {
+		badSubs := state.dispatch(ev)
+		assert.Equal(t, 0, len(badSubs))
+	}
+
+	select {
+	case err := <-outErr:
+		assert.FailNow(t, "should not have received an error, received %s", err)
+	case <-time.After(time.Millisecond):
+		break
+	}
+
+	// Next send should timeout
+	badSubs := state.dispatch(ev)
+	assert.Equal(t, 1, len(badSubs))
+
+	select {
+	case err := <-outErr:
+		require.NotNil(t, err)
+		assert.Equal(t, err, ErrEventTimeout)
+	case <-time.After(time.Second):
+		assert.FailNow(t, "should have received a timeout error")
+	}
+}

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -47,3 +47,10 @@ type eventStreamState struct {
 	cancelChan  chan struct{}
 	running     bool
 }
+
+func newEventStreamState() *eventStreamState {
+	return &eventStreamState{
+		subscribers: make(map[string]*eventSubscriber),
+		cancelChan:  make(chan struct{}),
+	}
+}

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -5,7 +5,11 @@
 
 package docker
 
-import "time"
+import (
+	"errors"
+	"sync"
+	"time"
+)
 
 // ContainerEvent describes an event from the docker daemon
 type ContainerEvent struct {
@@ -20,4 +24,26 @@ type ContainerEvent struct {
 // ContainerEntityName returns the event's container as a tagger entity name
 func (ev *ContainerEvent) ContainerEntityName() string {
 	return ContainerIDToEntityName(ev.ContainerID)
+}
+
+// Errors client might receive
+var (
+	ErrAlreadySubscribed = errors.New("already subscribed")
+	ErrNotSubscribed     = errors.New("not subscribed")
+	ErrEventTimeout      = errors.New("timeout on event sending, re-subscribe")
+)
+
+// eventSubscriber holds the state for a subscriber
+type eventSubscriber struct {
+	name      string
+	eventChan chan *ContainerEvent
+	errorChan chan error
+}
+
+// eventStreamState holds the state for event streaming towards subscribers
+type eventStreamState struct {
+	sync.RWMutex
+	subscribers map[string]*eventSubscriber
+	cancelChan  chan struct{}
+	running     bool
 }


### PR DESCRIPTION
### What does this PR do?

- Change the DockerUtil internals so `event_stream.go` logic only has one connection to the docker events, event if multiple packages subscribed to them.
- If one subscriber falls behind, the dispatch logic will timeout and forcefully unsubscribe them to keep the other ones fed. Handling of this will need to be implemented in client packages.
- Unit testing. Moving part of the logic to the separate `eventStreamState` class allows partial coverage. Integration tests cover the rest.

### Motivation

Reduce stress on the docker daemon

  