### PR TITLE
Move config provider info

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/mux"
@@ -230,7 +231,11 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 
 	var response response.ConfigCheckResponse
 
-	response.Configs = common.AC.GetProviderLoadedConfigs()
+	configs := common.AC.GetLoadedConfigs()
+	sort.Slice(configs, func(i, j int) bool {
+		return configs[i].Name < configs[j].Name
+	})
+	response.Configs = configs
 	response.ResolveWarnings = autodiscovery.GetResolveWarnings()
 	response.ConfigErrors = autodiscovery.GetConfigErrors()
 	response.Unresolved = common.AC.GetUnresolvedTemplates()

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -9,8 +9,8 @@ import "github.com/DataDog/datadog-agent/pkg/collector/check"
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         map[string][]check.Config `json:"configs"`
-	ResolveWarnings map[string][]string       `json:"resolve_warnings"`
-	ConfigErrors    map[string]string         `json:"config_errors"`
-	Unresolved      map[string]check.Config   `json:"unresolved"`
+	Configs         []check.Config          `json:"configs"`
+	ResolveWarnings map[string][]string     `json:"resolve_warnings"`
+	ConfigErrors    map[string]string       `json:"config_errors"`
+	Unresolved      map[string]check.Config `json:"unresolved"`
 }

--- a/pkg/collector/autodiscovery/autoconfig.go
+++ b/pkg/collector/autodiscovery/autoconfig.go
@@ -74,7 +74,7 @@ type AutoConfig struct {
 	config2checks     map[string][]check.ID       // cache the ID of checks we load for each config
 	check2config      map[check.ID]string         // cache the config digest corresponding to a check
 	name2jmxmetrics   map[string]check.ConfigData // holds the metrics to collect for JMX checks
-	loadedConfigs     []check.Config              // holds the resolved config per provider
+	loadedConfigs     []check.Config              // holds the resolved configs
 	stop              chan bool
 	pollerActive      bool
 	health            *health.Handle

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -155,6 +155,7 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 		InitConfig:    make(check.ConfigData, len(tpl.InitConfig)),
 		MetricConfig:  tpl.MetricConfig,
 		ADIdentifiers: tpl.ADIdentifiers,
+		Provider:      tpl.Provider,
 	}
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)
@@ -185,7 +186,7 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 	}
 
 	// store resolved configs in the AC
-	cr.ac.providerLoadedConfigs[tpl.Provider] = append(cr.ac.providerLoadedConfigs[tpl.Provider], resolvedConfig)
+	cr.ac.loadedConfigs = append(cr.ac.loadedConfigs, resolvedConfig)
 	cr.config2Service[resolvedConfig.Digest()] = svc.GetID()
 
 	return resolvedConfig, nil

--- a/pkg/collector/autodiscovery/configresolver.go
+++ b/pkg/collector/autodiscovery/configresolver.go
@@ -159,9 +159,6 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)
 
-	// Get provider to map configs with it
-	provider := cr.templates.GetProviderFromDigest(tpl.Digest())
-
 	tags, err := svc.GetTags()
 	if err != nil {
 		return resolvedConfig, err
@@ -188,7 +185,7 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 	}
 
 	// store resolved configs in the AC
-	cr.ac.providerLoadedConfigs[provider] = append(cr.ac.providerLoadedConfigs[provider], resolvedConfig)
+	cr.ac.providerLoadedConfigs[tpl.Provider] = append(cr.ac.providerLoadedConfigs[tpl.Provider], resolvedConfig)
 	cr.config2Service[resolvedConfig.Digest()] = svc.GetID()
 
 	return resolvedConfig, nil

--- a/pkg/collector/autodiscovery/configresolver_test.go
+++ b/pkg/collector/autodiscovery/configresolver_test.go
@@ -38,7 +38,7 @@ func TestResolveTemplate(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 	}
 	// add the template to the cache
-	tc.Set(tpl, "test provider")
+	tc.Set(tpl)
 
 	// no services
 	res := cr.ResolveTemplate(tpl)

--- a/pkg/collector/autodiscovery/configresolver_test.go
+++ b/pkg/collector/autodiscovery/configresolver_test.go
@@ -374,7 +374,7 @@ func TestResolve(t *testing.T) {
 		},
 	}
 	ac := &AutoConfig{
-		providerLoadedConfigs: make(map[string][]check.Config),
+		loadedConfigs: make([]check.Config, 0),
 	}
 	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	validTemplates := 0
@@ -396,6 +396,6 @@ func TestResolve(t *testing.T) {
 		})
 
 		// Assert the valid configs are stored in the AC
-		assert.Equal(t, validTemplates, len(ac.providerLoadedConfigs[UnknownProvider]))
+		assert.Equal(t, validTemplates, len(ac.loadedConfigs))
 	}
 }

--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -13,10 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
-// UnknownProvider is used if we can't match the config back
-// to its original provider
-const UnknownProvider string = "Unknown provider"
-
 // TemplateCache is a data structure to store configuration templates
 type TemplateCache struct {
 	id2digests      map[string][]string     // map an AD identifier to all the configs that have it

--- a/pkg/collector/autodiscovery/templatecache.go
+++ b/pkg/collector/autodiscovery/templatecache.go
@@ -22,7 +22,6 @@ type TemplateCache struct {
 	id2digests      map[string][]string     // map an AD identifier to all the configs that have it
 	digest2ids      map[string][]string     // map a config digest to the list of AD identifiers it has
 	digest2template map[string]check.Config // map a digest to the corresponding config object
-	digest2provider map[string]string       // map a digest to it's provider name
 	m               sync.RWMutex
 }
 
@@ -32,12 +31,11 @@ func NewTemplateCache() *TemplateCache {
 		id2digests:      map[string][]string{},
 		digest2ids:      map[string][]string{},
 		digest2template: map[string]check.Config{},
-		digest2provider: map[string]string{},
 	}
 }
 
 // Set stores or updates a template in the cache
-func (cache *TemplateCache) Set(tpl check.Config, provider string) error {
+func (cache *TemplateCache) Set(tpl check.Config) error {
 	// return an error if configuration has no AD identifiers
 	if len(tpl.ADIdentifiers) == 0 {
 		return fmt.Errorf("template has no AD identifiers, unable to store it in the cache")
@@ -57,7 +55,6 @@ func (cache *TemplateCache) Set(tpl check.Config, provider string) error {
 	// store the template
 	cache.digest2template[d] = tpl
 	cache.digest2ids[d] = tpl.ADIdentifiers
-	cache.digest2provider[d] = provider
 	for _, id := range tpl.ADIdentifiers {
 		cache.id2digests[id] = append(cache.id2digests[id], d)
 	}
@@ -80,14 +77,6 @@ func (cache *TemplateCache) Get(adID string) ([]check.Config, error) {
 	}
 
 	return nil, fmt.Errorf("AD id %s not found in cache", adID)
-}
-
-// GetProviderFromDigest returns the provider name from the config digest
-func (cache *TemplateCache) GetProviderFromDigest(digest string) string {
-	if provider, found := cache.digest2provider[digest]; found {
-		return provider
-	}
-	return UnknownProvider
 }
 
 // GetUnresolvedTemplates returns templates yet to be resolved
@@ -116,7 +105,6 @@ func (cache *TemplateCache) Del(tpl check.Config) error {
 	// remove the template
 	delete(cache.digest2ids, d)
 	delete(cache.digest2template, d)
-	delete(cache.digest2provider, d)
 
 	// iterate through the AD identifiers for this config
 	for _, id := range tpl.ADIdentifiers {

--- a/pkg/collector/autodiscovery/templatecache_test.go
+++ b/pkg/collector/autodiscovery/templatecache_test.go
@@ -24,10 +24,10 @@ func TestSet(t *testing.T) {
 	cache := NewTemplateCache()
 
 	tpl1 := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	err := cache.Set(tpl1, "test provider")
+	err := cache.Set(tpl1)
 	require.Nil(t, err)
 	// adding again should be no-op
-	err = cache.Set(tpl1, "test provider")
+	err = cache.Set(tpl1)
 	require.Nil(t, err)
 
 	assert.Len(t, cache.id2digests, 2)
@@ -37,7 +37,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2template, 1)
 
 	tpl2 := check.Config{ADIdentifiers: []string{"foo"}}
-	err = cache.Set(tpl2, "test provider")
+	err = cache.Set(tpl2)
 
 	require.Nil(t, err)
 	assert.Len(t, cache.id2digests, 2)
@@ -48,7 +48,7 @@ func TestSet(t *testing.T) {
 
 	// no identifiers at all
 	tpl3 := check.Config{ADIdentifiers: []string{}}
-	err = cache.Set(tpl3, "test provider")
+	err = cache.Set(tpl3)
 
 	require.NotNil(t, err)
 }
@@ -56,7 +56,7 @@ func TestSet(t *testing.T) {
 func TestDel(t *testing.T) {
 	cache := NewTemplateCache()
 	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	err := cache.Set(tpl, "test provider")
+	err := cache.Set(tpl)
 	require.Nil(t, err)
 
 	err = cache.Del(tpl)
@@ -76,7 +76,7 @@ func TestDel(t *testing.T) {
 func TestGet(t *testing.T) {
 	cache := NewTemplateCache()
 	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	cache.Set(tpl, "test provider")
+	cache.Set(tpl)
 
 	ret, err := cache.Get("foo")
 	require.Nil(t, err)
@@ -89,18 +89,10 @@ func TestGet(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestGetProviderFromDigest(t *testing.T) {
-	cache := NewTemplateCache()
-	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	cache.Set(tpl, "test provider")
-
-	assert.Equal(t, cache.digest2provider[tpl.Digest()], "test provider")
-}
-
 func TestGetUnresolvedTemplates(t *testing.T) {
 	cache := NewTemplateCache()
 	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
-	cache.Set(tpl, "test provider")
+	cache.Set(tpl)
 	expected := map[string]check.Config{
 		"foo,bar": tpl,
 	}

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -63,6 +63,7 @@ type Config struct {
 	MetricConfig  ConfigData   `json:"metric_config"`  // the metric config in Yaml (jmx check only)
 	LogsConfig    ConfigData   `json:"log_config"`     // the logs config in Yaml (logs-agent only)
 	ADIdentifiers []string     `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
+	Provider      string       `json:"provider"`       // the provider that issued the config
 }
 
 // Check is an interface for types capable to run checks

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -58,12 +58,13 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 // Ensure sensitive data is redacted
 func TestZipConfigCheck(t *testing.T) {
 	cr := response.ConfigCheckResponse{
-		Configs: make(map[string][]check.Config),
+		Configs: make([]check.Config, 0),
 	}
-	cr.Configs["FooProvider"] = []check.Config{{
+	cr.Configs = append(cr.Configs, check.Config{
 		Name:      "TestCheck",
 		Instances: []check.ConfigData{[]byte("username: User\npassword: MySecurePass")},
-	}}
+		Provider:  "FooProvider",
+	})
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		out, _ := json.Marshal(cr)

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -60,6 +60,8 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 		fmt.Fprintln(w, fmt.Sprintf("\n=== %s check ===", color.GreenString(c.Name)))
 		if len(c.Provider) > 0 {
 			fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Source"), color.CyanString(c.Provider)))
+		} else {
+			fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Source"), color.RedString("Unknown provider")))
 		}
 		for i, inst := range c.Instances {
 			fmt.Fprintln(w, fmt.Sprintf("%s %s:", color.BlueString("Instance"), color.CyanString(strconv.Itoa(i+1))))

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
@@ -57,36 +56,35 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 		}
 	}
 
-	for provider, configs := range cr.Configs {
-		fmt.Fprintln(w, fmt.Sprintf("\n=== Provider: %s ===", color.BlueString(provider)))
-		for _, c := range configs {
-			fmt.Fprintln(w, fmt.Sprintf("\n--- %s check ---", color.GreenString(c.Name)))
-			for i, inst := range c.Instances {
-				fmt.Fprintln(w, fmt.Sprintf("%s %s:", color.BlueString("Instance"), color.CyanString(strconv.Itoa(i+1))))
-				fmt.Fprint(w, fmt.Sprintf("%s", inst))
-				fmt.Fprintln(w, "~")
-			}
-			if len(c.InitConfig) > 0 {
-				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Init Config")))
-				fmt.Fprintln(w, string(c.InitConfig))
-			}
-			if len(c.MetricConfig) > 0 {
-				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Metric Config")))
-				fmt.Fprintln(w, string(c.MetricConfig))
-			}
-			if len(c.LogsConfig) > 0 {
-				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Log Config")))
-				fmt.Fprintln(w, string(c.LogsConfig))
-			}
-			if len(c.ADIdentifiers) > 0 {
-				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Auto-discovery IDs")))
-				for _, id := range c.ADIdentifiers {
-					fmt.Fprintln(w, fmt.Sprintf("* %s", color.CyanString(id)))
-				}
-			}
-			fmt.Fprintln(w, strings.Repeat("-", 3))
+	for _, c := range cr.Configs {
+		fmt.Fprintln(w, fmt.Sprintf("\n=== %s check ===", color.GreenString(c.Name)))
+		if len(c.Provider) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Source"), color.CyanString(c.Provider)))
 		}
-		fmt.Fprintln(w, strings.Repeat("=", 10))
+		for i, inst := range c.Instances {
+			fmt.Fprintln(w, fmt.Sprintf("%s %s:", color.BlueString("Instance"), color.CyanString(strconv.Itoa(i+1))))
+			fmt.Fprint(w, fmt.Sprintf("%s", inst))
+			fmt.Fprintln(w, "~")
+		}
+		if len(c.InitConfig) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Init Config")))
+			fmt.Fprintln(w, string(c.InitConfig))
+		}
+		if len(c.MetricConfig) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Metric Config")))
+			fmt.Fprintln(w, string(c.MetricConfig))
+		}
+		if len(c.LogsConfig) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Log Config")))
+			fmt.Fprintln(w, string(c.LogsConfig))
+		}
+		if len(c.ADIdentifiers) > 0 {
+			fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Auto-discovery IDs")))
+			for _, id := range c.ADIdentifiers {
+				fmt.Fprintln(w, fmt.Sprintf("* %s", color.CyanString(id)))
+			}
+		}
+		fmt.Fprintln(w, "===")
 	}
 
 	if withDebug {

--- a/releasenotes/notes/simplify-configcheck-af745c1069392673.yaml
+++ b/releasenotes/notes/simplify-configcheck-af745c1069392673.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The configcheck command now display checks in alphabetical orders and are
+    no longer grouped by configuration provider


### PR DESCRIPTION
### What does this PR do?

* Move the configuration provider to the config struct
* Change configcheck output accordingly

![screen shot 2018-04-25 at 17 31 03](https://user-images.githubusercontent.com/2368736/39256154-788fa3f0-48ae-11e8-8b62-b64a83c7313e.png)


### Motivation

Remove some mapping needed to match provider from conf + clarify output for the configcheck command
