### PR TITLE
Moving Kubernetes event collection to the node agent

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -115,7 +115,4 @@ You will need to allow the agent to be allowed to perform a few actions:
 The ConfigMap to store the `event.tokenKey` and the `event.tokenTimestamp` has to be deployed in the `default` namespace and be named `configmapdatadogtoken`
 One can simply run `kubectl create configmap configmapdatadogtoken --from-literal="event.tokenKey"="0"` .
 
-NB: you can set any resversion here, make sure it's **not** set to a value superior to the actual curent resversion.
-You can also set the `event.tokenTimestamp`, if not present, it will be automatically set.
-
 When the ConfigMap is not used, if the agent in charge (via the leader election) of collecting the events dies the  next leader elected will pull all the events from the API server's cache  which could result in duplicates.

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -98,8 +98,9 @@ To deploy the Agent in your Kubernetes cluster, you can use the manifest in mani
 Make sure you have the correct RBAC in place. You can use the files in manifest/rbac that contain the minimal requirements to collect events and perform the leader election.
 `kubectl create -f manifest/rbac`
 
-If you want the event collection to be resilient, please create a ConfigMap as follows:
-`kubectl create configmap configmapdatadogtoken --from-literal="event.tokenKey"="0"`
+If you want the event collection to be resilient, you can create a ConfigMap `configmapdatadogtoken` that agents will use to save and share a state reflecting which events where pulled last.
+To create such a ConfigMap, you can use the following command:
+`kubectl create -f manifest/datadog_configmap.yaml`
 See details in [Event Collection](#event-collection).
 
 ### Event Collection

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -98,10 +98,12 @@ To deploy the Agent in your Kubernetes cluster, you can use the manifest in mani
 Make sure you have the correct RBAC in place. You can use the files in manifest/rbac that contain the minimal requirements to collect events and perform the leader election.
 `kubectl create -f manifest/rbac`
 
-If you want the event collection to be resilient, you can create a ConfigMap `configmapdatadogtoken` that agents will use to save and share a state reflecting which events where pulled last.
+If you want the event collection to be resilient, you can create a ConfigMap `datadogtoken` that agents will use to save and share a state reflecting which events where pulled last.
 To create such a ConfigMap, you can use the following command:
 `kubectl create -f manifest/datadog_configmap.yaml`
 See details in [Event Collection](#event-collection).
+
+The agent also needs the right to `list` the `componentstatuses` resource, in order to submit service checks for the Controle Plane's components status.
 
 ### Event Collection
 <a name="event-collection"></a>
@@ -109,11 +111,11 @@ Similarly to the Agent 5, the Agent 6 can collect events from the Kubernetes API
 First and foremost, you need to set the `collect_kubernetes_events` variable to true in the datadog.yaml, this can be achieved via the environment variable `DD_COLLECT_KUBERNETES_EVENTS` that is resolved at start time.
 You will need to allow the agent to be allowed to perform a few actions:
 
-- `get` and `update` of the `Configmaps` named `configmapdatadogtoken` to update and query the most up to date version token corresponding to the latest event stored in ETCD.
+- `get` and `update` of the `Configmaps` named `datadogtoken` to update and query the most up to date version token corresponding to the latest event stored in ETCD.
 - `list` and `watch` of the `Events` to pull the events from the API Server, format and submit them.
 
 
-The ConfigMap to store the `event.tokenKey` and the `event.tokenTimestamp` has to be deployed in the `default` namespace and be named `configmapdatadogtoken`
-One can simply run `kubectl create configmap configmapdatadogtoken --from-literal="event.tokenKey"="0"` .
+The ConfigMap to store the `event.tokenKey` and the `event.tokenTimestamp` has to be deployed in the `default` namespace and be named `datadogtoken`
+One can simply run `kubectl create configmap datadogtoken --from-literal="event.tokenKey"="0"` .
 
 When the ConfigMap is not used, if the agent in charge (via the leader election) of collecting the events dies the  next leader elected will pull all the events from the API server's cache  which could result in duplicates.

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -13,7 +13,7 @@ The following environment variables are supported:
 - `DD_APM_ENABLED`: run the trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp
 - `DD_PROCESS_AGENT_ENABLED`: run the [process-agent](https://docs.datadoghq.com/graphing/infrastructure/process/) along with the infrastructure agent, feeding data to the Live Process View and Live Containers View
 - `DD_LOG_ENABLED`: run the [log-agent](https://docs.datadoghq.com/logs/) along with the infrastructure agent. See below for details
-
+- `DD_COLLECT_KUBERNETES_EVENTS`: Configures the agent to collect Kubernetes events. See [Event collection](#event-collection) for more details.
 Example usage: `docker run -e DD_API_KEY=your-api-key-here -it <image-name>`
 
 For a more detailed usage please refer to the official [Docker Hub](https://hub.docker.com/r/datadog/agent/)
@@ -90,3 +90,32 @@ logs:
      sourcecategory: sourcecode
 ```
 For more examples of configuration files or agent capabilities (such as filtering, redacting, multiline, …) read [this documentation](https://docs.datadoghq.com/logs/#filter-logs).
+
+### Kubernetes
+
+To deploy the Agent in your Kubernetes cluster, you can use the manifest in manifests/agent.yaml.
+`kubectl create -f manifest/agent.yaml`
+Make sure you have the correct RBAC in place. You can use the files in manifest/rbac that contain the minimal requirements to collect events and perform the leader election.
+`kubectl create -f manifest/rbac`
+
+If you want the event collection to be resilient, please create a ConfigMap as follows:
+`kubectl create configmap configmapdatadogtoken --from-literal="event.tokenKey"="0"`
+See details in [Event Collection](#event-collection).
+
+### Event Collection
+<a name="event-collection"></a>
+Similarly to the Agent 5, the Agent 6 can collect events from the Kubernetes API server.
+First and foremost, you need to set the `collect_kubernetes_events` variable to true in the datadog.yaml, this can be achieved via the environment variable `DD_COLLECT_KUBERNETES_EVENTS` that is resolved at start time.
+You will need to allow the agent to be allowed to perform a few actions:
+
+- `get` and `update` of the `Configmaps` named `configmapdatadogtoken` to update and query the most up to date version token corresponding to the latest event stored in ETCD.
+- `list` and `watch` of the `Events` to pull the events from the API Server, format and submit them.
+
+
+The ConfigMap to store the `event.tokenKey` and the `event.tokenTimestamp` has to be deployed in the `default` namespace and be named `configmapdatadogtoken`
+One can simply run `kubectl create configmap configmapdatadogtoken --from-literal="event.tokenKey"="0"` .
+
+NB: you can set any resversion here, make sure it's **not** set to a value superior to the actual curent resversion.
+You can also set the `event.tokenTimestamp`, if not present, it will be automatically set.
+
+When the ConfigMap is not used, if the agent in charge (via the leader election) of collecting the events dies the  next leader elected will pull all the events from the API server's cache  which could result in duplicates.

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: datadog-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: datadog-agent
+      name: datadog-agent
+      namespace: default
+    spec:
+      serviceAccountName: datadog-agent
+      containers:
+      - image: datadog/agent:latest
+        imagePullPolicy: Always
+        name: datadog-agent
+        env:
+          - name: DD_API_KEY
+            value: <YOUR_API_KEY>
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: True

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -19,4 +19,4 @@ spec:
           - name: DD_API_KEY
             value: <YOUR_API_KEY>
           - name: DD_COLLECT_KUBERNETES_EVENTS
-            value: True
+            value: true

--- a/Dockerfiles/manifests/datadog_configmap.yaml
+++ b/Dockerfiles/manifests/datadog_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: configmapdatadogtoken
+  name: datadogtoken
   namespace: default
 data:
-  event.tokenKey: "0" 
+  event.tokenKey: "0"

--- a/Dockerfiles/manifests/datadog_configmap.yaml
+++ b/Dockerfiles/manifests/datadog_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmapdatadogtoken
+  namespace: default
+data:
+  event.tokenKey: "0" 

--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
   - endpoints
   - pods
   - nodes
+  - componentstatuses
   verbs:
   - get
   - list
@@ -20,7 +21,7 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - configmapdatadogtoken
+  - datadogtoken
   verbs:
   - get
   - update

--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: datadog-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - events
+  - endpoints
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - configmapdatadogtoken
+  verbs:
+  - get
+  - update

--- a/Dockerfiles/manifests/rbac/clusterrolebinding.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: datadog-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: datadog-agent
+subjects:
+- kind: ServiceAccount
+  name: datadog-agent
+  namespace: default

--- a/Dockerfiles/manifests/rbac/serviceaccount.yaml
+++ b/Dockerfiles/manifests/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: datadog-agent
+  namespace: default

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/cobra"
 
 	// register core checks
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network"

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -1,0 +1,15 @@
+init_configs:
+instances:
+  - ## Tagging
+    ##
+
+    # You can add extra tags to your Kubernetes API Server metrics, events and Service Checks with the tags list option.
+    #
+    # tags: ["foo:bar"]
+    #
+    # To deactivate the event collection, flip the collect_events option to false.
+    # collect_events: false
+    #
+    # You can specify a filter over the event types you want the check to ignore.
+    # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20
+    # filtered_event_types: ["MissingClusterDNS"]

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.default
@@ -7,8 +7,6 @@ instances:
     #
     # tags: ["foo:bar"]
     #
-    # To deactivate the event collection, flip the collect_events option to false.
-    # collect_events: false
     #
     # You can specify a filter over the event types you want the check to ignore.
     # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -46,7 +47,7 @@ type KubeASCheck struct {
 
 func (c *KubeASConfig) parse(data []byte) error {
 	// default values
-	c.CollectEvent = true
+	c.CollectEvent = config.Datadog.GetBool("collect_kubernetes_events")
 
 	return yaml.Unmarshal(data, c)
 }

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+
 // +build kubeapiserver
 
 package cluster

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -206,6 +206,7 @@ func init() {
 	Datadog.BindEnv("kubernetes_https_kubelet_port")
 	Datadog.BindEnv("kubelet_client_crt")
 	Datadog.BindEnv("kubelet_client_key")
+	Datadog.BindEnv("collect_kubernetes_events")
 
 	Datadog.BindEnv("cluster_agent.auth_token")
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -31,7 +31,7 @@ import (
 var globalApiClient *APIClient
 
 const (
-	configMapDCAToken = "configmapdcatoken"
+	configMapDCAToken = "datadogtoken"
 	defaultNamespace  = "default"
 	tokenTime         = "tokenTimestamp"
 	tokenKey          = "tokenKey"
@@ -246,7 +246,7 @@ func (c *APIClient) ComponentStatuses() (*v1.ComponentStatusList, error) {
 	return c.client.CoreV1().ListComponentStatuses(ctx)
 }
 
-// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap configMapDCAToken if its timestamp is less than tokenTimeout old.
+// GetTokenFromConfigmap returns the value of the `tokenValue` from the `tokenKey` in the ConfigMap `configMapDCAToken` if its timestamp is less than tokenTimeout old.
 func (c *APIClient) GetTokenFromConfigmap(token string, tokenTimeout int64) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()

--- a/releasenotes/notes/port-event-collection-to-nda-ecba18efc37225bb.yaml
+++ b/releasenotes/notes/port-event-collection-to-nda-ecba18efc37225bb.yaml
@@ -1,0 +1,5 @@
+---
+
+features:
+  - adds a core check and the core logic to query the kubernetes API server and format the events into Datadog events. Also adds the Control Plane status check.
+


### PR DESCRIPTION
### What does this PR do?

Moving the event collection to the Node agent.
See core check initial PR [here](https://github.com/DataDog/datadog-agent/pull/1009)

Adding documentation and manifests.

### Motivation

Fully rely on the Node agent in the 6.0.0 to be iso-feature.
