### PR TITLE
[docker] fix cgroup matching on moby linux hosts

### DIFF
--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -571,19 +571,20 @@ func readCgroupPaths(pidCgroupPath string) (string, map[string]string, error) {
 // Returns the common containerID and a mapping of target => path
 // If the first line doesn't have a valid container ID we will return an empty string
 func parseCgroupPaths(r io.Reader) (string, map[string]string, error) {
-	var ok bool
 	var containerID string
 	paths := make(map[string]string)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		l := scanner.Text()
-		// Check if this process running inside a container.
-		containerID, ok = containerIDFromCgroup(l)
+		cID, ok := containerIDFromCgroup(l)
 		if !ok {
 			log.Debugf("could not parse container id from path '%s'", l)
 			continue
 		}
-
+		if containerID == "" {
+			// Take the first valid containerID
+			containerID = cID
+		}
 		sp := strings.SplitN(l, ":", 3)
 		if len(sp) < 3 {
 			continue

--- a/pkg/util/docker/cgroup_test.go
+++ b/pkg/util/docker/cgroup_test.go
@@ -339,12 +339,46 @@ func TestParseCgroupPaths(t *testing.T) {
 				"cpuset":  "/docker/9d76460be0e91bb0dd495e2ddcfa10db40c1ef0c1dbdb6a447a4974a9b58576e",
 			},
 		},
+		{
+			contents: []string{
+				"14:name=systemd:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"13:pids:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"12:hugetlb:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"11:net_prio:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"10:perf_event:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"9:net_cls:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"8:freezer:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"7:devices:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"6:memory:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"5:blkio:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"4:cpuacct:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"3:cpu:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"2:cpuset:/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"1:name=openrc:/docker",
+			},
+			expectedContainer: "af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+			expectedPaths: map[string]string{
+				"name=systemd": "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"pids":         "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"hugetlb":      "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"net_prio":     "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"perf_event":   "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"net_cls":      "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"freezer":      "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"devices":      "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"memory":       "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"blkio":        "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"cpuacct":      "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"cpu":          "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+				"cpuset":       "/docker/af1c1c0b02c6e45e0b6cb6151cd68fd02c7a6d91ad70d9bd72ccec8e83607841",
+			},
+		},
 	} {
 		contents := strings.NewReader(strings.Join(tc.contents, "\n"))
 		c, p, err := parseCgroupPaths(contents)
 		assert.NoError(t, err)
-		assert.Equal(t, c, tc.expectedContainer)
-		assert.Equal(t, p, tc.expectedPaths)
+		assert.Equal(t, tc.expectedContainer, c)
+		assert.Equal(t, tc.expectedPaths, p)
 	}
 }
 

--- a/releasenotes/notes/docker-cgroup-mobylinux-cfefa0d401706d0d.yaml
+++ b/releasenotes/notes/docker-cgroup-mobylinux-cfefa0d401706d0d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix docker metrics collection on Moby Linux hosts (default Swarm AMI)


### PR DESCRIPTION
### What does this PR do?

Since rc2 and https://github.com/DataDog/datadog-agent/commit/2fd1216ec1ca969a4fea061d23918e98c07b7093 , docker metric collection fails on Moby Linux (the recommended swarm host AMI).

Added a test case for this system, that has a malformed `"1:name=openrc:/docker"` line at the end of the cgroup file. Patch makes us keep the first valid cgroup line, instead of taking the last one (that is invalid on this system). 

This bug impacts both the docker corecheck and the process-agent.

**Test image : `xvellodatadog/agent-dev:moby`**