### PR TITLE
docker net stats: tag by iface name if network unknown

### DIFF
--- a/pkg/util/docker/networkstats.go
+++ b/pkg/util/docker/networkstats.go
@@ -67,10 +67,9 @@ func collectNetworkStats(containerID string, pid int, networks []dockerNetwork) 
 
 		if nw, ok := nwByIface[iface]; ok {
 			stat = &InterfaceNetStats{NetworkName: nw.dockerName}
+		} else if iface == "lo" {
+			continue // Ignore loopback
 		} else {
-			if iface == "lo" {
-				continue // Ignore loopback
-			}
 			log.Debugf("Container %s: interface %s does not match a network, tagging with interface name", containerID, iface)
 			stat = &InterfaceNetStats{NetworkName: iface}
 		}

--- a/pkg/util/docker/networkstats.go
+++ b/pkg/util/docker/networkstats.go
@@ -63,19 +63,28 @@ func collectNetworkStats(containerID string, pid int, networks []dockerNetwork) 
 		}
 		iface := fields[0][:len(fields[0])-1]
 
-		if nw, ok := nwByIface[iface]; ok {
-			stat := &InterfaceNetStats{NetworkName: nw.dockerName}
-			rcvd, _ := strconv.Atoi(fields[1])
-			stat.BytesRcvd = uint64(rcvd)
-			pktRcvd, _ := strconv.Atoi(fields[2])
-			stat.PacketsRcvd = uint64(pktRcvd)
-			sent, _ := strconv.Atoi(fields[9])
-			stat.BytesSent = uint64(sent)
-			pktSent, _ := strconv.Atoi(fields[10])
-			stat.PacketsSent = uint64(pktSent)
+		var stat *InterfaceNetStats
 
-			netStats = append(netStats, stat)
+		if nw, ok := nwByIface[iface]; ok {
+			stat = &InterfaceNetStats{NetworkName: nw.dockerName}
+		} else {
+			if iface == "lo" {
+				continue // Ignore loopback
+			}
+			log.Debugf("Container %s: interface %s does not match a network, tagging with interface name", containerID, iface)
+			stat = &InterfaceNetStats{NetworkName: iface}
 		}
+
+		rcvd, _ := strconv.Atoi(fields[1])
+		stat.BytesRcvd = uint64(rcvd)
+		pktRcvd, _ := strconv.Atoi(fields[2])
+		stat.PacketsRcvd = uint64(pktRcvd)
+		sent, _ := strconv.Atoi(fields[9])
+		stat.BytesSent = uint64(sent)
+		pktSent, _ := strconv.Atoi(fields[10])
+		stat.PacketsSent = uint64(pktSent)
+
+		netStats = append(netStats, stat)
 	}
 	return netStats, nil
 }

--- a/releasenotes/notes/docker-network-unknown-c0c5d84e575967c9.yaml
+++ b/releasenotes/notes/docker-network-unknown-c0c5d84e575967c9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Docker network metrics are now tagged by interface name as a fallback if a
+    docker network name cannot be determined (affects some Swarm stack deployments)


### PR DESCRIPTION
### What does this PR do?

Currently, container interfaces that do not match a docker network listed in the container inspect are ignored. We went through several cases of Swarm containers having the bridge interface attached in a container, but not listed in its inspect. 

This PR adds a fallback logic tagging by the interface name, to continue offering accurate per-container sums in queries and in the live container view. A debug line is also added to help with getting to the root cause:

> [Debug] Container 767645d8c511d026525163aa7129d06ae7d8c639d391f589786392eba4866773: interface eth0 does not match a network, tagging with interface name

### Motivation

Offer visibility when the network name matching fails. Tagging by interface name instead of `unknown` allows:
  - to keep container sum correct even if several interfaces were to fail matching
  - to help debugging the issue by pointing to the exact interface failing to match