### PR TITLE
integration-tests: add the pause container

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -44,7 +44,7 @@ func (m *MockSender) AssertMetricTaggedWith(t *testing.T, method string, metric 
 
 // AssertMetricNotTaggedWith allows to assert tags were never emitted for a metric.
 func (m *MockSender) AssertMetricNotTaggedWith(t *testing.T, method string, metric string, tags []string) bool {
-	return m.Mock.AssertCalled(t, method, metric, mock.AnythingOfType("float64"), mock.AnythingOfType("string"), AssertTagsNotContains(tags))
+	return m.Mock.AssertNotCalled(t, method, metric, mock.AnythingOfType("float64"), mock.AnythingOfType("string"), MatchTagsContains(tags))
 }
 
 // AssertEvent assert the expectedEvent was emitted with the following values:
@@ -80,14 +80,6 @@ func MatchTagsContains(expected []string) interface{} {
 func IsGreaterOrEqual(expectedMin float64) interface{} {
 	return mock.MatchedBy(func(actual float64) bool {
 		return expectedMin <= actual
-	})
-}
-
-// AssertTagsNotContains is a mock.argumentMatcher builder to be used in asserts.
-// It allows to check if tags are NOT emitted.
-func AssertTagsNotContains(expected []string) interface{} {
-	return mock.MatchedBy(func(actual []string) bool {
-		return !expectedInActual(expected, actual)
 	})
 }
 

--- a/test/integration/corechecks/docker/testdata/basemetrics.compose
+++ b/test/integration/corechecks/docker/testdata/basemetrics.compose
@@ -1,5 +1,7 @@
 version: '2'
 services:
+  pause:
+    image: "kubernetes/pause:latest"
   redis:
     image: "datadog/docker-library:redis_3_2_11-alpine"
     labels:


### PR DESCRIPTION
### What does this PR do?

Extend the integration tests to the pause containers.
The pause containers are black listed by default. So we only report a subset of metrics for them.


### Additional Notes

On purpose I selected a real pause container: `kubernetes/pause`
This one is hosted on docker hub because we experienced some errors on `gcr.io`.