### PR TITLE
Allow agent to become leader again after another agent became leader.

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -167,10 +167,10 @@ func (k *KubeASCheck) runLeaderElection() error {
 	}
 
 	if !leaderEngine.IsLeader() {
-		log.Debugf("Leader is %q. %s will not run Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName(), leaderEngine.HolderIdentity)
+		log.Debugf("Leader is %q. %s will not run Kubernetes cluster related checks and collecting events", leaderEngine.GetLeader(), leaderEngine.HolderIdentity)
 		return apiserver.ErrNotLeader
 	}
-	log.Tracef("Current leader: %q, running Kubernetes cluster related checks and collecting events", leaderEngine.CurrentLeaderName())
+	log.Tracef("Current leader: %q, running Kubernetes cluster related checks and collecting events", leaderEngine.GetLeader())
 	return nil
 }
 func (k *KubeASCheck) eventCollectionInit() {

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -78,6 +78,11 @@ func (k *KubeASCheck) Run() error {
 		return err
 	}
 
+	if config.Datadog.GetBool("cluster_agent") {
+		log.Debug("Cluster agent is enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")
+		return nil
+	}
+
 	// Only run if Leader Election is enabled.
 	if !config.Datadog.GetBool("leader_election") {
 		k.Warn("Leader Election not enabled. Not running Kubernetes API Server check or collecting Kubernetes Events.")

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -17,16 +17,16 @@ import (
 func getLeaderElectionDetails() map[string]string {
 	leaderElectionStats := make(map[string]string)
 
-	leaderElectionDetails, err := leaderelection.GetLeaderDetails()
+	record, err := leaderelection.GetLeaderElectionRecord()
 	if err != nil {
 		leaderElectionStats["status"] = "Failing"
 		leaderElectionStats["error"] = err.Error()
 		return leaderElectionStats
 	}
-	leaderElectionStats["leaderName"] = leaderElectionDetails.HolderIdentity
-	leaderElectionStats["acquiredTime"] = leaderElectionDetails.AcquireTime.Format(time.RFC1123)
-	leaderElectionStats["renewedTime"] = leaderElectionDetails.RenewTime.Format(time.RFC1123)
-	leaderElectionStats["transitions"] = fmt.Sprintf("%d transitions", leaderElectionDetails.LeaderTransitions)
+	leaderElectionStats["leaderName"] = record.HolderIdentity
+	leaderElectionStats["acquiredTime"] = record.AcquireTime.Format(time.RFC1123)
+	leaderElectionStats["renewedTime"] = record.RenewTime.Format(time.RFC1123)
+	leaderElectionStats["transitions"] = fmt.Sprintf("%d transitions", record.LeaderTransitions)
 	leaderElectionStats["status"] = "Running"
 	return leaderElectionStats
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -157,7 +157,7 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 
 	le.once.Do(
 		func() {
-			go le.startLeaderElection()
+			go le.runLeaderElection()
 		},
 	)
 
@@ -175,18 +175,17 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 				le.running = true
 				return nil
 			}
-
 		case <-timeout:
 			return fmt.Errorf("leader election still not running, timeout after %s", timeoutDuration)
 		}
 	}
 }
 
-func (le *LeaderEngine) startLeaderElection() {
+func (le *LeaderEngine) runLeaderElection() {
 	for {
 		log.Infof("Starting leader election process for %q...", le.HolderIdentity)
 		le.leaderElector.Run()
-		log.Info("Leading election lost")
+		log.Info("Leader election lost")
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -1,3 +1,5 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
@@ -73,17 +75,17 @@ func (le *LeaderEngine) newElection(electionId, namespace string, ttl time.Durat
 			le.currentHolderMutex.Lock()
 			le.currentHolderIdentity = identity
 			le.currentHolderMutex.Unlock()
-			log.Infof("Currently new leader %q", identity)
+			log.Infof("New leader %q", identity)
 		},
 		OnStartedLeading: func(stop <-chan struct{}) {
-			log.Infof("Leading as %q ...", le.HolderIdentity)
+			log.Infof("Started leading as %q ...", le.HolderIdentity)
 		},
 		// OnStoppedLeading shouldn't be called unless the election is lost
 		OnStoppedLeading: func() {
 			le.currentHolderMutex.Lock()
 			le.currentHolderIdentity = ""
 			le.currentHolderMutex.Unlock()
-			log.Warnf("Stop leading %q", le.HolderIdentity)
+			log.Infof("Stopped leading %q", le.HolderIdentity)
 		},
 	}
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -1,3 +1,5 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 

--- a/releasenotes/notes/restart-leader-election-on-stop-leading-8a64935375e2cf66.yaml
+++ b/releasenotes/notes/restart-leader-election-on-stop-leading-8a64935375e2cf66.yaml
@@ -1,0 +1,4 @@
+
+fixes:
+  - |
+    The leader election process is now restarted if the leader stops leading.

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -103,7 +103,7 @@ func (suite *apiserverSuite) waitForLeaderName(le *leaderelection.LeaderEngine) 
 	for {
 		select {
 		case <-tick.C:
-			leaderName = le.CurrentLeaderName()
+			leaderName = le.GetLeader()
 			if leaderName == le.HolderIdentity {
 				log.Infof("Waiting for leader: leader is %q", leaderName)
 				return
@@ -162,7 +162,7 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 
 	for i, testCase := range testCases {
 		assert.Equal(suite.T(), fmt.Sprintf("%s%d", baseIdentityName, i), testCase.leaderEngine.HolderIdentity)
-		assert.Equal(suite.T(), actualLeader.HolderIdentity, testCase.leaderEngine.CurrentLeaderName())
+		assert.Equal(suite.T(), actualLeader.HolderIdentity, testCase.leaderEngine.GetLeader())
 	}
 
 	c, err := apiserver.GetAPIClient()


### PR DESCRIPTION
### What does this PR do?

If for whatever reason the leader loses connection to the API server and another agent becomes the leader. Allow the previous leader to try to become the leader again.

This PR also checks the `DD_CLUSTER_AGENT` flag to determine whether or not to run the `KubeASCheck` before checking `DD_LEADER_ELECTION` since agents should never run this check if the DCA is running in the cluster.

### Motivation

Previously, if an agent stopped leading then it would never try to become the leader again.