### PR TITLE
Charly/leaderelection configmap

### DIFF
--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -33,4 +33,3 @@ rules:
   - get
   - update
   - create
-  - list

--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -28,8 +28,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
+  - configmaps
   verbs:
   - get
   - update
   - create
+  - list

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -129,7 +129,7 @@ func (le *LeaderEngine) init() error {
 		log.Errorf("Could not initialize the Leader Election process: %s", err)
 		return err
 	}
-	log.Debug("Leader Engine successfully initialized")
+	log.Debugf("Leader Engine for %q successfully initialized", le.HolderIdentity)
 	return nil
 }
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -117,10 +117,10 @@ func (le *LeaderEngine) init() error {
 		return err
 	}
 
-	// check if we can get endpoints.
-	_, err = le.coreClient.Endpoints(metav1.NamespaceDefault).List(metav1.ListOptions{Limit: 1})
+	// check if we can get ConfigMap.
+	_, err = le.coreClient.ConfigMaps(metav1.NamespaceDefault).List(metav1.ListOptions{Limit: 1})
 	if err != nil {
-		log.Errorf("Cannot retrieve endpoints from the %s namespace: %s", metav1.NamespaceDefault, err)
+		log.Errorf("Cannot retrieve ConfigMap from the %s namespace: %s", metav1.NamespaceDefault, err)
 		return err
 	}
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -27,7 +27,7 @@ func (le *LeaderEngine) getCurrentLeader(electionId, namespace string) (string, 
 
 	val, found := configMap.Annotations[rl.LeaderElectionRecordAnnotationKey]
 	if !found {
-		log.Infof("The configmap/%s in the namespace %s doesn't have the annotation %q: no-one is leading yet", electionId, namespace, rl.LeaderElectionRecordAnnotationKey)
+		log.Debugf("The configmap/%s in the namespace %s doesn't have the annotation %q: no one is leading yet", electionId, namespace, rl.LeaderElectionRecordAnnotationKey)
 		return "", configMap, nil
 	}
 

--- a/releasenotes/notes/leaderelection-use-configmap-30c89d2e733cd3f3.yaml
+++ b/releasenotes/notes/leaderelection-use-configmap-30c89d2e733cd3f3.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Change the kubernetes leader election system to use configmaps instead of endpoints. This
+    allows a simpler migration from Agent5, as Agent6 will not require additional permissions.

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -167,17 +167,17 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 
 	client, err := apiserver.GetCoreV1Client()
 	require.Nil(suite.T(), err)
-	epList, err := client.Endpoints(metav1.NamespaceDefault).List(metav1.ListOptions{})
+	cmList, err := client.ConfigMaps(metav1.NamespaceDefault).List(metav1.ListOptions{})
 	require.Nil(suite.T(), err)
-	require.Len(suite.T(), epList.Items, 2)
+	require.Len(suite.T(), cmList.Items, 2)
 
-	epList, err = client.Endpoints(metav1.NamespaceDefault).List(metav1.ListOptions{})
+	cmList, err = client.ConfigMaps(metav1.NamespaceDefault).List(metav1.ListOptions{})
 	require.Nil(suite.T(), err)
 
 	var leaderAnnotation string
-	for _, ep := range epList.Items {
-		if ep.Name == "datadog-leader-election" {
-			leaderAnnotation = ep.Annotations[rl.LeaderElectionRecordAnnotationKey]
+	for _, cm := range cmList.Items {
+		if cm.Name == "datadog-leader-election" {
+			leaderAnnotation = cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
 		}
 	}
 	require.Nil(suite.T(), err)

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -105,10 +105,10 @@ func (suite *apiserverSuite) waitForLeaderName(le *leaderelection.LeaderEngine) 
 		case <-tick.C:
 			leaderName = le.CurrentLeaderName()
 			if leaderName == le.HolderIdentity {
-				log.Infof("waiting for leader: Leader is %q", leaderName)
+				log.Infof("Waiting for leader: leader is %q", leaderName)
 				return
 			}
-			log.Infof("waiting for leader: Leader is %q", leaderName)
+			log.Infof("Waiting for leader: leader is %q", leaderName)
 		case <-timeout.C:
 			require.FailNow(suite.T(), "timeout after %s", t.String())
 		}

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -169,10 +169,8 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 	require.Nil(suite.T(), err)
 	cmList, err := client.ConfigMaps(metav1.NamespaceDefault).List(metav1.ListOptions{})
 	require.Nil(suite.T(), err)
-	require.Len(suite.T(), cmList.Items, 2)
-
-	cmList, err = client.ConfigMaps(metav1.NamespaceDefault).List(metav1.ListOptions{})
-	require.Nil(suite.T(), err)
+	// 1 ConfigMap or 2 Enpoints
+	require.Len(suite.T(), cmList.Items, 1)
 
 	var leaderAnnotation string
 	for _, cm := range cmList.Items {

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -105,10 +105,10 @@ func (suite *apiserverSuite) waitForLeaderName(le *leaderelection.LeaderEngine) 
 		case <-tick.C:
 			leaderName = le.CurrentLeaderName()
 			if leaderName == le.HolderIdentity {
-				log.Infof("leader is %s", leaderName)
+				log.Infof("waiting for leader: Leader is %q", leaderName)
 				return
 			}
-			log.Infof("leader is %q", leaderName)
+			log.Infof("waiting for leader: Leader is %q", leaderName)
 		case <-timeout.C:
 			require.FailNow(suite.T(), "timeout after %s", t.String())
 		}
@@ -169,17 +169,19 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 	require.Nil(suite.T(), err)
 	cmList, err := client.ConfigMaps(metav1.NamespaceDefault).List(metav1.ListOptions{})
 	require.Nil(suite.T(), err)
-	// 1 ConfigMap or 2 Enpoints
+	// 1 ConfigMap
 	require.Len(suite.T(), cmList.Items, 1)
 
 	var leaderAnnotation string
+	var found bool
 	for _, cm := range cmList.Items {
 		if cm.Name == "datadog-leader-election" {
-			leaderAnnotation = cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
+			require.False(suite.T(), found, "only one configmap match")
+			leaderAnnotation, found = cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
+			require.True(suite.T(), found)
 		}
 	}
 	require.Nil(suite.T(), err)
-	expectedMessage := fmt.Sprintf("\"holderIdentity\":\"%s\"", fmt.Sprintf("%s%d", baseIdentityName, 0))
+	expectedMessage := fmt.Sprintf(`"holderIdentity":"%s"`, testCases[0].leaderEngine.HolderIdentity)
 	assert.Contains(suite.T(), leaderAnnotation, expectedMessage)
-
 }

--- a/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
+++ b/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
@@ -20,7 +20,7 @@ services:
         --insecure-port=8080
         --service-cluster-ip-range=192.168.1.1/24
         --admission-control=NamespaceLifecycle,LimitRanger,DefaultStorageClass,ResourceQuota
-        --authorization-mode=AlwaysAllow
+        --authorization-mode=RBAC
         --etcd-servers=http://127.0.0.1:2379"
     network_mode: ${network_mode}
     depends_on:


### PR DESCRIPTION
### What does this PR do?

Moving the leader election to rely on configmaps a la Agent 5.

### Motivation

So that the helm chart's RBAC does not need to be modified.

### Testings

```
ubuntu@ci-charly:/go/src/github.com/DataDog/datadog-agent$ go test -tags "kubeapiserver docker" ./test/integration/util/leaderelection/ -v
=== RUN   TestSuiteAPIServer
[...]
=== RUN   TestSuiteAPIServer/TestLeaderElectionMulti
1519189667930732751 [Debug] HolderIdentity is "test-multi-0"
1519189667930786601 [Debug] LeaderLeaseDuration is 1m0s
1519189667938717163 [Debug] Current registered leader is ""
1519189667938793910 [Debug] Leader Engine successfully initialized
1519189667938820586 [Debug] HolderIdentity is "test-multi-1"
1519189667938922149 [Debug] LeaderLeaseDuration is 1m0s
=== RUN   TestSuiteAPIServer/TestLeaderElectionMulti/test-multi-0-0
1519189667951043647 [Debug] Current registered leader is ""
1519189667951077399 [Debug] Leader Engine successfully initialized
1519189667951740108 [Info] Starting Leader Election process for "test-multi-0" ...
1519189667957215943 [Info] Currently new leader "test-multi-0"
1519189667957261995 [Info] Leading as "test-multi-0" ...
=== RUN   TestSuiteAPIServer/TestLeaderElectionMulti/test-multi-1-1
1519189668461546629 [Info] Leader Election run, current leader is "test-multi-0"
1519189669464210462 [Info] Starting Leader Election process for "test-multi-1" ...
1519189669466600576 [Info] Currently new leader "test-multi-0"
1519189669973945940 [Info] Leader Election run, current leader is "test-multi-0"
1519189671982698726 [Info] leader is test-multi-0
--- PASS: TestSuiteAPIServer (20.23s)
    --- PASS: TestSuiteAPIServer/TestLeaderElectionMulti (4.57s)
        --- PASS: TestSuiteAPIServer/TestLeaderElectionMulti/test-multi-0-0 (0.51s)
        --- PASS: TestSuiteAPIServer/TestLeaderElectionMulti/test-multi-1-1 (1.51s)
PASS
ok  	github.com/DataDog/datadog-agent/test/integration/util/leaderelection	20.288s
```

Testing in real:
CM is created and has the correct metadata.
```
ubuntu@ci-charly:~$ kubectl describe cm datadog-leader-election
Name:         datadog-leader-election
Namespace:    default
Labels:       <none>
Annotations:  control-plane.alpha.kubernetes.io/leader={"holderIdentity":"datadog-agent-7bc6b4b775-82xhq","leaseDurationSeconds":60,"acquireTime":"2018-02-21T04:54:53Z","renewTime":"2018-02-21T04:56:53Z","leaderTra...

Data
====
Events:  <none>
```

Node1 (leader):
```
2018-02-21 04:54:53 UTC | DEBUG | (leaderelection_engine.go:68 in newElection) | Current registered leader is ""
2018-02-21 04:54:53 UTC | DEBUG | (leaderelection.go:132 in init) | Leader Engine successfully initialized
2018-02-21 04:54:53 UTC | INFO | (leaderelection.go:137 in startLeaderElection) | Starting Leader Election process for "datadog-agent-7bc6b4b775-82xhq" ...
2018-02-21 04:54:53 UTC | INFO | (leaderelection_engine.go:75 in func1) | Currently new leader "datadog-agent-7bc6b4b775-82xhq"
2018-02-21 04:54:53 UTC | INFO | (leaderelection_engine.go:78 in func2) | Leading as "datadog-agent-7bc6b4b775-82xhq" ...
2018-02-21 04:54:54 UTC | INFO | (leaderelection.go:155 in EnsureLeaderElectionRuns) | Leader Election run, current leader is "datadog-agent-7bc6b4b775-82xhq"
[...]
2018-02-21 04:59:23 UTC | INFO | (leaderelection.go:155 in EnsureLeaderElectionRuns) | Leader Election run, current leader is "datadog-agent-7bc6b4b775-82xhq"
```

Node2 (follower):
```
2018-02-21 04:59:14 UTC | INFO | (leaderelection.go:155 in EnsureLeaderElectionRuns) | Leader Election run, current leader is "datadog-agent-7bc6b4b775-82xhq"
2018-02-21 04:59:14 UTC | DEBUG | (kubernetes_apiserver.go:161 in runLeaderElection) | Leader is "datadog-agent-7bc6b4b775-82xhq". datadog-agent-1-7bc6b4b775-fcjcx will not run Kubernetes cluster related checks and collecting events
```