### PR TITLE
[systemd] fixing overall service behavior

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.process.service.erb
@@ -1,16 +1,15 @@
 [Unit]
-Description="Datadog Agent"
-Requisite=datadog-agent.service
-After=network.target datadog-agent.target
-PartOf=datadog-agent.service
+Description="Datadog Process Agent"
+After=network.target datadog-agent.service
+BindsTo=datadog-agent.service
+StartLimitIntervalSec=10
+StartLimitBurst=5
 
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
-StartLimitIntervalSec=10
-StartLimitBurst=5
 ExecStart=<%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --pid=<%= install_dir %>/run/process-agent.pid
 
 [Install]

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,14 +1,15 @@
 [Unit]
 Description="Datadog Agent"
 After=network.target
+Wants=datadog-agent-trace.service datadog-agent-process.service
+StartLimitIntervalSec=10
+StartLimitBurst=5
 
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-StartLimitIntervalSec=10
-StartLimitBurst=5
 ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
 
 [Install]

--- a/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
@@ -1,16 +1,15 @@
 [Unit]
-Description="Datadog Agent"
-Requisite=datadog-agent.service
-After=network.target datadog-agent.target
-PartOf=datadog-agent.service
+Description="Datadog Trace Agent (APM)"
+After=network.target datadog-agent.service
+BindsTo=datadog-agent.service
+StartLimitIntervalSec=10
+StartLimitBurst=5
 
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
-StartLimitIntervalSec=10
-StartLimitBurst=5
 ExecStart=<%= install_dir %>/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pid <%= install_dir %>/run/trace-agent.pid
 
 [Install]


### PR DESCRIPTION
### What does this PR do?

Fixes service dependencies in `systemd` to establish a stronger service dependency between "child" agents (trace, process) and the master systemd service unit that start the infrastructure agent.

The new behavior:
   - Main agent systemd unit wants `datadog-agent-process` and `datadog-agent-trace`. These units now bind back to `datadog-agent`
   - Restart to main `datadog-agent` service unit will restart all units even if they had been previously stopped.
   - Disabling a unit via systemd (eg. `systemctl disable datadog-agent-process`) will not effectively "disable" it, as the main agent (if it remains enabled) will still want `process` and `trace`. If you wish to disable these agent please do so in `datadog.yaml` or edit the systemd services at your own peril.

Persistent Behavior:
   - `process` and `trace` can be individually stopped, restarted.
   - a restart to `datadog-agent` will restart all three agents `datadog-agent`, `datadog-agent-process` and `datadog-agent-trace`.
   - stopping `datadog-agent` will stop all thee agents.

### Motivation

Found some unexpected behavior due to weak relationship between services. 

### Additional Notes

Anything else we should know when reviewing?
