### PR TITLE
[packaging] Remove executable permission from service def files

### DIFF
--- a/omnibus/config/software/datadog-agent-mac-app.rb
+++ b/omnibus/config/software/datadog-agent-mac-app.rb
@@ -17,7 +17,7 @@ build do
     block do # defer in a block to allow getting the project's build version
       erb source: "Info.plist.erb",
           dest: "#{app_temp_dir}/Info.plist",
-          mode: 0755,
+          mode: 0644,
           vars: { version: project.build_version, year: Time.now.year, executable: "gui" }
     end
 end

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -64,44 +64,44 @@ build do
     if debian?
       erb source: "upstart_debian.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_debian.process.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent-process.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_debian.trace.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent-trace.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
     elsif redhat? || suse?
       # Ship a different upstart job definition on RHEL to accommodate the old
       # version of upstart (0.6.5) that RHEL 6 provides.
       erb source: "upstart_redhat.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_redhat.process.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent-process.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_redhat.trace.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent-trace.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
     end
 
     erb source: "systemd.service.erb",
         dest: "#{install_dir}/scripts/datadog-agent.service",
-        mode: 0755,
+        mode: 0644,
         vars: { install_dir: install_dir, etc_dir: etc_dir }
     erb source: "systemd.process.service.erb",
         dest: "#{install_dir}/scripts/datadog-agent-process.service",
-        mode: 0755,
+        mode: 0644,
         vars: { install_dir: install_dir, etc_dir: etc_dir }
     erb source: "systemd.trace.service.erb",
         dest: "#{install_dir}/scripts/datadog-agent-trace.service",
-        mode: 0755,
+        mode: 0644,
         vars: { install_dir: install_dir, etc_dir: etc_dir }
   end
 
@@ -109,7 +109,7 @@ build do
     # Launchd service definition
     erb source: "launchd.plist.example.erb",
         dest: "#{conf_dir}/com.datadoghq.agent.plist.example",
-        mode: 0755,
+        mode: 0644,
         vars: { install_dir: install_dir }
 
     # Systray GUI

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -37,12 +37,12 @@ build do
   if linux?
     erb source: "upstart.conf.erb",
         dest: "#{install_dir}/scripts/datadog-dogstatsd.conf",
-        mode: 0755,
+        mode: 0644,
         vars: { install_dir: install_dir }
 
     erb source: "systemd.service.erb",
         dest: "#{install_dir}/scripts/datadog-dogstatsd.service",
-        mode: 0755,
+        mode: 0644,
         vars: { install_dir: install_dir }
   end
 

--- a/omnibus/config/software/datadog-puppy.rb
+++ b/omnibus/config/software/datadog-puppy.rb
@@ -25,14 +25,14 @@ build do
     if debian?
       erb source: "upstart.conf.erb",
           dest: "/etc/init/datadog-agent6.conf",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir }
     end
 
     if redhat? || debian? || suse?
       erb source: "systemd.service.erb",
           dest: "/lib/systemd/system/datadog-agent6.service",
-          mode: 0755,
+          mode: 0644,
           vars: { install_dir: install_dir }
     end
   end

--- a/releasenotes/notes/exec-perms-service-files-4bd3c0bc6ea77b1b.yaml
+++ b/releasenotes/notes/exec-perms-service-files-4bd3c0bc6ea77b1b.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Remove executable permission bits from systemd/upstart/launchd service definition
+    files.


### PR DESCRIPTION
### What does this PR do?

Whether the init system is systemd, upstart, or macOS' launchd, they
expect service def files not to have the executable bit.

Also, on recent systemd versions, having the exec bit on the service
files causes a warning. Let's remove it and normalize on all pkgs/platforms.

### Motivation

Fixes #1610

### Additional Notes

I originally used `0755` perms in the very first iteration of the v6 package (in #69). Let's fix that now