### PR TITLE
[tagger] add experimental full cardinality mode

### DIFF
--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/go-connections/nat"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -443,7 +442,7 @@ func parseDockerPort(port nat.Port) ([]int, error) {
 // GetTags retrieves tags using the Tagger
 func (s *DockerService) GetTags() ([]string, error) {
 	entity := docker.ContainerIDToEntityName(string(s.ID))
-	tags, err := tagger.Tag(entity, config.Datadog.GetBool("full_cardinality_tagging"))
+	tags, err := tagger.Tag(entity, tagger.IsFullCardinality())
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/go-connections/nat"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -442,7 +443,7 @@ func parseDockerPort(port nat.Port) ([]int, error) {
 // GetTags retrieves tags using the Tagger
 func (s *DockerService) GetTags() ([]string, error) {
 	entity := docker.ContainerIDToEntityName(string(s.ID))
-	tags, err := tagger.Tag(entity, false)
+	tags, err := tagger.Tag(entity, config.Datadog.GetBool("full_cardinality_tagging"))
 	if err != nil {
 		return []string{}, err
 	}

--- a/pkg/collector/listeners/ecs.go
+++ b/pkg/collector/listeners/ecs.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -163,7 +164,7 @@ func (l *ECSListener) createService(c ecs.Container) (ECSService, error) {
 
 	// Tags
 	entity := docker.ContainerIDToEntityName(string(c.DockerID))
-	tags, err := tagger.Tag(entity, false)
+	tags, err := tagger.Tag(entity, config.Datadog.GetBool("full_cardinality_tagging"))
 	if err != nil {
 		log.Errorf("Failed to extract tags for container %s - %s", cID[:12], err)
 	}

--- a/pkg/collector/listeners/ecs.go
+++ b/pkg/collector/listeners/ecs.go
@@ -13,7 +13,6 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -164,7 +163,7 @@ func (l *ECSListener) createService(c ecs.Container) (ECSService, error) {
 
 	// Tags
 	entity := docker.ContainerIDToEntityName(string(c.DockerID))
-	tags, err := tagger.Tag(entity, config.Datadog.GetBool("full_cardinality_tagging"))
+	tags, err := tagger.Tag(entity, tagger.IsFullCardinality())
 	if err != nil {
 		log.Errorf("Failed to extract tags for container %s - %s", cID[:12], err)
 	}

--- a/pkg/collector/listeners/kubelet.go
+++ b/pkg/collector/listeners/kubelet.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -238,5 +239,5 @@ func (s *PodContainerService) GetPorts() ([]int, error) {
 
 // GetTags retrieves tags using the Tagger
 func (s *PodContainerService) GetTags() ([]string, error) {
-	return tagger.Tag(string(s.ID), false)
+	return tagger.Tag(string(s.ID), config.Datadog.GetBool("full_cardinality_tagging"))
 }

--- a/pkg/collector/listeners/kubelet.go
+++ b/pkg/collector/listeners/kubelet.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -239,5 +238,5 @@ func (s *PodContainerService) GetPorts() ([]int, error) {
 
 // GetTags retrieves tags using the Tagger
 func (s *PodContainerService) GetTags() ([]string, error) {
-	return tagger.Tag(string(s.ID), config.Datadog.GetBool("full_cardinality_tagging"))
+	return tagger.Tag(string(s.ID), tagger.IsFullCardinality())
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -214,6 +214,10 @@ func init() {
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 
+	// Tagger full cardinality mode
+	// Undocumented opt-in feature for now
+	BindEnvAndSetDefault("full_cardinality_tagging", false)
+
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -37,6 +37,7 @@ type Server struct {
 	stopChan     chan bool
 	health       *health.Handle
 	metricPrefix string
+	fullCard     bool
 }
 
 // NewServer returns a running Dogstatsd server
@@ -92,6 +93,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		stopChan:     make(chan bool),
 		health:       health.Register("dogstatsd-main"),
 		metricPrefix: metricPrefix,
+		fullCard:     config.Datadog.GetBool("full_cardinality_tagging"),
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
@@ -166,7 +168,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 			if packet.Origin != listeners.NoOrigin {
 				var err error
 				log.Tracef("Dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
-				originTags, err = tagger.Tag(packet.Origin, false)
+				originTags, err = tagger.Tag(packet.Origin, s.fullCard)
 				if err != nil {
 					log.Errorf(err.Error())
 				}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -37,7 +37,6 @@ type Server struct {
 	stopChan     chan bool
 	health       *health.Handle
 	metricPrefix string
-	fullCard     bool
 }
 
 // NewServer returns a running Dogstatsd server
@@ -93,7 +92,6 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		stopChan:     make(chan bool),
 		health:       health.Register("dogstatsd-main"),
 		metricPrefix: metricPrefix,
-		fullCard:     config.Datadog.GetBool("full_cardinality_tagging"),
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
@@ -168,7 +166,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 			if packet.Origin != listeners.NoOrigin {
 				var err error
 				log.Tracef("Dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
-				originTags, err = tagger.Tag(packet.Origin, s.fullCard)
+				originTags, err = tagger.Tag(packet.Origin, tagger.IsFullCardinality())
 				if err != nil {
 					log.Errorf(err.Error())
 				}

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -6,14 +6,19 @@
 package tagger
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
 // defaultTagger is the shared tagger instance backing the global Tag and Init functions
 var defaultTagger *Tagger
 
+// fullCardinality caches the value of the full_cardinality_taggin option
+var fullCardinality bool
+
 // Init must be called once config is available, call it in your cmd
 func Init() error {
+	fullCardinality = config.Datadog.GetBool("full_cardinality_tagging")
 	return defaultTagger.Init(collectors.DefaultCatalog)
 }
 
@@ -25,6 +30,10 @@ func Tag(entity string, highCard bool) ([]string, error) {
 // Stop queues a stop signal to the defaultTagger
 func Stop() error {
 	return defaultTagger.Stop()
+}
+
+func IsFullCardinality() bool {
+	return fullCardinality
 }
 
 func init() {

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -32,6 +32,8 @@ func Stop() error {
 	return defaultTagger.Stop()
 }
 
+// IsFullCardinality returns the full_cardinality_tagging option
+// this caches the call to viper, that would lookup and parse envvars
 func IsFullCardinality() bool {
 	return fullCardinality
 }

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -12,7 +12,6 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
@@ -35,7 +34,6 @@ type Tagger struct {
 	retryTicker *time.Ticker
 	stop        chan bool
 	health      *health.Handle
-	fullCard    bool
 }
 
 type collectorReply struct {
@@ -61,7 +59,6 @@ func newTagger() *Tagger {
 		retryTicker: time.NewTicker(30 * time.Second),
 		stop:        make(chan bool),
 		health:      health.Register("tagger"),
-		fullCard:    config.Datadog.GetBool("full_cardinality_tagging"),
 	}
 }
 
@@ -222,10 +219,6 @@ func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
 	if entity == "" {
 		return nil, errors.New("empty entity ID")
 	}
-
-	// Temporary full cardinality mode override
-	highCard = highCard || t.fullCard
-
 	cachedTags, sources := t.tagStore.lookup(entity, highCard)
 
 	if len(sources) == len(t.fetchers) {

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -224,9 +224,7 @@ func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
 	}
 
 	// Temporary full cardinality mode override
-	if highCard == false && t.fullCard == true {
-		highCard = true
-	}
+	highCard = highCard || t.fullCard
 
 	cachedTags, sources := t.tagStore.lookup(entity, highCard)
 

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
@@ -285,27 +284,4 @@ func TestErrNotFound(t *testing.T) {
 	_, err = tagger.Tag("invalid", true)
 	assert.NoError(t, err)
 	c.AssertNumberOfCalls(t, "Fetch", 2)
-}
-
-func TestFullCardinality(t *testing.T) {
-	catalog := collectors.Catalog{"stream": NewDummyStreamer}
-	config.Datadog.SetDefault("full_cardinality_tagging", true)
-	tagger := newTagger()
-	config.Datadog.SetDefault("full_cardinality_tagging", false)
-	tagger.Init(catalog)
-
-	tagger.tagStore.processTagInfo(&collectors.TagInfo{
-		Entity:       "entity_name",
-		Source:       "stream",
-		LowCardTags:  []string{"low"},
-		HighCardTags: []string{"high"},
-	})
-
-	tags, err := tagger.Tag("entity_name", true)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []string{"high", "low"}, tags)
-
-	tags, err = tagger.Tag("entity_name", false)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []string{"high", "low"}, tags)
 }


### PR DESCRIPTION
### What does this PR do?

Add a `full_cardinality_tagging` undocumented option that bypasses cardinality filtering in the tagger.

**Note: this feature is experimental and not to be used by end-users as of 6.1**

Change the cardinality on the user side to keep two legit low-card uses:
  - [docker.containers.* metrics, with client-side aggregation](https://github.com/DataDog/datadog-agent/blob/81a2af3854e8f92d09b9633b83be5a6af70525e4/pkg/collector/corechecks/containers/docker.go#L91)
  - [kubernetes.pods.* metrics, ditto](https://github.com/DataDog/integrations-core/blob/eb6cb1430a29c16d52489462c9dd3c6fdd95c34b/kubelet/datadog_checks/kubelet/kubelet.py#L219)