### PR TITLE
[Logs]: Removed different implementations of Message and use only one instead

### DIFF
--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -201,9 +201,7 @@ func (dt *DockerTailer) forwardMessages() {
 		origin.Timestamp = ts
 		origin.Identifier = dt.Identifier()
 		origin.SetTags(dt.containerTags)
-		msg := message.New(content, origin)
-		msg.SetSeverity(sev)
-		dt.outputChan <- msg
+		dt.outputChan <- message.New(content, origin, sev)
 	}
 }
 

--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -192,20 +192,18 @@ func (dt *DockerTailer) forwardMessages() {
 		dt.done <- struct{}{}
 	}()
 	for output := range dt.decoder.OutputChan {
-		ts, sev, updatedMsg, err := parser.ParseMessage(output.Content)
+		ts, sev, content, err := parser.ParseMessage(output.Content)
 		if err != nil {
 			log.Warn(err)
 			continue
 		}
-		containerMsg := message.New(updatedMsg)
-		msgOrigin := message.NewOrigin()
-		msgOrigin.LogSource = dt.source
-		msgOrigin.Timestamp = ts
-		msgOrigin.Identifier = dt.Identifier()
-		msgOrigin.SetTags(dt.containerTags)
-		containerMsg.SetSeverity(sev)
-		containerMsg.SetOrigin(msgOrigin)
-		dt.outputChan <- containerMsg
+		origin := message.NewOrigin(dt.source)
+		origin.Timestamp = ts
+		origin.Identifier = dt.Identifier()
+		origin.SetTags(dt.containerTags)
+		msg := message.New(content, origin)
+		msg.SetSeverity(sev)
+		dt.outputChan <- msg
 	}
 }
 

--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -197,7 +197,7 @@ func (dt *DockerTailer) forwardMessages() {
 			log.Warn(err)
 			continue
 		}
-		containerMsg := message.NewContainerMessage(updatedMsg)
+		containerMsg := message.New(updatedMsg)
 		msgOrigin := message.NewOrigin()
 		msgOrigin.LogSource = dt.source
 		msgOrigin.Timestamp = ts

--- a/pkg/logs/input/listener/worker.go
+++ b/pkg/logs/input/listener/worker.go
@@ -66,7 +66,7 @@ func (w *Worker) forwardMessages() {
 	}()
 	for output := range w.decoder.OutputChan {
 		origin := message.NewOrigin(w.source)
-		w.outputChan <- message.New(output.Content, origin)
+		w.outputChan <- message.New(output.Content, origin, nil)
 	}
 }
 

--- a/pkg/logs/input/listener/worker.go
+++ b/pkg/logs/input/listener/worker.go
@@ -65,7 +65,7 @@ func (w *Worker) forwardMessages() {
 		w.done <- struct{}{}
 	}()
 	for output := range w.decoder.OutputChan {
-		netMsg := message.NewNetworkMessage(output.Content)
+		netMsg := message.New(output.Content)
 		o := message.NewOrigin()
 		o.LogSource = w.source
 		netMsg.SetOrigin(o)

--- a/pkg/logs/input/listener/worker.go
+++ b/pkg/logs/input/listener/worker.go
@@ -65,11 +65,8 @@ func (w *Worker) forwardMessages() {
 		w.done <- struct{}{}
 	}()
 	for output := range w.decoder.OutputChan {
-		netMsg := message.New(output.Content)
-		o := message.NewOrigin()
-		o.LogSource = w.source
-		netMsg.SetOrigin(o)
-		w.outputChan <- netMsg
+		origin := message.NewOrigin(w.source)
+		w.outputChan <- message.New(output.Content, origin)
 	}
 }
 

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -138,7 +138,7 @@ func (t *Tailer) forwardMessages() {
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {
-		fileMsg := message.NewFileMessage(output.Content)
+		fileMsg := message.New(output.Content)
 		msgOffset := t.decodedOffset + int64(output.RawDataLen)
 		identifier := t.Identifier()
 		if !t.shouldTrackOffset() {

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -138,20 +138,17 @@ func (t *Tailer) forwardMessages() {
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {
-		fileMsg := message.New(output.Content)
-		msgOffset := t.decodedOffset + int64(output.RawDataLen)
+		offset := t.decodedOffset + int64(output.RawDataLen)
 		identifier := t.Identifier()
 		if !t.shouldTrackOffset() {
-			msgOffset = 0
+			offset = 0
 			identifier = ""
 		}
-		t.decodedOffset = msgOffset
-		msgOrigin := message.NewOrigin()
-		msgOrigin.LogSource = t.source
-		msgOrigin.Identifier = identifier
-		msgOrigin.Offset = msgOffset
-		fileMsg.SetOrigin(msgOrigin)
-		t.outputChan <- fileMsg
+		t.decodedOffset = offset
+		origin := message.NewOrigin(t.source)
+		origin.Identifier = identifier
+		origin.Offset = offset
+		t.outputChan <- message.New(output.Content, origin)
 	}
 }
 

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -148,7 +148,7 @@ func (t *Tailer) forwardMessages() {
 		origin := message.NewOrigin(t.source)
 		origin.Identifier = identifier
 		origin.Offset = offset
-		t.outputChan <- message.New(output.Content, origin)
+		t.outputChan <- message.New(output.Content, origin, nil)
 	}
 }
 

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -10,7 +10,6 @@ type Message interface {
 	Content() []byte
 	SetContent([]byte)
 	GetOrigin() *Origin
-	SetOrigin(*Origin)
 	GetSeverity() []byte
 	SetSeverity([]byte)
 }
@@ -22,9 +21,10 @@ type message struct {
 }
 
 // New returns a new Message
-func New(content []byte) Message {
+func New(content []byte, origin *Origin) Message {
 	return &message{
 		content: content,
+		origin:  origin,
 	}
 }
 
@@ -41,11 +41,6 @@ func (m *message) SetContent(content []byte) {
 // GetOrigin returns the Origin from which the message comes
 func (m *message) GetOrigin() *Origin {
 	return m.origin
-}
-
-// SetOrigin sets the integration from which the message comes
-func (m *message) SetOrigin(Origin *Origin) {
-	m.origin = Origin
 }
 
 // GetSeverity returns the severity of the message when set

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -21,7 +21,8 @@ type message struct {
 	severity []byte
 }
 
-func newMessage(content []byte) *message {
+// New returns a new Message
+func New(content []byte) Message {
 	return &message{
 		content: content,
 	}
@@ -55,40 +56,4 @@ func (m *message) GetSeverity() []byte {
 // SetSeverity sets the severity of the message
 func (m *message) SetSeverity(severity []byte) {
 	m.severity = severity
-}
-
-// FileMessage is a message coming from a File
-type FileMessage struct {
-	*message
-}
-
-// NewFileMessage returns a new FileMessage
-func NewFileMessage(content []byte) *FileMessage {
-	return &FileMessage{
-		message: newMessage(content),
-	}
-}
-
-// NetworkMessage is a message coming from a network Source
-type NetworkMessage struct {
-	*message
-}
-
-// NewNetworkMessage returns a new NetworkMessage
-func NewNetworkMessage(content []byte) *NetworkMessage {
-	return &NetworkMessage{
-		message: newMessage(content),
-	}
-}
-
-// ContainerMessage is a message coming from a container Source
-type ContainerMessage struct {
-	*message
-}
-
-// NewContainerMessage returns a new ContainerMessage
-func NewContainerMessage(content []byte) *ContainerMessage {
-	return &ContainerMessage{
-		message: newMessage(content),
-	}
 }

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -11,7 +11,6 @@ type Message interface {
 	SetContent([]byte)
 	GetOrigin() *Origin
 	GetSeverity() []byte
-	SetSeverity([]byte)
 }
 
 type message struct {
@@ -21,10 +20,11 @@ type message struct {
 }
 
 // New returns a new Message
-func New(content []byte, origin *Origin) Message {
+func New(content []byte, origin *Origin, severity []byte) Message {
 	return &message{
-		content: content,
-		origin:  origin,
+		content:  content,
+		origin:   origin,
+		severity: severity,
 	}
 }
 
@@ -46,9 +46,4 @@ func (m *message) GetOrigin() *Origin {
 // GetSeverity returns the severity of the message when set
 func (m *message) GetSeverity() []byte {
 	return m.severity
-}
-
-// SetSeverity sets the severity of the message
-func (m *message) SetSeverity(severity []byte) {
-	m.severity = severity
 }

--- a/pkg/logs/message/message_test.go
+++ b/pkg/logs/message/message_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMessage(t *testing.T) {
 
-	message := New([]byte("hello"), nil)
+	message := New([]byte("hello"), nil, nil)
 	assert.Equal(t, "hello", string(message.Content()))
 
 	message.SetContent([]byte("world"))

--- a/pkg/logs/message/message_test.go
+++ b/pkg/logs/message/message_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMessage(t *testing.T) {
 
-	message := New([]byte("hello"))
+	message := New([]byte("hello"), nil)
 	assert.Equal(t, "hello", string(message.Content()))
 
 	message.SetContent([]byte("world"))

--- a/pkg/logs/message/message_test.go
+++ b/pkg/logs/message/message_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMessage(t *testing.T) {
 
-	message := newMessage([]byte("hello"))
+	message := New([]byte("hello"))
 	assert.Equal(t, "hello", string(message.Content()))
 
 	message.SetContent([]byte("world"))

--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -21,8 +21,10 @@ type Origin struct {
 }
 
 // NewOrigin returns a new Origin
-func NewOrigin() *Origin {
-	return &Origin{}
+func NewOrigin(source *config.LogSource) *Origin {
+	return &Origin{
+		LogSource: source,
+	}
 }
 
 // Tags returns the tags of the origin.

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -15,8 +15,7 @@ import (
 func TestSetTagsEmpty(t *testing.T) {
 	cfg := &config.LogsConfig{}
 	source := config.NewLogSource("", cfg)
-	origin := NewOrigin()
-	origin.LogSource = source
+	origin := NewOrigin(source)
 	origin.SetTags([]string{})
 	assert.Equal(t, []string{}, origin.Tags())
 	assert.Equal(t, []byte{}, origin.TagsPayload())
@@ -29,8 +28,7 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 		Tags:           []string{"c:d", "e"},
 	}
 	source := config.NewLogSource("", cfg)
-	origin := NewOrigin()
-	origin.LogSource = source
+	origin := NewOrigin(source)
 	assert.Equal(t, []string{"source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
 }
@@ -41,8 +39,7 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 		SourceCategory: "b",
 	}
 	source := config.NewLogSource("", cfg)
-	origin := NewOrigin()
-	origin.LogSource = source
+	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
@@ -55,8 +52,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 		Tags:           []string{"c:d", "e"},
 	}
 	source := config.NewLogSource("", cfg)
-	origin := NewOrigin()
-	origin.LogSource = source
+	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
 	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -34,8 +34,7 @@ func TestRawEncoder(t *testing.T) {
 	source := config.NewLogSource("", logsConfig)
 
 	rawMessage := "message"
-	message := newNetworkMessage([]byte(rawMessage), source)
-	message.SetSeverity(config.SevError)
+	message := newMessage([]byte(rawMessage), source, config.SevError)
 	message.GetOrigin().LogSource = source
 	message.GetOrigin().SetTags([]string{"a", "b:c"})
 
@@ -67,7 +66,7 @@ func TestRawEncoderDefaults(t *testing.T) {
 	source := config.NewLogSource("", logsConfig)
 
 	rawMessage := "a"
-	message := newNetworkMessage([]byte(rawMessage), source)
+	message := newMessage([]byte(rawMessage), source, nil)
 
 	redactedMessage := "a"
 
@@ -96,7 +95,7 @@ func TestRawEncoderEmpty(t *testing.T) {
 	source := config.NewLogSource("", logsConfig)
 
 	rawMessage := ""
-	message := newNetworkMessage([]byte(rawMessage), source)
+	message := newMessage([]byte(rawMessage), source, nil)
 
 	redactedMessage := "foo"
 
@@ -125,8 +124,7 @@ func TestProtoEncoder(t *testing.T) {
 	source := config.NewLogSource("", logsConfig)
 
 	rawMessage := "message"
-	message := newNetworkMessage([]byte(rawMessage), source)
-	message.SetSeverity(config.SevError)
+	message := newMessage([]byte(rawMessage), source, config.SevError)
 	message.GetOrigin().LogSource = source
 	message.GetOrigin().SetTags([]string{"a", "b:c"})
 
@@ -158,7 +156,7 @@ func TestProtoEncoderEmpty(t *testing.T) {
 	source := config.NewLogSource("", logsConfig)
 
 	rawMessage := ""
-	message := newNetworkMessage([]byte(rawMessage), source)
+	message := newMessage([]byte(rawMessage), source, nil)
 
 	redactedMessage := ""
 

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -26,9 +26,9 @@ func buildTestConfigLogSource(ruleType, replacePlaceholder, pattern string) conf
 	return config.LogSource{Config: &config.LogsConfig{ProcessingRules: []config.LogsProcessingRule{rule}}}
 }
 
-func newNetworkMessage(content []byte, source *config.LogSource) message.Message {
+func newMessage(content []byte, source *config.LogSource, severity []byte) message.Message {
 	origin := message.NewOrigin(source)
-	msg := message.New(content, origin)
+	msg := message.New(content, origin, severity)
 	return msg
 }
 
@@ -38,18 +38,18 @@ func TestExclusion(t *testing.T) {
 	var redactedMessage []byte
 
 	source := buildTestConfigLogSource("exclude_at_match", "", "world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("hello"), redactedMessage)
 
-	shouldProcess, _ = applyRedactingRules(newNetworkMessage([]byte("world"), &source))
+	shouldProcess, _ = applyRedactingRules(newMessage([]byte("world"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 
-	shouldProcess, _ = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, _ = applyRedactingRules(newMessage([]byte("a brand new world"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 
 	source = buildTestConfigLogSource("exclude_at_match", "", "$world")
-	shouldProcess, _ = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, _ = applyRedactingRules(newMessage([]byte("a brand new world"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 }
 
@@ -59,20 +59,20 @@ func TestInclusion(t *testing.T) {
 	var redactedMessage []byte
 
 	source := buildTestConfigLogSource("include_at_match", "", "world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("world"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("world"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("world"), redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("a brand new world"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("a brand new world"), redactedMessage)
 
 	source = buildTestConfigLogSource("include_at_match", "", "^world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("a brand new world"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("a brand new world"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 }
@@ -98,19 +98,19 @@ func TestExclusionWithInclusion(t *testing.T) {
 	}
 	source := config.LogSource{Config: &config.LogsConfig{ProcessingRules: []config.LogsProcessingRule{eRule, iRule}}}
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bob@datadoghq.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bob@datadoghq.com"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bill@datadoghq.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bill@datadoghq.com"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("bill@datadoghq.com"), redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bob@amail.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bob@amail.com"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("bill@amail.com"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("bill@amail.com"), &source, nil))
 	assert.Equal(t, false, shouldProcess)
 	assert.Nil(t, redactedMessage)
 }
@@ -121,21 +121,21 @@ func TestMask(t *testing.T) {
 	var redactedMessage []byte
 
 	source := buildTestConfigLogSource("mask_sequences", "[masked_world]", "world")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("hello"), redactedMessage)
 
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello world!"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("hello world!"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("hello [masked_world]!"), redactedMessage)
 
 	source = buildTestConfigLogSource("mask_sequences", "[masked_user]", "User=\\w+@datadoghq.com")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("new test launched by User=beats@datadoghq.com on localhost"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("new test launched by User=beats@datadoghq.com on localhost"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("new test launched by [masked_user] on localhost"), redactedMessage)
 
 	source = buildTestConfigLogSource("mask_sequences", "[masked_credit_card]", "(?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})")
-	shouldProcess, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("The credit card 4323124312341234 was used to buy some time"), &source))
+	shouldProcess, redactedMessage = applyRedactingRules(newMessage([]byte("The credit card 4323124312341234 was used to buy some time"), &source, nil))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("The credit card [masked_credit_card] was used to buy some time"), redactedMessage)
 }
@@ -145,6 +145,6 @@ func TestTruncate(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
 	var redactedMessage []byte
 
-	_, redactedMessage = applyRedactingRules(newNetworkMessage([]byte("hello"), source))
+	_, redactedMessage = applyRedactingRules(newMessage([]byte("hello"), source, nil))
 	assert.Equal(t, []byte("hello"), redactedMessage)
 }

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -27,7 +27,7 @@ func buildTestConfigLogSource(ruleType, replacePlaceholder, pattern string) conf
 }
 
 func newNetworkMessage(content []byte, source *config.LogSource) message.Message {
-	msg := message.NewNetworkMessage(content)
+	msg := message.New(content)
 	msgOrigin := message.NewOrigin()
 	msgOrigin.LogSource = source
 	msg.SetOrigin(msgOrigin)

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -27,10 +27,8 @@ func buildTestConfigLogSource(ruleType, replacePlaceholder, pattern string) conf
 }
 
 func newNetworkMessage(content []byte, source *config.LogSource) message.Message {
-	msg := message.New(content)
-	msgOrigin := message.NewOrigin()
-	msgOrigin.LogSource = source
-	msg.SetOrigin(msgOrigin)
+	origin := message.NewOrigin(source)
+	msg := message.New(content, origin)
 	return msg
 }
 


### PR DESCRIPTION
### What does this PR do?

Removed the message abstraction and its different implementations.

### Motivation

Simplify code.

### Additional Notes

I am wondering whether it's worth trying to have only one kind of offset in the message origin that would be a string for the auditor to be completely agnostic from integration types.
This would require some extra work to keep the backward compatibility though.
