### PR TITLE
Fix test/build for go 1.9.4

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -62,7 +62,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	av, _ := version.New(version.AgentVersion)
+	av, _ := version.New(version.AgentVersion, version.Commit)
 	j, _ := json.Marshal(av)
 	w.Write(j)
 }

--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -27,7 +27,7 @@ var versionCmd = &cobra.Command{
 		if flagNoColor {
 			color.NoColor = true
 		}
-		av, _ := version.New(version.AgentVersion)
+		av, _ := version.New(version.AgentVersion, version.Commit)
 		meta := ""
 		if av.Meta != "" {
 			meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -60,7 +60,7 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 
 // Sends the current agent version
 func getVersion(w http.ResponseWriter, r *http.Request) {
-	version, e := version.New(version.AgentVersion)
+	version, e := version.New(version.AgentVersion, version.Commit)
 	if e != nil {
 		log.Errorf("Error getting version: " + e.Error())
 		w.Write([]byte("Error: " + e.Error()))

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -60,7 +60,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	av, _ := version.New(version.AgentVersion)
+	av, _ := version.New(version.AgentVersion, version.Commit)
 	j, _ := json.Marshal(av)
 	w.Write(j)
 }

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -50,7 +51,7 @@ metadata for their metrics.`,
 		Short: "Print the version number",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			av, _ := version.New(version.AgentVersion)
+			av, _ := version.New(version.AgentVersion, version.Commit)
 			fmt.Println(fmt.Sprintf("Cluster Agent from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
 		},
 	}

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -55,7 +55,7 @@ extensions for special Datadog features.`,
 		Short: "Print the version number",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			av, _ := version.New(version.AgentVersion)
+			av, _ := version.New(version.AgentVersion, version.Commit)
 			fmt.Println(fmt.Sprintf("DogStatsD from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
 		},
 	}

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -35,7 +35,7 @@ import "C"
 // `self` is the module object.
 //export GetVersion
 func GetVersion(self *C.PyObject, args *C.PyObject) *C.PyObject {
-	av, _ := version.New(version.AgentVersion)
+	av, _ := version.New(version.AgentVersion, version.Commit)
 
 	cStr := C.CString(av.GetNumber())
 	pyStr := C.PyString_FromString(cStr)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -281,7 +281,7 @@ func addAgentVersionToDomain(domain string, app string) (string, error) {
 		return domain, nil
 	}
 
-	v, _ := version.New(version.AgentVersion)
+	v, _ := version.New(version.AgentVersion, version.Commit)
 	subdomain := strings.Split(u.Host, ".")[0]
 	newSubdomain := fmt.Sprintf("%d-%d-%d-%s.agent", v.Major, v.Minor, v.Patch, app)
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -37,7 +37,7 @@ func TestInitExtraHeadersNoopCompression(t *testing.T) {
 	assert.Equal(t, expected, jsonExtraHeaders)
 
 	expected = make(http.Header)
-	expected.Set(payloadVersionHTTPHeader, "")
+	expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
 	expected.Set("Content-Type", protobufContentType)
 	assert.Equal(t, expected, protobufExtraHeaders)
 
@@ -48,7 +48,7 @@ func TestInitExtraHeadersNoopCompression(t *testing.T) {
 
 	expected = make(http.Header)
 	expected.Set("Content-Type", protobufContentType)
-	expected.Set(payloadVersionHTTPHeader, "")
+	expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
 	assert.Equal(t, expected, protobufExtraHeadersWithCompression)
 }
 
@@ -64,7 +64,7 @@ func TestInitExtraHeadersWithCompression(t *testing.T) {
 
 	expected = make(http.Header)
 	expected.Set("Content-Type", protobufContentType)
-	expected.Set(payloadVersionHTTPHeader, "")
+	expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
 	assert.Equal(t, expected, protobufExtraHeaders)
 
 	// "Content-Encoding" header present with correct value
@@ -76,8 +76,12 @@ func TestInitExtraHeadersWithCompression(t *testing.T) {
 	expected = make(http.Header)
 	expected.Set("Content-Type", protobufContentType)
 	expected.Set("Content-Encoding", compression.ContentEncoding)
-	expected.Set(payloadVersionHTTPHeader, "")
+	expected.Set(payloadVersionHTTPHeader, AgentPayloadVersion)
 	assert.Equal(t, expected, protobufExtraHeadersWithCompression)
+}
+
+func TestAgentPayloadVersion(t *testing.T) {
+	assert.NotEmpty(t, AgentPayloadVersion, "AgentPayloadVersion is empty, indicates that the package was not built correctly")
 }
 
 var (

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -93,7 +93,7 @@ func EnsureParentDirsExist(p string) error {
 
 // HTTPHeaders returns a http headers including various basic information (User-Agent, Content-Type...).
 func HTTPHeaders() map[string]string {
-	av, _ := version.New(version.AgentVersion)
+	av, _ := version.New(version.AgentVersion, version.Commit)
 	return map[string]string{
 		"User-Agent":   fmt.Sprintf("Datadog Agent/%s", av.GetNumber()),
 		"Content-Type": "application/x-www-form-urlencoded",

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -10,6 +10,9 @@ package version
 // AgentVersion contains the version of the Agent
 var AgentVersion string
 
+// Commit is populated with the short commit hash from which the Agent was built
+var Commit string
+
 var agentVersionDefault = "6.0.0"
 
 func init() {

--- a/pkg/version/base_test.go
+++ b/pkg/version/base_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentVersion(t *testing.T) {
+	assert.NotEmpty(t, AgentVersion)
+}
+
+func TestCommit(t *testing.T) {
+	assert.NotEmpty(t, Commit, "The Commit var is empty, indicating that the package was not built correctly")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,10 +22,8 @@ type Version struct {
 	Commit string
 }
 
-var commit string
-
-// New parses a version string like `0.0.0` and returns an AgentVersion instance
-func New(version string) (Version, error) {
+// New parses a version string like `0.0.0` and a commit identifier and returns a Version instance
+func New(version, commit string) (Version, error) {
 	re := regexp.MustCompile(`(\d+\.\d+\.\d+)(\-[^\+]+)*(\+.+)*`)
 	toks := re.FindStringSubmatch(version)
 	if len(toks) == 0 || toks[0] != version {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -13,40 +13,41 @@ import (
 
 func TestNew(t *testing.T) {
 	// full fledge
-	v, err := New("1.2.3-pre+☢")
+	v, err := New("1.2.3-pre+☢", "deadbeef")
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), v.Major)
 	assert.Equal(t, int64(2), v.Minor)
 	assert.Equal(t, int64(3), v.Patch)
 	assert.Equal(t, "pre", v.Pre)
 	assert.Equal(t, "☢", v.Meta)
+	assert.Equal(t, "deadbeef", v.Commit)
 
 	// only pre
-	v, err = New("1.2.3-pre-pre.1")
+	v, err = New("1.2.3-pre-pre.1", "")
 	assert.Nil(t, err)
 	assert.Equal(t, "pre-pre.1", v.Pre)
 
 	// only meta
-	v, err = New("1.2.3+☢.1+")
+	v, err = New("1.2.3+☢.1+", "")
 	assert.Nil(t, err)
 	assert.Equal(t, "☢.1+", v.Meta)
 
-	_, err = New("")
+	_, err = New("", "")
 	assert.NotNil(t, err)
-	_, err = New("1.2.")
+	_, err = New("1.2.", "")
 	assert.NotNil(t, err)
-	_, err = New("1.2.3.4")
+	_, err = New("1.2.3.4", "")
 	assert.NotNil(t, err)
-	_, err = New("1.2.foo")
+	_, err = New("1.2.foo", "")
 	assert.NotNil(t, err)
 }
 
 func TestString(t *testing.T) {
-	v, _ := New("1.2.3-pre+☢")
-	assert.Equal(t, "1.2.3-pre+☢", v.String())
+	v, _ := New("1.2.3-pre+☢", "123beef")
+	assert.Equal(t, "1.2.3-pre+☢.commit.123beef", v.String())
 }
 
 func TestGetNumber(t *testing.T) {
-	v, _ := New("1.2.3-pre+☢")
+	v, _ := New("1.2.3-pre+☢", "123beef")
 	assert.Equal(t, "1.2.3", v.GetNumber())
 }

--- a/releasenotes/notes/go-update-1-9-4-71b6bf7a168d34fe.yaml
+++ b/releasenotes/notes/go-update-1-9-4-71b6bf7a168d34fe.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Upgraded Go runtime to `1.9.4` on Linux builds

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -52,9 +52,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     """
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
-    env = {
-        "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs)
-    }
+
+    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
 
     if invoke.platform.WINDOWS:
         # Don't build Docker support
@@ -83,7 +82,6 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         build_tags = get_default_build_tags(puppy=True)
     else:
         build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
 
     cmd = "go build {race_opt} {build_type} -tags \"{go_build_tags}\" "
     cmd += "-o {agent_bin} -gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/agent"

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -21,6 +21,7 @@ AGENT_TAG = "datadog/cluster_agent:master"
 DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
 ]
+
 @task
 def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False):
     """
@@ -32,7 +33,7 @@ def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False)
 
     build_tags = get_build_tags(DEFAULT_BUILD_TAGS, [])
 
-    ldflags, gcflags = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
 
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent/"
@@ -45,7 +46,7 @@ def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False)
         "ldflags": ldflags,
         "REPO_PATH": REPO_PATH,
     }
-    ctx.run(cmd.format(**args))
+    ctx.run(cmd.format(**args), env=env)
 
 @task
 def run(ctx, rebuild=False, race=False, skip_build=False, development=True):

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -29,7 +29,6 @@ DEFAULT_BUILD_TAGS = [
 ]
 
 
-
 @task
 def build(ctx, rebuild=False, race=False, static=False, build_include=None,
           build_exclude=None, use_embedded_libs=False):
@@ -39,7 +38,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
     bin_path = DOGSTATSD_BIN_PATH
 
     if static:
@@ -56,7 +55,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
         "ldflags": ldflags,
         "REPO_PATH": REPO_PATH,
     }
-    ctx.run(cmd.format(**args))
+    ctx.run(cmd.format(**args), env=env)
 
     # Render the configuration file template
     #

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -56,7 +56,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
     commit = ctx.run("git rev-parse --short HEAD", hide=True).stdout.strip()
 
     gcflags = ""
-    ldflags = "-X {}/pkg/version.commit={} ".format(REPO_PATH, commit)
+    ldflags = "-X {}/pkg/version.Commit={} ".format(REPO_PATH, commit)
     ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True))
     ldflags += "-X {}/pkg/serializer.AgentPayloadVersion={} ".format(REPO_PATH, payload_v)
     env = {


### PR DESCRIPTION
### What does this PR do?

Fixes test/build for go 1.9.4

1.9.4 enforces a whitelist of allowed compiler/linker flags for cgo
components. This affects our snmp build. We need to add one flag to the whitelist
using the CGO_CFLAGS_ALLOW env var.

### Motivation

We recently updated go to `1.9.4` in our test/build images, since then our tests and builds are broken .

### Additional Notes

Reference on the go project:
* commit that introduced the change: https://go.googlesource.com/go/+/867fb18b6d5bc73266b68c9a695558a04e060a8a
* open issue to add more options to cgo's default whitelist: https://github.com/golang/go/issues/23749