### PR TITLE
support legacy default_integration_http_timeout

### DIFF
--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -47,7 +47,10 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("forwarder_timeout", value)
 	}
 
-	// TODO: default_integration_http_timeout
+	if value, err := strconv.Atoi(agentConfig["default_integration_http_timeout"]); err == nil {
+		config.Datadog.Set("default_integration_http_timeout", value)
+	}
+
 	// TODO: collect_ec2_tags
 
 	// config.Datadog has a default value for this, do nothing if the value is empty

--- a/pkg/legacy/tests/datadog.conf
+++ b/pkg/legacy/tests/datadog.conf
@@ -41,7 +41,7 @@ forwarder_timeout: 20
 # Set timeout in seconds for integrations that use HTTP to fetch metrics, since
 # unbounded timeouts can potentially block the collector indefinitely and cause
 # problems!
-default_integration_http_timeout: 9
+default_integration_http_timeout: 7
 
 # Add one "dd_check:checkname" tag per running check. It makes it possible to slice
 # and dice per monitored app (= running Agent Check) on Datadog's backend.

--- a/releasenotes/notes/support-legacy-default_integration_http_timeout-bf8b810c0ad98639.yaml
+++ b/releasenotes/notes/support-legacy-default_integration_http_timeout-bf8b810c0ad98639.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support the legacy default_integration_http_timeout configuration option.


### PR DESCRIPTION
### What does this PR do?

Converts legacy `default_integration_http_timeout` to https://github.com/DataDog/datadog-agent/blob/eca175e4010af6dbccc930cb6db9caa8e6067452/pkg/config/config.go#L87.