### PR TITLE
remove support for config option collect_security_groups

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -52,6 +52,7 @@ differently from Agent version 5.
 | `dogstream_log` | |
 | `use_curl_http_client` | |
 | `gce_updated_hostname` | |
+| `collect_security_groups` | feature still available with the aws integration  |
 
 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,7 +174,6 @@ func init() {
 	// ECS
 	Datadog.SetDefault("ecs_agent_url", "") // Will be autodetected
 	Datadog.SetDefault("collect_ec2_tags", false)
-	Datadog.SetDefault("collect_security_groups", false)
 
 	// Cloud Foundry
 	Datadog.SetDefault("cloud_foundry", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -66,6 +66,8 @@ api_key:
 # Set this option to "yes" to output logs in JSON format
 # log_format_json: no
 
+# Collect AWS EC2 custom tags as agent tags
+# collect_ec2_tags: false
 {{ end }}
 {{- if .Agent }}
 # The path containing check configuration files

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -55,10 +55,6 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("collect_ec2_tags", enabled)
 	}
 
-	if enabled, err := isAffirmative(agentConfig["collect_security_groups"]); err == nil {
-		config.Datadog.Set("collect_security_groups", enabled)
-	}
-
 	// config.Datadog has a default value for this, do nothing if the value is empty
 	if agentConfig["additional_checksd"] != "" {
 		config.Datadog.Set("additional_checksd", agentConfig["additional_checksd"])

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -29,7 +29,6 @@ var (
 		"forwarder_timeout",
 		"default_integration_http_timeout",
 		"collect_ec2_tags",
-		"collect_security_groups",
 		"additional_checksd",
 		"exclude_process_args",
 		"histogram_aggregates",

--- a/pkg/legacy/tests/datadog.conf
+++ b/pkg/legacy/tests/datadog.conf
@@ -49,8 +49,6 @@ create_dd_check_tags: False
 
 # Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
 collect_ec2_tags: True
-# Incorporate security-groups into tags collected from AWS EC2
-collect_security_groups: True
 
 # Enable Agent Developer Mode
 # Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -78,7 +78,7 @@ func getHostTags() *tags {
 	hostTags := config.Datadog.GetStringSlice("tags")
 
 	if config.Datadog.GetBool("collect_ec2_tags") {
-		ec2Tags, err := getEC2Tags()
+		ec2Tags, err := ec2.GetTags()
 		if err != nil {
 			log.Debugf("No EC2 host tags %v", err)
 		} else {
@@ -95,24 +95,6 @@ func getHostTags() *tags {
 		System:              hostTags,
 		GoogleCloudPlatform: gceTags,
 	}
-}
-
-func getEC2Tags() ([]string, error) {
-	ec2Tags, err := ec2.GetTags()
-	if err != nil {
-		return ec2Tags, err
-	}
-
-	if !config.Datadog.GetBool("collect_security_groups") {
-		// remove the `security_group_name` tag if present
-		for i, s := range ec2Tags {
-			if strings.HasPrefix(s, "security_group_name:") {
-				ec2Tags = append(ec2Tags[:i], ec2Tags[i+1:]...)
-			}
-		}
-	}
-
-	return ec2Tags, nil
 }
 
 func getSystemStats() *systemStats {

--- a/releasenotes/notes/support-ec2-metadata-options-6287da5d6462fc44.yaml
+++ b/releasenotes/notes/support-ec2-metadata-options-6287da5d6462fc44.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add support for collect_ec2_tags and collect_security_groups configuration options.
+    Add support for collect_ec2_tags configuration option.


### PR DESCRIPTION
### What does this PR do?

Removes support for the `collect_security_groups` config option.

### Motivation

There seems to be a bug in agent5 with this option in that part of the code : https://github.com/DataDog/dd-agent/blob/5.21.2/utils/cloud_metadata.py#L212-L214

Basically, if there are multiple security groups, the agent5 will tag the host with something like : 

```
security-groups:sec-group-1
sec-group-2
```
(notice the `\n`)

The motivation for porting this option was to avoid context churn. Since we are not going to replicate the bug in agent6 let's remove this for now.

### Notes

This tag will still be applied properly if the AWS crawler is enabled.
