### PR TITLE
[Logs]: Removed read timeout for UDP connections

### DIFF
--- a/pkg/logs/input/listener/worker.go
+++ b/pkg/logs/input/listener/worker.go
@@ -8,6 +8,7 @@ package listener
 import (
 	"io"
 	"net"
+	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -15,6 +16,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
+
+// defaultTimeout represents the time after which a connection is closed when no data is read
+const defaultTimeout = 60000 * time.Millisecond
 
 // Worker reads data from a connection
 type Worker struct {
@@ -81,6 +85,7 @@ func (w *Worker) readForever() {
 			// stop reading data from the connection
 			return
 		default:
+			w.conn.SetReadDeadline(time.Now().Add(defaultTimeout))
 			inBuf := make([]byte, 4096)
 			n, err := w.conn.Read(inBuf)
 			if err == io.EOF {

--- a/pkg/logs/input/listener/worker.go
+++ b/pkg/logs/input/listener/worker.go
@@ -8,7 +8,6 @@ package listener
 import (
 	"io"
 	"net"
-	"time"
 
 	log "github.com/cihub/seelog"
 
@@ -16,9 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
-
-// defaultTimeout represents the time after which a connection is closed when no data is read
-const defaultTimeout = 60000 * time.Millisecond
 
 // Worker reads data from a connection
 type Worker struct {
@@ -85,7 +81,6 @@ func (w *Worker) readForever() {
 			// stop reading data from the connection
 			return
 		default:
-			w.conn.SetReadDeadline(time.Now().Add(defaultTimeout))
 			inBuf := make([]byte, 4096)
 			n, err := w.conn.Read(inBuf)
 			if err == io.EOF {

--- a/pkg/logs/input/listener/worker_test.go
+++ b/pkg/logs/input/listener/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -59,4 +60,17 @@ func (suite *WorkerTestSuite) TestReadAndForward() {
 
 func TestWorkerTestSuite(t *testing.T) {
 	suite.Run(t, new(WorkerTestSuite))
+}
+
+func TestMustKeepConnAlive(t *testing.T) {
+	var source *config.LogSource
+	var worker *Worker
+
+	source = config.NewLogSource("", &config.LogsConfig{Type: config.TCPType})
+	worker = NewWorker(source, nil, nil)
+	assert.False(t, worker.mustKeepConnAlive())
+
+	source = config.NewLogSource("", &config.LogsConfig{Type: config.UDPType})
+	worker = NewWorker(source, nil, nil)
+	assert.True(t, worker.mustKeepConnAlive())
 }

--- a/releasenotes/notes/logs_udp_read_timeout-10a6edcc290f16d4.yaml
+++ b/releasenotes/notes/logs_udp_read_timeout-10a6edcc290f16d4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Removed the read timeout for UDP connections causing the agent to stop forwarding logs after one minute of nonactivity.


### PR DESCRIPTION
### What does this PR do?

Removed read timeout for UDP connections.

### Motivation

Keep UDP connections alive.

### Additional Notes

This should solve https://github.com/DataDog/datadog-agent/issues/1508
