### PR TITLE
Add docker metric "docker.cpu.shares"

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -180,6 +180,7 @@ func (d *DockerCheck) Run() error {
 		sender.Rate("docker.cpu.user", float64(c.CPU.User), "", tags)
 		sender.Rate("docker.cpu.usage", c.CPU.UsageTotal, "", tags)
 		sender.Rate("docker.cpu.throttled", float64(c.CPUNrThrottled), "", tags)
+		sender.Gauge("docker.cpu.shares", float64(c.CPUShares), "", tags)
 		sender.Gauge("docker.mem.cache", float64(c.Memory.Cache), "", tags)
 		sender.Gauge("docker.mem.rss", float64(c.Memory.RSS), "", tags)
 		if c.Memory.SwapPresent == true {

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -283,6 +283,24 @@ func (c ContainerCgroup) CPUNrThrottled() (uint64, error) {
 	return 0, nil
 }
 
+// CPUShares returns the relative weight of CPU time
+// If the cgroup file does not exist then we just log debug and return 1024.
+func (c ContainerCgroup) CPUShares() (uint64, error) {
+	sharesfile := c.cgroupFilePath("cpu", "cpu.shares")
+	lines, err := readLines(sharesfile)
+	if os.IsNotExist(err) {
+		log.Debugf("missing cgroup file: %s", sharesfile)
+		return 1024, nil
+	} else if err != nil {
+		return 0, err
+	}
+	shares, err := strconv.ParseUint(lines[0], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return shares, nil
+}
+
 // CPULimit would show CPU limit for this cgroup.
 // It does so by checking the cpu period and cpu quota config
 // if a user does this:

--- a/pkg/util/docker/cgroup_test.go
+++ b/pkg/util/docker/cgroup_test.go
@@ -67,6 +67,32 @@ func TestCPUNrThrottled(t *testing.T) {
 	assert.Equal(t, value, uint64(10))
 }
 
+func TestCPUShares(t *testing.T) {
+	tempFolder, err := newTempFolder("cpu-shares")
+	assert.Nil(t, err)
+	defer tempFolder.removeAll()
+
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "cpu")
+
+	// No file
+	value, err := cgroup.CPUShares()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(1024))
+
+	// Invalid file
+	tempFolder.add("cpu/cpu.shares", "abc")
+	value, err = cgroup.CPUShares()
+	assert.NotNil(t, err)
+	assert.IsType(t, err, &strconv.NumError{})
+	assert.Equal(t, value, uint64(0))
+
+	// Valid file
+	tempFolder.add("cpu/cpu.shares", "512\n")
+	value, err = cgroup.CPUShares()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(512))
+}
+
 func TestMemLimit(t *testing.T) {
 	tempFolder, err := newTempFolder("mem-limit")
 	assert.Nil(t, err)

--- a/pkg/util/docker/container.go
+++ b/pkg/util/docker/container.go
@@ -33,6 +33,7 @@ type Container struct {
 	CPULimit       float64
 	MemLimit       uint64
 	CPUNrThrottled uint64
+	CPUShares      uint64
 	CPU            *CgroupTimesStat
 	Memory         *CgroupMemStat
 	IO             *CgroupIOStat

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -310,6 +310,11 @@ func (d *DockerUtil) Containers(cfg *ContainerListConfig) ([]*Container, error) 
 			log.Debugf("Cgroup cpuNrThrottled: %s", err)
 			continue
 		}
+		container.CPUShares, err = cgroup.CPUShares()
+		if err != nil {
+			log.Debugf("Cgroup cpuShares: %s", err)
+			continue
+		}
 		container.IO, err = cgroup.IO()
 		if err != nil {
 			log.Debugf("Cgroup i/o: %s", err)

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -35,6 +35,7 @@ func TestContainerMetricsTagging(t *testing.T) {
 			"docker.mem.limit",
 			"docker.container.size_rw",
 			"docker.container.size_rootfs",
+			"docker.cpu.shares",
 		},
 		"Rate": {
 			"docker.cpu.system",


### PR DESCRIPTION
### What does this PR do?

Adds `docker.cpu.shares` metric to the datadog agent.
It is the value of `/sys/fs/cgroup/cpu/cpu.shares`.

<img width="1062" alt="2018-04-07 21 39 22" src="https://user-images.githubusercontent.com/117768/38454975-292c903a-3aac-11e8-8708-26ecafb80ff9.png">

### Motivation

from https://help.datadoghq.com/hc/en-us/requests/138307 .

I want normalized CPU usage for container CPU monitoring.

`docker.cpu.usage: 100%` has a different meaning depending on the value of cpu.shares (=ECS task definition "cpu" parameter). 
If cps.shares is 1024, it reaches the limit. 
If cpu.shares is 2048, it has not reached its limit yet.

If the agent can get cpu.shares, I can make a monitor like this:

```
avg:docker.cpu.usage{*} by {container_name} * 1024 / avg:docker.cpu.shares{*} by {container_name}
```

<img width="908" alt="2018-04-07 21 50 09" src="https://user-images.githubusercontent.com/117768/38455090-ab703dfc-3aad-11e8-93e5-e16363dbc122.png">
