### PR TITLE
don't remove the network check twice

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-ecs.sh
+++ b/Dockerfiles/agent/entrypoint/50-ecs.sh
@@ -15,3 +15,8 @@ fi
 # Remove all default checks (no host)
 
 find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
+
+# Enable fargate check
+mv /etc/datadog-agent/conf.d/ecs_fargate.d/conf.yaml.example /etc/datadog-agent/conf.d/ecs_fargate.d/conf.yaml.default
+# (temporary) actually enable the instance in the config file
+sed -i -e "s/# \-/\-/" /etc/datadog-agent/conf.d/ecs_fargate.d/conf.yaml.default

--- a/Dockerfiles/agent/entrypoint/60-network-check.sh
+++ b/Dockerfiles/agent/entrypoint/60-network-check.sh
@@ -2,6 +2,11 @@
 
 # Disable the host network check if /host/proc is not mounted
 
+# It was already done by 50-ecs.sh if the agent is configured for Fargate
+if [[ -n "${ECS_FARGATE}" ]]; then
+    exit 0
+fi
+
 if [[ ! -d /host/proc ]]; then
     rm /etc/datadog-agent/conf.d/network.d/conf.yaml.default
 fi

--- a/releasenotes/notes/fix-container-start-on-fargate-614c65140b551f66.yaml
+++ b/releasenotes/notes/fix-container-start-on-fargate-614c65140b551f66.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the container startup on Fargate, where we tried and remove the same
+    file twice, failing hard (stopping) on the second attempt.


### PR DESCRIPTION
### What does this PR do?

avoid removing the network check config file twice (and failing).