### PR TITLE
fix docker agent tag

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -18,7 +18,7 @@ from .go import deps
 
 #constants
 BIN_PATH = os.path.join(".", "bin", "agent")
-AGENT_TAG = "datadog/agent:master"
+AGENT_TAG = "datadog/agent-dev:master"
 DEFAULT_BUILD_TAGS = [
     "apm",
     "consul",


### PR DESCRIPTION
```bash
$ docker pull datadog/agent:master                          
Error response from daemon: manifest for datadog/agent:master not found            
$ docker pull datadog/agent-dev:master                      
master: Pulling from datadog/agent-dev                                             
e7bb522d92ff: Already exists                                                       
24d12ce32acd: Pull complete                                                        
56479f52812b: Pull complete                                                        
96fd42f0a29c: Pull complete                                                        
aadb1f8d87d1: Pull complete                                                        
dbd88ed2ac34: Pull complete                                                        
518540bab712: Pull complete                                                        
Digest: sha256:24c9d9306e9d7e1f95c51d0d30fc2f717c498d563b5dfee89a427a4a9c44699d    
Status: Downloaded newer image for datadog/agent-dev:master                        
```