### PR TITLE
better docker port parsing for AD

### DIFF
--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -425,7 +425,7 @@ func TestParseDockerPort(t *testing.T) {
 			proto:         "tcp",
 			port:          "0",
 			expectedPorts: nil,
-			expectedError: errors.New("failed to extract port 0/tcp"),
+			expectedError: errors.New("failed to extract port from: 0/tcp"),
 		},
 	}
 

--- a/releasenotes/notes/ad_on_rancher1.x-f08a86be8a58b8f2.yaml
+++ b/releasenotes/notes/ad_on_rancher1.x-f08a86be8a58b8f2.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Support AD on Rancher 1.x by getting the container port through the
+    image's exposed ports as a fallback mechanism    


### PR DESCRIPTION
- use the docker lib's `Port.Int()` method instead of manualy parsing the string
- support port ranges
- extract ports from Config.ExposedPorts of NetworkSetting.Ports is empty (support Rancher 1.x)
- if getPortsFromPs finds no port, retry from inspect on template resolution
  