### PR TITLE
add envvars.log to the flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -222,7 +222,6 @@ func zipEnvvars(zipFile *archivex.ZipFile, hostname string) error {
 	var b bytes.Buffer
 
 	for _, envvar := range os.Environ() {
-
 		b.WriteString(envvar)
 		b.WriteString("\n")
 	}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -82,13 +82,14 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		return "", err
 	}
 
-	err = zipEnvvars(zipFile, hostname)
-	if err != nil {
-		return "", err
-	}
-
 	if config.IsContainerized() {
 		err = zipDockerSelfInspect(zipFile, hostname)
+		if err != nil {
+			return "", err
+		}
+		// Only collecting them if running in a container
+		// to avoid exposing sensitive credentials
+		err = zipEnvvars(zipFile, hostname)
 		if err != nil {
 			return "", err
 		}
@@ -221,6 +222,7 @@ func zipEnvvars(zipFile *archivex.ZipFile, hostname string) error {
 	var b bytes.Buffer
 
 	for _, envvar := range os.Environ() {
+
 		b.WriteString(envvar)
 		b.WriteString("\n")
 	}

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package flare
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jhoonb/archivex"
+)
+
+var envvarPrefixWhitelist = []string{
+	// Docker client
+	"DOCKER_API_VERSION=",
+	"DOCKER_CONFIG=",
+	"DOCKER_CERT_PATH=",
+	"DOCKER_HOST=",
+	"DOCKER_TLS_VERIFY=",
+	"HTTP_PROXY=",
+	"HTTPS_PROXY=",
+	"NO_PROXY=",
+
+	// Go runtime
+	"GOGC=",
+	"GODEBUG=",
+	"GOMAXPROCS=",
+	"GOTRACEBACK=",
+}
+
+func getWhitelistedEnvvars() []string {
+	var vars []string
+	for _, envvar := range os.Environ() {
+		for _, prefix := range envvarPrefixWhitelist {
+			if strings.HasPrefix(envvar, prefix) {
+				vars = append(vars, envvar)
+			}
+		}
+	}
+	return vars
+}
+
+// zipEnvvars collects whitelisted envvars that can affect the agent's
+// behaviour while not being handled by viper
+func zipEnvvars(zipFile *archivex.ZipFile, hostname string) error {
+	envvars := getWhitelistedEnvvars()
+	if len(envvars) == 0 {
+		// Don't create the file if we have nothing
+		return nil
+	}
+
+	var b bytes.Buffer
+	for _, envvar := range envvars {
+		b.WriteString(envvar)
+		b.WriteString("\n")
+	}
+
+	// Clean it up
+	cleaned, err := credentialsCleanerBytes(b.Bytes())
+	if err != nil {
+		return err
+	}
+
+	err = zipFile.Add(filepath.Join(hostname, "envvars.log"), cleaned)
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -38,6 +38,7 @@ func getWhitelistedEnvvars() []string {
 		for _, prefix := range envvarPrefixWhitelist {
 			if strings.HasPrefix(envvar, prefix) {
 				vars = append(vars, envvar)
+				continue
 			}
 		}
 	}

--- a/pkg/flare/envvars_test.go
+++ b/pkg/flare/envvars_test.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package flare
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvvarWhitelisting(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   map[string]string
+		out  []string
+	}{
+		{
+			name: "empty envvars",
+			in:   map[string]string{},
+			out:  []string{},
+		},
+		{
+			name: "nominal case",
+			in: map[string]string{
+				"DOCKER_HOST":   "tcp://10.0.0.10:8888",
+				"SECRET_ENVVAR": "don't pickup",
+				"GOGC":          "120",
+			},
+			out: []string{
+				"GOGC=120",
+				"DOCKER_HOST=tcp://10.0.0.10:8888",
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, test.name), func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range test.in {
+				os.Setenv(k, v)
+			}
+
+			result := getWhitelistedEnvvars()
+
+			assert.Equal(t, len(test.out), len(result))
+			for _, v := range test.out {
+				assert.Contains(t, result, v)
+			}
+			os.Clearenv()
+		})
+	}
+}

--- a/releasenotes/notes/flare-dump-envvars-cc0d31769ffd9889.yaml
+++ b/releasenotes/notes/flare-dump-envvars-cc0d31769ffd9889.yaml
@@ -1,3 +1,6 @@
 ---
 other:
-  - The flare now includes a dump of environment variables if running in a container.
+  - |
+    The flare now includes a dump of whitelisted environment variables
+    that can have an impact on agent behaviour. If no whitelisted envvar
+    is found, the envvars.log file is not created in the flare.

--- a/releasenotes/notes/flare-dump-envvars-cc0d31769ffd9889.yaml
+++ b/releasenotes/notes/flare-dump-envvars-cc0d31769ffd9889.yaml
@@ -1,3 +1,3 @@
 ---
 other:
-  - The flare now includes a dump of environment variables in the `envvars.log` file
+  - The flare now includes a dump of environment variables if running in a container.

--- a/releasenotes/notes/flare-dump-envvars-cc0d31769ffd9889.yaml
+++ b/releasenotes/notes/flare-dump-envvars-cc0d31769ffd9889.yaml
@@ -1,0 +1,3 @@
+---
+other:
+  - The flare now includes a dump of environment variables in the `envvars.log` file


### PR DESCRIPTION
### What does this PR do?

Add an `envvars.log` file in the flare, that is a text dump of `os.Environ()`.

### Motivation

Although we already have `runtime_config_dump.yaml` that will allow us to detect envvar bindings, the docker library relies on [other envvars](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables), that viper is not aware of.
