### PR TITLE
Fix EC2 tags when marketplaces are set.

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -32,10 +32,12 @@ func GetTags() ([]string, error) {
 		return tags, err
 	}
 
-	awsCreds := credentials.NewStaticCredentials(iamParams["AccessKeyId"], iamParams["SecretAccessKey"], iamParams["Token"])
+	awsCreds := credentials.NewStaticCredentials(iamParams.AccessKeyId,
+		iamParams.SecretAccessKey,
+		iamParams.Token)
 
 	awsSess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(instanceIdentity["region"]),
+		Region:      aws.String(instanceIdentity.Region),
 		Credentials: awsCreds,
 	})
 	if err != nil {
@@ -47,7 +49,7 @@ func GetTags() ([]string, error) {
 		Filters: []*ec2.Filter{{
 			Name: aws.String("resource-id"),
 			Values: []*string{
-				aws.String(instanceIdentity["instanceId"]),
+				aws.String(instanceIdentity.InstanceId),
 			},
 		}},
 	})
@@ -62,8 +64,13 @@ func GetTags() ([]string, error) {
 	return tags, nil
 }
 
-func getInstanceIdentity() (map[string]string, error) {
-	instanceIdentity := map[string]string{}
+type ec2Identity struct {
+	Region     string
+	InstanceId string
+}
+
+func getInstanceIdentity() (*ec2Identity, error) {
+	instanceIdentity := &ec2Identity{}
 
 	res, err := getResponse(instanceIdentityURL)
 	if err != nil {
@@ -84,8 +91,14 @@ func getInstanceIdentity() (map[string]string, error) {
 	return instanceIdentity, nil
 }
 
-func getSecurityCreds() (map[string]string, error) {
-	iamParams := map[string]string{}
+type ec2SecurityCred struct {
+	AccessKeyId     string
+	SecretAccessKey string
+	Token           string
+}
+
+func getSecurityCreds() (*ec2SecurityCred, error) {
+	iamParams := &ec2SecurityCred{}
 
 	iamRole, err := getIAMRole()
 	if err != nil {

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -8,55 +8,27 @@
 package ec2
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"sync"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type requestRecorder struct {
-	lastRequest    *http.Request
-	requestCounter int
-	mutex          sync.RWMutex
-}
-
-func (l *requestRecorder) recordRequest(r *http.Request) {
-	l.mutex.Lock()
-	l.lastRequest = r
-	l.requestCounter++
-	l.mutex.Unlock()
-}
-
-func (l *requestRecorder) getRequestCounter() int {
-	l.mutex.RLock()
-	defer l.mutex.RUnlock()
-	return l.requestCounter
-}
-
-func (l *requestRecorder) getRequestPath() string {
-	l.mutex.RLock()
-	defer l.mutex.RUnlock()
-	if l.lastRequest == nil {
-		return ""
-	}
-	return l.lastRequest.URL.Path
-}
-
 func TestGetIAMRole(t *testing.T) {
 	const expected = "test-role"
-	rr := &requestRecorder{}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		io.WriteString(w, expected)
-		rr.recordRequest(r)
+		if r.URL.Path == "/iam/security-credentials/" {
+			w.Header().Set("Content-Type", "text/plain")
+			io.WriteString(w, expected)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
@@ -64,81 +36,44 @@ func TestGetIAMRole(t *testing.T) {
 	val, err := getIAMRole()
 	require.Nil(t, err)
 	assert.Equal(t, expected, val)
-	assert.Equal(t, rr.getRequestPath(), "/iam/security-credentials/")
 }
 
 func TestGetSecurityCreds(t *testing.T) {
-	const expected1 = "test-role"
-	expected2Lock := sync.RWMutex{}
-	expected2 := map[string]string{
-		"Code":            "Success",
-		"LastUpdated":     "2017-09-06T19:18:06Z",
-		"Type":            "AWS-HMAC",
-		"AccessKeyId":     "123123",
-		"SecretAccessKey": "ddddd",
-		"Token":           "asdfasdf",
-		"Expiration":      "2017-09-07T01:45:43Z",
-	}
-	rr := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if rr.getRequestCounter() == 0 {
+		if r.URL.Path == "/iam/security-credentials/" {
 			w.Header().Set("Content-Type", "text/plain")
-			io.WriteString(w, expected1)
+			io.WriteString(w, "test-role")
+		} else if r.URL.Path == "/iam/security-credentials/test-role/" {
+			w.Header().Set("Content-Type", "text/plain")
+			content, err := ioutil.ReadFile("payloads/security_cred.json")
+			require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/security_cred.json: %v", err))
+			io.WriteString(w, string(content))
 		} else {
-			w.Header().Set("Content-Type", "text/plain")
-			expected2Lock.Lock()
-			b, err := json.Marshal(expected2)
-			expected2Lock.Unlock()
-			require.Nil(t, err, fmt.Sprintf("failed to marshall the map into json: %v", err))
-			io.WriteString(w, string(b))
+			w.WriteHeader(http.StatusInternalServerError)
 		}
-		rr.recordRequest(r)
 	}))
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	val, err := getSecurityCreds()
+	cred, err := getSecurityCreds()
 	require.Nil(t, err)
-	expected2Lock.Lock()
-	assert.Equal(t, expected2, val)
-	expected2Lock.Unlock()
-	assert.Equal(t, rr.getRequestPath(), "/iam/security-credentials/test-role/")
+	assert.Equal(t, "123456", cred.AccessKeyId)
+	assert.Equal(t, "secret access key", cred.SecretAccessKey)
+	assert.Equal(t, "secret token", cred.Token)
 }
 
 func TestGetInstanceIdentity(t *testing.T) {
-	expectedLock := sync.RWMutex{}
-	expected := map[string]string{
-		"privateIp":          "172.21.21.184",
-		"devpayProductCodes": "",
-		"availabilityZone":   "us-east-1a",
-		"version":            "2010-08-31",
-		"region":             "us-east-1",
-		"instanceId":         "i-07d4be5da8ffb9d1b",
-		"billingProducts":    "",
-		"instanceType":       "c3.xlarge",
-		"accountId":          "727006795293",
-		"architecture":       "x86_64",
-		"kernelId":           "",
-		"ramdiskId":          "",
-		"imageId":            "ami-ca5003dd",
-		"pendingTime":        "2017-05-22T15:15:20Z",
-	}
-	rr := &requestRecorder{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		expectedLock.Lock()
-		b, err := json.Marshal(expected)
-		expectedLock.Unlock()
-		require.Nil(t, err, fmt.Sprintf("failed to marshall the map into json: %v", err))
-		io.WriteString(w, string(b))
-		rr.recordRequest(r)
+		content, err := ioutil.ReadFile("payloads/instance_indentity.json")
+		require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/instance_indentity.json: %v", err))
+		io.WriteString(w, string(content))
 	}))
 	defer ts.Close()
 	instanceIdentityURL = ts.URL
 
 	val, err := getInstanceIdentity()
 	require.Nil(t, err)
-	expectedLock.RLock()
-	assert.Equal(t, expected, val)
-	expectedLock.RUnlock()
+	assert.Equal(t, "us-east-1", val.Region)
+	assert.Equal(t, "i-aaaaaaaaaaaaaaaaa", val.InstanceId)
 }

--- a/pkg/util/ec2/payloads/instance_indentity.json
+++ b/pkg/util/ec2/payloads/instance_indentity.json
@@ -1,0 +1,20 @@
+{
+  "devpayProductCodes": null,
+  "marketplaceProductCodes": [
+    "marketplaceID1",
+    "marketplaceID2"
+  ],
+  "version": "2017-09-30",
+  "instanceId": "i-aaaaaaaaaaaaaaaaa",
+  "billingProducts": null,
+  "instanceType": "m4.2xlarge",
+  "availabilityZone": "us-east-1a",
+  "kernelId": null,
+  "ramdiskId": null,
+  "accountId": "REMOVED",
+  "architecture": "x86_64",
+  "imageId": "ami-aaaaaaaa",
+  "pendingTime": "2018-04-06T18:10:21Z",
+  "privateIp": "1.2.3.4",
+  "region": "us-east-1"
+}

--- a/pkg/util/ec2/payloads/security_cred.json
+++ b/pkg/util/ec2/payloads/security_cred.json
@@ -1,0 +1,9 @@
+{
+  "Code" : "Success",
+  "LastUpdated" : "2017-09-06T19:18:06Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "123456",
+  "SecretAccessKey" : "secret access key",
+  "Token" : "secret token",
+  "Expiration" : "2017-09-07T01:45:43Z"
+}

--- a/releasenotes/notes/fix-ec2-tags-with-marketplaces-a9248bb432f80063.yaml
+++ b/releasenotes/notes/fix-ec2-tags-with-marketplaces-a9248bb432f80063.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix EC2 tags collection when multiple marketplaces are set.


### PR DESCRIPTION
### What does this PR do?

EC2 tags JSON answers can't always be unmarshal as "map[string]string".
We now unmarshal only the field we need and know of. For example: this
avoids the EC2 tags to crash loading tags with a list of marketplaces
set.