### PR TITLE
Adding a host alias fetch from the kubelet

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -217,7 +217,7 @@ func getHostAliases() []string {
 
 	k8sAlias, err := k8s.GetHostAlias()
 	if err != nil {
-		log.Debugf("no Kubernetes Host Alias: %s (through kubelet API)", err)
+		log.Debugf("no Kubernetes Host Alias (through kubelet API): %s", err)
 	} else if k8sAlias != "" {
 		aliases = append(aliases, k8sAlias)
 	}

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -24,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
-	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hosttags"
+	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
 )
 
 const packageCachePrefix = "host"
@@ -190,7 +190,7 @@ func getHostInfo() *host.InfoStat {
 }
 
 // getHostAliases returns the hostname aliases from different provider
-// This should include GCE, Azure, Cloud foundry.
+// This should include GCE, Azure, Cloud foundry, kubernetes
 func getHostAliases() []string {
 	aliases := []string{}
 
@@ -213,6 +213,13 @@ func getHostAliases() []string {
 		log.Debugf("no Cloud Foundry Host Alias: %s", err)
 	} else if cfAlias != "" {
 		aliases = append(aliases, cfAlias)
+	}
+
+	k8sAlias, err := k8s.GetHostAlias()
+	if err != nil {
+		log.Debugf("no Kubernetes Host Alias: %s (through kubelet API)", err)
+	} else if k8sAlias != "" {
+		aliases = append(aliases, k8sAlias)
 	}
 	return aliases
 }

--- a/pkg/util/kubernetes/hostinfo/host_alias.go
+++ b/pkg/util/kubernetes/hostinfo/host_alias.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build kubelet,kubeapiserver
+// +build kubelet
 
 package hostinfo
 
@@ -11,16 +11,14 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
 // GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
 func GetHostAlias() (string, error) {
-	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
-		name, err := getKubeletHostname("")
-		if err == nil && util.ValidHostname(name) == nil {
-			return name, nil
-		}
+	name, err := kubelet.HostnameProvider("")
+	if err == nil && util.ValidHostname(name) == nil {
+		return name, nil
 	}
 	return "", fmt.Errorf("Couldn't extract a host alias from the kubelet")
 }

--- a/pkg/util/kubernetes/hostinfo/host_alias.go
+++ b/pkg/util/kubernetes/hostinfo/host_alias.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet,kubeapiserver
+
+package hostinfo
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+)
+
+// GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
+func GetHostAlias() (string, error) {
+	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
+		name, err := getKubeletHostname("")
+		if err == nil && util.ValidHostname(name) == nil {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("Couldn't extract a host alias from the kubelet")
+}

--- a/pkg/util/kubernetes/hostinfo/no_host_alias.go
+++ b/pkg/util/kubernetes/hostinfo/no_host_alias.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !kubelet
+
+package hostinfo
+
+import (
+	"fmt"
+)
+
+// GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
+func GetHostAlias() (string, error) {
+	return "", fmt.Errorf("Kubernetes support not build: couldn't extract a host alias from the kubelet")
+}

--- a/pkg/util/kubernetes/hostinfo/no_tags.go
+++ b/pkg/util/kubernetes/hostinfo/no_tags.go
@@ -5,7 +5,7 @@
 
 // +build !kubelet !kubeapiserver
 
-package hosttags
+package hostinfo
 
 // GetTags gets the tags from the kubernetes apiserver
 func GetTags() ([]string, error) {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -5,7 +5,7 @@
 
 // +build kubelet,kubeapiserver
 
-package hosttags
+package hostinfo
 
 import (
 	"fmt"

--- a/pkg/util/kubernetes/hostinfo/tags_test.go
+++ b/pkg/util/kubernetes/hostinfo/tags_test.go
@@ -5,7 +5,7 @@
 
 // +build kubelet,kubeapiserver
 
-package hosttags
+package hostinfo
 
 import (
 	"testing"

--- a/releasenotes/notes/duplicated-hosts-add-kubernetes-hostname-as-alias-612825b5943aba4d.yaml
+++ b/releasenotes/notes/duplicated-hosts-add-kubernetes-hostname-as-alias-612825b5943aba4d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The agent now fetches a hostname alias from kubernetes when possible. It fixes some duplicated
+    host issues that could happen when metrics were using kubernetes host names, as the
+    kubernetes_state integration


### PR DESCRIPTION
### What does this PR do?

Making the host alias logic fetching the hostname used by kubernetes.

### Motivation

So that the metrics from kubernetes_state no longer create duplicated hosts as the host alias from kubernetes is different from the ones that are already fetched.