### PR TITLE
[gui] metrics.yaml is not a configurable file - do not show

### DIFF
--- a/cmd/agent/gui/views/private/js/javascript.js
+++ b/cmd/agent/gui/views/private/js/javascript.js
@@ -298,8 +298,9 @@ function loadCheckConfigFiles() {
     data.sort();
     data.forEach(function(item){
       // filter out the example / disabled files
-      if (item.substr(item.length - 8) == ".example" || 
-          item.substr(item.length - 9) == ".disabled" ) return;
+      if (item.endsWith(".example") ||
+          item.endsWith(".disabled") ||
+          item.endsWith("metrics.yaml")) return;
 
       $(".list").append('<a href="javascript:void(0)" onclick="showCheckConfig(\''
                         + item  + '\')" class="check">' +  item + '</a>');
@@ -327,8 +328,9 @@ function loadNewChecks() {
     if (typeof(data) == "string") return;
     data.sort();
     data.forEach(function(fileName){
-      if (fileName.substr(fileName.length - 8) == ".example" || 
-          fileName.substr(fileName.length - 9) == ".disabled") return;
+      if (fileName.endsWith(".example") ||
+          fileName.endsWith(".disabled") ||
+          fileName.endsWith("metrics.yaml")) return;
       var checkName = fileName.substr(0, fileName.indexOf("."));
       enabledChecks.push(checkName);
     });

--- a/releasenotes/notes/gui-metrics-yaml-fix-15797b896b32fe13.yaml
+++ b/releasenotes/notes/gui-metrics-yaml-fix-15797b896b32fe13.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    metrics.yaml is not a "configurable" file - it provides default metrics for
+    checks and shouldn't be altered. Removed from the GUI configuration file 
+    list.


### PR DESCRIPTION
### What does this PR do?

`metrics.yaml` is not a _"configurable"_ file - it provides default metrics for checks and shouldn't be altered. Remove from the GUI configuration file list.

If we decide to reintroduce it, we'll have to change the way the UI approaches checks.

### Motivation

`metrics.yaml` was showing up as files for "configured" checks even though these were disabled.
