### PR TITLE
Add cacerts as an explicit dependency.  Is getting included by other

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -111,6 +111,7 @@ if linux?
   dependency 'curl'
 end
 
+dependency 'cacerts'
 # creates required build directories
 dependency 'datadog-agent-prepare'
 

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "db/fix_http_cert_path",
+		"INTEGRATIONS_CORE_VERSION": "master",
 		"TRACE_AGENT_VERSION": "master",
 		"PROCESS_AGENT_VERSION": "master",
 		"JMXFETCH_VERSION": "0.18.2",

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "master",
+		"INTEGRATIONS_CORE_VERSION": "db/fix_http_cert_path",
 		"TRACE_AGENT_VERSION": "master",
 		"PROCESS_AGENT_VERSION": "master",
 		"JMXFETCH_VERSION": "0.18.2",


### PR DESCRIPTION
dependencies, but leaves open the possiblity of accidental omission;
Ensures its included on Windows


### Motivation

customer bug report

