### PR TITLE
implement `statsd_metric_namespace` config 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,6 +141,7 @@ func init() {
 	Datadog.SetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	Datadog.SetDefault("statsd_forward_host", "")
 	Datadog.SetDefault("statsd_forward_port", 0)
+	BindEnvAndSetDefault("statsd_metric_namespace", "")
 	// Autoconfig
 	Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
 	Datadog.SetDefault("exclude_pause_container", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -146,6 +146,11 @@ api_key:
 #
 # The port for the go_expvar server
 # dogstatsd_stats_port: 5000
+#
+# If you want all statsd metrics coming from this host to be namespaced
+# you can configure the namspace below. Each metric received will be prefixed
+# with the namespace before it's sent to Datadog.
+# statsd_metric_namespace:
 {{ end -}}
 {{- if .LogsAgent }}
 # Logs agent

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -231,7 +231,7 @@ func parseEventMessage(message []byte) (*metrics.Event, error) {
 	return &event, nil
 }
 
-func parseMetricMessage(message []byte) (*metrics.MetricSample, error) {
+func parseMetricMessage(message []byte, namespace string) (*metrics.MetricSample, error) {
 	// daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2
 	// daemon:666|g|@0.1|#sometag:somevalue"
 
@@ -243,7 +243,6 @@ func parseMetricMessage(message []byte) (*metrics.MetricSample, error) {
 	// Extract name, value and type
 	rawNameAndValue, remainder := nextField(message, fieldSeparator)
 	rawName, rawValue := nextField(rawNameAndValue, valueSeparator)
-
 	if rawValue == nil {
 		return nil, fmt.Errorf("invalid field format for %q", message)
 	}
@@ -278,7 +277,7 @@ func parseMetricMessage(message []byte) (*metrics.MetricSample, error) {
 		}
 	}
 
-	metricName := string(rawName)
+	metricName := namespace + string(rawName)
 
 	metricType, ok := metricTypes[string(rawType)]
 	if !ok {

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -277,7 +277,10 @@ func parseMetricMessage(message []byte, namespace string) (*metrics.MetricSample
 		}
 	}
 
-	metricName := namespace + string(rawName)
+	metricName := string(rawName)
+	if namespace != "" {
+		metricName = namespace + metricName
+	}
 
 	metricType, ok := metricTypes[string(rawType)]
 	if !ok {

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -65,7 +65,7 @@ func TestGaugePacketCounter(t *testing.T) {
 }
 
 func TestParseGauge(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "")
 
 	assert.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestParseGauge(t *testing.T) {
 }
 
 func TestParseCounter(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|c"))
+	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "")
 
 	assert.NoError(t, err)
 
@@ -90,7 +90,7 @@ func TestParseCounter(t *testing.T) {
 }
 
 func TestParseCounterWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"))
+	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "")
 
 	assert.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestParseCounterWithTags(t *testing.T) {
 }
 
 func TestParseHistogram(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|h"))
+	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "")
 
 	assert.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestParseHistogram(t *testing.T) {
 }
 
 func TestParseTimer(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"))
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "")
 
 	assert.NoError(t, err)
 
@@ -128,7 +128,7 @@ func TestParseTimer(t *testing.T) {
 }
 
 func TestParseSet(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:abc|s"))
+	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "")
 
 	assert.NoError(t, err)
 
@@ -140,7 +140,7 @@ func TestParseSet(t *testing.T) {
 }
 
 func TestParseDistribution(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"))
+	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "")
 
 	assert.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestParseDistribution(t *testing.T) {
 }
 
 func TestParseSetUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"))
+	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "")
 
 	assert.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestParseSetUnicode(t *testing.T) {
 }
 
 func TestParseGaugeWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "")
 
 	assert.NoError(t, err)
 
@@ -177,7 +177,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -191,7 +191,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithSampleRate(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "")
 
 	assert.NoError(t, err)
 
@@ -203,7 +203,7 @@ func TestParseGaugeWithSampleRate(t *testing.T) {
 }
 
 func TestParseGaugeWithPoundOnly(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"))
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "")
 
 	assert.NoError(t, err)
 
@@ -215,7 +215,7 @@ func TestParseGaugeWithPoundOnly(t *testing.T) {
 }
 
 func TestParseGaugeWithUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"))
+	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "")
 
 	assert.NoError(t, err)
 
@@ -229,36 +229,36 @@ func TestParseGaugeWithUnicode(t *testing.T) {
 
 func TestParseMetricError(t *testing.T) {
 	// not enough information
-	_, err := parseMetricMessage([]byte("daemon:666"))
+	_, err := parseMetricMessage([]byte("daemon:666"), "")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:666|"))
+	_, err = parseMetricMessage([]byte("daemon:666|"), "")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:|g"))
+	_, err = parseMetricMessage([]byte("daemon:|g"), "")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte(":666|g"))
+	_, err = parseMetricMessage([]byte(":666|g"), "")
 	assert.Error(t, err)
 
 	// too many value
-	_, err = parseMetricMessage([]byte("daemon:666:777|g"))
+	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "")
 	assert.Error(t, err)
 
 	// unknown metadata prefix
-	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"))
+	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "")
 	assert.NoError(t, err)
 
 	// invalid value
-	_, err = parseMetricMessage([]byte("daemon:abc|g"))
+	_, err = parseMetricMessage([]byte("daemon:abc|g"), "")
 	assert.Error(t, err)
 
 	// invalid metric type
-	_, err = parseMetricMessage([]byte("daemon:666|unknown"))
+	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "")
 	assert.Error(t, err)
 
 	// invalid sample rate
-	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"))
+	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "")
 	assert.Error(t, err)
 }
 
@@ -630,4 +630,12 @@ func TestEventMetadataMultiple(t *testing.T) {
 	assert.Equal(t, "aggKey", e.AggregationKey)
 	assert.Equal(t, "source test", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
+}
+
+func TestNamespace(t *testing.T) {
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.")
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testNamespace.daemon", parsed.Name)
 }

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -83,7 +83,7 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("dogstatsd_port", value)
 	}
 
-	// TODO: statsd_metric_namespace
+	config.Datadog.Set("statsd_metric_namespace", agentConfig["statsd_metric_namespace"])
 
 	// config.Datadog has a default value for this, do nothing if the value is empty
 	if agentConfig["log_level"] != "" {

--- a/releasenotes/notes/add-namespace-config-a9e7b3fb895ddd4a.yaml
+++ b/releasenotes/notes/add-namespace-config-a9e7b3fb895ddd4a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add namespace configuration for metric names for dogstatsd


### PR DESCRIPTION
### What does this PR do?

Import statsd_metric_namespace from agent5 config as well as the functionality in agent6.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
