### PR TITLE
[linting] Add task to check that no committed files have illegal character in name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,16 @@ jobs:
           name: run reno linting
           command: inv -e lint-releasenote
 
+  filename_linting:
+    <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - restore_cache: *restore_deps
+      - setup_remote_docker
+      - run:
+          name: run filename linting
+          command: inv -e lint-filenames
+
   docker_integration_tests:
     <<: *job_template
     steps:
@@ -136,6 +146,9 @@ workflows:
           requires:
             - dependencies
       - reno_linting:
+          requires:
+            - dependencies
+      - filename_linting:
           requires:
             - dependencies
       - docker_integration_tests:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,7 +7,7 @@ from invoke import Collection
 from . import agent, benchmarks, docker, dogstatsd, pylauncher, cluster_agent, systray
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
-from .test import test, integration_tests, version, lint_releasenote
+from .test import test, integration_tests, version, lint_releasenote, lint_filenames
 from .build_tags import audit_tag_impact
 
 # the root namespace
@@ -26,6 +26,7 @@ ns.add_task(deps)
 ns.add_task(reset)
 ns.add_task(version)
 ns.add_task(lint_releasenote)
+ns.add_task(lint_filenames)
 ns.add_task(audit_tag_impact)
 
 # add namespaced tasks to the root

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -211,6 +211,21 @@ def lint_releasenote(ctx):
 
     ctx.run("reno lint")
 
+@task
+def lint_filenames(ctx):
+    """
+    Scan files to ensure there are no filenames containing illegal character
+    """
+    forbidden_chars = '<>:"\\|?*'
+    files = ctx.run("git ls-files -z", hide=True).stdout.split("\0")
+    failure = False
+    for file in files:
+        if any([char in file for char in forbidden_chars]):
+            print("Error: Found illegal character in path {}".format(file))
+            failure = True
+    if failure:
+        raise Exit(1)
+
 
 @task
 def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -69,6 +69,7 @@ def test(ctx, targets=None, coverage=False, race=False, profile=False, use_embed
     # explicitly run these tasks instead of using pre-tasks so we can
     # pass the `target` param (pre-tasks are invoked without parameters)
     print("--- Linting:")
+    lint_filenames(ctx)
     fmt(ctx, targets=tool_targets, fail_on_fmt=fail_on_fmt)
     lint(ctx, targets=tool_targets)
     vet(ctx, targets=tool_targets)
@@ -214,17 +215,21 @@ def lint_releasenote(ctx):
 @task
 def lint_filenames(ctx):
     """
-    Scan files to ensure there are no filenames containing illegal character
+    Scan files to ensure there are no filenames containing illegal characters
     """
-    forbidden_chars = '<>:"\\|?*'
-    files = ctx.run("git ls-files -z", hide=True).stdout.split("\0")
-    failure = False
-    for file in files:
-        if any([char in file for char in forbidden_chars]):
-            print("Error: Found illegal character in path {}".format(file))
-            failure = True
-    if failure:
-        raise Exit(1)
+    if invoke.platform.WINDOWS:
+        print("Running on windows, no need to check filenames for illegal characters")
+    else:
+        print("Checking filenames for illegal characters")
+        forbidden_chars = '<>:"\\|?*'
+        files = ctx.run("git ls-files -z", hide=True).stdout.split("\0")
+        failure = False
+        for file in files:
+            if any(char in file for char in forbidden_chars):
+                print("Error: Found illegal character in path {}".format(file))
+                failure = True
+        if failure:
+            raise Exit(1)
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Scan all files in the repo and check that none of them contains any illegal character in its name

### Motivation

There was a case where a release note with a `:` in it was committed to the repo, and it messed things up on windows.

### Additional Notes

Anything else we should know when reviewing?
