### PR TITLE
Display config errors on the status command

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -188,10 +188,6 @@ func (ac *AutoConfig) getAllConfigs() []check.Config {
 		cfgs, _ := pd.provider.Collect()
 
 		if fileConfPd, ok := pd.provider.(*providers.FileConfigProvider); ok {
-			// Grab any errors that occurred when reading the YAML file
-			for name, e := range fileConfPd.Errors {
-				errorStats.setConfigError(name, e)
-			}
 
 			var goodConfs []check.Config
 			for _, cfg := range cfgs {
@@ -208,6 +204,11 @@ func (ac *AutoConfig) getAllConfigs() []check.Config {
 
 				// Clear any old errors if a valid config file is found
 				errorStats.removeConfigError(cfg.Name)
+			}
+
+			// Grab any errors that occurred when reading the YAML file
+			for name, e := range fileConfPd.Errors {
+				errorStats.setConfigError(name, e)
 			}
 
 			cfgs = goodConfs

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -29,6 +29,16 @@ Collector
 {{- end }}
 
 {{- with .AutoConfigStats }}
+  {{- if .ConfigErrors}}
+  Config Errors
+  ==============
+    {{- range $checkname, $error := .ConfigErrors }}
+    {{$checkname}}
+    {{printDashes $checkname "-"}}
+      {{ configError $error }}
+    {{- end }}
+  {{- end}}
+
   {{- if .LoaderErrors}}
   Loading Errors
   ==============

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -23,6 +23,7 @@ func init() {
 		"lastErrorTraceback": lastErrorTraceback,
 		"lastErrorMessage":   LastErrorMessage,
 		"pythonLoaderError":  pythonLoaderError,
+		"configError":        configError,
 		"printDashes":        printDashes,
 		"formatUnixTime":     FormatUnixTime,
 		"humanize":           MkHuman,
@@ -43,6 +44,10 @@ func pythonLoaderError(value string) template.HTML {
 	var loaderErrorArray []string
 	json.Unmarshal([]byte(value), &loaderErrorArray)
 	return template.HTML(value)
+}
+
+func configError(value string) template.HTML {
+	return template.HTML(value + "\n")
 }
 
 func lastError(value string) template.HTML {


### PR DESCRIPTION
### What does this PR do?

Displays the list of config errors (only yaml parsing errors for now), on the result of the status command.

### Motivation

There was no way to know that a config was not parsed successfully.
