### PR TITLE
[AD] Fix a possible race condition on container churn

### DIFF
--- a/releasenotes/notes/ad-scheduling-race-d664534209e66f03.yaml
+++ b/releasenotes/notes/ad-scheduling-race-d664534209e66f03.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix a possible race condition in AutoDiscovery where configuration is
+    identical on container churn and considered as duplicate before being
+    de-scheduled.


### PR DESCRIPTION
### What does this PR do?

Fix a possible race condition in AutoDiscovery where configuration is identical on container churn and considered as duplicate before being de-scheduled.

This can happen if the AD template does not use the `%%host%%` template (hardcoding DNS), or if the IP appen to be the same for both containers.

### Motivation

Reliability
