### PR TITLE
[gui][jmx] also submit jmxfetch as available checks via API

### DIFF
--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -280,6 +280,9 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 	goIntegrations := core.GetRegisteredFactoryKeys()
 	integrations = append(integrations, goIntegrations...)
 
+	// Get jmx-checks
+	integrations = append(integrations, check.JMXChecks...)
+
 	if len(integrations) == 0 {
 		w.Write([]byte("No check (.py) files found."))
 		return

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -36,7 +36,8 @@ var (
 	}
 )
 
-var jmxChecks = [...]string{
+// JMXChecks list of JMXFetch checks supported
+var JMXChecks = []string{
 	"activemq",
 	"activemq_58",
 	"cassandra",
@@ -353,7 +354,7 @@ func (c *Config) Digest() string {
 // IsConfigJMX checks if a certain YAML config is a JMX config
 func IsConfigJMX(name string, initConf ConfigData) bool {
 
-	for _, check := range jmxChecks {
+	for _, check := range JMXChecks {
 		if check == name {
 			return true
 		}

--- a/releasenotes/notes/win-jmxgui-fix-70011a5c5d31f7b1.yaml
+++ b/releasenotes/notes/win-jmxgui-fix-70011a5c5d31f7b1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix GUI for JMX checks, they are now manageable from the web UI.


### PR DESCRIPTION
### What does this PR do?
Enables management of the JMXFetch checks on the GUI.

### Motivation
Bug discovered while testing. Upgrading customers with checks configured should be fine, but new customers, or customers attempting to enable a check not previously configured would not see the available checks appear in the GUI.
