### PR TITLE
Revert "[Logs] Fixed a flaky test in scanner_test.go (#1043)"

### DIFF
--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -190,8 +190,8 @@ func (t *Tailer) readForever() {
 			t.wait()
 			continue
 		}
-		t.incrementReadOffset(n)
 		t.d.InputChan <- decoder.NewInput(inBuf[:n])
+		t.incrementReadOffset(n)
 	}
 }
 

--- a/releasenotes/notes/fix-tailer-flaky-test-e31dc9a78e3c6f65.yaml
+++ b/releasenotes/notes/fix-tailer-flaky-test-e31dc9a78e3c6f65.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Fixed a flaky test causing the build pipeline to fail


### PR DESCRIPTION
This reverts commit 58484a0e948b5d5ce33ebec6c4beeb55c47fd539.