### PR TITLE
[omnibus][linux] Add empty custom check and log dirs to the package

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -62,7 +62,6 @@ COPY --from=extract /output/ /
 RUN adduser --group dd-agent \
  && adduser --system --no-create-home --disabled-password --ingroup dd-agent dd-agent \
  && chown -R dd-agent:dd-agent /etc/datadog-agent/ \
- && mkdir /var/log/datadog \
  && chown dd-agent:dd-agent /var/log/datadog/
 
 # Expose DogStatsD and trace-agent ports

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -159,6 +159,7 @@ if linux?
   extra_package_file '/lib/systemd/system/datadog-agent.service'
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/usr/bin/dd-agent'
+  extra_package_file '/var/log/datadog/'
 end
 
 exclude '\.git*'

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -54,6 +54,11 @@ build do
             move "#{install_dir}/etc/datadog-agent/trace-agent.conf.example", "/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
 
+            # Create empty directories so that they're owned by the package
+            # (also requires `extra_package_file` directive in project def)
+            mkdir "/etc/datadog-agent/checks.d"
+            mkdir "/var/log/datadog"
+
             # cleanup clutter
             delete "#{install_dir}/etc"
         elsif osx?

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -8,12 +8,6 @@
 INSTALL_DIR=/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 SERVICE_NAME=datadog-agent
-CONFIG_DIR=/etc/datadog-agent
-
-# create all the paths needed to complete the installation
-mkdir -p $LOG_DIR
-mkdir -p $CONFIG_DIR/conf.d
-mkdir -p $CONFIG_DIR/checks.d
 
 KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
 DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || uname -s)
@@ -64,6 +58,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     fi
 else
     # macOS
+    mkdir -p $LOG_DIR
 
     CONF_DIR="$INSTALL_DIR/etc"
     APP_DIR="/Applications/Datadog Agent.app"

--- a/releasenotes/notes/linux-package-own-empty-dirs-a9238159d0028ca2.yaml
+++ b/releasenotes/notes/linux-package-own-empty-dirs-a9238159d0028ca2.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The linux packages now own the custom check directory (``/etc/datadog-agent/checks.d/``)
+    and the log directory (``/var/log/datadog/``)


### PR DESCRIPTION
### What does this PR do?

Adds empty custom check (`/etc/datadog-agent/checks.d/`) and log (`/var/log/datadog/`) dirs to the package file list.

### Motivation

It's better to have these directories in the package file list so that they're regarded as owned by our package. Also, we don't have to manage their creation/deletion in our pre/post scripts anymore. Good general practice for linux packages, and allows our docker image to have these dirs just by extracting the package.