### PR TITLE
adding fix to allow recovery from proto wiretype error

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -167,7 +167,7 @@ func (k *KubeASCheck) runLeaderElection() error {
 func (k *KubeASCheck) eventCollectionInit() {
 	if k.latestEventToken == "" {
 		// Initialization: Checking if we previously stored the latestEventToken in a configMap
-		tokenValue, found, err := k.ac.GetTokenFromConfigmap(eventTokenKey, 600)
+		tokenValue, found, err := k.ac.GetTokenFromConfigmap(eventTokenKey, 3600)
 		switch {
 		case err == apiserver.ErrOutdated:
 			k.configMapAvailable = found
@@ -207,7 +207,7 @@ func (k *KubeASCheck) eventCollectionCheck() ([]*v1.Event, []*v1.Event, error) {
 			return nil, nil, nil
 		}
 		// There was a protobuf error and new events were submitted. Processing them and updating the resVersion.
-		//k.latestEventToken = versionToken
+		k.latestEventToken = versionToken
 	}
 
 	// We check that the resversion gotten from the API Server is more recent than the one cached in the util.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -207,7 +207,7 @@ func (k *KubeASCheck) eventCollectionCheck() ([]*v1.Event, []*v1.Event, error) {
 			return nil, nil, nil
 		}
 		// There was a protobuf error and new events were submitted. Processing them and updating the resVersion.
-		k.latestEventToken = versionToken
+		//k.latestEventToken = versionToken
 	}
 
 	// We check that the resversion gotten from the API Server is more recent than the one cached in the util.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -154,9 +154,11 @@ func (k *KubeASCheck) Run() error {
 			return err
 		}
 		if k.latestEventToken == versionToken {
-			// No new events but protobuf error was caught.
+			// No new events but protobuf error was caught. Will retry at next run.
 			return nil
 		}
+		// There was a protobuf error and new events were submitted. Processing them and updating the resVersion.
+		k.latestEventToken = versionToken
 	}
 
 	// We check that the resversion gotten from the API Server is more recent than the one cached in the util.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -80,7 +80,7 @@ func (k *KubeASCheck) Run() error {
 		k.Warn("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
 		return nil
 	}
-	err = k.startLeaderElection()
+	err = k.runLeaderElection()
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func KubernetesASFactory() check.Check {
 	}
 }
 
-func (k *KubeASCheck) startLeaderElection() error {
+func (k *KubeASCheck) runLeaderElection() error {
 
 	leaderEngine, err := leaderelection.GetLeaderEngine()
 	if err != nil {
@@ -159,7 +159,7 @@ func (k *KubeASCheck) startLeaderElection() error {
 
 	if !leaderEngine.IsLeader() {
 		log.Debugf("Leader is %q. %s will not run Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName(), leaderEngine.HolderIdentity)
-		return nil
+		return apiserver.ErrNotLeader
 	}
 	log.Tracef("Currently Leader %q, running Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName())
 	return nil

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -153,6 +153,10 @@ func (k *KubeASCheck) Run() error {
 			k.Warnf("Could not collect cached events from the api server: %s", err.Error())
 			return err
 		}
+		if k.latestEventToken == versionToken {
+			// No new events but protobuf error was caught.
+			return nil
+		}
 	}
 
 	// We check that the resversion gotten from the API Server is more recent than the one cached in the util.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -167,7 +167,7 @@ func (k *KubeASCheck) runLeaderElection() error {
 func (k *KubeASCheck) eventCollectionInit() {
 	if k.latestEventToken == "" {
 		// Initialization: Checking if we previously stored the latestEventToken in a configMap
-		tokenValue, found, err := k.ac.GetTokenFromConfigmap(eventTokenKey, 120)
+		tokenValue, found, err := k.ac.GetTokenFromConfigmap(eventTokenKey, 600)
 		switch {
 		case err == apiserver.ErrOutdated:
 			k.configMapAvailable = found

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -196,7 +196,7 @@ func (k *KubeASCheck) eventCollectionCheck() ([]*v1.Event, []*v1.Event, error) {
 
 	if versionToken == "0" {
 		// API server cache expired or no recent events to process. Resetting the Resversion token.
-		newEvents, modifiedEvents, versionToken, err = k.ac.LatestEvents("0")
+		_, _, versionToken, err = k.ac.LatestEvents("0")
 		if err != nil {
 			k.Warnf("Could not collect cached events from the api server: %s", err.Error())
 			return nil, nil, err

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -30,8 +30,9 @@ import (
 var (
 	globalApiClient *APIClient
 
-	ErrNotFound = errors.New("entity not found")
-	ErrOutdated = errors.New("entity is outdated")
+	ErrNotFound  = errors.New("entity not found")
+	ErrOutdated  = errors.New("entity is outdated")
+	ErrNotLeader = errors.New("not Leader")
 )
 
 const (

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -69,6 +69,7 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 			if strings.Contains(err.Error(), "illegal wireType") {
 				log.Debugf("Protobuf error, no recent events to collect: %s", err) // To move to Tracef
 				*latestResVersion = "0"
+				continue
 				// break or continue ?
 			}
 			if err != context.Canceled && err != io.EOF && !strings.Contains(err.Error(), "illegal wireType") {

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -66,6 +66,10 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 	for {
 		meta, event, err := watcher.Next()
 		if err != nil {
+			// We sometimes face a protobuf unmarshal issue, it will happen if there is no event to collect.
+			// Or if the resVersion is not available in the API Server's cache.
+			// We need to reset the resVersion to seamlessly continue watching.
+			// The resVersion forced to "0" is dealt with in the check to avoid collecting duplicates.
 			if strings.Contains(err.Error(), "illegal wireType") {
 				log.Debugf("Protobuf error, no recent events to collect: %s", err) // To move to Tracef
 				*latestResVersion = "0"

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -66,9 +66,9 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 	for {
 		meta, event, err := watcher.Next()
 		if err != nil {
-			*latestResVersion = "0"
 			if strings.Contains(err.Error(), "illegal wireType") {
 				log.Debugf("Protobuf error, no recent events to collect: %s", err) // To move to Tracef
+				*latestResVersion = "0"
 				// break or continue ?
 			}
 			if err != context.Canceled && err != io.EOF && !strings.Contains(err.Error(), "illegal wireType") {

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"time"
 
+	"strings"
+
 	log "github.com/cihub/seelog"
 	"github.com/ericchiang/k8s"
 	"github.com/ericchiang/k8s/api/v1"
@@ -64,7 +66,12 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 	for {
 		meta, event, err := watcher.Next()
 		if err != nil {
-			if err != context.Canceled && err != io.EOF {
+			*latestResVersion = "0"
+			if strings.Contains(err.Error(), "illegal wireType") {
+				log.Debugf("Protobuf error, no recent events to collect: %s", err) // To move to Tracef
+				// break or continue ?
+			}
+			if err != context.Canceled && err != io.EOF && !strings.Contains(err.Error(), "illegal wireType") {
 				log.Debugf("Stopping event collection, got error: %s", err)
 			} // else silently stop
 			break

--- a/releasenotes/notes/no-events-failure-363d21a3154c3f37.yaml
+++ b/releasenotes/notes/no-events-failure-363d21a3154c3f37.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Make sure we don't get stuck if the API server does not return events.


### PR DESCRIPTION
### What does this PR do?

We get errors from unmarshalling the output of the API Server by the k8s client: 
```
1518621646997936570 [Debug] Stopping event collection, got error: proto: illegal wireType 6
```

The gist is to avoid stopping collecting events when the error occurs. Note that we would get stuck in a 
state where the `since` was not modified and it would be re-injected to try to get new events.

The workflow now is to check if we have a resVersion in a configMap. If yes we take it but if it's older than 1h (api server cache) we refresh it.
Refreshing means using the method LatestEvent with "0". This directly hits the cache and outputs the most up to date resVersion.

Then we check every 15 seconds for events watched. If we start seeing the error then we keep a record of the latestResVersion and we use LatestEvent with "0" until it outputs something different than latestResVersion. We know it will be either:
-  "0" -> no new events and failing
- latestResVersion -> no new events not failing
- larger than latestResVersion (it can only grow and was at latestResVersion when stopped) -> new events to process.

### Motivation

QA

### Additional Notes

*This should be fixed when we move to the official client.*
