### PR TITLE
Add support for port names in template vars for autodiscovery.

### DIFF
--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -11,7 +11,7 @@ type dummyService struct {
 	ID            listeners.ID
 	ADIdentifiers []string
 	Hosts         map[string]string
-	Ports         []int
+	Ports         []listeners.ContainerPort
 	Pid           int
 }
 
@@ -31,7 +31,7 @@ func (s *dummyService) GetHosts() (map[string]string, error) {
 }
 
 // GetPorts returns dummy ports
-func (s *dummyService) GetPorts() ([]int, error) {
+func (s *dummyService) GetPorts() ([]listeners.ContainerPort, error) {
 	return s.Ports, nil
 }
 

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -298,17 +298,23 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	}
 
 	if len(tplVar) == 0 {
-		return []byte(strconv.Itoa(ports[len(ports)-1])), nil
+		return []byte(strconv.Itoa(ports[len(ports)-1].ContainerPort)), nil
 	}
 
 	idx, err := strconv.Atoi((string(tplVar)))
 	if err != nil {
-		return nil, fmt.Errorf("index given for the port template var is not an int, skipping container %s", svc.GetID())
+		// The template variable is not an index so try to lookup port by name.
+		for _, port := range ports {
+			if port.Name == string(tplVar) {
+				return []byte(strconv.Itoa(port.ContainerPort)), nil
+			}
+		}
+		return nil, fmt.Errorf("port %s not found, skipping container %s", string(tplVar), svc.GetID())
 	}
 	if len(ports) <= idx {
 		return nil, fmt.Errorf("index given for the port template var is too big, skipping container %s", svc.GetID())
 	}
-	return []byte(strconv.Itoa(ports[idx])), nil
+	return []byte(strconv.Itoa(ports[idx].ContainerPort)), nil
 }
 
 // getPid returns the process identifier of the service

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -298,7 +298,7 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	}
 
 	if len(tplVar) == 0 {
-		return []byte(strconv.Itoa(ports[len(ports)-1].ContainerPort)), nil
+		return []byte(strconv.Itoa(ports[len(ports)-1].Port)), nil
 	}
 
 	idx, err := strconv.Atoi((string(tplVar)))
@@ -306,7 +306,7 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 		// The template variable is not an index so try to lookup port by name.
 		for _, port := range ports {
 			if port.Name == string(tplVar) {
-				return []byte(strconv.Itoa(port.ContainerPort)), nil
+				return []byte(strconv.Itoa(port.Port)), nil
 			}
 		}
 		return nil, fmt.Errorf("port %s not found, skipping container %s", string(tplVar), svc.GetID())
@@ -314,7 +314,7 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	if len(ports) <= idx {
 		return nil, fmt.Errorf("index given for the port template var is too big, skipping container %s", svc.GetID())
 	}
-	return []byte(strconv.Itoa(ports[idx].ContainerPort)), nil
+	return []byte(strconv.Itoa(ports[idx].Port)), nil
 }
 
 // getPid returns the process identifier of the service

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -220,7 +220,7 @@ func TestResolve(t *testing.T) {
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Ports:         []int{1, 2, 3},
+				Ports:         newFakeContainerPorts(),
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -238,7 +238,7 @@ func TestResolve(t *testing.T) {
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Ports:         []int{1, 2, 3},
+				Ports:         newFakeContainerPorts(),
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -252,11 +252,43 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
+			testName: "%%port_bar%%, found",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         newFakeContainerPorts(),
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("port: %%port_bar%%")},
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("port: 2")},
+			},
+		},
+		{
+			testName: "%%port_qux%%, not found, error",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Ports:         newFakeContainerPorts(),
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("port: %%port_qux%%")},
+			},
+			errorString: "port qux not found, skipping container a5901276aed1",
+		},
+		{
 			testName: "%%port_4%% too high, error",
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Ports:         []int{1, 2, 3},
+				Ports:         newFakeContainerPorts(),
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -266,25 +298,11 @@ func TestResolve(t *testing.T) {
 			errorString: "index given for the port template var is too big, skipping container a5901276aed1",
 		},
 		{
-			testName: "%%port_A%% not int, error",
-			svc: &dummyService{
-				ID:            "a5901276aed1",
-				ADIdentifiers: []string{"redis"},
-				Ports:         []int{1, 2, 3},
-			},
-			tpl: integration.Config{
-				Name:          "cpu",
-				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("port: %%port_A%%")},
-			},
-			errorString: "index given for the port template var is not an int, skipping container a5901276aed1",
-		},
-		{
 			testName: "%%port%% but no port in service, error",
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Ports:         []int{},
+				Ports:         []listeners.ContainerPort{},
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -399,5 +417,13 @@ func TestResolve(t *testing.T) {
 		// Assert the valid configs are stored in the AC and the store
 		assert.Equal(t, validTemplates, len(ac.loadedConfigs))
 		assert.Equal(t, len(ac.store.getConfigsForService(tc.svc.GetID())), validTemplates)
+	}
+}
+
+func newFakeContainerPorts() []listeners.ContainerPort {
+	return []listeners.ContainerPort{
+		{ContainerPort: 1, Name: "foo"},
+		{ContainerPort: 2, Name: "bar"},
+		{ContainerPort: 3, Name: "baz"},
 	}
 }

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -422,9 +422,8 @@ func TestResolve(t *testing.T) {
 
 func newFakeContainerPorts() []listeners.ContainerPort {
 	return []listeners.ContainerPort{
-		{ContainerPort: 1, Name: "foo"},
-		{ContainerPort: 2, Name: "bar"},
-		{ContainerPort: 3, Name: "baz"},
-		{ContainerPort: 4, Name: ""},
+		{Port: 1, Name: "foo"},
+		{Port: 2, Name: "bar"},
+		{Port: 3, Name: "baz"},
 	}
 }

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -425,5 +425,6 @@ func newFakeContainerPorts() []listeners.ContainerPort {
 		{ContainerPort: 1, Name: "foo"},
 		{ContainerPort: 2, Name: "bar"},
 		{ContainerPort: 3, Name: "baz"},
+		{ContainerPort: 4, Name: ""},
 	}
 }

--- a/pkg/autodiscovery/listeners/README.md
+++ b/pkg/autodiscovery/listeners/README.md
@@ -4,7 +4,7 @@ This package is providing the `ServiceListener` concept to the agent. A `Service
 
 ## `Service`
 
-`Service` represents an application we can run a integration against. It should be matched with a config template by the ConfigResolver.
+`Service` represents an application we can run an integration against. It should be matched with a config template by the ConfigResolver.
 Services can only be Docker containers for now.
 
 ## `ServiceListener`

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -414,7 +414,7 @@ func (s *DockerService) GetPorts() ([]ContainerPort, error) {
 	}
 
 	sort.Slice(ports, func(i, j int) bool {
-		return ports[i].ContainerPort < ports[j].ContainerPort
+		return ports[i].Port < ports[j].Port
 	})
 	s.Ports = ports
 	return ports, nil

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -43,7 +43,7 @@ type DockerService struct {
 	ID            ID
 	ADIdentifiers []string
 	Hosts         map[string]string
-	Ports         []int
+	Ports         []ContainerPort
 	Pid           int
 }
 
@@ -294,13 +294,13 @@ func (l *DockerListener) getHostsFromPs(co types.Container) map[string]string {
 }
 
 // getPortsFromPs gets the service ports of a container.
-func (l *DockerListener) getPortsFromPs(co types.Container) []int {
+func (l *DockerListener) getPortsFromPs(co types.Container) []ContainerPort {
 	// Nil array by default, we'll need to inspect the container
 	// later if we don't find any port in the PS
-	var ports []int
+	var ports []ContainerPort
 
 	for _, p := range co.Ports {
-		ports = append(ports, int(p.PrivatePort))
+		ports = append(ports, ContainerPort{int(p.PrivatePort), ""})
 	}
 	return ports
 }
@@ -374,13 +374,13 @@ func (s *DockerService) GetHosts() (map[string]string, error) {
 }
 
 // GetPorts returns the container's ports
-func (s *DockerService) GetPorts() ([]int, error) {
+func (s *DockerService) GetPorts() ([]ContainerPort, error) {
 	if s.Ports != nil {
 		return s.Ports, nil
 	}
 
 	// Make a non-nil array to avoid re-running if we find zero port
-	ports := []int{}
+	ports := []ContainerPort{}
 
 	du, err := docker.GetDockerUtil()
 	if err != nil {
@@ -413,19 +413,21 @@ func (s *DockerService) GetPorts() ([]int, error) {
 		}
 	}
 
-	sort.Ints(ports)
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].ContainerPort < ports[j].ContainerPort
+	})
 	s.Ports = ports
 	return ports, nil
 }
 
-func parseDockerPort(port nat.Port) ([]int, error) {
-	var output []int
+func parseDockerPort(port nat.Port) ([]ContainerPort, error) {
+	var output []ContainerPort
 
 	// Try to parse a port range, eg. 22-25
 	first, last, err := port.Range()
 	if err == nil && last > first {
 		for p := first; p <= last; p++ {
-			output = append(output, p)
+			output = append(output, ContainerPort{p, ""})
 		}
 		return output, nil
 	}
@@ -433,7 +435,7 @@ func parseDockerPort(port nat.Port) ([]int, error) {
 	// Try to parse a single port (most common case)
 	p := port.Int()
 	if p > 0 {
-		output = append(output, p)
+		output = append(output, ContainerPort{p, ""})
 		return output, nil
 	}
 

--- a/pkg/autodiscovery/listeners/docker_kubelet.go
+++ b/pkg/autodiscovery/listeners/docker_kubelet.go
@@ -25,7 +25,7 @@ type DockerKubeletService struct {
 	DockerService
 	kubeUtil *kubelet.KubeUtil
 	Hosts    map[string]string
-	Ports    []int
+	Ports    []ContainerPort
 }
 
 // getPod wraps KubeUtil init and pod lookup for both public methods.
@@ -57,7 +57,7 @@ func (s *DockerKubeletService) GetHosts() (map[string]string, error) {
 }
 
 // GetPorts returns the container's ports
-func (s *DockerKubeletService) GetPorts() ([]int, error) {
+func (s *DockerKubeletService) GetPorts() ([]ContainerPort, error) {
 	if s.Ports != nil {
 		return s.Ports, nil
 	}
@@ -76,11 +76,11 @@ func (s *DockerKubeletService) GetPorts() ([]int, error) {
 	if searchedContainerName == "" {
 		return nil, fmt.Errorf("can't find container %s in pod %s", searchedId, pod.Metadata.Name)
 	}
-	var ports []int
+	ports := []ContainerPort{}
 	for _, container := range pod.Spec.Containers {
 		if container.Name == searchedContainerName {
 			for _, port := range container.Ports {
-				ports = append(ports, port.ContainerPort)
+				ports = append(ports, ContainerPort{port.ContainerPort, port.Name})
 			}
 		}
 	}

--- a/pkg/autodiscovery/listeners/docker_kubelet.go
+++ b/pkg/autodiscovery/listeners/docker_kubelet.go
@@ -13,6 +13,7 @@ package listeners
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -85,6 +86,9 @@ func (s *DockerKubeletService) GetPorts() ([]ContainerPort, error) {
 		}
 	}
 
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Port < ports[j].Port
+	})
 	s.Ports = ports
 	return ports, nil
 }

--- a/pkg/autodiscovery/listeners/docker_test.go
+++ b/pkg/autodiscovery/listeners/docker_test.go
@@ -163,8 +163,8 @@ func TestGetPortsFromPs(t *testing.T) {
 	co.Ports = append(co.Ports, types.Port{PrivatePort: 4321})
 	ports := dl.getPortsFromPs(co)
 	assert.Equal(t, 2, len(ports))
-	assert.Contains(t, ports, 1234)
-	assert.Contains(t, ports, 4321)
+	assert.Contains(t, ports, ContainerPort{1234, ""})
+	assert.Contains(t, ports, ContainerPort{4321, ""})
 }
 
 func TestGetADIdentifiers(t *testing.T) {
@@ -366,10 +366,10 @@ func TestGetPorts(t *testing.T) {
 
 	pts, _ := svc.GetPorts()
 	assert.Equal(t, 4, len(pts))
-	assert.Contains(t, pts, 42)
-	assert.Contains(t, pts, 43)
-	assert.Contains(t, pts, 44)
-	assert.Contains(t, pts, 45)
+	assert.Contains(t, pts, ContainerPort{42, ""})
+	assert.Contains(t, pts, ContainerPort{43, ""})
+	assert.Contains(t, pts, ContainerPort{44, ""})
+	assert.Contains(t, pts, ContainerPort{45, ""})
 
 	// Both binding ports and exposed ports, only firsts should be picked up
 	id = "test"
@@ -407,8 +407,8 @@ func TestGetPorts(t *testing.T) {
 
 	pts, _ = svc.GetPorts()
 	assert.Equal(t, 2, len(pts))
-	assert.Contains(t, pts, 1234)
-	assert.Contains(t, pts, 4321)
+	assert.Contains(t, pts, ContainerPort{1234, ""})
+	assert.Contains(t, pts, ContainerPort{4321, ""})
 }
 
 func TestGetPid(t *testing.T) {
@@ -434,19 +434,19 @@ func TestParseDockerPort(t *testing.T) {
 	testCases := []struct {
 		proto         string
 		port          string
-		expectedPorts []int
+		expectedPorts []ContainerPort
 		expectedError error
 	}{
 		{
 			proto:         "tcp",
 			port:          "42",
-			expectedPorts: []int{42},
+			expectedPorts: []ContainerPort{{42, ""}},
 			expectedError: nil,
 		},
 		{
 			proto:         "udp",
 			port:          "500-503",
-			expectedPorts: []int{500, 501, 502, 503},
+			expectedPorts: []ContainerPort{{500, ""}, {501, ""}, {502, ""}, {503, ""}},
 			expectedError: nil,
 		},
 		{

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -203,7 +203,7 @@ func (s *ECSService) GetHosts() (map[string]string, error) {
 }
 
 // GetPorts returns nil and an error because port is not supported in Fargate-based ECS
-func (s *ECSService) GetPorts() ([]int, error) {
+func (s *ECSService) GetPorts() ([]ContainerPort, error) {
 	return nil, ErrNotSupported
 }
 

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -43,7 +43,7 @@ type PodContainerService struct {
 	ID            ID
 	ADIdentifiers []string
 	Hosts         map[string]string
-	Ports         []int
+	Ports         []ContainerPort
 }
 
 func init() {
@@ -155,11 +155,11 @@ func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
 	svc.Hosts = map[string]string{"pod": podIp}
 
 	// Ports
-	var ports []int
+	var ports []ContainerPort
 	for _, container := range pod.Spec.Containers {
 		if container.Name == containerName {
 			for _, port := range container.Ports {
-				ports = append(ports, port.ContainerPort)
+				ports = append(ports, ContainerPort{port.ContainerPort, port.Name})
 			}
 			break
 		}
@@ -232,7 +232,7 @@ func (s *PodContainerService) GetPid() (int, error) {
 }
 
 // GetPorts returns the container's ports
-func (s *PodContainerService) GetPorts() ([]int, error) {
+func (s *PodContainerService) GetPorts() ([]ContainerPort, error) {
 	return s.Ports, nil
 }
 

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -9,6 +9,7 @@ package listeners
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -164,6 +165,9 @@ func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
 			break
 		}
 	}
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Port < ports[j].Port
+	})
 	svc.Ports = ports
 	if len(svc.Ports) == 0 {
 		// Port might not be specified in pod spec

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -119,7 +119,7 @@ func TestProcessNewPod(t *testing.T) {
 		assert.Equal(t, map[string]string{"pod": "127.0.0.1"}, hosts)
 		ports, err := service.GetPorts()
 		assert.Nil(t, err)
-		assert.Equal(t, []int{1337, 1339}, ports)
+		assert.Equal(t, []ContainerPort{ContainerPort{1337, "footcpport"}, ContainerPort{1339, "fooudpport"}}, ports)
 		_, err = service.GetPid()
 		assert.Equal(t, ErrNotSupported, err)
 	default:
@@ -137,7 +137,7 @@ func TestProcessNewPod(t *testing.T) {
 		assert.Equal(t, map[string]string{"pod": "127.0.0.1"}, hosts)
 		ports, err := service.GetPorts()
 		assert.Nil(t, err)
-		assert.Equal(t, []int{1122}, ports)
+		assert.Equal(t, []ContainerPort{ContainerPort{1122, "barport"}}, ports)
 		_, err = service.GetPid()
 		assert.Equal(t, ErrNotSupported, err)
 	default:
@@ -155,7 +155,7 @@ func TestProcessNewPod(t *testing.T) {
 		assert.Equal(t, map[string]string{"pod": "127.0.0.1"}, hosts)
 		ports, err := service.GetPorts()
 		assert.Nil(t, err)
-		assert.Equal(t, []int{1122}, ports)
+		assert.Equal(t, []ContainerPort{ContainerPort{1122, "barport"}}, ports)
 		_, err = service.GetPid()
 		assert.Equal(t, ErrNotSupported, err)
 	default:

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -119,7 +119,7 @@ func TestProcessNewPod(t *testing.T) {
 		assert.Equal(t, map[string]string{"pod": "127.0.0.1"}, hosts)
 		ports, err := service.GetPorts()
 		assert.Nil(t, err)
-		assert.Equal(t, []ContainerPort{ContainerPort{1337, "footcpport"}, ContainerPort{1339, "fooudpport"}}, ports)
+		assert.Equal(t, []ContainerPort{{1337, "footcpport"}, {1339, "fooudpport"}}, ports)
 		_, err = service.GetPid()
 		assert.Equal(t, ErrNotSupported, err)
 	default:
@@ -137,7 +137,7 @@ func TestProcessNewPod(t *testing.T) {
 		assert.Equal(t, map[string]string{"pod": "127.0.0.1"}, hosts)
 		ports, err := service.GetPorts()
 		assert.Nil(t, err)
-		assert.Equal(t, []ContainerPort{ContainerPort{1122, "barport"}}, ports)
+		assert.Equal(t, []ContainerPort{{1122, "barport"}}, ports)
 		_, err = service.GetPid()
 		assert.Equal(t, ErrNotSupported, err)
 	default:
@@ -155,7 +155,7 @@ func TestProcessNewPod(t *testing.T) {
 		assert.Equal(t, map[string]string{"pod": "127.0.0.1"}, hosts)
 		ports, err := service.GetPorts()
 		assert.Nil(t, err)
-		assert.Equal(t, []ContainerPort{ContainerPort{1122, "barport"}}, ports)
+		assert.Equal(t, []ContainerPort{{1122, "barport"}}, ports)
 		_, err = service.GetPid()
 		assert.Equal(t, ErrNotSupported, err)
 	default:

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -21,17 +21,18 @@ func getMockedPod() *kubelet.Pod {
 			Name:  "foo",
 			Image: "datadoghq.com/foo:latest",
 			Ports: []kubelet.ContainerPortSpec{
-				{
-					ContainerPort: 1337,
-					HostPort:      1338,
-					Name:          "footcpport",
-					Protocol:      "TCP",
-				},
+				// test that resolved ports are sorted in ascending order
 				{
 					ContainerPort: 1339,
 					HostPort:      1340,
 					Name:          "fooudpport",
 					Protocol:      "UDP",
+				},
+				{
+					ContainerPort: 1337,
+					HostPort:      1338,
+					Name:          "footcpport",
+					Protocol:      "TCP",
 				},
 			},
 		},

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -14,7 +14,8 @@ import (
 // ID is the representation of the unique ID of a Service
 type ID string
 
-// ContainerPort represents a network port in a Service
+// ContainerPort represents a network port in a Service. Note that not all Services support
+// named network ports.
 type ContainerPort struct {
 	ContainerPort int
 	Name          string

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -14,11 +14,10 @@ import (
 // ID is the representation of the unique ID of a Service
 type ID string
 
-// ContainerPort represents a network port in a Service. Note that not all Services support
-// named network ports.
+// ContainerPort represents a network port in a Service.
 type ContainerPort struct {
-	ContainerPort int
-	Name          string
+	Port int
+	Name string
 }
 
 // Service represents an application we can run a check against.

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -14,6 +14,12 @@ import (
 // ID is the representation of the unique ID of a Service
 type ID string
 
+// ContainerPort represents a network port in a Service
+type ContainerPort struct {
+	ContainerPort int
+	Name          string
+}
+
 // Service represents an application we can run a check against.
 // It should be matched with a check template by the ConfigResolver using the
 // ADIdentifiers field.
@@ -21,7 +27,7 @@ type Service interface {
 	GetID() ID                            // unique ID
 	GetADIdentifiers() ([]string, error)  // identifiers on which templates will be matched
 	GetHosts() (map[string]string, error) // network --> IP address
-	GetPorts() ([]int, error)             // network ports
+	GetPorts() ([]ContainerPort, error)   // network ports
 	GetTags() ([]string, error)           // tags
 	GetPid() (int, error)                 // process identifier
 }

--- a/releasenotes/notes/add-support-for-port-names-in-template-vars-for-autodiscovery.-4645e174dd559435.yaml
+++ b/releasenotes/notes/add-support-for-port-names-in-template-vars-for-autodiscovery.-4645e174dd559435.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for port names in template vars for autodiscovery.


### PR DESCRIPTION
### What does this PR do?

Add support for using port names in template vars for k8s autodiscovery annotations.

### Motivation

Autodiscovery annotations currently support using port indexes like `%%port_0%%` but it would also be nice to support named ports in template variables like `%%port_http%%`.

### To Do

- [ ] Run agent in k8s for sanity check