### PR TITLE
lowercase kube host tag keys too (followup on #1593)

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -23,6 +23,13 @@ func GetTags() ([]string, error) {
 		// Nothing to extract
 		return nil, nil
 	}
+
+	// viper lower-cases map keys from yaml, but not from envvars
+	for label, value := range labelsToTags {
+		delete(labelsToTags, label)
+		labelsToTags[strings.ToLower(label)] = value
+	}
+
 	nodeName, err := kubelet.HostnameProvider("")
 	if err != nil {
 		return nil, err
@@ -42,7 +49,6 @@ func extractTags(nodeLabels, labelsToTags map[string]string) []string {
 	var tags []string
 
 	for labelName, labelValue := range nodeLabels {
-		// viper lower-cases map keys, so we must lowercase before matching
 		if tagName, found := labelsToTags[strings.ToLower(labelName)]; found {
 			tags = append(tags, fmt.Sprintf("%s:%s", tagName, labelValue))
 		}

--- a/releasenotes/notes/fix-env-and-labels-as-tags-d7ee859e3a47d0f4.yaml
+++ b/releasenotes/notes/fix-env-and-labels-as-tags-d7ee859e3a47d0f4.yaml
@@ -1,4 +1,3 @@
 ---
 fixes:
-  - |
-    Lower case the label and env keys gotten from the inspect of the containers and pods in kubeutil and dockerutil.
+  - Fix case issues in tag extraction for docker/kubernetes container tags and kubernetes host tags


### PR DESCRIPTION
### What does this PR do?

Follow-up https://github.com/DataDog/datadog-agent/pull/1593 with another case where the bug happens: kubernetes host tags
