### PR TITLE
manually pin gopsutil version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -554,7 +554,7 @@
     "net",
     "process"
   ]
-  revision = "fc04d2dd9a512906a2604242b35275179e250eda"
+  revision = "c95755e4bcd7a62bb8bd33f3a597a7c7f35e2cf3"
   version = "v2.18.04"
 
 [[projects]]
@@ -845,6 +845,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "87dbde113e3698dcb4123d383a1b58d457bd17ecd8762c271f09498f89a66f91"
+  inputs-digest = "c768e3f32aefa661ed7922fb185da197c0452fbee71c857942c40a7516217ddd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -201,12 +201,6 @@ def deps(ctx):
     ctx.run("go get -u github.com/gordonklaus/ineffassign")
     ctx.run("go get -u github.com/client9/misspell/cmd/misspell")
     ctx.run("dep ensure")
-    # prune packages from /vendor, remove this hack
-    # as soon as `dep prune` is merged within `dep ensure`,
-    # see https://github.com/golang/dep/issues/944
-    ctx.run("mv vendor/github.com/shirou/gopsutil/host/include .")
-    ctx.run("dep prune")
-    ctx.run("mv include vendor/github.com/shirou/gopsutil/host/")
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

Force update gopsutil in `Gopkg.lock`. Not sure why we ended up in this inconsistent state, maybe the tag was overridden.

### Motivation

Fix the bug described at https://github.com/DataDog/datadog-agent/pull/1652.
