### PR TITLE
Allow failover with http when tls communication is unauthorized

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -395,7 +395,10 @@ func (ku *KubeUtil) setupKubeletApiEndpoint() error {
 			log.Debugf("Kubelet endpoint is: %s", ku.kubeletApiEndpoint)
 			return nil
 		}
-		return fmt.Errorf("unexpected status code %d on endpoint %s%s", code, ku.kubeletApiEndpoint, kubeletPodPath)
+		if code != http.StatusUnauthorized {
+			return fmt.Errorf("unexpected status code %d on endpoint %s%s", code, ku.kubeletApiEndpoint, kubeletPodPath)
+		}
+		log.Info("The communication with the kubelet is unauthorized, trying to connect over HTTP")
 	}
 	log.Debugf("Cannot query %s%s: %s", ku.kubeletApiEndpoint, kubeletPodPath, httpsUrlErr)
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -398,7 +398,7 @@ func (ku *KubeUtil) setupKubeletApiEndpoint() error {
 		if code != http.StatusUnauthorized {
 			return fmt.Errorf("unexpected status code %d on endpoint %s%s", code, ku.kubeletApiEndpoint, kubeletPodPath)
 		}
-		log.Info("The communication with the kubelet is unauthorized, trying to connect over HTTP")
+		log.Warn("Failed to securely reach the kubelet over HTTPS. Trying a non secure connection over HTTP. We highly recommend configuring TLS to access the kubelet")
 	}
 	log.Debugf("Cannot query %s%s: %s", ku.kubeletApiEndpoint, kubeletPodPath, httpsUrlErr)
 

--- a/releasenotes/notes/kubelet-http-attempt-66433aa43e37e3f7.yaml
+++ b/releasenotes/notes/kubelet-http-attempt-66433aa43e37e3f7.yaml
@@ -1,0 +1,4 @@
+---
+issues:
+  - |
+    If the kubelet is not configured with TLS auth, the agent will fail to communicate with the API when it should still try HTTP.


### PR DESCRIPTION
### What does this PR do?

If the TLS communication fails, the agent should try over http before giving up.

### Motivation

Better support of kubernetes.

### Additional Notes

🍵 
