### PR TITLE
[docs] Update jmx debug command

### DIFF
--- a/docs/beta.md
+++ b/docs/beta.md
@@ -99,7 +99,7 @@ have to run some commands manually to debug the list of beans collected, JVMs,
 etc. A typical manual call will take the following form:
 
 ```shell
-/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent6/bin/agent/dist/jmx/jmxfetch-0.17.0-jar-with-dependencies.jar org.datadog.jmxfetch.App --check <check list> --conf_directory /etc/datadog-agent/conf.d --log_level INFO --log_location /opt/datadog-agent6/bin/agent/dist/jmx/jmxfetch.log --reporter console <command>
+/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.1-jar-with-dependencies.jar org.datadog.jmxfetch.App --check <check list> --conf_directory /opt/datadog-agent/etc/conf.d --log_level INFO --log_location /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.log --reporter console <command>
 ```
 
 where `<command>` can be any of:
@@ -119,7 +119,7 @@ and `<check list>` corresponds to a list of valid `yaml` configurations in
 
 Example:
 ```
-/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent6/bin/agent/dist/jmx/jmxfetch-0.17.0-jar-with-dependencies.jar org.datadog.jmxfetch.App --check cassandra.yaml jmx.yaml --conf_directory /etc/datadog-agent/conf.d --log_level INFO --log_location /opt/datadog-agent6/bin/agent/dist/jmx/jmxfetch.log --reporter console list_everything
+/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.1-jar-with-dependencies.jar org.datadog.jmxfetch.App --check cassandra.d/conf.yaml jmx.d/conf.yaml --conf_directory /opt/datadog-agent/etc/conf.d --log_level INFO --log_location /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.log --reporter console list_everything
 ```
 
 Note: the location to the JRE tools.jar (`/usr/lib/jvm/java-8-oracle/lib/tools.jar`

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -99,7 +99,7 @@ have to run some commands manually to debug the list of beans collected, JVMs,
 etc. A typical manual call will take the following form:
 
 ```shell
-/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.1-jar-with-dependencies.jar org.datadog.jmxfetch.App --check <check list> --conf_directory /opt/datadog-agent/etc/conf.d --log_level INFO --log_location /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.log --reporter console <command>
+/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.1-jar-with-dependencies.jar org.datadog.jmxfetch.App --check <check list> --conf_directory /etc/datadog-agent/conf.d --log_level INFO --log_location /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.log --reporter console <command>
 ```
 
 where `<command>` can be any of:
@@ -119,7 +119,7 @@ and `<check list>` corresponds to a list of valid `yaml` configurations in
 
 Example:
 ```
-/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.1-jar-with-dependencies.jar org.datadog.jmxfetch.App --check cassandra.d/conf.yaml jmx.d/conf.yaml --conf_directory /opt/datadog-agent/etc/conf.d --log_level INFO --log_location /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.log --reporter console list_everything
+/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.1-jar-with-dependencies.jar org.datadog.jmxfetch.App --check cassandra.d/conf.yaml jmx.d/conf.yaml --conf_directory /etc/datadog-agent/conf.d --log_level INFO --log_location /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.log --reporter console list_everything
 ```
 
 Note: the location to the JRE tools.jar (`/usr/lib/jvm/java-8-oracle/lib/tools.jar`


### PR DESCRIPTION
### What does this PR do?

Update the command provided to help debugging jmxfetch to work with the latest version of the agent.

### Motivation

JMX helper commands are not implemented yet.