### PR TITLE
[Docker check] fixes: cgroup parsing + docker.mem.in_use computation

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -185,7 +185,7 @@ func (d *DockerCheck) Run() error {
 		if c.Memory.HierarchicalMemoryLimit > 0 && c.Memory.HierarchicalMemoryLimit < uint64(math.Pow(2, 60)) {
 			sender.Gauge("docker.mem.limit", float64(c.Memory.HierarchicalMemoryLimit), "", tags)
 			if c.Memory.HierarchicalMemoryLimit != 0 {
-				sender.Gauge("docker.mem.in_use", float64(c.Memory.RSS/c.Memory.HierarchicalMemoryLimit), "", tags)
+				sender.Gauge("docker.mem.in_use", float64(c.Memory.RSS)/float64(c.Memory.HierarchicalMemoryLimit), "", tags)
 			}
 		}
 
@@ -193,7 +193,7 @@ func (d *DockerCheck) Run() error {
 			sender.Gauge("docker.mem.sw_limit", float64(c.Memory.HierarchicalMemSWLimit), "", tags)
 			if c.Memory.HierarchicalMemSWLimit != 0 {
 				sender.Gauge("docker.mem.sw_in_use",
-					float64((c.Memory.Swap+c.Memory.RSS)/c.Memory.HierarchicalMemSWLimit), "", tags)
+					float64(c.Memory.Swap+c.Memory.RSS)/float64(c.Memory.HierarchicalMemSWLimit), "", tags)
 			}
 		}
 

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -133,9 +133,9 @@ func (c ContainerCgroup) Mem() (*CgroupMemStat, error) {
 			ret.SwapPresent = true
 		case "rss":
 			ret.RSS = v
-		case "rssHuge":
+		case "rss_huge":
 			ret.RSSHuge = v
-		case "mappedFile":
+		case "mapped_file":
 			ret.MappedFile = v
 		case "pgpgin":
 			ret.Pgpgin = v
@@ -145,45 +145,45 @@ func (c ContainerCgroup) Mem() (*CgroupMemStat, error) {
 			ret.Pgfault = v
 		case "pgmajfault":
 			ret.Pgmajfault = v
-		case "inactiveAnon":
+		case "inactive_anon":
 			ret.InactiveAnon = v
-		case "activeAnon":
+		case "active_anon":
 			ret.ActiveAnon = v
-		case "inactiveFile":
+		case "inactive_file":
 			ret.InactiveFile = v
-		case "activeFile":
+		case "active_file":
 			ret.ActiveFile = v
 		case "unevictable":
 			ret.Unevictable = v
-		case "hierarchicalMemoryLimit":
+		case "hierarchical_memory_limit":
 			ret.HierarchicalMemoryLimit = v
 		case "hierarchical_memsw_limit":
 			ret.HierarchicalMemSWLimit = v
-		case "totalCache":
+		case "total_cache":
 			ret.TotalCache = v
-		case "totalRss":
+		case "total_rss":
 			ret.TotalRSS = v
-		case "totalRssHuge":
+		case "total_rssHuge":
 			ret.TotalRSSHuge = v
-		case "totalMappedFile":
+		case "total_mapped_file":
 			ret.TotalMappedFile = v
-		case "totalPgpgin":
+		case "total_pgpgin":
 			ret.TotalPgpgIn = v
-		case "totalPgpgout":
+		case "total_pgpgout":
 			ret.TotalPgpgOut = v
-		case "totalPgfault":
+		case "total_pgfault":
 			ret.TotalPgFault = v
-		case "totalPgmajfault":
+		case "total_pgmajfault":
 			ret.TotalPgMajFault = v
-		case "totalInactiveAnon":
+		case "total_inactive_anon":
 			ret.TotalInactiveAnon = v
-		case "totalActiveAnon":
+		case "total_active_anon":
 			ret.TotalActiveAnon = v
-		case "totalInactiveFile":
+		case "total_inactive_file":
 			ret.TotalInactiveFile = v
-		case "totalActiveFile":
+		case "total_active_file":
 			ret.TotalActiveFile = v
-		case "totalUnevictable":
+		case "total_unevictable":
 			ret.TotalUnevictable = v
 		}
 	}

--- a/releasenotes/notes/[Docker-check]-fixes:-cgroup-parsing-+-docker.mem.in_use-computation-e390c8f2c2541d2f.yaml
+++ b/releasenotes/notes/[Docker-check]-fixes:-cgroup-parsing-+-docker.mem.in_use-computation-e390c8f2c2541d2f.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
-  - |
-    Fix docker memory metrics parsing from cgroup files
-    Fix docker.mem.in_use metric computation
+  - Fix docker memory metrics parsing from cgroup files
+  - Fix docker.mem.in_use metric computation

--- a/releasenotes/notes/[Docker-check]-fixes:-cgroup-parsing-+-docker.mem.in_use-computation-e390c8f2c2541d2f.yaml
+++ b/releasenotes/notes/[Docker-check]-fixes:-cgroup-parsing-+-docker.mem.in_use-computation-e390c8f2c2541d2f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix docker memory metrics parsing from cgroup files
+    Fix docker.mem.in_use metric computation

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -31,6 +31,8 @@ func TestContainerMetricsTagging(t *testing.T) {
 		"Gauge": {
 			"docker.mem.cache",
 			"docker.mem.rss",
+                        "docker.mem.in_use",
+                        "docker.mem.limit",
 			"docker.container.size_rw",
 			"docker.container.size_rootfs",
 		},

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -31,8 +31,8 @@ func TestContainerMetricsTagging(t *testing.T) {
 		"Gauge": {
 			"docker.mem.cache",
 			"docker.mem.rss",
-                        "docker.mem.in_use",
-                        "docker.mem.limit",
+			"docker.mem.in_use",
+			"docker.mem.limit",
 			"docker.container.size_rw",
 			"docker.container.size_rootfs",
 		},

--- a/test/integration/corechecks/docker/testdata/basemetrics.compose
+++ b/test/integration/corechecks/docker/testdata/basemetrics.compose
@@ -10,3 +10,4 @@ services:
     environment:
         LOW_CARD_ENV: "redislowenv"
         HIGH_CARD_ENV: "redishighenv"
+    mem_limit: 32000000


### PR DESCRIPTION
### What does this PR do?
Fixes:
- Fix docker memory metrics parsing from cgroup files
- Fix docker.mem.in_use metric computation

### Motivation

Support case where some of the memory metrics where missing
