### PR TITLE
service mapper: remove the concurrency for the map reading

### DIFF
--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -58,7 +58,7 @@ func (smb *ServiceMapperBundle) mapServices(nodeName string, pods v1.PodList, en
 			smb.PodNameToServices[name] = svc
 		}
 	}
-	log.Tracef("The services matched %q", smb.PodNameToServices)
+	log.Tracef("The services matched %q", fmt.Sprintf("%s", smb.PodNameToServices))
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

During the concurrent tests (`t.Run`), we write in `allCasesBundle` twice. 
This is already protected by a RWSync lock.

But the async logger can create a data race because not processed yet at the 2nd write.