### PR TITLE
Basic JSON logs encoder support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -214,6 +214,7 @@ func init() {
 	BindEnvAndSetDefault("logs_config.dd_url", "intake.logs.datadoghq.com")
 	BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", false)
+	BindEnvAndSetDefault("logs_config.input_format", "raw")
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 	BindEnvAndSetDefault("logs_config.container_collect_all", false)


### PR DESCRIPTION
### What does this PR do?

This PR adds possibility to configure Datadog agent to forward JSON logs untouched (to avoid packing JSON logs into syslog format).

### Motivation

It's kind of useful in the case, when application is capable to send logs in JSON format which will allow users to bypass the usage of grok in order to get whatever fields they want. Personally I was kind of surprised that this kind of feature is missing, as it's possible when you directly send logs to Datadog server. Why to use agent in this situation? - API keys. It is not required to have an API key per application, but to have it only in datadog-agent - very useful on AWS ECS

### Additional Notes

I have made only basic JSON format bypasser (messages are checked if agent has received JSON format or not - in the second case it follows the old flow). This feature is flagged, so default agent behaviour is the same. I am not sure about config part, as while testing it I just created the binary with default configuration to use this feature, as I am using docker for test it was the easiest way for me. Haven't wrote `reno` notes, though it's not a problem for me to add it. Also the additional informations from datadog-agent are not added yet - it's not a critical issue for us at the moment, and not sure if you will be willing to add this PR, so didn't want to waste my time for nothing.

Looking forward for any comments from your side.