### PR TITLE
Maxime/fix110

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -7,7 +7,7 @@ import os
 from invoke import task
 from invoke.exceptions import Exit
 from .build_tags import get_default_build_tags
-from .utils import pkg_config_path
+from .utils import pkg_config_path, get_build_flags
 
 
 # List of modules to ignore when running lint on Windows platform
@@ -104,9 +104,7 @@ def vet(ctx, targets, use_embedded_libs=False):
     args = ["{}/...".format(t) for t in targets]
     build_tags = get_default_build_tags()
 
-    env = {
-        "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs),
-    }
+    _, _, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
 
     ctx.run("go vet -tags \"{}\" ".format(" ".join(build_tags)) + " ".join(args), env=env)
     # go vet exits with status 1 when it finds an issue, if we're here


### PR DESCRIPTION
Fix 'vet' command on windows

Since LDFLAGS are filtered by a whitelist for cgo
(https://github.com/golang/go/wiki/InvalidFlag) the vet command failed
on windows with go 1.10. We now use the same flags for 'vet' than for
building (or else pkg/collector/py would raise an "invalid flag in #cgo
CFLAGS" error).