### PR TITLE
Fix stop cmd

### DIFF
--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -33,7 +33,10 @@ func init() {
 
 func stop(*cobra.Command, []string) error {
 	// Global Agent configuration
-	common.SetupConfig("")
+	err := common.SetupConfig(confFilePath)
+	if err != nil {
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
+	}
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
 	// Set session token
@@ -49,5 +52,6 @@ func stop(*cobra.Command, []string) error {
 		return fmt.Errorf("Error stopping the agent: %v", e)
 	}
 
+	fmt.Println("Agent successfully stopped")
 	return nil
 }

--- a/releasenotes/notes/fix-stop-cmd-630e5967b51d2ba9.yaml
+++ b/releasenotes/notes/fix-stop-cmd-630e5967b51d2ba9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the agent stop command


### PR DESCRIPTION
### What does this PR do?

Fix the stop command

### Motivation

It was failing due to `Error: error creating authentication token: stat : no such file or directory`
