### PR TITLE
bump test timeout to 2min

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -45,7 +45,7 @@ DEFAULT_TEST_TARGETS = [
 
 @task()
 def test(ctx, targets=None, coverage=False, race=False, profile=False, use_embedded_libs=False, fail_on_fmt=False,
-         timeout=60):
+         timeout=120):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.


### PR DESCRIPTION
### What does this PR do?

bump test timeout to 2min

### Motivation

Some test might be taking more than one minute to run with the `-race` flag of `go test` enabled.