### PR TITLE
Add tagger list command

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -45,6 +46,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
 	r.HandleFunc("/gui/csrf-token", getCSRFToken).Methods("GET")
 	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
+	r.HandleFunc("/tagger-list", getTaggerList).Methods("GET")
 }
 
 func stopAgent(w http.ResponseWriter, r *http.Request) {
@@ -213,5 +215,15 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Unable to marshal config check response: %s", err)
 	}
 
+	w.Write(json)
+}
+
+func getTaggerList(w http.ResponseWriter, r *http.Request) {
+	response := tagger.List(tagger.IsFullCardinality())
+
+	json, err := json.Marshal(response)
+	if err != nil {
+		log.Errorf("Unable to marshal tagger list response: %s", err)
+	}
 	w.Write(json)
 }

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -210,20 +210,26 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	response.ConfigErrors = autodiscovery.GetConfigErrors()
 	response.Unresolved = common.AC.GetUnresolvedTemplates()
 
-	json, err := json.Marshal(response)
+	jsonConfig, err := json.Marshal(response)
 	if err != nil {
 		log.Errorf("Unable to marshal config check response: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
 	}
 
-	w.Write(json)
+	w.Write(jsonConfig)
 }
 
 func getTaggerList(w http.ResponseWriter, r *http.Request) {
 	response := tagger.List(tagger.IsFullCardinality())
 
-	json, err := json.Marshal(response)
+	jsonTags, err := json.Marshal(response)
 	if err != nil {
 		log.Errorf("Unable to marshal tagger list response: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
 	}
-	w.Write(json)
+	w.Write(jsonTags)
 }

--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -16,3 +16,14 @@ type ConfigCheckResponse struct {
 	ConfigErrors    map[string]string             `json:"config_errors"`
 	Unresolved      map[string]integration.Config `json:"unresolved"`
 }
+
+// TaggerListResponse holds the tagger list response
+type TaggerListResponse struct {
+	Entities map[string]TaggerListEntity `json:"entities"`
+}
+
+// TaggerListEntity holds the tagging info about an entity
+type TaggerListEntity struct {
+	Sources []string `json:"sources"`
+	Tags    []string `json:"tags"`
+}

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	AgentCmd.AddCommand(taggerListCommand)
+}
+
+var taggerListURL = fmt.Sprintf("https://localhost:%v/agent/tagger-list", config.Datadog.GetInt("cmd_port"))
+
+var taggerListCommand = &cobra.Command{
+	Use:   "tagger-list",
+	Short: "Print the tagger content of a running agent",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+		if flagNoColor {
+			color.NoColor = true
+		}
+		c := util.GetClient(false) // FIX: get certificates right then make this true
+
+		// Set session token
+		err = util.SetAuthToken()
+		if err != nil {
+			return err
+		}
+
+		r, err := util.DoGet(c, taggerListURL)
+		if err != nil {
+			if r != nil && string(r) != "" {
+				fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while getting tags list: %s", string(r)))
+			} else {
+				fmt.Fprintln(color.Output, fmt.Sprintf("Failed to query the agent (running?): %s", err))
+			}
+		}
+
+		tr := response.TaggerListResponse{}
+		err = json.Unmarshal(r, &tr)
+		if err != nil {
+			return err
+		}
+
+		for entity, tagItem := range tr.Entities {
+			fmt.Fprintln(color.Output, fmt.Sprintf("\n=== Entity %s ===", color.GreenString(entity)))
+
+			fmt.Fprint(color.Output, "Tags: [")
+			for i, tag := range tagItem.Tags {
+				tagInfo := strings.Split(tag, ":")
+				fmt.Fprintf(color.Output, fmt.Sprintf("%s:%s", color.BlueString(tagInfo[0]), color.CyanString(strings.Join(tagInfo[1:], ":"))))
+				if i != len(tagItem.Tags)-1 {
+					fmt.Fprintf(color.Output, " ")
+				}
+			}
+			fmt.Fprintln(color.Output, "]")
+			fmt.Fprint(color.Output, "Sources: [")
+			for i, source := range tagItem.Sources {
+				fmt.Fprintf(color.Output, fmt.Sprintf("%s", color.BlueString(source)))
+				if i != len(tagItem.Sources)-1 {
+					fmt.Fprintf(color.Output, " ")
+				}
+			}
+			fmt.Fprintln(color.Output, "]")
+			fmt.Fprintln(color.Output, "===")
+		}
+
+		return nil
+	},
+}

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -8,6 +8,7 @@ package tagger
 import (
 	"sync"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
@@ -43,6 +44,11 @@ func Stop() error {
 // this caches the call to viper, that would lookup and parse envvars
 func IsFullCardinality() bool {
 	return fullCardinality
+}
+
+// List the content of the defaulTagger
+func List(highCard bool) response.TaggerListResponse {
+	return defaultTagger.List(highCard)
 }
 
 func init() {

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
@@ -262,6 +263,25 @@ ITER_COLLECTORS:
 	computedTags := utils.ConcatenateTags(tagArrays)
 
 	return copyArray(computedTags), nil
+}
+
+// List the content of the tagger
+func (t *Tagger) List(highCard bool) response.TaggerListResponse {
+	r := response.TaggerListResponse{
+		Entities: make(map[string]response.TaggerListEntity),
+	}
+
+	t.tagStore.storeMutex.RLock()
+	defer t.tagStore.storeMutex.RUnlock()
+	for entityID, et := range t.tagStore.store {
+		entity := response.TaggerListEntity{}
+		tags, sources := et.get(highCard)
+		entity.Tags = copyArray(tags)
+		entity.Sources = copyArray(sources)
+		r.Entities[entityID] = entity
+	}
+
+	return r
 }
 
 // copyArray makes sure the tagger does not return internal slices

--- a/releasenotes/notes/add-tagger-list-22cd509b72d141a0.yaml
+++ b/releasenotes/notes/add-tagger-list-22cd509b72d141a0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a new "tagger-list" command that outputs the tagger content of a running agent.


### PR DESCRIPTION
### What does this PR do?

![screen shot 2018-05-29 at 10 18 20](https://user-images.githubusercontent.com/2368736/40646640-14376794-632a-11e8-8fd7-2f133d4cae76.png)

Add a `tagger-list` command that output the content of the tagger store of a running agent.

### Motivation

Useful for debugging

### Additional Notes

We might add it to the flare as well.
