### PR TITLE
Better api to collect external host tags

### DIFF
--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -22,7 +22,7 @@ PyObject* GetHostname(PyObject *self, PyObject *args);
 PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 PyObject* GetSubprocessOutput(char **args, int argc, int raise);
-PyObject* AddExternalTags(const char *hostname, const char *source_type, char **tags, int tags_s);
+PyObject* SetExternalTags(const char *hostname, const char *source_type, char **tags, int tags_s);
 
 // Exceptions
 PyObject* SubprocessOutputEmptyError;
@@ -115,7 +115,7 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     return py_result;
 }
 
-static PyObject *add_external_tags(PyObject *self, PyObject *args) {
+static PyObject *set_external_tags(PyObject *self, PyObject *args) {
     PyObject *input_list = NULL;
     PyGILState_STATE gstate = PyGILState_Ensure();
 
@@ -216,7 +216,7 @@ static PyObject *add_external_tags(PyObject *self, PyObject *args) {
         }
 
         // finally, invoke the Go function
-        AddExternalTags(hostname, source_type, tags, actual_size);
+        SetExternalTags(hostname, source_type, tags, actual_size);
 
         // cleanup
         for (j=0; j<actual_size; j++) {
@@ -235,7 +235,7 @@ static PyMethodDef datadogAgentMethods[] = {
   {"headers", Headers, METH_VARARGS | METH_KEYWORDS, "Get basic HTTP headers with the right UserAgent."},
   {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
   {"log", log_message, METH_VARARGS, "Log a message through the agent logger."},
-  {"add_external_tags", add_external_tags, METH_VARARGS, "Send external host tags."},
+  {"set_external_tags", set_external_tags, METH_VARARGS, "Send external host tags."},
   {NULL, NULL}
 };
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -252,11 +252,11 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	return pyResult
 }
 
-// AddExternalTags adds a set of tags for a given hostnane to the External Host
+// SetExternalTags adds a set of tags for a given hostnane to the External Host
 // Tags metadata provider cache.
-// Indirectly used by the C function `add_external_tags` that's mapped to `datadog_agent.add_external_tags`.
-//export AddExternalTags
-func AddExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int) *C.PyObject {
+// Indirectly used by the C function `set_external_tags` that's mapped to `datadog_agent.set_external_tags`.
+//export SetExternalTags
+func SetExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int) *C.PyObject {
 	hname := C.GoString(hostname)
 	tlen := int(tagsLen)
 	tagsSlice := (*[1 << 30]*C.char)(unsafe.Pointer(tags))[:tlen:tlen]
@@ -269,7 +269,7 @@ func AddExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int)
 
 	externalTags := externalhost.ExternalTags{C.GoString(sourceType): tagsStrings}
 
-	externalhost.AddExternalTags(hname, externalTags)
+	externalhost.SetExternalTags(hname, externalTags)
 	return C._none()
 }
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -258,6 +258,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 //export SetExternalTags
 func SetExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int) *C.PyObject {
 	hname := C.GoString(hostname)
+	stype := C.GoString(sourceType)
 	tlen := int(tagsLen)
 	tagsSlice := (*[1 << 30]*C.char)(unsafe.Pointer(tags))[:tlen:tlen]
 	tagsStrings := []string{}
@@ -267,9 +268,7 @@ func SetExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int)
 		tagsStrings = append(tagsStrings, tag)
 	}
 
-	externalTags := externalhost.ExternalTags{C.GoString(sourceType): tagsStrings}
-
-	externalhost.SetExternalTags(hname, externalTags)
+	externalhost.SetExternalTags(hname, stype, tagsStrings)
 	return C._none()
 }
 

--- a/pkg/collector/py/datadog_agent_test.go
+++ b/pkg/collector/py/datadog_agent_test.go
@@ -11,7 +11,7 @@ import (
 	python "github.com/sbinet/go-python"
 )
 
-func TestSetExternalTagsBindings(t *testing.T) {
+func TestAddExternalTagsBindings(t *testing.T) {
 	gstate := newStickyLock()
 	defer gstate.unlock()
 

--- a/pkg/collector/py/datadog_agent_test.go
+++ b/pkg/collector/py/datadog_agent_test.go
@@ -11,7 +11,7 @@ import (
 	python "github.com/sbinet/go-python"
 )
 
-func TestAddExternalTagsBindings(t *testing.T) {
+func TestSetExternalTagsBindings(t *testing.T) {
 	gstate := newStickyLock()
 	defer gstate.unlock()
 

--- a/pkg/collector/py/tests/external_host_tags.py
+++ b/pkg/collector/py/tests/external_host_tags.py
@@ -14,4 +14,4 @@ tags = [
 ]
 
 def test():
-    datadog_agent.add_external_tags(tags)
+    datadog_agent.set_external_tags(tags)

--- a/pkg/metadata/externalhost/externalhost.go
+++ b/pkg/metadata/externalhost/externalhost.go
@@ -5,25 +5,34 @@
 
 package externalhost
 
-type host2externalTags map[string]ExternalTags
+// hostname -> ExternalTags
+type externalHost map[string]ExternalTags
 
-// externalHostCache maps hostname -> ExternalTags
-var externalHostCache = make(map[string]ExternalTags)
+// externalHostCache maps source_type -> externalHost
+var externalHostCache = make(map[string]externalHost)
 
-// SetExternalTags adds external tags for a specific host to the cache
-func SetExternalTags(hostname string, tags ExternalTags) {
-	externalHostCache[hostname] = tags
+// SetExternalTags adds external tags for a specific host and source type
+// to the cache.
+func SetExternalTags(hostname, sourceType string, tags []string) {
+	_, found := externalHostCache[sourceType]
+	if !found {
+		externalHostCache[sourceType] = make(externalHost)
+	}
+
+	externalHostCache[sourceType][hostname] = ExternalTags{sourceType: tags}
 }
 
 // GetPayload fills and return the external host tags metadata payload
 func GetPayload() *Payload {
 	payload := Payload{}
-	for hostname, tags := range externalHostCache {
-		ht := hostTags{hostname, tags}
-		payload = append(payload, ht)
+	for _, extHost := range externalHostCache {
+		for hostname, tags := range extHost {
+			ht := hostTags{hostname, tags}
+			payload = append(payload, ht)
+		}
 	}
 
 	// clear the cache
-	externalHostCache = make(map[string]ExternalTags)
+	externalHostCache = make(map[string]externalHost)
 	return &payload
 }

--- a/pkg/metadata/externalhost/externalhost.go
+++ b/pkg/metadata/externalhost/externalhost.go
@@ -5,11 +5,13 @@
 
 package externalhost
 
-// externalHostCache maps hostname -> externalTags
+type host2externalTags map[string]ExternalTags
+
+// externalHostCache maps hostname -> ExternalTags
 var externalHostCache = make(map[string]ExternalTags)
 
-// AddExternalTags adds external tags for a specific host to the cache
-func AddExternalTags(hostname string, tags ExternalTags) {
+// SetExternalTags adds external tags for a specific host to the cache
+func SetExternalTags(hostname string, tags ExternalTags) {
 	externalHostCache[hostname] = tags
 }
 

--- a/pkg/metadata/externalhost/externalhost_test.go
+++ b/pkg/metadata/externalhost/externalhost_test.go
@@ -20,7 +20,7 @@ func TestGetPayload(t *testing.T) {
 	eTags := ExternalTags{"vsphere": []string{"foo", "bar"}}
 
 	// add one tag to the cache
-	AddExternalTags(host, eTags)
+	SetExternalTags(host, eTags)
 	p = *GetPayload()
 	assert.Len(t, p, 1)
 	hTags := p[0]

--- a/pkg/metadata/externalhost/externalhost_test.go
+++ b/pkg/metadata/externalhost/externalhost_test.go
@@ -17,10 +17,12 @@ func TestGetPayload(t *testing.T) {
 	assert.Len(t, p, 0)
 
 	host := "localhost"
-	eTags := ExternalTags{"vsphere": []string{"foo", "bar"}}
+	sourceType := "vsphere"
+	tags := []string{"foo", "bar"}
+	eTags := ExternalTags{sourceType: tags}
 
 	// add one tag to the cache
-	SetExternalTags(host, eTags)
+	SetExternalTags(host, sourceType, tags)
 	p = *GetPayload()
 	assert.Len(t, p, 1)
 	hTags := p[0]

--- a/pkg/metadata/externalhost/payload.go
+++ b/pkg/metadata/externalhost/payload.go
@@ -14,7 +14,7 @@ external_host_metadata = [
 ]
 */
 
-// ExternalTags maps SOURCE_TYPE -> list of tags
+// ExternalTags maps SOURCE_TYPE -> list of tags, exported to ease testing
 type ExternalTags map[string][]string
 
 // hostname -> list of externalTags

--- a/pkg/metadata/v5/v5_test.go
+++ b/pkg/metadata/v5/v5_test.go
@@ -35,10 +35,13 @@ func TestGetPayload(t *testing.T) {
 func TestExternalHostTags(t *testing.T) {
 	host1 := "localhost"
 	host2 := "127.0.0.1"
-	eTags1 := externalhost.ExternalTags{"vsphere": []string{"foo", "bar"}}
-	eTags2 := externalhost.ExternalTags{"vsphere": []string{"baz"}}
-	externalhost.AddExternalTags(host1, eTags1)
-	externalhost.AddExternalTags(host2, eTags2)
+	sourceType := "vsphere"
+	tags1 := []string{"foo", "bar"}
+	tags2 := []string{"baz"}
+	eTags1 := externalhost.ExternalTags{sourceType: tags1}
+	eTags2 := externalhost.ExternalTags{sourceType: tags2}
+	externalhost.SetExternalTags(host1, sourceType, tags1)
+	externalhost.SetExternalTags(host2, sourceType, tags2)
 
 	pl := GetPayload("")
 	hpl := pl.ExternalHostPayload.Payload


### PR DESCRIPTION
### What does this PR do?

Improves the existing api exposed to Python to collect the external host tags

### Motivation

 * tags for an host and source type were overwriting those for the same host but different source type (unlikely to happen but extremely painful to debug)
 * the api wasn't that clear, now it's more readable

### Additional Notes

According changes will be made to the `vsphere` check
