### PR TITLE
[config] support nested config option defined with env vars

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,8 @@ func init() {
 	Datadog.SetEnvPrefix("DD")
 	Datadog.SetTypeByDefaultValue(true)
 
+	Datadog.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
 	// Configuration defaults
 	// Agent
 	Datadog.SetDefault("dd_url", "https://app.datadoghq.com")
@@ -198,13 +200,13 @@ func init() {
 	BindEnvAndSetDefault("logset", "")
 
 	Datadog.SetDefault("logs_config.dd_url", "intake.logs.datadoghq.com")
-	Datadog.BindEnv("logs_config.dd_url", "DD_LOGS_CONFIG_DD_URL")
+	Datadog.BindEnv("logs_config.dd_url")
 
 	Datadog.SetDefault("logs_config.dd_port", 10516)
-	Datadog.BindEnv("logs_config.dd_port", "DD_LOGS_CONFIG_DD_PORT")
+	Datadog.BindEnv("logs_config.dd_port")
 
 	Datadog.SetDefault("logs_config.dev_mode_use_proto", false)
-	Datadog.BindEnv("logs_config.dev_mode_use_proto", "DD_LOGS_CONFIG_DEV_MODE_USE_PROTO")
+	Datadog.BindEnv("logs_config.dev_mode_use_proto")
 
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,9 @@ func init() {
 	Datadog.SetEnvPrefix("DD")
 	Datadog.SetTypeByDefaultValue(true)
 
+	// Replace '.' from config keys by '_' in env variables bindings.
+	// e.g. : BindEnv("foo.bar") will bind config key
+	// "foo.bar" to env variable "FOO_BAR"
 	Datadog.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	// Configuration defaults
@@ -199,15 +202,9 @@ func init() {
 	BindEnvAndSetDefault("log_enabled", false) // deprecated, use logs_enabled instead
 	BindEnvAndSetDefault("logset", "")
 
-	Datadog.SetDefault("logs_config.dd_url", "intake.logs.datadoghq.com")
-	Datadog.BindEnv("logs_config.dd_url")
-
-	Datadog.SetDefault("logs_config.dd_port", 10516)
-	Datadog.BindEnv("logs_config.dd_port")
-
-	Datadog.SetDefault("logs_config.dev_mode_use_proto", false)
-	Datadog.BindEnv("logs_config.dev_mode_use_proto")
-
+	BindEnvAndSetDefault("logs_config.dd_url", "intake.logs.datadoghq.com")
+	BindEnvAndSetDefault("logs_config.dd_port", 10516)
+	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", false)
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,7 @@ func init() {
 	Datadog.SetEnvPrefix("DD")
 	Datadog.SetTypeByDefaultValue(true)
 
-	// Replace '.' from config keys by '_' in env variables bindings.
+	// Replace '.' from config keys with '_' in env variables bindings.
 	// e.g. : BindEnv("foo.bar") will bind config key
 	// "foo.bar" to env variable "FOO_BAR"
 	Datadog.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -157,4 +158,12 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	newURL, err = addAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://app.myproxy.com", newURL)
+}
+
+func TestEnvNestedConfig(t *testing.T) {
+	Datadog.BindEnv("foo.bar.nested")
+	os.Setenv("DD_FOO_BAR_NESTED", "baz")
+
+	assert.Equal(t, "baz", Datadog.GetString("foo.bar.nested"))
+	os.Unsetenv("DD_FOO_BAR_NESTED")
 }

--- a/releasenotes/notes/normalize-nested-configs-1d65ffdfe2215ce1.yaml
+++ b/releasenotes/notes/normalize-nested-configs-1d65ffdfe2215ce1.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Normalize support of nested config options defined with env vars.


### PR DESCRIPTION
### What does this PR do?

Normalize support of nested config options defined with env vars.

`BindEnv("foo.bar")` will now directly bind env var `DD_FOO_BAR` to config key `foo.bar`.

### Additional Notes

Might cause issues in some cases : 
```go
BindEnv("api_key")
BindEnv("api.key")
```
Also, it probably fixed setting some config options with env vars : `logs_config.run_path`, `logs_config.open_files_limit`, ...
