### PR TITLE
util/docker: fix network parsing

### DIFF
--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -8,6 +8,9 @@
 package docker
 
 import (
+	"io/ioutil"
+	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -15,20 +18,66 @@ import (
 	"github.com/docker/docker/api/types"
 	dockernetwork "github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func TestFindDockerNetworks(t *testing.T) {
-	assert := assert.New(t)
+func TestDefaultGateway(t *testing.T) {
+	testCases := []struct {
+		netRouteContent []byte
+		expectedIP      string
+	}{
+		{
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+ens33	00000000	0280A8C0	0003	0	0	100	00000000	0	0	0
+`),
+			"192.168.128.2",
+		},
+		{
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+ens33	00000000	FE01A8C0	0003	0	0	100	00000000	0	0	0
+`),
+			"192.168.1.254",
+		},
+		{
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+ens33	00000000	FEFEA8C0	0003	0	0	100	00000000	0	0	0
+`),
+			"192.168.254.254",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			testProc, err := newTempFolder("test-default-gateway")
+			require.NoError(t, err)
+			defer testProc.removeAll()
+			err = os.MkdirAll(path.Join(testProc.RootPath, "net"), os.ModePerm)
+			require.NoError(t, err)
 
+			err = ioutil.WriteFile(path.Join(testProc.RootPath, "net", "route"), testCase.netRouteContent, os.ModePerm)
+			require.NoError(t, err)
+			config.Datadog.SetDefault("proc_root", testProc.RootPath)
+			ip, err := DefaultGateway()
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedIP, ip.String())
+
+			testProc.removeAll()
+			ip, err = DefaultGateway()
+			require.NoError(t, err)
+			require.Nil(t, ip)
+		})
+	}
+}
+
+func TestFindDockerNetworks(t *testing.T) {
 	dummyProcDir, err := newTempFolder("test-find-docker-networks")
-	assert.Nil(err)
+	assert.Nil(t, err)
 	defer dummyProcDir.removeAll() // clean up
 	config.Datadog.SetDefault("container_proc_root", dummyProcDir.RootPath)
 
 	containerNetworks := make(map[string][]dockerNetwork)
-	for nb, tc := range []struct {
+	for _, tc := range []struct {
 		pid         int
 		container   types.Container
 		routes, dev string
@@ -201,6 +250,51 @@ func TestFindDockerNetworks(t *testing.T) {
 				PacketsSent: 0,
 			},
 		},
+		{
+			pid: 1245,
+			container: types.Container{
+				ID: "test-find-docker-networks-gateway",
+				HostConfig: struct {
+					NetworkMode string `json:",omitempty"`
+				}{
+					NetworkMode: "simple",
+				},
+				NetworkSettings: &types.SummaryNetworkSettings{
+					Networks: map[string]*dockernetwork.EndpointSettings{
+						"eth0": {
+							Gateway: "192.168.254.254",
+						},
+					},
+				},
+			},
+			routes: detab(`
+		                Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
+		                eth0    00000000    FEFEA8C0    0003    0   0   0   00000000    0   0   0
+		                eth0    00FEA8C0    00000000    0001    0   0   0   00FFFFFF    0   0   0
+		            `),
+			dev: detab(`
+		                Inter-|   Receive                                                |  Transmit
+		                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+		                  eth0:    1296      16    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+		                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+		            `),
+			networks: []dockerNetwork{{iface: "eth0", dockerName: "eth0"}},
+			stat: ContainerNetStats{
+				&InterfaceNetStats{
+					NetworkName: "eth0",
+					BytesRcvd:   1296,
+					PacketsRcvd: 16,
+					BytesSent:   0,
+					PacketsSent: 0,
+				},
+			},
+			summedStat: &InterfaceNetStats{
+				BytesRcvd:   1296,
+				PacketsRcvd: 16,
+				BytesSent:   0,
+				PacketsSent: 0,
+			},
+		},
 		// Multiple docker networks
 		{
 			pid: 5153,
@@ -289,26 +383,27 @@ func TestFindDockerNetworks(t *testing.T) {
 			summedStat: &InterfaceNetStats{},
 		},
 	} {
-		t.Logf("test case %d", nb)
-		// Create temporary files on disk with the routes and stats.
-		err = dummyProcDir.add(filepath.Join(strconv.Itoa(int(tc.pid)), "net", "route"), tc.routes)
-		assert.NoError(err)
-		err = dummyProcDir.add(filepath.Join(strconv.Itoa(int(tc.pid)), "net", "dev"), tc.dev)
-		assert.NoError(err)
+		t.Run("", func(t *testing.T) {
+			// Create temporary files on disk with the routes and stats.
+			err = dummyProcDir.add(filepath.Join(strconv.Itoa(int(tc.pid)), "net", "route"), tc.routes)
+			assert.NoError(t, err)
+			err = dummyProcDir.add(filepath.Join(strconv.Itoa(int(tc.pid)), "net", "dev"), tc.dev)
+			assert.NoError(t, err)
 
-		// Use the routes file and settings to get our networks.
-		networks := findDockerNetworks(tc.container.ID, tc.pid, tc.container)
-		containerNetworks[tc.container.ID] = networks
-		// Resolve any container-dependent networks before checking values.
-		// This assumes that the test case can only depend on containers in earlier cases.
-		resolveDockerNetworks(containerNetworks)
-		networks = containerNetworks[tc.container.ID]
-		assert.Equal(tc.networks, networks)
+			// Use the routes file and settings to get our networks.
+			networks := findDockerNetworks(tc.container.ID, tc.pid, tc.container)
+			containerNetworks[tc.container.ID] = networks
+			// Resolve any container-dependent networks before checking values.
+			// This assumes that the test case can only depend on containers in earlier cases.
+			resolveDockerNetworks(containerNetworks)
+			networks = containerNetworks[tc.container.ID]
+			assert.Equal(t, tc.networks, networks)
 
-		// And collect the stats on these networks.
-		stat, err := collectNetworkStats(tc.container.ID, tc.pid, networks)
-		assert.NoError(err)
-		assert.Equal(tc.stat, stat)
-		assert.Equal(tc.summedStat, stat.SumInterfaces())
+			// And collect the stats on these networks.
+			stat, err := collectNetworkStats(tc.container.ID, tc.pid, networks)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.stat, stat)
+			assert.Equal(t, tc.summedStat, stat.SumInterfaces())
+		})
 	}
 }

--- a/releasenotes/notes/fix-network-gateway-d70fc60bab04f781.yaml
+++ b/releasenotes/notes/fix-network-gateway-d70fc60bab04f781.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixing docker network metrics collection for the docker check and the process agent on some network configurations.


### PR DESCRIPTION
### What does this PR do?

Fix the parsing of the network IPs in the docker util package.

I added some tests to cover the public function `DefaultGateway`.