### PR TITLE
[docker] be more resilient to high system loads

### DIFF
--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -334,7 +334,7 @@ func (ac *AutoConfig) AddListener(listener listeners.ServiceListener) {
 	}
 
 	ac.listeners = append(ac.listeners, listener)
-	listener.Listen(ac.configResolver.newService, ac.configResolver.delService)
+	go listener.Listen(ac.configResolver.newService, ac.configResolver.delService)
 }
 
 // AddLoader adds a new Loader that AutoConfig can use to load a check.

--- a/pkg/collector/autodiscovery/autoconfig_test.go
+++ b/pkg/collector/autodiscovery/autoconfig_test.go
@@ -42,13 +42,11 @@ type MockLoader struct{}
 func (l *MockLoader) Load(config check.Config) ([]check.Check, error) { return []check.Check{}, nil }
 
 type MockListener struct {
-	ListenCount  int
 	stopReceived bool
 	started      chan struct{}
 }
 
 func (l *MockListener) Listen(newSvc, delSvc chan<- listeners.Service) {
-	l.ListenCount++
 	l.started <- struct{}{}
 }
 
@@ -92,9 +90,7 @@ func TestAddListener(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		assert.FailNow(t, "listener didn't start in 100 ms")
 	}
-
 	require.Len(t, ac.listeners, 1)
-	assert.Equal(t, 1, ml.ListenCount)
 }
 
 func TestContains(t *testing.T) {

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -83,25 +83,23 @@ func (l *DockerListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 		return
 	}
 
-	go func() {
-		for {
-			select {
-			case <-l.stop:
-				l.dockerUtil.UnsubscribeFromContainerEvents("DockerListener")
-				l.health.Deregister()
-				return
-			case <-l.health.C:
-			case msg := <-messages:
-				l.processEvent(msg)
-			case err := <-errs:
-				if err != nil && err != io.EOF {
-					log.Errorf("docker listener error: %v", err)
-					signals.ErrorStopper <- true
-				}
-				return
+	for {
+		select {
+		case <-l.stop:
+			l.dockerUtil.UnsubscribeFromContainerEvents("DockerListener")
+			l.health.Deregister()
+			return
+		case <-l.health.C:
+		case msg := <-messages:
+			l.processEvent(msg)
+		case err := <-errs:
+			if err != nil && err != io.EOF {
+				log.Errorf("docker listener error: %v", err)
+				signals.ErrorStopper <- true
 			}
+			return
 		}
-	}()
+	}
 }
 
 // Stop queues a shutdown of DockerListener

--- a/pkg/collector/listeners/docker.go
+++ b/pkg/collector/listeners/docker.go
@@ -10,10 +10,10 @@ package listeners
 import (
 	"context"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
@@ -53,7 +53,6 @@ func init() {
 }
 
 // NewDockerListener creates a client connection to Docker and instantiate a DockerListener with it
-// TODO: TLS support
 func NewDockerListener() (ServiceListener, error) {
 	d, err := docker.GetDockerUtil()
 	if err != nil {
@@ -73,31 +72,38 @@ func (l *DockerListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	l.newService = newSvc
 	l.delService = delSvc
 
-	// process containers that might be already running
-	l.init()
-
-	messages, errs, err := l.dockerUtil.SubscribeToContainerEvents("DockerListener")
-	if err != nil {
-		log.Errorf("can't listen to docker events: %v", err)
-		signals.ErrorStopper <- true
-		return
-	}
-
+CONNECT: // Outer loop handles re-subscribing
 	for {
-		select {
-		case <-l.stop:
-			l.dockerUtil.UnsubscribeFromContainerEvents("DockerListener")
-			l.health.Deregister()
+		messages, errs, err := l.dockerUtil.SubscribeToContainerEvents("DockerListener")
+		if err != nil {
+			log.Errorf("Cannot listen to docker events: %v", err)
+			signals.ErrorStopper <- true
 			return
-		case <-l.health.C:
-		case msg := <-messages:
-			l.processEvent(msg)
-		case err := <-errs:
-			if err != nil && err != io.EOF {
-				log.Errorf("docker listener error: %v", err)
+		}
+
+		// Process current state
+		l.CatchUp()
+
+		for {
+			select {
+			case <-l.stop:
+				l.dockerUtil.UnsubscribeFromContainerEvents("DockerListener")
+				l.health.Deregister()
+				return
+			case <-l.health.C:
+			case msg := <-messages:
+				l.processEvent(msg)
+			case err := <-errs:
+				if err == docker.ErrEventTimeout {
+					// We fell behind, let's wait a second and re-subscribe
+					log.Infof("Restarting collection: %s", err)
+					time.Sleep(time.Second)
+					continue CONNECT // Re-subscribe to events
+				}
+				log.Warnf("Unexpected error: %s", err)
 				signals.ErrorStopper <- true
+				return
 			}
-			return
 		}
 	}
 }
@@ -107,22 +113,36 @@ func (l *DockerListener) Stop() {
 	l.stop <- true
 }
 
-// init looks at currently running Docker containers,
-// creates services for them, and pass them to the ConfigResolver.
-// It is typically called at start up.
-func (l *DockerListener) init() {
-	l.m.Lock()
-	defer l.m.Unlock()
+// CatchUp compares the currently running Docker containers to the l.services
+// state computes new/removed containers creates services for them, and passes
+// them to the ConfigResolver. It is typically called at start up.
+// Exported for integration testing
+func (l *DockerListener) CatchUp() {
+	l.m.RLock()
+	// Prepare a set of services we already know about.
+	// If we don't find them in the container list, we will need to remove them.
+	servicesToRemove := make(map[ID]struct{})
+	for cID := range l.services {
+		servicesToRemove[cID] = struct{}{}
+	}
+
+	var newServices []Service
 
 	containers, err := l.dockerUtil.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
-		log.Errorf("Couldn't retrieve container list - %s", err)
+		log.Errorf("Couldn't retrieve container list: %s", err)
 	}
 
 	for _, co := range containers {
 		id := ID(co.ID)
-		var svc Service
+		delete(servicesToRemove, id) // Don't delete the service if existing
 
+		if _, found := l.services[id]; found {
+			// Service already registered, skip this container
+			continue
+		}
+
+		var svc Service
 		if findKubernetesInLabels(co.Labels) {
 			svc = &DockerKubeletService{
 				DockerService: DockerService{
@@ -139,8 +159,21 @@ func (l *DockerListener) init() {
 				Ports:         l.getPortsFromPs(co),
 			}
 		}
-		l.newService <- svc
-		l.services[id] = svc
+		newServices = append(newServices, svc)
+	}
+	l.m.RUnlock()
+
+	if len(newServices) > 0 {
+		l.m.Lock()
+		for _, svc := range newServices {
+			l.newService <- svc
+			l.services[svc.GetID()] = svc
+		}
+		l.m.Unlock()
+	}
+
+	for id := range servicesToRemove {
+		l.removeService(id)
 	}
 }
 

--- a/pkg/collector/listeners/ecs.go
+++ b/pkg/collector/listeners/ecs.go
@@ -66,18 +66,16 @@ func (l *ECSListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	l.newService = newSvc
 	l.delService = delSvc
 
-	go func() {
-		for {
-			select {
-			case <-l.stop:
-				l.health.Deregister()
-				return
-			case <-l.health.C:
-			case <-l.t.C:
-				l.refreshServices()
-			}
+	for {
+		select {
+		case <-l.stop:
+			l.health.Deregister()
+			return
+		case <-l.health.C:
+		case <-l.t.C:
+			l.refreshServices()
 		}
-	}()
+	}
 }
 
 // Stop queues a shutdown of ECSListener

--- a/pkg/collector/providers/docker.go
+++ b/pkg/collector/providers/docker.go
@@ -73,8 +73,7 @@ func (d *DockerConfigProvider) listen() {
 	d.health = health.Register("ad-dockerprovider")
 	d.Unlock()
 
-	// Outer loop handles re-subscribing
-CONNECT:
+CONNECT: // Outer loop handles re-subscribing
 	for {
 		eventChan, errChan, err := d.dockerUtil.SubscribeToContainerEvents(d.String())
 		if err != nil {

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -58,8 +58,7 @@ func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) 
 func (c *DockerCollector) Stream() error {
 	healthHandle := health.Register("tagger-docker")
 
-	// Outer loop handles re-subscribing
-CONNECT:
+CONNECT: // Outer loop handles re-subscribing
 	for {
 		messages, errs, err := c.dockerUtil.SubscribeToContainerEvents("DockerCollector")
 		if err != nil {

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -8,8 +8,8 @@
 package collectors
 
 import (
-	"io"
 	"strings"
+	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -58,25 +58,36 @@ func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) 
 func (c *DockerCollector) Stream() error {
 	healthHandle := health.Register("tagger-docker")
 
-	messages, errs, err := c.dockerUtil.SubscribeToContainerEvents("DockerCollector")
-	if err != nil {
-		return err
-	}
-
+	// Outer loop handles re-subscribing
+CONNECT:
 	for {
-		select {
-		case <-c.stop:
-			healthHandle.Deregister()
-			return c.dockerUtil.UnsubscribeFromContainerEvents("DockerCollector")
-		case <-healthHandle.C:
-		case msg := <-messages:
-			c.processEvent(msg)
-		case err := <-errs:
-			if err != nil && err != io.EOF {
-				log.Errorf("stopping collection: %s", err)
+		messages, errs, err := c.dockerUtil.SubscribeToContainerEvents("DockerCollector")
+		if err != nil {
+			// Purposely keep the healthcheck open, we are unhealthy now
+			log.Errorf("Unexpected error, stopping collection: %s", err)
+			return err
+		}
+
+		for {
+			select {
+			case <-c.stop:
+				healthHandle.Deregister()
+				return c.dockerUtil.UnsubscribeFromContainerEvents("DockerCollector")
+			case <-healthHandle.C:
+			case msg := <-messages:
+				c.processEvent(msg)
+			case err := <-errs:
+				if err == docker.ErrEventTimeout {
+					// We fell behind, let's wait a second and re-subscribe
+					// If we were to miss containers, we'll handle them via Fetch
+					log.Infof("Restarting collection: %s", err)
+					time.Sleep(time.Second)
+					continue CONNECT // Re-subscribe to events
+				}
+				// Purposely keep the healthcheck open, we are unhealthy now
+				log.Errorf("Unexpected error, stopping collection: %s", err)
 				return err
 			}
-			return nil
 		}
 	}
 }

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -23,7 +23,7 @@ import (
 //// eventStreamState logic unit tested in event_stream_test.go
 //// DockerUtil logic covered by the listeners/docker and dogstatsd/origin_detection integration tests.
 
-const eventSendTimeout = 100 * time.Millisecond
+const eventSendTimeout = 500 * time.Millisecond
 const eventSendBuffer = 5
 
 // SubscribeToContainerEvents allows a package to subscribe to events from the event stream.

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -30,7 +30,7 @@ func (ev *ContainerEvent) ContainerEntityName() string {
 var (
 	ErrAlreadySubscribed = errors.New("already subscribed")
 	ErrNotSubscribed     = errors.New("not subscribed")
-	ErrEventTimeout      = errors.New("timeout on event sending, re-subscribe")
+	ErrEventTimeout      = errors.New("fell behind in processing docker events, unsubscribed")
 )
 
 // eventSubscriber holds the state for a subscriber

--- a/releasenotes/notes/docker-event-high-load-006516e4183d3585.yaml
+++ b/releasenotes/notes/docker-event-high-load-006516e4183d3585.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improve docker monitoring when the system is under a very high load. The agent
+    might still temporarily miss a healthcheck, but will be able to run already
+    scheduled checks, and recover once the spike ends


### PR DESCRIPTION
### What does this PR do?

When testing 6.0 on very high load, some asynchronous components might become unresponsive and be unsubscribed from docker event multiplexing. This mechanism was introduced to reduce the load on the docker daemon (avoiding 4 concurrent stream connections), while still ensuring the whole agent does not hang if one component fails.

This PR introduces the following changes:

- raise the event processing timeout from 100ms to 500ms. Worst case scenario, 2sec delay on events is acceptable
- homogenize error handling on all three consumers (AD listener, AD provider and tagger collector) to backoff for a second and try re-subscribing to events. If that happens, the following catchup is done:
    - AD listener: transform the `init` method building the initial state from the container list in a `catchup` method able to compare the current state with the container list and new/delete services for the diff. This makes sure we don't miss any service modification
    - AD provider: invalidate our cache, we'll pull all template in the next run
    - Tagger collector: continue on our merry way, if we missed containers, they'll be individually fetched and cached later
- set the AD listener goroutines to be spawned by the main component instead of the listeners themselves, to improve consistency and make stacktraces more readable

Individual components might still temporarily miss their healthchecks, but they'll be able to recover once the spike is over.

### Motivation

The agent should be able to recover, and keep monitoring the load to give insights on the source of the issue.
