### PR TITLE
[flare] use a credentials writer to write/clean flare files 

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -68,6 +68,12 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 
 	if local {
 		f := filepath.Join(tempDir, hostname, "local")
+
+		err := ensureParentDirsExist(f)
+		if err != nil {
+			return "", err
+		}
+
 		w, err := NewRedactingWriter(f, os.ModePerm, true)
 		if err != nil {
 			return "", err
@@ -155,6 +161,11 @@ func zipStatusFile(tempDir, hostname string) error {
 	}
 
 	f := filepath.Join(tempDir, hostname, "status.log")
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
 	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
@@ -203,6 +214,11 @@ func zipExpVar(tempDir, hostname string) error {
 		}
 
 		f := filepath.Join(tempDir, hostname, "expvar", key)
+		err = ensureParentDirsExist(f)
+		if err != nil {
+			return err
+		}
+
 		w, err := NewRedactingWriter(f, os.ModePerm, true)
 		if err != nil {
 			return err
@@ -225,6 +241,11 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths) error
 	}
 
 	f := filepath.Join(tempDir, hostname, "runtime_config_dump.yaml")
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
 	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
@@ -249,6 +270,11 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths) error
 		_, err := os.Stat(filePath)
 		if err == nil {
 			f = filepath.Join(tempDir, hostname, "etc", "datadog.yaml")
+			err := ensureParentDirsExist(f)
+			if err != nil {
+				return err
+			}
+
 			w, err := NewRedactingWriter(f, os.ModePerm, true)
 			if err != nil {
 				return err
@@ -273,6 +299,11 @@ func zipDiagnose(tempDir, hostname string) error {
 	writer.Flush()
 
 	f := filepath.Join(tempDir, hostname, "diagnose.log")
+	err := ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
 	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
@@ -291,6 +322,11 @@ func zipConfigCheck(tempDir, hostname string) error {
 	writer.Flush()
 
 	f := filepath.Join(tempDir, hostname, "config-check.log")
+	err := ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
 	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
@@ -312,6 +348,11 @@ func zipHealth(tempDir, hostname string) error {
 	}
 
 	f := filepath.Join(tempDir, hostname, "health.yaml")
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
 	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
@@ -340,6 +381,11 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths) 
 
 				baseName := strings.Replace(src, filePath, "", 1)
 				f := filepath.Join(tempDir, hostname, "etc", "confd", prefix, baseName)
+				err := ensureParentDirsExist(f)
+				if err != nil {
+					return err
+				}
+
 				w, err := NewRedactingWriter(f, os.ModePerm, true)
 				if err != nil {
 					return err

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -154,20 +154,9 @@ func zipStatusFile(tempDir, hostname string) error {
 		return err
 	}
 
-	// Clean it up
-	cleaned, err := credentialsCleanerBytes(s)
-	if err != nil {
-		return err
-	}
-
 	f := filepath.Join(tempDir, hostname, "status.log")
 
-	err = ensureParentDirsExist(f)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+	err = credentialsWriter(f, s, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -212,19 +201,9 @@ func zipExpVar(tempDir, hostname string) error {
 			return err
 		}
 
-		cleanedYAML, err := credentialsCleanerBytes(yamlValue)
-		if err != nil {
-			return err
-		}
-
 		f := filepath.Join(tempDir, hostname, "expvar", key)
 
-		err = ensureParentDirsExist(f)
-		if err != nil {
-			return err
-		}
-
-		err = ioutil.WriteFile(f, cleanedYAML, os.ModePerm)
+		err = credentialsWriter(f, yamlValue, os.ModePerm)
 		if err != nil {
 			return err
 		}
@@ -238,20 +217,10 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths) error
 	if err != nil {
 		return err
 	}
-	// zip up the actual config
-	cleaned, err := credentialsCleanerBytes(c)
-	if err != nil {
-		return err
-	}
 
 	f := filepath.Join(tempDir, hostname, "runtime_config_dump.yaml")
 
-	err = ensureParentDirsExist(f)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+	err = credentialsWriter(f, c, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -268,19 +237,9 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths) error
 		// Check if the file exists
 		_, err := os.Stat(filePath)
 		if err == nil {
-			cleaned, err = credentialsCleanerFile(filePath)
-			if err != nil {
-				return err
-			}
-
 			f = filepath.Join(tempDir, hostname, "etc", "datadog.yaml")
 
-			err = ensureParentDirsExist(f)
-			if err != nil {
-				return err
-			}
-
-			err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+			err = credentialsWriterFromFile(f, filePath, os.ModePerm)
 			if err != nil {
 				return err
 			}
@@ -321,17 +280,7 @@ func zipConfigCheck(tempDir, hostname string) error {
 
 	f := filepath.Join(tempDir, hostname, "config-check.log")
 
-	err := ensureParentDirsExist(f)
-	if err != nil {
-		return err
-	}
-
-	data, err := credentialsCleanerBytes(b.Bytes())
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(f, data, os.ModePerm)
+	err := credentialsWriter(f, b.Bytes(), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -379,20 +328,11 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths) 
 			}
 
 			if getFirstSuffix(f.Name()) == ".yaml" || filepath.Ext(f.Name()) == ".yaml" {
-				cleaned, err := credentialsCleanerFile(src)
-				if err != nil {
-					return err
-				}
 
 				baseName := strings.Replace(src, filePath, "", 1)
 				f := filepath.Join(tempDir, hostname, "etc", "confd", prefix, baseName)
 
-				err = ensureParentDirsExist(f)
-				if err != nil {
-					return err
-				}
-
-				err = ioutil.WriteFile(f, cleaned, os.ModePerm)
+				err = credentialsWriterFromFile(f, src, os.ModePerm)
 				if err != nil {
 					return err
 				}

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -10,7 +10,6 @@ package flare
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -45,7 +44,7 @@ func zipDockerSelfInspect(tempDir, hostname string) error {
 	}
 	defer w.Close()
 
-	w.RegisterReplacer(repl{
+	w.RegisterReplacer(replacer{
 		regex: regexp.MustCompile(`\"Image\": \"sha256:\w+"`),
 		replFunc: func(s []byte) []byte {
 			m := string(s[10 : len(s)-1])
@@ -54,6 +53,6 @@ func zipDockerSelfInspect(tempDir, hostname string) error {
 		},
 	})
 
-	_, err := w.Write(serialized)
+	_, err = w.Write(serialized)
 	return err
 }

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -38,30 +38,22 @@ func zipDockerSelfInspect(tempDir, hostname string) error {
 	json.Indent(&out, jsonStats, "", "\t")
 	serialized := out.Bytes()
 
-	// Clean it up
-	cleaned, err := credentialsCleanerBytes(serialized)
+	f := filepath.Join(tempDir, hostname, "docker_inspect.log")
+	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
 	}
+	defer w.Close()
 
-	imageSha := regexp.MustCompile(`\"Image\": \"sha256:\w+"`)
-	cleaned = imageSha.ReplaceAllFunc(cleaned, func(s []byte) []byte {
-		m := string(s[10 : len(s)-1])
-		shaResolvedInspect, _ := du.ResolveImageName(m)
-		return []byte(shaResolvedInspect)
+	w.RegisterReplacer(repl{
+		regex: regexp.MustCompile(`\"Image\": \"sha256:\w+"`),
+		replFunc: func(s []byte) []byte {
+			m := string(s[10 : len(s)-1])
+			shaResolvedInspect, _ := du.ResolveImageName(m)
+			return []byte(shaResolvedInspect)
+		},
 	})
 
-	f := filepath.Join(tempDir, hostname, "docker_inspect.log")
-
-	err = os.MkdirAll(filepath.Dir(f), os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
+	_, err := w.Write(serialized)
 	return err
 }

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -7,7 +7,6 @@ package flare
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,23 +58,13 @@ func zipEnvvars(tempDir, hostname string) error {
 		b.WriteString("\n")
 	}
 
-	// Clean it up
-	cleaned, err := credentialsCleanerBytes(b.Bytes())
-	if err != nil {
-		return err
-	}
-
 	f := filepath.Join(tempDir, hostname, "envvars.log")
-
-	err = os.MkdirAll(filepath.Dir(f), os.ModePerm)
+	w, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
 	}
+	defer w.Close()
 
-	err = ioutil.WriteFile(f, cleaned, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
+	_, err = w.Write(b.Bytes())
 	return err
 }

--- a/pkg/flare/strip.go
+++ b/pkg/flare/strip.go
@@ -10,11 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 	"regexp"
-
-	log "github.com/cihub/seelog"
 )
 
 type replacer struct {
@@ -59,45 +55,6 @@ func matchYAMLKeyPart(part string) *regexp.Regexp {
 
 func matchYAMLKey(key string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:).+`, key))
-}
-
-func credentialsWriter(filename string, data []byte, perm os.FileMode) error {
-
-	// Clean up creds
-	cleaned, err := credentialsCleanerBytes(data)
-	if err != nil {
-		return err
-	}
-
-	err = ensureParentDirsExist(filename)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(filename, cleaned, perm)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func credentialsWriterFromFile(filename string, filePath string, perm os.FileMode) error {
-	if _, err := os.Stat(filePath); err != nil {
-		if os.IsNotExist(err) {
-			log.Warnf("the specified path: %s does not exist", filePath)
-		}
-
-		return err
-	}
-
-	data, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-
-	return credentialsWriter(filename, data, perm)
-
 }
 
 func credentialsCleanerBytes(file []byte) ([]byte, error) {

--- a/pkg/flare/strip.go
+++ b/pkg/flare/strip.go
@@ -10,8 +10,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"regexp"
+
+	log "github.com/cihub/seelog"
 )
 
 type replacer struct {
@@ -58,13 +61,43 @@ func matchYAMLKey(key string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:).+`, key))
 }
 
-func credentialsCleanerFile(filePath string) ([]byte, error) {
-	file, err := os.Open(filePath)
-	defer file.Close()
+func credentialsWriter(filename string, data []byte, perm os.FileMode) error {
+
+	// Clean up creds
+	cleaned, err := credentialsCleanerBytes(data)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return credentialsCleaner(file)
+
+	err = ensureParentDirsExist(filename)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filename, cleaned, perm)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func credentialsWriterFromFile(filename string, filePath string, perm os.FileMode) error {
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			log.Warnf("the specified path: %s does not exist", filePath)
+		}
+
+		return err
+	}
+
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	return credentialsWriter(filename, data, perm)
+
 }
 
 func credentialsCleanerBytes(file []byte) ([]byte, error) {

--- a/pkg/flare/strip_test.go
+++ b/pkg/flare/strip_test.go
@@ -6,6 +6,7 @@
 package flare
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -228,7 +229,11 @@ log_level: info
 
 	wd, _ := os.Getwd()
 	filePath := filepath.Join(wd, "test", "datadog.yaml")
-	cleaned, err := credentialsCleanerFile(filePath)
+
+	data, err := ioutil.ReadFile(filePath)
+	assert.Nil(t, err)
+
+	cleaned, err := credentialsCleanerBytes(data)
 	assert.Nil(t, err)
 	cleanedString := string(cleaned)
 

--- a/pkg/flare/writer.go
+++ b/pkg/flare/writer.go
@@ -24,11 +24,6 @@ type RedactingWriter struct {
 
 //NewRedactingWriter instantiates a RedactingWriter to target with given permissions
 func NewRedactingWriter(t string, p os.FileMode, buffered bool) (*RedactingWriter, error) {
-	err := ensureParentDirsExist(t)
-	if err != nil {
-		return nil, err
-	}
-
 	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE, p)
 	if err != nil {
 		return nil, err
@@ -68,6 +63,8 @@ func (f *RedactingWriter) WriteFromFile(filePath string) (int, error) {
 		return 0, err
 	}
 
+	f.Truncate(0)
+	f.target.Seek(0, 0) // offset, whence: 0 relative to start of file
 	return f.Write(data)
 }
 
@@ -99,6 +96,11 @@ func (f *RedactingWriter) Write(p []byte) (int, error) {
 	}
 
 	return n, err
+}
+
+//Truncate truncates the file of the target file to the specified size
+func (f *RedactingWriter) Truncate(size int64) error {
+	return f.target.Truncate(size)
 }
 
 //Flush if this is a buffered writer, it flushes the buffer, otherwise NOP

--- a/pkg/flare/writer.go
+++ b/pkg/flare/writer.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package flare
+
+import (
+	"bufio"
+	"errors"
+	"io/ioutil"
+	"os"
+
+	log "github.com/cihub/seelog"
+)
+
+//RedactingWriter is a writer that will redact content before writing to target
+type RedactingWriter struct {
+	target    *os.File
+	targetBuf *bufio.Writer
+	perm      os.FileMode
+	r         []replacer
+}
+
+//NewRedactingWriter instantiates a RedactingWriter to target with given permissions
+func NewRedactingWriter(t string, p os.FileMode, buffered bool) (*RedactingWriter, error) {
+	err := ensureParentDirsExist(t)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Create(t)
+	if err != nil {
+		return nil, err
+	}
+
+	var b *bufio.Writer
+	if buffered {
+		b = bufio.NewWriter(f)
+	}
+
+	return &RedactingWriter{
+		target:    f,
+		targetBuf: b,
+		perm:      p,
+		r:         []replacer{},
+	}, nil
+}
+
+//RegisterReplacer register additional replacers to run on stream
+func (f *RedactingWriter) RegisterReplacer(r replacer) {
+	f.r = append(f.r, r)
+}
+
+//WriteFromFile will read contents from file and write them redacted to target
+func (f *RedactingWriter) WriteFromFile(filePath string) (int, error) {
+
+	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			log.Warnf("the specified path: %s does not exist", filePath)
+		}
+
+		return 0, err
+	}
+
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return 0, err
+	}
+
+	return f.Write(data)
+}
+
+//Write writes the redacted byte stream, applying all replacers and credential
+//cleanup to target
+func (f *RedactingWriter) Write(p []byte) (int, error) {
+	fReady, buffered := (f.target != nil), (f.targetBuf != nil)
+
+	if !fReady && !buffered {
+		return 0, errors.New("No viable target defined")
+	}
+
+	cleaned, err := credentialsCleanerBytes(p)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, r := range f.r {
+		if r.regex != nil && r.replFunc != nil {
+			cleaned = r.regex.ReplaceAllFunc(cleaned, r.replFunc)
+		}
+	}
+
+	var n int
+	if buffered {
+		n, err = f.targetBuf.Write(cleaned)
+	} else {
+		n, err = f.target.Write(cleaned)
+	}
+
+	return n, err
+}
+
+//Flush if this is a buffered writer, it flushes the buffer, otherwise NOP
+func (f *RedactingWriter) Flush() error {
+
+	if f.targetBuf == nil {
+		return nil
+	}
+
+	return f.targetBuf.Flush()
+}
+
+//Close closes the underlying file, if buffered previously flushes the contents
+func (f *RedactingWriter) Close() error {
+	var err error
+
+	if f.targetBuf != nil {
+		err = f.targetBuf.Flush()
+		if err != nil {
+			return err
+		}
+	}
+
+	if f.target != nil {
+		err = f.target.Close()
+	}
+
+	return err
+}

--- a/pkg/flare/writer.go
+++ b/pkg/flare/writer.go
@@ -29,7 +29,7 @@ func NewRedactingWriter(t string, p os.FileMode, buffered bool) (*RedactingWrite
 		return nil, err
 	}
 
-	f, err := os.Create(t)
+	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE, p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/flare/writer_test.go
+++ b/pkg/flare/writer_test.go
@@ -8,37 +8,96 @@ package flare
 import (
 	"bufio"
 	"bytes"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRedactingWriter(t *testing.T) {
-	input := `dd_url: https://app.datadoghq.com
+const (
+	input = `dd_url: https://app.datadoghq.com
 api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-proxy: http://user:password@host:port
+proxy: http://user:password@host:1234
 password: foo
 auth_token: bar
 # comment to strip
 log_level: info`
+)
+
+func TestRedactingWriter(t *testing.T) {
 	redacted := `dd_url: https://app.datadoghq.com
 api_key: ***************************aaaaa
-proxy: http://user:********@host:port
+proxy: http://user:********@host:1234
 password: ********
 auth_token: ********
 log_level: info
 `
 
 	buf := bytes.NewBuffer([]byte{})
-	r := RedactingWriter{
+	w := RedactingWriter{
 		targetBuf: bufio.NewWriter(buf),
 	}
 
-	n, err := r.Write([]byte(input))
+	n, err := w.Write([]byte(input))
 	assert.Nil(t, err)
-	err = r.Flush()
+	err = w.Flush()
 	assert.Nil(t, err)
-	assert.Equal(t, n, len(redacted))
-	assert.Equal(t, buf.String(), redacted)
+	assert.Equal(t, len(redacted), n)
+	assert.Equal(t, redacted, buf.String())
 
+}
+
+func TestRedactingWriterReplacers(t *testing.T) {
+	redacted := `dd_url: https://app.datadoghq.com
+api_key: ***************************aaaaa
+proxy: http://USERISREDACTEDTOO:********@foo:bar
+password: ********
+auth_token: ********
+log_level: info
+`
+
+	buf := bytes.NewBuffer([]byte{})
+	w := RedactingWriter{
+		targetBuf: bufio.NewWriter(buf),
+	}
+
+	w.RegisterReplacer(replacer{
+		regex: regexp.MustCompile(`user`),
+		replFunc: func(s []byte) []byte {
+			return []byte("USERISREDACTEDTOO")
+		},
+	})
+	w.RegisterReplacer(replacer{
+		regex: regexp.MustCompile(`@.*\:[0-9]+`),
+		replFunc: func(s []byte) []byte {
+			return []byte("@foo:bar")
+		},
+	})
+
+	n, err := w.Write([]byte(input))
+	assert.Nil(t, err)
+	err = w.Flush()
+	assert.Nil(t, err)
+	assert.Equal(t, len(redacted), n)
+	assert.Equal(t, redacted, buf.String())
+
+}
+func TestRedactingNothing(t *testing.T) {
+	src := `dd_url: https://app.datadoghq.com
+log_level: info`
+	dst := `dd_url: https://app.datadoghq.com
+log_level: info
+`
+
+	buf := bytes.NewBuffer([]byte{})
+	w := RedactingWriter{
+		targetBuf: bufio.NewWriter(buf),
+	}
+
+	n, err := w.Write([]byte(src))
+	assert.Nil(t, err)
+	err = w.Flush()
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(dst))
+	assert.Equal(t, dst, buf.String())
 }

--- a/pkg/flare/writer_test.go
+++ b/pkg/flare/writer_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package flare
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactingWriter(t *testing.T) {
+	input := `dd_url: https://app.datadoghq.com
+api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+proxy: http://user:password@host:port
+password: foo
+auth_token: bar
+# comment to strip
+log_level: info`
+	redacted := `dd_url: https://app.datadoghq.com
+api_key: ***************************aaaaa
+proxy: http://user:********@host:port
+password: ********
+auth_token: ********
+log_level: info
+`
+
+	buf := bytes.NewBuffer([]byte{})
+	r := RedactingWriter{
+		targetBuf: bufio.NewWriter(buf),
+	}
+
+	n, err := r.Write([]byte(input))
+	assert.Nil(t, err)
+	err = r.Flush()
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(redacted))
+	assert.Equal(t, buf.String(), redacted)
+
+}

--- a/releasenotes/notes/flare_scrubbin_writer-37fb2f355f80eb76.yaml
+++ b/releasenotes/notes/flare_scrubbin_writer-37fb2f355f80eb76.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Introduces a new redacting writer that will make sure anything written into
+    the flare is scrubbed from credentials and sensitive information.


### PR DESCRIPTION
### What does this PR do?

This PR provides a `RedactingWriter` that will clean/redact contents written with it scrubbing/replacing the output. It implements io.Writer(), and allows for buffered/unbuffered writing.

### Motivation

Provide a clean interface to write potentially sensitive content without having to explicitly be concerned with making the scrubbing/redacting calls, essentially reducing the likelihood of oversight.