### PR TITLE
Kubelet register a hostname Provider

### DIFF
--- a/pkg/collector/listeners/kubelet_test.go
+++ b/pkg/collector/listeners/kubelet_test.go
@@ -49,7 +49,6 @@ func getMockedPod() *kubelet.Pod {
 	}
 	kubeletSpec := kubelet.Spec{
 		HostNetwork: false,
-		Hostname:    "mock",
 		NodeName:    "mockn-node",
 		Containers:  containerSpecs,
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -317,3 +317,16 @@ func IsContainerized() bool {
 func FileUsedDir() string {
 	return filepath.Dir(Datadog.ConfigFileUsed())
 }
+
+// IsKubernetes returns whether the Agent is running on a kubernetes cluster
+func IsKubernetes() bool {
+	// Injected by Kubernetes itself
+	if os.Getenv("KUBERNETES_SERVICE_PORT") != "" {
+		return true
+	}
+	// support of Datadog environment variable for Kubernetes
+	if os.Getenv("KUBERNETES") != "" {
+		return true
+	}
+	return false
+}

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -162,8 +162,3 @@ func GetHostname() (string, error) {
 	cache.Cache.Set(cacheHostnameKey, hostName, cache.NoExpiration)
 	return hostName, err
 }
-
-// IsKubernetes returns whether the Agent is running on a kubernetes cluster
-func isKubernetes() bool {
-	return os.Getenv("KUBERNETES_PORT") != ""
-}

--- a/pkg/util/hostname/kubelet.go
+++ b/pkg/util/hostname/kubelet.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet
+
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+
+func init() {
+	RegisterHostnameProvider("kubelet", kubelet.HostnameProvider)
+}

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -10,9 +10,10 @@
 package util
 
 import (
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	log "github.com/cihub/seelog"
 )
 
 func getContainerHostname() (bool, string) {
@@ -31,6 +32,9 @@ func getContainerHostname() (bool, string) {
 		}
 	}
 
+	if config.IsKubernetes() == false {
+		return false, name
+	}
 	// Kubernetes
 	log.Debug("GetHostname trying Kubernetes trough kubelet API...")
 	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
@@ -39,6 +43,5 @@ func getContainerHostname() (bool, string) {
 			return true, name
 		}
 	}
-
 	return false, name
 }

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -17,17 +17,26 @@ import (
 
 func getContainerHostname() (bool, string) {
 	var name string
-	if config.IsContainerized() {
-		// Docker
-		log.Debug("GetHostname trying Docker API...")
-		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
-			name, err := getDockerHostname(name)
-			if err == nil && ValidHostname(name) == nil {
-				return true, name
-			} else if isKubernetes() {
-				log.Debug("GetHostname trying k8s...")
-				// TODO
-			}
+
+	if config.IsContainerized() == false {
+		return false, name
+	}
+
+	// Docker
+	log.Debug("GetHostname trying Docker API...")
+	if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
+		name, err := getDockerHostname(name)
+		if err == nil && ValidHostname(name) == nil {
+			return true, name
+		}
+	}
+
+	// Kubernetes
+	log.Debug("GetHostname trying Kubernetes trough kubelet API...")
+	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
+		name, err := getKubeletHostname(name)
+		if err == nil && ValidHostname(name) == nil {
+			return true, name
 		}
 	}
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -78,9 +78,17 @@ func GetKubeUtil() (*KubeUtil, error) {
 	return globalKubeUtil, nil
 }
 
-// GetNodeInfo returns the IP address and the hostname of the node where
-// this pod is running.
-func (ku *KubeUtil) GetNodeInfo() (ip, name string, err error) {
+// HostnameProvider kubelet implementation for the hostname provider
+func HostnameProvider(hostName string) (string, error) {
+	ku, err := GetKubeUtil()
+	if err != nil {
+		return "", err
+	}
+	return ku.GetHostname()
+}
+
+// GetNodeInfo returns the IP address and the hostname of the first valid pod in the PodList
+func (ku *KubeUtil) GetNodeInfo() (string, string, error) {
 	pods, err := ku.GetLocalPodList()
 	if err != nil {
 		return "", "", fmt.Errorf("error getting pod list from kubelet: %s", err)
@@ -92,10 +100,27 @@ func (ku *KubeUtil) GetNodeInfo() (ip, name string, err error) {
 		}
 	}
 
-	return "", "", fmt.Errorf("failed to get node info")
+	return "", "", fmt.Errorf("failed to get node info, pod list length: %d", len(pods))
 }
 
-// GetLocalPodList returns the list of pods running on the node where this pod is running
+// GetHostname returns the hostname of the first pod.spec.nodeName in the PodList
+func (ku *KubeUtil) GetHostname() (string, error) {
+	pods, err := ku.GetLocalPodList()
+	if err != nil {
+		return "", fmt.Errorf("error getting pod list from kubelet: %s", err)
+	}
+
+	for _, pod := range pods {
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		return pod.Spec.NodeName, nil
+	}
+
+	return "", fmt.Errorf("failed to get hostname, pod list length: %d", len(pods))
+}
+
+// GetLocalPodList returns the list of pods running on the node
 func (ku *KubeUtil) GetLocalPodList() ([]*Pod, error) {
 	data, code, err := ku.QueryKubelet(kubeletPodPath)
 	if err != nil {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -292,7 +292,7 @@ func (ku *KubeUtil) init() error {
 	// HTTPS first
 	_, errHTTPS = c.Get(fmt.Sprintf("https://%s:%d/", ku.kubeletHost, config.Datadog.GetInt("kubernetes_https_kubelet_port")))
 	if errHTTPS != nil {
-		log.Debugf("Cannot connect: %s, try trough http", errHTTPS)
+		log.Debugf("Cannot connect: %s, trying trough http", errHTTPS)
 		// Only try the HTTP if HTTPS failed
 		_, errHTTP = c.Get(fmt.Sprintf("http://%s:%d/", ku.kubeletHost, config.Datadog.GetInt("kubernetes_http_kubelet_port")))
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -248,6 +248,7 @@ func (ku *KubeUtil) setupKubeletApiEndpoint() error {
 	_, code, httpsUrlErr := ku.QueryKubelet(kubeletPodPath)
 	if httpsUrlErr == nil {
 		if code == http.StatusOK {
+			log.Debugf("Kubelet endpoint is: %s", ku.kubeletApiEndpoint)
 			return nil
 		}
 		return fmt.Errorf("unexpected status code %d on endpoint %s%s", code, ku.kubeletApiEndpoint, kubeletPodPath)
@@ -262,6 +263,7 @@ func (ku *KubeUtil) setupKubeletApiEndpoint() error {
 	_, code, httpUrlErr := ku.QueryKubelet(kubeletPodPath)
 	if httpUrlErr == nil {
 		if code == http.StatusOK {
+			log.Debugf("Kubelet endpoint is: %s", ku.kubeletApiEndpoint)
 			return nil
 		}
 		return fmt.Errorf("unexpected status code %d on endpoint %s%s", code, ku.kubeletApiEndpoint, kubeletPodPath)
@@ -290,13 +292,13 @@ func (ku *KubeUtil) init() error {
 	// HTTPS first
 	_, errHTTPS = c.Get(fmt.Sprintf("https://%s:%d/", ku.kubeletHost, config.Datadog.GetInt("kubernetes_https_kubelet_port")))
 	if errHTTPS != nil {
-		log.Debugf("cannot connect: %s", errHTTPS)
+		log.Debugf("Cannot connect: %s, try trough http", errHTTPS)
 		// Only try the HTTP if HTTPS failed
 		_, errHTTP = c.Get(fmt.Sprintf("http://%s:%d/", ku.kubeletHost, config.Datadog.GetInt("kubernetes_http_kubelet_port")))
 	}
 
 	if errHTTP != nil {
-		log.Debugf("cannot connect: %s", errHTTP)
+		log.Debugf("Cannot connect: %s", errHTTP)
 		return fmt.Errorf("cannot connect: https: %q, http: %q", errHTTPS, errHTTP)
 	}
 

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -40,7 +40,6 @@ type PodOwner struct {
 // Spec contains fields for unmarshalling a Pod.Spec
 type Spec struct {
 	HostNetwork bool            `json:"hostNetwork,omitempty"`
-	Hostname    string          `json:"hostname,omitempty"` // TODO: does it exist?
 	NodeName    string          `json:"nodeName,omitempty"`
 	Containers  []ContainerSpec `json:"containers,omitempty"`
 }

--- a/releasenotes/notes/kubelet-hostname-provider-c3755d746fea6122.yaml
+++ b/releasenotes/notes/kubelet-hostname-provider-c3755d746fea6122.yaml
@@ -1,5 +1,4 @@
 ---
 features:
   - |
-    The kubelet register a Hostname Provider function.
-    This function allows to get the spec.nodeName of any Pod running on the node.
+    Added ability to retrieve the hostname from the Kubernetes kubelet API.

--- a/releasenotes/notes/kubelet-hostname-provider-c3755d746fea6122.yaml
+++ b/releasenotes/notes/kubelet-hostname-provider-c3755d746fea6122.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The kubelet register a Hostname Provider function.
+    This function allows to get the spec.nodeName of any Pod running on the node.


### PR DESCRIPTION
### What does this PR do?

The kubelet register a Hostname Provider function.
This function allows to get the `spec.nodeName` of any Pod running on the node.

It cannot work if the PodList is empty.