### PR TITLE
honor proxy when validating api keys

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -385,7 +386,14 @@ func (f *DefaultForwarder) setAPIKeyStatus(apiKey string, domain string, status 
 func (f *DefaultForwarder) validateAPIKey(apiKey, domain string) (bool, error) {
 	url := fmt.Sprintf("%s%s?api_key=%s", config.Datadog.GetString("dd_url"), v1ValidateEndpoint, apiKey)
 
-	resp, err := http.Get(url)
+	transport := util.CreateHTTPTransport()
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   5 * time.Second,
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		f.setAPIKeyStatus(apiKey, domain, &apiKeyStatusUnknown)
 		return false, err

--- a/releasenotes/notes/validate-api-key-proxy-1f49f83f71750532.yaml
+++ b/releasenotes/notes/validate-api-key-proxy-1f49f83f71750532.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    API key validation logic was ignoring proxy settings, leading to situations
+    where the agent reported that it was "Unable to validate API key" in the GUI.


### PR DESCRIPTION
### What does this PR do?

The http request used to validate api keys was not going trough configured proxies. This should fix it.
