### PR TITLE
Remove Tagger error because always nil

### DIFF
--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -6,8 +6,6 @@
 package tagger
 
 import (
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
@@ -19,20 +17,16 @@ func Init() error {
 	return defaultTagger.Init(collectors.DefaultCatalog)
 }
 
-// Tag queries the defaulttagger to get entity tags from cache or sources
+// Tag queries the defaultTagger to get entity tags from cache or sources
 func Tag(entity string, highCard bool) ([]string, error) {
 	return defaultTagger.Tag(entity, highCard)
 }
 
-// Stop queues a stop signal to the defaulttagger
+// Stop queues a stop signal to the defaultTagger
 func Stop() error {
 	return defaultTagger.Stop()
 }
 
 func init() {
-	tagger, err := newTagger()
-	if err != nil {
-		log.Errorf("tagger initialisation failed: %s", err)
-	}
-	defaultTagger = tagger
+	defaultTagger = newTagger()
 }

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -46,13 +46,9 @@ type collectorReply struct {
 // once the config package is ready.
 // You are probably looking for tagger.Tag() using the global instance
 // instead of creating your own.
-func newTagger() (*Tagger, error) {
-	store, err := newTagStore()
-	if err != nil {
-		return nil, err
-	}
-	t := &Tagger{
-		tagStore:    store,
+func newTagger() *Tagger {
+	return &Tagger{
+		tagStore:    newTagStore(),
 		candidates:  make(map[string]collectors.CollectorFactory),
 		pullers:     make(map[string]collectors.Puller),
 		streamers:   make(map[string]collectors.Streamer),
@@ -64,8 +60,6 @@ func newTagger() (*Tagger, error) {
 		stop:        make(chan bool),
 		health:      health.Register("tagger"),
 	}
-
-	return t, nil
 }
 
 // Init goes through a catalog and tries to detect which are relevant

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -78,9 +78,8 @@ func TestInit(t *testing.T) {
 	}
 	assert.Equal(t, 3, len(catalog))
 
-	tagger, err := newTagger()
-	assert.Nil(t, err)
-	err = tagger.Init(catalog)
+	tagger := newTagger()
+	err := tagger.Init(catalog)
 	assert.Nil(t, err)
 
 	assert.Equal(t, 3, len(tagger.fetchers))
@@ -102,7 +101,7 @@ func TestInit(t *testing.T) {
 
 func TestFetchAllMiss(t *testing.T) {
 	catalog := collectors.Catalog{"stream": NewDummyStreamer, "pull": NewDummyPuller}
-	tagger, _ := newTagger()
+	tagger := newTagger()
 	tagger.Init(catalog)
 
 	streamer := tagger.streamers["stream"].(*DummyCollector)
@@ -124,7 +123,7 @@ func TestFetchAllMiss(t *testing.T) {
 
 func TestFetchAllCached(t *testing.T) {
 	catalog := collectors.Catalog{"stream": NewDummyStreamer, "pull": NewDummyPuller}
-	tagger, _ := newTagger()
+	tagger := newTagger()
 	tagger.Init(catalog)
 
 	tagger.tagStore.processTagInfo(&collectors.TagInfo{
@@ -162,7 +161,7 @@ func TestFetchOneCached(t *testing.T) {
 		"pull":    NewDummyPuller,
 		"fetcher": NewDummyFetcher,
 	}
-	tagger, _ := newTagger()
+	tagger := newTagger()
 	tagger.Init(catalog)
 
 	tagger.tagStore.processTagInfo(&collectors.TagInfo{
@@ -197,7 +196,7 @@ func TestEmptyEntity(t *testing.T) {
 	catalog := collectors.Catalog{
 		"fetcher": NewDummyFetcher,
 	}
-	tagger, _ := newTagger()
+	tagger := newTagger()
 	tagger.Init(catalog)
 
 	tagger.tagStore.processTagInfo(&collectors.TagInfo{
@@ -224,7 +223,7 @@ func TestRetryCollector(t *testing.T) {
 	catalog := collectors.Catalog{
 		"fetcher": func() collectors.Collector { return c },
 	}
-	tagger, _ := newTagger()
+	tagger := newTagger()
 	tagger.Init(catalog)
 
 	assert.Len(t, tagger.candidates, 1)
@@ -260,7 +259,7 @@ func TestErrNotFound(t *testing.T) {
 	catalog := collectors.Catalog{
 		"fetcher": func() collectors.Collector { return c },
 	}
-	tagger, _ := newTagger()
+	tagger := newTagger()
 	tagger.Init(catalog)
 
 	// Result should not be cached

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -30,12 +30,11 @@ type tagStore struct {
 	toDelete      map[string]struct{} // set emulation
 }
 
-func newTagStore() (*tagStore, error) {
-	t := &tagStore{
+func newTagStore() *tagStore {
+	return &tagStore{
 		store:    make(map[string]*entityTags),
 		toDelete: make(map[string]struct{}),
 	}
-	return t, nil
 }
 
 func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -20,9 +20,7 @@ type StoreTestSuite struct {
 }
 
 func (s *StoreTestSuite) SetupTest() {
-	var err error
-	s.store, err = newTagStore()
-	assert.Nil(s.T(), err)
+	s.store = newTagStore()
 }
 
 func (s *StoreTestSuite) TestIngest() {


### PR DESCRIPTION
### What does this PR do?

Remove the error checking because creating a tagger is always `error == nil`.