### PR TITLE
Added a configuration flag enabling to tail all container logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,7 +213,7 @@ func init() {
 	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", false)
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
-	BindEnvAndSetDefault("logs_config.collect_all", false)
+	BindEnvAndSetDefault("logs_config.container_collect_all", false)
 
 	// Tagger full cardinality mode
 	// Undocumented opt-in feature for now

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,6 +213,7 @@ func init() {
 	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", false)
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
+	BindEnvAndSetDefault("logs_config.collect_all", false)
 
 	// Tagger full cardinality mode
 	// Undocumented opt-in feature for now

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -15,7 +15,7 @@ var LogsAgent = config.Datadog
 
 // Build returns logs-agent sources
 func Build() (*LogSources, error) {
-	sources, err := buildLogSources(LogsAgent.GetString("confd_path"), LogsAgent.GetBool("logs_config.collect_all"))
+	sources, err := buildLogSources(LogsAgent.GetString("confd_path"), LogsAgent.GetBool("logs_config.container_collect_all"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -26,12 +26,14 @@ func Build() (*LogSources, error) {
 func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*LogSources, error) {
 	var sources []*LogSource
 
-	// append sources from all logs config file
+	// append sources from all logs config files
 	fileSources := buildLogSourcesFromDirectory(ddconfdPath)
 	sources = append(sources, fileSources...)
 
 	if collectAllLogsFromContainers {
-		// append source to collect all logs from all containers
+		// append source to collect all logs from all containers,
+		// this source must be added to the end of the list
+		// to assure sources metadata are not overridden when already defined
 		containersSource := NewLogSource("container_collect_all", &LogsConfig{
 			Type:    DockerType,
 			Service: "docker",

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -14,9 +15,36 @@ var LogsAgent = config.Datadog
 
 // Build returns logs-agent sources
 func Build() (*LogSources, error) {
-	sources, err := buildLogSources(LogsAgent.GetString("confd_path"))
+	sources, err := buildLogSources(LogsAgent.GetString("confd_path"), LogsAgent.GetBool("logs_config.collect_all"))
 	if err != nil {
 		return nil, err
 	}
 	return sources, nil
+}
+
+// buildLogSources returns all the logs sources computed from logs configuration files and environment variables
+func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*LogSources, error) {
+	var sources []*LogSource
+
+	// append sources from all logs config file
+	fileSources := buildLogSourcesFromDirectory(ddconfdPath)
+	sources = append(sources, fileSources...)
+
+	if collectAllLogsFromContainers {
+		// append source to collect all logs from all containers
+		containersSource := NewLogSource("container_collect_all", &LogsConfig{
+			Type:    DockerType,
+			Service: "docker",
+			Source:  "docker",
+		})
+		sources = append(sources, containersSource)
+	}
+
+	logSources := &LogSources{sources}
+
+	if len(logSources.GetValidSources()) == 0 {
+		return nil, fmt.Errorf("could not find any valid logs configuration")
+	}
+
+	return logSources, nil
 }

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -75,7 +75,7 @@ type IntegrationConfig struct {
 	Logs []LogsConfig
 }
 
-// buildLogSources looks for all yml configs in the ddconfdPath directory,
+// buildLogSourcesFromDirectory looks for all yml configs in the ddconfdPath directory,
 // and returns a list of all the valid logs sources along with their trackers
 func buildLogSourcesFromDirectory(ddconfdPath string) []*LogSource {
 	integrationConfigFiles := availableIntegrationConfigs(ddconfdPath)

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -77,7 +77,7 @@ type IntegrationConfig struct {
 
 // buildLogSources looks for all yml configs in the ddconfdPath directory,
 // and returns a list of all the valid logs sources along with their trackers
-func buildLogSources(ddconfdPath string) (*LogSources, error) {
+func buildLogSourcesFromDirectory(ddconfdPath string) []*LogSource {
 	integrationConfigFiles := availableIntegrationConfigs(ddconfdPath)
 	var sources []*LogSource
 	for _, file := range integrationConfigFiles {
@@ -130,13 +130,7 @@ func buildLogSources(ddconfdPath string) (*LogSources, error) {
 		}
 	}
 
-	logSources := &LogSources{sources}
-
-	if len(logSources.GetValidSources()) == 0 {
-		return nil, fmt.Errorf("could not find any valid logs configuration file in %s", ddconfdPath)
-	}
-
-	return logSources, nil
+	return sources
 }
 
 // buildIntegrationName returns the name of the integration

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -23,7 +23,7 @@ func TestAvailableIntegrationConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	allSources, err := buildLogSources(ddconfdPath)
+	allSources, err := buildLogSources(ddconfdPath, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(allSources.GetValidSources()))
@@ -83,23 +83,23 @@ func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
 	var ddconfdPath string
 	var err error
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
-	_, err = buildLogSources(ddconfdPath)
+	_, err = buildLogSources(ddconfdPath, false)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
-	_, err = buildLogSources(ddconfdPath)
+	_, err = buildLogSources(ddconfdPath, false)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
-	_, err = buildLogSources(ddconfdPath)
+	_, err = buildLogSources(ddconfdPath, false)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
-	_, err = buildLogSources(ddconfdPath)
+	_, err = buildLogSources(ddconfdPath, false)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
-	_, err = buildLogSources(ddconfdPath)
+	_, err = buildLogSources(ddconfdPath, false)
 	assert.NotNil(t, err)
 }
 

--- a/pkg/logs/config/tests/any_docker_integration.d/any_docker_integration.yaml
+++ b/pkg/logs/config/tests/any_docker_integration.d/any_docker_integration.yaml
@@ -1,0 +1,9 @@
+logs:
+  # docker with image filter
+  - type: docker
+    image: any_image
+    service: any_service
+  # docker with label filter
+  - type: docker
+    label: any_label
+    source: any_source

--- a/releasenotes/notes/logs_docker_environment_variable-daf65e8291a6d309.yaml
+++ b/releasenotes/notes/logs_docker_environment_variable-daf65e8291a6d309.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added an environment variable `DD_LOGS_CONFIG_COLLECT_ALL` to enable logs tailing on all containers.

--- a/releasenotes/notes/logs_docker_environment_variable-daf65e8291a6d309.yaml
+++ b/releasenotes/notes/logs_docker_environment_variable-daf65e8291a6d309.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Added an environment variable `DD_LOGS_CONFIG_COLLECT_ALL` to enable logs tailing on all containers.
+    Added an environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` to enable logs tailing on all containers.


### PR DESCRIPTION
### What does this PR do?

Added default source configuration forcing all containers to be tailed when config flag `logs_config.container_collect_all` or environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` is set to true.

### Motivation

Ease the configuration of logs-agent when running in container. 
