### PR TITLE
[windows] remove psutil from agent core

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
     "processes",
     "processes/gops"
   ]
-  revision = "d80d0f562a71fa2380fbeccc93ba5a2e325606e4"
+  revision = "60e13eaed98afa238ad6dfc98224c04fbb7b19b1"
 
 [[projects]]
   branch = "master"

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build kubeapiserver
+
 package app
 
 import (

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build kubeapiserver
+
 package app
 
 import (

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build kubeapiserver
+
 package app
 
 import (

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build kubeapiserver
+
 package app
 
 import (

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build kubeapiserver
+
 package main
 
 import (

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+// +build !windows
 
 package system
 

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -8,7 +8,6 @@ package system
 import (
 	"regexp"
 
-	"github.com/shirou/gopsutil/disk"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -21,9 +20,6 @@ const (
 	kB               = (1 << 10)
 	iostatsCheckName = "io"
 )
-
-// For testing purpose
-var ioCounters = disk.IOCounters
 
 // Configure the IOstats check
 func (c *IOCheck) commonConfigure(data check.ConfigData, initConfig check.ConfigData) error {

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -20,6 +20,9 @@ import (
 	"github.com/shirou/gopsutil/disk"
 )
 
+// For testing purpose
+var ioCounters = disk.IOCounters
+
 // kernel ticks / sec
 var hz int64
 

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -23,8 +23,6 @@ import (
 )
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-
 	procGetLogicalDriveStringsW = modkernel32.NewProc("GetLogicalDriveStringsW")
 	procGetDriveType            = modkernel32.NewProc("GetDriveTypeW")
 )

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+// +build !windows
 
 package system
 

--- a/pkg/collector/corechecks/system/load_test.go
+++ b/pkg/collector/corechecks/system/load_test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+// +build !windows
 
 package system
 

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -6,26 +6,11 @@
 package system
 
 import (
-	"runtime"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/shirou/gopsutil/mem"
 )
 
 const memCheckName = "memory"
-
-// For testing purpose
-var virtualMemory = mem.VirtualMemory
-var swapMemory = mem.SwapMemory
-var runtimeOS = runtime.GOOS
-
-// MemoryCheck doesn't need additional fields
-type MemoryCheck struct {
-	core.CheckBase
-}
-
-const mbSize float64 = 1024 * 1024
 
 // Configure the Python check from YAML data
 func (c *MemoryCheck) Configure(data check.ConfigData, initConfig check.ConfigData) error {

--- a/pkg/collector/corechecks/system/memory_nix.go
+++ b/pkg/collector/corechecks/system/memory_nix.go
@@ -9,12 +9,26 @@ package system
 
 import (
 	"fmt"
+	"runtime"
 
 	log "github.com/cihub/seelog"
 	"github.com/shirou/gopsutil/mem"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
+
+// For testing purpose
+var virtualMemory = mem.VirtualMemory
+var swapMemory = mem.SwapMemory
+var runtimeOS = runtime.GOOS
+
+// MemoryCheck doesn't need additional fields
+type MemoryCheck struct {
+	core.CheckBase
+}
+
+const mbSize float64 = 1024 * 1024
 
 // Run executes the check
 func (c *MemoryCheck) Run() error {

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -2,18 +2,32 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
-
 // +build windows
 
 package system
 
 import (
 	"fmt"
+	"runtime"
 
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
+
+// For testing purpose
+var virtualMemory = winutil.VirtualMemory
+var swapMemory = winutil.SwapMemory
+var runtimeOS = runtime.GOOS
+
+// MemoryCheck doesn't need additional fields
+type MemoryCheck struct {
+	core.CheckBase
+}
+
+const mbSize float64 = 1024 * 1024
 
 // Run executes the check
 func (c *MemoryCheck) Run() error {

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/shirou/gopsutil/mem"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/stretchr/testify/require"
 )
 
-func VirtualMemory() (*mem.VirtualMemoryStat, error) {
-	return &mem.VirtualMemoryStat{
+func VirtualMemory() (*winutil.VirtualMemoryStat, error) {
+	return &winutil.VirtualMemoryStat{
 		Total:       12345667890,
 		Available:   234567890,
 		Used:        10000000000,
@@ -24,14 +24,12 @@ func VirtualMemory() (*mem.VirtualMemoryStat, error) {
 	}, nil
 }
 
-func SwapMemory() (*mem.SwapMemoryStat, error) {
-	return &mem.SwapMemoryStat{
+func SwapMemory() (*winutil.SwapMemoryStat, error) {
+	return &winutil.SwapMemoryStat{
 		Total:       100000,
 		Used:        40000,
 		Free:        60000,
 		UsedPercent: 40,
-		Sin:         21,
-		Sout:        22,
 	}, nil
 }
 

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -9,15 +9,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	log "github.com/cihub/seelog"
-	"github.com/shirou/gopsutil/host"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 const uptimeCheckName = "uptime"
-
-// For testing purpose
-var uptime = host.Uptime
 
 // UptimeCheck doesn't need additional fields
 type UptimeCheck struct {

--- a/pkg/collector/corechecks/system/uptime_nix.go
+++ b/pkg/collector/corechecks/system/uptime_nix.go
@@ -2,15 +2,13 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+// +build !windows
 
-package host
+package system
 
 import (
-	"testing"
+	"github.com/shirou/gopsutil/host"
 )
 
-func TestFillOsVersion(t *testing.T) {
-	stats := &systemStats{}
-	info := getHostInfo()
-	fillOsVersion(stats, info)
-}
+// For testing purpose
+var uptime = host.Uptime

--- a/pkg/collector/corechecks/system/uptime_windows.go
+++ b/pkg/collector/corechecks/system/uptime_windows.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+// +build windows
+
+package system
+
+import (
+	"syscall"
+	"time"
+)
+
+// For testing purpose
+var uptime = calcUptime
+
+var (
+	modkernel = syscall.NewLazyDLL("kernel32.dll")
+
+	procGetTickCount64 = modkernel.NewProc("GetTickCount64")
+)
+
+func calcUptime() (uint64, error) {
+	upTime := time.Duration(getTickCount64()) * time.Millisecond
+	return uint64(upTime.Seconds()), nil
+}
+
+func getTickCount64() int64 {
+	ret, _, _ := procGetTickCount64.Call()
+	return int64(ret)
+}

--- a/pkg/metadata/common/common.go
+++ b/pkg/metadata/common/common.go
@@ -6,15 +6,10 @@
 package common
 
 import (
-	"path"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/version"
-
-	log "github.com/cihub/seelog"
-	gopsutilhost "github.com/shirou/gopsutil/host"
 )
 
 var (
@@ -43,20 +38,4 @@ func getAPIKey() string {
 	}
 
 	return apiKey
-}
-
-func getUUID() string {
-	key := path.Join(CachePrefix, "uuid")
-	if x, found := cache.Cache.Get(key); found {
-		return x.(string)
-	}
-
-	info, err := gopsutilhost.Info()
-	if err != nil {
-		// don't cache and return zero value
-		log.Errorf("failed to retrieve host info: %s", err)
-		return ""
-	}
-	cache.Cache.Set(key, info.HostID, cache.NoExpiration)
-	return info.HostID
 }

--- a/pkg/metadata/common/common_nix.go
+++ b/pkg/metadata/common/common_nix.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+// +build !windows
+
+package common
+
+import (
+	"path"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+
+	log "github.com/cihub/seelog"
+	gopsutilhost "github.com/shirou/gopsutil/host"
+)
+
+func getUUID() string {
+	key := path.Join(CachePrefix, "uuid")
+	if x, found := cache.Cache.Get(key); found {
+		return x.(string)
+	}
+
+	info, err := gopsutilhost.Info()
+	if err != nil {
+		// don't cache and return zero value
+		log.Errorf("failed to retrieve host info: %s", err)
+		return ""
+	}
+	cache.Cache.Set(key, info.HostID, cache.NoExpiration)
+	return info.HostID
+}

--- a/pkg/metadata/common/common_windows.go
+++ b/pkg/metadata/common/common_windows.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+// +build windows
+
+package common
+
+import (
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+var getUUID = GetUUID
+
+// GetUUID returns the machine GUID on windows; copied from gopsutil
+func GetUUID() string {
+	var h syscall.Handle
+	err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, syscall.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, syscall.KEY_READ|syscall.KEY_WOW64_64KEY, &h)
+	if err != nil {
+		return ""
+	}
+	defer syscall.RegCloseKey(h)
+
+	const windowsRegBufLen = 74 // len(`{`) + len(`abcdefgh-1234-456789012-123345456671` * 2) + len(`}`) // 2 == bytes/UTF16
+	const uuidLen = 36
+
+	var regBuf [windowsRegBufLen]uint16
+	bufLen := uint32(windowsRegBufLen)
+	var valType uint32
+	err = syscall.RegQueryValueEx(h, syscall.StringToUTF16Ptr(`MachineGuid`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+	if err != nil {
+		return ""
+	}
+
+	hostID := syscall.UTF16ToString(regBuf[:])
+	hostIDLen := len(hostID)
+	if hostIDLen != uuidLen {
+		return ""
+	}
+
+	return strings.ToLower(hostID)
+}

--- a/pkg/metadata/host/host_notwin.go
+++ b/pkg/metadata/host/host_notwin.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package host
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
+
+	log "github.com/cihub/seelog"
+)
+
+// Collect at init time
+var cpuInfo []cpu.InfoStat
+
+// InitHostMetadata initializes necessary CPU info
+func InitHostMetadata() error {
+	var err error
+	cpuInfo, err = cpu.Info()
+
+	return err
+
+}
+func getSystemStats() *systemStats {
+	var stats *systemStats
+	key := buildKey("systemStats")
+	if x, found := cache.Cache.Get(key); found {
+		stats = x.(*systemStats)
+	} else {
+		cpuInfo := getCPUInfo()
+		hostInfo := getHostInfo()
+
+		stats = &systemStats{
+			Machine:   runtime.GOARCH,
+			Platform:  runtime.GOOS,
+			Processor: cpuInfo.ModelName,
+			CPUCores:  cpuInfo.Cores,
+			Pythonv:   strings.Split(getPythonVersion(), " ")[0],
+		}
+
+		// fill the platform dependent bits of info
+		fillOsVersion(stats, hostInfo)
+		cache.Cache.Set(key, stats, cache.NoExpiration)
+	}
+
+	return stats
+}
+
+// getCPUInfo returns InfoStat for the first CPU gopsutil found
+func getCPUInfo() *cpu.InfoStat {
+	key := buildKey("cpuInfo")
+	if x, found := cache.Cache.Get(key); found {
+		return x.(*cpu.InfoStat)
+	}
+
+	i, err := cpu.Info()
+	if err != nil {
+		// don't cache and return zero value
+		log.Errorf("failed to retrieve cpu info: %s", err)
+		return &cpu.InfoStat{}
+	}
+	info := &i[0]
+	cache.Cache.Set(key, info, cache.NoExpiration)
+	return info
+}
+
+func getHostInfo() *host.InfoStat {
+	key := buildKey("hostInfo")
+	if x, found := cache.Cache.Get(key); found {
+		return x.(*host.InfoStat)
+	}
+
+	info, err := host.Info()
+	if err != nil {
+		// don't cache and return zero value
+		log.Errorf("failed to retrieve host info: %s", err)
+		return &host.InfoStat{}
+	}
+	cache.Cache.Set(key, info, cache.NoExpiration)
+	return info
+}
+
+// GetStatusInformation just returns an InfoStat object, we need some additional information that's not
+func GetStatusInformation() *host.InfoStat {
+	return getHostInfo()
+}

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+// +build !windows
 
 package host
 

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -5,14 +5,163 @@
 
 package host
 
-import "github.com/shirou/gopsutil/host"
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	"github.com/DataDog/gohai/cpu"
+	"github.com/DataDog/gohai/platform"
+	"github.com/shirou/w32"
+)
+
+var (
+	modkernel = syscall.NewLazyDLL("kernel32.dll")
+
+	procGetTickCount64 = modkernel.NewProc("GetTickCount64")
+)
+
+// InfoStat describes the host status.  This is not in the psutil but it useful.
+type InfoStat struct {
+	Hostname             string `json:"hostname"`
+	Uptime               uint64 `json:"uptime"`
+	BootTime             uint64 `json:"bootTime"`
+	Procs                uint64 `json:"procs"`           // number of processes
+	OS                   string `json:"os"`              // ex: freebsd, linux
+	Platform             string `json:"platform"`        // ex: ubuntu, linuxmint
+	PlatformFamily       string `json:"platformFamily"`  // ex: debian, rhel
+	PlatformVersion      string `json:"platformVersion"` // version of the complete OS
+	KernelVersion        string `json:"kernelVersion"`   // version of the OS kernel (if available)
+	VirtualizationSystem string `json:"virtualizationSystem"`
+	VirtualizationRole   string `json:"virtualizationRole"` // guest or host
+	HostID               string `json:"hostid"`             // ex: uuid
+}
 type osVersion [2]string
 
 //Set the OS to "win32" instead of the runtime.GOOS of "windows" for the in app icon
 const osName = "win32"
 
-func fillOsVersion(stats *systemStats, info *host.InfoStat) {
+// Collect at init time
+var cpuInfo []InfoStat
+
+// InitHostMetadata initializes necessary CPU info
+func InitHostMetadata() error {
+	var err error
+	info := getHostInfo()
+	cpuInfo = append(cpuInfo, *info)
+
+	return err
+
+}
+
+func fillOsVersion(stats *systemStats, info *InfoStat) {
 	// TODO
 	stats.Winver = osVersion{info.PlatformFamily, info.PlatformVersion}
+}
+
+// GetStatusInformation just returns an InfoStat object, filled in with various
+// operating system metadata
+func GetStatusInformation() *InfoStat {
+	return getHostInfo()
+}
+
+func getSystemStats() *systemStats {
+	var stats *systemStats
+	key := buildKey("systemStats")
+	if x, found := cache.Cache.Get(key); found {
+		stats = x.(*systemStats)
+	} else {
+		cpuInfo, _ := cpu.GetCpuInfo()
+		hostInfo := getHostInfo()
+		cores, _ := strconv.Atoi(cpuInfo["cpu_cores"])
+		c32 := int32(cores)
+
+		stats = &systemStats{
+			Machine:   runtime.GOARCH,
+			Platform:  runtime.GOOS,
+			Processor: cpuInfo["model_name"],
+			CPUCores:  c32,
+			Pythonv:   strings.Split(getPythonVersion(), " ")[0],
+		}
+
+		// fill the platform dependent bits of info
+		fillOsVersion(stats, hostInfo)
+		cache.Cache.Set(key, stats, cache.NoExpiration)
+	}
+
+	return stats
+}
+
+func getHostInfo() *InfoStat {
+	key := buildKey("hostInfo")
+	if x, found := cache.Cache.Get(key); found {
+		return x.(*InfoStat)
+	}
+
+	info := &InfoStat{}
+	info.Hostname, _ = os.Hostname()
+
+	upTime := time.Duration(getTickCount64()) * time.Millisecond
+	bootTime := time.Now().Add(-upTime)
+	info.Uptime = uint64(upTime.Seconds())
+	info.BootTime = uint64(bootTime.Unix())
+	pids, _ := Pids()
+	info.Procs = uint64(len(pids))
+	info.OS = runtime.GOOS
+
+	pi, _ := platform.GetArchInfo()
+	info.Platform = pi["os"].(string)
+	info.PlatformFamily = pi["os"].(string)
+
+	info.PlatformVersion, _ = winutil.GetWindowsBuildString()
+	info.HostID = common.GetUUID()
+
+	cache.Cache.Set(key, info, cache.NoExpiration)
+	return info
+}
+
+////////////////////////////////////////////////////////////
+// windows helpers
+//
+
+// getTickCount64() returns the time, in milliseconds, that have elapsed since
+// the system was started
+func getTickCount64() int64 {
+	ret, _, _ := procGetTickCount64.Call()
+	return int64(ret)
+}
+
+// Pids returns a list of process ids.
+func Pids() ([]int32, error) {
+
+	// inspired by https://gist.github.com/henkman/3083408
+	// and https://github.com/giampaolo/psutil/blob/1c3a15f637521ba5c0031283da39c733fda53e4c/psutil/arch/windows/process_info.c#L315-L329
+	var ret []int32
+	var read uint32
+	var psSize uint32 = 1024
+	const dwordSize uint32 = 4
+
+	for {
+		ps := make([]uint32, psSize)
+		if !w32.EnumProcesses(ps, uint32(len(ps)), &read) {
+			return nil, fmt.Errorf("could not get w32.EnumProcesses")
+		}
+		if uint32(len(ps)) == read { // ps buffer was too small to host every results, retry with a bigger one
+			psSize += 1024
+			continue
+		}
+		for _, pid := range ps[:read/dwordSize] {
+			ret = append(ret, int32(pid))
+		}
+		return ret, nil
+
+	}
+
 }

--- a/pkg/util/winutil/winmem.go
+++ b/pkg/util/winutil/winmem.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build windows
+
+package winutil
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
+	modPsapi    = syscall.NewLazyDLL("psapi.dll")
+
+	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+	procGetPerformanceInfo   = modPsapi.NewProc("GetPerformanceInfo")
+)
+
+// VirtualMemoryStat contains basic metrics for virtual memory
+type VirtualMemoryStat struct {
+	// Total amount of RAM on this system
+	Total uint64
+
+	// RAM available for programs to allocate
+	//
+	// This value is computed from the kernel specific values.
+	Available uint64
+
+	// RAM used by programs
+	//
+	// This value is computed from the kernel specific values.
+	Used uint64
+
+	// Percentage of RAM used by programs
+	//
+	// This value is computed from the kernel specific values.
+	UsedPercent float64
+}
+
+// SwapMemoryStat contains swap statistics
+type SwapMemoryStat struct {
+	Total       uint64
+	Used        uint64
+	Free        uint64
+	UsedPercent float64
+}
+
+type memoryStatusEx struct {
+	cbSize                  uint32
+	dwMemoryLoad            uint32
+	ullTotalPhys            uint64 // in bytes
+	ullAvailPhys            uint64
+	ullTotalPageFile        uint64
+	ullAvailPageFile        uint64
+	ullTotalVirtual         uint64
+	ullAvailVirtual         uint64
+	ullAvailExtendedVirtual uint64
+}
+
+// VirtualMemory returns virtual memory metrics for the machine
+func VirtualMemory() (*VirtualMemoryStat, error) {
+	var memInfo memoryStatusEx
+	memInfo.cbSize = uint32(unsafe.Sizeof(memInfo))
+	mem, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&memInfo)))
+	if mem == 0 {
+		return nil, windows.GetLastError()
+	}
+
+	ret := &VirtualMemoryStat{
+		Total:       memInfo.ullTotalPhys,
+		Available:   memInfo.ullAvailPhys,
+		Used:        memInfo.ullTotalPhys - memInfo.ullAvailPhys,
+		UsedPercent: float64(memInfo.dwMemoryLoad),
+	}
+
+	return ret, nil
+}
+
+type performanceInformation struct {
+	cb                uint32
+	commitTotal       uint64
+	commitLimit       uint64
+	commitPeak        uint64
+	physicalTotal     uint64
+	physicalAvailable uint64
+	systemCache       uint64
+	kernelTotal       uint64
+	kernelPaged       uint64
+	kernelNonpaged    uint64
+	pageSize          uint64
+	handleCount       uint32
+	processCount      uint32
+	threadCount       uint32
+}
+
+// SwapMemory returns swapfile statistics
+func SwapMemory() (*SwapMemoryStat, error) {
+	var perfInfo performanceInformation
+	perfInfo.cb = uint32(unsafe.Sizeof(perfInfo))
+	mem, _, _ := procGetPerformanceInfo.Call(uintptr(unsafe.Pointer(&perfInfo)), uintptr(perfInfo.cb))
+	if mem == 0 {
+		return nil, windows.GetLastError()
+	}
+	tot := perfInfo.commitLimit * perfInfo.pageSize
+	used := perfInfo.commitTotal * perfInfo.pageSize
+	free := tot - used
+	ret := &SwapMemoryStat{
+		Total:       tot,
+		Used:        used,
+		Free:        free,
+		UsedPercent: float64(used / tot),
+	}
+
+	return ret, nil
+}

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
+
 // +build windows
 
 package winutil

--- a/pkg/util/winutil/winver.go
+++ b/pkg/util/winutil/winver.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build windows
+
+package winutil
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	k32     = syscall.NewLazyDLL("kernel32.dll")
+	apicore = syscall.NewLazyDLL("api-ms-win-core-version-l1-1-0.dll")
+
+	procGetModuleHandle          = k32.NewProc("GetModuleHandleW")
+	procGetModuleFileName        = k32.NewProc("GetModuleFileNameW")
+	procGetFileVersionInfoSizeEx = apicore.NewProc("GetFileVersionInfoSizeExW")
+	procGetFileVersionInfoEx     = apicore.NewProc("GetFileVersionInfoExW")
+	procVerQueryValue            = apicore.NewProc("VerQueryValueW")
+)
+
+// GetWindowsBuildString retrieves the windows build version by querying
+// the resource string as directed here https://msdn.microsoft.com/en-us/library/windows/desktop/ms724429(v=vs.85).aspx
+// as of Windows 8.1, the core GetVersion() APIs have been changed to
+// return the version of Windows manifested with the application, not
+// the application version
+func GetWindowsBuildString() (verstring string, err error) {
+	h, err := getModuleHandle("kernel32.dll")
+	if err != nil {
+		return
+	}
+	fullpath, err := getModuleFileName(h)
+	if err != nil {
+		return
+	}
+	data, err := getFileVersionInfo(fullpath)
+	if err != nil {
+		return
+	}
+	return getVersionInfo(data)
+}
+
+func getModuleHandle(fname string) (handle uintptr, err error) {
+	file := syscall.StringToUTF16Ptr(fname)
+	handle, _, err = procGetModuleHandle.Call(uintptr(unsafe.Pointer(file)))
+	if handle == 0 {
+		return handle, err
+	}
+	return handle, nil
+}
+
+func getModuleFileName(h uintptr) (fname string, err error) {
+	fname = ""
+	err = nil
+	var sizeIncr = uint32(1024)
+	var size = sizeIncr
+	for {
+		buf := make([]uint16, size)
+		ret, _, err := procGetModuleFileName.Call(h, uintptr(unsafe.Pointer(&buf[0])), uintptr(size))
+		if ret == uintptr(size) || err == syscall.ERROR_INSUFFICIENT_BUFFER {
+			size += sizeIncr
+			continue
+		} else if err != nil {
+			fname = syscall.UTF16ToString(buf)
+		}
+		break
+	}
+	return
+
+}
+
+func getFileVersionInfo(filename string) (block []uint8, err error) {
+	fname := syscall.StringToUTF16Ptr(filename)
+	ret, _, err := procGetFileVersionInfoSizeEx.Call(uintptr(0x02),
+		uintptr(unsafe.Pointer(fname)), uintptr(0))
+	if ret == 0 {
+		return
+	}
+	size := uint32(ret)
+	block = make([]uint8, size)
+	ret, _, err = procGetFileVersionInfoEx.Call(uintptr(0x02),
+		uintptr(unsafe.Pointer(fname)), uintptr(0), uintptr(size), uintptr(unsafe.Pointer(&block[0])))
+	if ret == 0 {
+		return nil, err
+	}
+	return block, nil
+
+}
+
+type tagVSFIXEDFILEINFO struct {
+	dwSignature        uint32
+	dwStrucVersion     uint32
+	dwFileVersionMS    uint32
+	dwFileVersionLS    uint32
+	dwProductVersionMS uint32
+	dwProductVersionLS uint32
+	dwFileFlagsMask    uint32
+	dwFileFlags        uint32
+	dwFileOS           uint32
+	dwFileType         uint32
+	dwFileSubtype      uint32
+	dwFileDateMS       uint32
+	dwFileDateLS       uint32
+}
+
+func getVersionInfo(block []uint8) (ver string, err error) {
+
+	subblock := syscall.StringToUTF16Ptr("\\")
+	var infoptr unsafe.Pointer
+	var ulen uint32
+	ret, _, err := procVerQueryValue.Call(uintptr(unsafe.Pointer(&block[0])),
+		uintptr(unsafe.Pointer(subblock)),
+		uintptr(unsafe.Pointer(&infoptr)),
+		uintptr(unsafe.Pointer(&ulen)))
+	if ret == 0 {
+		return
+	}
+	ffi := (*tagVSFIXEDFILEINFO)(infoptr)
+	ver = fmt.Sprintf("%d.%d Build %d", ffi.dwProductVersionMS>>16, ffi.dwProductVersionMS&0xFF, ffi.dwProductVersionLS>>16)
+
+	return ver, nil
+
+}

--- a/releasenotes/notes/removpsutil-9369688a1b683ced.yaml
+++ b/releasenotes/notes/removpsutil-9369688a1b683ced.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Removes all use of `gopsutil` from Windows builds.  Fixes the problem
+    introduced in 6.2 where on some systems, core metrics (such as 
+    system.cpu.*) were lost

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -3,6 +3,7 @@ Golang related tasks go here
 """
 from __future__ import print_function
 import os
+import sys
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -201,6 +202,11 @@ def deps(ctx):
     ctx.run("go get -u github.com/gordonklaus/ineffassign")
     ctx.run("go get -u github.com/client9/misspell/cmd/misspell")
     ctx.run("dep ensure")
+    # make sure PSUTIL is gone on windows; the dep ensure above will vendor it
+    # in because it's necessary on other platforms
+    if sys.platform == 'win32':
+        print("Removing PSUTIL on Windows")
+        ctx.run("rd /s/q vendor\\github.com\\shirou\\gopsutil")
 
 
 @task


### PR DESCRIPTION
Initial revision.  Compiles without GOPSUTIL (with the objective of
removing WMI completely from the core checks)

update .gitlab-ci from master

Remove additional references to gopsutil

Fixes windows memory check registration

Fix linting & (windows) unit tests

Update Gopkg.lock (manually) again

Fix inithostmetadata() to actually query the information (on windows)

[windows] add code to get correct version string from kernel32.dll

Move code to the invoke deps command to remove gopsutil, to ensure we're
not including it anywhere.

Review feedback

gofmt

Fix cherry-pick problems

### Motivation

Customer problem reports.

### Additional Notes

Anything else we should know when reviewing?
