### PR TITLE
e2e: check if the image is available on the docker registry

### DIFF
--- a/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
@@ -2,6 +2,7 @@
 
 printf '=%.0s' {0..79} ; echo
 set -ex
+set -o pipefail
 
 cd "$(dirname $0)"
 
@@ -41,5 +42,19 @@ EOF
 
 echo "Using DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE}"
 echo "Running inside a gitlab pipeline, using DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE}"
+
+# Check is the image is hosted on a docker registry and if it's available
+if [[ "${DATADOG_AGENT_IMAGE:0:8}" == "datadog/" ]]
+then
+    echo "${DATADOG_AGENT_IMAGE} is hosted on a docker registry, checking if it's available"
+    IMAGE_TAG=${DATADOG_AGENT_IMAGE:8}
+    IMAGE_NAME=$(echo -n ${IMAGE_TAG} | cut -f1 -d ':')
+    IMAGE_TAG=$(echo -n ${IMAGE_TAG} | cut -f2 -d ':')
+    curl -Lfs https://registry.hub.docker.com/v1/repositories/datadog/${IMAGE_NAME}/tags | \
+        jq -re ".[] | select(.name==\"${IMAGE_TAG}\")" || {
+            echo "The DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE} returns a 404 on the registry.hub.docker.com"
+            exit 2
+    }
+fi
 
 exec ./02-ec2.sh


### PR DESCRIPTION
### What does this PR do?

Check if the image is available before running the all pipeline

### Motivation

Avoid to fail on bad image tags:

Gitlab provides the envvar `$CI_COMMIT_REF_SLUG` but it gaves a wrong image tag for a git tag: `6-3-0-beta-1`


