### PR TITLE
Set correct trace agent default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -192,8 +192,9 @@ func init() {
 
 	// Go_expvar server port
 	Datadog.SetDefault("expvar_port", "5000")
-	// Process Agent
-	BindEnvAndSetDefault("process_agent_enabled", true) // this is to support the transition to the new config file
+
+	// Trace agent
+	Datadog.SetDefault("apm_config.enabled", true)
 
 	// Logs Agent
 	BindEnvAndSetDefault("logs_enabled", false)

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -31,9 +31,12 @@ func FromAgentConfig(agentConfig Config) error {
 	config.Datadog.Set("api_key", agentConfig["api_key"])
 	config.Datadog.Set("hostname", agentConfig["hostname"])
 
-	if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); err == nil && !enabled {
-		// process agent is enabled in datadog.yaml
-		config.Datadog.Set("process_agent_enabled", false)
+	if enabled, err := isAffirmative(agentConfig["process_agent_enabled"]); enabled {
+		// process agent is explicitly enabled
+		config.Datadog.Set("process_config.enabled", "true")
+	} else if err == nil && !enabled {
+		// process agent is explicitly disabled
+		config.Datadog.Set("process_config.enabled", "disabled")
 	}
 
 	config.Datadog.Set("tags", strings.Split(agentConfig["tags"], ","))

--- a/releasenotes/notes/enable-apm-by-default-048e461de3228b14.yaml
+++ b/releasenotes/notes/enable-apm-by-default-048e461de3228b14.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Sets correct default value for apm config to enabled, so that the trace agent is
+    started by default
+    Removes deprecated process_agent_enabled flag


### PR DESCRIPTION
Set default value for APM to be enabled.  Causes apm to properly start
on agent start (and writes config to datadog.yaml on config change)

