### PR TITLE
[GUI] Get the GUI to properly create the flare

### DIFF
--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -131,8 +131,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		logFile = common.DefaultLogFile
 	}
 
-	// Initiate the flare locally
-	filePath, e := flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
+	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
 	if e != nil {
 		w.Write([]byte("Error creating flare zipfile: " + e.Error()))
 		log.Errorf("Error creating flare zipfile: " + e.Error())

--- a/releasenotes/notes/gui-should-properly-create-flare-6b69066b78ced7f5.yaml
+++ b/releasenotes/notes/gui-should-properly-create-flare-6b69066b78ced7f5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug that caused the GUI to create a flare without a status file


### PR DESCRIPTION
### What does this PR do?

Right now the GUI is falling back on a method that should only be used by the CLI if the agent cannot be reached via the API. The fallback creates a flare without without the kinds of stuff that only a running agent could create, like the status page. The GUI is only reachable on a running agent, so it doesn't make any sense to have this method called as the primary, or even as a fallback. 

The method (it's really just a flag on the main method) is poorly named and perhaps it should be renamed. I'm not sure what it should be named, though, and I think this is more urgent than making the method itself more clear.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
