### PR TITLE
[docker] fix exec events filtering

### DIFF
--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.example
@@ -13,13 +13,14 @@ instances:
     #
     # collect_events: false
 
-    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create'].
+    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create', 'exec_die'].
     # Here can be added additional statuses to be filtered.
     # List of available statuses can be found here https://docs.docker.com/engine/reference/commandline/events/#object-types
     # filtered_event_types:
     #    - 'top'
     #    - 'exec_start'
     #    - 'exec_create'
+    #    - 'exec_die'
 
     # Collect disk usage per container with docker.container.size_rw and
     # docker.container.size_rootfs metrics.

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -309,7 +309,7 @@ func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
 	d.instance.Parse(config)
 
 	if len(d.instance.FilteredEventType) == 0 {
-		d.instance.FilteredEventType = []string{"top", "exec_create", "exec_start"}
+		d.instance.FilteredEventType = []string{"top", "exec_create", "exec_start", "exec_die"}
 	}
 
 	var err error

--- a/pkg/collector/corechecks/containers/docker_events_test.go
+++ b/pkg/collector/corechecks/containers/docker_events_test.go
@@ -87,18 +87,18 @@ func TestAggregateEvents(t *testing.T) {
 		{
 			// One filtered out, and one not filtered
 			events: []*docker.ContainerEvent{
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "unfiltered_action",
 				},
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "top",
 				},
 			},
 			filteredActions: []string{"top", "exec_create", "exec_start"},
 			output: map[string]*dockerEventBundle{
-				"test_image": &dockerEventBundle{
+				"test_image": {
 					imageName: "test_image",
 					countByAction: map[string]int{
 						"unfiltered_action": 1,
@@ -109,7 +109,7 @@ func TestAggregateEvents(t *testing.T) {
 		{
 			// Only one filtered out action, empty output
 			events: []*docker.ContainerEvent{
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "top",
 				},
@@ -120,22 +120,22 @@ func TestAggregateEvents(t *testing.T) {
 		{
 			// 2+1 events, to count correctly
 			events: []*docker.ContainerEvent{
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "unfiltered_action",
 				},
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "unfiltered_action",
 				},
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "other_action",
 				},
 			},
 			filteredActions: []string{"top", "exec_create", "exec_start"},
 			output: map[string]*dockerEventBundle{
-				"test_image": &dockerEventBundle{
+				"test_image": {
 					imageName: "test_image",
 					countByAction: map[string]int{
 						"unfiltered_action": 2,
@@ -147,33 +147,33 @@ func TestAggregateEvents(t *testing.T) {
 		{
 			// Two images
 			events: []*docker.ContainerEvent{
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "unfiltered_action",
 				},
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "unfiltered_action",
 				},
-				&docker.ContainerEvent{
+				{
 					ImageName: "test_image",
 					Action:    "other_action",
 				},
-				&docker.ContainerEvent{
+				{
 					ImageName: "other_image",
 					Action:    "other_action",
 				},
 			},
 			filteredActions: []string{"top", "exec_create", "exec_start"},
 			output: map[string]*dockerEventBundle{
-				"test_image": &dockerEventBundle{
+				"test_image": {
 					imageName: "test_image",
 					countByAction: map[string]int{
 						"unfiltered_action": 2,
 						"other_action":      1,
 					},
 				},
-				"other_image": &dockerEventBundle{
+				"other_image": {
 					imageName: "other_image",
 					countByAction: map[string]int{
 						"other_action": 1,

--- a/pkg/collector/corechecks/containers/docker_events_test.go
+++ b/pkg/collector/corechecks/containers/docker_events_test.go
@@ -72,3 +72,126 @@ func TestReportExitCodes(t *testing.T) {
 	mockSender.AssertExpectations(t)
 	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 2)
 }
+
+func TestAggregateEvents(t *testing.T) {
+	testCases := []struct {
+		events          []*docker.ContainerEvent
+		filteredActions []string
+		output          map[string]*dockerEventBundle
+	}{
+		{
+			events:          nil,
+			filteredActions: nil,
+			output:          make(map[string]*dockerEventBundle),
+		},
+		{
+			// One filtered out, and one not filtered
+			events: []*docker.ContainerEvent{
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "unfiltered_action",
+				},
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "top",
+				},
+			},
+			filteredActions: []string{"top", "exec_create", "exec_start"},
+			output: map[string]*dockerEventBundle{
+				"test_image": &dockerEventBundle{
+					imageName: "test_image",
+					countByAction: map[string]int{
+						"unfiltered_action": 1,
+					},
+				},
+			},
+		},
+		{
+			// Only one filtered out action, empty output
+			events: []*docker.ContainerEvent{
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "top",
+				},
+			},
+			filteredActions: []string{"top", "exec_create", "exec_start"},
+			output:          map[string]*dockerEventBundle{},
+		},
+		{
+			// 2+1 events, to count correctly
+			events: []*docker.ContainerEvent{
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "unfiltered_action",
+				},
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "unfiltered_action",
+				},
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "other_action",
+				},
+			},
+			filteredActions: []string{"top", "exec_create", "exec_start"},
+			output: map[string]*dockerEventBundle{
+				"test_image": &dockerEventBundle{
+					imageName: "test_image",
+					countByAction: map[string]int{
+						"unfiltered_action": 2,
+						"other_action":      1,
+					},
+				},
+			},
+		},
+		{
+			// Two images
+			events: []*docker.ContainerEvent{
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "unfiltered_action",
+				},
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "unfiltered_action",
+				},
+				&docker.ContainerEvent{
+					ImageName: "test_image",
+					Action:    "other_action",
+				},
+				&docker.ContainerEvent{
+					ImageName: "other_image",
+					Action:    "other_action",
+				},
+			},
+			filteredActions: []string{"top", "exec_create", "exec_start"},
+			output: map[string]*dockerEventBundle{
+				"test_image": &dockerEventBundle{
+					imageName: "test_image",
+					countByAction: map[string]int{
+						"unfiltered_action": 2,
+						"other_action":      1,
+					},
+				},
+				"other_image": &dockerEventBundle{
+					imageName: "other_image",
+					countByAction: map[string]int{
+						"other_action": 1,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			bundles := aggregateEvents(tc.events, tc.filteredActions)
+			for _, b := range bundles {
+				// Strip underlying events to ease testing
+				// countByAction is enough for testing the
+				// filtering and aggregation
+				b.events = nil
+			}
+			assert.EqualValues(t, tc.output, bundles)
+		})
+	}
+}

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -93,6 +93,11 @@ func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 		Attributes:    msg.Actor.Attributes,
 	}
 
+	// Fix the "exec_start: /bin/sh -c true" case
+	if strings.Contains(event.Action, ":") {
+		event.Action = strings.SplitN(event.Action, ":", 2)[0]
+	}
+
 	return event, nil
 }
 

--- a/pkg/util/docker/event_pull_test.go
+++ b/pkg/util/docker/event_pull_test.go
@@ -138,6 +138,36 @@ func TestProcessContainerEvent(t *testing.T) {
 			event: nil,
 			err:   nil,
 		},
+		{
+			// Fix bad action
+			source: events.Message{
+				Type: "container",
+				Actor: events.Actor{
+					ID: "test_id",
+					Attributes: map[string]string{
+						"name":      "test_name",
+						"image":     "test_image",
+						"extra_key": "value",
+					},
+				},
+				Action:   "exec_start: /bin/sh -c true",
+				Time:     timestamp.Unix(),
+				TimeNano: timestamp.UnixNano(),
+			},
+			event: &ContainerEvent{
+				ContainerID:   "test_id",
+				ContainerName: "test_name",
+				ImageName:     "test_image",
+				Action:        "exec_start",
+				Timestamp:     timestamp,
+				Attributes: map[string]string{
+					"name":      "test_name",
+					"image":     "test_image",
+					"extra_key": "value",
+				},
+			},
+			err: nil,
+		},
 	} {
 		t.Logf("test case %d", nb)
 		event, err := dockerUtil.processContainerEvent(tc.source)

--- a/releasenotes/notes/docker-event-filtering-fix-2d952f26f8cfa76f.yaml
+++ b/releasenotes/notes/docker-event-filtering-fix-2d952f26f8cfa76f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Docker check: ignore the new exec_die event type by default
+fixes:
+  - Docker check: fix event filtering for exec events


### PR DESCRIPTION
### What does this PR do?

- move the `aggregateEvents` method from the docker corecheck to a standalone function for testing
- add logic to `processContainerEvent` to extract the action type from the docker `exec_start: /bin/sh -c true` strings, by splitting on `:` if present
- add the 18.02+ new `exec_die` event to the default blacklist
