### PR TITLE
add support for k8s legacy created-by annotation for tagging

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -59,7 +59,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		}
 
 		// Creator
-		for _, owner := range pod.Metadata.Owners {
+		for _, owner := range pod.Owners() {
 			switch owner.Kind {
 			case "":
 				continue

--- a/pkg/util/kubernetes/kubelet/pod.go
+++ b/pkg/util/kubernetes/kubelet/pod.go
@@ -31,7 +31,7 @@ func (p *Pod) Owners() []PodOwner {
 	// Else, try unserialising the legacy field
 	content, found := p.Metadata.Annotations["kubernetes.io/created-by"]
 	if !found {
-		return owners
+		return nil
 	}
 	var ref creatorRef
 	err := json.Unmarshal([]byte(content), &ref)
@@ -39,13 +39,13 @@ func (p *Pod) Owners() []PodOwner {
 	// Error handling
 	if err != nil {
 		log.Debugf("cannot parse created-by field for pod %q: %s", p.Metadata.Name, err)
-		return owners
+		return nil
 	}
 	if ref.Kind != "SerializedReference" {
 		log.Debugf("cannot parse created-by field for pod %q: unknown kind %q", p.Metadata.Name, ref.Kind)
-		return owners
+		return nil
 	}
 
-	owners = append(owners, ref.Reference)
+	owners = []PodOwner{ref.Reference}
 	return owners
 }

--- a/pkg/util/kubernetes/kubelet/pod.go
+++ b/pkg/util/kubernetes/kubelet/pod.go
@@ -38,11 +38,11 @@ func (p *Pod) Owners() []PodOwner {
 
 	// Error handling
 	if err != nil {
-		log.Debugf("cannot parse created-by field for pod %q: %s", p.Metadata.Name, err)
+		log.Debugf("Cannot parse created-by field for pod %q: %s", p.Metadata.Name, err)
 		return nil
 	}
 	if ref.Kind != "SerializedReference" {
-		log.Debugf("cannot parse created-by field for pod %q: unknown kind %q", p.Metadata.Name, ref.Kind)
+		log.Debugf("Cannot parse created-by field for pod %q: unknown kind %q", p.Metadata.Name, ref.Kind)
 		return nil
 	}
 

--- a/pkg/util/kubernetes/kubelet/pod.go
+++ b/pkg/util/kubernetes/kubelet/pod.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet
+
+package kubelet
+
+import (
+	"encoding/json"
+
+	log "github.com/cihub/seelog"
+)
+
+type creatorRef struct {
+	Kind      string
+	Reference PodOwner
+}
+
+// Owners returns pod owners, sourced either from:
+// - the new `Owners` field, exposed by the kubelet since 1.6
+// - the legacy `kubernetes.io/created-by` annotation, deprecated in 1.8
+func (p *Pod) Owners() []PodOwner {
+	// If we find the new field, return it
+	owners := p.Metadata.Owners
+	if len(owners) > 0 {
+		return owners
+	}
+
+	// Else, try unserialising the legacy field
+	content, found := p.Metadata.Annotations["kubernetes.io/created-by"]
+	if !found {
+		return owners
+	}
+	var ref creatorRef
+	err := json.Unmarshal([]byte(content), &ref)
+
+	// Error handling
+	if err != nil {
+		log.Debugf("cannot parse created-by field for pod %q: %s", p.Metadata.Name, err)
+		return owners
+	}
+	if ref.Kind != "SerializedReference" {
+		log.Debugf("cannot parse created-by field for pod %q: unknown kind %q", p.Metadata.Name, ref.Kind)
+		return owners
+	}
+
+	owners = append(owners, ref.Reference)
+	return owners
+}

--- a/pkg/util/kubernetes/kubelet/pod_test.go
+++ b/pkg/util/kubernetes/kubelet/pod_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet
+
+package kubelet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPodOwners(t *testing.T) {
+	dsOwner := []PodOwner{
+		{
+			Kind: "DaemonSet",
+			Name: "dd-agent-rc",
+			ID:   "6a76e51c-88d7-11e7-9a0f-42010a8401cc",
+		},
+	}
+
+	legacyDsAnnotation := "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+	legacyDsOwner := []PodOwner{
+		{
+			Kind: "DaemonSet",
+			Name: "dd-agent",
+			ID:   "12c56a58-33ca-11e6-ac8f-42010af00003",
+		},
+	}
+
+	legacyInvalidAnnotation := "{\"kind\":\"Unknown\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+
+	for nb, tc := range []struct {
+		pod            *Pod
+		expectedOwners []PodOwner
+	}{
+		{
+			pod:            &Pod{},
+			expectedOwners: nil,
+		},
+		{
+			pod: &Pod{
+				Metadata: PodMetadata{
+					Name:   "new-field",
+					Owners: dsOwner,
+				},
+			},
+			expectedOwners: dsOwner,
+		},
+		{
+			pod: &Pod{
+				Metadata: PodMetadata{
+					Name: "legacy-pod",
+					Annotations: map[string]string{
+						"kubernetes.io/created-by": legacyDsAnnotation,
+					},
+				},
+			},
+			expectedOwners: legacyDsOwner,
+		},
+		{
+			pod: &Pod{
+				Metadata: PodMetadata{
+					Name: "invalid-reference-kind",
+					Annotations: map[string]string{
+						"kubernetes.io/created-by": legacyInvalidAnnotation,
+					},
+				},
+			},
+			expectedOwners: nil,
+		},
+		{
+			pod: &Pod{
+				Metadata: PodMetadata{
+					Name:   "both-keep-new",
+					Owners: dsOwner,
+					Annotations: map[string]string{
+						"kubernetes.io/created-by": legacyDsAnnotation,
+					},
+				},
+			},
+			expectedOwners: dsOwner,
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.pod.Metadata.Name), func(t *testing.T) {
+			assert.EqualValues(t, tc.expectedOwners, tc.pod.Owners())
+		})
+	}
+}

--- a/releasenotes/notes/kubernetes-legacy-creator-annotation-dc1b909abb2a3682.yaml
+++ b/releasenotes/notes/kubernetes-legacy-creator-annotation-dc1b909abb2a3682.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Extract creator tags from kubernetes legacy `created-by` annotation if
+    the new `ownerReferences` field is not found


### PR DESCRIPTION
### What does this PR do?

On < 1.6 k8s clusters, the `ownerReferences` pod field is absent. In that case, unmarshall the legacy `kubernetes.io/created-by` annotation, in order to enable the tagger to extract creator tags

### Motivation

OpenShift 3.3 support

### Manual testing

Pod created from an OShift deploymentconfig:

```
      "tags": [
        "container_id:6e6fd6a6b516816386c38123265f5b09fa958614d9d1242a08a152d6d527e95f",
        "container_name:k8s_helloworld.f77a4e2_frontend-1-mas99_default_9252cdb8-3c6e-11e8-a6bc-525400daa710_6030b305",
        "docker_image:docker.io/redis:latest",
        "image_name:redis",
        "image_tag:latest",
        "kube_container_name:helloworld",
        "kube_namespace:default",
        "kube_replication_controller:frontend-1",
        "oshift_deployment:frontend-1",
        "oshift_deployment_config:frontend",
        "pod_name:frontend-1-mas99"
      ],
```

Pod created from a k8s deployment:

```
      "tags": [
        "container_id:34c35adb6824fc67a5da73eda561515ad42c30ed77a4b763c75c2d2109b5c44c",
        "container_name:k8s_redis.74c0a5e3_db2-3417816881-5pjd1_default_81c6d261-3c62-11e8-a6bc-525400daa710_3866b5f6",
        "docker_image:docker.io/redis:3.2",
        "image_name:redis",
        "image_tag:3.2",
        "kube_container_name:redis",
        "kube_deployment:db2",
        "kube_namespace:default",
        "kube_replica_set:db2-3417816881",
        "pod_name:db2-3417816881-5pjd1"
      ],
```