### PR TITLE
Support setting tags as an array

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -66,7 +66,7 @@ type LogsConfig struct {
 	Service         string
 	Source          string
 	SourceCategory  string
-	Tags            string
+	Tags            []string
 	ProcessingRules []LogsProcessingRule `mapstructure:"log_processing_rules"`
 }
 

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -101,6 +101,16 @@ func buildLogSources(ddconfdPath string) (*LogSources, error) {
 		}
 		for _, logSourceConfigIterator := range integrationConfig.Logs {
 			config := logSourceConfigIterator
+
+			// Users can specify tags as comma separated string, or as YAML array. Handle the first case here
+			if len(config.Tags) == 1 {
+				newSlice := []string{}
+				for _, splitted := range strings.Split(config.Tags[0], ",") {
+					newSlice = append(newSlice, strings.TrimSpace(splitted))
+				}
+				config.Tags = newSlice
+			}
+
 			source := NewLogSource(integrationName, &config)
 			sources = append(sources, source)
 			// Mis-configured sources are also tracked to report configuration errors

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -26,8 +26,8 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	allSources, err := buildLogSources(ddconfdPath)
 
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(allSources.GetValidSources()))
-	assert.Equal(t, 4, len(allSources.GetSources()))
+	assert.Equal(t, 4, len(allSources.GetValidSources()))
+	assert.Equal(t, 5, len(allSources.GetSources()))
 
 	sources := allSources.GetValidSources()
 
@@ -36,41 +36,48 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	assert.Equal(t, "nginx", sources[0].Config.Service)
 	assert.Equal(t, "nginx", sources[0].Config.Source)
 	assert.Equal(t, "http_access", sources[0].Config.SourceCategory)
-	assert.Equal(t, "env:prod", sources[0].Config.Tags)
+	assert.Equal(t, []string{"env:prod"}, sources[0].Config.Tags)
 
-	assert.Equal(t, "tcp", sources[1].Config.Type)
-	assert.Equal(t, 10514, sources[1].Config.Port)
-	assert.Equal(t, "", sources[1].Config.Service)
-	assert.Equal(t, "", sources[1].Config.Source)
-	assert.Equal(t, 0, len(sources[1].Config.Tags))
+	assert.Equal(t, "file", sources[1].Config.Type)
+	assert.Equal(t, "/var/log/access.log", sources[1].Config.Path)
+	assert.Equal(t, "nginx", sources[1].Config.Service)
+	assert.Equal(t, "nginx", sources[1].Config.Source)
+	assert.Equal(t, "http_access", sources[1].Config.SourceCategory)
+	assert.Equal(t, []string{"env:prod", "foo:bar"}, sources[1].Config.Tags)
 
-	assert.Equal(t, "docker", sources[2].Config.Type)
-	assert.Equal(t, "test", sources[2].Config.Image)
+	assert.Equal(t, "tcp", sources[2].Config.Type)
+	assert.Equal(t, 10514, sources[2].Config.Port)
+	assert.Equal(t, "", sources[2].Config.Service)
+	assert.Equal(t, "", sources[2].Config.Source)
+	assert.Equal(t, 0, len(sources[2].Config.Tags))
+
+	assert.Equal(t, "docker", sources[3].Config.Type)
+	assert.Equal(t, "test", sources[3].Config.Image)
 
 	// processing
 	assert.Equal(t, 0, len(sources[0].Config.ProcessingRules))
-	assert.Equal(t, 4, len(sources[1].Config.ProcessingRules))
+	assert.Equal(t, 4, len(sources[2].Config.ProcessingRules))
 
-	pRule := sources[1].Config.ProcessingRules[0]
+	pRule := sources[2].Config.ProcessingRules[0]
 	assert.Equal(t, "mask_sequences", pRule.Type)
 	assert.Equal(t, "mocked_mask_rule", pRule.Name)
 	assert.Equal(t, "[mocked]", pRule.ReplacePlaceholder)
 	assert.Equal(t, []byte("[mocked]"), pRule.ReplacePlaceholderBytes)
 	assert.Equal(t, ".*", pRule.Pattern)
 
-	mRule := sources[1].Config.ProcessingRules[1]
+	mRule := sources[2].Config.ProcessingRules[1]
 	assert.Equal(t, "multi_line", mRule.Type)
 	assert.Equal(t, "numbers", mRule.Name)
 	re := mRule.Reg
 	assert.True(t, re.MatchString("123"))
 	assert.False(t, re.MatchString("a123"))
 
-	eRule := sources[1].Config.ProcessingRules[2]
+	eRule := sources[2].Config.ProcessingRules[2]
 	assert.Equal(t, "exclude_at_match", eRule.Type)
 	assert.Equal(t, "exclude_bob", eRule.Name)
 	assert.Equal(t, "^bob", eRule.Pattern)
 
-	iRule := sources[1].Config.ProcessingRules[3]
+	iRule := sources[2].Config.ProcessingRules[3]
 	assert.Equal(t, "include_at_match", iRule.Type)
 	assert.Equal(t, "include_datadoghq", iRule.Name)
 	assert.Equal(t, ".*@datadoghq.com$", iRule.Pattern)

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -36,7 +36,7 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	assert.Equal(t, "nginx", sources[0].Config.Service)
 	assert.Equal(t, "nginx", sources[0].Config.Source)
 	assert.Equal(t, "http_access", sources[0].Config.SourceCategory)
-	assert.Equal(t, []string{"env:prod"}, sources[0].Config.Tags)
+	assert.Equal(t, []string{"env:prod", "foo:bar"}, sources[0].Config.Tags)
 
 	assert.Equal(t, "file", sources[1].Config.Type)
 	assert.Equal(t, "/var/log/access.log", sources[1].Config.Path)

--- a/pkg/logs/config/tests/complete/conf.d/integration.d/integration4.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/integration.d/integration4.yaml
@@ -1,0 +1,23 @@
+init_config:
+
+instances:
+  - whatever: anything
+
+logs:
+  # test for tags as comma separated string
+  - type: file
+    path: /var/log/access.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_access
+    tags: env:prod, foo:bar
+
+  # test for tags as array
+  - type: file
+    path: /var/log/access.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_access
+    tags:
+      - env:prod
+      - foo:bar

--- a/pkg/logs/config/tests/complete/conf.d/integration.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/integration.yaml
@@ -10,3 +10,13 @@ logs:
     source: nginx
     sourcecategory: http_access
     tags: env:prod
+
+  # test for tags as array
+  - type: file
+    path: /var/log/access.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_access
+    tags:
+      - env:prod
+      - foo:bar

--- a/pkg/logs/config/tests/complete/conf.d/integration.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/integration.yaml
@@ -9,7 +9,7 @@ logs:
     service: nginx
     source: nginx
     sourcecategory: http_access
-    tags: env:prod
+    tags: env:prod, foo:bar
 
   # test for tags as array
   - type: file

--- a/pkg/logs/config/tests/complete/conf.d/integration.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/integration.yaml
@@ -9,14 +9,4 @@ logs:
     service: nginx
     source: nginx
     sourcecategory: http_access
-    tags: env:prod, foo:bar
-
-  # test for tags as array
-  - type: file
-    path: /var/log/access.log
-    service: nginx
-    source: nginx
-    sourcecategory: http_access
-    tags:
-      - env:prod
-      - foo:bar
+    tags: env:prod

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -34,9 +34,8 @@ func (o *Origin) Tags() []string {
 	if o.LogSource.Config.SourceCategory != "" {
 		tags = append(tags, "sourcecategory:"+o.LogSource.Config.SourceCategory)
 	}
-	if len(o.LogSource.Config.Tags) != 0 {
-		tags = append(tags, o.LogSource.Config.Tags...)
-	}
+
+	tags = append(tags, o.LogSource.Config.Tags...)
 	return tags
 }
 
@@ -50,13 +49,13 @@ func (o *Origin) TagsPayload() []byte {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+o.LogSource.Config.SourceCategory+"\"]")...)
 	}
 	var tags []string
-	if len(o.LogSource.Config.Tags) != 0 {
+	if len(o.LogSource.Config.Tags) > 0 {
 		tags = o.LogSource.Config.Tags
 	}
 	if len(o.tags) > 0 {
 		tags = append(tags, o.tags...)
 	}
-	if len(tags) != 0 {
+	if len(tags) > 0 {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+strings.Join(tags, ",")+"\"]")...)
 	}
 	if len(tagsPayload) == 0 {

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -34,8 +34,8 @@ func (o *Origin) Tags() []string {
 	if o.LogSource.Config.SourceCategory != "" {
 		tags = append(tags, "sourcecategory:"+o.LogSource.Config.SourceCategory)
 	}
-	if o.LogSource.Config.Tags != "" {
-		tags = append(tags, strings.Split(o.LogSource.Config.Tags, ",")...)
+	if len(o.LogSource.Config.Tags) != 0 {
+		tags = append(tags, o.LogSource.Config.Tags...)
 	}
 	return tags
 }
@@ -49,18 +49,15 @@ func (o *Origin) TagsPayload() []byte {
 	if o.LogSource.Config.SourceCategory != "" {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+o.LogSource.Config.SourceCategory+"\"]")...)
 	}
-	var tags string
-	if o.LogSource.Config.Tags != "" {
+	var tags []string
+	if len(o.LogSource.Config.Tags) != 0 {
 		tags = o.LogSource.Config.Tags
 	}
 	if len(o.tags) > 0 {
-		if tags != "" {
-			tags = tags + ","
-		}
-		tags = tags + strings.Join(o.tags, ",")
+		tags = append(tags, o.tags...)
 	}
-	if tags != "" {
-		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+tags+"\"]")...)
+	if len(tags) != 0 {
+		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+strings.Join(tags, ",")+"\"]")...)
 	}
 	if len(tagsPayload) == 0 {
 		tagsPayload = []byte{}

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -48,13 +48,9 @@ func (o *Origin) TagsPayload() []byte {
 	if o.LogSource.Config.SourceCategory != "" {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+o.LogSource.Config.SourceCategory+"\"]")...)
 	}
-	var tags []string
-	if len(o.LogSource.Config.Tags) > 0 {
-		tags = o.LogSource.Config.Tags
-	}
-	if len(o.tags) > 0 {
-		tags = append(tags, o.tags...)
-	}
+
+	tags := append(o.LogSource.Config.Tags, o.tags...)
+
 	if len(tags) > 0 {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+strings.Join(tags, ",")+"\"]")...)
 	}

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -49,7 +49,9 @@ func (o *Origin) TagsPayload() []byte {
 		tagsPayload = append(tagsPayload, []byte("[dd ddsourcecategory=\""+o.LogSource.Config.SourceCategory+"\"]")...)
 	}
 
-	tags := append(o.LogSource.Config.Tags, o.tags...)
+	var tags []string
+	tags = append(tags, o.LogSource.Config.Tags...)
+	tags = append(tags, o.tags...)
 
 	if len(tags) > 0 {
 		tagsPayload = append(tagsPayload, []byte("[dd ddtags=\""+strings.Join(tags, ",")+"\"]")...)

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -26,7 +26,7 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",
 		SourceCategory: "b",
-		Tags:           "c:d,e",
+		Tags:           []string{"c:d", "e"},
 	}
 	source := config.NewLogSource("", cfg)
 	origin := NewOrigin()
@@ -52,7 +52,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	cfg := &config.LogsConfig{
 		Source:         "a",
 		SourceCategory: "b",
-		Tags:           "c:d,e",
+		Tags:           []string{"c:d", "e"},
 	}
 	source := config.NewLogSource("", cfg)
 	origin := NewOrigin()

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -28,7 +28,7 @@ func TestRawEncoder(t *testing.T) {
 		Service:        "Service",
 		Source:         "Source",
 		SourceCategory: "SourceCategory",
-		Tags:           "foo:bar,baz",
+		Tags:           []string{"foo:bar", "baz"},
 	}
 
 	source := config.NewLogSource("", logsConfig)
@@ -119,7 +119,7 @@ func TestProtoEncoder(t *testing.T) {
 		Service:        "Service",
 		Source:         "Source",
 		SourceCategory: "SourceCategory",
-		Tags:           "foo:bar,baz",
+		Tags:           []string{"foo:bar", "baz"},
 	}
 
 	source := config.NewLogSource("", logsConfig)

--- a/releasenotes/notes/tags-as-array-7a28bf7215af4dc7.yaml
+++ b/releasenotes/notes/tags-as-array-7a28bf7215af4dc7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support setting tags as a YAML array in the logs agent integration configuration


### PR DESCRIPTION
### What does this PR do?

Supports setting tags as a YAML array in addition to a comma-separated string

### Motivation

People are used to setting array in YAML syntax

### Additional Notes

n/c