### PR TITLE
add dd-agent user in docker image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -60,10 +60,11 @@ RUN if [ -n "$WITH_JMX" ]; then apt-get update \
 COPY --from=extract /output/ /
 
 # Prepare for running without root
-RUN adduser --system --no-create-home --disabled-password dd-agent \
- && chown -R dd-agent /etc/datadog-agent/ \
+RUN adduser --group dd-agent \
+ && adduser --system --no-create-home --disabled-password --ingroup dd-agent dd-agent \
+ && chown -R dd-agent:dd-agent /etc/datadog-agent/ \
  && mkdir /var/log/datadog \
- && chown dd-agent /var/log/datadog/
+ && chown dd-agent:dd-agent /var/log/datadog/
 
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -59,6 +59,12 @@ RUN if [ -n "$WITH_JMX" ]; then apt-get update \
 # Copy agent from extract stage
 COPY --from=extract /output/ /
 
+# Prepare for running without root
+RUN adduser --system --no-create-home --disabled-password dd-agent \
+ && chown -R dd-agent /etc/datadog-agent/ \
+ && mkdir /var/log/datadog \
+ && chown dd-agent /var/log/datadog/
+
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp
 

--- a/releasenotes/notes/create-dd-agent-user-in-docker-image-6d4ce835bac5ac43.yaml
+++ b/releasenotes/notes/create-dd-agent-user-in-docker-image-6d4ce835bac5ac43.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add a dd-agent user in the docker image to prepare for running root-less


### PR DESCRIPTION
### What does this PR do?

Add a dd-agent user in the docker image to prepare for running root-less. It's not used by default though as user action is needed to make it work.