### PR TITLE
[Test Kitchen] Cleans up some lingering kitchen errors

### DIFF
--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -37,11 +37,11 @@ platforms:
 # for both drivers
 <% azure_test_platforms = [
       # working
-      ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
-      ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201711151'],
-      ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201610200'],
-      ['debian-8', 'credativ:Debian:8:8.0.201801170'],
-      ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
+      # ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
+      # ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201711151'],
+      # ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201610200'],
+      # ['debian-8', 'credativ:Debian:8:8.0.201801170'],
+      # ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
 
       ['win2012', 'MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20171115'],
       ['win2012r2', 'MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20171115'],
@@ -106,6 +106,8 @@ platforms:
     location: <%= location %>
     <% if windows %>
     vm_name: ddat<%= platform[0] %>
+    username: datadog
+    password: <%= ENV['SERVER_PASSWORD'] %>
     <% else %>
     vm_name: dd-agent-testing-<%= platform[0] %>-azure
     <% end %>

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -37,11 +37,11 @@ platforms:
 # for both drivers
 <% azure_test_platforms = [
       # working
-      # ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
-      # ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201711151'],
-      # ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201610200'],
-      # ['debian-8', 'credativ:Debian:8:8.0.201801170'],
-      # ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
+      ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
+      ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201711151'],
+      ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201610200'],
+      ['debian-8', 'credativ:Debian:8:8.0.201801170'],
+      ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
 
       ['win2012', 'MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20171115'],
       ['win2012r2', 'MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20171115'],

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
@@ -48,17 +48,9 @@ remote_file temp_file do
   notifies :remove, 'package[Datadog Agent removal]', :immediately
 end
 
-# Install the package
-windows_package 'Datadog Agent' do # ~FC009
-  source temp_file
-  installer_type installer_type
-  options install_options
-  action :install
-  if respond_to?(:returns)
-    returns [0, 3010]
-  else
-    success_codes [0, 3010]
-  end
+execute "install-agent" do
+  command "start /wait #{temp_file} #{install_options}"
+  action :run
 end
 
 agent_config_file = ::File.join(node['dd-agent-install']['config_dir'], 'datadog.conf')

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -105,17 +105,10 @@ if node['platform_family'] == 'windows'
     retry_delay package_retry_delay unless package_retry_delay.nil?
   end
 
-  # Install the package
-  windows_package 'Datadog Agent' do # ~FC009
-    source temp_file
-    installer_type installer_type
-    options install_options
-    action :install
-    if respond_to?(:returns)
-      returns [0, 3010]
-    else
-      success_codes [0, 3010]
-    end
+  execute "install-agent" do
+    command "start /wait #{temp_file} #{install_options}"
+    action :run
     notifies :restart, 'service[datadog-agent]'
   end
+
 end

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -82,6 +82,11 @@ if [ -z ${AGENT_VERSION+x} ]; then
   popd
 fi
 
+# Generate a password to use for the windows servers
+if [ -z ${SERVER_PASSWORD+x} ]; then
+  export SERVER_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+fi
+
 chef gem install net-ssh berkshelf rake psych:2.2.2 kitchen-azurerm:0.13.0 test-kitchen
 cp .kitchen-azure.yml .kitchen.yml
 chef exec kitchen diagnose --no-instances --loader

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -84,7 +84,7 @@ fi
 
 # Generate a password to use for the windows servers
 if [ -z ${SERVER_PASSWORD+x} ]; then
-  export SERVER_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  export SERVER_PASSWORD=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)
 fi
 
 chef gem install net-ssh berkshelf rake psych:2.2.2 kitchen-azurerm:0.13.0 test-kitchen

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -197,6 +197,8 @@ shared_examples_for "an installed Agent" do
 
   it 'is properly signed' do
     if os == :windows
+      # The user in the yaml file is "datadog", however the default test kitchen user is azure.
+      # This allows either to be used without changing the test. 
       msi_path_base = 'C:\\Users\\'
       msi_path_end = '\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'
       msi_path_azure = msi_path_base + 'azure' + msi_path_end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -197,7 +197,15 @@ shared_examples_for "an installed Agent" do
 
   it 'is properly signed' do
     if os == :windows
-      msi_path = 'C:\\Users\\azure\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'
+      msi_path_base = 'C:\\Users\\'
+      msi_path_end = '\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'
+      msi_path_azure = msi_path_base + 'azure' + msi_path_end
+      msi_path_datadog = msi_path_base + 'datadog' + msi_path_end
+      if File.exist?(msi_path_azure)
+        msi_path = msi_path_azure
+      else
+        msi_path = msi_path_datadog
+      end
       output = `powershell -command "get-authenticodesignature #{msi_path}"`
       signature_hash = "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C"
       expect(output).to include(signature_hash)


### PR DESCRIPTION
### What does this PR do?

There were two small issues to fix in the test kitchen:

First, there was a race condition that this should help solve for in installing the agent. Since the chef install does not wait on the agent install being finished, it can lead to a race condition with the tests.

Second, it creates a random password, making it more secure than using the default one. (And it fixes an issue that cropped up with using the default username.)

### Motivation

I wanted the test kitchen to work!

### Additional Notes

I really hope there is no more work with the test kitchen.
