### PR TITLE
Adding an option to configure dogstatsd interface

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,6 +98,7 @@ func init() {
 	Datadog.SetDefault("check_runners", int64(1))
 	Datadog.SetDefault("expvar_port", "5000")
 	Datadog.SetDefault("auth_token_file_path", "")
+	Datadog.SetDefault("bind_host", "localhost")
 
 	// Use to output logs in JSON format
 	BindEnvAndSetDefault("log_format_json", false)
@@ -231,6 +232,7 @@ func init() {
 	Datadog.BindEnv("conf_path")
 	Datadog.BindEnv("enable_metadata_collection")
 	Datadog.BindEnv("dogstatsd_port")
+	Datadog.BindEnv("bind_host")
 	Datadog.BindEnv("proc_root")
 	Datadog.BindEnv("container_proc_root")
 	Datadog.BindEnv("container_cgroup_root")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -123,6 +123,11 @@ api_key:
 # Make sure your client is sending to the same UDP port
 # dogstatsd_port: 8125
 #
+# The host to bind to receive external metrics (used only by the dogstatsd
+# server for now). For dogstatsd this is ignored if
+# 'dogstatsd_non_local_traffic' is set to true
+# bind_host: localhost
+#
 # Whether dogstatsd should listen to a Unix Socket instead of UDP (*nix only).
 # Set to a valid filesystem path to enable
 # dogstatsd_socket:

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -40,7 +40,7 @@ func NewUDPListener(packetOut chan *Packet, packetPool *PacketPool) (*UDPListene
 		// Listen to all network interfaces
 		url = fmt.Sprintf(":%d", config.Datadog.GetInt("dogstatsd_port"))
 	} else {
-		url = fmt.Sprintf("localhost:%d", config.Datadog.GetInt("dogstatsd_port"))
+		url = fmt.Sprintf("%s:%d", config.Datadog.GetString("bind_host"), config.Datadog.GetInt("dogstatsd_port"))
 	}
 
 	conn, err = net.ListenPacket("udp", url)

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -123,6 +123,10 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("enable_gohai", enabled)
 	}
 
+	if agentConfig["bind_host"] != "" {
+		config.Datadog.Set("bind_host", agentConfig["bind_host"])
+	}
+
 	//Trace APM based configurations
 
 	if agentConfig["apm_enabled"] != "" {

--- a/pkg/legacy/importer.go
+++ b/pkg/legacy/importer.go
@@ -50,10 +50,10 @@ var (
 		"syslog_host",
 		"syslog_port",
 		"collect_instance_metadata",
-		"listen_port",                // not for 6.0, ignore for now
-		"non_local_traffic",          // not for 6.0, converted for the trace-agent
-		"create_dd_check_tags",       // not for 6.0, ignore for now
-		"bind_host",                  // not for 6.0, ignore for now
+		"listen_port",          // not for 6.0, ignore for now
+		"non_local_traffic",    // not for 6.0, converted for the trace-agent
+		"create_dd_check_tags", // not for 6.0, ignore for now
+		"bind_host",
 		"proxy_forbid_method_switch", // deprecated
 		"collect_orchestrator_tags",  // deprecated
 		"use_curl_http_client",       // deprecated

--- a/releasenotes/notes/option-to-configure-dogstatsd-bind-host-f82b0194bc558154.yaml
+++ b/releasenotes/notes/option-to-configure-dogstatsd-bind-host-f82b0194bc558154.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adding the 'bind_host' option to configure the interface to bind by dogstatsd and JMX.


### PR DESCRIPTION
In the end we use the same option than JMX: `bind_host`.