### PR TITLE
[docker] override s6-overlay stage3 script avoiding s6 nuke

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -80,6 +80,9 @@ COPY s6-services /etc/services.d/
 COPY entrypoint /etc/cont-init.d/
 COPY probe.sh initlog.sh /
 
+# Override the exit script by ours to fix --pid=host operations
+COPY init-stage3 /etc/s6/init/init-stage3
+
 # Prepare for running without root
 RUN adduser --group dd-agent \
  && adduser --system --no-create-home --disabled-password --ingroup dd-agent dd-agent \

--- a/Dockerfiles/agent/init-stage3
+++ b/Dockerfiles/agent/init-stage3
@@ -1,0 +1,14 @@
+#!/bin/execlineb -S0
+
+# This is the shutdown script, running as process 1.
+cd /
+
+# Merge environments from our custom stage into current context
+s6-envdir -I /var/run/s6/env-stage3
+
+# Reap all the zombies, and we're done.
+wait { }
+
+# Use CMD exit code defaulting to zero if not present.
+importas -u -D0 S6_STAGE2_EXITED S6_STAGE2_EXITED
+exit ${S6_STAGE2_EXITED}

--- a/Dockerfiles/agent/s6-services/agent/finish
+++ b/Dockerfiles/agent/s6-services/agent/finish
@@ -3,4 +3,6 @@
 # Kill the container if the main agent were to exit
 
 foreground { /initlog.sh "AGENT EXITED WITH CODE ${1}, SIGNAL ${2}, KILLING CONTAINER" }
-s6-svscanctl -t /var/run/s6/services
+
+# If the container is stopped via docker, s6 is already closing, silencing the error
+redirfd -w 2 /dev/null s6-svscanctl -t /var/run/s6/services

--- a/releasenotes/notes/dockerfile-pid-host-47ddbf2cdfa6e02e.yaml
+++ b/releasenotes/notes/dockerfile-pid-host-47ddbf2cdfa6e02e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix Docker container `--pid=host` operations. Previous RCs can cause host system
+    instabilities and should not be run in pid host mode.


### PR DESCRIPTION
### What does this PR do?

Upstream's (s6-overlay) stage3 script was executed on container stop. This script invokes `s6-nuke`, that sends SIGKILL to every process in the PID namespace except PID1: https://github.com/just-containers/s6-overlay/blob/master/builder/overlay-rootfs/etc/s6/init/init-stage3#L45-L65

This is not necessary when running in a container (as if there were leftover processes, it's docker's job to kill them and reparent zombies to PID1 for reaping), and can cause host system failures if running with `--pid=host`.

This PR replaces this stage3 with a custom script only doing logging + process reaping.
