### PR TITLE
Fetch encrypted password from configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,12 @@ func init() {
 	Datadog.SetDefault("auth_token_file_path", "")
 	Datadog.SetDefault("bind_host", "localhost")
 
+	// secrets backend
+	Datadog.BindEnv("secret_backend_command")
+	Datadog.BindEnv("secret_backend_arguments")
+	BindEnvAndSetDefault("secret_backend_output_max_size", 1024)
+	BindEnvAndSetDefault("secret_backend_timeout", 5)
+
 	// Retry settings
 	Datadog.SetDefault("forwarder_backoff_factor", 2)
 	Datadog.SetDefault("forwarder_backoff_base", 2)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -104,6 +104,36 @@ api_key:
 
 # IPC api server timeout in seconds
 # server_timeout: 15
+
+# BETA: Encrypted Secrets (Linux only)
+#
+# This feature is in beta and its options or behaviour might break between
+# minor or bugfix releases of the Agent.
+#
+# The agent can call an external command to fetch secrets. The command will be
+# executed maximum once per instance containing an encrypted password.
+# Secrets are cached by the agent, this will avoid executing again the
+# secret_backend_command to fetch an already known secret (useful when combine
+# with Autodiscovery). This feature is still in beta.
+#
+# For more information see: http://<some doc URL>
+#
+# Path to the script to execute. The script must belong to the same user used
+# to run the agent. Executable right must be given to the agent and no rights
+# for 'group' or 'other'.
+# secret_backend_command: /path/to/command
+#
+# A list of arguments to give the command at each run
+# secret_backend_arguments:
+#   - argument1
+#   - argument2
+#
+# The size in bytes of the buffer used to store the command answer:
+# secret_backend_output_max_size: 1024
+#
+# The timeout to execute the command in second
+# secret_backend_timeout: 5
+
 {{ end -}}
 {{- if .Metadata }}
 # Metadata providers, add or remove from the list to enable or disable collection.

--- a/pkg/secrets/check_right.go
+++ b/pkg/secrets/check_right.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"fmt"
+	"os/user"
+	"syscall"
+)
+
+func checkRights(path string) error {
+	var stat syscall.Stat_t
+	if err := syscall.Stat(path, &stat); err != nil {
+		return fmt.Errorf("invalid executable '%s': can't stat it: %s", path, err)
+	}
+
+	// checking that group and others don't have any rights
+	if stat.Mode&(syscall.S_IRWXG|syscall.S_IRWXO) != 0 {
+		return fmt.Errorf("invalid executable '%s', 'groups' or 'others' have rights on it", path)
+	}
+
+	// checking that the owner have exec rights
+	if stat.Mode&syscall.S_IXUSR == 0 {
+		return fmt.Errorf("invalid executable: '%s' is not executable", path)
+	}
+
+	// checking that we own the executable
+	usr, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("can't query current user UID")
+	}
+
+	// checking we own the executable. This is useless since we won't be able
+	// to execute it if not, but it gives a better error message to the
+	// user.
+	if fmt.Sprintf("%d", stat.Uid) != usr.Uid {
+		return fmt.Errorf("invalid executable: '%s' isn't owned by the user running the agent: name '%s', UID %s. We can't execute it", path, usr.Username, usr.Uid)
+	}
+
+	return nil
+}

--- a/pkg/secrets/check_right_test.go
+++ b/pkg/secrets/check_right_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrongPath(t *testing.T) {
+	require.NotNil(t, checkRights("does not exists"))
+}
+
+func TestGroupOtherRights(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "agent-collector-test")
+	require.Nil(t, err)
+
+	// file exists
+	require.NotNil(t, checkRights("/does not exists"))
+
+	require.Nil(t, os.Chmod(tmpfile.Name(), 0700))
+	require.Nil(t, checkRights(tmpfile.Name()))
+
+	// we should at least be able to execute it
+	require.Nil(t, os.Chmod(tmpfile.Name(), 0100))
+	require.Nil(t, checkRights(tmpfile.Name()))
+
+	// owner have exec right
+	require.Nil(t, os.Chmod(tmpfile.Name(), 0600))
+	require.NotNil(t, checkRights(tmpfile.Name()))
+
+	// group should have no right
+	require.Nil(t, os.Chmod(tmpfile.Name(), 0710))
+	require.NotNil(t, checkRights(tmpfile.Name()))
+
+	// other should have no right
+	require.Nil(t, os.Chmod(tmpfile.Name(), 0701))
+	require.NotNil(t, checkRights(tmpfile.Name()))
+}

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+const payloadVersion = "1.0"
+
+type limitBuffer struct {
+	max int
+	buf *bytes.Buffer
+}
+
+func (b *limitBuffer) Write(p []byte) (n int, err error) {
+	if len(p)+b.buf.Len() > b.max {
+		return 0, fmt.Errorf("command output was too long: exceeded %d bytes", b.max)
+	}
+	return b.buf.Write(p)
+}
+
+func execCommand(inputPayload string) ([]byte, error) {
+	command := config.Datadog.GetString("secret_backend_command")
+	args := config.Datadog.GetStringSlice("secret_backend_arguments")
+
+	if command == "" {
+		return nil, fmt.Errorf("no secret_backend_command set: could not decrypt secret")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		time.Duration(config.Datadog.GetInt("secret_backend_timeout"))*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	if err := checkRights(cmd.Path); err != nil {
+		return nil, err
+	}
+
+	cmd.Stdin = strings.NewReader(inputPayload)
+	// setting an empty env in case some secrets were set using the ENV (ex: API_KEY)
+	cmd.Env = []string{}
+
+	out := limitBuffer{
+		buf: &bytes.Buffer{},
+		max: config.Datadog.GetInt("secret_backend_output_max_size"),
+	}
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("error while running '%s': command timeout", command)
+		}
+		return nil, fmt.Errorf("error while running '%s': %s", command, err)
+	}
+	return out.buf.Bytes(), nil
+}
+
+type secret struct {
+	Value    string
+	ErrorMsg string `json:"error"`
+}
+
+// for testing purpose
+var runCommand = execCommand
+
+// fetchSecret receives a list of secrets name to fetch, exec a custom executable
+// to fetch the actual secrets and returns them.
+func fetchSecret(secretsHandle []string) (map[string]string, error) {
+	payload := map[string]interface{}{
+		"version": payloadVersion,
+		"secrets": secretsHandle,
+	}
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not serialize secrets IDs to fetch password: %s", err)
+	}
+	output, err := runCommand(string(jsonPayload))
+	if err != nil {
+		return nil, err
+	}
+
+	secrets := map[string]secret{}
+	err = json.Unmarshal(output, &secrets)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal 'secret_backend_command' output: %s", err)
+	}
+
+	res := map[string]string{}
+	for _, sec := range secretsHandle {
+		v, ok := secrets[sec]
+		if ok == false {
+			return nil, fmt.Errorf("secret handle '%s' was not decrypted by the secret_backend_command", sec)
+		}
+
+		if v.ErrorMsg != "" {
+			return nil, fmt.Errorf("an error occurred while decrypting '%s': %s", sec, v.ErrorMsg)
+		}
+		if v.Value == "" {
+			return nil, fmt.Errorf("decrypted secret for '%s' is empty", sec)
+		}
+		// add it to the cache
+		secretCache[sec] = v.Value
+		res[sec] = v.Value
+	}
+	return res, nil
+}

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -1,0 +1,177 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestLimitBuffer(t *testing.T) {
+	lb := limitBuffer{
+		buf: &bytes.Buffer{},
+		max: 5,
+	}
+
+	n, err := lb.Write([]byte("012"))
+	assert.Equal(t, 3, n)
+	require.Nil(t, err)
+	assert.Equal(t, []byte("012"), lb.buf.Bytes())
+
+	n, err = lb.Write([]byte("abc"))
+	assert.Equal(t, 0, n)
+	require.NotNil(t, err)
+	assert.Equal(t, []byte("012"), lb.buf.Bytes())
+
+	n, err = lb.Write([]byte("ab"))
+	assert.Equal(t, 2, n)
+	require.Nil(t, err)
+	assert.Equal(t, []byte("012ab"), lb.buf.Bytes())
+}
+
+func TestExecCommandError(t *testing.T) {
+	cmdBK := config.Datadog.GetString("secret_backend_command")
+	argsBK := config.Datadog.GetStringSlice("secret_backend_arguments")
+	timeoutBK := config.Datadog.GetInt("secret_backend_timeout")
+	defer func() {
+		config.Datadog.Set("secret_backend_command", cmdBK)
+		config.Datadog.Set("secret_backend_arguments", argsBK)
+		config.Datadog.Set("secret_backend_timeout", timeoutBK)
+	}()
+
+	inputPayload := "{\"version\": \"" + payloadVersion + "\" , \"secrets\": [\"sec1\", \"sec2\"]}"
+
+	// empty secret_backend_command
+	config.Datadog.Set("secret_backend_command", "")
+	_, err := execCommand(inputPayload)
+	require.NotNil(t, err)
+
+	// test timeout
+	os.Chmod("./test/timeout.sh", 0700)
+	config.Datadog.Set("secret_backend_command", "./test/timeout.sh")
+	config.Datadog.Set("secret_backend_timeout", 2)
+	_, err = execCommand(inputPayload)
+	require.NotNil(t, err)
+	require.Equal(t, "error while running './test/timeout.sh': command timeout", err.Error())
+
+	// test simple (no error)
+	os.Chmod("./test/simple.sh", 0700)
+	config.Datadog.Set("secret_backend_command", "./test/simple.sh")
+	resp, err := execCommand(inputPayload)
+	require.Nil(t, err)
+	require.Equal(t, []byte("{\"handle1\":{\"value\":\"simple_password\"}}"), resp)
+
+	// test error
+	config.Datadog.Set("secret_backend_command", "./test/error.sh")
+	_, err = execCommand(inputPayload)
+	require.NotNil(t, err)
+
+	// test arguments
+	os.Chmod("./test/argument.sh", 0700)
+	config.Datadog.Set("secret_backend_arguments", []string{"arg1"})
+	config.Datadog.Set("secret_backend_command", "./test/argument.sh")
+	_, err = execCommand(inputPayload)
+	require.NotNil(t, err)
+	config.Datadog.Set("secret_backend_arguments", []string{"arg1", "arg2"})
+	config.Datadog.Set("secret_backend_command", "./test/argument.sh")
+	resp, err = execCommand(inputPayload)
+	require.Nil(t, err)
+	require.Equal(t, []byte("{\"handle1\":{\"value\":\"arg_password\"}}"), resp)
+
+	// test input
+	os.Chmod("./test/input.sh", 0700)
+	config.Datadog.Set("secret_backend_command", "./test/input.sh")
+	resp, err = execCommand(inputPayload)
+	require.Nil(t, err)
+	require.Equal(t, []byte("{\"handle1\":{\"value\":\"input_password\"}}"), resp)
+
+	// test buffer limit
+	os.Chmod("./test/response_too_long.sh", 0700)
+	config.Datadog.Set("secret_backend_command", "./test/response_too_long.sh")
+	config.Datadog.Set("secret_backend_output_max_size", 20)
+	_, err = execCommand(inputPayload)
+	require.NotNil(t, err)
+	assert.Equal(t, "error while running './test/response_too_long.sh': command output was too long: exceeded 20 bytes", err.Error())
+}
+
+func TestFetchSecretExecError(t *testing.T) {
+	runCommand = func(string) ([]byte, error) { return nil, fmt.Errorf("some error") }
+	_, err := fetchSecret([]string{"handle1", "handle2"})
+	assert.NotNil(t, err)
+}
+
+func TestFetchSecretUnmarshalError(t *testing.T) {
+	runCommand = func(string) ([]byte, error) { return []byte("{"), nil }
+	_, err := fetchSecret([]string{"handle1", "handle2"})
+	assert.NotNil(t, err)
+}
+
+func TestFetchSecretMissingSecret(t *testing.T) {
+	secrets := []string{"handle1", "handle2"}
+
+	runCommand = func(string) ([]byte, error) { return []byte("{}"), nil }
+	_, err := fetchSecret(secrets)
+	assert.NotNil(t, err)
+	assert.Equal(t, "secret handle 'handle1' was not decrypted by the secret_backend_command", err.Error())
+}
+
+func TestFetchSecretErrorForHandle(t *testing.T) {
+	runCommand = func(string) ([]byte, error) {
+		return []byte("{\"handle1\":{\"value\": null, \"error\": \"some error\"}}"), nil
+	}
+	_, err := fetchSecret([]string{"handle1"})
+	assert.NotNil(t, err)
+	assert.Equal(t, "an error occurred while decrypting 'handle1': some error", err.Error())
+}
+
+func TestFetchSecretEmptyValue(t *testing.T) {
+	runCommand = func(string) ([]byte, error) {
+		return []byte("{\"handle1\":{\"value\": null}}"), nil
+	}
+	_, err := fetchSecret([]string{"handle1"})
+	assert.NotNil(t, err)
+	assert.Equal(t, "decrypted secret for 'handle1' is empty", err.Error())
+
+	runCommand = func(string) ([]byte, error) {
+		return []byte("{\"handle1\":{\"value\": \"\"}}"), nil
+	}
+	_, err = fetchSecret([]string{"handle1"})
+	assert.NotNil(t, err)
+	assert.Equal(t, "decrypted secret for 'handle1' is empty", err.Error())
+}
+
+func TestFetchSecret(t *testing.T) {
+	secrets := []string{"handle1", "handle2"}
+	// some dummy value to check the cache is not purge
+	secretCache["test"] = "yes"
+
+	runCommand = func(string) ([]byte, error) {
+		res := []byte("{\"handle1\":{\"value\":\"p1\"},")
+		res = append(res, []byte("\"handle2\":{\"value\":\"p2\"},")...)
+		res = append(res, []byte("\"handle3\":{\"value\":\"p3\"}}")...)
+		return res, nil
+	}
+	resp, err := fetchSecret(secrets)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]string{
+		"handle1": "p1",
+		"handle2": "p2",
+	}, resp)
+	assert.Equal(t, map[string]string{
+		"test":    "yes",
+		"handle1": "p1",
+		"handle2": "p2",
+	}, secretCache)
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/cihub/seelog"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var secretCache map[string]string
+
+func init() {
+	secretCache = make(map[string]string)
+}
+
+type walkerCallback func(string) (string, error)
+
+func walkSlice(data []interface{}, callback walkerCallback) error {
+	for idx, k := range data {
+		switch v := k.(type) {
+		case string:
+			newValue, err := callback(v)
+			if err != nil {
+				return err
+			}
+			data[idx] = newValue
+		case map[interface{}]interface{}:
+			if err := walkHash(v, callback); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := walkSlice(v, callback); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func walkHash(data map[interface{}]interface{}, callback walkerCallback) error {
+	for k := range data {
+		switch v := data[k].(type) {
+		case string:
+			newValue, err := callback(v)
+			if err != nil {
+				return err
+			}
+			data[k] = newValue
+		case map[interface{}]interface{}:
+			if err := walkHash(v, callback); err != nil {
+				return err
+			}
+		case []interface{}:
+			if err := walkSlice(v, callback); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// walk will go through loaded yaml and call callback on every strings allowing
+// the callback to overwrite the string value
+func walk(data *interface{}, callback walkerCallback) error {
+	switch v := (*data).(type) {
+	case string:
+		newValue, err := callback(v)
+		if err != nil {
+			return err
+		}
+		*data = newValue
+	case map[interface{}]interface{}:
+		return walkHash(v, callback)
+	case []interface{}:
+		return walkSlice(v, callback)
+	}
+	return nil
+}
+
+func isEnc(str string) (bool, string) {
+	// trimming space and tabs
+	str = strings.Trim(str, " 	")
+	if strings.HasPrefix(str, "ENC[") && strings.HasSuffix(str, "]") {
+		return true, str[4 : len(str)-1]
+	}
+	return false, ""
+}
+
+// testing purpose
+var secretFetcher = fetchSecret
+
+// Decrypt replaces all encrypted secrets in data by executing
+// "secret_backend_command" once if all secrets aren't present in the cache.
+func Decrypt(data []byte) ([]byte, error) {
+	if data == nil || config.Datadog.GetString("secret_backend_command") == "" {
+		return data, nil
+	}
+
+	var config interface{}
+	err := yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("could not Unmarshal config: %s", err)
+	}
+
+	// First we collect all new handles in the config
+	newHandles := []string{}
+	haveSecret := false
+	err = walk(&config, func(str string) (string, error) {
+		if ok, handle := isEnc(str); ok {
+			haveSecret = true
+			// Check if we already know this secret
+			if secret, ok := secretCache[handle]; ok {
+				log.Debugf("Secret '%s' was retrieved from cache", handle)
+				return secret, nil
+			}
+			newHandles = append(newHandles, handle)
+		}
+		return str, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// the configuration does not contain any secrets
+	if !haveSecret {
+		return data, nil
+	}
+
+	// check if any new secrets need to be fetch
+	if len(newHandles) != 0 {
+		secrets, err := secretFetcher(newHandles)
+		if err != nil {
+			return nil, err
+		}
+
+		// Replace all new encrypted secrets in the config
+		err = walk(&config, func(str string) (string, error) {
+			if ok, handle := isEnc(str); ok {
+				if secret, ok := secrets[handle]; ok {
+					log.Debugf("Secret '%s' was retrieved from executable", handle)
+					return secret, nil
+				}
+				// This should never happen since fetchSecret will return an error
+				// if not every handles have been fetched.
+				return str, fmt.Errorf("unknown secret '%s'", handle)
+			}
+			return str, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	finalConfig, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("could not Marshal config after replacing encrypted secrets: %s", err)
+	}
+	return finalConfig, nil
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,240 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var (
+	testYamlHash = []byte(`
+slice:
+  - "1"
+  - [test1, test2]
+  - 123
+hash:
+  a: test3
+  b: "2"
+  c: 456
+  slice:
+    - test4
+    - test5
+`)
+
+	testYamlHashUpdated = []byte(`hash:
+  a: test3_verified
+  b: 2_verified
+  c: 456
+  slice:
+  - test4_verified
+  - test5_verified
+slice:
+- 1_verified
+- - test1_verified
+  - test2_verified
+- 123
+`)
+
+	testConf = []byte(`---
+instances:
+- password: ENC[pass1]
+  user: test
+- password: ENC[pass2]
+  user: test2
+`)
+
+	testConfDecrypted = []byte(`instances:
+- password: password1
+  user: test
+- password: password2
+  user: test2
+`)
+)
+
+func TestIsEnc(t *testing.T) {
+	enc, secret := isEnc("")
+	assert.False(t, enc)
+	assert.Equal(t, "", secret)
+
+	enc, secret = isEnc("ENC[]")
+	assert.True(t, enc)
+	assert.Equal(t, "", secret)
+
+	enc, _ = isEnc("test")
+	assert.False(t, enc)
+
+	enc, _ = isEnc("ENC[")
+	assert.False(t, enc)
+
+	enc, secret = isEnc("ENC[test]")
+	assert.True(t, enc)
+	assert.Equal(t, "test", secret)
+
+	enc, secret = isEnc("ENC[]]]]")
+	assert.True(t, enc)
+	assert.Equal(t, "]]]", secret)
+
+	enc, secret = isEnc("  ENC[test]	")
+	assert.True(t, enc)
+	assert.Equal(t, "test", secret)
+}
+
+func TestWalkerError(t *testing.T) {
+	var config interface{}
+	err := yaml.Unmarshal(testYamlHash, &config)
+	require.Nil(t, err)
+
+	err = walk(&config, func(str string) (string, error) {
+		return "", fmt.Errorf("some error")
+	})
+	assert.NotNil(t, err)
+}
+
+func TestWalkerSimple(t *testing.T) {
+	var config interface{}
+	err := yaml.Unmarshal([]byte("test"), &config)
+	require.Nil(t, err)
+
+	stringsCollected := []string{}
+	err = walk(&config, func(str string) (string, error) {
+		stringsCollected = append(stringsCollected, str)
+		return str + "_verified", nil
+	})
+	require.Nil(t, err)
+
+	assert.Equal(t, []string{"test"}, stringsCollected)
+
+	updatedConf, err := yaml.Marshal(config)
+	require.Nil(t, err)
+	assert.Equal(t, string("test_verified\n"), string(updatedConf))
+}
+
+func TestWalkerComplex(t *testing.T) {
+	var config interface{}
+	err := yaml.Unmarshal(testYamlHash, &config)
+	require.Nil(t, err)
+
+	stringsCollected := []string{}
+	err = walk(&config, func(str string) (string, error) {
+		stringsCollected = append(stringsCollected, str)
+		return str + "_verified", nil
+	})
+	require.Nil(t, err)
+
+	sort.Strings(stringsCollected)
+	assert.Equal(t, []string{
+		"1",
+		"2",
+		"test1",
+		"test2",
+		"test3",
+		"test4",
+		"test5",
+	}, stringsCollected)
+
+	updatedConf, err := yaml.Marshal(config)
+	require.Nil(t, err)
+	assert.Equal(t, string(testYamlHashUpdated), string(updatedConf))
+}
+
+func TestDecryptNoCommand(t *testing.T) {
+	secretFetcher = func(secrets []string) (map[string]string, error) {
+		return nil, fmt.Errorf("some error")
+	}
+
+	// since we didn't set any command this should return without any error
+	_, err := Decrypt(testConf)
+	require.Nil(t, err)
+}
+
+func TestDecryptSecretError(t *testing.T) {
+	backup := config.Datadog.GetString("secret_backend_command")
+	config.Datadog.Set("secret_backend_command", "some_command")
+	defer config.Datadog.Set("secret_backend_command", backup)
+
+	secretFetcher = func(secrets []string) (map[string]string, error) {
+		return nil, fmt.Errorf("some error")
+	}
+
+	_, err := Decrypt(testConf)
+	require.NotNil(t, err)
+}
+
+func TestDecryptSecretNoCache(t *testing.T) {
+	backup := config.Datadog.GetString("secret_backend_command")
+	config.Datadog.Set("secret_backend_command", "some_command")
+	defer config.Datadog.Set("secret_backend_command", backup)
+
+	secretFetcher = func(secrets []string) (map[string]string, error) {
+		sort.Strings(secrets)
+		assert.Equal(t, []string{
+			"pass1",
+			"pass2",
+		}, secrets)
+
+		return map[string]string{
+			"pass1": "password1",
+			"pass2": "password2",
+		}, nil
+	}
+
+	newConf, err := Decrypt(testConf)
+	require.Nil(t, err)
+	assert.Equal(t, string(testConfDecrypted), string(newConf))
+}
+
+func TestDecryptSecretPartialCache(t *testing.T) {
+	backup := config.Datadog.GetString("secret_backend_command")
+	config.Datadog.Set("secret_backend_command", "some_command")
+	defer config.Datadog.Set("secret_backend_command", backup)
+
+	secretCache["pass1"] = "password1"
+	defer func() { secretCache = map[string]string{} }()
+
+	secretFetcher = func(secrets []string) (map[string]string, error) {
+		sort.Strings(secrets)
+		assert.Equal(t, []string{
+			"pass2",
+		}, secrets)
+
+		return map[string]string{
+			"pass2": "password2",
+		}, nil
+	}
+
+	newConf, err := Decrypt(testConf)
+	require.Nil(t, err)
+	assert.Equal(t, testConfDecrypted, newConf)
+}
+
+func TestDecryptSecretFullCache(t *testing.T) {
+	backup := config.Datadog.GetString("secret_backend_command")
+	config.Datadog.Set("secret_backend_command", "some_command")
+	defer config.Datadog.Set("secret_backend_command", backup)
+
+	secretCache["pass1"] = "password1"
+	secretCache["pass2"] = "password2"
+	defer func() { secretCache = map[string]string{} }()
+
+	secretFetcher = func(secrets []string) (map[string]string, error) {
+		require.Fail(t, "Secret Cache was not used properly")
+		return nil, nil
+	}
+
+	newConf, err := Decrypt(testConf)
+	require.Nil(t, err)
+	assert.Equal(t, testConfDecrypted, newConf)
+}

--- a/pkg/secrets/secrets_win.go
+++ b/pkg/secrets/secrets_win.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build windows
+
+package secrets
+
+// Decrypt encrypted secrets are not available on windows
+func Decrypt(data []byte) ([]byte, error) {
+	return data, nil
+}

--- a/pkg/secrets/test/argument.sh
+++ b/pkg/secrets/test/argument.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+if [ "$1" != "arg1" ]
+then
+	exit 1
+fi
+
+if [ "$2" != "arg2" ]
+then
+	exit 1
+fi
+
+echo -n '{"handle1":{"value":"arg_password"}}'

--- a/pkg/secrets/test/error.sh
+++ b/pkg/secrets/test/error.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo -n '{"handle1":{"value":"password1"}}'
+
+exit 1

--- a/pkg/secrets/test/input.sh
+++ b/pkg/secrets/test/input.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+input=`cat`
+
+if [[ "$input" == "{\"version\": \"1.0\" , \"secrets\": [\"sec1\", \"sec2\"]}" ]]
+then
+	echo -n '{"handle1":{"value":"input_password"}}'
+else
+	exit 1
+fi

--- a/pkg/secrets/test/response_too_long.sh
+++ b/pkg/secrets/test/response_too_long.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# 50 characters
+echo -n 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'

--- a/pkg/secrets/test/simple.sh
+++ b/pkg/secrets/test/simple.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo -n '{"handle1":{"value":"simple_password"}}'

--- a/pkg/secrets/test/timeout.sh
+++ b/pkg/secrets/test/timeout.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while [ true ]
+do
+	sleep 1
+done

--- a/releasenotes/notes/fetch-passwords-516ed9ff168ac8cf.yaml
+++ b/releasenotes/notes/fetch-passwords-516ed9ff168ac8cf.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    "[BETA] Encrypted passwords in configurations can now be fetched from a
+    secrets manager."

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -7,6 +7,7 @@ import os
 from invoke import task
 from invoke.exceptions import Exit
 from .build_tags import get_default_build_tags
+from .utils import pkg_config_path
 
 
 # List of modules to ignore when running lint on Windows platform
@@ -87,7 +88,7 @@ def lint(ctx, targets):
 
 
 @task
-def vet(ctx, targets):
+def vet(ctx, targets, use_embedded_libs=False):
     """
     Run go vet on targets.
 
@@ -102,7 +103,12 @@ def vet(ctx, targets):
     # add the /... suffix to the targets
     args = ["{}/...".format(t) for t in targets]
     build_tags = get_default_build_tags()
-    ctx.run("go vet -tags \"{}\" ".format(" ".join(build_tags)) + " ".join(args))
+
+    env = {
+        "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs),
+    }
+
+    ctx.run("go vet -tags \"{}\" ".format(" ".join(build_tags)) + " ".join(args), env=env)
     # go vet exits with status 1 when it finds an issue, if we're here
     # everything went smooth
     print("go vet found no issues")

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -72,7 +72,7 @@ def test(ctx, targets=None, coverage=False, race=False, profile=False, use_embed
     lint_filenames(ctx)
     fmt(ctx, targets=tool_targets, fail_on_fmt=fail_on_fmt)
     lint(ctx, targets=tool_targets)
-    vet(ctx, targets=tool_targets)
+    vet(ctx, targets=tool_targets, use_embedded_libs=use_embedded_libs)
     misspell(ctx, targets=tool_targets)
     ineffassign(ctx, targets=tool_targets)
 


### PR DESCRIPTION
### What does this PR do?

Encrypted password in configuration are fetch after being resolved by autodiscovery

### Motivation

This allow users to use any secret manager.

### Additional Notes

- Documentation is missing and will come in a later PR.
- fetching password in `datadog.yaml` will come in another PR.
