### PR TITLE
Get logs from all containers

### DIFF
--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -103,11 +103,11 @@ func (s *Scanner) run() {
 // tail, as well as stopped containers or containers that
 // restarted
 func (s *Scanner) scan(tailFromBeginning bool) {
-	runningContainers := s.listContainers()
+	allContainers := s.listContainers()
 	containersToMonitor := make(map[string]bool)
 
 	// monitor new containers, and restart tailers if needed
-	for _, container := range runningContainers {
+	for _, container := range allContainers {
 		source := NewContainer(container).findSource(s.sources)
 		if source == nil {
 			continue
@@ -187,7 +187,7 @@ func (s *Scanner) dismissTailer(tailer *DockerTailer) {
 }
 
 func (s *Scanner) listContainers() []types.Container {
-	containers, err := s.cli.ContainerList(context.Background(), types.ContainerListOptions{})
+	containers, err := s.cli.ContainerList(context.Background(), types.ContainerListOptions{All: true})
 	if err != nil {
 		log.Error("Can't tail containers, ", err)
 		log.Error("Is datadog-agent part of docker user group?")


### PR DESCRIPTION
Get logs from all containers, not just running ones so that the logs
form short-lived containers are also collected

### What does this PR do?

Changes the behavior of the Docker log scanner so that it retrieves logs from all containers, not just running ones

### Motivation

Sometimes, we are not seeing logs from short-lived containers being ingested, which makes it difficult to debug situations such as when services are flapping or when migrations fail. I believe this is because the agent polls for running containers to get logs from every 10 seconds, so if a container starts and exits between this time, the logs will not be collected.

### Additional Notes

I'm still trying to get tests running locally (I'm new to Go), so this PR is probably not complete, but I just want to see if I'm on the right track, or if someone from DataDog is willing to take this PR on. Thanks!
