### PR TITLE
[gitlab][deploy_deb] Fix deb pool pkg detection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,6 @@ variables:
   DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/test/kitchen
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
-  DEB_S3_BUCKET_DEPRECATED: apt-agent6.datad0g.com
   DEB_S3_BUCKET: apt.datad0g.com
   RPM_S3_BUCKET: yum.datad0g.com
   DEB_RPM_BUCKET_BRANCH: nightly  # branch of the DEB_S3_BUCKET and RPM_S3_BUCKET repos to release to, 'nightly' or 'beta'
@@ -626,30 +625,16 @@ deploy_deb:
     - rvm use 2.4
 
     - set +x # make sure we don't output the creds to the build log
-    - APT_SIGNING_KEY_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_id --with-decryption --query "Parameter.Value" --out text)
-    - APT_SIGNING_PRIVATE_KEY_PART1=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_private_key_part1 --with-decryption --query "Parameter.Value" --out text)
-    - APT_SIGNING_PRIVATE_KEY_PART2=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_private_key_part2 --with-decryption --query "Parameter.Value" --out text)
-    - APT_SIGNING_KEY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
-
-    - echo "$APT_SIGNING_KEY_ID"
-    - printf -- "$APT_SIGNING_PRIVATE_KEY_PART1\n$APT_SIGNING_PRIVATE_KEY_PART2\n" | gpg --import --batch
 
     - APT_SIGNING_KEY_DEPRECATED_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_deprecated_id --with-decryption --query "Parameter.Value" --out text)
     - APT_SIGNING_PRIVATE_KEY_DEPRECATED=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_deprecated --with-decryption --query "Parameter.Value" --out text)
     - APT_SIGNING_KEY_DEPRECATED_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.apt_signing_key_deprecated_passphrase --with-decryption --query "Parameter.Value" --out text)
 
-    - echo "$APT_SIGNING_KEY_ID"
-    - printf -- "$APT_SIGNING_PRIVATE_KEY_PART1\n$APT_SIGNING_PRIVATE_KEY_PART2\n" | gpg --import --batch
     - echo "$APT_SIGNING_KEY_DEPRECATED_ID"
     - printf -- "$APT_SIGNING_PRIVATE_KEY_DEPRECATED" | gpg --import --batch
 
     # grab the updated public key to extend the expiration date
     - gpg --keyserver hkp://keyserver.ubuntu.com:80 --receive-keys "$APT_SIGNING_KEY_DEPRECATED_ID"
-
-    # FIXME: remove this once we move to the new apt repo on our staging and production environments
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET_DEPRECATED -a amd64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*amd64.deb
-    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c unstable -b $DEB_S3_BUCKET_DEPRECATED -a x86_64 --sign=$APT_SIGNING_KEY_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*amd64.deb
-
 
     # Check if it is in the pool, if it is, do not release the new one
     # FIXME: move this to a script in the build image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -636,11 +636,10 @@ deploy_deb:
     # grab the updated public key to extend the expiration date
     - gpg --keyserver hkp://keyserver.ubuntu.com:80 --receive-keys "$APT_SIGNING_KEY_DEPRECATED_ID"
 
-    # Check if it is in the pool, if it is, do not release the new one
-    # FIXME: move this to a script in the build image
-    - PACKAGE_VERSION=`ls $OMNIBUS_PACKAGE_DIR/ | grep _amd64.deb | sed s/datadog-agent_// | sed s/_amd64.deb//`
-    - if curl --output /dev/null --silent --head --fail -v "https://s3.amazonaws.com/apt.datad0g.com/pool/d/da/datadog-agent_${PACKAGE_VERSION}_amd64.deb"; then echo "datadog-agent_${PACKAGE_VERSION}_amd64.deb already exists in the APT pool, releasing this one instead of the latest build."; rm -f $OMNIBUS_PACKAGE_DIR/datadog-agent_${PACKAGE_VERSION}_amd64.deb; curl -v -o $OMNIBUS_PACKAGE_DIR "https://s3.amazonaws.com/apt.datad0g.com/pool/d/da/datadog-agent_${PACKAGE_VERSION}_${1}.deb"; fi;
+    # Check if each artifact is already in the shared APT pool. If it is, re-release the one in the pool instead of the new artifact.
+    - cd $OMNIBUS_PACKAGE_DIR && /deploy_scripts/check_apt_pool.sh && cd -
 
+    # Release the artifacts
     - echo "$APT_SIGNING_KEY_DEPRECATED_PASSPHRASE" | deb-s3 upload -c $DEB_RPM_BUCKET_BRANCH -b $DEB_S3_BUCKET -a amd64 --sign=$APT_SIGNING_KEY_DEPRECATED_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*amd64.deb
     - echo "$APT_SIGNING_KEY_DEPRECATED_PASSPHRASE" | deb-s3 upload -c $DEB_RPM_BUCKET_BRANCH -b $DEB_S3_BUCKET -a x86_64 --sign=$APT_SIGNING_KEY_DEPRECATED_ID --gpg_options="--passphrase-fd 0 --pinentry-mode loopback --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/*amd64.deb
 


### PR DESCRIPTION
### What does this PR do?

Fixes the detection of existing packages in the pool of deb packages of the staging APT repo. We need to perform this check to avoid problems when the same package is pushed to different branches of the repo.

### Motivation

Fix root cause of issue we had on the staging repo when a `beta.9` deb from 2 different gitlab pipelines was deployed to respectively the `beta` and `nightly` branches of the staging repo.

### Additional Notes

The first commit removes some deprecated code that deployed to an old apt repo we don't use anymore. The related code that handled pulling the new APT key may be useful in the future, but not now.

The second commit is the fix itself.

Requires https://github.com/DataDog/datadog-agent-builders/pull/39

I've checked that the logic works well, see https://gitlab.ddbuild.io/datadog/datadog-agent/-/jobs/3053178 for an example of what the new script outputs for a typical deploy job.