### PR TITLE
integration-tests: add retries

### DIFF
--- a/test/integration/utils/compose.go
+++ b/test/integration/utils/compose.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"strings"
 
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -42,21 +44,38 @@ func (c *ComposeConf) Start() ([]byte, error) {
 	}
 
 	c.Variables["network_mode"] = c.NetworkMode
-	args := []string{
-		"--project-name", c.ProjectName,
-		"--file", c.FilePath,
-		"up",
-		"-d",
-	}
-	if c.RemoveRebuildImages {
-		args = append(args, "--build")
-	}
-	runCmd := exec.Command("docker-compose", args...)
 
 	customEnv := os.Environ()
 	for k, v := range c.Variables {
 		customEnv = append(customEnv, fmt.Sprintf("%s=%s", k, v))
 	}
+
+	args := []string{
+		"--project-name", c.ProjectName,
+		"--file", c.FilePath,
+	}
+	pullCmd := exec.Command("docker-compose", append(args, "pull", "--parallel")...)
+	pullCmd.Env = customEnv
+	output, err := pullCmd.CombinedOutput()
+	if err != nil {
+		log.Errorf("fail to pull: %s %s", err, string(output))
+		/*
+			We retry once if we cannot pull the images, example:
+			Pulling etcd (quay.io/coreos/etcd:latest)...
+			ERROR: Get https://quay.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+		*/
+		log.Infof("retrying pull...")
+		output, err = pullCmd.CombinedOutput()
+		if err != nil {
+			return output, err
+		}
+	}
+	args = append(args, "up", "-d")
+
+	if c.RemoveRebuildImages {
+		args = append(args, "--build")
+	}
+	runCmd := exec.Command("docker-compose", args...)
 	runCmd.Env = customEnv
 
 	return runCmd.CombinedOutput()


### PR DESCRIPTION
### What does this PR do?

This PR adds some retries in the integration tests.

#### Docker compose pull is flaky:
```text
$ docker-compose --file test/integration/util/kube_apiserver/testdata/apiserver-compose.yaml  pull
Pulling etcd (quay.io/coreos/etcd:latest)...
ERROR: Get https://quay.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)

$ docker-compose --file test/integration/util/kube_apiserver/testdata/apiserver-compose.yaml  pull 
Pulling etcd (quay.io/coreos/etcd:latest)...
latest: Pulling from coreos/etcd
ff3a5c916c92: Already exists
36d7e719964b: Already exists
14d54f56e38e: Already exists
75f84a6f1153: Already exists
033c14de6517: Already exists
d2b183c6d03a: Already exists
Digest: sha256:34681c0e21d0e251d1e7d7fa4c6feb16a4304893e7db600782da6992317563f0
Status: Image is up to date for quay.io/coreos/etcd:latest
Pulling apiserver (gcr.io/google_containers/hyperkube:v1.8.3)...
v1.8.3: Pulling from google_containers/hyperkube
Digest: sha256:2fbd3d9ace56ac3ec2775f64f5ec5e6551ab30c5e25cc0c2633f33b15b8ca542
Status: Image is up to date for gcr.io/google_containers/hyperkube:v1.8.3
Pulling pause (gcr.io/google_containers/pause:latest)...
latest: Pulling from google_containers/pause
Digest: sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f
Status: Image is up to date for gcr.io/google_containers/pause:latest
```
I added a single retry to pull the docker images, this is supposed to reduce the associated failures.
Also added the flag `--parallel` to the pull command.

#### kube-apiserver:
I added a TestSetup to wait for the apiserver readiness.
