### PR TITLE
Enable docker log collection only with autodiscovery

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -30,10 +29,9 @@ func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*Lo
 	fileSources := buildLogSourcesFromDirectory(ddconfdPath)
 	sources = append(sources, fileSources...)
 
+	// append sources from environment variables
 	if collectAllLogsFromContainers {
 		// append source to collect all logs from all containers,
-		// this source must be added to the end of the list
-		// to assure sources metadata are not overridden when already defined
 		containersSource := NewLogSource("container_collect_all", &LogsConfig{
 			Type:    DockerType,
 			Service: "docker",
@@ -42,11 +40,5 @@ func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*Lo
 		sources = append(sources, containersSource)
 	}
 
-	logSources := &LogSources{sources}
-
-	if len(logSources.GetValidSources()) == 0 {
-		return nil, fmt.Errorf("could not find any valid logs configuration")
-	}
-
-	return logSources, nil
+	return &LogSources{sources}, nil
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -29,9 +29,10 @@ func TestBuildLogsSources(t *testing.T) {
 	var source *LogSource
 	var err error
 
-	// should return an error
+	// should return an empty list
 	logsSources, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(logsSources.GetValidSources()))
 
 	// should return the default tail all containers source
 	logsSources, err = buildLogSources(ddconfdPath, true)

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -83,26 +83,33 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
 	var ddconfdPath string
+	var allSources *LogSources
 	var err error
+
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	allSources, err = buildLogSources(ddconfdPath, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(allSources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	allSources, err = buildLogSources(ddconfdPath, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(allSources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	allSources, err = buildLogSources(ddconfdPath, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(allSources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	allSources, err = buildLogSources(ddconfdPath, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(allSources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	allSources, err = buildLogSources(ddconfdPath, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(allSources.GetValidSources()))
 }
 
 func TestIntegrationName(t *testing.T) {

--- a/pkg/logs/input/container/scanner.go
+++ b/pkg/logs/input/container/scanner.go
@@ -138,10 +138,6 @@ func (s *Scanner) scan(tailFromBeginning bool) {
 
 // Start starts the Scanner
 func (s *Scanner) setup() error {
-	if len(s.sources) == 0 {
-		return fmt.Errorf("No container source defined")
-	}
-
 	cli, err := NewDockerClient()
 	if err != nil {
 		log.Error("Can't tail containers, ", err)

--- a/releasenotes/notes/collect-logs-with-docker-label-only-1ffa6daf6b93d635.yaml
+++ b/releasenotes/notes/collect-logs-with-docker-label-only-1ffa6daf6b93d635.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Collect logs for all containers defining a log autodiscovery label whatsoever the configuration.


### PR DESCRIPTION
### What does this PR do?

Removed all assertions on sources/configs length.

### Motivation

Enable log collection for all containers defining an autodiscovery label, even if:
- `logs_config.container_collect_all` is not set
-  `{logs:[{type:docker}]}` is not defined

### Additional Notes

This should solve https://github.com/DataDog/datadog-agent/issues/1736
