### PR TITLE
Add kubelet version container meta

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -282,7 +282,14 @@ func getContainerMeta(timeout time.Duration) map[string]string {
 	case <-c:
 		return containerMeta
 	case <-time.After(timeout):
-		return containerMeta
+		// in this case the map might be incomplete so return a copy to avoid race
+		incompleteMeta := make(map[string]string)
+		mutex.Lock()
+		for k, v := range containerMeta {
+			incompleteMeta[k] = v
+		}
+		mutex.Unlock()
+		return incompleteMeta
 	}
 }
 

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/cihub/seelog"
@@ -55,7 +56,7 @@ func GetPayload(hostname string) *Payload {
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
 		HostTags:      getHostTags(),
-		ContainerMeta: getContainerMeta(),
+		ContainerMeta: getContainerMeta(time.Second),
 	}
 
 	// Cache the metadata for use in other payloads
@@ -249,21 +250,40 @@ func getMeta() *Meta {
 	return m
 }
 
-func getContainerMeta() map[string]string {
+func getContainerMeta(timeout time.Duration) map[string]string {
+	wg := sync.WaitGroup{}
 	containerMeta := make(map[string]string)
+	// protecting the above map from concurrent access
+	mutex := &sync.Mutex{}
 
 	for provider, getMeta := range container.DefaultCatalog {
-		meta, err := getMeta()
-		if err != nil {
-			log.Debugf("Unable to get %s metadata: %s", provider, err)
-			continue
-		}
-		for k, v := range meta {
-			containerMeta[k] = v
-		}
+		wg.Add(1)
+		go func(provider string, getMeta container.MetadataProvider) {
+			defer wg.Done()
+			meta, err := getMeta()
+			if err != nil {
+				log.Debugf("Unable to get %s metadata: %s", provider, err)
+				return
+			}
+			mutex.Lock()
+			for k, v := range meta {
+				containerMeta[k] = v
+			}
+			mutex.Unlock()
+		}(provider, getMeta)
 	}
-
-	return containerMeta
+	// we want to timeout even if the wait group is not done yet
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return containerMeta
+	case <-time.After(timeout):
+		return containerMeta
+	}
 }
 
 func buildKey(key string) string {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -56,7 +56,7 @@ func GetPayload(hostname string) *Payload {
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
 		HostTags:      getHostTags(),
-		ContainerMeta: getContainerMeta(time.Second),
+		ContainerMeta: getContainerMeta(1 * time.Second),
 	}
 
 	// Cache the metadata for use in other payloads

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -7,8 +7,10 @@ package host
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
@@ -85,4 +87,25 @@ func TestGetEmptyHostTags(t *testing.T) {
 
 func TestBuildKey(t *testing.T) {
 	assert.Equal(t, "metadata/host/foo", buildKey("foo"))
+}
+
+func TestGetContainerMeta(t *testing.T) {
+
+	container.RegisterMetadataProvider("provider1", func() (map[string]string, error) { return map[string]string{"foo": "bar"}, nil })
+	container.RegisterMetadataProvider("provider2", func() (map[string]string, error) { return map[string]string{"fizz": "buzz"}, nil })
+	container.RegisterMetadataProvider("provider3", func() (map[string]string, error) { return map[string]string{"fizz": "buzz"}, nil })
+
+	meta := getContainerMeta(50 * time.Millisecond)
+	assert.Equal(t, map[string]string{"foo": "bar", "fizz": "buzz"}, meta)
+}
+
+func TestGetContainerMetaTimeout(t *testing.T) {
+	container.RegisterMetadataProvider("provider1", func() (map[string]string, error) { return map[string]string{"foo": "bar"}, nil })
+	container.RegisterMetadataProvider("provider2", func() (map[string]string, error) {
+		time.Sleep(time.Second)
+		return map[string]string{"fizz": "buzz"}, nil
+	})
+
+	meta := getContainerMeta(50 * time.Millisecond)
+	assert.Equal(t, map[string]string{"foo": "bar"}, meta)
 }

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -90,7 +90,8 @@ func TestBuildKey(t *testing.T) {
 }
 
 func TestGetContainerMeta(t *testing.T) {
-
+	// reset catalog
+	container.DefaultCatalog = make(container.Catalog)
 	container.RegisterMetadataProvider("provider1", func() (map[string]string, error) { return map[string]string{"foo": "bar"}, nil })
 	container.RegisterMetadataProvider("provider2", func() (map[string]string, error) { return map[string]string{"fizz": "buzz"}, nil })
 	container.RegisterMetadataProvider("provider3", func() (map[string]string, error) { return map[string]string{"fizz": "buzz"}, nil })
@@ -100,6 +101,8 @@ func TestGetContainerMeta(t *testing.T) {
 }
 
 func TestGetContainerMetaTimeout(t *testing.T) {
+	// reset catalog
+	container.DefaultCatalog = make(container.Catalog)
 	container.RegisterMetadataProvider("provider1", func() (map[string]string, error) { return map[string]string{"foo": "bar"}, nil })
 	container.RegisterMetadataProvider("provider2", func() (map[string]string, error) {
 		time.Sleep(time.Second)

--- a/pkg/util/docker/metadata.go
+++ b/pkg/util/docker/metadata.go
@@ -27,7 +27,7 @@ func getMetadata() (map[string]string, error) {
 		return metadata, err
 	}
 	// short timeout to minimize metadata collection time
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	i, err := du.cli.Info(ctx)
 	if err != nil {

--- a/pkg/util/docker/metadata.go
+++ b/pkg/util/docker/metadata.go
@@ -27,7 +27,7 @@ func getMetadata() (map[string]string, error) {
 		return metadata, err
 	}
 	// short timeout to minimize metadata collection time
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	i, err := du.cli.Info(ctx)
 	if err != nil {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -387,6 +387,7 @@ func (ku *KubeUtil) GetRawConnectionInfo() map[string]string {
 	return ku.rawConnectionInfo
 }
 
+// GetRawMetrics returns the raw kubelet metrics payload
 func (ku *KubeUtil) GetRawMetrics() ([]byte, error) {
 	data, code, err := ku.QueryKubelet(kubeletMetricsPath)
 	if err != nil {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	kubeletPodPath         = "/pods"
+	kubeletMetricsPath     = "/metrics"
 	authorizationHeaderKey = "Authorization"
 	podListCacheKey        = "KubeletPodListCacheKey"
 )
@@ -384,6 +385,18 @@ func (ku *KubeUtil) GetRawConnectionInfo() map[string]string {
 		ku.rawConnectionInfo["url"] = ku.kubeletApiEndpoint
 	}
 	return ku.rawConnectionInfo
+}
+
+func (ku *KubeUtil) GetRawMetrics() ([]byte, error) {
+	data, code, err := ku.QueryKubelet(kubeletMetricsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error performing kubelet query %s%s: %s", ku.kubeletApiEndpoint, kubeletMetricsPath, err)
+	}
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d on %s%s: %s", code, ku.kubeletApiEndpoint, kubeletMetricsPath, string(data))
+	}
+
+	return data, nil
 }
 
 func (ku *KubeUtil) setupKubeletApiEndpoint() error {

--- a/pkg/util/kubernetes/kubelet/kubelet_common.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common.go
@@ -6,8 +6,11 @@
 package kubelet
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -25,4 +28,20 @@ func PodUIDToEntityName(uid string) string {
 		return ""
 	}
 	return fmt.Sprintf("%s%s", KubePodPrefix, uid)
+}
+
+// ParseMetricFromRaw parses a metric from raw prometheus text
+func ParseMetricFromRaw(raw []byte, metric string) (string, error) {
+	bytesReader := bytes.NewReader(raw)
+	scanner := bufio.NewScanner(bytesReader)
+	for scanner.Scan() {
+		// skipping comments
+		if string(scanner.Text()[0]) == "#" {
+			continue
+		}
+		if strings.Contains(scanner.Text(), metric) {
+			return scanner.Text(), nil
+		}
+	}
+	return "", fmt.Errorf("%s metric not found in payload", metric)
 }

--- a/pkg/util/kubernetes/kubelet/kubelet_common_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMeta(t *testing.T) {
+	rawData := []byte(`kubelet_runtime_operations_latency_microseconds{operation_type="version",quantile="0.9"} 761
+kubelet_runtime_operations_latency_microseconds{operation_type="version",quantile="0.99"} 1372
+kubelet_runtime_operations_latency_microseconds_sum{operation_type="version"} 3.02124601e+08
+kubelet_runtime_operations_latency_microseconds_count{operation_type="version"} 361825
+# HELP kubernetes_build_info A metric with a constant '1' value labeled by major, minor, git version, git commit, git tree state, build date, Go version, and compiler from which Kubernetes was built, and platform on which it is running.
+# TYPE kubernetes_build_info gauge
+kubernetes_build_info{buildDate="2018-03-21T19:01:20Z",compiler="gc",gitCommit="cb151369f60073317da686a6ce7de36abe2bda8d",gitTreeState="clean",gitVersion="v1.9.6-gke.0",goVersion="go1.9.3b4",major="1",minor="9+",platform="linux/amd64"} 1
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 127923.04
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge`)
+	metric, err := ParseMetricFromRaw(rawData, "kubernetes_build_info")
+	assert.Empty(t, err)
+	assert.Equal(t, `kubernetes_build_info{buildDate="2018-03-21T19:01:20Z",compiler="gc",gitCommit="cb151369f60073317da686a6ce7de36abe2bda8d",gitTreeState="clean",gitVersion="v1.9.6-gke.0",goVersion="go1.9.3b4",major="1",minor="9+",platform="linux/amd64"} 1`, metric)
+
+	metric, err = ParseMetricFromRaw(rawData, "process_cpu_seconds_total")
+	assert.Empty(t, err)
+	assert.Equal(t, "process_cpu_seconds_total 127923.04", metric)
+}

--- a/pkg/util/kubernetes/kubelet/kubelet_common_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetMeta(t *testing.T) {
@@ -25,7 +26,7 @@ process_cpu_seconds_total 127923.04
 # HELP process_max_fds Maximum number of open file descriptors.
 # TYPE process_max_fds gauge`)
 	metric, err := ParseMetricFromRaw(rawData, "kubernetes_build_info")
-	assert.Empty(t, err)
+	require.Empty(t, err)
 	assert.Equal(t, `kubernetes_build_info{buildDate="2018-03-21T19:01:20Z",compiler="gc",gitCommit="cb151369f60073317da686a6ce7de36abe2bda8d",gitTreeState="clean",gitVersion="v1.9.6-gke.0",goVersion="go1.9.3b4",major="1",minor="9+",platform="linux/amd64"} 1`, metric)
 
 	metric, err = ParseMetricFromRaw(rawData, "process_cpu_seconds_total")

--- a/pkg/util/kubernetes/kubelet/metadata.go
+++ b/pkg/util/kubernetes/kubelet/metadata.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet
+
+package kubelet
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
+)
+
+func init() {
+	container.RegisterMetadataProvider("kubelet", getMetadata)
+}
+
+func getMetadata() (map[string]string, error) {
+	metadata := make(map[string]string)
+	ku, err := GetKubeUtil()
+	if err != nil {
+		return metadata, err
+	}
+	data, err := ku.GetRawMetrics()
+	if err != nil {
+		return metadata, err
+	}
+	metric, err := ParseMetricFromRaw(data, "kubernetes_build_info")
+	if err != nil {
+		return metadata, err
+	}
+	re := regexp.MustCompile("gitVersion=\"(.*?)\"")
+	matches := re.FindStringSubmatch(metric)
+	if len(matches) < 1 {
+		return metadata, fmt.Errorf("couldn't find kubelet git version")
+	}
+	metadata["kubelet_version"] = matches[1]
+
+	return metadata, nil
+}

--- a/releasenotes/notes/kubelet-version-container-meta-43d06205687035c5.yaml
+++ b/releasenotes/notes/kubelet-version-container-meta-43d06205687035c5.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add kubelet version to container metadata.


### PR DESCRIPTION
### What does this PR do?

* Handle concurrency with multiple container metadata provider + add timeout
* Add the kubelet version to container metada

### Motivation

![screen shot 2018-05-17 at 15 25 49](https://user-images.githubusercontent.com/2368736/40180288-bdd76c4c-59e6-11e8-81f0-807554599b79.png)

