### PR TITLE
bug fix for nil event processing

### DIFF
--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -43,6 +43,7 @@ func (d *DockerUtil) openEventChannel(since, until time.Time, filter map[string]
 func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent, error) {
 	// Type filtering
 	if msg.Type != "container" {
+		log.Warnf("Event skipped because of a type mismatch. Expected 'container' got %s", msg.Type)
 		return nil, nil
 	}
 
@@ -67,6 +68,7 @@ func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 		}
 	}
 	if d.cfg.filter.computeIsExcluded(containerName, imageName) {
+		log.Debugf("events from %s are skipped as the image is excluded for the event collection", containerName)
 		return nil, nil
 	}
 

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -40,10 +40,11 @@ func (d *DockerUtil) openEventChannel(since, until time.Time, filter map[string]
 	return d.cli.Events(context.Background(), options)
 }
 
+// processContainerEvent formats the events from a channel.
+// It can return nil, nil if the event is filtered out, one should check for nil pointers before using the event.
 func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent, error) {
 	// Type filtering
 	if msg.Type != "container" {
-		log.Warnf("Event skipped because of a type mismatch. Expected 'container' got %s", msg.Type)
 		return nil, nil
 	}
 
@@ -68,7 +69,7 @@ func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 		}
 	}
 	if d.cfg.filter.computeIsExcluded(containerName, imageName) {
-		log.Debugf("events from %s are skipped as the image is excluded for the event collection", containerName)
+		log.Tracef("events from %s are skipped as the image is excluded for the event collection", containerName)
 		return nil, nil
 	}
 

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -146,7 +146,6 @@ CONNECT:
 					continue
 				}
 				if event == nil {
-					log.Debug("Processed nil event, skipping")
 					continue
 				}
 				badSubs := d.eventState.dispatch(event)

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -145,7 +145,10 @@ CONNECT:
 					log.Debugf("Skipping event: %s", err)
 					continue
 				}
-
+				if event == nil {
+					log.Debug("Processed nil event, skipping")
+					continue
+				}
 				badSubs := d.eventState.dispatch(event)
 				for _, sub := range badSubs {
 					d.UnsubscribeFromContainerEvents(sub.name)

--- a/releasenotes/notes/fix_dockerevent_nil_pointer-73e665aee0a222a1.yaml
+++ b/releasenotes/notes/fix_dockerevent_nil_pointer-73e665aee0a222a1.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Avoid processing of nil events.
+    Fix a nil-pointer segfault in docker event processing when an event is ignored

--- a/releasenotes/notes/fix_dockerevent_nil_pointer-73e665aee0a222a1.yaml
+++ b/releasenotes/notes/fix_dockerevent_nil_pointer-73e665aee0a222a1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Avoid processing of nil events.


### PR DESCRIPTION
### What does this PR do?

Avoid processing of nil events. Adds logs for the event pull and stream failure cases.

### Motivation

This is a bug encountered by a user. Brought up in https://github.com/DataDog/datadog-agent/issues/1030