### PR TITLE
make tagger more resilient to malformed docker events

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -97,16 +97,18 @@ func (c *DockerCollector) Fetch(container string) ([]string, []string, error) {
 }
 
 func (c *DockerCollector) processEvent(e *docker.ContainerEvent) {
-	out := make([]*TagInfo, 1)
+	var info *TagInfo
 
 	switch e.Action {
 	case "die":
-		out[0] = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, DeleteEntity: true}
+		info = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, DeleteEntity: true}
 	case "start":
 		low, high, _ := c.fetchForDockerID(e.ContainerID)
-		out[0] = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, LowCardTags: low, HighCardTags: high}
+		info = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, LowCardTags: low, HighCardTags: high}
+	default:
+		return // Nothing to see here
 	}
-	c.infoOut <- out
+	c.infoOut <- []*TagInfo{info}
 }
 
 func (c *DockerCollector) fetchForDockerID(cID string) ([]string, []string, error) {

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -38,6 +38,9 @@ func newTagStore() *tagStore {
 }
 
 func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
+	if info == nil {
+		return fmt.Errorf("skipping nil message")
+	}
 	if info.Entity == "" {
 		return fmt.Errorf("empty entity name, skipping message")
 	}

--- a/releasenotes/notes/tagger-nil-taginfo-664b5f1a0756d3d6.yaml
+++ b/releasenotes/notes/tagger-nil-taginfo-664b5f1a0756d3d6.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - make tagger more resilient to malformed docker events


### PR DESCRIPTION
Found this `nil` pointer vulnerability while fiddling around with docker events.