### PR TITLE
Fix status page formating

### DIFF
--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -17,7 +17,7 @@ Collector
       Events: {{.Events}}, Total Events: {{humanize .TotalEvents}}
       Service Checks: {{.ServiceChecks}}, Total Service Checks: {{humanize .TotalServiceChecks}}
       Average Execution Time : {{.AverageExecutionTime}}ms
-      {{- if .LastError -}}
+      {{if .LastError -}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}
       {{- end }}


### PR DESCRIPTION
### What does this PR do?

The extra '-' cause the 'Error' to be concatenate to the average ms.

The output would be:
```
      Total Runs: 1
      Metrics: 0, Total Metrics: 0
      Events: 0, Total Events: 0
      Service Checks: 0, Total Service Checks: 0
      Average Execution Time : 0msError: UNKNOWN ERROR
      No traceback
```