### PR TITLE
Replace start command with run  to avoid confusion

### DIFF
--- a/Dockerfiles/agent/s6-services/agent/run
+++ b/Dockerfiles/agent/s6-services/agent/run
@@ -2,4 +2,4 @@
 
 foreground { /initlog.sh "starting agent" }
 fdmove -c 2 1
-agent start
+agent run

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please refer to the [Agent Developer Guide](docs/dev/README.md) for more details
 
 ## Run
 
-To start the agent type `agent start` from the `bin/agent` folder, it will take
+To start the agent type `agent run` from the `bin/agent` folder, it will take
 care of adjusting paths and run the binary in foreground.
 
 You need to provide a valid API key. You can either use the config file or

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"syscall"
+
+	_ "expvar"         // Blank import used because this isn't directly used in this file
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
+
+	"os"
+	"os/signal"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	log "github.com/cihub/seelog"
+	"github.com/spf13/cobra"
+)
+
+var (
+	runCmd = &cobra.Command{
+		Use:   "run",
+		Short: "Run the Agent",
+		Long:  `Runs the agent in the foreground`,
+		RunE:  run,
+	}
+)
+
+var (
+	// flags variables
+	runForeground bool
+	pidfilePath   string
+)
+
+// run the host metadata collector every 14400 seconds (4 hours)
+const hostMetadataCollectorInterval = 14400
+
+// run the agent checks metadata collector every 600 seconds (10 minutes)
+const agentChecksMetadataCollectorInterval = 600
+
+// run the resources metadata collector every 300 seconds (5 minutes) by default, configurable
+const defaultResourcesMetadataCollectorInterval = 300
+
+func init() {
+
+	// attach the command to the root
+	AgentCmd.AddCommand(runCmd)
+
+	// local flags
+	runCmd.Flags().StringVarP(&pidfilePath, "pidfile", "p", "", "path to the pidfile")
+}
+
+// Start the main loop
+func run(cmd *cobra.Command, args []string) error {
+	defer func() {
+		StopAgent()
+	}()
+
+	// Setup a channel to catch OS signals
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Make a channel to exit the function
+	stopCh := make(chan error)
+
+	go func() {
+		// Set up the signals async so we can Start the agent
+		select {
+		case <-signals.Stopper:
+			log.Info("Received stop command, shutting down...")
+			stopCh <- nil
+		case <-signals.ErrorStopper:
+			log.Critical("The Agent has encountered an error, shutting down...")
+			stopCh <- fmt.Errorf("shutting down because of an error")
+		case sig := <-signalCh:
+			log.Infof("Received signal '%s', shutting down...", sig)
+			stopCh <- nil
+		}
+	}()
+
+	if err := StartAgent(); err != nil {
+		return err
+	}
+
+	select {
+	case err := <-stopCh:
+		return err
+	}
+}

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -47,10 +47,9 @@ import (
 
 var (
 	startCmd = &cobra.Command{
-		Use:   "start",
-		Short: "(DEPRECATED) Use \"run\" instead to start the Agent",
-		Long:  `(DEPRECATED) Use \"run\" instead to runs the agent in the foreground.  Command will be removed in 6.4`,
-		RunE:  start,
+		Use:        "start",
+		Deprecated: "Use \"run\" instead to start the Agent",
+		RunE:       start,
 	}
 )
 
@@ -64,7 +63,6 @@ func init() {
 
 // Start the main loop
 func start(cmd *cobra.Command, args []string) error {
-	fmt.Printf("The start command is being deprecated.  Use \"agent run\".\n\n")
 	return run(cmd, args)
 }
 

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -8,7 +8,6 @@ package app
 import (
 	"fmt"
 	"runtime"
-	"syscall"
 	"time"
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
@@ -16,11 +15,9 @@ import (
 	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"os"
-	"os/signal"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -51,26 +48,11 @@ import (
 var (
 	startCmd = &cobra.Command{
 		Use:   "start",
-		Short: "Start the Agent",
-		Long:  `Runs the agent in the foreground`,
+		Short: "(DEPRECATED) Use \"run\" instead to start the Agent",
+		Long:  `(DEPRECATED) Use \"run\" instead to runs the agent in the foreground.  Command will be removed in 6.4`,
 		RunE:  start,
 	}
 )
-
-var (
-	// flags variables
-	runForeground bool
-	pidfilePath   string
-)
-
-// run the host metadata collector every 14400 seconds (4 hours)
-const hostMetadataCollectorInterval = 14400
-
-// run the agent checks metadata collector every 600 seconds (10 minutes)
-const agentChecksMetadataCollectorInterval = 600
-
-// run the resources metadata collector every 300 seconds (5 minutes) by default, configurable
-const defaultResourcesMetadataCollectorInterval = 300
 
 func init() {
 	// attach the command to the root
@@ -82,40 +64,8 @@ func init() {
 
 // Start the main loop
 func start(cmd *cobra.Command, args []string) error {
-	defer func() {
-		StopAgent()
-	}()
-
-	// Setup a channel to catch OS signals
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-
-	// Make a channel to exit the function
-	stopCh := make(chan error)
-
-	go func() {
-		// Set up the signals async so we can Start the agent
-		select {
-		case <-signals.Stopper:
-			log.Info("Received stop command, shutting down...")
-			stopCh <- nil
-		case <-signals.ErrorStopper:
-			log.Critical("The Agent has encountered an error, shutting down...")
-			stopCh <- fmt.Errorf("shutting down because of an error")
-		case sig := <-signalCh:
-			log.Infof("Received signal '%s', shutting down...", sig)
-			stopCh <- nil
-		}
-	}()
-
-	if err := StartAgent(); err != nil {
-		return err
-	}
-
-	select {
-	case err := <-stopCh:
-		return err
-	}
+	fmt.Printf("The start command is being deprecated.  Use \"agent run\".\n\n")
+	return run(cmd, args)
 }
 
 // StartAgent Initializes the agent process

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -20,7 +20,7 @@ import (
 var (
 	stopCmd = &cobra.Command{
 		Use:   "stop",
-		Short: "Stop the Agent",
+		Short: "Stops a running Agent",
 		Long:  ``,
 		RunE:  stop,
 	}
@@ -31,7 +31,7 @@ func init() {
 	AgentCmd.AddCommand(stopCmd)
 }
 
-func stop(*cobra.Command, []string) error {
+func stop(cmd *cobra.Command, args []string) error {
 	// Global Agent configuration
 	err := common.SetupConfig(confFilePath)
 	if err != nil {

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -31,7 +31,7 @@ func init() {
 	AgentCmd.AddCommand(stopCmd)
 }
 
-func stop(cmd *cobra.Command, args []string) error {
+func stop(*cobra.Command, []string) error {
 	// Global Agent configuration
 	err := common.SetupConfig(confFilePath)
 	if err != nil {

--- a/docs/dev/tools.md
+++ b/docs/dev/tools.md
@@ -48,7 +48,7 @@ A debugger for Go.
 
 Example usage:
 ```sh
-$ sudo dlv attach `pgrep -f '/opt/datadog-agent/bin/agent/agent start'`
+$ sudo dlv attach `pgrep -f '/opt/datadog-agent/bin/agent/agent run'`
 (dlv) help # help on all commands
 (dlv) goroutines # list goroutines
 (dlv) threads # list threads

--- a/omnibus/config/templates/datadog-agent/launchd.plist.example.erb
+++ b/omnibus/config/templates/datadog-agent/launchd.plist.example.erb
@@ -17,7 +17,7 @@
         <key>ProgramArguments</key>
         <array>
             <string><%= install_dir %>/bin/agent/agent</string>
-            <string>start</string>
+            <string>run</string>
         </array>
         <key>StandardOutPath</key>
         <string>/var/log/datadog/launchd.log</string>

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -10,7 +10,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+ExecStart=<%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.conf.erb
@@ -16,7 +16,7 @@ env DD_LOG_TO_CONSOLE=false
 setuid dd-agent
 
 script
-  exec <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+  exec <%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid
 end script
 
 post-stop script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.conf.erb
@@ -16,7 +16,7 @@ script
   #
   # setuid is not available in versions of upstart before 1.4. CentOS/RHEL6 use an earlier version of upstart.
   # This is the best way to set the user in the absence of setuid.
-  exec su -s /bin/sh -c 'DD_LOG_TO_CONSOLE=false exec "$0" "$@"' dd-agent -- <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid &>> /var/log/datadog/errors.log
+  exec su -s /bin/sh -c 'DD_LOG_TO_CONSOLE=false exec "$0" "$@"' dd-agent -- <%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid &>> /var/log/datadog/errors.log
 end script
 
 pre-start script

--- a/omnibus/config/templates/datadog-puppy/systemd.service.erb
+++ b/omnibus/config/templates/datadog-puppy/systemd.service.erb
@@ -7,7 +7,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStart=<%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+ExecStart=<%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-puppy/upstart.conf.erb
+++ b/omnibus/config/templates/datadog-puppy/upstart.conf.erb
@@ -9,7 +9,7 @@ setuid dd-agent
 console none
 
 script
-  exec <%= install_dir %>/bin/agent/agent start -p <%= install_dir %>/run/agent.pid
+  exec <%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid
 end script
 
 post-stop script

--- a/releasenotes/notes/replcmds-3a95564a5f58197b.yaml
+++ b/releasenotes/notes/replcmds-3a95564a5f58197b.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    Begin deprecating "Agent start".  It is being replaced by "run".  Command
+    will continue to function, with a deprecation notice
+other:
+  - |
+    Added new command "run" to the agent.  This command replacees the "start"
+    command, to reduce ambiguity with the service lifecycle commands
+

--- a/releasenotes/notes/replcmds-3a95564a5f58197b.yaml
+++ b/releasenotes/notes/replcmds-3a95564a5f58197b.yaml
@@ -1,10 +1,10 @@
 ---
 deprecations:
   - |
-    Begin deprecating "Agent start".  It is being replaced by "run".  Command
-    will continue to function, with a deprecation notice
+    Begin deprecating "Agent start" command.  It is being replaced by "run".  The "start"
+    command will continue to function, with a deprecation notice
 other:
   - |
-    Added new command "run" to the agent.  This command replacees the "start"
+    Added new command "run" to the agent.  This command replaces the "start"
     command, to reduce ambiguity with the service lifecycle commands
 


### PR DESCRIPTION
with service lifetime commands.  Commands still function (for now) with
a deprecation notice

