### PR TITLE
[windows] Fix tray menu version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ clone_folder: C:\gopath\src\github.com\DataDog\datadog-agent
 # environment must be set for python 64 bit
 environment:
   GOPATH: C:\gopath
+  GOROOT: C:\go19
   RUBY_PATH: C:\Ruby23-x64
   RI_DEVKIT: C:\Ruby23-x64\DevKit\
   PYTHONPATH: c:\python27-x64
@@ -23,7 +24,7 @@ install:
   - curl -fsS -o pkg-config.zip %PKG-CONFIG-URL%
   - curl -fsS -o gettext.zip %GETTEXT-URL%
   - 7z x *.zip > NUL
-  - set PATH=C:\deps\bin;%GOPATH%\bin;C:\go\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
+  - set PATH=C:\deps\bin;%GOPATH%\bin;%GOROOT%\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
   - go version
   - pip install invoke
 

--- a/releasenotes/notes/fixtrayver-035aadfbbc2ccb82.yaml
+++ b/releasenotes/notes/fixtrayver-035aadfbbc2ccb82.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Menu in system tray reports wrong version (6.0.0) for all versions of Agent.  This fixes the system tray menu to report the correct version.

--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -13,6 +13,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, pkg_config_path, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
+from .utils import get_version_ldflags
 from .build_tags import get_build_tags, get_default_build_tags, ALL_TAGS
 from .go import deps
 
@@ -49,8 +50,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     )
     command += "-i cmd/systray/systray.rc --target=pe-x86-64 -O coff -o cmd/systray/rsrc.syso"
     ctx.run(command)
-
-    ldflags = "-s -w -linkmode external -extldflags '-Wl,--subsystem,windows' "
+    ldflags = get_version_ldflags(ctx)
+    ldflags += "-s -w -linkmode external -extldflags '-Wl,--subsystem,windows' "
     cmd = "go build {race_opt} {build_type} -o {agent_bin} -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/systray"
     args = {
         "race_opt": "-race" if race else "",

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -52,13 +52,8 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
     We need to invoke external processes here so this function need the
     Context object.
     """
-    payload_v = get_payload_version()
-    commit = ctx.run("git rev-parse --short HEAD", hide=True).stdout.strip()
-
     gcflags = ""
-    ldflags = "-X {}/pkg/version.Commit={} ".format(REPO_PATH, commit)
-    ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True))
-    ldflags += "-X {}/pkg/serializer.AgentPayloadVersion={} ".format(REPO_PATH, payload_v)
+    ldflags = get_version_ldflags(ctx)
     env = {
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs),
         "CGO_CFLAGS_ALLOW": "-static-libgcc",  # whitelist additional flags, here a flag used for net-snmp
@@ -121,6 +116,18 @@ def get_payload_version():
 
     return ""
 
+def get_version_ldflags(ctx):
+    """
+    Compute the version from the git tags, and set the appropriate compiler
+    flags
+    """
+    payload_v = get_payload_version()
+    commit = ctx.run("git rev-parse --short HEAD", hide=True).stdout.strip()
+
+    ldflags = "-X {}/pkg/version.Commit={} ".format(REPO_PATH, commit)
+    ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True))
+    ldflags += "-X {}/pkg/serializer.AgentPayloadVersion={} ".format(REPO_PATH, payload_v)
+    return ldflags
 
 def get_root():
     """


### PR DESCRIPTION
Tray menu was reporting default (6.0.0) version regardless of actual
version.  Fix build script to report correct version at compile time


### Motivation

Noticed confusing version information

