### PR TITLE
Add image tags for kubelet

### DIFF
--- a/pkg/collector/py/tagger_test.go
+++ b/pkg/collector/py/tagger_test.go
@@ -11,6 +11,7 @@ package py
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -46,7 +47,7 @@ func TestGetTags(t *testing.T) {
 	require.Equal(t, low, []string{"test_entity:low"})
 	high, err := tagger.Tag("test_entity", true)
 	require.NoError(t, err)
-	require.Equal(t, high, []string{"test_entity:low", "test_entity:high", "other_tag:high"})
+	assert.ElementsMatch(t, high, []string{"test_entity:low", "test_entity:high", "other_tag:high"})
 
 	check, _ := getCheckInstance("testtagger", "TestCheck")
 	mockSender := mocksender.NewMockSender(check.ID())

--- a/pkg/tagger/README.md
+++ b/pkg/tagger/README.md
@@ -1,4 +1,4 @@
-## package `tagger`
+# package `tagger`
 
 The **Tagger** is the central source of truth for client-side entity tagging. It
 runs **Collector**s that detect entities and collect their tags. Tags are then
@@ -17,44 +17,49 @@ The tagger is also available to python checks via the `tagger` module exporting
 the `get_tags()` function. This function accepts the same arguments as the Go `Tag()`
 function, and returns an empty list on errors.
 
-### Collector
+## Collector
+
 A **Collector** connects to a single information source and pushes **TagInfo**
 structs to a channel, towards the **Tagger**. It can either run in streaming
 mode, pull or fetchonly mode, depending of what's most efficient for the data source:
 
-#### Streamer
+### Streamer
+
 The **DockerCollector** runs in stream mode as it collects events from the docker
 daemon and reacts to them, sending updates incrementally.
 
-#### Puller
+### Puller
+
 The **KubernetesCollector** will run in pull mode as it needs to query and filter a full entity list every time. It will only push
 updates to the store though, by keeping an internal state of the latest
 revision.
 
-#### FetchOnly
+### FetchOnly
+
 The **ECSCollector** does not push updates to the Store by itself, but is only triggered on cache misses. As tasks don't change after creation, there's no need for periodic pulling. It is designed to run alongside DockerCollector, that will trigger deletions in the store.
 
-### TagStore
+## TagStore
+
 The **TagStore** reads **TagInfo** structs and stores them in a in-memory
 cache. Cache invalidation is triggered by the collectors (or source) by either:
 
-  - sending new tags for the same `Entity`, all the tags from this `Source`
+* sending new tags for the same `Entity`, all the tags from this `Source`
   will be removed and replaced by the new tags
-  - sending a **TagInfo** with **DeleteEntity** set, all the entries for this
+* sending a **TagInfo** with **DeleteEntity** set, all the entries for this
   entity (including from other sources) will be deleted when **prune()** is
   called.
 
 The deletions are batched so that if two sources send coliding add and delete
 messages, the delete eventually wins.
 
-### Tagger
+## Tagger
+
 The Tagger handles the glue between **Collectors** and **TagStore** and the
 cache miss logic. If the tags from the **TagStore** are missing some sources,
 they will be manually queried in a block way, and the cache will be updated.
 
 For convenience, the package creates a **defaultTagger** object that is used
 when calling the `tagger.Tag()` method.
-
 
                    +-----------+
                    | Collector |

--- a/pkg/tagger/collectors/catalog.go
+++ b/pkg/tagger/collectors/catalog.go
@@ -14,7 +14,11 @@ type Catalog map[string]CollectorFactory
 // DefaultCatalog holds every compiled-in collector
 var DefaultCatalog = make(Catalog)
 
+// CollectorPriorities holds collector priorities
+var CollectorPriorities = make(map[string]CollectorPriority)
+
 // registerCollector is to be called by collectors to be added to the default catalog
-func registerCollector(name string, c CollectorFactory) {
+func registerCollector(name string, c CollectorFactory, p CollectorPriority) {
 	DefaultCatalog[name] = c
+	CollectorPriorities[name] = p
 }

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -42,7 +42,7 @@ func dockerExtractImage(tags *utils.TagList, dockerImage string) {
 	tags.AddLow("docker_image", dockerImage)
 	imageName, shortImage, imageTag, err := docker.SplitImageName(dockerImage)
 	if err != nil {
-		log.Debugf("Error splitting %s: %s", dockerImage, err)
+		log.Debugf("Cannot split %s: %s", dockerImage, err)
 		return
 	}
 	tags.AddLow("image_name", imageName)

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -126,5 +126,5 @@ func dockerFactory() Collector {
 }
 
 func init() {
-	registerCollector(dockerCollectorName, dockerFactory)
+	registerCollector(dockerCollectorName, dockerFactory, LowPriority)
 }

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -122,5 +122,5 @@ func ecsFargateFactory() Collector {
 }
 
 func init() {
-	registerCollector(ecsFargateCollectorName, ecsFargateFactory)
+	registerCollector(ecsFargateCollectorName, ecsFargateFactory, HighPriority)
 }

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -82,5 +82,5 @@ func ecsFactory() Collector {
 }
 
 func init() {
-	registerCollector(ecsCollectorName, ecsFactory)
+	registerCollector(ecsCollectorName, ecsFactory, LowPriority)
 }

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -98,7 +98,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 				if containerSpec.Name == container.Name {
 					imageName, shortImage, imageTag, err := docker.SplitImageName(containerSpec.Image)
 					if err != nil {
-						log.Debugf("Error splitting %s: %s", containerSpec.Image, err)
+						log.Debugf("Cannot split %s: %s", containerSpec.Image, err)
 						break
 					}
 					lowC = append(lowC, fmt.Sprintf("image_name:%s", imageName))

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -103,6 +103,10 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 					}
 					lowC = append(lowC, fmt.Sprintf("image_name:%s", imageName))
 					lowC = append(lowC, fmt.Sprintf("short_image:%s", shortImage))
+					if imageTag == "" {
+						// k8s default to latest if tag is omitted
+						imageTag = "latest"
+					}
 					lowC = append(lowC, fmt.Sprintf("image_tag:%s", imageTag))
 					break
 				}

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -92,6 +93,21 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		// container tags
 		for _, container := range pod.Status.Containers {
 			lowC := append(low, fmt.Sprintf("kube_container_name:%s", container.Name))
+			// check image tag in spec
+			for _, containerSpec := range pod.Spec.Containers {
+				if containerSpec.Name == container.Name {
+					imageName, shortImage, imageTag, err := docker.SplitImageName(containerSpec.Image)
+					if err != nil {
+						log.Debugf("Error splitting %s: %s", containerSpec.Image, err)
+						break
+					}
+					lowC = append(lowC, fmt.Sprintf("image_name:%s", imageName))
+					lowC = append(lowC, fmt.Sprintf("short_image:%s", shortImage))
+					lowC = append(lowC, fmt.Sprintf("image_tag:%s", imageTag))
+					break
+				}
+			}
+
 			info := &TagInfo{
 				Source:       kubeletCollectorName,
 				Entity:       container.ID,

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -17,13 +17,40 @@ import (
 )
 
 func TestParsePods(t *testing.T) {
-	entityID := "docker://d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f"
-	oneContainer := kubelet.Status{
+	dockerEntityID := "docker://d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f"
+	dockerContainerStatus := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
 			{
-				ID:    entityID,
+				ID:    dockerEntityID,
 				Image: "datadog/docker-dd-agent:latest5",
 				Name:  "dd-agent",
+			},
+		},
+	}
+	dockerContainerSpec := kubelet.Spec{
+		Containers: []kubelet.ContainerSpec{
+			{
+				Name:  "dd-agent",
+				Image: "datadog/docker-dd-agent:latest5",
+			},
+		},
+	}
+
+	criEntityId := "cri-containerd://acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1"
+	criContainerStatus := kubelet.Status{
+		Containers: []kubelet.ContainerStatus{
+			{
+				ID:    criEntityId,
+				Image: "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",
+				Name:  "redis-master",
+			},
+		},
+	}
+	criContainerSpec := kubelet.Spec{
+		Containers: []kubelet.ContainerSpec{
+			{
+				Name:  "redis-master",
+				Image: "gcr.io/google_containers/redis:e2e",
 			},
 		},
 	}
@@ -54,13 +81,21 @@ func TestParsePods(t *testing.T) {
 						},
 					},
 				},
-				Status: oneContainer,
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
 			expectedInfo: &TagInfo{
-				Source:       "kubelet",
-				Entity:       entityID,
-				LowCardTags:  []string{"kube_namespace:default", "kube_container_name:dd-agent", "kube_daemon_set:dd-agent-rc"},
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_namespace:default",
+					"kube_container_name:dd-agent",
+					"kube_daemon_set:dd-agent-rc",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
+				},
 				HighCardTags: []string{"pod_name:dd-agent-rc-qd876"},
 			},
 		},
@@ -75,13 +110,20 @@ func TestParsePods(t *testing.T) {
 						},
 					},
 				},
-				Status: oneContainer,
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
 			expectedInfo: &TagInfo{
-				Source:       "kubelet",
-				Entity:       entityID,
-				LowCardTags:  []string{"kube_container_name:dd-agent", "kube_replica_set:kubernetes-dashboard"},
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"kube_replica_set:kubernetes-dashboard",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
+				},
 				HighCardTags: []string{},
 			},
 		},
@@ -96,13 +138,20 @@ func TestParsePods(t *testing.T) {
 						},
 					},
 				},
-				Status: oneContainer,
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
 			expectedInfo: &TagInfo{
-				Source:       "kubelet",
-				Entity:       entityID,
-				LowCardTags:  []string{"kube_container_name:dd-agent", "kube_deployment:frontend"},
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"kube_deployment:frontend",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
+				},
 				HighCardTags: []string{"kube_replica_set:frontend-2891696001"},
 			},
 		},
@@ -117,13 +166,20 @@ func TestParsePods(t *testing.T) {
 						},
 					},
 				},
-				Status: oneContainer,
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
 			expectedInfo: &TagInfo{
-				Source:       "kubelet",
-				Entity:       entityID,
-				LowCardTags:  []string{"kube_container_name:dd-agent", "kube_deployment:front-end"},
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"kube_deployment:front-end",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
+				},
 				HighCardTags: []string{"kube_replica_set:front-end-768dd754b7"},
 			},
 		},
@@ -140,7 +196,8 @@ func TestParsePods(t *testing.T) {
 						"OwnerTeam":         "Kenafeh",
 					},
 				},
-				Status: oneContainer,
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{
 				"component": "component",
@@ -150,12 +207,15 @@ func TestParsePods(t *testing.T) {
 			},
 			expectedInfo: &TagInfo{
 				Source: "kubelet",
-				Entity: entityID,
+				Entity: dockerEntityID,
 				LowCardTags: []string{
 					"kube_container_name:dd-agent",
 					"team:Kenafeh",
 					"component:kube-proxy",
 					"tier:node",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
 				HighCardTags: []string{"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb"},
 			},
@@ -170,14 +230,42 @@ func TestParsePods(t *testing.T) {
 						"openshift.io/deployment.name":                  "gitlab-ce-1",
 					},
 				},
-				Status: oneContainer,
+				Status: dockerContainerStatus,
 			},
 			labelsAsTags: map[string]string{},
 			expectedInfo: &TagInfo{
 				Source:       "kubelet",
-				Entity:       entityID,
+				Entity:       dockerEntityID,
 				LowCardTags:  []string{"kube_container_name:dd-agent", "oshift_deployment_config:gitlab-ce"},
 				HighCardTags: []string{"oshift_deployment:gitlab-ce-1"},
+			},
+		},
+		{
+			desc: "CRI pod",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Owners: []kubelet.PodOwner{
+						{
+							Kind: "ReplicaSet",
+							Name: "redis-master-546dc4865f",
+						},
+					},
+				},
+				Status: criContainerStatus,
+				Spec:   criContainerSpec,
+			},
+			labelsAsTags: map[string]string{},
+			expectedInfo: &TagInfo{
+				Source: "kubelet",
+				Entity: criEntityId,
+				LowCardTags: []string{
+					"kube_container_name:redis-master",
+					"kube_deployment:redis-master",
+					"image_name:gcr.io/google_containers/redis",
+					"image_tag:e2e",
+					"short_image:redis",
+				},
+				HighCardTags: []string{"kube_replica_set:redis-master-546dc4865f"},
 			},
 		},
 	} {

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -124,5 +124,5 @@ func kubeletFactory() Collector {
 }
 
 func init() {
-	registerCollector(kubeletCollectorName, kubeletFactory)
+	registerCollector(kubeletCollectorName, kubeletFactory, HighPriority)
 }

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -112,5 +112,5 @@ func kubernetesFactory() Collector {
 }
 
 func init() {
-	registerCollector(kubeServiceCollectorName, kubernetesFactory)
+	registerCollector(kubeServiceCollectorName, kubernetesFactory, HighPriority)
 }

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -42,6 +42,15 @@ type Collector interface {
 	Detect(chan<- []*TagInfo) (CollectionMode, error)
 }
 
+// CollectorPriority helps resolving dupe tags from collectors
+type CollectorPriority int
+
+// List of collector priorities
+const (
+	LowPriority CollectorPriority = iota
+	HighPriority
+)
+
 // Fetcher allows to fetch tags on-demand in case of cache miss
 type Fetcher interface {
 	Fetch(string) ([]string, []string, error)

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -34,7 +34,6 @@ const (
 	PullCollection                            // Call regularly via the Pull method
 	StreamCollection                          // Will continuously feed updates on the channel from Steam() to Stop()
 	FetchOnlyCollection                       // Only call Fetch() on cache misses
-
 )
 
 // Collector retrieve entity tags from a given source and feeds

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -139,14 +139,15 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 
 	// Cache miss
 	var sources []string
-	var tagSortList []tagSort
+	tagSortList := make(map[string][]tagSort)
 
 	for source, tags := range e.lowCardTags {
 		sources = append(sources, source)
 		for _, t := range tags {
-			tagSortList = append(tagSortList, tagSort{
+			tagName := strings.Split(t, ":")[0]
+			tagSortList[tagName] = append(tagSortList[tagName], tagSort{
 				tag:        t,
-				tagName:    strings.Split(t, ":")[0],
+				tagName:    tagName,
 				source:     source,
 				isHighCard: false,
 			})
@@ -155,7 +156,8 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 
 	for source, tags := range e.highCardTags {
 		for _, t := range tags {
-			tagSortList = append(tagSortList, tagSort{
+			tagName := strings.Split(t, ":")[0]
+			tagSortList[tagName] = append(tagSortList[tagName], tagSort{
 				tag:        t,
 				tagName:    strings.Split(t, ":")[0],
 				source:     source,
@@ -166,21 +168,22 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 
 	lowCardTags := []string{}
 	highCardTags := []string{}
-	for i := 0; i < len(tagSortList); i++ {
-		insert := true
-		for j := 0; j < len(tagSortList); j++ {
-			// if we find a duplicate tag with higher priority we do not insert the tag
-			if i != j && tagSortList[i].tagName == tagSortList[j].tagName &&
-				collectors.CollectorPriorities[tagSortList[i].source] < collectors.CollectorPriorities[tagSortList[j].source] {
-				insert = false
-				break
+	for _, tags := range tagSortList {
+		for i := 0; i < len(tags); i++ {
+			insert := true
+			for j := 0; j < len(tags); j++ {
+				// if we find a duplicate tag with higher priority we do not insert the tag
+				if i != j && collectors.CollectorPriorities[tags[i].source] < collectors.CollectorPriorities[tags[j].source] {
+					insert = false
+					break
+				}
 			}
-		}
-		if insert {
-			if tagSortList[i].isHighCard {
-				highCardTags = append(highCardTags, tagSortList[i].tag)
-			} else {
-				lowCardTags = append(lowCardTags, tagSortList[i].tag)
+			if insert {
+				if tags[i].isHighCard {
+					highCardTags = append(highCardTags, tags[i].tag)
+				} else {
+					lowCardTags = append(lowCardTags, tags[i].tag)
+				}
 			}
 		}
 	}

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -119,10 +119,10 @@ func (s *tagStore) lookup(entity string, highCard bool) ([]string, []string) {
 }
 
 type tagSort struct {
-	tag         string // full tag
-	tagName     string // first part of the tag (before ":")
-	source      string // collector
-	cardinality bool   // true is high card
+	tag        string // full tag
+	tagName    string // first part of the tag (before ":")
+	source     string // collector
+	isHighCard bool   // is the tag high cardinality
 }
 
 func (e *entityTags) get(highCard bool) ([]string, []string) {
@@ -145,10 +145,10 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 		sources = append(sources, source)
 		for _, t := range tags {
 			tagSortList = append(tagSortList, tagSort{
-				tag:         t,
-				tagName:     strings.Split(t, ":")[0],
-				source:      source,
-				cardinality: false,
+				tag:        t,
+				tagName:    strings.Split(t, ":")[0],
+				source:     source,
+				isHighCard: false,
 			})
 		}
 	}
@@ -156,10 +156,10 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 	for source, tags := range e.highCardTags {
 		for _, t := range tags {
 			tagSortList = append(tagSortList, tagSort{
-				tag:         t,
-				tagName:     strings.Split(t, ":")[0],
-				source:      source,
-				cardinality: true,
+				tag:        t,
+				tagName:    strings.Split(t, ":")[0],
+				source:     source,
+				isHighCard: true,
 			})
 		}
 	}
@@ -173,10 +173,11 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 			if i != j && tagSortList[i].tagName == tagSortList[j].tagName &&
 				collectors.CollectorPriorities[tagSortList[i].source] < collectors.CollectorPriorities[tagSortList[j].source] {
 				insert = false
+				break
 			}
 		}
 		if insert {
-			if tagSortList[i].cardinality {
+			if tagSortList[i].isHighCard {
 				highCardTags = append(highCardTags, tagSortList[i].tag)
 			} else {
 				lowCardTags = append(lowCardTags, tagSortList[i].tag)
@@ -192,7 +193,7 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 	e.cacheValid = true
 	e.cachedSource = sources
 	e.cachedAll = tags
-	e.cachedLow = lowCardTags
+	e.cachedLow = e.cachedAll[:len(lowCardTags)]
 	e.Unlock()
 
 	if highCard {

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -120,7 +120,6 @@ func (s *tagStore) lookup(entity string, highCard bool) ([]string, []string) {
 
 type tagSort struct {
 	tag        string // full tag
-	tagName    string // first part of the tag (before ":")
 	source     string // collector
 	isHighCard bool   // is the tag high cardinality
 }
@@ -139,49 +138,24 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 
 	// Cache miss
 	var sources []string
-	var tagSortList []tagSort
+	tagSortList := make(map[string]tagSort)
 
 	for source, tags := range e.lowCardTags {
 		sources = append(sources, source)
-		for _, t := range tags {
-			tagSortList = append(tagSortList, tagSort{
-				tag:        t,
-				tagName:    strings.Split(t, ":")[0],
-				source:     source,
-				isHighCard: false,
-			})
-		}
+		insertWithPriority(tagSortList, tags, source, false)
 	}
 
 	for source, tags := range e.highCardTags {
-		for _, t := range tags {
-			tagSortList = append(tagSortList, tagSort{
-				tag:        t,
-				tagName:    strings.Split(t, ":")[0],
-				source:     source,
-				isHighCard: true,
-			})
-		}
+		insertWithPriority(tagSortList, tags, source, true)
 	}
 
 	lowCardTags := []string{}
 	highCardTags := []string{}
-	for i := 0; i < len(tagSortList); i++ {
-		insert := true
-		for j := 0; j < len(tagSortList); j++ {
-			// if we find a duplicate tag with higher priority we do not insert the tag
-			if i != j && tagSortList[i].tagName == tagSortList[j].tagName &&
-				collectors.CollectorPriorities[tagSortList[i].source] < collectors.CollectorPriorities[tagSortList[j].source] {
-				insert = false
-				break
-			}
-		}
-		if insert {
-			if tagSortList[i].isHighCard {
-				highCardTags = append(highCardTags, tagSortList[i].tag)
-			} else {
-				lowCardTags = append(lowCardTags, tagSortList[i].tag)
-			}
+	for _, tagSort := range tagSortList {
+		if tagSort.isHighCard {
+			highCardTags = append(highCardTags, tagSort.tag)
+		} else {
+			lowCardTags = append(lowCardTags, tagSort.tag)
 		}
 	}
 
@@ -200,4 +174,27 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 		return tags, sources
 	}
 	return lowCardTags, sources
+}
+
+func insertWithPriority(tagSortList map[string]tagSort, tags []string, source string, isHighCard bool) {
+	for _, t := range tags {
+		tagName := strings.Split(t, ":")[0]
+		insert := false
+		if originalTag, ok := tagSortList[tagName]; ok {
+			// if the new tag has higher prio we replace the tag
+			if collectors.CollectorPriorities[source] > collectors.CollectorPriorities[originalTag.source] {
+				insert = true
+			}
+		} else {
+			// if the tag was not present we insert it
+			insert = true
+		}
+		if insert {
+			tagSortList[tagName] = tagSort{
+				tag:        t,
+				source:     source,
+				isHighCard: isHighCard,
+			}
+		}
+	}
 }

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -27,13 +27,13 @@ func (s *StoreTestSuite) TestIngest() {
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test",
-		LowCardTags:  []string{"tag1"},
-		HighCardTags: []string{"tag2"},
+		LowCardTags:  []string{"tag"},
+		HighCardTags: []string{"tag"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:      "source2",
 		Entity:      "test",
-		LowCardTags: []string{"tag3"},
+		LowCardTags: []string{"tag"},
 	})
 
 	s.store.storeMutex.RLock()
@@ -48,13 +48,13 @@ func (s *StoreTestSuite) TestLookup() {
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test",
-		LowCardTags:  []string{"tag1"},
-		HighCardTags: []string{"tag2"},
+		LowCardTags:  []string{"tag"},
+		HighCardTags: []string{"tag"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:      "source2",
 		Entity:      "test",
-		LowCardTags: []string{"tag3"},
+		LowCardTags: []string{"tag"},
 	})
 
 	tagsHigh, sourcesHigh := s.store.lookup("test", true)
@@ -87,19 +87,19 @@ func (s *StoreTestSuite) TestPrune() {
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test1",
-		LowCardTags:  []string{"tag1"},
-		HighCardTags: []string{"tag2"},
+		LowCardTags:  []string{"tag"},
+		HighCardTags: []string{"tag"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:      "source2",
 		Entity:      "test1",
-		LowCardTags: []string{"tag3"},
+		LowCardTags: []string{"tag"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test2",
-		LowCardTags:  []string{"tag1"},
-		HighCardTags: []string{"tag2"},
+		LowCardTags:  []string{"tag"},
+		HighCardTags: []string{"tag"},
 	})
 
 	// Deletion, to be batched

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -27,13 +27,13 @@ func (s *StoreTestSuite) TestIngest() {
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test",
-		LowCardTags:  []string{"tag"},
-		HighCardTags: []string{"tag"},
+		LowCardTags:  []string{"tag1"},
+		HighCardTags: []string{"tag2"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:      "source2",
 		Entity:      "test",
-		LowCardTags: []string{"tag"},
+		LowCardTags: []string{"tag3"},
 	})
 
 	s.store.storeMutex.RLock()
@@ -48,13 +48,13 @@ func (s *StoreTestSuite) TestLookup() {
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test",
-		LowCardTags:  []string{"tag"},
-		HighCardTags: []string{"tag"},
+		LowCardTags:  []string{"tag1"},
+		HighCardTags: []string{"tag2"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:      "source2",
 		Entity:      "test",
-		LowCardTags: []string{"tag"},
+		LowCardTags: []string{"tag3"},
 	})
 
 	tagsHigh, sourcesHigh := s.store.lookup("test", true)
@@ -87,19 +87,19 @@ func (s *StoreTestSuite) TestPrune() {
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test1",
-		LowCardTags:  []string{"tag"},
-		HighCardTags: []string{"tag"},
+		LowCardTags:  []string{"tag1"},
+		HighCardTags: []string{"tag2"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:      "source2",
 		Entity:      "test1",
-		LowCardTags: []string{"tag"},
+		LowCardTags: []string{"tag3"},
 	})
 	s.store.processTagInfo(&collectors.TagInfo{
 		Source:       "source1",
 		Entity:       "test2",
-		LowCardTags:  []string{"tag"},
-		HighCardTags: []string{"tag"},
+		LowCardTags:  []string{"tag1"},
+		HighCardTags: []string{"tag2"},
 	})
 
 	// Deletion, to be batched

--- a/releasenotes/notes/kubelet-image-tags-b74a4dc514a33a58.yaml
+++ b/releasenotes/notes/kubelet-image-tags-b74a4dc514a33a58.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The kubelet will now collect image tags from the pod list

--- a/releasenotes/notes/kubelet-image-tags-b74a4dc514a33a58.yaml
+++ b/releasenotes/notes/kubelet-image-tags-b74a4dc514a33a58.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    The kubelet will now collect image tags from the pod list
+    The agent will now collect container image tags when running in kubernetes-only mode


### PR DESCRIPTION
### What does this PR do?

Add image tags for the kubelet tagger

### Motivation

Have image tags if running in kubelet-only mode

### Additional Notes

If kubernetes is running in docker runtime image tags should be both collected from doker & kubelet tagger but deduped in the store as they should be equivalent
