### PR TITLE
Initial OpenShift manifests and documentation

### DIFF
--- a/Dockerfiles/agent/OPENSHIFT.md
+++ b/Dockerfiles/agent/OPENSHIFT.md
@@ -24,7 +24,6 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 ```
 sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrole.yaml | oc apply -f -
 sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrolebinding.yaml | oc apply -f -
-
 ```
 
 ## Restricted SCC operations

--- a/Dockerfiles/agent/OPENSHIFT.md
+++ b/Dockerfiles/agent/OPENSHIFT.md
@@ -19,8 +19,13 @@ Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origi
 
 - You should first refer to the [common installation instructions](README.md), and its [Kubernetes section](README.md#Kubernetes)
 - We only support full operations on OpenShift 3.7.0 and later, as we rely on new monitoring endpoints introduced in this version
-- On OpenShift 3.7, you will need to change the provided RBAC files to refer to the `rbac.authorization.k8s.io/v1beta` apiVersion instead of `rbac.authorization.k8s.io/v1`
+- On OpenShift 3.7, you will need to change the provided RBAC files to refer to the `rbac.authorization.k8s.io/v1beta1` apiVersion instead of `rbac.authorization.k8s.io/v1`. You can pipe them through sed like below:
 
+```
+sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrole.yaml | oc apply -f -
+sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrolebinding.yaml | oc apply -f -
+
+```
 
 ## Restricted SCC operations
 

--- a/Dockerfiles/agent/OPENSHIFT.md
+++ b/Dockerfiles/agent/OPENSHIFT.md
@@ -1,0 +1,54 @@
+# Openshift installation and configuration instructions
+
+Starting with version 6.1, the Datadog Agent supports monitoring OpenShift Origin and Enterprise clusters. Depending on your needs and the [security constraints](https://docs.openshift.org/latest/admin_guide/manage_scc.html) of your cluster, we support three deployment scenarios:
+
+| Security Context Constraints   | Restricted | Host network | Custom |
+|--------------------------------|:----------:|:------------:|:------:|
+| Kubernetes layer monitoring    | ✅         | ✅          | ✅     |
+| Kubernetes-based Autodiscovery | ✅         | ✅          | ✅     |
+| Dogstatsd intake               | 🔶         | ✅          | ✅     |
+| APM trace intake               | 🔶         | ✅          | ✅     |
+| Logs network intake            | 🔶         | ✅          | ✅     |
+| Host network metrics           | ❌         | ❌          | ✅     |
+| Docker layer monitoring        | ❌         | ❌          | ✅     |
+| Container logs collection      | ❌         | ❌          | ✅     |
+| Live Container monitoring      | ❌         | ❌          | ✅     |
+| Live Process monitoring        | ❌         | ❌          | ✅     |
+
+## General information
+
+- You should first refer to the [common installation instructions](README.md), and its [Kubernetes section](README.md#Kubernetes)
+- We only support full operations on OpenShift 3.7.0 and later, as we rely on new monitoring endpoints introduced in this version
+- On OpenShift 3.7, you will need to change the provided RBAC files to refer to the `rbac.authorization.k8s.io/v1beta` apiVersion instead of `rbac.authorization.k8s.io/v1`
+
+
+## Restricted SCC operations
+
+This mode does not require granting special permissions to the `datadog-agent` daemonset, other than the [RBAC](../manifests/rbac) permissions needed to access the kubelet and the apiserver. You can get started with this [kubelet-only template](../manifests/agent-kubelet-only.yaml).
+
+Our recommended ingestion method for Dogstatsd, APM and logs is to bind our agent to a host port. This way, the target IP is constant and easily discoverable by your applications. As the default restricted OpenShift SCC does not allow to bind to host port, you can set the agent to listen on it's own IP, but you'll need to handle the discovery of that IP from your application.
+
+We are currently working on a `sidecar` run mode, to enable running the agent in your application's pod for easier discoverability.
+
+## Host network SCC operations
+
+For easier intake, you can add the `allowHostPorts` permission to the pod (either via the standard `hostnetwork` or `hostaccess` SCC, or by creating your own). In this case, you can add the relevant port bindings in your pod specs:
+
+```yaml
+        ports:
+          - containerPort: 8125
+            name: dogstatsdport
+            protocol: UDP
+          - containerPort: 8126
+            name: traceport
+            protocol: TCP
+```
+
+## Custom Datadog SCC for all features
+
+If SELinux is in permissive mode or disabled, you can simply enable the `hostaccess` SCC to benefit from all features. If SELinux is in enforcing mode, we recommend granting [the `spc_t` type](https://developers.redhat.com/blog/2014/11/06/introducing-a-super-privileged-container-concept/) to the datadog-agent pod. In order to easily deploy our agent, we created a [datadog-agent SCC](../manifests/openshift/scc.yaml) you can apply after [creating the datadog-agent service account](../manifests/rbac). It grants the following permissions:
+
+- `allowHostPorts: true`: to bind Dogstatsd / APM / Logs intakes to the node's IP
+- `allowHostPID: true`: to enable Origin Detection for Dogstatsd metrics submitted by Unix Socket
+- `volumes: hostPath`: to access the Docker socket and the host's `proc` and `cgroup` folders, for metric collection
+- `SELinux type: spc_t`: to access the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article](https://developers.redhat.com/blog/2014/11/06/introducing-a-super-privileged-container-concept/).

--- a/Dockerfiles/agent/OPENSHIFT.md
+++ b/Dockerfiles/agent/OPENSHIFT.md
@@ -57,3 +57,15 @@ If SELinux is in permissive mode or disabled, you can simply enable the `hostacc
 - `allowHostPID: true`: to enable Origin Detection for Dogstatsd metrics submitted by Unix Socket
 - `volumes: hostPath`: to access the Docker socket and the host's `proc` and `cgroup` folders, for metric collection
 - `SELinux type: spc_t`: to access the Docker socket and all processes' `proc` and `cgroup` folders, for metric collection. You can read more about this type [in this Red Hat article](https://developers.redhat.com/blog/2014/11/06/introducing-a-super-privileged-container-concept/).
+
+# Kubernetes-state metrics
+
+[Kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) does not collect metrics for OpenShift's DeploymentConfig objects. Although, you can get pod and container metrics tagging by deploying your kube-state-metrics pod with the following [Autodiscovery template in the pod annotations](https://docs.datadoghq.com/agent/autodiscovery/#template-source-kubernetes-pod-annotations).
+
+```yaml
+ad.datadoghq.com/kube-state-metrics.check_names: '["kubernetes_state"]'
+ad.datadoghq.com/kube-state-metrics.init_configs: '[{}]'
+ad.datadoghq.com/kube-state-metrics.instances: '[{"kube_state_url":"http://%%host%%:%%port%%/metrics","labels_mapper":{"namespace":"kube_namespace","label_deploymentconfig":"oshift_deployment_config","label_deployment":"oshift_deployment"},"label_joins":{"kube_pod_labels":{"label_to_match":"pod","labels_to_get":["label_deployment","label_deploymentconfig"]}}}]'
+```
+
+As OpenShift deployments create a Kubernetes replication controller with the same name, you can track you deployment's state via the `kubernetes_state.replicationcontroller.*` metrics.

--- a/Dockerfiles/manifests/agent-kubelet-only.yaml
+++ b/Dockerfiles/manifests/agent-kubelet-only.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: datadog-agent
+  namespace: default
 spec:
   template:
     metadata:

--- a/Dockerfiles/manifests/agent-kubelet-only.yaml
+++ b/Dockerfiles/manifests/agent-kubelet-only.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: datadog-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: datadog-agent
+      name: datadog-agent
+    spec:
+      serviceAccountName: datadog-agent
+      containers:
+      - image: datadog/agent:latest
+        imagePullPolicy: Always
+        name: datadog-agent
+        env:
+          - name: DD_API_KEY
+            value: <YOUR_API_KEY>
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_LEADER_ELECTION
+            value: "true"
+          - name: KUBERNETES
+            value: "yes"
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "250m"
+        livenessProbe:
+          exec:
+            command:
+            - ./probe.sh
+          initialDelaySeconds: 15
+          periodSeconds: 5

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: datadog-agent
+  namespace: default
 spec:
   template:
     metadata:

--- a/Dockerfiles/manifests/openshift/scc.yaml
+++ b/Dockerfiles/manifests/openshift/scc.yaml
@@ -1,0 +1,51 @@
+#
+# This SCC is required to enable the full featureset of the
+# Datadog Agent. The kubelet-only variant can run with the
+# default restricted SCC
+#
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: datadog-agent
+users:
+- system:serviceaccount:default:datadog-agent
+priority: 10
+# Allow host ports for dsd / trace / logs intake
+allowHostPorts: true
+# Allow host PID for dogstatsd origin detection
+allowHostPID: true
+# Allow hostPath for docker / process metrics
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- hostPath
+- secret
+# Use the `spc_t` selinux type to access the
+# docker socket + proc and cgroup stats
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    user: "system_u"
+    role: "system_r"
+    type: "spc_t"
+    level: "s0"
+#
+# The rest is copied from 3.7.0 restricted SCC
+#
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowPrivilegedContainer: false
+allowedFlexVolumes: []
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsRange
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles: []
+requiredDropCapabilities: []
+allowedCapabilities: []


### PR DESCRIPTION
This PR holds the installation instructions and material for OpenShift Enterprise/Origin.

Using an already-present "privileged container" SELinux role, our diff from the standard Kubernetes installation instructions is only one more manifest to apply.

Other PRs to come for adjustments/bugfixes before we can ship OpenShift support.