### PR TITLE
Speeding up log scrubbing regex matching

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -91,12 +91,10 @@ func credentialsCleaner(file io.Reader) ([]byte, error) {
 		if !commentRegex.Match(b) && !blankRegex.Match(b) && string(b) != "" {
 			for _, repl := range replacers {
 				containsHint := false
-				if len(repl.Hints) > 0 {
-					for _, hint := range repl.Hints {
-						if strings.Contains(string(b), hint) {
-							containsHint = true
-							break
-						}
+				for _, hint := range repl.Hints {
+					if strings.Contains(string(b), hint) {
+						containsHint = true
+						break
 					}
 				}
 				if len(repl.Hints) == 0 || containsHint {


### PR DESCRIPTION
### What does this PR do?

`strings.Contain()` is a lot faster than using `regex.Replace()`, so if we keep track of what keywords are mandatory for every regex, then we can first check to make sure it has one of those keywords before running the regex on it.

### Motivation

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkLogVanilla-4             2576          2580          +0.16%
BenchmarkLogVanillaLevels-4       63.0          60.9          -3.33%
BenchmarkLogScrubbing-4           28472         7833          -72.49%
BenchmarkLogScrubbingLevels-4     48.1          41.3          -14.14%
BenchmarkLogScrubbingMulti-4      31220         10555         -66.19%
```
