### PR TITLE
get pkg-config from gnome ftp to avoid flakes when SF.net is down

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,20 @@ environment:
   RI_DEVKIT: C:\Ruby23-x64\DevKit\
   PYTHONPATH: c:\python27-x64
   PYTHONHOME: c:\python27-x64
+  GLIB-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/glib/2.26/glib_2.26.1-1_win64.zip
+  PKG-CONFIG-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/dependencies/pkg-config_0.23-2_win64.zip
+  GETTEXT-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/dependencies/gettext-runtime_0.18.1.1-2_win64.zip
 
 install:
-  - set PATH=%GOPATH%\bin;C:\go\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
+  - mkdir c:\deps
+  - cd c:\deps
+  - curl -fsS -o glib.zip %GLIB-URL%
+  - curl -fsS -o pkg-config.zip %PKG-CONFIG-URL%
+  - curl -fsS -o gettext.zip %GETTEXT-URL%
+  - 7z x *.zip > NUL
+  - set PATH=C:\deps\bin;%GOPATH%\bin;C:\go\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
   - go version
   - pip install invoke
-  - choco install pkgconfiglite
 
 cache:
   - '%GOPATH%\bin'
@@ -26,6 +34,6 @@ cache:
 build: off
 
 test_script:
-  - cd
+  - cd %APPVEYOR_BUILD_FOLDER%
   - inv -e deps
   - inv -e test --race --profile --fail-on-fmt


### PR DESCRIPTION
We were using an outdated chocolatey package, that pulls a binary from sourceforge. It is once again down, making the Windows CI red.
This PR get gnome's build from their ftp.

Taken from https://github.com/FluidSynth/fluidsynth/blob/master/.appveyor.yml