### PR TITLE
fix docker legacy import

### DIFF
--- a/pkg/legacy/docker.go
+++ b/pkg/legacy/docker.go
@@ -99,7 +99,11 @@ func ImportDockerConf(src, dst string, overwrite bool) error {
 	}
 
 	// write docker.yaml
-	data, err := yaml.Marshal(dc)
+	newCfg := map[string][]*containers.DockerConfig{
+		"instances": {&dc},
+	}
+
+	data, err := yaml.Marshal(newCfg)
 	if err != nil {
 		return fmt.Errorf("Could not marshall final configuration for the new docker check: %s", err)
 	}

--- a/pkg/legacy/docker_test.go
+++ b/pkg/legacy/docker_test.go
@@ -53,23 +53,24 @@ instances:
     collect_labels_as_tags: ["test1", "test2"]
 `
 
-	dockerNewConf string = `collect_container_size: true
-collect_exit_codes: true
-collect_images_stats: false
-collect_image_size: true
-collect_disk_stats: true
-collect_volume_count: true
-tags:
-- tag:value
-- value
-collect_events: false
-filtered_event_types:
-- top
-- exec_start
-- exec_create
-capped_metrics:
-  docker.cpu.system: 1000
-  docker.cpu.user: 1000
+	dockerNewConf string = `instances:
+- collect_container_size: true
+  collect_exit_codes: true
+  collect_images_stats: false
+  collect_image_size: true
+  collect_disk_stats: true
+  collect_volume_count: true
+  tags:
+  - tag:value
+  - value
+  collect_events: false
+  filtered_event_types:
+  - top
+  - exec_start
+  - exec_create
+  capped_metrics:
+    docker.cpu.system: 1000
+    docker.cpu.user: 1000
 `
 )
 


### PR DESCRIPTION
### What does this PR do?

Bug found in testing: we serialise the config instance as yaml instead of serialising a valid config check file with an `instances:` section

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
