### PR TITLE
Improving logging and custom error handling for event collection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@
 /Dockerfiles/                           @DataDog/kenafeh
 /pkg/collector/autodiscovery/           @DataDog/kenafeh @DataDog/croissant
 /pkg/collector/corechecks/containers/   @DataDog/kenafeh
+/pkg/collector/corechecks/cluster/      @DataDog/kenafeh
 /pkg/collector/listeners/docker*        @DataDog/kenafeh
 /pkg/tagger/                            @DataDog/kenafeh
 /pkg/util/docker/                       @DataDog/kenafeh @DataDog/burrito

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -34,9 +34,10 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 	// If `since` is "" strconv.Atoi(*latestResVersion) below will panic as we evaluate the error.
 	// One could chose to use "" instead of 0 to not query the API Server cache.
 	// We decide to only rely on the cache as it avoids crawling everything from the API Server at once.
-	resVersionCached, cachedResErr := strconv.Atoi(since)
-	if cachedResErr != nil {
-		log.Errorf("The cached event token could not be parsed: %s, pulling events from the API server's cache", cachedResErr.Error())
+	log.Debugf("since value is %q", since)
+	resVersionCached, err := strconv.Atoi(since)
+	if err != nil {
+		log.Errorf("The cached event token could not be parsed: %s, pulling events from the API server's cache", err)
 	}
 	var sinceOption k8s.Option
 

--- a/releasenotes/notes/custome-error-event-collection-f6693b6fd5edcb3c.yaml
+++ b/releasenotes/notes/custome-error-event-collection-f6693b6fd5edcb3c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Updating custom error used to insure the collection of the token in the configmap datadogtoken.


### PR DESCRIPTION
### What does this PR do?

The error caught if the CM is found but there is no timestamp was not the one evaluated to refresh the state.

### Motivation

Make sure agents can share the state of the event collection in a CM.
