### PR TITLE
Log errors when we fail to send metadata paylaod.

### DIFF
--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -68,7 +68,9 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 			select {
 			case <-health.C:
 			case <-sendTicker.C:
-				p.Send(c.srl)
+				if err := p.Send(c.srl); err != nil {
+					log.Errorf("Unable to send '%s' metadata: %v", name, err)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
### What does this PR do?

This is useful when debugging missing EC2 tags for example.

We use to do this only for host metadata when the agent start. 