### PR TITLE
[windows] pass process-agent svc config file argument

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -242,7 +242,8 @@
                             Type="ownProcess"
                             Vital="yes"
                             Interactive="no"
-                            Account="LocalSystem">
+                            Account="LocalSystem"
+                            Arguments="--config=c:\programdata\datadog\datadog.yaml" >
               <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
               <util:ServiceConfig
                 FirstFailureActionType='restart'

--- a/releasenotes/notes/procees-svc-definition-fix-6ec12ffa86477ff2.yaml
+++ b/releasenotes/notes/procees-svc-definition-fix-6ec12ffa86477ff2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Process agent service should pass the configuration file argument to the
+    executable when launching - otherwise service will always come up on 
+    reboots.


### PR DESCRIPTION
### What does this PR do?

Process agent was always coming up on boot-up - it appears as if we're not passing the right arguments to the executable.

### Motivation

Found issue testing.

### Additional Notes

Anything else we should know when reviewing?
