### PR TITLE
[windows] remove pyc files before packaging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,6 +268,8 @@ agent_suse-x64:
 build_windows_msi_x64:
   before_script:
     - if exist .omnibus rd /s/q .omnibus
+    - if exist \omnibus-ruby rd /s/q \omnibus-ruby
+    - if exist \opt\datadog-agent rd /s/q \opt\datadog-agent
     - if exist %GOPATH%\src\github.com\DataDog\datadog-agent rd /s/q %GOPATH%\src\github.com\DataDog\datadog-agent
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
     - xcopy /q/h/e/s * %GOPATH%\src\github.com\DataDog\datadog-agent

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -136,7 +136,7 @@ end
 
 # Remove pyc/pyo files from package
 # should be built after all the other python-related software defs
-if linux?
+unless osx?
   dependency 'py-compiled-cleanup'
 end
 


### PR DESCRIPTION
### What does this PR do?

(re)enables cleaning of .pyc files before bundling for installation

### Motivation

shrinks package size ~20%

