### PR TITLE
[docker] use interface IPs for network matching instead of GW

### DIFF
--- a/pkg/util/docker/network_test.go
+++ b/pkg/util/docker/network_test.go
@@ -29,19 +29,19 @@ func TestDefaultGateway(t *testing.T) {
 		expectedIP      string
 	}{
 		{
-			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
 ens33	00000000	0280A8C0	0003	0	0	100	00000000	0	0	0
 `),
 			"192.168.128.2",
 		},
 		{
-			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
 ens33	00000000	FE01A8C0	0003	0	0	100	00000000	0	0	0
 `),
 			"192.168.1.254",
 		},
 		{
-			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
 ens33	00000000	FEFEA8C0	0003	0	0	100	00000000	0	0	0
 `),
 			"192.168.254.254",
@@ -217,7 +217,7 @@ func TestFindDockerNetworks(t *testing.T) {
 				NetworkSettings: &types.SummaryNetworkSettings{
 					Networks: map[string]*dockernetwork.EndpointSettings{
 						"eth0": {
-							Gateway: "172.17.0.1/24",
+							IPAddress: "172.17.0.1",
 						},
 					},
 				},
@@ -250,6 +250,7 @@ func TestFindDockerNetworks(t *testing.T) {
 				PacketsSent: 0,
 			},
 		},
+		// previous int32 overflow bug, now we parse uint32
 		{
 			pid: 1245,
 			container: types.Container{
@@ -262,7 +263,7 @@ func TestFindDockerNetworks(t *testing.T) {
 				NetworkSettings: &types.SummaryNetworkSettings{
 					Networks: map[string]*dockernetwork.EndpointSettings{
 						"eth0": {
-							Gateway: "192.168.254.254",
+							IPAddress: "192.168.254.254",
 						},
 					},
 				},
@@ -303,10 +304,10 @@ func TestFindDockerNetworks(t *testing.T) {
 				NetworkSettings: &types.SummaryNetworkSettings{
 					Networks: map[string]*dockernetwork.EndpointSettings{
 						"bridge": {
-							Gateway: "172.17.0.1",
+							IPAddress: "172.17.0.1",
 						},
 						"test": {
-							Gateway: "172.18.0.1",
+							IPAddress: "172.18.0.1",
 						},
 					},
 				},
@@ -363,10 +364,10 @@ func TestFindDockerNetworks(t *testing.T) {
 				NetworkSettings: &types.SummaryNetworkSettings{
 					Networks: map[string]*dockernetwork.EndpointSettings{
 						"isolated_nw": {
-							Gateway: "172.18.0.1",
+							IPAddress: "172.18.0.1",
 						},
 						"eth0": {
-							Gateway: "172.0.0.4/24",
+							IPAddress: "172.0.0.4/24",
 						},
 					},
 				},


### PR DESCRIPTION

This PR reworks the docker network matching to work even on private subnets without a gateway.

### Current code

The current code is a port of [this agent5 code](https://github.com/DataDog/dd-agent/blob/738f41bc1ea2db10400613b883d4e28c37826111/utils/dockerutil.py#L663-L695). Before that, we only collected metrics on the container's `eth0`. The goal of this feature is to support several network interfaces per container, and tag metrics by docker network name.

Docker handles multiple networks by creating several virtual interfaces in the container's network namespace, which we can list in `/host/proc/$PID/net/dev`:

```
Inter-|   Receive                                                |  Transmit
face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
  lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
eth0:     648       8    0    0    0     0          0         0        0       0    0    0    0     0       0          0
eth1:    1478      19    0    0    0     0          0         0      182       3    0    0    0     0       0          0
```

And provides metadata in the container's inspect:

```
"Networks": {
    "bridge": {
        "IPAMConfig": null,
        "Links": null,
        "Aliases": null,
        "NetworkID": "5a7ccc462dbed72865a9cd9a56f65ee8e3829a64d3ab407f01614e7715feea84",
        "EndpointID": "252c415509cbf023c0bd74c3c7e4cff9b769b1a52b99ce85fc7f12cd01d2ba0c",
        "Gateway": "172.17.0.1",
        "IPAddress": "172.17.0.4",
        "IPPrefixLen": 16,
        "IPv6Gateway": "",
        "GlobalIPv6Address": "",
        "GlobalIPv6PrefixLen": 0,
        "MacAddress": "02:42:ac:11:00:03",
        "DriverOpts": null
    },
    "secondnet": {
        "IPAMConfig": {},
        "Links": null,
        "Aliases": [
            "f953a75bbcac"
        ],
        "NetworkID": "18a16da80cb3bca0d98a2d47a255a3c0fea9b615d45910ac4138f7b0831ad388",
        "EndpointID": "1a73e63e7a572e21a93cf359795d1b492f0647ff707a76371a4402aaf85861a9",
        "Gateway": "172.18.0.1",
        "IPAddress": "172.18.0.2",
        "IPPrefixLen": 16,
        "IPv6Gateway": "",
        "GlobalIPv6Address": "",
        "GlobalIPv6PrefixLen": 0,
        "MacAddress": "02:42:ac:13:00:02",
        "DriverOpts": null
    }
}
```


The challenge is to map `eth1` to an actionable information for the users, via a `docker_network:secondnet` metric tag. Network namespacing is pretty effective at isolating containers, so matching the interfaces via MAC addresses would have required to switch network namespaces, which would be both costly and intrusive. Neither the NetworkID nor EndpointID were available in procfiles.

The only information we could cheaply access on all tested systems is `/host/proc/$PID/net/route`:

```
Iface	  Destination  Gateway   Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
eth0  00000000  010011AC   0003	0	0	0	00000000	0	0	0
eth0  000011AC  00000000   0001	0	0	0	0000FFFF	0	0	0
eth1  000012AC  00000000   0001	0	0	0	0000FFFF	0	0	0
```

Our first intent was to match the gateway IPs from the docker inspect and the routes, but unfortunately, only the default gateway is listed in there. This is why we resorted to match the gateway IP in the listed subnets, assuming the subnets are not overlaping (which is true in standard configurations). The matching code used a standard uint32 arithmetics algorithm: `if gateway_IP_from_inspect & network_mask_from_routes == destination_subnet_from_routes`.

### Issues

- The Go port suffered a int32-overflow bug, which was fixed in #1394 and released in 6.0.01

- The current code relies on having a gateway in the network, which swarm overlay networks do not have by default. This is a legitimate network configuration, as their purpose is to route isolated cluster-local traffic, while public-facing containers are also attached to a public-facing ingress network:

```
"overlay": {
    "IPAMConfig": {
        "IPv4Address": "10.0.2.11"
    },
    "Links": null,
    "Aliases": [
        "d6fb8e9daeea"
    ],
    "NetworkID": "jabs097l7b8izdadhsfjbtpls",
    "EndpointID": "162b4f913b71c02e1cef1e99b3acf8164c578f605bb1cb4bbbdf7806e6781aa7",
    "Gateway": "",
    "IPAddress": "10.0.2.11",
    "IPPrefixLen": 24,
    "IPv6Gateway": "",
    "GlobalIPv6Address": "",
    "GlobalIPv6PrefixLen": 0,
    "MacAddress": "02:42:0a:00:02:0b",
    "DriverOpts": null
}
```

### Proposed fix

The use of the gateway IP for the matching is only due to the original intent of exactly matching the GW IPs, but we kept the GW while moving to subnet matching. This PR uses the container IP insted of the GW, and keeps the existing subnet matching algorithm, that served us well for 10 monthes.

This approach has the following limitations:

- It will break on IPv6-only clusters, we should queue some work to add support for IPv6 in a future release
- It a container were to be connected to two overlapping subnets, [only one network would be tagged](https://github.com/DataDog/datadog-agent/blob/eee7ad9d10d270aa0a7050e0129df0e921a1a742/pkg/util/docker/networkstats.go#L47-L50), the latest interface to be attached. Is that even supported by the docke runtime?

The upside of this approach is that the change from the current logic is pretty limited, and will fix the gateway-less with minimal regression risks.