### PR TITLE
[Flare] add docker ps output

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -128,11 +128,11 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		if err != nil {
 			log.Errorf("Could not zip docker inspect: %s", err)
 		}
+	}
 
-		err = zipDockerPs(tempDir, hostname)
-		if err != nil {
-			log.Errorf("Could not zip docker ps: %s", err)
-		}
+	err = zipDockerPs(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not zip docker ps: %s", err)
 	}
 
 	err = zipTypeperfData(tempDir, hostname)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -128,6 +128,11 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		if err != nil {
 			log.Errorf("Could not zip docker inspect: %s", err)
 		}
+
+		err = zipDockerPs(tempDir, hostname)
+		if err != nil {
+			log.Errorf("Could not zip docker ps: %s", err)
+		}
 	}
 
 	err = zipTypeperfData(tempDir, hostname)

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -75,7 +75,7 @@ func zipDockerPs(tempDir, hostname string) error {
 
 	// Opening out file
 	f := filepath.Join(tempDir, hostname, "docker_ps.log")
-	file, err := os.Create(f)
+	file, err := NewRedactingWriter(f, os.ModePerm, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -69,7 +69,7 @@ func zipDockerPs(tempDir, hostname string) error {
 		log.Debugf("Couldn't reach docker for getting `docker ps`: %s", err)
 		return nil
 	}
-	options := types.ContainerListOptions{All: true, Limit: 50}
+	options := types.ContainerListOptions{All: true, Limit: 500}
 	containerList, err := du.RawContainerList(options)
 	if err != nil {
 		return err

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -16,10 +16,10 @@ import (
 	"regexp"
 	"text/tabwriter"
 
-	"github.com/docker/docker/api/types"
-
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/docker/docker/api/types"
 )
 
 func zipDockerSelfInspect(tempDir, hostname string) error {
@@ -65,7 +65,9 @@ func zipDockerSelfInspect(tempDir, hostname string) error {
 func zipDockerPs(tempDir, hostname string) error {
 	du, err := docker.GetDockerUtil()
 	if err != nil {
-		return err
+		// if we can't reach docker, let's do nothing
+		log.Debugf("Couldn't reach docker for getting `docker ps`: %s", err)
+		return nil
 	}
 	options := types.ContainerListOptions{All: true, Limit: 50}
 	containerList, err := du.RawContainerList(options)

--- a/pkg/flare/archive_nodocker.go
+++ b/pkg/flare/archive_nodocker.go
@@ -10,3 +10,7 @@ package flare
 func zipDockerSelfInspect(tempDir, hostname string) error {
 	return nil
 }
+
+func zipDockerPs(tempDir, hostname string) error {
+	return nil
+}

--- a/releasenotes/notes/flare-adding-docker-ps-27fc2ddb2ef29510.yaml
+++ b/releasenotes/notes/flare-adding-docker-ps-27fc2ddb2ef29510.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add `docker ps -a` output to the flare.


### PR DESCRIPTION
### What does this PR do?

Adds `docker ps -a` output to the flare

### Motivation

During troubleshooting AD, it's usually useful to be able to make sure what other containers are present.

### Additional Notes
The output is close to the standard `docker ps` output:

```
CONTAINER ID    IMAGE          COMMAND                                STATUS         PORTS              NAMES
0f8d6ffa7db9    redis          "docker-entrypoint.sh redis-server"    Up 17 hours    [{ 6379 0 tcp}]    [/laughing_bardeen]
9d8fd3947750    nginx          "nginx -g 'daemon off;'"    Up 17 hours    [{ 80 0 tcp}]    [/pensive_meitner]
```

while the original output gives

```
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
0f8d6ffa7db9        redis               "docker-entrypoint.s…"   17 hours ago        Up 17 hours         6379/tcp            laughing_bardeen
9d8fd3947750        nginx               "nginx -g 'daemon of…"   17 hours ago        Up 17 hours         80/tcp              pensive_meitner
```

Note: 
The CREATED entry was set aside, as it was only a timestamp in the API and probably the less helpful info here.
