### PR TITLE
Update trace-agent configuration

### DIFF
--- a/cmd/agent/dist/conf.d/apm.yaml.default
+++ b/cmd/agent/dist/conf.d/apm.yaml.default
@@ -4,7 +4,3 @@ instances:
 
 #   # path to trace agent binary, defaults to `embedded/bin/trace-agent` in agent installation dir
 # - bin_path: /opt/datadog-agent/embedded/bin/trace-agent
-
-#   # Path to classic agent configuration, defaults to `trace-agent.conf` in agent configuration dir
-#   # (i.e. same directory as the one the agent reads `datadog.yaml` from)
-#   conf_path: /etc/datadog-agent/trace-agent.conf

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"sync/atomic"
 	"time"
 
@@ -25,8 +24,7 @@ import (
 )
 
 type apmCheckConf struct {
-	BinPath  string `yaml:"bin_path,omitempty"`
-	ConfPath string `yaml:"conf_path,omitempty"`
+	BinPath string `yaml:"bin_path,omitempty"`
 }
 
 // APMCheck keeps track of the running command
@@ -151,18 +149,13 @@ func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData)
 		c.binPath = defaultBinPath
 	}
 
-	// let the trace-agent use its own config file provided by the Agent package
-	// if we haven't found one in the apm.yaml check config
-	configFile := checkConf.ConfPath
-	if configFile == "" {
-		configFile = path.Join(config.FileUsedDir(), "trace-agent.conf")
-	}
+	configFile := config.Datadog.ConfigFileUsed()
 
 	c.commandOpts = []string{}
 
-	// if the trace-agent.conf file is available, use it
+	// explicitly provide to the trace-agent the agent configuration file
 	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
-		c.commandOpts = append(c.commandOpts, fmt.Sprintf("-ddconfig=%s", configFile))
+		c.commandOpts = append(c.commandOpts, fmt.Sprintf("-config=%s", configFile))
 	}
 
 	return nil

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -384,3 +384,31 @@ metadata_collectors:
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
 {{ end -}}
+
+{{- if .TraceAgent }}
+# Trace Agent Specific Settings
+#
+# apm_config:
+#   Whether or not the APM Agent should run
+#   enabled: true
+#   The environment tag that Traces should be tagged with
+#   Will inherit from "env" tag if none is applied here
+#   env: none
+#   The port that the Receiver should listen on
+#   receiver_port: 8126
+#   Whether the Trace Agent should listen for non local traffic
+#   Only enable if Traces are being sent to this Agent from another host/container
+#   apm_non_local_traffic: false
+#   Extra global sample rate to apply on all the traces
+#   This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
+#   From 1 (no extra rate) to 0 (don't sample at all)
+#   extra_sample_rate: 1.0
+#   Maximum number of traces per second to sample.
+#   The limit is applied over an average over a few minutes ; much bigger spikes are possible.
+#   Set to 0 to disable the limit.
+#   max_traces_per_second: 10
+#   A blacklist of regular expressions can be provided to disable certain traces based on their resource name
+#   all entries must be surrounded by double quotes and separated by commas
+#   Example: "(GET|POST) /healthcheck","GET /V1"
+#   ignore_resource: ""
+{{ end -}}

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -31,6 +31,7 @@ type context struct {
 	ECS               bool
 	ProcessAgent      bool
 	KubeApiServer     bool
+	TraceAgent        bool
 }
 
 func mkContext(buildType string) context {
@@ -52,6 +53,7 @@ func mkContext(buildType string) context {
 			KubernetesTagging: true,
 			ECS:               true,
 			ProcessAgent:      true,
+			TraceAgent:        true,
 		}
 	case "dogstatsd":
 		return context{
@@ -61,6 +63,7 @@ func mkContext(buildType string) context {
 			Logging:           true,
 			KubernetesTagging: true,
 			ECS:               true,
+			TraceAgent:        true,
 		}
 	case "dca":
 		return context{

--- a/releasenotes/notes/Convert-trace-agent-configuration-to-datadog.yaml-99701baa7f04ad4b.yaml
+++ b/releasenotes/notes/Convert-trace-agent-configuration-to-datadog.yaml-99701baa7f04ad4b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Make the trace-agent read its configuration from datadog.yaml.
+


### PR DESCRIPTION
### What does this PR do?

- Provide the datadog.yaml file to the `trace-agent -config` command as the trace-agent now fully supports it by https://github.com/DataDog/datadog-trace-agent/pull/359 removing the need for a special `trace-agent.conf`
- Extend the datadog.yaml template with trace-agent attributes

### Motivation

Make the A6 release nice and smooth.

### Additional Notes

Will come in a second PR:

- update of the legacy converter to support trace-agent options
- full removal of `trace-agent.conf` from test/omnibus/dist files
