### PR TITLE
[docker] remove docker event multiplexing logic

### DIFF
--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -126,7 +126,7 @@ CONNECT: // Outer loop handles re-connecting in case the docker daemon closes th
 				}
 				// Block if the buffered channel is full, pausing the http
 				// stream. If docker closes because of client timeout, we
-				// will reconnect later an stream from latestTimestamp.
+				// will reconnect later and stream from latestTimestamp.
 				sub.eventChan <- event
 			}
 		}

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -35,9 +35,10 @@ var (
 
 // eventSubscriber holds the state for a subscriber
 type eventSubscriber struct {
-	name      string
-	eventChan chan *ContainerEvent
-	errorChan chan error
+	name       string
+	eventChan  chan *ContainerEvent
+	errorChan  chan error
+	cancelChan chan struct{}
 }
 
 // eventStreamState holds the state for event streaming towards subscribers
@@ -45,7 +46,6 @@ type eventStreamState struct {
 	sync.RWMutex
 	subscribers map[string]*eventSubscriber
 	cancelChan  chan struct{}
-	running     bool
 }
 
 func newEventStreamState() *eventStreamState {

--- a/releasenotes/notes/docker-event-streaming-fix-3d087e3f0850ce4e.yaml
+++ b/releasenotes/notes/docker-event-streaming-fix-3d087e3f0850ce4e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improve docker monitoring when the system is under a very high load. The agent
+    might still temporarily miss a healthcheck, but will be able to run already
+    scheduled checks, and recover once the spike ends


### PR DESCRIPTION
### What does this PR do?

When testing 6.0 on very high load, some asynchronous components might become unresponsive and be unsubscribed from docker event multiplexing. This mechanism was introduced to reduce the load on the docker daemon (avoiding 4 concurrent stream connections), while still ensuring the whole agent does not hang if one component fails.

This PR removes the internal multiplexing logic and relies on the [docker daemon's internal pub/sub mechanism](https://github.com/moby/moby/blob/master/pkg/pubsub/publisher.go) to handle the increased load.

The modules still offers to user classes:
  - error handling and reconnection on EOF
  - event validation and parsing

### Motivation

The agent should be able to recover, and keep monitoring the load to give insights on the source of the issue.
