### PR TITLE
[Import][A6] Import Trace configurations

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -375,7 +375,7 @@ metadata_collectors:
 #   receiver_port: 8126
 #   Whether the Trace Agent should listen for non local traffic
 #   Only enable if Traces are being sent to this Agent from another host/container
-#   trace_non_local_traffic: true
+#   apm_non_local_traffic: true
 #   How many unique client connections to allow during one 30 second lease period
 #   connection_limit: 2000
 #   Extra global sample rate to apply on all the traces

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -372,11 +372,11 @@ metadata_collectors:
 #   The port that the Receiver should listen on
 #   receiver_port: 8126
 #   How many unique client connections to allow during one 30 second lease period
-#   connection_limit: "2000"
+#   connection_limit: 2000
 #   Extra global sample rate to apply on all the traces
 #   This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 #   From 1 (no extra rate) to 0 (don't sample at all)
-#   extra_sample_rate: "1"
+#   extra_sample_rate: 1
 #   A blacklist of regular expressions can be provided to disable certain traces based on their resource name
 #   all entries must be surrounded by double quotes and separated by commas
 #   Example: "(GET|POST) /healthcheck","GET /V1"
@@ -384,5 +384,5 @@ metadata_collectors:
 #   Maximum number of traces per second to sample.
 #   The limit is applied over an average over a few minutes ; much bigger spikes are possible.
 #   Set to 0 to disable the limit.
-#   max_traces_per_second: "10" 
+#   max_traces_per_second: 10
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -372,11 +372,11 @@ metadata_collectors:
 #   The port that the Receiver should listen on
 #   receiver_port: 8126
 #   How many unique client connections to allow during one 30 second lease period
-#   connection_limit: "50000"
+#   connection_limit: "2000"
 #   Extra global sample rate to apply on all the traces
 #   This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 #   From 1 (no extra rate) to 0 (don't sample at all)
-#   extra_sample_rate: "12"
+#   extra_sample_rate: "1"
 #   A blacklist of regular expressions can be provided to disable certain traces based on their resource name
 #   all entries must be surrounded by double quotes and separated by commas
 #   Example: "(GET|POST) /healthcheck","GET /V1"

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -365,7 +365,7 @@ metadata_collectors:
 {{- if .TraceAgent }}
 # Trace Agent Specific Settings
 #
-# trace_config:
+# apm_config:
 #   Whether or not the APM Agent should run
 #   enabled: true
 #   The environment tag that Traces should be tagged with

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -370,18 +370,18 @@ metadata_collectors:
 #   enabled: true
 #   The environment tag that Traces should be tagged with
 #   Will inherit from "env" tag if none is applied here
-#   env: ""
+#   env: "none"
 #   The port that the Receiver should listen on
 #   receiver_port: 8126
 #   Whether the Trace Agent should listen for non local traffic
 #   Only enable if Traces are being sent to this Agent from another host/container
-#   apm_non_local_traffic: true
+#   apm_non_local_traffic: false
 #   How many unique client connections to allow during one 30 second lease period
 #   connection_limit: 2000
 #   Extra global sample rate to apply on all the traces
 #   This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 #   From 1 (no extra rate) to 0 (don't sample at all)
-#   extra_sample_rate: 1
+#   extra_sample_rate: 1.0
 #   A blacklist of regular expressions can be provided to disable certain traces based on their resource name
 #   all entries must be surrounded by double quotes and separated by commas
 #   Example: "(GET|POST) /healthcheck","GET /V1"

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -366,11 +366,16 @@ metadata_collectors:
 # Trace Agent Specific Settings
 #
 # trace_config:
+#   Whether or not the APM Agent shoudl run
+#   enabled: true
 #   The environment tag that Traces should be tagged with
 #   Will inherit from "env" tag if none is applied here
 #   env: ""
 #   The port that the Receiver should listen on
 #   receiver_port: 8126
+#   Whether the Trace Agent should listen for non local traffic
+#   Only enable if Traces are being sent to this Agent from another host/container
+#   trace_non_local_traffic: true
 #   How many unique client connections to allow during one 30 second lease period
 #   connection_limit: "2000"
 #   Extra global sample rate to apply on all the traces

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -366,7 +366,7 @@ metadata_collectors:
 # Trace Agent Specific Settings
 #
 # trace_config:
-#   Whether or not the APM Agent shoudl run
+#   Whether or not the APM Agent should run
 #   enabled: true
 #   The environment tag that Traces should be tagged with
 #   Will inherit from "env" tag if none is applied here

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -361,3 +361,28 @@ metadata_collectors:
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
 {{ end -}}
+
+{{- if .TraceAgent }}
+# Trace Agent Specific Settings
+#
+# trace_config:
+#   The environment tag that Traces should be tagged with
+#   Will inherit from "env" tag if none is applied here
+#   env: ""
+#   The port that the Receiver should listen on
+#   receiver_port: 8126
+#   How many unique client connections to allow during one 30 second lease period
+#   connection_limit: "50000"
+#   Extra global sample rate to apply on all the traces
+#   This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
+#   From 1 (no extra rate) to 0 (don't sample at all)
+#   extra_sample_rate: "12"
+#   A blacklist of regular expressions can be provided to disable certain traces based on their resource name
+#   all entries must be surrounded by double quotes and separated by commas
+#   Example: "(GET|POST) /healthcheck","GET /V1"
+#   ignore_resource: ""
+#   Maximum number of traces per second to sample.
+#   The limit is applied over an average over a few minutes ; much bigger spikes are possible.
+#   Set to 0 to disable the limit.
+#   max_traces_per_second: "10" 
+{{ end -}}

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -31,6 +31,7 @@ type context struct {
 	ECS               bool
 	ProcessAgent      bool
 	KubeApiServer     bool
+	TraceAgent        bool
 }
 
 func mkContext(buildType string) context {
@@ -52,6 +53,7 @@ func mkContext(buildType string) context {
 			KubernetesTagging: true,
 			ECS:               true,
 			ProcessAgent:      true,
+			TraceAgent:        true,
 		}
 	case "dogstatsd":
 		return context{

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -117,6 +117,15 @@ func FromAgentConfig(agentConfig Config) error {
 	}
 
 	//Set the Trace based configs. These should all have default values in the Trace Agent
+
+	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil {
+		config.Datadog.Set("trace_config.enabled", enabled)
+	}
+
+	if enabled, err := isAffirmative(agentConfig["non_local_traffic"]); err == nil {
+		config.Datadog.Set("trace_config.trace_non_local_traffic", enabled)
+	}
+
 	if agentConfig["env"] != "" {
 		config.Datadog.Set("trace_config.env", agentConfig["env"])
 	}

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -119,35 +119,35 @@ func FromAgentConfig(agentConfig Config) error {
 	//Set the Trace based configs. These should all have default values in the Trace Agent
 
 	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil {
-		config.Datadog.Set("trace_config.enabled", enabled)
+		config.Datadog.Set("apm_config.enabled", enabled)
 	}
 
 	if enabled, err := isAffirmative(agentConfig["non_local_traffic"]); err == nil {
-		config.Datadog.Set("trace_config.trace_non_local_traffic", enabled)
+		config.Datadog.Set("apm_config.apm_non_local_traffic", enabled)
 	}
 
 	if agentConfig["env"] != "" {
-		config.Datadog.Set("trace_config.env", agentConfig["env"])
+		config.Datadog.Set("apm_config.env", agentConfig["env"])
 	}
 
 	if value, err := strconv.Atoi(agentConfig["max_traces_per_second"]); err == nil {
-		config.Datadog.Set("trace_config.max_traces_per_second", value)
+		config.Datadog.Set("apm_config.max_traces_per_second", value)
 	}
 
 	if value, err := strconv.Atoi(agentConfig["extra_sample_rate"]); err == nil {
-		config.Datadog.Set("trace_config.extra_sample_rate", value)
+		config.Datadog.Set("apm_config.extra_sample_rate", value)
 	}
 
 	if value, err := strconv.Atoi(agentConfig["connection_limit"]); err == nil {
-		config.Datadog.Set("trace_config.connection_limit", value)
+		config.Datadog.Set("apm_config.connection_limit", value)
 	}
 
 	if value, err := strconv.Atoi(agentConfig["receiver_port"]); err == nil {
-		config.Datadog.Set("trace_config.receiver_port", value)
+		config.Datadog.Set("apm_config.receiver_port", value)
 	}
 
 	if agentConfig["resource"] != "" {
-		config.Datadog.Set("trace_config.ignore_resource", agentConfig["resource"])
+		config.Datadog.Set("apm_config.ignore_resource", agentConfig["resource"])
 	}
 
 	return nil

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -121,20 +121,20 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("trace_config.env", agentConfig["env"])
 	}
 
-	if agentConfig["max_traces_per_second"] != "" {
-		config.Datadog.Set("trace_config.max_traces_per_second", agentConfig["max_traces_per_second"])
+	if value, err := strconv.Atoi(agentConfig["max_traces_per_second"]); err == nil {
+		config.Datadog.Set("trace_config.max_traces_per_second", value)
 	}
 
-	if agentConfig["extra_sample_rate"] != "" {
-		config.Datadog.Set("trace_config.extra_sample_rate", agentConfig["extra_sample_rate"])
+	if value, err := strconv.Atoi(agentConfig["extra_sample_rate"]); err == nil {
+		config.Datadog.Set("trace_config.extra_sample_rate", value)
 	}
 
-	if agentConfig["connection_limit"] != "" {
-		config.Datadog.Set("trace_config.connection_limit", agentConfig["connection_limit"])
+	if value, err := strconv.Atoi(agentConfig["connection_limit"]); err == nil {
+		config.Datadog.Set("trace_config.connection_limit", value)
 	}
 
-	if agentConfig["receiver_port"] != "" {
-		config.Datadog.Set("trace_config.receiver_port", agentConfig["receiver_port"])
+	if value, err := strconv.Atoi(agentConfig["receiver_port"]); err == nil {
+		config.Datadog.Set("trace_config.receiver_port", value)
 	}
 
 	if agentConfig["resource"] != "" {

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -6,257 +6,274 @@
 package legacy
 
 import (
-    "fmt"
-    "net/url"
-    "strconv"
-    "strings"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
 
-    "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // FromAgentConfig reads the old agentConfig configuration, converts and merges
 // the values into the current config.Datadog object
 func FromAgentConfig(agentConfig Config) error {
 
-    config.Datadog.Set("dd_url", agentConfig["dd_url"])
+	config.Datadog.Set("dd_url", agentConfig["dd_url"])
 
-    if proxy, err := buildProxySettings(agentConfig); err == nil {
-        config.Datadog.Set("proxy", proxy)
-    }
+	if proxy, err := buildProxySettings(agentConfig); err == nil {
+		config.Datadog.Set("proxy", proxy)
+	}
 
-    if enabled, err := isAffirmative(agentConfig["skip_ssl_validation"]); err == nil {
-        config.Datadog.Set("skip_ssl_validation", enabled)
-    }
+	if enabled, err := isAffirmative(agentConfig["skip_ssl_validation"]); err == nil {
+		config.Datadog.Set("skip_ssl_validation", enabled)
+	}
 
-    config.Datadog.Set("api_key", agentConfig["api_key"])
-    config.Datadog.Set("hostname", agentConfig["hostname"])
+	config.Datadog.Set("api_key", agentConfig["api_key"])
+	config.Datadog.Set("hostname", agentConfig["hostname"])
 
-    if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil && !enabled {
-        // apm is enabled by default through the check config file `apm.yaml.default`
-        config.Datadog.Set("apm_enabled", false)
-    }
+	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil && !enabled {
+		// apm is enabled by default through the check config file `apm.yaml.default`
+		config.Datadog.Set("apm_enabled", false)
+	}
 
-    if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); err == nil && !enabled {
-        // process agent is enabled in datadog.yaml
-        config.Datadog.Set("process_agent_enabled", false)
-    }
+	if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); err == nil && !enabled {
+		// process agent is enabled in datadog.yaml
+		config.Datadog.Set("process_agent_enabled", false)
+	}
 
-    config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))
+	config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))
 
-    if value, err := strconv.Atoi(agentConfig["forwarder_timeout"]); err == nil {
-        config.Datadog.Set("forwarder_timeout", value)
-    }
+	if value, err := strconv.Atoi(agentConfig["forwarder_timeout"]); err == nil {
+		config.Datadog.Set("forwarder_timeout", value)
+	}
 
-    if value, err := strconv.Atoi(agentConfig["default_integration_http_timeout"]); err == nil {
-        config.Datadog.Set("default_integration_http_timeout", value)
-    }
+	if value, err := strconv.Atoi(agentConfig["default_integration_http_timeout"]); err == nil {
+		config.Datadog.Set("default_integration_http_timeout", value)
+	}
 
-    // TODO: collect_ec2_tags
+	// TODO: collect_ec2_tags
 
-    // config.Datadog has a default value for this, do nothing if the value is empty
-    if agentConfig["additional_checksd"] != "" {
-        config.Datadog.Set("additional_checksd", agentConfig["additional_checksd"])
-    }
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["additional_checksd"] != "" {
+		config.Datadog.Set("additional_checksd", agentConfig["additional_checksd"])
+	}
 
-    // TODO: exclude_process_args
-    config.Datadog.Set("histogram_aggregates", buildHistogramAggregates(agentConfig))
+	// TODO: exclude_process_args
+	config.Datadog.Set("histogram_aggregates", buildHistogramAggregates(agentConfig))
 
-    // TODO: histogram_percentiles
+	// TODO: histogram_percentiles
 
-    if agentConfig["service_discovery_backend"] == "docker" {
-        // `docker` is the only possible value also on the Agent v5
-        dockerListener := config.Listeners{Name: "docker"}
-        config.Datadog.Set("listeners", []config.Listeners{dockerListener})
-    }
+	if agentConfig["service_discovery_backend"] == "docker" {
+		// `docker` is the only possible value also on the Agent v5
+		dockerListener := config.Listeners{Name: "docker"}
+		config.Datadog.Set("listeners", []config.Listeners{dockerListener})
+	}
 
-    if providers, err := buildConfigProviders(agentConfig); err == nil {
-        config.Datadog.Set("config_providers", providers)
-    }
+	if providers, err := buildConfigProviders(agentConfig); err == nil {
+		config.Datadog.Set("config_providers", providers)
+	}
 
-    // config.Datadog has a default value for this, do nothing if the value is empty
-    if agentConfig["sd_template_dir"] != "" {
-        config.Datadog.Set("autoconf_template_dir", agentConfig["sd_template_dir"])
-    }
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["sd_template_dir"] != "" {
+		config.Datadog.Set("autoconf_template_dir", agentConfig["sd_template_dir"])
+	}
 
-    if enabled, err := isAffirmative(agentConfig["use_dogstatsd"]); err == nil {
-        config.Datadog.Set("use_dogstatsd", enabled)
-    }
+	if enabled, err := isAffirmative(agentConfig["use_dogstatsd"]); err == nil {
+		config.Datadog.Set("use_dogstatsd", enabled)
+	}
 
-    if value, err := strconv.Atoi(agentConfig["dogstatsd_port"]); err == nil {
-        config.Datadog.Set("dogstatsd_port", value)
-    }
+	if value, err := strconv.Atoi(agentConfig["dogstatsd_port"]); err == nil {
+		config.Datadog.Set("dogstatsd_port", value)
+	}
 
-    // TODO: statsd_metric_namespace
+	// TODO: statsd_metric_namespace
 
-    // config.Datadog has a default value for this, do nothing if the value is empty
-    if agentConfig["log_level"] != "" {
-        config.Datadog.Set("log_level", agentConfig["log_level"])
-    }
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["log_level"] != "" {
+		config.Datadog.Set("log_level", agentConfig["log_level"])
+	}
 
-    // config.Datadog has a default value for this, do nothing if the value is empty
-    if agentConfig["collector_log_file"] != "" {
-        config.Datadog.Set("log_file", agentConfig["collector_log_file"])
-    }
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["collector_log_file"] != "" {
+		config.Datadog.Set("log_file", agentConfig["collector_log_file"])
+	}
 
-    // config.Datadog has a default value for this, do nothing if the value is empty
-    if agentConfig["disable_file_logging"] != "" {
-        config.Datadog.Set("disable_file_logging", agentConfig["disable_file_logging"])
-    }
+	// config.Datadog has a default value for this, do nothing if the value is empty
+	if agentConfig["disable_file_logging"] != "" {
+		config.Datadog.Set("disable_file_logging", agentConfig["disable_file_logging"])
+	}
 
-    if enabled, err := isAffirmative(agentConfig["log_to_syslog"]); err == nil {
-        config.Datadog.Set("log_to_syslog", enabled)
-    }
-    config.Datadog.Set("syslog_uri", buildSyslogURI(agentConfig))
+	if enabled, err := isAffirmative(agentConfig["log_to_syslog"]); err == nil {
+		config.Datadog.Set("log_to_syslog", enabled)
+	}
+	config.Datadog.Set("syslog_uri", buildSyslogURI(agentConfig))
 
-    if enabled, err := isAffirmative(agentConfig["collect_instance_metadata"]); err == nil {
-        config.Datadog.Set("enable_metadata_collection", enabled)
-    }
+	if enabled, err := isAffirmative(agentConfig["collect_instance_metadata"]); err == nil {
+		config.Datadog.Set("enable_metadata_collection", enabled)
+	}
 
-    if enabled, err := isAffirmative(agentConfig["enable_gohai"]); err == nil {
-        config.Datadog.Set("enable_gohai", enabled)
-    }
+	if enabled, err := isAffirmative(agentConfig["enable_gohai"]); err == nil {
+		config.Datadog.Set("enable_gohai", enabled)
+	}
 
-    //Set the Trace based configs
-    config.Datadog.Set("trace_config.env", agentConfig["env"])
-    config.Datadog.Set("trace_config.max_traces_per_second", agentConfig["max_traces_per_second"])
-    config.Datadog.Set("trace_config.extra_sample_rate", agentConfig["extra_sample_rate"])
-    config.Datadog.Set("trace_config.connection_limit", agentConfig["connection_limit"])
-    config.Datadog.Set("trace_config.receiver_port", agentConfig["receiver_port"])
-    config.Datadog.Set("trace_config.ignore_resource", agentConfig["resource"])
-    return nil
+	//Set the Trace based configs. These should all have default values in the Trace Agent
+	if agentConfig["env"] != "" {
+		config.Datadog.Set("trace_config.env", agentConfig["env"])
+	}
+
+	if agentConfig["max_traces_per_second"] != "" {
+		config.Datadog.Set("trace_config.max_traces_per_second", agentConfig["max_traces_per_second"])
+	}
+
+	if agentConfig["extra_sample_rate"] != "" {
+		config.Datadog.Set("trace_config.extra_sample_rate", agentConfig["extra_sample_rate"])
+	}
+
+	if agentConfig["connection_limit"] != "" {
+		config.Datadog.Set("trace_config.connection_limit", agentConfig["connection_limit"])
+	}
+
+	if agentConfig["receiver_port"] != "" {
+		config.Datadog.Set("trace_config.receiver_port", agentConfig["receiver_port"])
+	}
+
+	if agentConfig["resource"] != "" {
+		config.Datadog.Set("trace_config.ignore_resource", agentConfig["resource"])
+	}
+
+	return nil
 }
 
 func isAffirmative(value string) (bool, error) {
-    if value == "" {
-        return false, fmt.Errorf("value is empty")
-    }
+	if value == "" {
+		return false, fmt.Errorf("value is empty")
+	}
 
-    v := strings.ToLower(value)
-    return v == "true" || v == "yes" || v == "1", nil
+	v := strings.ToLower(value)
+	return v == "true" || v == "yes" || v == "1", nil
 }
 
 func buildProxySettings(agentConfig Config) (map[string]string, error) {
-    proxyHost := agentConfig["proxy_host"]
+	proxyHost := agentConfig["proxy_host"]
 
-    proxyMap := make(map[string]string)
+	proxyMap := make(map[string]string)
 
-    if proxyHost == "" {
-        // this is expected, not an error
-        return nil, nil
-    }
+	if proxyHost == "" {
+		// this is expected, not an error
+		return nil, nil
+	}
 
-    var err error
-    var u *url.URL
+	var err error
+	var u *url.URL
 
-    if u, err = url.Parse(proxyHost); err != nil {
-        return nil, fmt.Errorf("unable to import value of settings 'proxy_host': %v", err)
-    }
+	if u, err = url.Parse(proxyHost); err != nil {
+		return nil, fmt.Errorf("unable to import value of settings 'proxy_host': %v", err)
+	}
 
-    // set scheme if missing
-    if u.Scheme == "" {
-        u, _ = url.Parse("http://" + proxyHost)
-    }
+	// set scheme if missing
+	if u.Scheme == "" {
+		u, _ = url.Parse("http://" + proxyHost)
+	}
 
-    if agentConfig["proxy_port"] != "" {
-        u.Host = u.Host + ":" + agentConfig["proxy_port"]
-    }
+	if agentConfig["proxy_port"] != "" {
+		u.Host = u.Host + ":" + agentConfig["proxy_port"]
+	}
 
-    if user := agentConfig["proxy_user"]; user != "" {
-        if pass := agentConfig["proxy_password"]; pass != "" {
-            u.User = url.UserPassword(user, pass)
-        } else {
-            u.User = url.User(user)
-        }
-    }
+	if user := agentConfig["proxy_user"]; user != "" {
+		if pass := agentConfig["proxy_password"]; pass != "" {
+			u.User = url.UserPassword(user, pass)
+		} else {
+			u.User = url.User(user)
+		}
+	}
 
-    proxyMap["http"] = u.String()
-    proxyMap["https"] = u.String()
+	proxyMap["http"] = u.String()
+	proxyMap["https"] = u.String()
 
-    return proxyMap, nil
+	return proxyMap, nil
 
 }
 
 func buildSyslogURI(agentConfig Config) string {
-    host := agentConfig["syslog_host"]
+	host := agentConfig["syslog_host"]
 
-    if host == "" {
-        // this is expected, not an error
-        return ""
-    }
+	if host == "" {
+		// this is expected, not an error
+		return ""
+	}
 
-    if agentConfig["syslog_port"] != "" {
-        host = host + ":" + agentConfig["syslog_port"]
-    }
+	if agentConfig["syslog_port"] != "" {
+		host = host + ":" + agentConfig["syslog_port"]
+	}
 
-    return host
+	return host
 }
 
 func buildConfigProviders(agentConfig Config) ([]config.ConfigurationProviders, error) {
-    // the list of SD_CONFIG_BACKENDS supported in v5
-    SdConfigBackends := map[string]struct{}{
-        "etcd":   {},
-        "consul": {},
-        "zk":     {},
-    }
+	// the list of SD_CONFIG_BACKENDS supported in v5
+	SdConfigBackends := map[string]struct{}{
+		"etcd":   {},
+		"consul": {},
+		"zk":     {},
+	}
 
-    if _, found := SdConfigBackends[agentConfig["sd_config_backend"]]; !found {
-        return nil, fmt.Errorf("configuration backend %s is invalid", agentConfig["sd_config_backend"])
-    }
+	if _, found := SdConfigBackends[agentConfig["sd_config_backend"]]; !found {
+		return nil, fmt.Errorf("configuration backend %s is invalid", agentConfig["sd_config_backend"])
+	}
 
-    url := agentConfig["sd_backend_host"]
-    if agentConfig["sd_backend_port"] != "" {
-        url = url + ":" + agentConfig["sd_backend_port"]
-    }
+	url := agentConfig["sd_backend_host"]
+	if agentConfig["sd_backend_port"] != "" {
+		url = url + ":" + agentConfig["sd_backend_port"]
+	}
 
-    cp := config.ConfigurationProviders{
-        Username:    agentConfig["sd_backend_username"],
-        Password:    agentConfig["sd_backend_password"],
-        TemplateURL: url,
-        Polling:     true,
-    }
+	cp := config.ConfigurationProviders{
+		Username:    agentConfig["sd_backend_username"],
+		Password:    agentConfig["sd_backend_password"],
+		TemplateURL: url,
+		Polling:     true,
+	}
 
-    // v5 supported only one configuration provider at a time
-    switch agentConfig["sd_config_backend"] {
-    case "etcd":
-        cp.Name = "etcd"
-    case "consul":
-        cp.Name = "consul"
-        cp.Token = agentConfig["consul_token"]
-    case "zk":
-        cp.Name = "zookeeper" // name is different in v6
-    }
+	// v5 supported only one configuration provider at a time
+	switch agentConfig["sd_config_backend"] {
+	case "etcd":
+		cp.Name = "etcd"
+	case "consul":
+		cp.Name = "consul"
+		cp.Token = agentConfig["consul_token"]
+	case "zk":
+		cp.Name = "zookeeper" // name is different in v6
+	}
 
-    return []config.ConfigurationProviders{cp}, nil
+	return []config.ConfigurationProviders{cp}, nil
 }
 
 func buildHistogramAggregates(agentConfig Config) []string {
-    configValue := agentConfig["histogram_aggregates"]
+	configValue := agentConfig["histogram_aggregates"]
 
-    var histogramBuild []string
-    // The valid values for histogram_aggregates as defined in agent5
-    validValues := []string{"min", "max", "median", "avg", "sum", "count"}
+	var histogramBuild []string
+	// The valid values for histogram_aggregates as defined in agent5
+	validValues := []string{"min", "max", "median", "avg", "sum", "count"}
 
-    if configValue == "" {
-        return nil
-    }
-    configValue = strings.Replace(configValue, " ", "", -1)
-    result := strings.Split(configValue, ",")
+	if configValue == "" {
+		return nil
+	}
+	configValue = strings.Replace(configValue, " ", "", -1)
+	result := strings.Split(configValue, ",")
 
-    for _, res := range result {
-        found := false
-        for _, val := range validValues {
-            if res == val {
-                histogramBuild = append(histogramBuild, res)
-                found = true
-                break
-            }
-        }
-        if !found {
-            // print the value skipped because invalid value
-            fmt.Println("warning: ignored histogram aggregate", res, "is invalid")
-        }
-    }
+	for _, res := range result {
+		found := false
+		for _, val := range validValues {
+			if res == val {
+				histogramBuild = append(histogramBuild, res)
+				found = true
+				break
+			}
+		}
+		if !found {
+			// print the value skipped because invalid value
+			fmt.Println("warning: ignored histogram aggregate", res, "is invalid")
+		}
+	}
 
-    return histogramBuild
+	return histogramBuild
 }
-

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -6,249 +6,257 @@
 package legacy
 
 import (
-	"fmt"
-	"net/url"
-	"strconv"
-	"strings"
+    "fmt"
+    "net/url"
+    "strconv"
+    "strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+    "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // FromAgentConfig reads the old agentConfig configuration, converts and merges
 // the values into the current config.Datadog object
 func FromAgentConfig(agentConfig Config) error {
 
-	config.Datadog.Set("dd_url", agentConfig["dd_url"])
+    config.Datadog.Set("dd_url", agentConfig["dd_url"])
 
-	if proxy, err := buildProxySettings(agentConfig); err == nil {
-		config.Datadog.Set("proxy", proxy)
-	}
+    if proxy, err := buildProxySettings(agentConfig); err == nil {
+        config.Datadog.Set("proxy", proxy)
+    }
 
-	if enabled, err := isAffirmative(agentConfig["skip_ssl_validation"]); err == nil {
-		config.Datadog.Set("skip_ssl_validation", enabled)
-	}
+    if enabled, err := isAffirmative(agentConfig["skip_ssl_validation"]); err == nil {
+        config.Datadog.Set("skip_ssl_validation", enabled)
+    }
 
-	config.Datadog.Set("api_key", agentConfig["api_key"])
-	config.Datadog.Set("hostname", agentConfig["hostname"])
+    config.Datadog.Set("api_key", agentConfig["api_key"])
+    config.Datadog.Set("hostname", agentConfig["hostname"])
 
-	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil && !enabled {
-		// apm is enabled by default through the check config file `apm.yaml.default`
-		config.Datadog.Set("apm_enabled", false)
-	}
+    if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil && !enabled {
+        // apm is enabled by default through the check config file `apm.yaml.default`
+        config.Datadog.Set("apm_enabled", false)
+    }
 
-	if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); err == nil && !enabled {
-		// process agent is enabled in datadog.yaml
-		config.Datadog.Set("process_agent_enabled", false)
-	}
+    if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); err == nil && !enabled {
+        // process agent is enabled in datadog.yaml
+        config.Datadog.Set("process_agent_enabled", false)
+    }
 
-	config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))
+    config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))
 
-	if value, err := strconv.Atoi(agentConfig["forwarder_timeout"]); err == nil {
-		config.Datadog.Set("forwarder_timeout", value)
-	}
+    if value, err := strconv.Atoi(agentConfig["forwarder_timeout"]); err == nil {
+        config.Datadog.Set("forwarder_timeout", value)
+    }
 
-	if value, err := strconv.Atoi(agentConfig["default_integration_http_timeout"]); err == nil {
-		config.Datadog.Set("default_integration_http_timeout", value)
-	}
+    if value, err := strconv.Atoi(agentConfig["default_integration_http_timeout"]); err == nil {
+        config.Datadog.Set("default_integration_http_timeout", value)
+    }
 
-	// TODO: collect_ec2_tags
+    // TODO: collect_ec2_tags
 
-	// config.Datadog has a default value for this, do nothing if the value is empty
-	if agentConfig["additional_checksd"] != "" {
-		config.Datadog.Set("additional_checksd", agentConfig["additional_checksd"])
-	}
+    // config.Datadog has a default value for this, do nothing if the value is empty
+    if agentConfig["additional_checksd"] != "" {
+        config.Datadog.Set("additional_checksd", agentConfig["additional_checksd"])
+    }
 
-	// TODO: exclude_process_args
-	config.Datadog.Set("histogram_aggregates", buildHistogramAggregates(agentConfig))
+    // TODO: exclude_process_args
+    config.Datadog.Set("histogram_aggregates", buildHistogramAggregates(agentConfig))
 
-	// TODO: histogram_percentiles
+    // TODO: histogram_percentiles
 
-	if agentConfig["service_discovery_backend"] == "docker" {
-		// `docker` is the only possible value also on the Agent v5
-		dockerListener := config.Listeners{Name: "docker"}
-		config.Datadog.Set("listeners", []config.Listeners{dockerListener})
-	}
+    if agentConfig["service_discovery_backend"] == "docker" {
+        // `docker` is the only possible value also on the Agent v5
+        dockerListener := config.Listeners{Name: "docker"}
+        config.Datadog.Set("listeners", []config.Listeners{dockerListener})
+    }
 
-	if providers, err := buildConfigProviders(agentConfig); err == nil {
-		config.Datadog.Set("config_providers", providers)
-	}
+    if providers, err := buildConfigProviders(agentConfig); err == nil {
+        config.Datadog.Set("config_providers", providers)
+    }
 
-	// config.Datadog has a default value for this, do nothing if the value is empty
-	if agentConfig["sd_template_dir"] != "" {
-		config.Datadog.Set("autoconf_template_dir", agentConfig["sd_template_dir"])
-	}
+    // config.Datadog has a default value for this, do nothing if the value is empty
+    if agentConfig["sd_template_dir"] != "" {
+        config.Datadog.Set("autoconf_template_dir", agentConfig["sd_template_dir"])
+    }
 
-	if enabled, err := isAffirmative(agentConfig["use_dogstatsd"]); err == nil {
-		config.Datadog.Set("use_dogstatsd", enabled)
-	}
+    if enabled, err := isAffirmative(agentConfig["use_dogstatsd"]); err == nil {
+        config.Datadog.Set("use_dogstatsd", enabled)
+    }
 
-	if value, err := strconv.Atoi(agentConfig["dogstatsd_port"]); err == nil {
-		config.Datadog.Set("dogstatsd_port", value)
-	}
+    if value, err := strconv.Atoi(agentConfig["dogstatsd_port"]); err == nil {
+        config.Datadog.Set("dogstatsd_port", value)
+    }
 
-	// TODO: statsd_metric_namespace
+    // TODO: statsd_metric_namespace
 
-	// config.Datadog has a default value for this, do nothing if the value is empty
-	if agentConfig["log_level"] != "" {
-		config.Datadog.Set("log_level", agentConfig["log_level"])
-	}
+    // config.Datadog has a default value for this, do nothing if the value is empty
+    if agentConfig["log_level"] != "" {
+        config.Datadog.Set("log_level", agentConfig["log_level"])
+    }
 
-	// config.Datadog has a default value for this, do nothing if the value is empty
-	if agentConfig["collector_log_file"] != "" {
-		config.Datadog.Set("log_file", agentConfig["collector_log_file"])
-	}
+    // config.Datadog has a default value for this, do nothing if the value is empty
+    if agentConfig["collector_log_file"] != "" {
+        config.Datadog.Set("log_file", agentConfig["collector_log_file"])
+    }
 
-	// config.Datadog has a default value for this, do nothing if the value is empty
-	if agentConfig["disable_file_logging"] != "" {
-		config.Datadog.Set("disable_file_logging", agentConfig["disable_file_logging"])
-	}
+    // config.Datadog has a default value for this, do nothing if the value is empty
+    if agentConfig["disable_file_logging"] != "" {
+        config.Datadog.Set("disable_file_logging", agentConfig["disable_file_logging"])
+    }
 
-	if enabled, err := isAffirmative(agentConfig["log_to_syslog"]); err == nil {
-		config.Datadog.Set("log_to_syslog", enabled)
-	}
-	config.Datadog.Set("syslog_uri", buildSyslogURI(agentConfig))
+    if enabled, err := isAffirmative(agentConfig["log_to_syslog"]); err == nil {
+        config.Datadog.Set("log_to_syslog", enabled)
+    }
+    config.Datadog.Set("syslog_uri", buildSyslogURI(agentConfig))
 
-	if enabled, err := isAffirmative(agentConfig["collect_instance_metadata"]); err == nil {
-		config.Datadog.Set("enable_metadata_collection", enabled)
-	}
+    if enabled, err := isAffirmative(agentConfig["collect_instance_metadata"]); err == nil {
+        config.Datadog.Set("enable_metadata_collection", enabled)
+    }
 
-	if enabled, err := isAffirmative(agentConfig["enable_gohai"]); err == nil {
-		config.Datadog.Set("enable_gohai", enabled)
-	}
+    if enabled, err := isAffirmative(agentConfig["enable_gohai"]); err == nil {
+        config.Datadog.Set("enable_gohai", enabled)
+    }
 
-	return nil
+    //Set the Trace based configs
+    config.Datadog.Set("trace_config.env", agentConfig["env"])
+    config.Datadog.Set("trace_config.max_traces_per_second", agentConfig["max_traces_per_second"])
+    config.Datadog.Set("trace_config.extra_sample_rate", agentConfig["extra_sample_rate"])
+    config.Datadog.Set("trace_config.connection_limit", agentConfig["connection_limit"])
+    config.Datadog.Set("trace_config.receiver_port", agentConfig["receiver_port"])
+    config.Datadog.Set("trace_config.ignore_resource", agentConfig["resource"])
+    return nil
 }
 
 func isAffirmative(value string) (bool, error) {
-	if value == "" {
-		return false, fmt.Errorf("value is empty")
-	}
+    if value == "" {
+        return false, fmt.Errorf("value is empty")
+    }
 
-	v := strings.ToLower(value)
-	return v == "true" || v == "yes" || v == "1", nil
+    v := strings.ToLower(value)
+    return v == "true" || v == "yes" || v == "1", nil
 }
 
 func buildProxySettings(agentConfig Config) (map[string]string, error) {
-	proxyHost := agentConfig["proxy_host"]
+    proxyHost := agentConfig["proxy_host"]
 
-	proxyMap := make(map[string]string)
+    proxyMap := make(map[string]string)
 
-	if proxyHost == "" {
-		// this is expected, not an error
-		return nil, nil
-	}
+    if proxyHost == "" {
+        // this is expected, not an error
+        return nil, nil
+    }
 
-	var err error
-	var u *url.URL
+    var err error
+    var u *url.URL
 
-	if u, err = url.Parse(proxyHost); err != nil {
-		return nil, fmt.Errorf("unable to import value of settings 'proxy_host': %v", err)
-	}
+    if u, err = url.Parse(proxyHost); err != nil {
+        return nil, fmt.Errorf("unable to import value of settings 'proxy_host': %v", err)
+    }
 
-	// set scheme if missing
-	if u.Scheme == "" {
-		u, _ = url.Parse("http://" + proxyHost)
-	}
+    // set scheme if missing
+    if u.Scheme == "" {
+        u, _ = url.Parse("http://" + proxyHost)
+    }
 
-	if agentConfig["proxy_port"] != "" {
-		u.Host = u.Host + ":" + agentConfig["proxy_port"]
-	}
+    if agentConfig["proxy_port"] != "" {
+        u.Host = u.Host + ":" + agentConfig["proxy_port"]
+    }
 
-	if user := agentConfig["proxy_user"]; user != "" {
-		if pass := agentConfig["proxy_password"]; pass != "" {
-			u.User = url.UserPassword(user, pass)
-		} else {
-			u.User = url.User(user)
-		}
-	}
+    if user := agentConfig["proxy_user"]; user != "" {
+        if pass := agentConfig["proxy_password"]; pass != "" {
+            u.User = url.UserPassword(user, pass)
+        } else {
+            u.User = url.User(user)
+        }
+    }
 
-	proxyMap["http"] = u.String()
-	proxyMap["https"] = u.String()
+    proxyMap["http"] = u.String()
+    proxyMap["https"] = u.String()
 
-	return proxyMap, nil
+    return proxyMap, nil
 
 }
 
 func buildSyslogURI(agentConfig Config) string {
-	host := agentConfig["syslog_host"]
+    host := agentConfig["syslog_host"]
 
-	if host == "" {
-		// this is expected, not an error
-		return ""
-	}
+    if host == "" {
+        // this is expected, not an error
+        return ""
+    }
 
-	if agentConfig["syslog_port"] != "" {
-		host = host + ":" + agentConfig["syslog_port"]
-	}
+    if agentConfig["syslog_port"] != "" {
+        host = host + ":" + agentConfig["syslog_port"]
+    }
 
-	return host
+    return host
 }
 
 func buildConfigProviders(agentConfig Config) ([]config.ConfigurationProviders, error) {
-	// the list of SD_CONFIG_BACKENDS supported in v5
-	SdConfigBackends := map[string]struct{}{
-		"etcd":   {},
-		"consul": {},
-		"zk":     {},
-	}
+    // the list of SD_CONFIG_BACKENDS supported in v5
+    SdConfigBackends := map[string]struct{}{
+        "etcd":   {},
+        "consul": {},
+        "zk":     {},
+    }
 
-	if _, found := SdConfigBackends[agentConfig["sd_config_backend"]]; !found {
-		return nil, fmt.Errorf("configuration backend %s is invalid", agentConfig["sd_config_backend"])
-	}
+    if _, found := SdConfigBackends[agentConfig["sd_config_backend"]]; !found {
+        return nil, fmt.Errorf("configuration backend %s is invalid", agentConfig["sd_config_backend"])
+    }
 
-	url := agentConfig["sd_backend_host"]
-	if agentConfig["sd_backend_port"] != "" {
-		url = url + ":" + agentConfig["sd_backend_port"]
-	}
+    url := agentConfig["sd_backend_host"]
+    if agentConfig["sd_backend_port"] != "" {
+        url = url + ":" + agentConfig["sd_backend_port"]
+    }
 
-	cp := config.ConfigurationProviders{
-		Username:    agentConfig["sd_backend_username"],
-		Password:    agentConfig["sd_backend_password"],
-		TemplateURL: url,
-		Polling:     true,
-	}
+    cp := config.ConfigurationProviders{
+        Username:    agentConfig["sd_backend_username"],
+        Password:    agentConfig["sd_backend_password"],
+        TemplateURL: url,
+        Polling:     true,
+    }
 
-	// v5 supported only one configuration provider at a time
-	switch agentConfig["sd_config_backend"] {
-	case "etcd":
-		cp.Name = "etcd"
-	case "consul":
-		cp.Name = "consul"
-		cp.Token = agentConfig["consul_token"]
-	case "zk":
-		cp.Name = "zookeeper" // name is different in v6
-	}
+    // v5 supported only one configuration provider at a time
+    switch agentConfig["sd_config_backend"] {
+    case "etcd":
+        cp.Name = "etcd"
+    case "consul":
+        cp.Name = "consul"
+        cp.Token = agentConfig["consul_token"]
+    case "zk":
+        cp.Name = "zookeeper" // name is different in v6
+    }
 
-	return []config.ConfigurationProviders{cp}, nil
+    return []config.ConfigurationProviders{cp}, nil
 }
 
 func buildHistogramAggregates(agentConfig Config) []string {
-	configValue := agentConfig["histogram_aggregates"]
+    configValue := agentConfig["histogram_aggregates"]
 
-	var histogramBuild []string
-	// The valid values for histogram_aggregates as defined in agent5
-	validValues := []string{"min", "max", "median", "avg", "sum", "count"}
+    var histogramBuild []string
+    // The valid values for histogram_aggregates as defined in agent5
+    validValues := []string{"min", "max", "median", "avg", "sum", "count"}
 
-	if configValue == "" {
-		return nil
-	}
-	configValue = strings.Replace(configValue, " ", "", -1)
-	result := strings.Split(configValue, ",")
+    if configValue == "" {
+        return nil
+    }
+    configValue = strings.Replace(configValue, " ", "", -1)
+    result := strings.Split(configValue, ",")
 
-	for _, res := range result {
-		found := false
-		for _, val := range validValues {
-			if res == val {
-				histogramBuild = append(histogramBuild, res)
-				found = true
-				break
-			}
-		}
-		if !found {
-			// print the value skipped because invalid value
-			fmt.Println("warning: ignored histogram aggregate", res, "is invalid")
-		}
-	}
+    for _, res := range result {
+        found := false
+        for _, val := range validValues {
+            if res == val {
+                histogramBuild = append(histogramBuild, res)
+                found = true
+                break
+            }
+        }
+        if !found {
+            // print the value skipped because invalid value
+            fmt.Println("warning: ignored histogram aggregate", res, "is invalid")
+        }
+    }
 
-	return histogramBuild
+    return histogramBuild
 }
+

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -14,118 +14,117 @@ import "github.com/go-ini/ini"
 type Config map[string]string
 
 var (
-    // Note: we'll only import a subset of these values.
-    supportedValues = []string{
-        "dd_url",
-        "proxy_host",
-        "proxy_port",
-        "proxy_user",
-        "proxy_password",
-        "skip_ssl_validation",
-        "api_key",
-        "hostname",
-        "apm_enabled",
-        "tags",
-        "forwarder_timeout",
-        "default_integration_http_timeout",
-        "collect_ec2_tags",
-        "additional_checksd",
-        "exclude_process_args",
-        "histogram_aggregates",
-        "histogram_percentiles",
-        "service_discovery_backend",
-        "sd_config_backend",
-        "sd_backend_host",
-        "sd_backend_port",
-        "sd_backend_username",
-        "sd_backend_password",
-        "sd_template_dir",
-        "consul_token",
-        "use_dogstatsd",
-        "dogstatsd_port",
-        "statsd_metric_namespace",
-        "log_level",
-        "collector_log_file",
-        "log_to_syslog",
-        "log_to_event_viewer", // maybe deprecated, ignore for now
-        "syslog_host",
-        "syslog_port",
-        "collect_instance_metadata",
-        "listen_port",                // not for 6.0, ignore for now
-        "non_local_traffic",          // not for 6.0, ignore for now
-        "create_dd_check_tags",       // not for 6.0, ignore for now
-        "bind_host",                  // not for 6.0, ignore for now
-        "proxy_forbid_method_switch", // deprecated
-        "collect_orchestrator_tags",  // deprecated
-        "use_curl_http_client",       // deprecated
-        "dogstatsd_target",           // deprecated
-        "gce_updated_hostname",       // deprecated
-        "process_agent_enabled",
-        "disable_file_logging",
-        "enable_gohai",
-        // trace-agent specific
-        "extra_sample_rate",
-        "max_traces_per_second",
-        "receiver_port",
-        "connection_limit",
-        "resource",
-    }
+	// Note: we'll only import a subset of these values.
+	supportedValues = []string{
+		"dd_url",
+		"proxy_host",
+		"proxy_port",
+		"proxy_user",
+		"proxy_password",
+		"skip_ssl_validation",
+		"api_key",
+		"hostname",
+		"apm_enabled",
+		"tags",
+		"forwarder_timeout",
+		"default_integration_http_timeout",
+		"collect_ec2_tags",
+		"additional_checksd",
+		"exclude_process_args",
+		"histogram_aggregates",
+		"histogram_percentiles",
+		"service_discovery_backend",
+		"sd_config_backend",
+		"sd_backend_host",
+		"sd_backend_port",
+		"sd_backend_username",
+		"sd_backend_password",
+		"sd_template_dir",
+		"consul_token",
+		"use_dogstatsd",
+		"dogstatsd_port",
+		"statsd_metric_namespace",
+		"log_level",
+		"collector_log_file",
+		"log_to_syslog",
+		"log_to_event_viewer", // maybe deprecated, ignore for now
+		"syslog_host",
+		"syslog_port",
+		"collect_instance_metadata",
+		"listen_port",                // not for 6.0, ignore for now
+		"non_local_traffic",          // not for 6.0, ignore for now
+		"create_dd_check_tags",       // not for 6.0, ignore for now
+		"bind_host",                  // not for 6.0, ignore for now
+		"proxy_forbid_method_switch", // deprecated
+		"collect_orchestrator_tags",  // deprecated
+		"use_curl_http_client",       // deprecated
+		"dogstatsd_target",           // deprecated
+		"gce_updated_hostname",       // deprecated
+		"process_agent_enabled",
+		"disable_file_logging",
+		"enable_gohai",
+		// trace-agent specific
+		"extra_sample_rate",
+		"max_traces_per_second",
+		"receiver_port",
+		"connection_limit",
+		"resource",
+	}
 )
 
 // GetAgentConfig reads `datadog.conf` and returns a map that contains the same
 // values as the agentConfig dictionary returned by `get_config()` in config.py
 func GetAgentConfig(datadogConfPath string) (Config, error) {
-    config := make(map[string]string)
-    iniFile, err := ini.Load(datadogConfPath)
-    if err != nil {
-        return config, err
-    }
+	config := make(map[string]string)
+	iniFile, err := ini.Load(datadogConfPath)
+	if err != nil {
+		return config, err
+	}
 
-    // get the Main section
-    main, err := iniFile.GetSection("Main")
-    if err != nil {
-        return config, err
-    }
+	// get the Main section
+	main, err := iniFile.GetSection("Main")
+	if err != nil {
+		return config, err
+	}
 
-    // get the Trace Agent sections
-    // Its likely that most of these sections won't exist
-    traceSampler := iniFile.Section("trace.sampler")
-    traceReceiver := iniFile.Section("trace.receiver")
-    traceIgnore := iniFile.Section("trace.ignore")
+	// get the Trace Agent sections
+	// Its likely that most of these sections won't exist
+	traceSampler := iniFile.Section("trace.sampler")
+	traceReceiver := iniFile.Section("trace.receiver")
+	traceIgnore := iniFile.Section("trace.ignore")
 
-    // Grab the values needed to do a comparison of the Go vs Python algorithm.
-    for _, supportedValue := range supportedValues {
-        if value, err := main.GetKey(supportedValue); err == nil {
-            config[supportedValue] = value.String()
-        } else if value, err := traceSampler.GetKey(supportedValue); err == nil {
-            config[supportedValue] = value.String()
-        } else if value, err := traceReceiver.GetKey(supportedValue); err == nil {
-            config[supportedValue] = value.String()
-        } else if value, err := traceIgnore.GetKey(supportedValue); err == nil {
-            config[supportedValue] = value.String()
-        } else {
-            // provide an empty default value so we don't need to check for
-            // key existence when browsing the old configuration
-            config[supportedValue] = ""
-        }
-    }
+	// Grab the values needed to do a comparison of the Go vs Python algorithm.
+	for _, supportedValue := range supportedValues {
+		if value, err := main.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceSampler.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceReceiver.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceIgnore.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else {
+			// provide an empty default value so we don't need to check for
+			// key existence when browsing the old configuration
+			config[supportedValue] = ""
+		}
+	}
 
-    // these are hardcoded in config.py
-    config["graphite_listen_port"] = "None"
-    config["watchdog"] = "True"
-    config["use_forwarder"] = "False" // this doesn't come from the config file
-    config["check_freq"] = "15"
-    config["utf8_decoding"] = "False"
-    config["ssl_certificate"] = "datadog-cert.pem"
-    config["use_web_info_page"] = "True"
+	// these are hardcoded in config.py
+	config["graphite_listen_port"] = "None"
+	config["watchdog"] = "True"
+	config["use_forwarder"] = "False" // this doesn't come from the config file
+	config["check_freq"] = "15"
+	config["utf8_decoding"] = "False"
+	config["ssl_certificate"] = "datadog-cert.pem"
+	config["use_web_info_page"] = "True"
 
-    // these values are postprocessed in config.py, manually overwrite them
-    config["histogram_percentiles"] = "['0.95']"
-    config["endpoints"] = "{}"
-    config["version"] = "5.18.0"
-    config["proxy_settings"] = "{'host': 'my-proxy.com', 'password': 'password', 'port': 3128, 'user': 'user'}"
-    config["service_discovery"] = "True"
+	// these values are postprocessed in config.py, manually overwrite them
+	config["histogram_percentiles"] = "['0.95']"
+	config["endpoints"] = "{}"
+	config["version"] = "5.18.0"
+	config["proxy_settings"] = "{'host': 'my-proxy.com', 'password': 'password', 'port': 3128, 'user': 'user'}"
+	config["service_discovery"] = "True"
 
-    return config, nil
+	return config, nil
 }
-

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -52,7 +52,7 @@ var (
 		"syslog_port",
 		"collect_instance_metadata",
 		"listen_port",                // not for 6.0, ignore for now
-		"non_local_traffic",          // not for 6.0, ignore for now
+		"non_local_traffic",          // Use for Trace Agent
 		"create_dd_check_tags",       // not for 6.0, ignore for now
 		"bind_host",                  // not for 6.0, ignore for now
 		"proxy_forbid_method_switch", // deprecated

--- a/releasenotes/notes/import_apm_configs-161f6226dc233f55.yaml
+++ b/releasenotes/notes/import_apm_configs-161f6226dc233f55.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+     Imports the APM configuration options from datadog.conf to datadog.yaml when using import command


### PR DESCRIPTION
### What does this PR do?

Allow the conversion from datadog.conf APM fields to datadog.yaml fields.

### Motivation

Make the Trace Agent ready for Agent 6 GA

### Additional Notes

When using the default datadog.conf and uncommenting all Trace sections (also added in a regex for resource ignoring), you get this after the `import` command:

```
apm_config:
  enabled: true
  apm_non_local_traffic: true
  connection_limit: 50000
  extra_sample_rate: 12
  ignore_resource: <Resource_regex>
  max_traces_per_second: 10
```

Sister PR to - https://github.com/DataDog/datadog-trace-agent/pull/357/files