### PR TITLE
[invoke] Address breaking changes in v0.23.0 of invoke

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -60,7 +60,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
             if ex not in build_exclude:
                 build_exclude.append(ex)
 
-    if invoke.platform.WINDOWS:
+    if sys.platform == 'win32':
         # This generates the manifest resource. The manifest resource is necessary for
         # being able to load the ancient C-runtime that comes along with Python 2.7
         # command = "rsrc -arch amd64 -manifest cmd/agent/agent.exe.manifest -o cmd/agent/rsrc.syso"
@@ -169,7 +169,7 @@ def image_build(ctx, base_dir="omnibus"):
     if not list_of_files:
         print("No debian package build found in {}".format(pkg_dir))
         print("See agent.omnibus-build")
-        raise Exit(1)
+        raise Exit(code=1)
     latest_file = max(list_of_files, key=os.path.getctime)
     shutil.copy2(latest_file, "Dockerfiles/agent/")
     ctx.run("docker build -t {} Dockerfiles/agent".format(AGENT_TAG))
@@ -234,7 +234,7 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
             cmd += " --path {}".format(gem_path)
         ctx.run(cmd, env=env)
 
-        omnibus = "bundle exec omnibus.bat" if invoke.platform.WINDOWS else "bundle exec omnibus"
+        omnibus = "bundle exec omnibus.bat" if sys.platform == 'win32' else "bundle exec omnibus"
         cmd = "{omnibus} build {project_name} --log-level={log_level} {overrides}"
         args = {
             "omnibus": omnibus,

--- a/tasks/benchmarks.py
+++ b/tasks/benchmarks.py
@@ -3,6 +3,7 @@ Benchmarking tasks
 """
 from __future__ import print_function
 import os
+import sys
 
 import invoke
 from invoke import task
@@ -29,7 +30,7 @@ def build_aggregator(ctx, rebuild=False):
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"
-        if invoke.platform.WINDOWS:
+        if sys.platform == 'win32':
             # On windows, need to build with the extra argument -ldflags="-linkmode internal"
             # if you want to be able to use the delve debugger.
             ldflags += " -linkmode internal"

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -123,7 +123,7 @@ def image_build(ctx):
     if not dca_binary:
         print("No bin found in {}".format(BIN_PATH))
         print("See cluster-agent.build")
-        raise Exit(1)
+        raise Exit(code=1)
     latest_file = max(dca_binary, key=os.path.getctime)
     ctx.run("chmod +x {}".format(latest_file))
 

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -95,7 +95,7 @@ COPY test.bin /test.bin
         client.images.remove(test_image.id)
 
     if exit_code != 0:
-        raise Exit(exit_code)
+        raise Exit(code=exit_code)
 
 
 @task
@@ -109,7 +109,7 @@ def mirror_image(ctx, src_image, dst_image="datadog/docker-library", dst_tag="au
         match = re.search('([^:\/\s]+):[v]?(.*)$', src_image)
         if not match:
             print("Cannot guess destination tag for {}, please provide a --dst-tag option".format(src_image))
-            raise Exit(1)
+            raise Exit(code=1)
         dst_tag = "_".join(match.groups()).replace(".", "_")
 
     dst = "{}:{}".format(dst_image, dst_tag)

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -138,7 +138,7 @@ def size_test(ctx, skip_build=False):
     if size > MAX_BINARY_SIZE:
         print("DogStatsD static build size too big: {} kB".format(size))
         print("This means your PR added big classes or dependencies in the packages dogstatsd uses")
-        raise Exit(1)
+        raise Exit(code=1)
 
     print("DogStatsD static build size OK: {} kB".format(size))
 
@@ -169,7 +169,7 @@ def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
         if gem_path:
             cmd += " --path {}".format(gem_path)
         ctx.run(cmd)
-        omnibus = "bundle exec omnibus.bat" if invoke.platform.WINDOWS else "bundle exec omnibus"
+        omnibus = "bundle exec omnibus.bat" if sys.platform == 'win32' else "bundle exec omnibus"
         cmd = "{omnibus} build dogstatsd --log-level={log_level} {overrides}"
         args = {
             "omnibus": omnibus,
@@ -220,7 +220,7 @@ def image_build(ctx, skip_build=False):
     if not skip_build:
         build(ctx, rebuild=True, static=True)
     if not os.path.exists(src):
-        raise Exit(1)
+        raise Exit(code=1)
     if not os.path.exists(dst):
         os.makedirs(dst)
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -44,7 +44,7 @@ def fmt(ctx, targets, fail_on_fmt=False):
         print("Reformatted the following files: {}".format(','.join(files)))
         if fail_on_fmt:
             print("Code was not properly formatted, exiting...")
-            raise Exit(1)
+            raise Exit(code=1)
     print("gofmt found no issues")
 
 
@@ -77,7 +77,7 @@ def lint(ctx, targets):
 
         if files:
             print("Linting issues found in {} files.".format(len(files)))
-            raise Exit(1)
+            raise Exit(code=1)
 
         if skipped_files:
             for skipped in skipped_files:

--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -3,6 +3,7 @@ systray tasks
 """
 from __future__ import print_function
 import os
+import sys
 
 import invoke
 from invoke import task
@@ -28,7 +29,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         inv systray.build
     """
 
-    if not invoke.platform.WINDOWS:
+    if not sys.platform == 'win32':
         print("Systray only available on Windows")
         return
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -109,7 +109,7 @@ def test(ctx, targets=None, coverage=False, race=False, profile=False, use_embed
         matches = ["{}/...".format(t) for t in test_targets]
     print("\n--- Running unit tests:")
     for match in matches:
-        if invoke.platform.WINDOWS:
+        if sys.platform == 'win32':
             if match in WIN_PKG_BLACKLIST:
                 print("Skipping blacklisted directory {}\n".format(match))
                 continue
@@ -182,7 +182,7 @@ def lint_releasenote(ctx):
                 url = res.links['next']['url']
             else:
                 print("Error: No releasenote was found for this PR. Please add one using 'reno'.")
-                raise Exit(1)
+                raise Exit(code=1)
 
     # The PR has not been created yet, let's compare with master (the usual base branch of the future PR)
     else:
@@ -208,7 +208,7 @@ def lint_releasenote(ctx):
                         url = res.links['next']['url']
                     else:
                         print("Error: No releasenote was found for this PR. Please add one using 'reno'.")
-                        raise Exit(1)
+                        raise Exit(code=1)
 
     ctx.run("reno lint")
 
@@ -217,7 +217,7 @@ def lint_filenames(ctx):
     """
     Scan files to ensure there are no filenames containing illegal characters
     """
-    if invoke.platform.WINDOWS:
+    if sys.platform == 'win32':
         print("Running on windows, no need to check filenames for illegal characters")
     else:
         print("Checking filenames for illegal characters")
@@ -229,7 +229,7 @@ def lint_filenames(ctx):
                 print("Error: Found illegal character in path {}".format(file))
                 failure = True
         if failure:
-            raise Exit(1)
+            raise Exit(code=1)
 
 
 @task

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import os
 import platform
 import re
+import sys
 import json
 from subprocess import check_output
 
@@ -20,7 +21,7 @@ def bin_name(name):
     """
     Generate platform dependent names for binaries
     """
-    if invoke.platform.WINDOWS:
+    if sys.platform == 'win32':
         return "{}.exe".format(name)
     return name
 
@@ -59,9 +60,9 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
         "CGO_CFLAGS_ALLOW": "-static-libgcc",  # whitelist additional flags, here a flag used for net-snmp
     }
 
-    if invoke.platform.WINDOWS:
+    if sys.platform == 'win32':
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
-    
+
     if static:
         ldflags += "-s -w -linkmode external -extldflags '-static' "
     elif use_embedded_libs:
@@ -74,7 +75,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"
-        if invoke.platform.WINDOWS:
+        if sys.platform == 'win32':
             # On windows, need to build with the extra argument -ldflags="-linkmode internal"
             # if you want to be able to use the delve debugger.
             ldflags += "-linkmode internal "


### PR DESCRIPTION
### What does this PR do?

Address breaking changes in v0.23.0 of invoke:

* `invoke.platforms` module has changed path, instead use python's `sys`
  module
* `invoke.exceptions.Exit`'s signature has changed, use invocation that's
  compatible with all existing versions of invoke

See http://www.pyinvoke.org/changelog.html

### Motivation

Unblock CI/build pipeline for 6.2.0.

### Additional Notes

We should pin the version of `invoke` we install/recommend installing across our dev/CI/build environments as things can break between `0.x` versions of invoke, and we don't want those to break at any time. I'll create a card in our backlog to tackle this
