### PR TITLE
Adding Service Mapper command to the DCA

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -15,7 +15,7 @@ COPY ./dist /opt/datadog-cluster-agent/bin/datadog-cluster-agent/dist
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl\
- && apt-get clean
+ && apt-get clean \
  && apt-get autoremove
 
 COPY entrypoint.sh .

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -16,6 +16,7 @@ COPY ./dist /opt/datadog-cluster-agent/bin/datadog-cluster-agent/dist
 RUN apt-get update \
  && apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl\
  && apt-get clean
+ && apt-get autoremove
 
 COPY entrypoint.sh .
 

--- a/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
@@ -1,0 +1,16 @@
+
+==============
+Service Mapper
+=============
+{{ if .Error }}
+Could not run the service mapper: {{.Error}}
+{{else}}
+{{- range $index, $element := .Nodes }}
+
+Node name: {{ $index -}}
+   {{ range $pod, $svc := $element }}
+ -  Pod name: {{ $pod }}
+    Service list: {{ $svc -}}
+   {{ end -}}
+{{- end }}
+{{ end }}

--- a/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
@@ -2,6 +2,9 @@
 ==============
 Service Mapper
 ==============
+{{- if .Errors }}
+Could not run the service mapper: {{.Errors}}
+{{ else }}
 {{- if .Warnings }}
 Warnings:
 {{- range .Warnings}}
@@ -17,4 +20,5 @@ Node detected: {{ $index -}}
     Services list: {{ $svc -}}
    {{ end -}}
 {{- end }}
+{{- end -}}
 {{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
@@ -2,15 +2,19 @@
 ==============
 Service Mapper
 ==============
-{{ if .Error }}
-Could not run the service mapper: {{.Error}}
-{{else}}
+{{- if .Warnings }}
+Warnings:
+{{- range .Warnings}}
+   - {{.}}
+{{ end -}}
+{{- end -}}
+{{if .Nodes}}
 {{- range $index, $element := .Nodes }}
 
-Node name: {{ $index -}}
+Node detected: {{ $index -}}
    {{ range $pod, $svc := $element }}
  -  Pod name: {{ $pod }}
-    Service list: {{ $svc -}}
+    Services list: {{ $svc -}}
    {{ end -}}
 {{- end }}
-{{ end }}
+{{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
@@ -1,7 +1,7 @@
 
 ==============
 Service Mapper
-=============
+==============
 {{ if .Error }}
 Could not run the service mapper: {{.Error}}
 {{else}}

--- a/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/servicemapper.tmpl
@@ -4,8 +4,8 @@ Service Mapper
 ==============
 {{- if .Errors }}
 Could not run the service mapper: {{.Errors}}
-{{ else }}
-{{- if .Warnings }}
+{{else}}
+{{ if .Warnings -}}
 Warnings:
 {{- range .Warnings}}
    - {{.}}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -54,14 +54,22 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		log.Errorf("Error getting status. Error: %v, Status: %v", err, s)
-		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		body, err := json.Marshal(map[string]string{"error": err.Error()})
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
+			return
+		}
 		http.Error(w, string(body), 500)
 		return
 	}
 	jsonStats, err := json.Marshal(s)
 	if err != nil {
 		log.Errorf("Error marshalling status. Error: %v, Status: %v", err, s)
-		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		body, err := json.Marshal(map[string]string{"error": err.Error()})
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
+			return
+		}
 		http.Error(w, string(body), 500)
 		return
 	}
@@ -85,8 +93,16 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	av, _ := version.New(version.AgentVersion, version.Commit)
-	j, _ := json.Marshal(av)
+	av, err := version.New(version.AgentVersion, version.Commit)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
+		return
+	}
+	j, err := json.Marshal(av)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
+		return
+	}
 	w.Write(j)
 }
 
@@ -100,7 +116,11 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 		log.Warnf("Error getting hostname: %s\n", err) // or something like this
 		hname = ""
 	}
-	j, _ := json.Marshal(hname)
+	j, err := json.Marshal(hname)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
+		return
+	}
 	w.Write(j)
 }
 

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -158,6 +158,9 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPodMetadata(w http.ResponseWriter, r *http.Request) {
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
 	vars := mux.Vars(r)
 	var err error
 	var slcB []byte

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -162,7 +162,6 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	/*
 		Input
-
 			localhost:5001/api/v1/metadata/localhost/my-nginx-5d69
 		Outputs
 			Status: 200
@@ -260,16 +259,17 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	// If we hit an error at this point, it is because we don't have access to the API server.
 	if errAPIServer != nil {
 		w.WriteHeader(503)
+		log.Errorf("There was an error querying the nodes from the API: %s", errAPIServer.Error())
 	} else {
 		w.WriteHeader(200)
 	}
-	slcB, err := json.Marshal(svcList)
+	svcListBytes, err := json.Marshal(svcList)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
 	}
-	if len(slcB) != 0 {
-		w.Write(slcB)
+	if len(svcListBytes) != 0 {
+		w.Write(svcListBytes)
 		return
 	}
 	w.WriteHeader(404)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -54,26 +54,15 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		log.Errorf("Error getting status. Error: %v, Status: %v", err, s)
-		body, err := json.Marshal(map[string]string{"error": err.Error()})
-		if err != nil {
-			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
-			return
-		}
-		http.Error(w, string(body), 500)
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
 		return
 	}
 	jsonStats, err := json.Marshal(s)
 	if err != nil {
 		log.Errorf("Error marshalling status. Error: %v, Status: %v", err, s)
-		body, err := json.Marshal(map[string]string{"error": err.Error()})
-		if err != nil {
-			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
-			return
-		}
-		http.Error(w, string(body), 500)
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
 		return
 	}
-
 	w.Write(jsonStats)
 }
 

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -41,6 +41,8 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/status", getStatus).Methods("GET")
 	// r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
 	r.HandleFunc("/api/v1/metadata/{nodeName}/{podName}", getPodMetadata).Methods("GET")
+	r.HandleFunc("/api/v1/metadata/{nodeName}", getNodeMetadata).Methods("GET")
+	r.HandleFunc("/api/v1/metadata", getAllMetadata).Methods("GET")
 	r.HandleFunc("/api/v1/{check}/events", getCheckLatestEvents).Methods("GET")
 }
 
@@ -158,6 +160,21 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPodMetadata(w http.ResponseWriter, r *http.Request) {
+	////// Input
+	//	localhost:5001/api/v1/metadata/localhost/my-nginx-5d69
+	////// Outputs
+	//	Status: 200
+	//	Returns: []string
+	//	Example: ["my-nginx-service"]
+	//
+	//	Status: 404
+	//	Returns: string
+	//	Example: 404 page not found
+	//
+	//	Status: 500
+	//	Returns: string
+	//	Example: "no cached metadata found for the pod my-nginx-5d69 on the node localhost"
+	//////
 	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
@@ -166,22 +183,15 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	var slcB []byte
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
+	fmt.Printf("podname is %s, nodeName is %s", podName, nodeName)
 
-	if podName == "*" {
-		log.Info("Computing service map on all nodes ...")
-		svcList, errNodes := as.GetServiceMapBundleOnNode(nodeName)
-		if errNodes != nil {
-			log.Errorf("could not collect the service map for %s: %s", nodeName, errNodes.Error())
-		}
-		slcB, err = json.Marshal(svcList)
+	svcList, errSvcList := as.GetPodServiceNames(nodeName, podName)
+	if errSvcList != nil {
+		slcB, err = json.Marshal(errSvcList.Error())
 	} else {
-		svcList, errSvcList := as.GetPodServiceNames(nodeName, podName)
-		if errSvcList != nil {
-			slcB, err = json.Marshal(errSvcList.Error())
-		} else {
-			slcB, err = json.Marshal(svcList)
-		}
+		slcB, err = json.Marshal(svcList)
 	}
+
 	if err != nil {
 		log.Errorf("Could not process the list of services of: %s", podName)
 	}
@@ -193,4 +203,74 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(404)
 	w.Write([]byte(fmt.Sprintf("Could not find associated services mapped to the pod: %s on node: %s", podName, nodeName)))
 
+}
+func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
+	// getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+	vars := mux.Vars(r)
+	nodeName := vars["nodeName"]
+	log.Info("Fetching service map on all pods of the node %s", nodeName)
+	svcList, errNodes := as.GetServiceMapBundleOnNode(nodeName)
+	if len(errNodes) != 0 {
+		log.Errorf("could not collect the service map for %s", nodeName)
+		svcList["Error"] = errNodes
+	}
+	slcB, err := json.Marshal(svcList)
+	if err != nil {
+		w.WriteHeader(500)
+		errB, _ := json.Marshal(err.Error())
+		w.Write(errB)
+		return
+	}
+
+	if len(slcB) != 0 {
+		w.WriteHeader(200)
+		w.Write(slcB)
+		return
+	}
+	w.WriteHeader(404)
+	return
+}
+
+func getAllMetadata(w http.ResponseWriter, r *http.Request) {
+	////// Input
+	//	localhost:5001/api/v1/metadata
+	////// Outputs
+	//	Status: 200
+	//	Returns: map[string][]string
+	//	Example: ["Node1":["pod1":["svc1"],"pod2":["svc2"]],"Node2":["pod3":["svc1"]], "Error":"the key KubernetesServiceMapping/Node3 not found in the cache"]
+	//
+	//	Status: 404
+	//	Returns: string
+	//	Example: 404 page not found
+	//
+	//	Status: 500
+	//	Returns: string
+	//	Example: "could not collect the service map for all nodes: List services is not permitted at the cluster scope."
+	//////
+	if err := apiutil.Validate(w, r); err != nil {
+		return
+	}
+	log.Info("Computing service map on all nodes")
+	svcList, errNodes := as.GetServiceMapBundleOnNode("")
+	if errNodes != nil {
+		log.Errorf("Could not collect the service map for all nodes")
+		svcList["Error"] = errNodes
+	}
+	slcB, err := json.Marshal(svcList)
+	if err != nil {
+		w.WriteHeader(500)
+		errB, _ := json.Marshal(err.Error())
+		w.Write(errB)
+		return
+	}
+	if len(slcB) != 0 {
+		w.WriteHeader(200)
+		w.Write(slcB)
+		return
+	}
+	w.WriteHeader(404)
+	return
 }

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -257,13 +257,16 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Info("Computing service map on all nodes")
 	svcList, err := as.GetServiceMapBundleOnAllNodes()
+	// If we hit an error at this point, it is because we don't have access to the API server.
 	if err != nil {
-		http.Error(w, err.Error(), 500)
+		w.WriteHeader(503)
+		log.Errorf("Failed to get nodes from the API server: %s", err)
 		return
 	}
 	slcB, err := json.Marshal(svcList)
 	if err != nil {
-		http.Error(w, err.Error(), 500)
+		w.WriteHeader(501)
+		log.Errorf("Failed to process the service map for all nodes")
 		return
 	}
 	if len(slcB) != 0 {

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -213,7 +213,7 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
 	nodeName := vars["nodeName"]
 	log.Info("Fetching service map on all pods of the node %s", nodeName)
 	svcList, errNodes := as.GetServiceMapBundleOnNode(nodeName)
-	if len(errNodes) != 0 {
+	if errNodes != nil {
 		log.Errorf("could not collect the service map for %s", nodeName)
 		svcList["Error"] = errNodes
 	}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -184,7 +184,6 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	var slcB []byte
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
-	fmt.Printf("podname is %s, nodeName is %s", podName, nodeName)
 
 	svcList, errSvcList := as.GetPodServiceNames(nodeName, podName)
 	if errSvcList != nil {
@@ -220,7 +219,6 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
 	svcList, errNodes := as.GetServiceMapBundleOnNode(nodeName)
 	if errNodes != nil {
 		log.Errorf("Could not collect the service map for %s", nodeName)
-		svcList["Error"] = errNodes
 	}
 	slcB, err := json.Marshal(svcList)
 	if err != nil {
@@ -258,10 +256,10 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Info("Computing service map on all nodes")
-	svcList, errNodes := as.GetServiceMapBundleOnNode("")
-	if errNodes != nil {
-		log.Errorf("Could not collect the service map for all nodes")
-		svcList["Error"] = errNodes
+	svcList, err := as.GetServiceMapBundleOnAllNodes()
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
 	}
 	slcB, err := json.Marshal(svcList)
 	if err != nil {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package app
 
 import (

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -8,6 +8,9 @@ import (
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
 
+	log "github.com/cihub/seelog"
+	"github.com/spf13/cobra"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -17,8 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	log "github.com/cihub/seelog"
-	"github.com/spf13/cobra"
 )
 
 // FIXME: move SetupAutoConfig and StartAutoConfig in their own package so we don't import cmd/agent
@@ -162,5 +163,4 @@ func start(cmd *cobra.Command, args []string) error {
 	log.Info("See ya!")
 	log.Flush()
 	return nil
-
 }

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package app
 
 import (

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -1,24 +1,22 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
-	"github.com/DataDog/datadog-agent/pkg/api/util"
 	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
-
-	"bytes"
-	"fmt"
 )
 
 func init() {
 	ClusterAgentCmd.AddCommand(svcMapperCmd)
 	svcMapperCmd.SetArgs([]string{"caseID"})
-
 }
 
 // TODO add all registered nodes command

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -24,11 +24,13 @@ func init() {
 	svcMapperCmd.SetArgs([]string{"caseID"})
 }
 
-// TODO add all registered nodes command
 var svcMapperCmd = &cobra.Command{
 	Use:   "svcmap [nodeName]",
 	Short: "Print the map between the services and the pods behind them",
-	Long:  ``,
+	Long: `The svcmap command is mostly designed for troubleshooting purposes.
+One can easily identify which pods are running on which nodes,
+as well as which services are service the pods.`,
+	Example: "datadog-cluster-agent svcmap ip-10-0-115-123",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configFound := false
 		// a path to the folder containing the config file was passed

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -73,7 +73,7 @@ func getServiceMap(nodeName string) error {
 		return e
 	}
 
-	r, e := util.DoGetExternal(c, urlstr)
+	r, e := util.DoGetExternalEndpoint(c, urlstr)
 	if e != nil {
 		fmt.Printf(`
 		Could not reach agent: %v

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -51,11 +51,7 @@ as well as which services are service the pods.`,
 		if len(args) > 0 {
 			nodeName = args[0]
 		}
-		err := getServiceMap(nodeName) // if nodeName == "", call all.
-		if err != nil {
-			return err
-		}
-		return nil
+		return getServiceMap(nodeName) // if nodeName == "", call all.
 	},
 }
 
@@ -79,13 +75,6 @@ func getServiceMap(nodeName string) error {
 
 	r, e := util.DoGet(c, urlstr)
 	if e != nil {
-		var errMap = make(map[string]string)
-		json.Unmarshal(r, errMap)
-		// If the error has been marshalled into a json object, check it and return it properly
-		if err, found := errMap["error"]; found {
-			e = fmt.Errorf(err)
-		}
-
 		fmt.Printf(`"Could not reach agent: %v
 		Make sure the agent is properly running before requesting the map of services to pods.
 		Contact support if you continue having issues."`, e)

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	log "github.com/cihub/seelog"
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status"
+
+	"bytes"
+	"fmt"
+)
+
+func init() {
+	ClusterAgentCmd.AddCommand(svcMapperCmd)
+	svcMapperCmd.SetArgs([]string{"caseID"})
+
+}
+
+// TODO add all registered nodes command
+var svcMapperCmd = &cobra.Command{
+	Use:   "svcmap [nodeName]",
+	Short: "Print the map between the services and the pods behind them",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configFound := false
+		// a path to the folder containing the config file was passed
+		if len(confPath) != 0 {
+			// we'll search for a config file named `datadog-cluster.yaml`
+			config.Datadog.AddConfigPath(confPath)
+			confErr := config.Datadog.ReadInConfig()
+			if confErr != nil {
+				log.Error(confErr)
+			} else {
+				configFound = true
+			}
+		}
+		if !configFound {
+			log.Debugf("Config read from env variables")
+		}
+		nodeName := ""
+		// "*" Can be used to output all nodes.
+		if len(args) == 0 {
+			log.Infof("You need to specify on which node you want to run the service mapper.")
+			return nil
+		}
+		nodeName = args[0]
+		err := getServiceMap(nodeName) // if nodeName == "*", call all.
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func getServiceMap(nodeName string) error {
+	var e error
+	var s string
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	// TODO use https
+	urlstr := fmt.Sprintf("http://localhost:%v/api/v1/metadata/%s/*", config.Datadog.GetInt("clusteragent_cmd_port"), nodeName)
+
+	// Set session token
+	e = util.SetAuthToken()
+	if e != nil {
+		return e
+	}
+
+	r, e := util.DoGet(c, urlstr)
+	if e != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, errMap)
+		// If the error has been marshalled into a json object, check it and return it properly
+		if err, found := errMap["error"]; found {
+			e = fmt.Errorf(err)
+		}
+
+		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the map of services to pods and contact support if you continue having issues. \n", e)
+		return e
+	}
+
+	// The rendering is done in the client so that the agent has less work to do
+	if prettyPrintJSON {
+		var prettyJSON bytes.Buffer
+		json.Indent(&prettyJSON, r, "", "  ")
+		s = prettyJSON.String()
+	} else if jsonStatus {
+		s = string(r)
+	} else {
+		formattedServiceMap, err := status.FormatServiceMapCLI(r)
+		if err != nil {
+			return err
+		}
+		s = formattedServiceMap
+	}
+
+	if statusFilePath != "" {
+		ioutil.WriteFile(statusFilePath, []byte(s), 0644)
+	} else {
+		fmt.Println(s)
+	}
+	return nil
+}

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -60,7 +60,7 @@ func getServiceMap(nodeName string) error {
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	// TODO use https
-	urlstr := fmt.Sprintf("http://localhost:%v/api/v1/metadata/%s/*", config.Datadog.GetInt("clusteragent_cmd_port"), nodeName)
+	urlstr := fmt.Sprintf("http://localhost:%v/api/v1/metadata/%s/*", config.Datadog.GetInt("cmd_port"), nodeName)
 
 	// Set session token
 	e = util.SetAuthToken()

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -75,7 +75,8 @@ func getServiceMap(nodeName string) error {
 
 	r, e := util.DoGet(c, urlstr)
 	if e != nil {
-		fmt.Printf(`"Could not reach agent: %v
+		fmt.Printf(`
+		"Could not reach agent: %v
 		Make sure the agent is properly running before requesting the map of services to pods.
 		Contact support if you continue having issues."`, e)
 		return e

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -73,12 +73,12 @@ func getServiceMap(nodeName string) error {
 		return e
 	}
 
-	r, e := util.DoGet(c, urlstr)
+	r, e := util.DoGetExternal(c, urlstr)
 	if e != nil {
 		fmt.Printf(`
-		"Could not reach agent: %v
+		Could not reach agent: %v
 		Make sure the agent is properly running before requesting the map of services to pods.
-		Contact support if you continue having issues."`, e)
+		Contact support if you continue having issues.`, e)
 		return e
 	}
 

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -12,11 +12,11 @@ import (
 	"io/ioutil"
 
 	log "github.com/cihub/seelog"
+	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -51,14 +51,14 @@ func DoGet(c *http.Client, url string) (body []byte, e error) {
 
 }
 
-// DoGetExternal is a wrapper around performing HTTP GET requests designed for external endpoints.
-func DoGetExternal(c *http.Client, url string) (body []byte, e error) {
+// DoGetExternalEndpoint is a wrapper around performing HTTP GET requests designed for external endpoints.
+func DoGetExternalEndpoint(c *http.Client, url string) (body []byte, e error) {
 	req, e := http.NewRequest("GET", url, nil)
 	if e != nil {
 		return body, e
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+GetAuthToken()) // To be updated for DCA token.
+	req.Header.Set("Authorization", "Bearer "+GetAuthToken()) // TODO update with function to check DCA token.
 
 	r, e := c.Do(req)
 	if e != nil {
@@ -79,7 +79,6 @@ func DoGetExternal(c *http.Client, url string) (body []byte, e error) {
 	}
 
 	return body, nil
-
 }
 
 // DoPost is a wrapper around performing HTTP POST requests
@@ -104,5 +103,4 @@ func DoPost(c *http.Client, url string, contentType string, body io.Reader) (res
 		return resp, fmt.Errorf("%s", resp)
 	}
 	return resp, nil
-
 }

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -51,6 +51,37 @@ func DoGet(c *http.Client, url string) (body []byte, e error) {
 
 }
 
+// DoGetExternal is a wrapper around performing HTTP GET requests designed for external endpoints.
+func DoGetExternal(c *http.Client, url string) (body []byte, e error) {
+	req, e := http.NewRequest("GET", url, nil)
+	if e != nil {
+		return body, e
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+GetAuthToken()) // To be updated for DCA token.
+
+	r, e := c.Do(req)
+	if e != nil {
+		return body, e
+	}
+	body, e = ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if e != nil {
+		return body, e
+	}
+	if r.StatusCode == 503 {
+		// 503 errors are used when the agent can't reach an external service to process a task.
+		// i.e. the svcmap requires access to the Kubernetes API Server.
+		return body, nil
+	}
+	if r.StatusCode >= 400 {
+		return body, fmt.Errorf("%s", body)
+	}
+
+	return body, nil
+
+}
+
 // DoPost is a wrapper around performing HTTP POST requests
 func DoPost(c *http.Client, url string, contentType string, body io.Reader) (resp []byte, e error) {
 	req, e := http.NewRequest("POST", url, body)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,7 +91,7 @@ func init() {
 	Datadog.SetDefault("syslog_pem", "")
 	Datadog.SetDefault("cmd_host", "localhost")
 	Datadog.SetDefault("cmd_port", 5001)
-	Datadog.SetDefault("clusteragent_cmd_port", 5005)
+	Datadog.SetDefault("cluster_agent_cmd_port", 5005) // TODO isolate internal and external APIs for the DCA.
 	Datadog.SetDefault("default_integration_http_timeout", 9)
 	Datadog.SetDefault("enable_metadata_collection", true)
 	Datadog.SetDefault("enable_gohai", true)
@@ -257,7 +257,7 @@ func init() {
 	Datadog.BindEnv("ac_exclude")
 
 	Datadog.BindEnv("cluster_agent.auth_token")
-	Datadog.BindEnv("clusteragent_cmd_port")
+	Datadog.BindEnv("cluster_agent_cmd_port")
 
 	Datadog.BindEnv("forwarder_timeout")
 	Datadog.BindEnv("forwarder_retry_queue_max_size")

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -69,6 +69,17 @@ func FormatDCAStatus(data []byte) (string, error) {
 	return b.String(), nil
 }
 
+// FormatServiceMapCLI builds the rendering in the servicemapper template.
+func FormatServiceMapCLI(data []byte) (string, error) {
+	var b = new(bytes.Buffer)
+
+	stats := make(map[string]interface{})
+	json.Unmarshal(data, &stats)
+	renderServiceMapper(b, stats)
+
+	return b.String(), nil
+}
+
 func renderHeader(w io.Writer, stats map[string]interface{}) {
 	t := template.Must(template.New("header.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "header.tmpl")))
 	err := t.Execute(w, stats)
@@ -132,6 +143,14 @@ func renderJMXFetchStatus(w io.Writer, jmxStats interface{}) {
 func renderLogsStatus(w io.Writer, logsStats interface{}) {
 	t := template.Must(template.New("logsagent.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "logsagent.tmpl")))
 	err := t.Execute(w, logsStats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderServiceMapper(w io.Writer, serviceMapperStats interface{}) {
+	t := template.Must(template.New("servicemapper.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "servicemapper.tmpl")))
+	err := t.Execute(w, serviceMapperStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -76,7 +76,7 @@ func FormatServiceMapCLI(data []byte) (string, error) {
 	stats := make(map[string]interface{})
 	err := json.Unmarshal(data, &stats)
 	if err != nil {
-		return b.String(), nil
+		return b.String(), err
 	}
 	renderServiceMapper(b, stats)
 

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -74,7 +74,10 @@ func FormatServiceMapCLI(data []byte) (string, error) {
 	var b = new(bytes.Buffer)
 
 	stats := make(map[string]interface{})
-	json.Unmarshal(data, &stats)
+	err := json.Unmarshal(data, &stats)
+	if err != nil {
+		return b.String(), nil
+	}
 	renderServiceMapper(b, stats)
 
 	return b.String(), nil

--- a/pkg/tagger/collectors/kubernetes_servicemapper.go
+++ b/pkg/tagger/collectors/kubernetes_servicemapper.go
@@ -49,7 +49,10 @@ func getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 
 		tagList := utils.NewTagList()
 
-		serviceNames := apiserver.GetPodServiceNames(po.Spec.NodeName, po.Metadata.Name)
+		serviceNames, err := apiserver.GetPodServiceNames(po.Spec.NodeName, po.Metadata.Name)
+		if err != nil {
+			log.Debugf("Could not fetch the services for the pod %s on the node %s: %s", po.Metadata.Name, po.Spec.NodeName, err.Error())
+		}
 		log.Debugf("nodeName: %s, podName: %s, services: %q", po.Spec.NodeName, po.Metadata.Name, strings.Join(serviceNames, ","))
 		for _, serviceName := range serviceNames {
 			log.Tracef("tagging %s kube_service:%s", po.Metadata.Name, serviceName)

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -412,10 +412,14 @@ func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, []error
 		return stats, errlist
 	}
 	for _, node := range nodes {
+		if node.Metadata == nil || node.Metadata.Name == nil {
+			errlist = append(errlist, fmt.Errorf("incorrect payload when evaluating a node for the service mapper"))
+			continue
+		}
 		nodePodServiceMap[*node.Metadata.Name], err = getSMBOnNodes(*node.Metadata.Name)
 		if err != nil {
 			errlist = append(errlist, err)
-			log.Errorf("Node %s could not be added to the service map bundle: %s", err.Error())
+			log.Errorf("Node %s could not be added to the service map bundle: %s", *node.Metadata.Name, err.Error())
 		}
 	}
 	stats["Nodes"] = nodePodServiceMap

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -448,12 +448,12 @@ func getNodeList() ([]*v1.Node, error) {
 	defer cancel()
 	cl, err := GetAPIClient()
 	if err != nil {
-		log.Error("Can't create client to query the API Server: %s", err.Error())
+		log.Errorf("Can't create client to query the API Server: %s", err.Error())
 		return nil, err
 	}
 	nodes, err := cl.client.CoreV1().ListNodes(ctx)
 	if err != nil {
-		log.Error("Can't list nodes from the API server: %s", err.Error())
+		log.Errorf("Can't list nodes from the API server: %s", err.Error())
 		return nil, err
 	}
 	return nodes.Items, nil

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -400,6 +400,7 @@ func GetServiceMapBundleOnAllNodes() (map[string]interface{}, error) {
 
 	nodes, err := getNodeList()
 	if err != nil {
+		stats["Errors"] = fmt.Sprintf("Failed to get nodes from the API server: %s", err.Error())
 		return stats, err
 	}
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -390,11 +390,12 @@ func (c *APIClient) NodeLabels(nodeName string) (map[string]string, error) {
 	return node.GetMetadata().GetLabels(), nil
 }
 
-// GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a
+// GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a nodeName.
 func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
 	nodePodServiceMap := make(map[string]map[string][]string)
 	stats := make(map[string]interface{})
 	var err error
+
 	if nodeName != "*" {
 		nodePodServiceMap[nodeName], err = getSMBOnNodes(nodeName)
 		if err != nil {
@@ -402,20 +403,21 @@ func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) 
 			return stats, err
 		}
 		stats["Nodes"] = nodePodServiceMap
-	} else {
-		nodes, err := getNodeList()
-		if err != nil {
-			stats["Error"] = err.Error()
-			return stats, err
-		}
-		for _, node := range nodes {
-			nodePodServiceMap[*node.Metadata.Name], err = getSMBOnNodes(*node.Metadata.Name)
-			if err != nil {
-				log.Error("Node %s could not be added to the service map bundle: %s", err.Error())
-			}
-		}
-		stats["Nodes"] = nodePodServiceMap
+		return stats, nil
 	}
+
+	nodes, err := getNodeList()
+	if err != nil {
+		stats["Error"] = err.Error()
+		return stats, err
+	}
+	for _, node := range nodes {
+		nodePodServiceMap[*node.Metadata.Name], err = getSMBOnNodes(*node.Metadata.Name)
+		if err != nil {
+			log.Error("Node %s could not be added to the service map bundle: %s", err.Error())
+		}
+	}
+	stats["Nodes"] = nodePodServiceMap
 	return stats, nil
 }
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -409,7 +409,7 @@ func GetServiceMapBundleOnAllNodes() (map[string]interface{}, error) {
 			log.Error("Incorrect payload when evaluating a node for the service mapper") // This will be removed as we move to the client-go
 			continue
 		}
-		nodePodServiceMap[*node.Metadata.Name], err = getSMBOnNodes(*node.Metadata.Name)
+		nodePodServiceMap[*node.Metadata.Name], err = getServiceMapBundleOnNodes(*node.Metadata.Name)
 		if err != nil {
 			warn = fmt.Sprintf("Node %s could not be added to the service map bundle: %s", *node.Metadata.Name, err.Error())
 			warnlist = append(warnlist, warn)
@@ -426,7 +426,7 @@ func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) 
 	stats := make(map[string]interface{})
 	var err error
 
-	nodePodServiceMap[nodeName], err = getSMBOnNodes(nodeName)
+	nodePodServiceMap[nodeName], err = getServiceMapBundleOnNodes(nodeName)
 	if err != nil {
 		stats["Warnings"] = []string{fmt.Sprintf("Node %s could not be added to the service map bundle: %s", nodeName, err.Error())}
 		return stats, err
@@ -435,7 +435,7 @@ func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) 
 	return stats, nil
 }
 
-func getSMBOnNodes(nodeName string) (map[string][]string, error) {
+func getServiceMapBundleOnNodes(nodeName string) (map[string][]string, error) {
 	nodeNameCacheKey := cache.BuildAgentKey(serviceMapperCachePrefix, nodeName)
 	smb, found := cache.Cache.Get(nodeNameCacheKey)
 	if !found {

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -25,8 +25,14 @@ func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
 	return nil, nil
 }
 
-// GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a
+// GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a nodeName
 func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
 	log.Errorf("GetServiceMapBundleOnNode not implemented %s", ErrNotCompiled.Error())
+	return nil, nil
+}
+
+// GetServiceMapBundleOnAllNodes is used for the CLI svcmap command to run fetch the service map of all nodes.
+func GetServiceMapBundleOnAllNodes() (map[string]interface{}, error) {
+	log.Errorf("GetServiceMapBundleOnAllNodes not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -27,6 +27,6 @@ func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
 
 // GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a
 func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
-	log.Errorf("GetPodServiceNames not implemented %s", ErrNotCompiled.Error())
+	log.Errorf("GetServiceMapBundleOnNode not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -20,7 +20,13 @@ var (
 )
 
 // GetPodServiceNames is used when the API endpoint of the DCA to get the services of a pod is hit.
-func GetPodServiceNames(nodeName string, podName string) []string {
+func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
 	log.Errorf("GetPodServiceNames not implemented %s", ErrNotCompiled.Error())
-	return nil
+	return nil, nil
+}
+
+// GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a
+func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
+	log.Errorf("GetPodServiceNames not implemented %s", ErrNotCompiled.Error())
+	return nil, nil
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -196,8 +196,7 @@ func GetLeaderDetails() (leaderDetails rl.LeaderElectionRecord, err error) {
 	if !found {
 		return led, apiserver.ErrNotFound
 	}
-	bytes := []byte(annotation)
-	err = json.Unmarshal(bytes, &led)
+	err = json.Unmarshal([]byte(annotation), &led)
 	if err != nil {
 		return led, err
 	}

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -63,28 +63,25 @@ func (smb *ServiceMapperBundle) mapServices(nodeName string, pods v1.PodList, en
 }
 
 // GetPodServiceNames is used when the API endpoint of the DCA to get the services of a pod is hit.
-func GetPodServiceNames(nodeName string, podName string) []string {
+func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
 	var serviceList []string
 	cacheKey := cache.BuildAgentKey(serviceMapperCachePrefix, nodeName)
 
 	smbInterface, found := cache.Cache.Get(cacheKey)
 	if !found {
-		log.Debugf("No metadata was found for the pod %s on node %s at the cache key %q", podName, nodeName, cacheKey)
-		return serviceList
+		return serviceList, fmt.Errorf("No metadata was found for the pod %s on node %s", podName, nodeName)
 	}
 
 	smb, ok := smbInterface.(*ServiceMapperBundle)
 	if !ok {
-		log.Warnf("Invalid cache format at cacheKey: %s", cacheKey)
-		return serviceList
+		return serviceList, fmt.Errorf("Invalid cache format for the cacheKey: %s", cacheKey)
 	}
 
 	serviceList, found = smb.PodNameToServices[podName]
 	if !found {
-		log.Debugf("No cached metadata found for the pod %s on the node %s", podName, nodeName)
-		return serviceList
+		return serviceList, fmt.Errorf("No cached metadata found for the pod %s on the node %s", podName, nodeName)
 	}
 
 	log.Debugf("cacheKey: %s, with %d services", cacheKey, len(serviceList))
-	return serviceList
+	return serviceList, nil
 }

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -69,17 +69,17 @@ func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
 
 	smbInterface, found := cache.Cache.Get(cacheKey)
 	if !found {
-		return serviceList, fmt.Errorf("No metadata was found for the pod %s on node %s", podName, nodeName)
+		return serviceList, fmt.Errorf("no metadata was found for the pod %s on node %s", podName, nodeName)
 	}
 
 	smb, ok := smbInterface.(*ServiceMapperBundle)
 	if !ok {
-		return serviceList, fmt.Errorf("Invalid cache format for the cacheKey: %s", cacheKey)
+		return serviceList, fmt.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
 	}
 
 	serviceList, found = smb.PodNameToServices[podName]
 	if !found {
-		return serviceList, fmt.Errorf("No cached metadata found for the pod %s on the node %s", podName, nodeName)
+		return serviceList, fmt.Errorf("no cached metadata found for the pod %s on the node %s", podName, nodeName)
 	}
 
 	log.Debugf("cacheKey: %s, with %d services", cacheKey, len(serviceList))

--- a/releasenotes/notes/dca-service-mapper-cli-c174cf3a3b8d6f74.yaml
+++ b/releasenotes/notes/dca-service-mapper-cli-c174cf3a3b8d6f74.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add a svcmap command in the CLI of the Datadog Cluster Agent. Core components will also be used for the flare.

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 const (
-	setupTimeout             = time.Second * 10
-	serviceMapperCachePrefix = "KubernetesServiceMapping"
+	setupTimeout = 10 * time.Second
 )
 
 type testSuite struct {

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -28,7 +28,10 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const setupTimeout = time.Second * 10
+const (
+	setupTimeout             = time.Second * 10
+	serviceMapperCachePrefix = "KubernetesServiceMapping"
+)
 
 type testSuite struct {
 	suite.Suite
@@ -303,4 +306,11 @@ func (suite *testSuite) TestServiceMapper() {
 	assert.Len(suite.T(), serviceNames, 2)
 	assert.Contains(suite.T(), serviceNames, "nginx-1")
 	assert.Contains(suite.T(), serviceNames, "nginx-2")
+
+	fullmapper, errList := apiserver.GetServiceMapBundleOnNode("")
+	require.Nil(suite.T(), errList)
+	list := fullmapper["Nodes"]
+	assert.Contains(suite.T(), list, "ip-172-31-119-125")
+	fullMap := list.(map[string]map[string][]string)
+	assert.Contains(suite.T(), fullMap["ip-172-31-119-125"]["nginx"], "nginx-1")
 }

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -281,7 +281,8 @@ func (suite *testSuite) TestServiceMapper() {
 	err = apiClient.ClusterServiceMapping()
 	require.Nil(suite.T(), err)
 
-	serviceNames := apiserver.GetPodServiceNames(node.Name, pod.Name)
+	serviceNames, err := apiserver.GetPodServiceNames(node.Name, pod.Name)
+	require.Nil(suite.T(), err)
 	assert.Len(suite.T(), serviceNames, 1)
 	assert.Contains(suite.T(), serviceNames, "nginx-1")
 
@@ -297,7 +298,8 @@ func (suite *testSuite) TestServiceMapper() {
 	err = apiClient.ClusterServiceMapping()
 	require.Nil(suite.T(), err)
 
-	serviceNames = apiserver.GetPodServiceNames(node.Name, pod.Name)
+	serviceNames, err = apiserver.GetPodServiceNames(node.Name, pod.Name)
+	require.Nil(suite.T(), err)
 	assert.Len(suite.T(), serviceNames, 2)
 	assert.Contains(suite.T(), serviceNames, "nginx-1")
 	assert.Contains(suite.T(), serviceNames, "nginx-2")

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -307,7 +307,7 @@ func (suite *testSuite) TestServiceMapper() {
 	assert.Contains(suite.T(), serviceNames, "nginx-1")
 	assert.Contains(suite.T(), serviceNames, "nginx-2")
 
-	fullmapper, errList := apiserver.GetServiceMapBundleOnNode("")
+	fullmapper, errList := apiserver.GetServiceMapBundleOnAllNodes()
 	require.Nil(suite.T(), errList)
 	list := fullmapper["Nodes"]
 	assert.Contains(suite.T(), list, "ip-172-31-119-125")


### PR DESCRIPTION
## What does this PR do?
Breaking #1356 into smaller PRs.

## Result
The service mapper command (svcmap) has a proper cobra command with dedicated examples and doc.
There is a clear definition of the API and the controller. 3 endpoints are available:
- `/api/v1/metadata/nodename/podname`
Is used by external agents to get the list of services for this tuple {nodename,podname}
- `/api/v1/metadata/nodename` 
Is used by the cli to troubleshoot which services are associated with which pods on the specified node.
- `/api/v1/metadata`
Is used by the flare command to list the nodes and their pods and services.

Error handling:
If the agent can't process the service map on certain nodes, Warnings will be displayed:
```
/# datadog-cluster-agent svcmap
1521669593375634437 [Debug] Config read from env variables

==============
Service Mapper
==============

Warnings:
   - Node ip-10-0-115-123.us-west-2.compute.internal could not be added to the service map bundle: the key agent/KubernetesServiceMapping/ip-10-0-115-123.us-west-2.compute.internal was not found in the cache
   - Node ip-10-0-150-17.us-west-2.compute.internal could not be added to the service map bundle: the key agent/KubernetesServiceMapping/ip-10-0-150-17.us-west-2.compute.internal was not found in the cache

Node detected: ip-10-0-115-123.us-west-2.compute.internal
Node detected: ip-10-0-150-17.us-west-2.compute.internal
```

If the agent can't reach the API server, we hit a 503 error and still publish it in the Service Mapper output.
```
/# datadog-cluster-agent svcmap
1521735426233216261 [Debug] Config read from env variables

==============
Service Mapper
==============
Could not run the service mapper: Failed to get nodes from the API server: temporary failure in apiserver, will retry later: Get https://10.100.0.1:443/version: context deadline exceeded

```

If all goes well:
```
/# datadog-cluster-agent svcmap
1521735861181828293 [Debug] Config read from env variables

==============
Service Mapper
==============

Node detected: ip-10-0-115-123.us-west-2.compute.internal
 -  Pod name: datadog-cluster-agent-2-d7b7cb7df-p4m5p
    Services list: [dca]
 -  Pod name: guestbook-s9zsk
    Services list: [guestbook]
 -  Pod name: redis-master-ndknc
    Services list: [redis-master]
 -  Pod name: redis-slave-69bbq
    Services list: [redis-slave]

Node detected: ip-10-0-150-17.us-west-2.compute.internal
 -  Pod name: datadog-cluster-agent-1-54f6b6d549-47vkj
    Services list: [dca]
 -  Pod name: guestbook-6cfwf
    Services list: [guestbook]
 -  Pod name: guestbook-fwjg8
    Services list: [guestbook]
 -  Pod name: kube-dns-b7d44b499-nw4dc
    Services list: [kube-dns kube-dns-prometheus-discovery]
 -  Pod name: redis-slave-kxcw8
    Services list: [redis-slave]
```

If the error is internal, agent can't marshal the output or the API is not reachable or something unexpected happens but is part of the agent's responsibilities then we throw a 500 internal error.
