### PR TITLE
Add configcheck command

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -15,12 +15,12 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -204,14 +204,8 @@ func getCSRFToken(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(gui.CsrfToken))
 }
 
-// ConfigCheckResponse holds the config check response
-type ConfigCheckResponse struct {
-	Configs  map[string][]check.Config `json:"configs"`
-	Warnings map[string]string         `json:"warnings"`
-}
-
 func getConfigCheck(w http.ResponseWriter, r *http.Request) {
-	var response ConfigCheckResponse
+	var response response.ConfigCheckResponse
 
 	response.Configs = common.AC.GetProviderLoadedConfigs()
 	response.Warnings = autodiscovery.GetResolveErrors()

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -209,6 +209,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 
 	response.Configs = common.AC.GetProviderLoadedConfigs()
 	response.Warnings = autodiscovery.GetResolveWarnings()
+	response.Unresolved = common.AC.GetUnresolvedTemplates()
 
 	json, err := json.Marshal(response)
 	if err != nil {

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -40,6 +40,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/{component}/status", componentStatusHandler).Methods("POST")
 	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
 	r.HandleFunc("/gui/csrf-token", getCSRFToken).Methods("GET")
+	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
@@ -199,4 +200,8 @@ func getCSRFToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write([]byte(gui.CsrfToken))
+}
+
+func getConfigCheck(w http.ResponseWriter, r *http.Request) {
+	w.Write(common.AC.GetMarshalledConfigs())
 }

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -208,7 +208,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	var response response.ConfigCheckResponse
 
 	response.Configs = common.AC.GetProviderLoadedConfigs()
-	response.Warnings = autodiscovery.GetResolveErrors()
+	response.Warnings = autodiscovery.GetResolveWarnings()
 
 	json, err := json.Marshal(response)
 	if err != nil {

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -19,6 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -202,6 +204,22 @@ func getCSRFToken(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(gui.CsrfToken))
 }
 
+// ConfigCheckResponse holds the config check response
+type ConfigCheckResponse struct {
+	Configs  map[string][]check.Config `json:"configs"`
+	Warnings map[string]string         `json:"warnings"`
+}
+
 func getConfigCheck(w http.ResponseWriter, r *http.Request) {
-	w.Write(common.AC.GetMarshalledConfigs())
+	var response ConfigCheckResponse
+
+	response.Configs = common.AC.GetProviderLoadedConfigs()
+	response.Warnings = autodiscovery.GetResolveErrors()
+
+	json, err := json.Marshal(response)
+	if err != nil {
+		log.Errorf("Unable to marshal config check response: %s", err)
+	}
+
+	w.Write(json)
 }

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package response
+
+import "github.com/DataDog/datadog-agent/pkg/collector/check"
+
+// ConfigCheckResponse holds the config check response
+type ConfigCheckResponse struct {
+	Configs  map[string][]check.Config `json:"configs"`
+	Warnings map[string][]string       `json:"warnings"`
+}

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -9,6 +9,7 @@ import "github.com/DataDog/datadog-agent/pkg/collector/check"
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs  map[string][]check.Config `json:"configs"`
-	Warnings map[string][]string       `json:"warnings"`
+	Configs    map[string][]check.Config `json:"configs"`
+	Warnings   map[string][]string       `json:"warnings"`
+	Unresolved map[string]check.Config   `json:"unresolved"`
 }

--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -6,22 +6,21 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/api/agent"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/flare"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
+var withResolveErrors bool
+
 func init() {
 	AgentCmd.AddCommand(configCheckCommand)
+
+	configCheckCommand.Flags().BoolVarP(&withResolveErrors, "verbose", "v", false, "prints resolve warnings/errors")
 }
 
 var configCheckCommand = &cobra.Command{
@@ -36,63 +35,10 @@ var configCheckCommand = &cobra.Command{
 		if flagNoColor {
 			color.NoColor = true
 		}
-		err = getConfigCheck()
+		err = flare.GetConfigCheck(color.Output, withResolveErrors)
 		if err != nil {
 			return err
 		}
 		return nil
 	},
-}
-
-func getConfigCheck() error {
-	c := util.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
-
-	// Set session token
-	err := util.SetAuthToken()
-	if err != nil {
-		return err
-	}
-
-	r, err := util.DoGet(c, urlstr)
-	if err != nil {
-		if r != nil && string(r) != "" {
-			fmt.Println(fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))
-		} else {
-			fmt.Println(fmt.Sprintf("Failed to query the agent (running?): %s", err))
-		}
-	}
-
-	w := color.Output
-
-	cr := agent.ConfigCheckResponse{}
-	err = json.Unmarshal(r, &cr)
-	if err != nil {
-		fmt.Println("json")
-		return err
-	}
-
-	for provider, configs := range cr.Configs {
-		fmt.Fprintln(w, fmt.Sprintf("====== Provider %s ======", color.BlueString(provider)))
-		for _, c := range configs {
-			fmt.Fprintln(w, fmt.Sprintf("\n--- Check %s ---", color.GreenString(c.Name)))
-			for i, inst := range c.Instances {
-				fmt.Fprintln(w, fmt.Sprintf("*** Instance %s", color.CyanString(strconv.Itoa(i+1))))
-				fmt.Fprint(w, fmt.Sprintf("%s", inst))
-				fmt.Fprintln(w, strings.Repeat("*", 3))
-			}
-			fmt.Fprintln(w, fmt.Sprintf("Init Config: %s", c.InitConfig))
-			fmt.Fprintln(w, fmt.Sprintf("Metric Config: %s", c.MetricConfig))
-			fmt.Fprintln(w, fmt.Sprintf("Log Config: %s", c.LogsConfig))
-			fmt.Fprintln(w, strings.Repeat("-", 3))
-		}
-		fmt.Fprintln(w, strings.Repeat("=", 10))
-	}
-
-	for check, warning := range cr.Warnings {
-		fmt.Fprintln(w, check)
-		fmt.Fprintln(w, warning)
-	}
-
-	return nil
 }

--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -15,12 +15,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var withResolveWarnings bool
+var withDebug bool
 
 func init() {
 	AgentCmd.AddCommand(configCheckCommand)
 
-	configCheckCommand.Flags().BoolVarP(&withResolveWarnings, "verbose", "v", false, "prints resolve warnings")
+	configCheckCommand.Flags().BoolVarP(&withDebug, "verbose", "v", false, "print additional debug info")
 }
 
 var configCheckCommand = &cobra.Command{
@@ -35,7 +35,7 @@ var configCheckCommand = &cobra.Command{
 		if flagNoColor {
 			color.NoColor = true
 		}
-		err = flare.GetConfigCheck(color.Output, withResolveWarnings)
+		err = flare.GetConfigCheck(color.Output, withDebug)
 		if err != nil {
 			return err
 		}

--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -15,17 +15,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var withResolveErrors bool
+var withResolveWarnings bool
 
 func init() {
 	AgentCmd.AddCommand(configCheckCommand)
 
-	configCheckCommand.Flags().BoolVarP(&withResolveErrors, "verbose", "v", false, "prints resolve warnings/errors")
+	configCheckCommand.Flags().BoolVarP(&withResolveWarnings, "verbose", "v", false, "prints resolve warnings")
 }
 
 var configCheckCommand = &cobra.Command{
 	Use:   "configcheck",
-	Short: "Execute some connectivity diagnosis on your system",
+	Short: "Print all configurations loaded & resolved of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := common.SetupConfig(confFilePath)
@@ -35,7 +35,7 @@ var configCheckCommand = &cobra.Command{
 		if flagNoColor {
 			color.NoColor = true
 		}
-		err = flare.GetConfigCheck(color.Output, withResolveErrors)
+		err = flare.GetConfigCheck(color.Output, withResolveWarnings)
 		if err != nil {
 			return err
 		}

--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	AgentCmd.AddCommand(configCheckCommand)
+}
+
+var configCheckCommand = &cobra.Command{
+	Use:   "configcheck",
+	Short: "Execute some connectivity diagnosis on your system",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+		if flagNoColor {
+			color.NoColor = true
+		}
+		err = getConfigCheck()
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func getConfigCheck() error {
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, urlstr)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Println(fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))
+		} else {
+			fmt.Println(fmt.Sprintf("Failed to query the agent (running?): %s", err))
+		}
+	}
+
+	fmt.Println(fmt.Sprintf("%s", r))
+	return nil
+}

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -6,7 +6,6 @@
 package common
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
@@ -26,7 +25,7 @@ func SetupAutoConfig(confdPath string) {
 	// start tagging system
 	err := tagger.Init()
 	if err != nil {
-		fmt.Printf("Unable to start tagging system: %s", err)
+		log.Errorf("Unable to start tagging system: %s", err)
 	}
 
 	// create the Collector instance and start all the components

--- a/cmd/agent/dist/conf.d/cpu.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/cpu.d/conf.yaml.default
@@ -1,2 +1,2 @@
 instances:
-  - foo: bar
+  - {}

--- a/cmd/agent/dist/conf.d/memory.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/memory.d/conf.yaml.default
@@ -1,2 +1,2 @@
 instances:
-  - foo: bar
+  - {}

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -503,7 +503,7 @@ func GetConfigErrors() map[string]string {
 	return errorStats.getConfigErrors()
 }
 
-// GetResolveErrors get the resolve errors
-func GetResolveErrors() map[string]string {
+// GetResolveErrors get the resolve warnings/errors
+func GetResolveErrors() map[string][]string {
 	return errorStats.getResolveErrors()
 }

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -481,6 +481,11 @@ func (ac *AutoConfig) GetProviderLoadedConfigs() map[string][]check.Config {
 	return ac.providerLoadedConfigs
 }
 
+// GetUnresolvedTemplates returns templates in cache yet to be resolved
+func (ac *AutoConfig) GetUnresolvedTemplates() map[string]check.Config {
+	return ac.templateCache.GetUnresolvedTemplates()
+}
+
 // check if the descriptor contains the Config passed
 func (pd *providerDescriptor) contains(c *check.Config) bool {
 	for _, config := range pd.configs {

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -37,8 +37,8 @@ func init() {
 	acErrors.Set("RunErrors", expvar.Func(func() interface{} {
 		return errorStats.getRunErrors()
 	}))
-	acErrors.Set("ResolveErrors", expvar.Func(func() interface{} {
-		return errorStats.getResolveErrors()
+	acErrors.Set("ResolveWarnings", expvar.Func(func() interface{} {
+		return errorStats.getResolveWarnings()
 	}))
 }
 
@@ -290,12 +290,11 @@ func (ac *AutoConfig) resolve(config check.Config, provider string) []check.Conf
 		resolvedConfigs := ac.configResolver.ResolveTemplate(config)
 		if len(resolvedConfigs) == 0 {
 			e := fmt.Sprintf("Can't resolve the template for %s at this moment.", config.Name)
+			errorStats.setResolveWarning(config.Name, e)
 			log.Infof(e)
-			// This might not be a legit error but we store it in errorStats for debug purposes
-			errorStats.setResolveError(config.Name, e)
 			return configs
 		}
-		errorStats.removeResolveError(config.Name)
+		errorStats.removeResolveWarnings(config.Name)
 
 		// each template can resolve to multiple configs
 		for _, config := range resolvedConfigs {
@@ -503,7 +502,7 @@ func GetConfigErrors() map[string]string {
 	return errorStats.getConfigErrors()
 }
 
-// GetResolveErrors get the resolve warnings/errors
-func GetResolveErrors() map[string][]string {
-	return errorStats.getResolveErrors()
+// GetResolveWarnings get the resolve warnings/errors
+func GetResolveWarnings() map[string][]string {
+	return errorStats.getResolveWarnings()
 }

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -6,6 +6,8 @@
 package autodiscovery
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -28,6 +30,10 @@ func (p *MockProvider) String() string {
 }
 func (p *MockProvider) IsUpToDate() (bool, error) {
 	return true, nil
+}
+
+func (p *MockProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
 }
 
 type MockProvider2 struct {
@@ -57,8 +63,8 @@ func TestAddProvider(t *testing.T) {
 	ac.LoadAndRun()
 	require.Len(t, ac.providers, 2)
 	assert.Equal(t, 1, mp.collectCounter)
-	assert.False(t, ac.providers[0].poll)
-	assert.True(t, ac.providers[1].poll)
+	assert.False(t, ac.providers[0].Poll)
+	assert.True(t, ac.providers[1].Poll)
 }
 
 func TestAddLoader(t *testing.T) {
@@ -82,7 +88,7 @@ func TestContains(t *testing.T) {
 	c1 := check.Config{Name: "bar"}
 	c2 := check.Config{Name: "foo"}
 	pd := providerDescriptor{}
-	pd.configs = append(pd.configs, c1)
+	pd.Configs = append(pd.Configs, c1)
 	assert.True(t, pd.contains(&c1))
 	assert.False(t, pd.contains(&c2))
 }
@@ -98,4 +104,19 @@ func TestStop(t *testing.T) {
 
 	assert.True(t, ml.stopReceived)
 	assert.True(t, ml.stopReceived)
+}
+
+func TestGetConfigs(t *testing.T) {
+	ac := NewAutoConfig(nil)
+	c1 := check.Config{
+		Name:          "http_check",
+		Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+		InitConfig:    check.ConfigData("{}"),
+		ADIdentifiers: []string{"id"},
+	}
+	mp := &MockProvider{}
+	pd := providerDescriptor{Configs: []check.Config{c1}, Provider: mp}
+	ac.providers = append(ac.providers, &pd)
+	json := ac.GetMarshalledConfigs()
+	fmt.Println(string(json))
 }

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -6,7 +6,6 @@
 package autodiscovery
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -27,12 +26,9 @@ func (p *MockProvider) Collect() ([]check.Config, error) {
 func (p *MockProvider) String() string {
 	return "mocked"
 }
+
 func (p *MockProvider) IsUpToDate() (bool, error) {
 	return true, nil
-}
-
-func (p *MockProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.String())
 }
 
 type MockProvider2 struct {

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -7,7 +7,6 @@ package autodiscovery
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -63,8 +62,8 @@ func TestAddProvider(t *testing.T) {
 	ac.LoadAndRun()
 	require.Len(t, ac.providers, 2)
 	assert.Equal(t, 1, mp.collectCounter)
-	assert.False(t, ac.providers[0].Poll)
-	assert.True(t, ac.providers[1].Poll)
+	assert.False(t, ac.providers[0].poll)
+	assert.True(t, ac.providers[1].poll)
 }
 
 func TestAddLoader(t *testing.T) {
@@ -88,7 +87,7 @@ func TestContains(t *testing.T) {
 	c1 := check.Config{Name: "bar"}
 	c2 := check.Config{Name: "foo"}
 	pd := providerDescriptor{}
-	pd.Configs = append(pd.Configs, c1)
+	pd.configs = append(pd.configs, c1)
 	assert.True(t, pd.contains(&c1))
 	assert.False(t, pd.contains(&c2))
 }
@@ -104,19 +103,4 @@ func TestStop(t *testing.T) {
 
 	assert.True(t, ml.stopReceived)
 	assert.True(t, ml.stopReceived)
-}
-
-func TestGetConfigs(t *testing.T) {
-	ac := NewAutoConfig(nil)
-	c1 := check.Config{
-		Name:          "http_check",
-		Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
-		InitConfig:    check.ConfigData("{}"),
-		ADIdentifiers: []string{"id"},
-	}
-	mp := &MockProvider{}
-	pd := providerDescriptor{Configs: []check.Config{c1}, Provider: mp}
-	ac.providers = append(ac.providers, &pd)
-	json := ac.GetMarshalledConfigs()
-	fmt.Println(string(json))
 }

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -108,7 +108,9 @@ func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 		// check out whether any service we know has this identifier
 		serviceIds, found := cr.adIDToServices[id]
 		if !found {
-			log.Debugf("No service found with this AD identifier: %s", id)
+			s := fmt.Sprintf("No service found with this AD identifier: %s", id)
+			log.Debugf(s)
+			errorStats.setResolveError(tpl.Name, s)
 			continue
 		}
 
@@ -117,8 +119,10 @@ func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 			if err == nil {
 				resolvedSet[config.Digest()] = config
 			} else {
-				log.Warnf("Error resolving template %s for service %s: %v",
+				err := fmt.Errorf("Error resolving template %s for service %s: %v",
 					config.Name, serviceID, err)
+				log.Warn(err)
+				errorStats.setResolveError(tpl.Name, err.Error())
 			}
 		}
 	}

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -146,6 +146,9 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)
 
+	// Get provider to map configs with it
+	provider := cr.templates.GetProviderFromDigest(tpl.Digest())
+
 	tags, err := svc.GetTags()
 	if err != nil {
 		return resolvedConfig, err
@@ -170,6 +173,9 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 			return resolvedConfig, err
 		}
 	}
+
+	// store resolved configs in the AC
+	cr.ac.providerLoadedConfigs[provider] = append(cr.ac.providerLoadedConfigs[provider], resolvedConfig)
 
 	return resolvedConfig, nil
 }

--- a/pkg/collector/autodiscovery/configresolver_test.go
+++ b/pkg/collector/autodiscovery/configresolver_test.go
@@ -36,7 +36,7 @@ func TestResolveTemplate(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 	}
 	// add the template to the cache
-	tc.Set(tpl)
+	tc.Set(tpl, "test provider")
 
 	// no services
 	res := cr.ResolveTemplate(tpl)
@@ -72,7 +72,10 @@ func TestParseTemplateVar(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
-	cr := newConfigResolver(nil, nil, NewTemplateCache())
+	ac := &AutoConfig{
+		providerLoadedConfigs: make(map[string][]check.Config),
+	}
+	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	service := listeners.DockerService{
 		ID:            "a5901276aed16ae9ea11660a41fecd674da47e8f5d8d5bce0080a611feed2be9",
 		ADIdentifiers: []string{"redis"},
@@ -97,6 +100,9 @@ func TestResolve(t *testing.T) {
 	config, err = cr.resolve(tpl, &service)
 	assert.Nil(t, err)
 	assert.Equal(t, "pid: 1337\ntags:\n- foo\n", string(config.Instances[0]))
+
+	// Assert we have the two configs in the AC
+	assert.Equal(t, 2, len(ac.providerLoadedConfigs[UnknownProvider]))
 
 	// template variable doesn't exist
 	tpl.Instances = []check.ConfigData{check.ConfigData("host: %%FOO%%")}

--- a/pkg/collector/autodiscovery/stats.go
+++ b/pkg/collector/autodiscovery/stats.go
@@ -19,7 +19,7 @@ type acErrorStats struct {
 	config  map[string]string       // config file name -> error
 	loader  map[string]LoaderErrors // check name -> LoaderErrors
 	run     map[check.ID]string     // check ID -> error
-	resolve map[string]string       // config file name -> error
+	resolve map[string][]string     // config file name -> errors
 	m       sync.RWMutex
 }
 
@@ -29,7 +29,7 @@ func newAcErrorStats() *acErrorStats {
 		config:  make(map[string]string),
 		loader:  make(map[string]LoaderErrors),
 		run:     make(map[check.ID]string),
-		resolve: make(map[string]string),
+		resolve: make(map[string][]string),
 	}
 }
 
@@ -131,7 +131,7 @@ func (es *acErrorStats) setResolveError(checkName string, err string) {
 	es.m.Lock()
 	defer es.m.Unlock()
 
-	es.config[checkName] = err
+	es.resolve[checkName] = append(es.resolve[checkName], err)
 }
 
 // removeResolveErrors removes the errors for a check config file
@@ -139,18 +139,18 @@ func (es *acErrorStats) removeResolveError(checkName string) {
 	es.m.Lock()
 	defer es.m.Unlock()
 
-	delete(es.config, checkName)
+	delete(es.resolve, checkName)
 }
 
 // getResolveErrors will safely get the errors a check config file
-func (es *acErrorStats) getResolveErrors() map[string]string {
+func (es *acErrorStats) getResolveErrors() map[string][]string {
 	es.m.RLock()
 	defer es.m.RUnlock()
 
-	configCopy := make(map[string]string)
-	for k, v := range es.config {
-		configCopy[k] = v
+	resolveCopy := make(map[string][]string)
+	for k, v := range es.resolve {
+		resolveCopy[k] = v
 	}
 
-	return configCopy
+	return resolveCopy
 }

--- a/pkg/collector/autodiscovery/stats.go
+++ b/pkg/collector/autodiscovery/stats.go
@@ -126,24 +126,24 @@ func (es *acErrorStats) getRunErrors() map[check.ID]string {
 	return runCopy
 }
 
-// setResolveError will safely set the error for a check configuration file
-func (es *acErrorStats) setResolveError(checkName string, err string) {
+// setResolveWarning will safely set the error for a check configuration file
+func (es *acErrorStats) setResolveWarning(checkName string, err string) {
 	es.m.Lock()
 	defer es.m.Unlock()
 
 	es.resolve[checkName] = append(es.resolve[checkName], err)
 }
 
-// removeResolveErrors removes the errors for a check config file
-func (es *acErrorStats) removeResolveError(checkName string) {
+// removeResolveWarnings removes the errors for a check config file
+func (es *acErrorStats) removeResolveWarnings(checkName string) {
 	es.m.Lock()
 	defer es.m.Unlock()
 
 	delete(es.resolve, checkName)
 }
 
-// getResolveErrors will safely get the errors a check config file
-func (es *acErrorStats) getResolveErrors() map[string][]string {
+// getResolveWarnings will safely get the errors a check config file
+func (es *acErrorStats) getResolveWarnings() map[string][]string {
 	es.m.RLock()
 	defer es.m.RUnlock()
 

--- a/pkg/collector/autodiscovery/stats.go
+++ b/pkg/collector/autodiscovery/stats.go
@@ -16,18 +16,20 @@ type LoaderErrors map[string]string
 
 // loaderErrorStats holds the error objects
 type acErrorStats struct {
-	config map[string]string       // config file name -> error
-	loader map[string]LoaderErrors // check name -> LoaderErrors
-	run    map[check.ID]string     // check ID -> error
-	m      sync.RWMutex
+	config  map[string]string       // config file name -> error
+	loader  map[string]LoaderErrors // check name -> LoaderErrors
+	run     map[check.ID]string     // check ID -> error
+	resolve map[string]string       // config file name -> error
+	m       sync.RWMutex
 }
 
 // newAcErrorStats returns an instance holding autoconfig errors stats
 func newAcErrorStats() *acErrorStats {
 	return &acErrorStats{
-		config: make(map[string]string),
-		loader: make(map[string]LoaderErrors),
-		run:    make(map[check.ID]string),
+		config:  make(map[string]string),
+		loader:  make(map[string]LoaderErrors),
+		run:     make(map[check.ID]string),
+		resolve: make(map[string]string),
 	}
 }
 
@@ -122,4 +124,33 @@ func (es *acErrorStats) getRunErrors() map[check.ID]string {
 	}
 
 	return runCopy
+}
+
+// setResolveError will safely set the error for a check configuration file
+func (es *acErrorStats) setResolveError(checkName string, err string) {
+	es.m.Lock()
+	defer es.m.Unlock()
+
+	es.config[checkName] = err
+}
+
+// removeResolveErrors removes the errors for a check config file
+func (es *acErrorStats) removeResolveError(checkName string) {
+	es.m.Lock()
+	defer es.m.Unlock()
+
+	delete(es.config, checkName)
+}
+
+// getResolveErrors will safely get the errors a check config file
+func (es *acErrorStats) getResolveErrors() map[string]string {
+	es.m.RLock()
+	defer es.m.RUnlock()
+
+	configCopy := make(map[string]string)
+	for k, v := range es.config {
+		configCopy[k] = v
+	}
+
+	return configCopy
 }

--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -12,25 +12,31 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
+// UnknownProvider is used if we can't match the config back
+// to its original provider
+const UnknownProvider string = "Unknown provider"
+
 // TemplateCache is a data structure to store configuration templates
 type TemplateCache struct {
 	id2digests      map[string][]string     // map an AD identifier to all the configs that have it
 	digest2ids      map[string][]string     // map a config digest to the list of AD identifiers it has
 	digest2template map[string]check.Config // map a digest to the corresponding config object
+	digest2provider map[string]string       // map a digest to it's provider name
 	m               sync.RWMutex
 }
 
 // NewTemplateCache creates a new cache
 func NewTemplateCache() *TemplateCache {
 	return &TemplateCache{
-		id2digests:      make(map[string][]string, 0),
-		digest2ids:      make(map[string][]string, 0),
-		digest2template: make(map[string]check.Config, 0),
+		id2digests:      map[string][]string{},
+		digest2ids:      map[string][]string{},
+		digest2template: map[string]check.Config{},
+		digest2provider: map[string]string{},
 	}
 }
 
 // Set stores or updates a template in the cache
-func (cache *TemplateCache) Set(tpl check.Config) error {
+func (cache *TemplateCache) Set(tpl check.Config, provider string) error {
 	// return an error if configuration has no AD identifiers
 	if len(tpl.ADIdentifiers) == 0 {
 		return fmt.Errorf("template has no AD identifiers, unable to store it in the cache")
@@ -50,6 +56,7 @@ func (cache *TemplateCache) Set(tpl check.Config) error {
 	// store the template
 	cache.digest2template[d] = tpl
 	cache.digest2ids[d] = tpl.ADIdentifiers
+	cache.digest2provider[d] = provider
 	for _, id := range tpl.ADIdentifiers {
 		cache.id2digests[id] = append(cache.id2digests[id], d)
 	}
@@ -74,6 +81,14 @@ func (cache *TemplateCache) Get(adID string) ([]check.Config, error) {
 	return nil, fmt.Errorf("AD id %s not found in cache", adID)
 }
 
+// GetProviderFromDigest returns the provider name from the config digest
+func (cache *TemplateCache) GetProviderFromDigest(digest string) string {
+	if provider, found := cache.digest2provider[digest]; found {
+		return provider
+	}
+	return UnknownProvider
+}
+
 // Del removes a template from the cache
 func (cache *TemplateCache) Del(tpl check.Config) error {
 	// compute the digest once
@@ -90,6 +105,7 @@ func (cache *TemplateCache) Del(tpl check.Config) error {
 	// remove the template
 	delete(cache.digest2ids, d)
 	delete(cache.digest2template, d)
+	delete(cache.digest2provider, d)
 
 	// iterate through the AD identifiers for this config
 	for _, id := range tpl.ADIdentifiers {

--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -7,6 +7,7 @@ package autodiscovery
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -87,6 +88,16 @@ func (cache *TemplateCache) GetProviderFromDigest(digest string) string {
 		return provider
 	}
 	return UnknownProvider
+}
+
+// GetUnresolvedTemplates returns templates yet to be resolved
+func (cache *TemplateCache) GetUnresolvedTemplates() map[string]check.Config {
+	tpls := make(map[string]check.Config)
+	for d, config := range cache.digest2template {
+		ids := strings.Join(cache.digest2ids[d][:], ",")
+		tpls[ids] = config
+	}
+	return tpls
 }
 
 // Del removes a template from the cache

--- a/pkg/collector/autodiscovery/templatecache_test.go
+++ b/pkg/collector/autodiscovery/templatecache_test.go
@@ -96,3 +96,14 @@ func TestGetProviderFromDigest(t *testing.T) {
 
 	assert.Equal(t, cache.digest2provider[tpl.Digest()], "test provider")
 }
+
+func TestGetUnresolvedTemplates(t *testing.T) {
+	cache := NewTemplateCache()
+	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	cache.Set(tpl, "test provider")
+	expected := map[string]check.Config{
+		"foo,bar": tpl,
+	}
+
+	assert.Equal(t, cache.GetUnresolvedTemplates(), expected)
+}

--- a/pkg/collector/autodiscovery/templatecache_test.go
+++ b/pkg/collector/autodiscovery/templatecache_test.go
@@ -24,10 +24,10 @@ func TestSet(t *testing.T) {
 	cache := NewTemplateCache()
 
 	tpl1 := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	err := cache.Set(tpl1)
+	err := cache.Set(tpl1, "test provider")
 	require.Nil(t, err)
 	// adding again should be no-op
-	err = cache.Set(tpl1)
+	err = cache.Set(tpl1, "test provider")
 	require.Nil(t, err)
 
 	assert.Len(t, cache.id2digests, 2)
@@ -37,7 +37,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2template, 1)
 
 	tpl2 := check.Config{ADIdentifiers: []string{"foo"}}
-	err = cache.Set(tpl2)
+	err = cache.Set(tpl2, "test provider")
 
 	require.Nil(t, err)
 	assert.Len(t, cache.id2digests, 2)
@@ -48,7 +48,7 @@ func TestSet(t *testing.T) {
 
 	// no identifiers at all
 	tpl3 := check.Config{ADIdentifiers: []string{}}
-	err = cache.Set(tpl3)
+	err = cache.Set(tpl3, "test provider")
 
 	require.NotNil(t, err)
 }
@@ -56,7 +56,7 @@ func TestSet(t *testing.T) {
 func TestDel(t *testing.T) {
 	cache := NewTemplateCache()
 	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	err := cache.Set(tpl)
+	err := cache.Set(tpl, "test provider")
 	require.Nil(t, err)
 
 	err = cache.Del(tpl)
@@ -76,7 +76,7 @@ func TestDel(t *testing.T) {
 func TestGet(t *testing.T) {
 	cache := NewTemplateCache()
 	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	cache.Set(tpl)
+	cache.Set(tpl, "test provider")
 
 	ret, err := cache.Get("foo")
 	require.Nil(t, err)
@@ -87,4 +87,12 @@ func TestGet(t *testing.T) {
 	// id not in cache
 	_, err = cache.Get("baz")
 	assert.NotNil(t, err)
+}
+
+func TestGetProviderFromDigest(t *testing.T) {
+	cache := NewTemplateCache()
+	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	cache.Set(tpl, "test provider")
+
+	assert.Equal(t, cache.digest2provider[tpl.Digest()], "test provider")
 }

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -7,7 +7,6 @@ package check
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"regexp"
@@ -49,11 +48,6 @@ var jmxChecks = [...]string{
 
 // ConfigData contains YAML code
 type ConfigData []byte
-
-// MarshalJSON returns the string representation of the config
-func (c *ConfigData) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string([]byte(*c)[:]))
-}
 
 // ConfigRawMap is the generic type to hold YAML configurations
 type ConfigRawMap map[interface{}]interface{}

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -7,6 +7,7 @@ package check
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"regexp"
@@ -49,6 +50,11 @@ var jmxChecks = [...]string{
 // ConfigData contains YAML code
 type ConfigData []byte
 
+// MarshalJSON returns the string representation of the config
+func (c *ConfigData) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string([]byte(*c)[:]))
+}
+
 // ConfigRawMap is the generic type to hold YAML configurations
 type ConfigRawMap map[interface{}]interface{}
 
@@ -57,12 +63,12 @@ type ConfigJSONMap map[string]interface{}
 
 // Config is a generic container for configuration files
 type Config struct {
-	Name          string       // the name of the check
-	Instances     []ConfigData // array of Yaml configurations
-	InitConfig    ConfigData   // the init_config in Yaml (python check only)
-	MetricConfig  ConfigData   // the metric config in Yaml (jmx check only)
-	LogsConfig    ConfigData   // the logs config in Yaml (logs-agent only)
-	ADIdentifiers []string     // the list of AutoDiscovery identifiers (optional)
+	Name          string       `json:"check_name"`     // the name of the check
+	Instances     []ConfigData `json:"instances"`      // array of Yaml configurations
+	InitConfig    ConfigData   `json:"init_config"`    // the init_config in Yaml (python check only)
+	MetricConfig  ConfigData   `json:"metric_config"`  // the metric config in Yaml (jmx check only)
+	LogsConfig    ConfigData   `json:"log_config"`     // the logs config in Yaml (logs-agent only)
+	ADIdentifiers []string     `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
 }
 
 // Check is an interface for types capable to run checks

--- a/pkg/collector/providers/consul.go
+++ b/pkg/collector/providers/consul.go
@@ -8,7 +8,9 @@
 package providers
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"sort"
 	"strings"
@@ -18,7 +20,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"math"
 )
 
 // Abstractions for testing
@@ -97,8 +98,14 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 
 }
 
+// String returns a string representation of the ConsulConfigProvider
 func (p *ConsulConfigProvider) String() string {
 	return "consul Configuration Provider"
+}
+
+// MarshalJSON returns the serialized json provider info
+func (p *ConsulConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
 }
 
 // Collect retrieves templates from consul, builds Config objects and returns them

--- a/pkg/collector/providers/consul.go
+++ b/pkg/collector/providers/consul.go
@@ -8,7 +8,6 @@
 package providers
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/url"
@@ -101,11 +100,6 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 // String returns a string representation of the ConsulConfigProvider
 func (p *ConsulConfigProvider) String() string {
 	return "consul Configuration Provider"
-}
-
-// MarshalJSON returns the serialized json provider info
-func (p *ConsulConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.String())
 }
 
 // Collect retrieves templates from consul, builds Config objects and returns them

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -8,7 +8,6 @@
 package providers
 
 import (
-	"encoding/json"
 	"sync"
 
 	log "github.com/cihub/seelog"
@@ -39,11 +38,6 @@ func NewDockerConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 // String returns a string representation of the DockerConfigProvider
 func (d *DockerConfigProvider) String() string {
 	return "Docker container labels"
-}
-
-// MarshalJSON returns the serialized json provider info
-func (d *DockerConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
 }
 
 // Collect retrieves all running containers and extract AD templates from their labels.

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -8,6 +8,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"sync"
 
 	log "github.com/cihub/seelog"
@@ -35,8 +36,14 @@ func NewDockerConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 	return &DockerConfigProvider{}, nil
 }
 
+// String returns a string representation of the DockerConfigProvider
 func (d *DockerConfigProvider) String() string {
 	return "Docker container labels"
+}
+
+// MarshalJSON returns the serialized json provider info
+func (d *DockerConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
 }
 
 // Collect retrieves all running containers and extract AD templates from their labels.

--- a/pkg/collector/providers/ecs.go
+++ b/pkg/collector/providers/ecs.go
@@ -44,6 +44,11 @@ func (p *ECSConfigProvider) String() string {
 	return "ECS container labels"
 }
 
+// MarshalJSON returns the serialized json provider info
+func (p *ECSConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
 // IsUpToDate updates the list of AD templates versions in the Agent's cache and checks the list is up to date compared to ECS' data.
 func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 	return false, nil

--- a/pkg/collector/providers/ecs.go
+++ b/pkg/collector/providers/ecs.go
@@ -44,11 +44,6 @@ func (p *ECSConfigProvider) String() string {
 	return "ECS container labels"
 }
 
-// MarshalJSON returns the serialized json provider info
-func (p *ECSConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.String())
-}
-
 // IsUpToDate updates the list of AD templates versions in the Agent's cache and checks the list is up to date compared to ECS' data.
 func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 	return false, nil

--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -8,16 +8,14 @@
 package providers
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	log "github.com/cihub/seelog"
 	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -190,11 +188,6 @@ func (p *EtcdConfigProvider) IsUpToDate() (bool, error) {
 // String returns a string representation of the EtcdConfigProvider
 func (p *EtcdConfigProvider) String() string {
 	return "etcd Configuration Provider"
-}
-
-// MarshalJSON returns the serialized json provider info
-func (p *EtcdConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.String())
 }
 
 // hasTemplateFields verifies that a node array contains

--- a/pkg/collector/providers/etcd.go
+++ b/pkg/collector/providers/etcd.go
@@ -8,11 +8,13 @@
 package providers
 
 import (
+	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
 	"math"
 	"strings"
 	"time"
+
+	"golang.org/x/net/context"
 
 	log "github.com/cihub/seelog"
 	"github.com/coreos/etcd/client"
@@ -185,8 +187,14 @@ func (p *EtcdConfigProvider) IsUpToDate() (bool, error) {
 	return true, nil
 }
 
+// String returns a string representation of the EtcdConfigProvider
 func (p *EtcdConfigProvider) String() string {
 	return "etcd Configuration Provider"
+}
+
+// MarshalJSON returns the serialized json provider info
+func (p *EtcdConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
 }
 
 // hasTemplateFields verifies that a node array contains

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -6,7 +6,6 @@
 package providers
 
 import (
-	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -136,11 +135,6 @@ func (c *FileConfigProvider) IsUpToDate() (bool, error) {
 // String returns a string representation of the FileConfigProvider
 func (c *FileConfigProvider) String() string {
 	return "File Configuration Provider"
-}
-
-// MarshalJSON returns the serialized json provider info
-func (c *FileConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(c.String())
 }
 
 // collectEntry collects a file entry and return it's configuration if valid

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -268,8 +268,10 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 	}
 
 	// at this point the Yaml was already parsed, no need to check the error
-	rawInitConfig, _ := yaml.Marshal(cf.InitConfig)
-	config.InitConfig = rawInitConfig
+	if cf.InitConfig != nil {
+		rawInitConfig, _ := yaml.Marshal(cf.InitConfig)
+		config.InitConfig = rawInitConfig
+	}
 
 	// Go through instances and return corresponding []byte
 	for _, instance := range cf.Instances {

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -6,6 +6,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -132,8 +133,14 @@ func (c *FileConfigProvider) IsUpToDate() (bool, error) {
 	return false, nil
 }
 
+// String returns a string representation of the FileConfigProvider
 func (c *FileConfigProvider) String() string {
 	return "File Configuration Provider"
+}
+
+// MarshalJSON returns the serialized json provider info
+func (c *FileConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
 }
 
 // collectEntry collects a file entry and return it's configuration if valid

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -8,6 +8,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -33,8 +34,14 @@ func NewKubeletConfigProvider(config config.ConfigurationProviders) (ConfigProvi
 	return &KubeletConfigProvider{}, nil
 }
 
+// String returns a string representation of the KubeletConfigProvider
 func (k *KubeletConfigProvider) String() string {
 	return "Kubernetes pod annotation"
+}
+
+// MarshalJSON returns the serialized json provider info
+func (k *KubeletConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }
 
 // Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them

--- a/pkg/collector/providers/kubelet.go
+++ b/pkg/collector/providers/kubelet.go
@@ -8,7 +8,6 @@
 package providers
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -37,11 +36,6 @@ func NewKubeletConfigProvider(config config.ConfigurationProviders) (ConfigProvi
 // String returns a string representation of the KubeletConfigProvider
 func (k *KubeletConfigProvider) String() string {
 	return "Kubernetes pod annotation"
-}
-
-// MarshalJSON returns the serialized json provider info
-func (k *KubeletConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(k.String())
 }
 
 // Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them

--- a/pkg/collector/providers/providers.go
+++ b/pkg/collector/providers/providers.go
@@ -48,5 +48,4 @@ type ConfigProvider interface {
 	Collect() ([]check.Config, error)
 	String() string
 	IsUpToDate() (bool, error)
-	MarshalJSON() ([]byte, error)
 }

--- a/pkg/collector/providers/providers.go
+++ b/pkg/collector/providers/providers.go
@@ -48,4 +48,5 @@ type ConfigProvider interface {
 	Collect() ([]check.Config, error)
 	String() string
 	IsUpToDate() (bool, error)
+	MarshalJSON() ([]byte, error)
 }

--- a/pkg/collector/providers/zookeeper.go
+++ b/pkg/collector/providers/zookeeper.go
@@ -8,16 +8,14 @@
 package providers
 
 import (
-	"encoding/json"
 	"fmt"
+	"math"
 	"path"
 	"strings"
 	"time"
 
 	log "github.com/cihub/seelog"
 	"github.com/samuel/go-zookeeper/zk"
-
-	"math"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -57,11 +55,6 @@ func NewZookeeperConfigProvider(cfg config.ConfigurationProviders) (ConfigProvid
 // String returns a string representation of the ZookeeperConfigProvider
 func (z *ZookeeperConfigProvider) String() string {
 	return "zookeeper Configuration Provider"
-}
-
-// MarshalJSON returns the serialized json provider info
-func (z *ZookeeperConfigProvider) MarshalJSON() ([]byte, error) {
-	return json.Marshal(z.String())
 }
 
 // Collect retrieves templates from Zookeeper, builds Config objects and returns them

--- a/pkg/collector/providers/zookeeper.go
+++ b/pkg/collector/providers/zookeeper.go
@@ -8,6 +8,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
@@ -16,9 +17,10 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/samuel/go-zookeeper/zk"
 
+	"math"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"math"
 )
 
 const sessionTimeout = 1 * time.Second
@@ -52,8 +54,14 @@ func NewZookeeperConfigProvider(cfg config.ConfigurationProviders) (ConfigProvid
 	}, nil
 }
 
+// String returns a string representation of the ZookeeperConfigProvider
 func (z *ZookeeperConfigProvider) String() string {
 	return "zookeeper Configuration Provider"
+}
+
+// MarshalJSON returns the serialized json provider info
+func (z *ZookeeperConfigProvider) MarshalJSON() ([]byte, error) {
+	return json.Marshal(z.String())
 }
 
 // Collect retrieves templates from Zookeeper, builds Config objects and returns them

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -87,6 +87,11 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		return "", err
 	}
 
+	err = zipConfigCheck(zipFile, hostname)
+	if err != nil {
+		return "", err
+	}
+
 	if config.IsContainerized() {
 		err = zipDockerSelfInspect(zipFile, hostname)
 		if err != nil {
@@ -210,6 +215,21 @@ func zipDiagnose(zipFile *archivex.ZipFile, hostname string) error {
 	writer.Flush()
 
 	err := zipFile.Add(filepath.Join(hostname, "diagnose.log"), b.Bytes())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func zipConfigCheck(zipFile *archivex.ZipFile, hostname string) error {
+	var b bytes.Buffer
+
+	writer := bufio.NewWriter(&b)
+	GetConfigCheck(writer, true)
+	writer.Flush()
+
+	err := zipFile.Add(filepath.Join(hostname, "config-check.log"), b.Bytes())
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -49,27 +49,43 @@ func GetConfigCheck(w io.Writer, withResolveWarnings bool) error {
 	}
 
 	for provider, configs := range cr.Configs {
-		fmt.Fprintln(w, fmt.Sprintf("====== Provider %s ======", color.BlueString(provider)))
+		fmt.Fprintln(w, fmt.Sprintf("=== Provider: %s ===", color.BlueString(provider)))
 		for _, c := range configs {
-			fmt.Fprintln(w, fmt.Sprintf("\n--- Check %s ---", color.GreenString(c.Name)))
+			fmt.Fprintln(w, fmt.Sprintf("\n--- %s check ---", color.GreenString(c.Name)))
 			for i, inst := range c.Instances {
-				fmt.Fprintln(w, fmt.Sprintf("*** Instance %s", color.CyanString(strconv.Itoa(i+1))))
+				fmt.Fprintln(w, fmt.Sprintf("%s %s:", color.BlueString("Instance"), color.CyanString(strconv.Itoa(i+1))))
 				fmt.Fprint(w, fmt.Sprintf("%s", inst))
-				fmt.Fprintln(w, strings.Repeat("*", 3))
+				fmt.Fprintln(w, "~")
 			}
-			fmt.Fprintln(w, fmt.Sprintf("Init Config: %s", c.InitConfig))
-			fmt.Fprintln(w, fmt.Sprintf("Metric Config: %s", c.MetricConfig))
-			fmt.Fprintln(w, fmt.Sprintf("Log Config: %s", c.LogsConfig))
+			if len(c.InitConfig) > 0 {
+				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Init Config")))
+				fmt.Fprintln(w, string(c.InitConfig))
+			}
+			if len(c.MetricConfig) > 0 {
+				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Metric Config")))
+				fmt.Fprintln(w, string(c.MetricConfig))
+			}
+			if len(c.LogsConfig) > 0 {
+				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Log Config")))
+				fmt.Fprintln(w, string(c.LogsConfig))
+			}
+			if len(c.ADIdentifiers) > 0 {
+				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Auto-discovery IDs")))
+				for _, id := range c.ADIdentifiers {
+					fmt.Fprintln(w, fmt.Sprintf("* %s", color.CyanString(id)))
+				}
+			}
 			fmt.Fprintln(w, strings.Repeat("-", 3))
 		}
 		fmt.Fprintln(w, strings.Repeat("=", 10))
 	}
 
-	if withResolveWarnings {
+	if withResolveWarnings && len(cr.Warnings) > 0 {
+		fmt.Fprintln(w, fmt.Sprintf("\n=== Resolve %s ===", color.YellowString("warnings")))
 		for check, warnings := range cr.Warnings {
-			fmt.Fprintln(w, check)
+			fmt.Fprintln(w, fmt.Sprintf("\n%s", color.YellowString(check)))
 			for _, warning := range warnings {
-				fmt.Fprintln(w, warning)
+				fmt.Fprintln(w, fmt.Sprintf("* %s", warning))
 			}
 		}
 	}

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GetConfigCheck dump all loaded configurations to the writer
-func GetConfigCheck(w io.Writer, withResolveWarnings bool) error {
+func GetConfigCheck(w io.Writer, withDebug bool) error {
 	if w != color.Output {
 		color.NoColor = true
 	}
@@ -80,12 +80,22 @@ func GetConfigCheck(w io.Writer, withResolveWarnings bool) error {
 		fmt.Fprintln(w, strings.Repeat("=", 10))
 	}
 
-	if withResolveWarnings && len(cr.Warnings) > 0 {
-		fmt.Fprintln(w, fmt.Sprintf("\n=== Resolve %s ===", color.YellowString("warnings")))
-		for check, warnings := range cr.Warnings {
-			fmt.Fprintln(w, fmt.Sprintf("\n%s", color.YellowString(check)))
-			for _, warning := range warnings {
-				fmt.Fprintln(w, fmt.Sprintf("* %s", warning))
+	if withDebug {
+		if len(cr.Warnings) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("\n=== Resolve %s ===", color.YellowString("warnings")))
+			for check, warnings := range cr.Warnings {
+				fmt.Fprintln(w, fmt.Sprintf("\n%s", color.YellowString(check)))
+				for _, warning := range warnings {
+					fmt.Fprintln(w, fmt.Sprintf("* %s", warning))
+				}
+			}
+		}
+		if len(cr.Unresolved) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("\n=== %s Configs ===", color.YellowString("Unresolved")))
+			for ids, config := range cr.Unresolved {
+				fmt.Fprintln(w, fmt.Sprintf("\n%s: %s", color.BlueString("Auto-discovery IDs"), color.YellowString(ids)))
+				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Template")))
+				fmt.Fprintln(w, config.String())
 			}
 		}
 	}

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package flare
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/fatih/color"
+)
+
+// GetConfigCheck dump all loaded configurations to the writer
+func GetConfigCheck(w io.Writer, withResolveWarnings bool) error {
+	if w != color.Output {
+		color.NoColor = true
+	}
+
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
+
+	// Set session token
+	err := util.SetAuthToken()
+	if err != nil {
+		return err
+	}
+
+	r, err := util.DoGet(c, urlstr)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintln(w, fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))
+		} else {
+			fmt.Fprintln(w, fmt.Sprintf("Failed to query the agent (running?): %s", err))
+		}
+	}
+
+	cr := response.ConfigCheckResponse{}
+	err = json.Unmarshal(r, &cr)
+	if err != nil {
+		return err
+	}
+
+	for provider, configs := range cr.Configs {
+		fmt.Fprintln(w, fmt.Sprintf("====== Provider %s ======", color.BlueString(provider)))
+		for _, c := range configs {
+			fmt.Fprintln(w, fmt.Sprintf("\n--- Check %s ---", color.GreenString(c.Name)))
+			for i, inst := range c.Instances {
+				fmt.Fprintln(w, fmt.Sprintf("*** Instance %s", color.CyanString(strconv.Itoa(i+1))))
+				fmt.Fprint(w, fmt.Sprintf("%s", inst))
+				fmt.Fprintln(w, strings.Repeat("*", 3))
+			}
+			fmt.Fprintln(w, fmt.Sprintf("Init Config: %s", c.InitConfig))
+			fmt.Fprintln(w, fmt.Sprintf("Metric Config: %s", c.MetricConfig))
+			fmt.Fprintln(w, fmt.Sprintf("Log Config: %s", c.LogsConfig))
+			fmt.Fprintln(w, strings.Repeat("-", 3))
+		}
+		fmt.Fprintln(w, strings.Repeat("=", 10))
+	}
+
+	if withResolveWarnings {
+		for check, warnings := range cr.Warnings {
+			fmt.Fprintln(w, check)
+			for _, warning := range warnings {
+				fmt.Fprintln(w, warning)
+			}
+		}
+	}
+
+	return nil
+}

--- a/releasenotes/notes/add-configcheck-9d27b88ee72473ff.yaml
+++ b/releasenotes/notes/add-configcheck-9d27b88ee72473ff.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a configcheck command to the agent API and CLI, it prints current loaded & resolved
+    configurations for each provider. The output of the command is also added to a new config-check.log
+    into the flare.


### PR DESCRIPTION
### What does this PR do?

Add a `configcheck` command that helps investigating the current loaded/resolved configs for each config provider:

![screen shot 2018-01-29 at 18 49 05](https://user-images.githubusercontent.com/2368736/35560546-0532aeb8-05ae-11e8-8850-5e407dc8f3d9.png)

Additionnally with a `-v` option it can output debug info such as the warnings during resolve and the templates yet to be resolved:

![screen shot 2018-01-30 at 11 02 11](https://user-images.githubusercontent.com/2368736/35560562-0c99667e-05ae-11e8-9dec-9de926d9aaaf.png)

The output of this commande (in debug mode) is added to the flare to a `config-check.log` file

### Motivation

The autodiscovery is a piece of the agent where a lot of components could go wrong (template, ad identifiers, discovery...) and that's why we need a tool to give an idea of the current state of a running agent for development & debugging purposes
