### PR TITLE
docker listener: fix nil pointer error if container is not inspectable

### DIFF
--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -191,11 +191,15 @@ func (l *DockerListener) createService(cID ID) {
 	var svc Service
 
 	// Detect whether that container is managed by Kubernetes
+	var isKube bool
 	cInspect, err := l.dockerUtil.Inspect(string(cID), false)
 	if err != nil {
 		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
+	} else if findKubernetesInLabels(cInspect.Config.Labels) {
+		isKube = true
 	}
-	if findKubernetesInLabels(cInspect.Config.Labels) {
+
+	if isKube {
 		svc = &DockerKubeletService{
 			DockerService: DockerService{
 				ID: cID,

--- a/releasenotes/notes/dockerlistener-race-e3553f1e492526f9.yaml
+++ b/releasenotes/notes/dockerlistener-race-e3553f1e492526f9.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix a possible race exception in the Docker AD listener


### PR DESCRIPTION
### What does this PR do?

If the container inspect fails during the service creation, we might fall into a nil pointer dereference.
Bug found while running the agent throttled at 0.1% CPU limit (container exited and removed before `createService` runs) for reproducing another issue.