### PR TITLE
Fixed a concurrent access issue in the logs auditor

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -45,7 +45,6 @@ func New(inputChan chan message.Message, runPath string) *Auditor {
 	return &Auditor{
 		inputChan:    inputChan,
 		registryPath: filepath.Join(runPath, "registry.json"),
-		mu:           sync.Mutex{},
 		entryTTL:     defaultTTL,
 		done:         make(chan struct{}),
 	}

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -35,7 +35,7 @@ type Auditor struct {
 	inputChan    chan message.Message
 	registry     map[string]*RegistryEntry
 	registryPath string
-	mu           *sync.Mutex
+	mu           sync.Mutex
 	entryTTL     time.Duration
 	done         chan struct{}
 }
@@ -45,7 +45,7 @@ func New(inputChan chan message.Message, runPath string) *Auditor {
 	return &Auditor{
 		inputChan:    inputChan,
 		registryPath: filepath.Join(runPath, "registry.json"),
-		mu:           &sync.Mutex{},
+		mu:           sync.Mutex{},
 		entryTTL:     defaultTTL,
 		done:         make(chan struct{}),
 	}

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -69,13 +69,13 @@ func (suite *AuditorTestSuite) TestAuditorFlushesAndRecoversRegistry() {
 		LastUpdated: time.Date(2006, time.January, 12, 1, 1, 1, 1, time.UTC),
 		Offset:      42,
 	}
-	suite.a.flushRegistry(suite.a.registry, suite.testPath)
+	suite.a.flushRegistry()
 	r, err := ioutil.ReadFile(suite.testPath)
 	suite.Nil(err)
 	suite.Equal("{\"Version\":1,\"Registry\":{\"testpath\":{\"Timestamp\":\"\",\"Offset\":42,\"LastUpdated\":\"2006-01-12T01:01:01.000000001Z\"}}}", string(r))
 
 	suite.a.registry = make(map[string]*RegistryEntry)
-	suite.a.registry = suite.a.recoverRegistry(suite.testPath)
+	suite.a.registry = suite.a.recoverRegistry()
 	suite.Equal(int64(42), suite.a.registry[suite.source.Config.Path].Offset)
 }
 
@@ -116,10 +116,10 @@ func (suite *AuditorTestSuite) TestAuditorCleansupRegistry() {
 		LastUpdated: time.Now().UTC(),
 		Offset:      43,
 	}
-	suite.a.flushRegistry(suite.a.registry, suite.testPath)
+	suite.a.flushRegistry()
 	suite.Equal(2, len(suite.a.registry))
 
-	suite.a.cleanupRegistry(suite.a.registry)
+	suite.a.cleanupRegistry()
 	suite.Equal(1, len(suite.a.registry))
 	suite.Equal(int64(43), suite.a.registry[otherpath].Offset)
 }

--- a/releasenotes/notes/logs_auditor_concurrency_issue-74c2b69e74c4f3c1.yaml
+++ b/releasenotes/notes/logs_auditor_concurrency_issue-74c2b69e74c4f3c1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a concurrent issue in the logs auditor causing the agent to crash.


### PR DESCRIPTION
### What does this PR do?

Added a lock to the auditor to ensure the registry is thread safe.

### Motivation

Ensuring the agent does not crash while discovery new containers
