### PR TITLE
[Logs]: Fixed container name filtering for log collection

### DIFF
--- a/pkg/logs/input/container/container.go
+++ b/pkg/logs/input/container/container.go
@@ -9,6 +9,7 @@ package container
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 
 	log "github.com/cihub/seelog"
@@ -96,8 +97,13 @@ func (c *Container) isImageMatch(imageFilter string) bool {
 
 // isNameMatch returns true if one of the container name matches with the filter.
 func (c *Container) isNameMatch(nameFilter string) bool {
+	re, err := regexp.Compile(nameFilter)
+	if err != nil {
+		log.Warn("used invalid name to filter containers: ", nameFilter)
+		return false
+	}
 	for _, name := range c.Names {
-		if name == nameFilter {
+		if re.MatchString(name) {
 			return true
 		}
 	}

--- a/pkg/logs/input/container/container_test.go
+++ b/pkg/logs/input/container/container_test.go
@@ -189,19 +189,14 @@ func TestIsNameMatch(t *testing.T) {
 	container = NewContainer(types.Container{Names: []string{"foo", "bar"}})
 	assert.True(t, container.isNameMatch("foo"))
 	assert.True(t, container.isNameMatch("bar"))
-	assert.False(t, container.isNameMatch("boo"))
-	assert.False(t, container.isNameMatch(""))
-
-	container = NewContainer(types.Container{Names: []string{""}})
-	assert.False(t, container.isNameMatch("foo"))
-	assert.False(t, container.isNameMatch("bar"))
+	assert.True(t, container.isNameMatch(""))
 	assert.False(t, container.isNameMatch("boo"))
 
-	container = NewContainer(types.Container{Names: nil})
-	assert.False(t, container.isNameMatch("foo"))
-	assert.False(t, container.isNameMatch("bar"))
+	container = NewContainer(types.Container{Names: []string{"/api/v1/pods/foo", "/bar"}})
+	assert.True(t, container.isNameMatch("foo"))
+	assert.True(t, container.isNameMatch("bar"))
+	assert.True(t, container.isNameMatch(""))
 	assert.False(t, container.isNameMatch("boo"))
-	assert.False(t, container.isNameMatch(""))
 }
 
 func TestParseConfigWithNoValidKeyShouldFail(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Used a regex instead of a full match to filter containers by their name.

### Motivation

The name of a container displayed by the command `docker ps` is not exactly the same as the name returned by the docker API.

### Additional Notes

See Kenafeh logic [here](https://github.com/DataDog/datadog-agent/blob/master/pkg/util/docker/filter.go)
