### PR TITLE
[Logs]: Fix a flaky test in scanner_test.go

### DIFF
--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -190,8 +190,8 @@ func (t *Tailer) readForever() {
 			t.wait()
 			continue
 		}
-		t.d.InputChan <- decoder.NewInput(inBuf[:n])
 		t.incrementReadOffset(n)
+		t.d.InputChan <- decoder.NewInput(inBuf[:n])
 	}
 }
 

--- a/releasenotes/notes/fix-tailer-flaky-test-e31dc9a78e3c6f65.yaml
+++ b/releasenotes/notes/fix-tailer-flaky-test-e31dc9a78e3c6f65.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a flaky test causing the build pipeline to fail


### PR DESCRIPTION
### What does this PR do?

Increment the read offset before sending data to the decoder in tailer

### Motivation

Fix flaky tests caused by race conditions:
- https://circleci.com/gh/DataDog/datadog-agent/13963
- https://circleci.com/gh/DataDog/datadog-agent/16070?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack
