### PR TITLE
[packaging][linux] Create dd-agent user without a login shell

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -38,7 +38,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                 set -e
                 if [ ! $USER_EXISTS -eq 0 ]; then
                     echo "Creating dd-agent user"
-                    adduser --system dd-agent --disabled-login --shell /bin/sh --home ${INSTALL_DIR} --no-create-home --group --quiet
+                    adduser --system dd-agent --disabled-login --shell /usr/sbin/nologin --home ${INSTALL_DIR} --no-create-home --group --quiet
                 elif id -nG dd-agent | grep --invert-match --word-regexp --quiet 'dd-agent'; then
                     # User exists but is not part of the dd-agent group
                     echo "Adding dd-agent user to dd-agent group"

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -47,7 +47,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Set up `dd-agent` user and group
         getent group dd-agent >/dev/null || groupadd -r dd-agent
         getent passwd dd-agent >/dev/null || \
-            useradd -r -M -g dd-agent -d $INSTALL_DIR -s /bin/sh \
+            useradd -r -M -g dd-agent -d $INSTALL_DIR -s /sbin/nologin \
                 -c "Datadog Agent" dd-agent && \
             usermod -L dd-agent
 

--- a/releasenotes/notes/nologin-shell-954a2d921dae2b3e.yaml
+++ b/releasenotes/notes/nologin-shell-954a2d921dae2b3e.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    The DEB and RPM packages now create the ``dd-agent`` user with no login shell (``/sbin/nologin``
+    or ``/usr/sbin/nologin``). The packages do not modify the login shell of the ``dd-agent`` user
+    if it already exists.


### PR DESCRIPTION
### What does this PR do?

Create dd-agent user without a login shell (`nologin` shell). Attempts to get a login shell with the `dd-agent` user will result in this error message:

```
This account is currently not available.
```

This should not affect the Agent 6 behavior in any way. Running shell commands with the `dd-agent` user, for ex. `sudo -u dd-agent --` won't be affected either.

Attempts to run dd-agent's login shell will fail though (ex. `su dd-agent` or `sudo -l -u dd-agent --`)

### Motivation

This follows most distros' recommendations when creating
system users such as `dd-agent`.

If the `dd-agent` user already exists, do not change its login shell to
allow users to change it if they want and persist that change across upgrades.

### Additional Notes

The path to `nologin` is different between RHEL/SUSE and debian/ubuntu,
account for that.