### PR TITLE
[Logs] Docker - properly stop tailing container

### DIFF
--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -74,6 +74,7 @@ func (dt *DockerTailer) Identifier() string {
 func (dt *DockerTailer) Stop() {
 	log.Info("Stop tailing container ", dt.ContainerID[:12])
 	dt.stop <- struct{}{}
+	dt.reader.Close()
 	dt.source.RemoveInput(dt.ContainerID)
 	// wait for the decoder to be flushed
 	<-dt.done

--- a/releasenotes/notes/logs-docker-stop-789a9c81daa77a62.yaml
+++ b/releasenotes/notes/logs-docker-stop-789a9c81daa77a62.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue that would prevent the agent from stopping when it was tailing logs
+    of a container that had no logs.


### PR DESCRIPTION
we were previously waiting for a log from the container
to check if we had to stop or not.
This stops the reader, so we won't block anymore
