### PR TITLE
[k8s] reduce the rbac permissions on configmaps

### DIFF
--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -21,25 +21,23 @@ rules:
   resources:
   - configmaps
   resourceNames:
-  - datadogtoken
+  - datadogtoken             # Kubernetes event collection state
+  - datadog-leader-election  # Leader election token
   verbs:
   - get
   - update
-- apiGroups:
+- apiGroups:  # To create the leader election token
   - ""
   resources:
   - configmaps
   verbs:
-  - get
-  - update
   - create
 - nonResourceURLs:
   - "/version"
   - "/healthz"
   verbs:
   - get
-# Kubelet connectivity
-- apiGroups:
+- apiGroups:  # Kubelet connectivity
   - ""
   resources:
   - nodes/metrics


### PR DESCRIPTION
### What does this PR do?

Rework our configmap permissions closer to the ones [in the chart](https://github.com/kubernetes/charts/blob/master/stable/datadog/templates/clusterrole.yaml#L39-L53):

- Allow get & update on:
  - `datadogtoken` : Kubernetes event collection state
  - `datadog-leader-election` : Leader election token

- Allow create in order to create `datadog-leader-election`. It is not possible to restrict the create permissions by resourceNames, so we need cluster-wide creation privileges

### Motivation

- Consistency with chart
- Least privilege deployment: although configmap should not store secrets, we should not risk it

