### PR TITLE
 Add support for `collect_ec2_tags` and `collect_security_groups` options

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,6 +173,8 @@ func init() {
 
 	// ECS
 	Datadog.SetDefault("ecs_agent_url", "") // Will be autodetected
+	Datadog.SetDefault("collect_ec2_tags", false)
+	Datadog.SetDefault("collect_security_groups", false)
 
 	// Cloud Foundry
 	Datadog.SetDefault("cloud_foundry", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -310,10 +310,6 @@ metadata_collectors:
 #
 # URL where the ECS agent can be found. Standard cases will be autodetected.
 # ecs_agent_url: http://localhost:51678
-# Collect AWS EC2 custom tags as agent tags
-# collect_ec2_tags: false
-# Incorporate security-groups into tags collected from AWS EC2
-# collect_security_groups: false
 #
 {{ end -}}
 {{- if .KubeApiServer }}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -310,6 +310,10 @@ metadata_collectors:
 #
 # URL where the ECS agent can be found. Standard cases will be autodetected.
 # ecs_agent_url: http://localhost:51678
+# Collect AWS EC2 custom tags as agent tags
+# collect_ec2_tags: false
+# Incorporate security-groups into tags collected from AWS EC2
+# collect_security_groups: false
 #
 {{ end -}}
 {{- if .KubeApiServer }}

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -51,7 +51,13 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("default_integration_http_timeout", value)
 	}
 
-	// TODO: collect_ec2_tags
+	if enabled, err := isAffirmative(agentConfig["collect_ec2_tags"]); err == nil {
+		config.Datadog.Set("collect_ec2_tags", enabled)
+	}
+
+	if enabled, err := isAffirmative(agentConfig["collect_security_groups"]); err == nil {
+		config.Datadog.Set("collect_security_groups", enabled)
+	}
 
 	// config.Datadog has a default value for this, do nothing if the value is empty
 	if agentConfig["additional_checksd"] != "" {

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -29,6 +29,7 @@ var (
 		"forwarder_timeout",
 		"default_integration_http_timeout",
 		"collect_ec2_tags",
+		"collect_security_groups",
 		"additional_checksd",
 		"exclude_process_args",
 		"histogram_aggregates",

--- a/pkg/legacy/tests/datadog.conf
+++ b/pkg/legacy/tests/datadog.conf
@@ -48,9 +48,9 @@ default_integration_http_timeout: 7
 create_dd_check_tags: False
 
 # Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
-collect_ec2_tags: False
+collect_ec2_tags: True
 # Incorporate security-groups into tags collected from AWS EC2
-# collect_security_groups: False
+collect_security_groups: True
 
 # Enable Agent Developer Mode
 # Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -104,7 +104,7 @@ func getEC2Tags() ([]string, error) {
 	}
 
 	if !config.Datadog.GetBool("collect_security_groups") {
-		// remove the `security_group_name` tag if it is present
+		// remove the `security_group_name` tag if present
 		for i, s := range ec2Tags {
 			if strings.HasPrefix(s, "security_group_name:") {
 				ec2Tags = append(ec2Tags[:i], ec2Tags[i+1:]...)

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -76,15 +76,17 @@ func GetMeta() *Meta {
 
 func getHostTags() *tags {
 	hostTags := config.Datadog.GetStringSlice("tags")
-	var gceTags []string
 
-	ec2Tags, err := ec2.GetTags()
-	if err != nil {
-		log.Debugf("No EC2 host tags %v", err)
+	if config.Datadog.GetBool("collect_ec2_tags") {
+		ec2Tags, err := getEC2Tags()
+		if err != nil {
+			log.Debugf("No EC2 host tags %v", err)
+		} else {
+			hostTags = append(hostTags, ec2Tags...)
+		}
 	}
-	hostTags = append(hostTags, ec2Tags...)
 
-	gceTags, err = gce.GetTags()
+	gceTags, err := gce.GetTags()
 	if err != nil {
 		log.Debugf("No GCE host tags %v", err)
 	}
@@ -93,6 +95,24 @@ func getHostTags() *tags {
 		System:              hostTags,
 		GoogleCloudPlatform: gceTags,
 	}
+}
+
+func getEC2Tags() ([]string, error) {
+	ec2Tags, err := ec2.GetTags()
+	if err != nil {
+		return ec2Tags, err
+	}
+
+	if !config.Datadog.GetBool("collect_security_groups") {
+		// remove the `security_group_name` tag if it is present
+		for i, s := range ec2Tags {
+			if strings.HasPrefix(s, "security_group_name:") {
+				ec2Tags = append(ec2Tags[:i], ec2Tags[i+1:]...)
+			}
+		}
+	}
+
+	return ec2Tags, nil
 }
 
 func getSystemStats() *systemStats {

--- a/releasenotes/notes/support-ec2-metadata-options-6287da5d6462fc44.yaml
+++ b/releasenotes/notes/support-ec2-metadata-options-6287da5d6462fc44.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for collect_ec2_tags and collect_security_groups configuration options.


### PR DESCRIPTION
### What does this PR do?

 Adds support for `collect_ec2_tags` and `collect_security_groups` config options.

### Motivation

Avoid context churn on A5=>A6 update.
