### PR TITLE
Set collect_ec2_tags from environment variable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -276,6 +276,8 @@ func init() {
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 	Datadog.BindEnv("leader_election")
 	Datadog.BindEnv("leader_lease_duration")
+
+	Datadog.BindEnv("collect_ec2_tags")
 }
 
 // BindEnvAndSetDefault sets the default value for a config parameter, and adds an env binding

--- a/releasenotes/notes/set-collect_ec2_tags-from-env-2b317dccfcae657f.yaml
+++ b/releasenotes/notes/set-collect_ec2_tags-from-env-2b317dccfcae657f.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Enable to set ec2_collect_tags from environment variable DD_COLLECT_EC2_TAGS

--- a/releasenotes/notes/set-collect_ec2_tags-from-env-2b317dccfcae657f.yaml
+++ b/releasenotes/notes/set-collect_ec2_tags-from-env-2b317dccfcae657f.yaml
@@ -1,3 +1,3 @@
 ---
 features:
-  - Enable to set ec2_collect_tags from environment variable DD_COLLECT_EC2_TAGS
+  - Enable to set collect_ec2_tags from environment variable DD_COLLECT_EC2_TAGS


### PR DESCRIPTION
### What does this PR do?

Set `collect_ec2_tags` from environment variable `DD_COLLECT_EC2_TAGS`.

### Motivation

I want to run official datadog-agent image on ECS, but there is no way to change `collect_ec2_tags`.
