### PR TITLE
Send win32 instead of windows as the platform name

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -108,7 +108,7 @@ func getSystemStats() *systemStats {
 
 		stats = &systemStats{
 			Machine:   runtime.GOARCH,
-			Platform:  runtime.GOOS,
+			Platform:  osName,
 			Processor: cpuInfo.ModelName,
 			CPUCores:  cpuInfo.Cores,
 			Pythonv:   strings.Split(getPythonVersion(), " ")[0],

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -33,12 +33,6 @@ const packageCachePrefix = "host"
 func GetPayload(hostname string) *Payload {
 	meta := getMeta()
 	meta.Hostname = hostname
-	osName := runtime.GOOS
-
-	//We expect this to be win32 on the backend
-	if osName == "windows" {
-		osName = "win32"
-	}
 
 	p := &Payload{
 		Os:            osName,

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -33,9 +33,15 @@ const packageCachePrefix = "host"
 func GetPayload(hostname string) *Payload {
 	meta := getMeta()
 	meta.Hostname = hostname
+	osName := runtime.GOOS
+
+	//We expect this to be win32 on the backend
+	if osName == "windows" {
+		osName = "win32"
+	}
 
 	p := &Payload{
-		Os:            runtime.GOOS,
+		Os:            osName,
 		PythonVersion: getPythonVersion(),
 		SystemStats:   getSystemStats(),
 		Meta:          meta,

--- a/pkg/metadata/host/host_darwin.go
+++ b/pkg/metadata/host/host_darwin.go
@@ -13,6 +13,8 @@ import (
 
 type osVersion [3]interface{}
 
+const osName = runtime.GOOS
+
 func fillOsVersion(stats *systemStats, info *host.InfoStat) {
 	stats.Macver = osVersion{info.PlatformVersion, [3]string{"", "", ""}, runtime.GOARCH}
 }

--- a/pkg/metadata/host/host_nix.go
+++ b/pkg/metadata/host/host_nix.go
@@ -7,9 +7,14 @@
 
 package host
 
-import "github.com/shirou/gopsutil/host"
+import (
+	"github.com/shirou/gopsutil/host"
+	"runtime"
+)
 
 type osVersion [3]string
+
+const osName = runtime.GOOS
 
 func fillOsVersion(stats *systemStats, info *host.InfoStat) {
 	stats.Nixver = osVersion{info.PlatformFamily, info.PlatformVersion, ""}

--- a/pkg/metadata/host/host_nix.go
+++ b/pkg/metadata/host/host_nix.go
@@ -8,8 +8,9 @@
 package host
 
 import (
-	"github.com/shirou/gopsutil/host"
 	"runtime"
+
+	"github.com/shirou/gopsutil/host"
 )
 
 type osVersion [3]string

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -9,6 +9,7 @@ import "github.com/shirou/gopsutil/host"
 
 type osVersion [2]string
 
+//Set the OS to "win32" instead of the runtime.GOOS of "windows" for the in app icon
 const osName = "win32"
 
 func fillOsVersion(stats *systemStats, info *host.InfoStat) {

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -9,6 +9,8 @@ import "github.com/shirou/gopsutil/host"
 
 type osVersion [2]string
 
+const osName = "win32"
+
 func fillOsVersion(stats *systemStats, info *host.InfoStat) {
 	// TODO
 	stats.Winver = osVersion{info.PlatformFamily, info.PlatformVersion}

--- a/releasenotes/notes/add_windows_icon-e868f85c18ea4070.yaml
+++ b/releasenotes/notes/add_windows_icon-e868f85c18ea4070.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Add the windows icon to the Infrastructure List for Agents installed on Windows machines. 


### PR DESCRIPTION
### What does this PR do?

Updates the platform name we send as the metadata payload for windows machines from `windows` to `win32`

### Motivation

We get more UI flavor when we use specific platform names as the metadata. 

### Additional Notes

Tested by running clean MSI on a windows instance. 
