### PR TITLE
Fix AD check unscheduling

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -500,6 +500,11 @@ func (ac *AutoConfig) GetUnresolvedTemplates() map[string]check.Config {
 	return ac.templateCache.GetUnresolvedTemplates()
 }
 
+// unschedule removes the check to config cache mapping
+func (ac *AutoConfig) unschedule(id check.ID) {
+	delete(ac.check2config, id)
+}
+
 // check if the descriptor contains the Config passed
 func (pd *providerDescriptor) contains(c *check.Config) bool {
 	for _, config := range pd.configs {

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -25,10 +25,9 @@ type variableGetter func(key []byte, svc listeners.Service) ([]byte, error)
 
 var (
 	templateVariables = map[string]variableGetter{
-		"host":           getHost,
-		"pid":            getPid,
-		"port":           getPort,
-		"container-name": getContainerName,
+		"host": getHost,
+		"pid":  getPid,
+		"port": getPort,
 	}
 )
 
@@ -42,6 +41,7 @@ type ConfigResolver struct {
 	services        map[listeners.ID]listeners.Service // Service.ID --> []Service
 	serviceToChecks map[listeners.ID][]check.ID        // Service.ID --> []CheckID
 	adIDToServices  map[string][]listeners.ID          // AD id --> services that have it
+	config2Service  map[string]listeners.ID            // config digest --> service ID
 	newService      chan listeners.Service
 	delService      chan listeners.Service
 	stop            chan bool
@@ -58,6 +58,7 @@ func newConfigResolver(coll *collector.Collector, ac *AutoConfig, tc *TemplateCa
 		services:        make(map[listeners.ID]listeners.Service),
 		serviceToChecks: make(map[listeners.ID][]check.ID, 0),
 		adIDToServices:  make(map[string][]listeners.ID),
+		config2Service:  make(map[string]listeners.ID),
 		newService:      make(chan listeners.Service),
 		delService:      make(chan listeners.Service),
 		stop:            make(chan bool),
@@ -186,6 +187,7 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 
 	// store resolved configs in the AC
 	cr.ac.providerLoadedConfigs[provider] = append(cr.ac.providerLoadedConfigs[provider], resolvedConfig)
+	cr.config2Service[resolvedConfig.Digest()] = svc.GetID()
 
 	return resolvedConfig, nil
 }
@@ -229,24 +231,10 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 		errorStats.removeResolveWarnings(config.Name)
 
 		// load the checks for this config using Autoconfig
-		checks, err := cr.ac.GetChecks(config)
-		if err != nil {
-			log.Errorf("Unable to load the check: %v", err)
-			continue
-		}
+		checks := cr.ac.getChecksFromConfigs([]check.Config{config}, true)
 
 		// ask the Collector to schedule the checks
-		for _, check := range checks {
-			id, err := cr.collector.RunCheck(check)
-			if err != nil {
-				log.Errorf("Unable to schedule the check: %v", err)
-				continue
-			}
-			// add the check to the list of checks running against the service
-			// this is used when a template or a service is removed
-			// and we want to stop their related checks
-			cr.serviceToChecks[svc.GetID()] = append(cr.serviceToChecks[svc.GetID()], id)
-		}
+		cr.ac.schedule(checks)
 	}
 }
 
@@ -262,6 +250,8 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 			if err != nil {
 				log.Errorf("Failed to stop check '%s': %s", id, err)
 			}
+			// cleaning up the cache map
+			delete(cr.ac.check2config, id)
 			stopped[id] = struct{}{}
 		}
 
@@ -325,6 +315,7 @@ func getFallbackHost(hosts map[string]string) (string, error) {
 	return "", errors.New("not able to determine which network is reachable")
 }
 
+// getPort returns ports of the service
 func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	ports, err := svc.GetPorts()
 	if err != nil {
@@ -354,11 +345,6 @@ func getPid(tplVar []byte, svc listeners.Service) ([]byte, error) {
 		return nil, fmt.Errorf("Failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
 	}
 	return []byte(strconv.Itoa(pid)), nil
-}
-
-// TODO
-func getContainerName(tplVar []byte, svc listeners.Service) ([]byte, error) {
-	return []byte("test-container-name"), nil
 }
 
 // parseTemplateVar extracts the name of the var

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -251,7 +251,7 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 				log.Errorf("Failed to stop check '%s': %s", id, err)
 			}
 			// cleaning up the cache map
-			delete(cr.ac.check2config, id)
+			cr.ac.unschedule(id)
 			stopped[id] = struct{}{}
 		}
 

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -95,7 +95,7 @@ func (s *Scheduler) Cancel(id check.ID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Infof("Uncheduling check %v ", check.IDToCheckName(id))
+	log.Infof("Unscheduling check %v ", check.IDToCheckName(id))
 
 	if _, ok := s.checkToQueue[id]; !ok {
 		return nil

--- a/releasenotes/notes/fix-ad-unschedulling-02916cbca111ce29.yaml
+++ b/releasenotes/notes/fix-ad-unschedulling-02916cbca111ce29.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue unscheduling checks discovered through auto-discovery


### PR DESCRIPTION
### What does this PR do?

Fix check unscheduling

### Motivation

Right now both configresolver & autoconfig can schedule checks, but the level of information is not the same & one of the path was breaking the unscheduling.
The PR add maps to make bridges to have the same level of info & unify a bit the flow but this is not ideal.
