### PR TITLE
Add configurations for the auth token

### DIFF
--- a/pkg/api/security/platform_darwin.go
+++ b/pkg/api/security/platform_darwin.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package security
 
 import (
@@ -9,7 +14,10 @@ import (
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
 func saveAuthToken(token, tokenPath string) error {
-	confFile, _ := os.Stat(config.Datadog.ConfigFileUsed())
+	confFile, err := os.Stat(config.Datadog.ConfigFileUsed())
+	if err != nil {
+		return err
+	}
 	permissions := confFile.Mode()
 
 	return ioutil.WriteFile(tokenPath, []byte(token), permissions)

--- a/pkg/api/security/platform_nix.go
+++ b/pkg/api/security/platform_nix.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build freebsd netbsd openbsd solaris dragonfly linux
 
 package security
@@ -10,8 +15,12 @@ import (
 )
 
 // writes auth token(s) to a file with the same permissions as datadog.yaml
+// if the datadog.yaml isn't here, create a 0400 permission
 func saveAuthToken(token, tokenPath string) error {
-	confFile, _ := os.Stat(config.Datadog.ConfigFileUsed())
+	confFile, err := os.Stat(config.Datadog.ConfigFileUsed())
+	if err != nil {
+		return err
+	}
 	permissions := confFile.Mode()
 
 	return ioutil.WriteFile(tokenPath, []byte(token), permissions)

--- a/pkg/api/security/platform_windows.go
+++ b/pkg/api/security/platform_windows.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package security
 
 import (

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -106,7 +106,7 @@ func GenerateRootCert(hosts []string, bits int) (
 }
 
 // FetchAuthToken gets the authentication token from:
-// - configuration (yaml or environment variable)
+// - configuration (datadog.yaml or environment variable)
 // - the auth token file & creates one if it doesn't exist
 // Requires that the config has been set up before calling
 func FetchAuthToken() (string, error) {

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -121,7 +121,7 @@ func FetchAuthToken() (string, error) {
 
 	if authTokenEnv != "" {
 		if isAuthTokenFile {
-			log.Warnf("authentication token configured via \"auth_token\", ignoring existing token file: %q", authTokenFile)
+			log.Infof("Authentication token configured via \"auth_token\", ignoring existing token file: %q", authTokenFile)
 		}
 		err := authTokenValidation(authTokenEnv)
 		if err != nil {

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package security
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestFetchAuthTokenTooShort(t *testing.T) {
+	config.Datadog.Set("auth_token", "123")
+	token, err := FetchAuthToken()
+	require.NotNil(t, err, fmt.Sprintf("%v", err))
+	assert.Equal(t, err, fmt.Errorf("invalid authentication token, length is 3: must be at least %d characters", authTokenLen))
+	assert.Equal(t, "", token)
+}
+
+func TestFetchAuthTokenValidConf(t *testing.T) {
+	const expectedToken = "1234567890123456789012345678901234567890"
+	config.Datadog.Set("auth_token", expectedToken)
+	token, err := FetchAuthToken()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	assert.Equal(t, expectedToken, token)
+}
+
+func TestFetchAuthTokenValidGen(t *testing.T) {
+	ddFile, err := ioutil.TempFile("", "fake-datadog-yaml-")
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	expectTokenPath := path.Join(path.Dir(ddFile.Name()), "auth_token")
+	defer os.Remove(expectTokenPath)
+	config.Datadog.SetConfigFile(ddFile.Name())
+	config.Datadog.Set("auth_token", "")
+	token, err := FetchAuthToken()
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	assert.True(t, len(token) > authTokenLen, fmt.Sprintf("%d", len(token)))
+	_, err = os.Stat(expectTokenPath)
+	require.Nil(t, err)
+}

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -37,11 +37,18 @@ func TestFetchAuthTokenValidConf(t *testing.T) {
 }
 
 func TestFetchAuthTokenValidGen(t *testing.T) {
-	ddFile, err := ioutil.TempFile("", "fake-datadog-yaml-")
+	testDir, err := ioutil.TempDir("", "fake-datadog-etc-")
 	require.Nil(t, err, fmt.Sprintf("%v", err))
-	expectTokenPath := path.Join(path.Dir(ddFile.Name()), "auth_token")
+	defer os.RemoveAll(testDir)
+
+	f, err := ioutil.TempFile(testDir, "fake-datadog-yaml-")
+	require.Nil(t, err, fmt.Errorf("%v", err))
+	defer os.Remove(f.Name())
+
+	config.Datadog.SetConfigFile(f.Name())
+	expectTokenPath := path.Join(testDir, "auth_token")
 	defer os.Remove(expectTokenPath)
-	config.Datadog.SetConfigFile(ddFile.Name())
+
 	config.Datadog.Set("auth_token", "")
 	token, err := FetchAuthToken()
 	require.Nil(t, err, fmt.Sprintf("%v", err))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,8 @@ func init() {
 	Datadog.SetDefault("enable_gohai", true)
 	Datadog.SetDefault("check_runners", int64(0))
 	Datadog.SetDefault("expvar_port", "5000")
+	// auth_token must be a string >= 32 chars
+	Datadog.SetDefault("auth_token", "")
 
 	// Use to force client side TLS version to 1.2
 	BindEnvAndSetDefault("force_tls_12", false)
@@ -195,6 +197,7 @@ func init() {
 	Datadog.BindEnv("log_file")
 	Datadog.BindEnv("log_level")
 	Datadog.BindEnv("log_to_console")
+	Datadog.BindEnv("auth_token")
 	Datadog.BindEnv("kubernetes_kubelet_host")
 	Datadog.BindEnv("kubernetes_http_kubelet_port")
 	Datadog.BindEnv("kubernetes_https_kubelet_port")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -28,6 +28,19 @@ api_key:
 # pushing data to the url specified in "dd_url".
 # force_tls_12: no
 
+# This authentication token is used for the authentication of the internal components of the agent to
+# the exposed API endpoints. It is also used optionally for the node-agent to authenticate against the
+# cluster-agent API endpoints.
+# The auth_token's stored value must be greater than 32 characters.
+#
+# Process to configure it:
+# - We first evaluate if it is set in datadog.yaml and meets the requirements.
+# - If not, we then evaluate if a file named "auth_token" exists in the same directory as
+# the datadog.yaml and auth_token key is not referenced in datadog.yaml
+# - Otherwise the token will be generated and therefore won't be shared amongst the node-agents and the
+# cluster-agent(s).
+# auth_token: ""
+
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 

--- a/releasenotes/notes/configure-token-83fccaa6e3b8dd31.yaml
+++ b/releasenotes/notes/configure-token-83fccaa6e3b8dd31.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Allows users to configure the token via datadog.yaml ("auth_token") or environment variable ("DD_AUTH_TOKEN")


### PR DESCRIPTION
### What does this PR do?

Allows users to configure the token via datadog.yaml (**"auth_token"**) or environment variable (**"DD_AUTH_TOKEN"**)

### Motivation

We need a configurable token to setup authNZ.
This is a requirement to build a secured client to reach the datadog cluster agent API.

