### PR TITLE
Fix tailer package tests

### DIFF
--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -170,6 +170,12 @@ func (t *Tailer) SetReadOffset(off int64) {
 	atomic.StoreInt64(&t.readOffset, off)
 }
 
+// GetDecodedOffset gets the position of the last byte decoded in the
+// file
+func (t *Tailer) GetDecodedOffset() int64 {
+	return atomic.LoadInt64(&t.decodedOffset)
+}
+
 // SetDecodedOffset sets the position of the last byte decoded in the
 // file
 func (t *Tailer) SetDecodedOffset(off int64) {

--- a/pkg/logs/input/tailer/tailer_test.go
+++ b/pkg/logs/input/tailer/tailer_test.go
@@ -87,7 +87,7 @@ func (suite *TailerTestSuite) TestTailFromBeginning() {
 	suite.Equal("good bye", string(msg.Content()))
 	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(msg.GetOrigin().Offset))
 
-	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tl.GetReadOffset()))
+	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tl.GetDecodedOffset()))
 }
 
 func (suite *TailerTestSuite) TestTailFromEnd() {
@@ -116,7 +116,7 @@ func (suite *TailerTestSuite) TestTailFromEnd() {
 	suite.Equal("good bye", string(msg.Content()))
 	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(msg.GetOrigin().Offset))
 
-	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tl.GetReadOffset()))
+	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tl.GetDecodedOffset()))
 }
 
 func (suite *TailerTestSuite) TestRecoverTailing() {
@@ -147,7 +147,7 @@ func (suite *TailerTestSuite) TestRecoverTailing() {
 	suite.Equal("good bye", string(msg.Content()))
 	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(msg.GetOrigin().Offset))
 
-	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tl.GetReadOffset()))
+	suite.Equal(len(lines[0])+len(lines[1])+len(lines[2]), int(suite.tl.GetDecodedOffset()))
 }
 
 func (suite *TailerTestSuite) TestTailerIdentifier() {


### PR DESCRIPTION
### Motivation

Tailer package tests are very flaky on gitlab.

### Notes

The tailer `readOffset` can not be trusted to have up to date values : 

https://github.com/DataDog/datadog-agent/blob/4f0a3402484e27fa0f16f080c603e4dce33b96db/pkg/logs/input/tailer/tailer_nix.go#L65-L66

Other goroutines might read the channel before the offset is updated. This is probably what happened here : https://gitlab.ddbuild.io/datadog/datadog-agent/-/jobs/3829229

I replaced the `GetReadOffset` call by `GetDecodedOffset` which is set before sending new messages to the channel read by the tests.

