### PR TITLE
[Windows] remove debug line in GetDistPath().  This function is called

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -78,7 +78,6 @@ func GetDistPath() string {
 			return ""
 		}
 		distPath = filepath.Join(s, `bin/agent/dist`)
-		log.Debug("DistPath is now %s", distPath)
 	}
 	return distPath
 }


### PR DESCRIPTION
through some init() functions, so it logs before logging is configured, resulting in logging to the command line and dirtying the command line output.

