### PR TITLE
[docker] various fixes

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -139,8 +139,7 @@ func ConnectToDocker() (*client.Client, error) {
 	// TODO: remove this logic when "client.NegotiateAPIVersion" function is released by moby/docker
 	serverVersion, err := detectServerAPIVersion()
 	if err != nil || serverVersion == "" {
-		log.Errorf("Could not determine docker server API version (using the client version): %s", err)
-		return cli, nil
+		return nil, fmt.Errorf("Could not determine docker server API version: %s", err)
 	}
 
 	clientVersion := cli.ClientVersion()

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -109,7 +109,7 @@ func (e *eventStreamState) unsubscribe(name string) (error, bool) {
 	return nil, shouldStop
 }
 
-func (d *DockerUtil) dispatchEvents(cancelChan <-chan struct{}) {
+func (d *DockerUtil) dispatchEvents(cancelChan chan struct{}) {
 	fltrs := filters.NewArgs()
 	fltrs.Add("type", "container")
 	fltrs.Add("event", "start")
@@ -141,7 +141,9 @@ CONNECT:
 					// Silently ignore io.EOF that happens on http connection reset
 					log.Debug("Got EOF, re-connecting")
 				} else {
-					log.Warnf("error getting docker events: %s", err)
+					// Else, let's wait 10 seconds and try reconnecting
+					log.Errorf("Error getting docker events: %s", err)
+					time.Sleep(10 * time.Second)
 				}
 				cancel()
 				continue CONNECT // Re-connect to docker

--- a/releasenotes/notes/docker-events-throttle-reconnects-112b048bcfdcce18.yaml
+++ b/releasenotes/notes/docker-events-throttle-reconnects-112b048bcfdcce18.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix docker event reconnection logic to gracefully wait if docker daemon is unresponsive


### PR DESCRIPTION
### What does this PR do?

- If the docker daemon becomes unresponsive after the agent is launched, the event collection reconnection logic can get a bit impatient. Make it wait 10 seconds to leave the docker daemon time to recover
- Rework the error handling in the docker corecheck to use integration warnings
- Make `GetDockerUtil` fail if it cannot query the docker server version. This can happen if docker is running but blocked by selinux: we enabled the docker integrations, and they failed in loop
