### PR TITLE
[jmx] add option to use cgroup memory limits for heap size

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -52,6 +52,8 @@ ENV DOCKER_DD_AGENT=yes \
     DD_APM_ENABLED=false \
     DD_APM_NON_LOCAL_TRAFFIC=true \
     DD_LOGS_ENABLED=false \
+    # Use java 8u131+ cgroup memory awareness
+    DD_JMX_USE_CGROUP_MEMORY_LIMIT=true \
     # Pass envvar variables to agents
     S6_KEEP_ENV=1 \
     # Direct all agent logs to stdout

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -274,13 +274,17 @@ func (c *JMXCheck) start() error {
 
 	javaOptions := c.javaOptions
 	if config.Datadog.GetBool("jmx_use_cgroup_memory_limit") {
+		passOption := true
 		// This option is incompatible with the Xmx and Xms options, log a warning if there are found in the javaOptions
 		for _, option := range jvmCgroupMemoryIncompatOptions {
 			if strings.Contains(javaOptions, option) {
-				log.Warnf("Java option %q is incompatible with cgroup memory limit, please remove it", option)
+				log.Warnf("Java option %q is incompatible with cgroup_memory_limit, disabling cgroup mode", option)
+				passOption = false
 			}
 		}
-		javaOptions += jvmCgroupMemoryAwareness
+		if passOption {
+			javaOptions += jvmCgroupMemoryAwareness
+		}
 	} else {
 		// Specify a maximum memory allocation pool for the JVM
 		if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -34,6 +34,7 @@ const (
 	jmxCollectCommand                 = "collect"
 	jvmDefaultMaxMemoryAllocation     = " -Xmx200m"
 	jvmDefaultInitialMemoryAllocation = " -Xms50m"
+	jvmCgroupMemoryAwareness          = " -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 	linkToDoc                         = "See http://docs.datadoghq.com/integrations/java/ for more information"
 )
 
@@ -47,6 +48,12 @@ var (
 		"error":    "ERROR",
 		"err":      "ERROR",
 		"critical": "FATAL",
+	}
+	jvmCgroupMemoryIncompatOptions = []string{
+		"Xmx",
+		"XX:MaxHeapSize",
+		"Xms",
+		"XX:InitialHeapSize",
 	}
 )
 
@@ -265,14 +272,24 @@ func (c *JMXCheck) start() error {
 
 	subprocessArgs := []string{}
 
-	// Specify a maximum memory allocation pool for the JVM
 	javaOptions := c.javaOptions
-	if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
-		javaOptions += jvmDefaultMaxMemoryAllocation
-	}
-	// Specify the initial memory allocation pool for the JVM
-	if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
-		javaOptions += jvmDefaultInitialMemoryAllocation
+	if config.Datadog.GetBool("jmx_use_cgroup_memory_limit") {
+		// This option is incompatible with the Xmx and Xms options, log a warning if there are found in the javaOptions
+		for _, option := range jvmCgroupMemoryIncompatOptions {
+			if strings.Contains(javaOptions, option) {
+				log.Warnf("Java option %q is incompatible with cgroup memory limit, please remove it", option)
+			}
+		}
+		javaOptions += jvmCgroupMemoryAwareness
+	} else {
+		// Specify a maximum memory allocation pool for the JVM
+		if !strings.Contains(javaOptions, "Xmx") && !strings.Contains(javaOptions, "XX:MaxHeapSize") {
+			javaOptions += jvmDefaultMaxMemoryAllocation
+		}
+		// Specify the initial memory allocation pool for the JVM
+		if !strings.Contains(javaOptions, "Xms") && !strings.Contains(javaOptions, "XX:InitialHeapSize") {
+			javaOptions += jvmDefaultInitialMemoryAllocation
+		}
 	}
 
 	subprocessArgs = append(subprocessArgs, strings.Fields(javaOptions)...)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,7 +195,8 @@ func init() {
 	Datadog.SetDefault("bosh_id", "")
 
 	// JMXFetch
-	Datadog.SetDefault("jmx_custom_jars", []string{})
+	BindEnvAndSetDefault("jmx_custom_jars", []string{})
+	BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 
 	// Go_expvar server port
 	Datadog.SetDefault("expvar_port", "5000")
@@ -235,7 +236,6 @@ func init() {
 	Datadog.BindEnv("dogstatsd_stats_port")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")
 	Datadog.BindEnv("dogstatsd_origin_detection")
-	Datadog.BindEnv("jmx_custom_jars")
 
 	Datadog.BindEnv("log_file")
 	Datadog.BindEnv("log_level")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -176,9 +176,10 @@ api_key:
 # jmx_custom_jars:
 #   - /jmx-jars/jboss-cli-client.jar
 #
-# When running in a container, java 8u131 and higher can automatically adjust its heap
-# memory usage in accordance to the container's memory limit.
+# When running in a memory cgroup, openjdk 8u131 and higher can automatically adjust
+# its heap memory usage in accordance to the cgroup/container's memory limit.
 # Default is false: we'll set a Xmx of 200MB if none is configured.
+# Note: older openjdk versions and other jvms might fail to start if this option is set
 #
 # jmx_use_cgroup_memory_limit: true
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -175,6 +175,13 @@ api_key:
 # set in the check templates. If that is the case, you can force custom jars here.
 # jmx_custom_jars:
 #   - /jmx-jars/jboss-cli-client.jar
+#
+# When running in a container, java 8u131 and higher can automatically adjust its heap
+# memory usage in accordance to the container's memory limit.
+# Default is false: we'll set a Xmx of 200MB if none is configured.
+#
+# jmx_use_cgroup_memory_limit: true
+#
 {{ end -}}
 {{- if .Autoconfig }}
 # Autoconfig

--- a/releasenotes/notes/jmxfetch-cgroup-memlimit-f8748199ef513ea4.yaml
+++ b/releasenotes/notes/jmxfetch-cgroup-memlimit-f8748199ef513ea4.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a jmx_use_cgroup_memory_limit option to set jmxfetch to use cgroup
+    memory limits when calculating its heap size. It is enabled by default
+    in the docker image.


### PR DESCRIPTION
Java 8u131 introduced an experimental `UseCGroupMemoryLimitForHeap` option, see these articles:

- https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
- https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/

This PR introduces a `jmx_use_cgroup_memory_limit` boolean option (and its envvar binding), to enable this mechanism. This disables the default hardcoded `-Xmx200m -Xms50m` options we pass to jmxfetch.

In Agent5, [our default jmxfetch memory limits](https://github.com/DataDog/dd-agent/blob/dd512f5904c7c1ccd5d2267fa1d715e6999cc949/jmxfetch.py#L47-L48) were:
  - 512 MB if using autodiscovery
  - 200 MB if not

In Agent6 we went with 200 MB in both cases, which can be too conservative for heavy users.

This mechanism allows jmxfetch to scale down when the container memory limit is low (I tested it with 200 MB), and scale up when more memory is available:

![Container Live view](https://cl.ly/1E3f002b1m2F/Image%202018-03-15%20at%203.19.40%20PM.png)