### PR TITLE
[Logs] Be more lenient when filtering containers using labels

### DIFF
--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -140,7 +140,7 @@ func (s *Scanner) sourceShouldMonitorContainer(source *config.IntegrationConfigL
 			})
 			// If we have exactly two parts, check there is a container label that matches both.
 			// Otherwise fall back to checking the whole label exists as a key.
-			if _, ok := container.Labels[label]; ok || len(parts) == 2 && container.Labels[parts[0]] == parts[1] {
+			if _, exists := container.Labels[label]; exists || len(parts) == 2 && container.Labels[parts[0]] == parts[1] {
 				return true
 			}
 		}

--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -122,9 +122,13 @@ func (s *Scanner) listContainers() []types.Container {
 	return containers
 }
 
+// sourceShouldMonitorContainer returns whether a container matches a log source configuration.
+// Both image and label may be used:
+// - If the source defines an image, the container must match it exactly.
+// - If the source defines one or several labels, at least one of them must match the labels of the container.
 func (s *Scanner) sourceShouldMonitorContainer(source *config.IntegrationConfigLogSource, container types.Container) bool {
-	if source.Image != "" {
-		return container.Image == source.Image
+	if source.Image != "" && container.Image != source.Image {
+		return false
 	}
 	if source.Label != "" {
 		// Expect a comma-separated list of labels, eg: foo:bar, baz

--- a/pkg/logs/input/container/scanner_test.go
+++ b/pkg/logs/input/container/scanner_test.go
@@ -32,7 +32,7 @@ func (suite *ContainerScannerTestSuite) TestContainerScannerFilter() {
 	container = types.Container{Image: "myapp2"}
 	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
 
-	cfg = &config.IntegrationConfigLogSource{Type: config.DockerType, Label: "mylabel"}
+	cfg = &config.IntegrationConfigLogSource{Type: config.DockerType, Image: "myapp", Label: "mylabel"}
 	l1 := make(map[string]string)
 	l2 := make(map[string]string)
 	l2["mylabel"] = "anything"

--- a/pkg/logs/input/container/scanner_test.go
+++ b/pkg/logs/input/container/scanner_test.go
@@ -45,6 +45,37 @@ func (suite *ContainerScannerTestSuite) TestContainerScannerFilter() {
 	suite.True(suite.c.sourceShouldMonitorContainer(cfg, container))
 }
 
+func (suite *ContainerScannerTestSuite) TestContainerLabelFilter() {
+
+	suite.False(suite.shouldMonitor("foo", map[string]string{"bar": ""}))
+	suite.True(suite.shouldMonitor("foo", map[string]string{"foo": ""}))
+	suite.True(suite.shouldMonitor("foo", map[string]string{"foo": "bar"}))
+
+	suite.False(suite.shouldMonitor("foo:bar", map[string]string{"bar": ""}))
+	suite.False(suite.shouldMonitor("foo:bar", map[string]string{"foo": ""}))
+	suite.True(suite.shouldMonitor("foo:bar", map[string]string{"foo": "bar"}))
+	suite.True(suite.shouldMonitor("foo:bar", map[string]string{"foo:bar": ""}))
+
+	suite.False(suite.shouldMonitor("foo:bar:baz", map[string]string{"foo": ""}))
+	suite.False(suite.shouldMonitor("foo:bar:baz", map[string]string{"foo": "bar"}))
+	suite.False(suite.shouldMonitor("foo:bar:baz", map[string]string{"foo": "bar:baz"}))
+	suite.False(suite.shouldMonitor("foo:bar:baz", map[string]string{"foo:bar": "baz"}))
+	suite.True(suite.shouldMonitor("foo:bar:baz", map[string]string{"foo:bar:baz": ""}))
+
+	suite.False(suite.shouldMonitor("foo=bar", map[string]string{"bar": ""}))
+	suite.False(suite.shouldMonitor("foo=bar", map[string]string{"foo": ""}))
+	suite.True(suite.shouldMonitor("foo=bar", map[string]string{"foo": "bar"}))
+
+	suite.True(suite.shouldMonitor(" a , b:c , foo:bar , d=e ", map[string]string{"foo": "bar"}))
+
+}
+
+func (suite *ContainerScannerTestSuite) shouldMonitor(configLabel string, containerLabels map[string]string) bool {
+	cfg := &config.IntegrationConfigLogSource{Type: config.DockerType, Label: configLabel}
+	container := types.Container{Labels: containerLabels}
+	return suite.c.sourceShouldMonitorContainer(cfg, container)
+}
+
 func TestContainerScannerTestSuite(t *testing.T) {
 	suite.Run(t, new(ContainerScannerTestSuite))
 }

--- a/releasenotes/notes/logs-filter-docker-label-88e6eecf9ad728ad.yaml
+++ b/releasenotes/notes/logs-filter-docker-label-88e6eecf9ad728ad.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Be more lenient when filtering containers using labels.


### PR DESCRIPTION
### What does this PR do?

This PR changes the way we filter Docker container when there is a `label` in the configuration.

Previously, we took the whole label and checked whether there was a container that had that label as a key.

With this change, we now accept a comma separated list of labels that can be formatted either as `key:value`, `key=value`, or simply `key`.

### Motivation

This should address https://github.com/DataDog/datadog-agent/issues/946.
