### PR TITLE
Node agent - DCA communication | Service Mapper

### DIFF
--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -135,13 +135,14 @@ You can pass the token as an environment variable: `DD_CLUSTER_AGENT_AUTH_TOKEN`
 
 #### Event collection
 
-You need:
+In order to collect events, you need the following environment varibales:
 ```
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: "true"
           - name: DD_LEADER_ELECTION
             value: "true"
 ```
+Enabling the leader election will ensure that only one agent collects the events.
 
 #### Cluster metadata provider
 

--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -1,36 +1,27 @@
 # Cluster Agent 6 docker image
 
-This is how the official Datadog Cluster Agent 6 (aka DCA) image available [here](https://hub.docker.com/r/datadog/cluster-agent/) is built.
+This is how the official Datadog Cluster Agent (also known as `DCA`) image, available [here](https://hub.docker.com/r/datadog/cluster-agent/), is built.
 
 ## How to run it
 
 The following environment variables are supported:
 
 - `DD_API_KEY`: your API key (**required**)
-- `DD_HOSTNAME`: hostname to use for metrics
-- 'DD_CMD_PORT': Port you want the DCA to serve
-
-Example usage: `docker run -e DD_API_KEY=your-api-key-here -e CMD_PORT=1234 -it <image-name>`
+- `DD_HOSTNAME`: hostname to use for the DCA.
+- `DD_CMD_PORT`: Port you want the DCA to serve
 
 For a more detailed usage please refer to the official [Docker Hub](https://hub.docker.com/r/datadog/cluster-agent/)
 
 ## How to build it
 
-### On debian-based systems
+### Dockerized Agent
 
-You can build your own debian package using `inv cluster-agent.omnibus-build`
+The Datadog Cluster Agent is designed to be used in a containerized ecosystem.
+Therefore, you will need to have docker installed on your system.
 
-Then you can call `inv cluster-agent.image-build` that will take the debian package generated above and use it to build the image
+Start by creating the binary by running `inv -e cluster-agent.build`. This will add a binary in `./bin/datadog-cluster-agent/`
+Then from the current folder, run `inv -e cluster-agent.image-build`.
 
-### On other systems
-
-To build the image you'll need the cluster-agent debian package that will soon be on our apt/yum repos. In the meantime, you can use the omnibus-build command listed above.
-
-You'll need to download one of the `datadog-cluster-agent*_amd64.deb` package in this directory, it will then be used by the `Dockerfile` and installed within the image.
-
-You can then build the image using `docker build -t datadog/cluster-agent:master .`
-
-If you are on macOS, use the --skip-sign option on the omnibus-build.
 
 ## Running the DCA with Kubernetes
 
@@ -49,7 +40,7 @@ spec:
       name: dca
       namespace: default
     spec:
-      serviceAccountName: dca
+      serviceAccountName: datadog-dca
       containers:
       - image: datadog/cluster-agent
         imagePullPolicy: Always
@@ -57,14 +48,8 @@ spec:
         env:
           - name: DD_API_KEY
             value: XXXX
-        volumeMounts:
-        - name: dca_auth_token
-          mountPath: /auth_token
-          readOnly: true
-      volumes:
-      - name: dca_auth_token
-        secret:
-          secretName: dca_auth_token
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            value: <32 characters long string shared with node agent>
 ```
 And use the RBAC below to get the best out of it.
 
@@ -144,33 +129,28 @@ You can also set the `event.tokenTimestamp`, if not present, it will be automati
 
 For the DCA to communicate with the Node Agent, you need to share an authentication token between the two agents.
 The Token needs to be longer than 32 characters and should only have upper case or lower case letters and numbers.
-You can pass the token as an environment variable: `DD_CLUSTER_AGENT_AUTH_TOKEN` or you can also mount it in:
-`/auth_token` in the DCA and `/etc/datadog-agent/dca_auth_token` in the Node Agent.
+You can pass the token as an environment variable: `DD_CLUSTER_AGENT_AUTH_TOKEN`.
 
-Finally, you can use the Kubernetes secrets, first encode the token:
-`echo -n <32 character token> | base64` and set this output in the following manifest:
+### Enabling Features
 
+#### Event collection
+
+You need:
 ```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dca-auth
-type: Opaque
-data:
-  dca_auth_token: <base64 encoded token>
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_LEADER_ELECTION
+            value: "true"
 ```
 
-Then run `kubectl create -f nameOfTheFile`
+#### Cluster metadata provider
 
-This should be mounted in the DCA manifest as follows:
-```
-        volumeMounts:
-        - name: dca_auth_token
-          mountPath: /auth_token
-          readOnly: true
-      volumes:
-      - name: dca_auth_token
-        secret:
-          secretName: dca_auth_token
-```
-And in the Node Agent at the mountPath `/etc/datadog-agent/dca_auth_token`
+You need to ensure the Node agents and the DCA can properly communicate.
+Create a service in front of the DCA (see /manifests/datadog-cluster-agent_service.yaml)
+Ensure an auth_token is properly shared between the agents.
+Confirm the RBAC rules are properly set (see /manifests/rbac/).
+
+In the Node Agent, make sure the `DD_CLUSTER_AGENT` env var is set to true.
+The env var `DD_KUBERNETES_SERVICE_TAG_UPDATE_FREQ` can be set to specify how often the node agents hit the DCA.
+You can disable the kubernetes service tag collection with `DD_KUBERNETES_COLLECT_SERVICE_TAGS`. 
+

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -25,10 +25,6 @@ spec:
         env:
           - name: DD_API_KEY
             value: <YOUR_API_KEY>
-          - name: DD_COLLECT_KUBERNETES_EVENTS
-            value: "true"
-          - name: DD_LEADER_ELECTION
-            value: "true"
           - name: KUBERNETES
             value: "yes"
           - name: DD_KUBERNETES_KUBELET_HOST

--- a/Dockerfiles/manifests/cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: datadog-cluster-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: datadog-cluster-agent
+      name: datadog-agent
+      namespace: default
+    spec:
+      serviceAccountName: datadog-agent
+      containers:
+      - image: datadog/cluster-agent:master # Image not available yet.
+        imagePullPolicy: Always
+        name: datadog-agent
+        env:
+          - name: DD_API_KEY
+            value: <YOUR_API_KEY>
+          - name: DD_COLLECT_KUBERNETES_EVENTS
+            value: "true"
+          - name: DD_LEADER_ELECTION
+            value: "true"

--- a/Dockerfiles/manifests/cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent.yaml
@@ -10,9 +10,9 @@ spec:
       name: datadog-agent
       namespace: default
     spec:
-      serviceAccountName: datadog-agent
+      serviceAccountName: datadog-dca
       containers:
-      - image: datadog/cluster-agent:master # Image not available yet.
+      - image: datadog/cluster-agent:latest
         imagePullPolicy: Always
         name: datadog-agent
         env:
@@ -22,3 +22,5 @@ spec:
             value: "true"
           - name: DD_LEADER_ELECTION
             value: "true"
+          - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+            value: <32 characters long token>

--- a/Dockerfiles/manifests/datadog-cluster-agent_service.yaml
+++ b/Dockerfiles/manifests/datadog-cluster-agent_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dca
+  labels:
+    app: datadog-cluster-agent
+spec:
+  ports:
+  - port: 5001 # Has to be the same as the one exposed in the DCA. Default is 5001.
+    protocol: TCP
+  selector:
+    app: datadog-cluster-agent

--- a/Dockerfiles/manifests/datadog_cluster_agent-secret.yaml
+++ b/Dockerfiles/manifests/datadog_cluster_agent-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dca-auth
+type: Opaque
+data:
+  dca_auth_token: <base64 encoded token>

--- a/Dockerfiles/manifests/datadog_cluster_agent-secret.yaml
+++ b/Dockerfiles/manifests/datadog_cluster_agent-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dca-auth
-type: Opaque
-data:
-  dca_auth_token: <base64 encoded token>

--- a/cmd/agent/common/common_darwin.go
+++ b/cmd/agent/common/common_darwin.go
@@ -14,6 +14,8 @@ const (
 	DefaultConfPath = "/opt/datadog-agent/etc"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "/var/log/datadog/agent.log"
+	// DefaultDCALogFile points to the log file that will be used if not configured
+	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
 )
 
 var (

--- a/cmd/agent/common/common_nix.go
+++ b/cmd/agent/common/common_nix.go
@@ -16,6 +16,8 @@ const (
 	DefaultConfPath = "/etc/datadog-agent"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "/var/log/datadog/agent.log"
+	// DefaultDCALogFile points to the log file that will be used if not configured
+	DefaultDCALogFile = "/var/log/datadog/cluster-agent.log"
 )
 
 var (

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -39,6 +39,8 @@ const (
 	DefaultConfPath = "c:\\programdata\\datadog"
 	// DefaultLogFile points to the log file that will be used if not configured
 	DefaultLogFile = "c:\\programdata\\datadog\\logs\\agent.log"
+	// DefaultDCALogFile points to the log file that will be used if not configured
+	DefaultDCALogFile = "c:\\programdata\\datadog\\logs\\cluster-agent.log"
 )
 
 // EnableLoggingToFile -- set up logging to file

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -47,7 +47,7 @@ func SetupHandlers(r *mux.Router) {
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 
@@ -70,7 +70,7 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 
 // TODO: make sure it works for DCA
 func stopAgent(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 	signals.Stopper <- true
@@ -80,7 +80,7 @@ func stopAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func getVersion(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -98,7 +98,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func getHostname(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -117,7 +117,7 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 
 // TODO: make a special flare for DCA
 func makeFlare(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 
@@ -209,7 +209,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 
 // getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.
 func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 	vars := mux.Vars(r)
@@ -251,7 +251,7 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: map[string]string
 			Example: "["Error":"could not collect the service map for all nodes: List services is not permitted at the cluster scope."]
 	*/
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 	log.Info("Computing service map on all nodes")

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -176,7 +176,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: string
 			Example: "no cached metadata found for the pod my-nginx-5d69 on the node localhost"
 	*/
-	if err := apiutil.Validate(w, r); err != nil {
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
 	vars := mux.Vars(r)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -104,7 +104,7 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	hname, err := util.GetHostname()
 	if err != nil {
-		log.Warnf("Error getting hostname: %s\n", err)
+		log.Warnf("Error getting hostname: %s", err)
 		hname = ""
 	}
 	j, err := json.Marshal(hname)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -104,7 +104,7 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	hname, err := util.GetHostname()
 	if err != nil {
-		log.Warnf("Error getting hostname: %s\n", err) // or something like this
+		log.Warnf("Error getting hostname: %s\n", err)
 		hname = ""
 	}
 	j, err := json.Marshal(hname)

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -124,7 +124,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Making a flare")
 	logFile := config.Datadog.GetString("log_file")
 	if logFile == "" {
-		logFile = common.DefaultLogFile
+		logFile = common.DefaultDCALogFile
 	}
 	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
 	if err != nil || filePath == "" {

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -75,10 +75,10 @@ func StartServer() error {
 		ErrorLog:  stdLog.New(&config.ErrorLogWriter{}, "", 0), // log errors to seelog
 		TLSConfig: &tlsConfig,
 	}
-	// TODO verify tls works. Change srv.Serve(listener) to srv.Serve(tlslistener)
-	//tlsListener := tls.NewListener(listener, &tlsConfig)
 
-	go srv.Serve(listener)
+	tlsListener := tls.NewListener(listener, &tlsConfig)
+
+	go srv.Serve(tlsListener)
 	return nil
 
 }

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -46,7 +46,7 @@ func StartServer() error {
 		// no way we can recover from this error
 		return fmt.Errorf("Unable to create the api server: %v", err)
 	}
-	util.SetAuthToken()
+	util.SetDCAAuthToken()
 
 	// create cert
 	hosts := []string{"127.0.0.1", "localhost"}

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -126,7 +126,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 	log.Infof("Hostname is: %s", hostname)
 
-	// start the cmd HTTP server
+	// start the cmd HTTPS server
 	if err = api.StartServer(); err != nil {
 		return log.Errorf("Error while starting api server, exiting: %v", err)
 	}
@@ -140,14 +140,8 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := &serializer.Serializer{Forwarder: f}
 
-	hname, err := util.GetHostname()
-	if err != nil {
-		log.Warnf("Error getting hostname: %s", err)
-		hname = ""
-	}
-	log.Debugf("Using hostname: %s", hname)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hname)
+	aggregatorInstance := aggregator.InitAggregator(s, hostname)
 	aggregatorInstance.AddAgentStartupEvent("DCA")
 
 	clusterAgent, err := clusteragent.Run(aggregatorInstance.GetChannels())

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -159,7 +159,7 @@ func start(cmd *cobra.Command, args []string) error {
 	// Start the Service Mapper.
 	asc, err := apiserver.GetAPIClient()
 	if err != nil {
-		log.Errorf("Could not instanciate the API Server Client: %s", err.Error())
+		log.Errorf("Could not instantiate the API Server Client: %s", err.Error())
 	} else {
 		asc.StartServiceMapping()
 	}

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -140,7 +140,6 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := &serializer.Serializer{Forwarder: f}
 
-
 	aggregatorInstance := aggregator.InitAggregator(s, hostname)
 	aggregatorInstance.AddAgentStartupEvent("DCA")
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -92,7 +92,7 @@ func start(cmd *cobra.Command, args []string) error {
 	syslogURI := config.GetSyslogURI()
 	logFile := config.Datadog.GetString("log_file")
 	if logFile == "" {
-		logFile = common.DefaultLogFile
+		logFile = common.DefaultDCALogFile
 	}
 	if config.Datadog.GetBool("disable_file_logging") {
 		// this will prevent any logging on file

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -154,6 +155,15 @@ func start(cmd *cobra.Command, args []string) error {
 		log.Errorf("Could not start the Cluster Agent Process.")
 
 	}
+
+	// Start the Service Mapper.
+	asc, err := apiserver.GetAPIClient()
+	if err != nil {
+		log.Errorf("Could not instanciate the API Server Client: %s", err.Error())
+	} else {
+		asc.StartServiceMapping()
+	}
+
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -21,7 +21,6 @@ import (
 
 func init() {
 	ClusterAgentCmd.AddCommand(svcMapperCmd)
-	svcMapperCmd.SetArgs([]string{"caseID"})
 }
 
 var svcMapperCmd = &cobra.Command{
@@ -67,7 +66,7 @@ func getServiceMap(nodeName string) error {
 	}
 
 	// Set session token
-	e = util.SetAuthToken()
+	e = util.SetDCAAuthToken()
 	if e != nil {
 		return e
 	}

--- a/cmd/cluster-agent/app/servicemapperdigest.go
+++ b/cmd/cluster-agent/app/servicemapperdigest.go
@@ -60,11 +60,10 @@ func getServiceMap(nodeName string) error {
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	var urlstr string
-	// TODO use https
 	if nodeName == "" {
-		urlstr = fmt.Sprintf("http://localhost:%v/api/v1/metadata", config.Datadog.GetInt("cmd_port"))
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata", config.Datadog.GetInt("cmd_port"))
 	} else {
-		urlstr = fmt.Sprintf("http://localhost:%v/api/v1/metadata/%s", config.Datadog.GetInt("cmd_port"), nodeName)
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/%s", config.Datadog.GetInt("cmd_port"), nodeName)
 	}
 
 	// Set session token

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -67,7 +67,7 @@ func requestStatus() error {
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	// TODO use https
-	urlstr := fmt.Sprintf("http://localhost:%v/status", config.Datadog.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/status", config.Datadog.GetInt("cmd_port"))
 
 	// Set session token
 	e = util.SetAuthToken()

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -62,7 +62,7 @@ var statusCmd = &cobra.Command{
 }
 
 func requestStatus() error {
-	fmt.Printf("Getting the status from the agent.\n\n")
+	fmt.Printf("Getting the status from the agent.\n")
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
@@ -84,7 +84,10 @@ func requestStatus() error {
 			e = fmt.Errorf(err)
 		}
 
-		fmt.Printf("Could not reach agent: %v \nMake sure the agent is running before requesting the status and contact support if you continue having issues. \n", e)
+		fmt.Printf(`
+		Could not reach agent: %v
+		Make sure the agent is running before requesting the status.
+		Contact support if you continue having issues.`, e)
 		return e
 	}
 

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -75,7 +75,7 @@ func requestStatus() error {
 		return e
 	}
 
-	r, e := util.DoGet(c, urlstr)
+	r, e := util.DoGetExternalEndpoint(c, urlstr)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, errMap)

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -70,7 +70,7 @@ func requestStatus() error {
 	urlstr := fmt.Sprintf("https://localhost:%v/status", config.Datadog.GetInt("cmd_port"))
 
 	// Set session token
-	e = util.SetAuthToken()
+	e = util.SetDCAAuthToken()
 	if e != nil {
 		return e
 	}

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -161,6 +161,7 @@ func DeleteAuthToken() error {
 func GetClusterAgentAuthToken() (string, error) {
 	authToken := config.Datadog.GetString("cluster_agent.auth_token")
 	if authToken != "" {
+		log.Debugf("Using cluster_agent.auth_token from datadog.yaml")
 		return authToken, validateAuthToken(authToken)
 	}
 

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	authTokenName       = "auth_token"
-	authTokenMinimalLen = 32
+	authTokenName                 = "auth_token"
+	authTokenMinimalLen           = 32
+	clusterAgentAuthTokenFilename = "dca_auth_token"
 )
 
 // GenerateKeyPair create a public/private keypair
@@ -150,4 +151,40 @@ func FetchAuthToken() (string, error) {
 func DeleteAuthToken() error {
 	authTokenFile := filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
 	return os.Remove(authTokenFile)
+}
+
+// GetClusterAgentAuthToken load the authentication token from:
+// 1st. the configuration value of "cluster_agent.auth_token" in datadog.yaml
+// 2nd. from the filesystem
+// If using the token from the filesystem, the token file must be next to the datadog.yaml
+// with the filename: dca_auth_token
+func GetClusterAgentAuthToken() (string, error) {
+	authToken := config.Datadog.GetString("cluster_agent.auth_token")
+	if authToken != "" {
+		return authToken, validateAuthToken(authToken)
+	}
+
+	// load the cluster agent auth token from filesystem
+	tokenAbsPath := filepath.Join(config.FileUsedDir(), clusterAgentAuthTokenFilename)
+	log.Debugf("Empty cluster_agent_auth_token, loading from %s", tokenAbsPath)
+	_, err := os.Stat(tokenAbsPath)
+	if err != nil {
+		return "", fmt.Errorf("empty cluster_agent_auth_token and cannot find %q: %s", tokenAbsPath, err)
+	}
+	b, err := ioutil.ReadFile(tokenAbsPath)
+	if err != nil {
+		return "", fmt.Errorf("empty cluster_agent_auth_token and cannot read %s: %s", tokenAbsPath, err)
+	}
+	log.Debugf("Cluster_agent_auth_token loaded from %s", tokenAbsPath)
+
+	authToken = string(b)
+	return authToken, validateAuthToken(authToken)
+}
+
+// TODO check the token is base64
+func validateAuthToken(authToken string) error {
+	if len(authToken) < authTokenMinimalLen {
+		return fmt.Errorf("cluster agent authentication token length must be greater than %d, curently: %d", authTokenMinimalLen, len(authToken))
+	}
+	return nil
 }

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -58,7 +58,7 @@ func DoGetExternalEndpoint(c *http.Client, url string) (body []byte, e error) {
 		return body, e
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+GetAuthToken()) // TODO update with function to check DCA token.
+	req.Header.Set("Authorization", "Bearer "+GetDCAAuthToken())
 
 	r, e := c.Do(req)
 	if e != nil {

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -62,7 +62,7 @@ func Validate(w http.ResponseWriter, r *http.Request) error {
 	var err error
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
-		w.Header().Set("WWW-Authenticate", "Bearer realm=\"Datadog Agent\"")
+		w.Header().Set("WWW-Authenticate", `Bearer realm="Datadog Agent"`)
 		err = fmt.Errorf("no session token provided")
 		http.Error(w, err.Error(), 401)
 		return err
@@ -70,7 +70,7 @@ func Validate(w http.ResponseWriter, r *http.Request) error {
 
 	tok := strings.Split(auth, " ")
 	if tok[0] != "Bearer" {
-		w.Header().Set("WWW-Authenticate", "Bearer realm=\"Datadog Agent\"")
+		w.Header().Set("WWW-Authenticate", `Bearer realm="Datadog Agent"`)
 		err = fmt.Errorf("unsupported authorization scheme: %s", tok[0])
 		http.Error(w, err.Error(), 401)
 		return err
@@ -90,7 +90,7 @@ func ValidateDCARequest(w http.ResponseWriter, r *http.Request) error {
 	var err error
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
-		w.Header().Set("WWW-Authenticate", "Bearer realm=\"Datadog Agent\"")
+		w.Header().Set("WWW-Authenticate", `Bearer realm="Datadog Agent"`)
 		err = fmt.Errorf("no session token provided")
 		http.Error(w, err.Error(), 401)
 		return err
@@ -98,7 +98,7 @@ func ValidateDCARequest(w http.ResponseWriter, r *http.Request) error {
 
 	tok := strings.Split(auth, " ")
 	if tok[0] != "Bearer" {
-		w.Header().Set("WWW-Authenticate", "Bearer realm=\"Datadog Agent\"")
+		w.Header().Set("WWW-Authenticate", `Bearer realm="Datadog Agent"`)
 		err = fmt.Errorf("unsupported authorization scheme: %s", tok[0])
 		http.Error(w, err.Error(), 401)
 		return err

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -108,7 +108,7 @@ func ValidateDCARequest(w http.ResponseWriter, r *http.Request) error {
 		dcaToken = GetDCAAuthToken()
 	}
 
-	if len(tok) < 2 || tok[1] != dcaToken {
+	if len(tok) != 2 || tok[1] != dcaToken {
 		err = fmt.Errorf("invalid session token")
 		http.Error(w, err.Error(), 403)
 	}

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -81,12 +81,12 @@ func ValidateDCARequest(w http.ResponseWriter, r *http.Request) error {
 		http.Error(w, err.Error(), 401)
 		return err
 	}
-	dca_token := config.Datadog.GetString("cluster_agent.auth_token")
-	if dca_token == "" {
-		dca_token = GetAuthToken()
+	dcaToken := config.Datadog.GetString("cluster_agent.auth_token")
+	if dcaToken == "" {
+		dcaToken = GetAuthToken()
 	}
 
-	if len(tok) < 2 || tok[1] != dca_token {
+	if len(tok) < 2 || tok[1] != dcaToken {
 		err = fmt.Errorf("invalid session token")
 		http.Error(w, err.Error(), 403)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -192,6 +192,7 @@ func init() {
 	Datadog.SetDefault("leader_election", false)
 
 	// Datadog cluster agent
+	Datadog.SetDefault("cluster_agent", false)
 	Datadog.SetDefault("cluster_agent.auth_token", "")
 	Datadog.SetDefault("cluster_agent.url", "")
 	Datadog.SetDefault("cluster_agent.kubernetes_service_name", "dca")
@@ -271,6 +272,7 @@ func init() {
 	Datadog.BindEnv("ac_include")
 	Datadog.BindEnv("ac_exclude")
 
+	Datadog.BindEnv("cluster_agent")
 	Datadog.BindEnv("cluster_agent.auth_token")
 	Datadog.BindEnv("cluster_agent_cmd_port")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -273,6 +273,7 @@ func init() {
 	Datadog.BindEnv("ac_exclude")
 
 	Datadog.BindEnv("cluster_agent")
+	Datadog.BindEnv("cluster_agent.url")
 	Datadog.BindEnv("cluster_agent.auth_token")
 	Datadog.BindEnv("cluster_agent_cmd_port")
 

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -49,7 +49,7 @@ func (c *KubeServiceCollector) Detect(out chan<- []*TagInfo) (CollectionMode, er
 	if config.Datadog.GetBool("cluster_agent") {
 		c.dcaClient, errDCA = clusteragent.GetClusterAgentClient()
 		if errDCA != nil {
-			log.Errorf("Could not initialise the communication with the DCA, falling back to local service mapping")
+			log.Errorf("Could not initialise the communication with the DCA, falling back to local service mapping: %s", errDCA.Error())
 		}
 	}
 	if !config.Datadog.GetBool("cluster_agent") || errDCA != nil {

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -82,7 +82,7 @@ func (c *KubeServiceCollector) Pull() error {
 		// If the DCA is not used, each agent stores a local cache of the ServiceMap.
 		err = c.addToCacheServiceMapping(pods)
 		if err != nil {
-			log.Debugf("cannot add the serviceMapping to cache: %s", err)
+			log.Debugf("Cannot add the serviceMapping to cache: %s", err)
 		}
 	}
 	c.infoOut <- c.getTagInfos(pods)
@@ -109,7 +109,7 @@ func (c *KubeServiceCollector) Fetch(entity string) ([]string, []string, error) 
 		// If the DCA is not used, each agent stores a local cache of the ServiceMap.
 		err = c.addToCacheServiceMapping(pods)
 		if err != nil {
-			log.Debugf("cannot add the serviceMapping to cache: %s", err)
+			log.Debugf("Cannot add the serviceMapping to cache: %s", err)
 		}
 	}
 

--- a/pkg/tagger/collectors/kubernetes_servicemapper.go
+++ b/pkg/tagger/collectors/kubernetes_servicemapper.go
@@ -8,8 +8,6 @@
 package collectors
 
 import (
-	"strings"
-
 	log "github.com/cihub/seelog"
 
 	"github.com/ericchiang/k8s/api/v1"

--- a/pkg/tagger/collectors/kubernetes_servicemapper.go
+++ b/pkg/tagger/collectors/kubernetes_servicemapper.go
@@ -21,10 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
-/*
-TODO remove this file when we have the DCA
-*/
-
 func (c *KubeServiceCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	var tagInfo []*TagInfo
 	var serviceNames []string
@@ -63,9 +59,8 @@ func (c *KubeServiceCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 			}
 
 		}
-		log.Debugf("nodeName: %s, podName: %s, services: %q", po.Spec.NodeName, po.Metadata.Name, strings.Join(serviceNames, ","))
 		for _, serviceName := range serviceNames {
-			log.Tracef("tagging %s kube_service:%s", po.Metadata.Name, serviceName)
+			log.Tracef("Tagging %s with kube_service:%s", po.Metadata.Name, serviceName)
 			tagList.AddLow("kube_service", serviceName)
 		}
 
@@ -86,11 +81,10 @@ func (c *KubeServiceCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 // addToCacheServiceMapping is acting like the DCA at the node level.
 func (c *KubeServiceCollector) addToCacheServiceMapping(kubeletPodList []*kubelet.Pod) error {
 	if len(kubeletPodList) == 0 {
-		log.Debugf("empty kubelet pod list")
+		log.Debugf("Empty kubelet pod list")
 		return nil
 	}
 
-	log.Debugf("refreshing the service mapping...")
 	podList := &v1.PodList{}
 	nodeName := ""
 	for _, p := range kubeletPodList {

--- a/pkg/tagger/collectors/kubernetes_servicemapper.go
+++ b/pkg/tagger/collectors/kubernetes_servicemapper.go
@@ -59,7 +59,8 @@ func (c *KubeServiceCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 		} else {
 			serviceNames, err = c.dcaClient.GetKubernetesServiceNames(po.Spec.NodeName, po.Metadata.Name)
 			if err != nil {
-				log.Debugf("Could not pull the service map from the Datadog Cluster Agent: %s", err.Error())
+				// TODO move this to trace
+				log.Debugf("Could not pull the service map of po %s on node %s from the Datadog Cluster Agent: %s", po.Spec.NodeName, po.Metadata.Name, err.Error())
 			}
 
 		}
@@ -83,8 +84,7 @@ func (c *KubeServiceCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	return tagInfo
 }
 
-// addToCacheServiceMapping TODO remove this when we have the DCA, we are currently acting like the
-// DCA but only on a node level
+// addToCacheServiceMapping is acting like the DCA at the node level.
 func (c *KubeServiceCollector) addToCacheServiceMapping(kubeletPodList []*kubelet.Pod) error {
 	if len(kubeletPodList) == 0 {
 		log.Debugf("empty kubelet pod list")

--- a/pkg/tagger/collectors/kubernetes_servicemapper.go
+++ b/pkg/tagger/collectors/kubernetes_servicemapper.go
@@ -59,8 +59,7 @@ func (c *KubeServiceCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 		} else {
 			serviceNames, err = c.dcaClient.GetKubernetesServiceNames(po.Spec.NodeName, po.Metadata.Name)
 			if err != nil {
-				// TODO move this to trace
-				log.Debugf("Could not pull the service map of po %s on node %s from the Datadog Cluster Agent: %s", po.Spec.NodeName, po.Metadata.Name, err.Error())
+				log.Tracef("Could not pull the service map of po %s on node %s from the Datadog Cluster Agent: %s", po.Spec.NodeName, po.Metadata.Name, err.Error())
 			}
 
 		}

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -134,6 +134,7 @@ func getClusterAgentEndpoint() (string, error) {
 	const configDcaSvcName = "cluster_agent.kubernetes_service_name"
 
 	dcaURL := config.Datadog.GetString(configDcaURL)
+	log.Debugf("dcaURL is %s", dcaURL)
 	if dcaURL != "" {
 		if strings.HasPrefix(dcaURL, "http://") {
 			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", dcaURL)
@@ -155,6 +156,7 @@ func getClusterAgentEndpoint() (string, error) {
 	// Construct the URL with the Kubernetes service environment variables
 	// *_SERVICE_HOST and *_SERVICE_PORT
 	dcaSvc := config.Datadog.GetString(configDcaSvcName)
+	log.Debugf("dcaSvc is %s", dcaSvc)
 	if dcaSvc == "" {
 		return "", fmt.Errorf("cannot get a cluster agent endpoint, both %q and %q are empty", configDcaURL, configDcaSvcName)
 	}
@@ -164,6 +166,7 @@ func getClusterAgentEndpoint() (string, error) {
 	// host
 	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)
 	dcaSvcHost := os.Getenv(dcaSvcHostEnv)
+	log.Debugf("dcaSvcHost is %s and dcaSvcHostEnv is %s", dcaSvcHost, dcaSvcHostEnv)
 	if dcaSvcHost == "" {
 		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %q, env %q is empty", dcaSvc, dcaSvcHostEnv)
 	}
@@ -191,6 +194,9 @@ func (c *DCAClient) GetKubernetesServiceNames(nodeName, podName string) ([]strin
 	var serviceNames serviceNames
 	var err error
 
+	if c.clusterAgentAPIRequestHeaders == nil || c.clusterAgentAPIClient == nil {
+		return nil, fmt.Errorf("cluster agent's client was not properly initialized")
+	}
 	req := &http.Request{
 		Header: *c.clusterAgentAPIRequestHeaders,
 	}

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -194,8 +194,8 @@ func (c *DCAClient) GetKubernetesServiceNames(nodeName, podName string) ([]strin
 	var serviceNames serviceNames
 	var err error
 
-	if c.clusterAgentAPIRequestHeaders == nil || c.clusterAgentAPIClient == nil {
-		return nil, fmt.Errorf("cluster agent's client was not properly initialized")
+	if c == nil {
+		return nil, fmt.Errorf("cluster agent's client is not properly initialized")
 	}
 	req := &http.Request{
 		Header: *c.clusterAgentAPIRequestHeaders,

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -75,7 +75,7 @@ func validateAuthToken(authToken string) error {
 }
 
 // GetClusterAgentAuthToken load the authentication token from:
-// 1srt. the configuration value of "cluster_agent_auth_token" in datadog.yaml
+// 1st. the configuration value of "cluster_agent_auth_token" in datadog.yaml
 // 2nd. from the filesystem
 // If using the token from the filesystem, the token file must be next to the datadog.yaml
 // with the filename: dca_auth_token
@@ -87,7 +87,7 @@ func GetClusterAgentAuthToken() (string, error) {
 
 	// load the cluster agent auth token from filesystem
 	tokenAbsPath := filepath.Join(config.FileUsedDir(), clusterAgentAuthTokenFilename)
-	log.Debugf("empty cluster_agent_auth_token, loading from %s", tokenAbsPath)
+	log.Debugf("Empty cluster_agent_auth_token, loading from %s", tokenAbsPath)
 	_, err := os.Stat(tokenAbsPath)
 	if err != nil {
 		return "", fmt.Errorf("empty cluster_agent_auth_token and cannot find %q: %s", tokenAbsPath, err)
@@ -96,7 +96,7 @@ func GetClusterAgentAuthToken() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("empty cluster_agent_auth_token and cannot read %s: %s", tokenAbsPath, err)
 	}
-	log.Debugf("cluster_agent_auth_token loaded from %s", tokenAbsPath)
+	log.Debugf("Cluster_agent_auth_token loaded from %s", tokenAbsPath)
 
 	authToken = string(b)
 	return authToken, validateAuthToken(authToken)
@@ -134,13 +134,12 @@ func getClusterAgentEndpoint() (string, error) {
 	const configDcaSvcName = "cluster_agent.kubernetes_service_name"
 
 	dcaURL := config.Datadog.GetString(configDcaURL)
-	log.Debugf("dcaURL is %s", dcaURL)
 	if dcaURL != "" {
 		if strings.HasPrefix(dcaURL, "http://") {
 			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", dcaURL)
 		}
 		if strings.Contains(dcaURL, "://") == false {
-			log.Tracef("adding https scheme to %s: https://%s", dcaURL, dcaURL)
+			log.Tracef("Adding https scheme to %s: https://%s", dcaURL, dcaURL)
 			dcaURL = fmt.Sprintf("https://%s", dcaURL)
 		}
 		u, err := url.Parse(dcaURL)
@@ -150,13 +149,14 @@ func getClusterAgentEndpoint() (string, error) {
 		if u.Scheme != "https" {
 			return "", fmt.Errorf("cannot get cluster agent endpoint, not a https scheme: %s", u.Scheme)
 		}
+		log.Debugf("Connecting to the configured URL for the Datadog Cluster Agent: %s", dcaURL)
 		return u.String(), nil
 	}
 
 	// Construct the URL with the Kubernetes service environment variables
 	// *_SERVICE_HOST and *_SERVICE_PORT
 	dcaSvc := config.Datadog.GetString(configDcaSvcName)
-	log.Debugf("dcaSvc is %s", dcaSvc)
+	log.Debugf("Identified service for the Datadog Cluster Agent: %s", dcaSvc)
 	if dcaSvc == "" {
 		return "", fmt.Errorf("cannot get a cluster agent endpoint, both %q and %q are empty", configDcaURL, configDcaSvcName)
 	}
@@ -166,7 +166,6 @@ func getClusterAgentEndpoint() (string, error) {
 	// host
 	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)
 	dcaSvcHost := os.Getenv(dcaSvcHostEnv)
-	log.Debugf("dcaSvcHost is %s and dcaSvcHostEnv is %s", dcaSvcHost, dcaSvcHostEnv)
 	if dcaSvcHost == "" {
 		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %q, env %q is empty", dcaSvc, dcaSvcHostEnv)
 	}

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -18,10 +18,10 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
-	"github.com/DataDog/datadog-agent/pkg/api/security"
 )
 
 /*
@@ -29,7 +29,7 @@ Client to query the Datadog Cluster Agent (DCA) API.
 */
 
 const (
-	authorizationHeaderKey        = "Authorization"
+	authorizationHeaderKey = "Authorization"
 )
 
 var globalClusterAgentClient *DCAClient
@@ -65,9 +65,6 @@ func GetClusterAgentClient() (*DCAClient, error) {
 	}
 	return globalClusterAgentClient, nil
 }
-
-
-
 
 func (c *DCAClient) init() error {
 	var err error

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/api/security"
 )
 
 type dummyClusterAgent struct {
@@ -130,7 +131,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointEmpty() {
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmpty() {
 	config.Datadog.Set("cluster_agent.auth_token", "")
 
-	_, err := GetClusterAgentAuthToken()
+	_, err := security.GetClusterAgentAuthToken()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
@@ -138,8 +139,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmptyFile() {
 	config.Datadog.Set("cluster_agent.auth_token", "")
 	err := ioutil.WriteFile(suite.authTokenPath, []byte(""), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
-
-	_, err = GetClusterAgentAuthToken()
+	_, err = security.GetClusterAgentAuthToken()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
@@ -148,7 +148,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenFileInvalid() {
 	err := ioutil.WriteFile(suite.authTokenPath, []byte("tooshort"), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
-	_, err = GetClusterAgentAuthToken()
+	_, err = security.GetClusterAgentAuthToken()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
@@ -158,7 +158,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthToken() {
 	err := ioutil.WriteFile(suite.authTokenPath, []byte(tokenFileValue), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
-	t, err := GetClusterAgentAuthToken()
+	t, err := security.GetClusterAgentAuthToken()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 	assert.Equal(suite.T(), tokenFileValue, t)
 }
@@ -170,7 +170,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenConfigPriority() {
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
 	// load config token value instead of filesystem
-	t, err := GetClusterAgentAuthToken()
+	t, err := security.GetClusterAgentAuthToken()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 	assert.Equal(suite.T(), clusterAgentTokenValue, t)
 }
@@ -181,7 +181,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenTooShort() {
 	err := ioutil.WriteFile(suite.authTokenPath, []byte(tokenValue), os.ModePerm)
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
-	_, err = GetClusterAgentAuthToken()
+	_, err = security.GetClusterAgentAuthToken()
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
@@ -305,6 +305,8 @@ func (suite *clusterAgentSuite) TestGetKubernetesServiceNames() {
 }
 
 func TestClusterAgentSuite(t *testing.T) {
+	clusterAgentAuthTokenFilename := "dca_auth_token"
+
 	fakeDir, err := ioutil.TempDir("", "fake-datadog-etc")
 	require.Nil(t, err, fmt.Sprintf("%v", err))
 	defer os.RemoveAll(fakeDir)

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 type dummyClusterAgent struct {

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -122,7 +122,6 @@ func (c *APIClient) connect() error {
 	if !useServiceMapper {
 		return nil
 	}
-	c.startServiceMapping()
 
 	return nil
 }
@@ -238,9 +237,9 @@ func processKubeResources(nodeList *v1.NodeList, podList *v1.PodList, endpointLi
 	}
 }
 
-// startServiceMapping is only called once, when we have confirmed we could correctly connect to the API server.
+// StartServiceMapping is only called once, when we have confirmed we could correctly connect to the API server.
 // The logic here is solely to retrieve Nodes, Pods and Endpoints. The processing part is in mapServices.
-func (c *APIClient) startServiceMapping() {
+func (c *APIClient) StartServiceMapping() {
 	tickerSvcProcess := time.NewTicker(servicesPollIntl)
 	go func() {
 		for {

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -141,7 +141,7 @@ func newServiceMapperBundle() *ServiceMapperBundle {
 
 // NodeServiceMapping only fetch the endpoints from Kubernetes apiserver and add the serviceMapper of the
 // node to the cache
-// TODO remove when the DCA is here
+// Only called when the node agent computes the service mapper locally and does not rely on the DCA.
 func (c *APIClient) NodeServiceMapping(nodeName string, podList *v1.PodList) error {
 	ctx, cancel := context.WithTimeout(context.Background(), servicesPollIntl)
 	defer cancel()
@@ -287,6 +287,14 @@ func (c *APIClient) checkResourcesAuth() error {
 	_, err = c.client.CoreV1().ListNodes(ctx)
 	if err != nil {
 		errorMessages = append(errorMessages, fmt.Sprintf("node collection: %q", err.Error()))
+	}
+	_, err = c.client.CoreV1().ListConfigMaps(ctx, "")
+	if err != nil {
+		errorMessages = append(errorMessages, fmt.Sprintf("configmap collection: %q", err.Error()))
+	}
+	_, err = c.client.CoreV1().ListEndpoints(ctx, "")
+	if err != nil {
+		errorMessages = append(errorMessages, fmt.Sprintf("endpoints collection: %q", err.Error()))
 	}
 	return aggregateCheckResourcesErrors(errorMessages)
 }

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -19,6 +19,9 @@ var (
 	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
 )
 
+// APIClient provides authenticated access to the
+type APIClient struct{}
+
 // GetPodServiceNames is used when the API endpoint of the DCA to get the services of a pod is hit.
 func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
 	log.Errorf("GetPodServiceNames not implemented %s", ErrNotCompiled.Error())
@@ -40,5 +43,5 @@ func GetServiceMapBundleOnAllNodes() (map[string]interface{}, error) {
 // StartServiceMapping is only called once, when we have confirmed we could correctly connect to the API server.
 func (c *APIClient) StartServiceMapping() {
 	log.Errorf("StartServiceMapping not implemented %s", ErrNotCompiled.Error())
-	return nil
+	return
 }

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -36,3 +36,9 @@ func GetServiceMapBundleOnAllNodes() (map[string]interface{}, error) {
 	log.Errorf("GetServiceMapBundleOnAllNodes not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }
+
+// StartServiceMapping is only called once, when we have confirmed we could correctly connect to the API server.
+func (c *APIClient) StartServiceMapping() {
+	log.Errorf("StartServiceMapping not implemented %s", ErrNotCompiled.Error())
+	return nil
+}

--- a/releasenotes/notes/dca-dna-communication-f1724e77525ed3d5.yaml
+++ b/releasenotes/notes/dca-dna-communication-f1724e77525ed3d5.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adding Datadog Cluster Agent client in Node Agent.
+    Adding support for TLS in the Datadog Cluster Agent API.


### PR DESCRIPTION
### What does this PR do?

- [x] Separate GetAPIClient and startServiceMapper.
- [x] Ensure the ServiceMapper is only started once and properly.
- [x] Isolate DCA and DNA behaviour when running the ServiceMapper.
- [x] Prepare the DNA to query the DCA with the DCAClient
- [x] Ensure correct failover for the DNA if the DCA is not used or not accessible so that the ServiceMapper is run.
- [x] Adding a service manifest
- [x] Align the auth_token strategies (dca_auth_token is located with the agent's auth_token)
- Check for a secret
- Make sure security approaches are all easily implementable (i.e. using generated certs)
- [x] Add integration tests (might happen in a different PR)
- [x] Documentation
- [ ] Load test

#### Testing the different configuration strategies
- [x] Use the auth_token generated in the DCA in the manifest of the node agent.
- [x] Validate the DD_CLUSTER_AGENT_URL.
- [x] Validate the usage of a service (no need for any env var).
- [ ] Use a secret to share the Auth_token (different PR)

### Motivation

Continue the DCA journey.
Adding the ServiceMapper computed by the DCA on it's API and making sure the DNA can properly access and retrieve the correct info.

### Additional Notes

💃 
