### PR TITLE
[docs] Fix link to docs in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)
 [![Go Report Card](https://goreportcard.com/badge/github.com/DataDog/datadog-agent)](https://goreportcard.com/report/github.com/DataDog/datadog-agent)
 
-The present repository contains the source code of the Datadog Agent version 6. Please refer to the [changes](docs/changes) document for information about differences between Agent 5 and Agent 6. Additionally, we provide a list of prepackaged binaries for an easy install process [here](https://app.datadoghq.com/account/settings#agent)
+The present repository contains the source code of the Datadog Agent version 6. Please refer to the [Agent user documentation](docs/agent) for information about differences between Agent 5 and Agent 6. Additionally, we provide a list of prepackaged binaries for an easy install process [here](https://app.datadoghq.com/account/settings#agent)
 
 **Note:** the source code of Datadog Agent 5 is located in the
 [dd-agent](https://github.com/DataDog/dd-agent) repository.


### PR DESCRIPTION
### What does this PR do?

Fixes link to docs in main README. Just link to the general Agent user docs instead of the specific "changes" document.