### PR TITLE
Remove the extra environment variables pass to the process-agent

### DIFF
--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -76,14 +76,6 @@ func (c *ProcessAgentCheck) run() error {
 
 	cmd := exec.Command(c.binPath, c.commandOpts...)
 
-	env := os.Environ()
-	env = append(env, fmt.Sprintf("DD_API_KEY=%s", config.Datadog.GetString("api_key")))
-	env = append(env, fmt.Sprintf("DD_HOSTNAME=%s", getHostname()))
-	env = append(env, fmt.Sprintf("DD_DOGSTATSD_PORT=%s", config.Datadog.GetString("dogstatsd_port")))
-	env = append(env, fmt.Sprintf("DD_LOG_LEVEL=%s", config.Datadog.GetString("log_level")))
-	env = append(env, fmt.Sprintf("DD_PROCESS_AGENT_ENABLED=%t", config.Datadog.GetBool("process_agent_enabled")))
-	cmd.Env = env
-
 	// forward the standard output to the Agent logger
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Now that the process-agent reads the `datadog.yaml` file directly (see https://github.com/DataDog/datadog-agent/pull/1136) we can stop passing this extra environment to the Agent. 

The last piece of config, the log level, is added in https://github.com/DataDog/datadog-process-agent/pull/100 but it doesn't need to block this as long as they all go in rc1

Thanks @truthbk for the heads up on this!

### Motivation


### Additional Notes

Anything else we should know when reviewing?
