### PR TITLE
Fixing env and labels as tags collection docker/kube

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -44,10 +44,18 @@ func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) 
 	c.stop = make(chan bool)
 	c.infoOut = out
 
-	// viper lower-cases map keys, so extractor must lowercase before matching
-	c.labelsAsTags = config.Datadog.GetStringMapString("docker_labels_as_tags")
-	c.envAsTags = config.Datadog.GetStringMapString("docker_env_as_tags")
+	// We lower-case the values collected by viper as well as the ones from inspecting the labels of containers.
+	labelsList := config.Datadog.GetStringMapString("docker_labels_as_tags")
+	for label, value := range labelsList {
+		labelsList[strings.ToLower(label)] = value
+	}
+	c.labelsAsTags = labelsList
 
+	envList := config.Datadog.GetStringMapString("docker_env_as_tags")
+	for env, value := range envList {
+		envList[strings.ToLower(env)] = value
+	}
+	c.envAsTags = envList
 	// TODO: list and inspect existing containers once docker utils are merged
 
 	return StreamCollection, nil

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -47,12 +47,14 @@ func (c *DockerCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) 
 	// We lower-case the values collected by viper as well as the ones from inspecting the labels of containers.
 	labelsList := config.Datadog.GetStringMapString("docker_labels_as_tags")
 	for label, value := range labelsList {
+		delete(labelsList, label)
 		labelsList[strings.ToLower(label)] = value
 	}
 	c.labelsAsTags = labelsList
 
 	envList := config.Datadog.GetStringMapString("docker_env_as_tags")
 	for env, value := range envList {
+		delete(envList, env)
 		envList[strings.ToLower(env)] = value
 	}
 	c.envAsTags = envList

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -47,12 +47,14 @@ func (c *KubeletCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error)
 	// We lower-case the values collected by viper as well as the ones from inspecting the labels of containers.
 	labelsList := config.Datadog.GetStringMapString("kubernetes_pod_labels_as_tags")
 	for label, value := range labelsList {
+		delete(labelsList, label)
 		labelsList[strings.ToLower(label)] = value
 	}
 	c.labelsAsTags = labelsList
 
 	annotationsList := config.Datadog.GetStringMapString("kubernetes_pod_annotations_as_tags")
 	for annotation, value := range annotationsList {
+		delete(annotationsList, annotation)
 		annotationsList[strings.ToLower(annotation)] = value
 	}
 	c.annotationsAsTags = annotationsList

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -8,12 +8,12 @@
 package collectors
 
 import (
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
-	"strings"
 )
 
 const (

--- a/releasenotes/notes/fix-env-and-labels-as-tags-d7ee859e3a47d0f4.yaml
+++ b/releasenotes/notes/fix-env-and-labels-as-tags-d7ee859e3a47d0f4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Lower case the label and env keys gotten from the inspect of the containers and pods in kubeutil and dockerutil.


### PR DESCRIPTION
### What does this PR do?

The docker and kubernetes integrations offer an option to map the labels/env associated with the pods and containers monitored by the agent.
The mapping is done in the utils of the integrations. The previous code assumed that the strings collected by viper when fetching the user configured env/labels_as_tags were lowercased but viper does not.
Hence, running a redis container with the following conf:
`docker run -d --name=redis -e testTag=1 -e testTag2=test redis`

And an agent container with the following conf:
```
docker run -d -e DD_API_KEY=REDACTED -e DD_DOCKER_ENV_AS_TAGS='{"Testag":"testTag"}' datadog/agent:latest
```

Would yield:
```
--- redisdb check ---
Instance 1:
host: 172.17.0.3
port: "6379"
tags:
- docker_image:redis:latest
- image_name:redis
- short_image:redis
- image_tag:latest
~
```
As we can see, the Testtag:1  is not showing up.
Should a user want to see these show up, they would need to lower case the key in the option of the agent as follows:
```
docker run -d -e DD_API_KEY=REDACTED -e DD_DOCKER_ENV_AS_TAGS='{"testag":"testTag"}' datadog/agent:latest
```
yields:
```
--- redisdb check ---
Instance 1:
host: 172.17.0.4
port: "6379"
tags:
- testTag:1
- docker_image:redis:latest
- image_name:redis
- short_image:redis
- image_tag:latest
```

### Motivation

User report of the bug, fixing both docker and kubernetes.
Tests in the kubelet_extract and docker_extract would not have helped to see this bug as the input is enforced and the actual problem occurs upstream in the docker/kubelet_main.go.\

### Additional Notes

🏭 
