### PR TITLE
tagger: fix docker environment extractor

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -83,11 +83,11 @@ func dockerExtractEnvironmentVariables(tags *utils.TagList, containerEnvVariable
 
 	for _, envEntry := range containerEnvVariables {
 		envSplit = strings.SplitN(envEntry, "=", 2)
-		envName = envSplit[0]
-		envValue = envSplit[1]
 		if len(envSplit) != 2 {
 			continue
 		}
+		envName = envSplit[0]
+		envValue = envSplit[1]
 		switch envName {
 		// Mesos/DCOS tags (mesos, marathon, chronos)
 		case "MARATHON_APP_ID":

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -102,6 +102,22 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			expectedHigh: []string{"mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"},
 		},
 		{
+			testName: "NoValue",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"NOVALUE=",
+						"AVALUE=value",
+					},
+					Labels: map[string]string{},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{"avalue": "v"},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow:          []string{"v:value"},
+			expectedHigh:         []string{},
+		},
+		{
 			testName: "extractSwarmLabels",
 			co: &types.ContainerJSON{
 				Config: &container.Config{


### PR DESCRIPTION
### What does this PR do?

This PR fix the way we are extracting the environment variables.

Ignore a case like `VAR=`