### PR TITLE
tagger: add a release note for the docker extract

### DIFF
--- a/releasenotes/notes/fix-environment-split-4fa3adcc557e8a68.yaml
+++ b/releasenotes/notes/fix-environment-split-4fa3adcc557e8a68.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the extraction of the environment variables in the pkg/tagger/collectors/docker_extract.go when the variable is
+    like "KEY="


### PR DESCRIPTION
### What does this PR do?

Add the reno file because it's missing in #1040 
