### PR TITLE
[deps] allow setting pins for bootstrap requirements

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,0 +1,9 @@
+{
+    "deps": {
+        "github.com/golang/dep/cmd/dep": "v0.4.1",
+        "github.com/golang/lint/golint": "master",
+        "github.com/fzipp/gocyclo": "master",
+        "github.com/gordonklaus/ineffassign": "master",
+        "github.com/client9/misspell/cmd/misspell": "master"
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This allows us to add, pin dependencies of bootstrapping deps and tools. 

We introduce a JSON file, `bootstrap.json` where we define these requirements, and we then enforce them with invoke when making the `invoke deps` call. 

### Motivation

Need to pin `dep` (and potentially other dependencies).

### Alternative 

Keep everything in `Gopkg.toml`

Flow to bootstrap:
 - go get -u github.com/golang/dep/cmd/dep (this will get and install `master` dep)
 - dep ensure (this will read Gopkg.toml where we could specify the versions).
 - go install github.com/DataDog/datadog-agent/vendor/github.com/golang/dep/cmd/dep (this would install the pinned version overriding what we have in `$GOPATH/src/github.com/golang/dep/cmd/dep`)

What I don't like about this alternative is that the user would end up with stuff in $GOPATH/bin which doesn't match what he might expect from $GOPATH/src (since it comes from a vendored directory).