### PR TITLE
Remove host checks/hostname for ECS Fargate

### DIFF
--- a/Dockerfiles/agent/entrypoint.sh
+++ b/Dockerfiles/agent/entrypoint.sh
@@ -38,7 +38,7 @@ fi
 if [[ "${KUBERNETES}" ]]; then
     ln -s /etc/datadog-agent/datadog-kubernetes.yaml /etc/datadog-agent/datadog.yaml
     mv /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.example /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
-elif [ $ECS ]; then
+elif [ $ECS_FARGATE ]; then
     ln -s /etc/datadog-agent/datadog-ecs.yaml /etc/datadog-agent/datadog.yaml
     find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete # remove all default checks (no host)
 else

--- a/Dockerfiles/agent/entrypoint.sh
+++ b/Dockerfiles/agent/entrypoint.sh
@@ -40,6 +40,7 @@ if [[ "${KUBERNETES}" ]]; then
     mv /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.example /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
 elif [ $ECS ]; then
     ln -s /etc/datadog-agent/datadog-ecs.yaml /etc/datadog-agent/datadog.yaml
+    find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete # remove all default checks (no host)
 else
     ln -s /etc/datadog-agent/datadog-docker.yaml /etc/datadog-agent/datadog.yaml
 fi

--- a/pkg/util/ecs/diagnosis.go
+++ b/pkg/util/ecs/diagnosis.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build docker
+
 package ecs
 
 import (

--- a/pkg/util/ecs/diagnosis.go
+++ b/pkg/util/ecs/diagnosis.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package ecs
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+	log "github.com/cihub/seelog"
+)
+
+func init() {
+	diagnosis.Register("ECS Metadata availability", diagnoseECS)
+	diagnosis.Register("ECS Fargate Metadata availability", diagnoseFargate)
+}
+
+// diagnose the ECS metadata API availability
+func diagnoseECS() error {
+	_, err := GetTasks()
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}
+
+// diagnose the ECS Fargate metadata API availability
+func diagnoseFargate() error {
+	_, err := GetTaskMetadata()
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -15,11 +15,11 @@ import (
 	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // dummyECS allows tests to mock a ECS's responses

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
 
@@ -105,6 +106,11 @@ func GetHostname() (string, error) {
 
 	log.Debugf("Unable to get the hostname from the config file: %s", err)
 	log.Debug("Trying to determine a reliable host name automatically...")
+
+	// if fargate we strip the hostname
+	if ecs.IsFargateInstance() {
+		return "", nil
+	}
 
 	// GCE metadata
 	log.Debug("GetHostname trying GCE metadata...")

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -168,7 +168,6 @@ func GetHostname() (string, error) {
 		err = nil
 	}
 
-	// fix caching
 	cache.Cache.Set(cacheHostnameKey, hostName, cache.NoExpiration)
 	return hostName, err
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -101,6 +101,7 @@ func GetHostname() (string, error) {
 	name := config.Datadog.GetString("hostname")
 	err = ValidHostname(name)
 	if err == nil {
+		cache.Cache.Set(cacheHostnameKey, name, cache.NoExpiration)
 		return name, err
 	}
 
@@ -109,6 +110,7 @@ func GetHostname() (string, error) {
 
 	// if fargate we strip the hostname
 	if ecs.IsFargateInstance() {
+		cache.Cache.Set(cacheHostnameKey, "", cache.NoExpiration)
 		return "", nil
 	}
 
@@ -117,6 +119,7 @@ func GetHostname() (string, error) {
 	if getGCEHostname, found := hostname.ProviderCatalog["gce"]; found {
 		name, err = getGCEHostname(name)
 		if err == nil {
+			cache.Cache.Set(cacheHostnameKey, name, cache.NoExpiration)
 			return name, err
 		}
 		log.Debug("Unable to get hostname from GCE: ", err)
@@ -165,6 +168,7 @@ func GetHostname() (string, error) {
 		err = nil
 	}
 
+	// fix caching
 	cache.Cache.Set(cacheHostnameKey, hostName, cache.NoExpiration)
 	return hostName, err
 }

--- a/releasenotes/notes/fargate-hostname-661280f885ecb825.yaml
+++ b/releasenotes/notes/fargate-hostname-661280f885ecb825.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Add ECS & ECS Fargate metadata API connectivity diagnose
+fixes:
+  - |
+    Strip hostname if running inside ECS Fargate and disable core checks (not relevant
+    without host infos)
+    Fix hostname caching consistency


### PR DESCRIPTION
### What does this PR do?

* Add ECS + Fargate diagnosis 
* Cache if this is a fargate instance
* Strip hostname if running on fargate
* Fix hostname caching consistency
* Disable default checks in ECS entrypoint

### Motivation

When running in fargate there should be no data reported about the underlying host, hence all the default cheks that are tied to the host should also be deactivated.
