### PR TITLE
Add docker & swarm container metadata

### DIFF
--- a/pkg/metadata/host/container/loader.go
+++ b/pkg/metadata/host/container/loader.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package container
+
+import log "github.com/cihub/seelog"
+
+// Catalog holds available metadata providers
+type Catalog map[string]MetadataProvider
+
+// DefaultCatalog holds every compiled-in container metadata provider
+var DefaultCatalog = make(Catalog)
+
+// RegisterMetadataProvider a container metadata provider
+func RegisterMetadataProvider(name string, m MetadataProvider) {
+	if _, ok := DefaultCatalog[name]; ok {
+		log.Warnf("Container metadata provider %s already registered, overriding it", name)
+	}
+	DefaultCatalog[name] = m
+}
+
+// MetadataProvider should return a map of metadata
+type MetadataProvider func() map[string]string

--- a/pkg/metadata/host/container/loader.go
+++ b/pkg/metadata/host/container/loader.go
@@ -22,4 +22,4 @@ func RegisterMetadataProvider(name string, m MetadataProvider) {
 }
 
 // MetadataProvider should return a map of metadata
-type MetadataProvider func() map[string]string
+type MetadataProvider func() (map[string]string, error)

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -54,6 +55,7 @@ func GetPayload(hostname string) *Payload {
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
 		HostTags:      getHostTags(),
+		ContainerMeta: getContainerMeta(),
 	}
 
 	// Cache the metadata for use in other payloads
@@ -245,6 +247,18 @@ func getMeta() *Meta {
 	cache.Cache.Set(key, m, cache.NoExpiration)
 
 	return m
+}
+
+func getContainerMeta() map[string]string {
+	containerMeta := make(map[string]string)
+
+	for _, getMeta := range container.DefaultCatalog {
+		for k, v := range getMeta() {
+			containerMeta[k] = v
+		}
+	}
+
+	return containerMeta
 }
 
 func buildKey(key string) string {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -252,8 +252,13 @@ func getMeta() *Meta {
 func getContainerMeta() map[string]string {
 	containerMeta := make(map[string]string)
 
-	for _, getMeta := range container.DefaultCatalog {
-		for k, v := range getMeta() {
+	for provider, getMeta := range container.DefaultCatalog {
+		meta, err := getMeta()
+		if err != nil {
+			log.Debugf("Unable to get %s metadata: %s", provider, err)
+			continue
+		}
+		for k, v := range meta {
 			containerMeta[k] = v
 		}
 	}

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -35,9 +35,10 @@ type tags struct {
 
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
-	Os            string       `json:"os"`
-	PythonVersion string       `json:"python"`
-	SystemStats   *systemStats `json:"systemStats"`
-	Meta          *Meta        `json:"meta"`
-	HostTags      *tags        `json:"host-tags"`
+	Os            string            `json:"os"`
+	PythonVersion string            `json:"python"`
+	SystemStats   *systemStats      `json:"systemStats"`
+	Meta          *Meta             `json:"meta"`
+	HostTags      *tags             `json:"host-tags"`
+	ContainerMeta map[string]string `json:"container-meta,omitempty"`
 }

--- a/pkg/metadata/v5/v5_test.go
+++ b/pkg/metadata/v5/v5_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build cpython
+
 package v5
 
 import (

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -18,7 +18,6 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 
@@ -501,15 +500,4 @@ func (d *DockerUtil) AllContainerLabels() (map[string]map[string]string, error) 
 	}
 
 	return labelMap, nil
-}
-
-// GetSwarmState returns the swarm local node state
-func (d *DockerUtil) GetSwarmState() (swarm.LocalNodeState, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), d.queryTimeout)
-	defer cancel()
-	info, err := d.cli.Info(ctx)
-	if err != nil {
-		return "", fmt.Errorf("unable to get Docker info: %s", err)
-	}
-	return info.Swarm.LocalNodeState, nil
 }

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -18,6 +18,7 @@ import (
 
 	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 
@@ -500,4 +501,15 @@ func (d *DockerUtil) AllContainerLabels() (map[string]map[string]string, error) 
 	}
 
 	return labelMap, nil
+}
+
+// GetSwarmState returns the swarm local node state
+func (d *DockerUtil) GetSwarmState() (swarm.LocalNodeState, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), d.queryTimeout)
+	defer cancel()
+	info, err := d.cli.Info(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to get Docker info: %s", err)
+	}
+	return info.Swarm.LocalNodeState, nil
 }

--- a/pkg/util/docker/metadata.go
+++ b/pkg/util/docker/metadata.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"context"
+
+	log "github.com/cihub/seelog"
+	"github.com/docker/docker/api/types/swarm"
+
+	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
+)
+
+func init() {
+	container.RegisterMetadataProvider("docker", getMetadata)
+}
+
+func getMetadata() map[string]string {
+	metadata := make(map[string]string)
+	du, err := GetDockerUtil()
+	if err != nil {
+		log.Debugf("Unable to collect Docker host metadata: %s", err)
+		return metadata
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), du.queryTimeout)
+	defer cancel()
+	v, err := du.cli.ServerVersion(ctx)
+	if err == nil {
+		metadata["docker_version"] = v.Version
+	}
+
+	swarmState, err := du.GetSwarmState()
+	if err == nil {
+		metadata["docker_swarm"] = "inactive"
+		if swarmState == swarm.LocalNodeStateActive {
+			metadata["docker_swarm"] = "active"
+		}
+	}
+
+	return metadata
+}

--- a/pkg/util/docker/metadata.go
+++ b/pkg/util/docker/metadata.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/docker/docker/api/types/swarm"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
@@ -21,19 +20,18 @@ func init() {
 	container.RegisterMetadataProvider("docker", getMetadata)
 }
 
-func getMetadata() map[string]string {
+func getMetadata() (map[string]string, error) {
 	metadata := make(map[string]string)
 	du, err := GetDockerUtil()
 	if err != nil {
-		log.Debugf("Unable to collect Docker host metadata: %s", err)
-		return metadata
+		return metadata, err
 	}
 	// short timeout to minimize metadata collection time
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	i, err := du.cli.Info(ctx)
 	if err != nil {
-		return metadata
+		return metadata, err
 	}
 	metadata["docker_version"] = i.ServerVersion
 	metadata["docker_swarm"] = "inactive"
@@ -41,5 +39,5 @@ func getMetadata() map[string]string {
 		metadata["docker_swarm"] = "active"
 	}
 
-	return metadata
+	return metadata, nil
 }

--- a/releasenotes/notes/docker-container-meta-952cceca1aa20939.yaml
+++ b/releasenotes/notes/docker-container-meta-952cceca1aa20939.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add docker & swarm information to host metadata


### PR DESCRIPTION
### What does this PR do?

Add a new `container-meta` field in metadata payload

Add `docker_version` and `docker_swarm` to it as it was reported by agent 5

### Motivation

![screen shot 2018-05-09 at 18 31 43](https://user-images.githubusercontent.com/2368736/39827245-b0ac80b4-53b7-11e8-8a0c-8a6f90a6ae0a.png)

### Additional Notes

Other container metadata provider should follow
