### PR TITLE
[DCA] Improving svcmap to metadata mapper

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -80,8 +80,8 @@ Please note that the `docker.containers.running`, `.stopped`, `.running.total` a
 
 Please refer to the dedicated section about the [Kubernetes integration](#kubernetes) for more details.
 
-- `DD_KUBERNETES_COLLECT_SERVICE_TAGS`: configures the agent to collect Kubernetes service names as tags.
-- `DD_KUBERNETES_SERVICE_TAG_UPDATE_FREQ`: set the collection frequency in seconds for the Kubernetes service names.
+- `DD_KUBERNETES_COLLECT_METADATA_TAGS`: configures the agent to collect Kubernetes metadata (service names) as tags.
+- `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ`: set the collection frequency in seconds for the Kubernetes metadata (service names).
 - `DD_COLLECT_KUBERNETES_EVENTS`: configures the agent to collect Kubernetes events. See [Event collection](#event-collection) for more details.
 - `DD_LEADER_ELECTION`: activates the [leader election](#leader-election). Will be activated if the `DD_COLLECT_KUBERNETES_EVENTS` is set to true. The expected value is a bool: true/false.
 - `DD_LEADER_LEASE_DURATION`: only used if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds.

--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -152,6 +152,6 @@ Ensure an auth_token is properly shared between the agents.
 Confirm the RBAC rules are properly set (see /manifests/rbac/).
 
 In the Node Agent, make sure the `DD_CLUSTER_AGENT` env var is set to true.
-The env var `DD_KUBERNETES_SERVICE_TAG_UPDATE_FREQ` can be set to specify how often the node agents hit the DCA.
-You can disable the kubernetes service tag collection with `DD_KUBERNETES_COLLECT_SERVICE_TAGS`. 
+The env var `DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ` can be set to specify how often the node agents hit the DCA.
+You can disable the kubernetes metadata tag collection with `DD_KUBERNETES_COLLECT_METADATA_TAGS`.
 

--- a/Dockerfiles/cluster-agent/datadog-cluster.yaml
+++ b/Dockerfiles/cluster-agent/datadog-cluster.yaml
@@ -32,10 +32,10 @@ api_key:
 #
 # In order to collect Kubernetes service names, the agent needs certain rights (see RBAC documentation in
 # [docker readme](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#kubernetes)).
-# You can disable this option or set how often (in seconds) the agent refreshes the internal mapping of services to
+# You can disable this option or set how often (in seconds) the agent refreshes the internal mapping of metadata (including service names) to
 # ContainerIDs with the following options:
-# kubernetes_collect_service_tags: true
-# kubernetes_service_tag_update_freq: 300
+# kubernetes_collect_metadata_tags: true
+# kubernetes_metadata_tag_update_freq: 300
 #
 #
 # To collect Kubernetes events, leader election must be enabled and collect_kubernetes_events set to true.

--- a/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
@@ -2,7 +2,7 @@
 ==============
 Service Mapper
 ==============
-{{- if .Errors }}
+{{- if .Errors -}}
 Could not run the service mapper: {{.Errors}}
 {{else}}
 {{ if .Warnings -}}
@@ -11,14 +11,15 @@ Warnings:
    - {{.}}
 {{ end -}}
 {{- end -}}
-{{if .Nodes}}
-{{- range $index, $element := .Nodes }}
-
+{{- if .Nodes}}
+{{- range $index, $meta_type := .Nodes }}
 Node detected: {{ $index -}}
-   {{ range $pod, $svc := $element }}
+{{- range $m := $meta_type }}
+   {{ range $pod, $svc := $m }}
  -  Pod name: {{ $pod }}
     Services list: {{ $svc -}}
    {{ end -}}
+{{- end -}}
 {{- end }}
 {{- end -}}
-{{- end -}}
+{{- end }}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -182,7 +182,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
-	var slcB []byte
+	var metaBytes []byte
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
 	metaList, errMetaList := as.GetPodMetadataNames(nodeName, podName)
@@ -192,15 +192,15 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slcB, err := json.Marshal(metaList)
+	metaBytes, err := json.Marshal(metaList)
 	if err != nil {
 		log.Errorf("Could not process the list of services for: %s", podName)
 		http.Error(w, err.Error(), 500)
 		return
 	}
-	if len(slcB) != 0 {
+	if len(metaBytes) != 0 {
 		w.WriteHeader(200)
-		w.Write(slcB)
+		w.Write(metaBytes)
 		return
 	}
 	w.WriteHeader(404)
@@ -216,11 +216,11 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	nodeName := vars["nodeName"]
 	log.Infof("Fetching metadata map on all pods of the node %s", nodeName)
-	svcList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
+	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
 		log.Errorf("Could not collect the service map for %s", nodeName)
 	}
-	slcB, err := json.Marshal(svcList)
+	slcB, err := json.Marshal(metaList)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -159,6 +159,8 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getPodMetadata is only used when the node agent hits the DCA for the tags list.
+// It returns a list of all the tags that can be directly used in the tagger of the agent.
 func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	/*
 		Input
@@ -166,7 +168,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 		Outputs
 			Status: 200
 			Returns: []string
-			Example: ["my-nginx-service"]
+			Example: ["kube_service:my-nginx-service"]
 
 			Status: 404
 			Returns: string
@@ -183,17 +185,16 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	var slcB []byte
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
-
-	svcList, errSvcList := as.GetPodServiceNames(nodeName, podName)
-	if errSvcList != nil {
-		log.Errorf("Could not retrieve the list of services of: %s from the cache", podName)
-		http.Error(w, errSvcList.Error(), 500)
+	metaList, errMetaList := as.GetPodMetadataNames(nodeName, podName)
+	if errMetaList != nil {
+		log.Errorf("Could not retrieve the metadata of: %s from the cache", podName)
+		http.Error(w, errMetaList.Error(), 500)
 		return
 	}
 
-	slcB, err := json.Marshal(svcList)
+	slcB, err := json.Marshal(metaList)
 	if err != nil {
-		log.Errorf("Could not process the list of services of: %s", podName)
+		log.Errorf("Could not process the list of services for: %s", podName)
 		http.Error(w, err.Error(), 500)
 		return
 	}
@@ -203,7 +204,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(404)
-	w.Write([]byte(fmt.Sprintf("Could not find associated services mapped to the pod: %s on node: %s", podName, nodeName)))
+	w.Write([]byte(fmt.Sprintf("Could not find associated metadata mapped to the pod: %s on node: %s", podName, nodeName)))
 
 }
 
@@ -214,8 +215,8 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	nodeName := vars["nodeName"]
-	log.Infof("Fetching service map on all pods of the node %s", nodeName)
-	svcList, errNodes := as.GetServiceMapBundleOnNode(nodeName)
+	log.Infof("Fetching metadata map on all pods of the node %s", nodeName)
+	svcList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
 		log.Errorf("Could not collect the service map for %s", nodeName)
 	}
@@ -234,6 +235,7 @@ func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+// getAllMetadata is used by the svcmap command.
 func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	/*
 		Input
@@ -241,7 +243,7 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 		Outputs
 			Status: 200
 			Returns: map[string][]string
-			Example: ["Node1":["pod1":["svc1"],"pod2":["svc2"]],"Node2":["pod3":["svc1"]], "Error":"the key KubernetesServiceMapping/Node3 not found in the cache"]
+			Example: ["Node1":["pod1":["svc1"],"pod2":["svc2"]],"Node2":["pod3":["svc1"]], "Error":"the key KubernetesMetadataMapping/Node3 not found in the cache"]
 
 			Status: 404
 			Returns: string
@@ -254,8 +256,8 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return
 	}
-	log.Info("Computing service map on all nodes")
-	svcList, errAPIServer := as.GetServiceMapBundleOnAllNodes()
+	log.Info("Computing metadata map on all nodes")
+	metaList, errAPIServer := as.GetMetadataMapBundleOnAllNodes()
 	// If we hit an error at this point, it is because we don't have access to the API server.
 	if errAPIServer != nil {
 		w.WriteHeader(503)
@@ -263,13 +265,13 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.WriteHeader(200)
 	}
-	svcListBytes, err := json.Marshal(svcList)
+	metaListBytes, err := json.Marshal(metaList)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
 	}
-	if len(svcListBytes) != 0 {
-		w.Write(svcListBytes)
+	if len(metaListBytes) != 0 {
+		w.Write(metaListBytes)
 		return
 	}
 	w.WriteHeader(404)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -154,7 +154,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Errorf("Could not instantiate the API Server Client: %s", err.Error())
 	} else {
-		asc.StartServiceMapping()
+		asc.StartMetadataMapping()
 	}
 
 	// Setup a channel to catch OS signals

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -20,16 +20,16 @@ import (
 )
 
 func init() {
-	ClusterAgentCmd.AddCommand(svcMapperCmd)
+	ClusterAgentCmd.AddCommand(metaMapperCmd)
 }
 
-var svcMapperCmd = &cobra.Command{
-	Use:   "svcmap [nodeName]",
-	Short: "Print the map between the services and the pods behind them",
-	Long: `The svcmap command is mostly designed for troubleshooting purposes.
+var metaMapperCmd = &cobra.Command{
+	Use:   "metamap [nodeName]",
+	Short: "Print the map between the metadata and the pods associated",
+	Long: `The metamap command is mostly designed for troubleshooting purposes.
 One can easily identify which pods are running on which nodes,
-as well as which services are service the pods.`,
-	Example: "datadog-cluster-agent svcmap ip-10-0-115-123",
+as well as which services are serving the pods. Or the deployment name for the pod`,
+	Example: "datadog-cluster-agent metamap ip-10-0-115-123",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configFound := false
 		// a path to the folder containing the config file was passed
@@ -50,11 +50,11 @@ as well as which services are service the pods.`,
 		if len(args) > 0 {
 			nodeName = args[0]
 		}
-		return getServiceMap(nodeName) // if nodeName == "", call all.
+		return getMetadataMap(nodeName) // if nodeName == "", call all.
 	},
 }
 
-func getServiceMap(nodeName string) error {
+func getMetadataMap(nodeName string) error {
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
@@ -88,11 +88,11 @@ func getServiceMap(nodeName string) error {
 	} else if jsonStatus {
 		s = string(r)
 	} else {
-		formattedServiceMap, err := status.FormatServiceMapCLI(r)
+		formattedMetadataMap, err := status.FormatMetadataMapCLI(r)
 		if err != nil {
 			return err
 		}
-		s = formattedServiceMap
+		s = formattedMetadataMap
 	}
 
 	if statusFilePath != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,7 +77,7 @@ func init() {
 	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
 	Datadog.SetDefault("confd_dca_path", defaultDCAConfdPath)
-	Datadog.SetDefault("use_service_mapper", true)
+	Datadog.SetDefault("use_metadata_mapper", true)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
 	Datadog.SetDefault("log_payloads", false)
 	Datadog.SetDefault("log_level", "info")
@@ -183,8 +183,8 @@ func init() {
 	Datadog.SetDefault("kubelet_client_crt", "")
 	Datadog.SetDefault("kubelet_client_key", "")
 
-	Datadog.SetDefault("kubernetes_collect_service_tags", true)
-	Datadog.SetDefault("kubernetes_service_tag_update_freq", 60*5) // 5 min
+	Datadog.SetDefault("kubernetes_collect_metadata_tags", true)
+	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60*5) // 5 min
 
 	// Kube ApiServer
 	Datadog.SetDefault("kubernetes_kubeconfig_path", "")
@@ -262,8 +262,8 @@ func init() {
 	Datadog.BindEnv("kubelet_client_crt")
 	Datadog.BindEnv("kubelet_client_key")
 	Datadog.BindEnv("collect_kubernetes_events")
-	Datadog.BindEnv("kubernetes_collect_service_tags")
-	Datadog.BindEnv("kubernetes_service_tag_update_freq")
+	Datadog.BindEnv("kubernetes_collect_metadata_tags")
+	Datadog.BindEnv("kubernetes_metadata_tag_update_freq")
 	Datadog.BindEnv("docker_labels_as_tags")
 	Datadog.BindEnv("docker_env_as_tags")
 	Datadog.BindEnv("kubernetes_pod_labels_as_tags")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -418,8 +418,8 @@ api_key:
 # [docker readme](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#kubernetes)).
 # You can disable this option or set how often (in seconds) the agent refreshes the internal mapping of services to
 # ContainerIDs with the following options:
-# kubernetes_collect_service_tags: true
-# kubernetes_service_tag_update_freq: 300
+# kubernetes_collect_metadata_tags: true
+# kubernetes_metadata_tag_update_freq: 300
 #
 #
 # To collect Kubernetes events, leader election must be enabled and collect_kubernetes_events set to true.

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -69,8 +69,8 @@ func FormatDCAStatus(data []byte) (string, error) {
 	return b.String(), nil
 }
 
-// FormatServiceMapCLI builds the rendering in the servicemapper template.
-func FormatServiceMapCLI(data []byte) (string, error) {
+// FormatMetadataMapCLI builds the rendering in the metadataMapper template.
+func FormatMetadataMapCLI(data []byte) (string, error) {
 	var b = new(bytes.Buffer)
 
 	stats := make(map[string]interface{})
@@ -78,7 +78,7 @@ func FormatServiceMapCLI(data []byte) (string, error) {
 	if err != nil {
 		return b.String(), err
 	}
-	renderServiceMapper(b, stats)
+	renderMetadataMapper(b, stats)
 
 	return b.String(), nil
 }
@@ -151,9 +151,9 @@ func renderLogsStatus(w io.Writer, logsStats interface{}) {
 	}
 }
 
-func renderServiceMapper(w io.Writer, serviceMapperStats interface{}) {
-	t := template.Must(template.New("servicemapper.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "servicemapper.tmpl")))
-	err := t.Execute(w, serviceMapperStats)
+func renderMetadataMapper(w io.Writer, metadataMapperStats interface{}) {
+	t := template.Must(template.New("metadatamapper.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "metadatamapper.tmpl")))
+	err := t.Execute(w, metadataMapperStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -136,5 +136,5 @@ func dockerFactory() Collector {
 }
 
 func init() {
-	registerCollector(dockerCollectorName, dockerFactory, LowPriority)
+	registerCollector(dockerCollectorName, dockerFactory, NodeRuntime)
 }

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -122,5 +122,5 @@ func ecsFargateFactory() Collector {
 }
 
 func init() {
-	registerCollector(ecsFargateCollectorName, ecsFargateFactory, HighPriority)
+	registerCollector(ecsFargateCollectorName, ecsFargateFactory, NodeOrchestrator)
 }

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -83,5 +83,5 @@ func ecsFactory() Collector {
 }
 
 func init() {
-	registerCollector(ecsCollectorName, ecsFactory, LowPriority)
+	registerCollector(ecsCollectorName, ecsFactory, NodeRuntime)
 }

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -138,5 +138,5 @@ func kubeletFactory() Collector {
 }
 
 func init() {
-	registerCollector(kubeletCollectorName, kubeletFactory, HighPriority)
+	registerCollector(kubeletCollectorName, kubeletFactory, NodeOrchestrator)
 }

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -128,5 +128,5 @@ func kubernetesFactory() Collector {
 }
 
 func init() {
-	registerCollector(kubeMetadataCollectorName, kubernetesFactory, HighPriority)
+	registerCollector(kubeMetadataCollectorName, kubernetesFactory, ClusterOrchestrator)
 }

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -8,8 +8,9 @@
 package collectors
 
 import (
-	log "github.com/cihub/seelog"
+	"strings"
 
+	log "github.com/cihub/seelog"
 	"github.com/ericchiang/k8s/api/v1"
 	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
-	"strings"
 )
 
 func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -37,7 +37,7 @@ type CollectorPriority int
 
 // List of collector priorities
 const (
-	NodeRuntime      CollectorPriority = iota
+	NodeRuntime CollectorPriority = iota
 	NodeOrchestrator
 	ClusterOrchestrator
 )

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -37,8 +37,9 @@ type CollectorPriority int
 
 // List of collector priorities
 const (
-	LowPriority CollectorPriority = iota
-	HighPriority
+	NodeRuntime      CollectorPriority = iota
+	NodeOrchestrator
+	ClusterOrchestrator
 )
 
 // Fetcher allows to fetch tags on-demand in case of cache miss

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -192,7 +192,7 @@ func insertWithPriority(tagPrioMapper map[string][]tagPriority, tags []string, s
 	priority, found := collectors.CollectorPriorities[source]
 	if !found {
 		log.Warnf("Tagger: %s collector has no defined priority, assuming low", source)
-		priority = collectors.LowPriority
+		priority = collectors.NodeRuntime
 	}
 
 	for _, t := range tags {

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -204,8 +204,8 @@ func TestDuplicateSourceTags(t *testing.T) {
 
 	// Mock collector priorities
 	collectors.CollectorPriorities = map[string]collectors.CollectorPriority{
-		"sourceHigh": collectors.HighPriority,
-		"sourceLow":  collectors.LowPriority,
+		"sourceHigh": collectors.NodeOrchestrator,
+		"sourceLow":  collectors.NodeRuntime,
 	}
 
 	// Add tags but don't invalidate the cache, we should return empty arrays

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -204,15 +204,18 @@ func TestDuplicateSourceTags(t *testing.T) {
 
 	// Mock collector priorities
 	collectors.CollectorPriorities = map[string]collectors.CollectorPriority{
-		"sourceHigh": collectors.NodeOrchestrator,
-		"sourceLow":  collectors.NodeRuntime,
+		"sourceNodeOrchestrator":    collectors.NodeOrchestrator,
+		"sourceNodeRuntime":         collectors.NodeRuntime,
+		"sourceClusterOrchestrator": collectors.ClusterOrchestrator,
 	}
 
 	// Add tags but don't invalidate the cache, we should return empty arrays
-	etags.lowCardTags["sourceHigh"] = []string{"bar", "tag1:sourceHigh", "tag2:sourceHigh"}
-	etags.lowCardTags["sourceLow"] = []string{"foo", "tag1:sourceLow", "tag2:sourceLow"}
-	etags.highCardTags["sourceLow"] = []string{"tag3:sourceLow", "tag5:sourceLow"}
-	etags.highCardTags["sourceHigh"] = []string{"tag3:sourceHigh", "tag4:sourceHigh"}
+	etags.lowCardTags["sourceNodeOrchestrator"] = []string{"bar", "tag1:sourceHigh", "tag2:sourceHigh"}
+	etags.lowCardTags["sourceNodeRuntime"] = []string{"foo", "tag1:sourceLow", "tag2:sourceLow"}
+	etags.highCardTags["sourceNodeRuntime"] = []string{"tag3:sourceLow", "tag5:sourceLow"}
+	etags.highCardTags["sourceNodeOrchestrator"] = []string{"tag3:sourceHigh", "tag4:sourceHigh"}
+	etags.highCardTags["sourceClusterOrchestrator"] = []string{"tag4:sourceClusterLow"}
+	etags.lowCardTags["sourceClusterOrchestrator"] = []string{"tag3:sourceClusterHigh", "tag1:sourceClusterLow"}
 	tags, sources = etags.get(true)
 	assert.Len(t, tags, 0)
 	assert.Len(t, sources, 0)
@@ -222,11 +225,11 @@ func TestDuplicateSourceTags(t *testing.T) {
 	etags.cacheValid = false
 	tags, sources = etags.get(true)
 	assert.Len(t, tags, 7)
-	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceHigh", "tag2:sourceHigh", "tag3:sourceHigh", "tag4:sourceHigh", "tag5:sourceLow"})
-	assert.Len(t, sources, 2)
+	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh", "tag4:sourceClusterLow", "tag5:sourceLow"})
+	assert.Len(t, sources, 3)
 	assert.True(t, etags.cacheValid)
 	tags, sources = etags.get(false)
-	assert.Len(t, sources, 2)
-	assert.Len(t, tags, 4)
-	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceHigh", "tag2:sourceHigh"})
+	assert.Len(t, sources, 3)
+	assert.Len(t, tags, 5)
+	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh"})
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -34,7 +34,7 @@ const (
 
 var globalClusterAgentClient *DCAClient
 
-type serviceNames []string
+type metadataNames []string
 
 // DCAClient is required to query the API of Datadog cluster agent
 type DCAClient struct {
@@ -150,11 +150,11 @@ func getClusterAgentEndpoint() (string, error) {
 	return u.String(), nil
 }
 
-// GetKubernetesServiceNames queries the datadog cluster agent to get nodeName/podName registered
-// Kubernetes services.
-func (c *DCAClient) GetKubernetesServiceNames(nodeName, podName string) ([]string, error) {
+// GetKubernetesMetadataNames queries the datadog cluster agent to get nodeName/podName registered
+// Kubernetes metadata.
+func (c *DCAClient) GetKubernetesMetadataNames(nodeName, podName string) ([]string, error) {
 	const dcaMetadataPath = "api/v1/metadata"
-	var serviceNames serviceNames
+	var metadataNames metadataNames
 	var err error
 
 	if c == nil {
@@ -167,26 +167,26 @@ func (c *DCAClient) GetKubernetesServiceNames(nodeName, podName string) ([]strin
 	rawURL := fmt.Sprintf("%s/%s/%s/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, podName)
 	req.URL, err = url.Parse(rawURL)
 	if err != nil {
-		return serviceNames, err
+		return metadataNames, err
 	}
 
 	resp, err := c.clusterAgentAPIClient.Do(req)
 	if err != nil {
-		return serviceNames, err
+		return metadataNames, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return serviceNames, fmt.Errorf("unexpected status code from cluster agent: %d", resp.StatusCode)
+		return metadataNames, fmt.Errorf("unexpected status code from cluster agent: %d", resp.StatusCode)
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return serviceNames, err
+		return metadataNames, err
 	}
-	err = json.Unmarshal(b, &serviceNames)
+	err = json.Unmarshal(b, &metadataNames)
 	if err != nil {
-		return serviceNames, err
+		return metadataNames, err
 	}
 
-	return serviceNames, nil
+	return metadataNames, nil
 }

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -37,11 +37,11 @@ type dummyClusterAgent struct {
 func newDummyClusterAgent() (*dummyClusterAgent, error) {
 	dca := &dummyClusterAgent{
 		responses: map[string][]string{
-			"node1/pod-00001": {"svc1"},
-			"node1/pod-00002": {"svc1", "svc2"},
-			"node1/pod-00003": {"svc1"},
-			"node2/pod-00004": {"svc2"},
-			"node2/pod-00005": {"svc3"},
+			"node1/pod-00001": {"kube_service:svc1"},
+			"node1/pod-00002": {"kube_service:svc1", "kube_service:svc2"},
+			"node1/pod-00003": {"kube_service:svc1"},
+			"node2/pod-00004": {"kube_service:svc2"},
+			"node2/pod-00005": {"kube_service:svc3"},
 			"node2/pod-00006": {},
 		},
 		token: config.Datadog.GetString("cluster_agent.auth_token"),
@@ -243,7 +243,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromKubernetesSvcEmpt
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
-func (suite *clusterAgentSuite) TestGetKubernetesServiceNames() {
+func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 	dca, err := newDummyClusterAgent()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
@@ -264,27 +264,27 @@ func (suite *clusterAgentSuite) TestGetKubernetesServiceNames() {
 		{
 			nodeName:    "node1",
 			podName:     "pod-00001",
-			expectedSvc: []string{"svc1"},
+			expectedSvc: []string{"kube_service:svc1"},
 		},
 		{
 			nodeName:    "node1",
 			podName:     "pod-00002",
-			expectedSvc: []string{"svc1", "svc2"},
+			expectedSvc: []string{"kube_service:svc1", "kube_service:svc2"},
 		},
 		{
 			nodeName:    "node1",
 			podName:     "pod-00003",
-			expectedSvc: []string{"svc1"},
+			expectedSvc: []string{"kube_service:svc1"},
 		},
 		{
 			nodeName:    "node2",
 			podName:     "pod-00004",
-			expectedSvc: []string{"svc2"},
+			expectedSvc: []string{"kube_service:svc2"},
 		},
 		{
 			nodeName:    "node2",
 			podName:     "pod-00005",
-			expectedSvc: []string{"svc3"},
+			expectedSvc: []string{"kube_service:svc3"},
 		},
 		{
 			nodeName:    "node2",
@@ -294,7 +294,8 @@ func (suite *clusterAgentSuite) TestGetKubernetesServiceNames() {
 	}
 	for _, testCase := range testSuite {
 		suite.T().Run("", func(t *testing.T) {
-			svc, err := ca.GetKubernetesServiceNames(testCase.nodeName, testCase.podName)
+			svc, err := ca.GetKubernetesMetadataNames(testCase.nodeName, testCase.podName)
+			fmt.Println("svc: ", svc)
 			require.Nil(t, err, fmt.Sprintf("%v", err))
 			require.Equal(t, len(testCase.expectedSvc), len(svc))
 			for _, elt := range testCase.expectedSvc {

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -9,6 +9,7 @@ package apiserver
 
 import (
 	"errors"
+	"sync"
 
 	log "github.com/cihub/seelog"
 )
@@ -22,26 +23,32 @@ var (
 // APIClient provides authenticated access to the
 type APIClient struct{}
 
-// GetPodServiceNames is used when the API endpoint of the DCA to get the services of a pod is hit.
-func GetPodServiceNames(nodeName string, podName string) ([]string, error) {
-	log.Errorf("GetPodServiceNames not implemented %s", ErrNotCompiled.Error())
+// MetadataMapperBundle maps the podNames to the metadata they are associated with.
+type MetadataMapperBundle struct {
+	PodNameToService map[string][]string
+	m                sync.RWMutex
+}
+
+// GetPodMetadataNames is used when the API endpoint of the DCA to get the services of a pod is hit.
+func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
+	log.Errorf("GetPodMetadataNames not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }
 
-// GetServiceMapBundleOnNode is used for the CLI svcmap command to output given a nodeName
-func GetServiceMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
-	log.Errorf("GetServiceMapBundleOnNode not implemented %s", ErrNotCompiled.Error())
+// GetMetadataMapBundleOnNode is used for the CLI svcmap command to output given a nodeName
+func GetMetadataMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
+	log.Errorf("GetMetadataMapBundleOnNode not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }
 
-// GetServiceMapBundleOnAllNodes is used for the CLI svcmap command to run fetch the service map of all nodes.
-func GetServiceMapBundleOnAllNodes() (map[string]interface{}, error) {
-	log.Errorf("GetServiceMapBundleOnAllNodes not implemented %s", ErrNotCompiled.Error())
+// GetMetadataMapBundleOnAllNodes is used for the CLI svcmap command to run fetch the service map of all nodes.
+func GetMetadataMapBundleOnAllNodes() (map[string]interface{}, error) {
+	log.Errorf("GetMetadataMapBundleOnAllNodes not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }
 
-// StartServiceMapping is only called once, when we have confirmed we could correctly connect to the API server.
-func (c *APIClient) StartServiceMapping() {
-	log.Errorf("StartServiceMapping not implemented %s", ErrNotCompiled.Error())
+// StartMetadataMapping is only called once, when we have confirmed we could correctly connect to the API server.
+func (c *APIClient) StartMetadataMapping() {
+	log.Errorf("StartMetadataMapping not implemented %s", ErrNotCompiled.Error())
 	return
 }

--- a/pkg/util/kubernetes/apiserver/metadata.go
+++ b/pkg/util/kubernetes/apiserver/metadata.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"fmt"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+)
+
+// GetPodMetadataNames is used when the API endpoint of the DCA to get the metadata of a pod is hit.
+func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
+	var metaList []string
+	cacheKey := cache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
+
+	metaBundleInterface, found := cache.Cache.Get(cacheKey)
+	if !found {
+		return nil, fmt.Errorf("no metadata was found for the pod %s on node %s", podName, nodeName)
+	}
+
+	metaBundle, ok := metaBundleInterface.(*MetadataMapperBundle)
+	if !ok {
+		return nil, fmt.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
+	}
+	// The list of metadata collected in the metaBundle is extensible and is handled here.
+	// If new cluster level tags need to be collected by the agent, only this needs to be modified.
+	serviceList, foundServices := metaBundle.PodNameToService[podName]
+	if !foundServices {
+		return nil, fmt.Errorf("no cached services list found for the pod %s on the node %s", podName, nodeName)
+
+	}
+	log.Debugf("cacheKey: %s, with %d services", cacheKey, len(serviceList))
+	for _, s := range serviceList {
+		metaList = append(metaList, fmt.Sprintf("kube_service:%s", s))
+	}
+
+	return metaList, nil
+}

--- a/pkg/util/kubernetes/apiserver/metadata.go
+++ b/pkg/util/kubernetes/apiserver/metadata.go
@@ -36,7 +36,7 @@ func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
 		return nil, fmt.Errorf("no cached services list found for the pod %s on the node %s", podName, nodeName)
 
 	}
-	log.Debugf("cacheKey: %s, with %d services", cacheKey, len(serviceList))
+	log.Debugf("CacheKey: %s, with %d services", cacheKey, len(serviceList))
 	for _, s := range serviceList {
 		metaList = append(metaList, fmt.Sprintf("kube_service:%s", s))
 	}

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -148,22 +148,22 @@ func TestMapServices(t *testing.T) {
 			},
 		},
 	}
-	expectedAllPodNameToServices := map[string][]string{
+	expectedAllPodNameToService := map[string][]string{
 		"pod1_name": {"svc1"},
 		"pod2_name": {"svc2", "svc3", "svc4"},
 		"pod3_name": {"svc4"},
 		"pod5_name": {"svc3"},
 	}
-	allCasesBundle := newServiceMapperBundle()
+	allCasesBundle := newMetadataMapperBundle()
 	allBundleMu := &sync.RWMutex{}
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("#%d %s", i, testCase.caseName), func(t *testing.T) {
-			testCaseBundle := newServiceMapperBundle()
+			testCaseBundle := newMetadataMapperBundle()
 			podList := createPodList(testCase.pods)
 			nodeName := *testCase.node.Metadata.Name
 			epList := createSvcList(nodeName, testCase.services)
 			testCaseBundle.mapServices(nodeName, podList, epList)
-			assert.Equal(t, testCase.expectedMapping, testCaseBundle.PodNameToServices)
+			assert.Equal(t, testCase.expectedMapping, testCaseBundle.PodNameToService)
 			allBundleMu.Lock()
 			allCasesBundle.mapServices(nodeName, podList, epList)
 			allBundleMu.Unlock()
@@ -171,5 +171,5 @@ func TestMapServices(t *testing.T) {
 	}
 	allBundleMu.RLock()
 	defer allBundleMu.RUnlock()
-	assert.Equal(t, expectedAllPodNameToServices, allCasesBundle.PodNameToServices)
+	assert.Equal(t, expectedAllPodNameToService, allCasesBundle.PodNameToService)
 }

--- a/releasenotes/notes/metamapper-2afeadefca338eae.yaml
+++ b/releasenotes/notes/metamapper-2afeadefca338eae.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Improving the service mapper to a metadata mapper.
+    The agent just queries metadata from the DCA and can directly tag the kubernetes metrics.
+    The processing of new tags can be easily done and only the DCA needs to be modified.


### PR DESCRIPTION
### What does this PR do?

- [x] Refactor the svcmap to the metamap
- [x] Documentation
- [x] Separate concerns between the agent and the cluster agent:
    - Node agent does not have logic specific to the tags exposed by the DCA
    - DCA is computing the metadata from the API server.
    - Logic to add new metadata is simple
- [x] CLI complies with the update and provides a flexible way to add new cluster level insight.

#### Testing the different configuration strategies

- [x] E2E task
- [x] Deployed and tested locally

### Motivation

Avoiding introducing debts on the metadata mapper.

### Additional Notes

💃 
