### PR TITLE
Check that a releasenote was added (or edited) for the PR

### DIFF
--- a/releasenotes/notes/making-reno-mandatory-96b8e3f2804c46ec.yaml
+++ b/releasenotes/notes/making-reno-mandatory-96b8e3f2804c46ec.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Reno and releasenotes are now mandatory. A test will fail if no
+    releasenotes where added/updated to the PR. A 'noreno' label can be added
+    to the PR to skip this test.


### PR DESCRIPTION
### What does this PR do?

Check that a releasenote was added (or edited) for the PR. This is linked to: #1023 (even if requests is already pulled by pyhton-docker).

### Motivation

This make using reno mandatory.

  