### PR TITLE
[AD] add `Uncheduling check` logline to help troubleshoot

### DIFF
--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -8,6 +8,7 @@ package check
 import (
 	"fmt"
 	"hash/fnv"
+	"strings"
 )
 
 // ID is the representation of the unique ID of a Check instance
@@ -26,4 +27,8 @@ func BuildID(checkName string, instance, initConfig ConfigData) ID {
 
 	id := fmt.Sprintf("%s:%x", checkName, h.Sum64())
 	return ID(id)
+}
+
+func IDToCheckName(id ID) string {
+	return strings.SplitN(string(id), ":", 2)[0]
 }

--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -29,6 +29,7 @@ func BuildID(checkName string, instance, initConfig ConfigData) ID {
 	return ID(id)
 }
 
+// IDToCheckName returns the check name from a check ID
 func IDToCheckName(id ID) string {
 	return strings.SplitN(string(id), ":", 2)[0]
 }

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -6,6 +6,7 @@
 package check
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -36,4 +37,38 @@ func TestIdentify(t *testing.T) {
 	instance3 := ConfigData("key1:value1\nkey2:value3")
 	initConfig3 := ConfigData("key:value")
 	assert.NotEqual(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance3, initConfig3))
+}
+
+func TestIDToCheckName(t *testing.T) {
+	testCases := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  "valid:9505c316b4e4a028",
+			out: "valid",
+		},
+		{
+			in:  "",
+			out: "",
+		},
+		{
+			in:  "nocolon",
+			out: "nocolon",
+		},
+		{
+			in:  "nohash:",
+			out: "nohash",
+		},
+		{
+			in:  "multiple:colon:9505c316b4e4a028",
+			out: "multiple",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.in), func(t *testing.T) {
+			assert.Equal(t, tc.out, IDToCheckName(ID(tc.in)))
+		})
+	}
 }

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -12,8 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
 var (
@@ -93,6 +94,8 @@ func (s *Scheduler) Enter(check check.Check) error {
 func (s *Scheduler) Cancel(id check.ID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	log.Infof("Uncheduling check %v ", check.IDToCheckName(id))
 
 	if _, ok := s.checkToQueue[id]; !ok {
 		return nil


### PR DESCRIPTION
### What does this PR do?

As we have a `Scheduling check redisdb with an interval of 15s` info line when scheduling a new check, add a `Uncheduling check redisdb` info line. Add helper `check.IDToCheckName` function.

### Motivation

Ease debugging AD issue with docker 1.12
