### PR TITLE
Change default pdh counter precision to float from int

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ clone_folder: C:\gopath\src\github.com\DataDog\datadog-agent
 # environment must be set for python 64 bit
 environment:
   GOPATH: C:\gopath
+  GOROOT: C:\go19
   RUBY_PATH: C:\Ruby23-x64
   RI_DEVKIT: C:\Ruby23-x64\DevKit\
   PYTHONPATH: c:\python27-x64
@@ -23,7 +24,7 @@ install:
   - curl -fsS -o pkg-config.zip %PKG-CONFIG-URL%
   - curl -fsS -o gettext.zip %GETTEXT-URL%
   - 7z x *.zip > NUL
-  - set PATH=C:\deps\bin;%GOPATH%\bin;C:\go\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
+  - set PATH=C:\deps\bin;%GOPATH%\bin;%GOROOT%\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
   - go version
   - pip install invoke
 

--- a/cmd/agent/dist/checks/libs/win/pdhbasecheck.py
+++ b/cmd/agent/dist/checks/libs/win/pdhbasecheck.py
@@ -67,7 +67,16 @@ class PDHBaseCheck(AgentCheck):
                     except Exception as e:
                         self.log.error("Failed to make remote connection %s" % str(e))
                         return
-                
+
+                ## counter_data_types allows the precision with which counters are queried
+                ## to be configured on a per-metric basis. In the metric instance, precision
+                ## should be specified as
+                ## counter_data_types:
+                ## - iis.httpd_request_method.get,int
+                ## - iis.net.bytes_rcvd,float
+                ##
+                ## the above would query the counter associated with iis.httpd_request_method.get
+                ## as an integer (LONG) and iis.net.bytes_rcvd as a double
                 datatypes = {}
                 precisions = instance.get('counter_data_types')
                 if precisions is not None:
@@ -92,10 +101,9 @@ class PDHBaseCheck(AgentCheck):
 
                 for counterset, inst_name, counter_name, dd_name, mtype in counter_list:
                     m = getattr(self, mtype.lower())
-                    precision = None
-                    if dd_name in datatypes:
-                        precision = datatypes[dd_name]
-                        
+
+                    precision = datatypes.get(dd_name)
+
                     obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine, precision=precision)
                     entry = [inst_name, dd_name, m, obj]
                     self.log.debug("entry: %s" % str(entry))
@@ -108,9 +116,8 @@ class PDHBaseCheck(AgentCheck):
                         if inst_name.lower() == "none" or len(inst_name) == 0 or inst_name == "*" or inst_name.lower() == "all":
                             inst_name = None
                         m = getattr(self, mtype.lower())
-                        precision = None
-                        if dd_name in datatypes:
-                            precision = datatypes[dd_name]
+
+                        precision = datatypes.get(dd_name)
 
                         obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine, precision = precision)
                         entry = [inst_name, dd_name, m, obj]

--- a/cmd/agent/dist/checks/libs/win/winpdh.py
+++ b/cmd/agent/dist/checks/libs/win/winpdh.py
@@ -15,7 +15,7 @@ class WinPDHCounter(object):
     # store the dictionary of pdh counter names
     pdh_counter_dict = {}
 
-    def __init__(self, class_name, counter_name, log, instance_name = None, machine_name = None, precision=DATA_TYPE_DOUBLE):
+    def __init__(self, class_name, counter_name, log, instance_name = None, machine_name = None, precision=None):
         self._get_counter_dictionary()
         self._class_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[class_name]))
         self._counter_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[counter_name]))

--- a/releasenotes/notes/pdhfloat-75f630da7c3a8236.yaml
+++ b/releasenotes/notes/pdhfloat-75f630da7c3a8236.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Changes default precision of pdh-based counters from int to float. Fixes bug where fidelity of some counters is quite low, especially counters with values between 0 and 1.

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -101,7 +101,7 @@ def vet(ctx, targets):
     # add the /... suffix to the targets
     args = ["{}/...".format(t) for t in targets]
     build_tags = get_default_build_tags()
-    ctx.run("go vet -tags \"{}\" ".format(build_tags) + " ".join(args))
+    ctx.run("go vet -x -tags \"{}\" ".format(build_tags) + " ".join(args))
     # go vet exits with status 1 when it finds an issue, if we're here
     # everything went smooth
     print("go vet found no issues")


### PR DESCRIPTION
### What does this PR do?

change default pdh counter precision to float from int.
Allows configuration to set specific counter types 

### Motivation

customer request

### Additional Notes


