### PR TITLE
[Logs] Increased decoder tests performance

### DIFF
--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -69,7 +69,7 @@ func InitializeDecoder(source *config.IntegrationConfigLogSource) *Decoder {
 			default:
 				lineUnwrapper = NewUnwrapper()
 			}
-			lineHandler = NewMultiLineHandler(outputChan, rule.Reg, lineUnwrapper)
+			lineHandler = NewMultiLineHandler(outputChan, rule.Reg, defaultFlushTimeout, lineUnwrapper)
 			break
 		}
 	}

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -51,7 +51,7 @@ func TestDecodeIncomingData(t *testing.T) {
 	assert.Equal(t, "goodandyou", d.lineBuffer.String())
 	d.lineBuffer.Reset()
 
-	// multiple lines in multiple raws should be sent
+	// multiple lines in multiple rows should be sent
 	d.decodeIncomingData([]byte("helloworld\nthisisa"))
 	line = <-h.lineChan
 	assert.Equal(t, "helloworld", string(line))
@@ -62,7 +62,7 @@ func TestDecodeIncomingData(t *testing.T) {
 	assert.Equal(t, "indeed", d.lineBuffer.String())
 	d.lineBuffer.Reset()
 
-	// one line in multiple raws should be sent
+	// one line in multiple rows should be sent
 	d.decodeIncomingData([]byte("hello world"))
 	d.decodeIncomingData([]byte("!\n"))
 	line = <-h.lineChan
@@ -75,7 +75,7 @@ func TestDecodeIncomingData(t *testing.T) {
 	line = <-h.lineChan
 	assert.Equal(t, strings.Repeat("a", 10), string(line))
 
-	// too long line in multiple raws should be sent by chuncks
+	// too long line in multiple rows should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
 	d.decodeIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
 	line = <-h.lineChan

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -6,217 +6,113 @@
 package decoder
 
 import (
-	"reflect"
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
-	outChan := make(chan *Output, 10)
-	d := New(nil, outChan, NewSingleLineHandler(outChan))
+type MockLineHandler struct {
+	lineChan chan []byte
+}
 
-	var out *Output
+func NewMockLineHandler() *MockLineHandler {
+	return &MockLineHandler{
+		lineChan: make(chan []byte, 10),
+	}
+}
 
-	// multiple messages in one buffer
+func (h *MockLineHandler) Handle(content []byte) {
+	h.lineChan <- content
+}
+
+func (h *MockLineHandler) Stop() {
+	close(h.lineChan)
+}
+
+func TestDecodeIncomingData(t *testing.T) {
+	h := NewMockLineHandler()
+	d := New(nil, nil, h)
+
+	var line []byte
+
+	// one line in one raw should be sent
 	d.decodeIncomingData([]byte("helloworld\n"))
-	out = <-outChan
-	assert.Equal(t, "helloworld", string(out.Content))
+	line = <-h.lineChan
+	assert.Equal(t, "helloworld", string(line))
 	assert.Equal(t, "", d.lineBuffer.String())
 
+	// multiple lines in one raw should be sent
 	d.decodeIncomingData([]byte("helloworld\nhowayou\ngoodandyou"))
-	out = <-outChan
-	assert.Equal(t, "helloworld", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, "howayou", string(out.Content))
+	line = <-h.lineChan
+	assert.Equal(t, "helloworld", string(line))
+	line = <-h.lineChan
+	assert.Equal(t, "howayou", string(line))
 	assert.Equal(t, "goodandyou", d.lineBuffer.String())
 	d.lineBuffer.Reset()
 
-	// messages overflow in the next buffer
+	// multiple lines in multiple raws should be sent
 	d.decodeIncomingData([]byte("helloworld\nthisisa"))
+	line = <-h.lineChan
+	assert.Equal(t, "helloworld", string(line))
 	assert.Equal(t, "thisisa", d.lineBuffer.String())
 	d.decodeIncomingData([]byte("longinput\nindeed"))
-	out = <-outChan
-	out = <-outChan
-	assert.Equal(t, "thisisalonginput", string(out.Content))
+	line = <-h.lineChan
+	assert.Equal(t, "thisisalonginput", string(line))
 	assert.Equal(t, "indeed", d.lineBuffer.String())
 	d.lineBuffer.Reset()
 
-	// edge cases, do not crash
-	d.decodeIncomingData([]byte("\n\n"))
-	d.decodeIncomingData([]byte(""))
-	d.lineBuffer.Reset()
-
-	// buffer overflow
+	// one line in multiple raws should be sent
 	d.decodeIncomingData([]byte("hello world"))
 	d.decodeIncomingData([]byte("!\n"))
-	out = <-outChan
-	assert.Equal(t, "hello world!", string(out.Content))
-	d.lineBuffer.Reset()
+	line = <-h.lineChan
+	assert.Equal(t, "hello world!", string(line))
 
-	// message too big
+	// too long line in one raw should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-	d.lineBuffer.Reset()
+	line = <-h.lineChan
+	assert.Equal(t, contentLenLimit, len(line))
+	line = <-h.lineChan
+	assert.Equal(t, strings.Repeat("a", 10), string(line))
 
-	// message too big, over several calls
+	// too long line in multiple raws should be sent by chuncks
 	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
 	d.decodeIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-	d.lineBuffer.Reset()
+	line = <-h.lineChan
+	assert.Equal(t, contentLenLimit, len(line))
+	line = <-h.lineChan
+	assert.Equal(t, strings.Repeat("a", 10), string(line))
 
-	// message twice too big
-	d.decodeIncomingData([]byte(strings.Repeat("a", 2*contentLenLimit+10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-
-	// message twice too big, over several calls
-	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+5)))
-	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+5) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-	d.lineBuffer.Reset()
-}
-
-func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
-	inChan := make(chan *Input, 10)
-	outChan := make(chan *Output, 10)
-	re := regexp.MustCompile("[0-9]+\\.")
-	d := New(inChan, outChan, NewMultiLineHandler(outChan, re, NewUnwrapper()))
-
-	var out *Output
-
-	// pending message in one raw data
-	d.decodeIncomingData([]byte("1. Hello world!"))
-	assert.Equal(t, "1. Hello world!", string(d.lineBuffer.Bytes()))
+	// empty lines should be sent
 	d.decodeIncomingData([]byte("\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello world!", string(out.Content))
+	line = <-h.lineChan
+	assert.Equal(t, "", string(line))
+	assert.Equal(t, "", d.lineBuffer.String())
 
-	go d.Start()
-
-	// two lines message in one raw data
-	inChan <- NewInput([]byte("1. Hello\nworld!\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
-
-	// multiple messages in one raw data
-	inChan <- NewInput([]byte("1. Hello\nworld!\n2. How are you\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, "2. How are you", string(out.Content))
-
-	// two lines message over two raw data
-	inChan <- NewInput([]byte("1. Hello\n"))
-	inChan <- NewInput([]byte("world!\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
-
-	// multiple messages over two raw data
-	inChan <- NewInput([]byte("1. Hello\n"))
-	inChan <- NewInput([]byte("world!\n2. How are you\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, "2. How are you", string(out.Content))
-
-	// single-line message in one raw data
-	inChan <- NewInput([]byte("1. Hello world!\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello world!", string(out.Content))
-
-	// multiple single-line messages in one raw data
-	inChan <- NewInput([]byte("1. Hello world!\n2. How are you\n"))
-	out = <-outChan
-	assert.Equal(t, "1. Hello world!", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, "2. How are you", string(out.Content))
-
-	// two lines too big message in one raw data
-	inChan <- NewInput([]byte("12345678.\n" + strings.Repeat("a", contentLenLimit+10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, 11+contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-
-	// two lines too big message in two raw data
-	inChan <- NewInput([]byte("12345678.\n"))
-	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, 11+contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-
-	// single-line too big message over two raw data
-	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit)))
-	inChan <- NewInput([]byte(strings.Repeat("a", 10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-
-	// single-line too big message in one raw data
-	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-
-	// message twice too big in one raw data
-	inChan <- NewInput([]byte(strings.Repeat("a", 2*contentLenLimit+10) + "\n"))
-	out = <-outChan
-	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
-
-	// message twice too big over two raw data
-	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+5)))
-	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+5) + "\n"))
-	out = <-outChan
-	assert.Equal(t, len(TRUNCATED)+contentLenLimit, len(out.Content))
-	out = <-outChan
-	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
-	out = <-outChan
-	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+	// empty message should not change anything
+	d.decodeIncomingData([]byte(""))
+	assert.Equal(t, "", d.lineBuffer.String())
 }
 
-func TestSingleLineDecoderLifecycle(t *testing.T) {
-	inChan := make(chan *Input, 10)
-	outChan := make(chan *Output, 10)
-	d := New(inChan, outChan, NewSingleLineHandler(outChan))
+func TestDecoderLifeCycle(t *testing.T) {
+	h := NewMockLineHandler()
+	d := New(nil, nil, h)
+
+	// lineHandler should not receive any lines
 	d.Start()
+	select {
+	case <-h.lineChan:
+		assert.Fail(t, "LineHandler should not handle anything")
+	default:
+		break
+	}
 
-	d.Stop()
-	out := <-outChan
-	assert.Equal(t, reflect.TypeOf(out), reflect.TypeOf(newStopOutput()))
-}
-
-func TestMultiLineDecoderLifecycle(t *testing.T) {
-	inChan := make(chan *Input, 10)
-	outChan := make(chan *Output, 10)
-	d := New(inChan, outChan, NewMultiLineHandler(outChan, nil, NewUnwrapper()))
-	d.Start()
-
-	d.Stop()
-	out := <-outChan
-	assert.Equal(t, reflect.TypeOf(out), reflect.TypeOf(newStopOutput()))
+	// lineHandler should not receive any lines
+	h.Stop()
+	select {
+	case <-h.lineChan:
+		break
+	default:
+		assert.Fail(t, "LineHandler should be stopped")
+	}
 }

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -7,8 +7,11 @@ package decoder
 
 import (
 	"bytes"
+	"reflect"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,45 +34,116 @@ func (u MockUnwrapper) Unwrap(line []byte) []byte {
 	return bytes.Replace(line, u.header, []byte(""), 1)
 }
 
-func TestTrimSingleLine(t *testing.T) {
-	outChan := make(chan *Output, 10)
-	h := NewSingleLineHandler(outChan)
+func TestSingleLineHandler(t *testing.T) {
+	outputChan := make(chan *Output, 10)
+	h := NewSingleLineHandler(outputChan)
 
-	var out *Output
+	var output *Output
+
+	// valid line should be sent
+	h.Handle([]byte("hello world"))
+	output = <-outputChan
+	assert.Equal(t, "hello world", string(output.Content))
+
+	// empty line should be dropped
+	h.Handle([]byte(""))
+	assert.Equal(t, 0, len(outputChan))
+
+	// too long line should be truncated
+	h.Handle([]byte(strings.Repeat("a", contentLenLimit+10)))
+	output = <-outputChan
+	assert.Equal(t, contentLenLimit+len(TRUNCATED)+10, len(output.Content))
+	h.Handle([]byte(strings.Repeat("a", 10)))
+	output = <-outputChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(output.Content))
+}
+
+func TestSingleLineHandlerLifeCyle(t *testing.T) {
+	outputChan := make(chan *Output, 10)
+	h := NewSingleLineHandler(outputChan)
+	h.Stop()
+	output := <-outputChan
+	assert.Equal(t, reflect.TypeOf(output), reflect.TypeOf(newStopOutput()))
+}
+
+func TestTrimSingleLine(t *testing.T) {
+	outputChan := make(chan *Output, 10)
+	h := NewSingleLineHandler(outputChan)
+
+	var output *Output
 
 	// All leading and trailing whitespace characters should be trimmed
 	h.Handle([]byte(whitespace + "foo" + whitespace + "bar" + whitespace))
-	out = <-outChan
-	assert.Equal(t, "foo"+whitespace+"bar", string(out.Content))
+	output = <-outputChan
+	assert.Equal(t, "foo"+whitespace+"bar", string(output.Content))
+}
+
+func TestMultiLineHandler(t *testing.T) {
+	re := regexp.MustCompile("[0-9]+\\.")
+	outputChan := make(chan *Output, 10)
+	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, NewUnwrapper())
+
+	var output *Output
+
+	// two lines long message should be sent
+	h.Handle([]byte("1. first line"))
+	h.Handle([]byte("second line"))
+
+	// one line long message should be sent
+	h.Handle([]byte("2. first line"))
+
+	output = <-outputChan
+	assert.Equal(t, "1. first line"+"\\n"+"second line", string(output.Content))
+	output = <-outputChan
+	assert.Equal(t, "2. first line", string(output.Content))
+
+	// too long line should be truncated
+	h.Handle([]byte(strings.Repeat("a", contentLenLimit+10)))
+	output = <-outputChan
+	assert.Equal(t, contentLenLimit+len(TRUNCATED)+10, len(output.Content))
+	h.Handle([]byte(strings.Repeat("a", 10)))
+	output = <-outputChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(output.Content))
+
+	// twice too long lines should be double truncated
+	h.Handle([]byte(strings.Repeat("a", contentLenLimit+10)))
+	output = <-outputChan
+	assert.Equal(t, contentLenLimit+len(TRUNCATED)+10, len(output.Content))
+	h.Handle([]byte(strings.Repeat("a", contentLenLimit+10)))
+	output = <-outputChan
+	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED)+10, len(output.Content))
+	h.Handle([]byte(strings.Repeat("a", 10)))
+	output = <-outputChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(output.Content))
 }
 
 func TestTrimMultiLine(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	outChan := make(chan *Output, 10)
-	h := NewMultiLineHandler(outChan, re, NewUnwrapper())
+	outputChan := make(chan *Output, 10)
+	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, NewUnwrapper())
 
-	var out *Output
+	var output *Output
 
 	// All leading and trailing whitespace characters should be trimmed
 	h.Handle([]byte(whitespace + "foo" + whitespace + "bar" + whitespace))
-	out = <-outChan
-	assert.Equal(t, "foo"+whitespace+"bar", string(out.Content))
+	output = <-outputChan
+	assert.Equal(t, "foo"+whitespace+"bar", string(output.Content))
 
 	// With line break
 	h.Handle([]byte(whitespace + "foo" + whitespace))
 	h.Handle([]byte("bar" + whitespace))
-	out = <-outChan
-	assert.Equal(t, "foo"+whitespace+"\\n"+"bar", string(out.Content))
+	output = <-outputChan
+	assert.Equal(t, "foo"+whitespace+"\\n"+"bar", string(output.Content))
 }
 
-func TestMultiLine(t *testing.T) {
+func TestUnwrapMultiLine(t *testing.T) {
 	const header = "HEADER"
 
 	re := regexp.MustCompile("[0-9]+\\.")
-	outChan := make(chan *Output, 10)
-	h := NewMultiLineHandler(outChan, re, NewMockUnwrapper(header))
+	outputChan := make(chan *Output, 10)
+	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, NewMockUnwrapper(header))
 
-	var out *Output
+	var output *Output
 
 	// Only the header of the first line of each Output should be kept
 	h.Handle([]byte(header + "1. first line"))
@@ -77,20 +151,29 @@ func TestMultiLine(t *testing.T) {
 	h.Handle([]byte(header + "2. first line"))
 	h.Handle([]byte(header + "3. first line"))
 
-	out = <-outChan
-	assert.Equal(t, header+"1. first line"+"\\n"+"second line", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, header+"2. first line", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, header+"3. first line", string(out.Content))
+	output = <-outputChan
+	assert.Equal(t, header+"1. first line"+"\\n"+"second line", string(output.Content))
+	output = <-outputChan
+	assert.Equal(t, header+"2. first line", string(output.Content))
+	output = <-outputChan
+	assert.Equal(t, header+"3. first line", string(output.Content))
 
 	// The header of the malformed content should remain
 	h.Handle([]byte(header + "malformed first line"))
 	h.Handle([]byte(header + "second line"))
 	h.Handle([]byte(header + "4. first line"))
 
-	out = <-outChan
-	assert.Equal(t, header+"malformed first line\\nsecond line", string(out.Content))
-	out = <-outChan
-	assert.Equal(t, header+"4. first line", string(out.Content))
+	output = <-outputChan
+	assert.Equal(t, header+"malformed first line\\nsecond line", string(output.Content))
+	output = <-outputChan
+	assert.Equal(t, header+"4. first line", string(output.Content))
+}
+
+func TestMultiLineHandlerLifeCyle(t *testing.T) {
+	re := regexp.MustCompile("[0-9]+\\.")
+	outputChan := make(chan *Output, 10)
+	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, NewUnwrapper())
+	h.Stop()
+	output := <-outputChan
+	assert.Equal(t, reflect.TypeOf(output), reflect.TypeOf(newStopOutput()))
 }


### PR DESCRIPTION
### What does this PR do?

Refactored tests in decoder

### Motivation

Decoder tests were taking too much time to proceed.

*Before*
```
ok  	github.com/DataDog/datadog-agent/pkg/logs/decoder	18.400s
```
*After*
```
ok  	github.com/DataDog/datadog-agent/pkg/logs/decoder	0.131s
```

### Additional Notes

Tests running time should be much faster 🚀 
