### PR TITLE
kubernetes apiserver: remove configmap listing logic

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -290,10 +290,6 @@ func (c *APIClient) checkResourcesAuth() error {
 	if err != nil {
 		errorMessages = append(errorMessages, fmt.Sprintf("node collection: %q", err.Error()))
 	}
-	_, err = c.client.CoreV1().ListConfigMaps(ctx, "")
-	if err != nil {
-		errorMessages = append(errorMessages, fmt.Sprintf("configmap collection: %q", err.Error()))
-	}
 	_, err = c.client.CoreV1().ListEndpoints(ctx, "")
 	if err != nil {
 		errorMessages = append(errorMessages, fmt.Sprintf("endpoints collection: %q", err.Error()))

--- a/releasenotes/notes/kubenetes-configmap-list-558603e0c0e90203.yaml
+++ b/releasenotes/notes/kubenetes-configmap-list-558603e0c0e90203.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Kubernetes: remove configmap listing logic, as leader election now uses endpoints


### PR DESCRIPTION
### Motivation

apiclient fails to init with our default RBAC