### PR TITLE
[Windows] remove `.pdh` suffix from system.io.wkb_s, system.io_w_s,

### DIFF
--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -90,11 +90,11 @@ func (c *IOCheck) Configure(data check.ConfigData, initConfig check.ConfigData) 
 	}
 
 	c.counternames = map[string]string{
-		"Disk Write Bytes/sec":      "system.io.wkb_s.pdh",
-		"Disk Writes/sec":           "system.io.w_s.pdh",
-		"Disk Read Bytes/sec":       "system.io.rkb_s.pdh",
-		"Disk Reads/sec":            "system.io.r_s.pdh",
-		"Current Disk Queue Length": "system.io.avg_q_sz.pdh"}
+		"Disk Write Bytes/sec":      "system.io.wkb_s",
+		"Disk Writes/sec":           "system.io.w_s",
+		"Disk Read Bytes/sec":       "system.io.rkb_s",
+		"Disk Reads/sec":            "system.io.r_s",
+		"Current Disk Queue Length": "system.io.avg_q_sz"}
 
 	c.counters = make(map[string]*pdhutil.PdhCounterSet)
 

--- a/releasenotes/notes/win-iostats-8f3eeb57a3d9e905.yaml
+++ b/releasenotes/notes/win-iostats-8f3eeb57a3d9e905.yaml
@@ -1,0 +1,9 @@
+---
+critical:
+  - |
+    ".pdh" suffix was added to `system.io` metrics on windows for side-by-side 
+    testing when changed the collection mechanism, and inadvertently left.
+fixes:
+  - |
+    remove `.pdh` suffix from system.io.wkb_s, system.io_w_s, system.io.rkb_s, 
+    system.io.r_s, system.io.avg_q_sz


### PR DESCRIPTION
system.io.rkb_s, system.io.r_s, system.io.avg_q_sz

Suffix was added for side-by-side testing when changed the collection
mechanism, and inadvertently left.

