### PR TITLE
[packaging] Allow installing the package on SysV-init systems

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -76,7 +76,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             :
         else
             echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-            exit 1
         fi
 
         # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
@@ -89,7 +88,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                 initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
             else
                 echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-                exit 1
             fi
         else
             # No datadog.yaml file is present. This is probably a clean install made with the

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -75,7 +75,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             # Nothing to do, this is defined directly in the upstart job file
             :
         else
-            echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+            echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
         fi
 
         # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
@@ -87,7 +87,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             elif command -v initctl >/dev/null 2>&1; then
                 initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
             else
-                echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+                echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
             fi
         else
             # No datadog.yaml file is present. This is probably a clean install made with the

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -21,7 +21,7 @@ elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :
 else
-    echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
 fi
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
@@ -33,7 +33,7 @@ if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
     elif command -v initctl >/dev/null 2>&1; then
         initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
     else
-        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
     fi
 else
     # No datadog.yaml file is present. This is probably a clean install made with the

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -22,7 +22,6 @@ elif command -v initctl >/dev/null 2>&1; then
     :
 else
     echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-    exit 1
 fi
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
@@ -35,7 +34,6 @@ if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
         initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
     else
         echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-        exit 1
     fi
 else
     # No datadog.yaml file is present. This is probably a clean install made with the

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -28,7 +28,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             initctl stop $SERVICE_NAME-trace || true
             initctl stop $SERVICE_NAME || true
         else
-            echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+            echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
         fi
     fi
 

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -29,7 +29,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             initctl stop $SERVICE_NAME || true
         else
             echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
-            exit 1
         fi
     fi
 

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -24,7 +24,7 @@ stop_agent()
         initctl stop $SERVICE_NAME-trace || true
         initctl stop $SERVICE_NAME || true
     else
-        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
     fi
 }
 
@@ -40,7 +40,7 @@ deregister_agent()
         # Nothing to do, this is defined directly in the upstart job file
         :
     else
-        echo "[ ${Red}FAILED ${RCol}]\tUnsupported init system."
+        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
     fi
 }
 

--- a/releasenotes/notes/pkg-script-no-exit-sysvinit-d193e6f603bee18d.yaml
+++ b/releasenotes/notes/pkg-script-no-exit-sysvinit-d193e6f603bee18d.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The scripts of the Linux packages now don't exit with errors when no supported init system is detected,
+    and only print warnings instead


### PR DESCRIPTION
### What does this PR do?

Allows installing the Linux packages on SysV-init-based systems.

### Motivation

It's legitimate to want to install the packaged agent even if we don't
provide scripts/service defs for the init system of the system.

Let's remove the failure exits that we do when we don't detect a
supported init system, and simply print errors.

### Additional Notes

Up for discussion. Exiting with errors makes the lack of support more explicit
so could be more desirable
