### PR TITLE
mirror agent 5 proxy behavior

### DIFF
--- a/cmd/agent/dist/checks/__init__.py
+++ b/cmd/agent/dist/checks/__init__.py
@@ -19,6 +19,7 @@ from config import (
 )
 from utils.proxy import (
     get_requests_proxy,
+    get_no_proxy_from_env,
     config_proxy_skip
 )
 
@@ -106,8 +107,9 @@ class AgentCheck(object):
         return False
 
 
-    def get_instance_proxy(self, instance, uri):
-        proxies = self.proxies.copy()
+    def get_instance_proxy(self, instance, uri, proxies=None):
+        proxies = proxies if proxies is not None else self.proxies.copy()
+        proxies['no'] = get_no_proxy_from_env()
 
         skip = _is_affirmative(instance.get('no_proxy', not self._use_agent_proxy))
         return config_proxy_skip(proxies, uri, skip)

--- a/cmd/agent/dist/utils/proxy.py
+++ b/cmd/agent/dist/utils/proxy.py
@@ -15,6 +15,10 @@ import datadog_agent
 log = logging.getLogger(__name__)
 
 
+def get_no_proxy_from_env():
+    return os.environ.get('no_proxy', os.environ.get('NO_PROXY', None))
+
+
 def get_requests_proxy(agentConfig):
     no_proxy_settings = {
         "http": None,
@@ -49,22 +53,14 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     parsed_uri = urlparse(uri)
 
     # disable proxy if necessary
+    # keep keys so `requests` doesn't use env var proxies either
     if skip_proxy:
-        if 'http' in proxies:
-            proxies.pop('http')
-        if 'https' in proxies:
-            proxies.pop('https')
+        proxies['http'] = None
+        proxies['https'] = None
     elif proxies.get('no'):
-        urls = []
-        if isinstance(proxies['no'], basestring):
-            urls = proxies['no'].replace(';', ',').split(",")
-        elif isinstance(proxies['no'], list):
-            urls = proxies['no']
-        for url in urls:
+        for url in proxies['no'].replace(';', ',').split(','):
             if url in parsed_uri.netloc:
-                if 'http' in proxies:
-                    proxies.pop('http')
-                if 'https' in proxies:
-                    proxies.pop('https')
+                proxies['http'] = None
+                proxies['https'] = None
 
     return proxies


### PR DESCRIPTION
### What does this PR do?

This mirrors the correct proxy behavior of Agent 5 more closely, mostly regarding the ability to skip proxies.

Pulls from:
https://github.com/DataDog/dd-agent/pull/3331
https://github.com/DataDog/dd-agent/pull/3644
https://github.com/DataDog/dd-agent/pull/3645
https://github.com/DataDog/dd-agent/pull/3646