### PR TITLE
Enable `resources` collector by default

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -229,48 +229,9 @@ func StartAgent() error {
 
 	// setup the metadata collector, this needs a working Python env to function
 	if config.Datadog.GetBool("enable_metadata_collection") {
-		addDefaultResourcesCollector := true
-		common.MetadataScheduler = metadata.NewScheduler(s, hostname)
-		var C []config.MetadataProviders
-		err = config.Datadog.UnmarshalKey("metadata_providers", &C)
-		if err == nil {
-			log.Debugf("Adding configured providers to the metadata collector")
-			for _, c := range C {
-				if c.Name == "host" || c.Name == "agent_checks" {
-					continue
-				}
-				if c.Name == "resources" {
-					addDefaultResourcesCollector = false
-				}
-				if c.Interval == 0 {
-					log.Infof("Interval of metadata provider '%v' set to 0, skipping provider", c.Name)
-					continue
-				}
-				intl := c.Interval * time.Second
-				err = common.MetadataScheduler.AddCollector(c.Name, intl)
-				if err != nil {
-					log.Errorf("Unable to add '%s' metadata provider: %v", c.Name, err)
-				} else {
-					log.Infof("Scheduled metadata provider '%v' to run every %v", c.Name, intl)
-				}
-			}
-		} else {
-			log.Errorf("Unable to parse metadata_providers config: %v", err)
-		}
-		// Should be always true, except in some edge cases (multiple agents per host)
-		err = common.MetadataScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
+		err = setupMetadataCollection(s, hostname)
 		if err != nil {
-			return log.Error("Host metadata is supposed to be always available in the catalog!")
-		}
-		err = common.MetadataScheduler.AddCollector("agent_checks", agentChecksMetadataCollectorInterval*time.Second)
-		if err != nil {
-			return log.Error("Agent Checks metadata is supposed to be always available in the catalog!")
-		}
-		if addDefaultResourcesCollector {
-			err = common.MetadataScheduler.AddCollector("resources", defaultResourcesMetadataCollectorInterval*time.Second)
-			if err != nil {
-				log.Warn("Could not add resources metadata provider: ", err)
-			}
+			return err
 		}
 	} else {
 		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")
@@ -278,6 +239,55 @@ func StartAgent() error {
 
 	// start dependent services
 	startDependentServices()
+	return nil
+}
+
+// setupMetadataCollection initializes the metadata scheduler and its collectors based on the config
+func setupMetadataCollection(s *serializer.Serializer, hostname string) error {
+	addDefaultResourcesCollector := true
+	common.MetadataScheduler = metadata.NewScheduler(s, hostname)
+	var C []config.MetadataProviders
+	err := config.Datadog.UnmarshalKey("metadata_providers", &C)
+	if err == nil {
+		log.Debugf("Adding configured providers to the metadata collector")
+		for _, c := range C {
+			if c.Name == "host" || c.Name == "agent_checks" {
+				continue
+			}
+			if c.Name == "resources" {
+				addDefaultResourcesCollector = false
+			}
+			if c.Interval == 0 {
+				log.Infof("Interval of metadata provider '%v' set to 0, skipping provider", c.Name)
+				continue
+			}
+			intl := c.Interval * time.Second
+			err = common.MetadataScheduler.AddCollector(c.Name, intl)
+			if err != nil {
+				log.Errorf("Unable to add '%s' metadata provider: %v", c.Name, err)
+			} else {
+				log.Infof("Scheduled metadata provider '%v' to run every %v", c.Name, intl)
+			}
+		}
+	} else {
+		log.Errorf("Unable to parse metadata_providers config: %v", err)
+	}
+	// Should be always true, except in some edge cases (multiple agents per host)
+	err = common.MetadataScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
+	if err != nil {
+		return log.Error("Host metadata is supposed to be always available in the catalog!")
+	}
+	err = common.MetadataScheduler.AddCollector("agent_checks", agentChecksMetadataCollectorInterval*time.Second)
+	if err != nil {
+		return log.Error("Agent Checks metadata is supposed to be always available in the catalog!")
+	}
+	if addDefaultResourcesCollector {
+		err = common.MetadataScheduler.AddCollector("resources", defaultResourcesMetadataCollectorInterval*time.Second)
+		if err != nil {
+			log.Warn("Could not add resources metadata provider: ", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -105,11 +105,10 @@ api_key:
 # server_timeout: 15
 {{ end -}}
 {{- if .Metadata }}
-# Metadata collectors, add or remove from the list to enable or disable collection.
-# Intervals are expressed in seconds.
-metadata_collectors:
-  - name: 'resources'
-    interval: 60
+# Metadata providers, add or remove from the list to enable or disable collection.
+# Intervals are expressed in seconds. You can also set a provider's interval to 0
+# to disable it.
+# metadata_providers:
 #  - name: k8s
 #    interval: 60
 {{ end -}}

--- a/releasenotes/notes/default-resources-meta-collector-efb09f46389293fc.yaml
+++ b/releasenotes/notes/default-resources-meta-collector-efb09f46389293fc.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The ``resources`` metadata provider is now enabled by default in order to
+    populate the "process treemap" visualization continuously (on host dashboards)


### PR DESCRIPTION
### What does this PR do?

Enables `resources` collector by default, with a 5min interval.

### Motivation

It's a deprecated feature overall, but we still want it enabled by default for 6.0.0 GA so that the "process treemap" on the host dashboards are still populated consistently.

### Additional Notes

Also:
* allow disabling (some) meta collectors by setting their interval to `0`
* fix key name in config template

Also, I should've refactored the code a bit and added tests but haven't...