### PR TITLE
Update the install script to use the official beta URLs

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -122,7 +122,7 @@ if [ $OS = "RedHat" ]; then
         ARCHI="x86_64"
     fi
 
-    $sudo_cmd sh -c "echo -e '[datadog-beta]\nname = Beta repo, Datadog, Inc.\nbaseurl = https://yum.${dd_url}/beta/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public\n       https://yum.${dd_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog-beta.repo"
+    $sudo_cmd sh -c "echo -e '[datadog-beta]\nname = Beta repo, Datadog, Inc.\nbaseurl = https://yum.${dd_url}/beta/6/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public\n       https://yum.${dd_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog-beta.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean expire-cache
@@ -138,7 +138,7 @@ elif [ $OS = "Debian" ]; then
       $sudo_cmd apt-get install -y dirmngr
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
-    $sudo_cmd sh -c "echo 'deb https://apt.${dd_url}/ beta main' > /etc/apt/sources.list.d/datadog-beta.list"
+    $sudo_cmd sh -c "echo 'deb https://apt.${dd_url}/ beta 6' > /etc/apt/sources.list.d/datadog-beta.list"
     $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
     $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
 
@@ -169,7 +169,7 @@ elif [ $OS = "SUSE" ]; then
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
-  $sudo_cmd sh -c "echo -e '[datadog-beta]\nname=datadog beta\nenabled=1\nbaseurl=https://yum.${dd_url}/suse/beta/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog-beta.repo"
+  $sudo_cmd sh -c "echo -e '[datadog-beta]\nname=datadog beta\nenabled=1\nbaseurl=https://yum.${dd_url}/suse/beta/6/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog-beta.repo"
 
   echo -e "\033[34m\n* Importing the Datadog GPG Key\n\033[0m"
   $sudo_cmd rpm --import https://yum.${dd_url}/DATADOG_RPM_KEY.public


### PR DESCRIPTION
### What does this PR do?

Update the install script to use the official beta URLs. This is a first step toward using the official stable URL once we go GA.
