### PR TITLE
Removing `dep prune` from `invoke deps`

### DIFF
--- a/releasenotes/notes/remove-dep-prune-from-invoke-deps-a336b874285c0351.yaml
+++ b/releasenotes/notes/remove-dep-prune-from-invoke-deps-a336b874285c0351.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Build steps in `invoke`: Removing `dep prune` from `invoke deps`

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -200,14 +200,9 @@ def deps(ctx):
     ctx.run("go get -u github.com/fzipp/gocyclo")
     ctx.run("go get -u github.com/gordonklaus/ineffassign")
     ctx.run("go get -u github.com/client9/misspell/cmd/misspell")
-    ctx.run("dep ensure")
-    # prune packages from /vendor, remove this hack
-    # as soon as `dep prune` is merged within `dep ensure`,
-    # see https://github.com/golang/dep/issues/944
-    ctx.run("mv vendor/github.com/shirou/gopsutil/host/include .")
-    ctx.run("dep prune")
-    ctx.run("mv include vendor/github.com/shirou/gopsutil/host/")
 
+    ctx.run("rm -rf vendor include")
+    ctx.run("dep ensure")
 
 @task
 def reset(ctx):


### PR DESCRIPTION
### What does this PR do?
Removing `dep prune` from `invoke deps`, as it is not necessary anymore as `dep ensure` now include it

### Motivation
Simplify and fix this step in the agent build

### Additional Notes

Tested locally on a VM
