### PR TITLE
Series split is now based on metric names.

### DIFF
--- a/pkg/serializer/split/split_test.go
+++ b/pkg/serializer/split/split_test.go
@@ -7,6 +7,7 @@ package split
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -31,7 +32,7 @@ func TestSplitPayloadsSeries(t *testing.T) {
 				{Ts: 9090.0, Value: float64(13.12)},
 			},
 			MType:    metrics.APIGaugeType,
-			Name:     "test.metrics",
+			Name:     fmt.Sprintf("test.metrics%d", i),
 			Interval: 1,
 			Host:     "localHost",
 			Tags:     []string{"tag1", "tag2:yes"},

--- a/releasenotes/notes/split-series-by-name-31b2bae1c13ccc69.yaml
+++ b/releasenotes/notes/split-series-by-name-31b2bae1c13ccc69.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Series for a common metric name will no longer be split among multiple
+    transactions/payload. This guarantee that every point for a time T and a metric
+    M will be bundled together when push to the backend. This allows some
+    optimization on the backend side.


### PR DESCRIPTION
### What does this PR do?

For backend optimisation we no longer split a metric name across
multiple transaction.

### Additional Notes

We could optimized the split by grouping series directly at `flush` time. This might be needed later when the backend behavior is more stable.
