### PR TITLE
update RBAC manifest

### DIFF
--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -33,6 +33,11 @@ rules:
   - get
   - update
   - create
+- nonResourceURLs:
+  - "/version"
+  - "/healthz"
+  verbs:
+  - get
 # Kubelet connectivity
 - apiGroups:
   - ""


### PR DESCRIPTION
### What does this PR do?

- Add permissions to `/version` and `/healthz` to the default datadog-agent serviceaccount's RBAC

### Motivation

We dropped these from the A5 RBACs, while we still consume the endpoints.
