### PR TITLE
[Logs] Windows file tailing - fix buffer reuse when line is big enough

### DIFF
--- a/pkg/logs/input/tailer/tailer_windows.go
+++ b/pkg/logs/input/tailer/tailer_windows.go
@@ -58,9 +58,9 @@ func (t *Tailer) readAvailable() (err error) {
 		return err
 	}
 	f.Seek(t.GetReadOffset(), io.SeekStart)
-	inBuf := make([]byte, 4096)
 
 	for {
+		inBuf := make([]byte, 4096)
 		n, err := f.Read(inBuf)
 		if n == 0 || err != nil {
 			log.Debugf("Done reading")

--- a/releasenotes/notes/logs-windows-file-tailing-7458d003a76cf7ff.yaml
+++ b/releasenotes/notes/logs-windows-file-tailing-7458d003a76cf7ff.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed an issue with collecting logs bigger than 4096 chars on windows.


### PR DESCRIPTION
### What does this PR do?

Fixes collection of logs on windows when tailing files with logs bigger than 4096 chars.

As we reuse the same buffer, we override it, and as a result keep
sending the same content over and over, content which is the end
of the line.
Let's instead instantiate a new buffer once the current one is full

