### PR TITLE
[Logs] let the scanner be less verbose

### DIFF
--- a/releasenotes/notes/logs-reduce-logs-noise-when-tailing-files-b22097fdcccbd449.yaml
+++ b/releasenotes/notes/logs-reduce-logs-noise-when-tailing-files-b22097fdcccbd449.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    Make file tailing a little less verbose. We avoid logging at every iteration
+    the different issues we encountered, instead we log them at first run only.
+    The status command shows the up-to-date information, and can
+    be used at anytime to troubleshoot such issues


### PR DESCRIPTION
### What does this PR do?

let the scanner be less verbose
It currently logs all errors at each iteration. This is more than
we'd like. Let's instead log errors at first iteration only,
knowing that the status pages shows up-to-date errors if needed
