### PR TITLE
Moved Config struct to AD

### DIFF
--- a/cmd/agent/api/agent/agent_jmx.go
+++ b/cmd/agent/api/agent/agent_jmx.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -51,7 +51,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
 
 	j := map[string]interface{}{}
-	configs := map[string]check.ConfigJSONMap{}
+	configs := map[string]adconfig.JSONMap{}
 
 	configItems := embed.JMXConfigCache.Items()
 	for name, config := range configItems {
@@ -63,7 +63,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		cfg, ok := m["config"].(check.Config)
+		cfg, ok := m["config"].(adconfig.Config)
 		if !ok {
 			err = fmt.Errorf("wrong type for config")
 			log.Errorf("%s", err.Error())
@@ -71,7 +71,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var rawInitConfig check.ConfigRawMap
+		var rawInitConfig adconfig.RawMap
 		err = yaml.Unmarshal(cfg.InitConfig, &rawInitConfig)
 		if err != nil {
 			log.Errorf("unable to parse JMX configuration: %s", err)
@@ -81,16 +81,16 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 
 		c := map[string]interface{}{}
 		c["init_config"] = util.GetJSONSerializableMap(rawInitConfig)
-		instances := []check.ConfigJSONMap{}
+		instances := []adconfig.JSONMap{}
 		for _, instance := range cfg.Instances {
-			var rawInstanceConfig check.ConfigJSONMap
+			var rawInstanceConfig adconfig.JSONMap
 			err = yaml.Unmarshal(instance, &rawInstanceConfig)
 			if err != nil {
 				log.Errorf("unable to parse JMX configuration: %s", err)
 				http.Error(w, err.Error(), 500)
 				return
 			}
-			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(check.ConfigJSONMap))
+			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(adconfig.JSONMap))
 		}
 
 		c["instances"] = instances

--- a/cmd/agent/api/agent/agent_jmx.go
+++ b/cmd/agent/api/agent/agent_jmx.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -51,7 +51,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
 
 	j := map[string]interface{}{}
-	configs := map[string]adconfig.JSONMap{}
+	configs := map[string]autodiscovery.JSONMap{}
 
 	configItems := embed.JMXConfigCache.Items()
 	for name, config := range configItems {
@@ -63,7 +63,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		cfg, ok := m["config"].(adconfig.Config)
+		cfg, ok := m["config"].(autodiscovery.Config)
 		if !ok {
 			err = fmt.Errorf("wrong type for config")
 			log.Errorf("%s", err.Error())
@@ -71,7 +71,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var rawInitConfig adconfig.RawMap
+		var rawInitConfig autodiscovery.RawMap
 		err = yaml.Unmarshal(cfg.InitConfig, &rawInitConfig)
 		if err != nil {
 			log.Errorf("unable to parse JMX configuration: %s", err)
@@ -81,16 +81,16 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 
 		c := map[string]interface{}{}
 		c["init_config"] = util.GetJSONSerializableMap(rawInitConfig)
-		instances := []adconfig.JSONMap{}
+		instances := []autodiscovery.JSONMap{}
 		for _, instance := range cfg.Instances {
-			var rawInstanceConfig adconfig.JSONMap
+			var rawInstanceConfig autodiscovery.JSONMap
 			err = yaml.Unmarshal(instance, &rawInstanceConfig)
 			if err != nil {
 				log.Errorf("unable to parse JMX configuration: %s", err)
 				http.Error(w, err.Error(), 500)
 				return
 			}
-			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(adconfig.JSONMap))
+			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(autodiscovery.JSONMap))
 		}
 
 		c["instances"] = instances

--- a/cmd/agent/api/agent/agent_jmx.go
+++ b/cmd/agent/api/agent/agent_jmx.go
@@ -21,8 +21,8 @@ import (
 	log "github.com/cihub/seelog"
 
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
@@ -51,7 +51,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 	log.Debugf("Getting latest JMX Configs as of: %#v", ts)
 
 	j := map[string]interface{}{}
-	configs := map[string]autodiscovery.JSONMap{}
+	configs := map[string]integration.JSONMap{}
 
 	configItems := embed.JMXConfigCache.Items()
 	for name, config := range configItems {
@@ -63,7 +63,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		cfg, ok := m["config"].(autodiscovery.Config)
+		cfg, ok := m["config"].(integration.Config)
 		if !ok {
 			err = fmt.Errorf("wrong type for config")
 			log.Errorf("%s", err.Error())
@@ -71,7 +71,7 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		var rawInitConfig autodiscovery.RawMap
+		var rawInitConfig integration.RawMap
 		err = yaml.Unmarshal(cfg.InitConfig, &rawInitConfig)
 		if err != nil {
 			log.Errorf("unable to parse JMX configuration: %s", err)
@@ -81,16 +81,16 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 
 		c := map[string]interface{}{}
 		c["init_config"] = util.GetJSONSerializableMap(rawInitConfig)
-		instances := []autodiscovery.JSONMap{}
+		instances := []integration.JSONMap{}
 		for _, instance := range cfg.Instances {
-			var rawInstanceConfig autodiscovery.JSONMap
+			var rawInstanceConfig integration.JSONMap
 			err = yaml.Unmarshal(instance, &rawInstanceConfig)
 			if err != nil {
 				log.Errorf("unable to parse JMX configuration: %s", err)
 				http.Error(w, err.Error(), 500)
 				return
 			}
-			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(autodiscovery.JSONMap))
+			instances = append(instances, util.GetJSONSerializableMap(rawInstanceConfig).(integration.JSONMap))
 		}
 
 		c["instances"] = instances

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -6,13 +6,13 @@
 package response
 
 import (
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         []adconfig.Config          `json:"configs"`
-	ResolveWarnings map[string][]string        `json:"resolve_warnings"`
-	ConfigErrors    map[string]string          `json:"config_errors"`
-	Unresolved      map[string]adconfig.Config `json:"unresolved"`
+	Configs         []autodiscovery.Config          `json:"configs"`
+	ResolveWarnings map[string][]string             `json:"resolve_warnings"`
+	ConfigErrors    map[string]string               `json:"config_errors"`
+	Unresolved      map[string]autodiscovery.Config `json:"unresolved"`
 }

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -5,12 +5,14 @@
 
 package response
 
-import "github.com/DataDog/datadog-agent/pkg/collector/check"
+import (
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+)
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         []check.Config          `json:"configs"`
-	ResolveWarnings map[string][]string     `json:"resolve_warnings"`
-	ConfigErrors    map[string]string       `json:"config_errors"`
-	Unresolved      map[string]check.Config `json:"unresolved"`
+	Configs         []adconfig.Config          `json:"configs"`
+	ResolveWarnings map[string][]string        `json:"resolve_warnings"`
+	ConfigErrors    map[string]string          `json:"config_errors"`
+	Unresolved      map[string]adconfig.Config `json:"unresolved"`
 }

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -6,13 +6,13 @@
 package response
 
 import (
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         []autodiscovery.Config          `json:"configs"`
-	ResolveWarnings map[string][]string             `json:"resolve_warnings"`
-	ConfigErrors    map[string]string               `json:"config_errors"`
-	Unresolved      map[string]autodiscovery.Config `json:"unresolved"`
+	Configs         []integration.Config          `json:"configs"`
+	ResolveWarnings map[string][]string           `json:"resolve_warnings"`
+	ConfigErrors    map[string]string             `json:"config_errors"`
+	Unresolved      map[string]integration.Config `json:"unresolved"`
 }

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -180,7 +180,7 @@ func loadConfigs() {
 	}
 }
 
-func configIncluded(config adconfig.Config) bool {
+func configIncluded(config autodiscovery.Config) bool {
 	for _, c := range checks {
 		if strings.EqualFold(config.Name, c) {
 			return true

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -179,7 +180,7 @@ func loadConfigs() {
 	}
 }
 
-func configIncluded(config check.Config) bool {
+func configIncluded(config adconfig.Config) bool {
 	for _, c := range checks {
 		if strings.EqualFold(config.Name, c) {
 			return true

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
 	"github.com/spf13/cobra"
 )
@@ -180,7 +180,7 @@ func loadConfigs() {
 	}
 }
 
-func configIncluded(config autodiscovery.Config) bool {
+func configIncluded(config integration.Config) bool {
 	for _, c := range checks {
 		if strings.EqualFold(config.Name, c) {
 			return true

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -181,7 +181,7 @@ type configFormat struct {
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []adconfig.RawMap
+	Instances     []autodiscovery.RawMap
 }
 
 // Overwrites a specific check's configuration (yaml) file with new data

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -180,7 +181,7 @@ type configFormat struct {
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []check.ConfigRawMap
+	Instances     []adconfig.RawMap
 }
 
 // Overwrites a specific check's configuration (yaml) file with new data

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 	"github.com/gorilla/mux"
 	yaml "gopkg.in/yaml.v2"
@@ -181,7 +181,7 @@ type configFormat struct {
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []autodiscovery.RawMap
+	Instances     []integration.RawMap
 }
 
 // Overwrites a specific check's configuration (yaml) file with new data

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -14,6 +14,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector"
@@ -48,7 +49,7 @@ func init() {
 // `providers.ConfigProvider` and whether it should be polled or not.
 type providerDescriptor struct {
 	provider providers.ConfigProvider
-	configs  []check.Config
+	configs  []adconfig.Config
 	poll     bool
 }
 
@@ -61,7 +62,7 @@ type providerDescriptor struct {
 //  - it holds a list of `listeners.ServiceListener`s` used to listen to container lifecycle events
 //  - it runs the `ConfigResolver` that resolves a configuration template to an actual configuration based on data it extracts from a service that matches it the template
 //
-// Notice the `AutoConfig` public API speaks in terms of `check.Config`,
+// Notice the `AutoConfig` public API speaks in terms of `adconfig.Config`,
 // meaning that you cannot use it to schedule check instances directly.
 type AutoConfig struct {
 	collector         *collector.Collector
@@ -71,10 +72,10 @@ type AutoConfig struct {
 	listeners         []listeners.ServiceListener
 	configResolver    *ConfigResolver
 	configsPollTicker *time.Ticker
-	config2checks     map[string][]check.ID       // cache the ID of checks we load for each config
-	check2config      map[check.ID]string         // cache the config digest corresponding to a check
-	name2jmxmetrics   map[string]check.ConfigData // holds the metrics to collect for JMX checks
-	loadedConfigs     []check.Config              // holds the resolved configs
+	config2checks     map[string][]check.ID    // cache the ID of checks we load for each config
+	check2config      map[check.ID]string      // cache the config digest corresponding to a check
+	name2jmxmetrics   map[string]adconfig.Data // holds the metrics to collect for JMX checks
+	loadedConfigs     []adconfig.Config        // holds the resolved configs
 	stop              chan bool
 	pollerActive      bool
 	health            *health.Handle
@@ -90,8 +91,8 @@ func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 		templateCache:   NewTemplateCache(),
 		config2checks:   make(map[string][]check.ID),
 		check2config:    make(map[check.ID]string),
-		name2jmxmetrics: make(map[string]check.ConfigData),
-		loadedConfigs:   make([]check.Config, 0),
+		name2jmxmetrics: make(map[string]adconfig.Data),
+		loadedConfigs:   make([]adconfig.Config, 0),
 		stop:            make(chan bool),
 		health:          health.Register("ad-autoconfig"),
 	}
@@ -160,7 +161,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 
 	pd := &providerDescriptor{
 		provider: provider,
-		configs:  []check.Config{},
+		configs:  []adconfig.Config{},
 		poll:     shouldPoll,
 	}
 	ac.providers = append(ac.providers, pd)
@@ -193,14 +194,14 @@ func (ac *AutoConfig) GetChecksByName(checkName string) []check.Check {
 
 // GetAllConfigs queries all the providers and returns all the check
 // configurations found, resolving the ones it can
-func (ac *AutoConfig) GetAllConfigs() []check.Config {
-	resolvedConfigs := []check.Config{}
+func (ac *AutoConfig) GetAllConfigs() []adconfig.Config {
+	resolvedConfigs := []adconfig.Config{}
 
 	for _, pd := range ac.providers {
 		cfgs, _ := pd.provider.Collect()
 
 		if fileConfPd, ok := pd.provider.(*providers.FileConfigProvider); ok {
-			var goodConfs []check.Config
+			var goodConfs []adconfig.Config
 			for _, cfg := range cfgs {
 				// JMX checks can have 2 YAML files: one containing the metrics to collect, one containing the
 				// instance configuration
@@ -240,7 +241,7 @@ func (ac *AutoConfig) GetAllConfigs() []check.Config {
 
 // getChecksFromConfigs gets all the check instances for given configurations
 // optionally can populate ac cache config2checks
-func (ac *AutoConfig) getChecksFromConfigs(configs []check.Config, populateCache bool) []check.Check {
+func (ac *AutoConfig) getChecksFromConfigs(configs []adconfig.Config, populateCache bool) []check.Check {
 	allChecks := []check.Check{}
 	for _, config := range configs {
 		configDigest := config.Digest()
@@ -280,8 +281,8 @@ func (ac *AutoConfig) schedule(checks []check.Check) {
 }
 
 // resolve loads and resolves a given config into a slice of resolved configs
-func (ac *AutoConfig) resolve(config check.Config) []check.Config {
-	configs := []check.Config{}
+func (ac *AutoConfig) resolve(config adconfig.Config) []adconfig.Config {
+	configs := []adconfig.Config{}
 
 	// add default metrics to collect to JMX checks
 	if check.CollectDefaultMetrics(config) {
@@ -441,9 +442,9 @@ func (ac *AutoConfig) pollConfigs() {
 
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
-func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []check.Config) {
-	new = []check.Config{}
-	removed = []check.Config{}
+func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []adconfig.Config) {
+	new = []adconfig.Config{}
+	removed = []adconfig.Config{}
 
 	fetched, err := pd.provider.Collect()
 	if err != nil {
@@ -473,7 +474,7 @@ func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []check.Conf
 
 // getChecks takes a check configuration and returns a slice of Check instances
 // along with any error it might happen during the process
-func (ac *AutoConfig) getChecks(config check.Config) ([]check.Check, error) {
+func (ac *AutoConfig) getChecks(config adconfig.Config) ([]check.Check, error) {
 	for _, loader := range ac.loaders {
 		res, err := loader.Load(config)
 		if err == nil {
@@ -495,12 +496,12 @@ func (ac *AutoConfig) getChecks(config check.Config) ([]check.Check, error) {
 }
 
 // GetLoadedConfigs returns configs loaded
-func (ac *AutoConfig) GetLoadedConfigs() []check.Config {
+func (ac *AutoConfig) GetLoadedConfigs() []adconfig.Config {
 	return ac.loadedConfigs
 }
 
 // GetUnresolvedTemplates returns templates in cache yet to be resolved
-func (ac *AutoConfig) GetUnresolvedTemplates() map[string]check.Config {
+func (ac *AutoConfig) GetUnresolvedTemplates() map[string]adconfig.Config {
 	return ac.templateCache.GetUnresolvedTemplates()
 }
 
@@ -510,7 +511,7 @@ func (ac *AutoConfig) unschedule(id check.ID) {
 }
 
 // check if the descriptor contains the Config passed
-func (pd *providerDescriptor) contains(c *check.Config) bool {
+func (pd *providerDescriptor) contains(c *adconfig.Config) bool {
 	for _, config := range pd.configs {
 		if config.Equal(c) {
 			return true

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -14,7 +14,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector"
@@ -49,7 +49,7 @@ func init() {
 // `providers.ConfigProvider` and whether it should be polled or not.
 type providerDescriptor struct {
 	provider providers.ConfigProvider
-	configs  []adconfig.Config
+	configs  []autodiscovery.Config
 	poll     bool
 }
 
@@ -62,7 +62,7 @@ type providerDescriptor struct {
 //  - it holds a list of `listeners.ServiceListener`s` used to listen to container lifecycle events
 //  - it runs the `ConfigResolver` that resolves a configuration template to an actual configuration based on data it extracts from a service that matches it the template
 //
-// Notice the `AutoConfig` public API speaks in terms of `adconfig.Config`,
+// Notice the `AutoConfig` public API speaks in terms of `autodiscovery.Config`,
 // meaning that you cannot use it to schedule check instances directly.
 type AutoConfig struct {
 	collector         *collector.Collector
@@ -72,10 +72,10 @@ type AutoConfig struct {
 	listeners         []listeners.ServiceListener
 	configResolver    *ConfigResolver
 	configsPollTicker *time.Ticker
-	config2checks     map[string][]check.ID    // cache the ID of checks we load for each config
-	check2config      map[check.ID]string      // cache the config digest corresponding to a check
-	name2jmxmetrics   map[string]adconfig.Data // holds the metrics to collect for JMX checks
-	loadedConfigs     []adconfig.Config        // holds the resolved configs
+	config2checks     map[string][]check.ID         // cache the ID of checks we load for each config
+	check2config      map[check.ID]string           // cache the config digest corresponding to a check
+	name2jmxmetrics   map[string]autodiscovery.Data // holds the metrics to collect for JMX checks
+	loadedConfigs     []autodiscovery.Config        // holds the resolved configs
 	stop              chan bool
 	pollerActive      bool
 	health            *health.Handle
@@ -91,8 +91,8 @@ func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 		templateCache:   NewTemplateCache(),
 		config2checks:   make(map[string][]check.ID),
 		check2config:    make(map[check.ID]string),
-		name2jmxmetrics: make(map[string]adconfig.Data),
-		loadedConfigs:   make([]adconfig.Config, 0),
+		name2jmxmetrics: make(map[string]autodiscovery.Data),
+		loadedConfigs:   make([]autodiscovery.Config, 0),
 		stop:            make(chan bool),
 		health:          health.Register("ad-autoconfig"),
 	}
@@ -161,7 +161,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 
 	pd := &providerDescriptor{
 		provider: provider,
-		configs:  []adconfig.Config{},
+		configs:  []autodiscovery.Config{},
 		poll:     shouldPoll,
 	}
 	ac.providers = append(ac.providers, pd)
@@ -194,14 +194,14 @@ func (ac *AutoConfig) GetChecksByName(checkName string) []check.Check {
 
 // GetAllConfigs queries all the providers and returns all the check
 // configurations found, resolving the ones it can
-func (ac *AutoConfig) GetAllConfigs() []adconfig.Config {
-	resolvedConfigs := []adconfig.Config{}
+func (ac *AutoConfig) GetAllConfigs() []autodiscovery.Config {
+	resolvedConfigs := []autodiscovery.Config{}
 
 	for _, pd := range ac.providers {
 		cfgs, _ := pd.provider.Collect()
 
 		if fileConfPd, ok := pd.provider.(*providers.FileConfigProvider); ok {
-			var goodConfs []adconfig.Config
+			var goodConfs []autodiscovery.Config
 			for _, cfg := range cfgs {
 				// JMX checks can have 2 YAML files: one containing the metrics to collect, one containing the
 				// instance configuration
@@ -241,7 +241,7 @@ func (ac *AutoConfig) GetAllConfigs() []adconfig.Config {
 
 // getChecksFromConfigs gets all the check instances for given configurations
 // optionally can populate ac cache config2checks
-func (ac *AutoConfig) getChecksFromConfigs(configs []adconfig.Config, populateCache bool) []check.Check {
+func (ac *AutoConfig) getChecksFromConfigs(configs []autodiscovery.Config, populateCache bool) []check.Check {
 	allChecks := []check.Check{}
 	for _, config := range configs {
 		configDigest := config.Digest()
@@ -281,8 +281,8 @@ func (ac *AutoConfig) schedule(checks []check.Check) {
 }
 
 // resolve loads and resolves a given config into a slice of resolved configs
-func (ac *AutoConfig) resolve(config adconfig.Config) []adconfig.Config {
-	configs := []adconfig.Config{}
+func (ac *AutoConfig) resolve(config autodiscovery.Config) []autodiscovery.Config {
+	configs := []autodiscovery.Config{}
 
 	// add default metrics to collect to JMX checks
 	if check.CollectDefaultMetrics(config) {
@@ -442,9 +442,9 @@ func (ac *AutoConfig) pollConfigs() {
 
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
-func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []adconfig.Config) {
-	new = []adconfig.Config{}
-	removed = []adconfig.Config{}
+func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []autodiscovery.Config) {
+	new = []autodiscovery.Config{}
+	removed = []autodiscovery.Config{}
 
 	fetched, err := pd.provider.Collect()
 	if err != nil {
@@ -474,7 +474,7 @@ func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []adconfig.C
 
 // getChecks takes a check configuration and returns a slice of Check instances
 // along with any error it might happen during the process
-func (ac *AutoConfig) getChecks(config adconfig.Config) ([]check.Check, error) {
+func (ac *AutoConfig) getChecks(config autodiscovery.Config) ([]check.Check, error) {
 	for _, loader := range ac.loaders {
 		res, err := loader.Load(config)
 		if err == nil {
@@ -496,12 +496,12 @@ func (ac *AutoConfig) getChecks(config adconfig.Config) ([]check.Check, error) {
 }
 
 // GetLoadedConfigs returns configs loaded
-func (ac *AutoConfig) GetLoadedConfigs() []adconfig.Config {
+func (ac *AutoConfig) GetLoadedConfigs() []autodiscovery.Config {
 	return ac.loadedConfigs
 }
 
 // GetUnresolvedTemplates returns templates in cache yet to be resolved
-func (ac *AutoConfig) GetUnresolvedTemplates() map[string]adconfig.Config {
+func (ac *AutoConfig) GetUnresolvedTemplates() map[string]autodiscovery.Config {
 	return ac.templateCache.GetUnresolvedTemplates()
 }
 
@@ -511,7 +511,7 @@ func (ac *AutoConfig) unschedule(id check.ID) {
 }
 
 // check if the descriptor contains the Config passed
-func (pd *providerDescriptor) contains(c *adconfig.Config) bool {
+func (pd *providerDescriptor) contains(c *autodiscovery.Config) bool {
 	for _, config := range pd.configs {
 		if config.Equal(c) {
 			return true

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -14,11 +14,11 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
@@ -49,7 +49,7 @@ func init() {
 // `providers.ConfigProvider` and whether it should be polled or not.
 type providerDescriptor struct {
 	provider providers.ConfigProvider
-	configs  []autodiscovery.Config
+	configs  []integration.Config
 	poll     bool
 }
 
@@ -62,7 +62,7 @@ type providerDescriptor struct {
 //  - it holds a list of `listeners.ServiceListener`s` used to listen to container lifecycle events
 //  - it runs the `ConfigResolver` that resolves a configuration template to an actual configuration based on data it extracts from a service that matches it the template
 //
-// Notice the `AutoConfig` public API speaks in terms of `autodiscovery.Config`,
+// Notice the `AutoConfig` public API speaks in terms of `integration.Config`,
 // meaning that you cannot use it to schedule check instances directly.
 type AutoConfig struct {
 	collector         *collector.Collector
@@ -72,10 +72,10 @@ type AutoConfig struct {
 	listeners         []listeners.ServiceListener
 	configResolver    *ConfigResolver
 	configsPollTicker *time.Ticker
-	config2checks     map[string][]check.ID         // cache the ID of checks we load for each config
-	check2config      map[check.ID]string           // cache the config digest corresponding to a check
-	name2jmxmetrics   map[string]autodiscovery.Data // holds the metrics to collect for JMX checks
-	loadedConfigs     []autodiscovery.Config        // holds the resolved configs
+	config2checks     map[string][]check.ID       // cache the ID of checks we load for each config
+	check2config      map[check.ID]string         // cache the config digest corresponding to a check
+	name2jmxmetrics   map[string]integration.Data // holds the metrics to collect for JMX checks
+	loadedConfigs     []integration.Config        // holds the resolved configs
 	stop              chan bool
 	pollerActive      bool
 	health            *health.Handle
@@ -91,8 +91,8 @@ func NewAutoConfig(collector *collector.Collector) *AutoConfig {
 		templateCache:   NewTemplateCache(),
 		config2checks:   make(map[string][]check.ID),
 		check2config:    make(map[check.ID]string),
-		name2jmxmetrics: make(map[string]autodiscovery.Data),
-		loadedConfigs:   make([]autodiscovery.Config, 0),
+		name2jmxmetrics: make(map[string]integration.Data),
+		loadedConfigs:   make([]integration.Config, 0),
 		stop:            make(chan bool),
 		health:          health.Register("ad-autoconfig"),
 	}
@@ -161,7 +161,7 @@ func (ac *AutoConfig) AddProvider(provider providers.ConfigProvider, shouldPoll 
 
 	pd := &providerDescriptor{
 		provider: provider,
-		configs:  []autodiscovery.Config{},
+		configs:  []integration.Config{},
 		poll:     shouldPoll,
 	}
 	ac.providers = append(ac.providers, pd)
@@ -194,14 +194,14 @@ func (ac *AutoConfig) GetChecksByName(checkName string) []check.Check {
 
 // GetAllConfigs queries all the providers and returns all the check
 // configurations found, resolving the ones it can
-func (ac *AutoConfig) GetAllConfigs() []autodiscovery.Config {
-	resolvedConfigs := []autodiscovery.Config{}
+func (ac *AutoConfig) GetAllConfigs() []integration.Config {
+	resolvedConfigs := []integration.Config{}
 
 	for _, pd := range ac.providers {
 		cfgs, _ := pd.provider.Collect()
 
 		if fileConfPd, ok := pd.provider.(*providers.FileConfigProvider); ok {
-			var goodConfs []autodiscovery.Config
+			var goodConfs []integration.Config
 			for _, cfg := range cfgs {
 				// JMX checks can have 2 YAML files: one containing the metrics to collect, one containing the
 				// instance configuration
@@ -241,7 +241,7 @@ func (ac *AutoConfig) GetAllConfigs() []autodiscovery.Config {
 
 // getChecksFromConfigs gets all the check instances for given configurations
 // optionally can populate ac cache config2checks
-func (ac *AutoConfig) getChecksFromConfigs(configs []autodiscovery.Config, populateCache bool) []check.Check {
+func (ac *AutoConfig) getChecksFromConfigs(configs []integration.Config, populateCache bool) []check.Check {
 	allChecks := []check.Check{}
 	for _, config := range configs {
 		configDigest := config.Digest()
@@ -281,8 +281,8 @@ func (ac *AutoConfig) schedule(checks []check.Check) {
 }
 
 // resolve loads and resolves a given config into a slice of resolved configs
-func (ac *AutoConfig) resolve(config autodiscovery.Config) []autodiscovery.Config {
-	configs := []autodiscovery.Config{}
+func (ac *AutoConfig) resolve(config integration.Config) []integration.Config {
+	configs := []integration.Config{}
 
 	// add default metrics to collect to JMX checks
 	if check.CollectDefaultMetrics(config) {
@@ -442,9 +442,9 @@ func (ac *AutoConfig) pollConfigs() {
 
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
-func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []autodiscovery.Config) {
-	new = []autodiscovery.Config{}
-	removed = []autodiscovery.Config{}
+func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []integration.Config) {
+	new = []integration.Config{}
+	removed = []integration.Config{}
 
 	fetched, err := pd.provider.Collect()
 	if err != nil {
@@ -474,7 +474,7 @@ func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []autodiscov
 
 // getChecks takes a check configuration and returns a slice of Check instances
 // along with any error it might happen during the process
-func (ac *AutoConfig) getChecks(config autodiscovery.Config) ([]check.Check, error) {
+func (ac *AutoConfig) getChecks(config integration.Config) ([]check.Check, error) {
 	for _, loader := range ac.loaders {
 		res, err := loader.Load(config)
 		if err == nil {
@@ -496,12 +496,12 @@ func (ac *AutoConfig) getChecks(config autodiscovery.Config) ([]check.Check, err
 }
 
 // GetLoadedConfigs returns configs loaded
-func (ac *AutoConfig) GetLoadedConfigs() []autodiscovery.Config {
+func (ac *AutoConfig) GetLoadedConfigs() []integration.Config {
 	return ac.loadedConfigs
 }
 
 // GetUnresolvedTemplates returns templates in cache yet to be resolved
-func (ac *AutoConfig) GetUnresolvedTemplates() map[string]autodiscovery.Config {
+func (ac *AutoConfig) GetUnresolvedTemplates() map[string]integration.Config {
 	return ac.templateCache.GetUnresolvedTemplates()
 }
 
@@ -511,7 +511,7 @@ func (ac *AutoConfig) unschedule(id check.ID) {
 }
 
 // check if the descriptor contains the Config passed
-func (pd *providerDescriptor) contains(c *autodiscovery.Config) bool {
+func (pd *providerDescriptor) contains(c *integration.Config) bool {
 	for _, config := range pd.configs {
 		if config.Equal(c) {
 			return true

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -8,6 +8,7 @@ package autodiscovery
 import (
 	"testing"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
@@ -18,9 +19,9 @@ type MockProvider struct {
 	collectCounter int
 }
 
-func (p *MockProvider) Collect() ([]check.Config, error) {
+func (p *MockProvider) Collect() ([]adconfig.Config, error) {
 	p.collectCounter++
-	return []check.Config{}, nil
+	return []adconfig.Config{}, nil
 }
 
 func (p *MockProvider) String() string {
@@ -37,7 +38,7 @@ type MockProvider2 struct {
 
 type MockLoader struct{}
 
-func (l *MockLoader) Load(config check.Config) ([]check.Check, error) { return []check.Check{}, nil }
+func (l *MockLoader) Load(config adconfig.Config) ([]check.Check, error) { return []check.Check{}, nil }
 
 type MockListener struct {
 	ListenCount  int
@@ -80,8 +81,8 @@ func TestAddListener(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	c1 := check.Config{Name: "bar"}
-	c2 := check.Config{Name: "foo"}
+	c1 := adconfig.Config{Name: "bar"}
+	c2 := adconfig.Config{Name: "foo"}
 	pd := providerDescriptor{}
 	pd.configs = append(pd.configs, c1)
 	assert.True(t, pd.contains(&c1))

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -8,7 +8,7 @@ package autodiscovery
 import (
 	"testing"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
@@ -19,9 +19,9 @@ type MockProvider struct {
 	collectCounter int
 }
 
-func (p *MockProvider) Collect() ([]adconfig.Config, error) {
+func (p *MockProvider) Collect() ([]autodiscovery.Config, error) {
 	p.collectCounter++
-	return []adconfig.Config{}, nil
+	return []autodiscovery.Config{}, nil
 }
 
 func (p *MockProvider) String() string {
@@ -38,7 +38,9 @@ type MockProvider2 struct {
 
 type MockLoader struct{}
 
-func (l *MockLoader) Load(config adconfig.Config) ([]check.Check, error) { return []check.Check{}, nil }
+func (l *MockLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
+	return []check.Check{}, nil
+}
 
 type MockListener struct {
 	ListenCount  int
@@ -81,8 +83,8 @@ func TestAddListener(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	c1 := adconfig.Config{Name: "bar"}
-	c2 := adconfig.Config{Name: "foo"}
+	c1 := autodiscovery.Config{Name: "bar"}
+	c2 := autodiscovery.Config{Name: "foo"}
 	pd := providerDescriptor{}
 	pd.configs = append(pd.configs, c1)
 	assert.True(t, pd.contains(&c1))

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -8,9 +8,9 @@ package autodiscovery
 import (
 	"testing"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,9 +19,9 @@ type MockProvider struct {
 	collectCounter int
 }
 
-func (p *MockProvider) Collect() ([]autodiscovery.Config, error) {
+func (p *MockProvider) Collect() ([]integration.Config, error) {
 	p.collectCounter++
-	return []autodiscovery.Config{}, nil
+	return []integration.Config{}, nil
 }
 
 func (p *MockProvider) String() string {
@@ -38,7 +38,7 @@ type MockProvider2 struct {
 
 type MockLoader struct{}
 
-func (l *MockLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
+func (l *MockLoader) Load(config integration.Config) ([]check.Check, error) {
 	return []check.Check{}, nil
 }
 
@@ -83,8 +83,8 @@ func TestAddListener(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	c1 := autodiscovery.Config{Name: "bar"}
-	c2 := autodiscovery.Config{Name: "foo"}
+	c1 := integration.Config{Name: "bar"}
+	c2 := integration.Config{Name: "foo"}
 	pd := providerDescriptor{}
 	pd.configs = append(pd.configs, c1)
 	assert.True(t, pd.contains(&c1))

--- a/pkg/autodiscovery/config/config.go
+++ b/pkg/autodiscovery/config/config.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-package check
+package config
 
 import (
 	"fmt"
@@ -17,33 +17,33 @@ import (
 
 var tplVarRegex = regexp.MustCompile(`%%.+?%%`)
 
-// ConfigData contains YAML code
-type ConfigData []byte
+// Data contains YAML code
+type Data []byte
 
-// ConfigRawMap is the generic type to hold YAML configurations
-type ConfigRawMap map[interface{}]interface{}
+// RawMap is the generic type to hold YAML configurations
+type RawMap map[interface{}]interface{}
 
-// ConfigJSONMap is the generic type to hold JSON configurations
-type ConfigJSONMap map[string]interface{}
+// JSONMap is the generic type to hold JSON configurations
+type JSONMap map[string]interface{}
 
 // Config is a generic container for configuration files
 type Config struct {
-	Name          string       `json:"check_name"`     // the name of the check
-	Instances     []ConfigData `json:"instances"`      // array of Yaml configurations
-	InitConfig    ConfigData   `json:"init_config"`    // the init_config in Yaml (python check only)
-	MetricConfig  ConfigData   `json:"metric_config"`  // the metric config in Yaml (jmx check only)
-	LogsConfig    ConfigData   `json:"log_config"`     // the logs config in Yaml (logs-agent only)
-	ADIdentifiers []string     `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
-	Provider      string       `json:"provider"`       // the provider that issued the config
+	Name          string   `json:"check_name"`     // the name of the check
+	Instances     []Data   `json:"instances"`      // array of Yaml configurations
+	InitConfig    Data     `json:"init_config"`    // the init_config in Yaml (python check only)
+	MetricConfig  Data     `json:"metric_config"`  // the metric config in Yaml (jmx check only)
+	LogsConfig    Data     `json:"log_config"`     // the logs config in Yaml (logs-agent only)
+	ADIdentifiers []string `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
+	Provider      string   `json:"provider"`       // the provider that issued the config
 }
 
 // Equal determines whether the passed config is the same
-func (c *Config) Equal(config *Config) bool {
-	if config == nil {
+func (c *Config) Equal(cfg *Config) bool {
+	if cfg == nil {
 		return false
 	}
 
-	return c.Digest() == config.Digest()
+	return c.Digest() == cfg.Digest()
 }
 
 // String YAML representation of the config
@@ -76,8 +76,8 @@ func (c *Config) IsTemplate() bool {
 }
 
 // AddMetrics adds metrics to a check configuration
-func (c *Config) AddMetrics(metrics ConfigData) error {
-	var rawInitConfig ConfigRawMap
+func (c *Config) AddMetrics(metrics Data) error {
+	var rawInitConfig RawMap
 	err := yaml.Unmarshal(c.InitConfig, &rawInitConfig)
 	if err != nil {
 		return err
@@ -134,8 +134,8 @@ func (c *Config) GetTemplateVariablesForInstance(i int) (vars [][]byte) {
 }
 
 // MergeAdditionalTags merges additional tags to possible existing config tags
-func (c *ConfigData) MergeAdditionalTags(tags []string) error {
-	rawConfig := ConfigRawMap{}
+func (c *Data) MergeAdditionalTags(tags []string) error {
+	rawConfig := RawMap{}
 	err := yaml.Unmarshal(*c, &rawConfig)
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func (c *ConfigData) MergeAdditionalTags(tags []string) error {
 	if err != nil {
 		return err
 	}
-	*c = ConfigData(out)
+	*c = Data(out)
 
 	return nil
 }

--- a/pkg/autodiscovery/config/config_test.go
+++ b/pkg/autodiscovery/config/config_test.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package config
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestConfigEqual(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.Equal(nil))
+
+	another := &Config{}
+	assert.True(t, config.Equal(another))
+
+	another.Name = "foo"
+	assert.False(t, config.Equal(another))
+	config.Name = another.Name
+	assert.True(t, config.Equal(another))
+
+	another.InitConfig = Data("fooBarBaz")
+	assert.False(t, config.Equal(another))
+	config.InitConfig = another.InitConfig
+	assert.True(t, config.Equal(another))
+
+	another.Instances = []Data{Data("justFoo")}
+	assert.False(t, config.Equal(another))
+	config.Instances = another.Instances
+	assert.True(t, config.Equal(another))
+
+	config.ADIdentifiers = []string{"foo", "bar"}
+	assert.False(t, config.Equal(another))
+	another.ADIdentifiers = []string{"foo", "bar"}
+	assert.True(t, config.Equal(another))
+	another.ADIdentifiers = []string{"bar", "foo"}
+	assert.False(t, config.Equal(another))
+}
+
+func TestString(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.Equal(nil))
+
+	config.Name = "foo"
+	config.InitConfig = Data("fooBarBaz: test")
+	config.Instances = []Data{Data("justFoo")}
+
+	expected := `init_config:
+  fooBarBaz: test
+instances:
+- justFoo
+`
+	assert.Equal(t, config.String(), expected)
+}
+
+func TestMergeAdditionalTags(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.Equal(nil))
+
+	config.Name = "foo"
+	config.InitConfig = Data("fooBarBaz")
+	config.Instances = []Data{Data("tags: [\"foo\", \"foo:bar\"]")}
+
+	config.Instances[0].MergeAdditionalTags([]string{"foo", "bar"})
+
+	rawConfig := RawMap{}
+	err := yaml.Unmarshal(config.Instances[0], &rawConfig)
+	assert.Nil(t, err)
+	assert.Contains(t, rawConfig["tags"], "foo")
+	assert.Contains(t, rawConfig["tags"], "bar")
+	assert.Contains(t, rawConfig["tags"], "foo:bar")
+
+	config.Name = "foo"
+	config.InitConfig = Data("fooBarBaz")
+	config.Instances = []Data{Data("other: foo")}
+
+	config.Instances[0].MergeAdditionalTags([]string{"foo", "bar"})
+
+	rawConfig = RawMap{}
+	err = yaml.Unmarshal(config.Instances[0], &rawConfig)
+	assert.Nil(t, err)
+	assert.Contains(t, rawConfig["tags"], "foo")
+	assert.Contains(t, rawConfig["tags"], "bar")
+}
+
+func TestDigest(t *testing.T) {
+	config := &Config{}
+	assert.Equal(t, 16, len(config.Digest()))
+}
+
+// this is here to prevent compiler optimization on the benchmarking code
+var result string
+
+func BenchmarkID(b *testing.B) {
+	var id string // store return value to avoid the compiler to strip the function call
+	config := &Config{}
+	config.InitConfig = make([]byte, 32000)
+	rand.Read(config.InitConfig)
+	for n := 0; n < b.N; n++ {
+		id = config.Digest()
+	}
+	result = id
+}

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -16,6 +16,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -98,7 +99,7 @@ func (cr *ConfigResolver) Stop() {
 }
 
 // ResolveTemplate attempts to resolve a configuration template using the AD
-// identifiers in the `check.Config` struct to match a Service.
+// identifiers in the `adconfig.Config` struct to match a Service.
 //
 // The function might return more than one configuration for a single template,
 // for example when the `ad_identifiers` section of a config.yaml file contains
@@ -108,9 +109,9 @@ func (cr *ConfigResolver) Stop() {
 // The function might return an empty list in the case the configuration has a
 // list of Autodiscovery identifiers for services that are unknown to the
 // resolver at this moment.
-func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
+func (cr *ConfigResolver) ResolveTemplate(tpl adconfig.Config) []adconfig.Config {
 	// use a map to dedupe configurations
-	resolvedSet := map[string]check.Config{}
+	resolvedSet := map[string]adconfig.Config{}
 
 	// go through the AD identifiers provided by the template
 	for _, id := range tpl.ADIdentifiers {
@@ -137,7 +138,7 @@ func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 	}
 
 	// build the slice of configs to return
-	resolved := []check.Config{}
+	resolved := []adconfig.Config{}
 	for _, v := range resolvedSet {
 		resolved = append(resolved, v)
 	}
@@ -147,12 +148,12 @@ func (cr *ConfigResolver) ResolveTemplate(tpl check.Config) []check.Config {
 
 // resolve takes a template and a service and generates a config with
 // valid connection info and relevant tags.
-func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (check.Config, error) {
+func (cr *ConfigResolver) resolve(tpl adconfig.Config, svc listeners.Service) (adconfig.Config, error) {
 	// Copy original template
-	resolvedConfig := check.Config{
+	resolvedConfig := adconfig.Config{
 		Name:          tpl.Name,
-		Instances:     make([]check.ConfigData, len(tpl.Instances)),
-		InitConfig:    make(check.ConfigData, len(tpl.InitConfig)),
+		Instances:     make([]adconfig.Data, len(tpl.Instances)),
+		InitConfig:    make(adconfig.Data, len(tpl.InitConfig)),
 		MetricConfig:  tpl.MetricConfig,
 		ADIdentifiers: tpl.ADIdentifiers,
 		Provider:      tpl.Provider,
@@ -172,7 +173,7 @@ func (cr *ConfigResolver) resolve(tpl check.Config, svc listeners.Service) (chec
 			if f, found := templateVariables[string(name)]; found {
 				resolvedVar, err := f(key, svc)
 				if err != nil {
-					return check.Config{}, err
+					return adconfig.Config{}, err
 				}
 				// init config vars are replaced by the first found
 				resolvedConfig.InitConfig = bytes.Replace(resolvedConfig.InitConfig, v, resolvedVar, -1)
@@ -203,7 +204,7 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 	cr.serviceToChecks[svc.GetID()] = make([]check.ID, 0)
 
 	// get all the templates matching service identifiers
-	templates := []check.Config{}
+	templates := []adconfig.Config{}
 	ADIdentifiers, err := svc.GetADIdentifiers()
 	if err != nil {
 		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetID(), err)
@@ -231,7 +232,7 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 		errorStats.removeResolveWarnings(config.Name)
 
 		// load the checks for this config using Autoconfig
-		checks := cr.ac.getChecksFromConfigs([]check.Config{config}, true)
+		checks := cr.ac.getChecksFromConfigs([]adconfig.Config{config}, true)
 
 		// ask the Collector to schedule the checks
 		cr.ac.schedule(checks)

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -16,10 +16,10 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
@@ -99,7 +99,7 @@ func (cr *ConfigResolver) Stop() {
 }
 
 // ResolveTemplate attempts to resolve a configuration template using the AD
-// identifiers in the `autodiscovery.Config` struct to match a Service.
+// identifiers in the `integration.Config` struct to match a Service.
 //
 // The function might return more than one configuration for a single template,
 // for example when the `ad_identifiers` section of a config.yaml file contains
@@ -109,9 +109,9 @@ func (cr *ConfigResolver) Stop() {
 // The function might return an empty list in the case the configuration has a
 // list of Autodiscovery identifiers for services that are unknown to the
 // resolver at this moment.
-func (cr *ConfigResolver) ResolveTemplate(tpl autodiscovery.Config) []autodiscovery.Config {
+func (cr *ConfigResolver) ResolveTemplate(tpl integration.Config) []integration.Config {
 	// use a map to dedupe configurations
-	resolvedSet := map[string]autodiscovery.Config{}
+	resolvedSet := map[string]integration.Config{}
 
 	// go through the AD identifiers provided by the template
 	for _, id := range tpl.ADIdentifiers {
@@ -138,7 +138,7 @@ func (cr *ConfigResolver) ResolveTemplate(tpl autodiscovery.Config) []autodiscov
 	}
 
 	// build the slice of configs to return
-	resolved := []autodiscovery.Config{}
+	resolved := []integration.Config{}
 	for _, v := range resolvedSet {
 		resolved = append(resolved, v)
 	}
@@ -148,12 +148,12 @@ func (cr *ConfigResolver) ResolveTemplate(tpl autodiscovery.Config) []autodiscov
 
 // resolve takes a template and a service and generates a config with
 // valid connection info and relevant tags.
-func (cr *ConfigResolver) resolve(tpl autodiscovery.Config, svc listeners.Service) (autodiscovery.Config, error) {
+func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service) (integration.Config, error) {
 	// Copy original template
-	resolvedConfig := autodiscovery.Config{
+	resolvedConfig := integration.Config{
 		Name:          tpl.Name,
-		Instances:     make([]autodiscovery.Data, len(tpl.Instances)),
-		InitConfig:    make(autodiscovery.Data, len(tpl.InitConfig)),
+		Instances:     make([]integration.Data, len(tpl.Instances)),
+		InitConfig:    make(integration.Data, len(tpl.InitConfig)),
 		MetricConfig:  tpl.MetricConfig,
 		ADIdentifiers: tpl.ADIdentifiers,
 		Provider:      tpl.Provider,
@@ -173,7 +173,7 @@ func (cr *ConfigResolver) resolve(tpl autodiscovery.Config, svc listeners.Servic
 			if f, found := templateVariables[string(name)]; found {
 				resolvedVar, err := f(key, svc)
 				if err != nil {
-					return autodiscovery.Config{}, err
+					return integration.Config{}, err
 				}
 				// init config vars are replaced by the first found
 				resolvedConfig.InitConfig = bytes.Replace(resolvedConfig.InitConfig, v, resolvedVar, -1)
@@ -204,7 +204,7 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 	cr.serviceToChecks[svc.GetID()] = make([]check.ID, 0)
 
 	// get all the templates matching service identifiers
-	templates := []autodiscovery.Config{}
+	templates := []integration.Config{}
 	ADIdentifiers, err := svc.GetADIdentifiers()
 	if err != nil {
 		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetID(), err)
@@ -232,7 +232,7 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 		errorStats.removeResolveWarnings(config.Name)
 
 		// load the checks for this config using Autoconfig
-		checks := cr.ac.getChecksFromConfigs([]autodiscovery.Config{config}, true)
+		checks := cr.ac.getChecksFromConfigs([]integration.Config{config}, true)
 
 		// ask the Collector to schedule the checks
 		cr.ac.schedule(checks)

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 
 	// we need some valid check in the catalog to run tests
@@ -33,7 +33,7 @@ func TestResolveTemplate(t *testing.T) {
 	ac.AddLoader(l)
 	tc := NewTemplateCache()
 	cr := newConfigResolver(nil, ac, tc)
-	tpl := check.Config{
+	tpl := adconfig.Config{
 		Name:          "cpu",
 		ADIdentifiers: []string{"redis"},
 	}
@@ -104,9 +104,9 @@ func TestResolve(t *testing.T) {
 
 	testCases := []struct {
 		testName    string
-		tpl         check.Config
+		tpl         adconfig.Config
 		svc         listeners.Service
-		out         check.Config
+		out         adconfig.Config
 		errorString string
 	}{
 		//// %%host%% tag testing
@@ -117,15 +117,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"bridge": "127.0.0.1"},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%host%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.1")},
+				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.1")},
 			},
 		},
 		{
@@ -135,15 +135,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"custom": "127.0.0.2"},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%host%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.2")},
+				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.2")},
 			},
 		},
 		{
@@ -153,15 +153,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"custom": "127.0.0.2", "other": "127.0.0.3"},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%host_custom%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.2")},
+				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.2")},
 			},
 		},
 		{
@@ -171,15 +171,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"other": "127.0.0.2", "custom_net": "127.0.0.3"},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom_net%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%host_custom_net%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.3")},
+				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.3")},
 			},
 		},
 		{
@@ -189,15 +189,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"other": "127.0.0.3"},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host_custom%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%host_custom%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: 127.0.0.3")},
+				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.3")},
 			},
 		},
 		{
@@ -207,10 +207,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%host%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%host%%")},
 			},
 			errorString: "no network found for container a5901276aed1, ignoring it",
 		},
@@ -222,15 +222,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: %%port%%")},
+				Instances:     []adconfig.Data{adconfig.Data("port: %%port%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: 3")},
+				Instances:     []adconfig.Data{adconfig.Data("port: 3")},
 			},
 		},
 		{
@@ -240,15 +240,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: %%port_0%%")},
+				Instances:     []adconfig.Data{adconfig.Data("port: %%port_0%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: 1")},
+				Instances:     []adconfig.Data{adconfig.Data("port: 1")},
 			},
 		},
 		{
@@ -258,10 +258,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: %%port_4%%")},
+				Instances:     []adconfig.Data{adconfig.Data("port: %%port_4%%")},
 			},
 			errorString: "index given for the port template var is too big, skipping container a5901276aed1",
 		},
@@ -272,10 +272,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: %%port_A%%")},
+				Instances:     []adconfig.Data{adconfig.Data("port: %%port_A%%")},
 			},
 			errorString: "index given for the port template var is not an int, skipping container a5901276aed1",
 		},
@@ -286,10 +286,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("port: %%port%%")},
+				Instances:     []adconfig.Data{adconfig.Data("port: %%port%%")},
 			},
 			errorString: "no port found for container a5901276aed1 - ignoring it",
 		},
@@ -301,15 +301,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("test: %%env_test_envvar_key%%")},
+				Instances:     []adconfig.Data{adconfig.Data("test: %%env_test_envvar_key%%")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("test: test_value")},
+				Instances:     []adconfig.Data{adconfig.Data("test: test_value")},
 			},
 		},
 		{
@@ -319,10 +319,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("test: %%env_test_envvar_not_set%%")},
+				Instances:     []adconfig.Data{adconfig.Data("test: %%env_test_envvar_not_set%%")},
 			},
 			errorString: "failed to retrieve envvar test_envvar_not_set, skipping service a5901276aed1"},
 		{
@@ -332,10 +332,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("test: %%env%%")},
+				Instances:     []adconfig.Data{adconfig.Data("test: %%env%%")},
 			},
 			errorString: "envvar name is missing, skipping service a5901276aed1",
 		},
@@ -347,15 +347,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("pid: %%pid%%\ntags: [\"foo\"]")},
+				Instances:     []adconfig.Data{adconfig.Data("pid: %%pid%%\ntags: [\"foo\"]")},
 			},
-			out: check.Config{
+			out: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("pid: 1337\ntags:\n- foo\n")},
+				Instances:     []adconfig.Data{adconfig.Data("pid: 1337\ntags:\n- foo\n")},
 			},
 		},
 		//// unknown tag
@@ -365,16 +365,16 @@ func TestResolve(t *testing.T) {
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
 			},
-			tpl: check.Config{
+			tpl: adconfig.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []check.ConfigData{check.ConfigData("host: %%FOO%%")},
+				Instances:     []adconfig.Data{adconfig.Data("host: %%FOO%%")},
 			},
 			errorString: "yaml: found character that cannot start any token",
 		},
 	}
 	ac := &AutoConfig{
-		loadedConfigs: make([]check.Config, 0),
+		loadedConfigs: make([]adconfig.Config, 0),
 	}
 	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	validTemplates := 0

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 
@@ -33,7 +33,7 @@ func TestResolveTemplate(t *testing.T) {
 	ac.AddLoader(l)
 	tc := NewTemplateCache()
 	cr := newConfigResolver(nil, ac, tc)
-	tpl := adconfig.Config{
+	tpl := autodiscovery.Config{
 		Name:          "cpu",
 		ADIdentifiers: []string{"redis"},
 	}
@@ -104,9 +104,9 @@ func TestResolve(t *testing.T) {
 
 	testCases := []struct {
 		testName    string
-		tpl         adconfig.Config
+		tpl         autodiscovery.Config
 		svc         listeners.Service
-		out         adconfig.Config
+		out         autodiscovery.Config
 		errorString string
 	}{
 		//// %%host%% tag testing
@@ -117,15 +117,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"bridge": "127.0.0.1"},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%host%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.1")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.1")},
 			},
 		},
 		{
@@ -135,15 +135,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"custom": "127.0.0.2"},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%host%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.2")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.2")},
 			},
 		},
 		{
@@ -153,15 +153,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"custom": "127.0.0.2", "other": "127.0.0.3"},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%host_custom%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host_custom%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.2")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.2")},
 			},
 		},
 		{
@@ -171,15 +171,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"other": "127.0.0.2", "custom_net": "127.0.0.3"},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%host_custom_net%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host_custom_net%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.3")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.3")},
 			},
 		},
 		{
@@ -189,15 +189,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"other": "127.0.0.3"},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%host_custom%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host_custom%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: 127.0.0.3")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.3")},
 			},
 		},
 		{
@@ -207,10 +207,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%host%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host%%")},
 			},
 			errorString: "no network found for container a5901276aed1, ignoring it",
 		},
@@ -222,15 +222,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: %%port%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: 3")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: 3")},
 			},
 		},
 		{
@@ -240,15 +240,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: %%port_0%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port_0%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: 1")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: 1")},
 			},
 		},
 		{
@@ -258,10 +258,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: %%port_4%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port_4%%")},
 			},
 			errorString: "index given for the port template var is too big, skipping container a5901276aed1",
 		},
@@ -272,10 +272,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: %%port_A%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port_A%%")},
 			},
 			errorString: "index given for the port template var is not an int, skipping container a5901276aed1",
 		},
@@ -286,10 +286,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("port: %%port%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port%%")},
 			},
 			errorString: "no port found for container a5901276aed1 - ignoring it",
 		},
@@ -301,15 +301,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("test: %%env_test_envvar_key%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("test: %%env_test_envvar_key%%")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("test: test_value")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("test: test_value")},
 			},
 		},
 		{
@@ -319,10 +319,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("test: %%env_test_envvar_not_set%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("test: %%env_test_envvar_not_set%%")},
 			},
 			errorString: "failed to retrieve envvar test_envvar_not_set, skipping service a5901276aed1"},
 		{
@@ -332,10 +332,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("test: %%env%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("test: %%env%%")},
 			},
 			errorString: "envvar name is missing, skipping service a5901276aed1",
 		},
@@ -347,15 +347,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("pid: %%pid%%\ntags: [\"foo\"]")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("pid: %%pid%%\ntags: [\"foo\"]")},
 			},
-			out: adconfig.Config{
+			out: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("pid: 1337\ntags:\n- foo\n")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("pid: 1337\ntags:\n- foo\n")},
 			},
 		},
 		//// unknown tag
@@ -365,16 +365,16 @@ func TestResolve(t *testing.T) {
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
 			},
-			tpl: adconfig.Config{
+			tpl: autodiscovery.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []adconfig.Data{adconfig.Data("host: %%FOO%%")},
+				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%FOO%%")},
 			},
 			errorString: "yaml: found character that cannot start any token",
 		},
 	}
 	ac := &AutoConfig{
-		loadedConfigs: make([]adconfig.Config, 0),
+		loadedConfigs: make([]autodiscovery.Config, 0),
 	}
 	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	validTemplates := 0

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 
 	// we need some valid check in the catalog to run tests
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system"
@@ -33,7 +33,7 @@ func TestResolveTemplate(t *testing.T) {
 	ac.AddLoader(l)
 	tc := NewTemplateCache()
 	cr := newConfigResolver(nil, ac, tc)
-	tpl := autodiscovery.Config{
+	tpl := integration.Config{
 		Name:          "cpu",
 		ADIdentifiers: []string{"redis"},
 	}
@@ -104,9 +104,9 @@ func TestResolve(t *testing.T) {
 
 	testCases := []struct {
 		testName    string
-		tpl         autodiscovery.Config
+		tpl         integration.Config
 		svc         listeners.Service
-		out         autodiscovery.Config
+		out         integration.Config
 		errorString string
 	}{
 		//// %%host%% tag testing
@@ -117,15 +117,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"bridge": "127.0.0.1"},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host%%")},
+				Instances:     []integration.Data{integration.Data("host: %%host%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.1")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.1")},
 			},
 		},
 		{
@@ -135,15 +135,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"custom": "127.0.0.2"},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host%%")},
+				Instances:     []integration.Data{integration.Data("host: %%host%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.2")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.2")},
 			},
 		},
 		{
@@ -153,15 +153,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"custom": "127.0.0.2", "other": "127.0.0.3"},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host_custom%%")},
+				Instances:     []integration.Data{integration.Data("host: %%host_custom%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.2")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.2")},
 			},
 		},
 		{
@@ -171,15 +171,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"other": "127.0.0.2", "custom_net": "127.0.0.3"},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host_custom_net%%")},
+				Instances:     []integration.Data{integration.Data("host: %%host_custom_net%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.3")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.3")},
 			},
 		},
 		{
@@ -189,15 +189,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{"other": "127.0.0.3"},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host_custom%%")},
+				Instances:     []integration.Data{integration.Data("host: %%host_custom%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: 127.0.0.3")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.3")},
 			},
 		},
 		{
@@ -207,10 +207,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Hosts:         map[string]string{},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%host%%")},
+				Instances:     []integration.Data{integration.Data("host: %%host%%")},
 			},
 			errorString: "no network found for container a5901276aed1, ignoring it",
 		},
@@ -222,15 +222,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port%%")},
+				Instances:     []integration.Data{integration.Data("port: %%port%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: 3")},
+				Instances:     []integration.Data{integration.Data("port: 3")},
 			},
 		},
 		{
@@ -240,15 +240,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port_0%%")},
+				Instances:     []integration.Data{integration.Data("port: %%port_0%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: 1")},
+				Instances:     []integration.Data{integration.Data("port: 1")},
 			},
 		},
 		{
@@ -258,10 +258,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port_4%%")},
+				Instances:     []integration.Data{integration.Data("port: %%port_4%%")},
 			},
 			errorString: "index given for the port template var is too big, skipping container a5901276aed1",
 		},
@@ -272,10 +272,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{1, 2, 3},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port_A%%")},
+				Instances:     []integration.Data{integration.Data("port: %%port_A%%")},
 			},
 			errorString: "index given for the port template var is not an int, skipping container a5901276aed1",
 		},
@@ -286,10 +286,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Ports:         []int{},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("port: %%port%%")},
+				Instances:     []integration.Data{integration.Data("port: %%port%%")},
 			},
 			errorString: "no port found for container a5901276aed1 - ignoring it",
 		},
@@ -301,15 +301,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("test: %%env_test_envvar_key%%")},
+				Instances:     []integration.Data{integration.Data("test: %%env_test_envvar_key%%")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("test: test_value")},
+				Instances:     []integration.Data{integration.Data("test: test_value")},
 			},
 		},
 		{
@@ -319,10 +319,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("test: %%env_test_envvar_not_set%%")},
+				Instances:     []integration.Data{integration.Data("test: %%env_test_envvar_not_set%%")},
 			},
 			errorString: "failed to retrieve envvar test_envvar_not_set, skipping service a5901276aed1"},
 		{
@@ -332,10 +332,10 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("test: %%env%%")},
+				Instances:     []integration.Data{integration.Data("test: %%env%%")},
 			},
 			errorString: "envvar name is missing, skipping service a5901276aed1",
 		},
@@ -347,15 +347,15 @@ func TestResolve(t *testing.T) {
 				ADIdentifiers: []string{"redis"},
 				Pid:           1337,
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("pid: %%pid%%\ntags: [\"foo\"]")},
+				Instances:     []integration.Data{integration.Data("pid: %%pid%%\ntags: [\"foo\"]")},
 			},
-			out: autodiscovery.Config{
+			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("pid: 1337\ntags:\n- foo\n")},
+				Instances:     []integration.Data{integration.Data("pid: 1337\ntags:\n- foo\n")},
 			},
 		},
 		//// unknown tag
@@ -365,16 +365,16 @@ func TestResolve(t *testing.T) {
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
 			},
-			tpl: autodiscovery.Config{
+			tpl: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []autodiscovery.Data{autodiscovery.Data("host: %%FOO%%")},
+				Instances:     []integration.Data{integration.Data("host: %%FOO%%")},
 			},
 			errorString: "yaml: found character that cannot start any token",
 		},
 	}
 	ac := &AutoConfig{
-		loadedConfigs: make([]autodiscovery.Config, 0),
+		loadedConfigs: make([]integration.Config, 0),
 	}
 	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	validTemplates := 0

--- a/pkg/autodiscovery/listeners/README.md
+++ b/pkg/autodiscovery/listeners/README.md
@@ -4,7 +4,7 @@ This package is providing the `ServiceListener` concept to the agent. A `Service
 
 ## `Service`
 
-`Service` represents an application we can run a check against. It should be matched with a check template by the ConfigResolver.
+`Service` represents an application we can run a integration against. It should be matched with a config template by the ConfigResolver.
 Services can only be Docker containers for now.
 
 ## `ServiceListener`

--- a/pkg/autodiscovery/providers/README.md
+++ b/pkg/autodiscovery/providers/README.md
@@ -1,7 +1,7 @@
 ## package `providers`
 
 Providers implement the `ConfigProvider` interface and are responsible for scanning different sources like files on
-disk, environment variables or databases, searching for check configurations. Every configuration, regardless of the
+disk, environment variables or databases, searching for integration configurations. Every configuration, regardless of the
 format, must specify at least one check `instance`. Providers dump every configuration they find into a `CheckConfig`
 struct containing an array of configuration instances. Configuration instances are converted in YAML format so that a
 check object will be eventually able to convert them into the appropriate data structure.

--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/cihub/seelog"
 	consul "github.com/hashicorp/consul/api"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -103,8 +103,8 @@ func (p *ConsulConfigProvider) String() string {
 }
 
 // Collect retrieves templates from consul, builds Config objects and returns them
-func (p *ConsulConfigProvider) Collect() ([]check.Config, error) {
-	configs := make([]check.Config, 0)
+func (p *ConsulConfigProvider) Collect() ([]adconfig.Config, error) {
+	configs := make([]adconfig.Config, 0)
 	identifiers := p.getIdentifiers(p.TemplateDir)
 	log.Debugf("identifiers found in backend: %v", identifiers)
 	for _, id := range identifiers {
@@ -196,8 +196,8 @@ func (p *ConsulConfigProvider) getIdentifiers(prefix string) []string {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (p *ConsulConfigProvider) getTemplates(key string) []check.Config {
-	templates := make([]check.Config, 0)
+func (p *ConsulConfigProvider) getTemplates(key string) []adconfig.Config {
+	templates := make([]adconfig.Config, 0)
 
 	checkNameKey := buildStoreKey(key, checkNamePath)
 	initKey := buildStoreKey(key, initConfigPath)
@@ -251,7 +251,7 @@ func (p *ConsulConfigProvider) getCheckNames(key string) ([]string, error) {
 	return checks, err
 }
 
-func (p *ConsulConfigProvider) getJSONValue(key string) ([]check.ConfigData, error) {
+func (p *ConsulConfigProvider) getJSONValue(key string) ([]adconfig.Data, error) {
 	rawValue, err := p.getValue(key)
 	if err != nil {
 		err := fmt.Errorf("Couldn't get key %s from consul: %s", key, err)

--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/cihub/seelog"
 	consul "github.com/hashicorp/consul/api"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -103,8 +103,8 @@ func (p *ConsulConfigProvider) String() string {
 }
 
 // Collect retrieves templates from consul, builds Config objects and returns them
-func (p *ConsulConfigProvider) Collect() ([]adconfig.Config, error) {
-	configs := make([]adconfig.Config, 0)
+func (p *ConsulConfigProvider) Collect() ([]autodiscovery.Config, error) {
+	configs := make([]autodiscovery.Config, 0)
 	identifiers := p.getIdentifiers(p.TemplateDir)
 	log.Debugf("identifiers found in backend: %v", identifiers)
 	for _, id := range identifiers {
@@ -196,8 +196,8 @@ func (p *ConsulConfigProvider) getIdentifiers(prefix string) []string {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (p *ConsulConfigProvider) getTemplates(key string) []adconfig.Config {
-	templates := make([]adconfig.Config, 0)
+func (p *ConsulConfigProvider) getTemplates(key string) []autodiscovery.Config {
+	templates := make([]autodiscovery.Config, 0)
 
 	checkNameKey := buildStoreKey(key, checkNamePath)
 	initKey := buildStoreKey(key, initConfigPath)
@@ -251,7 +251,7 @@ func (p *ConsulConfigProvider) getCheckNames(key string) ([]string, error) {
 	return checks, err
 }
 
-func (p *ConsulConfigProvider) getJSONValue(key string) ([]adconfig.Data, error) {
+func (p *ConsulConfigProvider) getJSONValue(key string) ([]autodiscovery.Data, error) {
 	rawValue, err := p.getValue(key)
 	if err != nil {
 		err := fmt.Errorf("Couldn't get key %s from consul: %s", key, err)

--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -17,8 +17,8 @@ import (
 	log "github.com/cihub/seelog"
 	consul "github.com/hashicorp/consul/api"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // Abstractions for testing
@@ -103,8 +103,8 @@ func (p *ConsulConfigProvider) String() string {
 }
 
 // Collect retrieves templates from consul, builds Config objects and returns them
-func (p *ConsulConfigProvider) Collect() ([]autodiscovery.Config, error) {
-	configs := make([]autodiscovery.Config, 0)
+func (p *ConsulConfigProvider) Collect() ([]integration.Config, error) {
+	configs := make([]integration.Config, 0)
 	identifiers := p.getIdentifiers(p.TemplateDir)
 	log.Debugf("identifiers found in backend: %v", identifiers)
 	for _, id := range identifiers {
@@ -196,8 +196,8 @@ func (p *ConsulConfigProvider) getIdentifiers(prefix string) []string {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (p *ConsulConfigProvider) getTemplates(key string) []autodiscovery.Config {
-	templates := make([]autodiscovery.Config, 0)
+func (p *ConsulConfigProvider) getTemplates(key string) []integration.Config {
+	templates := make([]integration.Config, 0)
 
 	checkNameKey := buildStoreKey(key, checkNamePath)
 	initKey := buildStoreKey(key, initConfigPath)
@@ -251,7 +251,7 @@ func (p *ConsulConfigProvider) getCheckNames(key string) ([]string, error) {
 	return checks, err
 }
 
-func (p *ConsulConfigProvider) getJSONValue(key string) ([]autodiscovery.Data, error) {
+func (p *ConsulConfigProvider) getJSONValue(key string) ([]integration.Data, error) {
 	rawValue, err := p.getValue(key)
 	if err != nil {
 		err := fmt.Errorf("Couldn't get key %s from consul: %s", key, err)

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -12,7 +12,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -43,19 +43,19 @@ func (d *DockerConfigProvider) String() string {
 }
 
 // Collect retrieves all running containers and extract AD templates from their labels.
-func (d *DockerConfigProvider) Collect() ([]check.Config, error) {
+func (d *DockerConfigProvider) Collect() ([]adconfig.Config, error) {
 	var err error
 	if d.dockerUtil == nil {
 		d.dockerUtil, err = docker.GetDockerUtil()
 		if err != nil {
-			return []check.Config{}, err
+			return []adconfig.Config{}, err
 		}
 		go d.listen()
 	}
 
 	containers, err := d.dockerUtil.AllContainerLabels()
 	if err != nil {
-		return []check.Config{}, err
+		return []adconfig.Config{}, err
 	}
 
 	d.Lock()
@@ -117,8 +117,8 @@ func (d *DockerConfigProvider) IsUpToDate() (bool, error) {
 	return (d.streaming && d.upToDate), nil
 }
 
-func parseDockerLabels(containers map[string]map[string]string) ([]check.Config, error) {
-	var configs []check.Config
+func parseDockerLabels(containers map[string]map[string]string) ([]adconfig.Config, error) {
+	var configs []adconfig.Config
 	for cID, labels := range containers {
 		c, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerADLabelPrefix)
 		switch {

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -12,7 +12,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -43,19 +43,19 @@ func (d *DockerConfigProvider) String() string {
 }
 
 // Collect retrieves all running containers and extract AD templates from their labels.
-func (d *DockerConfigProvider) Collect() ([]adconfig.Config, error) {
+func (d *DockerConfigProvider) Collect() ([]autodiscovery.Config, error) {
 	var err error
 	if d.dockerUtil == nil {
 		d.dockerUtil, err = docker.GetDockerUtil()
 		if err != nil {
-			return []adconfig.Config{}, err
+			return []autodiscovery.Config{}, err
 		}
 		go d.listen()
 	}
 
 	containers, err := d.dockerUtil.AllContainerLabels()
 	if err != nil {
-		return []adconfig.Config{}, err
+		return []autodiscovery.Config{}, err
 	}
 
 	d.Lock()
@@ -117,8 +117,8 @@ func (d *DockerConfigProvider) IsUpToDate() (bool, error) {
 	return (d.streaming && d.upToDate), nil
 }
 
-func parseDockerLabels(containers map[string]map[string]string) ([]adconfig.Config, error) {
-	var configs []adconfig.Config
+func parseDockerLabels(containers map[string]map[string]string) ([]autodiscovery.Config, error) {
+	var configs []autodiscovery.Config
 	for cID, labels := range containers {
 		c, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerADLabelPrefix)
 		switch {

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -12,8 +12,8 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
@@ -43,19 +43,19 @@ func (d *DockerConfigProvider) String() string {
 }
 
 // Collect retrieves all running containers and extract AD templates from their labels.
-func (d *DockerConfigProvider) Collect() ([]autodiscovery.Config, error) {
+func (d *DockerConfigProvider) Collect() ([]integration.Config, error) {
 	var err error
 	if d.dockerUtil == nil {
 		d.dockerUtil, err = docker.GetDockerUtil()
 		if err != nil {
-			return []autodiscovery.Config{}, err
+			return []integration.Config{}, err
 		}
 		go d.listen()
 	}
 
 	containers, err := d.dockerUtil.AllContainerLabels()
 	if err != nil {
-		return []autodiscovery.Config{}, err
+		return []integration.Config{}, err
 	}
 
 	d.Lock()
@@ -117,8 +117,8 @@ func (d *DockerConfigProvider) IsUpToDate() (bool, error) {
 	return (d.streaming && d.upToDate), nil
 }
 
-func parseDockerLabels(containers map[string]map[string]string) ([]autodiscovery.Config, error) {
-	var configs []autodiscovery.Config
+func parseDockerLabels(containers map[string]map[string]string) ([]integration.Config, error) {
+	var configs []integration.Config
 	for cID, labels := range containers {
 		c, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerADLabelPrefix)
 		switch {

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
@@ -51,7 +51,7 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 
 // Collect finds all running containers in the agent's task, reads their labels
 // and extract configuration templates from them for auto discovery.
-func (p *ECSConfigProvider) Collect() ([]adconfig.Config, error) {
+func (p *ECSConfigProvider) Collect() ([]autodiscovery.Config, error) {
 	meta, err := p.getTaskMetadata()
 	if err != nil {
 		return nil, err
@@ -80,8 +80,8 @@ func (p *ECSConfigProvider) getTaskMetadata() (ecs.TaskMetadata, error) {
 
 // parseECSContainers loops through ecs containers found in the ecs metadata response
 // and extracts configuration templates out of their labels.
-func parseECSContainers(containers []ecs.Container) ([]adconfig.Config, error) {
-	var templates []adconfig.Config
+func parseECSContainers(containers []ecs.Container) ([]autodiscovery.Config, error) {
+	var templates []autodiscovery.Config
 	for _, c := range containers {
 		configs, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(c.DockerID), c.Labels, ecsADLabelPrefix)
 		switch {

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
@@ -51,7 +51,7 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 
 // Collect finds all running containers in the agent's task, reads their labels
 // and extract configuration templates from them for auto discovery.
-func (p *ECSConfigProvider) Collect() ([]check.Config, error) {
+func (p *ECSConfigProvider) Collect() ([]adconfig.Config, error) {
 	meta, err := p.getTaskMetadata()
 	if err != nil {
 		return nil, err
@@ -80,8 +80,8 @@ func (p *ECSConfigProvider) getTaskMetadata() (ecs.TaskMetadata, error) {
 
 // parseECSContainers loops through ecs containers found in the ecs metadata response
 // and extracts configuration templates out of their labels.
-func parseECSContainers(containers []ecs.Container) ([]check.Config, error) {
-	var templates []check.Config
+func parseECSContainers(containers []ecs.Container) ([]adconfig.Config, error) {
+	var templates []adconfig.Config
 	for _, c := range containers {
 		configs, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(c.DockerID), c.Labels, ecsADLabelPrefix)
 		switch {

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	log "github.com/cihub/seelog"
@@ -51,7 +51,7 @@ func (p *ECSConfigProvider) IsUpToDate() (bool, error) {
 
 // Collect finds all running containers in the agent's task, reads their labels
 // and extract configuration templates from them for auto discovery.
-func (p *ECSConfigProvider) Collect() ([]autodiscovery.Config, error) {
+func (p *ECSConfigProvider) Collect() ([]integration.Config, error) {
 	meta, err := p.getTaskMetadata()
 	if err != nil {
 		return nil, err
@@ -80,8 +80,8 @@ func (p *ECSConfigProvider) getTaskMetadata() (ecs.TaskMetadata, error) {
 
 // parseECSContainers loops through ecs containers found in the ecs metadata response
 // and extracts configuration templates out of their labels.
-func parseECSContainers(containers []ecs.Container) ([]autodiscovery.Config, error) {
-	var templates []autodiscovery.Config
+func parseECSContainers(containers []ecs.Container) ([]integration.Config, error) {
+	var templates []integration.Config
 	for _, c := range containers {
 		configs, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(c.DockerID), c.Labels, ecsADLabelPrefix)
 		switch {

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -17,7 +17,7 @@ import (
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -57,8 +57,8 @@ func NewEtcdConfigProvider(config config.ConfigurationProviders) (ConfigProvider
 
 // Collect retrieves templates from etcd, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (p *EtcdConfigProvider) Collect() ([]check.Config, error) {
-	configs := make([]check.Config, 0)
+func (p *EtcdConfigProvider) Collect() ([]adconfig.Config, error) {
+	configs := make([]adconfig.Config, 0)
 	identifiers := p.getIdentifiers(p.templateDir)
 	for _, id := range identifiers {
 		templates := p.getTemplates(id)
@@ -89,7 +89,7 @@ func (p *EtcdConfigProvider) getIdentifiers(key string) []string {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (p *EtcdConfigProvider) getTemplates(key string) []check.Config {
+func (p *EtcdConfigProvider) getTemplates(key string) []adconfig.Config {
 	checkNameKey := buildStoreKey(key, checkNamePath)
 	initKey := buildStoreKey(key, initConfigPath)
 	instanceKey := buildStoreKey(key, instancePath)
@@ -135,7 +135,7 @@ func (p *EtcdConfigProvider) getCheckNames(key string) ([]string, error) {
 	return parseCheckNames(rawNames)
 }
 
-func (p *EtcdConfigProvider) getJSONValue(key string) ([]check.ConfigData, error) {
+func (p *EtcdConfigProvider) getJSONValue(key string) ([]adconfig.Data, error) {
 	rawValue, err := p.getEtcdValue(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key %s from etcd: %s", key, err)

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -17,7 +17,7 @@ import (
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -57,8 +57,8 @@ func NewEtcdConfigProvider(config config.ConfigurationProviders) (ConfigProvider
 
 // Collect retrieves templates from etcd, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (p *EtcdConfigProvider) Collect() ([]adconfig.Config, error) {
-	configs := make([]adconfig.Config, 0)
+func (p *EtcdConfigProvider) Collect() ([]autodiscovery.Config, error) {
+	configs := make([]autodiscovery.Config, 0)
 	identifiers := p.getIdentifiers(p.templateDir)
 	for _, id := range identifiers {
 		templates := p.getTemplates(id)
@@ -89,7 +89,7 @@ func (p *EtcdConfigProvider) getIdentifiers(key string) []string {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (p *EtcdConfigProvider) getTemplates(key string) []adconfig.Config {
+func (p *EtcdConfigProvider) getTemplates(key string) []autodiscovery.Config {
 	checkNameKey := buildStoreKey(key, checkNamePath)
 	initKey := buildStoreKey(key, initConfigPath)
 	instanceKey := buildStoreKey(key, instancePath)
@@ -135,7 +135,7 @@ func (p *EtcdConfigProvider) getCheckNames(key string) ([]string, error) {
 	return parseCheckNames(rawNames)
 }
 
-func (p *EtcdConfigProvider) getJSONValue(key string) ([]adconfig.Data, error) {
+func (p *EtcdConfigProvider) getJSONValue(key string) ([]autodiscovery.Data, error) {
 	rawValue, err := p.getEtcdValue(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key %s from etcd: %s", key, err)

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -17,8 +17,8 @@ import (
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 type etcdBackend interface {
@@ -57,8 +57,8 @@ func NewEtcdConfigProvider(config config.ConfigurationProviders) (ConfigProvider
 
 // Collect retrieves templates from etcd, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (p *EtcdConfigProvider) Collect() ([]autodiscovery.Config, error) {
-	configs := make([]autodiscovery.Config, 0)
+func (p *EtcdConfigProvider) Collect() ([]integration.Config, error) {
+	configs := make([]integration.Config, 0)
 	identifiers := p.getIdentifiers(p.templateDir)
 	for _, id := range identifiers {
 		templates := p.getTemplates(id)
@@ -89,7 +89,7 @@ func (p *EtcdConfigProvider) getIdentifiers(key string) []string {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (p *EtcdConfigProvider) getTemplates(key string) []autodiscovery.Config {
+func (p *EtcdConfigProvider) getTemplates(key string) []integration.Config {
 	checkNameKey := buildStoreKey(key, checkNamePath)
 	initKey := buildStoreKey(key, initConfigPath)
 	instanceKey := buildStoreKey(key, instancePath)
@@ -135,7 +135,7 @@ func (p *EtcdConfigProvider) getCheckNames(key string) ([]string, error) {
 	return parseCheckNames(rawNames)
 }
 
-func (p *EtcdConfigProvider) getJSONValue(key string) ([]autodiscovery.Data, error) {
+func (p *EtcdConfigProvider) getJSONValue(key string) ([]integration.Data, error) {
 	rawValue, err := p.getEtcdValue(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key %s from etcd: %s", key, err)

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -12,10 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	log "github.com/cihub/seelog"
 
 	"gopkg.in/yaml.v2"
+
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 type configFormat struct {
@@ -23,18 +24,18 @@ type configFormat struct {
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []check.ConfigRawMap
+	Instances     []adconfig.RawMap
 	DockerImages  []string `yaml:"docker_images"` // Only imported for deprecation warning
 }
 
 type configPkg struct {
-	confs    []check.Config
-	defaults []check.Config
-	metrics  []check.Config
+	confs    []adconfig.Config
+	defaults []adconfig.Config
+	metrics  []adconfig.Config
 }
 
 type configEntry struct {
-	conf       check.Config
+	conf       adconfig.Config
 	name       string
 	isDefault  bool
 	isMetric   bool
@@ -60,10 +61,10 @@ func NewFileConfigProvider(paths []string) *FileConfigProvider {
 // Collect scans provided paths searching for configuration files. When found,
 // it parses the files and try to unmarshall Yaml contents into a CheckConfig
 // instance
-func (c *FileConfigProvider) Collect() ([]check.Config, error) {
-	configs := []check.Config{}
+func (c *FileConfigProvider) Collect() ([]adconfig.Config, error) {
+	configs := []adconfig.Config{}
 	configNames := make(map[string]struct{}) // use this map as a python set
-	defaultConfigs := []check.Config{}
+	defaultConfigs := []adconfig.Config{}
 
 	for _, path := range c.paths {
 		log.Infof("%v: searching for configuration files at: %s", c, path)
@@ -196,9 +197,9 @@ func (c *FileConfigProvider) collectEntry(file os.FileInfo, path string, checkNa
 
 // collectDir collects entries in subdirectories of the main conf folder
 func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) configPkg {
-	configs := []check.Config{}
-	defaultConfigs := []check.Config{}
-	metricConfigs := []check.Config{}
+	configs := []adconfig.Config{}
+	defaultConfigs := []adconfig.Config{}
+	metricConfigs := []adconfig.Config{}
 	const dirExt string = ".d"
 	dirPath := filepath.Join(parentPath, folder.Name())
 
@@ -244,10 +245,10 @@ func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) c
 	return configPkg{confs: configs, defaults: defaultConfigs, metrics: metricConfigs}
 }
 
-// GetCheckConfigFromFile returns an instance of check.Config if `fpath` points to a valid config file
-func GetCheckConfigFromFile(name, fpath string) (check.Config, error) {
+// GetCheckConfigFromFile returns an instance of adconfig.Config if `fpath` points to a valid config file
+func GetCheckConfigFromFile(name, fpath string) (adconfig.Config, error) {
 	cf := configFormat{}
-	config := check.Config{Name: name}
+	config := adconfig.Config{Name: name}
 
 	// Read file contents
 	// FIXME: ReadFile reads the entire file, possible security implications

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -16,7 +16,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 type configFormat struct {
@@ -24,18 +24,18 @@ type configFormat struct {
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []adconfig.RawMap
+	Instances     []autodiscovery.RawMap
 	DockerImages  []string `yaml:"docker_images"` // Only imported for deprecation warning
 }
 
 type configPkg struct {
-	confs    []adconfig.Config
-	defaults []adconfig.Config
-	metrics  []adconfig.Config
+	confs    []autodiscovery.Config
+	defaults []autodiscovery.Config
+	metrics  []autodiscovery.Config
 }
 
 type configEntry struct {
-	conf       adconfig.Config
+	conf       autodiscovery.Config
 	name       string
 	isDefault  bool
 	isMetric   bool
@@ -61,10 +61,10 @@ func NewFileConfigProvider(paths []string) *FileConfigProvider {
 // Collect scans provided paths searching for configuration files. When found,
 // it parses the files and try to unmarshall Yaml contents into a CheckConfig
 // instance
-func (c *FileConfigProvider) Collect() ([]adconfig.Config, error) {
-	configs := []adconfig.Config{}
+func (c *FileConfigProvider) Collect() ([]autodiscovery.Config, error) {
+	configs := []autodiscovery.Config{}
 	configNames := make(map[string]struct{}) // use this map as a python set
-	defaultConfigs := []adconfig.Config{}
+	defaultConfigs := []autodiscovery.Config{}
 
 	for _, path := range c.paths {
 		log.Infof("%v: searching for configuration files at: %s", c, path)
@@ -197,9 +197,9 @@ func (c *FileConfigProvider) collectEntry(file os.FileInfo, path string, checkNa
 
 // collectDir collects entries in subdirectories of the main conf folder
 func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) configPkg {
-	configs := []adconfig.Config{}
-	defaultConfigs := []adconfig.Config{}
-	metricConfigs := []adconfig.Config{}
+	configs := []autodiscovery.Config{}
+	defaultConfigs := []autodiscovery.Config{}
+	metricConfigs := []autodiscovery.Config{}
 	const dirExt string = ".d"
 	dirPath := filepath.Join(parentPath, folder.Name())
 
@@ -245,10 +245,10 @@ func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) c
 	return configPkg{confs: configs, defaults: defaultConfigs, metrics: metricConfigs}
 }
 
-// GetCheckConfigFromFile returns an instance of adconfig.Config if `fpath` points to a valid config file
-func GetCheckConfigFromFile(name, fpath string) (adconfig.Config, error) {
+// GetCheckConfigFromFile returns an instance of autodiscovery.Config if `fpath` points to a valid config file
+func GetCheckConfigFromFile(name, fpath string) (autodiscovery.Config, error) {
 	cf := configFormat{}
-	config := adconfig.Config{Name: name}
+	config := autodiscovery.Config{Name: name}
 
 	// Read file contents
 	// FIXME: ReadFile reads the entire file, possible security implications

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -16,7 +16,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 type configFormat struct {
@@ -24,18 +24,18 @@ type configFormat struct {
 	InitConfig    interface{} `yaml:"init_config"`
 	MetricConfig  interface{} `yaml:"jmx_metrics"`
 	LogsConfig    interface{} `yaml:"logs"`
-	Instances     []autodiscovery.RawMap
+	Instances     []integration.RawMap
 	DockerImages  []string `yaml:"docker_images"` // Only imported for deprecation warning
 }
 
 type configPkg struct {
-	confs    []autodiscovery.Config
-	defaults []autodiscovery.Config
-	metrics  []autodiscovery.Config
+	confs    []integration.Config
+	defaults []integration.Config
+	metrics  []integration.Config
 }
 
 type configEntry struct {
-	conf       autodiscovery.Config
+	conf       integration.Config
 	name       string
 	isDefault  bool
 	isMetric   bool
@@ -61,10 +61,10 @@ func NewFileConfigProvider(paths []string) *FileConfigProvider {
 // Collect scans provided paths searching for configuration files. When found,
 // it parses the files and try to unmarshall Yaml contents into a CheckConfig
 // instance
-func (c *FileConfigProvider) Collect() ([]autodiscovery.Config, error) {
-	configs := []autodiscovery.Config{}
+func (c *FileConfigProvider) Collect() ([]integration.Config, error) {
+	configs := []integration.Config{}
 	configNames := make(map[string]struct{}) // use this map as a python set
-	defaultConfigs := []autodiscovery.Config{}
+	defaultConfigs := []integration.Config{}
 
 	for _, path := range c.paths {
 		log.Infof("%v: searching for configuration files at: %s", c, path)
@@ -197,9 +197,9 @@ func (c *FileConfigProvider) collectEntry(file os.FileInfo, path string, checkNa
 
 // collectDir collects entries in subdirectories of the main conf folder
 func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) configPkg {
-	configs := []autodiscovery.Config{}
-	defaultConfigs := []autodiscovery.Config{}
-	metricConfigs := []autodiscovery.Config{}
+	configs := []integration.Config{}
+	defaultConfigs := []integration.Config{}
+	metricConfigs := []integration.Config{}
 	const dirExt string = ".d"
 	dirPath := filepath.Join(parentPath, folder.Name())
 
@@ -245,10 +245,10 @@ func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) c
 	return configPkg{confs: configs, defaults: defaultConfigs, metrics: metricConfigs}
 }
 
-// GetCheckConfigFromFile returns an instance of autodiscovery.Config if `fpath` points to a valid config file
-func GetCheckConfigFromFile(name, fpath string) (autodiscovery.Config, error) {
+// GetCheckConfigFromFile returns an instance of integration.Config if `fpath` points to a valid config file
+func GetCheckConfigFromFile(name, fpath string) (integration.Config, error) {
 	cf := configFormat{}
-	config := autodiscovery.Config{Name: name}
+	config := integration.Config{Name: name}
 
 	// Read file contents
 	// FIXME: ReadFile reads the entire file, possible security implications

--- a/pkg/autodiscovery/providers/file_test.go
+++ b/pkg/autodiscovery/providers/file_test.go
@@ -8,7 +8,7 @@ package providers
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,8 +76,8 @@ func TestCollect(t *testing.T) {
 	assert.Nil(t, err)
 
 	// count how many configs were found for a given check
-	get := func(name string) []check.Config {
-		out := []check.Config{}
+	get := func(name string) []adconfig.Config {
+		out := []adconfig.Config{}
 		for _, c := range configs {
 			if c.Name == name {
 				out = append(out, c)

--- a/pkg/autodiscovery/providers/file_test.go
+++ b/pkg/autodiscovery/providers/file_test.go
@@ -8,7 +8,7 @@ package providers
 import (
 	"testing"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,8 +76,8 @@ func TestCollect(t *testing.T) {
 	assert.Nil(t, err)
 
 	// count how many configs were found for a given check
-	get := func(name string) []adconfig.Config {
-		out := []adconfig.Config{}
+	get := func(name string) []autodiscovery.Config {
+		out := []autodiscovery.Config{}
 		for _, c := range configs {
 			if c.Name == name {
 				out = append(out, c)

--- a/pkg/autodiscovery/providers/file_test.go
+++ b/pkg/autodiscovery/providers/file_test.go
@@ -8,7 +8,7 @@ package providers
 import (
 	"testing"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,8 +76,8 @@ func TestCollect(t *testing.T) {
 	assert.Nil(t, err)
 
 	// count how many configs were found for a given check
-	get := func(name string) []autodiscovery.Config {
-		out := []autodiscovery.Config{}
+	get := func(name string) []integration.Config {
+		out := []integration.Config{}
 		for _, c := range configs {
 			if c.Name == name {
 				out = append(out, c)

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -13,7 +13,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
@@ -43,18 +43,18 @@ func (k *KubeletConfigProvider) String() string {
 
 // Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (k *KubeletConfigProvider) Collect() ([]adconfig.Config, error) {
+func (k *KubeletConfigProvider) Collect() ([]autodiscovery.Config, error) {
 	var err error
 	if k.kubelet == nil {
 		k.kubelet, err = kubelet.GetKubeUtil()
 		if err != nil {
-			return []adconfig.Config{}, err
+			return []autodiscovery.Config{}, err
 		}
 	}
 
 	pods, err := k.kubelet.GetLocalPodList()
 	if err != nil {
-		return []adconfig.Config{}, err
+		return []autodiscovery.Config{}, err
 	}
 
 	return parseKubeletPodlist(pods)
@@ -65,8 +65,8 @@ func (k *KubeletConfigProvider) IsUpToDate() (bool, error) {
 	return false, nil
 }
 
-func parseKubeletPodlist(podlist []*kubelet.Pod) ([]adconfig.Config, error) {
-	var configs []adconfig.Config
+func parseKubeletPodlist(podlist []*kubelet.Pod) ([]autodiscovery.Config, error) {
+	var configs []autodiscovery.Config
 	for _, pod := range podlist {
 		// Filter out pods with no AD annotation
 		var adExtractFormat string

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -13,7 +13,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
@@ -43,18 +43,18 @@ func (k *KubeletConfigProvider) String() string {
 
 // Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (k *KubeletConfigProvider) Collect() ([]check.Config, error) {
+func (k *KubeletConfigProvider) Collect() ([]adconfig.Config, error) {
 	var err error
 	if k.kubelet == nil {
 		k.kubelet, err = kubelet.GetKubeUtil()
 		if err != nil {
-			return []check.Config{}, err
+			return []adconfig.Config{}, err
 		}
 	}
 
 	pods, err := k.kubelet.GetLocalPodList()
 	if err != nil {
-		return []check.Config{}, err
+		return []adconfig.Config{}, err
 	}
 
 	return parseKubeletPodlist(pods)
@@ -65,8 +65,8 @@ func (k *KubeletConfigProvider) IsUpToDate() (bool, error) {
 	return false, nil
 }
 
-func parseKubeletPodlist(podlist []*kubelet.Pod) ([]check.Config, error) {
-	var configs []check.Config
+func parseKubeletPodlist(podlist []*kubelet.Pod) ([]adconfig.Config, error) {
+	var configs []adconfig.Config
 	for _, pod := range podlist {
 		// Filter out pods with no AD annotation
 		var adExtractFormat string

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -13,8 +13,8 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -43,18 +43,18 @@ func (k *KubeletConfigProvider) String() string {
 
 // Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (k *KubeletConfigProvider) Collect() ([]autodiscovery.Config, error) {
+func (k *KubeletConfigProvider) Collect() ([]integration.Config, error) {
 	var err error
 	if k.kubelet == nil {
 		k.kubelet, err = kubelet.GetKubeUtil()
 		if err != nil {
-			return []autodiscovery.Config{}, err
+			return []integration.Config{}, err
 		}
 	}
 
 	pods, err := k.kubelet.GetLocalPodList()
 	if err != nil {
-		return []autodiscovery.Config{}, err
+		return []integration.Config{}, err
 	}
 
 	return parseKubeletPodlist(pods)
@@ -65,8 +65,8 @@ func (k *KubeletConfigProvider) IsUpToDate() (bool, error) {
 	return false, nil
 }
 
-func parseKubeletPodlist(podlist []*kubelet.Pod) ([]autodiscovery.Config, error) {
-	var configs []autodiscovery.Config
+func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
+	var configs []integration.Config
 	for _, pod := range podlist {
 		// Filter out pods with no AD annotation
 		var adExtractFormat string

--- a/pkg/autodiscovery/providers/kubelet_test.go
+++ b/pkg/autodiscovery/providers/kubelet_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -23,7 +23,7 @@ func TestParseKubeletPodlist(t *testing.T) {
 	for nb, tc := range []struct {
 		desc        string
 		pod         *kubelet.Pod
-		expectedCfg []adconfig.Config
+		expectedCfg []autodiscovery.Config
 	}{
 		{
 			desc: "No annotations",
@@ -61,12 +61,12 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []adconfig.Config{
+			expectedCfg: []autodiscovery.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    adconfig.Data("{}"),
-					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},
@@ -96,18 +96,18 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []adconfig.Config{
+			expectedCfg: []autodiscovery.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    adconfig.Data("{}"),
-					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
-					InitConfig:    adconfig.Data("{}"),
-					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
 				},
 			},
 		},
@@ -130,18 +130,18 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []adconfig.Config{
+			expectedCfg: []autodiscovery.Config{
 				{
 					Name:          "apache",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    adconfig.Data("{}"),
-					Instances:     []adconfig.Data{adconfig.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
 				},
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    adconfig.Data("{}"),
-					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},

--- a/pkg/autodiscovery/providers/kubelet_test.go
+++ b/pkg/autodiscovery/providers/kubelet_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -23,7 +23,7 @@ func TestParseKubeletPodlist(t *testing.T) {
 	for nb, tc := range []struct {
 		desc        string
 		pod         *kubelet.Pod
-		expectedCfg []check.Config
+		expectedCfg []adconfig.Config
 	}{
 		{
 			desc: "No annotations",
@@ -61,12 +61,12 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []check.Config{
+			expectedCfg: []adconfig.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    check.ConfigData("{}"),
-					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    adconfig.Data("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},
@@ -96,18 +96,18 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []check.Config{
+			expectedCfg: []adconfig.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    check.ConfigData("{}"),
-					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    adconfig.Data("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
-					InitConfig:    check.ConfigData("{}"),
-					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
+					InitConfig:    adconfig.Data("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
 				},
 			},
 		},
@@ -130,18 +130,18 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []check.Config{
+			expectedCfg: []adconfig.Config{
 				{
 					Name:          "apache",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    check.ConfigData("{}"),
-					Instances:     []check.ConfigData{check.ConfigData("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    adconfig.Data("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
 				},
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    check.ConfigData("{}"),
-					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    adconfig.Data("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},

--- a/pkg/autodiscovery/providers/kubelet_test.go
+++ b/pkg/autodiscovery/providers/kubelet_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -23,7 +23,7 @@ func TestParseKubeletPodlist(t *testing.T) {
 	for nb, tc := range []struct {
 		desc        string
 		pod         *kubelet.Pod
-		expectedCfg []autodiscovery.Config
+		expectedCfg []integration.Config
 	}{
 		{
 			desc: "No annotations",
@@ -61,12 +61,12 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []autodiscovery.Config{
+			expectedCfg: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    autodiscovery.Data("{}"),
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},
@@ -96,18 +96,18 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []autodiscovery.Config{
+			expectedCfg: []integration.Config{
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    autodiscovery.Data("{}"),
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://4ac8352d70bf1"},
-					InitConfig:    autodiscovery.Data("{}"),
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"Other service\",\"timeout\":1,\"url\":\"http://%%host_external%%\"}")},
 				},
 			},
 		},
@@ -130,18 +130,18 @@ func TestParseKubeletPodlist(t *testing.T) {
 					},
 				},
 			},
-			expectedCfg: []autodiscovery.Config{
+			expectedCfg: []integration.Config{
 				{
 					Name:          "apache",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    autodiscovery.Data("{}"),
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
 				},
 				{
 					Name:          "http_check",
 					ADIdentifiers: []string{"docker://3b8efe0c50e8"},
-					InitConfig:    autodiscovery.Data("{}"),
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
 				},
 			},
 		},

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -6,7 +6,7 @@
 package providers
 
 import (
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -45,7 +45,7 @@ func NewCPCache() *ProviderCache {
 // or data needed to access the resource providing the configuration.
 // IsUpToDate checks the local cache of the CP and returns accordingly.
 type ConfigProvider interface {
-	Collect() ([]adconfig.Config, error)
+	Collect() ([]autodiscovery.Config, error)
 	String() string
 	IsUpToDate() (bool, error)
 }

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -6,7 +6,7 @@
 package providers
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -45,7 +45,7 @@ func NewCPCache() *ProviderCache {
 // or data needed to access the resource providing the configuration.
 // IsUpToDate checks the local cache of the CP and returns accordingly.
 type ConfigProvider interface {
-	Collect() ([]check.Config, error)
+	Collect() ([]adconfig.Config, error)
 	String() string
 	IsUpToDate() (bool, error)
 }

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -6,8 +6,8 @@
 package providers
 
 import (
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // ProviderCatalog keeps track of config providers by name
@@ -45,7 +45,7 @@ func NewCPCache() *ProviderCache {
 // or data needed to access the resource providing the configuration.
 // IsUpToDate checks the local cache of the CP and returns accordingly.
 type ConfigProvider interface {
-	Collect() ([]autodiscovery.Config, error)
+	Collect() ([]integration.Config, error)
 	String() string
 	IsUpToDate() (bool, error)
 }

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"path"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 )
 
@@ -31,13 +31,13 @@ func init() {
 
 // parseJSONValue returns a slice of ConfigData parsed from the JSON
 // contained in the `value` parameter
-func parseJSONValue(value string) ([]autodiscovery.Data, error) {
+func parseJSONValue(value string) ([]integration.Data, error) {
 	if value == "" {
 		return nil, fmt.Errorf("Value is empty")
 	}
 
 	var rawRes []interface{}
-	var result []autodiscovery.Data
+	var result []integration.Data
 
 	err := json.Unmarshal([]byte(value), &rawRes)
 	if err != nil {
@@ -75,8 +75,8 @@ func buildStoreKey(key ...string) string {
 	return path.Join(parts...)
 }
 
-func buildTemplates(key string, checkNames []string, initConfigs, instances []autodiscovery.Data) []autodiscovery.Config {
-	templates := make([]autodiscovery.Config, 0)
+func buildTemplates(key string, checkNames []string, initConfigs, instances []integration.Data) []integration.Config {
+	templates := make([]integration.Config, 0)
 
 	// sanity check
 	if len(checkNames) != len(initConfigs) || len(checkNames) != len(instances) {
@@ -85,12 +85,12 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []au
 	}
 
 	for idx := range checkNames {
-		instance := autodiscovery.Data(instances[idx])
+		instance := integration.Data(instances[idx])
 
-		templates = append(templates, autodiscovery.Config{
+		templates = append(templates, integration.Config{
 			Name:          checkNames[idx],
-			InitConfig:    autodiscovery.Data(initConfigs[idx]),
-			Instances:     []autodiscovery.Data{instance},
+			InitConfig:    integration.Data(initConfigs[idx]),
+			Instances:     []integration.Data{instance},
 			ADIdentifiers: []string{key},
 		})
 	}
@@ -99,32 +99,32 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []au
 
 // extractTemplatesFromMap looks for autodiscovery configurations in a given map
 // (either docker labels or kubernetes annotations) and returns them if found.
-func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]autodiscovery.Config, error) {
+func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+checkNamePath]
 	if !found {
-		return []autodiscovery.Config{}, nil
+		return []integration.Config{}, nil
 	}
 	checkNames, err := parseCheckNames(value)
 	if err != nil {
-		return []autodiscovery.Config{}, fmt.Errorf("in %s: %s", checkNamePath, err)
+		return []integration.Config{}, fmt.Errorf("in %s: %s", checkNamePath, err)
 	}
 
 	value, found = input[prefix+initConfigPath]
 	if !found {
-		return []autodiscovery.Config{}, errors.New("missing init_configs key")
+		return []integration.Config{}, errors.New("missing init_configs key")
 	}
 	initConfigs, err := parseJSONValue(value)
 	if err != nil {
-		return []autodiscovery.Config{}, fmt.Errorf("in %s: %s", initConfigPath, err)
+		return []integration.Config{}, fmt.Errorf("in %s: %s", initConfigPath, err)
 	}
 
 	value, found = input[prefix+instancePath]
 	if !found {
-		return []autodiscovery.Config{}, errors.New("missing instances key")
+		return []integration.Config{}, errors.New("missing instances key")
 	}
 	instances, err := parseJSONValue(value)
 	if err != nil {
-		return []autodiscovery.Config{}, fmt.Errorf("in %s: %s", instancePath, err)
+		return []integration.Config{}, fmt.Errorf("in %s: %s", instancePath, err)
 	}
 
 	return buildTemplates(key, checkNames, initConfigs, instances), nil

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 func TestParseJSONValue(t *testing.T) {
@@ -43,8 +43,8 @@ func TestParseJSONValue(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
 	require.Len(t, res, 2)
-	assert.Equal(t, adconfig.Data("{\"test\":1}"), res[0])
-	assert.Equal(t, adconfig.Data("{\"test\":2}"), res[1])
+	assert.Equal(t, autodiscovery.Data("{\"test\":1}"), res[0])
+	assert.Equal(t, autodiscovery.Data("{\"test\":2}"), res[1])
 }
 
 func TestParseCheckNames(t *testing.T) {
@@ -93,27 +93,27 @@ func TestBuildTemplates(t *testing.T) {
 	// wrong number of checkNames
 	res := buildTemplates("id",
 		[]string{"a", "b"},
-		[]adconfig.Data{adconfig.Data("")},
-		[]adconfig.Data{adconfig.Data("")})
+		[]autodiscovery.Data{autodiscovery.Data("")},
+		[]autodiscovery.Data{autodiscovery.Data("")})
 	assert.Len(t, res, 0)
 
 	res = buildTemplates("id",
 		[]string{"a", "b"},
-		[]adconfig.Data{adconfig.Data("{\"test\": 1}"), adconfig.Data("{}")},
-		[]adconfig.Data{adconfig.Data("{}"), adconfig.Data("{1:2}")})
+		[]autodiscovery.Data{autodiscovery.Data("{\"test\": 1}"), autodiscovery.Data("{}")},
+		[]autodiscovery.Data{autodiscovery.Data("{}"), autodiscovery.Data("{1:2}")})
 	require.Len(t, res, 2)
 
 	assert.Len(t, res[0].ADIdentifiers, 1)
 	assert.Equal(t, "id", res[0].ADIdentifiers[0])
 	assert.Equal(t, res[0].Name, "a")
-	assert.Equal(t, res[0].InitConfig, adconfig.Data("{\"test\": 1}"))
-	assert.Equal(t, res[0].Instances, []adconfig.Data{adconfig.Data("{}")})
+	assert.Equal(t, res[0].InitConfig, autodiscovery.Data("{\"test\": 1}"))
+	assert.Equal(t, res[0].Instances, []autodiscovery.Data{autodiscovery.Data("{}")})
 
 	assert.Len(t, res[1].ADIdentifiers, 1)
 	assert.Equal(t, "id", res[1].ADIdentifiers[0])
 	assert.Equal(t, res[1].Name, "b")
-	assert.Equal(t, res[1].InitConfig, adconfig.Data("{}"))
-	assert.Equal(t, res[1].Instances, []adconfig.Data{adconfig.Data("{1:2}")})
+	assert.Equal(t, res[1].InitConfig, autodiscovery.Data("{}"))
+	assert.Equal(t, res[1].Instances, []autodiscovery.Data{autodiscovery.Data("{1:2}")})
 }
 
 func TestExtractTemplatesFromMap(t *testing.T) {
@@ -121,7 +121,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 		source       map[string]string
 		adIdentifier string
 		prefix       string
-		output       []adconfig.Config
+		output       []autodiscovery.Config
 		err          error
 	}{
 		{
@@ -133,17 +133,17 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output: []adconfig.Config{
+			output: []autodiscovery.Config{
 				{
 					Name:          "apache",
-					Instances:     []adconfig.Data{adconfig.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
-					InitConfig:    adconfig.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 				{
 					Name:          "http_check",
-					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
-					InitConfig:    adconfig.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -160,11 +160,11 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output: []adconfig.Config{
+			output: []autodiscovery.Config{
 				{
 					Name:          "apache",
-					Instances:     []adconfig.Data{adconfig.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
-					InitConfig:    adconfig.Data("{}"),
+					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    autodiscovery.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -177,7 +177,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []adconfig.Config{},
+			output:       []autodiscovery.Config{},
 		},
 		{
 			// Missing init_configs, error out
@@ -187,7 +187,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []adconfig.Config{},
+			output:       []autodiscovery.Config{},
 			err:          errors.New("missing init_configs key"),
 		},
 		{
@@ -199,7 +199,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []adconfig.Config{},
+			output:       []autodiscovery.Config{},
 			err:          errors.New("in instances: Failed to unmarshal JSON"),
 		},
 	} {

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 func TestParseJSONValue(t *testing.T) {
@@ -43,8 +43,8 @@ func TestParseJSONValue(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
 	require.Len(t, res, 2)
-	assert.Equal(t, check.ConfigData("{\"test\":1}"), res[0])
-	assert.Equal(t, check.ConfigData("{\"test\":2}"), res[1])
+	assert.Equal(t, adconfig.Data("{\"test\":1}"), res[0])
+	assert.Equal(t, adconfig.Data("{\"test\":2}"), res[1])
 }
 
 func TestParseCheckNames(t *testing.T) {
@@ -93,27 +93,27 @@ func TestBuildTemplates(t *testing.T) {
 	// wrong number of checkNames
 	res := buildTemplates("id",
 		[]string{"a", "b"},
-		[]check.ConfigData{check.ConfigData("")},
-		[]check.ConfigData{check.ConfigData("")})
+		[]adconfig.Data{adconfig.Data("")},
+		[]adconfig.Data{adconfig.Data("")})
 	assert.Len(t, res, 0)
 
 	res = buildTemplates("id",
 		[]string{"a", "b"},
-		[]check.ConfigData{check.ConfigData("{\"test\": 1}"), check.ConfigData("{}")},
-		[]check.ConfigData{check.ConfigData("{}"), check.ConfigData("{1:2}")})
+		[]adconfig.Data{adconfig.Data("{\"test\": 1}"), adconfig.Data("{}")},
+		[]adconfig.Data{adconfig.Data("{}"), adconfig.Data("{1:2}")})
 	require.Len(t, res, 2)
 
 	assert.Len(t, res[0].ADIdentifiers, 1)
 	assert.Equal(t, "id", res[0].ADIdentifiers[0])
 	assert.Equal(t, res[0].Name, "a")
-	assert.Equal(t, res[0].InitConfig, check.ConfigData("{\"test\": 1}"))
-	assert.Equal(t, res[0].Instances, []check.ConfigData{check.ConfigData("{}")})
+	assert.Equal(t, res[0].InitConfig, adconfig.Data("{\"test\": 1}"))
+	assert.Equal(t, res[0].Instances, []adconfig.Data{adconfig.Data("{}")})
 
 	assert.Len(t, res[1].ADIdentifiers, 1)
 	assert.Equal(t, "id", res[1].ADIdentifiers[0])
 	assert.Equal(t, res[1].Name, "b")
-	assert.Equal(t, res[1].InitConfig, check.ConfigData("{}"))
-	assert.Equal(t, res[1].Instances, []check.ConfigData{check.ConfigData("{1:2}")})
+	assert.Equal(t, res[1].InitConfig, adconfig.Data("{}"))
+	assert.Equal(t, res[1].Instances, []adconfig.Data{adconfig.Data("{1:2}")})
 }
 
 func TestExtractTemplatesFromMap(t *testing.T) {
@@ -121,7 +121,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 		source       map[string]string
 		adIdentifier string
 		prefix       string
-		output       []check.Config
+		output       []adconfig.Config
 		err          error
 	}{
 		{
@@ -133,17 +133,17 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output: []check.Config{
+			output: []adconfig.Config{
 				{
 					Name:          "apache",
-					Instances:     []check.ConfigData{check.ConfigData("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
-					InitConfig:    check.ConfigData("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    adconfig.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 				{
 					Name:          "http_check",
-					Instances:     []check.ConfigData{check.ConfigData("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
-					InitConfig:    check.ConfigData("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    adconfig.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -160,11 +160,11 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output: []check.Config{
+			output: []adconfig.Config{
 				{
 					Name:          "apache",
-					Instances:     []check.ConfigData{check.ConfigData("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
-					InitConfig:    check.ConfigData("{}"),
+					Instances:     []adconfig.Data{adconfig.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    adconfig.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -177,7 +177,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []check.Config{},
+			output:       []adconfig.Config{},
 		},
 		{
 			// Missing init_configs, error out
@@ -187,7 +187,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []check.Config{},
+			output:       []adconfig.Config{},
 			err:          errors.New("missing init_configs key"),
 		},
 		{
@@ -199,7 +199,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []check.Config{},
+			output:       []adconfig.Config{},
 			err:          errors.New("in instances: Failed to unmarshal JSON"),
 		},
 	} {

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 func TestParseJSONValue(t *testing.T) {
@@ -43,8 +43,8 @@ func TestParseJSONValue(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
 	require.Len(t, res, 2)
-	assert.Equal(t, autodiscovery.Data("{\"test\":1}"), res[0])
-	assert.Equal(t, autodiscovery.Data("{\"test\":2}"), res[1])
+	assert.Equal(t, integration.Data("{\"test\":1}"), res[0])
+	assert.Equal(t, integration.Data("{\"test\":2}"), res[1])
 }
 
 func TestParseCheckNames(t *testing.T) {
@@ -93,27 +93,27 @@ func TestBuildTemplates(t *testing.T) {
 	// wrong number of checkNames
 	res := buildTemplates("id",
 		[]string{"a", "b"},
-		[]autodiscovery.Data{autodiscovery.Data("")},
-		[]autodiscovery.Data{autodiscovery.Data("")})
+		[]integration.Data{integration.Data("")},
+		[]integration.Data{integration.Data("")})
 	assert.Len(t, res, 0)
 
 	res = buildTemplates("id",
 		[]string{"a", "b"},
-		[]autodiscovery.Data{autodiscovery.Data("{\"test\": 1}"), autodiscovery.Data("{}")},
-		[]autodiscovery.Data{autodiscovery.Data("{}"), autodiscovery.Data("{1:2}")})
+		[]integration.Data{integration.Data("{\"test\": 1}"), integration.Data("{}")},
+		[]integration.Data{integration.Data("{}"), integration.Data("{1:2}")})
 	require.Len(t, res, 2)
 
 	assert.Len(t, res[0].ADIdentifiers, 1)
 	assert.Equal(t, "id", res[0].ADIdentifiers[0])
 	assert.Equal(t, res[0].Name, "a")
-	assert.Equal(t, res[0].InitConfig, autodiscovery.Data("{\"test\": 1}"))
-	assert.Equal(t, res[0].Instances, []autodiscovery.Data{autodiscovery.Data("{}")})
+	assert.Equal(t, res[0].InitConfig, integration.Data("{\"test\": 1}"))
+	assert.Equal(t, res[0].Instances, []integration.Data{integration.Data("{}")})
 
 	assert.Len(t, res[1].ADIdentifiers, 1)
 	assert.Equal(t, "id", res[1].ADIdentifiers[0])
 	assert.Equal(t, res[1].Name, "b")
-	assert.Equal(t, res[1].InitConfig, autodiscovery.Data("{}"))
-	assert.Equal(t, res[1].Instances, []autodiscovery.Data{autodiscovery.Data("{1:2}")})
+	assert.Equal(t, res[1].InitConfig, integration.Data("{}"))
+	assert.Equal(t, res[1].Instances, []integration.Data{integration.Data("{1:2}")})
 }
 
 func TestExtractTemplatesFromMap(t *testing.T) {
@@ -121,7 +121,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 		source       map[string]string
 		adIdentifier string
 		prefix       string
-		output       []autodiscovery.Config
+		output       []integration.Config
 		err          error
 	}{
 		{
@@ -133,17 +133,17 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output: []autodiscovery.Config{
+			output: []integration.Config{
 				{
 					Name:          "apache",
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
-					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    integration.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 				{
 					Name:          "http_check",
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
-					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					InitConfig:    integration.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -160,11 +160,11 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output: []autodiscovery.Config{
+			output: []integration.Config{
 				{
 					Name:          "apache",
-					Instances:     []autodiscovery.Data{autodiscovery.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
-					InitConfig:    autodiscovery.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    integration.Data("{}"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -177,7 +177,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []autodiscovery.Config{},
+			output:       []integration.Config{},
 		},
 		{
 			// Missing init_configs, error out
@@ -187,7 +187,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []autodiscovery.Config{},
+			output:       []integration.Config{},
 			err:          errors.New("missing init_configs key"),
 		},
 		{
@@ -199,7 +199,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []autodiscovery.Config{},
+			output:       []integration.Config{},
 			err:          errors.New("in instances: Failed to unmarshal JSON"),
 		},
 	} {

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/samuel/go-zookeeper/zk"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -59,8 +59,8 @@ func (z *ZookeeperConfigProvider) String() string {
 
 // Collect retrieves templates from Zookeeper, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (z *ZookeeperConfigProvider) Collect() ([]check.Config, error) {
-	configs := make([]check.Config, 0)
+func (z *ZookeeperConfigProvider) Collect() ([]adconfig.Config, error) {
+	configs := make([]adconfig.Config, 0)
 	identifiers, err := z.getIdentifiers(z.templateDir)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (z *ZookeeperConfigProvider) getIdentifiers(key string) ([]string, error) {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (z *ZookeeperConfigProvider) getTemplates(key string) []check.Config {
+func (z *ZookeeperConfigProvider) getTemplates(key string) []adconfig.Config {
 	checkNameKey := path.Join(key, checkNamePath)
 	initKey := path.Join(key, initConfigPath)
 	instanceKey := path.Join(key, instancePath)
@@ -184,7 +184,7 @@ func (z *ZookeeperConfigProvider) getTemplates(key string) []check.Config {
 	return buildTemplates(key, checkNames, initConfigs, instances)
 }
 
-func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]check.ConfigData, error) {
+func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]adconfig.Data, error) {
 	rawValue, _, err := z.client.Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key '%s' from zookeeper: %s", key, err)

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/samuel/go-zookeeper/zk"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -59,8 +59,8 @@ func (z *ZookeeperConfigProvider) String() string {
 
 // Collect retrieves templates from Zookeeper, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (z *ZookeeperConfigProvider) Collect() ([]adconfig.Config, error) {
-	configs := make([]adconfig.Config, 0)
+func (z *ZookeeperConfigProvider) Collect() ([]autodiscovery.Config, error) {
+	configs := make([]autodiscovery.Config, 0)
 	identifiers, err := z.getIdentifiers(z.templateDir)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (z *ZookeeperConfigProvider) getIdentifiers(key string) ([]string, error) {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (z *ZookeeperConfigProvider) getTemplates(key string) []adconfig.Config {
+func (z *ZookeeperConfigProvider) getTemplates(key string) []autodiscovery.Config {
 	checkNameKey := path.Join(key, checkNamePath)
 	initKey := path.Join(key, initConfigPath)
 	instanceKey := path.Join(key, instancePath)
@@ -184,7 +184,7 @@ func (z *ZookeeperConfigProvider) getTemplates(key string) []adconfig.Config {
 	return buildTemplates(key, checkNames, initConfigs, instances)
 }
 
-func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]adconfig.Data, error) {
+func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]autodiscovery.Data, error) {
 	rawValue, _, err := z.client.Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key '%s' from zookeeper: %s", key, err)

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -17,8 +17,8 @@ import (
 	log "github.com/cihub/seelog"
 	"github.com/samuel/go-zookeeper/zk"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 const sessionTimeout = 1 * time.Second
@@ -59,8 +59,8 @@ func (z *ZookeeperConfigProvider) String() string {
 
 // Collect retrieves templates from Zookeeper, builds Config objects and returns them
 // TODO: cache templates and last-modified index to avoid future full crawl if no template changed.
-func (z *ZookeeperConfigProvider) Collect() ([]autodiscovery.Config, error) {
-	configs := make([]autodiscovery.Config, 0)
+func (z *ZookeeperConfigProvider) Collect() ([]integration.Config, error) {
+	configs := make([]integration.Config, 0)
 	identifiers, err := z.getIdentifiers(z.templateDir)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (z *ZookeeperConfigProvider) getIdentifiers(key string) ([]string, error) {
 
 // getTemplates takes a path and returns a slice of templates if it finds
 // sufficient data under this path to build one.
-func (z *ZookeeperConfigProvider) getTemplates(key string) []autodiscovery.Config {
+func (z *ZookeeperConfigProvider) getTemplates(key string) []integration.Config {
 	checkNameKey := path.Join(key, checkNamePath)
 	initKey := path.Join(key, initConfigPath)
 	instanceKey := path.Join(key, instancePath)
@@ -184,7 +184,7 @@ func (z *ZookeeperConfigProvider) getTemplates(key string) []autodiscovery.Confi
 	return buildTemplates(key, checkNames, initConfigs, instances)
 }
 
-func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]autodiscovery.Data, error) {
+func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]integration.Data, error) {
 	rawValue, _, err := z.client.Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key '%s' from zookeeper: %s", key, err)

--- a/pkg/autodiscovery/templatecache.go
+++ b/pkg/autodiscovery/templatecache.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 	"sync"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // TemplateCache is a data structure to store configuration templates
 type TemplateCache struct {
-	id2digests      map[string][]string        // map an AD identifier to all the configs that have it
-	digest2ids      map[string][]string        // map a config digest to the list of AD identifiers it has
-	digest2template map[string]adconfig.Config // map a digest to the corresponding config object
+	id2digests      map[string][]string             // map an AD identifier to all the configs that have it
+	digest2ids      map[string][]string             // map a config digest to the list of AD identifiers it has
+	digest2template map[string]autodiscovery.Config // map a digest to the corresponding config object
 	m               sync.RWMutex
 }
 
@@ -26,12 +26,12 @@ func NewTemplateCache() *TemplateCache {
 	return &TemplateCache{
 		id2digests:      map[string][]string{},
 		digest2ids:      map[string][]string{},
-		digest2template: map[string]adconfig.Config{},
+		digest2template: map[string]autodiscovery.Config{},
 	}
 }
 
 // Set stores or updates a template in the cache
-func (cache *TemplateCache) Set(tpl adconfig.Config) error {
+func (cache *TemplateCache) Set(tpl autodiscovery.Config) error {
 	// return an error if configuration has no AD identifiers
 	if len(tpl.ADIdentifiers) == 0 {
 		return fmt.Errorf("template has no AD identifiers, unable to store it in the cache")
@@ -59,13 +59,13 @@ func (cache *TemplateCache) Set(tpl adconfig.Config) error {
 }
 
 // Get retrieves a template from the cache
-func (cache *TemplateCache) Get(adID string) ([]adconfig.Config, error) {
+func (cache *TemplateCache) Get(adID string) ([]autodiscovery.Config, error) {
 	cache.m.RLock()
 	defer cache.m.RUnlock()
 
 	// do we know the identifier?
 	if digests, found := cache.id2digests[adID]; found {
-		templates := []adconfig.Config{}
+		templates := []autodiscovery.Config{}
 		for _, digest := range digests {
 			templates = append(templates, cache.digest2template[digest])
 		}
@@ -76,8 +76,8 @@ func (cache *TemplateCache) Get(adID string) ([]adconfig.Config, error) {
 }
 
 // GetUnresolvedTemplates returns templates yet to be resolved
-func (cache *TemplateCache) GetUnresolvedTemplates() map[string]adconfig.Config {
-	tpls := make(map[string]adconfig.Config)
+func (cache *TemplateCache) GetUnresolvedTemplates() map[string]autodiscovery.Config {
+	tpls := make(map[string]autodiscovery.Config)
 	for d, config := range cache.digest2template {
 		ids := strings.Join(cache.digest2ids[d][:], ",")
 		tpls[ids] = config
@@ -86,7 +86,7 @@ func (cache *TemplateCache) GetUnresolvedTemplates() map[string]adconfig.Config 
 }
 
 // Del removes a template from the cache
-func (cache *TemplateCache) Del(tpl adconfig.Config) error {
+func (cache *TemplateCache) Del(tpl autodiscovery.Config) error {
 	// compute the digest once
 	d := tpl.Digest()
 

--- a/pkg/autodiscovery/templatecache.go
+++ b/pkg/autodiscovery/templatecache.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 	"sync"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // TemplateCache is a data structure to store configuration templates
 type TemplateCache struct {
-	id2digests      map[string][]string             // map an AD identifier to all the configs that have it
-	digest2ids      map[string][]string             // map a config digest to the list of AD identifiers it has
-	digest2template map[string]autodiscovery.Config // map a digest to the corresponding config object
+	id2digests      map[string][]string           // map an AD identifier to all the configs that have it
+	digest2ids      map[string][]string           // map a config digest to the list of AD identifiers it has
+	digest2template map[string]integration.Config // map a digest to the corresponding config object
 	m               sync.RWMutex
 }
 
@@ -26,12 +26,12 @@ func NewTemplateCache() *TemplateCache {
 	return &TemplateCache{
 		id2digests:      map[string][]string{},
 		digest2ids:      map[string][]string{},
-		digest2template: map[string]autodiscovery.Config{},
+		digest2template: map[string]integration.Config{},
 	}
 }
 
 // Set stores or updates a template in the cache
-func (cache *TemplateCache) Set(tpl autodiscovery.Config) error {
+func (cache *TemplateCache) Set(tpl integration.Config) error {
 	// return an error if configuration has no AD identifiers
 	if len(tpl.ADIdentifiers) == 0 {
 		return fmt.Errorf("template has no AD identifiers, unable to store it in the cache")
@@ -59,13 +59,13 @@ func (cache *TemplateCache) Set(tpl autodiscovery.Config) error {
 }
 
 // Get retrieves a template from the cache
-func (cache *TemplateCache) Get(adID string) ([]autodiscovery.Config, error) {
+func (cache *TemplateCache) Get(adID string) ([]integration.Config, error) {
 	cache.m.RLock()
 	defer cache.m.RUnlock()
 
 	// do we know the identifier?
 	if digests, found := cache.id2digests[adID]; found {
-		templates := []autodiscovery.Config{}
+		templates := []integration.Config{}
 		for _, digest := range digests {
 			templates = append(templates, cache.digest2template[digest])
 		}
@@ -76,8 +76,8 @@ func (cache *TemplateCache) Get(adID string) ([]autodiscovery.Config, error) {
 }
 
 // GetUnresolvedTemplates returns templates yet to be resolved
-func (cache *TemplateCache) GetUnresolvedTemplates() map[string]autodiscovery.Config {
-	tpls := make(map[string]autodiscovery.Config)
+func (cache *TemplateCache) GetUnresolvedTemplates() map[string]integration.Config {
+	tpls := make(map[string]integration.Config)
 	for d, config := range cache.digest2template {
 		ids := strings.Join(cache.digest2ids[d][:], ",")
 		tpls[ids] = config
@@ -86,7 +86,7 @@ func (cache *TemplateCache) GetUnresolvedTemplates() map[string]autodiscovery.Co
 }
 
 // Del removes a template from the cache
-func (cache *TemplateCache) Del(tpl autodiscovery.Config) error {
+func (cache *TemplateCache) Del(tpl integration.Config) error {
 	// compute the digest once
 	d := tpl.Digest()
 

--- a/pkg/autodiscovery/templatecache_test.go
+++ b/pkg/autodiscovery/templatecache_test.go
@@ -8,7 +8,7 @@ package autodiscovery
 import (
 	"testing"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 func TestSet(t *testing.T) {
 	cache := NewTemplateCache()
 
-	tpl1 := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl1 := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl1)
 	require.Nil(t, err)
 	// adding again should be no-op
@@ -36,7 +36,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2ids, 1)
 	assert.Len(t, cache.digest2template, 1)
 
-	tpl2 := adconfig.Config{ADIdentifiers: []string{"foo"}}
+	tpl2 := autodiscovery.Config{ADIdentifiers: []string{"foo"}}
 	err = cache.Set(tpl2)
 
 	require.Nil(t, err)
@@ -47,7 +47,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2template, 2)
 
 	// no identifiers at all
-	tpl3 := adconfig.Config{ADIdentifiers: []string{}}
+	tpl3 := autodiscovery.Config{ADIdentifiers: []string{}}
 	err = cache.Set(tpl3)
 
 	require.NotNil(t, err)
@@ -55,7 +55,7 @@ func TestSet(t *testing.T) {
 
 func TestDel(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl)
 	require.Nil(t, err)
 
@@ -69,13 +69,13 @@ func TestDel(t *testing.T) {
 	assert.Len(t, cache.digest2template, 0)
 
 	// delete for an unknown identifier
-	err = cache.Del(adconfig.Config{ADIdentifiers: []string{"baz"}})
+	err = cache.Del(autodiscovery.Config{ADIdentifiers: []string{"baz"}})
 	require.NotNil(t, err)
 }
 
 func TestGet(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
 
 	ret, err := cache.Get("foo")
@@ -91,9 +91,9 @@ func TestGet(t *testing.T) {
 
 func TestGetUnresolvedTemplates(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
-	expected := map[string]adconfig.Config{
+	expected := map[string]autodiscovery.Config{
 		"foo,bar": tpl,
 	}
 

--- a/pkg/autodiscovery/templatecache_test.go
+++ b/pkg/autodiscovery/templatecache_test.go
@@ -8,7 +8,7 @@ package autodiscovery
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 func TestSet(t *testing.T) {
 	cache := NewTemplateCache()
 
-	tpl1 := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl1 := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl1)
 	require.Nil(t, err)
 	// adding again should be no-op
@@ -36,7 +36,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2ids, 1)
 	assert.Len(t, cache.digest2template, 1)
 
-	tpl2 := check.Config{ADIdentifiers: []string{"foo"}}
+	tpl2 := adconfig.Config{ADIdentifiers: []string{"foo"}}
 	err = cache.Set(tpl2)
 
 	require.Nil(t, err)
@@ -47,7 +47,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2template, 2)
 
 	// no identifiers at all
-	tpl3 := check.Config{ADIdentifiers: []string{}}
+	tpl3 := adconfig.Config{ADIdentifiers: []string{}}
 	err = cache.Set(tpl3)
 
 	require.NotNil(t, err)
@@ -55,7 +55,7 @@ func TestSet(t *testing.T) {
 
 func TestDel(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl)
 	require.Nil(t, err)
 
@@ -69,13 +69,13 @@ func TestDel(t *testing.T) {
 	assert.Len(t, cache.digest2template, 0)
 
 	// delete for an unknown identifier
-	err = cache.Del(check.Config{ADIdentifiers: []string{"baz"}})
+	err = cache.Del(adconfig.Config{ADIdentifiers: []string{"baz"}})
 	require.NotNil(t, err)
 }
 
 func TestGet(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
 
 	ret, err := cache.Get("foo")
@@ -91,9 +91,9 @@ func TestGet(t *testing.T) {
 
 func TestGetUnresolvedTemplates(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := check.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := adconfig.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
-	expected := map[string]check.Config{
+	expected := map[string]adconfig.Config{
 		"foo,bar": tpl,
 	}
 

--- a/pkg/autodiscovery/templatecache_test.go
+++ b/pkg/autodiscovery/templatecache_test.go
@@ -8,7 +8,7 @@ package autodiscovery
 import (
 	"testing"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 func TestSet(t *testing.T) {
 	cache := NewTemplateCache()
 
-	tpl1 := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl1 := integration.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl1)
 	require.Nil(t, err)
 	// adding again should be no-op
@@ -36,7 +36,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2ids, 1)
 	assert.Len(t, cache.digest2template, 1)
 
-	tpl2 := autodiscovery.Config{ADIdentifiers: []string{"foo"}}
+	tpl2 := integration.Config{ADIdentifiers: []string{"foo"}}
 	err = cache.Set(tpl2)
 
 	require.Nil(t, err)
@@ -47,7 +47,7 @@ func TestSet(t *testing.T) {
 	assert.Len(t, cache.digest2template, 2)
 
 	// no identifiers at all
-	tpl3 := autodiscovery.Config{ADIdentifiers: []string{}}
+	tpl3 := integration.Config{ADIdentifiers: []string{}}
 	err = cache.Set(tpl3)
 
 	require.NotNil(t, err)
@@ -55,7 +55,7 @@ func TestSet(t *testing.T) {
 
 func TestDel(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := integration.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl)
 	require.Nil(t, err)
 
@@ -69,13 +69,13 @@ func TestDel(t *testing.T) {
 	assert.Len(t, cache.digest2template, 0)
 
 	// delete for an unknown identifier
-	err = cache.Del(autodiscovery.Config{ADIdentifiers: []string{"baz"}})
+	err = cache.Del(integration.Config{ADIdentifiers: []string{"baz"}})
 	require.NotNil(t, err)
 }
 
 func TestGet(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := integration.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
 
 	ret, err := cache.Get("foo")
@@ -91,9 +91,9 @@ func TestGet(t *testing.T) {
 
 func TestGetUnresolvedTemplates(t *testing.T) {
 	cache := NewTemplateCache()
-	tpl := autodiscovery.Config{ADIdentifiers: []string{"foo", "bar"}}
+	tpl := integration.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
-	expected := map[string]autodiscovery.Config{
+	expected := map[string]integration.Config{
 		"foo,bar": tpl,
 	}
 

--- a/pkg/collector/check/README.md
+++ b/pkg/collector/check/README.md
@@ -6,7 +6,7 @@ existing configuration.
 
 ### Check Loaders
 Loaders implement the `CheckLoader` interface, they are responsible to instantiate one object of type `check.Check` for
-every configuration instance within a `CheckConfig` object. A Loader usually invokes the `Configure` method on check
+every configuration instance within a `integration.Config` object. A Loader usually invokes the `Configure` method on check
 objects passing in the configuration instance in YAML format: how to use it, it's up to the check itself.
 
 Usage example:

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -6,7 +6,7 @@
 package check
 
 import (
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"time"
 )
 
@@ -18,12 +18,12 @@ const (
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                                       // run the check
-	Stop()                                            // stop the check if it's running
-	String() string                                   // provide a printable version of the check name
-	Configure(config, initConfig adconfig.Data) error // configure the check from the outside
-	Interval() time.Duration                          // return the interval time for the check
-	ID() ID                                           // provide a unique identifier for every check instance
-	GetWarnings() []error                             // return the last warning registered by the check
-	GetMetricStats() (map[string]int64, error)        // get metric stats from the sender
+	Run() error                                            // run the check
+	Stop()                                                 // stop the check if it's running
+	String() string                                        // provide a printable version of the check name
+	Configure(config, initConfig autodiscovery.Data) error // configure the check from the outside
+	Interval() time.Duration                               // return the interval time for the check
+	ID() ID                                                // provide a unique identifier for every check instance
+	GetWarnings() []error                                  // return the last warning registered by the check
+	GetMetricStats() (map[string]int64, error)             // get metric stats from the sender
 }

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -6,6 +6,7 @@
 package check
 
 import (
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"time"
 )
 
@@ -17,12 +18,12 @@ const (
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                                    // run the check
-	Stop()                                         // stop the check if it's running
-	String() string                                // provide a printable version of the check name
-	Configure(config, initConfig ConfigData) error // configure the check from the outside
-	Interval() time.Duration                       // return the interval time for the check
-	ID() ID                                        // provide a unique identifier for every check instance
-	GetWarnings() []error                          // return the last warning registered by the check
-	GetMetricStats() (map[string]int64, error)     // get metric stats from the sender
+	Run() error                                       // run the check
+	Stop()                                            // stop the check if it's running
+	String() string                                   // provide a printable version of the check name
+	Configure(config, initConfig adconfig.Data) error // configure the check from the outside
+	Interval() time.Duration                          // return the interval time for the check
+	ID() ID                                           // provide a unique identifier for every check instance
+	GetWarnings() []error                             // return the last warning registered by the check
+	GetMetricStats() (map[string]int64, error)        // get metric stats from the sender
 }

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -6,7 +6,7 @@
 package check
 
 import (
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"time"
 )
 
@@ -18,12 +18,12 @@ const (
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                                            // run the check
-	Stop()                                                 // stop the check if it's running
-	String() string                                        // provide a printable version of the check name
-	Configure(config, initConfig autodiscovery.Data) error // configure the check from the outside
-	Interval() time.Duration                               // return the interval time for the check
-	ID() ID                                                // provide a unique identifier for every check instance
-	GetWarnings() []error                                  // return the last warning registered by the check
-	GetMetricStats() (map[string]int64, error)             // get metric stats from the sender
+	Run() error                                          // run the check
+	Stop()                                               // stop the check if it's running
+	String() string                                      // provide a printable version of the check name
+	Configure(config, initConfig integration.Data) error // configure the check from the outside
+	Interval() time.Duration                             // return the interval time for the check
+	ID() ID                                              // provide a unique identifier for every check instance
+	GetWarnings() []error                                // return the last warning registered by the check
+	GetMetricStats() (map[string]int64, error)           // get metric stats from the sender
 }

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 func TestCollectDefaultMetrics(t *testing.T) {
@@ -64,12 +64,12 @@ func TestAddMetrics(t *testing.T) {
 type config struct {
 	InitConfig interface{} `yaml:"init_config"`
 	JMXMetrics interface{} `yaml:"jmx_metrics"`
-	Instances  []adconfig.RawMap
+	Instances  []autodiscovery.RawMap
 }
 
-func LoadCheck(name, path string) (adconfig.Config, error) {
+func LoadCheck(name, path string) (autodiscovery.Config, error) {
 	cf := config{}
-	config := adconfig.Config{Name: name}
+	config := autodiscovery.Config{Name: name}
 
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -6,94 +6,14 @@
 package check
 
 import (
-	"crypto/rand"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
+
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
-
-func TestConfigEqual(t *testing.T) {
-	config := &Config{}
-	assert.False(t, config.Equal(nil))
-
-	another := &Config{}
-	assert.True(t, config.Equal(another))
-
-	another.Name = "foo"
-	assert.False(t, config.Equal(another))
-	config.Name = another.Name
-	assert.True(t, config.Equal(another))
-
-	another.InitConfig = ConfigData("fooBarBaz")
-	assert.False(t, config.Equal(another))
-	config.InitConfig = another.InitConfig
-	assert.True(t, config.Equal(another))
-
-	another.Instances = []ConfigData{ConfigData("justFoo")}
-	assert.False(t, config.Equal(another))
-	config.Instances = another.Instances
-	assert.True(t, config.Equal(another))
-
-	config.ADIdentifiers = []string{"foo", "bar"}
-	assert.False(t, config.Equal(another))
-	another.ADIdentifiers = []string{"foo", "bar"}
-	assert.True(t, config.Equal(another))
-	another.ADIdentifiers = []string{"bar", "foo"}
-	assert.False(t, config.Equal(another))
-}
-
-func TestString(t *testing.T) {
-	config := &Config{}
-	assert.False(t, config.Equal(nil))
-
-	config.Name = "foo"
-	config.InitConfig = ConfigData("fooBarBaz: test")
-	config.Instances = []ConfigData{ConfigData("justFoo")}
-
-	expected := `init_config:
-  fooBarBaz: test
-instances:
-- justFoo
-`
-	assert.Equal(t, config.String(), expected)
-}
-
-func TestMergeAdditionalTags(t *testing.T) {
-	config := &Config{}
-	assert.False(t, config.Equal(nil))
-
-	config.Name = "foo"
-	config.InitConfig = ConfigData("fooBarBaz")
-	config.Instances = []ConfigData{ConfigData("tags: [\"foo\", \"foo:bar\"]")}
-
-	config.Instances[0].MergeAdditionalTags([]string{"foo", "bar"})
-
-	rawConfig := ConfigRawMap{}
-	err := yaml.Unmarshal(config.Instances[0], &rawConfig)
-	assert.Nil(t, err)
-	assert.Contains(t, rawConfig["tags"], "foo")
-	assert.Contains(t, rawConfig["tags"], "bar")
-	assert.Contains(t, rawConfig["tags"], "foo:bar")
-
-	config.Name = "foo"
-	config.InitConfig = ConfigData("fooBarBaz")
-	config.Instances = []ConfigData{ConfigData("other: foo")}
-
-	config.Instances[0].MergeAdditionalTags([]string{"foo", "bar"})
-
-	rawConfig = ConfigRawMap{}
-	err = yaml.Unmarshal(config.Instances[0], &rawConfig)
-	assert.Nil(t, err)
-	assert.Contains(t, rawConfig["tags"], "foo")
-	assert.Contains(t, rawConfig["tags"], "bar")
-}
-
-func TestDigest(t *testing.T) {
-	config := &Config{}
-	assert.Equal(t, 16, len(config.Digest()))
-}
 
 func TestCollectDefaultMetrics(t *testing.T) {
 	cfg, err := LoadCheck("foo", "testdata/collect_default_false.yaml")
@@ -141,29 +61,15 @@ func TestAddMetrics(t *testing.T) {
 	assert.Equal(t, expected.String(), config.String())
 }
 
-// this is here to prevent compiler optimization on the benchmarking code
-var result string
-
-func BenchmarkID(b *testing.B) {
-	var id string // store return value to avoid the compiler to strip the function call
-	config := &Config{}
-	config.InitConfig = make([]byte, 32000)
-	rand.Read(config.InitConfig)
-	for n := 0; n < b.N; n++ {
-		id = config.Digest()
-	}
-	result = id
-}
-
 type config struct {
 	InitConfig interface{} `yaml:"init_config"`
 	JMXMetrics interface{} `yaml:"jmx_metrics"`
-	Instances  []ConfigRawMap
+	Instances  []adconfig.RawMap
 }
 
-func LoadCheck(name, path string) (Config, error) {
+func LoadCheck(name, path string) (adconfig.Config, error) {
 	cf := config{}
-	config := Config{Name: name}
+	config := adconfig.Config{Name: name}
 
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pkg/collector/check/check_test.go
+++ b/pkg/collector/check/check_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 func TestCollectDefaultMetrics(t *testing.T) {
@@ -64,12 +64,12 @@ func TestAddMetrics(t *testing.T) {
 type config struct {
 	InitConfig interface{} `yaml:"init_config"`
 	JMXMetrics interface{} `yaml:"jmx_metrics"`
-	Instances  []autodiscovery.RawMap
+	Instances  []integration.RawMap
 }
 
-func LoadCheck(name, path string) (autodiscovery.Config, error) {
+func LoadCheck(name, path string) (integration.Config, error) {
 	cf := config{}
-	config := autodiscovery.Config{Name: name}
+	config := integration.Config{Name: name}
 
 	yamlFile, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pkg/collector/check/config.go
+++ b/pkg/collector/check/config.go
@@ -9,13 +9,10 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log"
-	"regexp"
 	"strconv"
 
 	yaml "gopkg.in/yaml.v2"
 )
-
-var tplVarRegex = regexp.MustCompile(`%%.+?%%`)
 
 // ConfigData contains YAML code
 type ConfigData []byte

--- a/pkg/collector/check/config.go
+++ b/pkg/collector/check/config.go
@@ -9,10 +9,13 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log"
+	"regexp"
 	"strconv"
 
 	yaml "gopkg.in/yaml.v2"
 )
+
+var tplVarRegex = regexp.MustCompile(`%%.+?%%`)
 
 // ConfigData contains YAML code
 type ConfigData []byte

--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -9,18 +9,20 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
+
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // ID is the representation of the unique ID of a Check instance
 type ID string
 
 // Identify returns an unique ID for a check and its configuration
-func Identify(check Check, instance ConfigData, initConfig ConfigData) ID {
+func Identify(check Check, instance adconfig.Data, initConfig adconfig.Data) ID {
 	return BuildID(check.String(), instance, initConfig)
 }
 
 // BuildID returns an unique ID for a check name and its configuration
-func BuildID(checkName string, instance, initConfig ConfigData) ID {
+func BuildID(checkName string, instance, initConfig adconfig.Data) ID {
 	h := fnv.New64()
 	h.Write([]byte(instance))
 	h.Write([]byte(initConfig))

--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -10,19 +10,19 @@ import (
 	"hash/fnv"
 	"strings"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // ID is the representation of the unique ID of a Check instance
 type ID string
 
 // Identify returns an unique ID for a check and its configuration
-func Identify(check Check, instance adconfig.Data, initConfig adconfig.Data) ID {
+func Identify(check Check, instance autodiscovery.Data, initConfig autodiscovery.Data) ID {
 	return BuildID(check.String(), instance, initConfig)
 }
 
 // BuildID returns an unique ID for a check name and its configuration
-func BuildID(checkName string, instance, initConfig adconfig.Data) ID {
+func BuildID(checkName string, instance, initConfig autodiscovery.Data) ID {
 	h := fnv.New64()
 	h.Write([]byte(instance))
 	h.Write([]byte(initConfig))

--- a/pkg/collector/check/id.go
+++ b/pkg/collector/check/id.go
@@ -10,19 +10,19 @@ import (
 	"hash/fnv"
 	"strings"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // ID is the representation of the unique ID of a Check instance
 type ID string
 
 // Identify returns an unique ID for a check and its configuration
-func Identify(check Check, instance autodiscovery.Data, initConfig autodiscovery.Data) ID {
+func Identify(check Check, instance integration.Data, initConfig integration.Data) ID {
 	return BuildID(check.String(), instance, initConfig)
 }
 
 // BuildID returns an unique ID for a check name and its configuration
-func BuildID(checkName string, instance, initConfig autodiscovery.Data) ID {
+func BuildID(checkName string, instance, initConfig integration.Data) ID {
 	h := fnv.New64()
 	h.Write([]byte(instance))
 	h.Write([]byte(initConfig))

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -10,32 +10,33 @@ import (
 	"testing"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 )
 
 // FIXTURE
 type TestCheck struct{}
 
-func (c *TestCheck) String() string                            { return "TestCheck" }
-func (c *TestCheck) Stop()                                     {}
-func (c *TestCheck) Configure(ConfigData, ConfigData) error    { return nil }
-func (c *TestCheck) Interval() time.Duration                   { return 1 }
-func (c *TestCheck) Run() error                                { return nil }
-func (c *TestCheck) ID() ID                                    { return ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                      { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                               { return "TestCheck" }
+func (c *TestCheck) Stop()                                        {}
+func (c *TestCheck) Configure(adconfig.Data, adconfig.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                      { return 1 }
+func (c *TestCheck) Run() error                                   { return nil }
+func (c *TestCheck) ID() ID                                       { return ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                         { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)    { return make(map[string]int64), nil }
 
 func TestIdentify(t *testing.T) {
 	testCheck := &TestCheck{}
 
-	instance1 := ConfigData("key1:value1\nkey2:value2")
-	initConfig1 := ConfigData("key:value")
+	instance1 := adconfig.Data("key1:value1\nkey2:value2")
+	initConfig1 := adconfig.Data("key:value")
 	instance2 := instance1
 	initConfig2 := initConfig1
 	assert.Equal(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance2, initConfig2))
 
-	instance3 := ConfigData("key1:value1\nkey2:value3")
-	initConfig3 := ConfigData("key:value")
+	instance3 := adconfig.Data("key1:value1\nkey2:value3")
+	initConfig3 := adconfig.Data("key:value")
 	assert.NotEqual(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance3, initConfig3))
 }
 

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -10,33 +10,33 @@ import (
 	"testing"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 )
 
 // FIXTURE
 type TestCheck struct{}
 
-func (c *TestCheck) String() string                               { return "TestCheck" }
-func (c *TestCheck) Stop()                                        {}
-func (c *TestCheck) Configure(adconfig.Data, adconfig.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                      { return 1 }
-func (c *TestCheck) Run() error                                   { return nil }
-func (c *TestCheck) ID() ID                                       { return ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                         { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)    { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                                         { return "TestCheck" }
+func (c *TestCheck) Stop()                                                  {}
+func (c *TestCheck) Configure(autodiscovery.Data, autodiscovery.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                                { return 1 }
+func (c *TestCheck) Run() error                                             { return nil }
+func (c *TestCheck) ID() ID                                                 { return ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                                   { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)              { return make(map[string]int64), nil }
 
 func TestIdentify(t *testing.T) {
 	testCheck := &TestCheck{}
 
-	instance1 := adconfig.Data("key1:value1\nkey2:value2")
-	initConfig1 := adconfig.Data("key:value")
+	instance1 := autodiscovery.Data("key1:value1\nkey2:value2")
+	initConfig1 := autodiscovery.Data("key:value")
 	instance2 := instance1
 	initConfig2 := initConfig1
 	assert.Equal(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance2, initConfig2))
 
-	instance3 := adconfig.Data("key1:value1\nkey2:value3")
-	initConfig3 := adconfig.Data("key:value")
+	instance3 := autodiscovery.Data("key1:value1\nkey2:value3")
+	initConfig3 := autodiscovery.Data("key:value")
 	assert.NotEqual(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance3, initConfig3))
 }
 

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -10,33 +10,33 @@ import (
 	"testing"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 )
 
 // FIXTURE
 type TestCheck struct{}
 
-func (c *TestCheck) String() string                                         { return "TestCheck" }
-func (c *TestCheck) Stop()                                                  {}
-func (c *TestCheck) Configure(autodiscovery.Data, autodiscovery.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                                { return 1 }
-func (c *TestCheck) Run() error                                             { return nil }
-func (c *TestCheck) ID() ID                                                 { return ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                                   { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)              { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Stop()                                              {}
+func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                            { return 1 }
+func (c *TestCheck) Run() error                                         { return nil }
+func (c *TestCheck) ID() ID                                             { return ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                               { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
 
 func TestIdentify(t *testing.T) {
 	testCheck := &TestCheck{}
 
-	instance1 := autodiscovery.Data("key1:value1\nkey2:value2")
-	initConfig1 := autodiscovery.Data("key:value")
+	instance1 := integration.Data("key1:value1\nkey2:value2")
+	initConfig1 := integration.Data("key:value")
 	instance2 := instance1
 	initConfig2 := initConfig1
 	assert.Equal(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance2, initConfig2))
 
-	instance3 := autodiscovery.Data("key1:value1\nkey2:value3")
-	initConfig3 := autodiscovery.Data("key:value")
+	instance3 := integration.Data("key1:value1\nkey2:value3")
+	initConfig3 := integration.Data("key:value")
 	assert.NotEqual(t, Identify(testCheck, instance1, initConfig1), Identify(testCheck, instance3, initConfig3))
 }
 

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -7,6 +7,8 @@ package check
 
 import (
 	yaml "gopkg.in/yaml.v2"
+
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // JMXChecks list of JMXFetch checks supported
@@ -21,7 +23,7 @@ var JMXChecks = []string{
 }
 
 // IsJMXConfig checks if a certain YAML config is a JMX config
-func IsJMXConfig(name string, initConf ConfigData) bool {
+func IsJMXConfig(name string, initConf adconfig.Data) bool {
 
 	for _, check := range JMXChecks {
 		if check == name {
@@ -29,7 +31,7 @@ func IsJMXConfig(name string, initConf ConfigData) bool {
 		}
 	}
 
-	rawInitConfig := ConfigRawMap{}
+	rawInitConfig := adconfig.RawMap{}
 	err := yaml.Unmarshal(initConf, &rawInitConfig)
 	if err != nil {
 		return false
@@ -49,12 +51,12 @@ func IsJMXConfig(name string, initConf ConfigData) bool {
 }
 
 // CollectDefaultMetrics returns if the config is for a JMX check which has collect_default_metrics: true
-func CollectDefaultMetrics(c Config) bool {
+func CollectDefaultMetrics(c adconfig.Config) bool {
 	if !IsJMXConfig(c.String(), c.InitConfig) {
 		return false
 	}
 
-	rawInitConfig := ConfigRawMap{}
+	rawInitConfig := adconfig.RawMap{}
 	err := yaml.Unmarshal(c.InitConfig, &rawInitConfig)
 	if err != nil {
 		return false

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -8,7 +8,7 @@ package check
 import (
 	yaml "gopkg.in/yaml.v2"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // JMXChecks list of JMXFetch checks supported
@@ -23,7 +23,7 @@ var JMXChecks = []string{
 }
 
 // IsJMXConfig checks if a certain YAML config is a JMX config
-func IsJMXConfig(name string, initConf adconfig.Data) bool {
+func IsJMXConfig(name string, initConf autodiscovery.Data) bool {
 
 	for _, check := range JMXChecks {
 		if check == name {
@@ -31,7 +31,7 @@ func IsJMXConfig(name string, initConf adconfig.Data) bool {
 		}
 	}
 
-	rawInitConfig := adconfig.RawMap{}
+	rawInitConfig := autodiscovery.RawMap{}
 	err := yaml.Unmarshal(initConf, &rawInitConfig)
 	if err != nil {
 		return false
@@ -51,12 +51,12 @@ func IsJMXConfig(name string, initConf adconfig.Data) bool {
 }
 
 // CollectDefaultMetrics returns if the config is for a JMX check which has collect_default_metrics: true
-func CollectDefaultMetrics(c adconfig.Config) bool {
+func CollectDefaultMetrics(c autodiscovery.Config) bool {
 	if !IsJMXConfig(c.String(), c.InitConfig) {
 		return false
 	}
 
-	rawInitConfig := adconfig.RawMap{}
+	rawInitConfig := autodiscovery.RawMap{}
 	err := yaml.Unmarshal(c.InitConfig, &rawInitConfig)
 	if err != nil {
 		return false

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -8,7 +8,7 @@ package check
 import (
 	yaml "gopkg.in/yaml.v2"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // JMXChecks list of JMXFetch checks supported
@@ -23,7 +23,7 @@ var JMXChecks = []string{
 }
 
 // IsJMXConfig checks if a certain YAML config is a JMX config
-func IsJMXConfig(name string, initConf autodiscovery.Data) bool {
+func IsJMXConfig(name string, initConf integration.Data) bool {
 
 	for _, check := range JMXChecks {
 		if check == name {
@@ -31,7 +31,7 @@ func IsJMXConfig(name string, initConf autodiscovery.Data) bool {
 		}
 	}
 
-	rawInitConfig := autodiscovery.RawMap{}
+	rawInitConfig := integration.RawMap{}
 	err := yaml.Unmarshal(initConf, &rawInitConfig)
 	if err != nil {
 		return false
@@ -51,12 +51,12 @@ func IsJMXConfig(name string, initConf autodiscovery.Data) bool {
 }
 
 // CollectDefaultMetrics returns if the config is for a JMX check which has collect_default_metrics: true
-func CollectDefaultMetrics(c autodiscovery.Config) bool {
+func CollectDefaultMetrics(c integration.Config) bool {
 	if !IsJMXConfig(c.String(), c.InitConfig) {
 		return false
 	}
 
-	rawInitConfig := autodiscovery.RawMap{}
+	rawInitConfig := integration.RawMap{}
 	err := yaml.Unmarshal(c.InitConfig, &rawInitConfig)
 	if err != nil {
 		return false

--- a/pkg/collector/check/loader.go
+++ b/pkg/collector/check/loader.go
@@ -5,11 +5,15 @@
 
 package check
 
+import (
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+)
+
 // Loader is the interface wrapping the operations to load a check from
 // different sources, like Python modules or Go objects.
 //
 // A check is loaded for every `instance` found in the configuration file.
 // Load is supposed to break down instances and return different checks.
 type Loader interface {
-	Load(config Config) ([]Check, error)
+	Load(config adconfig.Config) ([]Check, error)
 }

--- a/pkg/collector/check/loader.go
+++ b/pkg/collector/check/loader.go
@@ -6,7 +6,7 @@
 package check
 
 import (
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 )
 
 // Loader is the interface wrapping the operations to load a check from
@@ -15,5 +15,5 @@ import (
 // A check is loaded for every `instance` found in the configuration file.
 // Load is supposed to break down instances and return different checks.
 type Loader interface {
-	Load(config adconfig.Config) ([]Check, error)
+	Load(config autodiscovery.Config) ([]Check, error)
 }

--- a/pkg/collector/check/loader.go
+++ b/pkg/collector/check/loader.go
@@ -6,7 +6,7 @@
 package check
 
 import (
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // Loader is the interface wrapping the operations to load a check from
@@ -15,5 +15,5 @@ import (
 // A check is loaded for every `instance` found in the configuration file.
 // Load is supposed to break down instances and return different checks.
 type Loader interface {
-	Load(config autodiscovery.Config) ([]Check, error)
+	Load(config integration.Config) ([]Check, error)
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
@@ -112,7 +113,7 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 }
 
 // ReloadCheck stops and restart a check with a new configuration
-func (c *Collector) ReloadCheck(id check.ID, config, initConfig check.ConfigData) error {
+func (c *Collector) ReloadCheck(id check.ID, config, initConfig adconfig.Data) error {
 	if !c.started() {
 		return fmt.Errorf("the collector is not running")
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
@@ -113,7 +113,7 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 }
 
 // ReloadCheck stops and restart a check with a new configuration
-func (c *Collector) ReloadCheck(id check.ID, config, initConfig adconfig.Data) error {
+func (c *Collector) ReloadCheck(id check.ID, config, initConfig autodiscovery.Data) error {
 	if !c.started() {
 		return fmt.Errorf("the collector is not running")
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -10,10 +10,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
 	"github.com/DataDog/datadog-agent/pkg/collector/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 )
 
@@ -113,7 +113,7 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 }
 
 // ReloadCheck stops and restart a check with a new configuration
-func (c *Collector) ReloadCheck(id check.ID, config, initConfig autodiscovery.Data) error {
+func (c *Collector) ReloadCheck(id check.ID, config, initConfig integration.Data) error {
 	if !c.started() {
 		return fmt.Errorf("the collector is not running")
 	}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -23,7 +24,7 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
-func (c *TestCheck) Configure(a, b check.ConfigData) error     { return nil }
+func (c *TestCheck) Configure(a, b adconfig.Data) error        { return nil }
 func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
@@ -98,7 +99,7 @@ func (suite *CollectorTestSuite) TestRunCheck() {
 
 func (suite *CollectorTestSuite) TestReloadCheck() {
 	ch := NewCheck()
-	empty := check.ConfigData{}
+	empty := adconfig.Data{}
 
 	// schedule a check
 	_, err := suite.c.RunCheck(ch)

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -24,7 +24,7 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
-func (c *TestCheck) Configure(a, b adconfig.Data) error        { return nil }
+func (c *TestCheck) Configure(a, b autodiscovery.Data) error   { return nil }
 func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
@@ -99,7 +99,7 @@ func (suite *CollectorTestSuite) TestRunCheck() {
 
 func (suite *CollectorTestSuite) TestReloadCheck() {
 	ch := NewCheck()
-	empty := adconfig.Data{}
+	empty := autodiscovery.Data{}
 
 	// schedule a check
 	_, err := suite.c.RunCheck(ch)

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,7 +24,7 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
-func (c *TestCheck) Configure(a, b autodiscovery.Data) error   { return nil }
+func (c *TestCheck) Configure(a, b integration.Data) error     { return nil }
 func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
@@ -99,7 +99,7 @@ func (suite *CollectorTestSuite) TestRunCheck() {
 
 func (suite *CollectorTestSuite) TestReloadCheck() {
 	ch := NewCheck()
-	empty := autodiscovery.Data{}
+	empty := integration.Data{}
 
 	// schedule a check
 	_, err := suite.c.RunCheck(ch)

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
@@ -44,7 +44,7 @@ func NewCheckBase(name string) CheckBase {
 
 // BuildID is to be called by the check's Config() method to generate
 // the unique check ID.
-func (c *CheckBase) BuildID(instance, initConfig adconfig.Data) {
+func (c *CheckBase) BuildID(instance, initConfig autodiscovery.Data) {
 	c.checkID = check.BuildID(c.checkName, instance, initConfig)
 }
 

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
@@ -43,7 +44,7 @@ func NewCheckBase(name string) CheckBase {
 
 // BuildID is to be called by the check's Config() method to generate
 // the unique check ID.
-func (c *CheckBase) BuildID(instance, initConfig check.ConfigData) {
+func (c *CheckBase) BuildID(instance, initConfig adconfig.Data) {
 	c.checkID = check.BuildID(c.checkName, instance, initConfig)
 }
 

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // CheckBase provides default implementations for most of the check.Check
@@ -44,7 +44,7 @@ func NewCheckBase(name string) CheckBase {
 
 // BuildID is to be called by the check's Config() method to generate
 // the unique check ID.
-func (c *CheckBase) BuildID(instance, initConfig autodiscovery.Data) {
+func (c *CheckBase) BuildID(instance, initConfig integration.Data) {
 	c.checkID = check.BuildID(c.checkName, instance, initConfig)
 }
 

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -56,7 +57,7 @@ func (c *KubeASConfig) parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check.
-func (k *KubeASCheck) Configure(config, initConfig check.ConfigData) error {
+func (k *KubeASCheck) Configure(config, initConfig adconfig.Data) error {
 	// Check connectivity to the APIServer
 	err := k.instance.parse(config)
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -57,7 +57,7 @@ func (c *KubeASConfig) parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check.
-func (k *KubeASCheck) Configure(config, initConfig adconfig.Data) error {
+func (k *KubeASCheck) Configure(config, initConfig autodiscovery.Data) error {
 	// Check connectivity to the APIServer
 	err := k.instance.parse(config)
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -15,9 +15,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	log "github.com/cihub/seelog"
@@ -57,7 +57,7 @@ func (c *KubeASConfig) parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check.
-func (k *KubeASCheck) Configure(config, initConfig autodiscovery.Data) error {
+func (k *KubeASCheck) Configure(config, initConfig integration.Data) error {
 	// Check connectivity to the APIServer
 	err := k.instance.parse(config)
 	if err != nil {

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -18,6 +18,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -310,7 +311,7 @@ func (d *DockerCheck) Run() error {
 }
 
 // Configure parses the check configuration and init the check
-func (d *DockerCheck) Configure(config, initConfig check.ConfigData) error {
+func (d *DockerCheck) Configure(config, initConfig adconfig.Data) error {
 	d.instance.Parse(config)
 
 	if len(d.instance.FilteredEventType) == 0 {

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -18,7 +18,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -311,7 +311,7 @@ func (d *DockerCheck) Run() error {
 }
 
 // Configure parses the check configuration and init the check
-func (d *DockerCheck) Configure(config, initConfig adconfig.Data) error {
+func (d *DockerCheck) Configure(config, initConfig autodiscovery.Data) error {
 	d.instance.Parse(config)
 
 	if len(d.instance.FilteredEventType) == 0 {

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -18,9 +18,9 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -311,7 +311,7 @@ func (d *DockerCheck) Run() error {
 }
 
 // Configure parses the check configuration and init the check
-func (d *DockerCheck) Configure(config, initConfig autodiscovery.Data) error {
+func (d *DockerCheck) Configure(config, initConfig integration.Data) error {
 	d.instance.Parse(config)
 
 	if len(d.instance.FilteredEventType) == 0 {

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -123,7 +123,7 @@ func (c *APMCheck) run() error {
 }
 
 // Configure the APMCheck
-func (c *APMCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *APMCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// handle the case when apm agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
 		return fmt.Errorf("APM agent disabled through main configuration file")

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -122,7 +123,7 @@ func (c *APMCheck) run() error {
 }
 
 // Configure the APMCheck
-func (c *APMCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *APMCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// handle the case when apm agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
 		return fmt.Errorf("APM agent disabled through main configuration file")

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -17,10 +17,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 
 	log "github.com/cihub/seelog"
 	yaml "gopkg.in/yaml.v2"
@@ -123,7 +123,7 @@ func (c *APMCheck) run() error {
 }
 
 // Configure the APMCheck
-func (c *APMCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// handle the case when apm agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
 		return fmt.Errorf("APM agent disabled through main configuration file")

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
@@ -115,7 +115,7 @@ func (c *JMXCheck) run() error {
 	return err
 }
 
-func (c *JMXCheck) Parse(data, initConfig adconfig.Data) error {
+func (c *JMXCheck) Parse(data, initConfig autodiscovery.Data) error {
 
 	var initConf checkInitCfg
 	var instanceConf checkInstanceCfg
@@ -168,7 +168,7 @@ func (c *JMXCheck) Parse(data, initConfig adconfig.Data) error {
 }
 
 // Configure the JMXCheck
-func (c *JMXCheck) Configure(data, initConfig adconfig.Data) error {
+func (c *JMXCheck) Configure(data, initConfig autodiscovery.Data) error {
 	return c.Parse(data, initConfig)
 }
 

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
@@ -114,7 +115,7 @@ func (c *JMXCheck) run() error {
 	return err
 }
 
-func (c *JMXCheck) Parse(data, initConfig check.ConfigData) error {
+func (c *JMXCheck) Parse(data, initConfig adconfig.Data) error {
 
 	var initConf checkInitCfg
 	var instanceConf checkInstanceCfg
@@ -167,7 +168,7 @@ func (c *JMXCheck) Parse(data, initConfig check.ConfigData) error {
 }
 
 // Configure the JMXCheck
-func (c *JMXCheck) Configure(data, initConfig check.ConfigData) error {
+func (c *JMXCheck) Configure(data, initConfig adconfig.Data) error {
 	return c.Parse(data, initConfig)
 }
 

--- a/pkg/collector/corechecks/embed/jmx.go
+++ b/pkg/collector/corechecks/embed/jmx.go
@@ -12,9 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/jmxfetch"
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
@@ -115,7 +115,7 @@ func (c *JMXCheck) run() error {
 	return err
 }
 
-func (c *JMXCheck) Parse(data, initConfig autodiscovery.Data) error {
+func (c *JMXCheck) Parse(data, initConfig integration.Data) error {
 
 	var initConf checkInitCfg
 	var instanceConf checkInstanceCfg
@@ -168,7 +168,7 @@ func (c *JMXCheck) Parse(data, initConfig autodiscovery.Data) error {
 }
 
 // Configure the JMXCheck
-func (c *JMXCheck) Configure(data, initConfig autodiscovery.Data) error {
+func (c *JMXCheck) Configure(data, initConfig integration.Data) error {
 	return c.Parse(data, initConfig)
 }
 

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -24,7 +25,7 @@ import (
 var JMXConfigCache = cache.NewBasicCache()
 
 // AddJMXCachedConfig adds a config to the jmx config cache
-func AddJMXCachedConfig(config check.Config) {
+func AddJMXCachedConfig(config adconfig.Config) {
 	mapConfig := map[string]interface{}{}
 	mapConfig["name"] = config.Name
 	mapConfig["timestamp"] = time.Now().Unix()
@@ -44,7 +45,7 @@ func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 }
 
 // Load returns an (empty?) list of checks and nil if it all works out
-func (jl *JMXCheckLoader) Load(config check.Config) ([]check.Check, error) {
+func (jl *JMXCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
 	var err error
 	checks := []check.Check{}
 
@@ -52,7 +53,7 @@ func (jl *JMXCheckLoader) Load(config check.Config) ([]check.Check, error) {
 		return checks, errors.New("check is not a jmx check, or unable to determine if it's so")
 	}
 
-	rawInitConfig := check.ConfigRawMap{}
+	rawInitConfig := adconfig.RawMap{}
 	err = yaml.Unmarshal(config.InitConfig, &rawInitConfig)
 	if err != nil {
 		log.Errorf("jmx.loader: could not unmarshal instance config: %s", err)

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -25,7 +25,7 @@ import (
 var JMXConfigCache = cache.NewBasicCache()
 
 // AddJMXCachedConfig adds a config to the jmx config cache
-func AddJMXCachedConfig(config adconfig.Config) {
+func AddJMXCachedConfig(config autodiscovery.Config) {
 	mapConfig := map[string]interface{}{}
 	mapConfig["name"] = config.Name
 	mapConfig["timestamp"] = time.Now().Unix()
@@ -45,7 +45,7 @@ func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 }
 
 // Load returns an (empty?) list of checks and nil if it all works out
-func (jl *JMXCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
+func (jl *JMXCheckLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
 	var err error
 	checks := []check.Check{}
 
@@ -53,7 +53,7 @@ func (jl *JMXCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
 		return checks, errors.New("check is not a jmx check, or unable to determine if it's so")
 	}
 
-	rawInitConfig := adconfig.RawMap{}
+	rawInitConfig := autodiscovery.RawMap{}
 	err = yaml.Unmarshal(config.InitConfig, &rawInitConfig)
 	if err != nil {
 		log.Errorf("jmx.loader: could not unmarshal instance config: %s", err)

--- a/pkg/collector/corechecks/embed/jmxloader.go
+++ b/pkg/collector/corechecks/embed/jmxloader.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	log "github.com/cihub/seelog"
 	yaml "gopkg.in/yaml.v2"
@@ -25,7 +25,7 @@ import (
 var JMXConfigCache = cache.NewBasicCache()
 
 // AddJMXCachedConfig adds a config to the jmx config cache
-func AddJMXCachedConfig(config autodiscovery.Config) {
+func AddJMXCachedConfig(config integration.Config) {
 	mapConfig := map[string]interface{}{}
 	mapConfig["name"] = config.Name
 	mapConfig["timestamp"] = time.Now().Unix()
@@ -45,7 +45,7 @@ func NewJMXCheckLoader() (*JMXCheckLoader, error) {
 }
 
 // Load returns an (empty?) list of checks and nil if it all works out
-func (jl *JMXCheckLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
+func (jl *JMXCheckLoader) Load(config integration.Config) ([]check.Check, error) {
 	var err error
 	checks := []check.Check{}
 
@@ -53,7 +53,7 @@ func (jl *JMXCheckLoader) Load(config autodiscovery.Config) ([]check.Check, erro
 		return checks, errors.New("check is not a jmx check, or unable to determine if it's so")
 	}
 
-	rawInitConfig := autodiscovery.RawMap{}
+	rawInitConfig := integration.RawMap{}
 	err = yaml.Unmarshal(config.InitConfig, &rawInitConfig)
 	if err != nil {
 		log.Errorf("jmx.loader: could not unmarshal instance config: %s", err)

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -127,7 +128,7 @@ func (c *ProcessAgentCheck) run() error {
 }
 
 // Configure the ProcessAgentCheck
-func (c *ProcessAgentCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *ProcessAgentCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// handle the case when the agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("process_agent_enabled"); !enabled {
 		return fmt.Errorf("Process Agent disabled through main configuration file")

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -128,7 +128,7 @@ func (c *ProcessAgentCheck) run() error {
 }
 
 // Configure the ProcessAgentCheck
-func (c *ProcessAgentCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *ProcessAgentCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// handle the case when the agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("process_agent_enabled"); !enabled {
 		return fmt.Errorf("Process Agent disabled through main configuration file")

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -17,10 +17,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 
 	log "github.com/cihub/seelog"
@@ -128,7 +128,7 @@ func (c *ProcessAgentCheck) run() error {
 }
 
 // Configure the ProcessAgentCheck
-func (c *ProcessAgentCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// handle the case when the agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("process_agent_enabled"); !enabled {
 		return fmt.Errorf("Process Agent disabled through main configuration file")

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	log "github.com/cihub/seelog"
@@ -53,7 +54,7 @@ func NewGoCheckLoader() (*GoCheckLoader, error) {
 }
 
 // Load returns a list of checks, one for every configuration instance found in `config`
-func (gl *GoCheckLoader) Load(config check.Config) ([]check.Check, error) {
+func (gl *GoCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 
 	// If JMX check, just skip - coincidence

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	log "github.com/cihub/seelog"
@@ -54,7 +54,7 @@ func NewGoCheckLoader() (*GoCheckLoader, error) {
 }
 
 // Load returns a list of checks, one for every configuration instance found in `config`
-func (gl *GoCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
+func (gl *GoCheckLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 
 	// If JMX check, just skip - coincidence

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"strings"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 )
 
@@ -54,7 +54,7 @@ func NewGoCheckLoader() (*GoCheckLoader, error) {
 }
 
 // Load returns a list of checks, one for every configuration instance found in `config`
-func (gl *GoCheckLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
+func (gl *GoCheckLoader) Load(config integration.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 
 	// If JMX check, just skip - coincidence

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
@@ -24,7 +24,7 @@ func (c *TestCheck) Interval() time.Duration                   { return 1 }
 func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
-func (c *TestCheck) Configure(data adconfig.Data, initData adconfig.Data) error {
+func (c *TestCheck) Configure(data autodiscovery.Data, initData autodiscovery.Data) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
 	}
@@ -53,11 +53,11 @@ func TestLoad(t *testing.T) {
 	RegisterCheck("foo", testCheckFactory)
 
 	// check is in catalog, pass 2 instances
-	i := []adconfig.Data{
-		adconfig.Data("foo: bar"),
-		adconfig.Data("bar: baz"),
+	i := []autodiscovery.Data{
+		autodiscovery.Data("foo: bar"),
+		autodiscovery.Data("bar: baz"),
 	}
-	cc := adconfig.Config{Name: "foo", Instances: i}
+	cc := autodiscovery.Config{Name: "foo", Instances: i}
 	l, _ := NewGoCheckLoader()
 
 	lst, err := l.Load(cc)
@@ -70,11 +70,11 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check is in catalog, pass 1 good instance & 1 bad instance
-	i = []adconfig.Data{
-		adconfig.Data("foo: bar"),
-		adconfig.Data("err"),
+	i = []autodiscovery.Data{
+		autodiscovery.Data("foo: bar"),
+		autodiscovery.Data("err"),
 	}
-	cc = adconfig.Config{Name: "foo", Instances: i}
+	cc = autodiscovery.Config{Name: "foo", Instances: i}
 
 	lst, err = l.Load(cc)
 
@@ -86,8 +86,8 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check is in catalog, pass no instances
-	i = []adconfig.Data{}
-	cc = adconfig.Config{Name: "foo", Instances: i}
+	i = []autodiscovery.Data{}
+	cc = autodiscovery.Config{Name: "foo", Instances: i}
 
 	lst, err = l.Load(cc)
 
@@ -99,7 +99,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check not in catalog
-	cc = adconfig.Config{Name: "bar", Instances: nil}
+	cc = autodiscovery.Config{Name: "bar", Instances: nil}
 
 	lst, err = l.Load(cc)
 

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 )
 
@@ -23,7 +24,7 @@ func (c *TestCheck) Interval() time.Duration                   { return 1 }
 func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
-func (c *TestCheck) Configure(data check.ConfigData, initData check.ConfigData) error {
+func (c *TestCheck) Configure(data adconfig.Data, initData adconfig.Data) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
 	}
@@ -52,11 +53,11 @@ func TestLoad(t *testing.T) {
 	RegisterCheck("foo", testCheckFactory)
 
 	// check is in catalog, pass 2 instances
-	i := []check.ConfigData{
-		check.ConfigData("foo: bar"),
-		check.ConfigData("bar: baz"),
+	i := []adconfig.Data{
+		adconfig.Data("foo: bar"),
+		adconfig.Data("bar: baz"),
 	}
-	cc := check.Config{Name: "foo", Instances: i}
+	cc := adconfig.Config{Name: "foo", Instances: i}
 	l, _ := NewGoCheckLoader()
 
 	lst, err := l.Load(cc)
@@ -69,11 +70,11 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check is in catalog, pass 1 good instance & 1 bad instance
-	i = []check.ConfigData{
-		check.ConfigData("foo: bar"),
-		check.ConfigData("err"),
+	i = []adconfig.Data{
+		adconfig.Data("foo: bar"),
+		adconfig.Data("err"),
 	}
-	cc = check.Config{Name: "foo", Instances: i}
+	cc = adconfig.Config{Name: "foo", Instances: i}
 
 	lst, err = l.Load(cc)
 
@@ -85,8 +86,8 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check is in catalog, pass no instances
-	i = []check.ConfigData{}
-	cc = check.Config{Name: "foo", Instances: i}
+	i = []adconfig.Data{}
+	cc = adconfig.Config{Name: "foo", Instances: i}
 
 	lst, err = l.Load(cc)
 
@@ -98,7 +99,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check not in catalog
-	cc = check.Config{Name: "bar", Instances: nil}
+	cc = adconfig.Config{Name: "bar", Instances: nil}
 
 	lst, err = l.Load(cc)
 

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 // FIXTURE
@@ -24,7 +24,7 @@ func (c *TestCheck) Interval() time.Duration                   { return 1 }
 func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
-func (c *TestCheck) Configure(data autodiscovery.Data, initData autodiscovery.Data) error {
+func (c *TestCheck) Configure(data integration.Data, initData integration.Data) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
 	}
@@ -53,11 +53,11 @@ func TestLoad(t *testing.T) {
 	RegisterCheck("foo", testCheckFactory)
 
 	// check is in catalog, pass 2 instances
-	i := []autodiscovery.Data{
-		autodiscovery.Data("foo: bar"),
-		autodiscovery.Data("bar: baz"),
+	i := []integration.Data{
+		integration.Data("foo: bar"),
+		integration.Data("bar: baz"),
 	}
-	cc := autodiscovery.Config{Name: "foo", Instances: i}
+	cc := integration.Config{Name: "foo", Instances: i}
 	l, _ := NewGoCheckLoader()
 
 	lst, err := l.Load(cc)
@@ -70,11 +70,11 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check is in catalog, pass 1 good instance & 1 bad instance
-	i = []autodiscovery.Data{
-		autodiscovery.Data("foo: bar"),
-		autodiscovery.Data("err"),
+	i = []integration.Data{
+		integration.Data("foo: bar"),
+		integration.Data("err"),
 	}
-	cc = autodiscovery.Config{Name: "foo", Instances: i}
+	cc = integration.Config{Name: "foo", Instances: i}
 
 	lst, err = l.Load(cc)
 
@@ -86,8 +86,8 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check is in catalog, pass no instances
-	i = []autodiscovery.Data{}
-	cc = autodiscovery.Config{Name: "foo", Instances: i}
+	i = []integration.Data{}
+	cc = integration.Config{Name: "foo", Instances: i}
 
 	lst, err = l.Load(cc)
 
@@ -99,7 +99,7 @@ func TestLoad(t *testing.T) {
 	}
 
 	// check not in catalog
-	cc = autodiscovery.Config{Name: "bar", Instances: nil}
+	cc = integration.Config{Name: "bar", Instances: nil}
 
 	lst, err = l.Load(cc)
 

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/beevik/ntp"
 	log "github.com/cihub/seelog"
@@ -92,7 +92,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 }
 
 // Configure configure the data from the yaml
-func (c *NTPCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *NTPCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	cfg := new(ntpConfig)
 	err := cfg.parse(data, initConfig)
 	if err != nil {

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/beevik/ntp"
 	log "github.com/cihub/seelog"
@@ -91,7 +92,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 }
 
 // Configure configure the data from the yaml
-func (c *NTPCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *NTPCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	cfg := new(ntpConfig)
 	err := cfg.parse(data, initConfig)
 	if err != nil {

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"math/rand"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/beevik/ntp"
 	log "github.com/cihub/seelog"
 
@@ -92,7 +92,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 }
 
 // Configure configure the data from the yaml
-func (c *NTPCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	cfg := new(ntpConfig)
 	err := cfg.parse(data, initConfig)
 	if err != nil {

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -32,7 +32,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -643,7 +643,7 @@ func (c *SNMPCheck) getSNMP() error {
 }
 
 // Configure the check from YAML data
-func (c *SNMPCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *SNMPCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 
 	cfg := new(snmpConfig)
 	err := cfg.parse(data, initConfig)

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -32,6 +32,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -642,7 +643,7 @@ func (c *SNMPCheck) getSNMP() error {
 }
 
 // Configure the check from YAML data
-func (c *SNMPCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *SNMPCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 
 	cfg := new(snmpConfig)
 	err := cfg.parse(data, initConfig)

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -32,9 +32,9 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
 	log "github.com/cihub/seelog"
@@ -643,7 +643,7 @@ func (c *SNMPCheck) getSNMP() error {
 }
 
 // Configure the check from YAML data
-func (c *SNMPCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *SNMPCheck) Configure(data integration.Data, initConfig integration.Data) error {
 
 	cfg := new(snmpConfig)
 	err := cfg.parse(data, initConfig)

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -8,6 +8,7 @@ package system
 import (
 	"fmt"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -76,7 +77,7 @@ func (c *CPUCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *CPUCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *CPUCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// do nothing
 	// NOTE: This runs before the python checks, so we should be good, but cpuInfo()
 	//       on windows initializes COM to the multithreaded model. Therefore,

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -8,7 +8,7 @@ package system
 import (
 	"fmt"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -77,7 +77,7 @@ func (c *CPUCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *CPUCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *CPUCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// do nothing
 	// NOTE: This runs before the python checks, so we should be good, but cpuInfo()
 	//       on windows initializes COM to the multithreaded model. Therefore,

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -8,9 +8,9 @@ package system
 import (
 	"fmt"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/cpu"
 
@@ -77,7 +77,7 @@ func (c *CPUCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *CPUCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// do nothing
 	// NOTE: This runs before the python checks, so we should be good, but cpuInfo()
 	//       on windows initializes COM to the multithreaded model. Therefore,

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -90,7 +90,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *fhCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -89,7 +90,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *fhCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -12,9 +12,9 @@ import (
 	"strconv"
 	"strings"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -90,7 +90,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/file_handles_windows.go
@@ -7,6 +7,7 @@
 package system
 
 import (
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
@@ -42,7 +43,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data check.ConfigData, initConfig check.ConfigData) (err error) {
+func (c *fhCheck) Configure(data adconfig.Data, initConfig adconfig.Data) (err error) {
 	c.counter, err = pdhutil.GetCounterSet("Process", "Handle Count", "_Total", nil)
 	return err
 }

--- a/pkg/collector/corechecks/system/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/file_handles_windows.go
@@ -7,7 +7,7 @@
 package system
 
 import (
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
@@ -43,7 +43,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data adconfig.Data, initConfig adconfig.Data) (err error) {
+func (c *fhCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) (err error) {
 	c.counter, err = pdhutil.GetCounterSet("Process", "Handle Count", "_Total", nil)
 	return err
 }

--- a/pkg/collector/corechecks/system/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/file_handles_windows.go
@@ -7,9 +7,9 @@
 package system
 
 import (
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 	log "github.com/cihub/seelog"
 
@@ -43,7 +43,7 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) (err error) {
+func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
 	c.counter, err = pdhutil.GetCounterSet("Process", "Handle Count", "_Total", nil)
 	return err
 }

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -11,7 +11,7 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	yaml "gopkg.in/yaml.v2"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
@@ -27,7 +27,7 @@ const (
 var ioCounters = disk.IOCounters
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *IOCheck) commonConfigure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	conf := make(map[interface{}]interface{})
 
 	err := yaml.Unmarshal([]byte(initConfig), &conf)

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	yaml "gopkg.in/yaml.v2"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
@@ -26,7 +27,7 @@ const (
 var ioCounters = disk.IOCounters
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *IOCheck) commonConfigure(data adconfig.Data, initConfig adconfig.Data) error {
 	conf := make(map[interface{}]interface{})
 
 	err := yaml.Unmarshal([]byte(initConfig), &conf)

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -11,9 +11,9 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	yaml "gopkg.in/yaml.v2"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 )
 
 const (
@@ -27,7 +27,7 @@ const (
 var ioCounters = disk.IOCounters
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.Data) error {
 	conf := make(map[interface{}]interface{})
 
 	err := yaml.Unmarshal([]byte(initConfig), &conf)

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/xc"
 	log "github.com/cihub/seelog"
@@ -32,7 +32,7 @@ type IOCheck struct {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *IOCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	err := c.commonConfigure(data, initConfig)
 	return err
 }

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/xc"
 	log "github.com/cihub/seelog"
@@ -32,7 +32,7 @@ type IOCheck struct {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *IOCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	err := c.commonConfigure(data, initConfig)
 	return err
 }

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/xc"
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/disk"
@@ -32,7 +32,7 @@ type IOCheck struct {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	err := c.commonConfigure(data, initConfig)
 	return err
 }

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
@@ -83,7 +83,7 @@ func isDrive(instance string) bool {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *IOCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	err := c.commonConfigure(data, initConfig)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
@@ -83,7 +84,7 @@ func isDrive(instance string) bool {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *IOCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	err := c.commonConfigure(data, initConfig)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -16,8 +16,8 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
@@ -83,7 +83,7 @@ func isDrive(instance string) bool {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	err := c.commonConfigure(data, initConfig)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -52,7 +53,7 @@ func (c *LoadCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *LoadCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *LoadCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// do nothing
 	// NOTE: This check is disabled on windows - so the following doesn't apply
 	//       currently:

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -53,7 +53,7 @@ func (c *LoadCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *LoadCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *LoadCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// do nothing
 	// NOTE: This check is disabled on windows - so the following doesn't apply
 	//       currently:

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/load"
 )
@@ -53,7 +53,7 @@ func (c *LoadCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *LoadCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *LoadCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// do nothing
 	// NOTE: This check is disabled on windows - so the following doesn't apply
 	//       currently:

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -8,6 +8,7 @@ package system
 import (
 	"runtime"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/shirou/gopsutil/mem"
@@ -28,7 +29,7 @@ type MemoryCheck struct {
 const mbSize float64 = 1024 * 1024
 
 // Configure the Python check from YAML data
-func (c *MemoryCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *MemoryCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -8,7 +8,7 @@ package system
 import (
 	"runtime"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/shirou/gopsutil/mem"
@@ -29,7 +29,7 @@ type MemoryCheck struct {
 const mbSize float64 = 1024 * 1024
 
 // Configure the Python check from YAML data
-func (c *MemoryCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *MemoryCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -8,9 +8,9 @@ package system
 import (
 	"runtime"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/shirou/gopsutil/mem"
 )
 
@@ -29,7 +29,7 @@ type MemoryCheck struct {
 const mbSize float64 = 1024 * 1024
 
 // Configure the Python check from YAML data
-func (c *MemoryCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *MemoryCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -6,6 +6,7 @@
 package system
 
 import (
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -44,7 +45,7 @@ func (c *UptimeCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *UptimeCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *UptimeCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -6,7 +6,7 @@
 package system
 
 import (
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
@@ -45,7 +45,7 @@ func (c *UptimeCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *UptimeCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *UptimeCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -6,9 +6,9 @@
 package system
 
 import (
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/host"
 
@@ -45,7 +45,7 @@ func (c *UptimeCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *UptimeCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *UptimeCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// do nothing
 	return nil
 }

--- a/pkg/collector/corechecks/system/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc_windows.go
@@ -8,7 +8,7 @@ package system
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
@@ -40,7 +40,7 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(data adconfig.Data, initConfig adconfig.Data) (err error) {
+func (c *processChk) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) (err error) {
 	c.numprocs, err = pdhutil.GetCounterSet("System", "Processes", "", nil)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc_windows.go
@@ -8,6 +8,7 @@ package system
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
@@ -39,7 +40,7 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(data check.ConfigData, initConfig check.ConfigData) (err error) {
+func (c *processChk) Configure(data adconfig.Data, initConfig adconfig.Data) (err error) {
 	c.numprocs, err = pdhutil.GetCounterSet("System", "Processes", "", nil)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/system/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc_windows.go
@@ -8,9 +8,9 @@ package system
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -40,7 +40,7 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) (err error) {
+func (c *processChk) Configure(data integration.Data, initConfig integration.Data) (err error) {
 	c.numprocs, err = pdhutil.GetCounterSet("System", "Processes", "", nil)
 	if err != nil {
 		return err

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"testing"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,15 +17,15 @@ import (
 
 type LoaderOne struct{}
 
-func (lo LoaderOne) Load(config adconfig.Config) ([]check.Check, error) { return nil, nil }
+func (lo LoaderOne) Load(config autodiscovery.Config) ([]check.Check, error) { return nil, nil }
 
 type LoaderTwo struct{}
 
-func (lt LoaderTwo) Load(config adconfig.Config) ([]check.Check, error) { return nil, nil }
+func (lt LoaderTwo) Load(config autodiscovery.Config) ([]check.Check, error) { return nil, nil }
 
 type LoaderThree struct{}
 
-func (lt *LoaderThree) Load(config adconfig.Config) ([]check.Check, error) { return nil, nil }
+func (lt *LoaderThree) Load(config autodiscovery.Config) ([]check.Check, error) { return nil, nil }
 
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,15 +17,15 @@ import (
 
 type LoaderOne struct{}
 
-func (lo LoaderOne) Load(config check.Config) ([]check.Check, error) { return nil, nil }
+func (lo LoaderOne) Load(config adconfig.Config) ([]check.Check, error) { return nil, nil }
 
 type LoaderTwo struct{}
 
-func (lt LoaderTwo) Load(config check.Config) ([]check.Check, error) { return nil, nil }
+func (lt LoaderTwo) Load(config adconfig.Config) ([]check.Check, error) { return nil, nil }
 
 type LoaderThree struct{}
 
-func (lt *LoaderThree) Load(config check.Config) ([]check.Check, error) { return nil, nil }
+func (lt *LoaderThree) Load(config adconfig.Config) ([]check.Check, error) { return nil, nil }
 
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -9,23 +9,23 @@ import (
 	"errors"
 	"testing"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type LoaderOne struct{}
 
-func (lo LoaderOne) Load(config autodiscovery.Config) ([]check.Check, error) { return nil, nil }
+func (lo LoaderOne) Load(config integration.Config) ([]check.Check, error) { return nil, nil }
 
 type LoaderTwo struct{}
 
-func (lt LoaderTwo) Load(config autodiscovery.Config) ([]check.Check, error) { return nil, nil }
+func (lt LoaderTwo) Load(config integration.Config) ([]check.Check, error) { return nil, nil }
 
 type LoaderThree struct{}
 
-func (lt *LoaderThree) Load(config autodiscovery.Config) ([]check.Check, error) { return nil, nil }
+func (lt *LoaderThree) Load(config integration.Config) ([]check.Check, error) { return nil, nil }
 
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/sbinet/go-python"
@@ -193,12 +194,12 @@ func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObje
 }
 
 // Configure the Python check from YAML data
-func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {
+func (c *PythonCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
 	// Generate check ID
 	c.id = check.Identify(c, data, initConfig)
 
 	// Unmarshal instances config to a RawConfigMap
-	rawInstances := check.ConfigRawMap{}
+	rawInstances := adconfig.RawMap{}
 	err := yaml.Unmarshal(data, &rawInstances)
 	if err != nil {
 		log.Errorf("error in yaml %s", err)
@@ -206,7 +207,7 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 	}
 
 	// Unmarshal initConfig to a RawConfigMap
-	rawInitConfig := check.ConfigRawMap{}
+	rawInitConfig := adconfig.RawMap{}
 	err = yaml.Unmarshal(initConfig, &rawInitConfig)
 	if err != nil {
 		log.Errorf("error in yaml %s", err)
@@ -225,7 +226,7 @@ func (c *PythonCheck) Configure(data check.ConfigData, initConfig check.ConfigDa
 
 	// To be retrocompatible with the Python code, still use an `instance` dictionary
 	// to contain the (now) unique instance for the check
-	conf := make(check.ConfigRawMap)
+	conf := make(adconfig.RawMap)
 	conf["name"] = c.ModuleName
 	conf["init_config"] = rawInitConfig
 	conf["instances"] = []interface{}{rawInstances}

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -16,7 +16,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/sbinet/go-python"
@@ -194,12 +194,12 @@ func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObje
 }
 
 // Configure the Python check from YAML data
-func (c *PythonCheck) Configure(data adconfig.Data, initConfig adconfig.Data) error {
+func (c *PythonCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
 	// Generate check ID
 	c.id = check.Identify(c, data, initConfig)
 
 	// Unmarshal instances config to a RawConfigMap
-	rawInstances := adconfig.RawMap{}
+	rawInstances := autodiscovery.RawMap{}
 	err := yaml.Unmarshal(data, &rawInstances)
 	if err != nil {
 		log.Errorf("error in yaml %s", err)
@@ -207,7 +207,7 @@ func (c *PythonCheck) Configure(data adconfig.Data, initConfig adconfig.Data) er
 	}
 
 	// Unmarshal initConfig to a RawConfigMap
-	rawInitConfig := adconfig.RawMap{}
+	rawInitConfig := autodiscovery.RawMap{}
 	err = yaml.Unmarshal(initConfig, &rawInitConfig)
 	if err != nil {
 		log.Errorf("error in yaml %s", err)
@@ -226,7 +226,7 @@ func (c *PythonCheck) Configure(data adconfig.Data, initConfig adconfig.Data) er
 
 	// To be retrocompatible with the Python code, still use an `instance` dictionary
 	// to contain the (now) unique instance for the check
-	conf := make(adconfig.RawMap)
+	conf := make(autodiscovery.RawMap)
 	conf["name"] = c.ModuleName
 	conf["init_config"] = rawInitConfig
 	conf["instances"] = []interface{}{rawInstances}

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -16,9 +16,9 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/sbinet/go-python"
 
 	log "github.com/cihub/seelog"
@@ -194,12 +194,12 @@ func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObje
 }
 
 // Configure the Python check from YAML data
-func (c *PythonCheck) Configure(data autodiscovery.Data, initConfig autodiscovery.Data) error {
+func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Data) error {
 	// Generate check ID
 	c.id = check.Identify(c, data, initConfig)
 
 	// Unmarshal instances config to a RawConfigMap
-	rawInstances := autodiscovery.RawMap{}
+	rawInstances := integration.RawMap{}
 	err := yaml.Unmarshal(data, &rawInstances)
 	if err != nil {
 		log.Errorf("error in yaml %s", err)
@@ -207,7 +207,7 @@ func (c *PythonCheck) Configure(data autodiscovery.Data, initConfig autodiscover
 	}
 
 	// Unmarshal initConfig to a RawConfigMap
-	rawInitConfig := autodiscovery.RawMap{}
+	rawInitConfig := integration.RawMap{}
 	err = yaml.Unmarshal(initConfig, &rawInitConfig)
 	if err != nil {
 		log.Errorf("error in yaml %s", err)
@@ -226,7 +226,7 @@ func (c *PythonCheck) Configure(data autodiscovery.Data, initConfig autodiscover
 
 	// To be retrocompatible with the Python code, still use an `instance` dictionary
 	// to contain the (now) unique instance for the check
-	conf := make(autodiscovery.RawMap)
+	conf := make(integration.RawMap)
 	conf["name"] = c.ModuleName
 	conf["init_config"] = rawInitConfig
 	conf["instances"] = []interface{}{rawInstances}

--- a/pkg/collector/py/config_test.go
+++ b/pkg/collector/py/config_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ func TestToPython(t *testing.T) {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
 
-	c := make(check.ConfigRawMap)
+	c := make(adconfig.RawMap)
 
 	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {

--- a/pkg/collector/py/config_test.go
+++ b/pkg/collector/py/config_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ func TestToPython(t *testing.T) {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
 
-	c := make(adconfig.RawMap)
+	c := make(autodiscovery.RawMap)
 
 	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {

--- a/pkg/collector/py/config_test.go
+++ b/pkg/collector/py/config_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/mitchellh/reflectwalk"
 	"github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ func TestToPython(t *testing.T) {
 		t.Fatalf("Expected empty error message, found: %s", err)
 	}
 
-	c := make(autodiscovery.RawMap)
+	c := make(integration.RawMap)
 
 	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/sbinet/go-python"
@@ -52,7 +52,7 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 
 // Load tries to import a Python module with the same name found in config.Name, searches for
 // subclasses of the AgentCheck class and returns the corresponding Check
-func (cl *PythonCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
+func (cl *PythonCheckLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 	moduleName := config.Name
 	whlModuleName := fmt.Sprintf("datadog_checks.%s", config.Name)

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
 	"github.com/sbinet/go-python"
@@ -51,7 +52,7 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 
 // Load tries to import a Python module with the same name found in config.Name, searches for
 // subclasses of the AgentCheck class and returns the corresponding Check
-func (cl *PythonCheckLoader) Load(config check.Config) ([]check.Check, error) {
+func (cl *PythonCheckLoader) Load(config adconfig.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 	moduleName := config.Name
 	whlModuleName := fmt.Sprintf("datadog_checks.%s", config.Name)

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -11,9 +11,9 @@ import (
 	"errors"
 	"fmt"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/sbinet/go-python"
 
 	log "github.com/cihub/seelog"
@@ -52,7 +52,7 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 
 // Load tries to import a Python module with the same name found in config.Name, searches for
 // subclasses of the AgentCheck class and returns the corresponding Check
-func (cl *PythonCheckLoader) Load(config autodiscovery.Config) ([]check.Check, error) {
+func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 	moduleName := config.Name
 	whlModuleName := fmt.Sprintf("datadog_checks.%s", config.Name)

--- a/pkg/collector/py/loader_test.go
+++ b/pkg/collector/py/loader_test.go
@@ -11,14 +11,14 @@ package py
 import (
 	"testing"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {
 	l, _ := NewPythonCheckLoader()
-	config := adconfig.Config{Name: "testcheck"}
+	config := autodiscovery.Config{Name: "testcheck"}
 	config.Instances = append(config.Instances, []byte("foo: bar"))
 	config.Instances = append(config.Instances, []byte("bar: baz"))
 
@@ -27,19 +27,19 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, 2, len(instances))
 
 	// the python module doesn't exist
-	config = adconfig.Config{Name: "doesntexist"}
+	config = autodiscovery.Config{Name: "doesntexist"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))
 
 	// the python module contains errors
-	config = adconfig.Config{Name: "bad"}
+	config = autodiscovery.Config{Name: "bad"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))
 
 	// the python module is good but nothing derives from AgentCheck
-	config = adconfig.Config{Name: "foo"}
+	config = autodiscovery.Config{Name: "foo"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))

--- a/pkg/collector/py/loader_test.go
+++ b/pkg/collector/py/loader_test.go
@@ -11,14 +11,14 @@ package py
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {
 	l, _ := NewPythonCheckLoader()
-	config := check.Config{Name: "testcheck"}
+	config := adconfig.Config{Name: "testcheck"}
 	config.Instances = append(config.Instances, []byte("foo: bar"))
 	config.Instances = append(config.Instances, []byte("bar: baz"))
 
@@ -27,19 +27,19 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, 2, len(instances))
 
 	// the python module doesn't exist
-	config = check.Config{Name: "doesntexist"}
+	config = adconfig.Config{Name: "doesntexist"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))
 
 	// the python module contains errors
-	config = check.Config{Name: "bad"}
+	config = adconfig.Config{Name: "bad"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))
 
 	// the python module is good but nothing derives from AgentCheck
-	config = check.Config{Name: "foo"}
+	config = adconfig.Config{Name: "foo"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))

--- a/pkg/collector/py/loader_test.go
+++ b/pkg/collector/py/loader_test.go
@@ -11,14 +11,14 @@ package py
 import (
 	"testing"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {
 	l, _ := NewPythonCheckLoader()
-	config := autodiscovery.Config{Name: "testcheck"}
+	config := integration.Config{Name: "testcheck"}
 	config.Instances = append(config.Instances, []byte("foo: bar"))
 	config.Instances = append(config.Instances, []byte("bar: baz"))
 
@@ -27,19 +27,19 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, 2, len(instances))
 
 	// the python module doesn't exist
-	config = autodiscovery.Config{Name: "doesntexist"}
+	config = integration.Config{Name: "doesntexist"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))
 
 	// the python module contains errors
-	config = autodiscovery.Config{Name: "bad"}
+	config = integration.Config{Name: "bad"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))
 
 	// the python module is good but nothing derives from AgentCheck
-	config = autodiscovery.Config{Name: "foo"}
+	config = integration.Config{Name: "foo"}
 	instances, err = l.Load(config)
 	assert.NotNil(t, err)
 	assert.Zero(t, len(instances))

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,10 +21,10 @@ type TestCheck struct {
 	hasRun bool
 }
 
-func (c *TestCheck) String() string                               { return "TestCheck" }
-func (c *TestCheck) Stop()                                        {}
-func (c *TestCheck) Configure(adconfig.Data, adconfig.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                      { return 1 }
+func (c *TestCheck) String() string                                         { return "TestCheck" }
+func (c *TestCheck) Stop()                                                  {}
+func (c *TestCheck) Configure(autodiscovery.Data, autodiscovery.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                                { return 1 }
 func (c *TestCheck) Run() error {
 	if c.doErr {
 		msg := "A tremendous error occurred."

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,10 +21,10 @@ type TestCheck struct {
 	hasRun bool
 }
 
-func (c *TestCheck) String() string                                     { return "TestCheck" }
-func (c *TestCheck) Stop()                                              {}
-func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
-func (c *TestCheck) Interval() time.Duration                            { return 1 }
+func (c *TestCheck) String() string                               { return "TestCheck" }
+func (c *TestCheck) Stop()                                        {}
+func (c *TestCheck) Configure(adconfig.Data, adconfig.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                      { return 1 }
 func (c *TestCheck) Run() error {
 	if c.doErr {
 		msg := "A tremendous error occurred."

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,10 +21,10 @@ type TestCheck struct {
 	hasRun bool
 }
 
-func (c *TestCheck) String() string                                         { return "TestCheck" }
-func (c *TestCheck) Stop()                                                  {}
-func (c *TestCheck) Configure(autodiscovery.Data, autodiscovery.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                                { return 1 }
+func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Stop()                                              {}
+func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                            { return 1 }
 func (c *TestCheck) Run() error {
 	if c.doErr {
 		msg := "A tremendous error occurred."

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,14 +17,14 @@ import (
 // FIXTURE
 type TestCheck struct{ intl time.Duration }
 
-func (c *TestCheck) String() string                               { return "TestCheck" }
-func (c *TestCheck) Configure(adconfig.Data, adconfig.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                      { return c.intl }
-func (c *TestCheck) Run() error                                   { return nil }
-func (c *TestCheck) Stop()                                        {}
-func (c *TestCheck) ID() check.ID                                 { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                         { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)    { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                                         { return "TestCheck" }
+func (c *TestCheck) Configure(autodiscovery.Data, autodiscovery.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                                { return c.intl }
+func (c *TestCheck) Run() error                                             { return nil }
+func (c *TestCheck) Stop()                                                  {}
+func (c *TestCheck) ID() check.ID                                           { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                                   { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)              { return make(map[string]int64), nil }
 
 var initialMinAllowedInterval = minAllowedInterval
 

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,14 +17,14 @@ import (
 // FIXTURE
 type TestCheck struct{ intl time.Duration }
 
-func (c *TestCheck) String() string                                     { return "TestCheck" }
-func (c *TestCheck) Configure(check.ConfigData, check.ConfigData) error { return nil }
-func (c *TestCheck) Interval() time.Duration                            { return c.intl }
-func (c *TestCheck) Run() error                                         { return nil }
-func (c *TestCheck) Stop()                                              {}
-func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                               { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                               { return "TestCheck" }
+func (c *TestCheck) Configure(adconfig.Data, adconfig.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                      { return c.intl }
+func (c *TestCheck) Run() error                                   { return nil }
+func (c *TestCheck) Stop()                                        {}
+func (c *TestCheck) ID() check.ID                                 { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                         { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)    { return make(map[string]int64), nil }
 
 var initialMinAllowedInterval = minAllowedInterval
 

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -9,22 +9,22 @@ import (
 	"testing"
 	"time"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 )
 
 // FIXTURE
 type TestCheck struct{ intl time.Duration }
 
-func (c *TestCheck) String() string                                         { return "TestCheck" }
-func (c *TestCheck) Configure(autodiscovery.Data, autodiscovery.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                                { return c.intl }
-func (c *TestCheck) Run() error                                             { return nil }
-func (c *TestCheck) Stop()                                                  {}
-func (c *TestCheck) ID() check.ID                                           { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                                   { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)              { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
+func (c *TestCheck) Interval() time.Duration                            { return c.intl }
+func (c *TestCheck) Run() error                                         { return nil }
+func (c *TestCheck) Stop()                                              {}
+func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                               { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
 
 var initialMinAllowedInterval = minAllowedInterval
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,11 +58,11 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 // Ensure sensitive data is redacted
 func TestZipConfigCheck(t *testing.T) {
 	cr := response.ConfigCheckResponse{
-		Configs: make([]check.Config, 0),
+		Configs: make([]adconfig.Config, 0),
 	}
-	cr.Configs = append(cr.Configs, check.Config{
+	cr.Configs = append(cr.Configs, adconfig.Config{
 		Name:      "TestCheck",
-		Instances: []check.ConfigData{[]byte("username: User\npassword: MySecurePass")},
+		Instances: []adconfig.Data{[]byte("username: User\npassword: MySecurePass")},
 		Provider:  "FooProvider",
 	})
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,11 +58,11 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 // Ensure sensitive data is redacted
 func TestZipConfigCheck(t *testing.T) {
 	cr := response.ConfigCheckResponse{
-		Configs: make([]adconfig.Config, 0),
+		Configs: make([]autodiscovery.Config, 0),
 	}
-	cr.Configs = append(cr.Configs, adconfig.Config{
+	cr.Configs = append(cr.Configs, autodiscovery.Config{
 		Name:      "TestCheck",
-		Instances: []adconfig.Data{[]byte("username: User\npassword: MySecurePass")},
+		Instances: []autodiscovery.Data{[]byte("username: User\npassword: MySecurePass")},
 		Provider:  "FooProvider",
 	})
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,11 +58,11 @@ func TestCreateArchiveBadConfig(t *testing.T) {
 // Ensure sensitive data is redacted
 func TestZipConfigCheck(t *testing.T) {
 	cr := response.ConfigCheckResponse{
-		Configs: make([]autodiscovery.Config, 0),
+		Configs: make([]integration.Config, 0),
 	}
-	cr.Configs = append(cr.Configs, autodiscovery.Config{
+	cr.Configs = append(cr.Configs, integration.Config{
 		Name:      "TestCheck",
-		Instances: []autodiscovery.Data{[]byte("username: User\npassword: MySecurePass")},
+		Instances: []integration.Data{[]byte("username: User\npassword: MySecurePass")},
 		Provider:  "FooProvider",
 	})
 

--- a/pkg/integration/README.md
+++ b/pkg/integration/README.md
@@ -1,0 +1,3 @@
+# package `integration`
+
+This package is responsible of defining the types representing an integration which can be used by several components of the agent to configure checks or logs collectors for example.

--- a/pkg/integration/config.go
+++ b/pkg/integration/config.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-package config
+package integration
 
 import (
 	"fmt"

--- a/pkg/integration/config_test.go
+++ b/pkg/integration/config_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-package config
+package integration
 
 import (
 	"crypto/rand"

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -19,7 +19,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -112,19 +112,19 @@ func GetJSONSerializableMap(m interface{}) interface{} {
 	switch x := m.(type) {
 	// unbelievably I cannot collapse this into the next (identical) case
 	case map[interface{}]interface{}:
-		j := check.ConfigJSONMap{}
+		j := adconfig.JSONMap{}
 		for k, v := range x {
 			j[k.(string)] = GetJSONSerializableMap(v)
 		}
 		return j
-	case check.ConfigRawMap:
-		j := check.ConfigJSONMap{}
+	case adconfig.RawMap:
+		j := adconfig.JSONMap{}
 		for k, v := range x {
 			j[k.(string)] = GetJSONSerializableMap(v)
 		}
 		return j
-	case check.ConfigJSONMap:
-		j := check.ConfigJSONMap{}
+	case adconfig.JSONMap:
+		j := adconfig.JSONMap{}
 		for k, v := range x {
 			j[k] = GetJSONSerializableMap(v)
 		}

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -19,7 +19,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -112,19 +112,19 @@ func GetJSONSerializableMap(m interface{}) interface{} {
 	switch x := m.(type) {
 	// unbelievably I cannot collapse this into the next (identical) case
 	case map[interface{}]interface{}:
-		j := adconfig.JSONMap{}
+		j := autodiscovery.JSONMap{}
 		for k, v := range x {
 			j[k.(string)] = GetJSONSerializableMap(v)
 		}
 		return j
-	case adconfig.RawMap:
-		j := adconfig.JSONMap{}
+	case autodiscovery.RawMap:
+		j := autodiscovery.JSONMap{}
 		for k, v := range x {
 			j[k.(string)] = GetJSONSerializableMap(v)
 		}
 		return j
-	case adconfig.JSONMap:
-		j := adconfig.JSONMap{}
+	case autodiscovery.JSONMap:
+		j := autodiscovery.JSONMap{}
 		for k, v := range x {
 			j[k] = GetJSONSerializableMap(v)
 		}

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -19,8 +19,8 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -112,19 +112,19 @@ func GetJSONSerializableMap(m interface{}) interface{} {
 	switch x := m.(type) {
 	// unbelievably I cannot collapse this into the next (identical) case
 	case map[interface{}]interface{}:
-		j := autodiscovery.JSONMap{}
+		j := integration.JSONMap{}
 		for k, v := range x {
 			j[k.(string)] = GetJSONSerializableMap(v)
 		}
 		return j
-	case autodiscovery.RawMap:
-		j := autodiscovery.JSONMap{}
+	case integration.RawMap:
+		j := integration.JSONMap{}
 		for k, v := range x {
 			j[k.(string)] = GetJSONSerializableMap(v)
 		}
 		return j
-	case autodiscovery.JSONMap:
-		j := autodiscovery.JSONMap{}
+	case integration.JSONMap:
+		j := integration.JSONMap{}
 		for k, v := range x {
 			j[k] = GetJSONSerializableMap(v)
 		}

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"gopkg.in/yaml.v2"
@@ -107,9 +107,9 @@ func TestJSONConverter(t *testing.T) {
 		"jmx_alt",
 	}
 
-	cache := map[string]check.ConfigRawMap{}
+	cache := map[string]adconfig.RawMap{}
 	for _, c := range checks {
-		var cf check.ConfigRawMap
+		var cf adconfig.RawMap
 
 		// Read file contents
 		yamlFile, err := ioutil.ReadFile(fmt.Sprintf("../collector/corechecks/embed/fixtures/%s.yaml", c))

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	adconfig "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
+	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"gopkg.in/yaml.v2"
@@ -107,9 +107,9 @@ func TestJSONConverter(t *testing.T) {
 		"jmx_alt",
 	}
 
-	cache := map[string]adconfig.RawMap{}
+	cache := map[string]autodiscovery.RawMap{}
 	for _, c := range checks {
-		var cf adconfig.RawMap
+		var cf autodiscovery.RawMap
 
 		// Read file contents
 		yamlFile, err := ioutil.ReadFile(fmt.Sprintf("../collector/corechecks/embed/fixtures/%s.yaml", c))

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	autodiscovery "github.com/DataDog/datadog-agent/pkg/autodiscovery/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/integration"
 
 	"gopkg.in/yaml.v2"
 )
@@ -107,9 +107,9 @@ func TestJSONConverter(t *testing.T) {
 		"jmx_alt",
 	}
 
-	cache := map[string]autodiscovery.RawMap{}
+	cache := map[string]integration.RawMap{}
 	for _, c := range checks {
-		var cf autodiscovery.RawMap
+		var cf integration.RawMap
 
 		// Read file contents
 		yamlFile, err := ioutil.ReadFile(fmt.Sprintf("../collector/corechecks/embed/fixtures/%s.yaml", c))


### PR DESCRIPTION
### What does this PR do?

Moved Config struct from `collector` package to autodiscovery.

### Motivation

Isolate config struct from check to be reused by any component (checks, logs, ..)

