### PR TITLE
reduce test sizes for quantile testing

### DIFF
--- a/pkg/metrics/percentile/gk_array_test.go
+++ b/pkg/metrics/percentile/gk_array_test.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/google/gofuzz"
+	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,7 +88,7 @@ func (d *Dataset) Sort() {
 
 var testQuantiles = []float64{0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.999, 1}
 
-var testSizes = []int{3, 5, 10, 100, 1000, 10000, 100000}
+var testSizes = []int{3, 5, 10, 100, 1000}
 
 func EvaluateSketch(t *testing.T, n int, gen Generator) {
 	g := NewGKArray()


### PR DESCRIPTION
### What does this PR do?

After profiling the unit-test step, the `pkg/metrics/percentile` package was the top3 in unit test runtime. This PR reduces the array sizes, bringing package run test from 12 secs to 1.3 secs.

Also make `gofuzz` -> `fuzz` aliasing explicit to make `goimports` happy.

### Motivation

Can I haz tests noa?
