### PR TITLE
Put process-agent in embedded/bin directory again

### DIFF
--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -28,6 +28,6 @@ build do
     curl_cmd = "curl -f #{url} -o #{binary}"
     command curl_cmd
     command "chmod +x #{binary}"
-    command "mv #{binary} #{install_dir}/bin/#{target_binary}"
+    command "mv #{binary} #{install_dir}/embedded/bin/#{target_binary}"
   end
 end


### PR DESCRIPTION
### What does this PR do?

Fixes a regression introduced in https://github.com/DataDog/datadog-agent/pull/1075 which put the process-agent into the wrong location for the linux build

### Motivation

Fixing

### Additional Notes

