### PR TITLE
Add the DD_CHECK_RUNNERS environment variable binding

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -240,6 +240,7 @@ func init() {
 	Datadog.BindEnv("dogstatsd_stats_port")
 	Datadog.BindEnv("dogstatsd_non_local_traffic")
 	Datadog.BindEnv("dogstatsd_origin_detection")
+	Datadog.BindEnv("check_runners")
 
 	Datadog.BindEnv("log_file")
 	Datadog.BindEnv("log_level")

--- a/releasenotes/notes/check-runners-envvar-77c97d1fb06e98aa.yaml
+++ b/releasenotes/notes/check-runners-envvar-77c97d1fb06e98aa.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add the DD_CHECK_RUNNERS environment variable binding


### PR DESCRIPTION
### What does this PR do?

As a mitigation strategy for situations where the collector's check runner is blocked on a slow check, allow users to easily increase the number of runners.

### Motivation

Providing a custom `datadog.yaml` file to the container image is non trivial
