### PR TITLE
Fixes to handling of `resources` collector and in metadata payload

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -7,6 +7,7 @@ package app
 
 import (
 	"fmt"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -281,7 +282,7 @@ func setupMetadataCollection(s *serializer.Serializer, hostname string) error {
 	if err != nil {
 		return log.Error("Agent Checks metadata is supposed to be always available in the catalog!")
 	}
-	if addDefaultResourcesCollector {
+	if addDefaultResourcesCollector && runtime.GOOS == "linux" {
 		err = common.MetadataScheduler.AddCollector("resources", defaultResourcesMetadataCollectorInterval*time.Second)
 		if err != nil {
 			log.Warn("Could not add resources metadata provider: ", err)

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -29,8 +29,8 @@ type Meta struct {
 }
 
 type tags struct {
-	System              []string `json:"system"`
-	GoogleCloudPlatform []string `json:"google cloud platform"`
+	System              []string `json:"system,omitempty"`
+	GoogleCloudPlatform []string `json:"google cloud platform,omitempty"`
 }
 
 // Payload handles the JSON unmarshalling of the metadata payload

--- a/pkg/metadata/resources.go
+++ b/pkg/metadata/resources.go
@@ -6,6 +6,7 @@
 package metadata
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
@@ -21,6 +22,10 @@ type ResourcesCollector struct{}
 func (rp *ResourcesCollector) Send(s *serializer.Serializer) error {
 	hostname, _ := util.GetHostname()
 
+	res := resources.GetPayload(hostname)
+	if res == nil {
+		return errors.New("empty processes metadata")
+	}
 	payload := map[string]interface{}{
 		"resources": resources.GetPayload(hostname),
 	}

--- a/pkg/metadata/resources/resources.go
+++ b/pkg/metadata/resources/resources.go
@@ -18,8 +18,8 @@ func GetPayload(hostname string) *Payload {
 	// Get processes metadata from gohai
 	proc, err := new(processes.Processes).Collect()
 	if err != nil {
-		log.Errorf("Failed to retrieve processes metadata: %s", err)
-		return &Payload{}
+		log.Warn("Failed to retrieve processes metadata: ", err)
+		return nil
 	}
 
 	processesPayload := map[string]interface{}{

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -14,19 +14,19 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/resources"
 )
 
-// CommonPayload wraps Payload from the `common` package
+// CommonPayload wraps Payload from the common package
 type CommonPayload struct {
 	common.Payload
 }
 
-// HostPayload wraps Payload from the `host` package
+// HostPayload wraps Payload from the host package
 type HostPayload struct {
 	host.Payload
 }
 
-// ResourcesPayload wraps Payload from the `resources` package
+// ResourcesPayload wraps Payload from the resources package
 type ResourcesPayload struct {
-	resources.Payload `json:"resources"`
+	resources.Payload `json:"resources,omitempty"`
 }
 
 // MarshalJSON serialization a Payload to JSON

--- a/pkg/metadata/v5/v5.go
+++ b/pkg/metadata/v5/v5.go
@@ -22,9 +22,12 @@ func GetPayload(hostname string) *Payload {
 	rp := resources.GetPayload(hostname)
 
 	p := &Payload{
-		CommonPayload:    CommonPayload{*cp},
-		HostPayload:      HostPayload{*hp},
-		ResourcesPayload: ResourcesPayload{*rp},
+		CommonPayload: CommonPayload{*cp},
+		HostPayload:   HostPayload{*hp},
+	}
+
+	if rp != nil {
+		p.ResourcesPayload = ResourcesPayload{*rp}
 	}
 
 	if config.Datadog.GetBool("enable_gohai") {

--- a/releasenotes/notes/metadata-fixes-6c96a2a7fc0f9a71.yaml
+++ b/releasenotes/notes/metadata-fixes-6c96a2a7fc0f9a71.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fix cases where empty host tags in the Agent ``datadog.yaml`` configuration caused
+    the host metadata payload parsing to fail in the backend.
+  - |
+    Fix ``resources`` metadata collector so that its payload is correctly parsed in the
+    backend even when empty.
+other:
+  - |
+    Only enable the ``resources`` metadata collector on Linux by default, to match
+    Agent 5's behavior.


### PR DESCRIPTION
### What does this PR do?

1. Fix the processing of the host metadata payload by sobotka when no `resources` are collected.
2. Only enable the `resources` metadata collector on Linux, to match A5's behavior.
3. Omit any empty entry from the `host-tags` JSON object. 

### Motivation

For `1.`: A6 Windows host metadata payloads cause exceptions in sobotka because when the `resources` key is present, it expects its dict value to be fully populated, which is not the case on Windows (and is not the case either when the collection from gohai fails). Should probably be fixed on sobotka's side too.
For `2.`: Match A5's behavior, see commit msg for more details.
For `3.`: Empty entries cause exceptions in sobotka.

### Additional Notes

The agent metadata endpoint is 😭 