### PR TITLE
Add datadog started metric

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -293,9 +293,10 @@ func (agg *BufferedAggregator) GetSeries() metrics.Series {
 func (agg *BufferedAggregator) flushSeries() {
 	start := time.Now()
 
+	// Send along a metric that showcases that this Agent is running
+	// This will also allow us to identify this as an Agent host and see the dogbone icon in the Infrastructure List
 	var Point = metrics.Point{Value: 1, Ts: float64(time.Now().Unix())}
 	var Points = []metrics.Point{Point}
-
 	series := agg.addSerie(metrics.Serie{Name: "datadog.agent.running", Points: Points})
 
 	addFlushCount("Series", int64(len(series)))

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -239,7 +239,7 @@ func (agg *BufferedAggregator) addServiceCheck(sc metrics.ServiceCheck) {
 		sc.Host = agg.hostname
 	}
 	if sc.Ts == 0 {
-		sc.Ts = int64(time.Now().Unix())
+		sc.Ts = time.Now().Unix()
 	}
 	sc.Tags = deduplicateTags(sc.Tags)
 

--- a/releasenotes/notes/datadog_agent_running_metric-09505629a67b788e.yaml
+++ b/releasenotes/notes/datadog_agent_running_metric-09505629a67b788e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds in a `datadog.agent.running` metric that showcases a value of 1 if the Agent is currently reporting to Datadog.


### PR DESCRIPTION
### What does this PR do?

Adds in a new metric `datadog.agent.running`

### Motivation

Showcase whether an Agent is running, similar to the service check.

### Additional Notes

This also allows us to identify this as an Agent host and showcase the dog bone icon in the Infrastructure List