### PR TITLE
check availability of dsd port in unit tests to avoid flakes

### DIFF
--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -46,12 +46,18 @@ func TestStartStopUDPListener(t *testing.T) {
 	assert.NotNil(t, err)
 
 	s.Stop()
-	// Port should be available again
-	conn, err := net.ListenUDP("udp", address)
-	require.NotNil(t, conn)
 
-	assert.Nil(t, err)
-	conn.Close()
+	// check that the port can be bound, try for 100 ms
+	for i := 0; i < 10; i++ {
+		var conn net.Conn
+		conn, err = net.ListenUDP("udp", address)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NoError(t, err, "port is not available, it should be")
 }
 
 func TestUDPNonLocal(t *testing.T) {

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -60,12 +60,19 @@ func TestStopServer(t *testing.T) {
 	require.NoError(t, err, "cannot start DSD")
 	s.Stop()
 
-	// check that the port can be bound
+	// check that the port can be bound, try for 100 ms
 	address, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
 	require.NoError(t, err, "cannot resolve address")
-	conn, err := net.ListenUDP("udp", address)
+	for i := 0; i < 10; i++ {
+		var conn net.Conn
+		conn, err = net.ListenUDP("udp", address)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	require.NoError(t, err, "port is not available, it should be")
-	conn.Close()
 }
 
 func TestUPDReceive(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Copy logic from the DSD UDP listener tests into the DSD server tests: instead of hardcoding port `8125`, use an available random port. This achieves two things:

- fixes flaky CI
- allows to run tests in parallel (future-proofing for golang 1.10)
- makes sure we don't assume `8125` in any part of the code
