### PR TITLE
Copy histogram points to distributions automatically when enabled

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,8 +146,6 @@ func init() {
 	Datadog.SetDefault("proc_root", "/proc")
 	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	Datadog.SetDefault("histogram_percentiles", []string{"0.95"})
-	Datadog.SetDefault("histogram_copy_to_distribution", false)
-	Datadog.SetDefault("histogram_copy_to_distribution_prefix", "")
 	// Serializer
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)
@@ -244,6 +242,9 @@ func init() {
 	// Undocumented opt-in feature for now
 	BindEnvAndSetDefault("full_cardinality_tagging", false)
 
+	BindEnvAndSetDefault("histogram_copy_to_distribution", false)
+	BindEnvAndSetDefault("histogram_copy_to_distribution_prefix", "")
+
 	// ENV vars bindings
 	Datadog.BindEnv("api_key")
 	Datadog.BindEnv("dd_url")
@@ -297,8 +298,6 @@ func init() {
 	Datadog.BindEnv("bosh_id")
 	Datadog.BindEnv("histogram_aggregates")
 	Datadog.BindEnv("histogram_percentiles")
-	Datadog.BindEnv("histogram_copy_to_distribution")
-	Datadog.BindEnv("histogram_copy_to_distribution_prefix")
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 	Datadog.BindEnv("leader_election")
 	Datadog.BindEnv("leader_lease_duration")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,6 +146,8 @@ func init() {
 	Datadog.SetDefault("proc_root", "/proc")
 	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	Datadog.SetDefault("histogram_percentiles", []string{"0.95"})
+	Datadog.SetDefault("histogram_copy_to_distribution", false)
+	Datadog.SetDefault("histogram_copy_to_distribution_prefix", "")
 	// Serializer
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)
@@ -295,6 +297,8 @@ func init() {
 	Datadog.BindEnv("bosh_id")
 	Datadog.BindEnv("histogram_aggregates")
 	Datadog.BindEnv("histogram_percentiles")
+	Datadog.BindEnv("histogram_copy_to_distribution")
+	Datadog.BindEnv("histogram_copy_to_distribution_prefix")
 	Datadog.BindEnv("kubernetes_kubeconfig_path")
 	Datadog.BindEnv("leader_election")
 	Datadog.BindEnv("leader_lease_duration")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -51,6 +51,12 @@ api_key:
 # Warning: percentiles must be specified as yaml strings
 #
 # histogram_percentiles: ["0.95"]
+#
+# Copy histgram values to distributions for true global distributions (in beta)
+# histogram_copy_to_distribution: true
+#
+# A prefix to add to distribution metrics created when histogram_copy_to_distributions is true
+# histogram_copy_to_distribution_prefix: ""
 
 # Forwarder timeout in seconds
 # forwarder_timeout: 20

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -53,6 +53,7 @@ api_key:
 # histogram_percentiles: ["0.95"]
 #
 # Copy histgram values to distributions for true global distributions (in beta)
+# This will increase the number of custom metrics created
 # histogram_copy_to_distribution: true
 #
 # A prefix to add to distribution metrics created when histogram_copy_to_distributions is true

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -52,9 +52,9 @@ api_key:
 #
 # histogram_percentiles: ["0.95"]
 #
-# Copy histgram values to distributions for true global distributions (in beta)
+# Copy histogram values to distributions for true global distributions (in beta)
 # This will increase the number of custom metrics created
-# histogram_copy_to_distribution: true
+# histogram_copy_to_distribution: false
 #
 # A prefix to add to distribution metrics created when histogram_copy_to_distributions is true
 # histogram_copy_to_distribution_prefix: ""

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -224,9 +224,9 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 					}
 					dogstatsdExpvar.Add("MetricPackets", 1)
 					metricOut <- sample
-					if s.histToDist && sample.MetricType == metrics.HistogramType {
+					if s.histToDist && sample.Mtype == metrics.HistogramType {
 						distSample := sample.Copy()
-						distSample.MetricType = metrics.DistributionType
+						distSample.Mtype = metrics.DistributionType
 						metricOut <- distSample
 					}
 				}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -225,8 +225,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 					dogstatsdExpvar.Add("MetricPackets", 1)
 					metricOut <- sample
 					if s.histToDist && sample.MetricType == metrics.HistogramType {
-						distSample := *metrics.MetricSample{}
-						sample.CopyTo(distSample)
+						distSample := sample.Copy()
 						distSample.MetricType = metrics.DistributionType
 						metricOut <- distSample
 					}

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -249,7 +249,8 @@ func TestHistToDist(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
-	config.Datadog.SetDefault("statsd_hist_to_dist", true)
+	config.Datadog.SetDefault("histogram_copy_to_distribution", true)
+	config.Datadog.SetDefault("histogram_copy_to_distribution", "dist.")
 
 	metricOut := make(chan *metrics.MetricSample)
 	eventOut := make(chan metrics.Event)
@@ -273,7 +274,7 @@ func TestHistToDist(t *testing.T) {
 
 	distMetric := <-metricOut
 	assert.NotNil(t, distMetric)
-	assert.Equal(t, distMetric.Name, "daemon")
+	assert.Equal(t, distMetric.Name, "dist.daemon")
 	assert.EqualValues(t, distMetric.Value, 666.0)
 	assert.Equal(t, metrics.DistributionType, distMetric.Mtype)
 }

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -248,9 +248,13 @@ func TestUDPForward(t *testing.T) {
 func TestHistToDist(t *testing.T) {
 	port, err := getAvailableUDPPort()
 	require.NoError(t, err)
+	defaultPort := config.Datadog.GetInt("dogstatsd_port")
 	config.Datadog.SetDefault("dogstatsd_port", port)
+	defer config.Datadog.SetDefault("dogstatsd_port", defaultPort)
 	config.Datadog.SetDefault("histogram_copy_to_distribution", true)
+	defer config.Datadog.SetDefault("histogram_copy_to_distribution", false)
 	config.Datadog.SetDefault("histogram_copy_to_distribution_prefix", "dist.")
+	defer config.Datadog.SetDefault("histogram_copy_to_distribution_prefix", "")
 
 	metricOut := make(chan *metrics.MetricSample)
 	eventOut := make(chan metrics.Event)

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -65,6 +65,11 @@ type MetricSample struct {
 	Timestamp  float64
 }
 
-func (src *MetricSample) CopyTo(dst *MetricSample) {
+// Copy returns a deep copy of the src MetricSample
+func (src *MetricSample) Copy() *MetricSample {
+	dst := &MetricSample{}
 	*dst = *src
+	dst.Tags = make([]string, len(src.Tags))
+	copy(dst.Tags, src.Tags)
+	return dst
 }

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -64,3 +64,7 @@ type MetricSample struct {
 	SampleRate float64
 	Timestamp  float64
 }
+
+func (src *MetricSample) CopyTo(dst *MetricSample) {
+	*dst = *src
+}

--- a/pkg/metrics/metric_sample_test.go
+++ b/pkg/metrics/metric_sample_test.go
@@ -25,5 +25,5 @@ func TestMetricSampleCopy(t *testing.T) {
 	dst := src.Copy()
 
 	assert.NotEqual(t, src, dst)
-	assert.True(t, reflect.DeepEqual(src, dst))
+	assert.True(t, reflect.DeepEqual(&src, &dst))
 }

--- a/pkg/metrics/metric_sample_test.go
+++ b/pkg/metrics/metric_sample_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package metrics
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricSampleCopy(t *testing.T) {
+	src := &MetricSample{}
+	src.Host = "foo"
+	src.Mtype = HistogramType
+	src.Name = "metric.name"
+	src.RawValue = "0.1"
+	src.SampleRate = 1
+	src.Tags = []string{"a:b", "c:d"}
+	src.Timestamp = 1234
+	src.Value = 0.1
+	dst := src.Copy()
+
+	assert.NotEqual(t, src, dst)
+	assert.True(t, reflect.DeepEqual(src, dst))
+}

--- a/pkg/metrics/metric_sample_test.go
+++ b/pkg/metrics/metric_sample_test.go
@@ -24,6 +24,6 @@ func TestMetricSampleCopy(t *testing.T) {
 	src.Value = 0.1
 	dst := src.Copy()
 
-	assert.NotEqual(t, src, dst)
+	assert.False(t, src == dst)
 	assert.True(t, reflect.DeepEqual(&src, &dst))
 }

--- a/releasenotes/notes/auto-add-distributions-for-histograms-b9827074a9777e23.yaml
+++ b/releasenotes/notes/auto-add-distributions-for-histograms-b9827074a9777e23.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add flag `histogram_copy_to_distribution` to send histogram metric values
+    as distributions automatically. Note that the distributions feature is in
+    beta. An additional flag `histogram_copy_to_distribution_prefix` modifies
+    the existing histogram metric name by adding a prefix, e.g. `dist.`, to
+    better distinguish between these values.


### PR DESCRIPTION
### What does this PR do?

This PR adds two new configuration options `histogram_copy_to_distribution` and `histogram_copy_to_distribution_prefix`. When the first option is enabled, histogram points are also copied and sent as distribution points and aggregated on the agent in sketches to be used to generate global distribution metrics. The prefix enables users to modify the metric name so that they are different from their histogram metrics.

### Motivation

The goal here is to add an easy way for users to onboard to global distribution metrics.

### Additional Notes

