### PR TITLE
fix windows io check

### DIFF
--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -27,6 +27,8 @@ var (
 
 	procGetLogicalDriveStringsW = modkernel32.NewProc("GetLogicalDriveStringsW")
 	procGetDriveType            = modkernel32.NewProc("GetDriveTypeW")
+
+	drivePattern = regexp.MustCompile(`[A-Z]:\\`)
 )
 
 const (
@@ -63,7 +65,7 @@ func init() {
 func isDrive(instance string) bool {
 	found := false
 	instance += "\\"
-	if instance != "C:\\" {
+	if !drivePattern.MatchString(instance) {
 		return false
 	}
 	for _, driveletter := range drivelist {

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -28,7 +28,7 @@ var (
 	procGetLogicalDriveStringsW = modkernel32.NewProc("GetLogicalDriveStringsW")
 	procGetDriveType            = modkernel32.NewProc("GetDriveTypeW")
 
-	drivePattern = regexp.MustCompile(`[A-Z]:\\`)
+	drivePattern = regexp.MustCompile(`[A-Za-z]:`)
 )
 
 const (
@@ -64,10 +64,10 @@ func init() {
 
 func isDrive(instance string) bool {
 	found := false
-	instance += "\\"
 	if !drivePattern.MatchString(instance) {
 		return false
 	}
+	instance += "\\"
 	for _, driveletter := range drivelist {
 		if instance == driveletter {
 			found = true

--- a/releasenotes/notes/fix-io-check-windows-drive-4c165375e26d570f.yaml
+++ b/releasenotes/notes/fix-io-check-windows-drive-4c165375e26d570f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug on windows where the io check was reporting metrics for the ``C:``
+    drive only.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that would, on windows, make the io check report metrics for the `C:` drive only.
The bug was introduced in this PR https://github.com/DataDog/datadog-agent/pull/1149 and was present since 6.0.

### Motivation

Support case.
