### PR TITLE
Fix gce_tags_test.go to incorporate host tags from instance metadata attributes

### DIFF
--- a/pkg/util/gce/gce_tags_test.go
+++ b/pkg/util/gce/gce_tags_test.go
@@ -40,7 +40,7 @@ func TestGetHostTags(t *testing.T) {
 	}
 
 	assert.Len(t, tags, 7)
-	expectedTags := []string{"tag", "zone:us-east1-b", "instance-type:n1-standard-1", "internal-hostname:dd-test.c.datadog-dd-test.internal", "instance-id:1111111111111111111", "project:111111111111", "numeric_project_id:111111111111"}
+	expectedTags := []string{"tag", "zone:us-east1-b", "instance-type:n1-standard-1", "internal-hostname:dd-test.c.datadog-dd-test.internal", "instance-id:1111111111111111111", "project:111111111111", "numeric_project_id:111111111111", "cluster-name": "test-cluster", "cluster-location": "us-east1-d"}
 	for i, actual := range tags {
 		expected := expectedTags[i]
 		assert.Equal(t, expected, actual)

--- a/pkg/util/gce/test/gce_metadata.json
+++ b/pkg/util/gce/test/gce_metadata.json
@@ -1,5 +1,8 @@
 {
-  "attributes": {},
+  "attributes": {
+    "cluster-name":"test-cluster",
+    "cluster-location":"us-east1-d"
+  },
   "cpuPlatform": "Intel Haswell",
   "description": "",
   "disks": [{


### PR DESCRIPTION
### What does this PR do?

This is quite important for google compute instances that run a Kubernetes cluster.
They are missing the `cluster-name` tag since Agent version 6. And it
is no longer automatically being fetched.

This test should showcase the problem.

A brief description of the change being made with this pull request.

### Motivation

I want someone to re-implement some vital Agent version 5 behaviour, to incorporate `cluster-name` into the host tags on Google Compute Engine nodes, if present in metadata.

### Additional Notes

I have conversed long with customer support, who suggested it might be a problem with now whitelisted Kubernetes or Docker labels/annotations.

This is not the case, as this is a host tag provided by the GCE integration. This is a regression compared to Agent version 5.

All GCE nodes running a Kubernetes cluster exhibit this instance metadata attribute.

