### PR TITLE
[forwarder] properly validate api keys

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -278,6 +278,7 @@ func (f *DefaultForwarder) healthCheckLoop() {
 	waitTick := time.Tick(time.Minute * 5)
 	validKey := false
 
+	// Try one time to validate without waiting then try every 5 minutes.
 	for c := waitTick; ; <-c {
 		f.validateAPIKeys()
 		apiKeyStatus.Do(func(entry expvar.KeyValue) {

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -281,7 +281,7 @@ func (f *DefaultForwarder) hasValidAPIKey() (bool, error) {
 
 	for domain, apiKeys := range f.KeysPerDomains {
 		for _, apiKey := range apiKeys {
-			v, err := f.ValidateAPIKey(apiKey, domain)
+			v, err := f.validateAPIKey(apiKey, domain)
 			if err != nil {
 				log.Debug(err)
 				apiError = true
@@ -383,7 +383,7 @@ func (f *DefaultForwarder) setAPIKeyStatus(apiKey string, domain string, status 
 	apiKeyStatus.Set(obfuscatedKey, status)
 }
 
-func (f *DefaultForwarder) ValidateAPIKey(apiKey, domain string) (bool, error) {
+func (f *DefaultForwarder) validateAPIKey(apiKey, domain string) (bool, error) {
 	url := fmt.Sprintf("%s%s?api_key=%s", config.Datadog.GetString("dd_url"), v1ValidateEndpoint, apiKey)
 
 	resp, err := http.Get(url)

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -275,10 +275,10 @@ func (f *DefaultForwarder) Stop() {
 func (f *DefaultForwarder) healthCheckLoop() {
 	log.Debug("Waiting for APIkey validity to be confirmed.")
 	// Wait until we confirmed we have one valid APIkey to become healthy
-	waitTicker := time.Tick(time.Minute * 5)
+	waitTick := time.Tick(time.Minute * 5)
 	validKey := false
 
-	for c := waitTicker; ; <-c {
+	for c := waitTick; ; <-c {
 		f.validateAPIKeys()
 		apiKeyStatus.Do(func(entry expvar.KeyValue) {
 			if entry.Value == &apiKeyValid {
@@ -363,6 +363,7 @@ func (f *DefaultForwarder) validateAPIKeys() error {
 
 			resp, err := http.Get(url)
 			if err != nil {
+				f.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
 				return err
 			}
 			defer resp.Body.Close()

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -300,9 +300,11 @@ func (f *DefaultForwarder) healthCheckLoop() {
 	validateTicker := time.NewTicker(time.Hour * 1)
 	defer validateTicker.Stop()
 
-	// If no key is valid, no need to keep checking, they won't magicaly become valid
 	valid, err := f.hasValidAPIKey()
+	// If there is an error during the api call, we assume that there is a valid
+	// key to avoid killing lots of agent on an outage.
 	if err == nil && !valid {
+		// If no key is valid, no need to keep checking, they won't magicaly become valid
 		log.Errorf("No valid api key found, reporting the forwarder as unhealthy.")
 		return
 	}

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -297,7 +297,7 @@ func (f *DefaultForwarder) hasValidAPIKey() (bool, error) {
 func (f *DefaultForwarder) healthCheckLoop() {
 	log.Debug("Waiting for APIkey validity to be confirmed.")
 
-	validateTicker := time.NewTicker(time.Minute * 10)
+	validateTicker := time.NewTicker(time.Hour * 1)
 	defer validateTicker.Stop()
 
 	// If no key is valid, no need to keep checking, they won't magicaly become valid

--- a/releasenotes/notes/validate-api-key-9243bf049d02eccc.yaml
+++ b/releasenotes/notes/validate-api-key-9243bf049d02eccc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    API keys are now properly validated and will no longer show as valid if they
+    have the correct length but do not exist in datadog.


### PR DESCRIPTION
### What does this PR do?

Validate the API keys using the `/api/v1/validate` endpoint.

### Motivation

Erroneous API keys where reported as valid as long as they where respecting the correct format.

### Additional Notes

Metrics are sent even if the key is confirmed invalid (same as before).
Could be improved to verify api keys periodically (removed key, etc).
