### PR TITLE
Lower log level of cgroup parsing

### DIFF
--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -578,7 +578,7 @@ func parseCgroupPaths(r io.Reader) (string, map[string]string, error) {
 		l := scanner.Text()
 		cID, ok := containerIDFromCgroup(l)
 		if !ok {
-			log.Debugf("could not parse container id from path '%s'", l)
+			log.Tracef("could not parse container id from path '%s'", l)
 			continue
 		}
 		if containerID == "" {


### PR DESCRIPTION
### What does this PR do?

Lower log level from debug to trace

### Motivation

This can be very noisy and make debug logs unreadable

