### PR TITLE
fix dsd standalone image build on gitlab

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh /entrypoint.sh
-COPY dogstatsd /dogstatsd
+COPY static/dogstatsd /dogstatsd
 
 EXPOSE 8125/udp
 

--- a/releasenotes/notes/fix-dsd-docker-image-d21b21be4e76893b.yaml
+++ b/releasenotes/notes/fix-dsd-docker-image-d21b21be4e76893b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The agent/dogstatsd docker image now ships the appropriate binary

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -207,15 +207,19 @@ def image_build(ctx, skip_build=False):
     import docker
     client = docker.from_env()
 
-    target = os.path.join(STATIC_BIN_PATH, bin_name("dogstatsd"))
+    src = os.path.join(STATIC_BIN_PATH, bin_name("dogstatsd"))
+    dst = os.path.join("Dockerfiles", "dogstatsd", "alpine", "static")
+
     if not skip_build:
         build(ctx, rebuild=True, static=True)
-    if not os.path.exists(target):
+    if not os.path.exists(src):
         raise Exit(1)
+    if not os.path.exists(dst):
+        os.makedirs(dst)
 
-    shutil.copy2(target, "Dockerfiles/dogstatsd/alpine/dogstatsd")
+    shutil.copy(src, dst)
     client.images.build(path="Dockerfiles/dogstatsd/alpine/", rm=True, tag=DOGSTATSD_TAG)
-    ctx.run("rm Dockerfiles/dogstatsd/alpine/dogstatsd")
+    ctx.run("rm -rf Dockerfiles/dogstatsd/alpine/static")
 
 
 @task


### PR DESCRIPTION
The `datadog/dogstatsd` image does not work due to a change in gitlab artifact paths. This PR updates the `Dockerfile` to use the new path, and updates the test to use it too.

The dsd docker integration test did not detect that as it currently builds its own image instead of using the one in the ECR.

### Testing

Pushed `datadog/dogstatsd-dev:xvello-dsd-standalone` image from the gitlab pipeline for testing, looks OK