### PR TITLE
[packaging/RPM] Write systemd service files to /usr/lib/systemd/system

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -157,9 +157,13 @@ if linux?
   extra_package_file '/etc/init/datadog-agent.conf'
   extra_package_file '/etc/init/datadog-agent-process.conf'
   extra_package_file '/etc/init/datadog-agent-trace.conf'
-  extra_package_file '/lib/systemd/system/datadog-agent.service'
-  extra_package_file '/lib/systemd/system/datadog-agent-process.service'
-  extra_package_file '/lib/systemd/system/datadog-agent-trace.service'
+  systemd_directory = "/usr/lib/systemd/system"
+  if debian?
+    systemd_directory = "/lib/systemd/system"
+  end
+  extra_package_file "#{systemd_directory}/datadog-agent.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-process.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-trace.service"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/usr/bin/dd-agent'
   extra_package_file '/var/log/datadog/'

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -46,10 +46,15 @@ build do
             move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
             move "#{install_dir}/scripts/datadog-agent-trace.conf", "/etc/init"
             move "#{install_dir}/scripts/datadog-agent-process.conf", "/etc/init"
-            mkdir "/lib/systemd/system"
-            move "#{install_dir}/scripts/datadog-agent.service", "/lib/systemd/system"
-            move "#{install_dir}/scripts/datadog-agent-trace.service", "/lib/systemd/system"
-            move "#{install_dir}/scripts/datadog-agent-process.service", "/lib/systemd/system"
+            systemd_directory = "/usr/lib/systemd/system"
+            if debian?
+                # debian recommends using a different directory for systemd unit files
+                systemd_directory = "/lib/systemd/system"
+            end
+            mkdir systemd_directory
+            move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-process.service", systemd_directory
 
             # Move checks and configuration files
             mkdir "/etc/datadog-agent"

--- a/releasenotes/notes/rpm-systemd-service-location-28ea07f7b292a5fb.yaml
+++ b/releasenotes/notes/rpm-systemd-service-location-28ea07f7b292a5fb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The RPM packages now write systemd service files to `/usr/lib/systemd/system/`
+    (recommended path on RHEL/SUSE) instead of `/lib/systemd/system/`


### PR DESCRIPTION
### What does this PR do?

Writes systemd service files to `/usr/lib/systemd/system` instead of `/lib/systemd/system`.

### Motivation

Recommended by the RHEL/SUSE docs, and [Agent 5 uses these recommended paths too](https://github.com/DataDog/dd-agent-omnibus/blob/5.22.3/config/software/datadog-agent.rb#L47-L59).

Both paths should work on most environments, but we got a report in https://github.com/DataDog/datadog-agent/issues/1706 of the `/lib` path not working. Let's just follow the official docs' recommendations. Fixes #1706.
