### PR TITLE
rename memory config

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -187,7 +187,7 @@ func zipConfigFiles(zipFile *archivex.ZipFile, hostname string, confSearchPaths 
 			if err != nil {
 				return e
 			}
-			fileName := filepath.Join(hostname, "etc", "datadog.yaml")
+			fileName := filepath.Join(hostname, "etc", "runtime_config_dump.yaml")
 			e = zipFile.Add(fileName, file)
 			if e != nil {
 				return e

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -187,7 +187,7 @@ func zipConfigFiles(zipFile *archivex.ZipFile, hostname string, confSearchPaths 
 			if err != nil {
 				return e
 			}
-			fileName := filepath.Join(hostname, "etc", "runtime_config_dump.yaml")
+			fileName := filepath.Join(hostname, "etc", "datadog.yaml")
 			e = zipFile.Add(fileName, file)
 			if e != nil {
 				return e

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -167,7 +167,7 @@ func zipConfigFiles(zipFile *archivex.ZipFile, hostname string, confSearchPaths 
 	if err != nil {
 		return err
 	}
-	err = zipFile.Add(filepath.Join(hostname, "datadog.yaml"), cleaned)
+	err = zipFile.Add(filepath.Join(hostname, "runtime_config_dump.yaml"), cleaned)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

This changes the archived config's file name to avoid confusion with the one in `/etc`.

### Motivation

This was causing unnecessary confusion for support.
