### PR TITLE
[docs] Document that go-metro is missing from 6.x release line for now

### DIFF
--- a/docs/agent/missing_features.md
+++ b/docs/agent/missing_features.md
@@ -6,4 +6,5 @@ the 6.x release line:
  * [Using the Agent as a Proxy](https://docs.datadoghq.com/agent/proxy/#using-the-agent-as-a-proxy)
  * [Custom emitters](https://github.com/DataDog/dd-agent/wiki/Using-custom-emitters)
  * [Dogstream](https://docs.datadoghq.com/agent/logs/)
+ * [go-metro](https://github.com/DataDog/integrations-core/tree/master/go-metro)
  * Graphite support


### PR DESCRIPTION
### What does this PR do?

Documents that go-metro is missing from 6.x release line for now
