### PR TITLE
[deps] Temp fix for golint dep install

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -183,9 +183,16 @@ def deps(ctx):
     # TODO: revert as soon as `go get -u github.com/golang/lint/golint` works again
     # See https://github.com/golang/lint/issues/396
     ctx.run("go get -u github.com/golang/lint")
-    ctx.run("git -C \"$GOPATH/src/github.com/golang/lint\" checkout c363707d68842c977f911634e06201907b60ce58^")
+    cloned_path = os.path.join(os.environ["GOPATH"], "src", "github.com", "golang", "lint")
+    ctx.run("git -C \"{cloned_path}\" checkout \"c363707d68842c977f911634e06201907b60ce58^\"".format(
+            cloned_path=cloned_path
+        )
+    )
     ctx.run("go install github.com/golang/lint/golint")
-    ctx.run("git -C \"$GOPATH/src/github.com/golang/lint\" checkout master")
+    ctx.run("git -C \"{cloned_path}\" checkout master".format(
+            cloned_path=cloned_path
+        )
+    )
 
     ctx.run("go get -u github.com/fzipp/gocyclo")
     ctx.run("go get -u github.com/gordonklaus/ineffassign")

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -184,12 +184,15 @@ def deps(ctx):
     # See https://github.com/golang/lint/issues/396
     ctx.run("go get -u github.com/golang/lint")
     cloned_path = os.path.join(os.environ["GOPATH"], "src", "github.com", "golang", "lint")
-    ctx.run("git -C \"{cloned_path}\" checkout \"c363707d68842c977f911634e06201907b60ce58^\"".format(
+    cloned_path_git = os.path.join(cloned_path, ".git")
+    ctx.run("git --git-dir=\"{cloned_path_git}\" --work-tree=\"{cloned_path}\" checkout \"c363707d68842c977f911634e06201907b60ce58^\"".format(
+            cloned_path_git=cloned_path_git,
             cloned_path=cloned_path
         )
     )
     ctx.run("go install github.com/golang/lint/golint")
-    ctx.run("git -C \"{cloned_path}\" checkout master".format(
+    ctx.run("git --git-dir=\"{cloned_path_git}\" --work-tree=\"{cloned_path}\" checkout master".format(
+            cloned_path_git=cloned_path_git,
             cloned_path=cloned_path
         )
     )

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -179,7 +179,14 @@ def deps(ctx):
     Setup Go dependencies
     """
     ctx.run("go get -u github.com/golang/dep/cmd/dep")
-    ctx.run("go get -u github.com/golang/lint/golint")
+
+    # TODO: revert as soon as `go get -u github.com/golang/lint/golint` works again
+    # See https://github.com/golang/lint/issues/396
+    ctx.run("go get -u github.com/golang/lint")
+    ctx.run("git -C \"$GOPATH/src/github.com/golang/lint\" checkout c363707d68842c977f911634e06201907b60ce58^")
+    ctx.run("go install github.com/golang/lint/golint")
+    ctx.run("git -C \"$GOPATH/src/github.com/golang/lint\" checkout master")
+
     ctx.run("go get -u github.com/fzipp/gocyclo")
     ctx.run("go get -u github.com/gordonklaus/ineffassign")
     ctx.run("go get -u github.com/client9/misspell/cmd/misspell")


### PR DESCRIPTION
Temp fix, until https://github.com/golang/lint/issues/396 is resolved. Unblocks our CI.