### PR TITLE
Removed logset from integrations

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -64,7 +64,6 @@ type LogsConfig struct {
 	Label string // Docker
 
 	Service        string
-	Logset         string
 	Source         string
 	SourceCategory string
 	Tags           string

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -36,13 +36,11 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	assert.Equal(t, "nginx", sources[0].Config.Service)
 	assert.Equal(t, "nginx", sources[0].Config.Source)
 	assert.Equal(t, "http_access", sources[0].Config.SourceCategory)
-	assert.Equal(t, "", sources[0].Config.Logset)
 	assert.Equal(t, "env:prod", sources[0].Config.Tags)
 	assert.Equal(t, "[dd ddsource=\"nginx\"][dd ddsourcecategory=\"http_access\"][dd ddtags=\"env:prod\"]", string(sources[0].Config.TagsPayload))
 
 	assert.Equal(t, "tcp", sources[1].Config.Type)
 	assert.Equal(t, 10514, sources[1].Config.Port)
-	assert.Equal(t, "devteam", sources[1].Config.Logset)
 	assert.Equal(t, "", sources[1].Config.Service)
 	assert.Equal(t, "", sources[1].Config.Source)
 	assert.Equal(t, 0, len(sources[1].Config.Tags))

--- a/pkg/logs/config/tests/complete/conf.d/integration2.yml
+++ b/pkg/logs/config/tests/complete/conf.d/integration2.yml
@@ -5,8 +5,7 @@ instances:
   
 logs:
   - type: tcp
-    port: 10514
-    logset: devteam
+    port: 10514    
     log_processing_rules:
       - type: mask_sequences
         name: mocked_mask_rule

--- a/pkg/logs/config/tests/complete/conf.d/misconfigured_integration.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/misconfigured_integration.yaml
@@ -5,4 +5,3 @@ instances:
 
 logs:
   - type: udp
-    logset: devteam

--- a/pkg/logs/config/tests/misconfigured_4/conf.d/integration.yaml
+++ b/pkg/logs/config/tests/misconfigured_4/conf.d/integration.yaml
@@ -1,3 +1,2 @@
 logs:
-  - type: tcp
-    logset: hasnoport
+  - type: tcp    

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func NewTestProcessor() Processor {
-	return Processor{nil, nil, "", "", nil}
+	return Processor{nil, nil, []byte("")}
 }
 
 func buildTestConfigLogSource(ruleType, replacePlaceholder, pattern string) config.LogSource {
@@ -44,9 +44,9 @@ func newNetworkMessage(content []byte, source *config.LogSource) message.Message
 func TestProcessor(t *testing.T) {
 	var p *Processor
 	p = New(nil, nil, "hello", "world")
-	assert.Equal(t, "hello/world", string(p.apikeyString))
+	assert.Equal(t, []byte("hello/world"), p.apiKey)
 	p = New(nil, nil, "helloworld", "")
-	assert.Equal(t, "helloworld", string(p.apikeyString))
+	assert.Equal(t, []byte("helloworld"), p.apiKey)
 }
 
 func TestExclusion(t *testing.T) {
@@ -198,16 +198,4 @@ func TestComputeExtraContent(t *testing.T) {
 	assert.Equal(t, "sev0", extraContentParts[0])
 	assert.Equal(t, "ts", extraContentParts[1])
 	assert.Equal(t, "tags", extraContentParts[6])
-}
-
-func TestComputeApiKeyString(t *testing.T) {
-	p := New(nil, nil, "hello", "world")
-
-	source := config.NewLogSource("", &config.LogsConfig{})
-	extraContent := p.computeAPIKeyString(newNetworkMessage(nil, source))
-	assert.Equal(t, "hello/world", string(extraContent))
-
-	source = config.NewLogSource("", &config.LogsConfig{Logset: "hi"})
-	extraContent = p.computeAPIKeyString(newNetworkMessage(nil, source))
-	assert.Equal(t, "hello/hi", string(extraContent))
 }


### PR DESCRIPTION
### What does this PR do?

Removed logset from integration sources

### Motivation

Do not enable users to override the logset value from integration files
