### PR TITLE
[Logs] Prevent from sending empty logs with multilines and reorganized code

### DIFF
--- a/pkg/logs/decoder/line_buffer.go
+++ b/pkg/logs/decoder/line_buffer.go
@@ -10,37 +10,33 @@ import (
 )
 
 // LineBuffer accumulates lines in buffer escaping all '\n'
-// and accumulates the total number of bytes of all lines in line representation (line + '\n') in contentLen
-// to form and forward outputs to outputChan
+// and accumulates the total number of bytes of all lines in line representation (line + '\n') in rawDataLen
 type LineBuffer struct {
-	outputChan chan *Output
 	buffer     *bytes.Buffer
-	contentLen int
+	rawDataLen int
 }
 
 // NewLineBuffer returns a new LineBuffer
-func NewLineBuffer(outputChan chan *Output) *LineBuffer {
-	buffer := bytes.Buffer{}
+func NewLineBuffer() *LineBuffer {
 	return &LineBuffer{
-		outputChan: outputChan,
-		buffer:     &buffer,
+		buffer: &bytes.Buffer{},
 	}
 }
 
 // IsEmpty returns true if buffer does not contain any line
 func (l *LineBuffer) IsEmpty() bool {
-	return l.contentLen == 0
+	return l.rawDataLen == 0
 }
 
-// Length returns the length of buffer which might be different from contentLen because of escaped '\n'
+// Length returns the length of buffer which might be different from rawDataLen because of escaped '\n'
 func (l *LineBuffer) Length() int {
 	return l.buffer.Len()
 }
 
 // Add stores line in buffer
-func (l *LineBuffer) Add(line *Line) {
-	l.buffer.Write(line.content)
-	l.contentLen += len(line.content) + 1 // add 1 for '\n'
+func (l *LineBuffer) Add(line []byte) {
+	l.buffer.Write(line)
+	l.rawDataLen += len(line) + 1 // add 1 for '\n'
 }
 
 // AddEndOfLine stores an escaped '\n' in buffer
@@ -49,34 +45,25 @@ func (l *LineBuffer) AddEndOfLine() {
 }
 
 // AddIncompleteLine stores a chunck of line in buff
-func (l *LineBuffer) AddIncompleteLine(line *Line) {
-	l.buffer.Write(line.content)
-	l.contentLen += len(line.content)
+func (l *LineBuffer) AddIncompleteLine(line []byte) {
+	l.buffer.Write(line)
+	l.rawDataLen += len(line)
 }
 
 // AddTruncate stores TRUNCATED in buffer
-func (l *LineBuffer) AddTruncate(line *Line) {
+func (l *LineBuffer) AddTruncate(line []byte) {
 	l.buffer.Write(TRUNCATED)
 }
 
-// Flush creates a new output from content in buffer and sends it to outputChan
-func (l *LineBuffer) Flush() {
-	defer l.reset()
+// Content returns the content in buffer and the length of the data that enabled to compute this content
+func (l *LineBuffer) Content() ([]byte, int) {
 	content := make([]byte, l.buffer.Len())
 	copy(content, l.buffer.Bytes())
-	if len(content) > 0 {
-		output := NewOutput(content, l.contentLen)
-		l.outputChan <- output
-	}
+	return content, l.rawDataLen
 }
 
-// Stop forwards stop event to outputChan
-func (l *LineBuffer) Stop() {
-	l.outputChan <- newStopOutput()
-}
-
-// reset prepares buffer to receive new lines
-func (l *LineBuffer) reset() {
-	l.contentLen = 0
+// Reset prepares buffer to receive new lines
+func (l *LineBuffer) Reset() {
+	l.rawDataLen = 0
 	l.buffer.Reset()
 }

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -129,7 +129,7 @@ func (p *Processor) buildPayload(apikeyString, redactedMessage, extraContent []b
 		payload = append(payload, extraContent...)
 	}
 	payload = append(payload, redactedMessage...)
-	payload = append(payload, '\n') // TODO: move this in decoder
+	payload = append(payload, '\n')
 	return payload
 }
 


### PR DESCRIPTION
### What does this PR do?

Prevent from sending empty logs with multilines and reorganised code to make it more readable.

### Motivation

Do not send empty logs to our backend.