### PR TITLE
[docker] check nil pointers on docker client return values

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -356,9 +356,11 @@ func (s *DockerService) GetHosts() (map[string]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect container %s", string(s.ID)[:12])
 	}
-	for net, settings := range cInspect.NetworkSettings.Networks {
-		if len(settings.IPAddress) > 0 {
-			ips[net] = settings.IPAddress
+	if cInspect.NetworkSettings != nil {
+		for net, settings := range cInspect.NetworkSettings.Networks {
+			if len(settings.IPAddress) > 0 {
+				ips[net] = settings.IPAddress
+			}
 		}
 	}
 

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -16,13 +16,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
@@ -143,6 +143,9 @@ func (d *DockerUtil) CountVolumes() (int, int, error) {
 // Docker API. This requires the running user to be in the "docker" user group
 // or have access to /tmp/docker.sock.
 func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*Container, error) {
+	if cfg == nil {
+		return nil, errors.New("configuration is nil")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), d.queryTimeout)
 	defer cancel()
 	containers, err := d.cli.ContainerList(ctx, types.ContainerListOptions{All: cfg.IncludeExited})
@@ -155,15 +158,10 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*Container, e
 			// FIXME: We might need to invalidate this cache if a containers networks are changed live.
 			d.Lock()
 			if _, ok := d.networkMappings[c.ID]; !ok {
-				// FIXME: Use du.Inspect instead
-				i, err := d.cli.ContainerInspect(ctx, c.ID)
-				if err != nil && client.IsErrContainerNotFound(err) {
+				i, err := d.Inspect(c.ID, false)
+				if err != nil {
 					d.Unlock()
 					log.Debugf("Error inspecting container %s: %s", c.ID, err)
-					continue
-				}
-				if i.ContainerJSONBase == nil {
-					log.Debugf("Invalid inspect data for container %s", c.ID)
 					continue
 				}
 				d.networkMappings[c.ID] = findDockerNetworks(c.ID, i.State.Pid, c)

--- a/releasenotes/notes/docker-inspect-error-panic-8e9c3e5876599012.yaml
+++ b/releasenotes/notes/docker-inspect-error-panic-8e9c3e5876599012.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Better handling of docker return values to avoid errors


### PR DESCRIPTION
### What does this PR do?

Remove the naked inspect call in `DockerUtil.dockerContainers`, to use `DockerUtil.Inspect` that checks for a `nil` `ContainerJSONBase` embed before using it. See [the type definition](https://godoc.org/github.com/docker/engine-api/types#ContainerJSON).

I also tracked down a possible nil pointer dereference while accessing `NetworkSettings` without check it's not nil, fixing this one too.

### Motivation

Fixes #1681 
