### PR TITLE
Add metric for logs agent status

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics/percentile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/logs"
 )
 
 // DefaultFlushInterval aggregator default flush interval
@@ -290,6 +291,18 @@ func (agg *BufferedAggregator) flushSeries() {
 	series = append(series, &metrics.Serie{
 		Name:           "datadog.agent.running",
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
+		Host:           agg.hostname,
+		MType:          metrics.APIGaugeType,
+		SourceTypeName: "System",
+	})
+
+	var logsIsRunning float64
+	if logs.IsRunning() {
+		logsIsRunning = 1
+	}
+	series = append(series, &metrics.Serie{
+		Name:           "datadog.logs.agent.running",
+		Points:         []metrics.Point{{Value: logsIsRunning, Ts: float64(start.Unix())}},
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -46,6 +46,7 @@ func Stop() {
 	if isRunning {
 		log.Info("Stopping logs-agent")
 		agent.Stop()
+		isRunning = false
 	}
 }
 
@@ -55,4 +56,9 @@ func GetStatus() status.Status {
 		return status.Status{IsRunning: false}
 	}
 	return status.Get()
+}
+
+// IsRunning returns the isRunning value for logs-agent
+func IsRunning() bool {
+	return isRunning
 }


### PR DESCRIPTION
### What does this PR do?
Add metric for logs agent status.

### Motivation
Because I need to configure a monitor that would be triggered when the logs agent stops reporting. Currently I do it with a custom check written in Python and I would prefer the agent to report it natively.