### PR TITLE
[forwarder] Increase default recovery interval from 1 to 2

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
+// DefaultForwarderRecoveryInterval is the default recovery interval, also used if
+// the user-provided value is invalid.
+const DefaultForwarderRecoveryInterval = 2
+
 // Datadog is the global configuration object
 var Datadog = viper.New()
 
@@ -104,7 +108,7 @@ func init() {
 	Datadog.SetDefault("forwarder_backoff_factor", 2)
 	Datadog.SetDefault("forwarder_backoff_base", 2)
 	Datadog.SetDefault("forwarder_backoff_max", 64)
-	Datadog.SetDefault("forwarder_recovery_interval", 1)
+	Datadog.SetDefault("forwarder_recovery_interval", DefaultForwarderRecoveryInterval)
 	Datadog.SetDefault("forwarder_recovery_reset", false)
 
 	// Use to output logs in JSON format

--- a/pkg/forwarder/README.md
+++ b/pkg/forwarder/README.md
@@ -49,7 +49,6 @@ Default: `2`
 - `forwarder_backoff_max` - This is the maximum number of seconds to wait for
 a retry. Default: `64`
 - `forwarder_recovery_interval` - This controls how many retry interval ranges to
-step down for an endpoint upon success. Increasing this should only be considered
-when `forwarder_backoff_max` is particularly high. Default: `1`
+step down for an endpoint upon success. Default: `2`
 - `forwarder_recovery_reset` - Whether or not a successful request should completely
 clear an endpoint's error count. Default: `false`

--- a/pkg/forwarder/blocked_endpoints.go
+++ b/pkg/forwarder/blocked_endpoints.go
@@ -76,8 +76,8 @@ func newBlockedEndpoints() *blockedEndpoints {
 
 	recInterval := config.Datadog.GetInt("forwarder_recovery_interval")
 	if recInterval <= 0 {
-		log.Warnf("Configured forwarder_recovery_interval (%v) is not positive; 1 will be used", recInterval)
-		recInterval = 1
+		log.Warnf("Configured forwarder_recovery_interval (%v) is not positive; %v will be used", recInterval, config.DefaultForwarderRecoveryInterval)
+		recInterval = config.DefaultForwarderRecoveryInterval
 	}
 
 	recoveryReset := config.Datadog.GetBool("forwarder_recovery_reset")

--- a/pkg/forwarder/blocked_endpoints_test.go
+++ b/pkg/forwarder/blocked_endpoints_test.go
@@ -108,7 +108,7 @@ func TestRecoveryIntervalValid(t *testing.T) {
 	// Verify default
 	defaultValue := e.recoveryInterval
 	recoveryReset := config.Datadog.GetBool("forwarder_recovery_reset")
-	assert.Equal(t, 1, defaultValue)
+	assert.Equal(t, 2, defaultValue)
 	assert.Equal(t, false, recoveryReset)
 
 	// Reset original values when finished
@@ -116,9 +116,9 @@ func TestRecoveryIntervalValid(t *testing.T) {
 	defer config.Datadog.Set("forwarder_recovery_interval", defaultValue)
 
 	// Verify configuration updates global var
-	config.Datadog.Set("forwarder_recovery_interval", 2)
+	config.Datadog.Set("forwarder_recovery_interval", 1)
 	e = newBlockedEndpoints()
-	assert.Equal(t, 2, e.recoveryInterval)
+	assert.Equal(t, 1, e.recoveryInterval)
 
 	// Verify invalid values recover gracefully
 	config.Datadog.Set("forwarder_recovery_interval", 0)


### PR DESCRIPTION
### What does this PR do?

Increases default forwarder recovery interval from 1 to 2. Tweak to #1458.

### Motivation

Once an endpoint seems to start recovering, let's be a bit more aggressive in
the forwarder's recovery speed to avoid increasing the size of the retry queue
too much (and potentially hit the max retry queue
size when the endpoint is available again.

A value of 2 doesn't avoid that completely but at least mitigates a bit
the increase of the retry queue size, while probably being
"nice enough" for the backend.