### PR TITLE
fix uploaded Flare archive name

### DIFF
--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -14,6 +14,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -33,7 +34,7 @@ func SendFlareWithHostname(archivePath string, caseID string, email string, host
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	p, err := writer.CreateFormFile("flare_file", archivePath)
+	p, err := writer.CreateFormFile("flare_file", filepath.Base(archivePath))
 	if err != nil {
 		return "", err
 	}

--- a/releasenotes/notes/fix-flare-archive-name-157af4901480ccc3.yaml
+++ b/releasenotes/notes/fix-flare-archive-name-157af4901480ccc3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the uploaded file name of the flare archive.


### PR DESCRIPTION
### What does this PR do?

This makes the uploaded file name the actual file name instead of the full path.

### Motivation

Incorrect on Windows