### PR TITLE
[ci] docker login to the correct server

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -567,7 +567,7 @@ build_dogstatsd:
     - export DOCKER_HOST=tcp://486234852809.dkr.ecr.us-east-1.amazonaws.com__docker-machine:2375
     - eval "$(aws ecr get-login --region us-east-1 --no-include-email --registry-ids 486234852809)"
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - LATEST_TAG=${LATEST_TAG:-latest}
     - docker pull $SOURCE_IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX
@@ -577,10 +577,12 @@ build_dogstatsd:
 .docker_hub_variables: &docker_hub_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
+  DOCKER_REGISTRY_URL: docker.io
 
 .quay_variables: &quay_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: quay_login
   DOCKER_REGISTRY_PWD_SSM_KEY: quay_pwd
+  DOCKER_REGISTRY_URL: quay.io
 
 agent6_dev_docker_hub:
   <<: *docker_tag_job_definition


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug introduced by https://github.com/DataDog/datadog-agent/pull/1367 where docker-release jobs always try to log in to the dockerhub registry.
It needs to be configurable : quay.io for jobs that push to quay and dockerhub for jobs that push to dockerhub. 


