### PR TITLE
[LOGS]:  Removed custom logic to compute hostname and use the agent one instead

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -6,13 +6,7 @@
 package config
 
 import (
-	"strings"
-
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
-
-	log "github.com/cihub/seelog"
-	"github.com/spf13/viper"
 )
 
 // LogsAgent is the global configuration object
@@ -20,14 +14,8 @@ var LogsAgent = ddconfig.Datadog
 
 // private configuration properties
 var (
-	hostname    string
 	logsSources []*IntegrationConfigLogSource
 )
-
-// GetHostname returns logs-agent hostname
-func GetHostname() string {
-	return hostname
-}
 
 // GetLogsSources returns the list of logs sources
 func GetLogsSources() []*IntegrationConfigLogSource {
@@ -41,20 +29,8 @@ func Build() error {
 		return err
 	}
 	logsSources = sources
-	hostname = buildHostname(LogsAgent)
-	return nil
-}
-
-// buildHostname computes the hostname for logs-agent
-func buildHostname(config *viper.Viper) string {
-	configHostname := config.GetString("hostname")
-	if strings.TrimSpace(configHostname) == "" {
-		hostname, err := util.GetHostname()
-		if err != nil {
-			log.Warn(err)
-			hostname = "unknown"
-		}
-		return hostname
+	if err != nil {
+		return err
 	}
-	return configHostname
+	return nil
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -8,7 +8,6 @@ package config
 import (
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,21 +19,4 @@ func TestLogsAgentDefaultValues(t *testing.T) {
 	assert.Equal(t, false, LogsAgent.GetBool("dev_mode_no_ssl"))
 	assert.Equal(t, false, LogsAgent.GetBool("log_enabled"))
 	assert.Equal(t, 100, LogsAgent.GetInt("log_open_files_limit"))
-}
-
-func TestBuildHostname(t *testing.T) {
-	var config = viper.New()
-	var hostname string
-
-	hostname = buildHostname(config)
-	assert.NotEqual(t, "", hostname)
-
-	config.SetDefault("hostname", "\t \n")
-	hostname = buildHostname(config)
-	assert.NotEqual(t, "\t \n", hostname)
-	assert.NotEqual(t, "", hostname)
-
-	config.SetDefault("hostname", "foo")
-	hostname = buildHostname(config)
-	assert.Equal(t, "foo", hostname)
 }

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
@@ -91,7 +93,12 @@ func (p *Processor) computeExtraContent(msg message.Message) []byte {
 		extraContent = append(extraContent, ' ')
 
 		// Hostname
-		extraContent = append(extraContent, []byte(config.GetHostname())...)
+		hostname, err := util.GetHostname()
+		if err != nil {
+			// this scenario is not likely to happen since the agent can not start without a hostname
+			hostname = "unknown"
+		}
+		extraContent = append(extraContent, []byte(hostname)...)
 		extraContent = append(extraContent, ' ')
 
 		// Service


### PR DESCRIPTION
### What does this PR do?

Removed the logic to compute a hostname in logs config, use agent's utilities instead.

### Motivation

Have a single source of truth.
