### PR TITLE
Changed the docker and k8 config providers to return logs config as well

### DIFF
--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -150,7 +150,8 @@ func extractCheckTemplatesFromMap(key string, input map[string]string, prefix st
 	return buildTemplates(key, checkNames, initConfigs, instances), nil
 }
 
-// extractLogsTemplatesFromMap returns the first logs configuration from a given map.
+// extractLogsTemplatesFromMap returns the first logs configuration from a given map
+// if none are found return an empty list.
 func extractLogsTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+logsConfigPath]
 	if !found {

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -105,13 +105,13 @@ func extractTemplatesFromMap(key string, input map[string]string, prefix string)
 
 	checksConfigs, err := extractCheckTemplatesFromMap(key, input, prefix)
 	if err != nil {
-		return []integration.Config{}, err
+		return configs, err
 	}
 	configs = append(configs, checksConfigs...)
 
 	logsConfigs, err := extractLogsTemplatesFromMap(key, input, prefix)
 	if err != nil {
-		return []integration.Config{}, err
+		return configs, err
 	}
 	configs = append(configs, logsConfigs...)
 


### PR DESCRIPTION
### What does this PR do?

Updated the utils method to extract config from docker labels and kubernetes annotations to return logs config.

### Motivation

Share a common logic to extract configs from docker labels and k8 annotations.

