### PR TITLE
Fix doGetHostname() to initialize the configuration from the conf file.

### DIFF
--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -30,7 +30,7 @@ func doGetHostname(cmd *cobra.Command, args []string) error {
 	config.SetupLogger("off", "", "", false, false, "", true, false)
 	err := common.SetupConfig(confFilePath)
 	if err != nil {
-		return fmt.Errorf("Error setting up the cnofig: %v", err)
+		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
 	hname, err := util.GetHostname()
 	if err != nil {

--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -8,6 +8,7 @@ package app
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/spf13/cobra"
@@ -27,6 +28,10 @@ var getHostnameCommand = &cobra.Command{
 // query for the version
 func doGetHostname(cmd *cobra.Command, args []string) error {
 	config.SetupLogger("off", "", "", false, false, "", true, false)
+	err := common.SetupConfig(confFilePath)
+	if err != nil {
+		return fmt.Errorf("Error setting up the cnofig: %v", err)
+	}
 	hname, err := util.GetHostname()
 	if err != nil {
 		return fmt.Errorf("Error getting the hostname: %v", err)

--- a/releasenotes/notes/fix-agent-hostname-f6d8b802fdc9e9f1.yaml
+++ b/releasenotes/notes/fix-agent-hostname-f6d8b802fdc9e9f1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes bug in agent hostname command, whereby the configuration library
+    wasn't initialized.  This caused `agent hostname` to use the default
+    computed hostname, rather than the entry in the configuration file


### PR DESCRIPTION
Otherwise, calls to `agent hostname` will ignore the `hostname` entry in
the config file, and return whatever defaults it can find.


### Motivation

Breaks process agent

