### PR TITLE
[k8s] add node labels as host tags

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -152,6 +152,10 @@ You will need to allow the agent to be allowed to perform a few actions:
 You can find the templates in manifests/rbac [here](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests/rbac).
 This will create the Service Account in the default namespace, a Cluster Role with the above rights and the Cluster Role Binding.
 
+### Node label collection
+
+The agent can collect node labels from the APIserver and report them as host tags. This feature is disabled by default, as it is usually redundant with cloud provider host tags. If you need to do so, you can provide a node label -> host tag mapping in the `DD_KUBERNETES_NODE_LABELS_AS_TAGS` environment variable. The format is the inline JSON described in the [tagging section](#Tagging).
+
 ## Log collection
 
 The Datadog Agent can collect logs from containers starting at the version 6. Two installations are possible:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -707,6 +707,12 @@
   revision = "95b47aa5df4eda9bfbc0133f77c0e320f0275eba"
 
 [[projects]]
+  name = "gopkg.in/Knetic/govaluate.v3"
+  packages = ["."]
+  revision = "d216395917cc49052c7c7094cf57f09657ca08a8"
+  version = "v3.0.0"
+
+[[projects]]
   name = "gopkg.in/inf.v0"
   packages = ["."]
   revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
@@ -839,6 +845,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f5ae0313a92b1cf98ae07c5eb9a633275141b3d3c8f960caf3e8fbd6becfe38e"
+  inputs-digest = "74342c7afe03c0a5f0996cfa44513e82b532f1556c99fd4f8d79e4ab3c1981e6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,6 +154,7 @@ func init() {
 	Datadog.SetDefault("docker_labels_as_tags", map[string]string{})
 	Datadog.SetDefault("docker_env_as_tags", map[string]string{})
 	Datadog.SetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
+	Datadog.SetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 
 	// Kubernetes
 	Datadog.SetDefault("kubernetes_http_kubelet_port", 10255)
@@ -247,6 +248,7 @@ func init() {
 	Datadog.BindEnv("docker_labels_as_tags")
 	Datadog.BindEnv("docker_env_as_tags")
 	Datadog.BindEnv("kubernetes_pod_labels_as_tags")
+	Datadog.BindEnv("kubernetes_node_labels_as_tags")
 	Datadog.BindEnv("ac_include")
 	Datadog.BindEnv("ac_exclude")
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -387,6 +387,14 @@ api_key:
 # leader_election: false
 # The leader election lease is an integer in seconds.
 # leader_lease_duration: 60
+#
+# Node labels that should be collected and their name in host tags. Off by default.
+# Some of these labels are redundant with metadata collected by
+# cloud provider crawlers (AWS, GCE, Azure)
+#
+# kubernetes_node_labels_as_tags:
+#   kubernetes.io/hostname: nodename
+#   beta.kubernetes.io/os: os
 {{ end -}}
 
 {{- if .ProcessAgent }}

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -12,18 +12,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/common"
-	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/azure"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
-	log "github.com/cihub/seelog"
+	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hosttags"
 )
 
 const packageCachePrefix = "host"
@@ -97,6 +98,13 @@ func getHostTags() *tags {
 		} else {
 			hostTags = append(hostTags, ec2Tags...)
 		}
+	}
+
+	k8sTags, err := k8s.GetTags()
+	if err != nil {
+		log.Debugf("No Kubernetes host tags %v", err)
+	} else {
+		hostTags = append(hostTags, k8sTags...)
 	}
 
 	gceTags, err := gce.GetTags()

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -379,3 +379,13 @@ func (c *APIClient) UpdateTokenInConfigmap(token, tokenValue string) error {
 	log.Debugf("Updated %s to %s in the ConfigMap %s", eventTokenKey, tokenValue, configMapDCAToken)
 	return nil
 }
+
+func (c *APIClient) NodeLabels(nodeName string) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	node, err := c.client.CoreV1().GetNode(ctx, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	return node.GetMetadata().GetLabels(), nil
+}

--- a/pkg/util/kubernetes/hosttags/no_tags.go
+++ b/pkg/util/kubernetes/hosttags/no_tags.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !kubelet !kubeapiserver
+
+package hosttags
+
+// GetTags gets the tags from the kubernetes apiserver
+func GetTags() ([]string, error) {
+	return nil, nil
+}

--- a/pkg/util/kubernetes/hosttags/tags.go
+++ b/pkg/util/kubernetes/hosttags/tags.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet,kubeapiserver
+
+package hosttags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+// GetTags gets the tags from the kubernetes apiserver
+func GetTags() ([]string, error) {
+	labelsToTags := config.Datadog.GetStringMapString("kubernetes_node_labels_as_tags")
+	if len(labelsToTags) == 0 {
+		// Nothing to extract
+		return nil, nil
+	}
+	nodeName, err := kubelet.HostnameProvider("")
+	if err != nil {
+		return nil, err
+	}
+	client, err := apiserver.GetAPIClient()
+	if err != nil {
+		return nil, err
+	}
+	nodeLabels, err := client.NodeLabels(nodeName)
+	if err != nil {
+		return nil, err
+	}
+	return extractTags(nodeLabels, labelsToTags), nil
+}
+
+func extractTags(nodeLabels, labelsToTags map[string]string) []string {
+	var tags []string
+
+	for labelName, labelValue := range nodeLabels {
+		// viper lower-cases map keys, so we must lowercase before matching
+		if tagName, found := labelsToTags[strings.ToLower(labelName)]; found {
+			tags = append(tags, fmt.Sprintf("%s:%s", tagName, labelValue))
+		}
+	}
+
+	return tags
+}

--- a/pkg/util/kubernetes/hosttags/tags_test.go
+++ b/pkg/util/kubernetes/hosttags/tags_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet,kubeapiserver
+
+package hosttags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractTags(t *testing.T) {
+	gkeLabels := map[string]string{
+		"beta.kubernetes.io/arch":       "amd64",
+		"beta.kubernetes.io/os":         "linux",
+		"cloud.google.com/gke-nodepool": "default-pool",
+		"kubernetes.io/hostname":        "gke-dummy-18-default-pool-6888842e-hcv0",
+	}
+
+	for _, tc := range []struct {
+		nodeLabels   map[string]string
+		labelsToTags map[string]string
+		expectedTags []string
+	}{
+		{
+			nodeLabels:   map[string]string{},
+			labelsToTags: map[string]string{},
+			expectedTags: nil,
+		},
+		{
+			nodeLabels: gkeLabels,
+			labelsToTags: map[string]string{
+				"kubernetes.io/hostname": "nodename",
+				"beta.kubernetes.io/os":  "os",
+			},
+			expectedTags: []string{
+				"nodename:gke-dummy-18-default-pool-6888842e-hcv0",
+				"os:linux",
+			},
+		},
+		{
+			nodeLabels: gkeLabels,
+			labelsToTags: map[string]string{
+				"kubernetes.io/hostname": "nodename",
+				"beta.kubernetes.io/os":  "os",
+			},
+			expectedTags: []string{
+				"nodename:gke-dummy-18-default-pool-6888842e-hcv0",
+				"os:linux",
+			},
+		},
+		{
+			nodeLabels: map[string]string{},
+			labelsToTags: map[string]string{
+				"kubernetes.io/hostname": "nodename",
+				"beta.kubernetes.io/os":  "os",
+			},
+			expectedTags: nil,
+		},
+		{
+			nodeLabels:   gkeLabels,
+			labelsToTags: map[string]string{},
+			expectedTags: nil,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			tags := extractTags(tc.nodeLabels, tc.labelsToTags)
+			assert.ElementsMatch(t, tc.expectedTags, tags)
+		})
+	}
+}

--- a/releasenotes/notes/kubernetes-host-tags-a2bffb53fd6cb1ec.yaml
+++ b/releasenotes/notes/kubernetes-host-tags-a2bffb53fd6cb1ec.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add kubernetes node label collection as host tags 


### PR DESCRIPTION
### What does this PR do?

Port the [Agent5 kubernetes host tags logic](https://github.com/DataDog/dd-agent/blob/master/utils/kubernetes/kubeutil.py#L507-L531) to Agent6.

I isolated it in its own package because:

- it depends on both the `kubelet` and the `apiserver` packages
- on the long term, we should rely on the DCA to get these, in order to avoid all node agents contacting the APIserver