### PR TITLE
[config][test] remove hardcoded 6.0.0

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -281,6 +281,12 @@ func GetMultipleEndpoints() (map[string][]string, error) {
 	return getMultipleEndpoints(Datadog)
 }
 
+// getDomainPrefix provides the right prefix for agent X.Y.Z
+func getDomainPrefix(app string) string {
+	v, _ := version.New(version.AgentVersion, version.Commit)
+	return fmt.Sprintf("%d-%d-%d-%s.agent", v.Major, v.Minor, v.Patch, app)
+}
+
 // addAgentVersionToDomain prefix the domain with the agent version: X-Y-Z.domain
 func addAgentVersionToDomain(domain string, app string) (string, error) {
 	u, err := url.Parse(domain)
@@ -293,9 +299,8 @@ func addAgentVersionToDomain(domain string, app string) (string, error) {
 		return domain, nil
 	}
 
-	v, _ := version.New(version.AgentVersion, version.Commit)
 	subdomain := strings.Split(u.Host, ".")[0]
-	newSubdomain := fmt.Sprintf("%d-%d-%d-%s.agent", v.Major, v.Minor, v.Patch, app)
+	newSubdomain := getDomainPrefix(app)
 
 	u.Host = strings.Replace(u.Host, subdomain, newSubdomain, 1)
 	return u.String(), nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const targetDomain string = "6-0-0-app.agent"
-
 func TestDefaults(t *testing.T) {
 	assert.Equal(t, Datadog.GetString("dd_url"), "https://app.datadoghq.com")
 }
@@ -48,7 +46,7 @@ additional_endpoints:
 		"https://foo.datadoghq.com": {
 			"someapikey",
 		},
-		"https://" + targetDomain + ".datadoghq.com": {
+		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
 			"fakeapikey",
 			"fakeapikey2",
 			"fakeapikey3",
@@ -70,7 +68,7 @@ api_key: fakeapikey
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
-		"https://" + targetDomain + ".datadoghq.com": {
+		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
 			"fakeapikey",
 		},
 	}
@@ -98,7 +96,7 @@ additional_endpoints:
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
-		"https://" + targetDomain + ".datadoghq.com": {
+		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
 			"fakeapikey",
 			"fakeapikey2",
 		},
@@ -131,7 +129,7 @@ additional_endpoints:
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
-		"https://" + targetDomain + ".datadoghq.com": {
+		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
 			"fakeapikey",
 			"fakeapikey2",
 		},
@@ -148,11 +146,11 @@ additional_endpoints:
 func TestAddAgentVersionToDomain(t *testing.T) {
 	newURL, err := addAgentVersionToDomain("https://app.datadoghq.com", "app")
 	require.Nil(t, err)
-	assert.Equal(t, "https://6-0-0-app.agent.datadoghq.com", newURL)
+	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.com", newURL)
 
 	newURL, err = addAgentVersionToDomain("https://app.datadoghq.com", "flare")
 	require.Nil(t, err)
-	assert.Equal(t, "https://6-0-0-flare.agent.datadoghq.com", newURL)
+	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.com", newURL)
 
 	newURL, err = addAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

Removes the `6.0.0` hardcoded assumption from `config` tests.

### Motivation

Failed CI/build as soon as we tried to build `6.0.1` 

### Additional Notes

Anything else we should know when reviewing?
