### PR TITLE
[Support] Adds option to print payloads

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -297,11 +297,11 @@ func (agg *BufferedAggregator) flushSeries() {
 
 	addFlushCount("Series", int64(len(series)))
 
-	//For debug purposes print out all metrics/tag combinations
+	// For debug purposes print out all metrics/tag combinations
 	if config.Datadog.GetBool("log_payloads") {
-		log.Infof("Flushing the following metrics:")
+		log.Debug("Flushing the following metrics:")
 		for _, serie := range series {
-			log.Infof("%s", serie)
+			log.Debugf("%s", serie)
 		}
 	}
 
@@ -339,11 +339,11 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 	serviceChecks := agg.GetServiceChecks()
 	addFlushCount("ServiceChecks", int64(len(serviceChecks)))
 
-	//For debug purposes print out all serviceCheck/tag combinations
+	// For debug purposes print out all serviceCheck/tag combinations
 	if config.Datadog.GetBool("log_payloads") {
-		log.Infof("Flushing the following Service Checks:")
+		log.Debug("Flushing the following Service Checks:")
 		for _, sc := range serviceChecks {
-			log.Infof("%s", sc)
+			log.Debugf("%s", sc)
 		}
 	}
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -407,11 +407,11 @@ func (agg *BufferedAggregator) flushEvents() {
 	}
 	addFlushCount("Events", int64(len(events)))
 
-	//For debug purposes print out all Event/tag combinations
+	// For debug purposes print out all Event/tag combinations
 	if config.Datadog.GetBool("log_payloads") {
-		log.Infof("Flushing the following Events:")
+		log.Debug("Flushing the following Events:")
 		for _, event := range events {
-			log.Infof("%s", event)
+			log.Debugf("%s", event)
 		}
 	}
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -298,7 +298,7 @@ func (agg *BufferedAggregator) flushSeries() {
 	addFlushCount("Series", int64(len(series)))
 
 	//For debug purposes print out all metrics/tag combinations
-	if config.Datadog.GetBool("print_payloads") {
+	if config.Datadog.GetBool("log_payload") {
 		log.Info("Flushing the following metrics:")
 		for _, serie := range series {
 			log.Info("%s", serie)
@@ -340,7 +340,7 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 	addFlushCount("ServiceChecks", int64(len(serviceChecks)))
 
 	//For debug purposes print out all serviceCheck/tag combinations
-	if config.Datadog.GetBool("print_payloads") {
+	if config.Datadog.GetBool("log_payload") {
 		log.Info("Flushing the following Service Checks:")
 		for _, sc := range serviceChecks {
 			log.Info("%s", sc)
@@ -408,7 +408,7 @@ func (agg *BufferedAggregator) flushEvents() {
 	addFlushCount("Events", int64(len(events)))
 
 	//For debug purposes print out all Event/tag combinations
-	if config.Datadog.GetBool("print_payloads") {
+	if config.Datadog.GetBool("log_payload") {
 		log.Info("Flushing the following Events:")
 		for _, event := range events {
 			log.Info("%s", event)

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metrics/percentile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -296,6 +297,14 @@ func (agg *BufferedAggregator) flushSeries() {
 
 	addFlushCount("Series", int64(len(series)))
 
+	//For debug purposes print out all metrics/tag combinations
+	if config.Datadog.GetBool("print_payloads") {
+		log.Info("Flushing the following metrics:")
+		for _, serie := range series {
+			log.Info("%s", serie)
+		}
+	}
+
 	// Serialize and forward in a separate goroutine
 	go func() {
 		log.Debug("Flushing ", len(series), " series to the forwarder")
@@ -329,6 +338,14 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 
 	serviceChecks := agg.GetServiceChecks()
 	addFlushCount("ServiceChecks", int64(len(serviceChecks)))
+
+	//For debug purposes print out all serviceCheck/tag combinations
+	if config.Datadog.GetBool("print_payloads") {
+		log.Info("Flushing the following Service Checks:")
+		for _, sc := range serviceChecks {
+			log.Info("%s", sc)
+		}
+	}
 
 	// Serialize and forward in a separate goroutine
 	go func() {
@@ -389,6 +406,14 @@ func (agg *BufferedAggregator) flushEvents() {
 		return
 	}
 	addFlushCount("Events", int64(len(events)))
+
+	//For debug purposes print out all serviceCheck/tag combinations
+	if config.Datadog.GetBool("print_payloads") {
+		log.Info("Flushing the following Events:")
+		for _, event := range events {
+			log.Info("%s", event)
+		}
+	}
 
 	go func() {
 		log.Debug("Flushing ", len(events), " events to the forwarder")

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -299,9 +299,9 @@ func (agg *BufferedAggregator) flushSeries() {
 
 	//For debug purposes print out all metrics/tag combinations
 	if config.Datadog.GetBool("log_payload") {
-		log.Info("Flushing the following metrics:")
+		log.Infof("Flushing the following metrics:")
 		for _, serie := range series {
-			log.Info("%s", serie)
+			log.Infof("%s", serie)
 		}
 	}
 
@@ -341,9 +341,9 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 
 	//For debug purposes print out all serviceCheck/tag combinations
 	if config.Datadog.GetBool("log_payload") {
-		log.Info("Flushing the following Service Checks:")
+		log.Infof("Flushing the following Service Checks:")
 		for _, sc := range serviceChecks {
-			log.Info("%s", sc)
+			log.Infof("%s", sc)
 		}
 	}
 
@@ -409,9 +409,9 @@ func (agg *BufferedAggregator) flushEvents() {
 
 	//For debug purposes print out all Event/tag combinations
 	if config.Datadog.GetBool("log_payload") {
-		log.Info("Flushing the following Events:")
+		log.Infof("Flushing the following Events:")
 		for _, event := range events {
-			log.Info("%s", event)
+			log.Infof("%s", event)
 		}
 	}
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -298,7 +298,7 @@ func (agg *BufferedAggregator) flushSeries() {
 	addFlushCount("Series", int64(len(series)))
 
 	//For debug purposes print out all metrics/tag combinations
-	if config.Datadog.GetBool("log_payload") {
+	if config.Datadog.GetBool("log_payloads") {
 		log.Infof("Flushing the following metrics:")
 		for _, serie := range series {
 			log.Infof("%s", serie)
@@ -340,7 +340,7 @@ func (agg *BufferedAggregator) flushServiceChecks() {
 	addFlushCount("ServiceChecks", int64(len(serviceChecks)))
 
 	//For debug purposes print out all serviceCheck/tag combinations
-	if config.Datadog.GetBool("log_payload") {
+	if config.Datadog.GetBool("log_payloads") {
 		log.Infof("Flushing the following Service Checks:")
 		for _, sc := range serviceChecks {
 			log.Infof("%s", sc)
@@ -408,7 +408,7 @@ func (agg *BufferedAggregator) flushEvents() {
 	addFlushCount("Events", int64(len(events)))
 
 	//For debug purposes print out all Event/tag combinations
-	if config.Datadog.GetBool("log_payload") {
+	if config.Datadog.GetBool("log_payloads") {
 		log.Infof("Flushing the following Events:")
 		for _, event := range events {
 			log.Infof("%s", event)

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -407,7 +407,7 @@ func (agg *BufferedAggregator) flushEvents() {
 	}
 	addFlushCount("Events", int64(len(events)))
 
-	//For debug purposes print out all serviceCheck/tag combinations
+	//For debug purposes print out all Event/tag combinations
 	if config.Datadog.GetBool("print_payloads") {
 		log.Info("Flushing the following Events:")
 		for _, event := range events {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ func init() {
 	Datadog.SetDefault("confd_dca_path", defaultDCAConfdPath)
 	Datadog.SetDefault("use_service_mapper", true)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
+	Datadog.SetDefault("log_payload", true)
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("log_to_syslog", false)
 	Datadog.SetDefault("log_to_console", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,7 +74,7 @@ func init() {
 	Datadog.SetDefault("confd_dca_path", defaultDCAConfdPath)
 	Datadog.SetDefault("use_service_mapper", true)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
-	Datadog.SetDefault("log_payload", true)
+	Datadog.SetDefault("log_payloads", false)
 	Datadog.SetDefault("log_level", "info")
 	Datadog.SetDefault("log_to_syslog", false)
 	Datadog.SetDefault("log_to_console", true)

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -182,16 +182,6 @@ func (p *Point) UnmarshalJSON(buf []byte) error {
 }
 
 func (e Serie) String() string {
-	// s := fmt.Sprintf("Name: %s, Device: %s, Host: %s ", serie.Name, serie.Device, serie.Host)
-	// s += fmt.Sprintf(" Tags: ")
-	// for _, tags := range serie.Tags {
-	// 	s += fmt.Sprintf("%s", tags)
-	// }
-	// for _, points := range serie.Points {
-	// 	s += fmt.Sprintf("Value/Timestamp: %f, %f", points.Value, points.Ts)
-	// }
-	// return s
-
 	s, err := json.Marshal(e)
 	if err != nil {
 		return ""

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -180,3 +180,21 @@ func (p *Point) UnmarshalJSON(buf []byte) error {
 	}
 	return nil
 }
+
+func (e Serie) String() string {
+	// s := fmt.Sprintf("Name: %s, Device: %s, Host: %s ", serie.Name, serie.Device, serie.Host)
+	// s += fmt.Sprintf(" Tags: ")
+	// for _, tags := range serie.Tags {
+	// 	s += fmt.Sprintf("%s", tags)
+	// }
+	// for _, points := range serie.Points {
+	// 	s += fmt.Sprintf("Value/Timestamp: %f, %f", points.Value, points.Ts)
+	// }
+	// return s
+
+	s, err := json.Marshal(e)
+	if err != nil {
+		return ""
+	}
+	return string(s)
+}

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -133,3 +133,11 @@ func (sc ServiceChecks) SplitPayload(times int) ([]marshaler.Marshaler, error) {
 	}
 	return splitPayloads, nil
 }
+
+func (sc ServiceCheck) String() string {
+	s, err := json.Marshal(sc)
+	if err != nil {
+		return ""
+	}
+	return string(s)
+}


### PR DESCRIPTION
### What does this PR do?

Adds ability to specify `print_payloads` in the yaml file to have the Aggregator print out the metrics, service checks, and events its going to send right before we send them. 

### Motivation

Can be useful both in local developing as well as in troubleshooting support cases. Specifically made part of this to help debug a possible issue with the Disk check.

### Additional Notes

Right now its an option in the yaml file that won't be written out in the config_template.yaml file, can add it to a knowledge base article or the Docs in the Github repo though.