### PR TITLE
[LOGS] Added a logic to compute a new hostname when it's not set in config

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package config
+
+import (
+	"strings"
+
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+
+	log "github.com/cihub/seelog"
+	"github.com/spf13/viper"
+)
+
+// LogsAgent is the global configuration object
+var LogsAgent = ddconfig.Datadog
+
+// private configuration properties
+var (
+	hostname    string
+	logsSources []*IntegrationConfigLogSource
+)
+
+// GetHostname returns logs-agent hostname
+func GetHostname() string {
+	return hostname
+}
+
+// GetLogsSources returns the list of logs sources
+func GetLogsSources() []*IntegrationConfigLogSource {
+	return logsSources
+}
+
+// Build initializes logs-agent configuration
+func Build() error {
+	sources, err := buildLogsSources(LogsAgent.GetString("confd_path"))
+	if err != nil {
+		return err
+	}
+	logsSources = sources
+	hostname = buildHostname(LogsAgent)
+	return nil
+}
+
+// buildHostname computes the hostname for logs-agent
+func buildHostname(config *viper.Viper) string {
+	configHostname := config.GetString("hostname")
+	if strings.TrimSpace(configHostname) == "" {
+		hostname, err := util.GetHostname()
+		if err != nil {
+			log.Warn(err)
+			hostname = "unknown"
+		}
+		return hostname
+	}
+	return configHostname
+}

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogsAgentDefaultValues(t *testing.T) {
+	assert.Equal(t, "", LogsAgent.GetString("logset"))
+	assert.Equal(t, "intake.logs.datadoghq.com", LogsAgent.GetString("log_dd_url"))
+	assert.Equal(t, 10516, LogsAgent.GetInt("log_dd_port"))
+	assert.Equal(t, false, LogsAgent.GetBool("skip_ssl_validation"))
+	assert.Equal(t, false, LogsAgent.GetBool("dev_mode_no_ssl"))
+	assert.Equal(t, false, LogsAgent.GetBool("log_enabled"))
+	assert.Equal(t, 100, LogsAgent.GetInt("log_open_files_limit"))
+}
+
+func TestBuildHostname(t *testing.T) {
+	var config = viper.New()
+	var hostname string
+
+	hostname = buildHostname(config)
+	assert.NotEqual(t, "", hostname)
+
+	config.SetDefault("hostname", "\t \n")
+	hostname = buildHostname(config)
+	assert.NotEqual(t, "\t \n", hostname)
+	assert.NotEqual(t, "", hostname)
+
+	config.SetDefault("hostname", "foo")
+	hostname = buildHostname(config)
+	assert.Equal(t, "foo", hostname)
+}

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,81 +23,80 @@ func TestAvailableIntegrationConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	var testConfig = viper.New()
-	buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	sources, err := buildLogsSources(ddconfdPath)
 
-	rules := getLogsSources(testConfig)
-	assert.Equal(t, 3, len(rules))
-	assert.Equal(t, "file", rules[0].Type)
-	assert.Equal(t, "/var/log/access.log", rules[0].Path)
-	assert.Equal(t, "nginx", rules[0].Service)
-	assert.Equal(t, "nginx", rules[0].Source)
-	assert.Equal(t, "http_access", rules[0].SourceCategory)
-	assert.Equal(t, "", rules[0].Logset)
-	assert.Equal(t, "env:prod", rules[0].Tags)
-	assert.Equal(t, "[dd ddsource=\"nginx\"][dd ddsourcecategory=\"http_access\"][dd ddtags=\"env:prod\"]", string(rules[0].TagsPayload))
+	assert.Nil(t, err)
 
-	assert.Equal(t, "tcp", rules[1].Type)
-	assert.Equal(t, 10514, rules[1].Port)
-	assert.Equal(t, "devteam", rules[1].Logset)
-	assert.Equal(t, "", rules[1].Service)
-	assert.Equal(t, "", rules[1].Source)
-	assert.Equal(t, 0, len(rules[1].Tags))
+	assert.Equal(t, 3, len(sources))
+	assert.Equal(t, "file", sources[0].Type)
+	assert.Equal(t, "/var/log/access.log", sources[0].Path)
+	assert.Equal(t, "nginx", sources[0].Service)
+	assert.Equal(t, "nginx", sources[0].Source)
+	assert.Equal(t, "http_access", sources[0].SourceCategory)
+	assert.Equal(t, "", sources[0].Logset)
+	assert.Equal(t, "env:prod", sources[0].Tags)
+	assert.Equal(t, "[dd ddsource=\"nginx\"][dd ddsourcecategory=\"http_access\"][dd ddtags=\"env:prod\"]", string(sources[0].TagsPayload))
 
-	assert.Equal(t, "docker", rules[2].Type)
-	assert.Equal(t, "test", rules[2].Image)
+	assert.Equal(t, "tcp", sources[1].Type)
+	assert.Equal(t, 10514, sources[1].Port)
+	assert.Equal(t, "devteam", sources[1].Logset)
+	assert.Equal(t, "", sources[1].Service)
+	assert.Equal(t, "", sources[1].Source)
+	assert.Equal(t, 0, len(sources[1].Tags))
+
+	assert.Equal(t, "docker", sources[2].Type)
+	assert.Equal(t, "test", sources[2].Image)
 
 	// processing
-	assert.Equal(t, 0, len(rules[0].ProcessingRules))
-	assert.Equal(t, 4, len(rules[1].ProcessingRules))
+	assert.Equal(t, 0, len(sources[0].ProcessingRules))
+	assert.Equal(t, 4, len(sources[1].ProcessingRules))
 
-	pRule := rules[1].ProcessingRules[0]
+	pRule := sources[1].ProcessingRules[0]
 	assert.Equal(t, "mask_sequences", pRule.Type)
 	assert.Equal(t, "mocked_mask_rule", pRule.Name)
 	assert.Equal(t, "[mocked]", pRule.ReplacePlaceholder)
 	assert.Equal(t, []byte("[mocked]"), pRule.ReplacePlaceholderBytes)
 	assert.Equal(t, ".*", pRule.Pattern)
 
-	mRule := rules[1].ProcessingRules[1]
+	mRule := sources[1].ProcessingRules[1]
 	assert.Equal(t, "multi_line", mRule.Type)
 	assert.Equal(t, "numbers", mRule.Name)
 	re := mRule.Reg
 	assert.True(t, re.MatchString("123"))
 	assert.False(t, re.MatchString("a123"))
 
-	eRule := rules[1].ProcessingRules[2]
+	eRule := sources[1].ProcessingRules[2]
 	assert.Equal(t, "exclude_at_match", eRule.Type)
 	assert.Equal(t, "exclude_bob", eRule.Name)
 	assert.Equal(t, "^bob", eRule.Pattern)
 
-	iRule := rules[1].ProcessingRules[3]
+	iRule := sources[1].ProcessingRules[3]
 	assert.Equal(t, "include_at_match", iRule.Type)
 	assert.Equal(t, "include_datadoghq", iRule.Name)
 	assert.Equal(t, ".*@datadoghq.com$", iRule.Pattern)
 }
 
 func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
-	var testConfig = viper.New()
 	var ddconfdPath string
 	var err error
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
-	err = buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	_, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
-	err = buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	_, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
-	err = buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	_, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
-	err = buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	_, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
-	err = buildLogsAgentIntegrationsConfig(testConfig, ddconfdPath)
+	_, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 }
 
@@ -106,14 +104,4 @@ func TestBuildTagsPayload(t *testing.T) {
 	assert.Equal(t, "-", string(BuildTagsPayload("", "", "")))
 	assert.Equal(t, "[dd ddtags=\"hello:world\"]", string(BuildTagsPayload("hello:world", "", "")))
 	assert.Equal(t, "[dd ddsource=\"nginx\"][dd ddsourcecategory=\"http_access\"][dd ddtags=\"hello:world, hi\"]", string(BuildTagsPayload("hello:world, hi", "nginx", "http_access")))
-}
-
-func TestLogsAgentDefaultValues(t *testing.T) {
-	assert.Equal(t, "", LogsAgent.GetString("logset"))
-	assert.Equal(t, "intake.logs.datadoghq.com", LogsAgent.GetString("log_dd_url"))
-	assert.Equal(t, 10516, LogsAgent.GetInt("log_dd_port"))
-	assert.Equal(t, false, LogsAgent.GetBool("skip_ssl_validation"))
-	assert.Equal(t, false, LogsAgent.GetBool("dev_mode_no_ssl"))
-	assert.Equal(t, false, LogsAgent.GetBool("log_enabled"))
-	assert.Equal(t, 100, LogsAgent.GetInt("log_open_files_limit"))
 }

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -20,7 +20,7 @@ import (
 
 // Start starts logs-agent
 func Start() error {
-	err := config.BuildLogsAgentIntegrationsConfigs()
+	err := config.Build()
 	if err != nil {
 		return err
 	}

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -91,7 +91,7 @@ func (p *Processor) computeExtraContent(msg message.Message) []byte {
 		extraContent = append(extraContent, ' ')
 
 		// Hostname
-		extraContent = append(extraContent, []byte(config.LogsAgent.GetString("hostname"))...)
+		extraContent = append(extraContent, []byte(config.GetHostname())...)
 		extraContent = append(extraContent, ' ')
 
 		// Service


### PR DESCRIPTION
### What does this PR do?

Added a logic to compute a hostname when it's not set in the config and moved some config code around.

### Motivation

Users must have a username set.

### Additional Notes

This is a regression that has been introduced while merging logs-agent code.
