### PR TITLE
Maxime/secret datadog yaml

### DIFF
--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -79,14 +79,14 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	// marshal the config object to YAML
 	b, err := yaml.Marshal(config.Datadog.AllSettings())
 	if err != nil {
-		return fmt.Errorf("unable to unmarshal config to YAML: %v", err)
+		return fmt.Errorf("unable to marshal config to YAML: %v", err)
 	}
 
 	// dump the current configuration to datadog.yaml
 	// file permissions will be used only to create the file if doesn't exist,
 	// please note on Windows such permissions have no effect.
 	if err = ioutil.WriteFile(datadogYamlPath, b, 0640); err != nil {
-		return fmt.Errorf("unable to unmarshal config to %s: %v", datadogYamlPath, err)
+		return fmt.Errorf("unable to write config to %s: %v", datadogYamlPath, err)
 	}
 
 	fmt.Fprintln(

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
@@ -161,9 +159,8 @@ func TestDecryptNoCommand(t *testing.T) {
 }
 
 func TestDecryptSecretError(t *testing.T) {
-	backup := config.Datadog.GetString("secret_backend_command")
-	config.Datadog.Set("secret_backend_command", "some_command")
-	defer config.Datadog.Set("secret_backend_command", backup)
+	secretBackendCommand = "some_command"
+	defer func() { secretBackendCommand = "" }()
 
 	secretFetcher = func(secrets []string) (map[string]string, error) {
 		return nil, fmt.Errorf("some error")
@@ -174,9 +171,8 @@ func TestDecryptSecretError(t *testing.T) {
 }
 
 func TestDecryptSecretNoCache(t *testing.T) {
-	backup := config.Datadog.GetString("secret_backend_command")
-	config.Datadog.Set("secret_backend_command", "some_command")
-	defer config.Datadog.Set("secret_backend_command", backup)
+	secretBackendCommand = "some_command"
+	defer func() { secretBackendCommand = "" }()
 
 	secretFetcher = func(secrets []string) (map[string]string, error) {
 		sort.Strings(secrets)
@@ -197,9 +193,8 @@ func TestDecryptSecretNoCache(t *testing.T) {
 }
 
 func TestDecryptSecretPartialCache(t *testing.T) {
-	backup := config.Datadog.GetString("secret_backend_command")
-	config.Datadog.Set("secret_backend_command", "some_command")
-	defer config.Datadog.Set("secret_backend_command", backup)
+	secretBackendCommand = "some_command"
+	defer func() { secretBackendCommand = "" }()
 
 	secretCache["pass1"] = "password1"
 	defer func() { secretCache = map[string]string{} }()
@@ -221,9 +216,8 @@ func TestDecryptSecretPartialCache(t *testing.T) {
 }
 
 func TestDecryptSecretFullCache(t *testing.T) {
-	backup := config.Datadog.GetString("secret_backend_command")
-	config.Datadog.Set("secret_backend_command", "some_command")
-	defer config.Datadog.Set("secret_backend_command", backup)
+	secretBackendCommand = "some_command"
+	defer func() { secretBackendCommand = "" }()
 
 	secretCache["pass1"] = "password1"
 	secretCache["pass2"] = "password2"

--- a/pkg/secrets/secrets_win.go
+++ b/pkg/secrets/secrets_win.go
@@ -7,6 +7,10 @@
 
 package secrets
 
+// Init encrypted secrets are not available on windows
+func Init(command string, arguments []string, timeout int, maxSize int) {
+}
+
 // Decrypt encrypted secrets are not available on windows
 func Decrypt(data []byte) ([]byte, error) {
 	return data, nil


### PR DESCRIPTION
### What does this PR do?

We now decrypt secrets from the datadog.yaml. This force us to decouple the `config` package from the `secrets` package. To allow the `config` package to decrypt itself, the `secrets` package now receive it's config parameter manually.