### PR TITLE
[tagger] Collect oshift_deployment_config and oshift_deployment tags

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -160,6 +160,26 @@ func TestParsePods(t *testing.T) {
 				HighCardTags: []string{"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb"},
 			},
 		},
+		{
+			desc: "openshift deploymentconfig",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Annotations: map[string]string{
+						"openshift.io/deployment-config.latest-version": "1",
+						"openshift.io/deployment-config.name":           "gitlab-ce",
+						"openshift.io/deployment.name":                  "gitlab-ce-1",
+					},
+				},
+				Status: oneContainer,
+			},
+			labelsAsTags: map[string]string{},
+			expectedInfo: &TagInfo{
+				Source:       "kubelet",
+				Entity:       entityID,
+				LowCardTags:  []string{"kube_container_name:dd-agent", "oshift_deployment_config:gitlab-ce"},
+				HighCardTags: []string{"oshift_deployment:gitlab-ce-1"},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
 			collector := &KubeletCollector{

--- a/releasenotes/notes/tagger-openshift-dc-371511ab4508d296.yaml
+++ b/releasenotes/notes/tagger-openshift-dc-371511ab4508d296.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Collect oshift_deployment_config and oshift_deployment tags on OpenShift


### PR DESCRIPTION
OpenShift has a [custom DeploymentConfig type](https://docs.openshift.com/enterprise/3.0/dev_guide/deployments.html) to handle deployments. Pods created from these have the following metadata:
```yaml
    annotations:
      kubernetes.io/created-by: |
        {"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicationController","namespace":"default","name":"gitlab-ce-1","uid":"f74e7dce-c6ad-11e5-9bbb-080027c5bfa9","apiVersion":"v1","resourceVersion":"120461"}}
      openshift.io/deployment-config.latest-version: "1"
      openshift.io/deployment-config.name: gitlab-ce
      openshift.io/deployment.name: gitlab-ce-1
      openshift.io/generated-by: OpenShiftNewApp
      openshift.io/scc: restricted
    labels:
      app: gitlab-ce
      deployment: gitlab-ce-1
      deploymentconfig: gitlab-ce
```

Instead of extracting the pod labels, that have a generic name that could be legitimately used out of OpenShift, I'm using the annotations, that have a proper prefix.
