### PR TITLE
Don't fail network check during container initialization if default config file is missing

### DIFF
--- a/Dockerfiles/agent/entrypoint/60-network-check.sh
+++ b/Dockerfiles/agent/entrypoint/60-network-check.sh
@@ -8,5 +8,5 @@ if [[ -n "${ECS_FARGATE}" ]]; then
 fi
 
 if [[ ! -d /host/proc ]]; then
-    rm /etc/datadog-agent/conf.d/network.d/conf.yaml.default
+    rm /etc/datadog-agent/conf.d/network.d/conf.yaml.default || true
 fi


### PR DESCRIPTION
### What does this PR do?

Don't fail network check during container initialization if `network.d/conf.yaml.default` config is missing.

### Motivation

We run agents where we have cleaned out the `conf.d/` directory in advance. This causes the container initialization step to do a dirty exit.

```
[cont-init.d] executing container initialization scripts...
[cont-init.d] 01-check-apikey.sh: executing...
[cont-init.d] 01-check-apikey.sh: exited 0.
[cont-init.d] 10-dogstatsd-socket.sh: executing...
[cont-init.d] 10-dogstatsd-socket.sh: exited 0.
[cont-init.d] 50-ecs.sh: executing...
[cont-init.d] 50-ecs.sh: exited 0.
[cont-init.d] 50-kubernetes.sh: executing...
[cont-init.d] 50-kubernetes.sh: exited 0.
[cont-init.d] 50-mesos.sh: executing...
[cont-init.d] 50-mesos.sh: exited 0.
[cont-init.d] 51-docker.sh: executing...
[cont-init.d] 51-docker.sh: exited 0.
[cont-init.d] 59-defaults.sh: executing...
[cont-init.d] 59-defaults.sh: exited 0.
[cont-init.d] 60-network-check.sh: executing...
rm: cannot remove '/etc/datadog-agent/conf.d/network.d/conf.yaml.default': No such file or directory
[cont-init.d] 60-network-check.sh: exited 1.
```