### PR TITLE
[Security] allow auth token file path to be set in the config

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -108,7 +108,12 @@ func GenerateRootCert(hosts []string, bits int) (
 // FetchAuthToken gets the authentication token from the auth token file & creates one if it doesn't exist
 // Requires that the config has been set up before calling
 func FetchAuthToken() (string, error) {
-	authTokenFile := filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
+	var authTokenFile string
+	if config.Datadog.GetString("auth_token_file_path") != "" {
+		authTokenFile = config.Datadog.GetString("auth_token_file")
+	} else {
+		authTokenFile = filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
+	}
 
 	// Create a new token if it doesn't exist
 	if _, e := os.Stat(authTokenFile); os.IsNotExist(e) {

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -110,7 +110,7 @@ func GenerateRootCert(hosts []string, bits int) (
 func FetchAuthToken() (string, error) {
 	var authTokenFile string
 	if config.Datadog.GetString("auth_token_file_path") != "" {
-		authTokenFile = config.Datadog.GetString("auth_token_file")
+		authTokenFile = config.Datadog.GetString("auth_token_file_path")
 	} else {
 		authTokenFile = filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,6 +90,7 @@ func init() {
 	Datadog.SetDefault("enable_gohai", true)
 	Datadog.SetDefault("check_runners", int64(1))
 	Datadog.SetDefault("expvar_port", "5000")
+	Datadog.SetDefault("auth_token_file_path", "")
 
 	// Use to output logs in JSON format
 	BindEnvAndSetDefault("log_format_json", false)

--- a/releasenotes/notes/allow-auth-token-path-to-be-set-18496202a7de9049.yaml
+++ b/releasenotes/notes/allow-auth-token-path-to-be-set-18496202a7de9049.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    allow auth token path to be set in the config file


### PR DESCRIPTION
### What does this PR do?

The auth token location should be able to be changed via a config setting. This will enable us to do that easily.

### Motivation

On Cloud Foundry, the config folder is destroyed and recreated every time it's deployed. So, the next run doesn't have access to the auth token and it cannot stop the agent easily. (It's much messier, at least.)

