### PR TITLE
[Logs] Added docker scanner errors to logs agent status

### DIFF
--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -130,8 +130,7 @@ func (s *Scanner) stopTailer(tailer *DockerTailer) {
 func (s *Scanner) listContainers() []types.Container {
 	containers, err := s.cli.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
-		err = fmt.Errorf("Can't tail containers, %s", err)
-		log.Error(err)
+		log.Error("Can't tail containers, ", err)
 		log.Error("Is datadog-agent part of docker user group?")
 		s.reportErrorToAllSources(err)
 		return []types.Container{}


### PR DESCRIPTION
### What does this PR do?

Added docker scanner errors to logs agent status

### Motivation

Tell users when something unexpected happened while tailing docker containers

### Additional Notes

Status example
```
==========
Logs-agent
==========

  logs_integration
  ----------------
    Type: docker
    Image: aImage
    Status: Error: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.25/version: dial unix /var/run/docker.sock: connect: permission denied
  
    Type: docker
    Status: Error: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.25/version: dial unix /var/run/docker.sock: connect: permission denied
  
    Type: file
    Path: /home/vagrant/test/test.log
    Status: Error: No file are matching pattern: /home/vagrant/test/test.log
```