### PR TITLE
Add option to force TLS version in the agent to 1.2

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,10 @@ func init() {
 	Datadog.SetDefault("enable_gohai", true)
 	Datadog.SetDefault("check_runners", int64(0))
 	Datadog.SetDefault("expvar_port", "5000")
+
+	// Use to force client side TLS version to 1.2
+	BindEnvAndSetDefault("force_tls_12", false)
+
 	// Agent GUI access port
 	Datadog.SetDefault("GUI_port", defaultGuiPort)
 	if IsContainerized() {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -24,6 +24,10 @@ api_key:
 # https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-haproxy-as-a-proxy
 # skip_ssl_validation: no
 
+# Setting this option to "yes" will force the agent to only use TLS 1.2 when
+# pushing data to the url specified in "dd_url".
+# force_tls_12: no
+
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -112,10 +112,16 @@ func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error
 
 // CreateHTTPTransport creates an *http.Transport for use in the agent
 func CreateHTTPTransport() *http.Transport {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: config.Datadog.GetBool("skip_ssl_validation"),
+	}
+
+	if config.Datadog.GetBool("force_tls_12") {
+		tlsConfig.MinVersion = tls.VersionTLS12
+	}
+
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: config.Datadog.GetBool("skip_ssl_validation"),
-		},
+		TLSClientConfig: tlsConfig,
 	}
 
 	if proxies := config.Datadog.Get("proxy"); proxies != nil {

--- a/releasenotes/notes/force-tls-12-db1564c0c1313d32.yaml
+++ b/releasenotes/notes/force-tls-12-db1564c0c1313d32.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add a new option, `force_tls_12`, to the agent configuration to force the
+    TLS version to 1.2 when contactin Datatog.


### PR DESCRIPTION
### What does this PR do?

Add option to force TLS version in the agent to `1.2`.  