### PR TITLE
[jmxfetch] Add agent5-like JMXFetch helper commands

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -95,3 +95,8 @@ func StopServer() {
 		listener.Close()
 	}
 }
+
+// ServerAddress retruns the server address.
+func ServerAddress() *net.TCPAddr {
+	return listener.Addr().(*net.TCPAddr)
+}

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -127,7 +127,7 @@ func runJmxCommand(command string) {
 	configs := common.AC.GetAllConfigs()
 
 	for _, c := range checks {
-		config, err := findConfigByCheckName(configs, c)
+		config, err := findJMXConfigByCheckName(configs, c)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -159,10 +159,12 @@ func runJmxCommand(command string) {
 	fmt.Println("JMXFetch exited successfully. If nothing was displayed please check your configuration, flags and the JMXFetch log file.")
 }
 
-func findConfigByCheckName(configs []check.Config, checkName string) (*check.Config, error) {
+func findJMXConfigByCheckName(configs []check.Config, checkName string) (*check.Config, error) {
 	for _, c := range configs {
 		if strings.EqualFold(c.Name, checkName) {
-			return &c, nil
+			if c.IsJMX() {
+				return &c, nil
+			}
 		}
 	}
 	return nil, fmt.Errorf("Unable to find config named %v", checkName)

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -123,5 +123,5 @@ func runJmxCommand(command string) {
 		log.Fatalln(err)
 	}
 
-	fmt.Println("JMXFetch exited sucessfully. If nothing was outputed please verify your \"checks\" and \"confdir\" flags or check JMXFetch log file.")
+	fmt.Println("JMXFetch exited successfully. If nothing was outputted please verify your \"checks\" and \"confdir\" flags or check JMXFetch log file.")
 }

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -33,6 +33,13 @@ var (
 		Long:  ``,
 	}
 
+	jmxCollectCmd = &cobra.Command{
+		Use:   "collect",
+		Short: "Start the collection of metrics based on your current configuration and display them in the console.",
+		Long:  ``,
+		Run:   doJmxCollect,
+	}
+
 	jmxListEverythingCmd = &cobra.Command{
 		Use:   "everything",
 		Short: "List every attributes available that has a type supported by JMXFetch.",
@@ -72,16 +79,22 @@ var (
 )
 
 func init() {
-	// attach list command to jmx command
+	// attach list and collect commands to jmx command
 	jmxCmd.AddCommand(jmxListCmd)
+	jmxCmd.AddCommand(jmxCollectCmd)
 
 	//attach list commands to list root
 	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd)
 
 	jmxListCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{"jmx"}, "JMX checks (ex: jmx,tomcat)")
+	jmxCollectCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{"jmx"}, "JMX checks (ex: jmx,tomcat)")
 
 	// attach the command to the root
 	AgentCmd.AddCommand(jmxCmd)
+}
+
+func doJmxCollect(cmd *cobra.Command, args []string) {
+	runJmxCommand("collect")
 }
 
 func doJmxListEverything(cmd *cobra.Command, args []string) {

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	"github.com/spf13/cobra"
+)
+
+var (
+	jmxCmd = &cobra.Command{
+		Use:   "jmx",
+		Short: "",
+		Long:  ``,
+	}
+
+	jmxListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List attributes matched by JMXFetch.",
+		Long:  ``,
+	}
+
+	jmxListEverythingCmd = &cobra.Command{
+		Use:   "everything",
+		Short: "List every attributes available that has a type supported by JMXFetch.",
+		Long:  ``,
+		Run:   doJmxListEverything,
+	}
+
+	jmxListMatchingCmd = &cobra.Command{
+		Use:   "matching",
+		Short: "List attributes that match at least one of your instances configuration.",
+		Long:  ``,
+		Run:   doJmxListMatching,
+	}
+
+	jmxListLimitedCmd = &cobra.Command{
+		Use:   "limited",
+		Short: "List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.",
+		Long:  ``,
+		Run:   doJmxListLimited,
+	}
+
+	jmxListCollectedCmd = &cobra.Command{
+		Use:   "collected",
+		Short: "List attributes that will actually be collected by your current instances configuration.",
+		Long:  ``,
+		Run:   doJmxListCollected,
+	}
+
+	jmxListNotMatchingCmd = &cobra.Command{
+		Use:   "not-matching",
+		Short: "List attributes that don’t match any of your instances configuration.",
+		Long:  ``,
+		Run:   doJmxListNotCollected,
+	}
+
+	checks   = []string{}
+	checkDir = "/opt/datadog-agent/etc/conf.d"
+)
+
+func init() {
+	// attach list command to jmx command
+	jmxCmd.AddCommand(jmxListCmd)
+
+	//attach list commands to list root
+	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd)
+
+	jmxListCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{}, "JMX checks (required)")
+	jmxListCmd.MarkPersistentFlagRequired("checks")
+
+	jmxListCmd.Flags().StringVarP(&checkDir, "confdir", "d", checkDir, "check configuration directory")
+
+	// attach the command to the root
+	AgentCmd.AddCommand(jmxCmd)
+}
+
+func doJmxListEverything(cmd *cobra.Command, args []string) {
+	runJmxCommand("list_everything")
+}
+
+func doJmxListMatching(cmd *cobra.Command, args []string) {
+	runJmxCommand("list_matching_attributes")
+}
+
+func doJmxListLimited(cmd *cobra.Command, args []string) {
+	runJmxCommand("list_limited_attributes")
+}
+
+func doJmxListCollected(cmd *cobra.Command, args []string) {
+	runJmxCommand("list_collected_attributes")
+}
+
+func doJmxListNotCollected(cmd *cobra.Command, args []string) {
+	runJmxCommand("list_not_matching_attributes")
+}
+
+func runJmxCommand(command string) {
+	runner := jmxfetch.New("")
+
+	runner.ReportOnConsole = true
+	runner.Command = command
+	runner.ConfDirectory = checkDir
+
+	for _, c := range checks {
+		checkFile := fmt.Sprintf("%v.d/conf.yaml", c)
+		runner.Checks = append(runner.Checks, checkFile)
+	}
+
+	err := runner.Run()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	err = runner.Wait()
+	if err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package app
 
 import (

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -67,10 +67,10 @@ func init() {
 	//attach list commands to list root
 	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd)
 
-	jmxListCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{}, "JMX checks (required)")
+	jmxListCmd.PersistentFlags().StringSliceVar(&checks, "checks", []string{}, "JMX checks (required) (ex: jmx,tomcat)")
 	jmxListCmd.MarkPersistentFlagRequired("checks")
 
-	jmxListCmd.Flags().StringVarP(&checkDir, "confdir", "d", checkDir, "check configuration directory")
+	jmxListCmd.PersistentFlags().StringVarP(&checkDir, "confdir", "d", checkDir, "check configuration directory")
 
 	// attach the command to the root
 	AgentCmd.AddCommand(jmxCmd)
@@ -97,7 +97,7 @@ func doJmxListNotCollected(cmd *cobra.Command, args []string) {
 }
 
 func runJmxCommand(command string) {
-	runner := jmxfetch.New("")
+	runner := jmxfetch.New()
 
 	runner.ReportOnConsole = true
 	runner.Command = command
@@ -117,4 +117,6 @@ func runJmxCommand(command string) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	fmt.Println("JMXFetch exited sucessfully. If nothing was outputed please verify your \"checks\" and \"confdir\" flags or check JMXFetch log file.")
 }

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -57,7 +57,7 @@ var (
 	}
 
 	checks   = []string{}
-	checkDir = "/opt/datadog-agent/etc/conf.d"
+	checkDir = "/etc/datadog-agent/conf.d"
 )
 
 func init() {

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -151,7 +151,7 @@ func runJmxCommand(command string) error {
 
 	loadConfigs()
 
-	err = runner.Run()
+	err = runner.Start()
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -127,7 +127,7 @@ func setupAgent() error {
 
 	common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 
-	// let the os asign an available port
+	// let the os assign an available port
 	config.Datadog.Set("cmd_port", 0)
 
 	// start the cmd HTTP server

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -9,7 +9,6 @@ package app
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
@@ -38,42 +37,42 @@ var (
 		Use:   "collect",
 		Short: "Start the collection of metrics based on your current configuration and display them in the console.",
 		Long:  ``,
-		Run:   doJmxCollect,
+		RunE:  doJmxCollect,
 	}
 
 	jmxListEverythingCmd = &cobra.Command{
 		Use:   "everything",
 		Short: "List every attributes available that has a type supported by JMXFetch.",
 		Long:  ``,
-		Run:   doJmxListEverything,
+		RunE:  doJmxListEverything,
 	}
 
 	jmxListMatchingCmd = &cobra.Command{
 		Use:   "matching",
 		Short: "List attributes that match at least one of your instances configuration.",
 		Long:  ``,
-		Run:   doJmxListMatching,
+		RunE:  doJmxListMatching,
 	}
 
 	jmxListLimitedCmd = &cobra.Command{
 		Use:   "limited",
 		Short: "List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.",
 		Long:  ``,
-		Run:   doJmxListLimited,
+		RunE:  doJmxListLimited,
 	}
 
 	jmxListCollectedCmd = &cobra.Command{
 		Use:   "collected",
 		Short: "List attributes that will actually be collected by your current instances configuration.",
 		Long:  ``,
-		Run:   doJmxListCollected,
+		RunE:  doJmxListCollected,
 	}
 
 	jmxListNotMatchingCmd = &cobra.Command{
 		Use:   "not-matching",
 		Short: "List attributes that don’t match any of your instances configuration.",
 		Long:  ``,
-		Run:   doJmxListNotCollected,
+		RunE:  doJmxListNotCollected,
 	}
 
 	checks = []string{}
@@ -94,28 +93,28 @@ func init() {
 	AgentCmd.AddCommand(jmxCmd)
 }
 
-func doJmxCollect(cmd *cobra.Command, args []string) {
-	runJmxCommand("collect")
+func doJmxCollect(cmd *cobra.Command, args []string) error {
+	return runJmxCommand("collect")
 }
 
-func doJmxListEverything(cmd *cobra.Command, args []string) {
-	runJmxCommand("list_everything")
+func doJmxListEverything(cmd *cobra.Command, args []string) error {
+	return runJmxCommand("list_everything")
 }
 
-func doJmxListMatching(cmd *cobra.Command, args []string) {
-	runJmxCommand("list_matching_attributes")
+func doJmxListMatching(cmd *cobra.Command, args []string) error {
+	return runJmxCommand("list_matching_attributes")
 }
 
-func doJmxListLimited(cmd *cobra.Command, args []string) {
-	runJmxCommand("list_limited_attributes")
+func doJmxListLimited(cmd *cobra.Command, args []string) error {
+	return runJmxCommand("list_limited_attributes")
 }
 
-func doJmxListCollected(cmd *cobra.Command, args []string) {
-	runJmxCommand("list_collected_attributes")
+func doJmxListCollected(cmd *cobra.Command, args []string) error {
+	return runJmxCommand("list_collected_attributes")
 }
 
-func doJmxListNotCollected(cmd *cobra.Command, args []string) {
-	runJmxCommand("list_not_matching_attributes")
+func doJmxListNotCollected(cmd *cobra.Command, args []string) error {
+	return runJmxCommand("list_not_matching_attributes")
 }
 
 func setupAgent() error {
@@ -154,12 +153,12 @@ func runJmxCommand(command string) error {
 
 	err = runner.Run()
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	err = runner.Wait()
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 
 	fmt.Println("JMXFetch exited successfully. If nothing was displayed please check your configuration, flags and the JMXFetch log file.")

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -466,7 +466,7 @@ You will have to install the missing dependencies manually as described above.
 
 ## JMX
 
-The Agent 6 ships JMXFetch and supports all of its features, except those listed below.
+The Agent 6 ships JMXFetch and include a few changes :
 
 The Agent 6 does not ship the `jmxterm` JAR. If you wish to download and use `jmxterm`, please refer to the [upstream project](https://github.com/jiaqi/jmxterm).
 

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -472,10 +472,15 @@ The Agent 6 does not ship the `jmxterm` JAR. If you wish to download and use `jm
 Troubleshooting commands syntax have changed :
 
 List attributes that match at least one of your instances configuration: `sudo datadog-agent jmx list matching`
+
 List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected: `sudo datadog-agent jmx list limited`
+
 List attributes that will actually be collected by your current instances configuration: `sudo datadog-agent jmx list collected`
+
 List attributes that don’t match any of your instances configuration: `sudo datadog-agent jmx list not-matching`
+
 List every attributes available that has a type supported by JMXFetch: `sudo datadog-agent jmx list everything`
+
 Start the collection of metrics based on your current configuration and display them in the console: `sudo datadog-agent jmx collect`
 
 By default theses command will run on the check called `jmx`. If you want to

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -472,20 +472,20 @@ The Agent 6 does not ship the `jmxterm` JAR. If you wish to download and use `jm
 
 Troubleshooting commands syntax have changed :
 
-`sudo datadog-agent jmx list matching`: List attributes that match at least one of your instances configuration.
+`sudo -u dd-agent datadog-agent jmx list matching`: List attributes that match at least one of your instances configuration.
 
-`sudo datadog-agent jmx list limited`: List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.
+`sudo -u dd-agent datadog-agent jmx list limited`: List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.
 
-`sudo datadog-agent jmx list collected`: List attributes that will actually be collected by your current instances configuration.
+`sudo -u dd-agent datadog-agent jmx list collected`: List attributes that will actually be collected by your current instances configuration.
 
-`sudo datadog-agent jmx list not-matching`: List attributes that don’t match any of your instances configuration.
+`sudo -u dd-agent datadog-agent jmx list not-matching`: List attributes that don’t match any of your instances configuration.
 
-`sudo datadog-agent jmx list everything`: List every attributes available that has a type supported by JMXFetch.
+`sudo -u dd-agent datadog-agent jmx list everything`: List every attributes available that has a type supported by JMXFetch.
 
-`sudo datadog-agent jmx collect`: Start the collection of metrics based on your current configuration and display them in the console.
+`sudo -u dd-agent datadog-agent jmx collect`: Start the collection of metrics based on your current configuration and display them in the console.
 
-By default theses command will run on all the checks. If you want to
-use them for other checks, you can specify them using the `--checks` flag :
+By default theses command will run on all the jmx checks. If you want to
+use them for specific checks, you can specify them using the `--checks` flag :
 `sudo datadog-agent jmx list collected --checks tomcat`
 
 ### GCE hostname

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -484,7 +484,7 @@ Troubleshooting commands syntax have changed :
 
 `sudo datadog-agent jmx collect`: Start the collection of metrics based on your current configuration and display them in the console.
 
-By default theses command will run on the check called `jmx`. If you want to
+By default theses command will run on all the checks. If you want to
 use them for other checks, you can specify them using the `--checks` flag :
 `sudo datadog-agent jmx list collected --checks tomcat`
 

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -469,40 +469,18 @@ The Agent 6 ships JMXFetch and supports all of its features, except those listed
 
 The Agent 6 does not ship the `jmxterm` JAR. If you wish to download and use `jmxterm`, please refer to the [upstream project](https://github.com/jiaqi/jmxterm).
 
-We still don't have a full featured interface to JMXFetch, so for now you may
-have to run some commands manually to debug the list of beans collected, JVMs,
-etc. A typical manual call will take the following form:
+Troubleshooting commands syntax have changed :
 
-```shell
-/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.2-jar-with-dependencies.jar org.datadog.jmxfetch.App --check <check list> --conf_directory /etc/datadog-agent/conf.d --log_level INFO --log_location /var/log/datadog/jmxfetch.log --reporter console <command>
-```
+List attributes that match at least one of your instances configuration: `sudo datadog-agent jmx list matching`
+List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected: `sudo datadog-agent jmx list limited`
+List attributes that will actually be collected by your current instances configuration: `sudo datadog-agent jmx list collected`
+List attributes that don’t match any of your instances configuration: `sudo datadog-agent jmx list not-matching`
+List every attributes available that has a type supported by JMXFetch: `sudo datadog-agent jmx list everything`
+Start the collection of metrics based on your current configuration and display them in the console: `sudo datadog-agent jmx collect`
 
-where `<command>` can be any of:
-- `list_everything`
-- `list_collected_attributes`
-- `list_matching_attributes`
-- `list_not_matching_attributes`
-- `list_limited_attributes`
-- `list_jvms`
-
-and `<check list>` corresponds to a list of valid `yaml` configurations in
-`/etc/datadog-agent/conf.d/`. For instance:
-- `cassandra.d/conf.yaml`
-- `kafka.d/conf.yaml`
-- `jmx.d/conf.yaml`
-- ...
-
-Example:
-```
-/usr/bin/java -Xmx200m -Xms50m -classpath /usr/lib/jvm/java-8-oracle/lib/tools.jar:/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.18.2-jar-with-dependencies.jar org.datadog.jmxfetch.App --check cassandra.d/conf.yaml jmx.d/conf.yaml --conf_directory /etc/datadog-agent/conf.d --log_level INFO --log_location /var/log/datadog/jmxfetch.log --reporter console list_everything
-```
-
-Note: the location to the JRE tools.jar (`/usr/lib/jvm/java-8-oracle/lib/tools.jar`
-in the example) might reside elsewhere in your system. You should be able to easily
-find it with `sudo find / -type f -name 'tools.jar'`.
-
-Note: you may wish to specify alternative JVM heap parameters `-Xmx`, `-Xms`, the
-values used in the example correspond to the JMXFetch defaults.
+By default theses command will run on the check called `jmx`. If you want to
+use them for other checks, you can specify them using the `--checks` flag :
+`sudo datadog-agent jmx list collected --checks tomcat`
 
 ### GCE hostname
 

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -484,7 +484,7 @@ Troubleshooting commands syntax have changed :
 
 `sudo -u dd-agent datadog-agent jmx collect`: Start the collection of metrics based on your current configuration and display them in the console.
 
-By default theses command will run on all the jmx checks. If you want to
+By default theses command will run on all the configured jmx checks. If you want to
 use them for specific checks, you can specify them using the `--checks` flag :
 `sudo datadog-agent jmx list collected --checks tomcat`
 

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -99,6 +99,7 @@ The new command line interface for the Agent is sub-command based:
 | start-service   | starts the agent within the service control manager |
 | status          | Print the current status |
 | stopservice     | stops the agent within the service control manager |
+| jmx             | JMX troubleshooting |
 | version         | Print the version info |
 
 To see the list of available sub-commands on your platform, run:
@@ -471,17 +472,17 @@ The Agent 6 does not ship the `jmxterm` JAR. If you wish to download and use `jm
 
 Troubleshooting commands syntax have changed :
 
-List attributes that match at least one of your instances configuration: `sudo datadog-agent jmx list matching`
+`sudo datadog-agent jmx list matching`: List attributes that match at least one of your instances configuration.
 
-List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected: `sudo datadog-agent jmx list limited`
+`sudo datadog-agent jmx list limited`: List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected.
 
-List attributes that will actually be collected by your current instances configuration: `sudo datadog-agent jmx list collected`
+`sudo datadog-agent jmx list collected`: List attributes that will actually be collected by your current instances configuration.
 
-List attributes that don’t match any of your instances configuration: `sudo datadog-agent jmx list not-matching`
+`sudo datadog-agent jmx list not-matching`: List attributes that don’t match any of your instances configuration.
 
-List every attributes available that has a type supported by JMXFetch: `sudo datadog-agent jmx list everything`
+`sudo datadog-agent jmx list everything`: List every attributes available that has a type supported by JMXFetch.
 
-Start the collection of metrics based on your current configuration and display them in the console: `sudo datadog-agent jmx collect`
+`sudo datadog-agent jmx collect`: Start the collection of metrics based on your current configuration and display them in the console.
 
 By default theses command will run on the check called `jmx`. If you want to
 use them for other checks, you can specify them using the `--checks` flag :

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -170,7 +170,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 // Check instances. Should always be run once so providers that don't need
 // polling will be queried at least once
 func (ac *AutoConfig) LoadAndRun() {
-	resolvedConfigs := ac.getAllConfigs()
+	resolvedConfigs := ac.GetAllConfigs()
 	checks := ac.getChecksFromConfigs(resolvedConfigs, true)
 	ac.schedule(checks)
 }
@@ -182,7 +182,7 @@ func (ac *AutoConfig) GetChecksByName(checkName string) []check.Check {
 	titleCheck := fmt.Sprintf("%s%s", strings.Title(checkName), "Check")
 	checks := []check.Check{}
 
-	for _, check := range ac.getChecksFromConfigs(ac.getAllConfigs(), false) {
+	for _, check := range ac.getChecksFromConfigs(ac.GetAllConfigs(), false) {
 		if checkName == check.String() || titleCheck == check.String() {
 			checks = append(checks, check)
 		}
@@ -191,9 +191,9 @@ func (ac *AutoConfig) GetChecksByName(checkName string) []check.Check {
 	return checks
 }
 
-// getAllConfigs queries all the providers and returns all the check
+// GetAllConfigs queries all the providers and returns all the check
 // configurations found, resolving the ones it can
-func (ac *AutoConfig) getAllConfigs() []check.Config {
+func (ac *AutoConfig) GetAllConfigs() []check.Config {
 	resolvedConfigs := []check.Config{}
 
 	for _, pd := range ac.providers {

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -324,6 +324,11 @@ func (c *Config) Digest() string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
+// IsJMX checks if the config is a JMX config
+func (c *Config) IsJMX() bool {
+	return IsConfigJMX(c.Name, c.InitConfig)
+}
+
 // IsConfigJMX checks if a certain YAML config is a JMX config
 func IsConfigJMX(name string, initConf ConfigData) bool {
 

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -6,12 +6,11 @@
 package check
 
 import (
-	"bytes"
 	"fmt"
 	"hash/fnv"
+	"log"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -163,35 +162,26 @@ func (c *Config) Equal(config *Config) bool {
 
 // String YAML representation of the config
 func (c *Config) String() string {
-	var yamlBuff bytes.Buffer
+	rawConfig := make(map[interface{}]interface{})
+	var initConfig interface{}
+	var instances []interface{}
 
-	yamlBuff.Write([]byte("init_config:\n"))
-	if c.InitConfig != nil {
-		yamlBuff.Write([]byte("- "))
-		strInit := strings.Split(string(c.InitConfig[:]), "\n")
-		for i, line := range strInit {
-			if i > 0 {
-				yamlBuff.Write([]byte("  "))
-			}
-			yamlBuff.Write([]byte(line))
-			yamlBuff.Write([]byte("\n"))
-		}
+	yaml.Unmarshal(c.InitConfig, &initConfig)
+	rawConfig["init_config"] = initConfig
+
+	for _, i := range c.Instances {
+		var instance interface{}
+		yaml.Unmarshal(i, &instance)
+		instances = append(instances, instance)
+	}
+	rawConfig["instances"] = instances
+
+	buffer, err := yaml.Marshal(&rawConfig)
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	yamlBuff.Write([]byte("instances:\n"))
-	for _, instance := range c.Instances {
-		strInst := strings.Split(string(instance[:]), "\n")
-		yamlBuff.Write([]byte("- "))
-		for i, line := range strInst {
-			if i > 0 {
-				yamlBuff.Write([]byte("  "))
-			}
-			yamlBuff.Write([]byte(line))
-			yamlBuff.Write([]byte("\n"))
-		}
-	}
-
-	return yamlBuff.String()
+	return string(buffer)
 }
 
 // IsTemplate returns if the config has AD identifiers

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -49,11 +49,11 @@ func TestString(t *testing.T) {
 	assert.False(t, config.Equal(nil))
 
 	config.Name = "foo"
-	config.InitConfig = ConfigData("fooBarBaz")
+	config.InitConfig = ConfigData("fooBarBaz: test")
 	config.Instances = []ConfigData{ConfigData("justFoo")}
 
 	expected := `init_config:
-- fooBarBaz
+  fooBarBaz: test
 instances:
 - justFoo
 `

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -53,7 +53,7 @@ var jmxLauncher = JMXCheck{
 	checks:   make(map[string]struct{}),
 	stop:     make(chan struct{}),
 	stopDone: make(chan struct{}),
-	runner:   jmxfetch.New(jmxExitFile),
+	runner:   jmxfetch.New(),
 }
 
 func (c *JMXCheck) String() string {
@@ -86,6 +86,7 @@ func (c *JMXCheck) run() error {
 	}
 
 	c.runner.LogLevel = config.Datadog.GetString("log_level")
+	c.runner.JmxExitFile = jmxExitFile
 
 	err := c.runner.Run()
 	if err != nil {

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -211,13 +211,7 @@ func (c *JMXCheck) Parse(data, initConfig check.ConfigData) error {
 
 // Configure the JMXCheck
 func (c *JMXCheck) Configure(data, initConfig check.ConfigData) error {
-
-	err := c.Parse(data, initConfig)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.Parse(data, initConfig)
 }
 
 // Interval returns the scheduling time for the check, this will be scheduled only once

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -88,7 +88,7 @@ func (c *JMXCheck) run() error {
 	c.runner.LogLevel = config.Datadog.GetString("log_level")
 	c.runner.JmxExitFile = jmxExitFile
 
-	err := c.runner.Run()
+	err := c.runner.Start()
 	if err != nil {
 		return retryExitError(err)
 	}

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -8,53 +8,19 @@
 package embed
 
 import (
-	"bufio"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"time"
 
-	log "github.com/cihub/seelog"
-	yaml "gopkg.in/yaml.v2"
-
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	api "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/executable"
+	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
+	log "github.com/cihub/seelog"
+	"gopkg.in/yaml.v2"
 )
 
 const (
-	jmxJarName                        = "jmxfetch-0.19.0-jar-with-dependencies.jar"
-	jmxMainClass                      = "org.datadog.jmxfetch.App"
-	jmxCollectCommand                 = "collect"
-	jvmDefaultMaxMemoryAllocation     = " -Xmx200m"
-	jvmDefaultInitialMemoryAllocation = " -Xms50m"
-	jvmCgroupMemoryAwareness          = " -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
-	linkToDoc                         = "See http://docs.datadoghq.com/integrations/java/ for more information"
-)
-
-var (
-	jmxLogLevelMap = map[string]string{
-		"trace":    "TRACE",
-		"debug":    "DEBUG",
-		"info":     "INFO",
-		"warn":     "WARN",
-		"warning":  "WARN",
-		"error":    "ERROR",
-		"err":      "ERROR",
-		"critical": "FATAL",
-	}
-	jvmCgroupMemoryIncompatOptions = []string{
-		"Xmx",
-		"XX:MaxHeapSize",
-		"Xms",
-		"XX:InitialHeapSize",
-	}
+	linkToDoc = "See http://docs.datadoghq.com/integrations/java/ for more information"
 )
 
 // checkInstanceCfg lists the config options on the instance against which we make some sanity checks
@@ -75,23 +41,19 @@ type checkInitCfg struct {
 
 // JMXCheck keeps track of the running command
 type JMXCheck struct {
-	cmd                *exec.Cmd
-	checks             map[string]struct{}
-	ExitFilePath       string
-	javaBinPath        string
-	javaOptions        string
-	javaToolsJarPath   string
-	javaCustomJarPaths []string
-	isAttachAPI        bool
-	running            uint32
-	stop               chan struct{}
-	stopDone           chan struct{}
+	runner      *jmxfetch.JMXFetch
+	checks      map[string]struct{}
+	isAttachAPI bool
+	running     uint32
+	stop        chan struct{}
+	stopDone    chan struct{}
 }
 
 var jmxLauncher = JMXCheck{
 	checks:   make(map[string]struct{}),
 	stop:     make(chan struct{}),
 	stopDone: make(chan struct{}),
+	runner:   jmxfetch.New(jmxExitFile),
 }
 
 func (c *JMXCheck) String() string {
@@ -123,31 +85,25 @@ func (c *JMXCheck) run() error {
 	default:
 	}
 
-	err := c.start()
+	c.runner.LogLevel = config.Datadog.GetString("log_level")
+
+	err := c.runner.Run()
 	if err != nil {
 		return retryExitError(err)
 	}
 
 	processDone := make(chan error)
 	go func() {
-		processDone <- c.cmd.Wait()
+		processDone <- c.runner.Wait()
 	}()
 
 	select {
 	case err = <-processDone:
 		return retryExitError(err)
 	case <-c.stop:
-		if jmxExitFile == "" {
-			// Unix
-			err = c.cmd.Process.Signal(os.Kill)
-			if err != nil {
-				log.Errorf("unable to stop JMX check: %s", err)
-			}
-		} else {
-			// Windows
-			if err = ioutil.WriteFile(c.ExitFilePath, nil, 0644); err != nil {
-				log.Errorf("unable to stop JMX check: %s", err)
-			}
+		err = c.runner.Kill()
+		if err != nil {
+			log.Errorf("unable to stop JMX check: %s", err)
 		}
 	}
 
@@ -172,35 +128,35 @@ func (c *JMXCheck) Parse(data, initConfig check.ConfigData) error {
 		return err
 	}
 
-	if c.javaBinPath == "" {
+	if c.runner.JavaBinPath == "" {
 		if instanceConf.JavaBinPath != "" {
-			c.javaBinPath = instanceConf.JavaBinPath
+			c.runner.JavaBinPath = instanceConf.JavaBinPath
 		} else if initConf.JavaBinPath != "" {
-			c.javaBinPath = initConf.JavaBinPath
+			c.runner.JavaBinPath = initConf.JavaBinPath
 		}
 	}
-	if c.javaOptions == "" {
+	if c.runner.JavaOptions == "" {
 		if instanceConf.JavaOptions != "" {
-			c.javaOptions = instanceConf.JavaOptions
+			c.runner.JavaOptions = instanceConf.JavaOptions
 		} else if initConf.JavaOptions != "" {
-			c.javaOptions = initConf.JavaOptions
+			c.runner.JavaOptions = initConf.JavaOptions
 		}
 	}
-	if c.javaToolsJarPath == "" {
+	if c.runner.JavaToolsJarPath == "" {
 		if instanceConf.ToolsJarPath != "" {
-			c.javaToolsJarPath = instanceConf.ToolsJarPath
+			c.runner.JavaToolsJarPath = instanceConf.ToolsJarPath
 		} else if initConf.ToolsJarPath != "" {
-			c.javaToolsJarPath = initConf.ToolsJarPath
+			c.runner.JavaToolsJarPath = initConf.ToolsJarPath
 		}
 	}
-	if c.javaCustomJarPaths == nil {
+	if c.runner.JavaCustomJarPaths == nil {
 		if initConf.CustomJarPaths != nil {
-			c.javaCustomJarPaths = initConf.CustomJarPaths
+			c.runner.JavaCustomJarPaths = initConf.CustomJarPaths
 		}
 	}
 
 	if instanceConf.ProcessNameRegex != "" {
-		if c.javaToolsJarPath == "" {
+		if c.runner.JavaToolsJarPath == "" {
 			return fmt.Errorf("You must specify the path to tools.jar. %s", linkToDoc)
 		}
 		c.isAttachAPI = true
@@ -239,126 +195,6 @@ func (c *JMXCheck) Stop() {
 
 	c.stop <- struct{}{}
 	<-c.stopDone
-}
-
-func (c *JMXCheck) start() error {
-	here, _ := executable.Folder()
-	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
-	if c.javaToolsJarPath != "" {
-		classpath = fmt.Sprintf("%s:%s", c.javaToolsJarPath, classpath)
-	}
-
-	globalCustomJars := config.Datadog.GetStringSlice("jmx_custom_jars")
-	if len(globalCustomJars) > 0 {
-		classpath = fmt.Sprintf("%s:%s", strings.Join(globalCustomJars, ":"), classpath)
-	}
-
-	if len(c.javaCustomJarPaths) > 0 {
-		classpath = fmt.Sprintf("%s:%s", strings.Join(c.javaCustomJarPaths, ":"), classpath)
-	}
-	bindHost := config.Datadog.GetString("bind_host")
-	if bindHost == "" || bindHost == "0.0.0.0" {
-		bindHost = "localhost"
-	}
-	reporter := fmt.Sprintf("statsd:%s:%s", bindHost, config.Datadog.GetString("dogstatsd_port"))
-
-	//TODO : support auto discovery
-
-	subprocessArgs := []string{}
-
-	javaOptions := c.javaOptions
-	if config.Datadog.GetBool("jmx_use_cgroup_memory_limit") {
-		passOption := true
-		// This option is incompatible with the Xmx and Xms options, log a warning if there are found in the javaOptions
-		for _, option := range jvmCgroupMemoryIncompatOptions {
-			if strings.Contains(javaOptions, option) {
-				log.Warnf("Java option %q is incompatible with cgroup_memory_limit, disabling cgroup mode", option)
-				passOption = false
-			}
-		}
-		if passOption {
-			javaOptions += jvmCgroupMemoryAwareness
-		}
-	} else {
-		// Specify a maximum memory allocation pool for the JVM
-		if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
-			javaOptions += jvmDefaultMaxMemoryAllocation
-		}
-		// Specify the initial memory allocation pool for the JVM
-		if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
-			javaOptions += jvmDefaultInitialMemoryAllocation
-		}
-	}
-
-	subprocessArgs = append(subprocessArgs, strings.Fields(javaOptions)...)
-
-	jmxLogLevel, ok := jmxLogLevelMap[strings.ToLower(config.Datadog.GetString("log_level"))]
-	if !ok {
-		jmxLogLevel = "INFO"
-	}
-	// checks are now enabled via IPC on JMXFetch
-	subprocessArgs = append(subprocessArgs,
-		"-classpath", classpath,
-		jmxMainClass,
-		"--ipc_host", config.Datadog.GetString("cmd_host"),
-		"--ipc_port", fmt.Sprintf("%v", config.Datadog.GetInt("cmd_port")),
-		"--check_period", fmt.Sprintf("%v", int(check.DefaultCheckInterval/time.Millisecond)), // Period of the main loop of jmxfetch in ms
-		"--log_level", jmxLogLevel,
-		"--reporter", reporter, // Reporter to use
-		jmxCollectCommand, // Name of the command
-	)
-
-	if jmxExitFile != "" {
-		c.ExitFilePath = filepath.Join(here, "dist", "jmx", jmxExitFile) // FIXME : At some point we should have a `run` folder
-		// Signal handlers are not supported on Windows:
-		// use a file to trigger JMXFetch exit instead
-		subprocessArgs = append(subprocessArgs, "--exit_file_location", c.ExitFilePath)
-	}
-
-	javaBinPath := c.javaBinPath
-	if javaBinPath == "" {
-		javaBinPath = "java"
-	}
-	c.cmd = exec.Command(javaBinPath, subprocessArgs...)
-
-	// set environment + token
-	c.cmd.Env = append(
-		os.Environ(),
-		fmt.Sprintf("SESSION_TOKEN=%s", api.GetAuthToken()),
-	)
-
-	// remove the exit file trigger (windows)
-	if jmxExitFile != "" {
-		os.Remove(c.ExitFilePath)
-	}
-
-	// forward the standard output to the Agent logger
-	stdout, err := c.cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	go func() {
-		in := bufio.NewScanner(stdout)
-		for in.Scan() {
-			log.Info(in.Text())
-		}
-	}()
-
-	// forward the standard error to the Agent logger
-	stderr, err := c.cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-	go func() {
-		in := bufio.NewScanner(stderr)
-		for in.Scan() {
-			log.Error(in.Text())
-		}
-	}()
-
-	log.Debugf("Args: %v", subprocessArgs)
-
-	return c.cmd.Start()
 }
 
 // GetWarnings does not return anything in JMX

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -19,8 +19,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// JMXConfigCache contains the last version of jmx configs that will be given
+// to jmxfetch when it calls the IPC server
 var JMXConfigCache = cache.NewBasicCache()
 
+// AddJMXCachedConfig adds a config to the jmx config cache
 func AddJMXCachedConfig(config check.Config) {
 	mapConfig := map[string]interface{}{}
 	mapConfig["name"] = config.Name

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -21,6 +21,15 @@ import (
 
 var JMXConfigCache = cache.NewBasicCache()
 
+func AddJMXCachedConfig(config check.Config) {
+	mapConfig := map[string]interface{}{}
+	mapConfig["name"] = config.Name
+	mapConfig["timestamp"] = time.Now().Unix()
+	mapConfig["config"] = config
+
+	JMXConfigCache.Add(config.Name, mapConfig)
+}
+
 // JMXCheckLoader is a specific loader for checks living in this package
 type JMXCheckLoader struct {
 	checks []string
@@ -35,7 +44,6 @@ func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 func (jl *JMXCheckLoader) Load(config check.Config) ([]check.Check, error) {
 	var err error
 	checks := []check.Check{}
-	mapConfig := map[string]interface{}{}
 
 	if !check.IsConfigJMX(config.Name, config.InitConfig) {
 		return checks, errors.New("check is not a jmx check, or unable to determine if it's so")
@@ -47,8 +55,6 @@ func (jl *JMXCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		log.Errorf("jmx.loader: could not unmarshal instance config: %s", err)
 		return checks, err
 	}
-	mapConfig["name"] = config.Name
-	mapConfig["timestamp"] = time.Now().Unix()
 
 	for _, instance := range config.Instances {
 		if err = jmxLauncher.Configure(instance, config.InitConfig); err != nil {
@@ -57,11 +63,10 @@ func (jl *JMXCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		}
 	}
 
-	JMXConfigCache.Add(config.Name, mapConfig)
 	jmxLauncher.checks[fmt.Sprintf("%s.yaml", config.Name)] = struct{}{} // exists
 	checks = append(checks, &jmxLauncher)
-	mapConfig["config"] = config
 
+	AddJMXCachedConfig(config)
 	return checks, err
 }
 

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -57,12 +57,11 @@ type JMXFetch struct {
 	exitFilePath       string
 }
 
-func New(exitFile string) *JMXFetch {
+func New() *JMXFetch {
 	return &JMXFetch{
 		JavaBinPath:        defaultJavaBinPath,
 		JavaCustomJarPaths: []string{},
 		LogLevel:           defaultLogLevel,
-		JmxExitFile:        exitFile,
 		Command:            defaultJmxCommand,
 		ReportOnConsole:    false,
 		Checks:             []string{},

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -46,6 +46,7 @@ var (
 	}
 )
 
+// JMXFetch represent a jmxfetch instance.
 type JMXFetch struct {
 	JavaBinPath        string
 	JavaOptions        string
@@ -62,6 +63,7 @@ type JMXFetch struct {
 	exitFilePath       string
 }
 
+// New returns a new instance of JMXFetch with default values.
 func New() *JMXFetch {
 	return &JMXFetch{
 		JavaBinPath:        defaultJavaBinPath,
@@ -73,6 +75,7 @@ func New() *JMXFetch {
 	}
 }
 
+// Run starts the JMXFetch process
 func (j *JMXFetch) Run() error {
 	here, _ := executable.Folder()
 	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
@@ -186,6 +189,7 @@ func (j *JMXFetch) Run() error {
 	return j.cmd.Start()
 }
 
+// Kill kills the JMXFetch process
 func (j *JMXFetch) Kill() error {
 	if j.JmxExitFile == "" {
 		// Unix
@@ -202,6 +206,7 @@ func (j *JMXFetch) Kill() error {
 	return nil
 }
 
+// Wait waits for the end of the JMXFetch process and returns the error code
 func (j *JMXFetch) Wait() error {
 	return j.cmd.Wait()
 }

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package jmxfetch
 
 import (

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -21,7 +21,7 @@ import (
 const (
 	jmxJarName                        = "jmxfetch-0.18.2-jar-with-dependencies.jar"
 	jmxMainClass                      = "org.datadog.jmxfetch.App"
-	jmxCollectCommand                 = "collect"
+	defaultJmxCommand                 = "collect"
 	defaultJvmMaxMemoryAllocation     = " -Xmx200m"
 	defaultJvmInitialMemoryAllocation = " -Xms50m"
 	defaultJavaBinPath                = "java"
@@ -48,8 +48,13 @@ type JMXFetch struct {
 	JavaCustomJarPaths []string
 	LogLevel           string
 	JmxExitFile        string
-	exitFilePath       string
+	Command            string
+	ReportOnConsole    bool
+	ConfDirectory      string
+	Checks             []string
+	defaultJmxCommand  string
 	cmd                *exec.Cmd
+	exitFilePath       string
 }
 
 func New(exitFile string) *JMXFetch {
@@ -58,6 +63,9 @@ func New(exitFile string) *JMXFetch {
 		JavaCustomJarPaths: []string{},
 		LogLevel:           defaultLogLevel,
 		JmxExitFile:        exitFile,
+		Command:            defaultJmxCommand,
+		ReportOnConsole:    false,
+		Checks:             []string{},
 	}
 }
 
@@ -80,7 +88,11 @@ func (j *JMXFetch) Run() error {
 	if bindHost == "" || bindHost == "0.0.0.0" {
 		bindHost = "localhost"
 	}
+
 	reporter := fmt.Sprintf("statsd:%s:%s", bindHost, config.Datadog.GetString("dogstatsd_port"))
+	if j.ReportOnConsole {
+		reporter = "console"
+	}
 
 	//TODO : support auto discovery
 
@@ -111,8 +123,15 @@ func (j *JMXFetch) Run() error {
 		"--check_period", fmt.Sprintf("%v", int(check.DefaultCheckInterval/time.Millisecond)), // Period of the main loop of jmxfetch in ms
 		"--log_level", jmxLogLevel,
 		"--reporter", reporter, // Reporter to use
-		jmxCollectCommand, // Name of the command
 	)
+
+	if j.ConfDirectory != "" {
+		subprocessArgs = append(subprocessArgs, "--check")
+		subprocessArgs = append(subprocessArgs, j.Checks...)
+		subprocessArgs = append(subprocessArgs, "--conf_directory", j.ConfDirectory)
+	}
+
+	subprocessArgs = append(subprocessArgs, j.Command)
 
 	if j.JmxExitFile != "" {
 		j.exitFilePath = filepath.Join(here, "dist", "jmx", j.JmxExitFile) // FIXME : At some point we should have a `run` folder

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -1,0 +1,184 @@
+package jmxfetch
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	api "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
+	log "github.com/cihub/seelog"
+)
+
+const (
+	jmxJarName                        = "jmxfetch-0.18.2-jar-with-dependencies.jar"
+	jmxMainClass                      = "org.datadog.jmxfetch.App"
+	jmxCollectCommand                 = "collect"
+	defaultJvmMaxMemoryAllocation     = " -Xmx200m"
+	defaultJvmInitialMemoryAllocation = " -Xms50m"
+	defaultJavaBinPath                = "java"
+	defaultLogLevel                   = "info"
+)
+
+var (
+	jmxLogLevelMap = map[string]string{
+		"trace":    "TRACE",
+		"debug":    "DEBUG",
+		"info":     "INFO",
+		"warn":     "WARN",
+		"warning":  "WARN",
+		"error":    "ERROR",
+		"err":      "ERROR",
+		"critical": "FATAL",
+	}
+)
+
+type JMXFetch struct {
+	JavaBinPath        string
+	JavaOptions        string
+	JavaToolsJarPath   string
+	JavaCustomJarPaths []string
+	LogLevel           string
+	JmxExitFile        string
+	exitFilePath       string
+	cmd                *exec.Cmd
+}
+
+func New(exitFile string) *JMXFetch {
+	return &JMXFetch{
+		JavaBinPath:        defaultJavaBinPath,
+		JavaCustomJarPaths: []string{},
+		LogLevel:           defaultLogLevel,
+		JmxExitFile:        exitFile,
+	}
+}
+
+func (j *JMXFetch) Run() error {
+	here, _ := executable.Folder()
+	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
+	if j.JavaToolsJarPath != "" {
+		classpath = fmt.Sprintf("%s:%s", j.JavaToolsJarPath, classpath)
+	}
+
+	globalCustomJars := config.Datadog.GetStringSlice("jmx_custom_jars")
+	if len(globalCustomJars) > 0 {
+		classpath = fmt.Sprintf("%s:%s", strings.Join(globalCustomJars, ":"), classpath)
+	}
+
+	if len(j.JavaCustomJarPaths) > 0 {
+		classpath = fmt.Sprintf("%s:%s", strings.Join(j.JavaCustomJarPaths, ":"), classpath)
+	}
+	bindHost := config.Datadog.GetString("bind_host")
+	if bindHost == "" || bindHost == "0.0.0.0" {
+		bindHost = "localhost"
+	}
+	reporter := fmt.Sprintf("statsd:%s:%s", bindHost, config.Datadog.GetString("dogstatsd_port"))
+
+	//TODO : support auto discovery
+
+	subprocessArgs := []string{}
+
+	// Specify a maximum memory allocation pool for the JVM
+	javaOptions := j.JavaOptions
+	if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
+		javaOptions += defaultJvmMaxMemoryAllocation
+	}
+	// Specify the initial memory allocation pool for the JVM
+	if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
+		javaOptions += defaultJvmInitialMemoryAllocation
+	}
+
+	subprocessArgs = append(subprocessArgs, strings.Fields(javaOptions)...)
+
+	jmxLogLevel, ok := jmxLogLevelMap[strings.ToLower(j.LogLevel)]
+	if !ok {
+		jmxLogLevel = "INFO"
+	}
+	// checks are now enabled via IPC on JMXFetch
+	subprocessArgs = append(subprocessArgs,
+		"-classpath", classpath,
+		jmxMainClass,
+		"--ipc_host", config.Datadog.GetString("cmd_host"),
+		"--ipc_port", fmt.Sprintf("%v", config.Datadog.GetInt("cmd_port")),
+		"--check_period", fmt.Sprintf("%v", int(check.DefaultCheckInterval/time.Millisecond)), // Period of the main loop of jmxfetch in ms
+		"--log_level", jmxLogLevel,
+		"--reporter", reporter, // Reporter to use
+		jmxCollectCommand, // Name of the command
+	)
+
+	if j.JmxExitFile != "" {
+		j.exitFilePath = filepath.Join(here, "dist", "jmx", j.JmxExitFile) // FIXME : At some point we should have a `run` folder
+		// Signal handlers are not supported on Windows:
+		// use a file to trigger JMXFetch exit instead
+		subprocessArgs = append(subprocessArgs, "--exit_file_location", j.exitFilePath)
+	}
+
+	j.cmd = exec.Command(j.JavaBinPath, subprocessArgs...)
+
+	// set environment + token
+	j.cmd.Env = append(
+		os.Environ(),
+		fmt.Sprintf("SESSION_TOKEN=%s", api.GetAuthToken()),
+	)
+
+	// remove the exit file trigger (windows)
+	if j.JmxExitFile != "" {
+		os.Remove(j.exitFilePath)
+	}
+
+	// forward the standard output to the Agent logger
+	stdout, err := j.cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		in := bufio.NewScanner(stdout)
+		for in.Scan() {
+			log.Info(in.Text())
+		}
+	}()
+
+	// forward the standard error to the Agent logger
+	stderr, err := j.cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		in := bufio.NewScanner(stderr)
+		for in.Scan() {
+			log.Error(in.Text())
+		}
+	}()
+
+	log.Debugf("Args: %v", subprocessArgs)
+
+	return j.cmd.Start()
+}
+
+func (j *JMXFetch) Kill() error {
+	if j.JmxExitFile == "" {
+		// Unix
+		err := j.cmd.Process.Signal(os.Kill)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Windows
+		if err := ioutil.WriteFile(j.exitFilePath, nil, 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *JMXFetch) Wait() error {
+	return j.cmd.Wait()
+}

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -86,8 +86,8 @@ func New() *JMXFetch {
 	}
 }
 
-// Run starts the JMXFetch process
-func (j *JMXFetch) Run() error {
+// Start starts the JMXFetch process
+func (j *JMXFetch) Start() error {
 	here, _ := executable.Folder()
 	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
 	if j.JavaToolsJarPath != "" {

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build jmx
+
 package jmxfetch
 
 import (

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -29,6 +29,7 @@ const (
 	defaultJmxCommand                 = "collect"
 	defaultJvmMaxMemoryAllocation     = " -Xmx200m"
 	defaultJvmInitialMemoryAllocation = " -Xms50m"
+	jvmCgroupMemoryAwareness          = " -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 	defaultJavaBinPath                = "java"
 	defaultLogLevel                   = "info"
 )
@@ -43,6 +44,12 @@ var (
 		"error":    "ERROR",
 		"err":      "ERROR",
 		"critical": "FATAL",
+	}
+	jvmCgroupMemoryIncompatOptions = []string{
+		"Xmx",
+		"XX:MaxHeapSize",
+		"Xms",
+		"XX:InitialHeapSize",
 	}
 )
 
@@ -109,12 +116,27 @@ func (j *JMXFetch) Run() error {
 
 	// Specify a maximum memory allocation pool for the JVM
 	javaOptions := j.JavaOptions
-	if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
-		javaOptions += defaultJvmMaxMemoryAllocation
-	}
-	// Specify the initial memory allocation pool for the JVM
-	if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
-		javaOptions += defaultJvmInitialMemoryAllocation
+	if config.Datadog.GetBool("jmx_use_cgroup_memory_limit") {
+		passOption := true
+		// This option is incompatible with the Xmx and Xms options, log a warning if there are found in the javaOptions
+		for _, option := range jvmCgroupMemoryIncompatOptions {
+			if strings.Contains(javaOptions, option) {
+				log.Warnf("Java option %q is incompatible with cgroup_memory_limit, disabling cgroup mode", option)
+				passOption = false
+			}
+		}
+		if passOption {
+			javaOptions += jvmCgroupMemoryAwareness
+		}
+	} else {
+		// Specify a maximum memory allocation pool for the JVM
+		if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
+			javaOptions += defaultJvmMaxMemoryAllocation
+		}
+		// Specify the initial memory allocation pool for the JVM
+		if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
+			javaOptions += defaultJvmInitialMemoryAllocation
+		}
 	}
 
 	subprocessArgs = append(subprocessArgs, strings.Fields(javaOptions)...)

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -65,7 +65,6 @@ type JMXFetch struct {
 	JmxExitFile        string
 	Command            string
 	ReportOnConsole    bool
-	ConfDirectory      string
 	Checks             []string
 	IPCPort            int
 	IPCHost            string
@@ -167,12 +166,6 @@ func (j *JMXFetch) Start() error {
 		"--log_level", jmxLogLevel,
 		"--reporter", reporter, // Reporter to use
 	)
-
-	if j.ConfDirectory != "" {
-		subprocessArgs = append(subprocessArgs, "--check")
-		subprocessArgs = append(subprocessArgs, j.Checks...)
-		subprocessArgs = append(subprocessArgs, "--conf_directory", j.ConfDirectory)
-	}
 
 	subprocessArgs = append(subprocessArgs, j.Command)
 

--- a/releasenotes/notes/jmx-helper-commands-af9350e1ac926b0b.yaml
+++ b/releasenotes/notes/jmx-helper-commands-af9350e1ac926b0b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add agent5-like JMXFetch helper commands to help with JMXFetch troubleshooting.


### PR DESCRIPTION
### What does this PR do?

Adds agent5-like JMXFetch helper commands. 

https://docs.datadoghq.com/integrations/java/#troubleshooting

### Motivation

Help with jmx troubleshooting.

### Additional Notes

I would advice to review the second commit (https://github.com/DataDog/datadog-agent/pull/1208/commits/656bb20e2b64c2b176cf5e52064184aa02331ca9) separately since it's a refactoring and could be merged separately from the rest. 

Depends on https://github.com/DataDog/jmxfetch/pull/171