### PR TITLE
Removed replace holder for include and exclude at match logs processing rules

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -229,7 +229,9 @@ func ValidateProcessingRules(rules []LogsProcessingRule) error {
 func CompileProcessingRules(rules []LogsProcessingRule) {
 	for i, rule := range rules {
 		switch rule.Type {
-		case ExcludeAtMatch, IncludeAtMatch, MaskSequences:
+		case ExcludeAtMatch, IncludeAtMatch:
+			rules[i].ReplacePlaceholderBytes = []byte(rule.ReplacePlaceholder)
+		case MaskSequences:
 			rules[i].Reg = regexp.MustCompile(rule.Pattern)
 			rules[i].ReplacePlaceholderBytes = []byte(rule.ReplacePlaceholder)
 		case MultiLine:


### PR DESCRIPTION
### What does this PR do?

Removed place holder for include and exclude processing rules.

### Motivation

Don't need it.

