### PR TITLE
Refine apiKeyReplacer regexp to avoid hiding ctr ids

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -23,7 +23,7 @@ type Replacer struct {
 	ReplFunc func(b []byte) []byte
 }
 
-var apiKeyReplacer, dockerAPIKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer Replacer
+var apiKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer Replacer
 var commentRegex = regexp.MustCompile(`^\s*#.*$`)
 var blankRegex = regexp.MustCompile(`^\s*$`)
 

--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -31,7 +31,7 @@ var replacers []Replacer
 
 func init() {
 	apiKeyReplacer := Replacer{
-		Regex: regexp.MustCompile(`[a-fA-F0-9]{27}([a-fA-F0-9]{5})`),
+		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`***************************$1`),
 	}
 	uriPasswordReplacer = Replacer{

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -57,6 +57,10 @@ func TestConfigStripApiKey(t *testing.T) {
 			"https://dog.datadoghq.com":
 			- ***************************abbbb,
 			- ***************************baaaa`)
+	// make sure we don't strip container ids
+	assertClean(t,
+		`container_id: "b32bd6f9b73ba7ccb64953a04b82b48e29dfafab65fd57ca01d3b94a0e024885"`,
+		`container_id: "b32bd6f9b73ba7ccb64953a04b82b48e29dfafab65fd57ca01d3b94a0e024885"`)
 }
 
 func TestConfigStripURLPassword(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Avoid taking container ids for two api keys and stripping them
 
### Motivation

This shouldn't happen:
```
2018-06-08 10:03:44 UTC | INFO | (tagstore.go:105 in digest) | digesting docker://***************************2a230***************************0c384 containing low [short_image:redis image_tag:latest docker_image:redis:latest image_name:redis] and high [container_name:frosty_hodgkin container_id:***************************2a230***************************0c384]
```

### Additional Notes

Anything else we should know when reviewing?
