### PR TITLE
Fix GCE hostname logic to pull in short name

### DIFF
--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -35,6 +35,7 @@ func GetHostname() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
 	}
+	hostname = strings.SplitN(hostname, ".", 2)[0]
 	return hostname, nil
 }
 

--- a/releasenotes/notes/pull-short-GCEhostname-d48b251339dea0d5.yaml
+++ b/releasenotes/notes/pull-short-GCEhostname-d48b251339dea0d5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Change GCE hostname logic to pull short hostname from GCE metadata to conform with similiar Agent 5 behavior 


### PR DESCRIPTION
### What does this PR do?

Updates the GCE `GetHostname()` function to pull in the short hostname to be consistent with the GCE hostname [logic of Agent 5](https://github.com/DataDog/dd-agent/blob/a7d1031b62301cd6e7c01cc50efbdf57b65c93ec/utils/cloud_metadata.py#L89)

### Motivation

Customer pointed out inconsistencies in GCE hostnames after upgrading to Agent 6

### Additional Notes

Anything else we should know when reviewing?
