### PR TITLE
Make the check-rate subcommand more visible

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -131,6 +131,10 @@ var checkCmd = &cobra.Command{
 			fmt.Println(string(checkStatus))
 		}
 
+		if checkRate == false {
+			color.Yellow("Currently only displaying Gauge metrics. Please run the command with --check-rate to see any other metric types if available.")
+		}
+
 		return nil
 	},
 }

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -132,7 +132,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		if checkRate == false {
-			color.Yellow("Currently only displaying Gauge metrics. Please run the command with --check-rate to see any other metric types if available.")
+			color.Yellow("Currently only displaying Gauge metrics. You can run the command with --check-rate to see any other metric types if available.")
 		}
 
 		return nil

--- a/releasenotes/notes/visible_check_rate_command-abefec0a675bf1f2.yaml
+++ b/releasenotes/notes/visible_check_rate_command-abefec0a675bf1f2.yaml
@@ -1,0 +1,3 @@
+---
+other:
+  - Make the check-rate command more visible when running "check` to get a list of metrics. 


### PR DESCRIPTION
### What does this PR do?

Adds a log line in yellow underneath the output of the `check` command that states running with check-rate will allow you to see non gauge metric types. 

### Motivation

Clear up confusion about the check and check-rate commands

### Additional Notes

Anything else we should know when reviewing?
