### PR TITLE
taglist: support multiple tags with the same name

### DIFF
--- a/pkg/tagger/utils/taglist.go
+++ b/pkg/tagger/utils/taglist.go
@@ -13,31 +13,31 @@ import (
 // TagList allows collector to incremental build a tag list
 // then export it easily to []string format
 type TagList struct {
-	lowCardTags  map[string]string
-	highCardTags map[string]string
+	lowCardTags  map[string]bool
+	highCardTags map[string]bool
 }
 
 // NewTagList creates a new object ready to use
 func NewTagList() *TagList {
 	return &TagList{
-		lowCardTags:  make(map[string]string),
-		highCardTags: make(map[string]string),
+		lowCardTags:  make(map[string]bool),
+		highCardTags: make(map[string]bool),
 	}
 }
 
-// AddHigh adds a new high cardinality tag to the list, or replace if name already exists.
+// AddHigh adds a new high cardinality tag to the map, or replace if already exists.
 // It will skip empty values/names, so it's safe to use without verifying the value is not empty.
 func (l *TagList) AddHigh(name string, value string) {
-	if len(name) > 0 && len(value) > 0 {
-		l.highCardTags[name] = value
+	if name != "" && value != "" {
+		l.highCardTags[fmt.Sprintf("%s:%s", name, value)] = true
 	}
 }
 
-// AddLow adds a new low cardinality tag to the list, or replace if name already exists.
+// AddLow adds a new low cardinality tag to the list, or replace if already exists.
 // It will skip empty values/names, so it's safe to use without verifying the value is not empty.
 func (l *TagList) AddLow(name string, value string) {
-	if len(name) > 0 && len(value) > 0 {
-		l.lowCardTags[name] = value
+	if name != "" && value != "" {
+		l.lowCardTags[fmt.Sprintf("%s:%s", name, value)] = true
 	}
 }
 
@@ -58,13 +58,13 @@ func (l *TagList) Compute() ([]string, []string) {
 	high := make([]string, len(l.highCardTags))
 
 	index := 0
-	for k, v := range l.lowCardTags {
-		low[index] = fmt.Sprintf("%s:%s", k, v)
+	for tag := range l.lowCardTags {
+		low[index] = tag
 		index++
 	}
 	index = 0
-	for k, v := range l.highCardTags {
-		high[index] = fmt.Sprintf("%s:%s", k, v)
+	for tag := range l.highCardTags {
+		high[index] = tag
 		index++
 	}
 	return low, high

--- a/pkg/tagger/utils/taglist_test.go
+++ b/pkg/tagger/utils/taglist_test.go
@@ -27,30 +27,43 @@ func TestAddLow(t *testing.T) {
 	list := NewTagList()
 	list.AddLow("foo", "bar")
 	list.AddLow("faa", "baz")
+	list.AddLow("empty", "")
 	require.Empty(t, list.highCardTags)
 	require.Len(t, list.lowCardTags, 2)
-	require.Equal(t, "bar", list.lowCardTags["foo"])
-	require.Equal(t, "baz", list.lowCardTags["faa"])
+	require.True(t, list.lowCardTags["foo:bar"])
+	require.True(t, list.lowCardTags["faa:baz"])
+
+	require.False(t, list.lowCardTags["empty:"])
+	require.False(t, list.lowCardTags["empty"])
 }
 
 func TestAddHigh(t *testing.T) {
 	list := NewTagList()
 	list.AddHigh("foo", "bar")
 	list.AddHigh("faa", "baz")
+	list.AddHigh("empty", "")
 	require.Empty(t, list.lowCardTags)
 	require.Len(t, list.highCardTags, 2)
-	require.Equal(t, "bar", list.highCardTags["foo"])
-	require.Equal(t, "baz", list.highCardTags["faa"])
+	require.True(t, list.highCardTags["foo:bar"])
+	require.True(t, list.highCardTags["faa:baz"])
+
+	require.False(t, list.highCardTags["empty:"])
+	require.False(t, list.highCardTags["empty"])
 }
 
 func TestAddHighOrLow(t *testing.T) {
 	list := NewTagList()
 	list.AddAuto("foo", "bar")
 	list.AddAuto("+faa", "baz")
+	list.AddAuto("+", "baz")
+	list.AddAuto("+empty", "")
 	require.Len(t, list.lowCardTags, 1)
 	require.Len(t, list.highCardTags, 1)
-	require.Equal(t, "bar", list.lowCardTags["foo"])
-	require.Equal(t, "baz", list.highCardTags["faa"])
+	require.True(t, list.lowCardTags["foo:bar"])
+	require.True(t, list.highCardTags["faa:baz"])
+
+	require.False(t, list.highCardTags["empty:"])
+	require.False(t, list.highCardTags["empty"])
 }
 
 func TestCompute(t *testing.T) {
@@ -60,6 +73,11 @@ func TestCompute(t *testing.T) {
 	list.AddLow("low", "yes")
 	list.AddAuto("+high", "yes-high")
 	list.AddAuto("lowlow", "yes-low")
+	list.AddAuto("empty", "")
+	list.AddAuto("+empty", "")
+	list.AddAuto("+", "")
+	list.AddAuto("+", "empty")
+	list.AddAuto("", "")
 
 	low, high := list.Compute()
 	require.Len(t, low, 3)


### PR DESCRIPTION
### What does this PR do?

Allows to create multiple tags with the same key but a different value.
The use-case it leads me there is the Kubernetes services.

We can have several service names on a single Pod/Container like:
`kube_service:front`
`kube_service:region-one`

### Additional Notes

I kept the map to avoid duplicate tags `key:value`.

I put a bool as value, it's the lightest data structure.