### PR TITLE
[metadata] Fix collection of host tags from GCP project & attributes

### DIFF
--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -20,12 +20,20 @@ var (
 )
 
 type gceMetadata struct {
-	ID               int64
-	Tags             []string
-	Zone             string
-	MachineType      string
-	Hostname         string
-	ProjectID        int64
+	Instance gceInstanceMetadata
+	Project  gceProjectMetadata
+}
+
+type gceInstanceMetadata struct {
+	ID          int64
+	Tags        []string
+	Zone        string
+	MachineType string
+	Hostname    string
+}
+
+type gceProjectMetadata struct {
+	ProjectID        string
 	NumericProjectID int64
 }
 

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -30,6 +30,7 @@ type gceInstanceMetadata struct {
 	Zone        string
 	MachineType string
 	Hostname    string
+	Attributes  map[string]string
 }
 
 type gceProjectMetadata struct {

--- a/pkg/util/gce/gce_tags.go
+++ b/pkg/util/gce/gce_tags.go
@@ -17,7 +17,7 @@ import (
 func GetTags() ([]string, error) {
 	tags := []string{}
 
-	metadataResponse, err := getResponse(metadataURL + "/instance/?recursive=true")
+	metadataResponse, err := getResponse(metadataURL + "/?recursive=true")
 	if err != nil {
 		return tags, err
 	}
@@ -29,26 +29,26 @@ func GetTags() ([]string, error) {
 		return tags, err
 	}
 
-	tags = metadata.Tags
-	if metadata.Zone != "" {
-		ts := strings.Split(metadata.Zone, "/")
+	tags = metadata.Instance.Tags
+	if metadata.Instance.Zone != "" {
+		ts := strings.Split(metadata.Instance.Zone, "/")
 		tags = append(tags, fmt.Sprintf("zone:%s", ts[len(ts)-1]))
 	}
-	if metadata.MachineType != "" {
-		ts := strings.Split(metadata.MachineType, "/")
+	if metadata.Instance.MachineType != "" {
+		ts := strings.Split(metadata.Instance.MachineType, "/")
 		tags = append(tags, fmt.Sprintf("instance-type:%s", ts[len(ts)-1]))
 	}
-	if metadata.Hostname != "" {
-		tags = append(tags, fmt.Sprintf("internal-hostname:%s", metadata.Hostname))
+	if metadata.Instance.Hostname != "" {
+		tags = append(tags, fmt.Sprintf("internal-hostname:%s", metadata.Instance.Hostname))
 	}
-	if metadata.ID != 0 {
-		tags = append(tags, fmt.Sprintf("instance-id:%d", metadata.ID))
+	if metadata.Instance.ID != 0 {
+		tags = append(tags, fmt.Sprintf("instance-id:%d", metadata.Instance.ID))
 	}
-	if metadata.ProjectID != 0 {
-		tags = append(tags, fmt.Sprintf("project:%d", metadata.ProjectID))
+	if metadata.Project.ProjectID != "" {
+		tags = append(tags, fmt.Sprintf("project:%s", metadata.Project.ProjectID))
 	}
-	if metadata.NumericProjectID != 0 {
-		tags = append(tags, fmt.Sprintf("numeric_project_id:%d", metadata.NumericProjectID))
+	if metadata.Project.NumericProjectID != 0 {
+		tags = append(tags, fmt.Sprintf("numeric_project_id:%d", metadata.Project.NumericProjectID))
 	}
 
 	return tags, nil

--- a/pkg/util/gce/gce_tags_test.go
+++ b/pkg/util/gce/gce_tags_test.go
@@ -25,7 +25,7 @@ func TestGetHostTags(t *testing.T) {
 		assert.Fail(t, fmt.Sprintf("Error getting test data: %v", err))
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Contains(t, r.URL.String(), "/instance/?recursive=true")
+		assert.Contains(t, r.URL.String(), "/?recursive=true")
 		assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, string(content))
@@ -40,7 +40,7 @@ func TestGetHostTags(t *testing.T) {
 	}
 
 	assert.Len(t, tags, 7)
-	expectedTags := []string{"tag", "zone:us-east1-b", "instance-type:n1-standard-1", "internal-hostname:dd-test.c.datadog-dd-test.internal", "instance-id:1111111111111111111", "project:111111111111", "numeric_project_id:111111111111"}
+	expectedTags := []string{"tag", "zone:us-east1-b", "instance-type:n1-standard-1", "internal-hostname:dd-test.c.datadog-dd-test.internal", "instance-id:1111111111111111111", "project:test-project", "numeric_project_id:111111111111"}
 	for i, actual := range tags {
 		expected := expectedTags[i]
 		assert.Equal(t, expected, actual)

--- a/pkg/util/gce/gce_tags_test.go
+++ b/pkg/util/gce/gce_tags_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetHostTags(t *testing.T) {
@@ -39,10 +40,24 @@ func TestGetHostTags(t *testing.T) {
 		assert.Fail(t, fmt.Sprintf("Error getting tags: %v", err))
 	}
 
-	assert.Len(t, tags, 7)
-	expectedTags := []string{"tag", "zone:us-east1-b", "instance-type:n1-standard-1", "internal-hostname:dd-test.c.datadog-dd-test.internal", "instance-id:1111111111111111111", "project:test-project", "numeric_project_id:111111111111"}
-	for i, actual := range tags {
-		expected := expectedTags[i]
-		assert.Equal(t, expected, actual)
+	expectedTags := []string{
+		"tag",
+		"zone:us-east1-b",
+		"instance-type:n1-standard-1",
+		"internal-hostname:dd-test.c.datadog-dd-test.internal",
+		"instance-id:1111111111111111111",
+		"project:test-project",
+		"numeric_project_id:111111111111",
+		"cluster-location:us-east1-b",
+		"cluster-name:test-cluster",
+		"created-by:projects/111111111111/zones/us-east1-b/instanceGroupManagers/gke-test-cluster-default-pool-0012834b-grp",
+		"gci-ensure-gke-docker:true",
+		"gci-update-strategy:update_disabled",
+		"google-compute-enable-pcid:true",
+		"instance-template:projects/111111111111/global/instanceTemplates/gke-test-cluster-default-pool-0012834b",
+	}
+	require.Len(t, tags, len(expectedTags))
+	for _, tag := range tags {
+		assert.Contains(t, expectedTags, tag)
 	}
 }

--- a/pkg/util/gce/test/gce_metadata.json
+++ b/pkg/util/gce/test/gce_metadata.json
@@ -1,56 +1,75 @@
 {
-  "attributes": {},
-  "cpuPlatform": "Intel Haswell",
-  "description": "",
-  "disks": [{
-    "deviceName": "dd-test",
-    "index": 0,
-    "mode": "READ_WRITE",
-    "type": "PERSISTENT"
-  }],
-  "hostname": "dd-test.c.datadog-dd-test.internal",
-  "id": 1111111111111111111,
-  "image": "projects/debian-cloud/global/images/debian-9-stretch-v20170816",
-  "licenses": [{
-    "id": "1000205"
-  }],
-  "projectId": 111111111111,
-  "NumericProjectId": 111111111111,
-  "machineType": "projects/111111111111/machineTypes/n1-standard-1",
-  "maintenanceEvent": "NONE",
-  "name": "dd-test",
-  "networkInterfaces": [{
-    "accessConfigs": [{
-      "externalIp": "111.111.111.11",
-      "type": "ONE_TO_ONE_NAT"
-    }],
-    "forwardedIps": [],
-    "ip": "10.142.0.2",
-    "ipAliases": [],
-    "mac": "42:01:0a:8e:00:02",
-    "network": "projects/111111111111/networks/default",
-    "targetInstanceIps": []
-  }],
-  "scheduling": {
-    "automaticRestart": "TRUE",
-    "onHostMaintenance": "MIGRATE",
-    "preemptible": "FALSE"
-  },
-  "serviceAccounts": {
-    "111111111111-compute@developer.gserviceaccount.com": {
-      "aliases": ["default"],
-      "email": "111111111111-compute@developer.gserviceaccount.com",
-      "scopes": ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/trace.append"]
+  "instance": {
+    "attributes": {
+      "cluster-location": "us-east1-b",
+      "cluster-name": "test-cluster",
+      "configure-sh": "#!/bin/bash # Copyright 2016 The Kubernetes Authors. # # Licensed under the Apache License, Version 2.0 (the \"License\"); # you may not use this file except in compliance with the License. # You may obtain a copy of the License at # # http://www.apache.org/licenses/LICENSE-2.0 # # Unless required by applicable law or agreed to in writing, software # distributed under the License is distributed on an \"AS IS\" BASIS, # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. # See the License for the specific language governing permissions and # limitations under the License. # Due to the GCE custom metadata size limit, we split the entire script into two # files configure.sh and configure-helper.sh. The functionality of downloading # kubernetes configuration, manifests, docker images, and binary files are # put in configure.sh, which is uploaded via GCE custom metadata.",
+      "created-by": "projects/111111111111/zones/us-east1-b/instanceGroupManagers/gke-test-cluster-default-pool-0012834b-grp",
+      "gci-ensure-gke-docker": "true",
+      "gci-update-strategy": "update_disabled",
+      "google-compute-enable-pcid": "true",
+      "instance-template": "projects/111111111111/global/instanceTemplates/gke-test-cluster-default-pool-0012834b",
+      "kube-env": "LOREM: IPSUM",
+      "user-data": "somedata"
     },
-    "default": {
-      "aliases": ["default"],
-      "email": "111111111111-compute@developer.gserviceaccount.com",
-      "scopes": ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/trace.append"]
-    }
+    "cpuPlatform": "Intel Haswell",
+    "description": "",
+    "disks": [{
+      "deviceName": "dd-test",
+      "index": 0,
+      "mode": "READ_WRITE",
+      "type": "PERSISTENT"
+    }],
+    "hostname": "dd-test.c.datadog-dd-test.internal",
+    "id": 1111111111111111111,
+    "image": "projects/debian-cloud/global/images/debian-9-stretch-v20170816",
+    "licenses": [{
+      "id": "1000205"
+    }],
+    "machineType": "projects/111111111111/machineTypes/n1-standard-1",
+    "maintenanceEvent": "NONE",
+    "name": "dd-test",
+    "networkInterfaces": [{
+      "accessConfigs": [{
+        "externalIp": "111.111.111.11",
+        "type": "ONE_TO_ONE_NAT"
+      }],
+      "forwardedIps": [],
+      "ip": "10.142.0.2",
+      "ipAliases": [],
+      "mac": "42:01:0a:8e:00:02",
+      "network": "projects/111111111111/networks/default",
+      "targetInstanceIps": []
+    }],
+    "scheduling": {
+      "automaticRestart": "TRUE",
+      "onHostMaintenance": "MIGRATE",
+      "preemptible": "FALSE"
+    },
+    "serviceAccounts": {
+      "111111111111-compute@developer.gserviceaccount.com": {
+        "aliases": ["default"],
+        "email": "111111111111-compute@developer.gserviceaccount.com",
+        "scopes": ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/trace.append"]
+      },
+      "default": {
+        "aliases": ["default"],
+        "email": "111111111111-compute@developer.gserviceaccount.com",
+        "scopes": ["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/servicecontrol", "https://www.googleapis.com/auth/service.management.readonly", "https://www.googleapis.com/auth/trace.append"]
+      }
+    },
+    "tags": ["tag"],
+    "virtualClock": {
+      "driftToken": "0"
+    },
+    "zone": "projects/111111111111/zones/us-east1-b"
   },
-  "tags": ["tag"],
-  "virtualClock": {
-    "driftToken": "0"
-  },
-  "zone": "projects/111111111111/zones/us-east1-b"
+  "oslogin": {},
+  "project": {
+    "attributes": {
+      "gke-user-test-cluster-0000000f-cidr": "default:10.1.0.0/14"
+    },
+    "numericProjectId": 111111111111,
+    "projectId": "test-project"
+  }
 }

--- a/releasenotes/notes/fix-gce-attributes-tags-d1715815467eb08e.yaml
+++ b/releasenotes/notes/fix-gce-attributes-tags-d1715815467eb08e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix collection of host tags pulled from GCP project (``project:`` and ``numeric_project_id:`` tags)
+    and GCP instance attributes.


### PR DESCRIPTION
### What does this PR do?

Fixes collection of host tags from the GCP:
- project: `project` and `numeric_project_id` tags
- instance attributes: these attributes may be anything (customized on instance launch or updated later), but may for example generate DD host tags such as `cluster_name`, `cluster_location`, etc

Fixes #1698, should fix everything on GCP tag collection that #1668 didn't fix.

### Motivation

Bring GCP host tag collection on-par with Agent5.

### Additional Notes

See commit descriptions for details.

For reference, see code in Agent5 that implements this: https://github.com/DataDog/dd-agent/blob/5.24.0/utils/cloud_metadata.py#L85-L111

I've updated the tests, and (**update**) I've double-checked on GCE that this does make the Agent6 collect the exact same tags as Agent5 (including project tags, and tags from instance attributes).
