### PR TITLE
[reno] Configure regexes to match our release and pre-release tags

### DIFF
--- a/reno.yaml
+++ b/reno.yaml
@@ -1,0 +1,3 @@
+---
+release_tag_re: '^([\d.-]|rc)+$'
+pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'


### PR DESCRIPTION
### What does this PR do?

Configure reno's regexes to match our release and pre-release tags.

### Motivation

Currently, reno doesn't properly understand which tags are release tags
and which are pre-release tags because its default regexes don't match
our tagging conventions. This makes release notes hard to generate
properly for a release when RC tags are present.

This adds a configuration file to reno with regexes that match our
tagging convention.

### Additional Notes

Followed reno's docs here: https://docs.openstack.org/reno/latest/user/usage.html#configuring-reno and double-checked the new regexes work fine on our repo.
