### PR TITLE
[tagger] return copies of the cache to avoid modifications

### DIFF
--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -222,7 +222,7 @@ func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
 
 	if len(sources) == len(t.fetchers) {
 		// All sources sent data to cache
-		return cachedTags, nil
+		return copyArray(cachedTags), nil
 	}
 	// Else, partial cache miss, query missing data
 	// TODO: get logging on that to make sure we should optimize
@@ -259,5 +259,17 @@ ITER_COLLECTORS:
 	}
 	t.RUnlock()
 
-	return utils.ConcatenateTags(tagArrays), nil
+	computedTags := utils.ConcatenateTags(tagArrays)
+
+	return copyArray(computedTags), nil
+}
+
+// copyArray makes sure the tagger does not return internal slices
+// that could be modified by others, by explicitly copying the slice
+// contents to a new slice. As strings are references, the size of
+// the new array is small enough.
+func copyArray(source []string) []string {
+	copied := make([]string, len(source))
+	copy(copied, source)
+	return copied
 }

--- a/releasenotes/notes/docker-tagging-fix-0e1bcc51ae825c97.yaml
+++ b/releasenotes/notes/docker-tagging-fix-0e1bcc51ae825c97.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug where the `docker_network` tag incorrectly appeared on
+    non-network docker metrics and autodiscovery tags


### PR DESCRIPTION
For performance reasons (DSD origin detection), the tagger returns a `[]string` slice that is cached and reused. Coupled to golang's un-intuitive `append` behaviour, this led to the docker corecheck creeping tags up to the tagstore cache.

[Playground link](https://play.golang.org/p/dFRiZ0QR7m-) illustrating the issue and one possible fix.

### Symptoms

- one tag missing from AD metrics, replaced by a `docker_network` tag
- duplicate contexts in docker / kubernetes metrics, leading to `sum` aggregation errors

### What does this PR do?

Make the tagger return copies of the slices to avoid users changing the common cache.

### Backport

The `datadog/agent-dev:backport-1574` backport image ships this fix on top of 6.1.2, while we work on a bugfix release.