### PR TITLE
Clean up auth token file after test

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -140,3 +140,9 @@ func FetchAuthToken() (string, error) {
 
 	return authToken, nil
 }
+
+// DeleteAuthToken removes auth_token file (test clean up)
+func DeleteAuthToken() error {
+	authTokenFile := filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
+	return os.Remove(authTokenFile)
+}

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,6 +29,8 @@ func TestCreateArchive(t *testing.T) {
 		assert.Fail(t, "The Zip File was not created")
 	} else {
 		os.Remove(zipFilePath)
+		err := security.DeleteAuthToken()
+		assert.Nil(t, err)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Clean up the auth token file

### Motivation

A file was created and not ignored by one of the test
