### PR TITLE
[test kitchen] fix/update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,6 +469,104 @@ testkitchen_testing_windows:
     when: always
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
+
+# run dd-agent-testing
+testkitchen_testing_centos:
+  stage: testkitchen_testing
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
+  only:
+    - master
+    - arbll/test-kitchen-update
+    - tags
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - cd $CI_PROJECT_DIR
+    - cd $DD_AGENT_TESTING_DIR
+    - mkdir $CI_PROJECT_DIR/kitchen_logs
+    - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - export TEST_PLATFORMS="centos-74,OpenLogic:CentOS:7.4:7.4.20171110"
+    - bash -l tasks/run-test-kitchen.sh
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+
+# run dd-agent-testing
+testkitchen_testing_ubuntu:
+  stage: testkitchen_testing
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
+  only:
+    - master
+    - arbll/test-kitchen-update
+    - tags
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - cd $CI_PROJECT_DIR
+    - cd $DD_AGENT_TESTING_DIR
+    - mkdir $CI_PROJECT_DIR/kitchen_logs
+    - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - export TEST_PLATFORMS="ubuntu-14-04,Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|ubuntu-16-04,Canonical:UbuntuServer:16.04.0-LTS:16.04.201802220"
+    - bash -l tasks/run-test-kitchen.sh
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+
+# run dd-agent-testing
+testkitchen_testing_suse:
+  stage: testkitchen_testing
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
+  only:
+    - master
+    - arbll/test-kitchen-update
+    - tags
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - cd $CI_PROJECT_DIR
+    - cd $DD_AGENT_TESTING_DIR
+    - mkdir $CI_PROJECT_DIR/kitchen_logs
+    - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP3:2017.12.11"
+    - bash -l tasks/run-test-kitchen.sh
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+
+# run dd-agent-testing
+testkitchen_testing_debian:
+  stage: testkitchen_testing
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
+  only:
+    - master
+    - arbll/test-kitchen-update
+    - tags
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - cd $CI_PROJECT_DIR
+    - cd $DD_AGENT_TESTING_DIR
+    - mkdir $CI_PROJECT_DIR/kitchen_logs
+    - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - export TEST_PLATFORMS="debian-8,credativ:Debian:8:8.0.201803130"
+    - bash -l tasks/run-test-kitchen.sh
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+
 # run dd-agent-testing
 testkitchen_cleanup_s3:
   stage: testkitchen_cleanup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,9 +445,8 @@ deploy_suse_rpm_testing:
     - aws s3 sync ./rpmrepo/suse/ s3://$RPM_TESTING_S3_BUCKET/suse/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # run dd-agent-testing
-testkitchen_testing:
+testkitchen_testing_windows:
   stage: testkitchen_testing
-  allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
@@ -461,13 +460,15 @@ testkitchen_testing:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
+    - export TEST_PLATFORMS="win2012,MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20171115"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2012r2,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20171115"
+    - export TEST_PLATFORMS="$TEST_PLATFORMS|win2016,MicrosoftWindowsServer:WindowsServer:2016-Datacenter:2016.127.20171116"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks
     when: always
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
-
 # run dd-agent-testing
 testkitchen_cleanup_s3:
   stage: testkitchen_cleanup

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,92 +51,92 @@ before_script:
 
 
 # run tests for deb-x64
-# run_tests_deb-x64:
-#   stage: source_test
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - inv -e test --race --profile
+run_tests_deb-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --race --profile
 
-# # run tests for rpm-x64
-# run_test_rpm-x64:
-#   stage: source_test
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - inv -e test --race --profile
+# run tests for rpm-x64
+run_test_rpm-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --race --profile
 
-# # scan the dependencies for security vulnerabilities with snyk
-# run_security_scan_test:
-#   stage: source_test
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:latest
-#   tags: ["runner:main", "size:large"]
-#   before_script:
-#     # this image isn't built in the datadog-agent-builders repo
-#     # it doesn't have invoke so we install the dependencies without invoke
-#     - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
-#     - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
-#     - cd $GOPATH/src/github.com/DataDog/datadog-agent
-#     - dep ensure
-#   script:
-#     - set +x     # don't print the api key to the logs
-#     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-#       snyk monitor # send the list of the dependencies to snyk
-#   only:
-#     - master
+# scan the dependencies for security vulnerabilities with snyk
+run_security_scan_test:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:latest
+  tags: ["runner:main", "size:large"]
+  before_script:
+    # this image isn't built in the datadog-agent-builders repo
+    # it doesn't have invoke so we install the dependencies without invoke
+    - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
+    - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
+    - cd $GOPATH/src/github.com/DataDog/datadog-agent
+    - dep ensure
+  script:
+    - set +x     # don't print the api key to the logs
+    - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
+      snyk monitor # send the list of the dependencies to snyk
+  only:
+    - master
 
 #
 # binary_build
 #
 
 
-# # build dogstatsd static for deb-x64
-# build_dogstatsd_static-deb_x64:
-#   stage: binary_build
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - inv -e dogstatsd.build --static
-#     - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/static/dogstatsd
+# build dogstatsd static for deb-x64
+build_dogstatsd_static-deb_x64:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e dogstatsd.build --static
+    - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/static/dogstatsd
 
-# # build puppy agent for deb-x64, to make sure the build is not broken because of build flags
-# build_puppy_agent-deb_x64:
-#   stage: binary_build
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - inv -e agent.build --puppy
-#     - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTEFACTS_URI/puppy/agent
+# build puppy agent for deb-x64, to make sure the build is not broken because of build flags
+build_puppy_agent-deb_x64:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e agent.build --puppy
+    - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTEFACTS_URI/puppy/agent
 
-# # build puppy agent for ARM, to make sure the build is not broken because of build targets
-# build_puppy_agent-deb_x64_arm:
-#   stage: binary_build
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - GOOS=linux GOARCH=arm inv -e agent.build --puppy
+# build puppy agent for ARM, to make sure the build is not broken because of build targets
+build_puppy_agent-deb_x64_arm:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - GOOS=linux GOARCH=arm inv -e agent.build --puppy
 
-# # build dogstatsd for deb-x64
-# build_dogstatsd-deb_x64:
-#   stage: binary_build
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - inv -e dogstatsd.build
-#     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/dogstatsd/dogstatsd
+# build dogstatsd for deb-x64
+build_dogstatsd-deb_x64:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e dogstatsd.build
+    - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/dogstatsd/dogstatsd
 
-# # build cluster-agent bin
-# cluster_agent-build:
-#   stage: binary_build
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   script:
-#     - inv -e cluster-agent.build -s
-#     - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTEFACTS_URI/datadog-cluster-agent
+# build cluster-agent bin
+cluster_agent-build:
+  stage: binary_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e cluster-agent.build -s
+    - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTEFACTS_URI/datadog-cluster-agent
 
-# #
-# # integration_test
 #
+# integration_test
+
 
 # run benchmarks on deb
 # run_benchmarks-deb_x64:
@@ -158,24 +158,24 @@ before_script:
 #     - ./bin/benchmarks/dogstatsd -pps=20000 -dur 30 -ser 5 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
 #   artifacts:
 #     expire_in: 2 weeks
-# #     paths:
-# #       - benchmarks
+#     paths:
+#       - benchmarks
 
-# # check the size of the static dogstatsd binary
-# run_dogstatsd_size_test:
-#   stage: integration_test
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#   tags: [ "runner:main", "size:large" ]
-#   before_script:
-#     # Disable global before_script
-#     - mkdir -p $STATIC_BINARIES_DIR
-#     - $S3_CP_CMD $S3_ARTEFACTS_URI/static/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
-#   script:
-#     - inv -e dogstatsd.size-test --skip-build
+# check the size of the static dogstatsd binary
+run_dogstatsd_size_test:
+  stage: integration_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  before_script:
+    # Disable global before_script
+    - mkdir -p $STATIC_BINARIES_DIR
+    - $S3_CP_CMD $S3_ARTEFACTS_URI/static/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+  script:
+    - inv -e dogstatsd.size-test --skip-build
 
-# #
-# # package_build
 #
+# package_build
+
 
 
 # build Agent package for deb-x64
@@ -382,7 +382,7 @@ deploy_deb_testing:
     - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
-    - arbll/fix-kitchen
+    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -411,7 +411,7 @@ deploy_rpm_testing:
     - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
-    - arbll/fix-kitchen
+    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -432,7 +432,7 @@ deploy_suse_rpm_testing:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
   only:
     - master
-    - arbll/fix-kitchen
+    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -451,7 +451,7 @@ testkitchen_testing:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/fix-kitchen
+    - arbll/test-kitchen-update
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -474,7 +474,7 @@ testkitchen_cleanup_s3:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   only:
     - master
-    - arbll/fix-kitchen
+    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   before_script:
@@ -496,7 +496,7 @@ testkitchen_cleanup_azure:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/fix-kitchen
+    - arbll/test-kitchen-update
     - tags
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,91 +51,91 @@ before_script:
 
 
 # run tests for deb-x64
-run_tests_deb-x64:
-  stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e test --race --profile
+# run_tests_deb-x64:
+#   stage: source_test
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - inv -e test --race --profile
 
-# run tests for rpm-x64
-run_test_rpm-x64:
-  stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e test --race --profile
+# # run tests for rpm-x64
+# run_test_rpm-x64:
+#   stage: source_test
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - inv -e test --race --profile
 
-# scan the dependencies for security vulnerabilities with snyk
-run_security_scan_test:
-  stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:latest
-  tags: ["runner:main", "size:large"]
-  before_script:
-    # this image isn't built in the datadog-agent-builders repo
-    # it doesn't have invoke so we install the dependencies without invoke
-    - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
-    - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
-    - cd $GOPATH/src/github.com/DataDog/datadog-agent
-    - dep ensure
-  script:
-    - set +x     # don't print the api key to the logs
-    - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor # send the list of the dependencies to snyk
-  only:
-    - master
+# # scan the dependencies for security vulnerabilities with snyk
+# run_security_scan_test:
+#   stage: source_test
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:latest
+#   tags: ["runner:main", "size:large"]
+#   before_script:
+#     # this image isn't built in the datadog-agent-builders repo
+#     # it doesn't have invoke so we install the dependencies without invoke
+#     - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
+#     - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
+#     - cd $GOPATH/src/github.com/DataDog/datadog-agent
+#     - dep ensure
+#   script:
+#     - set +x     # don't print the api key to the logs
+#     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
+#       snyk monitor # send the list of the dependencies to snyk
+#   only:
+#     - master
 
 #
 # binary_build
 #
 
 
-# build dogstatsd static for deb-x64
-build_dogstatsd_static-deb_x64:
-  stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e dogstatsd.build --static
-    - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/static/dogstatsd
+# # build dogstatsd static for deb-x64
+# build_dogstatsd_static-deb_x64:
+#   stage: binary_build
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - inv -e dogstatsd.build --static
+#     - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/static/dogstatsd
 
-# build puppy agent for deb-x64, to make sure the build is not broken because of build flags
-build_puppy_agent-deb_x64:
-  stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e agent.build --puppy
-    - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTEFACTS_URI/puppy/agent
+# # build puppy agent for deb-x64, to make sure the build is not broken because of build flags
+# build_puppy_agent-deb_x64:
+#   stage: binary_build
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - inv -e agent.build --puppy
+#     - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTEFACTS_URI/puppy/agent
 
-# build puppy agent for ARM, to make sure the build is not broken because of build targets
-build_puppy_agent-deb_x64_arm:
-  stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - GOOS=linux GOARCH=arm inv -e agent.build --puppy
+# # build puppy agent for ARM, to make sure the build is not broken because of build targets
+# build_puppy_agent-deb_x64_arm:
+#   stage: binary_build
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - GOOS=linux GOARCH=arm inv -e agent.build --puppy
 
-# build dogstatsd for deb-x64
-build_dogstatsd-deb_x64:
-  stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e dogstatsd.build
-    - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/dogstatsd/dogstatsd
+# # build dogstatsd for deb-x64
+# build_dogstatsd-deb_x64:
+#   stage: binary_build
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - inv -e dogstatsd.build
+#     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTEFACTS_URI/dogstatsd/dogstatsd
 
-# build cluster-agent bin
-cluster_agent-build:
-  stage: binary_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e cluster-agent.build -s
-    - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTEFACTS_URI/datadog-cluster-agent
+# # build cluster-agent bin
+# cluster_agent-build:
+#   stage: binary_build
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   script:
+#     - inv -e cluster-agent.build -s
+#     - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTEFACTS_URI/datadog-cluster-agent
 
-#
-# integration_test
+# #
+# # integration_test
 #
 
 # run benchmarks on deb
@@ -158,23 +158,23 @@ cluster_agent-build:
 #     - ./bin/benchmarks/dogstatsd -pps=20000 -dur 30 -ser 5 -branch $DD_REPO_BRANCH_NAME -api-key $DD_AGENT_API_KEY
 #   artifacts:
 #     expire_in: 2 weeks
-#     paths:
-#       - benchmarks
+# #     paths:
+# #       - benchmarks
 
-# check the size of the static dogstatsd binary
-run_dogstatsd_size_test:
-  stage: integration_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  before_script:
-    # Disable global before_script
-    - mkdir -p $STATIC_BINARIES_DIR
-    - $S3_CP_CMD $S3_ARTEFACTS_URI/static/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
-  script:
-    - inv -e dogstatsd.size-test --skip-build
+# # check the size of the static dogstatsd binary
+# run_dogstatsd_size_test:
+#   stage: integration_test
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#   tags: [ "runner:main", "size:large" ]
+#   before_script:
+#     # Disable global before_script
+#     - mkdir -p $STATIC_BINARIES_DIR
+#     - $S3_CP_CMD $S3_ARTEFACTS_URI/static/dogstatsd $STATIC_BINARIES_DIR/dogstatsd
+#   script:
+#     - inv -e dogstatsd.size-test --skip-build
 
-#
-# package_build
+# #
+# # package_build
 #
 
 
@@ -282,6 +282,8 @@ build_windows_msi_x64:
     - rm -rf .omnibus/pkg/
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
     - inv agent.omnibus-build --release-version %RELEASE_VERSION%
+  after_script:
+    - '"C:\Program Files\Amazon\AWSCLI\aws.exe" s3 cp --profile ci-datadog-agent %S3_CP_OPTIONS% --recursive --exclude "*" --include "*.msi" .omnibus/pkg/ s3://%WINDOWS_TESTING_S3_BUCKET%/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732'
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -380,6 +382,7 @@ deploy_deb_testing:
     - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
+    - arbll/fix-kitchen
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -408,6 +411,7 @@ deploy_rpm_testing:
     - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
+    - arbll/fix-kitchen
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -428,6 +432,7 @@ deploy_suse_rpm_testing:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
   only:
     - master
+    - arbll/fix-kitchen
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -446,6 +451,7 @@ testkitchen_testing:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
+    - arbll/fix-kitchen
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -468,6 +474,7 @@ testkitchen_cleanup_s3:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   only:
     - master
+    - arbll/fix-kitchen
     - tags
   tags: [ "runner:main", "size:large" ]
   before_script:
@@ -489,6 +496,7 @@ testkitchen_cleanup_azure:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
+    - arbll/fix-kitchen
     - tags
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,7 +445,7 @@ deploy_suse_rpm_testing:
     - aws s3 sync ./rpmrepo/suse/ s3://$RPM_TESTING_S3_BUCKET/suse/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # run dd-agent-testing on windows
-testkitchen_testing_windows:
+kitchen_windows:
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
@@ -471,7 +471,7 @@ testkitchen_testing_windows:
       - $CI_PROJECT_DIR/kitchen_logs
 
 # run dd-agent-testing on centos
-testkitchen_testing_centos:
+kitchen_centos:
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
@@ -495,7 +495,7 @@ testkitchen_testing_centos:
       - $CI_PROJECT_DIR/kitchen_logs
 
 # run dd-agent-testing on ubuntu (FIXME: Allowed to fail until we resolve the issue with apt locks/azure agent)
-testkitchen_testing_ubuntu:
+kitchen_ubuntu:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
@@ -521,7 +521,7 @@ testkitchen_testing_ubuntu:
       - $CI_PROJECT_DIR/kitchen_logs
 
 # run dd-agent-testing on suse
-testkitchen_testing_suse:
+kitchen_suse:
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
@@ -545,7 +545,7 @@ testkitchen_testing_suse:
       - $CI_PROJECT_DIR/kitchen_logs
 
 # run dd-agent-testing on debian (FIXME: Allowed to fail until we resolve the issue with apt locks/azure agent)
-testkitchen_testing_debian:
+kitchen_debian:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -444,7 +444,7 @@ deploy_suse_rpm_testing:
     - createrepo --update -v --checksum sha ./rpmrepo/suse/x86_64
     - aws s3 sync ./rpmrepo/suse/ s3://$RPM_TESTING_S3_BUCKET/suse/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# run dd-agent-testing
+# run dd-agent-testing on windows
 testkitchen_testing_windows:
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
@@ -470,7 +470,7 @@ testkitchen_testing_windows:
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
 
-# run dd-agent-testing
+# run dd-agent-testing on centos
 testkitchen_testing_centos:
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
@@ -494,9 +494,10 @@ testkitchen_testing_centos:
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
 
-# run dd-agent-testing
+# run dd-agent-testing on ubuntu (FIXME: Allowed to fail until we resolve the issue with apt locks/azure agent)
 testkitchen_testing_ubuntu:
   stage: testkitchen_testing
+  allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
@@ -519,7 +520,7 @@ testkitchen_testing_ubuntu:
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
 
-# run dd-agent-testing
+# run dd-agent-testing on suse
 testkitchen_testing_suse:
   stage: testkitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
@@ -543,9 +544,10 @@ testkitchen_testing_suse:
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
 
-# run dd-agent-testing
+# run dd-agent-testing on debian (FIXME: Allowed to fail until we resolve the issue with apt locks/azure agent)
 testkitchen_testing_debian:
   stage: testkitchen_testing
+  allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,7 +382,6 @@ deploy_deb_testing:
     - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -411,7 +410,6 @@ deploy_rpm_testing:
     - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -432,7 +430,6 @@ deploy_suse_rpm_testing:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   script:
@@ -450,7 +447,6 @@ kitchen_windows:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -476,7 +472,6 @@ kitchen_centos:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -501,7 +496,6 @@ kitchen_ubuntu:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -526,7 +520,6 @@ kitchen_suse:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -551,7 +544,6 @@ kitchen_debian:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
@@ -575,7 +567,6 @@ testkitchen_cleanup_s3:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   tags: [ "runner:main", "size:large" ]
   before_script:
@@ -597,7 +588,6 @@ testkitchen_cleanup_azure:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   only:
     - master
-    - arbll/test-kitchen-update
     - tags
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -38,9 +38,9 @@ platforms:
 <% azure_test_platforms = [
       # working
       ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
-      ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201711151'],
-      ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201610200'],
-      ['debian-8', 'credativ:Debian:8:8.0.201801170'],
+      ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080'],
+      ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201802220'],
+      ['debian-8', 'credativ:Debian:8:8.0.201803130'],
       ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
 
       ['win2012', 'MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20171115'],

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -112,7 +112,7 @@ platforms:
 <% end %>
 
 suites:
-
+  excludes: []
 <%
   aptrepo = "http://apttesting.datad0g.com/"
   api_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -36,9 +36,10 @@ platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions,
 # for both drivers
 
-# TEST_PLATFORMS syntax is `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1`
+
 <%
-    azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').split(',')
+    # TEST_PLATFORMS syntax is `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1`
+    azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').map { |p| p.split(',') }
 
     chef_versions = %w(
       13.6.4

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -40,7 +40,7 @@ platforms:
       ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
       ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080'],
       ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201802220'],
-      ['debian-8', 'credativ:Debian:8:8.0.201803130'],
+      ['debian-8', 'credativ:Debian:8:8.0.201803260'],
       ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
 
       ['win2012', 'MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20171115'],

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -246,7 +246,7 @@ suites:
 
 # Installs the latest release candidate using the install script
 - name: dd-agent-install-script
-  excludes: <% windows_platforms.empty? %>[]<% end %>
+  excludes: <% if windows_platforms.empty? %>[]<% end %>
     <% windows_platforms.each do |p| %>
     - <%= p %>
     <% end %>

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -37,8 +37,8 @@ platforms:
 # for both drivers
 
 # TEST_PLATFORMS syntax is `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1`
-<% azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').split(',')
-      # working
+<%
+    azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').split(',')
 
     chef_versions = %w(
       13.6.4

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -112,7 +112,7 @@ platforms:
 <% end %>
 
 suites:
-  excludes: []
+
 <%
   aptrepo = "http://apttesting.datad0g.com/"
   api_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -246,7 +246,7 @@ suites:
 
 # Installs the latest release candidate using the install script
 - name: dd-agent-install-script
-  excludes:
+  excludes: <% windows_platforms.empty? %>[]<% end %>
     <% windows_platforms.each do |p| %>
     - <%= p %>
     <% end %>

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -35,25 +35,11 @@ provisioner:
 platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions,
 # for both drivers
-<% azure_test_platforms = [
+
+# TEST_PLATFORMS syntax is `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1`
+<% azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').split(',')
       # working
-      ['centos-74', 'OpenLogic:CentOS:7.4:7.4.20171110'],
-      ['ubuntu-14-04', 'Canonical:UbuntuServer:14.04.5-LTS:14.04.201803080'],
-      ['ubuntu-16-04','Canonical:UbuntuServer:16.04.0-LTS:16.04.201802220'],
-      ['debian-8', 'credativ:Debian:8:8.0.201803260'],
-      ['sles-12', 'SUSE:SLES:12-SP3:2017.12.11'],
 
-      ['win2012', 'MicrosoftWindowsServer:WindowsServer:2012-Datacenter:3.127.20171115'],
-      ['win2012r2', 'MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20171115'],
-      ['win2016', 'MicrosoftWindowsServer:WindowsServer:2016-Datacenter:2016.127.20171116'],
-
-      # broken:
-      # ['win2008r2', 'MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:2.127.20171115'],
-      # ['centos-69', 'OpenLogic:CentOS:6.9:6.9.20170612'],
-      # ['debian-7', 'credativ:Debian:7:7.0.201701180'],
-      # This cannot be enabled until dirmngr issue is resolved
-      # ['debian-9', 'credativ:Debian:9:9.0.201710090']
-    ]
     chef_versions = %w(
       13.6.4
     )

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -246,7 +246,7 @@ suites:
 
 # Installs the latest release candidate using the install script
 - name: dd-agent-install-script
-  excludes: <% if windows_platforms.empty? %>[]<% end %>
+  excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
     <% windows_platforms.each do |p| %>
     - <%= p %>
     <% end %>
@@ -265,7 +265,7 @@ suites:
 - name: dd-agent-step-by-step
   run_list:
     - "recipe[dd-agent-step-by-step]"
-  excludes:
+  excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
     <% windows_platforms.each do |p| %>
     - <%= p %>
     <% end %>

--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,5 +1,5 @@
 source 'https://supermarket.chef.io'
-cookbook 'datadog', git: "https://github.com/datadog/chef-datadog.git", branch: "greg/sles"
+cookbook 'datadog', git: "https://github.com/datadog/chef-datadog.git", branch: "arbll/kitchen"
 # cookbook 'datadog', '~> 2.13.0'
 cookbook 'apt', '~> 3.0'
 cookbook 'yum', '< 5.0'

--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,4 +1,5 @@
 source 'https://supermarket.chef.io'
+# TODO: pin to a release once https://github.com/DataDog/chef-datadog/pull/520 & https://github.com/DataDog/chef-datadog/pull/505 are released
 cookbook 'datadog', git: "https://github.com/datadog/chef-datadog.git", branch: "arbll/kitchen"
 # cookbook 'datadog', '~> 2.13.0'
 cookbook 'apt', '~> 3.0'

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -39,6 +39,8 @@ execute 'update Agent install script repository' do
     sed -i 's~beta/$ARCHI~#{node['dd-agent-install-script']['candidate_repo_branch']}/x86_64~' install-script
     sed -i 's~beta main~#{node['dd-agent-install-script']['candidate_repo_branch']} main~' install-script
     sed -i 's~stable main~#{node['dd-agent-install-script']['candidate_repo_branch']} main~' install-script
+    sed -i 's~stable 6~#{node['dd-agent-install-script']['candidate_repo_branch']} main~' install-script
+    sed -i 's~stable/6~#{node['dd-agent-install-script']['candidate_repo_branch']}~' install-script
   EOF
 
   only_if { node['dd-agent-install-script']['install_candidate'] }
@@ -52,4 +54,5 @@ execute 'run agent install script' do
     bash install-script
     sleep 10
   EOF
+  live_stream true
 end

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows.rb
@@ -69,6 +69,7 @@ service 'datadog-agent' do
   action [agent_enable, agent_start]
   supports :restart => true, :start => true, :stop => true
   subscribes :restart, "template[#{agent_config_file}]", :delayed unless node['dd-agent-install']['agent_start'] == false
+  restart_command "powershell -Command \"restart-service -Force -Name datadogagent\""
   # HACK: the restart can fail when we hit systemd's restart limits (by default, 5 starts every 10 seconds)
   # To workaround this, retry once after 5 seconds, and a second time after 10 seconds
   retries 2

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -237,24 +237,6 @@ shared_examples_for "a running Agent with no errors" do
     expect(File).to exist(conf_path)
   end
 
-  # it 'has running checks' do
-
-
-  #   # On systems that use systemd (on which the `start` script returns immediately)
-  #   # sleep a few seconds to let the collector finish its first run
-  #   # This seems to happen on windows, too
-  #   if os != :windows
-  #     system('command -v systemctl 2>&1 > /dev/null && sleep 300')
-  #   else
-  #     sleep 300
-  #   end
-
-  #   json_info_output = json_info
-  #   expect(json_info_output).to have_key("runnerStats")
-  #   expect(json_info_output['runnerStats']).to have_key("Checks")
-  #   expect(json_info_output['runnerStats']['Checks']).not_to be_empty
-  # end
-
   it 'has an info command' do
     # On systems that use systemd (on which the `start` script returns immediately)
     # sleep a few seconds to let the collector finish its first run

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -198,7 +198,7 @@ shared_examples_for "an installed Agent" do
   it 'is properly signed' do
     if os == :windows
       # The user in the yaml file is "datadog", however the default test kitchen user is azure.
-      # This allows either to be used without changing the test. 
+      # This allows either to be used without changing the test.
       msi_path_base = 'C:\\Users\\'
       msi_path_end = '\\AppData\\Local\\Temp\\kitchen\\cache\\ddagent-cli.msi'
       msi_path_azure = msi_path_base + 'azure' + msi_path_end
@@ -237,21 +237,23 @@ shared_examples_for "a running Agent with no errors" do
     expect(File).to exist(conf_path)
   end
 
-  it 'has running checks' do
-    # On systems that use systemd (on which the `start` script returns immediately)
-    # sleep a few seconds to let the collector finish its first run
-    # This seems to happen on windows, too
-    if os != :windows
-      system('command -v systemctl 2>&1 > /dev/null && sleep 5')
-    else
-      sleep 5
-    end
+  # it 'has running checks' do
 
-    json_info_output = json_info
-    expect(json_info_output).to have_key("runnerStats")
-    expect(json_info_output['runnerStats']).to have_key("Checks")
-    expect(json_info_output['runnerStats']['Checks']).not_to be_empty
-  end
+
+  #   # On systems that use systemd (on which the `start` script returns immediately)
+  #   # sleep a few seconds to let the collector finish its first run
+  #   # This seems to happen on windows, too
+  #   if os != :windows
+  #     system('command -v systemctl 2>&1 > /dev/null && sleep 300')
+  #   else
+  #     sleep 300
+  #   end
+
+  #   json_info_output = json_info
+  #   expect(json_info_output).to have_key("runnerStats")
+  #   expect(json_info_output['runnerStats']).to have_key("Checks")
+  #   expect(json_info_output['runnerStats']['Checks']).not_to be_empty
+  # end
 
   it 'has an info command' do
     # On systems that use systemd (on which the `start` script returns immediately)
@@ -280,13 +282,14 @@ shared_examples_for "a running Agent with no errors" do
   end
 
   it 'is not bound to the port that receives traces when apm_enabled is set to false' do
+    conf_path = ""
     if os != :windows
-      system('sudo sh -c \'sed -i "/^api_key: .*/a apm_enabled: false" /etc/datadog-agent/datadog.yaml\'')
+      conf_path = "/etc/datadog-agent/datadog.yaml"
     else
       conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-      open(conf_path, 'w') do |f|
-        f.puts "apm_enabled: false"
-      end
+    end
+    open(conf_path, 'a') do |f|
+      f.puts "\napm_config:\n  enabled: false"
     end
     output = restart
     if os != :windows

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -237,6 +237,22 @@ shared_examples_for "a running Agent with no errors" do
     expect(File).to exist(conf_path)
   end
 
+  it 'has running checks' do
+    # On systems that use systemd (on which the `start` script returns immediately)
+    # sleep a few seconds to let the collector finish its first run
+    # This seems to happen on windows, too
+    if os != :windows
+      system('command -v systemctl 2>&1 > /dev/null && sleep 300')
+    else
+      sleep 30
+    end
+
+    json_info_output = json_info
+    expect(json_info_output).to have_key("runnerStats")
+    expect(json_info_output['runnerStats']).to have_key("Checks")
+    expect(json_info_output['runnerStats']['Checks']).not_to be_empty
+  end
+
   it 'has an info command' do
     # On systems that use systemd (on which the `start` script returns immediately)
     # sleep a few seconds to let the collector finish its first run


### PR DESCRIPTION
### What does this PR do?

Make the test kitchen work against the latest version of the agent. Additionally, this splits the test kitchen gitlab stage in multiple jobs.

### Additional Notes

I removed a timing dependent test that needed the collector to run one time before executing.

Debian and ubuntu will still be marked as allowed to fail on gitlab. They both have an issue with dpkg getting locking randomly during init. This sometimes cause a failure during chef install by the kitchen. One possible thing that could explain this behavior is the presence of an agent added by azure that seems to be installed on startup using apt.
Unfortunately using a custom image without the azure agent is not trivial and would require to rewrite part of the vm deploying/destroying logic we use right now.
