### PR TITLE
[install_script] fix script to work properly with root

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -215,7 +215,7 @@ else
     # If the import script failed for any reason, we might end here also in case
     # of upgrade, let's not start the agent or it would fail because the api key
     # is missing
-    if ! $sudo_cmd -u dd-agent -- grep -q -E '^api_key: .+' $CONF; then
+    if ! $sudo_cmd grep -q -E '^api_key: .+' $CONF; then
       printf "\033[31mThe Agent won't start automatically at the end of the script because the Api key is missing, please add one in datadog.yaml and start the agent manually.\n\033[0m\n"
       no_start=true
     fi


### PR DESCRIPTION
### What does this PR do?

The install script did not work properly if the user was root : 

https://github.com/DataDog/datadog-agent/blob/7e3503eb04f331ad7294fb58a4655abdb357a660/cmd/agent/install_script.sh#L107-L112

https://github.com/DataDog/datadog-agent/blob/ae1e73b8f54ee8b6c667f297608999050e9d2f55/cmd/agent/install_script.sh#L218

Since `$sudo_cmd` is empty, we try to run `-u dd-agent -- grep -q -E '^api_key: .+' $CONF`.

It does not make the script fail but it makes `no_start=true` thus preventing the agent from running at the end of the script.

