### PR TITLE
Fix empty repo tags #1502

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -124,6 +124,10 @@ func (d *DockerCheck) countAndWeightImages(sender aggregator.Sender, du *docker.
 
 	if d.instance.CollectImageSize {
 		for _, i := range availableImages {
+			if len(i.RepoTags) == 0 {
+				log.Tracef("Skipping image %s, no repo tags", i.ID)
+				continue
+			}
 			name, _, tag, err := docker.SplitImageName(i.RepoTags[0])
 			if err != nil {
 				log.Errorf("Could not parse image name and tag, RepoTag is: %s", i.RepoTags[0])

--- a/releasenotes/notes/fix-repo-tags-0cb1897ce17f1d2a.yaml
+++ b/releasenotes/notes/fix-repo-tags-0cb1897ce17f1d2a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a crash in the docker check when collecting sizes on an image with no repository tags.


### PR DESCRIPTION
### What does this PR do?

Fix a crash in the docker check when collecting sizes on an image with no repository tags. #1502
