### PR TITLE
fix agent_stats.yaml.example to reflect new netrics names

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -41,30 +41,26 @@ instances:
     namespace: datadog
     metrics:
       # datadog-agent forwarder monitoring
-      - path: forwarder/TransactionsCreated/Series
+      - path: forwarder/Transactions/Series
         type: rate
-      - path: forwarder/TransactionsCreated/Events
+      - path: forwarder/Transactions/Events
         type: rate
-      - path: forwarder/TransactionsCreated/ServiceChecks
+      - path: forwarder/Transactions/ServiceChecks
         type: rate
-      - path: forwarder/TransactionsCreated/HostMetadata
+      - path: forwarder/Transactions/HostMetadata
         type: rate
-      - path: forwarder/TransactionsCreated/Metadata
+      - path: forwarder/Transactions/Metadata
         type: rate
-      - path: forwarder/TransactionsCreated/TimeseriesV1
+      - path: forwarder/Transactions/TimeseriesV1
         type: rate
-      - path: forwarder/TransactionsCreated/CheckRunsV1
+      - path: forwarder/Transactions/CheckRunsV1
         type: rate
-      - path: forwarder/TransactionsCreated/IntakeV1
+      - path: forwarder/Transactions/IntakeV1
         type: rate
-      - path: forwarder/TransactionsCreated/Dropped
+      - path: forwarder/Transactions/DroppedOnInput
         type: rate
-      - path: forwarder/TransactionsCreated/RetryQueueSize
-      - path: forwarder/TransactionsCreated/Requeued
-        type: rate
-      - path: forwarder/TransactionsCreated/Errors
-        type: rate
-      - path: forwarder/TransactionsCreated/Success
+      - path: forwarder/Transactions/RetryQueueSize
+      - path: forwarder/Transactions/Success
         type: rate
 
       # datadog-agent dogstatsd monitoring

--- a/releasenotes/notes/agent-stats-forwarder-14b46251c225994e.yaml
+++ b/releasenotes/notes/agent-stats-forwarder-14b46251c225994e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Default config `agent_stats.yaml` used to collect go_expvar metrics from the
+    Agent has been updated.


### PR DESCRIPTION
### What does this PR do?

This PR fix the agent_stats.yaml.example file for the go_expvar check in order to reflect the new agent metrics names.

### Motivation

The false metrics names generated a lot of warnings in the agent status.
One customer complained about it. We gathered a lot less metrics as well from the agent.
