### PR TITLE
[core] custom checks location have lower precedence than wheels, bundled checks

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -44,9 +44,9 @@ var (
 func GetPythonPaths() []string {
 	return []string{
 		GetDistPath(),                                  // common modules are shipped in the dist path directly or under the "checks/" sub-dir
-		filepath.Join(GetDistPath(), "checks.d"),       // custom checks in the "checks.d/" sub-dir of the dist path
-		config.Datadog.GetString("additional_checksd"), // custom checks, have precedence over integrations-core checks
 		PySitePackages,                                 // integrations-core, wheels have precedence over old-school SDK
 		PyChecksPath,                                   // integrations-core checks
+		filepath.Join(GetDistPath(), "checks.d"),       // custom checks in the "checks.d/" sub-dir of the dist path
+		config.Datadog.GetString("additional_checksd"), // custom checks, least precedent check location
 	}
 }

--- a/releasenotes/notes/checks-loading-precedence-change-472c65d1af6e6739.yaml
+++ b/releasenotes/notes/checks-loading-precedence-change-472c65d1af6e6739.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    Custom checks (located by default on Linux in ``/etc/datadog-agent/checks.d/``) now have a
+    *lower* precedence than the checks that are bundled with the Agent. This means that a custom
+    check with the same name as a bundled check will now be ignored, and the bundled check will be
+    loaded instead. If you want to override a bundled check with a custom check, please use a
+    different name for your custom check, and use that name for the related yaml configuration file.

--- a/releasenotes/notes/checks-loading-precedence-change-472c65d1af6e6739.yaml
+++ b/releasenotes/notes/checks-loading-precedence-change-472c65d1af6e6739.yaml
@@ -5,4 +5,4 @@ upgrade:
     *lower* precedence than the checks that are bundled with the Agent. This means that a custom
     check with the same name as a bundled check will now be ignored, and the bundled check will be
     loaded instead. If you want to override a bundled check with a custom check, please use a
-    different name for your custom check, and use that name for the related yaml configuration file.
+    new name for your custom check, and use that new name for the related yaml configuration file.


### PR DESCRIPTION
### What does this PR do?

Custom checks should be loaded last. We should always look for the checks in the bundled locations first.

### Motivation

Wheels take precedence over old-style checks. However, some of the behavior was implicit. This ensures that no matter the check nomenclature, we always look for the integrations in the right order. 

First attempt to load integrations as wheels: locate check class in `datadog_checks.<integration>` module. Then old-style: locate check classes in `<integration>.py` files (see: https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/py/loader.go#L57-L60)
1) GetDistPath(): `/opt/datadog-agent/agent/dist` - common modules are shipped in the dist path directly or under the "checks/" sub-dir
2) PySitePackages: embedded/lib/python2.7/site-packages/
3) PyChecksPath: deprecated bundled check location
4) `GetDistPath()/checks.d`:  custom checks in the "checks.d/" sub-dir of the dist path
5) Additional locations: `/etc/datadog-agent/checks.d` least precedence

### Additional Notes

Anything else we should know when reviewing?
