### PR TITLE
Fix typo in config template.

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -140,7 +140,7 @@ api_key:
 # Whether dogstatsd should listen to non local UDP traffic
 # dogstatsd_non_local_traffic: no
 #
-# Publish dogstatsd's internal stats as Go epxvars
+# Publish dogstatsd's internal stats as Go expvars
 # dogstatsd_stats_enable: no
 #
 # How many items in the dogstatsd's stats circular buffer


### PR DESCRIPTION
### What does this PR do?

Typo in the config template.

### Motivation

I didn't know what a Go expvar was, and when I googled the typo "epxvar" it took me a moment to realize it was a typo.

### Additional Notes

