### PR TITLE
Docker soft memory limit metric

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -202,6 +202,10 @@ func (d *DockerCheck) Run() error {
 			}
 		}
 
+		if c.SoftMemLimit > 0 && c.SoftMemLimit < uint64(math.Pow(2, 60)) {
+			sender.Gauge("docker.mem.soft_limit", float64(c.SoftMemLimit), "", tags)
+		}
+
 		sender.Rate("docker.io.read_bytes", float64(c.IO.ReadBytes), "", tags)
 		sender.Rate("docker.io.write_bytes", float64(c.IO.WriteBytes), "", tags)
 

--- a/pkg/util/docker/container.go
+++ b/pkg/util/docker/container.go
@@ -31,6 +31,7 @@ type Container struct {
 	Excluded bool
 
 	CPULimit       float64
+	SoftMemLimit   uint64
 	MemLimit       uint64
 	CPUNrThrottled uint64
 	CPU            *CgroupTimesStat

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -256,7 +256,11 @@ func (d *DockerUtil) Containers(cfg *ContainerListConfig) ([]*Container, error) 
 			}
 			container.MemLimit, err = cgroup.MemLimit()
 			if err != nil {
-				log.Debugf("Cgroup cpu limit: %s", err)
+				log.Debugf("Cgroup mem limit: %s", err)
+			}
+			container.SoftMemLimit, err = cgroup.SoftMemLimit()
+			if err != nil {
+				log.Debugf("Cgroup soft mem limit: %s", err)
 			}
 		}
 		cache.Cache.Set(cacheKey, containers, d.cfg.CacheDuration)

--- a/releasenotes/notes/Docker-soft-memory-limit-metric-750882a933547b6a.yaml
+++ b/releasenotes/notes/Docker-soft-memory-limit-metric-750882a933547b6a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add docker memory soft limit metric.

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -34,6 +34,7 @@ func TestContainerMetricsTagging(t *testing.T) {
 			"docker.mem.rss",
 			"docker.mem.in_use",
 			"docker.mem.limit",
+			"docker.mem.soft_limit",
 			"docker.container.size_rw",
 			"docker.container.size_rootfs",
 		},

--- a/test/integration/corechecks/docker/testdata/basemetrics.compose
+++ b/test/integration/corechecks/docker/testdata/basemetrics.compose
@@ -11,3 +11,4 @@ services:
         LOW_CARD_ENV: "redislowenv"
         HIGH_CARD_ENV: "redishighenv"
     mem_limit: 32000000
+    mem_reservation: 31000000


### PR DESCRIPTION
### What does this PR do?

It brings back https://github.com/DataDog/integrations-core/pull/760
 
### Motivation

Currently, DD supports only hard memory limit metric. I would to know when containers are going above soft limit (wrong limit value, unexpected activity) and incorporate this data into my dashboards / alarms and correlate this with other events.

What is memory reservation:
```
Memory reservation is a kind of memory soft limit that allows for greater sharing of memory. ?
Under normal circumstances, containers can use as much of the memory as needed and are > constrained ?only by the hard limits set with the -m/--memory option. When memory reservation is > set, Docker ?
detects memory contention or low memory and forces containers to restrict their consumption to > a reservation limit.
```
See https://docs.docker.com/engine/reference/run/#specify-custom-cgroups

### Additional Notes

None