### PR TITLE
[jmx] use multi-platform GetDistPath to find JMX jar

### DIFF
--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +30,7 @@ func TestFetchAuthTokenValidGen(t *testing.T) {
 	defer os.Remove(f.Name())
 
 	config.Datadog.SetConfigFile(f.Name())
-	expectTokenPath := path.Join(testDir, "auth_token")
+	expectTokenPath := filepath.Join(testDir, "auth_token")
 	defer os.Remove(expectTokenPath)
 
 	config.Datadog.Set("auth_token", "")

--- a/pkg/collector/corechecks/embed/apm_nix.go
+++ b/pkg/collector/corechecks/embed/apm_nix.go
@@ -14,7 +14,7 @@ package embed
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
@@ -23,7 +23,7 @@ const apm_binary_name = "trace-agent"
 
 func getAPMAgentDefaultBinPath() (string, error) {
 	here, _ := executable.Folder()
-	binPath := path.Join(here, "..", "..", "embedded", "bin", apm_binary_name)
+	binPath := filepath.Join(here, "..", "..", "embedded", "bin", apm_binary_name)
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -13,7 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -242,7 +242,7 @@ func (c *JMXCheck) Stop() {
 
 func (c *JMXCheck) start() error {
 	here, _ := executable.Folder()
-	classpath := path.Join(common.GetDistPath(), "jmx", jmxJarName)
+	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
 	if c.javaToolsJarPath != "" {
 		classpath = fmt.Sprintf("%s:%s", c.javaToolsJarPath, classpath)
 	}
@@ -294,7 +294,7 @@ func (c *JMXCheck) start() error {
 	)
 
 	if jmxExitFile != "" {
-		c.ExitFilePath = path.Join(here, "dist", "jmx", jmxExitFile) // FIXME : At some point we should have a `run` folder
+		c.ExitFilePath = filepath.Join(here, "dist", "jmx", jmxExitFile) // FIXME : At some point we should have a `run` folder
 		// Signal handlers are not supported on Windows:
 		// use a file to trigger JMXFetch exit instead
 		subprocessArgs = append(subprocessArgs, "--exit_file_location", c.ExitFilePath)

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/cihub/seelog"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	api "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -241,7 +242,7 @@ func (c *JMXCheck) Stop() {
 
 func (c *JMXCheck) start() error {
 	here, _ := executable.Folder()
-	classpath := path.Join(here, "dist", "jmx", jmxJarName)
+	classpath := path.Join(common.GetDistPath(), "jmx", jmxJarName)
 	if c.javaToolsJarPath != "" {
 		classpath = fmt.Sprintf("%s:%s", c.javaToolsJarPath, classpath)
 	}

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -206,7 +206,7 @@ func init() {
 
 func getProcessAgentDefaultBinPath() (string, error) {
 	here, _ := executable.Folder()
-	binPath := path.Join(here, "..", "..", "embedded", "bin", "process-agent")
+	binPath := filepath.Join(here, "..", "..", "embedded", "bin", "process-agent")
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}

--- a/pkg/legacy/docker.go
+++ b/pkg/legacy/docker.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers"
@@ -81,8 +81,8 @@ func ImportDockerConf(src, dst string, overwrite bool) error {
 		}
 
 		if initConf.DockerRoot != "" {
-			config.Datadog.Set("container_cgroup_root", path.Join(initConf.DockerRoot, "sys", "fs", "cgroup"))
-			config.Datadog.Set("container_proc_root", path.Join(initConf.DockerRoot, "proc"))
+			config.Datadog.Set("container_cgroup_root", filepath.Join(initConf.DockerRoot, "sys", "fs", "cgroup"))
+			config.Datadog.Set("container_proc_root", filepath.Join(initConf.DockerRoot, "proc"))
 		}
 	}
 

--- a/pkg/legacy/docker_test.go
+++ b/pkg/legacy/docker_test.go
@@ -10,7 +10,7 @@ package legacy
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,8 +78,8 @@ func TestConvertDocker(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	src := path.Join(dir, "docker_daemon.yaml")
-	dst := path.Join(dir, "docker.yaml")
+	src := filepath.Join(dir, "docker_daemon.yaml")
+	dst := filepath.Join(dir, "docker.yaml")
 
 	err = ioutil.WriteFile(src, []byte(dockerDaemonLegacyConf), 0640)
 	require.Nil(t, err)
@@ -87,7 +87,7 @@ func TestConvertDocker(t *testing.T) {
 	err = ImportDockerConf(src, dst, true)
 	require.Nil(t, err)
 
-	newConf, err := ioutil.ReadFile(path.Join(dir, "docker.yaml"))
+	newConf, err := ioutil.ReadFile(filepath.Join(dir, "docker.yaml"))
 	require.Nil(t, err)
 
 	assert.Equal(t, dockerNewConf, string(newConf))
@@ -105,11 +105,11 @@ func TestConvertDocker(t *testing.T) {
 	// test overwrite
 	err = ImportDockerConf(src, dst, false)
 	require.NotNil(t, err)
-	_, err = os.Stat(path.Join(dir, "docker.yaml.bak"))
+	_, err = os.Stat(filepath.Join(dir, "docker.yaml.bak"))
 	assert.True(t, os.IsNotExist(err))
 
 	err = ImportDockerConf(src, dst, true)
 	require.Nil(t, err)
-	_, err = os.Stat(path.Join(dir, "docker.yaml.bak"))
+	_, err = os.Stat(filepath.Join(dir, "docker.yaml.bak"))
 	assert.False(t, os.IsNotExist(err))
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -86,7 +86,7 @@ func GetClusterAgentAuthToken() (string, error) {
 	}
 
 	// load the cluster agent auth token from filesystem
-	tokenAbsPath := path.Join(config.FileUsedDir(), clusterAgentAuthTokenFilename)
+	tokenAbsPath := filepath.Join(config.FileUsedDir(), clusterAgentAuthTokenFilename)
 	log.Debugf("empty cluster_agent_auth_token, loading from %s", tokenAbsPath)
 	_, err := os.Stat(tokenAbsPath)
 	if err != nil {

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -13,7 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -315,7 +315,7 @@ func TestClusterAgentSuite(t *testing.T) {
 
 	s := &clusterAgentSuite{}
 	config.Datadog.SetConfigFile(f.Name())
-	s.authTokenPath = path.Join(fakeDir, clusterAgentAuthTokenFilename)
+	s.authTokenPath = filepath.Join(fakeDir, clusterAgentAuthTokenFilename)
 	_, err = os.Stat(s.authTokenPath)
 	require.NotNil(t, err, fmt.Sprintf("%v", err))
 	defer os.Remove(s.authTokenPath)

--- a/pkg/util/docker/util_common.go
+++ b/pkg/util/docker/util_common.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -81,7 +80,7 @@ func getEnv(key string, dfault string, combineWith ...string) string {
 // overridden when running inside a container.
 func hostProc(combineWith ...string) string {
 	parts := append([]string{config.Datadog.GetString("container_proc_root")}, combineWith...)
-	return path.Join(parts...)
+	return filepath.Join(parts...)
 }
 
 // pathExists returns a boolean indicating if the given path exists on the file system.

--- a/releasenotes/notes/win-jmxlaunch-fix-ebb9eb556675eb75.yaml
+++ b/releasenotes/notes/win-jmxlaunch-fix-ebb9eb556675eb75.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the launch of JMXFetch on windows and make multiplatform treatment of
+    the launch more robust.


### PR DESCRIPTION
### What does this PR do?
Multi-platform collection for the correct `dist` path, should fix bug preventing JMXfetch from running on windows. 

### Motivation

Bug in 6.0.0

### Additional Notes

Tested on Windows and Linux
