### PR TITLE
Fix Go check error in the status page

### DIFF
--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -75,7 +75,7 @@ func LastErrorMessage(value string) template.HTML {
 			return template.HTML(lastErrorArray[0]["message"])
 		}
 	}
-	return template.HTML("UNKNOWN ERROR")
+	return template.HTML(value)
 }
 
 // FormatUnixTime formats the unix time to make it more readable

--- a/releasenotes/notes/fix-go-check-error-in-status-page-d0ef2c6aeab0d4b9.yaml
+++ b/releasenotes/notes/fix-go-check-error-in-status-page-d0ef2c6aeab0d4b9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix Go checks errors not being displayed in the status page.


### PR DESCRIPTION
### What does this PR do?

When a Go check return an error it's a simple string not a JSON payload (like python check).

Error in go check would produce status page like this:
```
      Total Runs: 4
      Metrics: 0, Total Metrics: 0
      Events: 0, Total Events: 0
      Service Checks: 0, Total Service Checks: 0
      Average Execution Time : 0ms
      Error: UNKNOWN ERROR
      No traceback
```