### PR TITLE
[config template] Document log_to_console and syslog_* options

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -264,10 +264,6 @@ api_key:
 #
 # syslog_tls: no
 #
-# If 'syslog_tls' is enabled, you can set your pem-encoded root ca certs here
-#
-# syslog_pem:
-#
 {{ end -}}
 {{- if .Autodiscovery }}
 # Autodiscovery

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -239,11 +239,14 @@ api_key:
 # log_level: info
 # log_file: /var/log/datadog/agent.log
 
-# Set to "yes" to output logs in JSON format
+# Set to 'yes' to output logs in JSON format
 # log_format_json: no
 
 # Set to 'no' to disable logging to stdout
 # log_to_console: yes
+
+# Set to 'yes' to disable logging to the log file
+# disable_file_logging: no
 
 # Set to 'yes' to enable logging to syslog.
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -63,9 +63,6 @@ api_key:
 # flush.
 # forwarder_num_workers: 1
 
-# Set this option to "yes" to output logs in JSON format
-# log_format_json: no
-
 # Collect AWS EC2 custom tags as agent tags
 # collect_ec2_tags: false
 {{ end }}
@@ -241,6 +238,33 @@ api_key:
 #
 # log_level: info
 # log_file: /var/log/datadog/agent.log
+
+# Set to "yes" to output logs in JSON format
+# log_format_json: no
+
+# Set to 'no' to disable logging to stdout
+# log_to_console: yes
+
+# Set to 'yes' to enable logging to syslog.
+#
+# log_to_syslog: no
+#
+# If 'syslog_uri' is left undefined/empty, a local domain socket connection will be attempted
+#
+# syslog_uri:
+#
+# Set to 'yes' to output in an RFC 5424-compliant format
+#
+# syslog_rfc: no
+#
+# If connecting through a TCP socket, set to 'yes' to enable TLS
+#
+# syslog_tls: no
+#
+# If 'syslog_tls' is enabled, you can set your pem-encoded root ca certs here
+#
+# syslog_pem:
+#
 {{ end -}}
 {{- if .Autodiscovery }}
 # Autodiscovery


### PR DESCRIPTION
### What does this PR do?

Documents `log_to_console` and `syslog_*` options in the example yaml file.

### Motivation

These were previously not documented (for no good reason I think).

### Additional notes

While documenting this, I realized that `syslog_pem` was expecting a raw string of PEM encoded certificates. Would it make more sense to allow specifying a path instead? cc @truthbk 

update: I've left this option undocumented for now, we'll open a separate PR to change its behavior
