### PR TITLE
Adding host tag to the kubernetes events

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -48,13 +48,13 @@ func (m *MockSender) AssertMetricNotTaggedWith(t *testing.T, method string, metr
 }
 
 // AssertEvent assert the expectedEvent was emitted with the following values:
-// AggregationKey, Priority, SourceTypeName, EventType and a Ts range weighted with the parameter allowedDelta
+// AggregationKey, Priority, SourceTypeName, EventType, Host and a Ts range weighted with the parameter allowedDelta
 func (m *MockSender) AssertEvent(t *testing.T, expectedEvent metrics.Event, allowedDelta time.Duration) bool {
 	return m.Mock.AssertCalled(t, "Event", MatchEventLike(expectedEvent, allowedDelta))
 }
 
 // AssertEventMissing assert the expectedEvent was never emitted with the following values:
-// AggregationKey, Priority, SourceTypeName, EventType and a Ts range weighted with the parameter allowedDelta
+// AggregationKey, Priority, SourceTypeName, EventType, Host and a Ts range weighted with the parameter allowedDelta
 func (m *MockSender) AssertEventMissing(t *testing.T, expectedEvent metrics.Event, allowedDelta time.Duration) bool {
 	return m.Mock.AssertNotCalled(t, "Event", MatchEventLike(expectedEvent, allowedDelta))
 }
@@ -93,7 +93,7 @@ func AssertFloatInRange(min float64, max float64) interface{} {
 
 // MatchEventLike is a mock.argumentMatcher builder to be used in asserts.
 // It allows to check if an event is Equal on the following Event elements:
-// AggregationKey, Priority, SourceTypeName, EventType and Tag list
+// AggregationKey, Priority, SourceTypeName, EventType, Host and Tag list
 // Also do a timestamp comparison with a tolerance defined by allowedDelta
 func MatchEventLike(expected metrics.Event, allowedDelta time.Duration) interface{} {
 	return mock.MatchedBy(func(actual metrics.Event) bool {
@@ -108,16 +108,14 @@ func MatchEventLike(expected metrics.Event, allowedDelta time.Duration) interfac
 }
 
 // Compare an Event on specifics values:
-// AggregationKey, Priority, SourceTypeName, EventType and tag list
+// AggregationKey, Priority, SourceTypeName, EventType, Host, and tag list
 func eventLike(expectedEvent, actualEvent metrics.Event) bool {
-	if assert.ObjectsAreEqualValues(expectedEvent.AggregationKey, actualEvent.AggregationKey) &&
+	return (assert.ObjectsAreEqualValues(expectedEvent.AggregationKey, actualEvent.AggregationKey) &&
 		assert.ObjectsAreEqualValues(expectedEvent.Priority, actualEvent.Priority) &&
 		assert.ObjectsAreEqualValues(expectedEvent.SourceTypeName, actualEvent.SourceTypeName) &&
 		assert.ObjectsAreEqualValues(expectedEvent.EventType, actualEvent.EventType) &&
-		expectedInActual(expectedEvent.Tags, actualEvent.Tags) {
-		return true
-	}
-	return false
+		assert.ObjectsAreEqualValues(expectedEvent.Host, actualEvent.Host) &&
+		expectedInActual(expectedEvent.Tags, actualEvent.Tags))
 }
 
 // Return a bool value if all the elements of expected are inside the actual array

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -327,8 +328,10 @@ ITER_EVENTS:
 			log.Debugf("Filtered out the following events: %s", formatStringIntMap(filteredByType))
 		}
 	}
+
+	clusterName := clustername.GetClusterName()
 	for _, bundle := range eventsByObject {
-		datadogEv, err := bundle.formatEvents(k.KubeAPIServerHostname, modified)
+		datadogEv, err := bundle.formatEvents(modified, clusterName)
 		if err != nil {
 			k.Warnf("Error while formatting bundled events, %s. Not submitting", err.Error())
 			continue

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver_test.go
@@ -18,7 +18,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -122,7 +124,7 @@ func TestParseComponentStatus(t *testing.T) {
 	mocked.AssertExpectations(t)
 }
 
-func createEvent(count int32, namespace, objname, objkind, objuid, component, reason string, message string, timestamp int64) *v1.Event {
+func createEvent(count int32, namespace, objname, objkind, objuid, component, hostname, reason string, message string, timestamp int64) *v1.Event {
 	return &v1.Event{
 		InvolvedObject: v1.ObjectReference{
 			Name:      objname,
@@ -133,6 +135,7 @@ func createEvent(count int32, namespace, objname, objkind, objuid, component, re
 		Count: count,
 		Source: v1.EventSource{
 			Component: component,
+			Host:      hostname,
 		},
 		Reason: reason,
 		FirstTimestamp: obj.Time{
@@ -144,13 +147,15 @@ func createEvent(count int32, namespace, objname, objkind, objuid, component, re
 		Message: message,
 	}
 }
+
 func TestProcessBundledEvents(t *testing.T) {
 	// We want to check if the format of several new events and several modified events creates DD events accordingly
 	// We also want to check that a modified event with an existing key is aggregated (i.e. the key is already known)
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
-	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "Started", "Started container", 709662600)
-	ev3 := createEvent(1, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709662600)
-	ev4 := createEvent(29, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709675200)
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
+	ev2 := createEvent(3, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Started", "Started container", 709662600)
+	ev3 := createEvent(1, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709662600)
+	ev4 := createEvent(29, "default", "localhost", "Node", "e63e74fa-f566-11e7-9749-0e4863e1cbf4", "kubelet", "machine-blue", "MissingClusterDNS", "MountVolume.SetUp succeeded", 709675200)
+	// (As Object kinds are Pod and Node here, the event should take the remote hostname `machine-blue`)
 
 	kubeASCheck := &KubeASCheck{
 		instance: &KubeASConfig{
@@ -187,14 +192,14 @@ func TestProcessBundledEvents(t *testing.T) {
 		ev4,
 	}
 	modifiedNewDatadogEvents := metrics.Event{
-		Title:          "Events from the localhost Node",
+		Title:          "Events from the machine-blue Node",
 		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at " + time.Unix(709675200, 0).String() + "_ \n\n %%%",
 		Priority:       "normal",
 		Tags:           []string{"test", "namespace:default", "source_component:kubelet"},
 		AggregationKey: "kubernetes_apiserver:e63e74fa-f566-11e7-9749-0e4863e1cbf4",
 		SourceTypeName: "kubernetes",
 		Ts:             709675200,
-		Host:           "hostname",
+		Host:           "machine-blue",
 		EventType:      "kubernetes_apiserver",
 	}
 	mocked = mocksender.NewMockSender(kubeASCheck.ID())
@@ -204,11 +209,41 @@ func TestProcessBundledEvents(t *testing.T) {
 
 	mocked.AssertEvent(t, modifiedNewDatadogEvents, 0)
 	mocked.AssertExpectations(t)
+
+	// Test the hostname change when a cluster name is set
+	var testClusterName = "Laika"
+	config.Datadog.Set("cluster_name", testClusterName)
+	clustername.ResetClusterName() // reset state as clustername was already read
+	// defer a reset of the state so that future hostname fetches are not impacted
+	defer config.Datadog.Set("cluster_name", nil)
+	defer clustername.ResetClusterName()
+
+	modifiedNewDatadogEventsWithClusterName := metrics.Event{
+		Title:          "Events from the machine-blue Node",
+		Text:           "%%% \n30 **MissingClusterDNS**: MountVolume.SetUp succeeded\n \n _Events emitted by the kubelet seen at " + time.Unix(709675200, 0).String() + "_ \n\n %%%",
+		Priority:       "normal",
+		Tags:           []string{"test", "namespace:default", "source_component:kubelet"},
+		AggregationKey: "kubernetes_apiserver:e63e74fa-f566-11e7-9749-0e4863e1cbf4",
+		SourceTypeName: "kubernetes",
+		Ts:             709675200,
+		Host:           "machine-blue-" + testClusterName,
+		EventType:      "kubernetes_apiserver",
+	}
+
+	mocked = mocksender.NewMockSender(kubeASCheck.ID())
+	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
+
+	kubeASCheck.processEvents(mocked, modifiedKubeEventsBundle, true)
+
+	mocked.AssertEvent(t, modifiedNewDatadogEventsWithClusterName, 0)
+	mocked.AssertExpectations(t)
 }
+
 func TestProcessEvent(t *testing.T) {
 	// We want to check if the format of 1 New event creates a DD event accordingly.
 	// We also want to check that filtered and empty events aren't submitted
-	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "Pod", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
+	ev1 := createEvent(2, "default", "dca-789976f5d7-2ljx6", "ReplicaSet", "e6417a7f-f566-11e7-9749-0e4863e1cbf4", "default-scheduler", "machine-blue", "Scheduled", "Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54", 709662600)
+	// (Object kind was changed from Pod to ReplicaSet to test the choice of hostname: it should take here the local hostname below `hostname`)
 
 	kubeASCheck := &KubeASCheck{
 		instance: &KubeASConfig{
@@ -225,14 +260,14 @@ func TestProcessEvent(t *testing.T) {
 	}
 	// 1 Scheduled:
 	newDatadogEvent := metrics.Event{
-		Title:          "Events from the dca-789976f5d7-2ljx6 Pod",
+		Title:          "Events from the dca-789976f5d7-2ljx6 ReplicaSet",
 		Text:           "%%% \n2 **Scheduled**: Successfully assigned dca-789976f5d7-2ljx6 to ip-10-0-0-54\n \n _New events emitted by the default-scheduler seen at " + time.Unix(709662600000, 0).String() + "_ \n\n %%%",
 		Priority:       "normal",
 		Tags:           []string{"test", "source_component:default-scheduler", "namespace:default"},
 		AggregationKey: "kubernetes_apiserver:e6417a7f-f566-11e7-9749-0e4863e1cbf4",
 		SourceTypeName: "kubernetes",
 		Ts:             709662600,
-		Host:           "hostname",
+		Host:           "",
 		EventType:      "kubernetes_apiserver",
 	}
 	mocked.On("Event", mock.AnythingOfType("metrics.Event"))
@@ -248,7 +283,7 @@ func TestProcessEvent(t *testing.T) {
 	mocked.AssertExpectations(t)
 
 	// Ignored Event
-	ev5 := createEvent(1, "default", "localhost", "Node", "529fe848-e132-11e7-bad4-0e4863e1cbf4", "kubelet", "ignored", "", 709675200)
+	ev5 := createEvent(1, "default", "machine-blue", "Node", "529fe848-e132-11e7-bad4-0e4863e1cbf4", "kubelet", "machine-blue", "ignored", "", 709675200)
 	filteredKubeEventsBundle := []*v1.Event{
 		ev5,
 	}

--- a/releasenotes/notes/kubernetes-set-events-tag-according-to-involved-host-3f25d35c576ae5c1.yaml
+++ b/releasenotes/notes/kubernetes-set-events-tag-according-to-involved-host-3f25d35c576ae5c1.yaml
@@ -1,3 +1,4 @@
 ---
 features:
-    - Kubernetes events: setting event host tags to the related hosts, instead of the host collecting the events.
+    - |
+      Kubernetes events: setting event host tags to the related hosts, instead of the host collecting the events.

--- a/releasenotes/notes/kubernetes-set-events-tag-according-to-involved-host-3f25d35c576ae5c1.yaml
+++ b/releasenotes/notes/kubernetes-set-events-tag-according-to-involved-host-3f25d35c576ae5c1.yaml
@@ -1,0 +1,3 @@
+---
+features:
+    - Kubernetes events: setting event host tags to the related hosts, instead of the host collecting the events.

--- a/test/integration/corechecks/docker/events_test.go
+++ b/test/integration/corechecks/docker/events_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 func init() {
@@ -26,6 +29,9 @@ func TestEvents(t *testing.T) {
 		"lowcardenvtag:eventlowenv",
 	}
 
+	localHostname, err := util.GetHostname()
+	assert.Nil(t, err)
+
 	expectedBusyboxEvent := metrics.Event{
 		Ts:        nowTimestamp,
 		EventType: "docker",
@@ -40,6 +46,7 @@ func TestEvents(t *testing.T) {
 		AggregationKey: "docker:datadog/docker-library:busybox_1_28_0",
 		SourceTypeName: "docker",
 		Priority:       metrics.EventPriorityNormal,
+		Host:           localHostname,
 	}
 	sender.AssertEvent(t, expectedBusyboxEvent, time.Minute)
 
@@ -56,6 +63,7 @@ func TestEvents(t *testing.T) {
 		AggregationKey: "docker:datadog/docker-library:redis_3_2_11-alpine",
 		SourceTypeName: "docker",
 		Priority:       metrics.EventPriorityNormal,
+		Host:           localHostname,
 	}
 	sender.AssertEvent(t, expectedRedisEvent, time.Minute)
 


### PR DESCRIPTION
### What does this PR do?
Changing host tag from kubernetes events from the submitter hostname to the involved hostname.

### Motivation
Allowing to use events by _host_ , for instance for alerting.

### Additional Notes
To be merged in master after https://github.com/DataDog/datadog-agent/pull/2172

Tested on a GKE cluster