### PR TITLE
Update small fixes for import groups and check-rate PRs

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -132,7 +132,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		if checkRate == false {
-			color.Yellow("Currently only displaying Gauge metrics. You can run the command with --check-rate to see any other metric types if available.")
+			color.Yellow("Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.")
 		}
 
 		return nil

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -217,29 +217,26 @@ func copyFile(src, dst string, overwrite bool) error {
 		return err
 	}
 
-	ddGroup, err := user.LookupGroup("dd-agent")
-	if err != nil {
-		return fmt.Errorf("Couldn't detect the dd-agent group id: %s", err)
-	}
+	ddGroup, errGroup := user.LookupGroup("dd-agent")
+	ddUser, errUser := user.LookupId("dd-agent")
 
-	ddUser, err := user.LookupId("dd-agent")
-	if err != nil {
-		return fmt.Errorf("Couldn't detect the dd-agent User id: %s", err)
-	}
+	// Only change the owner/group of the configuration fiels if we can detect the dd-agent user
+	// This will not take affect on Windows/MacOS as the user is not available.
+	if errGroup == nil && errUser == nil {
+		ddGID, err := strconv.Atoi(ddGroup.Gid)
+		if err != nil {
+			return fmt.Errorf("Couldn't convert dd-agent group ID: %s into an int: %s", ddGroup.Gid, err)
+		}
 
-	ddGID, err := strconv.Atoi(ddGroup.Gid)
-	if err != nil {
-		return fmt.Errorf("Couldn't convert dd-agent group ID: %s into an int: %s", ddGroup.Gid, err)
-	}
+		ddUID, err := strconv.Atoi(ddUser.Uid)
+		if err != nil {
+			return fmt.Errorf("Couldn't convert dd-agent user ID: %s into an int: %s", ddUser.Uid, err)
+		}
 
-	ddUID, err := strconv.Atoi(ddUser.Uid)
-	if err != nil {
-		return fmt.Errorf("Couldn't convert dd-agent user ID: %s into an int: %s", ddUser.Uid, err)
-	}
-
-	err = out.Chown(ddUID, ddGID)
-	if err != nil {
-		return fmt.Errorf("Couldn't change the file permissions for this check. Please ensure the dd-agent user has access to read the configuration files. Error: %s", err)
+		err = out.Chown(ddUID, ddGID)
+		if err != nil {
+			return fmt.Errorf("Couldn't change the file permissions for this check. Error: %s", err)
+		}
 	}
 
 	err = out.Chmod(0640)

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -220,7 +220,7 @@ func copyFile(src, dst string, overwrite bool) error {
 	ddGroup, errGroup := user.LookupGroup("dd-agent")
 	ddUser, errUser := user.LookupId("dd-agent")
 
-	// Only change the owner/group of the configuration fiels if we can detect the dd-agent user
+	// Only change the owner/group of the configuration files if we can detect the dd-agent user
 	// This will not take affect on Windows/MacOS as the user is not available.
 	if errGroup == nil && errUser == nil {
 		ddGID, err := strconv.Atoi(ddGroup.Gid)


### PR DESCRIPTION
### What does this PR do?

Updates the wording in the output of the `check` command to be more clear.
Update the logic for the import command with regards to changing the group/user of config files to not error out on platforms that don't have that user/group (as of this writing, Mac and Windows)

### Motivation

Keep things clean/working. 

### Additional Notes

The previous PRs where these were added hasn't been released yet, so no releasenotes were needed here. 