### PR TITLE
add forwarder healthcheck logic 

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -344,7 +344,6 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*HTTPTransaction)
 		case f.highPrio <- t:
 		default:
 			log.Errorf("the input queue of the forwarder is full: dropping transaction")
-			transactionsExpvar.Add("Dropped", 1)
 			transactionsExpvar.Add("DroppedOnInput", 1)
 		}
 	}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -293,9 +293,9 @@ func (f *DefaultForwarder) healthCheckLoop() {
 	// Once we're healthy, make sure we don't drop packets
 	for range f.health.C {
 		// By ranging, we will exit the goroutine when the channel closes.
-		// If we dropped a transaction (full queue or invalid APIkey),
+		// If we dropped a transaction in input from the aggregator (full intake queue),
 		// we exit the loop and let the forwarder become unhealthy.
-		if transactionsExpvar.Get("Dropped") != nil {
+		if transactionsExpvar.Get("DroppedOnInput") != nil {
 			log.Errorf("Detected dropped transaction, reporting the forwarder as unhealthy.")
 			return
 		}
@@ -345,6 +345,7 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*HTTPTransaction)
 		default:
 			log.Errorf("the input queue of the forwarder is full: dropping transaction")
 			transactionsExpvar.Add("Dropped", 1)
+			transactionsExpvar.Add("DroppedOnInput", 1)
 		}
 	}
 

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -155,6 +155,9 @@ func TestRetryTransactions(t *testing.T) {
 	forwarder.init()
 	forwarder.retryQueueLimit = 1
 
+	// Default value should be nil
+	assert.Nil(t, transactionsExpvar.Get("Dropped"))
+
 	t1 := NewHTTPTransaction()
 	t1.nextFlush = time.Now().Add(-1 * time.Hour)
 	t2 := NewHTTPTransaction()
@@ -165,6 +168,7 @@ func TestRetryTransactions(t *testing.T) {
 	forwarder.retryTransactions(time.Now())
 	assert.Len(t, forwarder.retryQueue, 1)
 	assert.Len(t, forwarder.lowPrio, 1)
+	require.NotNil(t, transactionsExpvar.Get("Dropped"))
 	dropped, _ := strconv.ParseInt(transactionsExpvar.Get("Dropped").String(), 10, 64)
 	assert.Equal(t, int64(1), dropped)
 }

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -6,6 +6,14 @@ Forwarder
   {{$key}}: {{$value}}
   {{- end }}
 {{- end}}
+{{- if .Transactions.DroppedOnInput }}
+
+  Dropped {{ .Transactions.DroppedOnInput }} transactions because of busy workers.
+{{- end}}
+{{- if .Transactions.Dropped }}
+
+  Dropped {{ .Transactions.Dropped }} transactions because of network errors.
+{{- end}}
 {{- if .APIKeyStatus }}
 
   API Keys status

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -5,15 +5,14 @@ Forwarder
   {{- range $key, $value := .Transactions }}
   {{$key}}: {{$value}}
   {{- end }}
-{{- end}}
-{{- if .Transactions.DroppedOnInput }}
+  {{- if .Transactions.DroppedOnInput }}
 
-  Dropped {{ .Transactions.DroppedOnInput }} transactions because of busy workers.
+  Warning: the forwarder dropped transactions because all workers were busy.
+  You should review your network performance, and tune the forwarder_num_workers
+  and forwarder_timeout options.
+  {{- end}}
 {{- end}}
-{{- if .Transactions.Dropped }}
 
-  Dropped {{ .Transactions.Dropped }} transactions because of network errors.
-{{- end}}
 {{- if .APIKeyStatus }}
 
   API Keys status

--- a/releasenotes/notes/forwarder-healthcheck-207a3bd52b334447.yaml
+++ b/releasenotes/notes/forwarder-healthcheck-207a3bd52b334447.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     Add healthcheck to the forwarder. The agent will be unhealthy if the apikey
-    is invalid or if transations are dropped
+    is invalid or if transactions are dropped because all workers are busy.

--- a/releasenotes/notes/forwarder-healthcheck-207a3bd52b334447.yaml
+++ b/releasenotes/notes/forwarder-healthcheck-207a3bd52b334447.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add healthcheck to the forwarder. The agent will be unhealthy if the apikey
+    is invalid or if transations are dropped


### PR DESCRIPTION
### What does this PR do?

Add a healthcheck loop to the forwarder so that it can be monitored through the `agent health` command.

As all other subsystems, the forwarder starts unhealthy, then:

- waits for a transaction to finish with a valid APIkey (usually it's the host metadata collector, that runs just after agent startup), then becomes healthy
- every 15 seconds, check that we never dropped packets and, if so, sets the forwarder to unhealthy. This could be caused by all workers being deadlocked.
