### PR TITLE
Display config errors on the web ui

### DIFF
--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -30,6 +30,19 @@
   </div>
 
   {{- with .autoConfigStats -}}
+    {{- if .ConfigErrors}}
+      <div class="stat">
+        <span class="stat_title">Config Errors</span>
+        <span class="stat_data">
+          {{- range $checkname, $error := .ConfigErrors}}
+            <span class="stat_subtitle">{{$checkname}}</span>
+            <span class="stat_subdata">
+              {{ stringToHTML $error -}}
+            </span>
+          {{end -}}
+        </span>
+      </div>
+    {{- end}}
     {{- if .LoaderErrors}}
       <div class="stat">
         <span class="stat_title">Loading Errors</span>

--- a/releasenotes/notes/display-config-errors-129218164f621464.yaml
+++ b/releasenotes/notes/display-config-errors-129218164f621464.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Config parsing errors are now displayed in the output of the 'status' command and on the web ui.


### PR DESCRIPTION
### What does this PR do?

Displays the list of config errors (only yaml parsing errors for now), on the web ui.
