### PR TITLE
[Logs]: Removed the abstraction for Message and the different implementations for each integration

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -35,7 +35,7 @@ type Agent struct {
 // NewAgent returns a new Agent
 func NewAgent(sources *config.LogSources) *Agent {
 	// setup the auditor
-	messageChan := make(chan message.Message, config.ChanSize)
+	messageChan := make(chan *message.Message, config.ChanSize)
 	auditor := auditor.New(messageChan, config.LogsAgent.GetString("logs_config.run_path"))
 
 	// setup the pipeline provider that provides pairs of processor and sender

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -32,7 +32,7 @@ type RegistryEntry struct {
 
 // An Auditor handles messages successfully submitted to the intake
 type Auditor struct {
-	inputChan    chan message.Message
+	inputChan    chan *message.Message
 	registry     map[string]*RegistryEntry
 	registryPath string
 	mu           sync.Mutex
@@ -41,7 +41,7 @@ type Auditor struct {
 }
 
 // New returns an initialized Auditor
-func New(inputChan chan message.Message, runPath string) *Auditor {
+func New(inputChan chan *message.Message, runPath string) *Auditor {
 	return &Auditor{
 		inputChan:    inputChan,
 		registryPath: filepath.Join(runPath, "registry.json"),
@@ -87,7 +87,7 @@ func (a *Auditor) run() {
 				return
 			}
 			// update the registry with new entry
-			a.updateRegistry(msg.GetOrigin().Identifier, msg.GetOrigin().Offset, msg.GetOrigin().Timestamp)
+			a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset, msg.Origin.Timestamp)
 		case <-cleanUpTicker.C:
 			// remove expired offsets from registry
 			a.cleanupRegistry()

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -25,7 +25,7 @@ type AuditorTestSuite struct {
 	testPath string
 	testFile *os.File
 
-	inputChan chan message.Message
+	inputChan chan *message.Message
 	a         *Auditor
 	source    *config.LogSource
 }
@@ -39,7 +39,7 @@ func (suite *AuditorTestSuite) SetupTest() {
 	_, err := os.Create(suite.testPath)
 	suite.Nil(err)
 
-	suite.inputChan = make(chan message.Message)
+	suite.inputChan = make(chan *message.Message)
 	suite.a = New(suite.inputChan, "")
 	suite.a.registryPath = suite.testPath
 	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})

--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -162,7 +162,7 @@ func (s *Scanner) setup() error {
 
 // setupTailer sets one tailer, making it tail from the beginning or the end,
 // returns true if the setup succeeded, false otherwise
-func (s *Scanner) setupTailer(cli *client.Client, container types.Container, source *config.LogSource, tailFromBeginning bool, outputChan chan message.Message) bool {
+func (s *Scanner) setupTailer(cli *client.Client, container types.Container, source *config.LogSource, tailFromBeginning bool, outputChan chan *message.Message) bool {
 	log.Info("Detected container ", container.Image, " - ", s.humanReadableContainerID(container.ID))
 	t := NewDockerTailer(cli, container.ID, source, outputChan)
 	var err error

--- a/pkg/logs/input/listener/tcp_test.go
+++ b/pkg/logs/input/listener/tcp_test.go
@@ -22,7 +22,7 @@ const tcpTestPort = 10512
 type TCPTestSuite struct {
 	suite.Suite
 
-	outputChan chan message.Message
+	outputChan chan *message.Message
 	pp         pipeline.Provider
 	source     *config.LogSource
 	tcpl       *TCPListener

--- a/pkg/logs/input/listener/udp_test.go
+++ b/pkg/logs/input/listener/udp_test.go
@@ -22,7 +22,7 @@ const udpTestPort = 10513
 type UDPTestSuite struct {
 	suite.Suite
 
-	outputChan chan message.Message
+	outputChan chan *message.Message
 	pp         pipeline.Provider
 	source     *config.LogSource
 	udpl       *UDPListener

--- a/pkg/logs/input/listener/worker_test.go
+++ b/pkg/logs/input/listener/worker_test.go
@@ -23,12 +23,12 @@ type WorkerTestSuite struct {
 
 	w       *Worker
 	conn    net.Conn
-	msgChan chan message.Message
+	msgChan chan *message.Message
 }
 
 func (suite *WorkerTestSuite) SetupTest() {
 	source := config.NewLogSource("", &config.LogsConfig{Type: config.TCPType, Port: port})
-	msgChan := make(chan message.Message)
+	msgChan := make(chan *message.Message)
 	r, w := net.Pipe()
 
 	suite.w = NewWorker(source, r, msgChan)

--- a/pkg/logs/input/tailer/scanner.go
+++ b/pkg/logs/input/tailer/scanner.go
@@ -82,7 +82,7 @@ func (s *Scanner) cleanup() {
 }
 
 // createTailer returns a new initialized tailer
-func (s *Scanner) createTailer(file *File, outputChan chan message.Message) *Tailer {
+func (s *Scanner) createTailer(file *File, outputChan chan *message.Message) *Tailer {
 	return NewTailer(outputChan, file.Source, file.Path, s.tailerSleepDuration)
 }
 

--- a/pkg/logs/input/tailer/scanner_test.go
+++ b/pkg/logs/input/tailer/scanner_test.go
@@ -32,7 +32,7 @@ type ScannerTestSuite struct {
 	testRotatedPath string
 	testRotatedFile *os.File
 
-	outputChan     chan message.Message
+	outputChan     chan *message.Message
 	pp             pipeline.Provider
 	sources        []*config.LogSource
 	openFilesLimit int

--- a/pkg/logs/input/tailer/tailer_test.go
+++ b/pkg/logs/input/tailer/tailer_test.go
@@ -29,7 +29,7 @@ type TailerTestSuite struct {
 	testFile *os.File
 
 	tl         *Tailer
-	outputChan chan message.Message
+	outputChan chan *message.Message
 	source     *config.LogSource
 }
 
@@ -42,7 +42,7 @@ func (suite *TailerTestSuite) SetupTest() {
 	f, err := os.Create(suite.testPath)
 	suite.Nil(err)
 	suite.testFile = f
-	suite.outputChan = make(chan message.Message, chanSize)
+	suite.outputChan = make(chan *message.Message, chanSize)
 	suite.source = config.NewLogSource("", &config.LogsConfig{
 		Type: config.FileType,
 		Path: suite.testPath,

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -6,89 +6,17 @@
 package message
 
 // Message represents a log line sent to datadog, with its metadata
-type Message interface {
-	Content() []byte
-	SetContent([]byte)
-	GetOrigin() *Origin
-	SetOrigin(*Origin)
-	GetSeverity() []byte
-	SetSeverity([]byte)
+type Message struct {
+	Content  []byte
+	Origin   *Origin
+	Severity []byte
 }
 
-type message struct {
-	content  []byte
-	origin   *Origin
-	severity []byte
-}
-
-func newMessage(content []byte) *message {
-	return &message{
-		content: content,
-	}
-}
-
-// Content returns the content the message, the actual log line
-func (m *message) Content() []byte {
-	return m.content
-}
-
-// SetContent updates the content the message
-func (m *message) SetContent(content []byte) {
-	m.content = content
-}
-
-// GetOrigin returns the Origin from which the message comes
-func (m *message) GetOrigin() *Origin {
-	return m.origin
-}
-
-// SetOrigin sets the integration from which the message comes
-func (m *message) SetOrigin(Origin *Origin) {
-	m.origin = Origin
-}
-
-// GetSeverity returns the severity of the message when set
-func (m *message) GetSeverity() []byte {
-	return m.severity
-}
-
-// SetSeverity sets the severity of the message
-func (m *message) SetSeverity(severity []byte) {
-	m.severity = severity
-}
-
-// FileMessage is a message coming from a File
-type FileMessage struct {
-	*message
-}
-
-// NewFileMessage returns a new FileMessage
-func NewFileMessage(content []byte) *FileMessage {
-	return &FileMessage{
-		message: newMessage(content),
-	}
-}
-
-// NetworkMessage is a message coming from a network Source
-type NetworkMessage struct {
-	*message
-}
-
-// NewNetworkMessage returns a new NetworkMessage
-func NewNetworkMessage(content []byte) *NetworkMessage {
-	return &NetworkMessage{
-		message: newMessage(content),
-	}
-}
-
-// ContainerMessage is a message coming from a container Source
-type ContainerMessage struct {
-	*message
-}
-
-// NewContainerMessage returns a new ContainerMessage
-func NewContainerMessage(content []byte) *ContainerMessage {
-	return &ContainerMessage{
-		message: newMessage(content),
+// NewMessage returns a new message
+func NewMessage(content []byte, origin *Origin, severity []byte) *Message {
+	return &Message{
+		Content:  content,
+		Origin:   origin,
+		Severity: severity,
 	}
 }

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -21,8 +21,14 @@ type Origin struct {
 }
 
 // NewOrigin returns a new Origin
-func NewOrigin() *Origin {
-	return &Origin{}
+func NewOrigin(identifier string, logSource *config.LogSource, offset int64, timestamp string, tags []string) *Origin {
+	return &Origin{
+		Identifier: identifier,
+		LogSource:  logSource,
+		Offset:     offset,
+		Timestamp:  timestamp,
+		tags:       tags,
+	}
 }
 
 // Tags returns the tags of the origin.

--- a/pkg/logs/pipeline/mock/mock.go
+++ b/pkg/logs/pipeline/mock/mock.go
@@ -12,13 +12,13 @@ import (
 
 // mockProvider mocks pipeline providing logic
 type mockProvider struct {
-	msgChan chan message.Message
+	msgChan chan *message.Message
 }
 
 // NewMockProvider returns a new mockProvider
 func NewMockProvider() pipeline.Provider {
 	return &mockProvider{
-		msgChan: make(chan message.Message),
+		msgChan: make(chan *message.Message),
 	}
 }
 
@@ -29,6 +29,6 @@ func (p *mockProvider) Start() {}
 func (p *mockProvider) Stop() {}
 
 // NextPipelineChan returns the next pipeline
-func (p *mockProvider) NextPipelineChan() chan message.Message {
+func (p *mockProvider) NextPipelineChan() chan *message.Message {
 	return p.msgChan
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -14,23 +14,23 @@ import (
 
 // Pipeline processes and sends messages to the backend
 type Pipeline struct {
-	InputChan chan message.Message
+	InputChan chan *message.Message
 	processor *processor.Processor
 	sender    *sender.Sender
 }
 
 // NewPipeline returns a new Pipeline
-func NewPipeline(connManager *sender.ConnectionManager, outputChan chan message.Message) *Pipeline {
+func NewPipeline(connManager *sender.ConnectionManager, outputChan chan *message.Message) *Pipeline {
 
 	useProto := config.LogsAgent.GetBool("logs_config.dev_mode_use_proto")
 
 	// initialize the sender
-	senderChan := make(chan message.Message, config.ChanSize)
+	senderChan := make(chan *message.Message, config.ChanSize)
 	delimiter := sender.NewDelimiter(useProto)
 	sender := sender.New(senderChan, outputChan, connManager, delimiter)
 
 	// initialize the input chan
-	inputChan := make(chan message.Message, config.ChanSize)
+	inputChan := make(chan *message.Message, config.ChanSize)
 
 	// initialize the processor
 	encoder := processor.NewEncoder(useProto)

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -17,20 +17,20 @@ import (
 type Provider interface {
 	Start()
 	Stop()
-	NextPipelineChan() chan message.Message
+	NextPipelineChan() chan *message.Message
 }
 
 // provider implements providing logic
 type provider struct {
 	numberOfPipelines    int
 	connManager          *sender.ConnectionManager
-	outputChan           chan message.Message
+	outputChan           chan *message.Message
 	pipelines            []*Pipeline
 	currentPipelineIndex int32
 }
 
 // NewProvider returns a new Provider
-func NewProvider(numberOfPipelines int, connManager *sender.ConnectionManager, outputChan chan message.Message) Provider {
+func NewProvider(numberOfPipelines int, connManager *sender.ConnectionManager, outputChan chan *message.Message) Provider {
 	return &provider{
 		numberOfPipelines: numberOfPipelines,
 		connManager:       connManager,
@@ -60,7 +60,7 @@ func (p *provider) Stop() {
 }
 
 // NextPipelineChan returns the next pipeline input channel
-func (p *provider) NextPipelineChan() chan message.Message {
+func (p *provider) NextPipelineChan() chan *message.Message {
 	pipelinesLen := len(p.pipelines)
 	if pipelinesLen == 0 {
 		return nil

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -15,15 +15,15 @@ import (
 // A Processor updates messages from an inputChan and pushes
 // in an outputChan.
 type Processor struct {
-	inputChan  chan message.Message
-	outputChan chan message.Message
+	inputChan  chan *message.Message
+	outputChan chan *message.Message
 	encoder    Encoder
 	prefixer   Prefixer
 	done       chan struct{}
 }
 
 // New returns an initialized Processor.
-func New(inputChan, outputChan chan message.Message, encoder Encoder, prefixer Prefixer) *Processor {
+func New(inputChan, outputChan chan *message.Message, encoder Encoder, prefixer Prefixer) *Processor {
 	return &Processor{
 		inputChan:  inputChan,
 		outputChan: outputChan,
@@ -60,7 +60,7 @@ func (p *Processor) run() {
 			}
 			// Prefix the message with the API key
 			content = p.prefixer.prefix(content)
-			msg.SetContent(content)
+			msg.Content = content
 			p.outputChan <- msg
 		}
 	}
@@ -68,9 +68,9 @@ func (p *Processor) run() {
 
 // applyRedactingRules returns given a message if we should process it or not,
 // and a copy of the message with some fields redacted, depending on config
-func applyRedactingRules(msg message.Message) (bool, []byte) {
-	content := msg.Content()
-	for _, rule := range msg.GetOrigin().LogSource.Config.ProcessingRules {
+func applyRedactingRules(msg *message.Message) (bool, []byte) {
+	content := msg.Content
+	for _, rule := range msg.Origin.LogSource.Config.ProcessingRules {
 		switch rule.Type {
 		case config.ExcludeAtMatch:
 			if rule.Reg.Match(content) {

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -26,11 +26,10 @@ func buildTestConfigLogSource(ruleType, replacePlaceholder, pattern string) conf
 	return config.LogSource{Config: &config.LogsConfig{ProcessingRules: []config.LogsProcessingRule{rule}}}
 }
 
-func newNetworkMessage(content []byte, source *config.LogSource) message.Message {
-	msg := message.NewNetworkMessage(content)
-	msgOrigin := message.NewOrigin()
+func newMessage(content []byte, source *config.LogSource) message.Message {
+	msgOrigin := message.NewOrigin("", source, 0, "", nil)
 	msgOrigin.LogSource = source
-	msg.SetOrigin(msgOrigin)
+	msg := message.NewMessage(content, nil, nil)
 	return msg
 }
 
@@ -40,18 +39,18 @@ func TestExclusion(t *testing.T) {
 	var redactedMessage []byte
 
 	source := buildTestConfigLogSource("exclude_at_match", "", "world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("hello"), redactedMessage)
 
-	shouldProcess, _ = applyRedactingRules(newNetworkMessage([]byte("world"), &source))
+	shouldProcess, _ = applyRedactingRules(newMessage([]byte("world"), &source))
 	assert.Equal(t, false, shouldProcess)
 
-	shouldProcess, _ = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, _ = applyRedactingRules(newMessage([]byte("a brand new world"), &source))
 	assert.Equal(t, false, shouldProcess)
 
 	source = buildTestConfigLogSource("exclude_at_match", "", "$world")
-	shouldProcess, _ = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, _ = applyRedactingRules(newMessage([]byte("a brand new world"), &source))
 	assert.Equal(t, true, shouldProcess)
 }
 
@@ -61,20 +60,20 @@ func TestInclusion(t *testing.T) {
 	var redactedMessage []byte
 
 	source := buildTestConfigLogSource("include_at_match", "", "world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), &source))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("world"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("world"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("world"), redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("a brand new world"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("a brand new world"), redactedMessage)
 
 	source = buildTestConfigLogSource("include_at_match", "", "^world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("a brand new world"), &source))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 }
@@ -100,19 +99,19 @@ func TestExclusionWithInclusion(t *testing.T) {
 	}
 	source := config.LogSource{Config: &config.LogsConfig{ProcessingRules: []config.LogsProcessingRule{eRule, iRule}}}
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bob@datadoghq.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bob@datadoghq.com"), &source))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bill@datadoghq.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bill@datadoghq.com"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("bill@datadoghq.com"), redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bob@amail.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bob@amail.com"), &source))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bill@amail.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bill@amail.com"), &source))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 }
@@ -123,21 +122,21 @@ func TestMask(t *testing.T) {
 	var redactedMessage []byte
 
 	source := buildTestConfigLogSource("mask_sequences", "[masked_world]", "world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("hello"), redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello world!"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello world!"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("hello [masked_world]!"), redactedMessage)
 
 	source = buildTestConfigLogSource("mask_sequences", "[masked_user]", "User=\\w+@datadoghq.com")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("new test launched by User=beats@datadoghq.com on localhost"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("new test launched by User=beats@datadoghq.com on localhost"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("new test launched by [masked_user] on localhost"), redactedMessage)
 
 	source = buildTestConfigLogSource("mask_sequences", "[masked_credit_card]", "(?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("The credit card 4323124312341234 was used to buy some time"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("The credit card 4323124312341234 was used to buy some time"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("The credit card [masked_credit_card] was used to buy some time"), redactedMessage)
 }
@@ -147,6 +146,6 @@ func TestTruncate(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
 	var redactedMessage []byte
 
-	_, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), source))
+	_, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), source))
 	assert.Equal(t, []byte("hello"), redactedMessage)
 }

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -15,8 +15,8 @@ import (
 // A Sender sends messages from an inputChan to datadog's intake,
 // handling connections and retries.
 type Sender struct {
-	inputChan   chan message.Message
-	outputChan  chan message.Message
+	inputChan   chan *message.Message
+	outputChan  chan *message.Message
 	connManager *ConnectionManager
 	conn        net.Conn
 	delimiter   Delimiter
@@ -24,7 +24,7 @@ type Sender struct {
 }
 
 // New returns an initialized Sender
-func New(inputChan, outputChan chan message.Message, connManager *ConnectionManager, delimiter Delimiter) *Sender {
+func New(inputChan, outputChan chan *message.Message, connManager *ConnectionManager, delimiter Delimiter) *Sender {
 	return &Sender{
 		inputChan:   inputChan,
 		outputChan:  outputChan,
@@ -57,12 +57,12 @@ func (s *Sender) run() {
 }
 
 // wireMessage lets the Sender send a message to datadog's intake
-func (s *Sender) wireMessage(payload message.Message) {
+func (s *Sender) wireMessage(payload *message.Message) {
 	for {
 		if s.conn == nil {
 			s.conn = s.connManager.NewConnection() // blocks until a new conn is ready
 		}
-		frame, err := s.delimiter.delimit(payload.Content())
+		frame, err := s.delimiter.delimit(payload.Content)
 		if err != nil {
 			log.Error("can't send payload: ", payload, err)
 			continue


### PR DESCRIPTION
### What does this PR do?

Removed the message abstraction and its different implementations and created custom message origins instead.

### Motivation

Simplify codd.

### Additional Notes

I am wondering whether it's worth trying to have only one kind of offset in the message origin that would be a string for the auditor to be completely agnostic from integration types.
This would require some extra work to keep the backward compatibility though.
