### PR TITLE
[aggregator] Log minor flush errors with readable metric context

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -34,7 +34,9 @@ func newCheckSampler(hostname string) *CheckSampler {
 func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample) {
 	contextKey := cs.contextResolver.trackContext(metricSample, metricSample.Timestamp)
 
-	cs.metrics.AddSample(contextKey, metricSample, metricSample.Timestamp, 1)
+	if err := cs.metrics.AddSample(contextKey, metricSample, metricSample.Timestamp, 1); err != nil {
+		log.Debug("Ignoring sample '%s' on host '%s' and tags '%s': %s", metricSample.Name, metricSample.Host, metricSample.Tags, err)
+	}
 }
 
 func (cs *CheckSampler) commit(timestamp float64) {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -42,12 +42,20 @@ func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample) {
 func (cs *CheckSampler) commit(timestamp float64) {
 	series, errors := cs.metrics.Flush(timestamp)
 	for ckey, err := range errors {
-		context := cs.contextResolver.contextsByKey[ckey]
-		log.Infof("An error occurred while flushing check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags, err)
+		context, ok := cs.contextResolver.contextsByKey[ckey]
+		if !ok {
+			log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
+			continue
+		}
+		log.Infof("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags, err)
 	}
 	for _, serie := range series {
 		// Resolve context and populate new []Serie
-		context := cs.contextResolver.contextsByKey[serie.ContextKey]
+		context, ok := cs.contextResolver.contextsByKey[serie.ContextKey]
+		if !ok {
+			log.Errorf("Ignoring all metrics on context key '%v': inconsistent context resolver state: the context is not tracked", serie.ContextKey)
+			continue
+		}
 		serie.Name = context.Name + serie.NameSuffix
 		serie.Tags = context.Tags
 		serie.SourceTypeName = checksSourceTypeName // this source type is required for metrics coming from the checks

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -66,7 +66,9 @@ func (s *TimeSampler) addSample(metricSample *metrics.MetricSample, timestamp fl
 	}
 
 	// Add sample to bucket
-	bucketMetrics.AddSample(contextKey, metricSample, timestamp, s.interval)
+	if err := bucketMetrics.AddSample(contextKey, metricSample, timestamp, s.interval); err != nil {
+		log.Debug("Ignoring sample '%s' on host '%s' and tags '%s': %s", metricSample.Name, metricSample.Host, metricSample.Tags, err)
+	}
 }
 
 func (s *TimeSampler) flush(timestamp float64) metrics.Series {

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -12,9 +12,6 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// ContextKey is a non-cryptographic hash unique to a context
-type ContextKey [16]byte
-
 // ContextMetrics stores all the metrics by context key
 type ContextMetrics map[ckey.ContextKey]Metric
 

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -54,8 +54,8 @@ func (m ContextMetrics) AddSample(contextKey ckey.ContextKey, sample *MetricSamp
 	return nil
 }
 
-// Flush flushes every metrics in the ContextMetrics
-// Returns the slice of Series and a map of errors by context key
+// Flush flushes every metrics in the ContextMetrics.
+// Returns the slice of Series and a map of errors by context key.
 func (m ContextMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey]error) {
 	var series []*Serie
 	errors := make(map[ckey.ContextKey]error)

--- a/releasenotes/notes/aggregator-log-message-with-readable-metric-context-2c9cc095dc04431e.yaml
+++ b/releasenotes/notes/aggregator-log-message-with-readable-metric-context-2c9cc095dc04431e.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    In the metrics aggregator, log readable context information (metric name,
+    host, tags) instead of the raw context key to help troubleshooting


### PR DESCRIPTION
### What does this PR do?

Adds readable metric context when logging a flush error (or an error that occurs when adding a sample).

### Motivation

In practice, changes the cryptic log messages like (with raw context keys):

```
2018-04-16 19:14:22 CEST | INFO | (context_metrics.go:76 in Flush) | An error occurred while flushing metric on context key '81cc203f3b14b19c8d780420187366fb': Rate value is negative, discarding it (the underlying counter may have been reset)
```

into messages with fully readable context elements:

```
2018-04-16 19:14:22 CEST | INFO | (check_sampler.go:44 in commit) | An error occurred while flushing check metric 'test.metric' on host 'myhost' and tags '[foo:bar foo:baz]': Rate value is negative, discarding it (the underlying counter may have been reset)
```

Should make it possible to understand these log messages.

### Additional Notes

Every commit can be reviewed independently. The implementation is a bit convoluted for what it does, happy to hear improvement suggestions.
