### PR TITLE
add DD_ENABLE_GOHAI as an env var option

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -72,15 +72,16 @@ Please note that the `docker.containers.running`, `.stopped`, `.running.total` a
 
 Please refer to the dedicated section about the [Kubernetes integration](#kubernetes) for more details.
 
-- `DD_KUBERNETES_COLLECT_SERVICE_TAGS`: Configures the agent to collect Kubernetes service names as tags.
-- `DD_KUBERNETES_SERVICE_TAG_UPDATE_FREQ`: Set the collection frequency in seconds for the Kubernetes service names.
-- `DD_COLLECT_KUBERNETES_EVENTS`: Configures the agent to collect Kubernetes events. See [Event collection](#event-collection) for more details.
-- `DD_LEADER_ELECTION`: Activates the [leader election](#leader-election). Will be activated if the `DD_COLLECT_KUBERNETES_EVENTS` is set to true. The expected value is a bool: true/false.
-- `DD_LEADER_LEASE_DURATION`: Only used if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds.
+- `DD_KUBERNETES_COLLECT_SERVICE_TAGS`: configures the agent to collect Kubernetes service names as tags.
+- `DD_KUBERNETES_SERVICE_TAG_UPDATE_FREQ`: set the collection frequency in seconds for the Kubernetes service names.
+- `DD_COLLECT_KUBERNETES_EVENTS`: configures the agent to collect Kubernetes events. See [Event collection](#event-collection) for more details.
+- `DD_LEADER_ELECTION`: activates the [leader election](#leader-election). Will be activated if the `DD_COLLECT_KUBERNETES_EVENTS` is set to true. The expected value is a bool: true/false.
+- `DD_LEADER_LEASE_DURATION`: only used if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds.
 
 #### Others
 
 - `DD_JMX_CUSTOM_JARS`: space-separated list of custom jars to load in jmxfetch (only for the `-jmx` variants)
+- `DD_ENABLE_GOHAI`: enable or disable the system information collector [gohai](https://github.com/DataDog/gohai)
 
 ### Optional volumes
 

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -81,7 +81,7 @@ Please refer to the dedicated section about the [Kubernetes integration](#kubern
 #### Others
 
 - `DD_JMX_CUSTOM_JARS`: space-separated list of custom jars to load in jmxfetch (only for the `-jmx` variants)
-- `DD_ENABLE_GOHAI`: enable or disable the system information collector [gohai](https://github.com/DataDog/gohai)
+- `DD_ENABLE_GOHAI`: enable or disable the system information collector [gohai](https://github.com/DataDog/gohai) (enabled by default if not set)
 
 ### Optional volumes
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -230,6 +230,7 @@ func init() {
 	Datadog.BindEnv("cmd_port")
 	Datadog.BindEnv("conf_path")
 	Datadog.BindEnv("enable_metadata_collection")
+	Datadog.BindEnv("enable_gohai")
 	Datadog.BindEnv("dogstatsd_port")
 	Datadog.BindEnv("proc_root")
 	Datadog.BindEnv("container_proc_root")

--- a/releasenotes/notes/add-envvar-option-for-gohai-275db61980e29f4a.yaml
+++ b/releasenotes/notes/add-envvar-option-for-gohai-275db61980e29f4a.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Add environment variable DD_ENABLE_GOHAI for setting option enable_gohai when running in a container.


### PR DESCRIPTION
### What does this PR do?

add DD_ENABLE_GOHAI as an env var option

### Motivation

Make it easier to modify when running the agent as a container