### PR TITLE
e2e: remove white spaces in username

### DIFF
--- a/test/e2e/scripts/setup-instance/02-ec2.sh
+++ b/test/e2e/scripts/setup-instance/02-ec2.sh
@@ -8,7 +8,7 @@ cd "$(dirname $0)"
 
 export COMMIT_ID=$(git rev-parse --verify HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-COMMIT_USER=$(git log -1 --pretty=format:'%an')
+COMMIT_USER=$(git log -1 --pretty=format:'%an' | tr -d [:space:])
 
 # If not using the default value, remember to change the following settings:
 # - AMI


### PR DESCRIPTION
### What does this PR do?

The username can contain a white space so I removed it to avoid any failure on the `aws ec2 create-tags` call.

```
aws ec2 create-tags --resources [...] --region us-east-1 --tags Key=repository,Value=github.com/DataDog/datadog-agent Key=branch,Value=HEAD Key=commit,Value=3aef42c7 Key=user,Value=Julien Balestra

Error parsing parameter '--tags': Expected: '=', received: 'EOF' for input:
Balestra
```

Note :disappointed: :
This is super strange because I never had this issue before (I didn't change my own username).