### PR TITLE
[aggregation] Ignore metric samples with NaN values

### DIFF
--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -26,8 +26,8 @@ func MakeContextMetrics() ContextMetrics {
 // AddSample add a sample to the current ContextMetrics and initialize a new metrics if needed.
 // TODO: Pass a reference to *MetricSample instead
 func (m ContextMetrics) AddSample(contextKey ckey.ContextKey, sample *MetricSample, timestamp float64, interval int64) {
-	if math.IsInf(sample.Value, 0) {
-		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
+	if math.IsInf(sample.Value, 0) || math.IsNaN(sample.Value) {
+		log.Warn("Ignoring sample with ", sample.Value, " value on context key:", contextKey)
 		return
 	}
 	if _, ok := m[contextKey]; !ok {

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -27,7 +27,7 @@ func MakeContextMetrics() ContextMetrics {
 // TODO: Pass a reference to *MetricSample instead
 func (m ContextMetrics) AddSample(contextKey ckey.ContextKey, sample *MetricSample, timestamp float64, interval int64) {
 	if math.IsInf(sample.Value, 0) || math.IsNaN(sample.Value) {
-		log.Warn("Ignoring sample with ", sample.Value, " value on context key:", contextKey)
+		log.Debug("Ignoring sample with ", sample.Value, " value on context key:", contextKey)
 		return
 	}
 	if _, ok := m[contextKey]; !ok {

--- a/pkg/metrics/context_sketch.go
+++ b/pkg/metrics/context_sketch.go
@@ -30,7 +30,7 @@ func MakeContextSketch() ContextSketch {
 // AddSample adds a sample to the ContextSketch
 func (c ContextSketch) AddSample(contextKey ckey.ContextKey, sample *MetricSample, timestamp float64, interval int64) {
 	if math.IsInf(sample.Value, 0) || math.IsNaN(sample.Value) {
-		log.Warn("Ignoring sample with ", sample.Value, " value on context key:", contextKey)
+		log.Debug("Ignoring sample with ", sample.Value, " value on context key:", contextKey)
 		return
 	}
 	if _, ok := c[contextKey]; !ok {

--- a/pkg/metrics/context_sketch.go
+++ b/pkg/metrics/context_sketch.go
@@ -29,8 +29,8 @@ func MakeContextSketch() ContextSketch {
 
 // AddSample adds a sample to the ContextSketch
 func (c ContextSketch) AddSample(contextKey ckey.ContextKey, sample *MetricSample, timestamp float64, interval int64) {
-	if math.IsInf(sample.Value, 0) {
-		log.Warn("Ignoring sample with +/-Inf value on context key:", contextKey)
+	if math.IsInf(sample.Value, 0) || math.IsNaN(sample.Value) {
+		log.Warn("Ignoring sample with ", sample.Value, " value on context key:", contextKey)
 		return
 	}
 	if _, ok := c[contextKey]; !ok {

--- a/pkg/metrics/context_sketch_test.go
+++ b/pkg/metrics/context_sketch_test.go
@@ -39,13 +39,14 @@ func TestContextSketchSampling(t *testing.T) {
 	assert.Equal(t, 0, len(resultSeries))
 }
 
-// The sketches ignore sample values of +Inf/-Inf
+// The sketches ignore sample values of +Inf/-Inf/NaN
 func TestContextSketchSamplingInfinity(t *testing.T) {
 	ctxSketch := MakeContextSketch()
 	contextKey, _ := ckey.Parse("ffffffffffffffffffffffffffffffff")
 
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: math.Inf(1), Mtype: DistributionType}, 1, 10)
 	ctxSketch.AddSample(contextKey, &MetricSample{Value: math.Inf(-1), Mtype: DistributionType}, 2, 10)
+	ctxSketch.AddSample(contextKey, &MetricSample{Value: math.NaN(), Mtype: DistributionType}, 3, 10)
 	resultSeries := ctxSketch.Flush(12345.0)
 
 	assert.Equal(t, 0, len(resultSeries))

--- a/releasenotes/notes/aggregator-ignore-nan-values-10f8bdff5c0a233b.yaml
+++ b/releasenotes/notes/aggregator-ignore-nan-values-10f8bdff5c0a233b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The aggregator now discards metric samples with ``NaN`` values. Also solves a serializing error
+    on metric payloads.


### PR DESCRIPTION
### What does this PR do?

Handle `NaN` values the same way we already handle `+Inf`/`-Inf`, i.e. ignore them.

### Motivation

The individual metric aggregators (`Gauge`, `Count`, `Rate`, etc) don't check for this value (and can't do anything with it anyway), and, more importantly (but incidentally), the JSON serialization of the final `Series` downstream fail if there are such values.
