### PR TITLE
add a `tagger` python bridge module

### DIFF
--- a/pkg/collector/py/kubeutil.go
+++ b/pkg/collector/py/kubeutil.go
@@ -69,6 +69,6 @@ func GetKubeletConnectionInfo() *C.PyObject {
 	return dict
 }
 
-func initkubeutil() {
+func initKubeutil() {
 	C.initkubeutil()
 }

--- a/pkg/collector/py/kubeutil_nokubelet.go
+++ b/pkg/collector/py/kubeutil_nokubelet.go
@@ -8,5 +8,5 @@
 package py
 
 // Stub
-func initkubeutil() {
+func initKubeutil() {
 }

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -110,7 +110,9 @@ func Initialize(paths ...string) *python.PyThreadState {
 	// (all these calls will take care of the GIL)
 	initAPI()          // `aggregator` module
 	initDatadogAgent() // `datadog_agent` module
-	initkubeutil()     // `kubeutil` module if compiled in
+	initKubeutil()     // `kubeutil` module if compiled in
+	initTagger()       // `tagger` module
+
 	// return the state so the caller can resume
 	return state
 }

--- a/pkg/collector/py/tagger.c
+++ b/pkg/collector/py/tagger.c
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython
 
 #include "tagger.h"

--- a/pkg/collector/py/tagger.c
+++ b/pkg/collector/py/tagger.c
@@ -1,0 +1,37 @@
+// +build cpython
+
+#include "tagger.h"
+
+// Functions
+PyObject* GetTags(char *id, int highCard);
+
+static PyObject *get_tags(PyObject *self, PyObject *args) {
+    char *entity;
+    int  high_card;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    if (!PyArg_ParseTuple(args, "si", &entity, &high_card)) {
+      PyGILState_Release(gstate);
+      return NULL;
+    }
+
+    PyGILState_Release(gstate);
+    return GetTags(entity, high_card);
+}
+
+static PyMethodDef taggerMethods[] = {
+  {"get_tags", get_tags, METH_VARARGS, "Get tags for an entity."},
+  {NULL, NULL}
+};
+
+void inittagger()
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *tagger = Py_InitModule("tagger", taggerMethods);
+
+  PyGILState_Release(gstate);
+}

--- a/pkg/collector/py/tagger.go
+++ b/pkg/collector/py/tagger.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython
+
+package py
+
+// #cgo pkg-config: python-2.7
+// #cgo linux CFLAGS: -std=gnu99
+// #include "tagger.h"
+import "C"
+import (
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+)
+
+// GetTags XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+//export GetTags
+func GetTags(id *C.char, highCard int) *C.PyObject {
+	goID := C.GoString(id)
+	var highCardBool bool
+	if highCard > 0 {
+		highCardBool = true
+	}
+
+	tags, _ := tagger.Tag(goID, highCardBool)
+	output := C.PyList_New(0)
+
+	for _, t := range tags {
+		cTag := C.CString(t)
+		pyTag := C.PyString_FromString(cTag)
+		defer C.Py_DecRef(pyTag)
+		C.free(unsafe.Pointer(cTag))
+		C.PyList_Append(output, pyTag)
+	}
+
+	return output
+}
+
+func initTagger() {
+	C.inittagger()
+}

--- a/pkg/collector/py/tagger.go
+++ b/pkg/collector/py/tagger.go
@@ -17,7 +17,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 )
 
-// GetTags XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// GetTags queries the agent6 tagger and returns a string array containing
+// tags for the entity. If entity not found, or tagging error, the returned
+// array is empty but valid.
 //export GetTags
 func GetTags(id *C.char, highCard int) *C.PyObject {
 	goID := C.GoString(id)

--- a/pkg/collector/py/tagger.h
+++ b/pkg/collector/py/tagger.h
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 // +build cpython
 
 #ifndef TAGGER_HEADER

--- a/pkg/collector/py/tagger.h
+++ b/pkg/collector/py/tagger.h
@@ -1,0 +1,10 @@
+// +build cpython
+
+#ifndef TAGGER_HEADER
+#define TAGGER_HEADER
+
+#include <Python.h>
+
+void inittagger();
+
+#endif /* TAGGER_HEADER */

--- a/pkg/collector/py/tagger_test.go
+++ b/pkg/collector/py/tagger_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython
+
+// NOTICE: See TestMain function in `utils_test.go` for Python initialization
+package py
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+)
+
+type DummyCollector struct {
+}
+
+func (c *DummyCollector) Detect(out chan<- []*collectors.TagInfo) (collectors.CollectionMode, error) {
+	return collectors.FetchOnlyCollection, nil
+}
+func (c *DummyCollector) Fetch(entity string) ([]string, []string, error) {
+	return []string{entity + ":low"}, []string{entity + ":high", "other_tag:high"}, nil
+}
+
+func TestGetTags(t *testing.T) {
+	collectors.DefaultCatalog = map[string]collectors.CollectorFactory{
+		"dummy": func() collectors.Collector {
+			return &DummyCollector{}
+		},
+	}
+	tagger.Init()
+
+	// Make sure tagger works as expected first
+	low, err := tagger.Tag("test_entity", false)
+	require.NoError(t, err)
+	require.Equal(t, low, []string{"test_entity:low"})
+	high, err := tagger.Tag("test_entity", true)
+	require.NoError(t, err)
+	require.Equal(t, high, []string{"test_entity:low", "test_entity:high", "other_tag:high"})
+
+	check, _ := getCheckInstance("testtagger", "TestCheck")
+	mockSender := mocksender.NewMockSender(check.ID())
+	mockSender.SetupAcceptAll()
+
+	err = check.Run()
+	require.NoError(t, err)
+
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.low_card", []string{"test_entity:low"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.high_card", []string{"test_entity:low", "test_entity:high", "other_tag:high"})
+}

--- a/pkg/collector/py/tagger_test.go
+++ b/pkg/collector/py/tagger_test.go
@@ -25,7 +25,11 @@ func (c *DummyCollector) Detect(out chan<- []*collectors.TagInfo) (collectors.Co
 	return collectors.FetchOnlyCollection, nil
 }
 func (c *DummyCollector) Fetch(entity string) ([]string, []string, error) {
-	return []string{entity + ":low"}, []string{entity + ":high", "other_tag:high"}, nil
+	if entity == "404" {
+		return nil, nil, collectors.ErrNotFound
+	} else {
+		return []string{entity + ":low"}, []string{entity + ":high", "other_tag:high"}, nil
+	}
 }
 
 func TestGetTags(t *testing.T) {
@@ -53,4 +57,5 @@ func TestGetTags(t *testing.T) {
 
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.low_card", []string{"test_entity:low"})
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.high_card", []string{"test_entity:low", "test_entity:high", "other_tag:high"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.unknown", []string{})
 }

--- a/pkg/collector/py/tests/testtagger.py
+++ b/pkg/collector/py/tests/testtagger.py
@@ -14,3 +14,6 @@ class TestCheck(AgentCheck):
 
         alltags = get_tags("test_entity", True)
         self.gauge("metric.high_card", 1, tags=alltags)
+
+        notags = get_tags("404", True)
+        self.gauge("metric.unknown", 1, tags=notags)

--- a/pkg/collector/py/tests/testtagger.py
+++ b/pkg/collector/py/tests/testtagger.py
@@ -1,0 +1,16 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2018 Datadog, Inc.
+
+from checks import AgentCheck
+from tagger import get_tags
+
+
+class TestCheck(AgentCheck):
+    def check(self, instance):
+        lowtags = get_tags("test_entity", False)
+        self.gauge("metric.low_card", 1, tags=lowtags)
+
+        alltags = get_tags("test_entity", True)
+        self.gauge("metric.high_card", 1, tags=alltags)

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -12,11 +12,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/sbinet/go-python"
+	python "github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 // Setup the test module
@@ -34,8 +36,8 @@ func TestMain(m *testing.M) {
 	state := Initialize(rootDir, testsDir, distDir)
 
 	// testing this package needs an inited aggregator
-	// to work properly
-	aggregator.InitAggregator(nil, "")
+	// to work properly.
+	aggregator.InitAggregatorWithFlushInterval(nil, "", time.Hour)
 
 	ret := m.Run()
 

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -13,6 +13,10 @@ The package will implement an IPC mechanism (a server and a client) to allow
 other agents to query the **DefaultTagger** and avoid duplicating the information
 in their process. Switch between local and client mode will be done via a build flag.
 
+The tagger is also available to python checks via the `tagger` module exporting
+the `get_tags()` function. This function accepts the same arguments as the Go `Tag()`
+function, and returns an empty list on errors.
+
 ### Collector
 A **Collector** connects to a single information source and pushes **TagInfo**
 structs to a channel, towards the **Tagger**. It can either run in streaming

--- a/releasenotes/notes/releasenotes/notes/tagger-python-bridge-26523aa128122ab2.yaml
+++ b/releasenotes/notes/releasenotes/notes/tagger-python-bridge-26523aa128122ab2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support the new `kubelet` integration by providing the container tags to it    


### PR DESCRIPTION
### What does this PR do?

Add the `tagger` python module with the `get_tags(string, bool)` function bridging to the `pkg/tagger`  `Tag` function. Update tests
