### PR TITLE
docker image: run two collector runners by default

### DIFF
--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -8,6 +8,10 @@ config_providers:
   - name: docker
     polling: true
 
+# Run two runners by default, this needs to be adjusted depending
+# on the number of checks (static + AD) expected to run.
+check_runners: 2
+
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
   enabled: false

--- a/Dockerfiles/agent/datadog-ecs.yaml
+++ b/Dockerfiles/agent/datadog-ecs.yaml
@@ -8,6 +8,10 @@ config_providers:
   - name: ecs
     polling: true
 
+# Run two runners by default, this needs to be adjusted depending
+# on the number of checks (static + AD) expected to run.
+check_runners: 2
+
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
   enabled: false

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -8,6 +8,10 @@ config_providers:
   - name: kubelet
     polling: true
 
+# Run two runners by default, this needs to be adjusted depending
+# on the number of checks (static + AD) expected to run.
+check_runners: 2
+
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
   enabled: false

--- a/releasenotes/notes/dockerimage-two-runners-15f1f47a9312e67f.yaml
+++ b/releasenotes/notes/dockerimage-two-runners-15f1f47a9312e67f.yaml
@@ -1,0 +1,3 @@
+---
+other:
+  - The datadog/agent docker image now runs two collector runners by default


### PR DESCRIPTION
### What does this PR do?

Set the default configuration in the docker image to run two collectors by default, unless overriden by `DD_CHECK_RUNNERS` envvars or custom datadog.yaml

### Motivation

Mitigate unhealthy `collector-queue` on slow checks