### PR TITLE
Use agent hostname as hostname for docker events.

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -23,6 +23,7 @@ import (
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
@@ -323,7 +324,10 @@ func (d *DockerCheck) Configure(config, initConfig integration.Data) error {
 	}
 
 	var err error
-	d.dockerHostname, err = docker.HostnameProvider("")
+	// Use the same hostname as the agent so that host tags (like `availability-zone:us-east-1b`)
+	// are attached to Docker events from this host. The hostname from the docker api may be
+	// different than the agent hostname depending on the environment (like EC2 or GCE).
+	d.dockerHostname, err = util.GetHostname()
 	if err != nil {
 		log.Warnf("Can't get hostname from docker, events will not have it: %s", err)
 	}

--- a/releasenotes/notes/use-agent-hostname-as-hostname-for-docker-events-2e76350b90849540.yaml
+++ b/releasenotes/notes/use-agent-hostname-as-hostname-for-docker-events-2e76350b90849540.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Changes the hostname used for Docker events to be the hostname of the agent.


### PR DESCRIPTION
### What does this PR do?

Use the same hostname as the agent so that host tags (like `availability-zone:us-east-1b`) are attached to Docker events from this host. The hostname from the docker api may be different than the agent hostname depending on the environment (like EC2 or GCE).

The Agent5 already does this https://github.com/DataDog/integrations-core/blob/master/docker_daemon/datadog_checks/docker_daemon/docker_daemon.py#L907.

### Motivation

Host tags (like `availability-zone:us-east-1b` when running in AWS) were not getting attached to Docker events.

### To do

- [ ] Sanity check that tags are correctly added to Docker events for EC2 instances