### PR TITLE
Switch logs agent default configuration to use protobuf

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,9 +221,9 @@ func init() {
 	BindEnvAndSetDefault("log_enabled", false) // deprecated, use logs_enabled instead
 	BindEnvAndSetDefault("logset", "")
 
-	BindEnvAndSetDefault("logs_config.dd_url", "intake.logs.datadoghq.com")
+	BindEnvAndSetDefault("logs_config.dd_url", "agent-intake.logs.datadoghq.com")
 	BindEnvAndSetDefault("logs_config.dd_port", 10516)
-	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", false)
+	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	BindEnvAndSetDefault("logs_config.run_path", defaultRunPath)
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 	BindEnvAndSetDefault("logs_config.container_collect_all", false)

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -16,10 +16,10 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, false, LogsAgent.GetBool("log_enabled"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_enabled"))
 	assert.Equal(t, "", LogsAgent.GetString("logset"))
-	assert.Equal(t, "intake.logs.datadoghq.com", LogsAgent.GetString("logs_config.dd_url"))
+	assert.Equal(t, "agent-intake.logs.datadoghq.com", LogsAgent.GetString("logs_config.dd_url"))
 	assert.Equal(t, 10516, LogsAgent.GetInt("logs_config.dd_port"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_config.dev_mode_no_ssl"))
-	assert.Equal(t, false, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
+	assert.Equal(t, true, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
 	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.open_files_limit"))
 }
 

--- a/releasenotes/notes/logs_use_proto-dd9460455fd718a1.yaml
+++ b/releasenotes/notes/logs_use_proto-dd9460455fd718a1.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Change logs agent configuration to use protocol buffers encoding and 
+    endpoint by default.


### PR DESCRIPTION
### What does this PR do?

Switch logs agent default configuration to use protocol buffers encoding and endpoint.

### Motivation

We want to use as it as the default from now on.

### Additional Notes


