### PR TITLE
[Import] Adds ability to import the trace configs from datadog.conf

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,8 +181,6 @@ func init() {
 	// Cloud Foundry
 	Datadog.SetDefault("cloud_foundry", false)
 	Datadog.SetDefault("bosh_id", "")
-	// APM
-	BindEnvAndSetDefault("apm_enabled", true) // this is to support the transition to the new config file
 
 	// JMXFetch
 	Datadog.SetDefault("jmx_custom_jars", []string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -409,6 +409,6 @@ metadata_collectors:
 #   max_traces_per_second: 10
 #   A blacklist of regular expressions can be provided to disable certain traces based on their resource name
 #   all entries must be surrounded by double quotes and separated by commas
-#   Example: "(GET|POST) /healthcheck","GET /V1"
-#   ignore_resource: ""
+#   Example: ["(GET|POST) /healthcheck", "GET /V1"]
+#   ignore_resources: []
 {{ end -}}

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -122,6 +122,35 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("enable_gohai", enabled)
 	}
 
+	//Trace APM based configurations
+	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil {
+		config.Datadog.Set("apm_config.enabled", enabled)
+	}
+
+	if receiverPort, err := strconv.Atoi(agentConfig["receiver_port"]); err == nil {
+		config.Datadog.Set("apm_config.receiver_port", receiverPort)
+	}
+
+	if sampleRate, err := strconv.ParseFloat(agentConfig["extra_sample_rate"], 64); err == nil {
+		config.Datadog.Set("apm_config.extra_sample_rate", sampleRate)
+	}
+
+	if maxTraces, err := strconv.ParseFloat(agentConfig["max_traces_per_second"], 64); err == nil {
+		config.Datadog.Set("apm_config.max_traces_per_second", maxTraces)
+	}
+
+	if connectionLimit, err := strconv.Atoi(agentConfig["connection_limit"]); err == nil {
+		config.Datadog.Set("apm_config.max_connections", connectionLimit)
+	}
+
+	if agentConfig["resource"] != "" {
+		config.Datadog.Set("apm_config.ignore_resource", agentConfig["resource"])
+	}
+
+	if enabled, err := isAffirmative(agentConfig["non_local_traffic"]); err == nil {
+		config.Datadog.Set("apm_config.apm_non_local_traffic", enabled)
+	}
+
 	return nil
 }
 

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -31,11 +31,6 @@ func FromAgentConfig(agentConfig Config) error {
 	config.Datadog.Set("api_key", agentConfig["api_key"])
 	config.Datadog.Set("hostname", agentConfig["hostname"])
 
-	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil && !enabled {
-		// apm is enabled by default through the check config file `apm.yaml.default`
-		config.Datadog.Set("apm_enabled", false)
-	}
-
 	if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); err == nil && !enabled {
 		// process agent is enabled in datadog.yaml
 		config.Datadog.Set("process_agent_enabled", false)
@@ -123,12 +118,27 @@ func FromAgentConfig(agentConfig Config) error {
 	}
 
 	//Trace APM based configurations
-	if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil {
-		config.Datadog.Set("apm_config.enabled", enabled)
+
+	if agentConfig["apm_enabled"] != "" {
+		if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil && !enabled {
+			// apm is enabled by default, convert the config only if it was disabled
+			config.Datadog.Set("apm_config.enabled", enabled)
+		}
+	}
+
+	if agentConfig["env"] != "" {
+		config.Datadog.Set("apm_config.env", agentConfig["env"])
 	}
 
 	if receiverPort, err := strconv.Atoi(agentConfig["receiver_port"]); err == nil {
 		config.Datadog.Set("apm_config.receiver_port", receiverPort)
+	}
+
+	if agentConfig["non_local_traffic"] != "" {
+		if enabled, err := isAffirmative(agentConfig["non_local_traffic"]); err == nil && enabled {
+			// trace-agent listen locally by default, convert the config only if configured to listen to more
+			config.Datadog.Set("apm_config.apm_non_local_traffic", enabled)
+		}
 	}
 
 	if sampleRate, err := strconv.ParseFloat(agentConfig["extra_sample_rate"], 64); err == nil {
@@ -139,16 +149,8 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("apm_config.max_traces_per_second", maxTraces)
 	}
 
-	if connectionLimit, err := strconv.Atoi(agentConfig["connection_limit"]); err == nil {
-		config.Datadog.Set("apm_config.max_connections", connectionLimit)
-	}
-
 	if agentConfig["resource"] != "" {
-		config.Datadog.Set("apm_config.ignore_resource", agentConfig["resource"])
-	}
-
-	if enabled, err := isAffirmative(agentConfig["non_local_traffic"]); err == nil {
-		config.Datadog.Set("apm_config.apm_non_local_traffic", enabled)
+		config.Datadog.Set("apm_config.ignore_resources", strings.Split(agentConfig["resource"], ","))
 	}
 
 	return nil

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -24,7 +24,6 @@ var (
 		"skip_ssl_validation",
 		"api_key",
 		"hostname",
-		"apm_enabled",
 		"tags",
 		"forwarder_timeout",
 		"default_integration_http_timeout",
@@ -53,7 +52,7 @@ var (
 		"syslog_port",
 		"collect_instance_metadata",
 		"listen_port",                // not for 6.0, ignore for now
-		"non_local_traffic",          // not for 6.0, ignore for now
+		"non_local_traffic",          // not for 6.0, converted for the trace-agent
 		"create_dd_check_tags",       // not for 6.0, ignore for now
 		"bind_host",                  // not for 6.0, ignore for now
 		"proxy_forbid_method_switch", // deprecated
@@ -65,10 +64,11 @@ var (
 		"disable_file_logging",
 		"enable_gohai",
 		// trace-agent specific
+		"apm_enabled",
+		"env",
+		"receiver_port",
 		"extra_sample_rate",
 		"max_traces_per_second",
-		"receiver_port",
-		"connection_limit",
 		"resource",
 	}
 )
@@ -90,17 +90,20 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 
 	// get the Trace sections
 	// some of these aren't likely to exist
-	traceSampler := iniFile.Section("trace.sampler")
+	traceConfig := iniFile.Section("trace.config")
 	traceReceiver := iniFile.Section("trace.receiver")
+	traceSampler := iniFile.Section("trace.sampler")
 	traceIgnore := iniFile.Section("trace.ignore")
 
 	// Grab the values needed to do a comparison of the Go vs Python algorithm.
 	for _, supportedValue := range supportedValues {
 		if value, err := main.GetKey(supportedValue); err == nil {
 			config[supportedValue] = value.String()
-		} else if value, err := traceSampler.GetKey(supportedValue); err == nil {
+		} else if value, err := traceConfig.GetKey(supportedValue); err == nil {
 			config[supportedValue] = value.String()
 		} else if value, err := traceReceiver.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceSampler.GetKey(supportedValue); err == nil {
 			config[supportedValue] = value.String()
 		} else if value, err := traceIgnore.GetKey(supportedValue); err == nil {
 			config[supportedValue] = value.String()

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -62,14 +62,14 @@ var (
 		"dogstatsd_target",           // deprecated
 		"gce_updated_hostname",       // deprecated
 		"process_agent_enabled",
+		"disable_file_logging",
+		"enable_gohai",
 		// trace-agent specific
 		"extra_sample_rate",
 		"max_traces_per_second",
 		"receiver_port",
 		"connection_limit",
 		"resource",
-		"disable_file_logging",
-		"enable_gohai",
 	}
 )
 
@@ -88,9 +88,21 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 		return config, err
 	}
 
+	// get the Trace sections
+	// some of these aren't likely to exist
+	traceSampler := iniFile.Section("trace.sampler")
+	traceReceiver := iniFile.Section("trace.receiver")
+	traceIgnore := iniFile.Section("trace.ignore")
+
 	// Grab the values needed to do a comparison of the Go vs Python algorithm.
 	for _, supportedValue := range supportedValues {
 		if value, err := main.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceSampler.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceReceiver.GetKey(supportedValue); err == nil {
+			config[supportedValue] = value.String()
+		} else if value, err := traceIgnore.GetKey(supportedValue); err == nil {
 			config[supportedValue] = value.String()
 		} else {
 			// provide an empty default value so we don't need to check for

--- a/releasenotes/notes/import_apm_configs-0a2c5e9a9c2693d1.yaml
+++ b/releasenotes/notes/import_apm_configs-0a2c5e9a9c2693d1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds the ability to import the Trace configuration options from datadog.conf to their respective datadog.yaml fields with the `import` command.


### PR DESCRIPTION
### What does this PR do?

Adds in the ability to import the trace config options from datadog.conf into the new datadog.yaml format

### Motivation

Fully utilize datadog.yaml for all config options. Additional note from here - https://github.com/DataDog/datadog-agent/pull/1230

### Additional Notes
Tested by generating the datadog.yaml from the default datadog.conf (with all fields uncommented) and ran with the master build of the Trace Agent. 