### PR TITLE
health: de-register healthcheck on both jobQueue stop code paths

### DIFF
--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -93,6 +93,7 @@ func (jq *jobQueue) waitForTick(out chan<- check.Check) bool {
 			select {
 			case <-jq.stop:
 				jq.ticker.Stop()
+				jq.health.Deregister()
 				jq.mu.RUnlock()
 				return false
 			case out <- check:

--- a/releasenotes/notes/collector-healthcheck-fix-c88561c557b61542.yaml
+++ b/releasenotes/notes/collector-healthcheck-fix-c88561c557b61542.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix a false positive in the collector-queue healthcheck


### PR DESCRIPTION
### What does this PR do?

If the collector stops a given jobQueue while it is running a check, the code path is different. Also de-register the jobQueue from heathcheck in this case.