### PR TITLE
Make sure we the collector won't block if the user set only 1 runner

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -97,7 +97,15 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 
 	// Track the total number of checks running in order to have an appropriate number of workers
 	c.checkInstances++
-	c.runner.UpdateNumWorkers(c.checkInstances)
+	if ch.Interval() == 0 {
+		// Adding a temporary runner for long running check in case the
+		// number of runners is lower than the number of long running
+		// checks.
+		log.Infof("Adding an extra runner for the '%s' long running check", ch)
+		c.runner.AddWorker()
+	} else {
+		c.runner.UpdateNumWorkers(c.checkInstances)
+	}
 
 	c.checks[ch.ID()] = ch
 	return ch.ID(), nil

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -86,13 +86,18 @@ func NewRunner() *Runner {
 
 	// start the workers
 	for i := 0; i < numWorkers; i++ {
-		TestWg.Add(1)
-		go r.work()
+		r.AddWorker()
 	}
 
 	log.Infof("Runner started with %d workers.", numWorkers)
-	runnerStats.Add("Workers", int64(numWorkers))
 	return r
+}
+
+// AddWorker adds a new worker to the worker pull
+func (r *Runner) AddWorker() {
+	runnerStats.Add("Workers", 1)
+	TestWg.Add(1)
+	go r.work()
 }
 
 // UpdateNumWorkers checks if the current number of workers is reasonable, and adds more if needed
@@ -124,9 +129,7 @@ func (r *Runner) UpdateNumWorkers(numChecks int64) {
 		if numWorkers >= desiredNumWorkers {
 			break
 		}
-		runnerStats.Add("Workers", 1)
-		TestWg.Add(1)
-		go r.work()
+		r.AddWorker()
 		numWorkers++
 		added++
 	}
@@ -222,6 +225,7 @@ func (r *Runner) StopCheck(id check.ID) error {
 func (r *Runner) work() {
 	log.Debug("Ready to process checks...")
 	defer TestWg.Done()
+	defer runnerStats.Add("Workers", -1)
 
 	for check := range r.pending {
 		// see if the check is already running
@@ -298,6 +302,11 @@ func (r *Runner) work() {
 			log.Infof(l, check)
 		} else {
 			log.Debugf(l, check)
+		}
+
+		if check.Interval() == 0 {
+			log.Infof("Check %v one-time's execution has finished", check)
+			return
 		}
 	}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -87,8 +87,11 @@ api_key:
 # Default is '5002' on Windows and macOS ; turned off on Linux
 # GUI_port: -1
 
-# How many workers will be used to run the check (if not specified, is automatically
-# determined based on number of checks running)
+
+# The Agent runs workers in parallel to execute checks. By default the number
+# of workers is automatically determined based on the number of checks running.
+# This optimizes checks collection time but might produce CPU spikes. You can
+# enforce a fix number of workers so less CPU is used.
 # check_runners: 4
 
 # Metadata collection should always be enabled, except if you are running several

--- a/releasenotes/notes/low-runner-with-long-running-check-359849baabe58011.yaml
+++ b/releasenotes/notes/low-runner-with-long-running-check-359849baabe58011.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The collector will no longer block when the number of runners is lower than
+    the number of long running check. We now start a new runner for those
+    checks.


### PR DESCRIPTION
### What does this PR do?

In case the number of runners is lower than the long running check the
collector will block (no worker will be available). We now start a new
worker for each long running check. This allows the agent to run with
only one worker for recurrent checks.

### Motivation

ref: #919

### Additional Notes

Do we want to force/default to only 1 runner or let users activate the option if they want to ? I think updating the comment is enough.

In any case we now can do it in another PR if we want to.
