### PR TITLE
[DCA] Refacto and clean up

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -9,8 +9,8 @@ RUN mkdir -p /opt/datadog-cluster-agent/bin/datadog-cluster-agent/
 
 COPY datadog-cluster-agent /opt/datadog-cluster-agent/bin/datadog-cluster-agent/datadog-cluster-agent
 
-COPY ./conf.d /etc/datadog-cluster-agent/etc/conf.d
-COPY ./datadog-cluster.yaml /etc/datadog-cluster-agent/etc/datadog-cluster.yaml
+COPY ./conf.d /etc/datadog-agent/etc/conf.d
+COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog.yaml
 COPY ./dist /opt/datadog-cluster-agent/bin/datadog-cluster-agent/dist
 
 RUN apt-get update \
@@ -21,7 +21,7 @@ RUN apt-get update \
 COPY entrypoint.sh .
 
 RUN chmod 755 /entrypoint.sh \
-    && chmod g+r,g+w,g+X -R /etc/datadog-cluster-agent/
+    && chmod g+r,g+w,g+X -R /etc/datadog-agent/
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -2,16 +2,16 @@ FROM debian:stretch-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV PATH="/opt/datadog-cluster-agent/bin/datadog-cluster-agent/:/opt/datadog-cluster-agent/embedded/bin/":$PATH
+ENV PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH
 
 # Install the Agent
-RUN mkdir -p /opt/datadog-cluster-agent/bin/datadog-cluster-agent/
+RUN mkdir -p /opt/datadog-agent/bin/datadog-cluster-agent/
 
-COPY datadog-cluster-agent /opt/datadog-cluster-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+COPY datadog-cluster-agent /opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
 
 COPY ./conf.d /etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog.yaml
-COPY ./dist /opt/datadog-cluster-agent/bin/datadog-cluster-agent/dist
+COPY ./dist /opt/datadog-agent/bin/datadog-cluster-agent/dist
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl\

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /opt/datadog-cluster-agent/bin/datadog-cluster-agent/
 
 COPY datadog-cluster-agent /opt/datadog-cluster-agent/bin/datadog-cluster-agent/datadog-cluster-agent
 
-COPY ./conf.d /etc/datadog-agent/etc/conf.d
+COPY ./conf.d /etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog.yaml
 COPY ./dist /opt/datadog-cluster-agent/bin/datadog-cluster-agent/dist
 

--- a/Dockerfiles/cluster-agent/dist/templates/header.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/header.tmpl
@@ -12,7 +12,7 @@
   Paths
   =====
     Config File: {{if .conf_file}}{{.conf_file}}{{else}}There is no config file{{end}}
-    conf.d: {{.config.confd_dca_path}}
+    conf.d: {{.config.confd_path}}
 
   Clocks
   ======

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -8,12 +8,12 @@
 
 ##### Core config #####
 
-if [[ -z $DD_API_KEY ]]; then
+if [[ -z "$DD_API_KEY" ]]; then
     echo "You must set an DD_API_KEY environment variable to run the Datadog Agent container"
     exit 1
 fi
 
-if [ -z $DD_DD_URL ]; then
+if [[ -z "$DD_DD_URL" ]]; then
     export DD_DD_URL="https://app.datadoghq.com"
 fi
 

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -17,10 +17,10 @@ if [ -z $DD_DD_URL ]; then
     export DD_DD_URL="https://app.datadoghq.com"
 fi
 
-chmod +x /opt/datadog-cluster-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+chmod +x /opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
 sync	# Fix for 'Text file busy' error
 
 ##### Starting up #####
-export PATH="/opt/datadog-cluster-agent/bin/datadog-cluster-agent/:/opt/datadog-cluster-agent/embedded/bin/":$PATH
+export PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH
 
 exec "$@"

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -83,7 +83,7 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	av, err := version.New(version.AgentVersion, version.Commit)
+	av, err := version.New(version.DCAVersion, version.Commit)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
 		return

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -67,7 +67,6 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonStats)
 }
 
-// TODO: make sure it works for DCA
 func stopAgent(w http.ResponseWriter, r *http.Request) {
 	if err := apiutil.ValidateDCARequest(w, r); err != nil {
 		return

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -46,10 +46,6 @@ func SetupHandlers(r *mux.Router) {
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
-
 	log.Info("Got a request for the status. Making status.")
 	s, err := status.GetDCAStatus()
 	w.Header().Set("Content-Type", "application/json")
@@ -68,9 +64,6 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
-		return
-	}
 	signals.Stopper <- true
 	w.Header().Set("Content-Type", "application/json")
 	j, _ := json.Marshal("")
@@ -78,9 +71,6 @@ func stopAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 func getVersion(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
 	av, err := version.New(version.DCAVersion, version.Commit)
 	if err != nil {
@@ -96,9 +86,6 @@ func getVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func getHostname(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
 	w.Header().Set("Content-Type", "application/json")
 	hname, err := util.GetHostname()
 	if err != nil {
@@ -114,10 +101,6 @@ func getHostname(w http.ResponseWriter, r *http.Request) {
 }
 
 func makeFlare(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
-
 	log.Infof("Making a flare")
 	w.Header().Set("Content-Type", "application/json")
 	logFile := config.Datadog.GetString("log_file")
@@ -208,9 +191,6 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 
 // getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.
 func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
 	vars := mux.Vars(r)
 	nodeName := vars["nodeName"]
 	log.Infof("Fetching metadata map on all pods of the node %s", nodeName)
@@ -251,9 +231,6 @@ func getAllMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: map[string]string
 			Example: "["Error":"could not collect the service map for all nodes: List services is not permitted at the cluster scope."]
 	*/
-	if err := apiutil.Validate(w, r); err != nil {
-		return
-	}
 	log.Info("Computing metadata map on all nodes")
 	metaList, errAPIServer := as.GetMetadataMapBundleOnAllNodes()
 	// If we hit an error at this point, it is because we don't have access to the API server.

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -128,7 +128,7 @@ func start(cmd *cobra.Command, args []string) error {
 	s := &serializer.Serializer{Forwarder: f}
 
 	aggregatorInstance := aggregator.InitAggregator(s, hostname)
-	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("DCA %s", version.DCAVersion))
+	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.DCAVersion))
 
 	clusterAgent, err := clusteragent.Run(aggregatorInstance.GetChannels())
 	if err != nil {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -51,7 +51,7 @@ metadata for their metrics.`,
 		Short: "Print the version number",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			av, _ := version.New(version.AgentVersion, version.Commit)
+			av, _ := version.New(version.DCAVersion, version.Commit)
 			fmt.Println(fmt.Sprintf("Cluster Agent from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
 		},
 	}
@@ -128,7 +128,7 @@ func start(cmd *cobra.Command, args []string) error {
 	s := &serializer.Serializer{Forwarder: f}
 
 	aggregatorInstance := aggregator.InitAggregator(s, hostname)
-	aggregatorInstance.AddAgentStartupEvent("DCA")
+	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("DCA %s", version.DCAVersion))
 
 	clusterAgent, err := clusteragent.Run(aggregatorInstance.GetChannels())
 	if err != nil {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/fatih/color"
 )
 
 // FIXME: move SetupAutoConfig and StartAutoConfig in their own package so we don't import cmd/agent
@@ -48,11 +49,26 @@ metadata for their metrics.`,
 
 	versionCmd = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number",
+		Short: "Print the version info",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
+			if flagNoColor {
+				color.NoColor = true
+			}
 			av, _ := version.New(version.DCAVersion, version.Commit)
-			fmt.Println(fmt.Sprintf("Cluster Agent from Agent %s - Codename: %s - Commit: %s - Serialization version: %s", av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion))
+			meta := ""
+			if av.Meta != "" {
+				meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
+			}
+			fmt.Fprintln(
+				color.Output,
+				fmt.Sprintf("Agent %s %s- Commit: '%s' - Serialization version: %s",
+					color.BlueString(av.GetNumberAndPre()),
+					meta,
+					color.GreenString(version.Commit),
+					color.MagentaString(serializer.AgentPayloadVersion),
+				),
+			)
 		},
 	}
 

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 
-	log "github.com/cihub/seelog"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
@@ -37,20 +36,9 @@ var flareCmd = &cobra.Command{
 	Short: "Collect a flare and send it to Datadog",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configFound := false
-		// a path to the folder containing the config file was passed
-		if len(confPath) != 0 {
-			// we'll search for a config file named `datadog-cluster.yaml`
-			config.Datadog.AddConfigPath(confPath)
-			confErr := config.Load()
-			if confErr != nil {
-				log.Error(confErr)
-			} else {
-				configFound = true
-			}
-		}
-		if !configFound {
-			log.Debugf("Config read from env variables")
+		err := common.SetupConfig(confPath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
 		}
 
 		caseID := ""

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -31,20 +31,9 @@ One can easily identify which pods are running on which nodes,
 as well as which services are serving the pods. Or the deployment name for the pod`,
 	Example: "datadog-cluster-agent metamap ip-10-0-115-123",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configFound := false
-		// a path to the folder containing the config file was passed
-		if len(confPath) != 0 {
-			// we'll search for a config file named `datadog-cluster.yaml`
-			config.Datadog.AddConfigPath(confPath)
-			confErr := config.Load()
-			if confErr != nil {
-				log.Error(confErr)
-			} else {
-				configFound = true
-			}
-		}
-		if !configFound {
-			log.Debugf("Config read from env variables")
+		err := common.SetupConfig(confPath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global cluster agent configuration: %v", err)
 		}
 		nodeName := ""
 		if len(args) > 0 {

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	log "github.com/cihub/seelog"
 	"github.com/spf13/cobra"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -37,23 +37,11 @@ var statusCmd = &cobra.Command{
 	Short: "Print the current status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configFound := false
-		// a path to the folder containing the config file was passed
-		if len(confPath) != 0 {
-			// we'll search for a config file named `datadog-cluster.yaml`
-			config.Datadog.AddConfigPath(confPath)
-			confErr := config.Load()
-			if confErr != nil {
-				log.Error(confErr)
-			} else {
-				configFound = true
-			}
+		err := common.SetupConfig(confPath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
-		if !configFound {
-			log.Debugf("Config read from env variables")
-		}
-
-		err := requestStatus()
+		err = requestStatus()
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+//go:generate go run ../../pkg/config/render_config.go dca ../../pkg/config/config_template.yaml ../../Dockerfiles/cluster-agent/datadog-cluster.yaml
+
 package main
 
 import (

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -157,7 +157,7 @@ func DeleteAuthToken() error {
 // 1st. the configuration value of "cluster_agent.auth_token" in datadog.yaml
 // 2nd. from the filesystem
 // If using the token from the filesystem, the token file must be next to the datadog.yaml
-// with the filename: dca_auth_token
+// with the filename: cluster_agent_auth_token
 func GetClusterAgentAuthToken() (string, error) {
 	authToken := config.Datadog.GetString("cluster_agent.auth_token")
 	if authToken != "" {
@@ -199,7 +199,6 @@ func GetClusterAgentAuthToken() (string, error) {
 	return authToken, validateAuthToken(authToken)
 }
 
-// TODO check the token is base64
 func validateAuthToken(authToken string) error {
 	if len(authToken) < authTokenMinimalLen {
 		return fmt.Errorf("cluster agent authentication token length must be greater than %d, curently: %d", authTokenMinimalLen, len(authToken))

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -51,36 +51,6 @@ func DoGet(c *http.Client, url string) (body []byte, e error) {
 
 }
 
-// DoGetExternalEndpoint is a wrapper around performing HTTP GET requests designed for external endpoints.
-func DoGetExternalEndpoint(c *http.Client, url string) (body []byte, e error) {
-	req, e := http.NewRequest("GET", url, nil)
-	if e != nil {
-		return body, e
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+GetDCAAuthToken())
-
-	r, e := c.Do(req)
-	if e != nil {
-		return body, e
-	}
-	body, e = ioutil.ReadAll(r.Body)
-	r.Body.Close()
-	if e != nil {
-		return body, e
-	}
-	if r.StatusCode == 503 {
-		// 503 errors are used when the agent can't reach an external service to process a task.
-		// i.e. the svcmap requires access to the Kubernetes API Server.
-		return body, nil
-	}
-	if r.StatusCode >= 400 {
-		return body, fmt.Errorf("%s", body)
-	}
-
-	return body, nil
-}
-
 // DoPost is a wrapper around performing HTTP POST requests
 func DoPost(c *http.Client, url string, contentType string, body io.Reader) (resp []byte, e error) {
 	req, e := http.NewRequest("POST", url, body)

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -7,11 +7,11 @@ package util
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"net/http"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -169,7 +169,7 @@ func (k *KubeASCheck) runLeaderElection() error {
 		log.Debugf("Leader is %q. %s will not run Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName(), leaderEngine.HolderIdentity)
 		return apiserver.ErrNotLeader
 	}
-	log.Tracef("Currently Leader %q, running Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName())
+	log.Tracef("Current leader: %q, running Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName())
 	return nil
 }
 func (k *KubeASCheck) eventCollectionInit() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,7 +80,6 @@ func init() {
 	Datadog.SetDefault("tags", []string{})
 	Datadog.SetDefault("conf_path", ".")
 	Datadog.SetDefault("confd_path", defaultConfdPath)
-	Datadog.SetDefault("confd_dca_path", defaultDCAConfdPath)
 	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
 	Datadog.SetDefault("log_payloads", false)
 	Datadog.SetDefault("log_level", "info")

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -7,7 +7,6 @@ package config
 
 const (
 	defaultConfdPath            = "/opt/datadog-agent/etc/conf.d"
-	defaultDCAConfdPath         = "/opt/datadog-cluster-agent/etc/conf.d"
 	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
 	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///var/run/syslog"

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -9,7 +9,6 @@ package config
 
 const (
 	defaultConfdPath            = "/etc/datadog-agent/conf.d"
-	defaultDCAConfdPath         = "/etc/datadog-cluster-agent/etc/conf.d"
 	defaultAdditionalChecksPath = "/etc/datadog-agent/checks.d"
 	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///dev/log"

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -7,7 +7,6 @@ package config
 
 const (
 	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
-	defaultDCAConfdPath         = "c:\\programdata\\datadog\\conf.d"
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
 	defaultRunPath              = ""
 	defaultSyslogURI            = ""

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -26,7 +26,7 @@ import (
 func CreateDCAArchive(local bool, distPath, logFilePath string) (string, error) {
 	zipFilePath := getArchivePath()
 	confSearchPaths := SearchPaths{
-		"":     config.Datadog.GetString("confd_dca_path"),
+		"":     config.Datadog.GetString("confd_path"),
 		"dist": filepath.Join(distPath, "conf.d"),
 	}
 	return createDCAArchive(zipFilePath, local, confSearchPaths, logFilePath)

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -60,7 +60,7 @@ func FormatDCAStatus(data []byte) (string, error) {
 	forwarderStats := stats["forwarderStats"]
 	runnerStats := stats["runnerStats"]
 	autoConfigStats := stats["autoConfigStats"]
-	title := fmt.Sprintf("Agent (v%s)", stats["version"])
+	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
 	renderChecksStats(b, runnerStats, autoConfigStats, "")

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -153,7 +153,7 @@ func getDCAPartialConfig() map[string]string {
 	conf := make(map[string]string)
 	conf["log_file"] = config.Datadog.GetString("log_file")
 	conf["log_level"] = config.Datadog.GetString("log_level")
-	conf["confd_dca_path"] = config.Datadog.GetString("confd_dca_path")
+	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	return conf
 }
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -111,8 +111,8 @@ func GetDCAStatus() (map[string]interface{}, error) {
 		log.Errorf("Error Getting ExpVar Stats: %v", err)
 	}
 	stats["config"] = getDCAPartialConfig()
-
-	stats["version"] = version.AgentVersion
+	stats["conf_file"] = config.Datadog.ConfigFileUsed()
+	stats["version"] = version.DCAVersion
 	stats["pid"] = os.Getpid()
 	hostname, err := util.GetHostname()
 	if err != nil {

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -37,6 +37,7 @@ type KubeMetadataCollector struct {
 // Detect tries to connect to the kubelet and the API Server if the DCA is not used or the DCA.
 func (c *KubeMetadataCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") == false {
+		log.Infof("The metadata mapper was configured to be disabled, not collecting metadata for the pods from the API Server")
 		return NoCollection, fmt.Errorf("collection disabled by the configuration")
 	}
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -40,7 +40,7 @@ const (
 	tokenTime                 = "tokenTimestamp"
 	tokenKey                  = "tokenKey"
 	metadataPollIntl          = 20 * time.Second
-	metadataMapExpire         = 5 * time.Minute
+	metadataMapExpire         = 1 * time.Minute
 	metadataMapperCachePrefix = "KubernetesMetadataMapping"
 )
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -221,7 +221,7 @@ func processKubeServices(nodeList *v1.NodeList, podList *v1.PodList, endpointLis
 		nodeNameCacheKey := cache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
 		freshness := cache.BuildAgentKey(metadataMapperCachePrefix, nodeName, "freshness")
 
-		metaBundle, found := cache.Cache.Get(nodeNameCacheKey) // We get the old one with the dead pods. if diff reset metabundle and deledte key. Then compute again.
+		metaBundle, found := cache.Cache.Get(nodeNameCacheKey)       // We get the old one with the dead pods. if diff reset metabundle and deledte key. Then compute again.
 		freshnessCache, freshnessFound := cache.Cache.Get(freshness) // if expired, freshness not found deal with that
 
 		if !found {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -148,7 +148,7 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 	le.m.Lock()
 	defer le.m.Unlock()
 	if le.running {
-		log.Debugf("Currently leader %s, leader identity: %q", le.IsLeader(), le.CurrentLeaderName())
+		log.Debugf("Currently leader %t, leader identity: %q", le.IsLeader(), le.CurrentLeaderName())
 		return nil
 	}
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -148,7 +148,7 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 	le.m.Lock()
 	defer le.m.Unlock()
 	if le.running {
-		log.Debugf("Currently leader %t, leader identity: %q", le.IsLeader(), le.CurrentLeaderName())
+		log.Debugf("Currently leader: %t. Leader identity: %q", le.IsLeader(), le.CurrentLeaderName())
 		return nil
 	}
 

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -10,13 +10,20 @@ package version
 // AgentVersion contains the version of the Agent
 var AgentVersion string
 
+// DCAVersion contains the version of the Datatog Cluster Agent
+var DCAVersion string
+
 // Commit is populated with the short commit hash from which the Agent was built
 var Commit string
 
 var agentVersionDefault = "6.0.0"
+var clusterAgentVersionDefault = "1.0.0"
 
 func init() {
 	if AgentVersion == "" {
 		AgentVersion = agentVersionDefault
+	}
+	if DCAVersion == "" {
+		DCAVersion = clusterAgentVersionDefault
 	}
 }

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -46,7 +46,19 @@ def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False)
         "ldflags": ldflags,
         "REPO_PATH": REPO_PATH,
     }
+
     ctx.run(cmd.format(**args), env=env)
+    # Render the configuration file template
+    #
+    # We need to remove cross compiling bits if any because go generate must
+    # build and execute in the native platform
+    env.update({
+        "GOOS": "",
+        "GOARCH": "",
+    })
+    cmd = "go generate {}/cmd/cluster-agent"
+
+    ctx.run(cmd.format(REPO_PATH), env=env)
 
 
 @task

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -36,7 +36,7 @@ def build(ctx, rebuild=False, race=False, static=False, use_embedded_libs=False)
     ldflags, gcflags, env = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
 
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
-    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent/"
+    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent"
     args = {
         "race_opt": "-race" if race else "",
         "build_type": "-a" if rebuild else "-i",


### PR DESCRIPTION
### What does this PR do?

- [x] Consistent binary and conf files path with the agent `/opt/datadog-agent/bin/datadog-cluster-agent/` and `/etc/datadog-agent/conf.d`.
- [x] Properly version the DCA. Fix `datadog-cluster-agent version`.
- [x] Use `datadog.yaml`.
- [x] Fix the metamapper cache churn.
- [x] Move internal API token validation to use the middleware

### Motivation
Preparation for the ß release.

### Results
```
/# datadog-cluster-agent version
Agent 1.0.0 - Commit: 'fc4958c0' - Serialization version: 4.7
```

```
/# datadog-cluster-agent status
Getting the status from the agent.
==============================
Datadog Cluster Agent (v1.0.0)
==============================

  Status date: 2018-05-28 17:37:02.239681 UTC
  Pid: 1
  Check Runners: 1
  Log Level: debug

  Paths
  =====
    Config File: /etc/datadog-agent/datadog.yaml
    conf.d: /etc/datadog-agent/conf.d

  Clocks
  ======
    System UTC time: 2018-05-28 17:37:02.239681 UTC

  Hostnames
  =========
    hostname: datadog-cluster-agent-9859b7cd8-vgnb9
    socket-fqdn: datadog-cluster-agent-9859b7cd8-vgnb9
    socket-hostname: datadog-cluster-agent-9859b7cd8-vgnb9

  Leader Election
  ===============
    Leader Election Status:  Running
    Leader Name is: datadog-cluster-agent-9859b7cd8-vgnb9
    Last Acquisition of the lease: Mon, 28 May 2018 17:14:28 UTC
    Renewed leadership: Mon, 28 May 2018 17:36:58 UTC
    Number of leader transitions: 9 transitions


=========
Collector
=========

  Running Checks
  ==============
    kubernetes_apiserver
    --------------------
      Total Runs: 95
      Metrics: 0, Total Metrics: 0
      Events: 0, Total Events: 11
      Service Checks: 3, Total Service Checks: 270
  
=========
Forwarder
=========

  CheckRunsV1: 95
  DroppedOnInput: 0
  IntakeV1: 3
  RetryQueueSize: 0
  Success: 193
  TimeseriesV1: 95

  API Keys status
  ===============
    https://6-2-0-app.agent.datadoghq.com,*************************33a36: API Key valid

```

```
/# datadog-cluster-agent flare  
Please enter your email: 
foo@bar.com
Asking the Cluster Agent to build the flare archive.
/tmp/datadog-agent-2018-05-28-17-37-49.zip is going to be uploaded to Datadog
Are you sure you want to upload a flare? [Y/N]
N
Aborting. (You can still use /tmp/datadog-agent-2018-05-28-17-37-49.zip) 
```

```
/# unzip /tmp/datadog-agent-2018-05-28
Archive:  /tmp/datadog-agent-2018-05-28-17-37-49.zip
   creating: datadog-cluster-agent-9859b7cd8-vgnb9/
  inflating: datadog-cluster-agent-9859b7cd8-vgnb9/cluster-agent-metadatamapper.log  
  inflating: datadog-cluster-agent-9859b7cd8-vgnb9/cluster-agent-status.log  
   creating: datadog-cluster-agent-9859b7cd8-vgnb9/etc/
   creating: datadog-cluster-agent-9859b7cd8-vgnb9/etc/confd/
   creating: datadog-cluster-agent-9859b7cd8-vgnb9/etc/confd/kubernetes_apiserver.d/
  inflating: datadog-cluster-agent-9859b7cd8-vgnb9/etc/confd/kubernetes_apiserver.d/conf.yaml.default  
  inflating: datadog-cluster-agent-9859b7cd8-vgnb9/etc/datadog.yaml  
   creating: datadog-cluster-agent-9859b7cd8-vgnb9/expvar/
 [...]
   creating: datadog-cluster-agent-9859b7cd8-vgnb9/logs/
  inflating: datadog-cluster-agent-9859b7cd8-vgnb9/logs/cluster-agent.log  
  inflating: datadog-cluster-agent-9859b7cd8-vgnb9/runtime_config_dump.yaml 
```
