### PR TITLE
[install script] Stop installing old APT key

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -139,7 +139,6 @@ elif [ $OS = "Debian" ]; then
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb https://apt.${dd_url}/ stable 6' > /etc/apt/sources.list.d/datadog.list"
-    $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
     $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"

--- a/docs/agent/downgrade.md
+++ b/docs/agent/downgrade.md
@@ -23,7 +23,7 @@ sudo apt-get install apt-transport-https
 ```shell
 sudo rm /etc/apt/sources.list.d/datadog-beta.list
 [ ! -f /etc/apt/sources.list.d/datadog.list ] &&  echo 'deb https://apt.datadoghq.com/ stable main' | sudo tee /etc/apt/sources.list.d/datadog.list
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
 ```
 
 ##### Update apt and downgrade the agent

--- a/docs/agent/upgrade.md
+++ b/docs/agent/upgrade.md
@@ -53,7 +53,7 @@ sudo apt-get install apt-transport-https
 
 ```shell
 echo 'deb https://apt.datadoghq.com/ beta main' | sudo tee /etc/apt/sources.list.d/datadog-beta.list
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
 ```
 
 ##### Update Apt and Install the agent


### PR DESCRIPTION
It's useless now that we've switched to the new key.