### PR TITLE
Add Logs Agent status to the GUI General Status Page

### DIFF
--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -49,7 +49,6 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	json, _ := json.Marshal(status)
-
 	html, e := renderStatus(json, statusType)
 	if e != nil {
 		w.Write([]byte("Error generating status html: " + e.Error()))

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -126,8 +126,8 @@
       {{ if (not .is_running) }}
         logs-agent is not running </br>
       {{ else }}
-      {{- range .integrations }}
-        <span class="stat_subtitle">{{.name}}</span>
+      {{- range .integrations -}}
+        <span class="stat_subtitle">{{- .name }}</span>
         <span class="stat_subdata">
           {{- range .sources }}
             Type: {{ .type }}</br>

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -151,7 +151,6 @@
             {{- end }}
           {{- end }}
         </span>
-        </span>
         {{ end }}
       {{- end }}
     {{- end -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -120,6 +120,45 @@
   </div>
 
   <div class="stat">
+    <span class="stat_title">Logs-agent</span>
+    <span class="stat_data">
+    {{- with .logsStats -}}
+      {{ if (not .is_running) }}
+        logs-agent is not running </br>
+      {{ else }}
+      {{- range .integrations }}
+        <span class="stat_subtitle">{{.name}}</span>
+        <span class="stat_subdata">
+          {{- range .sources }}
+            Type: {{ .type }}</br>
+            {{- if .path }}
+            Path: {{ .path }}</br>
+            {{- end }}
+            {{- if .port }}
+            Port: {{ .port }}</br>
+            {{- end }}
+            {{- if .image }}
+            Image: {{ .image }}</br>
+            {{- end }}
+            {{- if .label }}
+            Label: {{ .label }}</br>
+            {{- end }}
+            {{- if .status }}
+            Status: {{ .status }}</br>
+            {{- end }}
+            {{- if .inputs }}
+            Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
+            {{- end }}
+          {{- end }}
+        </span>
+        </span>
+        {{ end }}
+      {{- end }}
+    {{- end -}}
+    </span>
+  </div>
+
+  <div class="stat">
     <span class="stat_title">DogStatsD</span>
     <span class="stat_data">
       {{- with .aggregatorStats -}}
@@ -154,6 +193,6 @@
           Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}<br>
         {{- end}}
       {{- end -}}
-    <span>
+    </span>
   </div>
 {{- end -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -120,11 +120,11 @@
   </div>
 
   <div class="stat">
-    <span class="stat_title">Logs-agent</span>
+    <span class="stat_title">Logs Agent</span>
     <span class="stat_data">
     {{- with .logsStats -}}
       {{ if (not .is_running) }}
-        logs-agent is not running </br>
+        Logs Agent is not running </br>
       {{ else }}
       {{- range .integrations -}}
         <span class="stat_subtitle">{{- .name }}</span>

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -1,8 +1,8 @@
 ==========
-Logs-agent
+Logs Agent
 ==========
 {{ if (not .is_running) }}
-  logs-agent is not running
+  Logs Agent is not running
 {{ else }}
 {{- range .integrations }}
   {{ .name }}

--- a/releasenotes/notes/add_logs_status_to_gui-bb7c92da73597960.yaml
+++ b/releasenotes/notes/add_logs_status_to_gui-bb7c92da73597960.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add information about Log Agent checks to the GUI General Status page.


### PR DESCRIPTION
### What does this PR do?

Adds the Logs Agent status component to the GUI "General Status" page. 

### Motivation

Keep the GUI more in line with with the "Status' command at the terminal.

### Additional Notes

What this looks like: 
https://cl.ly/2G3J2X1r3C34