### PR TITLE
Fix JMXFetch jar permissions

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -25,5 +25,6 @@ relative_path "jmxfetch"
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
   mkdir jar_dir
-  copy "jmxfetch-*-jar-with-dependencies.jar", jar_dir
+  copy "jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar", jar_dir
+  File.chmod(0644,  "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar")
 end

--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -26,5 +26,5 @@ build do
   ship_license "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
   mkdir jar_dir
   copy "jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar", jar_dir
-  File.chmod(0644,  "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar")
+  block { File.chmod(0644,  "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar") }
 end

--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -26,5 +26,5 @@ build do
   ship_license "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
   mkdir jar_dir
   copy "jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar", jar_dir
-  block { File.chmod(0644,  "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar") }
+  block { File.chmod(0644, "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar") }
 end

--- a/releasenotes/notes/osx-jmffetch-perm-bf2a08eeb0c610dd.yaml
+++ b/releasenotes/notes/osx-jmffetch-perm-bf2a08eeb0c610dd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Modify JMXFetch jar permissions to allow the agent to read it on osx.


### PR DESCRIPTION
### What does this PR do?

Modify the permissions of JMXFetch jar from 0600 to 0644.

### Motivation

For some reason JMXFetch jar permissions were set to `0600`. On mac osx a standard install will result in all files in `/opt/datadog-agent` being owned by `root`. Under these conditions it was not possible for the agent to read the jar file. 

Agent5: https://github.com/DataDog/omnibus-software/pull/180