### PR TITLE
[install_script][centos] Fix failures on repo/package install

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -126,7 +126,6 @@ if [ $OS = "RedHat" ]; then
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean expire-cache
-    $sudo_cmd yum -y check-update
     $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog-beta' install datadog-agent || $sudo_cmd yum -y install datadog-agent
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -122,12 +122,12 @@ if [ $OS = "RedHat" ]; then
         ARCHI="x86_64"
     fi
 
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${dd_url}/beta/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public\n       https://yum.${dd_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog-beta.repo"
+    $sudo_cmd sh -c "echo -e '[datadog-beta]\nname = Beta repo, Datadog, Inc.\nbaseurl = https://yum.${dd_url}/beta/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public\n       https://yum.${dd_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog-beta.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean expire-cache
     $sudo_cmd yum -y check-update
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent || $sudo_cmd yum -y install datadog-agent
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog-beta' install datadog-agent || $sudo_cmd yum -y install datadog-agent
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
     $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
@@ -170,13 +170,13 @@ elif [ $OS = "SUSE" ]; then
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
-  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${dd_url}/suse/beta/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog.repo"
+  $sudo_cmd sh -c "echo -e '[datadog-beta]\nname=datadog beta\nenabled=1\nbaseurl=https://yum.${dd_url}/suse/beta/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog-beta.repo"
 
   echo -e "\033[34m\n* Importing the Datadog GPG Key\n\033[0m"
   $sudo_cmd rpm --import https://yum.${dd_url}/DATADOG_RPM_KEY.public
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
-  $sudo_cmd zypper --non-interactive --no-gpg-check refresh datadog
+  $sudo_cmd zypper --non-interactive --no-gpg-check refresh datadog-beta
 
   echo -e "\033[34m\n* Installing Datadog Agent\n\033[0m"
   $sudo_cmd zypper --non-interactive install datadog-agent

--- a/docs/agent/upgrade.md
+++ b/docs/agent/upgrade.md
@@ -65,8 +65,8 @@ sudo apt-get install datadog-agent
 ##### Set up Datadog's Yum repo on your system
 
 ```
-[datadog]
-name = Datadog, Inc.
+[datadog-beta]
+name = Beta, Datadog, Inc.
 baseurl = https://yum.datadoghq.com/beta/x86_64/
 enabled=1
 gpgcheck=1
@@ -79,14 +79,13 @@ You can use this command to do it directly:
 
 ```shell
 # Red Hat
-echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/beta/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog-beta.repo
+echo -e '[datadog-beta]\nname = Beta, Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/beta/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog-beta.repo
 ```
 
 ##### Update your local yum cache and install/update the agent
 
 ```shell
 sudo yum clean expire-cache
-sudo yum check-update
 sudo yum install datadog-agent
 ```
 


### PR DESCRIPTION
### What does this PR do?

Fixes 2 issues that can happen in the install script, during repo update or package install, and that can make the install script fail:

1. use a unique name for the beta repository
2. remove `yum check-update` from install script

See commit messages for more info.

### Additional Notes

I've tested this on clean install and upgrade on CentOS 7. Hopefully the kitchen tests on the install script + CentOS should be fixed with this change (although I'm not super clear on why they're failing right now)
