### PR TITLE
[Logs]: Fixed issue with missing tags when collecting logs from docker container

### DIFF
--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -55,10 +55,9 @@ func (o *Origin) TagsPayload() []byte {
 	}
 	if len(o.tags) > 0 {
 		if tags != "" {
-			tags = tags + "," + strings.Join(o.tags, ",")
-		} else {
-			tags = strings.Join(o.tags, ",")
+			tags = tags + ","
 		}
+		tags = tags + strings.Join(o.tags, ",")
 	}
 	if tags != "" {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+tags+"\"]")...)

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -49,10 +49,12 @@ func (o *Origin) TagsPayload() []byte {
 	if o.LogSource.Config.SourceCategory != "" {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+o.LogSource.Config.SourceCategory+"\"]")...)
 	}
-	if o.LogSource.Config.Tags != "" {
+	if o.LogSource.Config.Tags != "" || len(o.tags) != 0 {
 		tags := o.LogSource.Config.Tags
-		if len(o.tags) > 0 {
+		if len(o.tags) > 0 && tags != "" {
 			tags = tags + "," + strings.Join(o.tags, ",")
+		} else {
+			tags = strings.Join(o.tags, ",")
 		}
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+tags+"\"]")...)
 	}

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -49,13 +49,18 @@ func (o *Origin) TagsPayload() []byte {
 	if o.LogSource.Config.SourceCategory != "" {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+o.LogSource.Config.SourceCategory+"\"]")...)
 	}
-	if o.LogSource.Config.Tags != "" || len(o.tags) != 0 {
-		tags := o.LogSource.Config.Tags
-		if len(o.tags) > 0 && tags != "" {
+	var tags string
+	if o.LogSource.Config.Tags != "" {
+		tags = o.LogSource.Config.Tags
+	}
+	if len(o.tags) > 0 {
+		if tags != "" {
 			tags = tags + "," + strings.Join(o.tags, ",")
 		} else {
 			tags = strings.Join(o.tags, ",")
 		}
+	}
+	if tags != "" {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+tags+"\"]")...)
 	}
 	if len(tagsPayload) == 0 {

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -22,6 +22,32 @@ func TestSetTagsEmpty(t *testing.T) {
 	assert.Equal(t, []byte{}, origin.TagsPayload())
 }
 
+func TestTagsWithConfigTagsOnly(t *testing.T) {
+	cfg := &config.LogsConfig{
+		Source:         "a",
+		SourceCategory: "b",
+		Tags:           "c:d,e",
+	}
+	source := config.NewLogSource("", cfg)
+	origin := NewOrigin()
+	origin.LogSource = source
+	assert.Equal(t, []string{"source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
+	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
+}
+
+func TestSetTagsWithNoConfigTags(t *testing.T) {
+	cfg := &config.LogsConfig{
+		Source:         "a",
+		SourceCategory: "b",
+	}
+	source := config.NewLogSource("", cfg)
+	origin := NewOrigin()
+	origin.LogSource = source
+	origin.SetTags([]string{"foo:bar", "baz"})
+	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b"}, origin.Tags())
+	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
+}
+
 func TestSetTagsWithConfigTags(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",
@@ -34,17 +60,4 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))
-}
-
-func TestSetTagsWithoutConfigTags(t *testing.T) {
-	cfg := &config.LogsConfig{
-		Source:         "a",
-		SourceCategory: "b",
-	}
-	source := config.NewLogSource("", cfg)
-	origin := NewOrigin()
-	origin.LogSource = source
-	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b"}, origin.Tags())
-	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
 }

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -22,7 +22,7 @@ func TestSetTagsEmpty(t *testing.T) {
 	assert.Equal(t, []byte{}, origin.TagsPayload())
 }
 
-func TestSetTags(t *testing.T) {
+func TestSetTagsWithConfigTags(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",
 		SourceCategory: "b",
@@ -34,4 +34,17 @@ func TestSetTags(t *testing.T) {
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))
+}
+
+func TestSetTagsWithoutConfigTags(t *testing.T) {
+	cfg := &config.LogsConfig{
+		Source:         "a",
+		SourceCategory: "b",
+	}
+	source := config.NewLogSource("", cfg)
+	origin := NewOrigin()
+	origin.LogSource = source
+	origin.SetTags([]string{"foo:bar", "baz"})
+	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b"}, origin.Tags())
+	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
 }

--- a/releasenotes/notes/logs-fix-msg-tags-missing-b4215986dbc67aab.yaml
+++ b/releasenotes/notes/logs-fix-msg-tags-missing-b4215986dbc67aab.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed the issue preventing from having docker tags when collecting logs from containers.


### PR DESCRIPTION
### What does this PR do?

Compute `ddtags` even if there is no tags specified in the integration file

### Motivation

Be able to collect docker tags all the time
