### PR TITLE
[py/checks] Set `urllib3`'s logger to WARN level by default

### DIFF
--- a/cmd/agent/dist/checks/__init__.py
+++ b/cmd/agent/dist/checks/__init__.py
@@ -34,12 +34,29 @@ class AgentLogHandler(logging.Handler):
         msg = self.format(record)
         datadog_agent.log("(%s:%s) | %s" % (record.filename, record.lineno, msg), record.levelno)
 
-rootLogger = logging.getLogger()
-rootLogger.addHandler(AgentLogHandler())
-rootLogger.setLevel(_get_py_loglevel(datadog_agent.get_config('log_level')))
+
+def init_logging():
+    """
+    Initialize logging (set up forwarding to Go backend and sane defaults)
+    """
+    # Forward to Go backend
+    rootLogger = logging.getLogger()
+    rootLogger.addHandler(AgentLogHandler())
+    rootLogger.setLevel(_get_py_loglevel(datadog_agent.get_config('log_level')))
+
+    # `requests` (used in a lot of checks) imports `urllib3`, which logs a bunch of stuff at the info level
+    # Therefore, pre-emptively increase the default level of that logger to `WARN`
+    urllib_logger = logging.getLogger("requests.packages.urllib3")
+    urllib_logger.setLevel(logging.WARN)
+    urllib_logger.propagate = True
+
+
+init_logging()
+
 
 class CheckException(Exception):
     pass
+
 
 class AgentCheck(object):
     OK, WARNING, CRITICAL, UNKNOWN = (0, 1, 2, 3)

--- a/releasenotes/notes/default-urllib3-logging-6a8aebc47b5f9754.yaml
+++ b/releasenotes/notes/default-urllib3-logging-6a8aebc47b5f9754.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Decrease verbosity of ``urllib3``'s logger (used by python checks through the ``requests`` module)


### PR DESCRIPTION
### What does this PR do?

Sets `urllib3`'s logger to WARN level by default

### Motivation

Same approach as Agent 5. Avoids too verbose logging when `requests`
is used in a check.
