### PR TITLE
[Logs] Tag messages with file name

### DIFF
--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -15,6 +15,8 @@ import (
 
 	"io"
 
+	"path/filepath"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -150,6 +152,7 @@ func (t *Tailer) forwardMessages() {
 		origin := message.NewOrigin(t.source)
 		origin.Identifier = identifier
 		origin.Offset = offset
+		origin.SetTags([]string{fmt.Sprintf("filename:%s", filepath.Base(t.path))})
 		t.outputChan <- message.New(output.Content, origin, nil)
 	}
 }

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -15,8 +15,6 @@ import (
 
 	"io"
 
-	"path/filepath"
-
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -32,6 +30,7 @@ type Tailer struct {
 	path     string
 	fullpath string
 	file     *os.File
+	tags     []string
 
 	readOffset    int64
 	decodedOffset int64
@@ -152,7 +151,7 @@ func (t *Tailer) forwardMessages() {
 		origin := message.NewOrigin(t.source)
 		origin.Identifier = identifier
 		origin.Offset = offset
-		origin.SetTags([]string{fmt.Sprintf("filename:%s", filepath.Base(t.path))})
+		origin.SetTags(t.tags)
 		t.outputChan <- message.New(output.Content, origin, nil)
 	}
 }

--- a/pkg/logs/input/tailer/tailer.go
+++ b/pkg/logs/input/tailer/tailer.go
@@ -13,6 +13,8 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"io"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -68,18 +70,18 @@ func (t *Tailer) Identifier() string {
 // tailFromBeginning lets the tailer start tailing its file
 // from the beginning
 func (t *Tailer) tailFromBeginning() error {
-	return t.tailFrom(0, os.SEEK_SET)
+	return t.tailFrom(0, io.SeekStart)
 }
 
 // tailFromEnd lets the tailer start tailing its file
 // from the end
 func (t *Tailer) tailFromEnd() error {
-	return t.tailFrom(0, os.SEEK_END)
+	return t.tailFrom(0, io.SeekEnd)
 }
 
 // recoverTailingFrom starts the tailing from the last log line processed
 func (t *Tailer) recoverTailing(offset int64) error {
-	return t.tailFrom(offset, os.SEEK_SET)
+	return t.tailFrom(offset, io.SeekStart)
 }
 
 // Stop stops the tailer and returns only when the decoder is flushed

--- a/pkg/logs/input/tailer/tailer_nix.go
+++ b/pkg/logs/input/tailer/tailer_nix.go
@@ -15,6 +15,8 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 )
 
@@ -24,6 +26,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 	if err != nil {
 		return err
 	}
+	t.tags = []string{fmt.Sprintf("filename:%s", filepath.Base(t.path))}
 	log.Info("Opening ", t.path)
 	f, err := os.Open(fullpath)
 	if err != nil {

--- a/pkg/logs/input/tailer/tailer_test.go
+++ b/pkg/logs/input/tailer/tailer_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"path/filepath"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
@@ -153,6 +155,20 @@ func (suite *TailerTestSuite) TestRecoverTailing() {
 func (suite *TailerTestSuite) TestTailerIdentifier() {
 	suite.tl.tailFromBeginning()
 	suite.Equal(fmt.Sprintf("file:%s/tailer.log", suite.testDir), suite.tl.Identifier())
+}
+
+func (suite *TailerTestSuite) TestOriginTagsWhenTailingFiles() {
+
+	suite.tl.tailFromBeginning()
+
+	_, err := suite.testFile.WriteString("foo\n")
+	suite.Nil(err)
+
+	msg := <-suite.outputChan
+	tags := msg.GetOrigin().Tags()
+	suite.Equal(1, len(tags))
+	suite.Equal("filename:"+filepath.Base(suite.testFile.Name()), tags[0])
+
 }
 
 func TestTailerTestSuite(t *testing.T) {

--- a/pkg/logs/input/tailer/tailer_windows.go
+++ b/pkg/logs/input/tailer/tailer_windows.go
@@ -8,6 +8,7 @@
 package tailer
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 	if err != nil {
 		return err
 	}
+	t.tags = []string{fmt.Sprintf("filename:%s", filepath.Base(t.path))}
 	t.fullpath = path
 	t.readOffset = offset
 	t.decodedOffset = offset

--- a/releasenotes/notes/logs_tag_filename-d449ff6b8f18fbfc.yaml
+++ b/releasenotes/notes/logs_tag_filename-d449ff6b8f18fbfc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a `filename` tag to messages with the name of the file being tailed.


### PR DESCRIPTION
### What does this PR do?

This PR adds a `filename` tag to messages sent by the logs agent that contains the name of the file being tailed.

### Motivation

Some customers using wildcards would like to be able to see which file their messages originated from.

