### PR TITLE
image-filter: catch region pause container

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -29,8 +29,9 @@ import (
 const (
 	// pauseContainerGCR regex matches:
 	// - k8s.gcr.io/pause-amd64:3.1
+	// - asia.gcr.io/google_containers/pause-amd64:3.0
 	// - gcr.io/google_containers/pause-amd64:3.0
-	pauseContainerGCR        = `image:(k8s.|^)gcr\.io(/google_containers/|/)pause(.*)`
+	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/)pause(.*)`
 	pauseContainerOpenshift  = "image:openshift/origin-pod"
 	pauseContainerKubernetes = "image:kubernetes/pause"
 )

--- a/pkg/util/docker/filter_test.go
+++ b/pkg/util/docker/filter_test.go
@@ -61,6 +61,11 @@ func TestContainerFilter(t *testing.T) {
 			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
 			Image: "kubernetes/pause:latest",
 		},
+		{
+			ID:    "10",
+			Name:  "k8s_POD_kube-apiserver-node-name_kube-system_1ffeada3879805c883bb6d9ba7beca44_0",
+			Image: "asia.gcr.io/google_containers/pause-amd64:3.0",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -69,25 +74,25 @@ func TestContainerFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
 		},
 		{
 			blacklist:   []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10"},
 		},
 		{
 			blacklist:   []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
 		},
 		{
 			whitelist:   []string{},
 			blacklist:   []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10"},
 		},
 		{
 			whitelist:   []string{"name:mysql"},
 			blacklist:   []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10"},
 		},
 		// Test kubernetes defaults
 		{


### PR DESCRIPTION
### What does this PR do?

Extend the support of the pause container regex.

This will catch regional pause containers like:
`asia.gcr.io/google_containers/pause-amd64:3.0`