### PR TITLE
Forward dogstatsd packets to another UDP server

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,7 +138,7 @@ func init() {
 	Datadog.SetDefault("dogstatsd_expiry_seconds", 300)
 	Datadog.SetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	Datadog.SetDefault("statsd_forward_host", "")
-	Datadog.SetDefault("statsd_forward_port", "")
+	Datadog.SetDefault("statsd_forward_port", 0)
 	// Autoconfig
 	Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
 	Datadog.SetDefault("exclude_pause_container", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,6 @@ func init() {
 	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
 	Datadog.SetDefault("dogstatsd_expiry_seconds", 300)
 	Datadog.SetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
-	Datadog.SetDefault("dogstatsd_origin_detection", false)
 	Datadog.SetDefault("statsd_forward_host", "")
 	Datadog.SetDefault("statsd_forward_port", "")
 	// Autoconfig

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,6 +137,9 @@ func init() {
 	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
 	Datadog.SetDefault("dogstatsd_expiry_seconds", 300)
 	Datadog.SetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
+	Datadog.SetDefault("dogstatsd_origin_detection", false)
+	Datadog.SetDefault("statsd_forward_host", "")
+	Datadog.SetDefault("statsd_forward_port", "")
 	// Autoconfig
 	Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
 	Datadog.SetDefault("exclude_pause_container", true)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -83,19 +83,18 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
-	forwardPort := config.Datadog.GetString("statsd_forward_port")
+	forwardPort := config.Datadog.GetInt("statsd_forward_port")
 
-	if forwardHost != "" && forwardPort != "" {
+	if forwardHost != "" && forwardPort != 0 {
 
-		forwardAddress := fmt.Sprintf("%s:%s", forwardHost, forwardPort)
+		forwardAddress := fmt.Sprintf("%s:%d", forwardHost, forwardPort)
 
 		con, err := net.Dial("udp", forwardAddress)
 
 		if err != nil {
 			log.Warnf("could not connect to statsd forward host : %s", err)
 		} else {
-			forwardedPacketChanel := make(chan *listeners.Packet, 100)
-			s.packetIn = forwardedPacketChanel
+			s.packetIn = make(chan *listeners.Packet, 100)
 			go s.forwarder(con, packetChannel)
 		}
 	}

--- a/releasenotes/notes/forward-dogstatsd-packets-691c8e4d6062416e.yaml
+++ b/releasenotes/notes/forward-dogstatsd-packets-691c8e4d6062416e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add optional forwarding of dogstatsd packets to another UDP server.


### PR DESCRIPTION
### What does this PR do?

Adds optional forwarding of dogstatsd packets to another UDP server

### Motivation

Agent5 functionality used by some customers.
