### PR TITLE
Fixing log level and avoiding starting svcmapper at every run

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -46,6 +46,7 @@ type KubeASCheck struct {
 	latestEventToken      string
 	configMapAvailable    bool
 	ac                    *apiserver.APIClient
+	init                  bool
 }
 
 func (c *KubeASConfig) parse(data []byte) error {
@@ -86,13 +87,14 @@ func (k *KubeASCheck) Run() error {
 		return err
 	}
 
-	if k.ac == nil {
+	if k.init == true {
 		// We start the API Server Client.
 		k.ac, err = apiserver.GetAPIClient()
 		if err != nil {
 			k.Warn("Could not connect to apiserver: %s", err)
 			return err
 		}
+		k.init = false
 	}
 
 	if errLeader == apiserver.ErrNotLeader {
@@ -147,6 +149,7 @@ func KubernetesASFactory() check.Check {
 		CheckBase: core.NewCheckBase(kubernetesAPIServerCheckName),
 		instance:  &KubeASConfig{},
 		ac:        &apiserver.APIClient{},
+		init:      true,
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -82,7 +82,11 @@ func (k *KubeASCheck) Run() error {
 	}
 
 	errLeader := k.runLeaderElection()
-	if errLeader != nil && errLeader != apiserver.ErrNotLeader {
+	if errLeader != nil {
+		if errLeader == apiserver.ErrNotLeader {
+			// Only the leader can instantiate the apiserver client.
+			return nil
+		}
 		return err
 	}
 
@@ -93,10 +97,6 @@ func (k *KubeASCheck) Run() error {
 			k.Warn("Could not connect to apiserver: %s", err)
 			return err
 		}
-	}
-
-	if errLeader == apiserver.ErrNotLeader {
-		return nil
 	}
 
 	// Running the Control Plane status check.

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -46,7 +46,6 @@ type KubeASCheck struct {
 	latestEventToken      string
 	configMapAvailable    bool
 	ac                    *apiserver.APIClient
-	init                  bool
 }
 
 func (c *KubeASConfig) parse(data []byte) error {
@@ -87,14 +86,13 @@ func (k *KubeASCheck) Run() error {
 		return err
 	}
 
-	if k.init == true {
+	if k.ac == nil {
 		// We start the API Server Client.
 		k.ac, err = apiserver.GetAPIClient()
 		if err != nil {
 			k.Warn("Could not connect to apiserver: %s", err)
 			return err
 		}
-		k.init = false
 	}
 
 	if errLeader == apiserver.ErrNotLeader {
@@ -148,8 +146,6 @@ func KubernetesASFactory() check.Check {
 	return &KubeASCheck{
 		CheckBase: core.NewCheckBase(kubernetesAPIServerCheckName),
 		instance:  &KubeASConfig{},
-		ac:        &apiserver.APIClient{},
-		init:      true,
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -221,7 +221,7 @@ func processKubeResources(nodeList *v1.NodeList, podList *v1.PodList, endpointLi
 	if nodeList.Items == nil || podList.Items == nil || endpointList.Items == nil {
 		return
 	}
-	log.Debugf("%d node, %d pod, %d endpoints", len(nodeList.Items), len(podList.Items), len(endpointList.Items))
+	log.Debugf("Identified: %d node, %d pod, %d endpoints", len(nodeList.Items), len(podList.Items), len(endpointList.Items))
 	for _, node := range nodeList.Items {
 		nodeName := *node.Metadata.Name
 		nodeNameCacheKey := cache.BuildAgentKey(serviceMapperCachePrefix, nodeName)

--- a/releasenotes/notes/fix-log-nonleader-servicemapper-run-8aa5b7da56fdc4c0.yaml
+++ b/releasenotes/notes/fix-log-nonleader-servicemapper-run-8aa5b7da56fdc4c0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - Run the service mapper on all the agents running the apiserver check.
+    Exit before running the rest of the check if the agent is not the leader.
+other:
+  - Avoid logging an error if the agent is not a leader.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -36,7 +36,6 @@ DEFAULT_BUILD_TAGS = [
     "snmp",
     "zk",
     "zlib",
-    "kubeapiserver",
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

- [x] Avoid logging an error when an agent is not the leader.
- [x] Make sure we run the service mapper on all the agents.
- [x] Make sure we only run it once.

### Motivation

BugFix/ Improvement