### PR TITLE
 Don't Import empty histogram configs

### DIFF
--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -61,7 +61,7 @@ func FromAgentConfig(agentConfig Config) error {
 	// TODO: exclude_process_args
 
 	histogramAggregates := buildHistogramAggregates(agentConfig)
-	if histogramAggrates != nil && len(histogramAggregates) != 0 {
+	if histogramAggregates != nil && len(histogramAggregates) != 0 {
 		config.Datadog.Set("histogram_aggregates", histogramAggregates)
 	}
 

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -59,9 +59,16 @@ func FromAgentConfig(agentConfig Config) error {
 	}
 
 	// TODO: exclude_process_args
-	config.Datadog.Set("histogram_aggregates", buildHistogramAggregates(agentConfig))
 
-	config.Datadog.Set("histogram_percentiles", buildHistogramPercentiles(agentConfig))
+	histogramAggregates := buildHistogramAggregates(agentConfig)
+	if histogramAggrates != nil && len(histogramAggregates) != 0 {
+		config.Datadog.Set("histogram_aggregates", histogramAggregates)
+	}
+
+	histogramPercentiles := buildHistogramPercentiles(agentConfig)
+	if histogramPercentiles != nil && len(histogramPercentiles) != 0 {
+		config.Datadog.Set("histogram_percentiles", histogramPercentiles)
+	}
 
 	if agentConfig["service_discovery_backend"] == "docker" {
 		// `docker` is the only possible value also on the Agent v5

--- a/releasenotes/notes/fix_import_empty_histograms-78adf3a00fc7984e.yaml
+++ b/releasenotes/notes/fix_import_empty_histograms-78adf3a00fc7984e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - Fixed an issue where the import script would put an empty histogram aggregates and
+    percentiles in datadog.yaml if they didn't exist in datadog.conf.


### PR DESCRIPTION
### What does this PR do?

If there are no histogram percentiles or aggregates in datadog.conf, don't import an empty list

### Motivation

Customers had this field commented out in datadog.conf, expecting defaults. When the import script was run, datadog.yaml contained empty lists, so no histogram metrics were being reported. 

### Additional Notes

If the histogram percentiles or aggregates is an empty list, or invalid, we take the defaults of:

```
histogram_aggregates:
- max
- median
- avg
- count
histogram_percentiles:
- "0.95"
```