### PR TITLE
[DCA] Adding flare command to the DCA

### DIFF
--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -8,7 +8,7 @@ The following environment variables are supported:
 
 - `DD_API_KEY`: your API key (**required**)
 - `DD_HOSTNAME`: hostname to use for the DCA.
-- `DD_CMD_PORT`: Port you want the DCA to serve
+- `DD_CLUSTER_AGENT_CMD_PORT`: Port you want the DCA to serve
 
 For a more detailed usage please refer to the official [Docker Hub](https://hub.docker.com/r/datadog/cluster-agent/)
 
@@ -124,6 +124,17 @@ One can simply run `kubectl create configmap configmapdcatoken --from-literal="e
 NB: you can set any resversion here, make sure it's not set to a value superior to the actual curent resversion.
 
 You can also set the `event.tokenTimestamp`, if not present, it will be automatically set.
+
+### Command line interface of the Cluster Agent
+
+The available commands for the cluster agents are:
+- `datadog-cluster-agent status`: This will give you an overview of the components of the agent and their health.
+- `datadog-cluster-agent metamap [nodeName]`: Will query the local cache of the mapping between the pods living on `nodeName`
+    and the cluster level metadata it's associated with (endpoints ...).
+    One can also not specify the `nodeName` to run the mapper on all the nodes of the cluster.
+- `datadog-cluster-agent flare [caseID]`: Similarly to the node agent, the cluster agent can aggregate the logs and the configurations used
+    and forward an archive to the support team or be deflated and used locally.
+
 
 ### Communication with the Datadog Node Agent.
 

--- a/Dockerfiles/manifests/datadog-cluster-agent_service.yaml
+++ b/Dockerfiles/manifests/datadog-cluster-agent_service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: datadog-cluster-agent
 spec:
   ports:
-  - port: 5001 # Has to be the same as the one exposed in the DCA. Default is 5001.
+  - port: 5005 # Has to be the same as the one exposed in the DCA. Default is 5005.
     protocol: TCP
   selector:
     app: datadog-cluster-agent

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -13,7 +13,8 @@ import (
 	"fmt"
 	"net/http"
 
-	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	log "github.com/cihub/seelog"
+	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
@@ -22,9 +23,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	log "github.com/cihub/seelog"
-	"github.com/gorilla/mux"
 )
 
 // EventChecks are checks that send events and are supported by the DCA
@@ -47,7 +47,7 @@ func SetupHandlers(r *mux.Router) {
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
 
@@ -80,7 +80,7 @@ func stopAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func getVersion(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -98,7 +98,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func getHostname(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -115,18 +115,18 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
-// TODO: make a special flare for DCA
 func makeFlare(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
 
 	log.Infof("Making a flare")
+	w.Header().Set("Content-Type", "application/json")
 	logFile := config.Datadog.GetString("log_file")
 	if logFile == "" {
 		logFile = common.DefaultDCALogFile
 	}
-	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, logFile)
+	filePath, err := flare.CreateDCAArchive(false, common.GetDistPath(), logFile)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)
@@ -210,7 +210,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 
 // getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.
 func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
 	vars := mux.Vars(r)
@@ -253,7 +253,7 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: map[string]string
 			Example: "["Error":"could not collect the service map for all nodes: List services is not permitted at the cluster scope."]
 	*/
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+	if err := apiutil.Validate(w, r); err != nil {
 		return
 	}
 	log.Info("Computing metadata map on all nodes")

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -39,7 +39,6 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/flare", makeFlare).Methods("POST")
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
 	r.HandleFunc("/status", getStatus).Methods("GET")
-	// r.HandleFunc("/status/formatted", getFormattedStatus).Methods("GET")
 	r.HandleFunc("/api/v1/metadata/{nodeName}/{podName}", getPodMetadata).Methods("GET")
 	r.HandleFunc("/api/v1/metadata/{nodeName}", getNodeMetadata).Methods("GET")
 	r.HandleFunc("/api/v1/metadata", getAllMetadata).Methods("GET")

--- a/cmd/cluster-agent/api/listener.go
+++ b/cmd/cluster-agent/api/listener.go
@@ -19,5 +19,5 @@ import (
 
 // getListener returns a listening connection
 func getListener() (net.Listener, error) {
-	return net.Listen("tcp", fmt.Sprintf("0.0.0.0:%v", config.Datadog.GetInt("cmd_port")))
+	return net.Listen("tcp", fmt.Sprintf("0.0.0.0:%v", config.Datadog.GetInt("cluster_agent_cmd_port")))
 }

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -46,6 +46,10 @@ func StartServer() error {
 		// no way we can recover from this error
 		return fmt.Errorf("Unable to create the api server: %v", err)
 	}
+	// Internal token
+	util.SetAuthToken()
+
+	// DCA client token
 	util.SetDCAAuthToken()
 
 	// create cert

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -69,6 +69,10 @@ var flareCmd = &cobra.Command{
 			}
 		}
 
+		if flagNoColor {
+			color.NoColor = true
+		}
+
 		return requestFlare(caseID)
 	},
 }

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -77,7 +77,7 @@ func requestFlare(caseID string) error {
 	fmt.Println("Asking the Cluster Agent to build the flare archive.")
 	var e error
 	c := util.GetClient(false) // FIX: get certificates right then make this true
-	urlstr := fmt.Sprintf("https://localhost:%v/flare", config.Datadog.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/flare", config.Datadog.GetInt("cluster_agent_cmd_port"))
 
 	logFile := config.Datadog.GetString("log_file")
 	if logFile == "" {

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package app
+
+import (
+	"bytes"
+	"fmt"
+
+	log "github.com/cihub/seelog"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/flare"
+)
+
+var (
+	customerEmail string
+	autoconfirm   bool
+)
+
+func init() {
+	ClusterAgentCmd.AddCommand(flareCmd)
+
+	flareCmd.Flags().StringVarP(&customerEmail, "email", "e", "", "Your email")
+	flareCmd.Flags().BoolVarP(&autoconfirm, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	flareCmd.SetArgs([]string{"caseID"})
+}
+
+var flareCmd = &cobra.Command{
+	Use:   "flare [caseID]",
+	Short: "Collect a flare and send it to Datadog",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configFound := false
+		// a path to the folder containing the config file was passed
+		if len(confPath) != 0 {
+			// we'll search for a config file named `datadog-cluster.yaml`
+			config.Datadog.AddConfigPath(confPath)
+			confErr := config.Datadog.ReadInConfig()
+			if confErr != nil {
+				log.Error(confErr)
+			} else {
+				configFound = true
+			}
+		}
+		if !configFound {
+			log.Debugf("Config read from env variables")
+		}
+
+		caseID := ""
+		if len(args) > 0 {
+			caseID = args[0]
+		}
+
+		// The flare command should not log anything, all errors should be reported directly to the console without the log format
+		config.SetupLogger("off", "", "", false, false, "", true, false)
+		if customerEmail == "" {
+			var err error
+			customerEmail, err = flare.AskForEmail()
+			if err != nil {
+				fmt.Println("Error reading email, please retry or contact support")
+				return err
+			}
+		}
+
+		return requestFlare(caseID)
+	},
+}
+
+func requestFlare(caseID string) error {
+	fmt.Println("Asking the Cluster Agent to build the flare archive.")
+	var e error
+	c := util.GetClient(false) // FIX: get certificates right then make this true
+	urlstr := fmt.Sprintf("https://localhost:%v/flare", config.Datadog.GetInt("cmd_port"))
+
+	logFile := config.Datadog.GetString("log_file")
+	if logFile == "" {
+		logFile = common.DefaultDCALogFile
+	}
+
+	// Set session token
+	e = util.SetAuthToken()
+	if e != nil {
+		return e
+	}
+
+	r, e := util.DoPost(c, urlstr, "application/json", bytes.NewBuffer([]byte{}))
+	var filePath string
+	if e != nil {
+		if r != nil && string(r) != "" {
+			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
+		} else {
+			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
+		}
+		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be mising."))
+
+		filePath, e = flare.CreateDCAArchive(true, common.GetDistPath(), logFile)
+		if e != nil {
+			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
+			return e
+		}
+	} else {
+		filePath = string(r)
+	}
+
+	fmt.Printf("%s is going to be uploaded to Datadog\n", filePath)
+	if !autoconfirm {
+		confirmation := flare.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
+		if !confirmation {
+			fmt.Printf("Aborting. (You can still use %s) \n", filePath)
+			return nil
+		}
+	}
+
+	response, e := flare.SendFlare(filePath, caseID, customerEmail)
+	fmt.Println(response)
+	if e != nil {
+		return e
+	}
+	return nil
+}

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -66,12 +66,12 @@ func getMetadataMap(nodeName string) error {
 	}
 
 	// Set session token
-	e = util.SetDCAAuthToken()
+	e = util.SetAuthToken()
 	if e != nil {
 		return e
 	}
 
-	r, e := util.DoGetExternalEndpoint(c, urlstr)
+	r, e := util.DoGet(c, urlstr)
 	if e != nil {
 		fmt.Printf(`
 		Could not reach agent: %v

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -60,9 +60,9 @@ func getMetadataMap(nodeName string) error {
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	var urlstr string
 	if nodeName == "" {
-		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata", config.Datadog.GetInt("cmd_port"))
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata", config.Datadog.GetInt("cluster_agent_cmd_port"))
 	} else {
-		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/%s", config.Datadog.GetInt("cmd_port"), nodeName)
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/%s", config.Datadog.GetInt("cluster_agent_cmd_port"), nodeName)
 	}
 
 	// Set session token

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -67,7 +67,7 @@ func requestStatus() error {
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	// TODO use https
-	urlstr := fmt.Sprintf("https://localhost:%v/status", config.Datadog.GetInt("cmd_port"))
+	urlstr := fmt.Sprintf("https://localhost:%v/status", config.Datadog.GetInt("cluster_agent_cmd_port"))
 
 	// Set session token
 	e = util.SetAuthToken()

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -70,12 +70,12 @@ func requestStatus() error {
 	urlstr := fmt.Sprintf("https://localhost:%v/status", config.Datadog.GetInt("cmd_port"))
 
 	// Set session token
-	e = util.SetDCAAuthToken()
+	e = util.SetAuthToken()
 	if e != nil {
 		return e
 	}
 
-	r, e := util.DoGetExternalEndpoint(c, urlstr)
+	r, e := util.DoGet(c, urlstr)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, errMap)

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -51,7 +51,7 @@ DD_API_KEY=12345678990 ./bin/datadog-cluster-agent/datadog-cluster-agent
 Once built, you can use the `start` command and the DCA will also try to connect to the API Server.
 If successful, it will forward the events from the API Server to your Datadog app and a health check for each component of the control pane.
 
-Secondly, it will start serving the CMD_PORT if set or 5001 by default with the following endpoints:
+Secondly, it will start serving the DD_CLUSTER_AGENT_CMD_PORT if set or 5005 by default with the following endpoints:
 
 ```
 - /hostname

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -51,7 +51,7 @@ DD_API_KEY=12345678990 ./bin/datadog-cluster-agent/datadog-cluster-agent
 Once built, you can use the `start` command and the DCA will also try to connect to the API Server.
 If successful, it will forward the events from the API Server to your Datadog app and a health check for each component of the control pane.
 
-Secondly, it will start serving the DD_CLUSTER_AGENT_CMD_PORT if set or 5005 by default with the following endpoints:
+Secondly, it will start serving the `DD_CLUSTER_AGENT_CMD_PORT` if set or 5005 by default with the following endpoints:
 
 ```
 - /hostname

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,7 +91,7 @@ func init() {
 	Datadog.SetDefault("syslog_pem", "")
 	Datadog.SetDefault("cmd_host", "localhost")
 	Datadog.SetDefault("cmd_port", 5001)
-	Datadog.SetDefault("cluster_agent_cmd_port", 5005) // TODO isolate internal and external APIs for the DCA.
+	Datadog.SetDefault("cluster_agent_cmd_port", 5005)
 	Datadog.SetDefault("default_integration_http_timeout", 9)
 	Datadog.SetDefault("enable_metadata_collection", true)
 	Datadog.SetDefault("enable_gohai", true)

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -98,10 +98,6 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		return "", err
 	}
 
-	err = zipConfigCheck(tempDir, hostname)
-	if err != nil {
-		return "", err
-	}
 	err = zipMetadataMap(tempDir, hostname)
 	if err != nil {
 		return "", err
@@ -166,7 +162,7 @@ func zipMetadataMap(tempDir, hostname string) error {
 
 	sByte := []byte(str)
 	f := filepath.Join(tempDir, hostname, "cluster-agent-metadatamapper.log")
-	log.Infof("Flare service mapper made at %s", tempDir)
+	log.Infof("Flare metadata mapper made at %s", tempDir)
 	err = ensureParentDirsExist(f)
 	if err != nil {
 		return err

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -1,0 +1,180 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package flare
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	log "github.com/cihub/seelog"
+	"github.com/mholt/archiver"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+// CreateDCAArchive packages up the files
+func CreateDCAArchive(local bool, distPath, logFilePath string) (string, error) {
+	zipFilePath := getArchivePath()
+	confSearchPaths := SearchPaths{
+		"":     config.Datadog.GetString("confd_dca_path"),
+		"dist": filepath.Join(distPath, "conf.d"),
+	}
+	return createDCAArchive(zipFilePath, local, confSearchPaths, logFilePath)
+}
+
+func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, logFilePath string) (string, error) {
+	b := make([]byte, 10)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+
+	dirName := hex.EncodeToString([]byte(b))
+	tempDir, err := ioutil.TempDir("", dirName)
+	if err != nil {
+		return "", err
+	}
+
+	defer os.RemoveAll(tempDir)
+
+	// Get hostname, if there's an error in getting the hostname,
+	// set the hostname to unknown
+	hostname, err := util.GetHostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
+	// If the request against the API does not go through we don't collect the status log.
+	if local {
+		f := filepath.Join(tempDir, hostname, "local")
+		err = ensureParentDirsExist(f)
+		if err != nil {
+			return "", err
+		}
+
+		err = ioutil.WriteFile(f, []byte{}, os.ModePerm)
+		if err != nil {
+			return "", err
+		}
+		log.Infof("local true")
+	} else {
+		// The Status will be unavailable unless the agent is running.
+		// Only zip it up if the agent is running
+		err = zipDCAStatusFile(tempDir, hostname)
+		if err != nil {
+			log.Infof("Error getting the status of the DCA, %q", err)
+			return "", err
+		}
+	}
+
+	err = zipLogFiles(tempDir, hostname, logFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	err = zipConfigFiles(tempDir, hostname, confSearchPaths)
+
+	if err != nil {
+		return "", err
+	}
+
+	err = zipExpVar(tempDir, hostname)
+	if err != nil {
+		return "", err
+	}
+
+	err = zipEnvvars(tempDir, hostname)
+	if err != nil {
+		return "", err
+	}
+
+	err = zipConfigCheck(tempDir, hostname)
+	if err != nil {
+		return "", err
+	}
+	err = zipMetadataMap(tempDir, hostname)
+	if err != nil {
+		return "", err
+	}
+
+	err = archiver.Zip.Make(zipFilePath, []string{filepath.Join(tempDir, hostname)})
+	if err != nil {
+		return "", err
+	}
+
+	return zipFilePath, nil
+}
+
+func zipDCAStatusFile(tempDir, hostname string) error {
+	// Grab the status
+	log.Infof("Zipping the status at %s for %s", tempDir, hostname)
+	s, err := status.GetAndFormatDCAStatus()
+	if err != nil {
+		log.Infof("Error zipping the status: %q", err)
+		return err
+	}
+
+	// Clean it up
+	cleaned, err := credentialsCleanerBytes(s)
+	if err != nil {
+		log.Infof("Error redacting the log files: %q", err)
+		return err
+	}
+
+	f := filepath.Join(tempDir, hostname, "cluster-agent-status.log")
+	log.Infof("Flare status made at %s", tempDir)
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func zipMetadataMap(tempDir, hostname string) error {
+	// Grab the metadata map for all nodes.
+	metaList, err := apiserver.GetMetadataMapBundleOnAllNodes()
+	if err != nil {
+		log.Infof("Error while collecting the cluster level metadata: %q", err)
+	}
+
+	metaBytes, err := json.Marshal(metaList)
+	if err != nil {
+		log.Infof("Error while marshalling the cluster level metadata: %q", err)
+		return err
+	}
+
+	str, err := status.FormatMetadataMapCLI(metaBytes)
+	if err != nil {
+		log.Infof("Error while rendering the cluster level metadata: %q", err)
+		return err
+	}
+
+	sByte := []byte(str)
+	f := filepath.Join(tempDir, hostname, "cluster-agent-metadatamapper.log")
+	log.Infof("Flare service mapper made at %s", tempDir)
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(f, sByte, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -66,7 +66,6 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		if err != nil {
 			return "", err
 		}
-		log.Infof("local true")
 	} else {
 		// The Status will be unavailable unless the agent is running.
 		// Only zip it up if the agent is running
@@ -153,8 +152,14 @@ func zipMetadataMap(tempDir, hostname string) error {
 		log.Infof("Error while marshalling the cluster level metadata: %q", err)
 		return err
 	}
+	// Clean it up
+	cleanedMetaBytes, err := credentialsCleanerBytes(metaBytes)
+	if err != nil {
+		log.Infof("Error redacting the log files: %q", err)
+		return err
+	}
 
-	str, err := status.FormatMetadataMapCLI(metaBytes)
+	str, err := status.FormatMetadataMapCLI(cleanedMetaBytes)
 	if err != nil {
 		log.Infof("Error while rendering the cluster level metadata: %q", err)
 		return err

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -12,13 +12,14 @@ import (
 	"strconv"
 	"time"
 
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	log "github.com/cihub/seelog"
 )
 
 var timeFormat = "2006-01-02 15:04:05.000000 UTC"
@@ -125,6 +126,26 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	stats["leaderelection"] = getLeaderElectionDetails()
 
 	return stats, nil
+}
+
+// GetAndFormatDCAStatus gets and formats the DCA status all in one go.
+func GetAndFormatDCAStatus() ([]byte, error) {
+	s, err := GetDCAStatus()
+	if err != nil {
+		log.Infof("Error while getting status %q", err)
+		return nil, err
+	}
+	statusJSON, err := json.Marshal(s)
+	if err != nil {
+		log.Infof("Error while marshalling %q", err)
+		return nil, err
+	}
+	st, err := FormatDCAStatus(statusJSON)
+	if err != nil {
+		log.Infof("Error formatting the status %q", err)
+		return nil, err
+	}
+	return []byte(st), nil
 }
 
 // getDCAPartialConfig returns config parameters of interest for the status page.

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -132,7 +132,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmpty() {
 	config.Datadog.Set("cluster_agent.auth_token", "")
 
 	_, err := security.GetClusterAgentAuthToken()
-	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
+	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
 func (suite *clusterAgentSuite) TestGetClusterAgentAuthTokenEmptyFile() {
@@ -306,7 +306,7 @@ func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 }
 
 func TestClusterAgentSuite(t *testing.T) {
-	clusterAgentAuthTokenFilename := "dca_auth_token"
+	clusterAgentAuthTokenFilename := "cluster_agent_auth_token"
 
 	fakeDir, err := ioutil.TempDir("", "fake-datadog-etc")
 	require.Nil(t, err, fmt.Sprintf("%v", err))

--- a/releasenotes/notes/dca-flare-1f0bb281cd38a592.yaml
+++ b/releasenotes/notes/dca-flare-1f0bb281cd38a592.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Introduce the flare command for the DCA CLI.
+security:
+  - |
+    Separate the tokens for the internal API (used for flare, status, metamap) and the external enpoint (used for the tagger of the agent).


### PR DESCRIPTION
### What does this PR do?

Adding the Flare command to the DCA.
- [x] Flare can fallback to env var
- [x] Internal API and External API (metamap vs flare/status) use distinct tokens
- [x] Properly bundles:
    -   Status
    -   Metamap
    -   Logs
    -   Configs (temporary)
    -   Can be extended to contain other logs
- [ ] E2E
- [x] Check it makes its way through zendesk


### Motivation

DCA 1.0.0 CLI requires the Flare.

### Additional Notes

🏋️
