### PR TITLE
[Logs] Processing - strengthen how we validate rfc5424 source

### DIFF
--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -7,6 +7,7 @@ package processor
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -14,6 +15,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
+
+var rfc5424Pattern, _ = regexp.Compile("<[0-9]{1,3}>[0-9] ")
 
 // A Processor updates messages from an inputChan and pushes
 // in an outputChan
@@ -60,7 +63,7 @@ func (p *Processor) run() {
 func (p *Processor) computeExtraContent(msg message.Message) []byte {
 	// if the first char is '<', we can assume it's already formatted as RFC5424, thus skip this step
 	// (for instance, using tcp forwarding. We don't want to override the hostname & co)
-	if len(msg.Content()) > 0 && msg.Content()[0] != '<' {
+	if len(msg.Content()) > 0 && !p.isRFC5424Formatted(msg.Content()) {
 		// fit RFC5424
 		// <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %$!new-appname% - - - %msg%\n
 		extraContent := []byte("")
@@ -112,6 +115,17 @@ func (p *Processor) computeExtraContent(msg message.Message) []byte {
 		return extraContent
 	}
 	return nil
+}
+
+func (p *Processor) isRFC5424Formatted(content []byte) bool {
+	// RFC2424 formatted messages start with `<%pri%>%protocol-version% `
+	// pri is 1 to 3 digits, protocol-version is one digit (won't realisticly
+	// be more before we kill this custom code)
+	// As a result, the start is between 5 and 7 chars.
+	if len(content) < 8 { // even is start could be only 5 chars, RFC5424 must have other chars like `-`
+		return false
+	}
+	return rfc5424Pattern.Match(content[:8])
 }
 
 // buildPayload returns a processed payload from a raw message

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -185,6 +185,9 @@ func TestComputeExtraContent(t *testing.T) {
 	assert.True(t, math.Abs(time.Now().UTC().Sub(timestamp).Minutes()) < 1)
 
 	extraContent = p.computeExtraContent(newNetworkMessage([]byte("<message"), source))
+	assert.NotNil(t, extraContent)
+
+	extraContent = p.computeExtraContent(newNetworkMessage([]byte("<46>0 message"), source))
 	assert.Nil(t, extraContent)
 
 	// message with additional information
@@ -198,4 +201,12 @@ func TestComputeExtraContent(t *testing.T) {
 	assert.Equal(t, "sev0", extraContentParts[0])
 	assert.Equal(t, "ts", extraContentParts[1])
 	assert.Equal(t, "tags", extraContentParts[6])
+}
+
+func TestIsRFC5424Formatted(t *testing.T) {
+	p := NewTestProcessor()
+	assert.False(t, p.isRFC5424Formatted([]byte("<- test message ->")))
+	assert.False(t, p.isRFC5424Formatted([]byte("- test message ->")))
+	assert.False(t, p.isRFC5424Formatted([]byte("<46> the rest of the message")))
+	assert.True(t, p.isRFC5424Formatted([]byte("<46>0 the rest of the message")))
 }

--- a/releasenotes/notes/logs-update-rfc5424-detection-25a4dab5e1164bd7.yaml
+++ b/releasenotes/notes/logs-update-rfc5424-detection-25a4dab5e1164bd7.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Log lines starting with the special character `<` were considered rfc5424
+    formatted, and any further formatting was skipped. This commit updates the
+    detection rule to match logs starting with `<pri>version `, to reduce
+    false positives


### PR DESCRIPTION
see https://trello.com/c/WArpjBAT/273-agent-special-characters-in-log-break-the-format-and-give-empty-metadata-hostname-service-tags
The assumption that all non rfc5424 logs wouldn't start with `<`
has been proved wrong at this point
