### PR TITLE
[GCE] Fix metadata URL for tag collection

### DIFF
--- a/pkg/util/gce/gce_tags.go
+++ b/pkg/util/gce/gce_tags.go
@@ -17,7 +17,7 @@ import (
 func GetTags() ([]string, error) {
 	tags := []string{}
 
-	metadataResponse, err := getResponse(metadataURL + "/instance")
+	metadataResponse, err := getResponse(metadataURL + "/instance/?recursive=true")
 	if err != nil {
 		return tags, err
 	}

--- a/pkg/util/gce/gce_tags_test.go
+++ b/pkg/util/gce/gce_tags_test.go
@@ -25,6 +25,8 @@ func TestGetHostTags(t *testing.T) {
 		assert.Fail(t, fmt.Sprintf("Error getting test data: %v", err))
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.String(), "/instance/?recursive=true")
+		assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, string(content))
 		lastRequests = append(lastRequests, r)

--- a/releasenotes/notes/fix-gce-tags-collection-ccf88d34141ca47c.yaml
+++ b/releasenotes/notes/fix-gce-tags-collection-ccf88d34141ca47c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes collection of host tags from GCE metadata


### PR DESCRIPTION
### What does this PR do?

Fixes the URL (query string) used to fetch the GCE instance tags.

### Motivation

URL was incorrect, tags collection from agent 6 would fail.

### Additional Notes

I've confirmed the fixed URL is the correct one from a test GCE instance. Still need to run a patched agent there to confirm the tags are collected and sent properly with this fix.
