### PR TITLE
[Logs]: Added Logs-Agent section to Agent status

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -7,6 +7,8 @@ package config
 
 import (
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 // LogsAgent is the global configuration object
@@ -24,13 +26,11 @@ func GetLogsSources() []*IntegrationConfigLogSource {
 
 // Build initializes logs-agent configuration
 func Build() error {
-	sources, err := buildLogsSources(LogsAgent.GetString("confd_path"))
+	sources, sourcesToTrack, err := buildLogsSources(LogsAgent.GetString("confd_path"))
 	if err != nil {
 		return err
 	}
 	logsSources = sources
-	if err != nil {
-		return err
-	}
+	status.Initialize(sourcesToTrack)
 	return nil
 }

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -102,6 +102,7 @@ func buildLogsSources(ddconfdPath string) ([]*IntegrationConfigLogSource, []*sta
 		for _, logSourceConfigIterator := range integrationConfig.Logs {
 			logSourceConfig := logSourceConfigIterator
 			tracker := status.NewTracker(logSourceConfig.Type)
+			// misconfigured sources are also tracked to repport configuration errors
 			sourcesToTrack = append(sourcesToTrack, status.NewSourceToTrack(integrationName, tracker))
 			err = validateSource(logSourceConfig)
 			if err != nil {

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -23,11 +23,12 @@ func TestAvailableIntegrationConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	sources, err := buildLogsSources(ddconfdPath)
+	sources, sourcesToTrack, err := buildLogsSources(ddconfdPath)
 
 	assert.Nil(t, err)
-
 	assert.Equal(t, 3, len(sources))
+	assert.Equal(t, 4, len(sourcesToTrack))
+
 	assert.Equal(t, "file", sources[0].Type)
 	assert.Equal(t, "/var/log/access.log", sources[0].Path)
 	assert.Equal(t, "nginx", sources[0].Service)
@@ -80,23 +81,23 @@ func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
 	var ddconfdPath string
 	var err error
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
-	_, err = buildLogsSources(ddconfdPath)
+	_, _, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
-	_, err = buildLogsSources(ddconfdPath)
+	_, _, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
-	_, err = buildLogsSources(ddconfdPath)
+	_, _, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
-	_, err = buildLogsSources(ddconfdPath)
+	_, _, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
-	_, err = buildLogsSources(ddconfdPath)
+	_, _, err = buildLogsSources(ddconfdPath)
 	assert.NotNil(t, err)
 }
 

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -106,3 +106,26 @@ func TestBuildTagsPayload(t *testing.T) {
 	assert.Equal(t, "[dd ddtags=\"hello:world\"]", string(BuildTagsPayload("hello:world", "", "")))
 	assert.Equal(t, "[dd ddsource=\"nginx\"][dd ddsourcecategory=\"http_access\"][dd ddtags=\"hello:world, hi\"]", string(BuildTagsPayload("hello:world, hi", "nginx", "http_access")))
 }
+
+func TestIntegrationName(t *testing.T) {
+	var integrationName string
+	var err error
+
+	integrationName, err = buildIntegrationName("foo.d/bar.yml")
+	assert.Equal(t, "foo", integrationName)
+	assert.Nil(t, err)
+
+	integrationName, err = buildIntegrationName("bar.yaml")
+	assert.Equal(t, "bar", integrationName)
+	assert.Nil(t, err)
+
+	integrationName, err = buildIntegrationName("bar.yml")
+	assert.Equal(t, "bar", integrationName)
+	assert.Nil(t, err)
+
+	_, err = buildIntegrationName("foo.bar")
+	assert.NotNil(t, err)
+
+	_, err = buildIntegrationName("foo.b/bar.yml")
+	assert.NotNil(t, err)
+}

--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -128,8 +128,10 @@ func (dt *DockerTailer) startReading(from string) error {
 	}
 	reader, err := dt.cli.ContainerLogs(context.Background(), dt.ContainerID, options)
 	if err != nil {
+		dt.source.Tracker.TrackError(err)
 		return err
 	}
+	dt.source.Tracker.TrackSuccess()
 	dt.reader = reader
 	go dt.readForever()
 	return nil
@@ -155,6 +157,7 @@ func (dt *DockerTailer) readForever() {
 			continue
 		}
 		if err != nil {
+			dt.source.Tracker.TrackError(err)
 			log.Error("Err: ", err)
 			return
 		}

--- a/pkg/logs/input/listener/connection_handler.go
+++ b/pkg/logs/input/listener/connection_handler.go
@@ -52,6 +52,7 @@ func (connHandler *ConnectionHandler) handleConnection(conn net.Conn) {
 			return
 		}
 		if err != nil {
+			connHandler.source.Tracker.TrackError(err)
 			log.Warn("Couldn't read message from connection: ", err)
 			d.Stop()
 			return

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -54,6 +54,7 @@ func (tcpListener *TCPListener) run() {
 			log.Error("Can't listen: ", err)
 			return
 		}
+		tcpListener.connHandler.source.Tracker.TrackSuccess()
 		go tcpListener.connHandler.handleConnection(conn)
 	}
 }

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -26,8 +26,10 @@ func NewTCPListener(pp pipeline.Provider, source *config.IntegrationConfigLogSou
 	log.Info("Starting TCP forwarder on port ", source.Port)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", source.Port))
 	if err != nil {
+		source.Tracker.TrackError(err)
 		return nil, err
 	}
+	source.Tracker.TrackSuccess()
 	connHandler := &ConnectionHandler{
 		pp:     pp,
 		source: source,
@@ -48,6 +50,7 @@ func (tcpListener *TCPListener) run() {
 	for {
 		conn, err := tcpListener.listener.Accept()
 		if err != nil {
+			tcpListener.connHandler.source.Tracker.TrackError(err)
 			log.Error("Can't listen: ", err)
 			return
 		}

--- a/pkg/logs/input/listener/tcp_test.go
+++ b/pkg/logs/input/listener/tcp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -31,7 +32,7 @@ type TCPTestSuite struct {
 func (suite *TCPTestSuite) SetupTest() {
 	suite.pp = mock.NewMockProvider()
 	suite.outputChan = suite.pp.NextPipelineChan()
-	suite.source = &config.IntegrationConfigLogSource{Type: config.TCPType, Port: tcpTestPort}
+	suite.source = &config.IntegrationConfigLogSource{Type: config.TCPType, Port: tcpTestPort, Tracker: status.NewTracker()}
 	tcpl, err := NewTCPListener(suite.pp, suite.source)
 	suite.Nil(err)
 	suite.tcpl = tcpl

--- a/pkg/logs/input/listener/udp.go
+++ b/pkg/logs/input/listener/udp.go
@@ -26,12 +26,15 @@ func NewUDPListener(pp pipeline.Provider, source *config.IntegrationConfigLogSou
 	log.Info("Starting UDP forwarder on port ", source.Port)
 	udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", source.Port))
 	if err != nil {
+		source.Tracker.TrackError(err)
 		return nil, err
 	}
 	conn, err := net.ListenUDP("udp", udpAddr)
 	if err != nil {
+		source.Tracker.TrackError(err)
 		return nil, err
 	}
+	source.Tracker.TrackSuccess()
 	connHandler := &ConnectionHandler{
 		pp:     pp,
 		source: source,

--- a/pkg/logs/input/listener/udp_test.go
+++ b/pkg/logs/input/listener/udp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/mock"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -31,7 +32,7 @@ type UDPTestSuite struct {
 func (suite *UDPTestSuite) SetupTest() {
 	suite.pp = mock.NewMockProvider()
 	suite.outputChan = suite.pp.NextPipelineChan()
-	suite.source = &config.IntegrationConfigLogSource{Type: config.UDPType, Port: udpTestPort}
+	suite.source = &config.IntegrationConfigLogSource{Type: config.UDPType, Port: udpTestPort, Tracker: status.NewTracker()}
 	udpl, err := NewUDPListener(suite.pp, suite.source)
 	suite.Nil(err)
 	suite.udpl = udpl

--- a/pkg/logs/input/tailer/file_provider.go
+++ b/pkg/logs/input/tailer/file_provider.go
@@ -55,7 +55,7 @@ func (r *FileProvider) FilesToTail() []*File {
 		pattern := source.Path
 		paths, err := filepath.Glob(pattern)
 		if err != nil {
-			err := fmt.Errorf("Malformed pattern, could not find any file: ", pattern)
+			err := fmt.Errorf("Malformed pattern, could not find any file: %s", pattern)
 			source.Tracker.TrackError(err)
 			log.Error(err)
 			continue

--- a/pkg/logs/input/tailer/file_provider.go
+++ b/pkg/logs/input/tailer/file_provider.go
@@ -54,6 +54,7 @@ func (r *FileProvider) FilesToTail() []*File {
 		pattern := source.Path
 		paths, err := filepath.Glob(pattern)
 		if err != nil {
+			source.Tracker.TrackError(err)
 			log.Warn("Malformed pattern, could not find any file: ", pattern)
 			continue
 		}

--- a/pkg/logs/input/tailer/file_provider.go
+++ b/pkg/logs/input/tailer/file_provider.go
@@ -8,6 +8,7 @@
 package tailer
 
 import (
+	"fmt"
 	"path/filepath"
 
 	log "github.com/cihub/seelog"
@@ -54,8 +55,15 @@ func (r *FileProvider) FilesToTail() []*File {
 		pattern := source.Path
 		paths, err := filepath.Glob(pattern)
 		if err != nil {
+			err := fmt.Errorf("Malformed pattern, could not find any file: ", pattern)
 			source.Tracker.TrackError(err)
-			log.Warn("Malformed pattern, could not find any file: ", pattern)
+			log.Error(err)
+			continue
+		}
+		if len(paths) == 0 {
+			err := fmt.Errorf("No file are matching pattern: %s", pattern)
+			source.Tracker.TrackError(err)
+			log.Error(err)
 			continue
 		}
 		for _, path := range paths {

--- a/pkg/logs/input/tailer/scanner.go
+++ b/pkg/logs/input/tailer/scanner.go
@@ -151,11 +151,13 @@ func (s *Scanner) scan() {
 func (s *Scanner) didFileRotate(file *File, tailer *Tailer) (bool, error) {
 	f, err := os.Open(file.Path)
 	if err != nil {
+		tailer.source.Tracker.TrackError(err)
 		return false, err
 	}
 
 	stat1, err := f.Stat()
 	if err != nil {
+		tailer.source.Tracker.TrackError(err)
 		return false, err
 	}
 

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -111,13 +111,17 @@ func (t *Tailer) tailFrom(offset int64, whence int) error {
 func (t *Tailer) startReading(offset int64, whence int) error {
 	fullpath, err := filepath.Abs(t.path)
 	if err != nil {
+		t.source.Tracker.TrackError(err)
 		return err
 	}
 	log.Info("Opening ", t.path)
 	f, err := os.Open(fullpath)
 	if err != nil {
+		t.source.Tracker.TrackError(err)
 		return err
 	}
+	t.source.Tracker.TrackSuccess()
+
 	ret, _ := f.Seek(offset, whence)
 	t.file = f
 	t.readOffset = ret
@@ -183,7 +187,8 @@ func (t *Tailer) readForever() {
 			continue
 		}
 		if err != nil {
-			log.Warn("Err: ", err)
+			t.source.Tracker.TrackError(err)
+			log.Error("Err: ", err)
 			return
 		}
 		if n == 0 {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 // Start starts logs-agent
@@ -52,4 +53,11 @@ func run() {
 
 	c := container.New(config.GetLogsSources(), pp, a)
 	c.Start()
+}
+
+func GetStatus() status.Status {
+	if config.LogsAgent.GetBool("log_enabled") {
+		return status.Status{IsEnabled: false}
+	}
+	return status.Get()
 }

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -19,6 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
+// isRunning indicates whether logs-agent is running or not
+var isRunning bool
+
 // Start starts logs-agent
 func Start() error {
 	err := config.Build()
@@ -31,6 +34,8 @@ func Start() error {
 
 // run sets up the pipeline to process logs and them to Datadog back-end
 func run() {
+	isRunning = true
+
 	cm := sender.NewConnectionManager(
 		config.LogsAgent.GetString("log_dd_url"),
 		config.LogsAgent.GetInt("log_dd_port"),
@@ -56,8 +61,8 @@ func run() {
 }
 
 func GetStatus() status.Status {
-	if config.LogsAgent.GetBool("log_enabled") {
-		return status.Status{IsEnabled: false}
+	if !isRunning {
+		return status.Status{IsRunning: false}
 	}
 	return status.Get()
 }

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -60,6 +60,7 @@ func run() {
 	c.Start()
 }
 
+// GetStatus returns logs-agent status
 func GetStatus() status.Status {
 	if !isRunning {
 		return status.Status{IsRunning: false}

--- a/pkg/logs/logs_windows.go
+++ b/pkg/logs/logs_windows.go
@@ -7,6 +7,8 @@ package logs
 
 import (
 	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
 )
 
 // Start returns an error because logs-agent is not supported on windows yet
@@ -16,3 +18,8 @@ func Start() error {
 
 // Stop does nothing at the moment
 func Stop() {}
+
+// GetStatus returns is not running at the moment
+func GetStatus() status.Status {
+	return status.Status{IsRunning: false}
+}

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package status
+
+// SourceToTrack represents a source tracker for a given integration space
+type SourceToTrack struct {
+	integrationName string
+	tracker         *Tracker
+}
+
+// NewSourceToTrack returns a new SourceToTrack
+func NewSourceToTrack(integrationName string, tracker *Tracker) *SourceToTrack {
+	return &SourceToTrack{
+		integrationName: integrationName,
+		tracker:         tracker,
+	}
+}
+
+// Builder builds the status
+type Builder struct {
+	integrationsTrackers map[string][]*Tracker
+}
+
+// NewBuilder returns a new Builder
+func NewBuilder(sourcesToTrack []*SourceToTrack) *Builder {
+	integrationsTrackers := make(map[string][]*Tracker)
+	for _, source := range sourcesToTrack {
+		_, exists := integrationsTrackers[source.integrationName]
+		if !exists {
+			integrationsTrackers[source.integrationName] = []*Tracker{}
+		}
+		integrationsTrackers[source.integrationName] = append(integrationsTrackers[source.integrationName], source.tracker)
+	}
+	return &Builder{
+		integrationsTrackers: integrationsTrackers,
+	}
+}
+
+// Build returns the status
+func (b *Builder) Build() Status {
+	integrations := []Integration{}
+	for name, trackers := range b.integrationsTrackers {
+		sources := []Source{}
+		for _, tracker := range trackers {
+			sources = append(sources, tracker.GetSource())
+		}
+		integrations = append(integrations, Integration{Name: name, Sources: sources})
+	}
+	return Status{
+		IsEnabled:    true,
+		Integrations: integrations,
+	}
+}

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -50,7 +50,7 @@ func (b *Builder) Build() Status {
 		integrations = append(integrations, Integration{Name: name, Sources: sources})
 	}
 	return Status{
-		IsEnabled:    true,
+		IsRunning:    true,
 		Integrations: integrations,
 	}
 }

--- a/pkg/logs/status/builder_test.go
+++ b/pkg/logs/status/builder_test.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSourceAreGroupedByIntegrations(t *testing.T) {
+	sourcesToTrack := []*SourceToTrack{
+		NewSourceToTrack("foo", NewTracker("")),
+		NewSourceToTrack("bar", NewTracker("")),
+		NewSourceToTrack("foo", NewTracker("")),
+	}
+	builder := NewBuilder(sourcesToTrack)
+
+	var integration Integration
+
+	status := builder.Build()
+	assert.Equal(t, true, status.IsRunning)
+	assert.Equal(t, 2, len(status.Integrations))
+
+	integration = status.Integrations[0]
+	assert.Equal(t, "foo", integration.Name)
+	assert.Equal(t, 2, len(integration.Sources))
+
+	integration = status.Integrations[1]
+	assert.Equal(t, "bar", integration.Name)
+	assert.Equal(t, 1, len(integration.Sources))
+}

--- a/pkg/logs/status/builder_test.go
+++ b/pkg/logs/status/builder_test.go
@@ -6,6 +6,7 @@
 package status
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,17 +20,18 @@ func TestSourceAreGroupedByIntegrations(t *testing.T) {
 	}
 	builder := NewBuilder(sourcesToTrack)
 
-	var integration Integration
-
 	status := builder.Build()
 	assert.Equal(t, true, status.IsRunning)
 	assert.Equal(t, 2, len(status.Integrations))
 
-	integration = status.Integrations[0]
-	assert.Equal(t, "foo", integration.Name)
-	assert.Equal(t, 2, len(integration.Sources))
-
-	integration = status.Integrations[1]
-	assert.Equal(t, "bar", integration.Name)
-	assert.Equal(t, 1, len(integration.Sources))
+	for _, integration := range status.Integrations {
+		switch integration.Name {
+		case "foo":
+			assert.Equal(t, 2, len(integration.Sources))
+		case "bar":
+			assert.Equal(t, 1, len(integration.Sources))
+		default:
+			assert.Fail(t, fmt.Sprintf("Expected foo or bar, got %s", integration.Name))
+		}
+	}
 }

--- a/pkg/logs/status/mock/mock.go
+++ b/pkg/logs/status/mock/mock.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package mock
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
+)
+
+// NewTracker returns a new mock Tracker
+func NewTracker() *status.Tracker {
+	return status.NewTracker("")
+}

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -23,7 +23,7 @@ type Integration struct {
 
 // Status provides some information about logs-agent
 type Status struct {
-	IsEnabled    bool          `json:"is_enabled"`
+	IsRunning    bool          `json:"is_running"`
 	Integrations []Integration `json:"integrations"`
 }
 

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package status
+
+var (
+	builder *Builder
+)
+
+// Source provides some information about a logs source
+type Source struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+// Integration provides some information about a logs integration
+type Integration struct {
+	Name    string   `json:"name"`
+	Sources []Source `json:"sources"`
+}
+
+// Status provides some information about logs-agent
+type Status struct {
+	IsEnabled    bool          `json:"is_enabled"`
+	Integrations []Integration `json:"integrations"`
+}
+
+// Initialize instanciates builder
+func Initialize(sourcesToTrack []*SourceToTrack) {
+	builder = NewBuilder(sourcesToTrack)
+}
+
+// Get returns the status of logs-agent computed on the fly
+func Get() Status {
+	return builder.Build()
+}

--- a/pkg/logs/status/tracker.go
+++ b/pkg/logs/status/tracker.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package status
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Tracker Tracks errors and success operations for a given source
+// it's designed to be thread safe
+type Tracker struct {
+	sourceType string
+	status     string
+	mu         *sync.Mutex
+}
+
+// NewTracker returns a new Tracker
+func NewTracker(sourceType string) *Tracker {
+	return &Tracker{
+		sourceType: sourceType,
+		status:     "Status: Undefined",
+		mu:         &sync.Mutex{},
+	}
+}
+
+// TrackError formats the error and keeps it in status
+func (t *Tracker) TrackError(err error) {
+	t.mu.Lock()
+	t.status = fmt.Sprintf("Status: Error: %s", err.Error())
+	t.mu.Unlock()
+}
+
+// TrackSuccess formats the success operation and keeps it in status
+func (t *Tracker) TrackSuccess() {
+	t.mu.Lock()
+	t.status = "Status: OK"
+	t.mu.Unlock()
+}
+
+// GetSource returns the source computed from sourceType and status
+func (t *Tracker) GetSource() Source {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return Source{
+		Type:   t.sourceType,
+		Status: t.status,
+	}
+}

--- a/pkg/logs/status/tracker.go
+++ b/pkg/logs/status/tracker.go
@@ -22,7 +22,7 @@ type Tracker struct {
 func NewTracker(sourceType string) *Tracker {
 	return &Tracker{
 		sourceType: sourceType,
-		status:     "Status: Undefined",
+		status:     "Pending",
 		mu:         &sync.Mutex{},
 	}
 }
@@ -30,14 +30,14 @@ func NewTracker(sourceType string) *Tracker {
 // TrackError formats the error and keeps it in status
 func (t *Tracker) TrackError(err error) {
 	t.mu.Lock()
-	t.status = fmt.Sprintf("Status: Error: %s", err.Error())
+	t.status = fmt.Sprintf("Error: %s", err.Error())
 	t.mu.Unlock()
 }
 
 // TrackSuccess formats the success operation and keeps it in status
 func (t *Tracker) TrackSuccess() {
 	t.mu.Lock()
-	t.status = "Status: OK"
+	t.status = "OK"
 	t.mu.Unlock()
 }
 

--- a/pkg/logs/status/tracker_test.go
+++ b/pkg/logs/status/tracker_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package status
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TrackerSuite struct {
+	suite.Suite
+	tracker *Tracker
+}
+
+func (s *TrackerSuite) SetupTest() {
+	s.tracker = NewTracker("foo")
+}
+
+func (s *TrackerSuite) TestPending() {
+	source := s.tracker.GetSource()
+	s.Equal("foo", source.Type)
+	s.Equal("Pending", source.Status)
+}
+
+func (s *TrackerSuite) TestTrackSuccess() {
+	s.tracker.TrackSuccess()
+	source := s.tracker.GetSource()
+	s.Equal("foo", source.Type)
+	s.Equal("OK", source.Status)
+}
+
+func (s *TrackerSuite) TestTrackError() {
+	s.tracker.TrackError(errors.New("bar"))
+	source := s.tracker.GetSource()
+	s.Equal("foo", source.Type)
+	s.Equal("Error: bar", source.Status)
+}
+
+func TestTrackerSuite(t *testing.T) {
+	suite.Run(t, new(TrackerSuite))
+}

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -4,20 +4,12 @@ Logs-agent
 {{ if (not .is_running) }}
   logs-agent is not running
 {{ else }}
-{{- if (not .integrations) }}
-  no integrations
-{{- else }}
 {{- range .integrations }}
   {{ .name }}
   {{printDashes .name "-"}}
-  {{- if (not .sources) }}
-    no sources
-  {{- else }}
   {{- range .sources }}
     Type: {{ .type }}
-    Status: {{ .status }}  
-  {{- end }}
-  {{- end }}
+    Status: {{ .status }}
+  {{ end }}
 {{- end }}
 {{- end }}
-{{ end }}

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -1,0 +1,23 @@
+==========
+Logs-agent
+==========
+{{ if (not .is_running) }}
+  logs-agent is not running
+{{ else }}
+{{- if (not .integrations) }}
+  no integrations
+{{- else }}
+{{- range .integrations }}
+  {{ .name }}
+  {{printDashes .name "-"}}
+  {{- if (not .sources) }}
+    no sources
+  {{- else }}
+  {{- range .sources }}
+    Type: {{ .type }}
+    Status: {{ .status }}  
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -38,12 +38,14 @@ func FormatStatus(data []byte) (string, error) {
 	autoConfigStats := stats["autoConfigStats"]
 	aggregatorStats := stats["aggregatorStats"]
 	jmxStats := stats["JMXStatus"]
+	logsStats := stats["logsStats"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
 	renderChecksStats(b, runnerStats, autoConfigStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
+	renderLogsStatus(b, logsStats)
 	renderDogstatsdStatus(b, aggregatorStats)
 
 	return b.String(), nil
@@ -104,6 +106,14 @@ func renderJMXFetchStatus(w io.Writer, jmxStats interface{}) {
 	t := template.Must(template.New("jmxfetch.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "jmxfetch.tmpl")))
 
 	err := t.Execute(w, stats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderLogsStatus(w io.Writer, logsStats interface{}) {
+	t := template.Must(template.New("logsagent.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "logsagent.tmpl")))
+	err := t.Execute(w, logsStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -54,6 +55,8 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["time"] = now.Format(timeFormat)
 
 	stats["JMXStatus"] = GetJMXStatus()
+
+	stats["logsStats"] = logs.GetStatus()
 
 	return stats, nil
 }

--- a/releasenotes/notes/logs-agent-status-f4c3a51f7c0ecd03.yaml
+++ b/releasenotes/notes/logs-agent-status-f4c3a51f7c0ecd03.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added a section to the agent status to report live information about logs-agent


### PR DESCRIPTION
### What does this PR do?

Added a logic to compute the logs-agent status which gathers running time information about logs collectors.

### Motivation

Report logs-agent status running `datadog-agent status`

### Additional Notes

**No test has been written to test whether `TrackError` or `TrackSuccess` is called at the right place**

Output examples:

_Running_
```
==========
Logs-agent
==========

  logs
  ----
    Type: docker
    Status: Pending
  
    Type: file
    Status: Error: A file source must have a path
  
  logs_integration
  ----------------
    Type: docker
    Status: Pending
  
    Type: file
    Status: Error: A file source must have a path
  
```
_Disabled_
```
==========
Logs-agent
==========

  logs-agent is not running

```
