### PR TITLE
[docker] honor `$DOCKER_HOST`, print version in debug logs

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -53,24 +52,6 @@ type DockerUtil struct {
 	imageNameBySha map[string]string
 	// event subscribers and state
 	eventState *eventStreamState
-}
-
-func detectServerAPIVersion() (string, error) {
-	host := os.Getenv("DOCKER_HOST")
-	if host == "" {
-		host = client.DefaultDockerHost
-	}
-	cli, err := client.NewClient(host, "", nil, nil)
-	if err != nil {
-		return "", err
-	}
-
-	// Create the client using the server's API version
-	v, err := cli.ServerVersion(context.Background())
-	if err != nil {
-		return "", err
-	}
-	return v.APIVersion, nil
 }
 
 // init makes an empty DockerUtil bootstrap itself.
@@ -118,29 +99,17 @@ func (d *DockerUtil) init() error {
 // TODO: REMOVE USES AND MOVE TO PRIVATE
 //
 func ConnectToDocker() (*client.Client, error) {
-	// If we don't have a docker.sock then return a known error.
-	sockPath := getEnv("DOCKER_SOCKET_PATH", "/var/run/docker.sock")
-	if !pathExists(sockPath) {
-		return nil, ErrDockerNotAvailable
-	}
-	// The /proc/mounts file won't be available on non-Linux systems
-	// and we only support Linux for now.
-	mountsFile := "/proc/mounts"
-	if !pathExists(mountsFile) {
-		return nil, ErrDockerNotAvailable
-	}
-
-	// Connect again using the known server version.
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO: remove this logic when "client.NegotiateAPIVersion" function is released by moby/docker
-	serverVersion, err := detectServerAPIVersion()
-	if err != nil || serverVersion == "" {
+	v, err := cli.ServerVersion(context.Background())
+	if err != nil || v.APIVersion == "" {
 		return nil, fmt.Errorf("Could not determine docker server API version: %s", err)
 	}
+	serverVersion := v.APIVersion
 
 	clientVersion := cli.ClientVersion()
 	if versions.LessThan(serverVersion, clientVersion) {
@@ -148,6 +117,9 @@ func ConnectToDocker() (*client.Client, error) {
 			serverVersion, clientVersion)
 		cli.UpdateClientVersion(serverVersion)
 	}
+
+	log.Debugf("Successfully connected to Docker server version %s", v.Version)
+
 	return cli, nil
 }
 

--- a/releasenotes/notes/docker-support-docker-host-var-6bad5c289940afcd.yaml
+++ b/releasenotes/notes/docker-support-docker-host-var-6bad5c289940afcd.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Try to connect to Docker even `/var/run/docker.sock` is absent, to honor the
+    $DOCKER_HOST environment variable.
+  - |
+    Get the docker server version in the debug logs for troubleshooting


### PR DESCRIPTION
- Remove the check for `/var/run/docker.sock` to support TCP connections and custom socket paths
- Remove the test for os == Linux, build tags already disable the code on !Linux
- Print Docker server version as debug, so it's accessible in `agent diagnose`:

```
=== Running Docker availability diagnosis ===
[DEBUG] ConnectToDocker: Successfully connected to Docker server version 17.11.0-ce - 1518103495845533971
[INFO] diagnose: successfully connected to docker - 1518103495845598568
[INFO] diagnose: successfully got hostname "ci-xaviervello" from docker - 1518103495866897014
===> PASS
```