### PR TITLE
Changed image filtering for docker to better work with orchestrators

### DIFF
--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -174,7 +174,7 @@ func (s *Scanner) listContainers() []types.Container {
 
 // sourceShouldMonitorContainer returns whether a container matches a log source configuration.
 // Both image and label may be used:
-// - If the source defines an image, the image must be present in the container with format "Y/image@sha256:X" with Y and @sha256:X optional
+// - If the source defines an image, the image must match with container with format "Y/image@sha256:X" where Y and @sha256:X are optional.
 // - If the source defines one or several labels, at least one of them must match the labels of the container.
 func (s *Scanner) sourceShouldMonitorContainer(source *config.LogSource, container types.Container) bool {
 	if source.Config.Image != "" {

--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -180,11 +180,11 @@ func (s *Scanner) sourceShouldMonitorContainer(source *config.LogSource, contain
 	if source.Config.Image != "" {
 		image := container.Image
 		if strings.Contains(image, digestPrefix) {
-			// Trim digest with format @256:X
+			// Trim digest if present
 			splitted := strings.SplitN(image, digestPrefix, 2)
 			image = splitted[0]
 		}
-		// Expect prefix to be a repository or null
+		// Expect prefix to end with '/'
 		repository := strings.TrimSuffix(image, source.Config.Image)
 		if len(repository) != 0 && !strings.HasSuffix(repository, "/") {
 			return false

--- a/pkg/logs/input/container/scanner_test.go
+++ b/pkg/logs/input/container/scanner_test.go
@@ -27,9 +27,23 @@ func (suite *ContainerScannerTestSuite) SetupTest() {
 
 func (suite *ContainerScannerTestSuite) TestContainerScannerFilter() {
 	cfg := config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Image: "myapp"})
+
 	container := types.Container{Image: "myapp"}
 	suite.True(suite.c.sourceShouldMonitorContainer(cfg, container))
+	container = types.Container{Image: "repository/myapp"}
+	suite.True(suite.c.sourceShouldMonitorContainer(cfg, container))
+	container = types.Container{Image: "myapp@sha256:1234567890"}
+	suite.True(suite.c.sourceShouldMonitorContainer(cfg, container))
+	container = types.Container{Image: "repository/myapp@sha256:1234567890"}
+	suite.True(suite.c.sourceShouldMonitorContainer(cfg, container))
+
 	container = types.Container{Image: "myapp2"}
+	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
+	container = types.Container{Image: "myapp2@sha256:1234567890"}
+	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
+	container = types.Container{Image: "repository/myapp2"}
+	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
+	container = types.Container{Image: "repository/myapp2@sha256:1234567890"}
 	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
 
 	cfg = config.NewLogSource("", &config.LogsConfig{Type: config.DockerType, Image: "myapp", Label: "mylabel"})

--- a/pkg/logs/input/container/scanner_test.go
+++ b/pkg/logs/input/container/scanner_test.go
@@ -37,6 +37,9 @@ func (suite *ContainerScannerTestSuite) TestContainerScannerFilter() {
 	container = types.Container{Image: "repository/myapp@sha256:1234567890"}
 	suite.True(suite.c.sourceShouldMonitorContainer(cfg, container))
 
+	container = types.Container{Image: "repositorymyapp"}
+	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
+
 	container = types.Container{Image: "myapp2"}
 	suite.False(suite.c.sourceShouldMonitorContainer(cfg, container))
 	container = types.Container{Image: "myapp2@sha256:1234567890"}

--- a/releasenotes/notes/logs-docker-image-filtering-105495238e64d948.yaml
+++ b/releasenotes/notes/logs-docker-image-filtering-105495238e64d948.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Accept now short names for docker image in logs configuration file and added to the possibilty to filter containers by image name with Kubernetes.


### PR DESCRIPTION
### What does this PR do?

Match now image with repository and sha256.

### Motivation

Be able to filter containers tailing with Kubernetes.