### PR TITLE
[sketches] Decrease epsilon to increase sketch accuracy

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,7 +149,6 @@ func init() {
 	Datadog.SetDefault("proc_root", "/proc")
 	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	Datadog.SetDefault("histogram_percentiles", []string{"0.95"})
-	Datadog.SetDefault("distribution_epsilon", 0.005)
 	// Serializer
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,7 @@ func init() {
 	Datadog.SetDefault("proc_root", "/proc")
 	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	Datadog.SetDefault("histogram_percentiles", []string{"0.95"})
+	Datadog.SetDefault("distribution_epsilon", 0.005)
 	// Serializer
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -21,6 +21,9 @@ import (
 // EPSILON represents the accuracy of the sketch.
 const EPSILON float64 = 0.005
 
+// INCOMING_BUF_SIZE sets the incoming buffer size to a power of 2 that prevents compression before submission in 99% of cases
+const INCOMING_BUF_SIZE int = 256
+
 // Entry is an element of the sketch. For the definition of g and delta, see the original paper
 // http://infolab.stanford.edu/~datar/courses/cs361a/papers/quantiles.pdf
 type Entry struct {
@@ -102,7 +105,7 @@ func (e *Entry) UnmarshalJSON(b []byte) error {
 func NewGKArray() GKArray {
 	return GKArray{
 		// preallocate the incoming array for better insert throughput (5% faster)
-		Incoming: make([]float64, 0, int(1/EPSILON)+1),
+		Incoming: make([]float64, 0, INCOMING_BUF_SIZE),
 		Min:      math.Inf(1),
 		Max:      math.Inf(-1),
 	}

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -19,7 +19,7 @@ import (
 )
 
 // EPSILON represents the accuracy of the sketch.
-const EPSILON float64 = 0.01
+const EPSILON float64 = 0.005
 
 // Entry is an element of the sketch. For the definition of g and delta, see the original paper
 // http://infolab.stanford.edu/~datar/courses/cs361a/papers/quantiles.pdf

--- a/pkg/metrics/percentile/gk_array.go
+++ b/pkg/metrics/percentile/gk_array.go
@@ -21,8 +21,8 @@ import (
 // EPSILON represents the accuracy of the sketch.
 const EPSILON float64 = 0.005
 
-// INCOMING_BUF_SIZE sets the incoming buffer size to a power of 2 that prevents compression before submission in 99% of cases
-const INCOMING_BUF_SIZE int = 256
+// INCOMINGBUFSIZE sets the incoming buffer size to a power of 2 that prevents compression before submission in 99% of cases
+const INCOMINGBUFSIZE int = 256
 
 // Entry is an element of the sketch. For the definition of g and delta, see the original paper
 // http://infolab.stanford.edu/~datar/courses/cs361a/papers/quantiles.pdf
@@ -105,7 +105,7 @@ func (e *Entry) UnmarshalJSON(b []byte) error {
 func NewGKArray() GKArray {
 	return GKArray{
 		// preallocate the incoming array for better insert throughput (5% faster)
-		Incoming: make([]float64, 0, INCOMING_BUF_SIZE),
+		Incoming: make([]float64, 0, INCOMINGBUFSIZE),
 		Min:      math.Inf(1),
 		Max:      math.Inf(-1),
 	}

--- a/releasenotes/notes/decrease-sketch-epsilon-e8a08d9e624de094.yaml
+++ b/releasenotes/notes/decrease-sketch-epsilon-e8a08d9e624de094.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Decrease percentile epsilon for improved accuracy of distribution metrics.

--- a/releasenotes/notes/decrease-sketch-epsilon-e8a08d9e624de094.yaml
+++ b/releasenotes/notes/decrease-sketch-epsilon-e8a08d9e624de094.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Decrease percentile epsilon for improved accuracy of distribution metrics.
+    Decrease percentile epsilon and increase incoming buffer size for improved
+    accuracy of distribution metrics.

--- a/releasenotes/notes/decrease-sketch-epsilon-e8a08d9e624de094.yaml
+++ b/releasenotes/notes/decrease-sketch-epsilon-e8a08d9e624de094.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Decrease percentile epsilon and increase incoming buffer size for improved
-    accuracy of distribution metrics.
+    Decrease epsilon and increase incoming buffer size for improved accuracy of
+    distribution metrics.


### PR DESCRIPTION
### What does this PR do?

Decrease the epsilon on the agent to increase accuracy

### Motivation


### Additional Notes

This should not have an impact on memory usage as the vast majority of sketches do not get compressed already.
