### PR TITLE
Support setting a proxy with environment variables

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -27,6 +27,19 @@ The agent is highly customizable, here are the most used environment variables:
 - `DD_TAGS`: host tags, separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`
 - `DD_CHECK_RUNNERS`: the agent runs all checks in sequence by default (default value = `1` runner). If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel
 
+#### Proxies
+
+The agent proxy settings can be overridden with the standard `*_PROXY`
+environment variables:
+
+- `HTTP_PROXY`: an http URL to use as a proxy for `http` requests.
+- `HTTPS_PROXY`: an http URL to use as a proxy for `https` requests.
+- `NO_PROXY`: a comma-separated list of URLs for which no proxy should be used.
+
+Notice: these variables don't use the `DD_` prefix.
+
+For more information: https://docs.datadoghq.com/agent/proxy/#agent-v6
+
 #### Optional collection agents
 
 These features are disabled by default for security or performance reasons, you need to explicitly enable them:
@@ -92,7 +105,7 @@ Please refer to the dedicated section about the [Kubernetes integration](#kubern
 - `DD_JMX_CUSTOM_JARS`: space-separated list of custom jars to load in jmxfetch (only for the `-jmx` variants)
 - `DD_ENABLE_GOHAI`: enable or disable the system information collector [gohai](https://github.com/DataDog/gohai) (enabled by default if not set)
 
-Some options are not yet available as environment variable bindings (including proxy settings). To customize these, the agent supports mounting a custom `/etc/datadog-agent/datadog.yaml` configuration file (based on the [docker](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/datadog-docker.yaml) or [kubernetes](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/datadog-kubernetes.yaml) base configurations) for these options, and using environment variables for the rest.
+Some options are not yet available as environment variable bindings. To customize these, the agent supports mounting a custom `/etc/datadog-agent/datadog.yaml` configuration file (based on the [docker](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/datadog-docker.yaml) or [kubernetes](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/datadog-kubernetes.yaml) base configurations) for these options, and using environment variables for the rest.
 
 ### Optional volumes
 

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -111,7 +111,7 @@ func CheckAndUpgradeConfig() error {
 		return nil
 	}
 	config.Datadog.AddConfigPath(DefaultConfPath)
-	err := config.Datadog.ReadInConfig()
+	err := config.Load()
 	if err == nil {
 		// was able to read config, check for api key
 		if config.Datadog.GetString("api_key") != "" {

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -27,7 +27,7 @@ func SetupConfig(confFilePath string) error {
 	config.Datadog.AddConfigPath(DefaultConfPath)
 
 	// load the configuration
-	err := config.Datadog.ReadInConfig()
+	err := config.Load()
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -51,7 +51,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 
 	// setup the configuration system
 	config.Datadog.AddConfigPath(newConfigDir)
-	err = config.Datadog.ReadInConfig()
+	err = config.Load()
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -76,7 +76,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if len(confPath) != 0 {
 		// we'll search for a config file named `datadog-cluster.yaml`
 		config.Datadog.AddConfigPath(confPath)
-		confErr := config.Datadog.ReadInConfig()
+		confErr := config.Load()
 		if confErr != nil {
 			log.Error(confErr)
 		} else {

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -42,7 +42,7 @@ var flareCmd = &cobra.Command{
 		if len(confPath) != 0 {
 			// we'll search for a config file named `datadog-cluster.yaml`
 			config.Datadog.AddConfigPath(confPath)
-			confErr := config.Datadog.ReadInConfig()
+			confErr := config.Load()
 			if confErr != nil {
 				log.Error(confErr)
 			} else {

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -36,7 +36,7 @@ as well as which services are serving the pods. Or the deployment name for the p
 		if len(confPath) != 0 {
 			// we'll search for a config file named `datadog-cluster.yaml`
 			config.Datadog.AddConfigPath(confPath)
-			confErr := config.Datadog.ReadInConfig()
+			confErr := config.Load()
 			if confErr != nil {
 				log.Error(confErr)
 			} else {

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -42,7 +42,7 @@ var statusCmd = &cobra.Command{
 		if len(confPath) != 0 {
 			// we'll search for a config file named `datadog-cluster.yaml`
 			config.Datadog.AddConfigPath(confPath)
-			confErr := config.Datadog.ReadInConfig()
+			confErr := config.Load()
 			if confErr != nil {
 				log.Error(confErr)
 			} else {

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -87,7 +87,7 @@ func start(cmd *cobra.Command, args []string) error {
 		// we'll search for a config file named `dogstastd.yaml`
 		config.Datadog.SetConfigName("dogstatsd")
 		config.Datadog.AddConfigPath(confPath)
-		confErr := config.Datadog.ReadInConfig()
+		confErr := config.Load()
 		if confErr != nil {
 			log.Error(confErr)
 		} else {

--- a/cmd/py-launcher/py-launcher.go
+++ b/cmd/py-launcher/py-launcher.go
@@ -36,7 +36,7 @@ func main() {
 
 	if *conf != "" {
 		config.Datadog.SetConfigFile(*conf)
-		confErr := config.Datadog.ReadInConfig()
+		confErr := config.Load()
 		if confErr != nil {
 			fmt.Printf("unable to parse Datadog config file, running with env variables: %s", confErr)
 		}

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -90,6 +90,30 @@ When running the agent in a container, it is also possible to set some of the co
 
 To not miss some specific configuration details, if you are currently using environment variables to setup your agent's v5 configuration, [consult the new list of environment variables for Agent v6](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent#environment-variables).
 
+#### Proxies
+
+The agent proxy settings can be overridden with the standard `*_PROXY`
+environment variables:
+
+- `HTTP_PROXY`: an http URL to use as a proxy for `http` requests.
+- `HTTPS_PROXY`: an http URL to use as a proxy for `https` requests.
+- `NO_PROXY`: a comma-separated list of URLs for which no proxy should be used.
+
+Notice: these variables don't use the `DD_` prefix.
+
+**The behaviour of the Agent 6 is different from Agent 5**:
+
+The Agent 6 will first use the environment variables and the configuration file
+(as for every other setting available through environment variables). This is
+the opposite of Agent 5, which would always use the proxy from the configuration
+file if set.
+
+For proxies, the Agent 6 will override the values from the configuration file
+with the ones in the environment. This means that if both a `HTTP` and `HTTPS`
+proxy are set in the configuration file but only the `HTTPS_PROXY` is set in
+the environment, the agent will use the `HTTPS` value from the environment and
+the `HTTP` value from the configuration file.
+
 ## GUI
 
 Agent 6 deprecated Agent5's Windows Agent Manager GUI, replacing it with a browser-based, cross-platform one. See the [specific docs](gui.md) for more details.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -8,9 +8,11 @@ dd_url: https://app.datadoghq.com
 api_key:
 
 # If you need a proxy to connect to the Internet, provide it here (default:
-# disabled). You can use the 'no_proxy' list to specify hosts that should bypass the
-# proxy. These settings might impact your checks requests, please refer to the
-# specific check documentation for more details.
+# disabled). You can use the 'no_proxy' list to specify hosts that should
+# bypass the proxy. These settings might impact your checks requests, please
+# refer to the specific check documentation for more details. Environment
+# variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (coma-separated string) will
+# override the values set here. See https://docs.datadoghq.com/agent/proxy/.
 #
 # proxy:
 #   http: http(s)://user:password@proxy_for_http:port

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -165,3 +165,95 @@ func TestEnvNestedConfig(t *testing.T) {
 	assert.Equal(t, "baz", Datadog.GetString("foo.bar.nested"))
 	os.Unsetenv("DD_FOO_BAR_NESTED")
 }
+
+func TestLoadProxyFromEnvNoValue(t *testing.T) {
+	// circleCI set some proxy setting
+	ciValue := os.Getenv("NO_PROXY")
+	os.Unsetenv("NO_PROXY")
+	defer os.Setenv("NO_PROXY", ciValue)
+
+	loadProxyFromEnv()
+	assert.Nil(t, Datadog.Get("proxy"))
+
+	proxies, err := GetProxies()
+	require.Nil(t, err)
+	require.Nil(t, proxies)
+}
+
+func TestLoadProxyConfOnly(t *testing.T) {
+	// check value loaded before aren't overwrite when no env variables are set
+	p := &Proxy{HTTP: "test", HTTPS: "test2", NoProxy: []string{"a", "b", "c"}}
+	Datadog.Set("proxy", p)
+	defer Datadog.Set("proxy", nil)
+
+	// circleCI set some proxy setting
+	ciValue := os.Getenv("NO_PROXY")
+	os.Unsetenv("NO_PROXY")
+	defer os.Setenv("NO_PROXY", ciValue)
+
+	loadProxyFromEnv()
+	proxies, err := GetProxies()
+	require.Nil(t, err)
+	assert.Equal(t, p, proxies)
+}
+
+func TestLoadProxyEnvOnly(t *testing.T) {
+	// uppercase
+	os.Setenv("HTTP_PROXY", "http_url")
+	os.Setenv("HTTPS_PROXY", "https_url")
+	os.Setenv("NO_PROXY", "a,b,c")
+
+	loadProxyFromEnv()
+
+	proxies, err := GetProxies()
+	require.Nil(t, err)
+	assert.Equal(t,
+		&Proxy{
+			HTTP:    "http_url",
+			HTTPS:   "https_url",
+			NoProxy: []string{"a", "b", "c"}},
+		proxies)
+
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("HTTP_PROXY")
+	Datadog.Set("proxy", nil)
+
+	// lowercase
+	os.Setenv("http_proxy", "http_url2")
+	os.Setenv("https_proxy", "https_url2")
+	os.Setenv("no_proxy", "1,2,3")
+
+	loadProxyFromEnv()
+	proxies, err = GetProxies()
+	require.Nil(t, err)
+	assert.Equal(t,
+		&Proxy{
+			HTTP:    "http_url2",
+			HTTPS:   "https_url2",
+			NoProxy: []string{"1", "2", "3"}},
+		proxies)
+
+	os.Unsetenv("no_proxy")
+	os.Unsetenv("https_proxy")
+	os.Unsetenv("http_proxy")
+	Datadog.Set("proxy", nil)
+}
+
+func TestLoadProxyEnvAndConf(t *testing.T) {
+	os.Setenv("HTTP", "http_env")
+	Datadog.Set("proxy.no_proxy", []string{"d", "e", "f"})
+	Datadog.Set("proxy.http", "http_conf")
+	defer os.Unsetenv("HTTP")
+	defer Datadog.Set("proxy", nil)
+
+	loadProxyFromEnv()
+	proxies, err := GetProxies()
+	require.Nil(t, err)
+	assert.Equal(t,
+		&Proxy{
+			HTTP:    "http_conf",
+			HTTPS:   "",
+			NoProxy: []string{"d", "e", "f"}},
+		proxies)
+}

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -202,19 +202,11 @@ func CreateHTTPTransport() *http.Transport {
 		TLSClientConfig: tlsConfig,
 	}
 
-	if proxies := config.Datadog.Get("proxy"); proxies != nil {
-		proxies := &config.Proxy{}
-		if err := config.Datadog.UnmarshalKey("proxy", proxies); err != nil {
-			log.Errorf("Could not load the proxy configuration: %s", err)
-		} else {
-			transport.Proxy = GetProxyTransportFunc(proxies)
-		}
+	proxies, err := config.GetProxies()
+	if err != nil {
+		log.Errorf("%s", err)
+	} else if proxies != nil {
+		transport.Proxy = GetProxyTransportFunc(proxies)
 	}
-
-	if os.Getenv("http_proxy") != "" || os.Getenv("https_proxy") != "" ||
-		os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "" {
-		log.Warn("Env variables 'http_proxy' and 'https_proxy' are not enforced by the agent, please use the configuration file.")
-	}
-
 	return transport
 }

--- a/releasenotes/notes/handle-env-proxy-4de0aa39ef379f1d.yaml
+++ b/releasenotes/notes/handle-env-proxy-4de0aa39ef379f1d.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    The agent now supports the environment variables "HTTP_PROXY", "HTTPS_PROXY" and
+    "NO_PROXY". If set these variables will override the setting in
+    datadog.yaml.
+features:
+  - |
+    The agent now supports setting/overriding proxy URLs through environment
+    variables (HTTP_PROXY, HTTPS_PROXY and NO_PROXY).


### PR DESCRIPTION
### What does this PR do?

The agent now supports setting/overwriting proxy configuration through
the environment. HTTP_PROXY, HTTPS_PROXY and NO_PROXY (both upper and
lower case) will have precedence over the configuration file values.