### PR TITLE
Fix a possible panic when docker cannot inspect a container

### DIFF
--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -155,10 +155,15 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*Container, e
 			// FIXME: We might need to invalidate this cache if a containers networks are changed live.
 			d.Lock()
 			if _, ok := d.networkMappings[c.ID]; !ok {
+				// FIXME: Use du.Inspect instead
 				i, err := d.cli.ContainerInspect(ctx, c.ID)
 				if err != nil && client.IsErrContainerNotFound(err) {
 					d.Unlock()
 					log.Debugf("Error inspecting container %s: %s", c.ID, err)
+					continue
+				}
+				if i.ContainerJSONBase == nil {
+					log.Debugf("Invalid inspect data for container %s", c.ID)
 					continue
 				}
 				d.networkMappings[c.ID] = findDockerNetworks(c.ID, i.State.Pid, c)

--- a/releasenotes/notes/docker-inspect-panic-25cfa5b77a801715.yaml
+++ b/releasenotes/notes/docker-inspect-panic-25cfa5b77a801715.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix a possible panic when docker cannot inspect a container


### PR DESCRIPTION
### What does this PR do?

In some error cases, docker returns a `ContainerJSON` object with a nil [`ContainerJSONBase` embed](https://godoc.org/github.com/docker/engine-api/types#ContainerJSON). This leads to an panic. Both infra and process agents are impacted.

https://github.com/DataDog/datadog-agent/pull/1683 is a longer-term fix aimed at 6.3.0

### Motivation

Fixes #1681 