### PR TITLE
[Upstart] CentOS 6 uses `network` in addition to `networking`

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog Agent"
 
-start on started networking
+start on started networking or started network
 stop on runlevel [!2345]
 
 respawn

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog Agent"
 
-start on started networking or started network
+start on started network
 stop on runlevel [!2345]
 
 respawn

--- a/omnibus/config/templates/datadog-cluster-agent/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-cluster-agent/upstart.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog Cluster Agent"
 
-start on started networking
+start on started networking or started network
 stop on runlevel [!2345]
 
 respawn

--- a/omnibus/config/templates/datadog-dogstatsd/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/upstart.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog statsd server"
 
-start on started networking
+start on started networking or started network
 stop on runlevel [!2345]
 
 respawn

--- a/omnibus/config/templates/datadog-puppy/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-puppy/upstart.conf.erb
@@ -1,6 +1,6 @@
 description "Datadog Agent"
 
-start on started networking
+start on started networking or started network
 stop on runlevel [!2345]
 
 respawn

--- a/releasenotes/notes/centos6_start_on_reboot-18774a79a6626f1f.yaml
+++ b/releasenotes/notes/centos6_start_on_reboot-18774a79a6626f1f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Properly listen for events emitted on OSes like CentOS 6 so the Agent starts on reboot


### PR DESCRIPTION
### What does this PR do?

Adds the condition for Redhat systems to start the Agent based on either the `network` or `networking` emitted event. 

### Motivation

Older versions of CentOS (CentOS 6, RHEL 6) don't emit a `networking` event so the Agent doesn't start when the system is rebooted. After logging what events are typically emitted on boot, there is a `network` event, ex:

```
debug/ (/dev/fd/9):1135:Job network/ started. Environment was:
TERM=linux
PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
JOB=network
UPSTART_EVENTS=started
UPSTART_JOB=debug
_=/usr/bin/env
```

### Additional Notes
