### PR TITLE
Add more logs for diagnosing issues connecting to kubelet using TLS

### DIFF
--- a/pkg/collector/py/kubeutil.go
+++ b/pkg/collector/py/kubeutil.go
@@ -35,17 +35,19 @@ func GetKubeletConnectionInfo() *C.PyObject {
 	dict := C.PyDict_New()
 
 	if cached, hit := cache.Cache.Get(kubeletCacheKey); hit {
-		creds, ok = cached.(map[string]string)
-		if !ok {
-			log.Errorf("invalid cache format, forcing a cache miss")
+		log.Debug("cache hit for kubelet connection info")
+		if creds, ok = cached.(map[string]string); !ok {
+			log.Error("invalid cache format, forcing a cache miss")
 			creds = nil
 		}
 	}
 
 	if creds == nil { // Cache miss
+		log.Debug("cache miss for kubelet connection info")
 		kubeutil, err := kubelet.GetKubeUtil()
 		if err != nil {
 			// Connection to the kubelet fail, return empty dict
+			log.Errorf("connection to kubelet failed: %v", err)
 			return dict
 		}
 		// At this point, we have valid credentials to get

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -58,8 +58,7 @@ func GetClusterAgentClient() (*DCAClient, error) {
 			RetryDelay:    30 * time.Second,
 		})
 	}
-	err := globalClusterAgentClient.initRetry.TriggerRetry()
-	if err != nil {
+	if err := globalClusterAgentClient.initRetry.TriggerRetry(); err != nil {
 		log.Debugf("Init error: %s", err)
 		return nil, err
 	}

--- a/pkg/util/docker/global.go
+++ b/pkg/util/docker/global.go
@@ -45,8 +45,7 @@ func GetDockerUtil() (*DockerUtil, error) {
 			RetryDelay:    30 * time.Second,
 		})
 	}
-	err := globalDockerUtil.initRetry.TriggerRetry()
-	if err != nil {
+	if err := globalDockerUtil.initRetry.TriggerRetry(); err != nil {
 		log.Debugf("Docker init error: %s", err)
 		return nil, err
 	}

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -63,7 +63,7 @@ type (
 
 var globalUtil *Util
 
-// GetUtil returns a ready to use DockerUtil. It is backed by a shared singleton.
+// GetUtil returns a ready to use ecs Util. It is backed by a shared singleton.
 func GetUtil() (*Util, error) {
 	if globalUtil == nil {
 		globalUtil = &Util{}
@@ -75,8 +75,7 @@ func GetUtil() (*Util, error) {
 			RetryDelay:    30 * time.Second,
 		})
 	}
-	err := globalUtil.initRetry.TriggerRetry()
-	if err != nil {
+	if err := globalUtil.initRetry.TriggerRetry(); err != nil {
 		log.Debugf("ECS init error: %s", err)
 		return nil, err
 	}

--- a/pkg/util/kubernetes/kubelet/init.go
+++ b/pkg/util/kubernetes/kubelet/init.go
@@ -31,12 +31,13 @@ func isConfiguredTLSVerify() bool {
 func buildTLSConfig(verifyTLS bool, caPath string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{}
 	if verifyTLS == false {
+		log.Info("Skipping TLS verification")
 		tlsConfig.InsecureSkipVerify = true
 		return tlsConfig, nil
 	}
 
 	if caPath == "" {
-		log.Debugf("kubelet_client_ca isn't configured: certificate authority must be trusted")
+		log.Debug("kubelet_client_ca isn't configured: certificate authority must be trusted")
 		return nil, nil
 	}
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -439,7 +439,7 @@ func (ku *KubeUtil) init() error {
 	// setting the kubeletHost
 	ku.kubeletHost = config.Datadog.GetString("kubernetes_kubelet_host")
 	if ku.kubeletHost == "" {
-		ku.kubeletHost, err = docker.HostnameProvider("")
+		ku.kubeletHost, err := docker.HostnameProvider("")
 		if err != nil {
 			return fmt.Errorf("unable to get hostname from docker, please set the kubernetes_kubelet_host option: %s", err)
 		}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -437,10 +437,12 @@ func (ku *KubeUtil) setupKubeletApiEndpoint() error {
 }
 
 func (ku *KubeUtil) init() error {
+	var err error
+
 	// setting the kubeletHost
 	ku.kubeletHost = config.Datadog.GetString("kubernetes_kubelet_host")
 	if ku.kubeletHost == "" {
-		ku.kubeletHost, err := docker.HostnameProvider("")
+		ku.kubeletHost, err = docker.HostnameProvider("")
 		if err != nil {
 			return fmt.Errorf("unable to get hostname from docker, please set the kubernetes_kubelet_host option: %s", err)
 		}
@@ -461,7 +463,8 @@ func (ku *KubeUtil) init() error {
 		}
 	}
 
-	if err := ku.setupKubeletApiClient(); err != nil {
+	err = ku.setupKubeletApiClient()
+	if err != nil {
 		return err
 	}
 	return ku.setupKubeletApiEndpoint()

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -265,7 +265,7 @@ func (ku *KubeUtil) setupKubeletApiClient() error {
 		transport)
 	if err != nil {
 		log.Debugf("Failed to init tls, will try http only: %s", err)
-		return err
+		return nil
 	}
 
 	ku.kubeletApiClient.Transport = transport
@@ -284,9 +284,10 @@ func (ku *KubeUtil) setupKubeletApiClient() error {
 	case kubernetes.IsServiceAccountTokenAvailable():
 		log.Debug("Using HTTPS with service account bearer token")
 		return ku.setBearerToken(kubernetes.ServiceAccountTokenPath)
+	default:
+		log.Debug("No configured token or TLS certificates, will try http only")
+		return nil
 	}
-	log.Debug("No configured token or TLS certificates, will try http only")
-	return nil
 }
 
 func (ku *KubeUtil) setupTLS(verifyTLS bool, caPath string, transport *http.Transport) error {


### PR DESCRIPTION
### What does this PR do?

Add more logs for diagnosing issues connecting to kubelet using TLS. This PR does not solve this problem but adds more logs around connecting to the kubelet using TLS to have more visibility into this issue and other related issues.

### Motivation

The logs contained in a flare from running diagnose was reporting `PASS` for the kubelet check while the logs for running the diagnose command with the cli was reporting `FAIL`. 