### PR TITLE
Kubernetes Config Maps' namespace is configurable

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -85,6 +85,7 @@ Please refer to the dedicated section about the [Kubernetes integration](#kubern
 - `DD_COLLECT_KUBERNETES_EVENTS`: configures the agent to collect Kubernetes events. See [Event collection](#event-collection) for more details.
 - `DD_LEADER_ELECTION`: activates the [leader election](#leader-election). Will be activated if the `DD_COLLECT_KUBERNETES_EVENTS` is set to true. The expected value is a bool: true/false.
 - `DD_LEADER_LEASE_DURATION`: only used if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds.
+- `DD_KUBE_RESOURCES_NAMESPACE`: can be used to configure the namespace where the configmaps of the Leader Election and the Event Collection live.
 
 #### Others
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,6 +190,7 @@ func init() {
 	Datadog.SetDefault("kubernetes_kubeconfig_path", "")
 	Datadog.SetDefault("leader_lease_duration", "60")
 	Datadog.SetDefault("leader_election", false)
+	Datadog.SetDefault("kube_resources_namespace", "")
 
 	// Datadog cluster agent
 	Datadog.SetDefault("cluster_agent", false)
@@ -286,6 +287,7 @@ func init() {
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 	Datadog.BindEnv("leader_election")
 	Datadog.BindEnv("leader_lease_duration")
+	Datadog.BindEnv("kube_resources_namespace")
 
 	Datadog.BindEnv("collect_ec2_tags")
 }

--- a/releasenotes/notes/agent-kube-config-namespace-80e3dfb6b278493a.yaml
+++ b/releasenotes/notes/agent-kube-config-namespace-80e3dfb6b278493a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ability to configure the namespace in which the resources related to the kubernetes check are created.


### PR DESCRIPTION
### What does this PR do?

As per the issue https://github.com/DataDog/datadog-agent/issues/1407, the namespace of the resources used by the Kubernetes check and related features was not configurable.
The choice of using the default namespace instead of a dedicated one (as in the agent5) lack clarity.

This PR introduces the `DD_KUBE_RESOURCES_NAMESPACE ` as well as the logic to allow users to configure where those resources are created.

### Motivation

Community request, reduce the changes between the A5 and the A6.

### Additional Notes

:electron: 
