### PR TITLE
[docker image] remove all default envvars from the dockerfile

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -47,13 +47,6 @@ ARG WITH_JMX
 ENV DOCKER_DD_AGENT=yes \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
     CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem \
-    # Disable dsd, apm and logs listening until user decides so, to avoid unknown open ports
-    DD_DOGSTATSD_NON_LOCAL_TRAFFIC=false \
-    DD_APM_ENABLED=false \
-    DD_APM_NON_LOCAL_TRAFFIC=true \
-    DD_LOGS_ENABLED=false \
-    # Use java 8u131+ cgroup memory awareness
-    DD_JMX_USE_CGROUP_MEMORY_LIMIT=true \
     # Pass envvar variables to agents
     S6_KEEP_ENV=1 \
     # Direct all agent logs to stdout

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -190,7 +190,7 @@ Our default configuration targets Kubernetes 1.7.6 and later, as we rely on feat
   * `rbac.authorization.k8s.io/v1` in Kubernetes 1.8+ (and OpenShift 3.9+), the default apiVersion we target
   * `rbac.authorization.k8s.io/v1beta1` in Kubernetes 1.5 to 1.7 (and OpenShift 3.7)
   * `v1` in Openshift 1.3 to 3.6
-  
+
 You can apply our yaml manifests with the following `sed` invocations:
 ```
 sed "s%authorization.k8s.io/v1%authorization.k8s.io/v1beta1%" clusterrole.yaml | kubectl apply -f -

--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -1,12 +1,17 @@
-## Provides autodetected defaults, for non-kubernetes environments,
+## Provides autodetected defaults, for vanilla Docker environments,
 ## please see datadog.yaml.example for all supported options
 
-# Autodiscovery
+# Autodiscovery settings for vanilla Docker
 listeners:
   - name: docker
-
 config_providers:
-## The docker provider handles templates embedded in container labels, see
-## https://docs.datadoghq.com/guides/autodiscovery/#template-source-docker-label-annotations
   - name: docker
     polling: true
+
+# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
+apm_config:
+  enabled: false
+  apm_non_local_traffic: true
+
+# Use java cgroup memory awareness
+jmx_use_cgroup_memory_limit: true

--- a/Dockerfiles/agent/datadog-ecs.yaml
+++ b/Dockerfiles/agent/datadog-ecs.yaml
@@ -1,12 +1,17 @@
-## Provides autodetected defaults, for kubernetes environments,
+## Provides autodetected defaults, for ECS Fargate environments,
 ## please see datadog.yaml.example for all supported options
 
-# Autodiscovery
+# Autodiscovery for ECS Fargate, use docker for classic ECS+EC2
 listeners:
   - name: ecs
-
 config_providers:
-  ## The ecs provider handles templates embedded in container labels, see
-  ## https://docs.datadoghq.com/guides/autodiscovery/#template-source-docker-label-annotations
   - name: ecs
     polling: true
+
+# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
+apm_config:
+  enabled: false
+  apm_non_local_traffic: true
+
+# Use java cgroup memory awareness
+jmx_use_cgroup_memory_limit: true

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -1,12 +1,17 @@
 ## Provides autodetected defaults, for kubernetes environments,
 ## please see datadog.yaml.example for all supported options
 
-# Autodiscovery
+# Autodiscovery for Kubernetes
 listeners:
   - name: kubelet
-
 config_providers:
-# The kubelet provider handles templates embedded in pod annotations, see
-# https://docs.datadoghq.com/guides/autodiscovery/#template-source-kubernetes-pod-annotations
   - name: kubelet
     polling: true
+
+# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
+apm_config:
+  enabled: false
+  apm_non_local_traffic: true
+
+# Use java cgroup memory awareness
+jmx_use_cgroup_memory_limit: true

--- a/releasenotes/notes/docker-image-default-envvars-192d75def10335e2.yaml
+++ b/releasenotes/notes/docker-image-default-envvars-192d75def10335e2.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    Docker image: we moved the default configuration from the docker image's default
+    environment variables to the `datadog-*.yaml` files. This allows users to easily
+    mount a custom `datadog.yaml` configuration file to set all options.
+    If you already did so, you will need to update your `datadog.yaml` to include
+    these new defaults. If you only used envvars, no change is needed.


### PR DESCRIPTION
### What does this PR do?

Move all default configuration from the dockerfile to the `datadog-*.yaml` files:

- `DD_DOGSTATSD_NON_LOCAL_TRAFFIC=false`: default value, removed
- `DD_APM_ENABLED=false` and `DD_APM_NON_LOCAL_TRAFFIC=true`: moved to yaml
- `DD_LOGS_ENABLED=false`: default value, removed
- `DD_JMX_USE_CGROUP_MEMORY_LIMIT=true`: moved to yaml

### Motivation

As viper allows envvars to override the configuration file, several users were surprised by their custom `datadog.yaml` not taking effect, because options were overridden by our default envvars.

See https://github.com/DataDog/datadog-agent/issues/1761 for an example.

### Upgrade notes

This requires users already providing a custom `datadog.yaml` to add these options to their configuration to keep APM and JMX cgroup memlimits. Users only using envvars are unaffected. Added an upgrade note for users and support.
