### PR TITLE
Fix log format when no log file is specified

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -45,13 +45,11 @@ func SetupLogger(logLevel, logFile, uri string, rfc, tls bool, pem string, logTo
 		seelogLogLevel = "warn"
 	}
 
-	configTemplate := `<seelog minlevel="%s">`
+	configTemplate := fmt.Sprintf(`<seelog minlevel="%s">`, seelogLogLevel)
 
-	formatID := ""
+	formatID := "common"
 	if jsonFormat {
 		formatID = "json"
-	} else {
-		formatID = "common"
 	}
 
 	configTemplate += fmt.Sprintf(`<outputs formatid="%s">`, formatID)
@@ -60,7 +58,7 @@ func SetupLogger(logLevel, logFile, uri string, rfc, tls bool, pem string, logTo
 		configTemplate += `<console />`
 	}
 	if logFile != "" {
-		configTemplate += `<rollingfile type="size" filename="%s" maxsize="%d" maxrolls="1" />`
+		configTemplate += fmt.Sprintf(`<rollingfile type="size" filename="%s" maxsize="%d" maxrolls="1" />`, logFile, logFileMaxSize)
 	}
 	if syslog {
 		var syslogTemplate string
@@ -77,18 +75,16 @@ func SetupLogger(logLevel, logFile, uri string, rfc, tls bool, pem string, logTo
 		configTemplate += syslogTemplate
 	}
 
-	configTemplate += `</outputs>
+	configTemplate += fmt.Sprintf(`</outputs>
 	<formats>
 		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%File&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
 		<format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n"/>
-		<format id="syslog-json" format="%%CustomSyslogHeader(20,` + strconv.FormatBool(rfc) + `){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
-		<format id="syslog-common" format="%%CustomSyslogHeader(20,` + strconv.FormatBool(rfc) + `) %%LEVEL | (%%RelFile:%%Line) | %%Msg%%n" />`
+		<format id="syslog-json" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
+		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%RelFile:%%Line) | %%Msg%%n" />
+	</formats>
+</seelog>`, logDateFormat, logDateFormat)
 
-	configTemplate += `</formats>
-	</seelog>`
-	config := fmt.Sprintf(configTemplate, seelogLogLevel, logFile, logFileMaxSize, logDateFormat, logDateFormat)
-
-	logger, err := log.LoggerFromConfigAsString(config)
+	logger, err := log.LoggerFromConfigAsString(configTemplate)
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/fix-check-cmd-log-format-55837ac1c66ef62a.yaml
+++ b/releasenotes/notes/fix-check-cmd-log-format-55837ac1c66ef62a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix log format when no log file is specified which cause the log date to
+    not be correctly displayed.


### PR DESCRIPTION
### What does this PR do?

When no logFile is specified an extra parameter (logFileMaxSize) would
be given to the final Sprintf and used as the date format.

This would procude an output such as:
```
%!s(int=507859760) | INFO | (log.go:266 in Info) | starting the tagging system
%!s(int=507859760) | INFO | (log.go:218 in Infof) | docker tag collector successfully started
%!s(int=50880760) | INFO | (log.go:218 in Infof) | Runner started with 1 workers.
```