### PR TITLE
Better permissions for auth_token

### DIFF
--- a/pkg/api/security/platform_nowindows.go
+++ b/pkg/api/security/platform_nowindows.go
@@ -11,7 +11,7 @@ import (
 	"io/ioutil"
 )
 
-// writes auth token(s) to a file that is only readable by the user running the agent
+// writes auth token(s) to a file that is only readable/writable by the user running the agent
 func saveAuthToken(token, tokenPath string) error {
 	return ioutil.WriteFile(tokenPath, []byte(token), 0600)
 }

--- a/pkg/api/security/platform_nowindows.go
+++ b/pkg/api/security/platform_nowindows.go
@@ -9,16 +9,9 @@ package security
 
 import (
 	"io/ioutil"
-	"os"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// writes auth token(s) to a file with the same permissions as datadog.yaml
+// writes auth token(s) to a file that is only readable by the user running the agent
 func saveAuthToken(token, tokenPath string) error {
-	confFile, err := os.Stat(config.Datadog.ConfigFileUsed())
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(tokenPath, []byte(token), confFile.Mode())
+	return ioutil.WriteFile(tokenPath, []byte(token), 0600)
 }

--- a/releasenotes/notes/more-secure-permissions-authtoken-412767d86975bd02.yaml
+++ b/releasenotes/notes/more-secure-permissions-authtoken-412767d86975bd02.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    The `auth_token` file, used to store the api authentication token, is now
+    only readable/writable by the user running the agent instead of inheriting
+    datadog.yaml permissions.


### PR DESCRIPTION
### What does this PR do?

Change the permissions of the `auth_token` file to `0600`. 

### Motivation

Security reasons.

### Additional Notes

This change will prevent users that can't read the `auth_token` from running any `datadog-agent` commands that need to talk to the running agent endpoint. While this make sense IMO, it remove some ease of use. On linux the user will have to `su dd-agent`. 
