### PR TITLE
[docs] Document breaking change on GCE hostname

### DIFF
--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -22,6 +22,7 @@ open an issue or submit a Pull Request.
   * [Check API](#check-api)
   * [Custom Checks](#custom-checks)
 * [JMX](#jmx)
+* [GCE hostname](#gce-hostname)
 
 ## Configuration Files
 
@@ -153,9 +154,9 @@ There are a few major changes
 * The configuration GUI is now a web-based configuration application, it can be easily accessed by running
   the command `"c:\program files\datadog\datadog agent\embedded\agent.exe" launch-gui` or using the systray app.
 * The Windows service is now started "Automatic-Delayed"; it is started automatically on boot, but after
-  all other services.  This will result in a small delay in reporting of metrics after a reboot of a 
+  all other services.  This will result in a small delay in reporting of metrics after a reboot of a
   Windows device.
-* The Windows GUI and Windows system tray icon are now implemented separately.  See the 
+* The Windows GUI and Windows system tray icon are now implemented separately.  See the
   [specific docs](gui.md) for more details.
 
 ### MacOS
@@ -475,6 +476,18 @@ find it with `sudo find / -type f -name 'tools.jar'`.
 
 Note: you may wish to specify alternative JVM heap parameters `-Xmx`, `-Xms`, the
 values used in the example correspond to the JMXFetch defaults.
+
+### GCE hostname
+
+_Only affects Agents running on GCE_
+
+When running on GCE, by default, Agent 6 uses the instance's hostname provided by GCE as its hostname.
+This matches the behavior of Agent 5 (since v5.5.1) if `gce_updated_hostname` is set to true in `datadog.conf`,
+which is recommended.
+
+If you're upgrading from an Agent 5 with `gce_updated_hostname` unset or set to false, and the hostname
+of the Agent is not hardcoded in `datadog.conf`/`datadog.yaml`, the reported hostname on Datadog
+will change from the GCE instance _name_ to the full GCE instance _hostname_ (which includes the GCE project id).
 
 
 [known-issues]: known_issues.md

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -12,8 +12,8 @@ might mean:
 
 Orchestration has now been deferred to OS facilities wherever possible. To this purpose
 we now rely on upstart/systemd on linux environments and windows services on Windows.
-Enabling the APM and Process agents bundled with the agent can now be achieved via 
-configuration flags defined in the main configuration file: `datadog.yaml`. 
+Enabling the APM and Process agents bundled with the agent can now be achieved via
+configuration flags defined in the main configuration file: `datadog.yaml`.
 
 ### Process Agent
 To enable the process agent add the following to `datadog.yaml`:
@@ -33,7 +33,7 @@ apm_config:
 ...
 ```
 
-The OS-level services will be enabled by default for all agents. The agents will process 
+The OS-level services will be enabled by default for all agents. The agents will process
 the configuration and decide whether to stay up or gracefully shut down. You may decide
 to disable the OS-level service units, but that will require your manual intervention if
 you ever wish to re-enable any of the agents.
@@ -83,9 +83,10 @@ differently from Agent version 5.
 | `autorestart` | |
 | `dogstream_log` | |
 | `use_curl_http_client` | |
-| `gce_updated_hostname` | |
+| `gce_updated_hostname` | v6 behaves like v5 with `gce_updated_hostname` set to true. May affect reported hostname, see [doc][gce-hostname] |
 | `collect_security_groups` | feature still available with the aws integration  |
 
 
 
 [datadog-yaml]: https://raw.githubusercontent.com/DataDog/datadog-agent/master/pkg/config/config_template.yaml
+[gce-hostname]: changes.md#gce-hostname


### PR DESCRIPTION
### What does this PR do?

Document breaking change on GCE hostname. Agent 6 now _forces_ the behavior that was only _recommended_ on Agent 5.

Related to #1410 and #1451