### PR TITLE
[forwarder] Use proxy settings from env

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -6,22 +6,14 @@
 package util
 
 import (
-	"crypto/tls"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math/rand"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 func init() {
@@ -97,16 +89,6 @@ func EnsureParentDirsExist(p string) error {
 	return nil
 }
 
-// HTTPHeaders returns a http headers including various basic information (User-Agent, Content-Type...).
-func HTTPHeaders() map[string]string {
-	av, _ := version.New(version.AgentVersion, version.Commit)
-	return map[string]string{
-		"User-Agent":   fmt.Sprintf("Datadog Agent/%s", av.GetNumber()),
-		"Content-Type": "application/x-www-form-urlencoded",
-		"Accept":       "text/html, */*",
-	}
-}
-
 // GetJSONSerializableMap returns a JSON serializable map from a raw map
 func GetJSONSerializableMap(m interface{}) interface{} {
 	switch x := m.(type) {
@@ -139,85 +121,4 @@ func GetJSONSerializableMap(m interface{}) interface{} {
 	}
 	return m
 
-}
-
-// GetProxyTransportFunc return a proxy function for a http.Transport that
-// would return the right proxy depending on the configuration.
-func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error) {
-	return func(r *http.Request) (*url.URL, error) {
-		// check no_proxy list first
-		for _, host := range p.NoProxy {
-			if r.URL.Host == host {
-				log.Debugf("URL match no_proxy list item '%s': not using any proxy", host)
-				return nil, nil
-			}
-		}
-
-		// check proxy by scheme
-		confProxy := ""
-		if r.URL.Scheme == "http" {
-			confProxy = p.HTTP
-		} else if r.URL.Scheme == "https" {
-			confProxy = p.HTTPS
-		} else {
-			log.Warnf("Proxy configuration do not support scheme '%s'", r.URL.Scheme)
-		}
-
-		if confProxy != "" {
-			proxyURL, err := url.Parse(confProxy)
-			if err != nil {
-				err := fmt.Errorf("Could not parse the proxy URL for scheme %s from configuration: %s", r.URL.Scheme, err)
-				log.Error(err.Error())
-				return nil, err
-			}
-			userInfo := ""
-			if proxyURL.User != nil {
-				if _, isSet := proxyURL.User.Password(); isSet {
-					userInfo = "*****:*****@"
-				} else {
-					userInfo = "*****@"
-				}
-			}
-
-			log.Debugf("Using proxy %s://%s%s for URL '%s'", proxyURL.Scheme, userInfo, proxyURL.Host, r.URL)
-			return proxyURL, nil
-		}
-
-		// no proxy set for this request
-		return nil, nil
-	}
-}
-
-// CreateHTTPTransport creates an *http.Transport for use in the agent
-func CreateHTTPTransport() *http.Transport {
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: config.Datadog.GetBool("skip_ssl_validation"),
-	}
-
-	if config.Datadog.GetBool("force_tls_12") {
-		tlsConfig.MinVersion = tls.VersionTLS12
-	}
-
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-
-	if proxies := config.Datadog.Get("proxy"); proxies != nil {
-		if os.Getenv("http_proxy") != "" || os.Getenv("https_proxy") != "" ||
-			os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
-			log.Info("Using agent's proxy configuration instead of env vars 'http_proxy', 'https_proxy' and 'no_proxy'")
-		}
-
-		proxies := &config.Proxy{}
-		if err := config.Datadog.UnmarshalKey("proxy", proxies); err != nil {
-			log.Errorf("Could not load the proxy configuration: %s", err)
-		} else {
-			transport.Proxy = GetProxyTransportFunc(proxies)
-		}
-	} else {
-		log.Info("Using proxy settings from environment")
-		transport.Proxy = http.ProxyFromEnvironment
-	}
-
-	return transport
 }

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,4 +157,13 @@ func TestCreateHTTPTransport(t *testing.T) {
 	transport = CreateHTTPTransport()
 	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
+}
+
+func TestCreateHTTPTransportEnvVarProxy(t *testing.T) {
+	// Test that the transport uses proxy from environment when not defined in config
+	transport := CreateHTTPTransport()
+
+	// To compare functions here, we're relying on behavior that's undefined in the golang spec, but works
+	// in the Go1 implementation. See https://stackoverflow.com/a/9644797 for details
+	assert.Equal(t, reflect.ValueOf(http.ProxyFromEnvironment).Pointer(), reflect.ValueOf(transport.Proxy).Pointer())
 }

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -1,103 +1,17 @@
 package util
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"gopkg.in/yaml.v2"
 )
-
-func TestEmptyProxy(t *testing.T) {
-	r, err := http.NewRequest("GET", "https://test.com", nil)
-	require.Nil(t, err)
-
-	proxies := &config.Proxy{}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-}
-
-func TestHTTPProxy(t *testing.T) {
-	rHTTP, _ := http.NewRequest("GET", "http://test.com/api/v1?arg=21", nil)
-	rHTTPS, _ := http.NewRequest("GET", "https://test.com/api/v1?arg=21", nil)
-
-	proxies := &config.Proxy{
-		HTTP: "https://user:pass@proxy.com:3128",
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(rHTTP)
-	assert.Nil(t, err)
-	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
-
-	proxyURL, err = proxyFunc(rHTTPS)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-}
-
-func TestNoProxy(t *testing.T) {
-	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
-	r2, _ := http.NewRequest("GET", "http://test_http.com/api/v1?arg=21", nil)
-	r3, _ := http.NewRequest("GET", "https://test_https.com/api/v1?arg=21", nil)
-
-	proxies := &config.Proxy{
-		HTTP:    "https://user:pass@proxy.com:3128",
-		HTTPS:   "https://user:pass@proxy_https.com:3128",
-		NoProxy: []string{"test_no_proxy.com", "test.org"},
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-
-	proxyURL, err = proxyFunc(r2)
-	assert.Nil(t, err)
-	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
-
-	proxyURL, err = proxyFunc(r3)
-	assert.Nil(t, err)
-	assert.Equal(t, "https://user:pass@proxy_https.com:3128", proxyURL.String())
-}
-
-func TestErrorParse(t *testing.T) {
-	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
-
-	proxies := &config.Proxy{
-		HTTP: "21://test.com",
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r1)
-	assert.NotNil(t, err)
-	assert.Nil(t, proxyURL)
-}
-
-func TestBadScheme(t *testing.T) {
-	r1, _ := http.NewRequest("GET", "ftp://test.com", nil)
-
-	proxies := &config.Proxy{
-		HTTP: "http://test.com",
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-}
 
 func TestJSONConverter(t *testing.T) {
 
@@ -134,36 +48,4 @@ func TestJSONConverter(t *testing.T) {
 	//json encode
 	_, err := json.Marshal(GetJSONSerializableMap(j))
 	assert.Nil(t, err)
-}
-
-func TestCreateHTTPTransport(t *testing.T) {
-	skipSSL := config.Datadog.GetBool("skip_ssl_validation")
-	forceTLS := config.Datadog.GetBool("force_tls_12")
-	defer config.Datadog.Set("skip_ssl_validation", skipSSL)
-	defer config.Datadog.Set("force_tls_12", forceTLS)
-
-	config.Datadog.Set("skip_ssl_validation", false)
-	config.Datadog.Set("force_tls_12", false)
-	transport := CreateHTTPTransport()
-	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
-
-	config.Datadog.Set("skip_ssl_validation", true)
-	transport = CreateHTTPTransport()
-	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
-
-	config.Datadog.Set("force_tls_12", true)
-	transport = CreateHTTPTransport()
-	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
-}
-
-func TestCreateHTTPTransportEnvVarProxy(t *testing.T) {
-	// Test that the transport uses proxy from environment when not defined in config
-	transport := CreateHTTPTransport()
-
-	// To compare functions here, we're relying on behavior that's undefined in the golang spec, but works
-	// in the Go1 implementation. See https://stackoverflow.com/a/9644797 for details
-	assert.Equal(t, reflect.ValueOf(http.ProxyFromEnvironment).Pointer(), reflect.ValueOf(transport.Proxy).Pointer())
 }

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,104 @@
+package util
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	log "github.com/cihub/seelog"
+)
+
+// HTTPHeaders returns a http headers including various basic information (User-Agent, Content-Type...).
+func HTTPHeaders() map[string]string {
+	av, _ := version.New(version.AgentVersion, version.Commit)
+	return map[string]string{
+		"User-Agent":   fmt.Sprintf("Datadog Agent/%s", av.GetNumber()),
+		"Content-Type": "application/x-www-form-urlencoded",
+		"Accept":       "text/html, */*",
+	}
+}
+
+// getProxyTransportFunc return a proxy function for a http.Transport that
+// would return the right proxy depending on the configuration.
+func getProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error) {
+	return func(r *http.Request) (*url.URL, error) {
+		// check no_proxy list first
+		for _, host := range p.NoProxy {
+			if r.URL.Host == host {
+				log.Debugf("URL match no_proxy list item '%s': not using any proxy", host)
+				return nil, nil
+			}
+		}
+
+		// check proxy by scheme
+		confProxy := ""
+		if r.URL.Scheme == "http" {
+			confProxy = p.HTTP
+		} else if r.URL.Scheme == "https" {
+			confProxy = p.HTTPS
+		} else {
+			log.Warnf("Proxy configuration do not support scheme '%s'", r.URL.Scheme)
+		}
+
+		if confProxy != "" {
+			proxyURL, err := url.Parse(confProxy)
+			if err != nil {
+				err := fmt.Errorf("Could not parse the proxy URL for scheme %s from configuration: %s", r.URL.Scheme, err)
+				log.Error(err.Error())
+				return nil, err
+			}
+			userInfo := ""
+			if proxyURL.User != nil {
+				if _, isSet := proxyURL.User.Password(); isSet {
+					userInfo = "*****:*****@"
+				} else {
+					userInfo = "*****@"
+				}
+			}
+
+			log.Debugf("Using proxy %s://%s%s for URL '%s'", proxyURL.Scheme, userInfo, proxyURL.Host, r.URL)
+			return proxyURL, nil
+		}
+
+		// no proxy set for this request
+		return nil, nil
+	}
+}
+
+// CreateHTTPTransport creates an *http.Transport for use in the agent
+func CreateHTTPTransport() *http.Transport {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: config.Datadog.GetBool("skip_ssl_validation"),
+	}
+
+	if config.Datadog.GetBool("force_tls_12") {
+		tlsConfig.MinVersion = tls.VersionTLS12
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	if proxies := config.Datadog.Get("proxy"); proxies != nil {
+		if os.Getenv("http_proxy") != "" || os.Getenv("https_proxy") != "" ||
+			os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
+			log.Info("Using agent's proxy configuration instead of env vars 'http_proxy', 'https_proxy' and 'no_proxy'")
+		}
+
+		proxies := &config.Proxy{}
+		if err := config.Datadog.UnmarshalKey("proxy", proxies); err != nil {
+			log.Errorf("Could not load the proxy configuration: %s", err)
+		} else {
+			transport.Proxy = getProxyTransportFunc(proxies)
+		}
+	} else {
+		log.Info("Using proxy settings from environment")
+		transport.Proxy = http.ProxyFromEnvironment
+	}
+
+	return transport
+}

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,126 @@
+package util
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestEmptyProxy(t *testing.T) {
+	r, err := http.NewRequest("GET", "https://test.com", nil)
+	require.Nil(t, err)
+
+	proxies := &config.Proxy{}
+	proxyFunc := getProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestHTTPProxy(t *testing.T) {
+	rHTTP, _ := http.NewRequest("GET", "http://test.com/api/v1?arg=21", nil)
+	rHTTPS, _ := http.NewRequest("GET", "https://test.com/api/v1?arg=21", nil)
+
+	proxies := &config.Proxy{
+		HTTP: "https://user:pass@proxy.com:3128",
+	}
+	proxyFunc := getProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(rHTTP)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
+
+	proxyURL, err = proxyFunc(rHTTPS)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestNoProxy(t *testing.T) {
+	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
+	r2, _ := http.NewRequest("GET", "http://test_http.com/api/v1?arg=21", nil)
+	r3, _ := http.NewRequest("GET", "https://test_https.com/api/v1?arg=21", nil)
+
+	proxies := &config.Proxy{
+		HTTP:    "https://user:pass@proxy.com:3128",
+		HTTPS:   "https://user:pass@proxy_https.com:3128",
+		NoProxy: []string{"test_no_proxy.com", "test.org"},
+	}
+	proxyFunc := getProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r1)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+
+	proxyURL, err = proxyFunc(r2)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
+
+	proxyURL, err = proxyFunc(r3)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://user:pass@proxy_https.com:3128", proxyURL.String())
+}
+
+func TestErrorParse(t *testing.T) {
+	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
+
+	proxies := &config.Proxy{
+		HTTP: "21://test.com",
+	}
+	proxyFunc := getProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r1)
+	assert.NotNil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestBadScheme(t *testing.T) {
+	r1, _ := http.NewRequest("GET", "ftp://test.com", nil)
+
+	proxies := &config.Proxy{
+		HTTP: "http://test.com",
+	}
+	proxyFunc := getProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r1)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestCreateHTTPTransport(t *testing.T) {
+	skipSSL := config.Datadog.GetBool("skip_ssl_validation")
+	forceTLS := config.Datadog.GetBool("force_tls_12")
+	defer config.Datadog.Set("skip_ssl_validation", skipSSL)
+	defer config.Datadog.Set("force_tls_12", forceTLS)
+
+	config.Datadog.Set("skip_ssl_validation", false)
+	config.Datadog.Set("force_tls_12", false)
+	transport := CreateHTTPTransport()
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
+
+	config.Datadog.Set("skip_ssl_validation", true)
+	transport = CreateHTTPTransport()
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
+
+	config.Datadog.Set("force_tls_12", true)
+	transport = CreateHTTPTransport()
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
+}
+
+func TestCreateHTTPTransportEnvVarProxy(t *testing.T) {
+	// Test that the transport uses proxy from environment when not defined in config
+	transport := CreateHTTPTransport()
+
+	// To compare functions here, we're relying on behavior that's undefined in the golang spec, but works
+	// in the Go1 implementation. See https://stackoverflow.com/a/9644797 for details
+	assert.Equal(t, reflect.ValueOf(http.ProxyFromEnvironment).Pointer(), reflect.ValueOf(transport.Proxy).Pointer())
+}

--- a/releasenotes/notes/env-var-proxy-044703db01425a1e.yaml
+++ b/releasenotes/notes/env-var-proxy-044703db01425a1e.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    The Agent's forwarder now reads the proxy settings of the environment (``HTTP_PROXY``,
+    ``HTTPS_PROXY`` and ``NO_PROXY``) unless proxy settings are configured in the Agent's
+    configuration. This will affect your Agents if `proxy` is not specified in your
+    Agent configuration.
+fixes:
+  - |
+    Read proxy settings from the environment when none are set in the Agent's configuration.


### PR DESCRIPTION
### What does this PR do?

Use environment proxy settings (`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`) if none are defined in conf. Affects the forwarder and other parts of the Agent that use the same function to create an `http.Transport`.

Review notes: first commit is the actual change, second commit just moves things around.

### Motivation

This was the intended behavior since the very first PR adding proxy support to Agent 6 (see #154), but never worked.

The confusion here probably stems from the fact that, unlike the [`http.DefaultTransport`](https://golang.org/pkg/net/http/#RoundTripper) which uses the [`http.ProxyFromEnvironment`](https://golang.org/pkg/net/http/#ProxyFromEnvironment) as the proxy function, an [`http.Transport{}`](https://golang.org/pkg/net/http/#Transport) doesn't use `http.ProxyFromEnvironment` as its proxy function unless explicitly set.

### Additional Notes

This is a breaking change (especially since it changes the agent's default behavior). Agent 5's forwarder (-> `tornado`) never picked up proxy settings from the env vars. I'm conflicted as to whether we can ship this safely in 6.2.0...

**Correction**: Agent5 does pull proxy settings from the "system" env vars, only if none are in the agent's `datadog.conf`. So this PR would reflect Agent5's behavior.