### PR TITLE
Use configs for scheduling/unscheduling

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -202,10 +203,14 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	var response response.ConfigCheckResponse
 
 	configs := common.AC.GetLoadedConfigs()
-	sort.Slice(configs, func(i, j int) bool {
-		return configs[i].Name < configs[j].Name
+	configSlice := make([]integration.Config, 0)
+	for _, config := range configs {
+		configSlice = append(configSlice, config)
+	}
+	sort.Slice(configSlice, func(i, j int) bool {
+		return configSlice[i].Name < configSlice[j].Name
 	})
-	response.Configs = configs
+	response.Configs = configSlice
 	response.ResolveWarnings = autodiscovery.GetResolveWarnings()
 	response.ConfigErrors = autodiscovery.GetConfigErrors()
 	response.Unresolved = common.AC.GetUnresolvedTemplates()

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -184,6 +184,8 @@ func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service)
 	}
 
 	// store resolved configs in the AC
+	cr.ac.m.Lock()
+	defer cr.ac.m.Unlock()
 	cr.ac.loadedConfigs[resolvedConfig.Digest()] = resolvedConfig
 	cr.ac.store.addConfigForService(svc.GetID(), resolvedConfig)
 	cr.configToService[resolvedConfig.Digest()] = svc.GetID()

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -151,7 +151,7 @@ func TestResolve(t *testing.T) {
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Hosts:         map[string]string{"custom": "127.0.0.2", "other": "127.0.0.3"},
+				Hosts:         map[string]string{"custom": "127.0.0.5", "other": "127.0.0.3"},
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -161,7 +161,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.2")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.5")},
 			},
 		},
 		{
@@ -187,7 +187,7 @@ func TestResolve(t *testing.T) {
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Hosts:         map[string]string{"other": "127.0.0.3"},
+				Hosts:         map[string]string{"other": "127.0.0.4"},
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -197,7 +197,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("host: 127.0.0.3")},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.4")},
 			},
 		},
 		{
@@ -374,7 +374,8 @@ func TestResolve(t *testing.T) {
 		},
 	}
 	ac := &AutoConfig{
-		loadedConfigs: make([]integration.Config, 0),
+		loadedConfigs: make(map[string]integration.Config),
+		store:         newStore(),
 	}
 	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	validTemplates := 0
@@ -395,7 +396,8 @@ func TestResolve(t *testing.T) {
 			}
 		})
 
-		// Assert the valid configs are stored in the AC
+		// Assert the valid configs are stored in the AC and the store
 		assert.Equal(t, validTemplates, len(ac.loadedConfigs))
+		assert.Equal(t, len(ac.store.getConfigsForService(tc.svc.GetID())), validTemplates)
 	}
 }

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package autodiscovery
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
+)
+
+// store holds useful mappings for the AD
+type store struct {
+	serviceToConfigs map[listeners.ID][]integration.Config
+	m                sync.RWMutex
+}
+
+// newStore creates a store
+func newStore() *store {
+	s := store{
+		serviceToConfigs: make(map[listeners.ID][]integration.Config),
+	}
+
+	return &s
+}
+
+// getConfigsForService gets config for a specified service
+func (s *store) getConfigsForService(serviceID listeners.ID) []integration.Config {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.serviceToConfigs[serviceID]
+}
+
+// getConfigsForService gets config for a specified service
+func (s *store) removeConfigsForService(serviceID listeners.ID) {
+	s.m.Lock()
+	delete(s.serviceToConfigs, serviceID)
+	s.m.Unlock()
+}
+
+func (s *store) addConfigForService(serviceID listeners.ID, config integration.Config) {
+	s.m.Lock()
+	existingConfigs, found := s.serviceToConfigs[serviceID]
+	if found {
+		s.serviceToConfigs[serviceID] = append(existingConfigs, config)
+	} else {
+		s.serviceToConfigs[serviceID] = []integration.Config{config}
+	}
+	s.m.Unlock()
+}

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -34,20 +34,20 @@ func (s *store) getConfigsForService(serviceID listeners.ID) []integration.Confi
 	return s.serviceToConfigs[serviceID]
 }
 
-// getConfigsForService gets config for a specified service
+// removeConfigsForService removes a config for a specified service
 func (s *store) removeConfigsForService(serviceID listeners.ID) {
 	s.m.Lock()
+	defer s.m.Unlock()
 	delete(s.serviceToConfigs, serviceID)
-	s.m.Unlock()
 }
 
 func (s *store) addConfigForService(serviceID listeners.ID, config integration.Config) {
 	s.m.Lock()
+	defer s.m.Unlock()
 	existingConfigs, found := s.serviceToConfigs[serviceID]
 	if found {
 		s.serviceToConfigs[serviceID] = append(existingConfigs, config)
 	} else {
 		s.serviceToConfigs[serviceID] = []integration.Config{config}
 	}
-	s.m.Unlock()
 }

--- a/pkg/autodiscovery/store_test.go
+++ b/pkg/autodiscovery/store_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package autodiscovery
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceToConfig(t *testing.T) {
+	s := newStore()
+	service := dummyService{
+		ID:            "a5901276aed1",
+		ADIdentifiers: []string{"redis"},
+		Hosts:         map[string]string{"bridge": "127.0.0.1"},
+	}
+	s.addConfigForService(service.GetID(), integration.Config{Name: "foo"})
+	s.addConfigForService(service.GetID(), integration.Config{Name: "bar"})
+	assert.Equal(t, len(s.getConfigsForService(service.GetID())), 2)
+	s.removeConfigsForService(service.GetID())
+	s.addConfigForService(service.GetID(), integration.Config{Name: "foo"})
+	assert.Equal(t, len(s.getConfigsForService(service.GetID())), 1)
+}

--- a/releasenotes/notes/fix-configcheck-removal-06b817114105b94b.yaml
+++ b/releasenotes/notes/fix-configcheck-removal-06b817114105b94b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Configurations of unscheduled checks are now properly removed from the configcheck command display.


### PR DESCRIPTION
### What does this PR do?

Preparatory work for the check scheduler:
* Use configs for scheduling/unscheduling
* Create a new AD store object to hold the service/config mapping
* Remove unused mapping
* Use config digest as key for loaded config to properly remove unscheduled configs (fix `configcheck` bug)
