### PR TITLE
[upstart] exit code 0 is all :ok_hand:

### DIFF
--- a/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
@@ -4,6 +4,8 @@ start on started networking
 stop on runlevel [!2345]
 
 respawn
+respawn limit 10 5
+normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or
 # syslog depending on its configuration. We make upstart log what the process still outputs in order

--- a/omnibus/config/templates/datadog-agent/upstart_debian.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.process.conf.erb
@@ -5,6 +5,7 @@ stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
 respawn limit 10 5
+normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or
 # syslog depending on its configuration. We make upstart log what the process still outputs in order

--- a/omnibus/config/templates/datadog-agent/upstart_debian.trace.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.trace.conf.erb
@@ -5,6 +5,7 @@ stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
 respawn limit 10 5
+normal exit 0
 
 # Logging to console from the agent is disabled since the agent already logs using file or
 # syslog depending on its configuration. We make upstart log what the process still outputs in order

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -4,6 +4,8 @@ start on started network
 stop on runlevel [!2345]
 
 respawn
+respawn limit 10 5
+normal exit 0
 
 console output
 

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
@@ -5,6 +5,7 @@ stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
 respawn limit 10 5
+normal exit 0
 
 console output
 

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.trace.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.trace.conf.erb
@@ -5,6 +5,7 @@ stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn
 respawn limit 10 5
+normal exit 0
 
 console output
 

--- a/releasenotes/notes/initctl-fixes-22daf659220f0d16.yaml
+++ b/releasenotes/notes/initctl-fixes-22daf659220f0d16.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Upstart would indefinitely respawn trace and process agents even when exiting
+    with a zero status code. We now explicitly define exit code 0 as a valid exit
+    code to prevent respawn when the agents are disabled.


### PR DESCRIPTION
### What does this PR do?

Not all upstart versions deal with exit code zero as expected. By making it explicit we should always be good.

### Motivation

Buggy behavior stopping optional agents.

### Additional Notes

https://askubuntu.com/questions/62434/why-does-upstart-keep-respawning-my-process
