### PR TITLE
Update to README

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -24,6 +24,7 @@ The agent is highly customizable, here are the most used environment variables:
 
 - `DD_API_KEY`: your API key (**required**)
 - `DD_HOSTNAME`: hostname to use for metrics (if autodetection fails)
+- `DD_DD_URL`: set alternate URL for sending metrics here
 - `DD_TAGS`: host tags, separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`
 - `DD_CHECK_RUNNERS`: the agent runs all checks in sequence by default (default value = `1` runner). If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel
 


### PR DESCRIPTION
### What does this PR do?

Added the option `DD_DD_URL` for using an alternate URL to send metrics to DD.  This is helpful for enterprise orgs that do not have the ability to frequently change or modify outbound internet firewall rules to accommodate the DD ingestion URL.

### Motivation

Options missing from docs

### Additional Notes


