### PR TITLE
[AD] fix %%host_custom%% and %%port_1%% resolution, improve tests

### DIFF
--- a/pkg/collector/autodiscovery/configresolver_test.go
+++ b/pkg/collector/autodiscovery/configresolver_test.go
@@ -195,24 +195,6 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
-			testName: "%%host_custom%% with invalid name, default to fallbackHost",
-			svc: &listeners.DockerService{
-				ID:            "a5901276aed1",
-				ADIdentifiers: []string{"redis"},
-				Hosts:         map[string]string{"other": "127.0.0.3"},
-			},
-			tpl: check.Config{
-				Name:          "cpu",
-				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom%%")},
-			},
-			out: check.Config{
-				Name:          "cpu",
-				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.3")},
-			},
-		},
-		{
 			testName: "%%host%% with no host in service, error",
 			svc: &listeners.DockerService{
 				ID:            "a5901276aed1",

--- a/pkg/collector/autodiscovery/configresolver_test.go
+++ b/pkg/collector/autodiscovery/configresolver_test.go
@@ -8,12 +8,14 @@
 package autodiscovery
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/listeners"
-	"github.com/stretchr/testify/assert"
 
 	// we need some valid check in the catalog to run tests
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system"
@@ -68,46 +70,11 @@ func TestParseTemplateVar(t *testing.T) {
 
 	name, key = parseTemplateVar([]byte("%%host_0_1%%"))
 	assert.Equal(t, "host", string(name))
-	assert.Equal(t, "", string(key))
-}
+	assert.Equal(t, "0_1", string(key))
 
-func TestResolve(t *testing.T) {
-	ac := &AutoConfig{
-		providerLoadedConfigs: make(map[string][]check.Config),
-	}
-	cr := newConfigResolver(nil, ac, NewTemplateCache())
-	service := listeners.DockerService{
-		ID:            "a5901276aed16ae9ea11660a41fecd674da47e8f5d8d5bce0080a611feed2be9",
-		ADIdentifiers: []string{"redis"},
-		Hosts:         map[string]string{"bridge": "127.0.0.1"},
-		Pid:           1337,
-	}
-	cr.processNewService(&service)
-
-	tpl := check.Config{
-		Name:          "cpu",
-		ADIdentifiers: []string{"redis"},
-	}
-
-	tpl.Instances = []check.ConfigData{check.ConfigData("host: %%host%%")}
-	config, err := cr.resolve(tpl, &service)
-	assert.Nil(t, err)
-	// we must not modify original template
-	assert.Equal(t, "host: %%host%%", string(tpl.Instances[0]))
-	assert.Equal(t, "host: 127.0.0.1", string(config.Instances[0]))
-
-	tpl.Instances = []check.ConfigData{check.ConfigData("pid: %%pid%%\ntags: [\"foo\"]")}
-	config, err = cr.resolve(tpl, &service)
-	assert.Nil(t, err)
-	assert.Equal(t, "pid: 1337\ntags:\n- foo\n", string(config.Instances[0]))
-
-	// Assert we have the two configs in the AC
-	assert.Equal(t, 2, len(ac.providerLoadedConfigs[UnknownProvider]))
-
-	// template variable doesn't exist
-	tpl.Instances = []check.ConfigData{check.ConfigData("host: %%FOO%%")}
-	config, err = cr.resolve(tpl, &service)
-	assert.NotNil(t, err)
+	name, key = parseTemplateVar([]byte("%%host_network_name%%"))
+	assert.Equal(t, "host", string(name))
+	assert.Equal(t, "network_name", string(key))
 }
 
 func TestGetFallbackHost(t *testing.T) {
@@ -126,4 +93,275 @@ func TestGetFallbackHost(t *testing.T) {
 	ip, err = getFallbackHost(map[string]string{"foo": "172.17.0.1", "bar": "172.17.0.2"})
 	assert.Equal(t, "", ip)
 	assert.NotNil(t, err)
+}
+
+func TestResolve(t *testing.T) {
+	testCases := []struct {
+		testName    string
+		tpl         check.Config
+		svc         listeners.Service
+		out         check.Config
+		errorString string
+	}{
+		//// %%host%% tag testing
+		{
+			testName: "simple %%host%% with bridge fallback",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"bridge": "127.0.0.1"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.1")},
+			},
+		},
+		{
+			testName: "simple %%host%% with non-bridge fallback",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"custom": "127.0.0.2"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.2")},
+			},
+		},
+		{
+			testName: "%%host_custom%% with two custom networks",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"custom": "127.0.0.2", "other": "127.0.0.3"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.2")},
+			},
+		},
+		{
+			testName: "%%host_custom_net%% for docker compose support",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"other": "127.0.0.2", "custom_net": "127.0.0.3"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom_net%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.3")},
+			},
+		},
+		{
+			testName: "%%host_custom%% with invalid name, default to fallbackHost",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"other": "127.0.0.3"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.3")},
+			},
+		},
+		{
+			testName: "%%host_custom%% with invalid name, default to fallbackHost",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"other": "127.0.0.3"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.3")},
+			},
+		},
+		{
+			testName: "%%host%% with no host in service, error",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%host%%")},
+			},
+			errorString: "no network found for container a5901276aed1, ignoring it",
+		},
+		//// %%port%% tag testing
+		{
+			testName: "simple %%port%%, pick last",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         []int{1, 2, 3},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: %%port%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: 3")},
+			},
+		},
+		{
+			testName: "%%port_0%%, pick first",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         []int{1, 2, 3},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: %%port_0%%")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: 1")},
+			},
+		},
+		{
+			testName: "%%port_4%% too high, error",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         []int{1, 2, 3},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: %%port_4%%")},
+			},
+			errorString: "index given for the port template var is too big, skipping container a5901276aed1",
+		},
+		{
+			testName: "%%port_A%% not int, error",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         []int{1, 2, 3},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: %%port_A%%")},
+			},
+			errorString: "index given for the port template var is not an int, skipping container a5901276aed1",
+		},
+		{
+			testName: "%%port%% but no port in service, error",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         []int{},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("port: %%port%%")},
+			},
+			errorString: "no port found for container a5901276aed1 - ignoring it",
+		},
+		//// other tags testing
+		{
+			testName: "simple %%pid%%",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Pid:           1337,
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("pid: %%pid%%\ntags: [\"foo\"]")},
+			},
+			out: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("pid: 1337\ntags:\n- foo\n")},
+			},
+		},
+		//// unknown tag
+		{
+			testName: "invalid %%FOO%% tag",
+			svc: &listeners.DockerService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+			},
+			tpl: check.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []check.ConfigData{check.ConfigData("host: %%FOO%%")},
+			},
+			errorString: "yaml: found character that cannot start any token",
+		},
+	}
+	ac := &AutoConfig{
+		providerLoadedConfigs: make(map[string][]check.Config),
+	}
+	cr := newConfigResolver(nil, ac, NewTemplateCache())
+	validTemplates := 0
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.testName), func(t *testing.T) {
+			// Make sure we don't modify the template object
+			checksum := tc.tpl.Digest()
+
+			cfg, err := cr.resolve(tc.tpl, tc.svc)
+			if tc.errorString != "" {
+				assert.EqualError(t, err, tc.errorString)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.out, cfg)
+				assert.Equal(t, checksum, tc.tpl.Digest())
+				validTemplates++
+			}
+		})
+
+		// Assert the valid configs are stored in the AC
+		assert.Equal(t, validTemplates, len(ac.providerLoadedConfigs[UnknownProvider]))
+	}
 }

--- a/releasenotes/notes/ad-host-port-tags-fix-a299e1407c1f5136.yaml
+++ b/releasenotes/notes/ad-host-port-tags-fix-a299e1407c1f5136.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix handling of the %%host%% and %%port%% autodiscovery tags


### PR DESCRIPTION
### What does this PR do?

Fix handling of the `%%host_xxxxx%%` and `%%port_xxxxx%%` AD template tags:

- support `_` in the second part, as compose creates network names like `project_network`. We then need to support the `%%host_project_network%%` syntax
- argument passed to `getPort` and `getHost` are already split, don't split them again
- rework the `TestResolve` on dict pattern and add a ton of test cases to cover this
