### PR TITLE
dd-agent-testing should use latest image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -441,7 +441,7 @@ deploy_suse_rpm_testing:
 testkitchen_testing:
   stage: testkitchen_testing
   allow_failure: true
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:pipeline-189121
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
     - tags
@@ -484,7 +484,7 @@ testkitchen_cleanup_s3:
 # run dd-agent-testing
 testkitchen_cleanup_azure:
   stage: testkitchen_cleanup
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:pipeline-189121
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
     - tags


### PR DESCRIPTION
### What does this PR do?

While testing the dd-agent-testing I set the pipeline to use a pipeline image. I should have changed it to latest before I merged the PR, apparently I missed it. This fixes it!

### Motivation

Something was broken. :)

### Additional Notes

Anything else we should know when reviewing?
