### PR TITLE
[Logs] Don't submit invalid UTF-8 in payloads

### DIFF
--- a/pkg/logs/processor/encoder.go
+++ b/pkg/logs/processor/encoder.go
@@ -10,6 +10,10 @@ import (
 
 	"regexp"
 
+	"unicode/utf8"
+
+	"errors"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pb"
@@ -103,6 +107,9 @@ func (r *raw) isRFC5424Formatted(content []byte) bool {
 type proto struct{}
 
 func (p *proto) encode(msg message.Message, redactedMsg []byte) ([]byte, error) {
+	if !utf8.Valid(redactedMsg) {
+		return nil, errors.New("invalid UTF-8 string: " + string(redactedMsg))
+	}
 	return (&pb.Log{
 		Message:   string(redactedMsg),
 		Status:    msg.GetStatus(),

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -180,3 +180,9 @@ func TestProtoEncoderEmpty(t *testing.T) {
 	assert.NotEmpty(t, log.Timestamp)
 
 }
+
+func TestProtoEncoderInvalidUTF8(t *testing.T) {
+	msg, err := protoEncoder.encode(nil, []byte("\xde\xea\xca\xfe"))
+	assert.Nil(t, msg)
+	assert.Error(t, err)
+}

--- a/releasenotes/notes/logs_proto_invalid_utf8-aaad0c13757a19fe.yaml
+++ b/releasenotes/notes/logs_proto_invalid_utf8-aaad0c13757a19fe.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Prevent logs agent from submitting protocol buffer payloads with invalid UTF-8.


### PR DESCRIPTION
### What does this PR do?

Prevent logs agent from submitting protocol buffer payloads with invalid UTF-8.

Currently, the protobuf implementation does not check strings are valid UTF-8, which may result in decoding errors further down in the processing pipeline. This change will prevent the agent from submitting invalid payloads and instead log an error. Catching the problem earlier will also allow users to troubleshoot encoding / character set problems themselves.
