### PR TITLE
document the device_blacklist_re option in the io corecheck

### DIFF
--- a/cmd/agent/dist/conf.d/io.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/io.d/conf.yaml.default
@@ -1,2 +1,10 @@
+init_config:
+  # By default, stats for all block devices (listed in /proc/diskstats on Linux)
+  # will be collected. You might want to ignore sub-devices and transient devices
+  # for more accurate accounting, by providing a regex pattern acting as a blacklist.
+  #
+  # This example regexp excludes LVM logical volumes:
+  # device_blacklist_re: "^dm-[0-9]+"
+
 instances:
 - {}


### PR DESCRIPTION
### What does this PR do?

Document the `device_blacklist_re` option in the io check, and provide an example blacklisting LVM logical volumes.

### Motivation

Docker's [devicemapper storage backend](https://docs.docker.com/storage/storagedriver/device-mapper-driver/) can create a significant churn of LVM logical volumes, creating false-positive spikes on `system.io.util`. Monitoring the underlying block device instead brings a saner view of the actual IO load.

### Additional Notes

Anything else we should know when reviewing?
