### PR TITLE
Remove error exits from prerm/postrm scripts

### DIFF
--- a/omnibus/package-scripts/agent/postrm
+++ b/omnibus/package-scripts/agent/postrm
@@ -46,7 +46,6 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
     esac
 else
     echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
-    exit 1;
 fi
 
 exit 0

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -25,7 +25,6 @@ stop_agent()
         initctl stop $SERVICE_NAME || true
     else
         echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-        exit 1
     fi
 }
 
@@ -42,7 +41,6 @@ deregister_agent()
         :
     else
         echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-        exit 1
     fi
 }
 
@@ -77,7 +75,6 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
     esac
 else
     echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
-    exit 1;
 fi
 
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs

--- a/releasenotes/notes/no-error-exit-package-removal-scripts-1640defbe202fa83.yaml
+++ b/releasenotes/notes/no-error-exit-package-removal-scripts-1640defbe202fa83.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Allow Linux package uninstallation to proceed without errors even on platforms
+    that aren't supported by the Agent


### PR DESCRIPTION
### What does this PR do?

Removes error exits from prerm/postrm scripts

### Motivation

If for some reason the Agent was installed on a platform that's not
supported (for example because we don't support its init system), we
should still let the uninstall of the Agent proceed. So remove error
exits from the prerm and postrm scripts.

This could happen for example on Debian 7 machines that only have sysV-init.