### PR TITLE
Improve check cmd output, fixes #1159

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -104,6 +104,14 @@ var checkCmd = &cobra.Command{
 					}
 				}
 			}
+			for check, warnings := range autodiscovery.GetResolveWarnings() {
+				if checkName == check {
+					fmt.Fprintln(color.Output, fmt.Sprintf("\n%s: could not resolve %s config:", color.YellowString("Warning"), color.YellowString(check)))
+					for _, warning := range warnings {
+						fmt.Fprintln(color.Output, fmt.Sprintf("* %s", warning))
+					}
+				}
+			}
 			return fmt.Errorf("no valid check found")
 		}
 

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -10,14 +10,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -49,6 +52,10 @@ var checkCmd = &cobra.Command{
 		if err != nil {
 			fmt.Printf("Cannot setup config, exiting: %v\n", err)
 			return err
+		}
+
+		if flagNoColor {
+			color.NoColor = true
 		}
 
 		if logLevel == "" {
@@ -84,8 +91,20 @@ var checkCmd = &cobra.Command{
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 		cs := common.AC.GetChecksByName(checkName)
 		if len(cs) == 0 {
-			fmt.Println("no check found")
-			return fmt.Errorf("no check found")
+			for check, error := range autodiscovery.GetConfigErrors() {
+				if checkName == check {
+					fmt.Fprintln(color.Output, fmt.Sprintf("\n%s: invalid config for %s: %s", color.RedString("Error"), color.YellowString(check), error))
+				}
+			}
+			for check, errors := range autodiscovery.GetLoaderErrors() {
+				if checkName == check {
+					fmt.Fprintln(color.Output, fmt.Sprintf("\n%s: could not load %s:", color.RedString("Error"), color.YellowString(checkName)))
+					for loader, error := range errors {
+						fmt.Fprintln(color.Output, fmt.Sprintf("* %s: %s", color.YellowString(loader), error))
+					}
+				}
+			}
+			return fmt.Errorf("no valid check found")
 		}
 
 		if len(cs) > 1 {
@@ -130,28 +149,28 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 func printMetrics(agg *aggregator.BufferedAggregator) {
 	series := agg.GetSeries()
 	if len(series) != 0 {
-		fmt.Println("Series: ")
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Series")))
 		j, _ := json.MarshalIndent(series, "", "  ")
 		fmt.Println(string(j))
 	}
 
 	sketches := agg.GetSketches()
 	if len(sketches) != 0 {
-		fmt.Println("Sketches: ")
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Sketches")))
 		j, _ := json.MarshalIndent(sketches, "", "  ")
 		fmt.Println(string(j))
 	}
 
 	serviceChecks := agg.GetServiceChecks()
 	if len(serviceChecks) != 0 {
-		fmt.Println("Service Checks: ")
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Service Checks")))
 		j, _ := json.MarshalIndent(serviceChecks, "", "  ")
 		fmt.Println(string(j))
 	}
 
 	events := agg.GetEvents()
 	if len(events) != 0 {
-		fmt.Println("Events: ")
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Events")))
 		j, _ := json.MarshalIndent(events, "", "  ")
 		fmt.Println(string(j))
 	}

--- a/releasenotes/notes/improve-check-cli-e08f666abf9157f4.yaml
+++ b/releasenotes/notes/improve-check-cli-e08f666abf9157f4.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix https://github.com/DataDog/datadog-agent/issues/1159 where error was not
+    explicit when the check had invalid configuration or code


### PR DESCRIPTION
### What does this PR do?

Improve the CLI output for the `check` command it now correctly displays relevant errors:

* invalid config:
![screen shot 2018-02-08 at 19 51 00](https://user-images.githubusercontent.com/2368736/35992059-7695b55c-0d09-11e8-9b2e-2d96f724758f.png)

* invalid code:
![screen shot 2018-02-08 at 19 51 21](https://user-images.githubusercontent.com/2368736/35992074-879f7824-0d09-11e8-9bdd-34c7c1066853.png)



### Motivation

Fix #1159 & improve troubleshooting

