### PR TITLE
[windows][services] infra, apm, process agents delayed start

### DIFF
--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -96,8 +96,8 @@ func main() {
 		}
 
 		if err := ni.ShowCustom(
-			"Walk NotifyIcon Example",
-			"There are multiple ShowX methods sporting different icons."); err != nil {
+			"Datadog Agent Manager",
+			"Please right click to display available options."); err != nil {
 
 			log.Warnf("Failed to show custom message %v", err)
 		}

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -148,6 +148,7 @@
                           Vital="yes"
                           Interactive="no"
                           Account="LocalSystem">
+            <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
             <util:ServiceConfig
               FirstFailureActionType='restart'
               SecondFailureActionType='restart'
@@ -192,6 +193,7 @@
                             Interactive="no"
                             Account="LocalSystem"
                             Arguments="--config=c:\programdata\datadog\datadog.yaml" >
+              <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
               <util:ServiceConfig
                 FirstFailureActionType='restart'
                 SecondFailureActionType='restart'
@@ -231,6 +233,7 @@
                             Vital="yes"
                             Interactive="no"
                             Account="LocalSystem">
+              <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
               <util:ServiceConfig
                 FirstFailureActionType='restart'
                 SecondFailureActionType='restart'


### PR DESCRIPTION
### What does this PR do?

Sets the services for all three agents as `Automatic (delayed start)` services to mitigate known go windows issues with 1.9.2: https://github.com/golang/go/issues/23479

Services now will come up, but only after all other services start. This extends the window after restarts when we are not collecting metrics.

### Motivation

Services would not restart across reboots on `Automatic` services, they would timeout before coming up and the service control manager would give up spawning them.

### Additional Notes

It would be nice to get @derekwbrown input regarding reverting this behavior on subsequent releases - it looks trivial, harmless to do so, but it would be nice to get his opinion.
