### PR TITLE
Make the classpath seperator in jmxfetch adjust to the os.

### DIFF
--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -90,16 +90,16 @@ func (j *JMXFetch) Start() error {
 	here, _ := executable.Folder()
 	classpath := filepath.Join(common.GetDistPath(), "jmx", jmxJarName)
 	if j.JavaToolsJarPath != "" {
-		classpath = fmt.Sprintf("%s:%s", j.JavaToolsJarPath, classpath)
+		classpath = fmt.Sprintf("%s%s%s", j.JavaToolsJarPath, string(os.PathListSeparator), classpath)
 	}
 
 	globalCustomJars := config.Datadog.GetStringSlice("jmx_custom_jars")
 	if len(globalCustomJars) > 0 {
-		classpath = fmt.Sprintf("%s:%s", strings.Join(globalCustomJars, ":"), classpath)
+		classpath = fmt.Sprintf("%s%s%s", strings.Join(globalCustomJars, string(os.PathListSeparator)), string(os.PathListSeparator), classpath)
 	}
 
 	if len(j.JavaCustomJarPaths) > 0 {
-		classpath = fmt.Sprintf("%s:%s", strings.Join(j.JavaCustomJarPaths, ":"), classpath)
+		classpath = fmt.Sprintf("%s%s%s", strings.Join(j.JavaCustomJarPaths, string(os.PathListSeparator)), string(os.PathListSeparator), classpath)
 	}
 	bindHost := config.Datadog.GetString("bind_host")
 	if bindHost == "" || bindHost == "0.0.0.0" {

--- a/releasenotes/notes/make_the_classpath_seperator_in_jmxfetch_adjust_to_the_os-b38560b076f55479.yaml
+++ b/releasenotes/notes/make_the_classpath_seperator_in_jmxfetch_adjust_to_the_os-b38560b076f55479.yaml
@@ -1,27 +1,5 @@
 ---
-prelude: >
-    Linux uses a colon (:) and Windows a semicolon (;). os.pathsep knows this.
-features:
-  - |
-    jmxfetch now also supports Windows with custom_jar_pathss
-issues:
-  - |
-    No known issues.
-upgrade:
-  - |
-    No upgrade notes. Fully backwards compatible.
-deprecations:
-  - |
-    None.
-critical:
-  - |
-    n.a.
-security:
-  - |
-    n.a.
 fixes:
   - |
-    When using the jmx agent on Windows in combination with a custom_jar_paths and or tools_jar_path the agent will fail because the classpath seperator is a colon. On Windows a path seperator has to be a semicolon. The python function os.pathsep return the correct seperator.
-other:
-  - |
-    n.a.
+    Fixes JMXFetch on Windows when the ``custom_jar_paths`` and/or ``tools_jar_path`` options are set,
+    by using a semicolon as the path separator on Windows.

--- a/releasenotes/notes/make_the_classpath_seperator_in_jmxfetch_adjust_to_the_os-b38560b076f55479.yaml
+++ b/releasenotes/notes/make_the_classpath_seperator_in_jmxfetch_adjust_to_the_os-b38560b076f55479.yaml
@@ -1,0 +1,27 @@
+---
+prelude: >
+    Linux uses a colon (:) and Windows a semicolon (;). os.pathsep knows this.
+features:
+  - |
+    jmxfetch now also supports Windows with custom_jar_pathss
+issues:
+  - |
+    No known issues.
+upgrade:
+  - |
+    No upgrade notes. Fully backwards compatible.
+deprecations:
+  - |
+    None.
+critical:
+  - |
+    n.a.
+security:
+  - |
+    n.a.
+fixes:
+  - |
+    When using the jmx agent on Windows in combination with a custom_jar_paths and or tools_jar_path the agent will fail because the classpath seperator is a colon. On Windows a path seperator has to be a semicolon. The python function os.pathsep return the correct seperator.
+other:
+  - |
+    n.a.


### PR DESCRIPTION
TL;DR Linux uses a colon (:) and Windows a semicolon (;). os.pathsep knows
this.

When using the jmx agent on Windows in combination with a custom_jar_paths and or tools_jar_path the agent will fail because the classpath seperator is a colon. On Windows a path seperator has to be a semicolon. The python function os.pathsep return the correct seperator.