### PR TITLE
[docs] Consolidate legal docs under docs/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,5 @@ DD_API_KEY=12345678990 ./bin/agent/agent -c bin/agent/dist/datadog.yaml
 
 ## Contributing code
 
-You must sign a CLA before we can accept your contributions. The first time you
-submit a PR, a bot will walk you through the automated process. On subsequent
-contributions you will not be prompted unless the content of the agreement has
-changed. We sincerely appreciate your contribution and have worked hard to ensure
-the CLA wording is simple, clear, and concise. It does not require you to give up
-ownership of your contributions, or prevent you from using your contributions for
-other purposes. We've put the agreement in place to explicitly clarify your
-intellectual property license grant, for your protection as well as ours.
+You'll find information and help on how to contribute code to this project under
+[the `docs/dev` directory](docs/dev) of the present repo.

--- a/docs/dev/legal.md
+++ b/docs/dev/legal.md
@@ -1,6 +1,7 @@
 # Legal
 
-You must sign a CLA before we can accept your contributions. The first time you
+You must sign [our CLA](https://gist.github.com/bits-bot/55bdc97a4fdad52d97feb4d6c3d1d618)
+before we can accept your contributions. The first time you
 submit a PR, a bot will walk you through the automated process. On subsequent
 contributions you will not be prompted unless the content of the agreement has
 changed.

--- a/docs/dev/legal.md
+++ b/docs/dev/legal.md
@@ -1,3 +1,12 @@
-In order for your contributions to be accepted, you will be required to sign a CLA.
-When a PR is opened a bot will prompt you to sign the CLA. Once signed you will
-be set for all contributions going forward.
+# Legal
+
+You must sign a CLA before we can accept your contributions. The first time you
+submit a PR, a bot will walk you through the automated process. On subsequent
+contributions you will not be prompted unless the content of the agreement has
+changed.
+
+We sincerely appreciate your contribution and have worked hard to ensure
+the CLA wording is simple, clear, and concise. It does not require you to give up
+ownership of your contributions, or prevent you from using your contributions for
+other purposes. We've put the agreement in place to explicitly clarify your
+intellectual property license grant, for your protection as well as ours.


### PR DESCRIPTION
Consolidate legal docs under `docs/dev` to avoid diverging docs and give contributors a single view of the whole contribution process under `docs/dev/README.md`