### PR TITLE
add rbac rules for kubelet access (AD/tagger/check)

### DIFF
--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -33,3 +33,12 @@ rules:
   - get
   - update
   - create
+# Kubelet connectivity
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  - nodes/spec
+  - nodes/proxy
+  verbs:
+  - get


### PR DESCRIPTION
Needed in OpenShift, where the kubelet is blocked by default

See https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/server/auth.go