### PR TITLE
[docs] Add section on runnng subprocesses from Agent checks

### DIFF
--- a/docs/dev/checks/python/check_api.md
+++ b/docs/dev/checks/python/check_api.md
@@ -166,8 +166,8 @@ following:
 
 ## Running subprocesses
 
-Because of the embedded and multi-threaded nature of the Python runtime in Agent v6 there are some
-limitations to running subprocesses from Agent Checks.
+Due to the Python interpreter being embedded in an inherently multi-threaded environment (the go runtime)
+there are some limitations to the ways in which Python Checks can run subprocesses.
 
 To run a subprocess from your Check, please use the `get_subprocess_output` function
 provided in `datadog_checks.utils.subprocess_output`:

--- a/docs/dev/checks/python/check_api.md
+++ b/docs/dev/checks/python/check_api.md
@@ -164,6 +164,27 @@ following:
   configuration file (to be backwards compatible we agent5 checks we have to
   pass a list here).
 
+## Running subprocesses
+
+Because of the embedded and multi-threaded nature of the Python runtime in Agent v6 there are some
+limitations to running subprocesses from Agent Checks.
+
+To run a subprocess from your Check, please use the `get_subprocess_output` function
+provided in `datadog_checks.utils.subprocess_output`:
+
+```python
+from datadog_checks.utils.subprocess_output import get_subprocess_output
+
+class MyCheck(AgentCheck):
+    def check(self, instance):
+    # [...]
+    out, err, retcode = get_subprocess_output(cmd, self.log, raise_on_empty_output=True)
+```
+
+Using the `subprocess` and `multiprocessing` modules provided by the python standard library is _not
+supported_, and may result in your Agent crashing and/or creating processes that remain in a stuck or zombie
+state.
+
 
 
 [collector]: /pkg/collector

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -255,7 +255,7 @@ static PyMethodDef _utilMethods[] = {
   {"get_subprocess_output", (PyCFunction)get_subprocess_output,
       METH_VARARGS, "Run subprocess and return its output. "
                     "This is a private method and should not be called directly. "
-                    "Please use the utils.subprocess_output.get_subprocess_output wrapper."},
+                    "Please use the datadog_checks.utils.subprocess_output.get_subprocess_output wrapper."},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
### What does this PR do?

* Add section on running subprocesses from Agent checks
* update `_util` python module doc with new path to `subprocess_output` module

### Motivation

Have this documented explicitly
