### PR TITLE
Make sure we don't block the aggregator from the forwarder

### DIFF
--- a/releasenotes/notes/forwarder-block-e6c44a997720c5aa.yaml
+++ b/releasenotes/notes/forwarder-block-e6c44a997720c5aa.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Don't block the aggregator if the fowarder input queue is full (we now drop
+    transaction).


### PR DESCRIPTION
### What does this PR do?

If the input queue in the forwarder is full, we don't want to block the
aggregator. This could only happen if we receive more new transaction
that the worker can try.