### PR TITLE
Tweak log if no port is found for pod

### DIFF
--- a/pkg/collector/listeners/kubelet.go
+++ b/pkg/collector/listeners/kubelet.go
@@ -167,7 +167,7 @@ func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
 	svc.Ports = ports
 	if len(svc.Ports) == 0 {
 		// Port might not be specified in pod spec
-		log.Errorf("Failed to get ports for pod %s", podName)
+		log.Debugf("No ports found for pod %s", podName)
 	}
 
 	l.m.Lock()


### PR DESCRIPTION
Pods can have no ports so let's not log an error about this.