### PR TITLE
Fixed bug preventing docker client to retrieve container logs when docker server has version prior to 1.25

### DIFF
--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -226,6 +226,8 @@ func (s *Scanner) newDockerClient() (*client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// assure the client can communicate with the server
+	client.UpdateClientVersion("")
 	v, err := client.ServerVersion(context.Background())
 	if err != nil {
 		return nil, err

--- a/releasenotes/notes/logs-fix-docker-issue-api-version-1ed6a65d6c4322c6.yaml
+++ b/releasenotes/notes/logs-fix-docker-issue-api-version-1ed6a65d6c4322c6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue preventing logs-agent to tail container logs when docker API version is prior to 1.25


### PR DESCRIPTION
### What does this PR do?

Prevent the docker client to use an API version when retrieving the docker API version of the server

### Motivation

Enabled users to use docker API engine with a version prior to `1.25`

### Additional notes

This bug fix this [issue](https://github.com/DataDog/datadog-agent/issues/1300).
It has been tested with docker API version `1.25` and `1.24`