### PR TITLE
[Logs] Increased the number of versions we support for Docker API

### DIFF
--- a/pkg/logs/input/container/scanner_test.go
+++ b/pkg/logs/input/container/scanner_test.go
@@ -70,6 +70,25 @@ func (suite *ContainerScannerTestSuite) TestContainerLabelFilter() {
 
 }
 
+func (suite *ContainerScannerTestSuite) TestComputeClientAPIVersion() {
+	var version string
+	var err error
+
+	// should raise an error
+	_, err = suite.c.computeClientAPIVersion("1.12")
+	suite.NotNil(err)
+
+	// should return a version lower than the max
+	version, err = suite.c.computeClientAPIVersion("1.24")
+	suite.Nil(err)
+	suite.Equal("1.24", version)
+
+	// should return the max version
+	version, err = suite.c.computeClientAPIVersion("1.35")
+	suite.Nil(err)
+	suite.Equal(maxVersion, version)
+}
+
 func (suite *ContainerScannerTestSuite) shouldMonitor(configLabel string, containerLabels map[string]string) bool {
 	cfg := config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Label: configLabel})
 	container := types.Container{Labels: containerLabels}

--- a/releasenotes/notes/logs-increased-docker-versions-supported-f394ba9755ce355b.yaml
+++ b/releasenotes/notes/logs-increased-docker-versions-supported-f394ba9755ce355b.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Increased the number of versions of Docker API that logs-agent support from 1.25 to 1.18


### PR DESCRIPTION
### What does this PR do?

Added a rule to support all the version of Docker API greater than `1.18` and limit the version number when it's higher to `1.25`.
