### PR TITLE
[tagger] add nomad support

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -99,6 +99,21 @@ func dockerExtractEnvironmentVariables(tags *utils.TagList, containerEnvVariable
 		case "MESOS_TASK_ID":
 			tags.AddHigh("mesos_task", envValue)
 
+		// Nomad
+		case "NOMAD_TASK_NAME":
+			tags.AddLow("nomad_task", envValue)
+		case "NOMAD_JOB_NAME":
+			tags.AddLow("nomad_job", envValue)
+		case "NOMAD_ALLOC_NAME":
+			// Known format is test-task.test-group[0]
+			start := strings.Index(envValue, ".")
+			end := strings.LastIndex(envValue, "[")
+			if end > start && start > -1 {
+				tags.AddLow("nomad_group", envValue[start+1:end])
+			} else {
+				log.Debugf("Cannot extract nomad_group tag from the NOMAD_ALLOC_NAME envvar: %s", envValue)
+			}
+
 		default:
 			if tagName, found := envAsTags[strings.ToLower(envSplit[0])]; found {
 				tags.AddAuto(tagName, envValue)

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -104,15 +104,8 @@ func dockerExtractEnvironmentVariables(tags *utils.TagList, containerEnvVariable
 			tags.AddLow("nomad_task", envValue)
 		case "NOMAD_JOB_NAME":
 			tags.AddLow("nomad_job", envValue)
-		case "NOMAD_ALLOC_NAME":
-			// Known format is test-task.test-group[0]
-			start := strings.Index(envValue, ".")
-			end := strings.LastIndex(envValue, "[")
-			if end > start && start > -1 {
-				tags.AddLow("nomad_group", envValue[start+1:end])
-			} else {
-				log.Debugf("Cannot extract nomad_group tag from the NOMAD_ALLOC_NAME envvar: %s", envValue)
-			}
+		case "NOMAD_GROUP_NAME":
+			tags.AddLow("nomad_group", envValue)
 
 		default:
 			if tagName, found := envAsTags[strings.ToLower(envSplit[0])]; found {

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -201,7 +201,7 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 					Env: []string{
 						"NOMAD_TASK_NAME=test-task",
 						"NOMAD_JOB_NAME=test-job",
-						"NOMAD_ALLOC_NAME=test-task.test-group[0]",
+						"NOMAD_GROUP_NAME=test-group",
 					},
 					Labels: map[string]string{},
 				},
@@ -212,26 +212,6 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 				"nomad_task:test-task",
 				"nomad_job:test-job",
 				"nomad_group:test-group",
-			},
-			expectedHigh: []string{},
-		},
-		{
-			testName: "extractNomadInvalidGroup",
-			co: &types.ContainerJSON{
-				Config: &container.Config{
-					Env: []string{
-						"NOMAD_TASK_NAME=test-task",
-						"NOMAD_JOB_NAME=test-job",
-						"NOMAD_ALLOC_NAME=test-group[0]",
-					},
-					Labels: map[string]string{},
-				},
-			},
-			toRecordEnvAsTags:    map[string]string{},
-			toRecordLabelsAsTags: map[string]string{},
-			expectedLow: []string{
-				"nomad_task:test-task",
-				"nomad_job:test-job",
 			},
 			expectedHigh: []string{},
 		},

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -194,6 +194,47 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 				"rancher_container:testAD-redis-1",
 			},
 		},
+		{
+			testName: "extractNomad",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"NOMAD_TASK_NAME=test-task",
+						"NOMAD_JOB_NAME=test-job",
+						"NOMAD_ALLOC_NAME=test-task.test-group[0]",
+					},
+					Labels: map[string]string{},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"nomad_task:test-task",
+				"nomad_job:test-job",
+				"nomad_group:test-group",
+			},
+			expectedHigh: []string{},
+		},
+		{
+			testName: "extractNomadInvalidGroup",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"NOMAD_TASK_NAME=test-task",
+						"NOMAD_JOB_NAME=test-job",
+						"NOMAD_ALLOC_NAME=test-group[0]",
+					},
+					Labels: map[string]string{},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow: []string{
+				"nomad_task:test-task",
+				"nomad_job:test-job",
+			},
+			expectedHigh: []string{},
+		},
 	}
 
 	dc := &DockerCollector{}

--- a/releasenotes/notes/nomad-tagging-8ede1cecb11fc8da.yaml
+++ b/releasenotes/notes/nomad-tagging-8ede1cecb11fc8da.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support tagging on Nomad clusters

--- a/releasenotes/notes/nomad-tagging-8ede1cecb11fc8da.yaml
+++ b/releasenotes/notes/nomad-tagging-8ede1cecb11fc8da.yaml
@@ -1,4 +1,8 @@
 ---
 features:
   - |
-    Support tagging on Nomad clusters
+    Support tagging on Nomad 0.6.0+ clusters
+upgrade:
+  - |
+    If you run a Nomad agent older than 0.6.0, the `nomad_group`
+    tag will be absent until you upgrade your orchestrator.


### PR DESCRIPTION
### What does this PR do?

Port agent5's Nomad tagging to the Docker collector.

See:

- https://github.com/DataDog/dd-agent/blob/master/utils/orchestrator/nomadutil.py
- https://github.com/DataDog/dd-agent/blob/master/tests/core/test_nomadutil.py

### Motivation

Feature parity with agent5