### PR TITLE
[status/gui] Fix GUI and cluster agent templates after var renaming

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -13,9 +13,9 @@ Collector
     {{.CheckName}}
     {{printDashes .CheckName "-"}}
       Total Runs: {{.TotalRuns}}
-      Metrics: {{.Metrics}}, Total Metrics: {{humanize .TotalMetrics}}
-      Events: {{.Events}}, Total Events: {{humanize .TotalEvents}}
-      Service Checks: {{.ServiceChecks}}, Total Service Checks: {{humanize .TotalServiceChecks}}
+      Metrics: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+      Events: {{.Events}}, Total: {{humanize .TotalEvents}}
+      Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
       {{- if .LastError -}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -11,9 +11,9 @@
           <span class="stat_subtitle">{{.CheckName}}</span>
           <span class="stat_subdata">
               Total Runs: {{.TotalRuns}}<br>
-              Metrics: {{.Metrics}}, Total Metrics: {{humanizeF .TotalMetrics}}<br>
-              Events: {{.Events}}, Total Events: {{humanizeF .TotalEvents}}<br>
-              Service Checks: {{.ServiceChecks}}, Total Service Checks: {{humanizeF .TotalServiceChecks}}<br>
+              Metrics: {{.MetricSamples}}, Total: {{humanizeF .TotalMetricSamples}}<br>
+              Events: {{.Events}}, Total: {{humanizeF .TotalEvents}}<br>
+              Service Checks: {{.ServiceChecks}}, Total: {{humanizeF .TotalServiceChecks}}<br>
               Average Execution Time : {{.AverageExecutionTime}}ms<br>
             {{- if .LastError}}
               <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -4,9 +4,9 @@
   <span class="stat_subtitle">Instance {{add $i 1}}</span>
     <span class="stat_data">
         Total Runs: {{.TotalRuns}}<br>
-        Metrics: {{.Metrics}}, Total Metrics: {{humanizeI .TotalMetrics}}<br>
-        Events: {{.Events}}, Total Events: {{humanizeI .TotalEvents}}<br>
-        Service Checks: {{.ServiceChecks}}, Total Service Checks: {{humanizeI .TotalServiceChecks}}<br>
+        Metrics: {{.MetricSamples}}, Total: {{humanizeI .TotalMetricSamples}}<br>
+        Events: {{.Events}}, Total: {{humanizeI .TotalEvents}}<br>
+        Service Checks: {{.ServiceChecks}}, Total: {{humanizeI .TotalServiceChecks}}<br>
       {{- if .LastError}}
         <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
               {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -1,4 +1,9 @@
-=========
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/collectorStatus.tmpl
+* cmd/agent/gui/views/templates/singleCheck.tmpl
+* Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+*/}}=========
 Collector
 =========
 

--- a/pkg/status/dist/templates/dogstatsd.tmpl
+++ b/pkg/status/dist/templates/dogstatsd.tmpl
@@ -1,4 +1,7 @@
-=========
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}=========
 DogStatsD
 =========
 {{ if .ChecksMetricSample }}

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -1,4 +1,8 @@
-=========
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+* Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
+*/}}=========
 Forwarder
 =========
 {{ if .Transactions }}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -1,4 +1,8 @@
-{{printDashes .title "="}}
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+* Dockerfiles/cluster-agent/dist/templates/header.tmpl
+*/}}{{printDashes .title "="}}
 {{doNotEscape .title}}
 {{printDashes .title "="}}
 

--- a/pkg/status/dist/templates/jmxfetch.tmpl
+++ b/pkg/status/dist/templates/jmxfetch.tmpl
@@ -1,4 +1,7 @@
-========
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}========
 JMXFetch
 ========
 {{ with .JMXStatus }}

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -1,4 +1,7 @@
-==========
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}==========
 Logs Agent
 ==========
 {{ if (not .is_running) }}


### PR DESCRIPTION
### What does this PR do?

* Fix GUI and cluster agent templates after `MetricSamples` var renaming.
* Add a comment on the agent status templates to remind devs to update the other similar templates.

### Motivation

#1769 broke the GUI and cluster-agent templates. Fix them, and document template duplication
