### PR TITLE
Add docker CPU shares gauge

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -179,6 +179,7 @@ func (d *DockerCheck) Run() error {
 		sender.Rate("docker.cpu.system", float64(c.CPU.System), "", tags)
 		sender.Rate("docker.cpu.user", float64(c.CPU.User), "", tags)
 		sender.Rate("docker.cpu.usage", c.CPU.UsageTotal, "", tags)
+		sender.Gauge("docker.cpu.shares", float64(c.CPU.Shares), "", tags)
 		sender.Rate("docker.cpu.throttled", float64(c.CPUNrThrottled), "", tags)
 		sender.Gauge("docker.mem.cache", float64(c.Memory.Cache), "", tags)
 		sender.Gauge("docker.mem.rss", float64(c.Memory.RSS), "", tags)

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -113,7 +113,7 @@ func (c ContainerCgroup) Mem() (*CgroupMemStat, error) {
 
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s", statfile)
+		log.Debugf("Missing cgroup file: %s", statfile)
 		return ret, nil
 	} else if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ func (c ContainerCgroup) Mem() (*CgroupMemStat, error) {
 func (c ContainerCgroup) MemLimit() (uint64, error) {
 	v, err := c.ParseSingleStat("memory", "memory.limit_in_bytes")
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s",
+		log.Debugf("Missing cgroup file: %s",
 			c.cgroupFilePath("memory", "memory.limit_in_bytes"))
 		return 0, nil
 	} else if err != nil {
@@ -220,7 +220,7 @@ func (c ContainerCgroup) CPU() (*CgroupTimesStat, error) {
 	statfile := c.cgroupFilePath("cpuacct", "cpuacct.stat")
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s", statfile)
+		log.Debugf("Missing cgroup file: %s", statfile)
 		return ret, nil
 	} else if err != nil {
 		return nil, err
@@ -250,14 +250,14 @@ func (c ContainerCgroup) CPU() (*CgroupTimesStat, error) {
 	if err == nil {
 		ret.UsageTotal = float64(usage) / NanoToUserHZDivisor
 	} else {
-		log.Debugf("missing total cpu usage stat for %s: %s", c.ContainerID, err.Error())
+		log.Debugf("Missing total cpu usage stat for %s: %s", c.ContainerID, err.Error())
 	}
 
 	shares, err := c.ParseSingleStat("cpu", "cpu.shares")
 	if err == nil {
 		ret.Shares = shares
 	} else {
-		log.Debugf("missing cpu shares stat for %s: %s", c.ContainerID, err.Error())
+		log.Debugf("Missing cpu shares stat for %s: %s", c.ContainerID, err.Error())
 	}
 
 	return ret, nil
@@ -270,7 +270,7 @@ func (c ContainerCgroup) CPUNrThrottled() (uint64, error) {
 	statfile := c.cgroupFilePath("cpu", "cpu.stat")
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s", statfile)
+		log.Debugf("Missing cgroup file: %s", statfile)
 		return 0, nil
 	} else if err != nil {
 		return 0, err
@@ -287,7 +287,7 @@ func (c ContainerCgroup) CPUNrThrottled() (uint64, error) {
 			return value, nil
 		}
 	}
-	log.Debugf("missing nr_throttled line in %s", statfile)
+	log.Debugf("Missing nr_throttled line in %s", statfile)
 	return 0, nil
 }
 
@@ -305,14 +305,14 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 	quotaFile := c.cgroupFilePath("cpu", "cpu.cfs_quota_us")
 	plines, err := readLines(periodFile)
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s", periodFile)
+		log.Debugf("Missing cgroup file: %s", periodFile)
 		return 100, nil
 	} else if err != nil {
 		return 0, err
 	}
 	qlines, err := readLines(quotaFile)
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s", quotaFile)
+		log.Debugf("Missing cgroup file: %s", quotaFile)
 		return 100, nil
 	} else if err != nil {
 		return 0, err
@@ -352,7 +352,7 @@ func (c ContainerCgroup) IO() (*CgroupIOStat, error) {
 	statfile := c.cgroupFilePath("blkio", "blkio.throttle.io_service_bytes")
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
-		log.Debugf("missing cgroup file: %s", statfile)
+		log.Debugf("Missing cgroup file: %s", statfile)
 		return ret, nil
 	} else if err != nil {
 		return nil, err
@@ -415,12 +415,12 @@ func (c ContainerCgroup) ContainerStartTime() (int64, error) {
 func (c ContainerCgroup) cgroupFilePath(target, file string) string {
 	mount, ok := c.Mounts[target]
 	if !ok {
-		log.Errorf("missing target %s from mounts", target)
+		log.Errorf("Missing target %s from mounts", target)
 		return ""
 	}
 	targetPath, ok := c.Paths[target]
 	if !ok {
-		log.Errorf("missing target %s from paths", target)
+		log.Errorf("Missing target %s from paths", target)
 		return ""
 	}
 	// sometimes the container is running inside a "dind container" instead of directly on the host,

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -85,6 +85,7 @@ type CgroupTimesStat struct {
 	User        uint64
 	UsageTotal  float64
 	SystemUsage uint64
+	Shares      uint64
 }
 
 // CgroupIOStat store I/O statistics about a cgroup.
@@ -250,6 +251,13 @@ func (c ContainerCgroup) CPU() (*CgroupTimesStat, error) {
 		ret.UsageTotal = float64(usage) / NanoToUserHZDivisor
 	} else {
 		log.Debugf("missing total cpu usage stat for %s: %s", c.ContainerID, err.Error())
+	}
+
+	shares, err := c.ParseSingleStat("cpu", "cpu.shares")
+	if err == nil {
+		ret.Shares = shares
+	} else {
+		log.Debugf("missing cpu shares stat for %s: %s", c.ContainerID, err.Error())
 	}
 
 	return ret, nil

--- a/pkg/util/docker/cgroup_test.go
+++ b/pkg/util/docker/cgroup_test.go
@@ -26,6 +26,7 @@ func TestCPU(t *testing.T) {
 	}
 	tempFolder.add("cpuacct/cpuacct.stat", cpuacctStats.String())
 	tempFolder.add("cpuacct/cpuacct.usage", "915266418275")
+	tempFolder.add("cpu/cpu.shares", "1024")
 
 	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "cpuacct")
 
@@ -34,6 +35,7 @@ func TestCPU(t *testing.T) {
 	assert.Equal(t, timeStat.ContainerID, "dummy")
 	assert.Equal(t, timeStat.User, uint64(64140))
 	assert.Equal(t, timeStat.System, uint64(18327))
+	assert.Equal(t, timeStat.Shares, uint64(1024))
 	assert.InDelta(t, timeStat.UsageTotal, 91526.6418275, 0.0000001)
 }
 

--- a/pkg/util/docker/cgroup_test.go
+++ b/pkg/util/docker/cgroup_test.go
@@ -28,7 +28,7 @@ func TestCPU(t *testing.T) {
 	tempFolder.add("cpuacct/cpuacct.usage", "915266418275")
 	tempFolder.add("cpu/cpu.shares", "1024")
 
-	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "cpuacct")
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "cpuacct", "cpu")
 
 	timeStat, err := cgroup.CPU()
 	assert.Nil(t, err)

--- a/releasenotes/notes/add-docker-cpu-shares-gauge-b5a60b49570771a6.yaml
+++ b/releasenotes/notes/add-docker-cpu-shares-gauge-b5a60b49570771a6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Introduce new docker cpu shares gauge.

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -29,6 +29,7 @@ func TestContainerMetricsTagging(t *testing.T) {
 
 	expectedMetrics := map[string][]string{
 		"Gauge": {
+			"docker.cpu.shares",
 			"docker.mem.cache",
 			"docker.mem.rss",
 			"docker.mem.in_use",


### PR DESCRIPTION
### What does this PR do?

Add docker CPU shares gauge

### Motivation

- Parity with agent 5 (see https://github.com/DataDog/integrations-core/pull/1358)
- Allows graphing CPU usage for containers more realistically.

### Additional Notes

Anything else we should know when reviewing?
