### PR TITLE
Fix a race condition in the kubernetes service tagging logic

### DIFF
--- a/pkg/util/kubernetes/apiserver/metadata.go
+++ b/pkg/util/kubernetes/apiserver/metadata.go
@@ -31,10 +31,9 @@ func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
 	}
 	// The list of metadata collected in the metaBundle is extensible and is handled here.
 	// If new cluster level tags need to be collected by the agent, only this needs to be modified.
-	serviceList, foundServices := metaBundle.PodNameToService[podName]
+	serviceList, foundServices := metaBundle.ServicesForPod(podName)
 	if !foundServices {
 		return nil, fmt.Errorf("no cached services list found for the pod %s on the node %s", podName, nodeName)
-
 	}
 	log.Debugf("CacheKey: %s, with %d services", cacheKey, len(serviceList))
 	for _, s := range serviceList {

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -60,3 +60,12 @@ func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.Pod
 	log.Tracef("The services matched %q", fmt.Sprintf("%s", metaBundle.PodNameToService))
 	return nil
 }
+
+// ServicesForPod returns the services mapped to a given pod.
+// If nothing is found, the boolean is false. This call is thread-safe.
+func (metaBundle *MetadataMapperBundle) ServicesForPod(podName string) ([]string, bool) {
+	metaBundle.m.RLock()
+	svc, found := metaBundle.PodNameToService[podName]
+	metaBundle.m.RUnlock()
+	return svc, found
+}

--- a/releasenotes/notes/metadatamapper-race-6f06357a81519855.yaml
+++ b/releasenotes/notes/metadatamapper-race-6f06357a81519855.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix a race condition in the kubernetes service tagging logic

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -20,12 +20,13 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/ericchiang/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
 const (
@@ -311,5 +312,7 @@ func (suite *testSuite) TestMetadataMapper() {
 	list := fullmapper["Nodes"]
 	assert.Contains(suite.T(), list, "ip-172-31-119-125")
 	fullMap := list.(map[string]*apiserver.MetadataMapperBundle)
-	assert.Contains(suite.T(), fullMap["ip-172-31-119-125"].PodNameToService["nginx"], "nginx-1")
+	services, found := fullMap["ip-172-31-119-125"].ServicesForPod("nginx")
+	assert.True(suite.T(), found)
+	assert.Contains(suite.T(), services, "nginx-1")
 }


### PR DESCRIPTION
### What does this PR do?

The kubernetes service mapping update runs in a separate goroutine, which leads to race conditions in the map update, if the tagger is currently accessing it.

This PR moves the map access behind a method call to wrap it in a `mutex.RLock`.

### Motivation

Fixes #1641