### PR TITLE
docker container with network procfs path

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -37,8 +37,7 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 #   - enable process agent
 COPY datadog*.yaml etc/datadog-agent/
 RUN mv etc/datadog-agent/conf.d/docker.d/conf.yaml.example etc/datadog-agent/conf.d/docker.d/conf.yaml.default \
- && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default \
- && echo "procfs_path: /host/proc" >> etc/datadog-agent/datadog.yaml
+ && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default
 
 COPY entrypoint.sh .
 
@@ -48,7 +47,8 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ENV DOCKER_DD_AGENT=yes \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
-    CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem
+    CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem \
+    DD_PROCFS_PATH="/host/proc"
 
 # Install openjdk-8-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then apt-get update \

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -47,8 +47,7 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ENV DOCKER_DD_AGENT=yes \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
-    CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem \
-    DD_PROCFS_PATH="/host/proc"
+    CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem
 
 # Install openjdk-8-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then apt-get update \

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -37,7 +37,9 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 #   - enable process agent
 COPY datadog*.yaml etc/datadog-agent/
 RUN mv etc/datadog-agent/conf.d/docker.d/conf.yaml.example etc/datadog-agent/conf.d/docker.d/conf.yaml.default \
- && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default
+ && sed -i "s/enabled: false/enabled: true/" etc/datadog-agent/conf.d/process_agent.yaml.default \
+ && echo "procfs_path: /host/proc" >> etc/datadog-agent/datadog.yaml
+
 COPY entrypoint.sh .
 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,6 +98,7 @@ func init() {
 		Datadog.SetDefault("container_proc_root", "/host/proc")
 		Datadog.SetDefault("procfs_path", "/host/proc")
 		Datadog.SetDefault("container_cgroup_root", "/host/sys/fs/cgroup/")
+		Datadog.BindEnv("procfs_path")
 	} else {
 		Datadog.SetDefault("container_proc_root", "/proc")
 		// for amazon linux the cgroup directory on host is /cgroup/
@@ -195,7 +196,6 @@ func init() {
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 
 	Datadog.BindEnv("process_agent_enabled")
-	Datadog.BindEnv("procfs_path")
 
 	// Logs
 	BindEnvAndSetDefault("log_enabled", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,8 +96,8 @@ func init() {
 	Datadog.SetDefault("GUI_port", defaultGuiPort)
 	if IsContainerized() {
 		Datadog.SetDefault("container_proc_root", "/host/proc")
+		Datadog.SetDefault("procfs_path", "/host/proc")
 		Datadog.SetDefault("container_cgroup_root", "/host/sys/fs/cgroup/")
-
 	} else {
 		Datadog.SetDefault("container_proc_root", "/proc")
 		// for amazon linux the cgroup directory on host is /cgroup/
@@ -195,6 +195,7 @@ func init() {
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 
 	Datadog.BindEnv("process_agent_enabled")
+	Datadog.BindEnv("procfs_path")
 
 	// Logs
 	BindEnvAndSetDefault("log_enabled", false)

--- a/releasenotes/notes/procfs-path-to-host-proc-324c6ed8aa08a100.yaml
+++ b/releasenotes/notes/procfs-path-to-host-proc-324c6ed8aa08a100.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added the "procfs_path" to `/host/proc` in the `/etc/datadog-agent/datadog.yaml` docker image.
+    This change allow the network check to collect metrics from the host.

--- a/releasenotes/notes/procfs-path-to-host-proc-324c6ed8aa08a100.yaml
+++ b/releasenotes/notes/procfs-path-to-host-proc-324c6ed8aa08a100.yaml
@@ -1,5 +1,6 @@
 ---
 features:
   - |
-    Added the "procfs_path" to `/host/proc` in the `/etc/datadog-agent/datadog.yaml` docker image.
+    Added the "procfs_path" configuration to `/host/proc` when containerized.
+    This configuration is binded with the envvar DD_PROCFS_PATH.
     This change allow the network check to collect metrics from the host.

--- a/releasenotes/notes/procfs-path-to-host-proc-324c6ed8aa08a100.yaml
+++ b/releasenotes/notes/procfs-path-to-host-proc-324c6ed8aa08a100.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Added the "procfs_path" configuration to `/host/proc` when containerized.
-    This configuration is binded with the envvar DD_PROCFS_PATH.
-    This change allow the network check to collect metrics from the host.
+    Set the default "procfs_path" configuration to `/host/proc` when containerized
+    to allow the network check to collect the host's network metrics. This can be
+    overriden with the the DD_PROCFS_PATH envvar.


### PR DESCRIPTION
### What does this PR do?

Following the integration-core/network PR [#994](https://github.com/DataDog/integrations-core/pull/994), I added the **procfs_path** to `/host/proc` in the `/etc/datadog-agent/datadog.yaml`

### Additional Notes

Tried on a dedicated image build `datadog/agent-dev:julienbalestra-docker-with-network`.

I'm able to observe my host metrics with a `docker exec -it <cID> agent check -r network`