### PR TITLE
Improve the management of excluded containers

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -24,7 +24,7 @@ func (c *DockerCollector) extractFromInspect(co types.ContainerJSON) ([]string, 
 	//TODO: remove when Inspect returns resolved image names
 	dockerImage, err := c.dockerUtil.ResolveImageName(co.Image)
 	if err != nil {
-		log.Debugf("error resolving image %s: %s", co.Image, err)
+		log.Debugf("Error resolving image %s: %s", co.Image, err)
 	} else {
 		dockerExtractImage(tags, dockerImage)
 	}
@@ -42,7 +42,7 @@ func dockerExtractImage(tags *utils.TagList, dockerImage string) {
 	tags.AddLow("docker_image", dockerImage)
 	imageName, shortImage, imageTag, err := docker.SplitImageName(dockerImage)
 	if err != nil {
-		log.Debugf("error splitting %s: %s", dockerImage, err)
+		log.Debugf("Error splitting %s: %s", dockerImage, err)
 		return
 	}
 	tags.AddLow("image_name", imageName)

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -27,8 +27,12 @@ import (
 )
 
 const (
-	pauseContainerGCR       = `image:(k8s.|^)gcr\.io(/google_containers/|/)pause(.*)`
-	pauseContainerOpenshift = "image:openshift/origin-pod"
+	// pauseContainerGCR regex matches:
+	// - k8s.gcr.io/pause-amd64:3.1
+	// - gcr.io/google_containers/pause-amd64:3.0
+	pauseContainerGCR        = `image:(k8s.|^)gcr\.io(/google_containers/|/)pause(.*)`
+	pauseContainerOpenshift  = "image:openshift/origin-pod"
+	pauseContainerKubernetes = "image:kubernetes/pause"
 )
 
 // FIXME: remove once DockerListener is moved to .Containers
@@ -73,7 +77,7 @@ func (d *DockerUtil) init() error {
 	blacklist := config.Datadog.GetStringSlice("ac_exclude")
 
 	if config.Datadog.GetBool("exclude_pause_container") {
-		blacklist = append(blacklist, pauseContainerGCR, pauseContainerOpenshift)
+		blacklist = append(blacklist, pauseContainerGCR, pauseContainerOpenshift, pauseContainerKubernetes)
 	}
 
 	// Pre-parse the filter and use that internally.

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	pauseContainerGCR       = "image:.*gcr.io/.*pause.*"
+	pauseContainerGCR       = `image:(k8s.|^)gcr\.io(/google_containers/|/)pause(.*)`
 	pauseContainerOpenshift = "image:openshift/origin-pod"
 )
 

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	pauseContainerGCR       string = "image:gcr.io/google_containers/pause.*"
-	pauseContainerOpenshift string = "image:openshift/origin-pod"
+	pauseContainerGCR       = "image:.*gcr.io/.*pause.*"
+	pauseContainerOpenshift = "image:openshift/origin-pod"
 )
 
 // FIXME: remove once DockerListener is moved to .Containers
@@ -107,7 +107,7 @@ func ConnectToDocker() (*client.Client, error) {
 	// TODO: remove this logic when "client.NegotiateAPIVersion" function is released by moby/docker
 	v, err := cli.ServerVersion(context.Background())
 	if err != nil || v.APIVersion == "" {
-		return nil, fmt.Errorf("Could not determine docker server API version: %s", err)
+		return nil, fmt.Errorf("could not determine docker server API version: %s", err)
 	}
 	serverVersion := v.APIVersion
 

--- a/pkg/util/docker/filter.go
+++ b/pkg/util/docker/filter.go
@@ -77,32 +77,28 @@ func (cf containerFilter) computeIsExcluded(containerName, containerImage string
 		return false
 	}
 
-	var excluded bool
+	// Any whitelisted take precedence on excluded
+	for _, r := range cf.ImageWhitelist {
+		if r.MatchString(containerImage) {
+			return false
+		}
+	}
+	for _, r := range cf.NameWhitelist {
+		if r.MatchString(containerName) {
+			return false
+		}
+	}
+
+	// Check if blacklisted
 	for _, r := range cf.ImageBlacklist {
 		if r.MatchString(containerImage) {
-			excluded = true
-			break
+			return true
 		}
 	}
 	for _, r := range cf.NameBlacklist {
 		if r.MatchString(containerName) {
-			excluded = true
-			break
+			return true
 		}
 	}
-
-	// Any excluded container could be whitelisted.
-	if excluded {
-		for _, r := range cf.ImageWhitelist {
-			if r.MatchString(containerImage) {
-				return false
-			}
-		}
-		for _, r := range cf.NameWhitelist {
-			if r.MatchString(containerName) {
-				return false
-			}
-		}
-	}
-	return excluded
+	return false
 }

--- a/pkg/util/docker/filter_test.go
+++ b/pkg/util/docker/filter_test.go
@@ -16,12 +16,46 @@ import (
 
 func TestContainerFilter(t *testing.T) {
 	containers := []*Container{
-		{ID: "1", Name: "secret-container-dd", Image: "docker-dd-agent"},
-		{ID: "2", Name: "webapp1-dd", Image: "apache:2.2"},
-		{ID: "3", Name: "mysql-dd", Image: "mysql:5.3"},
-		{ID: "4", Name: "linux-dd", Image: "alpine:latest"},
-		{ID: "5", Name: "k8s_POD.f8120f_kube-proxy-gke-pool-1-2890-pv0", Image: "gcr.io/google_containers/pause-amd64:3.0"},
-		{ID: "6", Name: "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0", Image: "k8s.gcr.io/pause-amd64:3.1"},
+		{
+			ID:    "1",
+			Name:  "secret-container-dd",
+			Image: "docker-dd-agent",
+		},
+		{
+			ID:    "2",
+			Name:  "webapp1-dd",
+			Image: "apache:2.2",
+		},
+		{
+			ID:    "3",
+			Name:  "mysql-dd",
+			Image: "mysql:5.3",
+		},
+		{
+			ID:    "4",
+			Name:  "linux-dd",
+			Image: "alpine:latest",
+		},
+		{
+			ID:    "5",
+			Name:  "k8s_superpause_kube-apiserver-mega-node_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+			Image: "gcr.io/random-project/superpause:1.0",
+		},
+		{
+			ID:    "6",
+			Name:  "k8s_superpause_kube-apiserver-mega-node_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+			Image: "gcr.io/random-project/pause:1.0",
+		},
+		{
+			ID:    "7",
+			Name:  "k8s_POD.f8120f_kube-proxy-gke-pool-1-2890-pv0",
+			Image: "gcr.io/google_containers/pause-amd64:3.0",
+		},
+		{
+			ID:    "8",
+			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+			Image: "k8s.gcr.io/pause-amd64:3.1",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -30,25 +64,25 @@ func TestContainerFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6"},
+			expectedIDs: []string{"3", "5", "6", "7", "8"},
 		},
 		// Test kubernetes defaults
 		{
@@ -56,7 +90,7 @@ func TestContainerFilter(t *testing.T) {
 				pauseContainerGCR,
 				pauseContainerOpenshift,
 			},
-			expectedIDs: []string{"1", "2", "3", "4"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
 		},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/pkg/util/docker/filter_test.go
+++ b/pkg/util/docker/filter_test.go
@@ -11,16 +11,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContainerFilter(t *testing.T) {
-	assert := assert.New(t)
 	containers := []*Container{
 		{ID: "1", Name: "secret-container-dd", Image: "docker-dd-agent"},
 		{ID: "2", Name: "webapp1-dd", Image: "apache:2.2"},
 		{ID: "3", Name: "mysql-dd", Image: "mysql:5.3"},
 		{ID: "4", Name: "linux-dd", Image: "alpine:latest"},
 		{ID: "5", Name: "k8s_POD.f8120f_kube-proxy-gke-pool-1-2890-pv0", Image: "gcr.io/google_containers/pause-amd64:3.0"},
+		{ID: "6", Name: "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0", Image: "k8s.gcr.io/pause-amd64:3.1"},
 	}
 
 	for i, tc := range []struct {
@@ -29,44 +30,46 @@ func TestContainerFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5"},
+			expectedIDs: []string{"2", "3", "4", "5", "6"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5"},
+			expectedIDs: []string{"1", "3", "5", "6"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
-			expectedIDs: []string{"3", "5"},
+			expectedIDs: []string{"3", "5", "6"},
 		},
 		// Test kubernetes defaults
 		{
 			blacklist: []string{
-				"image:gcr.io/google_containers/pause.*",
-				"image:openshift/origin-pod",
+				pauseContainerGCR,
+				pauseContainerOpenshift,
 			},
 			expectedIDs: []string{"1", "2", "3", "4"},
 		},
 	} {
-		f, err := newContainerFilter(tc.whitelist, tc.blacklist)
-		assert.NoError(err, "case %d", i)
+		t.Run("", func(t *testing.T) {
+			f, err := newContainerFilter(tc.whitelist, tc.blacklist)
+			require.Nil(t, err, "case %d", i)
 
-		var allowed []string
-		for _, c := range containers {
-			if !f.IsExcluded(c) {
-				allowed = append(allowed, c.ID)
+			var allowed []string
+			for _, c := range containers {
+				if !f.IsExcluded(c) {
+					allowed = append(allowed, c.ID)
+				}
 			}
-		}
-		assert.Equal(tc.expectedIDs, allowed, "case %d", i)
+			assert.Equal(t, tc.expectedIDs, allowed, "case %d", i)
+		})
 	}
 }

--- a/pkg/util/docker/filter_test.go
+++ b/pkg/util/docker/filter_test.go
@@ -56,6 +56,11 @@ func TestContainerFilter(t *testing.T) {
 			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
 			Image: "k8s.gcr.io/pause-amd64:3.1",
 		},
+		{
+			ID:    "9",
+			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+			Image: "kubernetes/pause:latest",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -64,31 +69,32 @@ func TestContainerFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9"},
 		},
 		// Test kubernetes defaults
 		{
 			blacklist: []string{
 				pauseContainerGCR,
 				pauseContainerOpenshift,
+				pauseContainerKubernetes,
 			},
 			expectedIDs: []string{"1", "2", "3", "4", "5", "6"},
 		},


### PR DESCRIPTION
### What does this PR do?

**Pause container**

Following [this](https://github.com/kubernetes/kubernetes/commit/3586986416b174d390376311c909d665416bf5c0#diff-8cfbccadb55fb07d421430cd1779e7a2) we need to extend the support of pause containers.

The GCR pause image name moved from `gcr.io/google_containers/pause-amd64` to `k8s.gcr.io/pause-amd64`.


**Tagger call**

When a container is excluded, I propose to alter the call `updateContainerRunningCount` to handle the excluded containers differently.

In this function, we were calling the tagger on possible excluded container. A pause container on a Kubernetes setup will always display this warning:
```text
error collecting from kubelet: container docker://3082ac233e2393e0319b5b7bb367fc0cd2575643c13cee123a05041a5b91130d not found in podList
```
