### PR TITLE
[Logs] Use syslog NILVALUE instead of blank when no structured data is defined

### DIFF
--- a/pkg/logs/processor/encoder.go
+++ b/pkg/logs/processor/encoder.go
@@ -79,7 +79,12 @@ func (r *raw) encode(msg message.Message, redactedMsg []byte) ([]byte, error) {
 		extraContent = append(extraContent, []byte(" - - ")...)
 
 		// Tags
-		extraContent = append(extraContent, msg.GetOrigin().TagsPayload()...)
+		tagsPayload := msg.GetOrigin().TagsPayload()
+		if len(tagsPayload) > 0 {
+			extraContent = append(extraContent, tagsPayload...)
+		} else {
+			extraContent = append(extraContent, '-')
+		}
 		extraContent = append(extraContent, ' ')
 
 		return append(extraContent, redactedMsg...), nil

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -78,14 +78,15 @@ func TestRawEncoderDefaults(t *testing.T) {
 
 	msg := string(raw)
 	parts := strings.Fields(msg)
-	assert.Equal(t, 7, len(parts))
+	assert.Equal(t, 8, len(parts))
 	assert.Equal(t, string(config.SevInfo)+"0", parts[0])
 	assert.Equal(t, day, parts[1][:len(day)])
 	assert.NotEmpty(t, parts[2])
 	assert.Equal(t, "-", parts[3])
 	assert.Equal(t, "-", parts[4])
 	assert.Equal(t, "-", parts[5])
-	assert.Equal(t, "a", parts[6])
+	assert.Equal(t, "-", parts[6])
+	assert.Equal(t, "a", parts[7])
 
 }
 


### PR DESCRIPTION
### What does this PR do?

Replace tags by `-` in raw encoder when none are defined.

### Motivation

Enable JSON payload to be parsed when no service and no tags are set.

### Additional Nodes

*works*
```bash
<API_KEY> <46>0 2018-04-20T12:01:32.395698554Z ajacquemot - - - - {"foo":"bar","message":"boo"}
```

*doesn't work*
```bash
<API_KEY> <46>0 2018-04-20T12:01:32.395698554Z ajacquemot - - - {"foo":"bar","message":"boo"}
```