### PR TITLE
[omnibus] fix windows build + update blacklist

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -28,8 +28,6 @@ blacklist = [
   'docker_daemon',
   'kubernetes',
   'ntp',  # provided as a go check by the core agent
-  'sqlserver',
-  'vsphere',
 ]
 
 build do

--- a/releasenotes/notes/unblacklist-checks-04a8d836e22598e9.yaml
+++ b/releasenotes/notes/unblacklist-checks-04a8d836e22598e9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Removing `vsphere` and `sqlserver` from the blacklist. The former is 
+    available on all platforms, `sqlserver` is currently windows-only.


### PR DESCRIPTION
### What does this PR do?

Fixes problem with windows pip integration installation with blobs. 

Also removes relevant checks from blacklist (`sqlserver` should be skipped on linux/mac by virtue of the manifest.json `supported_os` json field).

### Motivation

Agent was shipping with no integrations. Blacklist required an update.

### Additional Notes

Anything else we should know when reviewing?
