### PR TITLE
[macos][install_script] Update URL of latest Agent 6

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -7,7 +7,7 @@
 set -e
 logfile=ddagent-install.log
 dmg_file=/tmp/datadog-agent.dmg
-dmg_url="https://s3.amazonaws.com/dd-agent/datadog-agent-6-latest.dmg"
+dmg_url="https://s3.amazonaws.com/dd-agent/datadogagent.dmg"
 
 dd_upgrade=
 if [ -n "$DD_UPGRADE" ]; then


### PR DESCRIPTION
### What does this PR do?

Updates URL of latest Agent 6.

### Motivation

We've decided to change the URL of the latest macOS Agent 6 to the (formerly) "latest macOS Agent 5" URL.

That URL was formerly pointing to an outdated 5.11.3 Agent, and we're not planning to release new Agent 5 DMGs for macOS.

### Additional Notes

Will make related changes to our docs on app and docs website.