### PR TITLE
[flare][windows] Fix collection of log files

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"expvar"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -109,7 +108,7 @@ func zipStatusFile(zipFile *archivex.ZipFile, hostname string) error {
 }
 
 func zipLogFiles(zipFile *archivex.ZipFile, hostname, logFilePath string) error {
-	logFileDir := path.Dir(logFilePath)
+	logFileDir := filepath.Dir(logFilePath)
 	err := filepath.Walk(logFileDir, func(path string, f os.FileInfo, err error) error {
 		if f == nil {
 			return nil
@@ -259,6 +258,6 @@ func mkFilePath() string {
 	timeString := t.Format("2006-01-02-15-04-05")
 	fileName := strings.Join([]string{"datadog", "agent", timeString}, "-")
 	fileName = strings.Join([]string{fileName, "zip"}, ".")
-	filePath := path.Join(dir, fileName)
+	filePath := filepath.Join(dir, fileName)
 	return filePath
 }

--- a/pkg/flare/strip_test.go
+++ b/pkg/flare/strip_test.go
@@ -7,7 +7,7 @@ package flare
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +47,7 @@ log_level: info
 `
 
 	wd, _ := os.Getwd()
-	filePath := path.Join(wd, "test", "datadog.yaml")
+	filePath := filepath.Join(wd, "test", "datadog.yaml")
 	cleaned, err := credentialsCleanerFile(filePath)
 	assert.Nil(t, err)
 	cleanedString := string(cleaned)

--- a/releasenotes/notes/fix-flare-windows-logs-2dd7edd39b6db96e.yaml
+++ b/releasenotes/notes/fix-flare-windows-logs-2dd7edd39b6db96e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix path of logs collected by flare on Windows, was breaking flare command


### PR DESCRIPTION
### What does this PR do?

Fixes flare command on windows (by fixing the path on which log files are collected).

### Additional Notes

Use `path/filepath` instead of `path` for filepath handling.

`path` is not meant to be used with file paths since it always uses forward slashes as the path separator (which doesn't work on windows).


