### PR TITLE
[DCA] Introduction of the Service Mapper

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -135,8 +135,11 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Could not process the list of services of: %s", podName)
 	}
 	if len(svcList) != 0 {
+		w.WriteHeader(200)
 		w.Write(slcB)
 		return
 	}
-	w.Write([]byte("Could not find associated services mapped to the pod: " + podName + " on node: " + nodeName))
+	w.WriteHeader(404)
+	w.Write([]byte(fmt.Sprintf("Could not find associated services mapped to the pod: %s on node: %s", podName, nodeName)))
+
 }

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -6,9 +6,6 @@
 // Package agent implements the api endpoints for the `/agent` prefix.
 // This group of endpoints is meant to provide high-level functionalities
 // at the agent level.
-
-// +build kubeapiserver
-
 package agent
 
 import (

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -6,6 +6,9 @@
 // Package agent implements the api endpoints for the `/agent` prefix.
 // This group of endpoints is meant to provide high-level functionalities
 // at the agent level.
+
+// +build kubeapiserver
+
 package agent
 
 import (
@@ -129,6 +132,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
 	svcList := as.GetPodSvcs(nodeName, podName)
+
 	slcB, err := json.Marshal(svcList)
 	if err != nil {
 		log.Errorf("Could not process the list of services of: %s", podName)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -13,13 +13,14 @@ import (
 	"fmt"
 	"net/http"
 
+	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/mux"
@@ -127,7 +128,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
-	svcList := apiserver.GetPodSvcs(nodeName, podName)
+	svcList := as.GetPodSvcs(nodeName, podName)
 	slcB, err := json.Marshal(svcList)
 	if err != nil {
 		log.Errorf("Could not process the list of services of: %s", podName)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/mux"
@@ -37,7 +38,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
 	// r.HandleFunc("/status", getStatus).Methods("GET")
 	// r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
-	r.HandleFunc("/api/v1/metadata/{host}/{container:[0-9a-z]{64}}", getContainerMetadata).Methods("GET")
+	r.HandleFunc("/api/v1/metadata/{nodeName}/{podName}", getPodMetadata).Methods("GET")
 	r.HandleFunc("/api/v1/{check}/events", getCheckLatestEvents).Methods("GET")
 }
 
@@ -122,12 +123,18 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// TODO: complete it
-func getContainerMetadata(w http.ResponseWriter, r *http.Request) {
+func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	host := vars["host"]
-	cID := vars["container"]
-	// TODO: check host (in store/ not in store)
-	// then check container
-	w.Write([]byte("host: " + host + ", container: " + cID))
+	nodeName := vars["nodeName"]
+	podName := vars["podName"]
+	svcList := apiserver.GetPodSvcs(nodeName, podName)
+	slcB, err := json.Marshal(svcList)
+	if err != nil {
+		log.Errorf("Could not process the list of services of: %s", podName)
+	}
+	if len(svcList) != 0 {
+		w.Write(slcB)
+		return
+	}
+	w.Write([]byte("Could not find associated services mapped to the pod: " + podName + " on node: " + nodeName))
 }

--- a/cmd/cluster-agent/api/listener.go
+++ b/cmd/cluster-agent/api/listener.go
@@ -3,12 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+/*
+Package api implements the agent IPC api. Using HTTP
+calls, it's possible to communicate with the agent,
+sending commands and receiving infos.
+*/
 package api
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"net"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // getListener returns a listening connection

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,7 @@ func init() {
 	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
 	Datadog.SetDefault("confd_dca_path", defaultDCAConfdPath)
+	Datadog.SetDefault("use_service_mapper", true)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("log_to_syslog", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -304,6 +304,10 @@ metadata_collectors:
 #
 # kubernetes_kubeconfig_path: /path/to/file
 #
+# By default use_service_mapper is set to true, as it allows the DCA to fetch services and map them to pods.
+# Uncomment if you don't want the DCA to perform this action.
+#
+# use_service_mapper: false
 {{ end -}}
 
 {{- if .ProcessAgent }}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -163,7 +163,7 @@ func (c *APIClient) startServiceMapping() {
 					}
 					err := smb.(*ServiceMapperBundle).mapServices(*node.Metadata.Name, *pods, *endpointList)
 					if err != nil {
-						log.Errorf("could not map the services: %s on node %s", err.Error, *node.Metadata.Name)
+						log.Errorf("could not map the services: %s on node %s", err.Error(), *node.Metadata.Name)
 						continue
 					}
 					cache.Cache.Set(*node.Metadata.Name, smb, serviceMapExpire)

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -100,7 +100,7 @@ func (c *APIClient) connect() error {
 		return err
 	}
 	log.Debugf("connected to kubernetes apiserver, version %s", version.GitVersion)
-	useServiceMapper := config.Datadog.GetBool("service_mapper_disabled")
+	useServiceMapper := config.Datadog.GetBool("use_service_mapper")
 	if !useServiceMapper {
 		return nil
 	}

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -9,6 +9,8 @@ package apiserver
 
 import (
 	"errors"
+
+	log "github.com/cihub/seelog"
 )
 
 var (
@@ -16,3 +18,9 @@ var (
 	// User classes should handle that case as gracefully as possible.
 	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
 )
+
+// GetPodSvcs is used when the API endpoint of the DCA to get the services of a pod is hit.
+func GetPodSvcs(nodeName string, podName string) []string {
+	log.Errorf("GetPodSvcs not implemented %s", ErrNotCompiled.Error())
+	return nil
+}

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -59,7 +59,7 @@ func (smb *ServiceMapperBundle) mapServices(nodeName string, pods v1.PodList, en
 			smb.PodNameToServices[name] = svc
 		}
 	}
-	log.Tracef("the services matched %q", smb.PodNameToServices)
+	log.Tracef("The services matched %q", smb.PodNameToServices)
 	return nil
 }
 

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -28,6 +28,9 @@ func (smb *ServiceMapperBundle) mapServices(nodeName string, pods v1.PodList, en
 		err := errors.New("empty podlist received")
 		return err
 	}
+	if nodeName == "" {
+		log.Debugf("Service mapper was given an empty node name. Mapping might be incorrect.")
+	}
 
 	for _, pod := range pods.Items {
 		if *pod.Status.PodIP != "" {
@@ -56,7 +59,7 @@ func (smb *ServiceMapperBundle) mapServices(nodeName string, pods v1.PodList, en
 			smb.PodNameToServices[name] = svc
 		}
 	}
-	log.Tracef("the services matched %q \n", smb.PodNameToServices)
+	log.Tracef("the services matched %q", smb.PodNameToServices)
 	return nil
 }
 
@@ -68,6 +71,10 @@ func GetPodSvcs(nodeName string, podName string) []string {
 		return nil
 	}
 
-	serviceList, _ := smb.(*ServiceMapperBundle).PodNameToServices[podName]
+	serviceList, found := smb.(*ServiceMapperBundle).PodNameToServices[podName]
+	if !found {
+		log.Debugf("No cached metadata found for the pod %s on the node %s", podName, nodeName)
+		return nil
+	}
 	return serviceList
 }

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+//// Covered by test/integration/util/kube_apiserver/services_test.go
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/ericchiang/k8s/api/v1"
+)
+
+func (smb *ServiceMapperBundle) mapServices(pods v1.PodList, endpointList v1.EndpointsList) error {
+	smb.m.Lock()
+	defer smb.m.Unlock()
+	ipToEndpoint := make(map[string][]string) // maps the Ips endpoints for a given service
+	podToIp := make(map[string]string)
+
+	for _, pod := range pods.Items {
+		if *pod.Status.PodIP != "" {
+			podToIp[*pod.Metadata.Name] = *pod.Status.PodIP
+		}
+	}
+	log.Infof("this is the podToIp %q", podToIp)
+	log.Infof("There are %d services in the cluster\n", len(endpointList.Items))
+	for _, svc := range endpointList.Items {
+		log.Infof("evanluated svc is %q \n", svc)
+		for _, endpointsSubsets := range svc.Subsets {
+			log.Infof("evanluated endpointSub is %q \n", *endpointsSubsets)
+			for _, edpt := range endpointsSubsets.Addresses {
+				ipToEndpoint[*edpt.Ip] = append(ipToEndpoint[*edpt.Ip], *svc.Metadata.Name)
+				if edpt.NodeName != nil {
+					log.Infof("nodename for %s is %q\n\n", *svc.Metadata.Name, edpt.NodeName)
+				}
+			}
+		}
+	}
+	log.Infof("This is ipToEndpoint %q \n", ipToEndpoint)
+	for name, ip := range podToIp {
+		if svc, found := ipToEndpoint[ip]; found {
+			smb.PodNameToServices[name] = svc
+		}
+	}
+	log.Infof("the services matched %q \n", smb.PodNameToServices)
+	return nil
+}
+
+// GetPodSvcs is used when the API endpoint of the DCA to get the services of a pod is hit.
+func GetPodSvcs(nodeName string, podName string) []string {
+	smb, found := cache.Cache.Get(nodeName)
+	if !found {
+		log.Debugf("No metadata was found for the pod %s", podName)
+		return nil
+	}
+
+	serviceList, _ := smb.(*ServiceMapperBundle).PodNameToServices[podName]
+	return serviceList
+}

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -64,7 +64,7 @@ func (smb *ServiceMapperBundle) mapServices(nodeName string, pods v1.PodList, en
 func GetPodSvcs(nodeName string, podName string) []string {
 	smb, found := cache.Cache.Get(nodeName)
 	if !found {
-		log.Debugf("No metadata was found for the pod %s", podName)
+		log.Debugf("No metadata was found for the pod %s on node %s", podName, nodeName)
 		return nil
 	}
 

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -19,7 +19,7 @@ import (
 func (smb *ServiceMapperBundle) mapServices(pods v1.PodList, endpointList v1.EndpointsList) error {
 	smb.m.Lock()
 	defer smb.m.Unlock()
-	ipToEndpoint := make(map[string][]string) // maps the Ips endpoints for a given service
+	ipToEndpoints := make(map[string][]string) // maps an IP address to associated services svc/endpoint
 	podToIp := make(map[string]string)
 
 	for _, pod := range pods.Items {
@@ -34,16 +34,16 @@ func (smb *ServiceMapperBundle) mapServices(pods v1.PodList, endpointList v1.End
 		for _, endpointsSubsets := range svc.Subsets {
 			log.Infof("evanluated endpointSub is %q \n", *endpointsSubsets)
 			for _, edpt := range endpointsSubsets.Addresses {
-				ipToEndpoint[*edpt.Ip] = append(ipToEndpoint[*edpt.Ip], *svc.Metadata.Name)
+				ipToEndpoints[*edpt.Ip] = append(ipToEndpoints[*edpt.Ip], *svc.Metadata.Name)
 				if edpt.NodeName != nil {
-					log.Infof("nodename for %s is %q\n\n", *svc.Metadata.Name, edpt.NodeName)
+					log.Infof("service for %s is %q\n\n", *svc.Metadata.Name, edpt.NodeName)
 				}
 			}
 		}
 	}
-	log.Infof("This is ipToEndpoint %q \n", ipToEndpoint)
+	log.Infof("This is ipToEndpoint %q \n", ipToEndpoints)
 	for name, ip := range podToIp {
-		if svc, found := ipToEndpoint[ip]; found {
+		if svc, found := ipToEndpoints[ip]; found {
 			smb.PodNameToServices[name] = svc
 		}
 	}

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -58,8 +58,6 @@ func createPodList(listPodStructs []podTest) v1.PodList {
 		pod.Metadata = &metav1.ObjectMeta{}
 		pod.Status.PodIP = toPtr(ps.ip)
 		pod.Metadata.Name = toPtr(ps.name)
-		fmt.Printf("\n ps.name is %s, toPtr ps.name is %q and &ps.name is %q \n\n", ps.name, toPtr(ps.name), &ps.name)
-		//fmt.Printf("current pod added is %s and pod list is %q \n", ps.name, podlist.Items)
 		podlist.Items = append(podlist.Items, &pod)
 	}
 

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/ericchiang/k8s/api/v1"
+	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type podStruct struct {
+	ip   string
+	name string
+}
+
+type svcStruct struct {
+	svcName string
+	podIps  []string
+}
+
+func createSvcList(nodeName string, svc svcStruct) v1.EndpointsList {
+	var list v1.EndpointsList
+	var endpoints v1.Endpoints
+	var endpointsSubset v1.EndpointSubset
+	var edpt v1.EndpointAddress
+
+	endpoints.Metadata = &metav1.ObjectMeta{}
+
+	endpoints.Subsets = append(endpoints.Subsets, &endpointsSubset)
+
+	endpoints.Metadata.Name = &svc.svcName
+	edpt.NodeName = &nodeName
+
+	for _, e := range svc.podIps {
+		edpt.Ip = &e
+		endpointsSubset.Addresses = append(endpointsSubset.Addresses, &edpt)
+	}
+
+	list.Items = append(list.Items, &endpoints)
+	return list
+}
+
+func createPodList(listPodStructs []podStruct) v1.PodList {
+	var podlist v1.PodList
+	var pod v1.Pod
+	pod.Status = &v1.PodStatus{}
+	pod.Metadata = &metav1.ObjectMeta{}
+	for _, ps := range listPodStructs {
+		pod.Status.PodIP = &ps.ip
+		pod.Metadata.Name = &ps.name
+		podlist.Items = append(podlist.Items, &pod)
+	}
+
+	return podlist
+}
+func createNode(nodeName string) v1.Node {
+	var node v1.Node
+
+	node.Metadata = &metav1.ObjectMeta{}
+	node.Metadata.Name = &nodeName
+	return node
+}
+
+func TestMapServices(t *testing.T) {
+	// Test 1 node 1 pod 1 service.
+	smb := newServiceMapperBundle()
+
+	node1 := createNode("firstNode")
+	pod1 := podStruct{
+		ip:   "1.2.3.4",
+		name: "foo",
+	}
+	svc := svcStruct{
+		svcName: "svc1",
+		podIps: []string{
+			"1.2.3.4",
+		},
+	}
+	k8PodList1 := createPodList([]podStruct{pod1})
+	k8EpList := createSvcList(*node1.Metadata.Name, svc)
+
+	smb.mapServices(*node1.Metadata.Name, k8PodList1, k8EpList)
+	res := make(map[string][]string)
+	res[pod1.name] = []string{svc.svcName}
+	require.Equal(t, res, smb.PodNameToServices)
+
+	// Test 3 nodes, 5 pods, 4 services
+	// smb := newServiceMapperBundle()
+
+	// node1 := createNode("firstNode")
+	// node2 := createNode("firstNode")
+	// node2 := createNode("firstNode")
+	// pod1 := podStruct{
+	// 	ip:   "1.2.3.4",
+	// 	name: "foo",
+	// }
+	// svc := svcStruct{
+	// 	svcName: "svc1",
+	// 	podIps: []string{
+	// 		"1.2.3.4",
+	// 	},
+	// }
+	// k8PodList1 := createPodList([]podStruct{pod1})
+	// k8EpList := createSvcList(*node1.Metadata.Name, svc)
+
+	// node2 := createNode("secondNode")
+	// pod2 := podStruct{
+	// 	ip: '0.0.0.0',
+	// 	name: 'bar'
+	// }
+	// pod3 := podStruct{
+	// 	ip: '0.1.0.1',
+	// 	name: 'baz'
+	// }
+	// k8PodList2 := createPodList([]podStruct{pod2,pod3})
+}

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -4,9 +4,11 @@
 // Copyright 2018 Datadog, Inc.
 
 // +build kubeapiserver
+
 package apiserver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ericchiang/k8s/api/v1"
@@ -24,36 +26,41 @@ type svcStruct struct {
 	podIps  []string
 }
 
-func createSvcList(nodeName string, svc svcStruct) v1.EndpointsList {
+func toPtr(str string) *string {
+	strToptr := str
+	return &strToptr
+}
+
+func createSvcList(nodeName string, svcs []svcStruct) v1.EndpointsList {
 	var list v1.EndpointsList
-	var endpoints v1.Endpoints
-	var endpointsSubset v1.EndpointSubset
-	var edpt v1.EndpointAddress
+	for _, svc := range svcs {
+		var endpoints v1.Endpoints
+		var endpointsSubset v1.EndpointSubset
+		endpoints.Metadata = &metav1.ObjectMeta{}
+		endpoints.Subsets = append(endpoints.Subsets, &endpointsSubset)
+		endpoints.Metadata.Name = toPtr(svc.svcName)
 
-	endpoints.Metadata = &metav1.ObjectMeta{}
-
-	endpoints.Subsets = append(endpoints.Subsets, &endpointsSubset)
-
-	endpoints.Metadata.Name = &svc.svcName
-	edpt.NodeName = &nodeName
-
-	for _, e := range svc.podIps {
-		edpt.Ip = &e
-		endpointsSubset.Addresses = append(endpointsSubset.Addresses, &edpt)
+		for _, e := range svc.podIps {
+			var edpt v1.EndpointAddress
+			edpt.NodeName = &nodeName
+			edpt.Ip = toPtr(e)
+			endpointsSubset.Addresses = append(endpointsSubset.Addresses, &edpt)
+		}
+		list.Items = append(list.Items, &endpoints)
 	}
-
-	list.Items = append(list.Items, &endpoints)
 	return list
 }
 
 func createPodList(listPodStructs []podStruct) v1.PodList {
 	var podlist v1.PodList
-	var pod v1.Pod
-	pod.Status = &v1.PodStatus{}
-	pod.Metadata = &metav1.ObjectMeta{}
 	for _, ps := range listPodStructs {
-		pod.Status.PodIP = &ps.ip
-		pod.Metadata.Name = &ps.name
+		var pod v1.Pod
+		pod.Status = &v1.PodStatus{}
+		pod.Metadata = &metav1.ObjectMeta{}
+		pod.Status.PodIP = toPtr(ps.ip)
+		pod.Metadata.Name = toPtr(ps.name)
+		fmt.Printf("\n ps.name is %s, toPtr ps.name is %q and &ps.name is %q \n\n", ps.name, toPtr(ps.name), &ps.name)
+		//fmt.Printf("current pod added is %s and pod list is %q \n", ps.name, podlist.Items)
 		podlist.Items = append(podlist.Items, &pod)
 	}
 
@@ -73,50 +80,84 @@ func TestMapServices(t *testing.T) {
 
 	node1 := createNode("firstNode")
 	pod1 := podStruct{
-		ip:   "1.2.3.4",
-		name: "foo",
+		ip:   "1.1.1.1",
+		name: "pod1_name",
 	}
-	svc := svcStruct{
+	svc1 := svcStruct{
 		svcName: "svc1",
-		podIps: []string{
-			"1.2.3.4",
-		},
+		podIps:  []string{"1.1.1.1"},
 	}
 	k8PodList1 := createPodList([]podStruct{pod1})
-	k8EpList := createSvcList(*node1.Metadata.Name, svc)
+	k8EpList := createSvcList(*node1.Metadata.Name, []svcStruct{svc1})
 
 	smb.mapServices(*node1.Metadata.Name, k8PodList1, k8EpList)
+
 	res := make(map[string][]string)
-	res[pod1.name] = []string{svc.svcName}
+	res[pod1.name] = []string{svc1.svcName}
+
 	require.Equal(t, res, smb.PodNameToServices)
 
 	// Test 3 nodes, 5 pods, 4 services
-	// smb := newServiceMapperBundle()
+	smb1 := newServiceMapperBundle()
 
-	// node1 := createNode("firstNode")
-	// node2 := createNode("firstNode")
-	// node2 := createNode("firstNode")
-	// pod1 := podStruct{
-	// 	ip:   "1.2.3.4",
-	// 	name: "foo",
-	// }
-	// svc := svcStruct{
-	// 	svcName: "svc1",
-	// 	podIps: []string{
-	// 		"1.2.3.4",
-	// 	},
-	// }
-	// k8PodList1 := createPodList([]podStruct{pod1})
-	// k8EpList := createSvcList(*node1.Metadata.Name, svc)
+	node2 := createNode("secondNode")
+	pod2 := podStruct{
+		ip:   "2.2.2.2",
+		name: "pod2_name",
+	}
+	pod3 := podStruct{
+		ip:   "3.3.3.3",
+		name: "pod3_name",
+	}
+	pod4 := podStruct{
+		ip:   "4.4.4.4",
+		name: "pod4_name",
+	}
+	pod5 := podStruct{
+		ip:   "5.5.5.5",
+		name: "pod5_name",
+	}
+	svc2 := svcStruct{
+		svcName: "svc2",
+		podIps: []string{
+			"2.2.2.2",
+		},
+	}
+	svc3 := svcStruct{
+		svcName: "svc3",
+		podIps: []string{
+			"2.2.2.2",
+			"5.5.5.5",
+			"1.1.1.1",
+		},
+	}
+	svc4 := svcStruct{
+		svcName: "svc4",
+		podIps: []string{
+			"2.2.2.2",
+			"3.3.3.3",
+		},
+	}
+	k8PodList2 := createPodList([]podStruct{pod1, pod2, pod3, pod4})
+	k8EpList2 := createSvcList(*node2.Metadata.Name, []svcStruct{svc1, svc3, svc4})
 
-	// node2 := createNode("secondNode")
-	// pod2 := podStruct{
-	// 	ip: '0.0.0.0',
-	// 	name: 'bar'
-	// }
-	// pod3 := podStruct{
-	// 	ip: '0.1.0.1',
-	// 	name: 'baz'
-	// }
-	// k8PodList2 := createPodList([]podStruct{pod2,pod3})
+	fmt.Printf("input is pod list %q and ep list %q", k8PodList2, k8EpList2)
+	smb1.mapServices(*node2.Metadata.Name, k8PodList2, k8EpList2) // Simulate that we evaluate the node2
+
+	res2 := make(map[string][]string)
+	res2[pod1.name] = []string{svc1.svcName, svc3.svcName}
+	res2[pod2.name] = []string{svc3.svcName, svc4.svcName} // No SV2 as it's on pod2
+	res2[pod3.name] = []string{svc4.svcName}
+	fmt.Printf("smb is %q", smb1.PodNameToServices)
+	require.Equal(t, res2, smb1.PodNameToServices) // Though pod4 and sv4 are being evaluated, as none of the svcs point to pod4, it won't be in the list.
+
+	// We check that evaluating new services/pods on a given SMB (that would be gotten from the cache) maps as expected.
+	k8PodList3 := createPodList([]podStruct{pod1, pod2, pod3, pod4, pod5})
+	k8EpLis3 := createSvcList(*node2.Metadata.Name, []svcStruct{svc1, svc2, svc3, svc4})
+
+	res2[pod5.name] = []string{svc3.svcName}
+	res2[pod2.name] = []string{svc2.svcName, svc3.svcName, svc4.svcName} // SV2 as it's on pod2
+	smb1.mapServices(*node2.Metadata.Name, k8PodList3, k8EpLis3)
+	fmt.Printf("smb is %q", smb1.PodNameToServices)
+	require.Equal(t, res2, smb1.PodNameToServices) // We can imagine a case
 }

--- a/releasenotes/notes/adding-service-mapper-dca-57f6187dc91179e9.yaml
+++ b/releasenotes/notes/adding-service-mapper-dca-57f6187dc91179e9.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Introducing the service mapper strategy for the DCA. We periodically hit the API server,
+    to get the list of pods, nodes and services. Then we proceed to match which endpoint (i.e. pod)
+    is covered by which service.
+    We create a map of pod name to service names, cache it and expose a public method.
+    This method is called when the Service Mapper endpoint of the DCA API is hit.
+    We also query the cache instead of the API Server if a cache miss happens, to separate the concerns.

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -26,6 +26,7 @@ PROFILE_COV = "profile.cov"
 WIN_PKG_BLACKLIST = [
     "./pkg\\util\\xc",
     "./pkg\\util\\container",
+    "./pkg\\util\\kubernetes",
 ]
 
 DEFAULT_TOOL_TARGETS = [
@@ -101,7 +102,6 @@ def test(ctx, targets=None, coverage=False, race=False, profile=False, use_embed
                     matches.append(root)
     else:
         matches = ["{}/...".format(t) for t in test_targets]
-
     print("\n--- Running unit tests:")
     for match in matches:
         if invoke.platform.WINDOWS:


### PR DESCRIPTION
### What does this PR do?

Introduction of the service mapper.
The gist here is to keep a map of pod names to service names in-memory. The services being the ones serving the pods.
We rely on the IPs of the pods and the IPs listed in the subsets of the endpoints.
We rely on the node names as well, to avoid conflicting in case the user configures the network for the node IPAM to overlap (same subnet of IPs on all the nodes)

### Motivation

This is so the node agents can fetch the kube-service tags.

### Tests

- [x] Unit tests
~- [ ] Integration test~ This was moved to an entire task in the backlog.
- [x] DCA builds
### Features and Design choices

We use the go-cache to keep the map, it expires every 5 minutes.
This is thread safe, though we use a mutex in the process to update the map.

### Improvement/Discussion

We could use a watch to avoid fetching and reprocessing the whole lists every 10 seconds.
We could check the freshness of our cache.