### PR TITLE
tagger: avoid multiple initializations

### DIFF
--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -20,17 +20,13 @@ var initOnce sync.Once
 var fullCardinality bool
 
 // Init must be called once config is available, call it in your cmd
+// defaultTagger.Init cannot fail for now, keeping the `error` for API stability
 func Init() error {
-	var err error
 	initOnce.Do(func() {
 		fullCardinality = config.Datadog.GetBool("full_cardinality_tagging")
-		err = defaultTagger.Init(collectors.DefaultCatalog)
+		defaultTagger.Init(collectors.DefaultCatalog)
 	})
-	if err != nil {
-		// Let's allow a retry if we failed
-		initOnce = sync.Once{}
-	}
-	return err
+	return nil
 }
 
 // Tag queries the defaultTagger to get entity tags from cache or sources

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -66,7 +66,7 @@ func newTagger() *Tagger {
 // Init goes through a catalog and tries to detect which are relevant
 // for this host. It then starts the collection logic and is ready for
 // requests.
-func (t *Tagger) Init(catalog collectors.Catalog) error {
+func (t *Tagger) Init(catalog collectors.Catalog) {
 	t.Lock()
 	// Populate collector candidate list from catalog
 	// as we'll remove entries we need to copy the map
@@ -80,8 +80,6 @@ func (t *Tagger) Init(catalog collectors.Catalog) error {
 	t.startCollectors()
 	go t.run()
 	go t.pull()
-
-	return nil
 }
 
 func (t *Tagger) run() error {

--- a/pkg/tagger/tagger_test.go
+++ b/pkg/tagger/tagger_test.go
@@ -80,8 +80,7 @@ func TestInit(t *testing.T) {
 	assert.Equal(t, 3, len(catalog))
 
 	tagger := newTagger()
-	err := tagger.Init(catalog)
-	assert.NoError(t, err)
+	tagger.Init(catalog)
 
 	assert.Equal(t, 3, len(tagger.fetchers))
 	assert.Equal(t, 1, len(tagger.streamers))

--- a/releasenotes/notes/tagger-init-once-77c027ccec5c337a.yaml
+++ b/releasenotes/notes/tagger-init-once-77c027ccec5c337a.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Avoid multiple initializations of the tagger subsystem


### PR DESCRIPTION
### What does this PR do?

Fix multiple instances of the tagger collector being spawned when the log agent is enabled. This caused duplicate work to be done.
