### PR TITLE
Move circleci build image version to go1.9.4

### DIFF
--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.1
+FROM golang:1.9.4
 
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
     && sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list \


### PR DESCRIPTION
### What does this PR do?

Upgrade the circleci build image Dockerfile to use golang1.9.4

### Motivation

Keep Golang up to date after the latest release with a security related fix.

### Additional Notes

Anything else we should know when reviewing?
