### PR TITLE
Splitting the forwarder to have one per domain.

### DIFF
--- a/pkg/forwarder/README.md
+++ b/pkg/forwarder/README.md
@@ -1,7 +1,7 @@
 ## package `forwarder`
 
 This package is responsible for sending payloads to the backend. Payloads can
-come from different sources in different format, the forwarder will not inspect
+come from different sources in different formats, the forwarder will not inspect
 them.
 
 The forwarder can receive multiple domains with a list of API keys for each of
@@ -18,13 +18,15 @@ KeysPerDomains := map[string][]string{
 }
 
 forwarder := forwarder.NewForwarder(KeysPerDomains)
-forwarder.NumberOfWorkers = 1 // default 4
+forwarder.NumberOfWorkers = 1 // default: config.Datadog.GetInt("forwarder_num_workers")
 forwarder.Start()
 
 // ...
 
-payload := []byte("some payload")
-forwarder.SubmitTimeseries(&payload)
+payload1 := []byte("some payload")
+payload2 := []byte("another payload")
+forwarder.SubmitSeries(Payloads{&payload1, &payload2}
+)
 
 // ...
 
@@ -52,3 +54,54 @@ a retry. Default: `64`
 step down for an endpoint upon success. Default: `2`
 - `forwarder_recovery_reset` - Whether or not a successful request should completely
 clear an endpoint's error count. Default: `false`
+
+### Internal
+
+The forwarder is composed of multiple parts:
+
+#### DefaultForwarder
+
+`DefaultForwarder` it the default implementation of the `Forwarder` interface
+(and the only one for now). This class is in charge of receiving payloads,
+creating the HTTP transactions and distributing them among every
+`domainForwarder`.
+
+#### domainForwarder
+
+The agent can be configured to send the same payload to multiple destinations.
+Each destination (or domain) can be configured with 1 or more API keys. Every
+payload will be sent to each domain/API key pair.
+
+A `domainForwarder` is in charge of sending payloads to one domain. This avoids
+slowing down every domain when one is down/slow. Each `domainForwarder` will
+have a number of dedicated `Worker` to process `Transaction`. We process new
+transactions first and then (when the workers have time) we retry the erroneous
+ones (newest transactions are retried first).
+
+We start dropping transactions (oldest first) when the number of transactions
+in the retry queue is bigger than `forwarder_retry_queue_max_size` (see the
+agent configuration).
+
+Disclaimer: using multiple API keys with the **Datadog** backend will multiply
+your billing ! Most customers will only use one API key.
+
+#### Worker
+
+A `Worker` processes transactions coming from 2 queues: `HighPrio` and `LowPrio`.
+New transactions are sent to the `HighPrio` queue and the ones to retry are
+sent to `LowPrio`. A `Worker` is dedicated to on domain (ie: domainForwarder).
+
+#### blockedEndpoints (or exponential backoff)
+
+When a transaction fails to be sent to a backend we blacklist that particular
+endpoints for some time to avoid flooding an unavailable endpoint (the
+transactions will be retried later). A blacklist is specific to one endpoint on
+one domain (ie: "http(s)://<domain>/<endpoint>"). The blacklist time will grow,
+up to a maximum, has more and more errors are encountered for that endpoint and
+is gradually cleared when a transaction is successful. The blacklist is shared
+by all workers.
+
+#### Transaction
+
+A `HTTPTransaction` contains every information about a payload and how/where to
+send it. On failure a transaction will be retried later (see blockedEndpoints).

--- a/pkg/forwarder/domain_forwarder.go
+++ b/pkg/forwarder/domain_forwarder.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package forwarder
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	log "github.com/cihub/seelog"
+)
+
+var (
+	chanBufferSize = 100
+	flushInterval  = 5 * time.Second
+)
+
+// domainForwarder is in charge of sending Transactions to Datadog backend over
+// HTTP and retrying them if needed. One domainForwarder is created per HTTP
+// backend.
+type domainForwarder struct {
+	domain              string
+	numberOfWorkers     int
+	highPrio            chan Transaction // use to receive new transactions
+	lowPrio             chan Transaction // use to retry transactions
+	requeuedTransaction chan Transaction
+	stopRetry           chan bool
+	workers             []*Worker
+	retryQueue          []Transaction
+	retryQueueLimit     int
+	internalState       uint32
+	m                   sync.Mutex // To control Start/Stop races
+	blockedList         *blockedEndpoints
+}
+
+func newDomainForwarder(domain string, numberOfWorkers int, retryQueueLimit int) *domainForwarder {
+	return &domainForwarder{
+		domain:          domain,
+		numberOfWorkers: numberOfWorkers,
+		retryQueueLimit: retryQueueLimit,
+		internalState:   Stopped,
+		blockedList:     newBlockedEndpoints(),
+	}
+}
+
+type byCreatedTime []Transaction
+
+func (v byCreatedTime) Len() int           { return len(v) }
+func (v byCreatedTime) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
+func (v byCreatedTime) Less(i, j int) bool { return v[i].GetCreatedAt().After(v[j].GetCreatedAt()) }
+
+func (f *domainForwarder) retryTransactions(retryBefore time.Time) {
+	newQueue := []Transaction{}
+	droppedRetryQueueFull := 0
+	droppedWorkerBusy := 0
+
+	sort.Sort(byCreatedTime(f.retryQueue))
+
+	for _, t := range f.retryQueue {
+		if !f.blockedList.isBlock(t.GetTarget()) {
+			select {
+			case f.lowPrio <- t:
+				transactionsExpvar.Add("Retried", 1)
+			default:
+				droppedWorkerBusy++
+				transactionsExpvar.Add("Dropped", 1)
+			}
+		} else if len(newQueue) < f.retryQueueLimit {
+			newQueue = append(newQueue, t)
+			transactionsExpvar.Add("Requeued", 1)
+		} else {
+			droppedRetryQueueFull++
+			transactionsExpvar.Add("Dropped", 1)
+		}
+	}
+
+	f.retryQueue = newQueue
+	retryQueueSize.Set(int64(len(f.retryQueue)))
+
+	if droppedRetryQueueFull+droppedWorkerBusy > 0 {
+		log.Errorf("Dropped %d transactions in this retry attempt: %d for exceeding the retry queue size limit of %d, %d because the workers are too busy",
+			droppedRetryQueueFull+droppedWorkerBusy, droppedRetryQueueFull, f.retryQueueLimit, droppedWorkerBusy)
+	}
+}
+
+func (f *domainForwarder) requeueTransaction(t Transaction) {
+	f.retryQueue = append(f.retryQueue, t)
+	transactionsExpvar.Add("Requeued", 1)
+	retryQueueSize.Set(int64(len(f.retryQueue)))
+}
+
+func (f *domainForwarder) handleFailedTransactions() {
+	ticker := time.NewTicker(flushInterval)
+	for {
+		select {
+		case tickTime := <-ticker.C:
+			f.retryTransactions(tickTime)
+		case t := <-f.requeuedTransaction:
+			f.requeueTransaction(t)
+		case <-f.stopRetry:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (f *domainForwarder) init() {
+	f.highPrio = make(chan Transaction, chanBufferSize)
+	f.lowPrio = make(chan Transaction, chanBufferSize)
+	f.requeuedTransaction = make(chan Transaction, chanBufferSize)
+	f.stopRetry = make(chan bool)
+	f.workers = []*Worker{}
+	f.retryQueue = []Transaction{}
+}
+
+// Start starts a domainForwarder.
+func (f *domainForwarder) Start() error {
+	// Lock so we can't stop a Forwarder while is starting
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if f.internalState == Started {
+		return fmt.Errorf("the forwarder is already started")
+	}
+
+	// reset internal state to purge transactions from past starts
+	f.init()
+
+	for i := 0; i < f.numberOfWorkers; i++ {
+		w := NewWorker(f.highPrio, f.lowPrio, f.requeuedTransaction, f.blockedList)
+		w.Start()
+		f.workers = append(f.workers, w)
+	}
+	go f.handleFailedTransactions()
+
+	f.internalState = Started
+	return nil
+}
+
+// Stop stops a domainForwarder, all transactions not yet flushed will be lost.
+func (f *domainForwarder) Stop() {
+	// Lock so we can't start a Forwarder while is stopping
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	if f.internalState == Stopped {
+		log.Warnf("the forwarder is already stopped")
+		return
+	}
+
+	f.stopRetry <- true
+	for _, w := range f.workers {
+		w.Stop()
+	}
+	f.workers = []*Worker{}
+	f.retryQueue = []Transaction{}
+	close(f.highPrio)
+	close(f.lowPrio)
+	close(f.requeuedTransaction)
+	log.Info("domainForwarder stopped")
+	f.internalState = Stopped
+}
+
+func (f *domainForwarder) State() uint32 {
+	// Lock so we can't start/stop a Forwarder while getting its state
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	return f.internalState
+}
+
+func (f *domainForwarder) sendHTTPTransactions(transaction Transaction) error {
+	// We don't want to block the collector if the highPrio queue is full
+	select {
+	case f.highPrio <- transaction:
+	default:
+		transactionsExpvar.Add("DroppedOnInput", 1)
+		return fmt.Errorf("the forwarder input queue for %s is full: dropping transaction", f.domain)
+	}
+	return nil
+}

--- a/pkg/forwarder/domain_forwarder_test.go
+++ b/pkg/forwarder/domain_forwarder_test.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package forwarder
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDomainForwarder(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+
+	assert.NotNil(t, forwarder)
+	assert.Equal(t, 1, forwarder.numberOfWorkers)
+	assert.Equal(t, 10, forwarder.retryQueueLimit)
+	assert.Equal(t, Stopped, forwarder.State())
+	assert.Nil(t, forwarder.highPrio)
+	assert.Nil(t, forwarder.lowPrio)
+	assert.Nil(t, forwarder.requeuedTransaction)
+	assert.Nil(t, forwarder.stopRetry)
+	assert.Len(t, forwarder.workers, 0)
+	assert.Len(t, forwarder.retryQueue, 0)
+	assert.NotNil(t, forwarder.blockedList, 0)
+}
+
+func TestDomainForwarderStart(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	err := forwarder.Start()
+
+	assert.Nil(t, err)
+	require.Len(t, forwarder.retryQueue, 0)
+	require.Len(t, forwarder.workers, 1)
+	assert.Equal(t, Started, forwarder.State())
+	assert.NotNil(t, forwarder.highPrio)
+	assert.NotNil(t, forwarder.lowPrio)
+	assert.NotNil(t, forwarder.requeuedTransaction)
+	assert.NotNil(t, forwarder.stopRetry)
+
+	assert.NotNil(t, forwarder.Start())
+
+	forwarder.Stop()
+}
+
+func TestDomainForwarderInit(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder.init()
+	assert.Len(t, forwarder.workers, 0)
+	assert.Len(t, forwarder.retryQueue, 0)
+}
+
+func TestDomainForwarderStop(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder.Stop() // this should be a noop
+	forwarder.Start()
+	assert.Equal(t, Started, forwarder.State())
+	forwarder.Stop()
+	assert.Len(t, forwarder.workers, 0)
+	assert.Len(t, forwarder.retryQueue, 0)
+	assert.Equal(t, Stopped, forwarder.State())
+}
+
+func TestDomainForwarderSubmitIfStopped(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+
+	require.NotNil(t, forwarder)
+	assert.NotNil(t, forwarder.sendHTTPTransactions(nil))
+}
+
+func TestDomainForwarderSendHTTPTransactions(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	tr := newTestTransaction()
+
+	// fw is stopped, we should get an error
+	err := forwarder.sendHTTPTransactions(tr)
+	assert.NotNil(t, err)
+
+	forwarder.Start()
+	// Stopping the worker for the TestRequeueTransaction
+	forwarder.workers[0].Stop()
+
+	err = forwarder.sendHTTPTransactions(tr)
+	assert.Nil(t, err)
+	transactionToProcess := <-forwarder.highPrio
+	assert.Equal(t, tr, transactionToProcess)
+}
+
+func TestRequeueTransaction(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	tr := NewHTTPTransaction()
+	assert.Len(t, forwarder.retryQueue, 0)
+	forwarder.requeueTransaction(tr)
+	assert.Len(t, forwarder.retryQueue, 1)
+}
+
+func TestRetryTransactions(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder.init()
+	forwarder.retryQueueLimit = 1
+
+	// Default value should be nil
+	assert.Nil(t, transactionsExpvar.Get("Dropped"))
+
+	t1 := NewHTTPTransaction()
+	t1.Domain = "domain/"
+	t1.Endpoint = "test1"
+	t2 := NewHTTPTransaction()
+	t2.Domain = "domain/"
+	t2.Endpoint = "test2"
+
+	// Create blocks
+	forwarder.blockedList.recover(t1.GetTarget())
+	forwarder.blockedList.recover(t2.GetTarget())
+
+	forwarder.blockedList.errorPerEndpoint[t1.GetTarget()].until = time.Now().Add(-1 * time.Hour)
+	forwarder.blockedList.errorPerEndpoint[t2.GetTarget()].until = time.Now().Add(1 * time.Hour)
+
+	forwarder.requeueTransaction(t2)
+	forwarder.requeueTransaction(t2) // this second one should be dropped
+	forwarder.requeueTransaction(t1) // the queue should be sorted
+	forwarder.retryTransactions(time.Now())
+	assert.Len(t, forwarder.retryQueue, 1)
+	assert.Len(t, forwarder.lowPrio, 1)
+	require.NotNil(t, transactionsExpvar.Get("Dropped"))
+	dropped, _ := strconv.ParseInt(transactionsExpvar.Get("Dropped").String(), 10, 64)
+	assert.Equal(t, int64(1), dropped)
+}
+
+func TestForwarderRetry(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder.Start()
+	defer forwarder.Stop()
+
+	forwarder.blockedList.close("blocked")
+	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Hour)
+
+	ready := newTestTransaction()
+	notReady := newTestTransaction()
+
+	forwarder.requeueTransaction(ready)
+	forwarder.requeueTransaction(notReady)
+	require.Len(t, forwarder.retryQueue, 2)
+
+	ready.On("Process", forwarder.workers[0].Client).Return(nil).Times(1)
+	ready.On("GetTarget").Return("").Times(2)
+	ready.On("GetCreatedAt").Return(time.Now()).Times(1)
+	notReady.On("GetCreatedAt").Return(time.Now()).Times(1)
+	notReady.On("GetTarget").Return("blocked").Times(1)
+
+	forwarder.retryTransactions(time.Now())
+	<-ready.processed
+
+	ready.AssertExpectations(t)
+	notReady.AssertExpectations(t)
+	notReady.AssertNumberOfCalls(t, "Process", 0)
+	notReady.AssertNumberOfCalls(t, "GetTarget", 1)
+	require.Len(t, forwarder.retryQueue, 1)
+	assert.Equal(t, forwarder.retryQueue[0], notReady)
+}
+
+func TestForwarderRetryLifo(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder.init()
+
+	transaction1 := newTestTransaction()
+	transaction2 := newTestTransaction()
+
+	forwarder.requeueTransaction(transaction1)
+	forwarder.requeueTransaction(transaction2)
+
+	transaction1.On("GetCreatedAt").Return(time.Now()).Times(1)
+	transaction1.On("GetTarget").Return("").Times(1)
+
+	transaction2.On("GetCreatedAt").Return(time.Now().Add(1 * time.Minute)).Times(1)
+	transaction2.On("GetTarget").Return("").Times(1)
+
+	forwarder.retryTransactions(time.Now())
+
+	firstOut := <-forwarder.lowPrio
+	assert.Equal(t, firstOut, transaction2)
+
+	secondOut := <-forwarder.lowPrio
+	assert.Equal(t, secondOut, transaction1)
+
+	transaction1.AssertExpectations(t)
+	transaction2.AssertExpectations(t)
+	assert.Len(t, forwarder.retryQueue, 0)
+}
+
+func TestForwarderRetryLimitQueue(t *testing.T) {
+	forwarder := newDomainForwarder("test", 1, 10)
+	forwarder.init()
+
+	forwarder.retryQueueLimit = 1
+	forwarder.blockedList.close("blocked")
+	forwarder.blockedList.errorPerEndpoint["blocked"].until = time.Now().Add(1 * time.Minute)
+
+	transaction1 := newTestTransaction()
+	transaction2 := newTestTransaction()
+
+	forwarder.requeueTransaction(transaction1)
+	forwarder.requeueTransaction(transaction2)
+
+	transaction1.On("GetCreatedAt").Return(time.Now()).Times(1)
+	transaction1.On("GetTarget").Return("blocked").Times(1)
+
+	transaction2.On("GetCreatedAt").Return(time.Now().Add(1 * time.Minute)).Times(1)
+	transaction2.On("GetTarget").Return("blocked").Times(1)
+
+	forwarder.retryTransactions(time.Now())
+
+	transaction1.AssertExpectations(t)
+	transaction2.AssertExpectations(t)
+	require.Len(t, forwarder.retryQueue, 1)
+	require.Len(t, forwarder.highPrio, 0)
+	require.Len(t, forwarder.lowPrio, 0)
+	// assert that the oldest transaction was dropped
+	assert.Equal(t, transaction2, forwarder.retryQueue[0])
+}

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package forwarder
+
+import (
+	"expvar"
+	"fmt"
+	"net/http"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+var (
+	apiKeyStatusUnknown = expvar.String{}
+	apiKeyInvalid       = expvar.String{}
+	apiKeyValid         = expvar.String{}
+
+	validateAPIKeyTimeout = 10 * time.Second
+)
+
+func init() {
+	apiKeyStatusUnknown.Set("Unable to validate API Key")
+	apiKeyInvalid.Set("API Key invalid")
+	apiKeyValid.Set("API Key valid")
+}
+
+// forwarderHealth report the health status of the Forwarder. A Forwarder is
+// unhealthy if the API keys are not longer valid or if to many transactions
+// were dropped
+type forwarderHealth struct {
+	health  *health.Handle
+	stop    chan bool
+	stopped chan struct{}
+	ddURL   string
+	timeout time.Duration
+}
+
+func (fh *forwarderHealth) init(keysPerDomains map[string][]string) {
+	fh.stop = make(chan bool, 1)
+	fh.stopped = make(chan struct{})
+	fh.ddURL = config.Datadog.GetString("dd_url")
+
+	// Since timeout is the maximum duration we can wait, we need to divide it
+	// by the total number of api keys to obtain the max duration for each key
+	apiKeyCount := 0
+	for _, apiKeys := range keysPerDomains {
+		apiKeyCount += len(apiKeys)
+	}
+
+	fh.timeout = validateAPIKeyTimeout
+	if apiKeyCount != 0 {
+		fh.timeout /= time.Duration(apiKeyCount)
+	}
+}
+
+func (fh *forwarderHealth) Start(keysPerDomains map[string][]string) {
+	fh.health = health.Register("forwarder")
+	fh.init(keysPerDomains)
+	go fh.healthCheckLoop(keysPerDomains)
+}
+
+func (fh *forwarderHealth) Stop() {
+	fh.health.Deregister()
+	fh.stop <- true
+	<-fh.stopped
+}
+
+func (fh *forwarderHealth) healthCheckLoop(keysPerDomains map[string][]string) {
+	log.Debug("Waiting for APIkey validity to be confirmed.")
+
+	validateTicker := time.NewTicker(time.Hour * 1)
+	defer validateTicker.Stop()
+	defer close(fh.stopped)
+
+	valid := fh.hasValidAPIKey(keysPerDomains)
+	// If no key is valid, no need to keep checking, they won't magicaly become valid
+	if !valid {
+		log.Errorf("No valid api key found, reporting the forwarder as unhealthy.")
+		return
+	}
+
+	for {
+		select {
+		case <-fh.stop:
+			return
+		case <-validateTicker.C:
+			valid := fh.hasValidAPIKey(keysPerDomains)
+			if !valid {
+				log.Errorf("No valid api key found, reporting the forwarder as unhealthy.")
+				return
+			}
+		case <-fh.health.C:
+			if transactionsExpvar.Get("DroppedOnInput") != nil && transactionsExpvar.Get("DroppedOnInput").String() != "0" {
+				log.Errorf("Detected dropped transaction, reporting the forwarder as unhealthy: %v.", transactionsExpvar.Get("DroppedOnInput"))
+				return
+			}
+		}
+	}
+}
+
+func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status expvar.Var) {
+	obfuscatedKey := fmt.Sprintf("%s,*************************", domain)
+	if len(apiKey) > 5 {
+		obfuscatedKey += apiKey[len(apiKey)-5:]
+	}
+	apiKeyStatus.Set(obfuscatedKey, status)
+}
+
+func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
+	url := fmt.Sprintf("%s%s?api_key=%s", fh.ddURL, v1ValidateEndpoint, apiKey)
+
+	transport := util.CreateHTTPTransport()
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   fh.timeout,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	// Server will respond 200 if the key is valid or 403 if invalid
+	if resp.StatusCode == 200 {
+		fh.setAPIKeyStatus(apiKey, domain, &apiKeyValid)
+		return true, nil
+	} else if resp.StatusCode == 403 {
+		fh.setAPIKeyStatus(apiKey, domain, &apiKeyInvalid)
+		return false, nil
+	}
+
+	fh.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
+	return false, fmt.Errorf("Unexpected response code from the apikey validation endpoint: %v", resp.StatusCode)
+}
+
+func (fh *forwarderHealth) hasValidAPIKey(keysPerDomains map[string][]string) bool {
+	validKey := false
+	apiError := false
+
+	for domain, apiKeys := range keysPerDomains {
+		for _, apiKey := range apiKeys {
+			v, err := fh.validateAPIKey(apiKey, domain)
+			if err != nil {
+				log.Debug(err)
+				apiError = true
+			} else if v {
+				validKey = true
+			}
+		}
+	}
+
+	// If there is an error during the api call, we assume that there is a
+	// valid key to avoid killing lots of agent on an outage.
+	if apiError {
+		return true
+	}
+	return validKey
+}

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package forwarder
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestHasValidAPIKey(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	ddURL := config.Datadog.Get("dd_url")
+	config.Datadog.Set("dd_url", ts.URL)
+	defer ts.Close()
+	defer func() { config.Datadog.Set("dd_url", ddURL) }()
+
+	keysPerDomains := map[string][]string{
+		"domain1": {"api_key1", "api_key2"},
+		"domain2": {"key3"},
+	}
+
+	fh := forwarderHealth{}
+	fh.init(keysPerDomains)
+	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
+
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain1,*************************_key1"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain1,*************************_key2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain2,*************************"))
+}
+
+func TestHasValidAPIKeyErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		if r.Form.Get("api_key") == "api_key1" {
+			w.WriteHeader(http.StatusForbidden)
+		} else if r.Form.Get("api_key") == "api_key2" {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	ddURL := config.Datadog.Get("dd_url")
+	config.Datadog.Set("dd_url", ts.URL)
+	defer ts.Close()
+	defer func() { config.Datadog.Set("dd_url", ddURL) }()
+
+	keysPerDomains := map[string][]string{
+		"domain1": {"api_key1", "api_key2"},
+		"domain2": {"key3"},
+	}
+
+	fh := forwarderHealth{}
+	fh.init(keysPerDomains)
+	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
+
+	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("domain1,*************************_key1"))
+	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("domain1,*************************_key2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain2,*************************"))
+}

--- a/pkg/forwarder/transaction.go
+++ b/pkg/forwarder/transaction.go
@@ -34,6 +34,13 @@ type HTTPTransaction struct {
 	createdAt time.Time
 }
 
+// Transaction represents the task to process for a Worker.
+type Transaction interface {
+	Process(ctx context.Context, client *http.Client) error
+	GetCreatedAt() time.Time
+	GetTarget() string
+}
+
 // NewHTTPTransaction returns a new HTTPTransaction.
 func NewHTTPTransaction() *HTTPTransaction {
 	return &HTTPTransaction{

--- a/pkg/forwarder/transaction_test.go
+++ b/pkg/forwarder/transaction_test.go
@@ -103,6 +103,12 @@ func TestProcessHTTPError(t *testing.T) {
 	errorCode = http.StatusRequestEntityTooLarge
 	err = transaction.Process(context.Background(), client)
 	assert.Nil(t, err)
+	assert.Equal(t, transaction.ErrorCount, 1)
+
+	errorCode = http.StatusForbidden
+	err = transaction.Process(context.Background(), client)
+	assert.Nil(t, err)
+	assert.Equal(t, transaction.ErrorCount, 1)
 }
 
 func TestProcessCancel(t *testing.T) {

--- a/pkg/forwarder/worker_test.go
+++ b/pkg/forwarder/worker_test.go
@@ -50,21 +50,16 @@ func TestWorkerStart(t *testing.T) {
 	mock2.On("Process", w.Client).Return(nil).Times(1)
 	mock2.On("GetTarget").Return("").Times(1)
 
-	dummy := newTestTransaction()
-	dummy.On("Process", w.Client).Return(nil).Times(2)
-	dummy.On("GetTarget").Return("").Times(2)
-
 	w.Start()
 
 	highPrio <- mock
-	// since highPrio and lowPrio have no buffering the worker won't take another Transaction until it has processed the first one
-	highPrio <- dummy
+	<-mock.processed
 
 	mock.AssertExpectations(t)
 	mock.AssertNumberOfCalls(t, "Process", 1)
 
 	lowPrio <- mock2
-	lowPrio <- dummy
+	<-mock2.processed
 
 	mock2.AssertExpectations(t)
 	mock2.AssertNumberOfCalls(t, "Process", 1)

--- a/releasenotes/notes/split-forwarder-per-domain-3ff887b4bdcd4aa3.yaml
+++ b/releasenotes/notes/split-forwarder-per-domain-3ff887b4bdcd4aa3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The fowarder will now spaw specific workers per domain to avoid slow down when one domain is down.


### PR DESCRIPTION
### What does this PR do?

The forwarder class has been split in two: forwarder and domainForwarder.

We now spawn one `domainForwarder` per domain in the configuration. This avoids slowing down one domain when the another one is down.

We also split the health report for the forwarder to its own class to ease testing.

Test coverage has been pushed from 78.4% to 92.4% and the README has been updated.