### PR TITLE
[corechecks/memory] Add Linux metrics `commit_limit` and `committed_as`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -554,8 +554,8 @@
     "net",
     "process"
   ]
-  revision = "48fc5612898a1213aa5d6a0fb2d4f7b968e898fb"
-  version = "v2.17.10"
+  revision = "fc04d2dd9a512906a2604242b35275179e250eda"
+  version = "v2.18.03"
 
 [[projects]]
   branch = "master"
@@ -845,6 +845,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "79d78a565c09d8a1abc6af0992bb277523a61618b875913c5923dfd0c9f0d931"
+  inputs-digest = "f4b015f37e24c4fa8e7621f7f50b881ab7c29592b07f48003db37cc0583a7e06"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -88,7 +88,7 @@
 
 [[constraint]]
   name = "github.com/shirou/gopsutil"
-  version = "=v2.17.10"
+  version = "^v2.18.3"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/pkg/collector/corechecks/system/memory_nix.go
+++ b/pkg/collector/corechecks/system/memory_nix.go
@@ -75,6 +75,8 @@ func (c *MemoryCheck) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) 
 	sender.Gauge("system.mem.shared", float64(v.Shared)/mbSize, "", nil)
 	sender.Gauge("system.mem.slab", float64(v.Slab)/mbSize, "", nil)
 	sender.Gauge("system.mem.page_tables", float64(v.PageTables)/mbSize, "", nil)
+	sender.Gauge("system.mem.commit_limit", float64(v.CommitLimit)/mbSize, "", nil)
+	sender.Gauge("system.mem.committed_as", float64(v.CommittedAS)/mbSize, "", nil)
 	sender.Gauge("system.swap.cached", float64(v.SwapCached)/mbSize, "", nil)
 	return nil
 }

--- a/pkg/collector/corechecks/system/memory_nix_test.go
+++ b/pkg/collector/corechecks/system/memory_nix_test.go
@@ -83,7 +83,7 @@ func TestMemoryCheckLinux(t *testing.T) {
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 14)
+	mock.AssertNumberOfCalls(t, "Gauge", 16)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }
 

--- a/pkg/collector/corechecks/system/memory_nix_test.go
+++ b/pkg/collector/corechecks/system/memory_nix_test.go
@@ -36,6 +36,8 @@ func VirtualMemory() (*mem.VirtualMemoryStat, error) {
 		Slab:         327680000000,
 		PageTables:   37790679040,
 		SwapCached:   25000000000,
+		CommitLimit:  785338368,
+		CommittedAS:  433750016,
 	}, nil
 }
 
@@ -68,6 +70,8 @@ func TestMemoryCheckLinux(t *testing.T) {
 	mock.On("Gauge", "system.mem.shared", 327680000000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.slab", 327680000000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.page_tables", 37790679040.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.commit_limit", 785338368.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.committed_as", 433750016.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.total", 100000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.free", 60000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.used", 40000.0/mbSize, "", []string(nil)).Return().Times(1)
@@ -173,13 +177,15 @@ func TestSwapMemoryError(t *testing.T) {
 	mock.On("Gauge", "system.mem.shared", 327680000000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.slab", 327680000000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.mem.page_tables", 37790679040.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.commit_limit", 785338368.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.committed_as", 433750016.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.cached", 25000000000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
 	err := memCheck.Run()
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 10)
+	mock.AssertNumberOfCalls(t, "Gauge", 12)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }
 

--- a/releasenotes/notes/linux-mem-metrics-commit-16b0f60ac51a3fef.yaml
+++ b/releasenotes/notes/linux-mem-metrics-commit-16b0f60ac51a3fef.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The memory corecheck sends 2 new metrics on Linux: ``system.mem.commit_limit``
+    and ``system.mem.committed_as``


### PR DESCRIPTION
### What does this PR do?

Adds 2 metrics to core memory check, on Linux only.

### Motivation

Feature request in https://github.com/DataDog/dd-agent/pull/3130

### Additional Notes

Requires an update on gopsutil (only v2.18.3 and up collect these metrics).
Will require an update on the system metrics metadata, I'll do it as soon as this is merged.
