### PR TITLE
[omnibus] stop preinst from removing a tmp file postinst needs

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -79,7 +79,6 @@ else
     if [ -z "$INSTALL_USER" ] || [ "$INSTALL_USER" = "root" ]; then
         SCRIPT_INSTALL="yes"
         INSTALL_USER=`cat /tmp/datadog-install-user || echo 'root'`
-        rm -v /tmp/datadog-install-user || true
     fi
     echo "INSTALL_USER: $INSTALL_USER"
 


### PR DESCRIPTION
### What does this PR do?

Prevents the `preinst` script from removing `/tmp/datadog-install-user` after using it.

This file is needed by `postinst` when doing a script install : https://github.com/DataDog/datadog-agent/blob/2b3ea853a94203b794c13effa4c8372d0c9c7bb3/omnibus/package-scripts/agent/postinst#L126-L130

It led to failure to execute the `postinst` script : 

https://github.com/DataDog/datadog-agent/blob/2b3ea853a94203b794c13effa4c8372d0c9c7bb3/omnibus/package-scripts/agent/postinst#L175-L179

### Motivation

Automated script install was failing because of this.
