### PR TITLE
removing bad / in value

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -216,7 +216,7 @@ api_key:
 
 #   - name: consul
 #     polling: true
-#     template_dir: /datadog/check_configs
+#     template_dir: datadog/check_configs
 #     template_url: http://127.0.0.1
 #     ca_file:
 #     ca_path:


### PR DESCRIPTION
### What does this PR do?

Fixing displayed placeholder value for consul

### Motivation

There is a / in the sample config that causes issues with the Consul integration.

Doc PR : https://github.com/DataDog/documentation/pull/2487