### PR TITLE
New errors package

### DIFF
--- a/pkg/collector/py/tagger_test.go
+++ b/pkg/collector/py/tagger_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
@@ -26,7 +27,7 @@ func (c *DummyCollector) Detect(out chan<- []*collectors.TagInfo) (collectors.Co
 }
 func (c *DummyCollector) Fetch(entity string) ([]string, []string, error) {
 	if entity == "404" {
-		return nil, nil, collectors.ErrNotFound
+		return nil, nil, errors.NewNotFound(entity)
 	} else {
 		return []string{entity + ":low"}, []string{entity + ":high", "other_tag:high"}, nil
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package errors
+
+import "fmt"
+
+type errorReason int
+
+const (
+	notFoundError errorReason = iota
+	unknownError
+)
+
+// AgentError is an error intended for consumption by a datadog pkg; it can also be
+// reconstructed by clients from a error response. Public to allow easy type switches.
+type AgentError struct {
+	error
+	message     string
+	errorReason errorReason
+}
+
+// Error satisfies the error interface
+func (e AgentError) Error() string {
+	return e.message
+}
+
+// NewNotFound returns a new error which indicates that the object passed in parameter was not found.
+func NewNotFound(notFoundObject string) *AgentError {
+	return &AgentError{
+		message:     fmt.Sprintf("%q not found", notFoundObject),
+		errorReason: notFoundError,
+	}
+}
+
+// IsNotFound returns true if the specified error was created by NewNotFound.
+func IsNotFound(err error) bool {
+	return reasonForError(err) == notFoundError
+}
+
+func reasonForError(err error) errorReason {
+	switch t := err.(type) {
+	case *AgentError:
+		return t.errorReason
+	}
+	return unknownError
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -14,22 +14,21 @@ const (
 	unknownError
 )
 
-// AgentError is an error intended for consumption by a datadog pkg; it can also be
-// reconstructed by clients from a error response. Public to allow easy type switches.
-type AgentError struct {
+// agentError is an error intended for consumption by a datadog pkg
+type agentError struct {
 	error
 	message     string
 	errorReason errorReason
 }
 
 // Error satisfies the error interface
-func (e AgentError) Error() string {
+func (e agentError) Error() string {
 	return e.message
 }
 
 // NewNotFound returns a new error which indicates that the object passed in parameter was not found.
-func NewNotFound(notFoundObject string) *AgentError {
-	return &AgentError{
+func NewNotFound(notFoundObject string) *agentError {
+	return &agentError{
 		message:     fmt.Sprintf("%q not found", notFoundObject),
 		errorReason: notFoundError,
 	}
@@ -42,7 +41,7 @@ func IsNotFound(err error) bool {
 
 func reasonForError(err error) errorReason {
 	switch t := err.(type) {
-	case *AgentError:
+	case *agentError:
 		return t.errorReason
 	}
 	return unknownError

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -14,21 +14,22 @@ const (
 	unknownError
 )
 
-// agentError is an error intended for consumption by a datadog pkg
-type agentError struct {
+// AgentError is an error intended for consumption by a datadog pkg; it can also be
+// reconstructed by clients from a error response. Public to allow easy type switches.
+type AgentError struct {
 	error
 	message     string
 	errorReason errorReason
 }
 
 // Error satisfies the error interface
-func (e agentError) Error() string {
+func (e AgentError) Error() string {
 	return e.message
 }
 
 // NewNotFound returns a new error which indicates that the object passed in parameter was not found.
-func NewNotFound(notFoundObject string) *agentError {
-	return &agentError{
+func NewNotFound(notFoundObject string) *AgentError {
+	return &AgentError{
 		message:     fmt.Sprintf("%q not found", notFoundObject),
 		errorReason: notFoundError,
 	}
@@ -41,7 +42,7 @@ func IsNotFound(err error) bool {
 
 func reasonForError(err error) errorReason {
 	switch t := err.(type) {
-	case *agentError:
+	case *AgentError:
 		return t.errorReason
 	}
 	return unknownError

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,7 +15,7 @@ const (
 )
 
 // AgentError is an error intended for consumption by a datadog pkg; it can also be
-// reconstructed by clients from a error response. Public to allow easy type switches.
+// reconstructed by clients from an error response. Public to allow easy type switches.
 type AgentError struct {
 	error
 	message     string

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotFound(t *testing.T) {
+	// New
+	err := NewNotFound("foo")
+	require.Error(t, err)
+	require.Equal(t, `"foo" not found`, err.Error())
+
+	// Is
+	require.True(t, IsNotFound(err))
+	require.False(t, IsNotFound(fmt.Errorf("fake")))
+	require.False(t, IsNotFound(fmt.Errorf(`"foo" not found`)))
+}

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
@@ -138,5 +139,5 @@ func (c *ECSFargateCollector) fetchMetadata(meta ecs.TaskMetadata, container str
 		}
 		return info.LowCardTags, info.HighCardTags, nil
 	}
-	return nil, nil, ErrNotFound
+	return nil, nil, errors.NewNotFound(fmt.Sprintf("%s/%s", meta.TaskARN, container))
 }

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
@@ -74,7 +75,7 @@ func (c *ECSCollector) Fetch(container string) ([]string, []string, error) {
 		}
 	}
 	// container not found in updates
-	return []string{}, []string{}, ErrNotFound
+	return []string{}, []string{}, errors.NewNotFound(container)
 }
 
 func ecsFactory() Collector {

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -102,7 +103,7 @@ func (c *KubeletCollector) Fetch(entity string) ([]string, []string, error) {
 		}
 	}
 	// entity not found in updates
-	return []string{}, []string{}, ErrNotFound
+	return []string{}, []string{}, errors.NewNotFound(entity)
 }
 
 // parseExpires transforms event from the PodWatcher to TagInfo objects

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
@@ -91,7 +92,7 @@ func (c *KubeServiceCollector) Fetch(entity string) ([]string, []string, error) 
 	}
 
 	if kubelet.IsPodReady(pod) == false {
-		return lowCards, highCards, ErrNotFound
+		return lowCards, highCards, errors.NewNotFound(entity)
 	}
 
 	pods := []*kubelet.Pod{pod}
@@ -104,7 +105,7 @@ func (c *KubeServiceCollector) Fetch(entity string) ([]string, []string, error) 
 			return info.LowCardTags, info.HighCardTags, nil
 		}
 	}
-	return lowCards, highCards, ErrNotFound
+	return lowCards, highCards, errors.NewNotFound(entity)
 }
 
 func kubernetesFactory() Collector {

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -5,8 +5,6 @@
 
 package collectors
 
-import "errors"
-
 // TagInfo holds the tag information for a given entity and source. It's meant
 // to be created from collectors and read by the store.
 type TagInfo struct {
@@ -19,14 +17,6 @@ type TagInfo struct {
 
 // CollectionMode informs the Tagger of how to schedule a Collector
 type CollectionMode int
-
-// ErrNotFound is returned by Fetch if no collection error occurred but
-// the entity is not found in the source
-var ErrNotFound = errors.New("entity not found")
-
-// ErrOutdated is returned when an entity is found but
-// it's value is outdated compared to the one locally saved
-var ErrOutdated = errors.New("entity is outdated")
 
 // Return values for Collector.Init to inform the Tagger of the scheduling needed
 const (

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -186,8 +186,8 @@ func (ku *KubeUtil) GetPodForContainerID(containerID string) (*Pod, error) {
 		return nil, err
 	}
 	pod, err := ku.searchPodForContainerID(pods, containerID)
-	if err != nil {
-		log.Debugf("cannot get the containerID %q: %s, retrying without cache...", containerID, err)
+	if err != nil && errors.IsNotFound(err) {
+		log.Debugf("Cannot get the containerID %q: %s, retrying without cache...", containerID, err)
 		pods, err = ku.ForceGetLocalPodList()
 		if err != nil {
 			return nil, err
@@ -197,7 +197,7 @@ func (ku *KubeUtil) GetPodForContainerID(containerID string) (*Pod, error) {
 			return nil, err
 		}
 	}
-	return pod, nil
+	return pod, err
 }
 
 func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) (*Pod, error) {

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 )
 
 const (
@@ -373,7 +374,7 @@ func (suite *KubeletTestSuite) TestGetPodForContainerID() {
 	// The /pods request is still cached
 	require.Nil(suite.T(), pod)
 	require.NotNil(suite.T(), err)
-	require.Contains(suite.T(), err.Error(), "container invalid not found in podList")
+	require.True(suite.T(), errors.IsNotFound(err))
 
 	// Valid container ID
 	pod, err = kubeutil.GetPodForContainerID("docker://b3e4cd65204e04d1a2d4b7683cae2f59b2075700f033a6b09890bd0d3fecf6b6")


### PR DESCRIPTION
### What does this PR do?

Introduce a new package: `github.com/DataDog/datadog-agent/pkg/errors`

This package is deeply inspired from [kubernetes](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go) and very conveniant to use ([example in the agent](https://github.com/DataDog/datadog-agent/blob/86281592735ffa53f3101400ba15460f2e8b82a0/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go#L123)).

The usage of this can be compared with `os.IsNotExist`.

Today it will solve two issues we have:

* Stop logging when an entity is not found in the tagger (Kubernetes static pods issue)
* Do not force a cache miss when the error is different than **IsNotFound**.

But, I only have a single error to introduce, so this solution can be too heavy.

### Another option
The alternative can be a new global variable in the `pkg/util/kubernetes/kubelet/kubelet.go` like:
```go
var ErrNotFound = errors.New("not found text")
```
And then return it in place of ```errors.NewNotFound("not found text with context")``` + handle it in the associated collector. 

### Motivation

Today it's too verbose for various reasons.

The main issue is in the Kubernetes kubelet code with non updated Static Pods:
```
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:49 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://7c3d6b021ee8ae048a557595becf33e74fde5095ba31ed3f22b8ad317f3c32f2 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kubelet: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
[ AGENT ] 2018-02-23 15:30:50 UTC | WARN | (tagger.go:246 in Tag) | error collecting from kube-service-collector: container docker://10f1442e162659d1143b4ac333d9d77e0e07adf1d008b401c3d2e5f7e66558a9 not found in podList
```
