### PR TITLE
Adjust some logs

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -295,7 +295,7 @@ func (ac *AutoConfig) resolve(config check.Config, provider string) []check.Conf
 		if len(resolvedConfigs) == 0 {
 			e := fmt.Sprintf("Can't resolve the template for %s at this moment.", config.Name)
 			errorStats.setResolveWarning(config.Name, e)
-			log.Infof(e)
+			log.Debugf(e)
 			return configs
 		}
 		errorStats.removeResolveWarnings(config.Name)

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -126,7 +126,7 @@ func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 				resolvedSet[config.Digest()] = config
 			} else {
 				err := fmt.Errorf("Error resolving template %s for service %s: %v",
-					config.Name, serviceID, err)
+					tpl.Name, serviceID, err)
 				errorStats.setResolveWarning(tpl.Name, err.Error())
 				log.Warn(err)
 			}

--- a/pkg/util/cloudfoundry/cloudfoundry.go
+++ b/pkg/util/cloudfoundry/cloudfoundry.go
@@ -17,7 +17,7 @@ import (
 // GetHostAlias returns the host alias from Cloud Foundry
 func GetHostAlias() (string, error) {
 	if !config.Datadog.GetBool("cloud_foundry") {
-		log.Info("cloud_foundry is not enable in the conf: not cloudfoudry host alias")
+		log.Debugf("cloud_foundry is not enabled in the conf: no cloudfoudry host alias")
 		return "", nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adjust some losg

### Motivation

With the `configcheck` command now available we can lower resolve warnings to `debug` as it'll be displayed for most templates
