### PR TITLE
[core][py] site-packages already in sys.path, don't re-append

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -42,10 +42,10 @@ var (
 // GetPythonPaths returns the paths (in order of precedence) from where the agent
 // should load python modules and checks
 func GetPythonPaths() []string {
+	// wheels install in default site - already in sys.path; takes precedence over any additional location
 	return []string{
 		GetDistPath(),                                  // common modules are shipped in the dist path directly or under the "checks/" sub-dir
-		PySitePackages,                                 // integrations-core, wheels have precedence over old-school SDK
-		PyChecksPath,                                   // integrations-core checks
+		PyChecksPath,                                   // integrations-core legacy checks
 		filepath.Join(GetDistPath(), "checks.d"),       // custom checks in the "checks.d/" sub-dir of the dist path
 		config.Datadog.GetString("additional_checksd"), // custom checks, least precedent check location
 	}

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -19,8 +19,6 @@ const (
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
-	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
-	PySitePackages = filepath.Join(_here, "..", "..", "embedded", "lib", "python2.7", "site-packages")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
 )

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -21,8 +21,6 @@ const (
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "..", "checks.d")
-	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
-	PySitePackages = filepath.Join(_here, "..", "..", "embedded", "lib", "python2.7", "site-packages")
 	// DistPath holds the path to the folder containing distribution files
 	distPath = filepath.Join(_here, "dist")
 )

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -24,9 +24,7 @@ import (
 var (
 	// PyChecksPath holds the path to the python checks from integrations-core shipped with the agent
 	PyChecksPath = filepath.Join(_here, "..", "checks.d")
-	// PySitePackages holds the path to the python checks from integrations-core installed via wheels
-	PySitePackages = filepath.Join(_here, "lib", "python2.7", "site-packages")
-	distPath       string
+	distPath     string
 	// ViewsPath holds the path to the folder containing the GUI support files
 	viewsPath string
 )

--- a/releasenotes/notes/dont-add-sitepackages-redundantly-b0b45bdd81c5d361.yaml
+++ b/releasenotes/notes/dont-add-sitepackages-redundantly-b0b45bdd81c5d361.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The checks packaged with the new wheels method are in the default python 
+    package site, already included in ``sys.path``. We therefore removed this 
+    path them from the locations that are appended to the default python ``sys.path``


### PR DESCRIPTION
### What does this PR do?

No need to add site-packages redundantly (and misleadingly), it already takes precedence over other locations as additional "PythonPaths" are appended at the *end* of `sys.path`. Adds note, removes location.

### Motivation

Observations made here: https://github.com/DataDog/datadog-agent/pull/1087

