### PR TITLE
[AD] normalize label/annotation names, update doc and tests

### DIFF
--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -17,6 +17,7 @@ open an issue or submit a Pull Request.
 * [Python Modules](#python-modules)
 * [Docker](#docker-check)
 * [Kubernetes](#kubernetes-support)
+* [Autodiscovery](#autodiscovery)
 * [JMX](#jmx)
 * [GUI](#gui)
 
@@ -283,6 +284,29 @@ The following options and tags are deprecated:
 
 The `kube_service` tagging depends on the `Datadog Cluster Agent`, which is not released yet.
 
+## Autodiscovery
+
+We reworked the [Autodiscovery](https://docs.datadoghq.com/agent/autodiscovery/) system from the ground up to be faster and more reliable.
+We also worked on decoupling container runtimes and orchestrators, to be more flexible in the future.
+
+All documented use cases are supported, please contact our support team if you run into issues.
+
+### Kubernetes
+
+When using Kubernetes, the Autodiscovery system now sources information from the kubelet, instead of the Docker daemon. This will allow AD
+to work without access to the Docker socket, and enable a more consistent experience accross all parts of the agent. The side effect of that
+is that templates in Docker labels are not supported when using the kubelet AD listener. Templates in pod annotations still work as intended.
+
+When specifying AD templates in pod annotations, the new annotation name prefix is `ad.datadoghq.com/`. the previous annotation prefix
+`service-discovery.datadoghq.com/` is still supported for Agent6 but support will be removed in Agent7.
+
+### Other orchestrators
+
+Autodiscovery templates in Docker labels still work, with the same `com.datadoghq.ad.` name prefix.
+
+The identifier override label has been renamed from `com.datadoghq.sd.check.id` to `com.datadoghq.ad.check.id` for consistency. The previous
+name is still supported for Agent6 but support will be removed in Agent7.
+
 ## Python Modules
 
 While we are continuing to ship the python libraries that ship with Agent 5,
@@ -309,8 +333,6 @@ The Agent 6 does not ship the `jmxterm` JAR. If you wish to download and use `jm
 ## GUI
 
 Agent 6 deprecated Agent5's Windows Agent Manager GUI, replacing it with a browser-based, cross-platform one. See the [specific docs](gui.md) for more details.
-
-
 
 
 [known-issues]: known_issues.md

--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -53,10 +53,30 @@ func TestGetConfigIDFromPs(t *testing.T) {
 	labeledCo := types.Container{
 		ID:     "deadbeef",
 		Image:  "test",
-		Labels: map[string]string{"io.datadog.check.id": "w00tw00t"},
+		Labels: map[string]string{"com.datadoghq.ad.check.id": "w00tw00t"},
 	}
 	ids = dl.getConfigIDFromPs(labeledCo)
 	assert.Equal(t, []string{"w00tw00t"}, ids)
+
+	legacyCo := types.Container{
+		ID:     "deadbeef",
+		Image:  "test",
+		Labels: map[string]string{"com.datadoghq.sd.check.id": "w00tw00t"},
+	}
+	ids = dl.getConfigIDFromPs(legacyCo)
+	assert.Equal(t, []string{"w00tw00t"}, ids)
+
+	doubleCo := types.Container{
+		ID:    "deadbeef",
+		Image: "test",
+		Labels: map[string]string{
+			// Both labels, new one takes over
+			"com.datadoghq.ad.check.id": "new",
+			"com.datadoghq.sd.check.id": "old",
+		},
+	}
+	ids = dl.getConfigIDFromPs(doubleCo)
+	assert.Equal(t, []string{"new"}, ids)
 }
 
 func TestGetHostsFromPs(t *testing.T) {
@@ -160,7 +180,7 @@ func TestGetADIdentifiers(t *testing.T) {
 	labeledCo := types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "test"},
 		Mounts:            make([]types.MountPoint, 0),
-		Config:            &container.Config{Labels: map[string]string{"io.datadog.check.id": "w00tw00t"}},
+		Config:            &container.Config{Labels: map[string]string{"com.datadoghq.ad.check.id": "w00tw00t"}},
 		NetworkSettings:   &types.NetworkSettings{},
 	}
 	cache.Cache.Set(cacheKey, labeledCo, 10*time.Second)
@@ -179,7 +199,7 @@ func TestGetHosts(t *testing.T) {
 	cj := types.ContainerJSON{
 		ContainerJSONBase: &cBase,
 		Mounts:            make([]types.MountPoint, 0),
-		Config:            &container.Config{Labels: map[string]string{"io.datadog.check.id": "w00tw00t"}},
+		Config:            &container.Config{Labels: map[string]string{"com.datadoghq.ad.check.id": "w00tw00t"}},
 		NetworkSettings:   &types.NetworkSettings{},
 	}
 	// add cj to the cache to avoir having to query docker in the test
@@ -250,8 +270,8 @@ func TestGetRancherIP(t *testing.T) {
 		ContainerJSONBase: &cBase,
 		Mounts:            make([]types.MountPoint, 0),
 		Config: &container.Config{Labels: map[string]string{
-			"io.datadog.check.id":     "w00tw00t",
-			"io.rancher.container.ip": "10.42.90.224/16",
+			"com.datadoghq.ad.check.id": "w00tw00t",
+			"io.rancher.container.ip":   "10.42.90.224/16",
 		}},
 		NetworkSettings: &networkSettings,
 	}

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -129,7 +129,6 @@ func parseDockerLabels(containers map[string]map[string]string) ([]check.Config,
 			continue
 		default:
 			configs = append(configs, c...)
-
 		}
 	}
 	return configs, nil

--- a/pkg/collector/providers/kubelet_test.go
+++ b/pkg/collector/providers/kubelet_test.go
@@ -8,64 +8,150 @@
 package providers
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
 // Only testing parseKubeletPodlist, lifecycle should be tested in end-to-end test
 
 func TestParseKubeletPodlist(t *testing.T) {
-	podlist := []*kubelet.Pod{
+	for nb, tc := range []struct {
+		desc        string
+		pod         *kubelet.Pod
+		expectedCfg []check.Config
+	}{
 		{
-			Status: kubelet.Status{
-				Containers: []kubelet.ContainerStatus{
-					{
-						Name: "testName",
-						ID:   "testID",
+			desc: "No annotations",
+			pod: &kubelet.Pod{
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "testName",
+							ID:   "testID",
+						},
 					},
+				},
+			},
+			expectedCfg: nil,
+		},
+		{
+			desc: "New + old, new takes over",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/apache.check_names":                 "[\"http_check\"]",
+						"ad.datadoghq.com/apache.init_configs":                "[{}]",
+						"ad.datadoghq.com/apache.instances":                   "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"service-discovery.datadoghq.com/apache.check_names":  "[\"invalid\"]",
+						"service-discovery.datadoghq.com/apache.init_configs": "[{}]",
+						"service-discovery.datadoghq.com/apache.instances":    "[{}]",
+					},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "apache",
+							ID:   "docker://3b8efe0c50e8",
+						},
+					},
+				},
+			},
+			expectedCfg: []check.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    check.ConfigData("{}"),
+					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},
 		{
-			Metadata: kubelet.PodMetadata{
-				Annotations: map[string]string{
-					"service-discovery.datadoghq.com/apache.check_names":  "[\"apache\",\"http_check\"]",
-					"service-discovery.datadoghq.com/apache.init_configs": "[{},{}]",
-					"service-discovery.datadoghq.com/apache.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+			desc: "New annotation prefix, two templates",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Annotations: map[string]string{
+						"ad.datadoghq.com/apache.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/apache.init_configs": "[{}]",
+						"ad.datadoghq.com/apache.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/nginx.check_names":   "[\"http_check\"]",
+						"ad.datadoghq.com/nginx.init_configs":  "[{}]",
+						"ad.datadoghq.com/nginx.instances":     "[{\"name\": \"Other service\", \"url\": \"http://%%host_external%%\", \"timeout\": 1}]",
+					},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "apache",
+							ID:   "docker://3b8efe0c50e8",
+						},
+						{
+							Name: "nginx",
+							ID:   "docker://4ac8352d70bf1",
+						},
+					},
 				},
 			},
-			Status: kubelet.Status{
-				Containers: []kubelet.ContainerStatus{
-					{
-						Name: "apache",
-						ID:   "docker://3b8efe0c50e8",
-					},
-					{
-						Name: "testName",
-						ID:   "testID",
-					},
+			expectedCfg: []check.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    check.ConfigData("{}"),
+					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+				},
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
+					InitConfig:    check.ConfigData("{}"),
+					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
 				},
 			},
 		},
+		{
+			desc: "Legacy annotation prefix, two checks in one template",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Annotations: map[string]string{
+						"service-discovery.datadoghq.com/apache.check_names":  "[\"apache\",\"http_check\"]",
+						"service-discovery.datadoghq.com/apache.init_configs": "[{},{}]",
+						"service-discovery.datadoghq.com/apache.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"},{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+					},
+				},
+				Status: kubelet.Status{
+					Containers: []kubelet.ContainerStatus{
+						{
+							Name: "apache",
+							ID:   "docker://3b8efe0c50e8",
+						},
+					},
+				},
+			},
+			expectedCfg: []check.Config{
+				{
+					Name:          "apache",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    check.ConfigData("{}"),
+					Instances:     []check.ConfigData{check.ConfigData("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+				},
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
+					InitConfig:    check.ConfigData("{}"),
+					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
+			checks, err := parseKubeletPodlist([]*kubelet.Pod{tc.pod})
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.expectedCfg), len(checks))
+			assert.EqualValues(t, tc.expectedCfg, checks)
+
+		})
 	}
-
-	checks, err := parseKubeletPodlist(podlist)
-	assert.Nil(t, err)
-
-	assert.Len(t, checks, 2)
-
-	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[0].ADIdentifiers)
-	assert.Equal(t, "{}", string(checks[0].InitConfig))
-	assert.Len(t, checks[0].Instances, 1)
-	assert.Equal(t, "{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}", string(checks[0].Instances[0]))
-	assert.Equal(t, "apache", checks[0].Name)
-
-	assert.Equal(t, []string{"docker://3b8efe0c50e8"}, checks[1].ADIdentifiers)
-	assert.Equal(t, "{}", string(checks[1].InitConfig))
-	assert.Len(t, checks[1].Instances, 1)
-	assert.Equal(t, "{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}", string(checks[1].Instances[0]))
-	assert.Equal(t, "http_check", checks[1].Name)
 }

--- a/releasenotes/notes/consistent-ad-labels-05d271735c91819f.yaml
+++ b/releasenotes/notes/consistent-ad-labels-05d271735c91819f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Rework autodiscovery label names to be consistent, still support the
+    previous names

--- a/test/integration/listeners/docker/testdata/redis.yaml
+++ b/test/integration/listeners/docker/testdata/redis.yaml
@@ -5,4 +5,4 @@ services:
   redis-with-id:
     image: "datadog/docker-library:redis_3_2_11-alpine"
     labels:
-      io.datadog.check.id: "custom-id"
+      com.datadoghq.ad.check.id: "custom-id"


### PR DESCRIPTION
### What does this PR do?

For a consistent AD experience, use the same name for all AD annotation/label names. Keep/re-introduce support for the Agent5 names, as dropping them from Agent6 could add significant friction in the migration (what if they want to rollback)? We will deprecate them in Agent7. If both new and legacy labels are found, the new ones take precedence.

|                                     | Official                          | Legacy (but still supported, remove in Agent7) |
|-------------------------------------|-----------------------------------|------------------------------------------------|
| Template in Kube pod annotations    | `ad.datadoghq.com/*`              | `service-discovery.datadoghq.com/*`            |
| Template in Docker container labels |  `com.datadoghq.ad.*` (no change) |                                                |
| Docker AD ID override label         | `com.datadoghq.ad.check.id`       | `com.datadoghq.sd.check.id`                    |

Update the `changes.md` documentation and tests.