### PR TITLE
[Logs] Enable protobuf transport by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -208,9 +208,9 @@ func init() {
 	BindEnvAndSetDefault("log_enabled", false) // deprecated, use logs_enabled instead
 	BindEnvAndSetDefault("logset", "")
 
-	BindEnvAndSetDefault("logs_config.dd_url", "intake.logs.datadoghq.com")
+	BindEnvAndSetDefault("logs_config.dd_url", "intake-agent.logs.datadoghq.com")
 	BindEnvAndSetDefault("logs_config.dd_port", 10516)
-	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", false)
+	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -15,9 +15,9 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, false, LogsAgent.GetBool("log_enabled"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_enabled"))
 	assert.Equal(t, "", LogsAgent.GetString("logset"))
-	assert.Equal(t, "intake.logs.datadoghq.com", LogsAgent.GetString("logs_config.dd_url"))
+	assert.Equal(t, "intake-agent.logs.datadoghq.com", LogsAgent.GetString("logs_config.dd_url"))
 	assert.Equal(t, 10516, LogsAgent.GetInt("logs_config.dd_port"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_config.dev_mode_no_ssl"))
-	assert.Equal(t, false, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
+	assert.Equal(t, true, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
 	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.open_files_limit"))
 }

--- a/releasenotes/notes/logs-update-transport-2c173f5d5231e751.yaml
+++ b/releasenotes/notes/logs-update-transport-2c173f5d5231e751.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    Use protobuf based transport for sending logs to datadog. This doesn't have any impact, besides a small
+    reduction of the payload size.
+    


### PR DESCRIPTION
Previously logs would be submitted as strings, following the rfc5424
protoco. In parallel, we had an option to submit logs using protobuf.
This commit defaults the transport to protobuf.
Note, we have to use a different endpoint. A different port would impact
servers that have whitelisted outbound ports, so instead we opted for
a different dns.
It is important to note that `intake-agent.logs.datadoghq.com` on port 10516
will accept protobuf only. Thus, to disable this we would need to both
set `dev_mode_use_proto` to false, and update the `dd_url`.
We're fine with that, as this should be transparent for the user, and this
option was added only for testing purposes. A later commit will remove the
option, and all agents will use protobuf.
