### PR TITLE
Include system.mem.usable on Windows

### DIFF
--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -26,6 +26,7 @@ func (c *MemoryCheck) Run() error {
 	if errVirt == nil {
 		sender.Gauge("system.mem.total", float64(v.Total)/mbSize, "", nil)
 		sender.Gauge("system.mem.free", float64(v.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.usable", float64(v.Available)/mbSize, "", nil)
 		sender.Gauge("system.mem.used", float64(v.Total-v.Available)/mbSize, "", nil)
 		sender.Gauge("system.mem.pct_usable", float64(100-v.UsedPercent)/100, "", nil)
 	} else {

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -42,9 +42,8 @@ func TestMemoryCheckWindows(t *testing.T) {
 
 	mock := mocksender.NewMockSender(memCheck.ID())
 
-	runtimeOS = "linux"
-
 	mock.On("Gauge", "system.mem.free", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.usable", 234567890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.used", 12111100000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.total", 12345667890.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.pct_usable", 0.19, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -58,6 +58,6 @@ func TestMemoryCheckWindows(t *testing.T) {
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 8)
+	mock.AssertNumberOfCalls(t, "Gauge", 9)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/releasenotes/notes/readd_win_sys_mem_usable-3b7e91533da8b269.yaml
+++ b/releasenotes/notes/readd_win_sys_mem_usable-3b7e91533da8b269.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Adds back the removed system.mem.usable metric for Agents running on Windows.


### PR DESCRIPTION
### What does this PR do?

When the memory metrics were split between windows and linux, the `system.mem.usable` metric was removed as it wasn't available through gopsutil. This introduces it back and makes it report the same value as "system.mem.free".

### Motivation

Our default dashboards use this metric to to help visualize the amount of free memory on the system. Some versions of Agent 6 are currently reporting without this metric causing the graph to be blank

### Additional Notes

Anything else we should know when reviewing?
