### PR TITLE
improve `inv test` command:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - restore_cache: *restore_deps
       - run:
           name: run unit tests
-          command: inv -e test --coverage --race --fail-on-fmt
+          command: inv -e test --coverage --race --profile --fail-on-fmt
 
   integration_tests:
     <<: *job_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ run_tests_deb-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --coverage --profile
+    - inv -e test --race --profile
 
 # run tests for rpm-x64
 run_test_rpm-x64:
@@ -55,7 +55,7 @@ run_test_rpm-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --coverage --profile
+    - inv -e test --race --profile
 
 
 #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ run_tests_deb-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --coverage
+    - inv -e test --coverage --profile
 
 # run tests for rpm-x64
 run_test_rpm-x64:
@@ -55,7 +55,7 @@ run_test_rpm-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --coverage
+    - inv -e test --coverage --profile
 
 
 #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,4 +30,4 @@ test_script:
   - cd
   - inv -e deps
   - inv -e agent.build --race --precompile-only
-  - inv -e test --race --fail-on-fmt
+  - inv -e test --race --profile --fail-on-fmt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ install:
 
 cache:
   - '%GOPATH%\bin'
-  - '%GOPATH%\pkg'
   - '%GOPATH%\src\github.com\DataDog\datadog-agent\vendor'
 
 build: off
@@ -29,5 +28,4 @@ build: off
 test_script:
   - cd
   - inv -e deps
-  - inv -e agent.build --race --precompile-only
   - inv -e test --race --profile --fail-on-fmt

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -5,6 +5,9 @@ from __future__ import print_function
 
 import os
 import fnmatch
+import re
+import operator
+import sys
 
 import invoke
 from invoke import task
@@ -36,7 +39,7 @@ DEFAULT_TEST_TARGETS = [
 
 
 @task()
-def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False, fail_on_fmt=False):
+def test(ctx, targets=None, coverage=False, race=False, profile=False, use_embedded_libs=False, fail_on_fmt=False):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -58,6 +61,7 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
 
     # explicitly run these tasks instead of using pre-tasks so we can
     # pass the `target` param (pre-tasks are invoked without parameters)
+    print("--- Linting:")
     fmt(ctx, targets=tool_targets, fail_on_fmt=fail_on_fmt)
     lint(ctx, targets=tool_targets)
     vet(ctx, targets=tool_targets)
@@ -70,6 +74,11 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
     env = {
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)
     }
+
+    if profile:
+        test_profiler = TestProfiler()
+    else:
+        test_profiler = None  # Use stdout
 
     race_opt = ""
     covermode_opt = ""
@@ -84,7 +93,7 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
         else:
             covermode_opt = "-covermode=count"
 
-    if race or coverage:
+    if coverage:
         matches = []
         for target in test_targets:
             for root, _, filenames in os.walk(target):
@@ -93,6 +102,7 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
     else:
         matches = ["{}/...".format(t) for t in test_targets]
 
+    print("\n--- Running unit tests:")
     for match in matches:
         if invoke.platform.WINDOWS:
             if match in WIN_PKG_BLACKLIST:
@@ -111,7 +121,7 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
             "coverprofile": coverprofile,
             "pkg_folder": match,
         }
-        ctx.run(cmd.format(**args), env=env)
+        ctx.run(cmd.format(**args), env=env, out_stream=test_profiler)
 
         if coverage:
             if os.path.exists(profile_tmp):
@@ -119,7 +129,13 @@ def test(ctx, targets=None, coverage=False, race=False, use_embedded_libs=False,
                 os.remove(profile_tmp)
 
     if coverage:
+        print("\n--- Test coverage:")
         ctx.run("go tool cover -func {}".format(PROFILE_COV))
+
+    if profile:
+        print ("\n--- Top 15 packages sorted by run time:")
+        test_profiler.print_sorted(15)
+
 
 @task
 def lint_releasenote(ctx):
@@ -149,6 +165,7 @@ def lint_releasenote(ctx):
 
     ctx.run("reno lint")
 
+
 @task
 def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
     """
@@ -162,3 +179,30 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
 @task
 def version(ctx):
     print(get_version(ctx, include_git=True))
+
+
+class TestProfiler:
+    times = []
+    parser = re.compile("^ok\s+github.com\/DataDog\/datadog-agent\/(\S+)\s+([0-9\.]+)s", re.MULTILINE)
+
+    def write(self, txt):
+        # Output to stdout
+        sys.stdout.write(txt)
+        # Extract the run time
+        for result in self.parser.finditer(txt):
+            self.times.append((result.group(1), float(result.group(2))))
+
+    def flush(self):
+        sys.stdout.flush()
+
+    def reset(self):
+        self.out_buffer = ""
+
+    def print_sorted(self, limit=0):
+        if self.times:
+            sorted_times = sorted(self.times, key=operator.itemgetter(1), reverse=True)
+
+            if limit:
+                sorted_times = sorted_times[:limit]
+            for pkg, time in sorted_times:
+                print("{}s\t{}".format(time, pkg))


### PR DESCRIPTION
- add --profile switch to profile test run time
- enable profiling on all CIs
- clearer test output

- remove coverage report in gitlab (we already have it in circleci) + reintroduce race (13 ➘ 4 min)
- iterate packages in gotest instead of python for --race with no --coverage, (appveyor: 7 ➘ 6 min)
- remove pre-compilation on appveyor as caching cost is now higher than test speedup (6 ➘ 5 min)

New output:
```
inv -e test --coverage --race --profile --fail-on-fmt

--- Linting:
gofmt -l -w -s ./pkg ./cmd
gofmt found no issues
golint ./pkg/... ./cmd/...
golint found no issues
go vet -tags "['jmx', 'gce', 'log', 'cpython', 'zk', 'process', 'consul', 'zlib', 'snmp', 'kubelet', 'ec2', 'etcd', 'apm', 'kubeapiserver', 'docker']" ./pkg/... ./cmd/...
go vet found no issues
misspell found no issues
ineffassign ./pkg ./cmd
ineffassign found no issues

--- Running unit tests:
go test -tags "jmx gce log cpython zk process consul zlib snmp kubelet ec2 etcd apm kubeapiserver docker" -race -short -covermode=atomic -coverprofile=./pkg/metadata/profile.tmp ./pkg/metadata
ok  	github.com/DataDog/datadog-agent/pkg/metadata	2.742s	coverage: 38.2% of statements
cat ./pkg/metadata/profile.tmp | tail -n +2 >> profile.cov

...

cat ./pkg/aggregator/ckey/profile.tmp | tail -n +2 >> profile.cov
go test -tags "jmx gce log cpython zk process consul zlib snmp kubelet ec2 etcd apm kubeapiserver docker" -race -short -covermode=atomic -coverprofile=./pkg/flare/profile.tmp ./pkg/flare
ok  	github.com/DataDog/datadog-agent/pkg/flare	3.425s	coverage: 42.2% of statements
cat ./pkg/flare/profile.tmp | tail -n +2 >> profile.cov

--- Test coverage:
go tool cover -func profile.cov
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:35:					add					0.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:44:					newFlushTimeStats			100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:48:					addFlushTime				0.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:52:					newFlushCountStats			100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:56:					addFlushCount				0.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:60:					expStatsMap				50.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:66:					timeNowNano				100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:79:					init					100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:95:					InitAggregator				100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:100:					InitAggregatorWithFlushInterval		100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:111:					SetDefaultAggregator			0.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:137:					NewBufferedAggregator			100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:156:					deduplicateTags				100.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:172:					IsInputQueueEmpty			0.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:180:					GetChannels				0.0%
github.com/DataDog/datadog-agent/pkg/aggregator/aggregator.go:186:					SetHostname				100.0%

...

github.com/DataDog/datadog-agent/pkg/version/base.go:15:						init					100.0%
github.com/DataDog/datadog-agent/pkg/version/version.go:28:						New					100.0%
github.com/DataDog/datadog-agent/pkg/version/version.go:60:						String					70.0%
github.com/DataDog/datadog-agent/pkg/version/version.go:80:						GetNumber				100.0%
github.com/DataDog/datadog-agent/pkg/version/version.go:85:						GetNumberAndPre				0.0%
total:													(statements)				56.7%

--- Top 15 packages sorted by run time:
32.444s	pkg/serializer/split
21.767s	pkg/logs/decoder
16.206s	pkg/metrics/percentile
3.907s	pkg/metadata/host
3.425s	pkg/flare
2.742s	pkg/metadata
2.529s	pkg/metadata/v5
2.195s	pkg/collector/corechecks/system
1.99s	pkg/collector/runner
1.522s	pkg/collector/py
1.405s	pkg/logs/processor
1.26s	pkg/collector/corechecks/network
1.241s	pkg/util/docker
1.194s	pkg/util/kubernetes/kubelet
1.169s	pkg/collector/corechecks/embed

```