### PR TITLE
Add host tag for docker swarm node role.

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -6,7 +6,6 @@
 package host
 
 import (
-	"context"
 	"os"
 	"path"
 	"runtime"
@@ -112,10 +111,7 @@ func getHostTags() *tags {
 		hostTags = append(hostTags, k8sTags...)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-
-	dockerTags, err := docker.GetTags(ctx)
+	dockerTags, err := docker.GetTags()
 	if err != nil {
 		log.Debugf("No Docker host tags %v", err)
 	} else {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -6,6 +6,7 @@
 package host
 
 import (
+	"context"
 	"os"
 	"path"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
@@ -108,6 +110,16 @@ func getHostTags() *tags {
 		log.Debugf("No Kubernetes host tags %v", err)
 	} else {
 		hostTags = append(hostTags, k8sTags...)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	dockerTags, err := docker.GetTags(ctx)
+	if err != nil {
+		log.Debugf("No Docker host tags %v", err)
+	} else {
+		hostTags = append(hostTags, dockerTags...)
 	}
 
 	gceTags, err := gce.GetTags()

--- a/pkg/util/docker/fake/client.go
+++ b/pkg/util/docker/fake/client.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build docker
+
 package fake
 
 import (
@@ -13,27 +15,27 @@ import (
 	"github.com/docker/docker/api/types/registry"
 )
 
-type FakeSystemAPIClient struct {
+type SystemAPIClient struct {
 	InfoFunc func() (types.Info, error)
 }
 
-func (c *FakeSystemAPIClient) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+func (c *SystemAPIClient) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
 	return nil, nil
 }
 
-func (c *FakeSystemAPIClient) Info(ctx context.Context) (types.Info, error) {
+func (c *SystemAPIClient) Info(ctx context.Context) (types.Info, error) {
 	return c.InfoFunc()
 }
 
-func (c *FakeSystemAPIClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+func (c *SystemAPIClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
 	return registry.AuthenticateOKBody{}, nil
 }
 
-func (c *FakeSystemAPIClient) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
+func (c *SystemAPIClient) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
 	return types.DiskUsage{}, nil
 }
 
-func (c *FakeSystemAPIClient) Ping(ctx context.Context) (types.Ping, error) {
+func (c *SystemAPIClient) Ping(ctx context.Context) (types.Ping, error) {
 	return types.Ping{}, nil
 
 }

--- a/pkg/util/docker/fake/client.go
+++ b/pkg/util/docker/fake/client.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package fake
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/registry"
+)
+
+type FakeSystemAPIClient struct {
+	InfoFunc func() (types.Info, error)
+}
+
+func (c *FakeSystemAPIClient) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+	return nil, nil
+}
+
+func (c *FakeSystemAPIClient) Info(ctx context.Context) (types.Info, error) {
+	return c.InfoFunc()
+}
+
+func (c *FakeSystemAPIClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registry.AuthenticateOKBody, error) {
+	return registry.AuthenticateOKBody{}, nil
+}
+
+func (c *FakeSystemAPIClient) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
+	return types.DiskUsage{}, nil
+}
+
+func (c *FakeSystemAPIClient) Ping(ctx context.Context) (types.Ping, error) {
+	return types.Ping{}, nil
+
+}

--- a/pkg/util/docker/global_nodocker.go
+++ b/pkg/util/docker/global_nodocker.go
@@ -32,6 +32,8 @@ func IsContainerized() bool {
 	return false
 }
 
+// GetTags returns tags that are automatically added to metrics and events on a
+// host that is running docker.
 func GetTags(ctx context.Context) ([]string, error) {
 	return []string{}, nil
 }

--- a/pkg/util/docker/global_nodocker.go
+++ b/pkg/util/docker/global_nodocker.go
@@ -7,6 +7,8 @@
 
 package docker
 
+import "context"
+
 var (
 	// NullContainer is an empty container object that has
 	// default values for all fields including sub-fields.
@@ -28,4 +30,8 @@ func HostnameProvider(hostName string) (string, error) {
 // IsContainerized returns True if we're running in the docker-dd-agent container.
 func IsContainerized() bool {
 	return false
+}
+
+func GetTags(ctx context.Context) ([]string, error) {
+	return []string{}, nil
 }

--- a/pkg/util/docker/global_nodocker.go
+++ b/pkg/util/docker/global_nodocker.go
@@ -7,8 +7,6 @@
 
 package docker
 
-import "context"
-
 var (
 	// NullContainer is an empty container object that has
 	// default values for all fields including sub-fields.
@@ -34,6 +32,6 @@ func IsContainerized() bool {
 
 // GetTags returns tags that are automatically added to metrics and events on a
 // host that is running docker.
-func GetTags(ctx context.Context) ([]string, error) {
+func GetTags() ([]string, error) {
 	return []string{}, nil
 }

--- a/pkg/util/docker/tags.go
+++ b/pkg/util/docker/tags.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+)
+
+type SystemInfoClient interface {
+	Info(ctx context.Context) (types.Info, error)
+}
+
+func GetTags(ctx context.Context) ([]string, error) {
+	du, err := GetDockerUtil()
+	if err != nil {
+		return nil, err
+	}
+	return getTags(du.cli, ctx)
+}
+
+func getTags(client SystemInfoClient, ctx context.Context) ([]string, error) {
+	tags := []string{}
+	info, err := client.Info(ctx)
+	if err != nil {
+		return tags, err
+	}
+	switch info.Swarm.LocalNodeState {
+	case swarm.LocalNodeStateActive:
+		nodeRole := swarm.NodeRoleWorker
+		if info.Swarm.ControlAvailable {
+			nodeRole = swarm.NodeRoleManager
+		}
+		tags = append(tags, fmt.Sprintf("docker_swarm_node_role:%s", nodeRole))
+	default:
+		break
+	}
+	return tags, nil
+}

--- a/pkg/util/docker/tags.go
+++ b/pkg/util/docker/tags.go
@@ -19,6 +19,8 @@ type SystemInfoClient interface {
 	Info(ctx context.Context) (types.Info, error)
 }
 
+// GetTags returns tags that are automatically added to metrics and events on a
+// host that is running docker.
 func GetTags(ctx context.Context) ([]string, error) {
 	du, err := GetDockerUtil()
 	if err != nil {

--- a/pkg/util/docker/tags.go
+++ b/pkg/util/docker/tags.go
@@ -10,6 +10,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -17,15 +18,17 @@ import (
 
 // GetTags returns tags that are automatically added to metrics and events on a
 // host that is running docker.
-func GetTags(ctx context.Context) ([]string, error) {
+func GetTags() ([]string, error) {
 	du, err := GetDockerUtil()
 	if err != nil {
 		return nil, err
 	}
-	return getTags(du.cli, ctx)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	return getTags(ctx.Background(), du.cli)
 }
 
-func getTags(client client.SystemAPIClient, ctx context.Context) ([]string, error) {
+func getTags(ctx context.Context, client client.SystemAPIClient) ([]string, error) {
 	tags := []string{}
 	info, err := client.Info(ctx)
 	if err != nil {

--- a/pkg/util/docker/tags.go
+++ b/pkg/util/docker/tags.go
@@ -11,13 +11,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
 )
-
-type SystemInfoClient interface {
-	Info(ctx context.Context) (types.Info, error)
-}
 
 // GetTags returns tags that are automatically added to metrics and events on a
 // host that is running docker.
@@ -29,7 +25,7 @@ func GetTags(ctx context.Context) ([]string, error) {
 	return getTags(du.cli, ctx)
 }
 
-func getTags(client SystemInfoClient, ctx context.Context) ([]string, error) {
+func getTags(client client.SystemAPIClient, ctx context.Context) ([]string, error) {
 	tags := []string{}
 	info, err := client.Info(ctx)
 	if err != nil {

--- a/pkg/util/docker/tags.go
+++ b/pkg/util/docker/tags.go
@@ -25,7 +25,7 @@ func GetTags() ([]string, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	return getTags(ctx.Background(), du.cli)
+	return getTags(ctx, du.cli)
 }
 
 func getTags(ctx context.Context, client client.SystemAPIClient) ([]string, error) {

--- a/pkg/util/docker/tags_test.go
+++ b/pkg/util/docker/tags_test.go
@@ -71,7 +71,7 @@ func TestGetTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx := context.TODO()
-			tags, err := getTags(tt.client, ctx)
+			tags, err := getTags(ctx, tt.client)
 			require.NoError(t, err)
 			assert.Equal(t, tt.tags, tags)
 		})

--- a/pkg/util/docker/tags_test.go
+++ b/pkg/util/docker/tags_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 type MockSystemInfoClient struct {
-	Swarm swarm.Info
+	SwarmInfo swarm.Info
 }
 
 func (c *MockSystemInfoClient) Info(ctx context.Context) (types.Info, error) {
-	return types.Info{Swarm: c.Swarm}, nil
+	return types.Info{Swarm: c.SwarmInfo}, nil
 }
 
 func TestGetTags(t *testing.T) {
@@ -33,7 +33,7 @@ func TestGetTags(t *testing.T) {
 	}{
 		{
 			"manager node with swarm active",
-			&MockSystemInfoClient{Swarm: swarm.Info{
+			&MockSystemInfoClient{SwarmInfo: swarm.Info{
 				LocalNodeState:   swarm.LocalNodeStateActive,
 				ControlAvailable: true,
 			}},
@@ -41,7 +41,7 @@ func TestGetTags(t *testing.T) {
 		},
 		{
 			"worker node with swarm active",
-			&MockSystemInfoClient{Swarm: swarm.Info{
+			&MockSystemInfoClient{SwarmInfo: swarm.Info{
 				LocalNodeState:   swarm.LocalNodeStateActive,
 				ControlAvailable: false,
 			}},
@@ -49,7 +49,7 @@ func TestGetTags(t *testing.T) {
 		},
 		{
 			"swarm inactive",
-			&MockSystemInfoClient{Swarm: swarm.Info{
+			&MockSystemInfoClient{SwarmInfo: swarm.Info{
 				LocalNodeState:   swarm.LocalNodeStatePending,
 				ControlAvailable: true,
 			}},

--- a/pkg/util/docker/tags_test.go
+++ b/pkg/util/docker/tags_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type MockSystemInfoClient struct {
+	Swarm swarm.Info
+}
+
+func (c *MockSystemInfoClient) Info(ctx context.Context) (types.Info, error) {
+	return types.Info{Swarm: c.Swarm}, nil
+}
+
+func TestGetTags(t *testing.T) {
+	tests := []struct {
+		desc       string
+		mockClient SystemInfoClient
+		tags       []string
+	}{
+		{
+			"manager node with swarm active",
+			&MockSystemInfoClient{Swarm: swarm.Info{
+				LocalNodeState:   swarm.LocalNodeStateActive,
+				ControlAvailable: true,
+			}},
+			[]string{"docker_swarm_node_role:manager"},
+		},
+		{
+			"worker node with swarm active",
+			&MockSystemInfoClient{Swarm: swarm.Info{
+				LocalNodeState:   swarm.LocalNodeStateActive,
+				ControlAvailable: false,
+			}},
+			[]string{"docker_swarm_node_role:worker"},
+		},
+		{
+			"swarm inactive",
+			&MockSystemInfoClient{Swarm: swarm.Info{
+				LocalNodeState:   swarm.LocalNodeStatePending,
+				ControlAvailable: true,
+			}},
+			[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx := context.TODO()
+			tags, err := getTags(tt.mockClient, ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.tags, tags)
+		})
+	}
+}

--- a/pkg/util/docker/tags_test.go
+++ b/pkg/util/docker/tags_test.go
@@ -27,7 +27,7 @@ func TestGetTags(t *testing.T) {
 	}{
 		{
 			"manager node with swarm active",
-			&fake.FakeSystemAPIClient{
+			&fake.SystemAPIClient{
 				InfoFunc: func() (types.Info, error) {
 					return types.Info{
 						Swarm: swarm.Info{
@@ -41,7 +41,7 @@ func TestGetTags(t *testing.T) {
 		},
 		{
 			"worker node with swarm active",
-			&fake.FakeSystemAPIClient{
+			&fake.SystemAPIClient{
 				InfoFunc: func() (types.Info, error) {
 					return types.Info{
 						Swarm: swarm.Info{
@@ -55,7 +55,7 @@ func TestGetTags(t *testing.T) {
 		},
 		{
 			"swarm inactive",
-			&fake.FakeSystemAPIClient{
+			&fake.SystemAPIClient{
 				InfoFunc: func() (types.Info, error) {
 					return types.Info{
 						Swarm: swarm.Info{

--- a/releasenotes/notes/add-host-tag-for-docker-swarm-node-role-e25a7c87fe05618f.yaml
+++ b/releasenotes/notes/add-host-tag-for-docker-swarm-node-role-e25a7c87fe05618f.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added a host tag for docker swarm node role.


### PR DESCRIPTION
### What does this PR do?

This adds a host tag to docker swarm nodes containing the node role (manager or worker).  

### Motivation

This was also added to agent 5 (https://github.com/DataDog/dd-agent/pull/3735).

### Additional Notes

To determine if the node is a manager/worker this checks the `ControlAvailable` flag in the response from `docker info` the same it is done by the [docker cli](https://github.com/docker/cli/blob/c889ea1bca95f78d10e9e8f7869d5cfd755850eb/cli/command/system/info.go#L259).

### To Do

- [x] Sanity check
