### PR TITLE
Fixes intermittent failure in the runner test.

### DIFF
--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -7,6 +7,7 @@ package runner
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 	"time"
 
@@ -118,8 +119,10 @@ type TimingoutCheck struct {
 
 func (tc *TimingoutCheck) Stop() {
 	for {
+		runtime.Gosched()
 	}
 }
+func (tc *TimingoutCheck) String() string { return "TimeoutTestCheck" }
 
 func TestStopCheck(t *testing.T) {
 	r := NewRunner()


### PR DESCRIPTION
Was failing the timeout test because on low CPU count environment, the
goroutine that services the timer may not get scheduled, since the
"TimingOutCheck" Stop routine was busy looping

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
