### PR TITLE
test for build regressions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,7 +88,7 @@ build_puppy_agent-deb_x64:
     - inv -e agent.build --puppy
 
 # build puppy agent for ARM, to make sure the build is not broken because of build targets
-build_puppy_agent-deb_x64:
+build_puppy_agent-deb_x64_arm:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,14 @@ build_puppy_agent-deb_x64:
   script:
     - inv -e agent.build --puppy
 
+# build puppy agent for ARM, to make sure the build is not broken because of build targets
+build_puppy_agent-deb_x64:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - GOOS=linux GOARCH=arm inv -e agent.build --puppy
+
 # build dogstatsd for deb-x64
 build_dogstatsd-deb_x64:
   stage: binary_build


### PR DESCRIPTION
### What does this PR do?

This tests that `go generate` properly ignores `GOOS`/`GOARCH`.

https://github.com/DataDog/datadog-agent/pull/1070#issuecomment-361217209