### PR TITLE
[gitlab] Disable build cache of `package_build` jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,11 +164,12 @@ agent_deb-x64:
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-agent*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent*_amd64.deb $S3_ARTEFACTS_URI/datadog-agent_amd64.deb
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -192,11 +193,12 @@ agent_rpm-x64:
     - set -x
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
     - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -223,11 +225,12 @@ agent_suse-x64:
     # FIXME: skip the installation step until we fix the preinst/postinst scripts in the rpm package
     # to also work with SUSE11
     # - rpm -i $OMNIBUS_PACKAGE_DIR_SUSE/*.rpm
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR_SUSE
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR_SUSE
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -268,11 +271,12 @@ cluster-agent_deb-x64:
     - inv -e cluster-agent.omnibus-build --base-dir $OMNIBUS_BASE_DIR
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-cluster-agent*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-cluster-agent*_amd64.deb $S3_ARTEFACTS_URI/datadog-cluster-agent_amd64.deb
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -296,11 +300,12 @@ cluster-agent_rpm-x64:
     - set -x
     - inv -e cluster-agent.omnibus-build --base-dir $OMNIBUS_BASE_DIR
     - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -320,11 +325,12 @@ dogstatsd_deb-x64:
     - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb $S3_ARTEFACTS_URI/datadog-dogstatsd_amd64.deb
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -348,11 +354,12 @@ dogstatsd_rpm-x64:
     - set -x
     - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR
     - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -378,11 +385,12 @@ dogstatsd_suse-x64:
     - set -x
     - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR_SUSE
     - rpm -i $OMNIBUS_PACKAGE_DIR_SUSE/*.rpm
-  cache:
-    # cache per branch
-    key: $CI_COMMIT_REF_NAME
-    paths:
-      - $OMNIBUS_BASE_DIR_SUSE
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR_SUSE
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
### What does this PR do?

Disables build cache of `package_build` jobs. Should fix these jobs on master.

### Motivation

Builds on master were getting slower and slower on master, seems to be
related to the cache. Let's disable it for now since (the cache wasn't
working at all until ~10 days ago anyway).
