### PR TITLE
Fix tailer package tests

### DIFF
--- a/pkg/logs/input/tailer/scanner_test.go
+++ b/pkg/logs/input/tailer/scanner_test.go
@@ -68,6 +68,7 @@ func (suite *ScannerTestSuite) TearDownTest() {
 	suite.testFile.Close()
 	suite.testRotatedFile.Close()
 	os.Remove(suite.testDir)
+	suite.s.cleanup()
 }
 
 func (suite *ScannerTestSuite) TestScannerStartsTailers() {


### PR DESCRIPTION
### Motivation

Tailer package tests are very flaky on gitlab. 

This PR cleans up properly the scanners used by the tests. Goroutines launched by the scanner tailers where staying alive.

This might not resolve 100% of the issues but will at least help with the debugging by not having multiple Goroutines alive at all time.