### PR TITLE
lower log level on buildTemplates sanity check

### DIFF
--- a/pkg/collector/providers/utils.go
+++ b/pkg/collector/providers/utils.go
@@ -80,7 +80,7 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []ch
 
 	// sanity check
 	if len(checkNames) != len(initConfigs) || len(checkNames) != len(instances) {
-		log.Error("Template entries don't all have the same length, not using them.")
+		log.Warnf("Template entries don't all have the same length, not using them.")
 		return templates
 	}
 


### PR DESCRIPTION
There can be valid reasons to add a check with no instances. For example to disable an auto-discovered check by adding Kubernetes annotations. This lowers the log level for that configuration since it is not necessarily an error.