### PR TITLE
Remove broken link

### DIFF
--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -5,8 +5,7 @@ a drop in replacement, there were a small number of deprecations or changes in
 behavior which will be listed in this document.
 For a list of features that haven't been ported, see [this doc](missing_features.md).
 
-Note: If you see anything that's incorrect about this document (and that's not
-covered by the [known_issues.md][known-issues] document), do not hesitate to
+Note: If you see anything that's incorrect about this document, do not hesitate to
 open an issue or submit a Pull Request.
 
 * [Configuration Files](#configuration-files)


### PR DESCRIPTION
This link resolves on github to https://github.com/DataDog/datadog-agent/blob/master/docs/agent/known_issues.md which 404's