### PR TITLE
avoid printf of pointers

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_eventbundle.go
@@ -44,7 +44,7 @@ func (k *kubernetesEventBundle) addEvent(event *v1.Event) error {
 		return errors.New("could not retrieve some attributes of the event")
 	}
 	if *event.InvolvedObject.Uid != k.objUid {
-		return fmt.Errorf("mismatching Object UIDs: %s != %s", event.InvolvedObject.Uid, k.objUid)
+		return fmt.Errorf("mismatching Object UIDs: %s != %s", *event.InvolvedObject.Uid, k.objUid)
 	}
 
 	k.events = append(k.events, event)

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -69,14 +69,14 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 			break
 		}
 		timeout.Reset(eventReadTimeout)
-		if event == nil || event.Metadata == nil || event.Metadata.ResourceVersion == nil {
+		if event == nil || event.Metadata == nil || event.Metadata.ResourceVersion == nil || event.Metadata.Uid == nil {
 			log.Tracef("Skipping invalid event: %v", event)
 			continue
 		}
 
 		resVersionMetadata, kubeEventErr := strconv.Atoi(*event.Metadata.ResourceVersion)
 		if kubeEventErr != nil {
-			log.Errorf("The Resource version associated with the event %s is not supported: %s", event.Metadata.Uid, err.Error())
+			log.Errorf("The Resource version associated with the event %s is not supported: %s", *event.Metadata.Uid, err.Error())
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?
Causes issue during govet  with go 1.9.1

### Motivation

improves logging and also avoids a panic if printing a nil pointer.

### Additional Notes

Anything else we should know when reviewing?
