### PR TITLE
[dogstatsd] handle ipv6 binding properly

### DIFF
--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -40,7 +40,7 @@ func NewUDPListener(packetOut chan *Packet, packetPool *PacketPool) (*UDPListene
 		// Listen to all network interfaces
 		url = fmt.Sprintf(":%d", config.Datadog.GetInt("dogstatsd_port"))
 	} else {
-		url = fmt.Sprintf("%s:%d", config.Datadog.GetString("bind_host"), config.Datadog.GetInt("dogstatsd_port"))
+		url = net.JoinHostPort(config.Datadog.GetString("bind_host"), config.Datadog.GetString("dogstatsd_port"))
 	}
 
 	conn, err = net.ListenPacket("udp", url)

--- a/releasenotes/notes/dogstatsd-bind-ipv6-1dcdcdf33d3c230c.yaml
+++ b/releasenotes/notes/dogstatsd-bind-ipv6-1dcdcdf33d3c230c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Dogstatsd now support listening on an IPv6 address when using ``bind_host``
+    config option.
+


### PR DESCRIPTION
### What does this PR do?

Properly concatenate ipv6 when using `bind_host` config option.

![image](https://user-images.githubusercontent.com/9051073/37984821-528abcd0-31c5-11e8-9644-63fab1ac0723.png)

### Motivation

Client request.

### Additional Notes

jmxfetch also uses `bind_host` config option but seems to handle IPv6 properly : https://github.com/DataDog/jmxfetch/blob/bc8ed2166e93a460f9fe2cdb4e5fa8bd9efaf883/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java#L20

