### PR TITLE
improve timeout logic for api key validation

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -283,7 +283,7 @@ func (f *DefaultForwarder) hasValidAPIKey(timeout time.Duration) (bool, error) {
 		apiKeyCount += len(apiKeys)
 	}
 	if apiKeyCount == 0 {
-		return true, nil
+		return false, nil
 	}
 
 	validKey := false

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -285,6 +285,10 @@ func (f *DefaultForwarder) hasValidAPIKey(timeout time.Duration) (bool, error) {
 	for _, apiKeys := range f.KeysPerDomains {
 		apiKeyCount += len(apiKeys)
 	}
+	if apiKeyCount == 0 {
+		return true, nil
+	}
+
 	keyTimeout := timeout / time.Duration(apiKeyCount)
 
 	for domain, apiKeys := range f.KeysPerDomains {

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -279,9 +279,15 @@ func (f *DefaultForwarder) hasValidAPIKey(timeout time.Duration) (bool, error) {
 	validKey := false
 	apiError := false
 
+	apiKeyCount := 0
+	for _, apiKeys := range f.KeysPerDomains {
+		apiKeyCount += len(apiKeys)
+	}
+	keyTimeout := timeout / time.Duration(apiKeyCount)
+
 	for domain, apiKeys := range f.KeysPerDomains {
 		for _, apiKey := range apiKeys {
-			v, err := f.validateAPIKey(apiKey, domain, timeout)
+			v, err := f.validateAPIKey(apiKey, domain, keyTimeout)
 			if err != nil {
 				log.Debug(err)
 				apiError = true

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -317,7 +317,7 @@ func (f *DefaultForwarder) healthCheckLoop() {
 		case <-f.stop:
 			return
 		case <-validateTicker.C:
-			// Timeout should always be lower than pingFrequency.pingFrequency to avoid
+			// Timeout should always be lower than health.pingFrequency to avoid
 			// reporting the forwarder as unhealthy
 			valid, err := f.hasValidAPIKey(10 * time.Second)
 			if err == nil && !valid {

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -276,9 +276,6 @@ func (f *DefaultForwarder) Stop() {
 }
 
 func (f *DefaultForwarder) hasValidAPIKey(timeout time.Duration) (bool, error) {
-	validKey := false
-	apiError := false
-
 	// Since timeout is the maximum duration we can wait, we need to divide it
 	// by the total number of api keys to obtain the max duration for each key
 	apiKeyCount := 0
@@ -288,6 +285,9 @@ func (f *DefaultForwarder) hasValidAPIKey(timeout time.Duration) (bool, error) {
 	if apiKeyCount == 0 {
 		return true, nil
 	}
+
+	validKey := false
+	apiError := false
 
 	keyTimeout := timeout / time.Duration(apiKeyCount)
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -279,6 +279,8 @@ func (f *DefaultForwarder) hasValidAPIKey(timeout time.Duration) (bool, error) {
 	validKey := false
 	apiError := false
 
+	// Since timeout is the maximum duration we can wait, we need to divide it
+	// by the total number of api keys to obtain the max duration for each key
 	apiKeyCount := 0
 	for _, apiKeys := range f.KeysPerDomains {
 		apiKeyCount += len(apiKeys)

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -390,7 +390,7 @@ func (f *DefaultForwarder) validateAPIKey(apiKey, domain string) (bool, error) {
 
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   5 * time.Second,
+		Timeout:   config.Datadog.GetDuration("forwarder_timeout") * time.Second,
 	}
 
 	resp, err := client.Get(url)


### PR DESCRIPTION
### What does this PR do?

Since validating api key is done in the forwarder health check, we need to be careful not to take too much time to timeout in case of an unresponsive server.