### PR TITLE
Updates Windows memory metrics

### DIFF
--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -6,15 +6,11 @@
 package system
 
 import (
-	"fmt"
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/mem"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 const memCheckName = "memory"
@@ -30,79 +26,6 @@ type MemoryCheck struct {
 }
 
 const mbSize float64 = 1024 * 1024
-
-func (c *MemoryCheck) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return err
-	}
-
-	sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
-	sender.Gauge("system.mem.shared", float64(v.Shared)/mbSize, "", nil)
-	sender.Gauge("system.mem.slab", float64(v.Slab)/mbSize, "", nil)
-	sender.Gauge("system.mem.page_tables", float64(v.PageTables)/mbSize, "", nil)
-	sender.Gauge("system.swap.cached", float64(v.SwapCached)/mbSize, "", nil)
-	return nil
-}
-
-func (c *MemoryCheck) freebsdSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return err
-	}
-
-	sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
-	return nil
-}
-
-// Run executes the check
-func (c *MemoryCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
-	if err != nil {
-		return err
-	}
-
-	v, errVirt := virtualMemory()
-	if errVirt == nil {
-		sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
-		sender.Gauge("system.mem.free", float64(v.Free)/mbSize, "", nil)
-		sender.Gauge("system.mem.used", float64(v.Total-v.Free)/mbSize, "", nil)
-		sender.Gauge("system.mem.usable", float64(v.Available)/mbSize, "", nil)
-		sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
-
-		switch runtimeOS {
-		case "linux":
-			e := c.linuxSpecificVirtualMemoryCheck(v)
-			if e != nil {
-				return e
-			}
-		case "freebsd":
-			e := c.freebsdSpecificVirtualMemoryCheck(v)
-			if e != nil {
-				return e
-			}
-		}
-	} else {
-		log.Errorf("system.MemoryCheck: could not retrieve virtual memory stats: %s", errVirt)
-	}
-
-	s, errSwap := swapMemory()
-	if errSwap == nil {
-		sender.Gauge("system.swap.total", float64(s.Total)/mbSize, "", nil)
-		sender.Gauge("system.swap.free", float64(s.Free)/mbSize, "", nil)
-		sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
-		sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
-	} else {
-		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
-	}
-
-	if errVirt != nil && errSwap != nil {
-		return fmt.Errorf("failed to gather any memory information")
-	}
-
-	sender.Commit()
-	return nil
-}
 
 // Configure the Python check from YAML data
 func (c *MemoryCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {

--- a/pkg/collector/corechecks/system/memory_nix.go
+++ b/pkg/collector/corechecks/system/memory_nix.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package system
+
+import (
+	"fmt"
+
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/mem"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+// Run executes the check
+func (c *MemoryCheck) Run() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	v, errVirt := virtualMemory()
+	if errVirt == nil {
+		sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
+		sender.Gauge("system.mem.free", float64(v.Free)/mbSize, "", nil)
+		sender.Gauge("system.mem.used", float64(v.Total-v.Free)/mbSize, "", nil)
+		sender.Gauge("system.mem.usable", float64(v.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
+
+		switch runtimeOS {
+		case "linux":
+			e := c.linuxSpecificVirtualMemoryCheck(v)
+			if e != nil {
+				return e
+			}
+		case "freebsd":
+			e := c.freebsdSpecificVirtualMemoryCheck(v)
+			if e != nil {
+				return e
+			}
+		}
+	} else {
+		log.Errorf("system.MemoryCheck: could not retrieve virtual memory stats: %s", errVirt)
+	}
+
+	s, errSwap := swapMemory()
+	if errSwap == nil {
+		sender.Gauge("system.swap.total", float64(s.Total)/mbSize, "", nil)
+		sender.Gauge("system.swap.free", float64(s.Free)/mbSize, "", nil)
+		sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
+		sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
+	} else {
+		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
+	}
+
+	if errVirt != nil && errSwap != nil {
+		return fmt.Errorf("failed to gather any memory information")
+	}
+
+	sender.Commit()
+	return nil
+}
+
+func (c *MemoryCheck) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
+	sender.Gauge("system.mem.shared", float64(v.Shared)/mbSize, "", nil)
+	sender.Gauge("system.mem.slab", float64(v.Slab)/mbSize, "", nil)
+	sender.Gauge("system.mem.page_tables", float64(v.PageTables)/mbSize, "", nil)
+	sender.Gauge("system.swap.cached", float64(v.SwapCached)/mbSize, "", nil)
+	return nil
+}
+
+func (c *MemoryCheck) freebsdSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	sender.Gauge("system.mem.cached", float64(v.Cached)/mbSize, "", nil)
+	return nil
+}

--- a/pkg/collector/corechecks/system/memory_nix_test.go
+++ b/pkg/collector/corechecks/system/memory_nix_test.go
@@ -57,10 +57,11 @@ func TestMemoryCheckLinux(t *testing.T) {
 
 	runtimeOS = "linux"
 
-	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.free", 11554304000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.pct_usable", 0.19, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.cached", 2596446142464.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.shared", 327680000000.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -72,6 +73,7 @@ func TestMemoryCheckLinux(t *testing.T) {
 	mock.On("Gauge", "system.swap.pct_free", 0.6, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.cached", 25000000000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
+
 	err := memCheck.Run()
 	require.Nil(t, err)
 

--- a/pkg/collector/corechecks/system/memory_nix_test.go
+++ b/pkg/collector/corechecks/system/memory_nix_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build !windows
+
 package system
 
 import (
@@ -58,7 +60,6 @@ func TestMemoryCheckLinux(t *testing.T) {
 	runtimeOS = "linux"
 
 	mock.On("Gauge", "system.mem.free", 11554304000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.used", 791363890/mbSize, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build windows
+
+package system
+
+import (
+	"fmt"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+)
+
+// Run executes the check
+func (c *MemoryCheck) Run() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	v, errVirt := virtualMemory()
+	if errVirt == nil {
+		sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
+		sender.Gauge("system.mem.free", float64(v.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.used", float64(v.Total-v.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
+	} else {
+		log.Errorf("system.MemoryCheck: could not retrieve virtual memory stats: %s", errVirt)
+	}
+
+	s, errSwap := swapMemory()
+	if errSwap == nil {
+		sender.Gauge("system.swap.total", float64(s.Total)/mbSize, "", nil)
+		sender.Gauge("system.swap.free", float64(s.Free)/mbSize, "", nil)
+		sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
+		sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
+	} else {
+		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
+	}
+
+	if errVirt != nil && errSwap != nil {
+		return fmt.Errorf("failed to gather any memory information")
+	}
+
+	sender.Commit()
+	return nil
+}

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build windows
+
+package system
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func VirtualMemory() (*mem.VirtualMemoryStat, error) {
+	return &mem.VirtualMemoryStat{
+		Total:       12345667890,
+		Available:   234567890,
+		Used:        10000000000,
+		UsedPercent: 81,
+	}, nil
+}
+
+func SwapMemory() (*mem.SwapMemoryStat, error) {
+	return &mem.SwapMemoryStat{
+		Total:       100000,
+		Used:        40000,
+		Free:        60000,
+		UsedPercent: 40,
+		Sin:         21,
+		Sout:        22,
+	}, nil
+}
+
+func TestMemoryCheckWindows(t *testing.T) {
+	virtualMemory = VirtualMemory
+	swapMemory = SwapMemory
+	memCheck := new(MemoryCheck)
+
+	mock := mocksender.NewMockSender(memCheck.ID())
+
+	runtimeOS = "linux"
+
+	mock.On("Gauge", "system.mem.free", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.used", 12111100000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pct_usable", 0.19, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.swap.total", 100000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.swap.free", 60000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.swap.used", 40000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.swap.pct_free", 0.6, "", []string(nil)).Return().Times(1)
+
+	mock.On("Commit").Return().Times(1)
+
+	err := memCheck.Run()
+	require.Nil(t, err)
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 8)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -8,12 +8,10 @@
 package system
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/shirou/gopsutil/mem"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 

--- a/releasenotes/notes/fix_windows_mem_metrics-3d889b12477d98c1.yaml
+++ b/releasenotes/notes/fix_windows_mem_metrics-3d889b12477d98c1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - Replaces the system.mem.free metric with gopsutil's 'available' and splits the windows and linux memory checks. Previously this reported
+    with a value of 0 and `system.mem.used` was reporting the same as `system.mem.total`


### PR DESCRIPTION
### What does this PR do?

Splits the windows and Linux core memory check and replace `system.mem.free` with a separate value returned by gopsutil for windows. 

### Motivation

`System.mem.free` was reporting 0 on windows platforms, and so `system.mem.usable` was reporting the same as `system.mem.total`. 

### Additional Notes

Uses `available` instead of `free` - https://github.com/shirou/gopsutil/blob/master/mem/mem_windows.go#L42-L48. 