### PR TITLE
Return an error when the GCE metadata API responds with an empty body

### DIFF
--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -88,6 +88,7 @@ func getResponse(url string) (string, error) {
 		return "", fmt.Errorf("GCE hostname, error reading response body: %s", err)
 	}
 
+	// Some cloud platforms will respond with an empty body, causing the agent to assume a faulty hostname
 	if len(all) <= 0 {
 		return "", fmt.Errorf("empty response body")
 	}

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -88,6 +88,10 @@ func getResponse(url string) (string, error) {
 		return "", fmt.Errorf("GCE hostname, error reading response body: %s", err)
 	}
 
+	if len(all) <= 0 {
+		return "", fmt.Errorf("empty response body")
+	}
+
 	return string(all), nil
 }
 

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -42,7 +42,7 @@ func TestGetHostnameEmptyBody(t *testing.T) {
 
 	val, err := GetHostname()
 	assert.Error(t, err)
-	assert.Equal(t, "", val)
+	assert.Empty(t, val)
 	assert.Equal(t, "/instance/hostname", lastRequest.URL.Path)
 }
 

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -28,7 +28,7 @@ func TestGetHostname(t *testing.T) {
 	val, err := GetHostname()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, val)
-	assert.Equal(t, lastRequest.URL.Path, "/instance/hostname")
+	assert.Equal(t, "/instance/hostname", lastRequest.URL.Path)
 }
 
 func TestGetHostnameEmptyBody(t *testing.T) {
@@ -43,7 +43,7 @@ func TestGetHostnameEmptyBody(t *testing.T) {
 	val, err := GetHostname()
 	assert.Error(t, err)
 	assert.Equal(t, "", val)
-	assert.Equal(t, lastRequest.URL.Path, "/instance/hostname")
+	assert.Equal(t, "/instance/hostname", lastRequest.URL.Path)
 }
 
 func TestGetHostAliases(t *testing.T) {

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -31,6 +31,21 @@ func TestGetHostname(t *testing.T) {
 	assert.Equal(t, lastRequest.URL.Path, "/instance/hostname")
 }
 
+func TestGetHostnameEmptyBody(t *testing.T) {
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetHostname()
+	assert.Error(t, err)
+	assert.Equal(t, "", val)
+	assert.Equal(t, lastRequest.URL.Path, "/instance/hostname")
+}
+
 func TestGetHostAliases(t *testing.T) {
 	lastRequests := []*http.Request{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/releasenotes/notes/return-an-error-when-the-GCE-metadata-API-responds-with-an-empty-body-eab83cb87cbfa848.yaml
+++ b/releasenotes/notes/return-an-error-when-the-GCE-metadata-API-responds-with-an-empty-body-eab83cb87cbfa848.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Prevent an empty response body from being marked as a "successfull call to the GCE metadata api".
+    Fixes a bug where hostnames became an empty string when using docker swarm and a non GCE environment.


### PR DESCRIPTION
### What does this PR do?

Hey there :wave:, 

After updating my agent instances to version 6 this morning, my datadog lost a lot of data needed for metrics and alerts.
After a short investigation it turns out that the hostname autoresolving stopped working on my swarm setup and it assigns an empty hostname to all agents running.
Below you can see the excerpt of the logs that lead to this conclusion:

```
[services.d] done.
[ AGENT ] 2018-05-19 10:00:30 UTC | INFO | (start.go:156 in StartAgent) | Starting Datadog Agent v6.2.0
[ AGENT ] 2018-05-19 10:00:30 UTC | DEBUG | (hostname.go:108 in GetHostname) | Unable to get the hostname from the config file: host name is empty
[ AGENT ] 2018-05-19 10:00:30 UTC | DEBUG | (hostname.go:109 in GetHostname) | Trying to determine a reliable host name automatically...
[PROCESS] 2018-05-19 10:00:30 INFO (tagger.go:78) - starting the tagging system
[ AGENT ] 2018-05-19 10:00:30 UTC | DEBUG | (hostname.go:118 in GetHostname) | GetHostname trying GCE metadata...
[ TRACE ] 2018-05-19 10:00:30 INFO (main.go:175) - trace-agent not enabled.
[ TRACE ] Set env var DD_APM_ENABLED=true or add
[ TRACE ] apm_enabled: true
[ TRACE ] to your datadog.conf file.
[ TRACE ] Exiting.
[ AGENT ] 2018-05-19 10:00:30 UTC | INFO | (start.go:174 in StartAgent) | Hostname is: 
[ AGENT ] 2018-05-19 10:00:30 UTC | INFO | (security.go:132 in FetchAuthToken) | Saved a new authentication token to /etc/datadog-agent/auth_token
[ AGENT ] 2018-05-19 10:00:30 UTC | INFO | (start.go:191 in StartAgent) | GUI server port -1 specified: not starting the GUI.
[ AGENT ] 2018-05-19 10:00:30 UTC | DEBUG | (start.go:202 in StartAgent) | Starting forwarder
[ AGENT ] 2018-05-19 10:00:30 UTC | INFO | (forwarder.go:235 in Start) | DefaultForwarder started (1 workers), sending to 1 endpoint(s): "https://6-2-0-app.agent.datadoghq.com" (1 api key(s))
```

Turns out that the line https://github.com/DataDog/datadog-agent/blob/6.2.x/pkg/util/gce/gce.go#L56 is hit because my setup is returning a valid response. Below is a curl call from the dd-agent container:
```
# curl http://169.254.169.254/computeMetadata/v1/instance/hostname -vvv
*   Trying 169.254.169.254...
* TCP_NODELAY set
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /computeMetadata/v1/instance/hostname HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.51.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx
< Date: Sat, 19 May 2018 10:14:50 GMT
< Content-Type: text/html; charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Expires: Sat, 19 May 2018 10:14:49 GMT
< Cache-Control: no-cache
< X-Frame-Options: DENY
< X-Content-Type-Options: nosniff
< 
* Curl_http_done: called premature == 0
* Connection #0 to host 169.254.169.254 left intact
```
### Motivation

Instead of investigating who/what is running on this endpoint or figuring out a way to bypass the GCE hostname discovery I'd figured it would probably be a good thing to assert a non-empty response body for all GCE related calls.

### Additional Notes
- Besides the unit test, is there a way to functionally assert the behavior?
- I'm still new to golang, any feedback is welcome

Let me know what you think!