### PR TITLE
Launch GUI asynchronously

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -90,7 +90,7 @@
         Id="LaunchApp"
         Directory="AGENT"
         Execute="immediate"
-        Return="check"
+        Return="asyncNoWait"
         ExeCommand="&quot;[AGENT]ddtray.exe&quot; &quot;-launch-gui&quot;" />
 
 


### PR DESCRIPTION
### What does this PR do?

Runs the GUI from the installer asynchronously and doesn't wait for the response. 

### Motivation

When installing the Agent on Windows, the final dialog box allows you to specify a checkbox to optionally start the GUI. When clicked, the MSI Installer will hang indefinitely (not using any CPU) but never exiting or allowing you to click "Finish" Changing this from `check` to `asyncNoWait` tells the installer not to wait for a status code - http://wixtoolset.org/documentation/manual/v3/xsd/wix/customaction.html

### Additional Notes

Tested on Windows 2012/2016