### PR TITLE
[log] TLS syslog TLS PEM is a path to a file, not a cert

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -50,6 +50,7 @@ in any way.
 | `collect_instance_metadata` | `enable_metadata_collection` | This now enabled the new metadata collection mechanism |
 | `collector_log_file` | `log_file` ||
 | `syslog_host`  | `syslog_uri`  | The Syslog configuration is now expressed as an URI |
+|| `syslog_pem`  | Syslog configuration root CA for TLS client server validation |
 
 
 ## Removed options

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -264,6 +264,10 @@ api_key:
 #
 # syslog_tls: no
 #
+# If TLS enabled, you may specify a path to a PEM certificate here
+#
+# syslog_pem: /path/to/certificate.pem
+# 
 {{ end -}}
 {{- if .Autodiscovery }}
 # Autodiscovery

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -34,10 +35,15 @@ func SetupLogger(logLevel, logFile, uri string, rfc, tls bool, pem string, logTo
 	}
 
 	if pem != "" {
-		if logCertPool == nil {
-			logCertPool = x509.NewCertPool()
+		if cert, err := ioutil.ReadFile(pem); err == nil {
+			if logCertPool == nil {
+				logCertPool = x509.NewCertPool()
+			}
+			logCertPool.AppendCertsFromPEM(cert)
+		} else {
+			log.Errorf("Unable to read PEM certificate")
+			return err
 		}
-		logCertPool.AppendCertsFromPEM([]byte(pem))
 	}
 
 	seelogLogLevel := strings.ToLower(logLevel)

--- a/releasenotes/notes/tls_log_pem_path-db4e010f2be3c625.yaml
+++ b/releasenotes/notes/tls_log_pem_path-db4e010f2be3c625.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Config option specified in `syslog_pem` if syslog logging is enabled with
+    TLS should be a path to the certificate, not a textual certificate in the 
+    configuration.


### PR DESCRIPTION
### What does this PR do?

The `syslog_pem` config option should be a path to a PEM cert, this PR implements that.

### Motivation

Providing the (undocumented) PEM option in the datadog.yaml wasn't user-friendly.

### Additional Notes

Anything else we should know when reviewing?
