### PR TITLE
Default number of workers to 1 for the collector

### DIFF
--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -66,7 +66,7 @@ type Runner struct {
 
 // NewRunner takes the number of desired goroutines processing incoming checks.
 func NewRunner() *Runner {
-	numWorkers := config.Datadog.GetInt("check_runners") // = 0 if no value is specified by the user
+	numWorkers := config.Datadog.GetInt("check_runners")
 	if numWorkers > maxNumWorkers {
 		numWorkers = maxNumWorkers
 		log.Warnf("Configured number of checks workers (%v) is too high: %v will be used", numWorkers, maxNumWorkers)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,7 +87,7 @@ func init() {
 	Datadog.SetDefault("default_integration_http_timeout", 9)
 	Datadog.SetDefault("enable_metadata_collection", true)
 	Datadog.SetDefault("enable_gohai", true)
-	Datadog.SetDefault("check_runners", int64(0))
+	Datadog.SetDefault("check_runners", int64(1))
 	Datadog.SetDefault("expvar_port", "5000")
 
 	// Use to output logs in JSON format

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -87,12 +87,11 @@ api_key:
 # Default is '5002' on Windows and macOS ; turned off on Linux
 # GUI_port: -1
 
-
 # The Agent runs workers in parallel to execute checks. By default the number
-# of workers is automatically determined based on the number of checks running.
-# This optimizes checks collection time but might produce CPU spikes. You can
-# enforce a fix number of workers so less CPU is used.
-# check_runners: 4
+# of workers is set to 1. If set to 0 the agent will automatically determine
+# the best number of runners needed based on the number of checks running. This
+# would optimize the check collection time but may produce CPU spikes.
+# check_runners: 1
 
 # Metadata collection should always be enabled, except if you are running several
 # agents/dsd instances per host. In that case, only one agent should have it on.


### PR DESCRIPTION
### What does this PR do?

Default number of workers to 1 for the collector
This will produce a more constant CPU usage.