### PR TITLE
[AD] fix AD starting two checks if using templates in labels

### DIFF
--- a/pkg/collector/listeners/docker_test.go
+++ b/pkg/collector/listeners/docker_test.go
@@ -77,6 +77,14 @@ func TestGetConfigIDFromPs(t *testing.T) {
 	}
 	ids = dl.getConfigIDFromPs(doubleCo)
 	assert.Equal(t, []string{"new"}, ids)
+
+	templatedCo := types.Container{
+		ID:     "deadbeef",
+		Image:  "org/test",
+		Labels: map[string]string{"com.datadoghq.ad.instances": "[]]"},
+	}
+	ids = dl.getConfigIDFromPs(templatedCo)
+	assert.Equal(t, []string{"docker://deadbeef"}, ids)
 }
 
 func TestGetHostsFromPs(t *testing.T) {

--- a/releasenotes/notes/ad-double-checks-864cdb8950cbfa5c.yaml
+++ b/releasenotes/notes/ad-double-checks-864cdb8950cbfa5c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Don't try to match containers by image name if they provide an AD template
+    via docker labels or pod annotations. This avoid scheduling double checks.


### PR DESCRIPTION
### What does this PR do?

Don't add image names to container AD identifiers if we detect an AD template in docker labels / kube pod annotations. We don't try to parse / validate it, that's for the configresolver to do / log.

This PR is rebased on https://github.com/DataDog/datadog-agent/pull/1271 , so that one must be merged before.