### PR TITLE
Fix issue when creating tags from conf file in PDH checks

### DIFF
--- a/cmd/agent/dist/checks/libs/win/pdhbasecheck.py
+++ b/cmd/agent/dist/checks/libs/win/pdhbasecheck.py
@@ -35,7 +35,7 @@ class PDHBaseCheck(AgentCheck):
 
                 cfg_tags = instance.get('tags')
                 if cfg_tags is not None:
-                    tags = cfg_tags.join(",")
+                    tags = ",".join(cfg_tags)
                     self._tags[key] = list(tags) if tags else []
                 remote_machine = None
                 host = instance.get('host')

--- a/releasenotes/notes/pdh_tags_fix-ce574faff4b8cf4d.yaml
+++ b/releasenotes/notes/pdh_tags_fix-ce574faff4b8cf4d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue when pulling tags from a yaml config file with any integration
+    that uses the PDHBaseCheck class


### PR DESCRIPTION
### What does this PR do?

Fixes an issue when pulling tags from a yaml config file with any integration that uses the `PDHBaseCheck` class

### Motivation

Users have [reported an issue](https://github.com/DataDog/dd-agent/pull/3635) with this class in Agent 5 and Agent 6 uses the same class

### Additional Notes

Anything else we should know when reviewing?
