### PR TITLE
Fix panics from Viper lib when using proxy

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -175,8 +175,7 @@ func TestLoadProxyFromEnvNoValue(t *testing.T) {
 	loadProxyFromEnv()
 	assert.Nil(t, Datadog.Get("proxy"))
 
-	proxies, err := GetProxies()
-	require.Nil(t, err)
+	proxies := GetProxies()
 	require.Nil(t, proxies)
 }
 
@@ -192,8 +191,7 @@ func TestLoadProxyConfOnly(t *testing.T) {
 	defer os.Setenv("NO_PROXY", ciValue)
 
 	loadProxyFromEnv()
-	proxies, err := GetProxies()
-	require.Nil(t, err)
+	proxies := GetProxies()
 	assert.Equal(t, p, proxies)
 }
 
@@ -205,8 +203,7 @@ func TestLoadProxyEnvOnly(t *testing.T) {
 
 	loadProxyFromEnv()
 
-	proxies, err := GetProxies()
-	require.Nil(t, err)
+	proxies := GetProxies()
 	assert.Equal(t,
 		&Proxy{
 			HTTP:    "http_url",
@@ -225,8 +222,7 @@ func TestLoadProxyEnvOnly(t *testing.T) {
 	os.Setenv("no_proxy", "1,2,3")
 
 	loadProxyFromEnv()
-	proxies, err = GetProxies()
-	require.Nil(t, err)
+	proxies = GetProxies()
 	assert.Equal(t,
 		&Proxy{
 			HTTP:    "http_url2",
@@ -248,8 +244,7 @@ func TestLoadProxyEnvAndConf(t *testing.T) {
 	defer Datadog.Set("proxy", nil)
 
 	loadProxyFromEnv()
-	proxies, err := GetProxies()
-	require.Nil(t, err)
+	proxies := GetProxies()
 	assert.Equal(t,
 		&Proxy{
 			HTTP:    "http_conf",

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -202,10 +202,7 @@ func CreateHTTPTransport() *http.Transport {
 		TLSClientConfig: tlsConfig,
 	}
 
-	proxies, err := config.GetProxies()
-	if err != nil {
-		log.Errorf("%s", err)
-	} else if proxies != nil {
+	if proxies := config.GetProxies(); proxies != nil {
 		transport.Proxy = GetProxyTransportFunc(proxies)
 	}
 	return transport

--- a/releasenotes/notes/fix-panic-viper-211eace2eae26842.yaml
+++ b/releasenotes/notes/fix-panic-viper-211eace2eae26842.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix panics within the agent when using non thread safe method from Viper
+    library (Unmarshall).


### PR DESCRIPTION
### What does this PR do?

The 'Unmarshal' method from viper is no longer thread safe (since viper
autoupdate his internal map to be case insensitive). This may cause the
agent to panic when creating a HTTP transaction while another goroutine
read the configuration.

We now save the proxy settings when we first load the configuration.
This avoids calling 'Unmarshal' each time we create an HTTP transaction
and remove potential panics.