### PR TITLE
[windows] GUI should launch, but systray instance should also be set

### DIFF
--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -64,7 +64,6 @@ func main() {
 		defer log.Flush()
 		log.Debug("Preparing to launch configuration interface...")
 		onConfigure()
-		return
 	}
 	// check to see if the process is already running.  If so, just exit
 	h, _ := windows.OpenEvent(0x1F0003, // EVENT_ALL_ACCESS


### PR DESCRIPTION
### What does this PR do?

When the Start Menu icon is clicked launch the web GUI, and if not already launched, launch the systray icon. If the systray icon is already launched, then the GUI is launched but no more instances will be created on the systray.

### Motivation

Found issue while testing.
