### PR TITLE
[status] Rename `Metrics` to `Metric Samples` to reflect stat meaning

### DIFF
--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -37,7 +37,7 @@ type Sender interface {
 }
 
 type metricStats struct {
-	Metrics       int64
+	MetricSamples int64
 	Events        int64
 	ServiceChecks int64
 	Lock          sync.RWMutex
@@ -145,7 +145,7 @@ func (s *checkSender) GetMetricStats() map[string]int64 {
 	defer s.priormetricStats.Lock.RUnlock()
 
 	metricStats := make(map[string]int64)
-	metricStats["Metrics"] = s.priormetricStats.Metrics
+	metricStats["MetricSamples"] = s.priormetricStats.MetricSamples
 	metricStats["Events"] = s.priormetricStats.Events
 	metricStats["ServiceChecks"] = s.priormetricStats.ServiceChecks
 
@@ -155,10 +155,10 @@ func (s *checkSender) GetMetricStats() map[string]int64 {
 func (s *checkSender) cyclemetricStats() {
 	s.metricStats.Lock.Lock()
 	s.priormetricStats.Lock.Lock()
-	s.priormetricStats.Metrics = s.metricStats.Metrics
+	s.priormetricStats.MetricSamples = s.metricStats.MetricSamples
 	s.priormetricStats.Events = s.metricStats.Events
 	s.priormetricStats.ServiceChecks = s.metricStats.ServiceChecks
-	s.metricStats.Metrics = 0
+	s.metricStats.MetricSamples = 0
 	s.metricStats.Events = 0
 	s.metricStats.ServiceChecks = 0
 	s.metricStats.Lock.Unlock()
@@ -187,7 +187,7 @@ func (s *checkSender) sendMetricSample(metric string, value float64, hostname st
 	s.smsOut <- senderMetricSample{s.id, metricSample, false}
 
 	s.metricStats.Lock.Lock()
-	s.metricStats.Metrics++
+	s.metricStats.MetricSamples++
 	s.metricStats.Lock.Unlock()
 }
 

--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -17,10 +17,10 @@ type Stats struct {
 	TotalRuns            uint64
 	TotalErrors          uint64
 	TotalWarnings        uint64
-	Metrics              int64
+	MetricSamples        int64
 	Events               int64
 	ServiceChecks        int64
-	TotalMetrics         int64
+	TotalMetricSamples   int64
 	TotalEvents          int64
 	TotalServiceChecks   int64
 	ExecutionTimes       [32]int64 // circular buffer of recent run durations, most recent at [(TotalRuns+31) % 32]
@@ -74,10 +74,10 @@ func (cs *Stats) Add(t time.Duration, err error, warnings []error, metricStats m
 	}
 	cs.UpdateTimestamp = time.Now().Unix()
 
-	if m, ok := metricStats["Metrics"]; ok {
-		cs.Metrics = m
-		if cs.TotalMetrics <= 1000001 {
-			cs.TotalMetrics += m
+	if m, ok := metricStats["MetricSamples"]; ok {
+		cs.MetricSamples = m
+		if cs.TotalMetricSamples <= 1000001 {
+			cs.TotalMetricSamples += m
 		}
 	}
 	if ev, ok := metricStats["Events"]; ok {

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -13,9 +13,9 @@ Collector
     {{.CheckName}}
     {{printDashes .CheckName "-"}}
       Total Runs: {{.TotalRuns}}
-      Metrics: {{.Metrics}}, Total Metrics: {{humanize .TotalMetrics}}
-      Events: {{.Events}}, Total Events: {{humanize .TotalEvents}}
-      Service Checks: {{.ServiceChecks}}, Total Service Checks: {{humanize .TotalServiceChecks}}
+      Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+      Events: {{.Events}}, Total: {{humanize .TotalEvents}}
+      Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       Average Execution Time : {{.AverageExecutionTime}}ms
       {{if .LastError -}}
       Error: {{lastErrorMessage .LastError}}

--- a/releasenotes/notes/rename-metric-check-stat-c2eb00055bbb9151.yaml
+++ b/releasenotes/notes/rename-metric-check-stat-c2eb00055bbb9151.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    On the status and check command outputs, rename checks' ``Metrics`` to ``Metric Samples``
+    to reflect that the number represents the number of samples submitted by the check, not
+    the number of metrics after aggregation.


### PR DESCRIPTION
### What does this PR do?

Renames `Metrics` to `Metric Samples` to reflect stat meaning.

### Motivation

Unlike v5, the "Metrics" stat on the status page/output of the `check`
command reflects the number of metric samples that were submitted to
the aggregator, not the actual number of metrics after aggregation.

Rename the stat to avoid confusion.

### Additional Notes

The reason we don't display the actual number of metrics after aggregation is
that it's a stat that's harder to get per check given the aggregator's architecture.
Something we can explore in the future though.
