### PR TITLE
[windows] require administrator rights to launch systray.

### DIFF
--- a/cmd/systray/ddtray.exe.manifest
+++ b/cmd/systray/ddtray.exe.manifest
@@ -11,4 +11,11 @@
                         <dpiAware>true</dpiAware>
                 </asmv3:windowsSettings>
         </asmv3:application>
+        <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
 </assembly>

--- a/releasenotes/notes/systray-admin-ef67f095d58d5f8b.yaml
+++ b/releasenotes/notes/systray-admin-ef67f095d58d5f8b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Add administrator requirement to the systray manifest.  Doing so will prevent
+    systray from being launched by non-admin user (will prompt for admin level
+    user/password)


### PR DESCRIPTION
### What does this PR do?

Always launch `systray.exe` with admin rights.  Causes prompt to ask for credentials when launched by user that doesn't have admin rights.

### Motivation

Customer reported issue

### Additional Notes

Needs careful consideration.  Side effect is that browser process is launched as administrator (root).  May have unwanted consequences.
