### PR TITLE
Re-add docker check conversion in the import command Fix #1469

### DIFF
--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -24,8 +24,7 @@ var (
 		SilenceUsage: true,
 	}
 
-	force         = false
-	convertDocker = false
+	force = false
 )
 
 func init() {
@@ -34,7 +33,6 @@ func init() {
 
 	// local flags
 	importCmd.Flags().BoolVarP(&force, "force", "f", force, "overwrite existing files")
-	importCmd.Flags().BoolVarP(&convertDocker, "docker", "", convertDocker, "convert docker_daemon.yaml to the new format")
 }
 
 func doImport(cmd *cobra.Command, args []string) error {

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -118,6 +118,13 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 				return err
 			}
 			continue
+		} else if f.Name() == "docker.yaml" {
+			// if people upgrade from a very old version of the agent who ship the old docker check.
+			fmt.Fprintln(
+				color.Output,
+				fmt.Sprintf("Ignoring %s, old docker check has been deprecated.", color.YellowString(src)),
+			)
+			continue
 		}
 
 		if err := copyFile(src, dst, force); err != nil {

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -112,6 +112,14 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 		src := filepath.Join(oldConfigDir, "conf.d", f.Name())
 		dst := filepath.Join(newConfigDir, "conf.d", checkName+dirExt, "conf"+cfgExt)
 
+		if f.Name() == "docker_daemon.yaml" {
+			err := legacy.ImportDockerConf(src, filepath.Join(newConfigDir, "conf.d", "docker.yaml"), force)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
 		if err := copyFile(src, dst, force); err != nil {
 			return fmt.Errorf("unable to copy %s to %s: %v", src, dst, err)
 		}

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -153,9 +153,9 @@ There are a few major changes
 * The configuration GUI is now a web-based configuration application, it can be easily accessed by running
   the command `"c:\program files\datadog\datadog agent\embedded\agent.exe" launch-gui` or using the systray app.
 * The Windows service is now started "Automatic-Delayed"; it is started automatically on boot, but after
-  all other services.  This will result in a small delay in reporting of metrics after a reboot of a 
+  all other services.  This will result in a small delay in reporting of metrics after a reboot of a
   Windows device.
-* The Windows GUI and Windows system tray icon are now implemented separately.  See the 
+* The Windows GUI and Windows system tray icon are now implemented separately.  See the
   [specific docs](gui.md) for more details.
 
 ### MacOS
@@ -254,7 +254,7 @@ are ported, excepted the following deprecations:
     Kubernetes and Openshift (default to true). This will avoid removing
     them from the exclude list by error
 
-The [`import`](#configuration-files) command support a `--docker` flag to convert the old
+The [`import`](#configuration-files) will help you converting the old
 `docker_daemon.yaml` to the new `docker.yaml`. The command will also move
 needed settings from `docker_daemon.yaml` to `datadog.yaml`.
 

--- a/pkg/legacy/docker.go
+++ b/pkg/legacy/docker.go
@@ -27,7 +27,7 @@ const (
 		"docker.yaml.example for more information\n"
 	excludeIncludeBadFormat string = "\t- Warning: \"%s\" item wrongly formatted (should be 'tag:value'), got '%s'. Dropping it\n"
 
-	warningNewCheck string = "Warning: the new docker check includes a change in the exclude/include list that may impact your billing. Please check docs/beta/changes.md documentation to learn more."
+	warningNewCheck string = "Warning: the new docker check includes a change in the exclude/include list that may impact your billing. Please check docs/agent/changes.md#docker-check documentation to learn more."
 )
 
 func handleFilterList(input []string, name string) []string {

--- a/releasenotes/notes/convert-docker-daemon-05e7f75a0eba4dcc.yaml
+++ b/releasenotes/notes/convert-docker-daemon-05e7f75a0eba4dcc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The old docker_daemon check is now properly converted in the "import" command
+

--- a/releasenotes/notes/convert-docker-daemon-05e7f75a0eba4dcc.yaml
+++ b/releasenotes/notes/convert-docker-daemon-05e7f75a0eba4dcc.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    The old docker_daemon check is now properly converted in the "import" command
+    The old docker_daemon check is now properly converted in the "import" command by default
 


### PR DESCRIPTION
### What does this PR do?

The docker check import was mistakenly removed in #688 this adds it back by default.

### Motivation

Fix #1469 and have a better upgrade experience

