### PR TITLE
[gui] allow logs only config in the gui

### DIFF
--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -179,6 +179,7 @@ type configFormat struct {
 	ADIdentifiers []string    `yaml:"ad_identifiers"`
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
+	LogsConfig    interface{} `yaml:"logs"`
 	Instances     []check.ConfigRawMap
 }
 
@@ -205,8 +206,8 @@ func setCheckConfigFile(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("Error: " + e.Error()))
 			return
 		}
-		if len(cf.Instances) < 1 && cf.MetricConfig == nil {
-			w.Write([]byte("Configuration file contains no valid instances"))
+		if cf.MetricConfig == nil && cf.LogsConfig == nil && len(cf.Instances) < 1 {
+			w.Write([]byte("Configuration file contains no valid instances or log configuration"))
 			return
 		}
 

--- a/releasenotes/notes/allow-logs-only-config-gui-ffeb404355324839.yaml
+++ b/releasenotes/notes/allow-logs-only-config-gui-ffeb404355324839.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+      It is now possible to save logs only configuration in the GUI without getting an error message.


### PR DESCRIPTION
### What does this PR do?

Allow users that only want to use logs to save their config in the GUI.

### Motivation

Client request.

### Notes

Mirrors https://github.com/DataDog/datadog-agent/blob/84c36e57e21bbca34f5215db26f489a13948c580/pkg/collector/providers/file.go#L267-L269
