### PR TITLE
add kubeutil python module to support kubelet check

### DIFF
--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython
 
 #include "api.h"

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython
 
 #ifndef _PY_API_H

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython
 
 #include "datadog_agent.h"

--- a/pkg/collector/py/datadog_agent.h
+++ b/pkg/collector/py/datadog_agent.h
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython
 
 #ifndef DATADOG_HEADER

--- a/pkg/collector/py/kubeutil.c
+++ b/pkg/collector/py/kubeutil.c
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython,kubelet
 
 #include "kubeutil.h"

--- a/pkg/collector/py/kubeutil.c
+++ b/pkg/collector/py/kubeutil.c
@@ -1,0 +1,21 @@
+// +build cpython,kubelet
+
+#include "kubeutil.h"
+
+// Functions
+PyObject* GetKubeletConnectionInfo();
+
+static PyMethodDef kubeutilMethods[] = {
+  {"get_connection_info", GetKubeletConnectionInfo, METH_NOARGS, "Get kubelet connection information."},
+  {NULL, NULL}
+};
+
+void initkubeutil()
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *da = Py_InitModule("kubeutil", kubeutilMethods);
+
+  PyGILState_Release(gstate);
+}

--- a/pkg/collector/py/kubeutil.c
+++ b/pkg/collector/py/kubeutil.c
@@ -15,7 +15,7 @@ void initkubeutil()
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 
-  PyObject *da = Py_InitModule("kubeutil", kubeutilMethods);
+  PyObject *ku = Py_InitModule("kubeutil", kubeutilMethods);
 
   PyGILState_Release(gstate);
 }

--- a/pkg/collector/py/kubeutil.go
+++ b/pkg/collector/py/kubeutil.go
@@ -42,11 +42,13 @@ func GetKubeletConnectionInfo() *C.PyObject {
 		}
 	}
 
-	if creds == nil { // cache miss
+	if creds == nil { // Cache miss
 		kubeutil, err := kubelet.GetKubeUtil()
 		if err != nil {
+			// Connection to the kubelet fail, return empty dict
 			return dict
 		}
+		// At this point, we have valid credentials to get
 		creds = kubeutil.GetRawConnectionInfo()
 		cache.Cache.Set(kubeletCacheKey, creds, 5*time.Minute)
 	}

--- a/pkg/collector/py/kubeutil.go
+++ b/pkg/collector/py/kubeutil.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython,kubelet
+
+package py
+
+import (
+	"time"
+	"unsafe"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+// #cgo pkg-config: python-2.7
+// #cgo linux CFLAGS: -std=gnu99
+// #include "api.h"
+// #include "kubeutil.h"
+import "C"
+
+var kubeletCacheKey = cache.BuildAgentKey("py", "kubeutil", "connection_info")
+
+// GetKubeletConnectionInfo returns a dict containing url and credentials to connect to the kubelet.
+// The dict is empty if the kubelet was not detected. The call to kubeutil is cached for 5 minutes.
+// See the documentation of kubelet.GetRawConnectionInfo for dict contents.
+//export GetKubeletConnectionInfo
+func GetKubeletConnectionInfo() *C.PyObject {
+	var creds map[string]string
+	var ok bool
+	dict := C.PyDict_New()
+
+	if cached, hit := cache.Cache.Get(kubeletCacheKey); hit {
+		creds, ok = cached.(map[string]string)
+		if !ok {
+			log.Errorf("invalid cache format, forcing a cache miss")
+			creds = nil
+		}
+	}
+
+	if creds == nil { // cache miss
+		kubeutil, err := kubelet.GetKubeUtil()
+		if err != nil {
+			return dict
+		}
+		creds = kubeutil.GetRawConnectionInfo()
+		cache.Cache.Set(kubeletCacheKey, creds, 5*time.Minute)
+	}
+
+	for k, v := range creds {
+		cKey := C.CString(k)
+		pyKey := C.PyString_FromString(cKey)
+		defer C.Py_DecRef(pyKey)
+		C.free(unsafe.Pointer(cKey))
+
+		cVal := C.CString(v)
+		pyVal := C.PyString_FromString(cVal)
+		defer C.Py_DecRef(pyVal)
+		C.free(unsafe.Pointer(cVal))
+
+		C.PyDict_SetItem(dict, pyKey, pyVal)
+	}
+	return dict
+}
+
+func initkubeutil() {
+	C.initkubeutil()
+}

--- a/pkg/collector/py/kubeutil.h
+++ b/pkg/collector/py/kubeutil.h
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython,kubelet
 
 #ifndef KUBEUTIL_HEADER

--- a/pkg/collector/py/kubeutil.h
+++ b/pkg/collector/py/kubeutil.h
@@ -1,0 +1,10 @@
+// +build cpython,kubelet
+
+#ifndef KUBEUTIL_HEADER
+#define KUBEUTIL_HEADER
+
+#include <Python.h>
+
+void initkubeutil();
+
+#endif /* KUBEUTIL_HEADER */

--- a/pkg/collector/py/kubeutil_nokubelet.go
+++ b/pkg/collector/py/kubeutil_nokubelet.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython,!kubelet
+
+package py
+
+// Stub
+func initkubeutil() {
+}

--- a/pkg/collector/py/kubeutil_test.go
+++ b/pkg/collector/py/kubeutil_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython,kubelet
+
+// NOTICE: See TestMain function in `utils_test.go` for Python initialization
+package py
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+func TestGetKubeletConnectionInfoNotFound(t *testing.T) {
+	config.Datadog.Set("kubernetes_http_kubelet_port", 0)
+	config.Datadog.Set("kubernetes_https_kubelet_port", 0)
+	kubelet.ResetGlobalKubeUtil()
+	cache.Cache.Delete(kubeletCacheKey)
+
+	check, _ := getCheckInstance("testkubeutil", "TestCheck")
+	err := check.Run()
+	assert.Nil(t, err)
+
+	warnings := check.GetWarnings()
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "Kubelet not found", warnings[0].Error())
+}
+
+func TestGetKubeletConnectionInfoFromCache(t *testing.T) {
+	dummyCreds := map[string]string{
+		"url": "https://10.0.0.1:10250",
+	}
+	cache.Cache.Set(kubeletCacheKey, dummyCreds, 5*time.Minute)
+
+	check, _ := getCheckInstance("testkubeutil", "TestCheck")
+	err := check.Run()
+	assert.Nil(t, err)
+
+	warnings := check.GetWarnings()
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "Found kubelet at https://10.0.0.1:10250", warnings[0].Error())
+}

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -110,7 +110,7 @@ func Initialize(paths ...string) *python.PyThreadState {
 	// (all these calls will take care of the GIL)
 	initAPI()          // `aggregator` module
 	initDatadogAgent() // `datadog_agent` module
-
+	initkubeutil()     // `kubeutil` module if compiled in
 	// return the state so the caller can resume
 	return state
 }

--- a/pkg/collector/py/tests/testkubeutil.py
+++ b/pkg/collector/py/tests/testkubeutil.py
@@ -1,0 +1,16 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2018 Datadog, Inc.
+
+from checks import AgentCheck
+from kubeutil import get_connection_info
+
+
+class TestCheck(AgentCheck):
+    def check(self, instance):
+        creds = get_connection_info()
+        if creds.get("url"):
+            self.warning("Found kubelet at " + creds.get("url"))
+        else:
+            self.warning("Kubelet not found")

--- a/pkg/util/kubernetes/auth.go
+++ b/pkg/util/kubernetes/auth.go
@@ -31,7 +31,7 @@ func GetBearerToken(authTokenPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not read token from %s: %s", authTokenPath, err)
 	}
-	return fmt.Sprintf("bearer %s", token), nil
+	return string(token), nil
 }
 
 // GetCertificates loads the certificate and the private key

--- a/pkg/util/kubernetes/kubelet/init.go
+++ b/pkg/util/kubernetes/kubelet/init.go
@@ -28,20 +28,19 @@ func isConfiguredTLSVerify() bool {
 	return config.Datadog.GetBool("kubelet_tls_verify")
 }
 
-func getTLSConfig() (*tls.Config, error) {
+func buildTLSConfig(verifyTLS bool, caPath string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{}
-	if isConfiguredTLSVerify() == false {
+	if verifyTLS == false {
 		tlsConfig.InsecureSkipVerify = true
 		return tlsConfig, nil
 	}
 
-	certPath := config.Datadog.GetString("kubelet_client_ca")
-	if certPath == "" {
+	if caPath == "" {
 		log.Debugf("kubelet_client_ca isn't configured: certificate authority must be trusted")
 		return nil, nil
 	}
 
-	caPool, err := kubernetes.GetCertificateAuthority(certPath)
+	caPool, err := kubernetes.GetCertificateAuthority(caPath)
 	if err != nil {
 		return tlsConfig, err
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -183,6 +183,11 @@ func (suite *KubeletTestSuite) TestLocateKubeletHTTP() {
 	case <-time.After(2 * time.Second):
 		require.FailNow(suite.T(), "Timeout on receive channel")
 	}
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url": fmt.Sprintf("http://127.0.0.1:%d", kubeletPort),
+		}, ku.GetRawConnectionInfo())
 }
 
 func (suite *KubeletTestSuite) TestGetLocalPodList() {
@@ -394,6 +399,13 @@ func (suite *KubeletTestSuite) TestKubeletInitTokenHttps() {
 	r := <-k.Requests
 	assert.Equal(suite.T(), "bearer fakeBearerToken", r.Header.Get(authorizationHeaderKey))
 	assert.Equal(suite.T(), 0, len(ku.kubeletApiClient.Transport.(*http.Transport).TLSClientConfig.Certificates))
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url":        fmt.Sprintf("https://127.0.0.1:%d", kubeletPort),
+			"verify_tls": "false",
+			"token":      "fakeBearerToken",
+		}, ku.GetRawConnectionInfo())
 }
 
 func (suite *KubeletTestSuite) TestKubeletInitHttpsCerts() {
@@ -431,6 +443,15 @@ func (suite *KubeletTestSuite) TestKubeletInitHttpsCerts() {
 	clientCerts := ku.kubeletApiClient.Transport.(*http.Transport).TLSClientConfig.Certificates
 	require.Equal(suite.T(), 1, len(clientCerts))
 	assert.Equal(suite.T(), clientCerts, s.TLS.Certificates)
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url":        fmt.Sprintf("https://127.0.0.1:%d", kubeletPort),
+			"verify_tls": "true",
+			"client_crt": k.testingCertificate,
+			"client_key": k.testingPrivateKey,
+			"ca_cert":    k.testingCertificate,
+		}, ku.GetRawConnectionInfo())
 }
 
 func (suite *KubeletTestSuite) TestKubeletInitTokenHttp() {
@@ -458,6 +479,12 @@ func (suite *KubeletTestSuite) TestKubeletInitTokenHttp() {
 	assert.Equal(suite.T(), "ok", string(b))
 	assert.Equal(suite.T(), 200, code)
 	assert.Equal(suite.T(), 0, len(ku.kubeletApiClient.Transport.(*http.Transport).TLSClientConfig.Certificates))
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url": fmt.Sprintf("http://127.0.0.1:%d", kubeletPort),
+			// token must be unset
+		}, ku.GetRawConnectionInfo())
 }
 
 func (suite *KubeletTestSuite) TestKubeletInitHttp() {
@@ -485,6 +512,11 @@ func (suite *KubeletTestSuite) TestKubeletInitHttp() {
 	assert.Equal(suite.T(), "ok", string(b))
 	assert.Equal(suite.T(), 200, code)
 	assert.Equal(suite.T(), 0, len(ku.kubeletApiClient.Transport.(*http.Transport).TLSClientConfig.Certificates))
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url": fmt.Sprintf("http://127.0.0.1:%d", kubeletPort),
+		}, ku.GetRawConnectionInfo())
 }
 
 func TestKubeletTestSuite(t *testing.T) {

--- a/releasenotes/notes/kubelet-pass-credentials-to-python-5933e794d29bbded.yaml
+++ b/releasenotes/notes/kubelet-pass-credentials-to-python-5933e794d29bbded.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support the new `kubelet` integration by providing the kubelet url and credentials to it

--- a/test/integration/util/kubelet/insecurekubelet_test.go
+++ b/test/integration/util/kubelet/insecurekubelet_test.go
@@ -48,12 +48,17 @@ func (suite *InsecureTestSuite) TestHTTP() {
 
 	b, code, err = ku.QueryKubelet("/pods")
 	assert.Equal(suite.T(), 200, code)
-	require.Nil(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), emptyPodList, string(b))
 
 	podList, err := ku.GetLocalPodList()
-	require.Nil(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 0, len(podList))
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url": "http://127.0.0.1:10255",
+		}, ku.GetRawConnectionInfo())
 }
 
 func (suite *InsecureTestSuite) TestInsecureHTTPS() {
@@ -64,21 +69,27 @@ func (suite *InsecureTestSuite) TestInsecureHTTPS() {
 	config.Datadog.Set("kubernetes_kubelet_host", "127.0.0.1")
 
 	ku, err := kubelet.GetKubeUtil()
-	require.Nil(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "https://127.0.0.1:10250", ku.GetKubeletApiEndpoint())
 	b, code, err := ku.QueryKubelet("/healthz")
 	assert.Equal(suite.T(), 200, code)
-	require.Nil(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "ok", string(b))
 
 	b, code, err = ku.QueryKubelet("/pods")
 	assert.Equal(suite.T(), 200, code)
-	require.Nil(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), emptyPodList, string(b))
 
 	podList, err := ku.GetLocalPodList()
-	require.Nil(suite.T(), err)
+	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 0, len(podList))
+
+	require.EqualValues(suite.T(),
+		map[string]string{
+			"url":        "https://127.0.0.1:10250",
+			"verify_tls": "false",
+		}, ku.GetRawConnectionInfo())
 }
 
 func TestInsecureKubeletSuite(t *testing.T) {

--- a/test/integration/util/kubelet/testdata/secure-kubelet-compose.yaml
+++ b/test/integration/util/kubelet/testdata/secure-kubelet-compose.yaml
@@ -10,11 +10,13 @@ services:
         --make-iptables-util-chains=false
         --hairpin-mode=none
         --read-only-port 0
-        --client-ca-file=/etc/secrets/cert.pem
+        --anonymous-auth=true
         --tls-cert-file=/etc/secrets/cert.pem
         --tls-private-key-file=/etc/secrets/key.pem
         --pod-manifest-path=/opt
         "
+        # Removed --client-ca-file=/etc/secrets/cert.pem as it
+        # depends on an apiserver running to verify the username
     network_mode: ${network_mode}
     healthcheck:
       test: ["CMD", "/bin/ls", "/var/lib/kubelet"]


### PR DESCRIPTION
### What does this PR do?

The new `kubelet` check for kubernetes metrics though the kubelet's prometheus endpoint will be a python check.
In order for it to work, it needs to pull the kubelet url and credentials from the Go kubeutil. This PR:

- adds a `rawConnectionInfo` map in the `KubeUtil`, that is populated during init and can be retrieved via the `GetRawConnectionInfo()` method. Only fields that are relevant are added to the map. It can contain only a `url` in case of insecure http traffic.
- add a `kubeutil` module injected in the python namespace, providing a `get_connection_info()` function to retrieve that map as a python dict. If the kubelet is not detected, the dict is empty
- updates all `kubelet` unit and integration tests to check the value of the rawConnectionInfo map is correct

In agent5, the `from kubeutil import get_connection_info` import will fail, we'll need to catch the exception and use agent5 code to get the credentials.

### Motivation

Make this new check behave in a consistent way with the rest of the agent.

### Additional Notes

I pushed the `datadog/agent-dev:xvello-kubelet-python-creds` image for this git branch.

Example custom python check to use the API:
```python
from checks import AgentCheck
from kubeutil import get_connection_info


class TestCheck(AgentCheck):
    def check(self, instance):
        creds = get_connection_info()
        if creds.get("url"):
            self.warning("Found kubelet, conf: " + str(creds))
        else:
            self.warning("Kubelet not found")
```

We get on my test kubelet:
```
    kubelettester
    -------------
      Total Runs: 1
      Metrics: 0, Total Metrics: 0
      Events: 0, Total Events: 0
      Service Checks: 0, Total Service Checks: 0
      Warning: Found kubelet, conf: {"url": "http://ci-xaviervello:10255"}
```