### PR TITLE
tagger: extract the swarm_namespace tag from docker

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -59,6 +59,8 @@ func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string,
 		// Docker swarm
 		case "com.docker.swarm.service.name":
 			tags.AddLow("swarm_service", labelValue)
+		case "com.docker.stack.namespace":
+			tags.AddLow("swarm_namespace", labelValue)
 
 		// Rancher 1.x
 		case "io.rancher.container.name":

--- a/releasenotes/notes/docker-more-tags-106b6865c6fcc29f.yaml
+++ b/releasenotes/notes/docker-more-tags-106b6865c6fcc29f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Extract the swarm_namespace tag for docker swarm containers, in addition
+    to the already present swarm_service tag.


### PR DESCRIPTION
### What does this PR do?

Extract the `swarm_namespace` tag for docker swarm containers, in addition to the already present `swarm_service` tag.

The docker label is `com.docker.stack.namespace`, but the `swarm_` prefix makes its origin clearer and its discoverability better.