### PR TITLE
Allow empty hostname for dogstatsd metrics

### DIFF
--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -128,11 +128,7 @@ func (s *TimeSampler) flush(timestamp float64) metrics.Series {
 			}
 			serie.Name = context.Name + serie.NameSuffix
 			serie.Tags = context.Tags
-			if context.Host != "" {
-				serie.Host = context.Host
-			} else {
-				serie.Host = s.defaultHostname
-			}
+			serie.Host = context.Host
 			serie.Interval = s.interval
 
 			serieBySignature[serieSignature] = serie

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -114,7 +114,7 @@ func TestContextSampling(t *testing.T) {
 		Name:     "my.metric.name1",
 		Points:   []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
 		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
+		Host:     "",
 		MType:    metrics.APIGaugeType,
 		Interval: 10,
 	}
@@ -130,7 +130,7 @@ func TestContextSampling(t *testing.T) {
 		Name:     "my.metric.name2",
 		Points:   []metrics.Point{{Ts: 12340.0, Value: float64(1)}},
 		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
+		Host:     "",
 		MType:    metrics.APIGaugeType,
 		Interval: 10,
 	}
@@ -186,7 +186,7 @@ func TestCounterExpirySeconds(t *testing.T) {
 		Name:     "my.counter1",
 		Points:   []metrics.Point{{Ts: 1000.0, Value: .1}},
 		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
+		Host:     "",
 		MType:    metrics.APIRateType,
 		Interval: 10,
 	}
@@ -195,7 +195,7 @@ func TestCounterExpirySeconds(t *testing.T) {
 		Name:     "my.counter2",
 		Points:   []metrics.Point{{Ts: 1000.0, Value: .2}},
 		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
+		Host:     "",
 		MType:    metrics.APIRateType,
 		Interval: 10,
 	}
@@ -228,7 +228,7 @@ func TestCounterExpirySeconds(t *testing.T) {
 		Name:     "my.counter1",
 		Points:   []metrics.Point{{Ts: 1010.0, Value: .1}, {Ts: 1020.0, Value: 0.0}, {Ts: 1030.0, Value: 0.0}},
 		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
+		Host:     "",
 		MType:    metrics.APIRateType,
 		Interval: 10,
 	}
@@ -237,7 +237,7 @@ func TestCounterExpirySeconds(t *testing.T) {
 		Name:     "my.counter2",
 		Points:   []metrics.Point{{Ts: 1010, Value: 0}, {Ts: 1020.0, Value: .2}, {Ts: 1030.0, Value: .2}},
 		Tags:     []string{"bar", "foo"},
-		Host:     "default-hostname",
+		Host:     "",
 		MType:    metrics.APIRateType,
 		Interval: 10,
 	}

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -62,7 +62,9 @@ func parseTags(rawTags []byte, extractHost bool) ([]string, string) {
 	if len(rawTags) == 0 {
 		return nil, ""
 	}
-	var host string
+
+	// GetHostname should be cached
+	host := defaultHostname
 	tagsList := make([]string, 0, bytes.Count(rawTags, tagSeparator)+1)
 	remainder := rawTags
 

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -63,7 +63,6 @@ func parseTags(rawTags []byte, extractHost bool) ([]string, string) {
 		return nil, ""
 	}
 
-	// GetHostname should be cached
 	host := defaultHostname
 	tagsList := make([]string, 0, bytes.Count(rawTags, tagSeparator)+1)
 	remainder := rawTags

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -190,6 +190,37 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
+func TestParseGaugeWithEmptyHostTag(t *testing.T) {
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "daemon", parsed.Name)
+	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
+	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
+	require.Equal(t, 2, len(parsed.Tags))
+	assert.Equal(t, "sometag1:somevalue1", parsed.Tags[0])
+	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
+	assert.Equal(t, "", parsed.Host)
+	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+}
+
+func TestParseGaugeWithNoHostTag(t *testing.T) {
+	defaultHostname = "test-hostname"
+	defer func() { defaultHostname = "" }()
+
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "daemon", parsed.Name)
+	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
+	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
+	require.Equal(t, 2, len(parsed.Tags))
+	assert.Equal(t, "sometag1:somevalue1", parsed.Tags[0])
+	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
+	assert.Equal(t, "test-hostname", parsed.Host)
+	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+}
+
 func TestParseGaugeWithSampleRate(t *testing.T) {
 	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "")
 

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -25,6 +25,9 @@ import (
 
 var (
 	dogstatsdExpvar = expvar.NewMap("dogstatsd")
+
+	// The default hostname to enforce on metrics
+	defaultHostname = ""
 )
 
 // Server represent a Dogstatsd server
@@ -118,6 +121,11 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 	}
 
 	s.handleMessages(metricOut, eventOut, serviceCheckOut)
+
+	// We enforce the defaultHostname on metrics when none is set. This
+	// should never change while the agent is running, to avoid checking
+	// the cache on every metrics we save it here.
+	defaultHostname, _ = util.GetHostname()
 
 	return s, nil
 }

--- a/releasenotes/notes/allow-empty-host-from-dogstatsd-7895ace81adbc974.yaml
+++ b/releasenotes/notes/allow-empty-host-from-dogstatsd-7895ace81adbc974.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Take into account empty hosts on metrics coming from dogstatsd, instead of
+    ignoring them and applying the Agent's hostname.


### PR DESCRIPTION
### What does this PR do?

The tag "host:" can now be use to set an empty hostname with dogstatsd
(like with agent5).