### PR TITLE
Move external host tags payload to agentchecks provider

### DIFF
--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
@@ -60,10 +61,12 @@ func GetPayload() *Payload {
 	metaPayload := host.GetMeta()
 	metaPayload.Hostname = hostname
 	cp := common.GetPayload(hostname)
+	ehp := externalhost.GetPayload()
 	payload := &Payload{
 		CommonPayload{*cp},
 		MetaPayload{*metaPayload},
 		agentChecksPayload,
+		ExternalHostPayload{*ehp},
 	}
 
 	return payload

--- a/pkg/collector/metadata/agentchecks/agentchecks_test.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package agentchecks
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExternalHostTags(t *testing.T) {
+	host1 := "localhost"
+	host2 := "127.0.0.1"
+	sourceType := "vsphere"
+	tags1 := []string{"foo", "bar"}
+	tags2 := []string{"baz"}
+	eTags1 := externalhost.ExternalTags{sourceType: tags1}
+	eTags2 := externalhost.ExternalTags{sourceType: tags2}
+	externalhost.SetExternalTags(host1, sourceType, tags1)
+	externalhost.SetExternalTags(host2, sourceType, tags2)
+
+	pl := GetPayload()
+	hpl := pl.ExternalHostPayload.Payload
+	assert.Len(t, hpl, 2)
+	for _, elem := range hpl {
+		if elem[0] == host1 {
+			assert.Equal(t, eTags1, elem[1])
+		} else if elem[0] == host2 {
+			assert.Equal(t, eTags2, elem[1])
+		} else {
+			assert.Fail(t, "Unexpected value for hostname: %s", elem[0])
+		}
+	}
+}

--- a/pkg/collector/metadata/agentchecks/payload.go
+++ b/pkg/collector/metadata/agentchecks/payload.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
@@ -19,6 +20,7 @@ type Payload struct {
 	CommonPayload
 	MetaPayload
 	ACPayload
+	ExternalHostPayload
 }
 
 // MetaPayload wraps Meta from the host package (this is cached)
@@ -34,6 +36,11 @@ type CommonPayload struct {
 // ACPayload wraps the Agent Checks payload
 type ACPayload struct {
 	AgentChecks []interface{} `json:"agent_checks"`
+}
+
+// ExternalHostPayload wraps Payload from the `externalhost` package
+type ExternalHostPayload struct {
+	externalhost.Payload `json:"external_host_tags"`
 }
 
 // MarshalJSON serialization a Payload to JSON

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
-	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
@@ -28,11 +27,6 @@ type HostPayload struct {
 // ResourcesPayload wraps Payload from the `resources` package
 type ResourcesPayload struct {
 	resources.Payload `json:"resources"`
-}
-
-// ExternalHostPayload wraps Payload from the `externalhost` package
-type ExternalHostPayload struct {
-	externalhost.Payload `json:"external_host_tags"`
 }
 
 // MarshalJSON serialization a Payload to JSON

--- a/pkg/metadata/v5/payload_gohai.go
+++ b/pkg/metadata/v5/payload_gohai.go
@@ -62,7 +62,6 @@ type Payload struct {
 	HostPayload
 	ResourcesPayload
 	// TODO: host-tags
-	ExternalHostPayload
 	GohaiPayload
 }
 

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -10,7 +10,6 @@ package v5
 import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
-	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
@@ -21,13 +20,11 @@ func GetPayload(hostname string) *Payload {
 	cp := common.GetPayload(hostname)
 	hp := host.GetPayload(hostname)
 	rp := resources.GetPayload(hostname)
-	ehp := externalhost.GetPayload()
 
 	p := &Payload{
-		CommonPayload:       CommonPayload{*cp},
-		HostPayload:         HostPayload{*hp},
-		ResourcesPayload:    ResourcesPayload{*rp},
-		ExternalHostPayload: ExternalHostPayload{*ehp},
+		CommonPayload:    CommonPayload{*cp},
+		HostPayload:      HostPayload{*hp},
+		ResourcesPayload: ResourcesPayload{*rp},
 	}
 
 	if config.Datadog.GetBool("enable_gohai") {

--- a/pkg/metadata/v5/v5_other.go
+++ b/pkg/metadata/v5/v5_other.go
@@ -9,7 +9,6 @@ package v5
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
-	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
@@ -19,12 +18,10 @@ func GetPayload(hostname string) *Payload {
 	cp := common.GetPayload(hostname)
 	hp := host.GetPayload(hostname)
 	rp := resources.GetPayload(hostname)
-	ehp := externalhost.GetPayload()
 
 	return &Payload{
 		CommonPayload:    CommonPayload{*cp},
 		HostPayload:      HostPayload{*hp},
 		ResourcesPayload: ResourcesPayload{*rp},
-		ExternalHostTags: ExternalHostTags{*ehp},
 	}
 }

--- a/pkg/metadata/v5/v5_test.go
+++ b/pkg/metadata/v5/v5_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
-	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	python "github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,29 +29,4 @@ func TestMain(m *testing.M) {
 func TestGetPayload(t *testing.T) {
 	pl := GetPayload("testhostname")
 	assert.NotNil(t, pl)
-}
-
-func TestExternalHostTags(t *testing.T) {
-	host1 := "localhost"
-	host2 := "127.0.0.1"
-	sourceType := "vsphere"
-	tags1 := []string{"foo", "bar"}
-	tags2 := []string{"baz"}
-	eTags1 := externalhost.ExternalTags{sourceType: tags1}
-	eTags2 := externalhost.ExternalTags{sourceType: tags2}
-	externalhost.SetExternalTags(host1, sourceType, tags1)
-	externalhost.SetExternalTags(host2, sourceType, tags2)
-
-	pl := GetPayload("")
-	hpl := pl.ExternalHostPayload.Payload
-	assert.Len(t, hpl, 2)
-	for _, elem := range hpl {
-		if elem[0] == host1 {
-			assert.Equal(t, eTags1, elem[1])
-		} else if elem[0] == host2 {
-			assert.Equal(t, eTags2, elem[1])
-		} else {
-			assert.Fail(t, "Unexpected value for hostname: %s", elem[0])
-		}
-	}
 }


### PR DESCRIPTION
### What does this PR do?

Send external host tags payload along with the `agent_checks` provider instead of the `host` provider.

### Motivation

The `host` provider sends the payload every 4 hours, too much for external host tags. `agent_checks` provider sends every 10 minutes which is fine and closer to what we did in A5.

### Additional Notes

~Will run the artifact from this branch to confirm it's working as expected~
Check works as expected with an agent built from this branch.
