### PR TITLE
[invoke] disable container integrations on OSX build

### DIFF
--- a/releasenotes/notes/disable-container-integrations-if-not-linux-b6f76cc5200d7a6e.yaml
+++ b/releasenotes/notes/disable-container-integrations-if-not-linux-b6f76cc5200d7a6e.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    The OSX build of the agent does not include the containers integrations
+    as they are only supported on Linux for now. The Windows build already
+    excluded them since beta1

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -14,7 +14,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, pkg_config_path, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, ALL_TAGS, LINUX_ONLY
+from .build_tags import get_build_tags, get_default_build_tags, ALL_TAGS, LINUX_ONLY_TAGS
 from .go import deps
 
 #constants
@@ -57,7 +57,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
 
     if not sys.platform.startswith('linux'):
-        for ex in LINUX_ONLY:
+        for ex in LINUX_ONLY_TAGS:
             if ex not in build_exclude:
                 build_exclude.append(ex)
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -1,7 +1,7 @@
 """
 Utilities to manage build tags
 """
-import invoke
+import sys
 from invoke import task
 
 # ALL_TAGS lists any available build tag
@@ -28,16 +28,25 @@ PUPPY_TAGS = set([
     "zlib",
 ])
 
+LINUX_ONLY = [
+    "docker",
+    "kubelet",
+    "kubeapiserver"
+]
+
 
 def get_default_build_tags(puppy=False):
     """
     Build the default list of tags based on the current platform.
+
+    The container integrations are currently only supported on Linux, disabling on
+    the Windows and Darwin builds.
     """
     if puppy:
         return PUPPY_TAGS
 
     include = ["all"]
-    exclude = ["docker", "kubelet", "kubeapiserver"] if invoke.platform.WINDOWS else []
+    exclude = [] if sys.platform.startswith('linux') else LINUX_ONLY
     return get_build_tags(include, exclude)
 
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -28,7 +28,7 @@ PUPPY_TAGS = set([
     "zlib",
 ])
 
-LINUX_ONLY = [
+LINUX_ONLY_TAGS = [
     "docker",
     "kubelet",
     "kubeapiserver"
@@ -46,7 +46,7 @@ def get_default_build_tags(puppy=False):
         return PUPPY_TAGS
 
     include = ["all"]
-    exclude = [] if sys.platform.startswith('linux') else LINUX_ONLY
+    exclude = [] if sys.platform.startswith('linux') else LINUX_ONLY_TAGS
     return get_build_tags(include, exclude)
 
 


### PR DESCRIPTION
### What does this PR do?

Disable the "docker", "kubelet", "kubeapiserver" build tags on the OSX build like we do on Windows, to make clear these integrations are only supported on Linux for now.

Also makes the binary a bit lighter too.

Tested by running `agent diagnose` on both systems OSX and Linux.