### PR TITLE
Adding a warning when loading a config YAML with a docker_images section, instead of an ad_identifiers section

### DIFF
--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -24,7 +24,7 @@ type configFormat struct {
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
 	Instances     []check.ConfigRawMap
-        DockerImages []string `yaml:"docker_images"` // To avoid issues if check uses former conf
+	DockerImages  []string `yaml:"docker_images"` // To avoid issues if check uses former conf
 }
 
 type configPkg struct {
@@ -296,13 +296,10 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 		config.LogsConfig = rawLogsConfig
 	}
 
-        // DockerImages entry was found: we ignore it if no ADIdentifiers has been found
-        if cf.DockerImages != nil && cf.ADIdentifiers == nil {
-            log.Warnf("In check `%s`: The 'docker_images:' section has been deprecated in favor of 'ad_identifiers:'. " +
-                      "Please make change in your configuration it in order to load the check", name)
-
-            return config, errors.New("unexpected 'docker_images:' section found in configuration")
-        }
+	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
+	if cf.DockerImages != nil && cf.ADIdentifiers == nil {
+		return config, errors.New("the 'docker_images:' section is deprecated, please use 'ad_identifiers:' instead")
+	}
 
 	return config, err
 }

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -298,7 +298,7 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if cf.DockerImages != nil && cf.ADIdentifiers == nil {
-		return config, errors.New("the 'docker_images:' section is deprecated, please use 'ad_identifiers:' instead")
+		return config, errors.New("the 'docker_images' section is deprecated, please use 'ad_identifiers' instead")
 	}
 
 	return config, err

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -24,7 +24,7 @@ type configFormat struct {
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
 	Instances     []check.ConfigRawMap
-	DockerImages  []string `yaml:"docker_images"` // To avoid issues if check uses former conf
+	DockerImages  []string `yaml:"docker_images"` // Only imported for deprecation warning
 }
 
 type configPkg struct {
@@ -297,7 +297,7 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 	}
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
-	if cf.DockerImages != nil && cf.ADIdentifiers == nil {
+	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {
 		return config, errors.New("the 'docker_images' section is deprecated, please use 'ad_identifiers' instead")
 	}
 

--- a/pkg/collector/providers/file.go
+++ b/pkg/collector/providers/file.go
@@ -24,6 +24,7 @@ type configFormat struct {
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
 	Instances     []check.ConfigRawMap
+        DockerImages []string `yaml:"docker_images"` // To avoid issues if check uses former conf
 }
 
 type configPkg struct {
@@ -294,6 +295,14 @@ func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
 		rawLogsConfig, _ := yaml.Marshal(cf.LogsConfig)
 		config.LogsConfig = rawLogsConfig
 	}
+
+        // DockerImages entry was found: we ignore it if no ADIdentifiers has been found
+        if cf.DockerImages != nil && cf.ADIdentifiers == nil {
+            log.Warnf("In check `%s`: The 'docker_images:' section has been deprecated in favor of 'ad_identifiers:'. " +
+                      "Please make change in your configuration it in order to load the check", name)
+
+            return config, errors.New("unexpected 'docker_images:' section found in configuration")
+        }
 
 	return config, err
 }

--- a/pkg/collector/providers/file_test.go
+++ b/pkg/collector/providers/file_test.go
@@ -51,6 +51,10 @@ func TestGetCheckConfig(t *testing.T) {
 	config, err = GetCheckConfigFromFile("foo", "tests/ad.yaml")
 	require.Nil(t, err)
 	assert.Equal(t, config.ADIdentifiers, []string{"foo_id", "bar_id"})
+
+	// autodiscovery: check if we correctly refuse to load if a 'docker_images' section is present
+	config, err = GetCheckConfigFromFile("foo", "tests/ad_deprecated.yaml")
+	assert.NotNil(t, err)
 }
 
 func TestNewYamlConfigProvider(t *testing.T) {

--- a/pkg/collector/providers/file_test.go
+++ b/pkg/collector/providers/file_test.go
@@ -115,6 +115,6 @@ func TestCollect(t *testing.T) {
 	// total number of configurations found
 	assert.Equal(t, 11, len(configs))
 
-	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml)
-	assert.Equal(t, 2, len(provider.Errors))
+	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml & ad_deprecated.yaml)
+	assert.Equal(t, 3, len(provider.Errors))
 }

--- a/pkg/collector/providers/tests/ad_deprecated.yaml
+++ b/pkg/collector/providers/tests/ad_deprecated.yaml
@@ -1,0 +1,9 @@
+docker_images:
+  - foo_id
+  - bar_id
+
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar


### PR DESCRIPTION
### What does this PR do?

Forbid the load of a YAML with a `docker_images:` section so that check configs copied from version 5 of the agent are not loaded as static checks. Add a Warning to explain this.

### Motivation

This could be confusing for troubleshooting.