### PR TITLE
Prevent flare from failing when we can

### DIFF
--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -92,7 +92,10 @@ func requestFlare(caseID string) error {
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally."))
 		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFile)
-		color.NoColor = false // enable back color output
+		// enable back color output
+		if flagNoColor {
+			color.NoColor = true
+		}
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/releasenotes/notes/fix-failing-flare-a7d1fb49258b6373.yaml
+++ b/releasenotes/notes/fix-failing-flare-a7d1fb49258b6373.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix flare failing on zipping individual components


### PR DESCRIPTION
### What does this PR do?

Prevent flare from failing on zipping individual components
Also colorized a bit the output 👨‍🎨 

### Motivation

Even if the flare on some component we might get valuable information from the other on support cases

### Additional Notes

The logging is disabled if we're making the flare locally
