### PR TITLE
[tagger] extract kubernetes pod annotations

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -51,6 +51,7 @@ We automatically collect common tags from [Docker](https://github.com/DataDog/da
 - `DD_DOCKER_LABELS_AS_TAGS` : extract docker container labels
 - `DD_DOCKER_ENV_AS_TAGS` : extract docker container environment variables
 - `DD_KUBERNETES_POD_LABELS_AS_TAGS` : extract pod labels
+- `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS` : extract pod annotations
 
 You can either define them in your custom `datadog.yaml`, or set them as JSON maps in these envvars. The map key is the source (label/envvar) name, and the map value the datadog tag name.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -160,6 +160,7 @@ func init() {
 	Datadog.SetDefault("docker_labels_as_tags", map[string]string{})
 	Datadog.SetDefault("docker_env_as_tags", map[string]string{})
 	Datadog.SetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
+	Datadog.SetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
 	Datadog.SetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 
 	// Kubernetes
@@ -252,6 +253,7 @@ func init() {
 	Datadog.BindEnv("docker_labels_as_tags")
 	Datadog.BindEnv("docker_env_as_tags")
 	Datadog.BindEnv("kubernetes_pod_labels_as_tags")
+	Datadog.BindEnv("kubernetes_pod_annotations_as_tags")
 	Datadog.BindEnv("kubernetes_node_labels_as_tags")
 	Datadog.BindEnv("ac_include")
 	Datadog.BindEnv("ac_exclude")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -323,12 +323,17 @@ api_key:
 {{- if .KubernetesTagging }}
 # Kubernetes tag extraction
 #
-# We can extract pod labels as metric tags. If you prefix your
+# We can extract pod labels and annotations as metric tags. If you prefix your
 # tag name with +, it will only be added to high cardinality metrics
 #
 # kubernetes_pod_labels_as_tags:
 #   app:               kube_app
 #   pod-template-hash: +kube_pod-template-hash
+#
+# kubernetes_pod_annotations_as_tags:
+#   app:               kube_app
+#   pod-template-hash: +kube_pod-template-hash
+#
 {{ end -}}
 {{- if .ECS }}
 # ECS integration

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -37,16 +37,16 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		tags.AddLow("kube_namespace", pod.Metadata.Namespace)
 
 		// Pod labels
-		for labelName, labelValue := range pod.Metadata.Labels {
-			if tagName, found := c.labelsAsTags[strings.ToLower(labelName)]; found {
-				tags.AddAuto(tagName, labelValue)
+		for name, value := range pod.Metadata.Labels {
+			if tagName, found := c.labelsAsTags[strings.ToLower(name)]; found {
+				tags.AddAuto(tagName, value)
 			}
 		}
 
 		// Pod annotations
-		for labelName, labelValue := range pod.Metadata.Annotations {
-			if tagName, found := c.annotationsAsTags[strings.ToLower(labelName)]; found {
-				tags.AddAuto(tagName, labelValue)
+		for name, value := range pod.Metadata.Annotations {
+			if tagName, found := c.annotationsAsTags[strings.ToLower(name)]; found {
+				tags.AddAuto(tagName, value)
 			}
 		}
 

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -43,6 +43,13 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			}
 		}
 
+		// Pod annotations
+		for labelName, labelValue := range pod.Metadata.Annotations {
+			if tagName, found := c.annotationsAsTags[strings.ToLower(labelName)]; found {
+				tags.AddAuto(tagName, labelValue)
+			}
+		}
+
 		// OpenShift pod annotations
 		if dc_name, found := pod.Metadata.Annotations["openshift.io/deployment-config.name"]; found {
 			tags.AddLow("oshift_deployment_config", dc_name)

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -24,11 +24,12 @@ const (
 // tags. It is to be supplemented by the cluster agent collector for tags from
 // the apiserver.
 type KubeletCollector struct {
-	watcher      *kubelet.PodWatcher
-	infoOut      chan<- []*TagInfo
-	lastExpire   time.Time
-	expireFreq   time.Duration
-	labelsAsTags map[string]string
+	watcher           *kubelet.PodWatcher
+	infoOut           chan<- []*TagInfo
+	lastExpire        time.Time
+	expireFreq        time.Duration
+	labelsAsTags      map[string]string
+	annotationsAsTags map[string]string
 }
 
 // Detect tries to connect to the kubelet
@@ -44,6 +45,7 @@ func (c *KubeletCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error)
 
 	// viper lower-cases map keys, so extractor must lowercase before matching
 	c.labelsAsTags = config.Datadog.GetStringMapString("kubernetes_pod_labels_as_tags")
+	c.annotationsAsTags = config.Datadog.GetStringMapString("kubernetes_pod_annotations_as_tags")
 
 	return PullCollection, nil
 }

--- a/releasenotes/notes/kubernetes-pod-annotations-as-tags-ea5ecd1ebbf99826.yaml
+++ b/releasenotes/notes/kubernetes-pod-annotations-as-tags-ea5ecd1ebbf99826.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add option to extract kubernetes pod annotations as tags, similar to labels


### PR DESCRIPTION
Add option to extract kubernetes pod annotations as tags, similar to labels. Document config.yaml and envvar binding