### PR TITLE
[Logs] Avoid setting source as tag when using proto

### DIFF
--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -32,10 +32,6 @@ func NewOrigin(source *config.LogSource) *Origin {
 func (o *Origin) Tags() []string {
 	tags := o.tags
 
-	source := o.Source()
-	if source != "" {
-		tags = append(tags, "source:"+source)
-	}
 	sourceCategory := o.LogSource.Config.SourceCategory
 	if sourceCategory != "" {
 		tags = append(tags, "sourcecategory:"+sourceCategory)

--- a/pkg/logs/message/origin_test.go
+++ b/pkg/logs/message/origin_test.go
@@ -29,7 +29,7 @@ func TestTagsWithConfigTagsOnly(t *testing.T) {
 	}
 	source := config.NewLogSource("", cfg)
 	origin := NewOrigin(source)
-	assert.Equal(t, []string{"source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
+	assert.Equal(t, []string{"sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e\"]", string(origin.TagsPayload()))
 }
 
@@ -41,7 +41,7 @@ func TestSetTagsWithNoConfigTags(t *testing.T) {
 	source := config.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b"}, origin.Tags())
+	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"foo:bar,baz\"]", string(origin.TagsPayload()))
 }
 
@@ -54,7 +54,7 @@ func TestSetTagsWithConfigTags(t *testing.T) {
 	source := config.NewLogSource("", cfg)
 	origin := NewOrigin(source)
 	origin.SetTags([]string{"foo:bar", "baz"})
-	assert.Equal(t, []string{"foo:bar", "baz", "source:a", "sourcecategory:b", "c:d", "e"}, origin.Tags())
+	assert.Equal(t, []string{"foo:bar", "baz", "sourcecategory:b", "c:d", "e"}, origin.Tags())
 	assert.Equal(t, "[dd ddsource=\"a\"][dd ddsourcecategory=\"b\"][dd ddtags=\"c:d,e,foo:bar,baz\"]", string(origin.TagsPayload()))
 }
 

--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -143,7 +143,7 @@ func TestProtoEncoder(t *testing.T) {
 
 	assert.Equal(t, logsConfig.Service, log.Service)
 	assert.Equal(t, logsConfig.Source, log.Source)
-	assert.Equal(t, []string{"a", "b:c", "source:" + logsConfig.Source, "sourcecategory:" + logsConfig.SourceCategory, "foo:bar", "baz"}, log.Tags)
+	assert.Equal(t, []string{"a", "b:c", "sourcecategory:" + logsConfig.SourceCategory, "foo:bar", "baz"}, log.Tags)
 
 	assert.Equal(t, redactedMessage, log.Message)
 	assert.Equal(t, message.StatusError, log.Status)

--- a/releasenotes/notes/fix-duplicated-source-tag-49b84ab34eeb4a08.yaml
+++ b/releasenotes/notes/fix-duplicated-source-tag-49b84ab34eeb4a08.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The agent would send the source twice when protobuf enabled (default),
+    once in the source field and once in tags. As a result, we would see the
+    source twice in the app. This PR fixes it, by sending it only in the source
+    field.


### PR DESCRIPTION
### What does this PR do?

When payload is protobuf, we have a specific source field in the
payload, we don't need to add it as a tag as our backend will do it
already

