### PR TITLE
External Host Tags metadata provider

### DIFF
--- a/pkg/metadata/externalhost/doc.go
+++ b/pkg/metadata/externalhost/doc.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+/*
+Package externalhost implements the External Host Tags metadata provider.
+
+In older versions of the Agent, it was the general metadata collector to invoke
+a special method on the check instance to collect a list of tags attached to a
+specific hostname, add this tuple to the metadata payload and send upstream. At
+this moment the approach has changed from the Agent "pulling" from the check, to
+the check "pushing" to the Agent. See the RFC at docs/proposal/metadata/external-host-tags.md
+for more details.
+
+The collector keeps a cache of hostnames mapped to a list of tags called `externalHostCache`
+and exports the function `AddExternalTags` so that entries can be added from
+other packages. This metadata provider is different from the others because it
+doesn't actually collect any info, it only sends whatever it finds stored in the
+cache. The cache is cleared at every collection.
+*/
+package externalhost

--- a/pkg/metadata/externalhost/externalhost.go
+++ b/pkg/metadata/externalhost/externalhost.go
@@ -6,22 +6,22 @@
 package externalhost
 
 // externalHostCache maps hostname -> externalTags
-var externalHostCache = make(map[string]externalTags)
+var externalHostCache = make(map[string]ExternalTags)
 
 // AddExternalTags adds external tags for a specific host to the cache
-func AddExternalTags(hostname string, tags externalTags) {
+func AddExternalTags(hostname string, tags ExternalTags) {
 	externalHostCache[hostname] = tags
 }
 
 // GetPayload fills and return the external host tags metadata payload
 func GetPayload() *Payload {
-	payload := make(Payload, 0)
+	payload := Payload{}
 	for hostname, tags := range externalHostCache {
 		ht := hostTags{hostname, tags}
 		payload = append(payload, ht)
 	}
 
 	// clear the cache
-	externalHostCache = make(map[string]externalTags)
+	externalHostCache = make(map[string]ExternalTags)
 	return &payload
 }

--- a/pkg/metadata/externalhost/externalhost.go
+++ b/pkg/metadata/externalhost/externalhost.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package externalhost
+
+// externalHostCache maps hostname -> externalTags
+var externalHostCache = make(map[string]externalTags)
+
+// AddExternalTags adds external tags for a specific host to the cache
+func AddExternalTags(hostname string, tags externalTags) {
+	externalHostCache[hostname] = tags
+}
+
+// GetPayload fills and return the external host tags metadata payload
+func GetPayload() *Payload {
+	payload := make(Payload, 0)
+	for hostname, tags := range externalHostCache {
+		ht := hostTags{hostname, tags}
+		payload = append(payload, ht)
+	}
+
+	// clear the cache
+	externalHostCache = make(map[string]externalTags)
+	return &payload
+}

--- a/pkg/metadata/externalhost/externalhost_test.go
+++ b/pkg/metadata/externalhost/externalhost_test.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package externalhost
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPayload(t *testing.T) {
+	// empty cache, empty payload
+	p := *GetPayload()
+	assert.Len(t, p, 0)
+
+	host := "localhost"
+	eTags := ExternalTags{"vsphere": []string{"foo", "bar"}}
+
+	// add one tag to the cache
+	AddExternalTags(host, eTags)
+	p = *GetPayload()
+	assert.Len(t, p, 1)
+	hTags := p[0]
+	assert.Contains(t, hTags, host)
+	assert.Contains(t, hTags, eTags)
+
+	// GetPayload is supposed to empty the cache
+	assert.Len(t, externalHostCache, 0)
+}

--- a/pkg/metadata/externalhost/payload.go
+++ b/pkg/metadata/externalhost/payload.go
@@ -14,8 +14,8 @@ external_host_metadata = [
 ]
 */
 
-// SOURCE_TYPE -> list of tags
-type externalTags map[string][]string
+// ExternalTags maps SOURCE_TYPE -> list of tags
+type ExternalTags map[string][]string
 
 // hostname -> list of externalTags
 type hostTags []interface{}

--- a/pkg/metadata/externalhost/payload.go
+++ b/pkg/metadata/externalhost/payload.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package externalhost
+
+/*
+The payload looks like this when SOURCE_TYPE is `vsphere`:
+
+external_host_metadata = [
+	["hostname1", {"vsphere": ["foo:val1", "bar:val1"]}],
+	["hostname2", {"vsphere": ["foo:val2", "bar:val2"]}]
+]
+*/
+
+// SOURCE_TYPE -> list of tags
+type externalTags map[string][]string
+
+// hostname -> list of externalTags
+type hostTags []interface{}
+
+// Payload handles the JSON unmarshalling of the external host tags payload
+type Payload []hostTags

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -30,8 +30,8 @@ type ResourcesPayload struct {
 	resources.Payload `json:"resources"`
 }
 
-// ExternalHostTags wraps Payload from the `externalhost` package
-type ExternalHostTags struct {
+// ExternalHostPayload wraps Payload from the `externalhost` package
+type ExternalHostPayload struct {
 	externalhost.Payload `json:"external_host_tags"`
 }
 

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -10,23 +10,29 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
 
-// CommonPayload wraps Payload from the common package
+// CommonPayload wraps Payload from the `common` package
 type CommonPayload struct {
 	common.Payload
 }
 
-// HostPayload wraps Payload from the host package
+// HostPayload wraps Payload from the `host` package
 type HostPayload struct {
 	host.Payload
 }
 
-// ResourcesPayload wraps Payload from the resources package
+// ResourcesPayload wraps Payload from the `resources` package
 type ResourcesPayload struct {
 	resources.Payload `json:"resources"`
+}
+
+// ExternalHostTags wraps Payload from the `externalhost` package
+type ExternalHostTags struct {
+	externalhost.Payload `json:"external_host_tags"`
 }
 
 // MarshalJSON serialization a Payload to JSON

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -62,7 +62,7 @@ type Payload struct {
 	HostPayload
 	ResourcesPayload
 	// TODO: host-tags
-	// TODO: external_host_tags
+	ExternalHostTags
 	GohaiPayload
 }
 

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -62,7 +62,7 @@ type Payload struct {
 	HostPayload
 	ResourcesPayload
 	// TODO: host-tags
-	ExternalHostTags
+	ExternalHostPayload
 	GohaiPayload
 }
 

--- a/pkg/metadata/v5/payload_other.go
+++ b/pkg/metadata/v5/payload_other.go
@@ -13,6 +13,6 @@ type Payload struct {
 	HostPayload
 	ResourcesPayload
 	// TODO: host-tags
-	ExternalHostTags
+	ExternalHostPayload
 	// TODO: gohai alternative (or fix gohai)
 }

--- a/pkg/metadata/v5/payload_other.go
+++ b/pkg/metadata/v5/payload_other.go
@@ -13,6 +13,6 @@ type Payload struct {
 	HostPayload
 	ResourcesPayload
 	// TODO: host-tags
-	// TODO: external_host_tags
+	ExternalHostTags
 	// TODO: gohai alternative (or fix gohai)
 }

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -10,6 +10,7 @@ package v5
 import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
@@ -20,11 +21,13 @@ func GetPayload(hostname string) *Payload {
 	cp := common.GetPayload(hostname)
 	hp := host.GetPayload(hostname)
 	rp := resources.GetPayload(hostname)
+	ehp := externalhost.GetPayload()
 
 	p := &Payload{
 		CommonPayload:    CommonPayload{*cp},
 		HostPayload:      HostPayload{*hp},
 		ResourcesPayload: ResourcesPayload{*rp},
+		ExternalHostTags: ExternalHostTags{*ehp},
 	}
 
 	if config.Datadog.GetBool("enable_gohai") {

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -24,10 +24,10 @@ func GetPayload(hostname string) *Payload {
 	ehp := externalhost.GetPayload()
 
 	p := &Payload{
-		CommonPayload:    CommonPayload{*cp},
-		HostPayload:      HostPayload{*hp},
-		ResourcesPayload: ResourcesPayload{*rp},
-		ExternalHostTags: ExternalHostTags{*ehp},
+		CommonPayload:       CommonPayload{*cp},
+		HostPayload:         HostPayload{*hp},
+		ResourcesPayload:    ResourcesPayload{*rp},
+		ExternalHostPayload: ExternalHostPayload{*ehp},
 	}
 
 	if config.Datadog.GetBool("enable_gohai") {

--- a/pkg/metadata/v5/v5_other.go
+++ b/pkg/metadata/v5/v5_other.go
@@ -9,6 +9,7 @@ package v5
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
@@ -18,9 +19,12 @@ func GetPayload(hostname string) *Payload {
 	cp := common.GetPayload(hostname)
 	hp := host.GetPayload(hostname)
 	rp := resources.GetPayload(hostname)
+	ehp := externalhost.GetPayload()
+
 	return &Payload{
 		CommonPayload:    CommonPayload{*cp},
 		HostPayload:      HostPayload{*hp},
 		ResourcesPayload: ResourcesPayload{*rp},
+		ExternalHostTags: ExternalHostTags{*ehp},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds a metadata provider to collect external host tags collected by special checks (namely VSphere and Openstack). There isn't any reason at this moment to use this provider as standalone and all the info collected are added to the `v5` payload in a backward compatible manner.

The provider doesn't collect any info on its own, it only keeps a cache that will be eventually filled by the checks and sends upstream whatever it's in the cache.

### Motivation

Add support for VSphere and Openstack checks.

### Additional Notes

This is the first step towards adding back the aforementioned checks, next steps will be addressed in separate PRs.
