### PR TITLE
add pkg/status/health package and health command

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -40,6 +40,7 @@ RUN mv etc/datadog-agent/conf.d/docker.d/conf.yaml.example etc/datadog-agent/con
 COPY entrypoint.sh probe.sh .
 
 
+
 FROM debian:stretch-slim
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
@@ -70,8 +71,7 @@ EXPOSE 8125/udp 8126/tcp
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]
 
-# Placeholder healthcheck, to be improved
-HEALTHCHECK --interval=5m --timeout=20s --retries=1 \
+HEALTHCHECK --interval=2m --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -37,7 +37,7 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 COPY datadog*.yaml etc/datadog-agent/
 RUN mv etc/datadog-agent/conf.d/docker.d/conf.yaml.example etc/datadog-agent/conf.d/docker.d/conf.yaml.default
 
-COPY entrypoint.sh .
+COPY entrypoint.sh probe.sh .
 
 
 FROM debian:stretch-slim
@@ -72,7 +72,7 @@ VOLUME ["/conf.d", "/checks.d"]
 
 # Placeholder healthcheck, to be improved
 HEALTHCHECK --interval=5m --timeout=20s --retries=1 \
-  CMD ["/opt/datadog-agent/bin/agent/agent", "status"]
+  CMD ["/probe.sh"]
 
 ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
 CMD ["/opt/datadog-agent/bin/agent/agent", "start"]

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -37,7 +37,7 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 COPY datadog*.yaml etc/datadog-agent/
 RUN mv etc/datadog-agent/conf.d/docker.d/conf.yaml.example etc/datadog-agent/conf.d/docker.d/conf.yaml.default
 
-COPY entrypoint.sh probe.sh .
+COPY entrypoint.sh probe.sh /
 
 
 

--- a/Dockerfiles/agent/probe.sh
+++ b/Dockerfiles/agent/probe.sh
@@ -1,0 +1,3 @@
+#/bin/sh
+
+exec /opt/datadog-agent/bin/agent/agent health

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -203,7 +203,7 @@ func getHealth(w http.ResponseWriter, r *http.Request) {
 	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
-	h := health.Status()
+	h := health.GetStatus()
 
 	jsonHealth, err := json.Marshal(h)
 	if err != nil {

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -62,7 +62,7 @@ func requestHealth() error {
 		return err
 	}
 
-	s := new(health.HealthStatus)
+	s := new(health.Status)
 	if err = json.Unmarshal(r, s); err != nil {
 		return fmt.Errorf("Error unmarshalling json: %s", err)
 	}

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+)
+
+var (
+	healthVerbose bool
+)
+
+func init() {
+	AgentCmd.AddCommand(healthCmd)
+	healthCmd.Flags().BoolVarP(&healthVerbose, "verbose", "v", false, "verbose output")
+}
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Print the current agent component health",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+		return requestHealth()
+	},
+}
+
+func requestHealth() error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/status/health", config.Datadog.GetInt("cmd_port"))
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, urlstr)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, errMap)
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			err = fmt.Errorf(e)
+		}
+
+		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", err)
+		return err
+	}
+
+	s := new(health.HealthStatus)
+	if err = json.Unmarshal(r, s); err != nil {
+		return fmt.Errorf("Error unmarshalling json: %s", err)
+	}
+
+	if healthVerbose {
+		fmt.Printf("Agent health: %+v \n", s)
+	}
+
+	if len(s.UnHealthy) > 0 {
+		return fmt.Errorf("Found %d unhealthy components: %v", len(s.UnHealthy), s.UnHealthy)
+	}
+
+	return nil
+}

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -8,6 +8,8 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -27,9 +29,10 @@ func init() {
 }
 
 var healthCmd = &cobra.Command{
-	Use:   "health",
-	Short: "Print the current agent component health",
-	Long:  ``,
+	Use:          "health",
+	Short:        "Print the current agent health",
+	Long:         ``,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := common.SetupConfig(confFilePath)
 		if err != nil {
@@ -68,11 +71,24 @@ func requestHealth() error {
 	}
 
 	if healthVerbose {
-		fmt.Printf("Agent health: %+v \n", s)
+		if len(s.Unhealthy) > 0 {
+			sort.Strings(s.Unhealthy)
+			fmt.Printf("Agent health: NOK\n")
+			fmt.Printf("\tUnhealthy: %s\n", strings.Join(s.Unhealthy, ", "))
+		} else {
+			fmt.Printf("Agent health: OK\n")
+
+		}
+		if len(s.Healthy) > 0 {
+			sort.Strings(s.Healthy)
+			fmt.Printf("\tHealthy: %s\n", strings.Join(s.Healthy, ", "))
+		}
+		fmt.Print("\n")
 	}
 
-	if len(s.UnHealthy) > 0 {
-		return fmt.Errorf("Found %d unhealthy components: %v", len(s.UnHealthy), s.UnHealthy)
+	if len(s.Unhealthy) > 0 {
+		sort.Strings(s.Unhealthy)
+		return fmt.Errorf("found %d unhealthy components: %v", len(s.Unhealthy), strings.Join(s.Unhealthy, ", "))
 	}
 
 	return nil

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -78,15 +78,15 @@ func requestHealth() error {
 		sort.Strings(s.Healthy)
 
 		if len(s.Unhealthy) > 0 {
-			fmt.Println(color.RedString("Agent health: FAIL"))
-			fmt.Println("=== Unhealthy components ===")
-			fmt.Println(strings.Join(s.Unhealthy, ", "))
+			fmt.Fprintln(color.Output, color.RedString("Agent health: FAIL"))
+			fmt.Fprintln(color.Output, "=== Unhealthy components ===")
+			fmt.Fprintln(color.Output, strings.Join(s.Unhealthy, ", "))
 		} else {
-			fmt.Println(color.GreenString("Agent health: PASS"))
+			fmt.Fprintln(color.Output, color.GreenString("Agent health: PASS"))
 		}
 		if len(s.Healthy) > 0 {
-			fmt.Println("=== Healthy components ===")
-			fmt.Println(strings.Join(s.Healthy, ", "))
+			fmt.Fprintln(color.Output, "=== Healthy components ===")
+			fmt.Fprintln(color.Output, strings.Join(s.Healthy, ", "))
 		}
 	}
 

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -19,9 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
-var (
-	healthVerbose bool
-)
+var healthVerbose bool
 
 func init() {
 	AgentCmd.AddCommand(healthCmd)
@@ -77,7 +75,6 @@ func requestHealth() error {
 			fmt.Printf("\tUnhealthy: %s\n", strings.Join(s.Unhealthy, ", "))
 		} else {
 			fmt.Printf("Agent health: OK\n")
-
 		}
 		if len(s.Healthy) > 0 {
 			sort.Strings(s.Healthy)

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -151,7 +151,7 @@ func NewBufferedAggregator(s *serializer.Serializer, hostname string, flushInter
 		hostname:           hostname,
 		hostnameUpdate:     make(chan string),
 		hostnameUpdateDone: make(chan struct{}),
-		healthTicker:       time.NewTicker(15 * time.Second),
+		healthTicker:       time.NewTicker(health.DefaultPingFreq),
 		healthToken:        health.Register("aggregator"),
 	}
 

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -92,7 +92,7 @@ func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 		name2jmxmetrics:       make(map[string]check.ConfigData),
 		providerLoadedConfigs: make(map[string][]check.Config),
 		stop:         make(chan bool),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("ad-autoconfig"),
 	}
 	ac.configResolver = newConfigResolver(collector, ac, ac.templateCache)

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -76,8 +76,7 @@ type AutoConfig struct {
 	providerLoadedConfigs map[string][]check.Config   // holds the resolved config per provider
 	stop                  chan bool
 	pollerActive          bool
-	healthTicker          *time.Ticker
-	healthToken           health.ID
+	health                *health.Handle
 	m                     sync.RWMutex
 }
 
@@ -91,9 +90,8 @@ func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 		config2checks:         make(map[string][]check.ID),
 		name2jmxmetrics:       make(map[string]check.ConfigData),
 		providerLoadedConfigs: make(map[string][]check.Config),
-		stop:         make(chan bool),
-		healthTicker: time.NewTicker(health.DefaultPingFreq),
-		healthToken:  health.Register("ad-autoconfig"),
+		stop:   make(chan bool),
+		health: health.Register("ad-autoconfig"),
 	}
 	ac.configResolver = newConfigResolver(collector, ac, ac.templateCache)
 	return ac
@@ -353,11 +351,9 @@ func (ac *AutoConfig) pollConfigs() {
 				if ac.configsPollTicker != nil {
 					ac.configsPollTicker.Stop()
 				}
-				ac.healthTicker.Stop()
-				health.Deregister(ac.healthToken)
+				ac.health.Deregister()
 				return
-			case <-ac.healthTicker.C:
-				health.Ping(ac.healthToken)
+			case <-ac.health.C:
 			case <-ac.configsPollTicker.C:
 				ac.m.RLock()
 				// invoke Collect on the known providers

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -63,7 +63,7 @@ func newConfigResolver(coll *collector.Collector, ac *AutoConfig, tc *TemplateCa
 		newService:      make(chan listeners.Service),
 		delService:      make(chan listeners.Service),
 		stop:            make(chan bool),
-		healthTicker:    time.NewTicker(15 * time.Second),
+		healthTicker:    time.NewTicker(health.DefaultPingFreq),
 		healthToken:     health.Register("ad-configresolver"),
 	}
 

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -65,7 +65,7 @@ func NewDockerListener() (ServiceListener, error) {
 		dockerUtil:   d,
 		services:     make(map[ID]Service),
 		stop:         make(chan bool),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("ad-dockerlistener"),
 	}, nil
 }

--- a/pkg/collector/listeners/ecs.go
+++ b/pkg/collector/listeners/ecs.go
@@ -11,23 +11,27 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
-	log "github.com/cihub/seelog"
 )
 
 // ECSListener implements the ServiceListener interface for fargate-backed ECS cluster.
 // It pulls its tasks container list periodically and checks for
 // new containers to monitor, and old containers to stop monitoring
 type ECSListener struct {
-	task       ecs.TaskMetadata
-	services   map[string]Service // maps container IDs to services
-	newService chan<- Service
-	delService chan<- Service
-	stop       chan bool
-	m          sync.RWMutex
-	t          *time.Ticker
+	task         ecs.TaskMetadata
+	services     map[string]Service // maps container IDs to services
+	newService   chan<- Service
+	delService   chan<- Service
+	stop         chan bool
+	t            *time.Ticker
+	healthTicker *time.Ticker
+	healthToken  health.ID
+	m            sync.RWMutex
 }
 
 // ECSService implements and store results from the Service interface for the ECS listener
@@ -50,9 +54,11 @@ func init() {
 // NewECSListener creates an ECSListener
 func NewECSListener() (ServiceListener, error) {
 	return &ECSListener{
-		services: make(map[string]Service),
-		stop:     make(chan bool),
-		t:        time.NewTicker(2 * time.Second),
+		services:     make(map[string]Service),
+		stop:         make(chan bool),
+		t:            time.NewTicker(2 * time.Second),
+		healthTicker: time.NewTicker(15 * time.Second),
+		healthToken:  health.Register("ad-ecslistener"),
 	}, nil
 }
 
@@ -65,10 +71,14 @@ func (l *ECSListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	go func() {
 		for {
 			select {
+			case <-l.stop:
+				l.healthTicker.Stop()
+				health.Deregister(l.healthToken)
+				return
+			case <-l.healthTicker.C:
+				health.Ping(l.healthToken)
 			case <-l.t.C:
 				l.refreshServices()
-			case <-l.stop:
-				return
 			}
 		}
 	}()

--- a/pkg/collector/listeners/ecs.go
+++ b/pkg/collector/listeners/ecs.go
@@ -57,7 +57,7 @@ func NewECSListener() (ServiceListener, error) {
 		services:     make(map[string]Service),
 		stop:         make(chan bool),
 		t:            time.NewTicker(2 * time.Second),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("ad-ecslistener"),
 	}, nil
 }

--- a/pkg/collector/listeners/kubelet.go
+++ b/pkg/collector/listeners/kubelet.go
@@ -55,7 +55,7 @@ func NewKubeletListener() (ServiceListener, error) {
 		services:     make(map[ID]Service),
 		ticker:       time.NewTicker(15 * time.Second),
 		stop:         make(chan bool),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("ad-kubeletlistener"),
 	}, nil
 }

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -71,7 +71,7 @@ func (d *DockerConfigProvider) Collect() ([]check.Config, error) {
 func (d *DockerConfigProvider) listen() {
 	d.Lock()
 	d.streaming = true
-	d.healthTicker = time.NewTicker(15 * time.Second)
+	d.healthTicker = time.NewTicker(health.DefaultPingFreq)
 	d.healthToken = health.Register("ad-dockerprovider")
 	d.Unlock()
 

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -9,7 +9,6 @@ package providers
 
 import (
 	"sync"
-	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -26,11 +25,10 @@ const (
 // DockerConfigProvider implements the ConfigProvider interface for the docker labels.
 type DockerConfigProvider struct {
 	sync.RWMutex
-	dockerUtil   *docker.DockerUtil
-	upToDate     bool
-	streaming    bool
-	healthTicker *time.Ticker
-	healthToken  health.ID
+	dockerUtil *docker.DockerUtil
+	upToDate   bool
+	streaming  bool
+	health     *health.Handle
 }
 
 // NewDockerConfigProvider returns a new ConfigProvider connected to docker.
@@ -71,8 +69,7 @@ func (d *DockerConfigProvider) Collect() ([]check.Config, error) {
 func (d *DockerConfigProvider) listen() {
 	d.Lock()
 	d.streaming = true
-	d.healthTicker = time.NewTicker(health.DefaultPingFreq)
-	d.healthToken = health.Register("ad-dockerprovider")
+	d.health = health.Register("ad-dockerprovider")
 	d.Unlock()
 
 CONNECT:
@@ -85,8 +82,7 @@ CONNECT:
 
 		for {
 			select {
-			case <-d.healthTicker.C:
-				health.Ping(d.healthToken)
+			case <-d.health.C:
 			case ev := <-eventChan:
 				// As our input is the docker `client.ContainerList`, which lists running containers,
 				// only these two event types will change what containers appear.
@@ -109,8 +105,7 @@ CONNECT:
 
 	d.Lock()
 	d.streaming = false
-	d.healthTicker.Stop()
-	health.Deregister(d.healthToken)
+	d.health.Deregister()
 	d.Unlock()
 }
 

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -37,7 +37,7 @@ func newJobQueue(interval time.Duration) *jobQueue {
 		ticker:       time.NewTicker(time.Duration(interval)),
 		stop:         make(chan bool),
 		stopped:      make(chan bool),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("collector-queue"),
 	}
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -86,7 +86,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		listeners:    tmpListeners,
 		packetPool:   packetPool,
 		stopChan:     make(chan bool),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("dogstatsd-main"),
 	}
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"runtime"
 	"sync"
-	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -31,14 +30,13 @@ var (
 // Server represent a Dogstatsd server
 type Server struct {
 	sync.RWMutex
-	listeners    []listeners.StatsdListener
-	packetIn     chan *listeners.Packet
-	Statistics   *util.Stats
-	Started      bool
-	packetPool   *listeners.PacketPool
-	stopChan     chan bool
-	healthTicker *time.Ticker
-	healthToken  health.ID
+	listeners  []listeners.StatsdListener
+	packetIn   chan *listeners.Packet
+	Statistics *util.Stats
+	Started    bool
+	packetPool *listeners.PacketPool
+	stopChan   chan bool
+	health     *health.Handle
 }
 
 // NewServer returns a running Dogstatsd server
@@ -80,14 +78,13 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 	}
 
 	s := &Server{
-		Started:      true,
-		Statistics:   stats,
-		packetIn:     packetChannel,
-		listeners:    tmpListeners,
-		packetPool:   packetPool,
-		stopChan:     make(chan bool),
-		healthTicker: time.NewTicker(health.DefaultPingFreq),
-		healthToken:  health.Register("dogstatsd-main"),
+		Started:    true,
+		Statistics: stats,
+		packetIn:   packetChannel,
+		listeners:  tmpListeners,
+		packetPool: packetPool,
+		stopChan:   make(chan bool),
+		health:     health.Register("dogstatsd-main"),
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
@@ -158,12 +155,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 		select {
 		case <-s.stopChan:
 			return
-		case <-s.healthTicker.C:
-			// Shared token between all workers, one healthy worker is enough
-			// to get data through, we can refine later if needed.
-			s.RLock()
-			health.Ping(s.healthToken)
-			s.RUnlock()
+		case <-s.health.C:
 		case packet := <-s.packetIn:
 			var originTags []string
 
@@ -241,8 +233,7 @@ func (s *Server) Stop() {
 	if s.Statistics != nil {
 		s.Statistics.Stop()
 	}
-	s.healthTicker.Stop()
-	health.Deregister(s.healthToken)
+	s.health.Deregister()
 	s.Lock()
 	s.Started = false
 	s.Unlock()

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -46,7 +46,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		buff := config.Datadog.GetInt("dogstatsd_stats_buffer")
 		s, err := util.NewStats(uint32(buff))
 		if err != nil {
-			log.Errorf("dogstatsd: unable to start statistics facilities")
+			log.Errorf("Dogstatsd: unable to start statistics facilities")
 		}
 		stats = s
 	}
@@ -97,7 +97,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		con, err := net.Dial("udp", forwardAddress)
 
 		if err != nil {
-			log.Warnf("could not connect to statsd forward host : %s", err)
+			log.Warnf("Could not connect to statsd forward host : %s", err)
 		} else {
 			s.packetIn = make(chan *listeners.Packet, 100)
 			go s.forwarder(con, packetChannel)
@@ -143,7 +143,7 @@ func (s *Server) forwarder(fcon net.Conn, packetChannel chan *listeners.Packet) 
 		_, err := fcon.Write(packet.Contents)
 
 		if err != nil {
-			log.Warnf("forwarding packet failed : %s", err)
+			log.Warnf("Forwarding packet failed : %s", err)
 		}
 
 		s.packetIn <- packet
@@ -161,14 +161,14 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 
 			if packet.Origin != listeners.NoOrigin {
 				var err error
-				log.Tracef("dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
+				log.Tracef("Dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
 				originTags, err = tagger.Tag(packet.Origin, false)
 				if err != nil {
 					log.Errorf(err.Error())
 				}
-				log.Tracef("tags for %s: %s", packet.Origin, originTags)
+				log.Tracef("Tags for %s: %s", packet.Origin, originTags)
 			} else {
-				log.Tracef("dogstatsd receive: %s", packet.Contents)
+				log.Tracef("Dogstatsd receive: %s", packet.Contents)
 			}
 
 			for {
@@ -184,7 +184,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 				if bytes.HasPrefix(message, []byte("_sc")) {
 					serviceCheck, err := parseServiceCheckMessage(message)
 					if err != nil {
-						log.Errorf("dogstatsd: error parsing service check: %s", err)
+						log.Errorf("Dogstatsd: error parsing service check: %s", err)
 						dogstatsdExpvar.Add("ServiceCheckParseErrors", 1)
 						continue
 					}
@@ -196,7 +196,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 				} else if bytes.HasPrefix(message, []byte("_e")) {
 					event, err := parseEventMessage(message)
 					if err != nil {
-						log.Errorf("dogstatsd: error parsing event: %s", err)
+						log.Errorf("Dogstatsd: error parsing event: %s", err)
 						dogstatsdExpvar.Add("EventParseErrors", 1)
 						continue
 					}
@@ -208,7 +208,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 				} else {
 					sample, err := parseMetricMessage(message)
 					if err != nil {
-						log.Errorf("dogstatsd: error parsing metrics: %s", err)
+						log.Errorf("Dogstatsd: error parsing metrics: %s", err)
 						dogstatsdExpvar.Add("MetricParseErrors", 1)
 						continue
 					}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -90,6 +90,10 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 	}
 
 	err = zipConfigCheck(zipFile, hostname)
+	if err != nil {
+		return "", err
+	}
+
 	err = zipHealth(zipFile, hostname)
 	if err != nil {
 		return "", err

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -242,12 +242,8 @@ func zipConfigCheck(zipFile *archivex.ZipFile, hostname string) error {
 
 func zipHealth(zipFile *archivex.ZipFile, hostname string) error {
 	s := health.GetStatus()
-	if len(s.Healthy) > 0 {
-		sort.Strings(s.Healthy)
-	}
-	if len(s.Unhealthy) > 0 {
-		sort.Strings(s.Unhealthy)
-	}
+	sort.Strings(s.Healthy)
+	sort.Strings(s.Unhealthy)
 
 	yamlValue, err := yaml.Marshal(s)
 	if err != nil {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -245,8 +245,8 @@ func zipHealth(zipFile *archivex.ZipFile, hostname string) error {
 	if len(s.Healthy) > 0 {
 		sort.Strings(s.Healthy)
 	}
-	if len(s.UnHealthy) > 0 {
-		sort.Strings(s.UnHealthy)
+	if len(s.Unhealthy) > 0 {
+		sort.Strings(s.Unhealthy)
 	}
 
 	yamlValue, err := yaml.Marshal(s)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -12,12 +12,14 @@ import (
 	"expvar"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 	"github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
 	"github.com/jhoonb/archivex"
@@ -88,6 +90,7 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 	}
 
 	err = zipConfigCheck(zipFile, hostname)
+	err = zipHealth(zipFile, hostname)
 	if err != nil {
 		return "", err
 	}
@@ -230,6 +233,27 @@ func zipConfigCheck(zipFile *archivex.ZipFile, hostname string) error {
 	writer.Flush()
 
 	err := zipFile.Add(filepath.Join(hostname, "config-check.log"), b.Bytes())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func zipHealth(zipFile *archivex.ZipFile, hostname string) error {
+	s := health.GetStatus()
+	if len(s.Healthy) > 0 {
+		sort.Strings(s.Healthy)
+	}
+	if len(s.UnHealthy) > 0 {
+		sort.Strings(s.UnHealthy)
+	}
+
+	yamlValue, err := yaml.Marshal(s)
+	if err != nil {
+		return err
+	}
+	err = zipFile.Add(filepath.Join(hostname, "health.yaml"), yamlValue)
 	if err != nil {
 		return err
 	}

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -62,7 +62,7 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 
 	sendTicker := time.NewTicker(interval)
 	healthTicker := time.NewTicker(15 * time.Second)
-	healthToken := health.Register("metadata" + name)
+	healthToken := health.Register("metadata-" + name)
 
 	go func() {
 		for {

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -61,7 +61,7 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 	}
 
 	sendTicker := time.NewTicker(interval)
-	healthTicker := time.NewTicker(15 * time.Second)
+	healthTicker := time.NewTicker(health.DefaultPingFreq)
 	healthToken := health.Register("metadata-" + name)
 
 	go func() {

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -62,7 +62,7 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 
 	sendTicker := time.NewTicker(interval)
 	healthTicker := time.NewTicker(15 * time.Second)
-	healthToken := health.Register("metadata-" + name)
+	healthToken := health.Register("metadata" + name)
 
 	go func() {
 		for {

--- a/pkg/status/health/README.md
+++ b/pkg/status/health/README.md
@@ -1,0 +1,30 @@
+## package `health`
+
+The `health` package handles internal healthchecks for the agents, that allow to
+check every asynchronous component is running as intended.
+
+For more information on the context, see the `agent-healthcheck.md` proposal.
+
+### How to add a component?
+
+- First, you need to register, by calling `health.Register` with a user-visible name. You will
+receive a `*health.Handle` to keep. As soon as `Register` is called, you need to start reading
+the channel to be considered healthy.
+
+- In your main goroutine, you need to read from the `handle.C` channel, at least every 15 seconds.
+This is accomplished by using a `select` statement in your main goroutine. If the channel is full
+(after two tries), your component will be considered unhealthy, which might result in the agent
+getting killed by the system.
+
+- If your component is stopping, it should call `handle.Deregister()` before stopping. It will
+then be removed from the healthcheck system.
+
+### Where should I tick?
+
+It depends on your component lifecycle, but the check's purpose is to check that your component
+is able to process new input and act accordingly. For components that read input from a channel,
+you should read the channel from this logic.
+
+This is usually hightly unprobable, but it's exactly the scope of this system: be able to
+detect if a component is frozen because of a bug / race condition. This is usually the only
+kind of issue that could be solved by the agent restarting.

--- a/pkg/status/health/global.go
+++ b/pkg/status/health/global.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package health
+
+var globalCatalog = newCatalog()
+
+// Register a component with the default 30 seconds timeout, returns a token
+func Register(name string) *Handle {
+	return globalCatalog.register(name)
+}
+
+// Deregister a component from the healthcheck
+func Deregister(handle *Handle) error {
+	return globalCatalog.deregister(handle)
+}
+
+// GetStatus allows to query the health status of the agent
+func GetStatus() Status {
+	return globalCatalog.getStatus()
+}

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -34,8 +34,8 @@ var catalog = componentCatalog{
 	components: make(map[ID]*component),
 }
 
-// HealthStatus represents the current status of registered components
-type HealthStatus struct {
+// Status represents the current status of registered components
+type Status struct {
 	Healthy   []string
 	UnHealthy []string
 }
@@ -88,9 +88,9 @@ func registerPing(token ID, timestamp time.Time) error {
 	return nil
 }
 
-// Status allows to query the health status of the agent
-func Status() HealthStatus {
-	status := HealthStatus{}
+// GetStatus allows to query the health status of the agent
+func GetStatus() Status {
+	status := Status{}
 	now := time.Now()
 
 	catalog.RLock()

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package health
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/cihub/seelog"
+)
+
+// DefaultTimeout holds the duration used for default
+const DefaultTimeout = 30 * time.Second
+
+// ID is returned when registering and is to be used when pinging
+type ID string
+
+type component struct {
+	name       string
+	timeout    time.Duration
+	latestPing time.Time
+}
+
+type componentCatalog struct {
+	sync.RWMutex
+	components map[ID]*component
+}
+
+var catalog = componentCatalog{
+	components: make(map[ID]*component),
+}
+
+// HealthStatus represents the current status of registered components
+type HealthStatus struct {
+	Healthy   []string
+	UnHealthy []string
+}
+
+// Register a component with the default 30 seconds timeout, returns a token
+func Register(name string) ID {
+	return RegisterWithCustomTimeout(name, DefaultTimeout)
+}
+
+// RegisterWithCustomTimeout allows to register with a custom timeout duration
+func RegisterWithCustomTimeout(name string, timeout time.Duration) ID {
+	catalog.Lock()
+	defer catalog.Unlock()
+
+	// TODO: create unique IDs
+	catalog.components[ID(name)] = &component{
+		name:       name,
+		timeout:    timeout,
+		latestPing: time.Now().Add(-2 * timeout), // Register as unhealthy by default
+	}
+
+	return ID(name)
+}
+
+// Deregister a component from the healthcheck
+func Deregister(token ID) error {
+	catalog.Lock()
+	defer catalog.Unlock()
+	if _, found := catalog.components[token]; !found {
+		return fmt.Errorf("component %s not registered", token)
+	}
+	delete(catalog.components, token)
+	return nil
+}
+
+// Ping is to be called regularly by component to signal they are still healthy
+func Ping(token ID) error {
+	return registerPing(token, time.Now())
+}
+
+// registerPing is private and used for unit testing
+func registerPing(token ID, timestamp time.Time) error {
+	catalog.Lock()
+	defer catalog.Unlock()
+	c, found := catalog.components[token]
+	if !found {
+		return fmt.Errorf("component %s not registered", token)
+	}
+	c.latestPing = timestamp
+	return nil
+}
+
+// Status allows to query the health status of the agent
+func Status() HealthStatus {
+	status := HealthStatus{}
+	now := time.Now()
+
+	catalog.RLock()
+	defer catalog.RUnlock()
+
+	for _, c := range catalog.components {
+		if c.latestPing.IsZero() {
+			log.Warnf("Error processing component %q, considering it unhealthy", c.name)
+			status.UnHealthy = append(status.UnHealthy, c.name)
+			continue
+		}
+		if now.After(c.latestPing.Add(c.timeout)) {
+			status.UnHealthy = append(status.UnHealthy, c.name)
+		} else {
+			status.Healthy = append(status.Healthy, c.name)
+		}
+	}
+	return status
+}
+
+// reset is used for unit testing
+func reset() {
+	catalog.Lock()
+	for token := range catalog.components {
+		delete(catalog.components, token)
+	}
+	catalog.Unlock()
+}

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -12,6 +12,7 @@ import (
 )
 
 var pingFrequency = 15 * time.Second
+var bufferSize = 2
 
 // Handle holds the token and the channel for components to use
 type Handle struct {
@@ -53,11 +54,16 @@ func (c *catalog) register(name string) *Handle {
 
 	component := &component{
 		name:       name,
-		healthChan: make(chan struct{}, 2),
+		healthChan: make(chan struct{}, bufferSize),
 		healthy:    false,
 	}
 	h := &Handle{
 		C: component.healthChan,
+	}
+
+	// Start with a full channel to component is unhealthy until its first read
+	for i := 0; i < bufferSize; i++ {
+		component.healthChan <- struct{}{}
 	}
 
 	c.components[h] = component

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -53,15 +53,18 @@ func RegisterWithCustomTimeout(name string, timeout time.Duration) ID {
 	id := ID(name)
 	_, taken := catalog.components[id]
 	if taken {
-		for n := 2; n < 99; n++ {
-			// Loop to 99 to avoid introducing an infinite loop
-			//
+		for n := 2; n < 100; n++ {
+			// Loop to 99 to avoid introducing an infinite loop.
 			newid := ID(fmt.Sprintf("%s-%d", name, n))
-			_, taken := catalog.components[newid]
+			_, taken = catalog.components[newid]
 			if !taken {
 				id = newid
 				break
 			}
+		}
+		// The case is improbable though, so we errorf and continue
+		if taken {
+			log.Errorf("Failed to find a unique token for component %s", name)
 		}
 	}
 

--- a/pkg/status/health/health.go
+++ b/pkg/status/health/health.go
@@ -13,11 +13,20 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// DefaultTimeout holds the duration used for default
+// DefaultPingFreq holds the preferred time between two pings
+const DefaultPingFreq = 15 * time.Second
+
+// DefaultTimeout holds the duration used for default (twice DefaultPingFreq)
 const DefaultTimeout = 30 * time.Second
 
-// ID is returned when registering and is to be used when pinging
+// ID objects are returned when registering and are to be used when pinging
 type ID string
+
+// Status represents the current status of registered components
+type Status struct {
+	Healthy   []string
+	Unhealthy []string
+}
 
 type component struct {
 	name       string
@@ -32,12 +41,6 @@ type componentCatalog struct {
 
 var catalog = componentCatalog{
 	components: make(map[ID]*component),
-}
-
-// Status represents the current status of registered components
-type Status struct {
-	Healthy   []string
-	Unhealthy []string
 }
 
 // Register a component with the default 30 seconds timeout, returns a token

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type HealthTestSuite struct {
+	suite.Suite
+}
+
+// put configuration back in a known state before each test
+func (s *HealthTestSuite) SetupTest() {
+	reset()
+}
+
+func (s *HealthTestSuite) TestRegisterAndUnhealthy() {
+	token := Register("test1")
+
+	c, found := catalog.components[token]
+	require.True(s.T(), found)
+
+	assert.Equal(s.T(), "test1", c.name)
+	assert.EqualValues(s.T(), 30, c.timeout.Seconds())
+	assert.True(s.T(), time.Now().After(c.latestPing))
+
+	status := Status()
+	assert.Len(s.T(), status.Healthy, 0)
+	assert.Len(s.T(), status.UnHealthy, 1)
+	assert.Contains(s.T(), status.UnHealthy, "test1")
+}
+
+func (s *HealthTestSuite) TestRegisterCustomTimeout() {
+	token := RegisterWithCustomTimeout("test1", 90*time.Second)
+
+	c, found := catalog.components[token]
+	require.True(s.T(), found)
+
+	assert.Equal(s.T(), "test1", c.name)
+	assert.EqualValues(s.T(), 90, c.timeout.Seconds())
+}
+
+func (s *HealthTestSuite) TestDeregister() {
+	token1 := Register("test1")
+	token2 := Register("test2")
+
+	assert.Len(s.T(), catalog.components, 2)
+
+	err := Deregister(token1)
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), catalog.components, 1)
+	assert.Contains(s.T(), catalog.components, token2)
+}
+
+func (s *HealthTestSuite) TestDeregisterBadToken() {
+	token1 := Register("test1")
+
+	assert.Len(s.T(), catalog.components, 1)
+
+	err := Deregister("invalid")
+	assert.NotNil(s.T(), err)
+	assert.Len(s.T(), catalog.components, 1)
+	assert.Contains(s.T(), catalog.components, token1)
+}
+
+func (s *HealthTestSuite) TestPing() {
+	token := Register("test")
+	c := catalog.components[token]
+	assert.True(s.T(), time.Now().After(c.latestPing.Add(c.timeout)))
+
+	err := Ping(token)
+	assert.NoError(s.T(), err)
+	assert.False(s.T(), time.Now().After(c.latestPing.Add(c.timeout)))
+}
+
+func (s *HealthTestSuite) TestPingNotRegistered() {
+	err := Ping("invalid")
+	assert.Error(s.T(), err)
+}
+
+func (s *HealthTestSuite) TestUnhealthyAndBack() {
+	token := Register("test")
+	status := Status()
+	assert.NotContains(s.T(), status.Healthy, "test")
+	assert.Contains(s.T(), status.UnHealthy, "test")
+
+	// Become healthy
+	Ping(token)
+	status = Status()
+	assert.NotContains(s.T(), status.UnHealthy, "test")
+	assert.Contains(s.T(), status.Healthy, "test")
+
+	// Become unhealthy
+	registerPing(token, time.Now().Add(-10*time.Minute))
+	status = Status()
+	assert.NotContains(s.T(), status.Healthy, "test")
+	assert.Contains(s.T(), status.UnHealthy, "test")
+
+	// Become healthy again
+	Ping(token)
+	status = Status()
+	assert.NotContains(s.T(), status.UnHealthy, "test")
+	assert.Contains(s.T(), status.Healthy, "test")
+}
+
+func TestHealthSuite(t *testing.T) {
+	suite.Run(t, &HealthTestSuite{})
+}

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -33,7 +33,7 @@ func (s *HealthTestSuite) TestRegisterAndUnhealthy() {
 	assert.EqualValues(s.T(), 30, c.timeout.Seconds())
 	assert.True(s.T(), time.Now().After(c.latestPing))
 
-	status := Status()
+	status := GetStatus()
 	assert.Len(s.T(), status.Healthy, 0)
 	assert.Len(s.T(), status.UnHealthy, 1)
 	assert.Contains(s.T(), status.UnHealthy, "test1")
@@ -89,7 +89,7 @@ func (s *HealthTestSuite) TestPingNotRegistered() {
 
 func (s *HealthTestSuite) TestUnhealthyAndBack() {
 	token := Register("test")
-	status := Status()
+	status := GetStatus()
 	assert.NotContains(s.T(), status.Healthy, "test")
 	assert.Contains(s.T(), status.UnHealthy, "test")
 

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -56,7 +56,6 @@ func TestRegisterTriplets(t *testing.T) {
 	cat.register("triplet")
 	cat.register("triplet")
 	assert.Len(t, cat.components, 3)
-
 }
 
 func TestDeregister(t *testing.T) {

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -10,10 +10,12 @@ package collectors
 import (
 	"io"
 	"strings"
+	"time"
 
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -30,6 +32,8 @@ type DockerCollector struct {
 	infoOut      chan<- []*TagInfo
 	labelsAsTags map[string]string
 	envAsTags    map[string]string
+	healthTicker *time.Ticker
+	healthToken  health.ID
 }
 
 // Detect tries to connect to the docker socket and returns success
@@ -55,6 +59,9 @@ func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) 
 // Stream runs the continuous event watching loop and sends new info
 // to the channel. But be called in a goroutine.
 func (c *DockerCollector) Stream() error {
+	c.healthTicker = time.NewTicker(health.DefaultPingFreq)
+	c.healthToken = health.Register("tagger-docker")
+
 	messages, errs, err := c.dockerUtil.SubscribeToContainerEvents("DockerCollector")
 	if err != nil {
 		return err
@@ -63,7 +70,11 @@ func (c *DockerCollector) Stream() error {
 	for {
 		select {
 		case <-c.stop:
+			c.healthTicker.Stop()
+			health.Deregister(c.healthToken)
 			return c.dockerUtil.UnsubscribeFromContainerEvents("DockerCollector")
+		case <-c.healthTicker.C:
+			health.Ping(c.healthToken)
 		case msg := <-messages:
 			c.processEvent(msg)
 		case err := <-errs:

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -107,9 +107,10 @@ func (t *Tagger) run() error {
 			t.pruneTicker.Stop()
 			t.retryTicker.Stop()
 			t.healthTicker.Stop()
+			health.Deregister(t.healthToken)
 			return nil
 		case <-t.healthTicker.C:
-			err := health.Ping(t.healthToken)
+			health.Ping(t.healthToken)
 		case msg := <-t.infoIn:
 			for _, info := range msg {
 				t.tagStore.processTagInfo(info)

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -63,7 +63,7 @@ func newTagger() (*Tagger, error) {
 		pruneTicker:  time.NewTicker(5 * time.Minute),
 		retryTicker:  time.NewTicker(30 * time.Second),
 		stop:         make(chan bool),
-		healthTicker: time.NewTicker(15 * time.Second),
+		healthTicker: time.NewTicker(health.DefaultPingFreq),
 		healthToken:  health.Register("tagger"),
 	}
 

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -16,6 +16,8 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
 //// eventStreamState logic unit tested in event_stream_test.go
@@ -113,6 +115,9 @@ func (d *DockerUtil) dispatchEvents(cancelChan <-chan struct{}) {
 	fltrs.Add("event", "start")
 	fltrs.Add("event", "die")
 
+	healthTicker := time.NewTicker(15 * time.Second)
+	healthToken := health.Register("dockerutil-event-dispatch")
+
 	// Outer loop handles re-connecting in case the docker daemon closes the connection
 CONNECT:
 	for {
@@ -129,7 +134,11 @@ CONNECT:
 			select {
 			case <-cancelChan:
 				cancel()
+				healthTicker.Stop()
+				health.Deregister(healthToken)
 				return
+			case <-healthTicker.C:
+				health.Ping(healthToken)
 			case err := <-errs:
 				if err == io.EOF {
 					// Silently ignore io.EOF that happens on http connection reset

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -115,8 +115,7 @@ func (d *DockerUtil) dispatchEvents(cancelChan <-chan struct{}) {
 	fltrs.Add("event", "start")
 	fltrs.Add("event", "die")
 
-	healthTicker := time.NewTicker(health.DefaultPingFreq)
-	healthToken := health.Register("dockerutil-event-dispatch")
+	healthHandle := health.Register("dockerutil-event-dispatch")
 
 	// Outer loop handles re-connecting in case the docker daemon closes the connection
 CONNECT:
@@ -134,11 +133,9 @@ CONNECT:
 			select {
 			case <-cancelChan:
 				cancel()
-				healthTicker.Stop()
-				health.Deregister(healthToken)
+				healthHandle.Deregister()
 				return
-			case <-healthTicker.C:
-				health.Ping(healthToken)
+			case <-healthHandle.C:
 			case err := <-errs:
 				if err == io.EOF {
 					// Silently ignore io.EOF that happens on http connection reset

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -115,7 +115,7 @@ func (d *DockerUtil) dispatchEvents(cancelChan <-chan struct{}) {
 	fltrs.Add("event", "start")
 	fltrs.Add("event", "die")
 
-	healthTicker := time.NewTicker(15 * time.Second)
+	healthTicker := time.NewTicker(health.DefaultPingFreq)
 	healthToken := health.Register("dockerutil-event-dispatch")
 
 	// Outer loop handles re-connecting in case the docker daemon closes the connection

--- a/releasenotes/notes/healthcheck-subsystem-ab672b94ef0ef0c3.yaml
+++ b/releasenotes/notes/healthcheck-subsystem-ab672b94ef0ef0c3.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The agent has internal healthchecks on all subsystems. The result is exposed
+    via the `agent health` command and used in the docker image as a healthcheck.
+    The `/probe.sh` wrapper is provided for compatibility with agent5 and future-proofing.    


### PR DESCRIPTION
### What does this PR do?

WIP implementation of the healthcheck described in https://github.com/DataDog/datadog-agent/pull/1055

Meat of the business logic is in:
 - https://github.com/DataDog/datadog-agent/blob/xvello/healthz/pkg/status/health/health.go
 - https://github.com/DataDog/datadog-agent/blob/xvello/healthz/cmd/agent/app/health.go

### Monitored subsystems:
- `tagger`: main tag ingestion goroutine
- `tagger-docker`: the only stream mode tagger collector
- `dogstatsd-main`: parsing and intake goroutine, listeners are not monitored yet
- `ad-configresolver` and `ad-autoconfig` for AD "core"
- `ad-dockerlistener`, `ad-kubeletlistener`, `ad-ecslistener`,  for AD listeners
- `ad-dockerprovider`, other AD configproviders rely on `ad-configresolver` for scheduling
- `dockerutil-event-dispatch` for docker event dispatching to tagger + AD
- `metadata-*` for metadata collectors (only `metadata-host` for now)

Forwarder is missing and will be added in a follow-up PR after some changes in the forwarder logic (drop new transactions if queue is full, and trigger unhealthy state).

Process and trace agents are not supervised, logs either, could be added in follow-up PRs.

Default timeout is 30 seconds, components ping every 15 seconds

### `agent health` output

![](https://cl.ly/3I262E180u2k/Image%202018-02-01%20at%203.57.49%20PM.png)

Default output is empty if healthy (exit code 0), list of unhealthy components if any (exit code <>
0):
```
$ ./bin/agent/agent -c ./bin/agent/dist/ health
Error: found 2 unhealthy components: metadata-agent_checks, metadata-host
```

A verbose switch allows to list all components:
```
$ ./bin/agent/agent -c ./bin/agent/dist/ health --verbose
Agent health: OK
	Healthy: ad-autoconfig, ad-configresolver, ad-dockerlistener, ad-dockerprovider, aggregator, collector-queue, dockerutil-event-dispatch, dogstatsd-main, metadata-agent_checks, metadata-host, tagger
```

### Other outputs

A systemd liveliness probe and an internal watchdog can be added later in individual PRs.