### PR TITLE
Bind tls_verify for kubelet

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -246,6 +246,7 @@ func init() {
 	Datadog.BindEnv("kubernetes_https_kubelet_port")
 	Datadog.BindEnv("kubelet_client_crt")
 	Datadog.BindEnv("kubelet_client_key")
+	Datadog.BindEnv("kubelet_tls_verify")
 	Datadog.BindEnv("collect_kubernetes_events")
 	Datadog.BindEnv("kubernetes_collect_service_tags")
 	Datadog.BindEnv("kubernetes_service_tag_update_freq")

--- a/releasenotes/notes/kubelet-tls-bind-9010729a663f083b.yaml
+++ b/releasenotes/notes/kubelet-tls-bind-9010729a663f083b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Bind the kubelet_tls_verify as an environment variable.


### PR DESCRIPTION
### What does this PR do?

Make sure the tls option is binded to the env var.

### Motivation

no need to set the var in the datadog.yaml
