### PR TITLE
Fix dogstatsd unix socket rights

### DIFF
--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -47,6 +47,10 @@ func NewUDSListener(packetOut chan *Packet, packetPool *PacketPool) (*UDSListene
 	if err != nil {
 		return nil, fmt.Errorf("can't listen: %s", err)
 	}
+	err = os.Chmod(socketPath, 0722)
+	if err != nil {
+		return nil, fmt.Errorf("can't set the socket at write only: %s", err)
+	}
 
 	if originDection {
 		err = enableUDSPassCred(conn)

--- a/pkg/dogstatsd/listeners/uds_common_test.go
+++ b/pkg/dogstatsd/listeners/uds_common_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -36,6 +37,9 @@ func TestNewUDSListener(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
+	fi, err := os.Stat(socketPath)
+	require.Nil(t, err)
+	assert.Equal(t, "Srwx-w--w-", fi.Mode().String())
 }
 
 func TestStartStopUDSListener(t *testing.T) {

--- a/releasenotes/notes/set-unix-socket-rights-41516c4bf15f6699.yaml
+++ b/releasenotes/notes/set-unix-socket-rights-41516c4bf15f6699.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix dogstatsd unix socket rights so every user could write to it.


### PR DESCRIPTION
### What does this PR do?

By default a unix socket is created to be readable by everybody but only
writable by the owner. This defeat the purpose of a unix socket for
dogstatsd. This commit set write access to the socket for every user and
read access only for the owner (dd-agent).