### PR TITLE
[Logs] Fixed a bug in the pipeline provider preventing the logs to be authenticated

### DIFF
--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -26,7 +26,7 @@ type provider struct {
 	chanSize          int
 	numberOfPipelines int32
 	currentChanIdx    int32
-	config            config.Config
+	config            *config.Config
 }
 
 // NewProvider returns a new Provider
@@ -36,6 +36,7 @@ func NewProvider(config *config.Config) Provider {
 		chanSize:          config.GetChanSize(),
 		numberOfPipelines: int32(config.GetNumberOfPipelines()),
 		currentChanIdx:    0,
+		config:            config,
 	}
 }
 

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -8,6 +8,7 @@ package pipeline
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/stretchr/testify/suite"
 )
@@ -23,6 +24,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 		chanSize:          10,
 		pipelinesChans:    [](chan message.Message){},
 		currentChanIdx:    0,
+		config:            &config.Config{},
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix missing field in the pipeline provider

### Motivation

All logs are dropped by the back-end