### PR TITLE
add support for %%env_%% AD template tag

### DIFF
--- a/pkg/collector/autodiscovery/common_test.go
+++ b/pkg/collector/autodiscovery/common_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package autodiscovery
+
+import "github.com/DataDog/datadog-agent/pkg/collector/listeners"
+
+type dummyService struct {
+	ID            listeners.ID
+	ADIdentifiers []string
+	Hosts         map[string]string
+	Ports         []int
+	Pid           int
+}
+
+// GetID returns the service ID
+func (s *dummyService) GetID() listeners.ID {
+	return s.ID
+}
+
+// GetADIdentifiers returns dummy identifiers
+func (s *dummyService) GetADIdentifiers() ([]string, error) {
+	return s.ADIdentifiers, nil
+}
+
+// GetHosts returns dummy hosts
+func (s *dummyService) GetHosts() (map[string]string, error) {
+	return s.Hosts, nil
+}
+
+// GetPorts returns dummy ports
+func (s *dummyService) GetPorts() ([]int, error) {
+	return s.Ports, nil
+}
+
+// GetTags returns mil
+func (s *dummyService) GetTags() ([]string, error) {
+	return nil, nil
+}
+
+// GetPid return a dummy pid
+func (s *dummyService) GetPid() (int, error) {
+	return s.Pid, nil
+}

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 	"unicode"
@@ -28,6 +29,7 @@ var (
 		"host": getHost,
 		"pid":  getPid,
 		"port": getPort,
+		"env":  getEnvvar,
 	}
 )
 
@@ -345,6 +347,18 @@ func getPid(tplVar []byte, svc listeners.Service) ([]byte, error) {
 		return nil, fmt.Errorf("Failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
 	}
 	return []byte(strconv.Itoa(pid)), nil
+}
+
+// getEnvvar returns a system environment variable if found
+func getEnvvar(tplVar []byte, svc listeners.Service) ([]byte, error) {
+	if len(tplVar) == 0 {
+		return nil, fmt.Errorf("envvar name is missing, skipping service %s", svc.GetID())
+	}
+	value, found := os.LookupEnv(string(tplVar))
+	if !found {
+		return nil, fmt.Errorf("failed to retrieve envvar %s, skipping service %s", tplVar, svc.GetID())
+	}
+	return []byte(value), nil
 }
 
 // parseTemplateVar extracts the name of the var

--- a/pkg/collector/autodiscovery/stats_test.go
+++ b/pkg/collector/autodiscovery/stats_test.go
@@ -1,10 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package autodiscovery
 
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
 func TestNewAcErrorStats(t *testing.T) {

--- a/pkg/collector/listeners/README.md
+++ b/pkg/collector/listeners/README.md
@@ -33,8 +33,8 @@ The `KubeletListener` relies on the Kubelet API. We're listening on changes on t
 
 ### Template variable support
 
-| Listener | AD identifiers | Host | Port | Tag | Pid |
+| Listener | AD identifiers | Host | Port | Tag | Pid | Env
 |---|---|---|---|---|---|
-| Docker | ✅ | ✅ | ✅ | ✅ | ✅ |
-| ECS | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Kubelet | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Docker | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| ECS | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Kubelet | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |

--- a/releasenotes/notes/ad_envvar_tag-eae282a10d79b3ae.yaml
+++ b/releasenotes/notes/ad_envvar_tag-eae282a10d79b3ae.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add %%env_XXXX%% tag support for Autodiscovery templates. This allows to
+    substitute environment variables into check templates at runtime.
+    **Note:** the environment variables are extracted from the agent's context,
+    not from the monitored container's envvars.


### PR DESCRIPTION
### What does this PR do?

As discussed in https://github.com/DataDog/datadog-agent/issues/1250, add a new tag in AD templates, to inject environment variables during template resolution.

This allows to inject kubernetes downwards API information, or credentials, in templates.

For example, if I want to monitor a pod running on host networking, and already injected my node's IP in the `$KUBERNETES_KUBELET_HOST` envvar, I can use the following template:

```yaml
ad_identifiers:
  - redis

init_config:

instances:
  - host: "%%env_KUBERNETES_KUBELET_HOST%%"
    port: "1234"
```
