### PR TITLE
Add a job in gitlab-CI to run security checks on the dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,8 @@ run_security_scan_test:
     - set +x     # don't print the api key to the logs
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor # send the list of the dependencies to snyk
+  only:
+    - master
 
 #
 # binary_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,22 @@ run_test_rpm-x64:
   script:
     - inv -e test --race --profile
 
+# scan the dependencies for security vulnerabilities with snyk
+run_security_scan_test:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:latest
+  tags: ["runner:main", "size:large"]
+  before_script:
+    # this image isn't built in the datadog-agent-builders repo
+    # it doesn't have invoke so we install the dependencies without invoke
+    - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
+    - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
+    - cd $GOPATH/src/github.com/DataDog/datadog-agent
+    - dep ensure
+  script:
+    - set +x     # don't print the api key to the logs
+    - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
+      snyk monitor # send the list of the dependencies to snyk
 
 #
 # binary_build


### PR DESCRIPTION
### What does this PR do?

This PR adds a job to gitlab CI that uses snyk-cli to send the list of the agent dependencies to snyk. Snyk will then analyze the list and alert us if it finds any known vulnerability.

### Additional Notes

The goal of the job is only to send the list of the dependencies to snyk. It won't block the pipeline if it finds any vulnerability. 