### PR TITLE
[metadata/resources] Fix test on Windows

### DIFF
--- a/pkg/metadata/resources/resources_test.go
+++ b/pkg/metadata/resources/resources_test.go
@@ -6,9 +6,10 @@
 package resources
 
 import (
-	"github.com/stretchr/testify/assert"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPayload(t *testing.T) {
@@ -18,8 +19,7 @@ func TestGetPayload(t *testing.T) {
 
 	if runtime.GOOS == "windows" {
 		// re-enable expected output, below when windows implements process metadata
-		assert.Nil(t, processesPayload.Processes["snaps"])
-		assert.Equal(t, "", processesPayload.Meta["host"])
+		assert.Nil(t, processesPayload)
 	} else {
 		assert.NotNil(t, processesPayload.Processes["snaps"])
 		assert.Equal(t, hostname, processesPayload.Meta["host"])


### PR DESCRIPTION
Fix a test that was broken on Windows since #1286. We're now expecting a `nil` value from `resources.GetPayload` when process metadata collection isn't implemented on the platform.