### PR TITLE
[CI] pin the go version in appveyor to 1.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ clone_folder: C:\gopath\src\github.com\DataDog\datadog-agent
 # environment must be set for python 64 bit
 environment:
   GOPATH: C:\gopath
+  GOROOT: C:\go19
   RUBY_PATH: C:\Ruby23-x64
   RI_DEVKIT: C:\Ruby23-x64\DevKit\
   PYTHONPATH: c:\python27-x64
@@ -23,7 +24,7 @@ install:
   - curl -fsS -o pkg-config.zip %PKG-CONFIG-URL%
   - curl -fsS -o gettext.zip %GETTEXT-URL%
   - 7z x *.zip > NUL
-  - set PATH=C:\deps\bin;%GOPATH%\bin;C:\go\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
+  - set PATH=C:\deps\bin;%GOPATH%\bin;%GOROOT%\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
   - go version
   - pip install invoke
 


### PR DESCRIPTION
### What does this PR do?

Appveyor automatically upgrades the shipped Go in `c:\go`, pinning to `c:\go19` until we update all build pipelines to 1.10
