### PR TITLE
[windows] fix formatting of proxy settings added on windows installer

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -222,7 +222,10 @@ func ImportRegistryConfig() error {
 				}
 			}
 		}
-		config.Datadog.Set("proxy", u.String())
+		proxyMap := make(map[string]string)
+		proxyMap["http"] = u.String()
+		proxyMap["https"] = u.String()
+		config.Datadog.Set("proxy", proxyMap)
 	} else {
 		log.Debug("proxy key not found, not setting proxy config")
 	}


### PR DESCRIPTION
command line.


### Motivation

there was a bug; causes agent to not start.

