### PR TITLE
clean dogstatsd workers properly

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -231,7 +231,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 
 // Stop stops a running Dogstatsd server
 func (s *Server) Stop() {
-	s.stopChan <- true
+	close(s.stopChan)
 	for _, l := range s.listeners {
 		l.Stop()
 	}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -236,6 +236,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 
 // Stop stops a running Dogstatsd server
 func (s *Server) Stop() {
+	s.stopChan <- true
 	for _, l := range s.listeners {
 		l.Stop()
 	}


### PR DESCRIPTION
### What does this PR do?

Dogstatsd workers were not stopped properly during the `Stop` method. This had not impact on the agent since dogstatsd is never stoped. It however made the tests freak out since they use multiple instances of dogstatsd.

I also added a small refactor to make every goroutine in the dogstatsd use the stop channel.

### Motivation

Make the ci work.

