### PR TITLE
[Logs]: Changed the file provider to always return a file even when not found

### DIFF
--- a/pkg/logs/input/tailer/file_provider.go
+++ b/pkg/logs/input/tailer/file_provider.go
@@ -7,7 +7,9 @@ package tailer
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	log "github.com/cihub/seelog"
 
@@ -46,12 +48,18 @@ func NewFileProvider(sources []*config.LogSource, filesLimit int) *FileProvider 
 // it cannot return more than filesLimit Files.
 // For now, there is no way to prioritize specific Files over others,
 // they are just returned in alphabetical order
-func (r *FileProvider) FilesToTail() []*File {
+func (p *FileProvider) FilesToTail() []*File {
 	filesToTail := []*File{}
-	for i := 0; i < len(r.sources) && len(filesToTail) < r.filesLimit; i++ {
-		source := r.sources[i]
+	for i := 0; i < len(p.sources) && len(filesToTail) < p.filesLimit; i++ {
+		source := p.sources[i]
+		sourcePath := source.Config.Path
+		if p.exists(sourcePath) {
+			// no need to traverse the file system here as we found a file
+			filesToTail = append(filesToTail, NewFile(sourcePath, source))
+			continue
+		}
 		// search all files matching pattern and append them all until filesLimit is reached
-		pattern := source.Config.Path
+		pattern := sourcePath
 		paths, err := filepath.Glob(pattern)
 		if err != nil {
 			err := fmt.Errorf("Malformed pattern, could not find any file: %s", pattern)
@@ -60,18 +68,36 @@ func (r *FileProvider) FilesToTail() []*File {
 			continue
 		}
 		if len(paths) == 0 {
-			// no file was found, appends a File with the path specified in source
-			filesToTail = append(filesToTail, NewFile(source.Config.Path, source))
+			// no file was found, its parent directories might have wrong permissions or it just does not exist
+			if p.containsWildcard(pattern) {
+				log.Warnf("Could not find any file matching pattern %s, check that all its subdirectories are exectutable", pattern)
+			} else {
+				log.Warn("File %s does not exist", sourcePath)
+			}
+			continue
 		}
-		for j := 0; j < len(paths) && len(filesToTail) < r.filesLimit; j++ {
+		for j := 0; j < len(paths) && len(filesToTail) < p.filesLimit; j++ {
 			path := paths[j]
 			filesToTail = append(filesToTail, NewFile(path, source))
 		}
 	}
-	if len(filesToTail) == r.filesLimit {
-		log.Warn("Reached the limit on the maximum number of files in use: ", r.filesLimit)
+	if len(filesToTail) == p.filesLimit {
+		log.Warn("Reached the limit on the maximum number of files in use: ", p.filesLimit)
 		return filesToTail
 	}
 
 	return filesToTail
+}
+
+// exists returns true if the file at path filePath exists
+func (p *FileProvider) exists(filePath string) bool {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// containsWildcard returns true if the path contains any wildcard character
+func (p *FileProvider) containsWildcard(path string) bool {
+	return strings.ContainsAny(path, "*?[")
 }

--- a/pkg/logs/input/tailer/file_provider_test.go
+++ b/pkg/logs/input/tailer/file_provider_test.go
@@ -51,6 +51,10 @@ func (suite *FileProviderTestSuite) SetupTest() {
 	_, err = os.Create(path)
 	suite.Nil(err)
 
+	path = fmt.Sprintf("%s/1/?.log", suite.testDir)
+	_, err = os.Create(path)
+	suite.Nil(err)
+
 	path = fmt.Sprintf("%s/2", suite.testDir)
 	err = os.Mkdir(path, os.ModePerm)
 	suite.Nil(err)
@@ -77,33 +81,34 @@ func (suite *FileProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
 }
 
-func (suite *FileProviderTestSuite) TestFilesToTailReturnsAllFilesInDirectory() {
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
+	fileProvider := suite.newFileProvider(path)
+	files := fileProvider.FilesToTail()
+
+	suite.Equal(3, len(files))
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[1].Path)
+	suite.Equal(fmt.Sprintf("%s/1/?.log", suite.testDir), files[2].Path)
+}
+
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWithRightPermissions() {
+	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
 	fileProvider := suite.newFileProvider(path)
 	files := fileProvider.FilesToTail()
 
 	suite.Equal(2, len(files))
 	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
-	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[1].Path)
-}
-
-func (suite *FileProviderTestSuite) TestFilesToTailReturnsAllFilesInAnyDirectory() {
-	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
-	fileProvider := suite.newFileProvider(path)
-	files := fileProvider.FilesToTail()
-
-	suite.Equal(len(files), 2)
-	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
 	suite.Equal(fmt.Sprintf("%s/2/1.log", suite.testDir), files[1].Path)
 }
 
-func (suite *FileProviderTestSuite) TestFilesToTailReturnsAlwaysFileEvenWhenNotFound() {
-	path := fmt.Sprintf("%s/n/1.log", suite.testDir)
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard() {
+	path := fmt.Sprintf("%s/1/?.log", suite.testDir)
 	fileProvider := suite.newFileProvider(path)
 	files := fileProvider.FilesToTail()
 
-	suite.Equal(len(files), 1)
-	suite.Equal(fmt.Sprintf("%s/n/1.log", suite.testDir), files[0].Path)
+	suite.Equal(1, len(files))
+	suite.Equal(fmt.Sprintf("%s/1/?.log", suite.testDir), files[0].Path)
 }
 
 func (suite *FileProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {

--- a/pkg/logs/input/tailer/file_provider_test.go
+++ b/pkg/logs/input/tailer/file_provider_test.go
@@ -68,33 +68,42 @@ func (suite *FileProviderTestSuite) TearDownTest() {
 	os.Remove(suite.testDir)
 }
 
-func (suite *FileProviderTestSuite) TestFilesToTailReturnSpecificFile() {
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsSpecificFile() {
 	path := fmt.Sprintf("%s/1/1.log", suite.testDir)
 	fileProvider := suite.newFileProvider(path)
 	files := fileProvider.FilesToTail()
 
-	suite.Equal(len(files), 1)
-	suite.Equal(files[0].Path, fmt.Sprintf("%s/1/1.log", suite.testDir))
+	suite.Equal(1, len(files))
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
 }
 
-func (suite *FileProviderTestSuite) TestFilesToTailReturnAllFilesInDirectory() {
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsAllFilesInDirectory() {
 	path := fmt.Sprintf("%s/1/*.log", suite.testDir)
 	fileProvider := suite.newFileProvider(path)
 	files := fileProvider.FilesToTail()
 
-	suite.Equal(len(files), 2)
-	suite.Equal(files[0].Path, fmt.Sprintf("%s/1/1.log", suite.testDir))
-	suite.Equal(files[1].Path, fmt.Sprintf("%s/1/2.log", suite.testDir))
+	suite.Equal(2, len(files))
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[1].Path)
 }
 
-func (suite *FileProviderTestSuite) TestFilesToTailReturnAllFilesInAnyDirectory() {
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsAllFilesInAnyDirectory() {
 	path := fmt.Sprintf("%s/*/*1.log", suite.testDir)
 	fileProvider := suite.newFileProvider(path)
 	files := fileProvider.FilesToTail()
 
 	suite.Equal(len(files), 2)
-	suite.Equal(files[0].Path, fmt.Sprintf("%s/1/1.log", suite.testDir))
-	suite.Equal(files[1].Path, fmt.Sprintf("%s/2/1.log", suite.testDir))
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/2/1.log", suite.testDir), files[1].Path)
+}
+
+func (suite *FileProviderTestSuite) TestFilesToTailReturnsAlwaysFileEvenWhenNotFound() {
+	path := fmt.Sprintf("%s/n/1.log", suite.testDir)
+	fileProvider := suite.newFileProvider(path)
+	files := fileProvider.FilesToTail()
+
+	suite.Equal(len(files), 1)
+	suite.Equal(fmt.Sprintf("%s/n/1.log", suite.testDir), files[0].Path)
 }
 
 func (suite *FileProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {
@@ -102,7 +111,7 @@ func (suite *FileProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() 
 	fileProvider := suite.newFileProvider(path)
 	files := fileProvider.FilesToTail()
 
-	suite.Equal(len(files), suite.filesLimit)
+	suite.Equal(suite.filesLimit, len(files))
 }
 
 func TestFileProviderTestSuite(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Changed the file provider to always return a file even when not found to provide better details to users.

### Motivation

Raise an error when the permissions are wrong and a file can not be tailed.
