### PR TITLE
[omnibus] remove linux-specific config files on osx

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -58,6 +58,12 @@ build do
             # cleanup clutter
             delete "#{install_dir}/etc"
         elsif osx?
+            # Remove linux specific configs
+            conf_dir = "#{install_dir}/etc/conf.d"
+            delete "#{conf_dir}/process_agent.yaml.default"
+            delete "#{conf_dir}/file_handle.d"
+            delete "#{install_dir}/etc/process-agent.conf.example"
+
             # Nothing to move on osx, the confs already live in /opt/datadog-agent/etc/
         end
     end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -59,10 +59,7 @@ build do
             delete "#{install_dir}/etc"
         elsif osx?
             # Remove linux specific configs
-            conf_dir = "#{install_dir}/etc/conf.d"
-            delete "#{conf_dir}/process_agent.yaml.default"
-            delete "#{conf_dir}/file_handle.d"
-            delete "#{install_dir}/etc/process-agent.conf.example"
+            delete "#{install_dir}/etc/conf.d/file_handle.d"
 
             # Nothing to move on osx, the confs already live in /opt/datadog-agent/etc/
         end

--- a/releasenotes/notes/remove-linux-specific-configs-osx-51120930c6457fbb.yaml
+++ b/releasenotes/notes/remove-linux-specific-configs-osx-51120930c6457fbb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Deleted linux-specific configuration files on macosx to avoid polluting the logs and the web ui.


### PR DESCRIPTION
### What does this PR do?

Removes linux-specific config files on osx.

### Motivation

Avoid logs & ui pollution.