### PR TITLE
[packaging] Fix condition to stop agent in preinst script for RPM

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -16,7 +16,7 @@ DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || gre
 if [ "$DISTRIBUTION" != "Darwin" ]; then
     set -e
 
-    if [ -f "/lib/systemd/system/datadog-agent.service" ]; then
+    if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/system/$SERVICE_NAME.service" ]; then
         # Stop an already running agent
         # Only supports systemd and upstart
         if command -v systemctl >/dev/null 2>&1; then

--- a/releasenotes/notes/fix-preinst-stop-rpm-930dd762811a6dda.yaml
+++ b/releasenotes/notes/fix-preinst-stop-rpm-930dd762811a6dda.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    On RHEL/SUSE, stop the Agent properly in the pre-install RPM script on systems where
+    ``/lib`` is not a symlink to ``/usr/lib``.


### PR DESCRIPTION
### What does this PR do?

Fix condition to stop agent in preinst script for RPM.

### Motivation

Since https://github.com/DataDog/datadog-agent/pull/1711 (`6.2.1`) the systemd service file is in /usr/lib in our RPM package. Forgot to update the preinst script too, let's fix that. Bug affected only RHEL/SUSE environments where `/lib` is not a symlink to `/usr/lib` (which is pretty rare)
