### PR TITLE
cache mechanism for AD docker label provider

### DIFF
--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -79,6 +79,10 @@ CONNECT:
 		for {
 			select {
 			case ev := <-eventChan:
+				// As our input is the docker `client.ContainerList`, which lists running containers,
+				// only these two event types will change what containers appear.
+				// Container labels cannot change once they are created, so we don't need to react on
+				// other lifecycle events.
 				if ev.Action == "start" || ev.Action == "die" {
 					d.Lock()
 					d.upToDate = false

--- a/releasenotes/notes/docker-ad-provider-caching-db701e7fe04c87a2.yaml
+++ b/releasenotes/notes/docker-ad-provider-caching-db701e7fe04c87a2.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The Docker label AD provider now watches container events and
+    only updates when containers start/die to save resources
+ 


### PR DESCRIPTION
### What does this PR do?

Reuse the docker events to detect whether the AD docker provider should parse again the containers. This allows to save resources and reduce the load on the docker daemon.

### Motivation

https://github.com/DataDog/datadog-agent/pull/1016 will make it cost-effective (not opening a new event stream, but reusing the one we already have for the listener.