### PR TITLE
Omnibus s3 caching

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ variables:
   S3_CP_OPTIONS: --only-show-errors --region us-east-1 --sse AES256
   S3_CP_CMD: aws s3 cp $S3_CP_OPTIONS
   S3_ARTEFACTS_URI: s3://dd-ci-artefacts-build-stable/$CI_PROJECT_NAME/$CI_PIPELINE_ID
+  S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
   S3_DSD6_URI: s3://dsd6-staging/linux
   RELEASE_VERSION: nightly
 
@@ -43,6 +44,7 @@ before_script:
   - rsync -azr --delete ./ $SRC_PATH
   - cd $SRC_PATH
   - inv -e deps
+
 
 
 #
@@ -183,6 +185,8 @@ agent_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -208,6 +212,8 @@ agent_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -238,6 +244,8 @@ agent_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:latest
   tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -276,6 +284,9 @@ build_windows_msi_x64:
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
     - inv -e deps
   stage: package_build
+  variables:
+    WINDOWS_BUILDER: 'true'
+    CREDENTIALS_FILE_PATH: 'c:\users\gitlab\.aws\config'
   tags: ["runner:windows-agent6"]
   script:
     # remove artifacts from previous pipelines that may come from the cache
@@ -294,6 +305,8 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -319,6 +332,8 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*
@@ -350,6 +365,8 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:latest
   tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,7 +193,7 @@ agent_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-agent*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent*_amd64.deb $S3_ARTEFACTS_URI/datadog-agent_amd64.deb
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -225,7 +225,7 @@ agent_rpm-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
     - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
   # cache:
@@ -257,7 +257,7 @@ agent_suse-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache
     # FIXME: skip the installation step until we fix the preinst/postinst scripts in the rpm package
     # to also work with SUSE11
     # - rpm -i $OMNIBUS_PACKAGE_DIR_SUSE/*.rpm
@@ -292,7 +292,7 @@ build_windows_msi_x64:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf .omnibus/pkg/
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - inv agent.omnibus-build --release-version %RELEASE_VERSION%
+    - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache
   after_script:
     - '"C:\Program Files\Amazon\AWSCLI\aws.exe" s3 cp --profile ci-datadog-agent %S3_CP_OPTIONS% --recursive --exclude "*" --include "*.msi" .omnibus/pkg/ s3://%WINDOWS_TESTING_S3_BUCKET%/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732'
   artifacts:
@@ -313,7 +313,7 @@ dogstatsd_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR
+    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb $S3_ARTEFACTS_URI/datadog-dogstatsd_amd64.deb
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -345,7 +345,7 @@ dogstatsd_rpm-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR
+    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
     - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
   # cache:
@@ -378,7 +378,7 @@ dogstatsd_suse-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR_SUSE
+    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache
     - rpm -i $OMNIBUS_PACKAGE_DIR_SUSE/*.rpm
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
   # cache:

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -6,3 +6,23 @@
 windows_arch :x86_64
 # Don't append a timestamp to the package version
 append_timestamp false
+
+# Do not set this environment variable if building locally.
+# This cache is only necessary because Datadog is building
+# the agent over and over again in a highly distributed environment.
+if ENV["S3_OMNIBUS_CACHE_BUCKET"]
+  use_s3_caching true
+  s3_bucket ENV["S3_OMNIBUS_CACHE_BUCKET"]
+  s3_endpoint "https://s3.amazonaws.com"
+  s3_region 'us-east-1'
+  s3_force_path_style true
+  s3_authenticated_download true
+  if ENV['WINDOWS_BUILDER']
+    s3_role true
+    s3_role_arn 'arn:aws:iam::486234852809:role/ci-datadog-agent'
+    s3_role_session_name 'datadog-agent-builder'
+    s3_sts_creds_instance_profile true
+  else
+    s3_instance_profile true
+  end
+end

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -244,12 +244,13 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
         ctx.run(cmd, env=env)
 
         omnibus = "bundle exec omnibus.bat" if sys.platform == 'win32' else "bundle exec omnibus"
-        cmd = "{omnibus} build {project_name} --log-level={log_level} {overrides}"
+        cmd = "{omnibus} build {project_name} --log-level={log_level} {populate_s3_cache} {overrides}"
         args = {
             "omnibus": omnibus,
             "project_name": "puppy" if puppy else "agent",
             "log_level": log_level,
-            "overrides": overrides_cmd
+            "overrides": overrides_cmd,
+            "populate_s3_cache": " --populate-s3-cache "
         }
         if skip_sign:
             env['SKIP_SIGN_MAC'] = 'true'

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -217,7 +217,7 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
 
 @task(help={'skip-sign': "On macOS, use this option to build an unsigned package if you don't have Datadog's developer keys."})
 def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=None,
-                  skip_deps=False, skip_sign=False, release_version="nightly"):
+                  skip_deps=False, skip_sign=False, release_version="nightly", omnibus_s3_cache=False):
     """
     Build the Agent packages with Omnibus Installer.
     """
@@ -250,8 +250,10 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
             "project_name": "puppy" if puppy else "agent",
             "log_level": log_level,
             "overrides": overrides_cmd,
-            "populate_s3_cache": " --populate-s3-cache "
+            "populate_s3_cache": ""
         }
+        if omnibus_s3_cache:
+            args['populate_s3_cache'] = " --populate-s3-cache "
         if skip_sign:
             env['SKIP_SIGN_MAC'] = 'true'
         ctx.run(cmd.format(**args), env=env)

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -146,7 +146,7 @@ def size_test(ctx, skip_build=False):
 
 @task
 def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
-                  skip_deps=False, omnibus_cache=False):
+                  skip_deps=False, omnibus_s3_cache=False):
     """
     Build the Dogstatsd packages with Omnibus Installer.
     """

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -146,7 +146,7 @@ def size_test(ctx, skip_build=False):
 
 @task
 def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
-                  skip_deps=False):
+                  skip_deps=False, omnibus_cache=False):
     """
     Build the Dogstatsd packages with Omnibus Installer.
     """
@@ -178,7 +178,8 @@ def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
             "overrides": overrides_cmd,
             "populate_s3_cache": ""
         }
-        args['populate_s3_cache'] = " --populate-s3-cache "
+        if omnibus_s3_cache:
+            args['populate_s3_cache'] = " --populate-s3-cache "
         ctx.run(cmd.format(**args))
 
 

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -171,12 +171,14 @@ def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
             cmd += " --path {}".format(gem_path)
         ctx.run(cmd)
         omnibus = "bundle exec omnibus.bat" if sys.platform == 'win32' else "bundle exec omnibus"
-        cmd = "{omnibus} build dogstatsd --log-level={log_level} {overrides}"
+        cmd = "{omnibus} build dogstatsd --log-level={log_level} {populate_s3_cache} {overrides}"
         args = {
             "omnibus": omnibus,
             "log_level": log_level,
-            "overrides": overrides_cmd
+            "overrides": overrides_cmd,
+            "populate_s3_cache": ""
         }
+        args['populate_s3_cache'] = " --populate-s3-cache "
         ctx.run(cmd.format(**args))
 
 


### PR DESCRIPTION
### What does this PR do?

This PR adds s3 caching to Omnibus. It requires this PR to be merged in order to use it: https://github.com/DataDog/omnibus-ruby/pull/52

### Motivation

This should speed up builds significantly and prevent sourceforge and others from mucking it up!


