### PR TITLE
[osx install script] fix stop/start race

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -103,6 +103,16 @@ if egrep 'api_key:( APIKEY)?$' "/opt/datadog-agent/etc/datadog.yaml" > /dev/null
     fi
     printf "\n\033[34m* Restarting the Agent...\n\033[0m\n"
     $cmd_launchctl stop com.datadoghq.agent
+
+    # Wait for the agent to fully stop
+    retry=0
+    until [ $retry -ge 5 ]
+    do
+        curl -m 5 -o /dev/null -s -I http://127.0.0.1:5002 || break
+        retry=$[$retry+1]
+        sleep 5
+    done
+
     $cmd_launchctl start com.datadoghq.agent
 else
     printf "\033[34m\n* A datadog.yaml configuration file already exists. It will not be overwritten.\n\033[0m\n"

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -106,12 +106,16 @@ if egrep 'api_key:( APIKEY)?$' "/opt/datadog-agent/etc/datadog.yaml" > /dev/null
 
     # Wait for the agent to fully stop
     retry=0
-    until [ $retry -ge 5 ]
-    do
+    until [ $retry -ge 5 ]; do
         curl -m 5 -o /dev/null -s -I http://127.0.0.1:5002 || break
         retry=$[$retry+1]
         sleep 5
     done
+    if [ $retry -ge 5 ]; then
+        printf "\n\033[33mCould not restart the agent.
+You may have to restart it manualy using the systray app or the \
+\"launchctl start com.datadoghq.agent\" command.\n\033[0m\n"
+    fi
 
     $cmd_launchctl start com.datadoghq.agent
 else

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -113,7 +113,7 @@ if egrep 'api_key:( APIKEY)?$' "/opt/datadog-agent/etc/datadog.yaml" > /dev/null
     done
     if [ $retry -ge 5 ]; then
         printf "\n\033[33mCould not restart the agent.
-You may have to restart it manualy using the systray app or the \
+You may have to restart it manually using the systray app or the
 \"launchctl start com.datadoghq.agent\" command.\n\033[0m\n"
     fi
 


### PR DESCRIPTION
### What does this PR do?

Fix a bug where the agent would fail to restart at the end of the installation of the osx script.

https://github.com/DataDog/datadog-agent/blob/e6163b0afc09a0dee6425aa79b8fd6220f6c898c/cmd/agent/install_mac_os.sh#L105-L106

`launchctl stop` is non-blocking and running `launchctl start` immediately after will do nothing.

This lead to a race between the shutdown of the agent and the auto-restart of the agent systray app : https://github.com/DataDog/datadog-agent/blob/e6163b0afc09a0dee6425aa79b8fd6220f6c898c/cmd/agent/gui/systray/Sources/gui.swift#L103

This PR adds some logic to wait until the agent is fully stop before attempting to start it again.