### PR TITLE
More unit tests for flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -79,11 +79,16 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 			return "", err
 		}
 	} else {
-		// The Status will be unavailable unless the agent is running.
-		// Only zip it up if the agent is running
+		// Status informations will be unavailable unless the agent is running.
+		// Only zip them up if the agent is running
 		err = zipStatusFile(tempDir, hostname)
 		if err != nil {
 			log.Errorf("Could not zip status: %s", err)
+		}
+
+		err = zipConfigCheck(tempDir, hostname)
+		if err != nil {
+			log.Errorf("Could not zip config check: %s", err)
 		}
 	}
 
@@ -105,11 +110,6 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 	err = zipEnvvars(tempDir, hostname)
 	if err != nil {
 		log.Errorf("Could not zip env vars: %s", err)
-	}
-
-	err = zipConfigCheck(tempDir, hostname)
-	if err != nil {
-		log.Errorf("Could not zip config check: %s", err)
 	}
 
 	err = zipHealth(tempDir, hostname)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -6,11 +6,19 @@
 package flare
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,11 +42,8 @@ func TestCreateArchive(t *testing.T) {
 	}
 }
 
+// The zipfile should be created even if there is no config file.
 func TestCreateArchiveBadConfig(t *testing.T) {
-	/**
-		The zipfile should be created even if there is no config file.
-	**/
-
 	common.SetupConfig("")
 	zipFilePath := getArchivePath()
 	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
@@ -51,4 +56,36 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 	} else {
 		os.Remove(zipFilePath)
 	}
+}
+
+// Ensure sensitive data is redacted
+func TestZipConfigCheck(t *testing.T) {
+	cr := response.ConfigCheckResponse{
+		Configs: make(map[string][]check.Config),
+	}
+	cr.Configs["FooProvider"] = []check.Config{{
+		Name:      "TestCheck",
+		Instances: []check.ConfigData{[]byte("username: User\npassword: MySecurePass")},
+	}}
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		out, _ := json.Marshal(cr)
+		w.Write(out)
+	}))
+	defer ts.Close()
+	ConfigCheckURL = ts.URL
+
+	dir, err := ioutil.TempDir("", "TestZipConfigCheck")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	zipConfigCheck(dir, "")
+	content, err := ioutil.ReadFile(filepath.Join(dir, "config-check.log"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.NotContains(t, string(content), "MySecurePass")
 }

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -37,8 +36,6 @@ func TestCreateArchive(t *testing.T) {
 		assert.Fail(t, "The Zip File was not created")
 	} else {
 		os.Remove(zipFilePath)
-		err := security.DeleteAuthToken()
-		assert.Nil(t, err)
 	}
 }
 

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -18,6 +18,9 @@ import (
 	"github.com/fatih/color"
 )
 
+// ConfigCheckURL contains the Agent API endpoint URL exposing the loaded checks
+var ConfigCheckURL = fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
+
 // GetConfigCheck dump all loaded configurations to the writer
 func GetConfigCheck(w io.Writer, withDebug bool) error {
 	if w != color.Output {
@@ -25,7 +28,6 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 	}
 
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
 
 	// Set session token
 	err := util.SetAuthToken()
@@ -33,7 +35,7 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 		return err
 	}
 
-	r, err := util.DoGet(c, urlstr)
+	r, err := util.DoGet(c, ConfigCheckURL)
 	if err != nil {
 		if r != nil && string(r) != "" {
 			fmt.Fprintln(w, fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -102,7 +102,7 @@ def vet(ctx, targets):
     # add the /... suffix to the targets
     args = ["{}/...".format(t) for t in targets]
     build_tags = get_default_build_tags()
-    ctx.run("go vet -x -tags \"{}\" ".format(build_tags) + " ".join(args))
+    ctx.run("go vet -tags \"{}\" ".format(build_tags) + " ".join(args))
     # go vet exits with status 1 when it finds an issue, if we're here
     # everything went smooth
     print("go vet found no issues")


### PR DESCRIPTION
### What does this PR do?

Add a unit test to ensure we clean up credentials contained in config files before creating the flare.

### Motivation

Avoid regressions

### Additional Notes

Switch back `go vet` to silence
