### PR TITLE
change the name of the base check folder on integrations-core

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -28,7 +28,7 @@ default_version integrations_core_version
 
 
 blacklist = [
-  'datadog-checks-base',  # namespacing package for wheels (NOT AN INTEGRATION)
+  'datadog_checks_base',  # namespacing package for wheels (NOT AN INTEGRATION)
   'agent_metrics',
   'docker_daemon',
   'kubernetes',
@@ -75,15 +75,15 @@ build do
     python_pip = "\"import pip, glob; pip.main(['install', '-c', '#{install_dir}/agent_requirements.txt'] + glob.glob('*.whl'))\""
 
     if windows?
-      pip "wheel --no-deps .", :cwd => "#{project_dir}/datadog-checks-base"
-      command("#{python_bin} -c #{python_pip}", cwd: "#{project_dir}/datadog-checks-base")
+      pip "wheel --no-deps .", :cwd => "#{project_dir}/datadog_checks_base"
+      command("#{python_bin} -c #{python_pip}", cwd: "#{project_dir}/datadog_checks_base")
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
-      pip "wheel --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog-checks-base"
-      pip "install -c #{install_dir}/agent_requirements.txt *.whl", :env => build_env, :cwd => "#{project_dir}/datadog-checks-base"
+      pip "wheel --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
+      pip "install -c #{install_dir}/agent_requirements.txt *.whl", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
     end
 
     Dir.glob("#{project_dir}/*").each do |check_dir|


### PR DESCRIPTION
### What does this PR do?

Makes Omnibus aware of the new path to the folder containing the base check on `integrations-core`.
Sister PR: https://github.com/DataDog/integrations-core/pull/1384
