### PR TITLE
Fix kube_service tagging of kubernetes network metrics

### DIFF
--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -68,6 +68,17 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 		}
 
 		low, high := tagList.Compute()
+		// Register the tags for the pod itself
+		if po.Metadata.UID != "" {
+			podInfo := &TagInfo{
+				Source:       kubeMetadataCollectorName,
+				Entity:       kubelet.PodUIDToEntityName(po.Metadata.UID),
+				HighCardTags: high,
+				LowCardTags:  low,
+			}
+			tagInfo = append(tagInfo, podInfo)
+		}
+		// Register the tags for all its containers
 		for _, container := range po.Status.Containers {
 			info := &TagInfo{
 				Source:       kubeMetadataCollectorName,

--- a/releasenotes/notes/kube-service-service-tag-70d8d889fac12e87.yaml
+++ b/releasenotes/notes/kube-service-service-tag-70d8d889fac12e87.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix kube_service tagging of kubernetes network metrics


### PR DESCRIPTION
### What does this PR do?

Register kubernetes metadata mapper tags for the pod entity too

### Motivation

`kube_service` tags were missing from the pod-level `k.network.*` metrics:

```
{
      "metric": "kubernetes.network.tx_bytes",
...
      "tags": [
        "kube_deployment:db2",
        "kube_namespace:default",
        "kube_replica_set:db2-6799f9b6f8",
        "pod_name:db2-6799f9b6f8-h6ndw"
      ],
...
    },
```

fixed 

```
    {
      "metric": "kubernetes.network.rx_bytes",
...
      ],
      "tags": [
        "kube_deployment:db2",
        "kube_namespace:default",
        "kube_replica_set:db2-6799f9b6f8",
        "kube_service:redis-db2",
        "kube_service:redis-db2-bis",
        "pod_name:db2-6799f9b6f8-prtbn"
      ],
...
    },
```
