### PR TITLE
[py/utils/proxy] Fix missing import

### DIFF
--- a/cmd/agent/dist/utils/proxy.py
+++ b/cmd/agent/dist/utils/proxy.py
@@ -7,6 +7,7 @@
 # All rights reserved
 
 import logging
+import os
 from urlparse import urlparse
 
 import datadog_agent


### PR DESCRIPTION
### What does this PR do?

Fix missing `os` import.

### Motivation

Was breaking all the checks that use `self.get_instance_proxy`, which includes the core checks `nginx`, `rabbitmq`, and `http_check`

### Additional Notes

Hopefully at some point `datadog_checks_base` will replace all the duplicated and untested python code we have in `datadog-agent`