### PR TITLE
Custom config file to expand environment when copying

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -68,7 +68,7 @@ RUN if [ -n "$WITH_JMX" ]; then apt-get update \
 # make sure we have recent dependencies
 RUN apt-get update \
   # CVE-fixing time!
-  && apt-get install -y util-linux ncurses-bin ncurses-base libncursesw5:amd64 \
+  && apt-get install -y util-linux ncurses-bin ncurses-base libncursesw5:amd64 gettext-base \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954

--- a/Dockerfiles/agent/entrypoint/89-copy-customfiles.sh
+++ b/Dockerfiles/agent/entrypoint/89-copy-customfiles.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+#Expand environment variables
+for file in /conf.d/*.yaml.tpl;
+do
+  conf_file=`echo $file | sed 's/\.tpl//'`
+  envsubst < $file > $conf_file
+done
 # Copy the custom checks and confs in the /etc/datadog-agent folder
 find /conf.d -name '*.yaml' -exec cp --parents -fv {} /etc/datadog-agent/ \;
 find /checks.d -name '*.py' -exec cp --parents -fv {} /etc/datadog-agent/ \;

--- a/releasenotes/notes/add-envsubst-4b4792bdb0aff7d8.yaml
+++ b/releasenotes/notes/add-envsubst-4b4792bdb0aff7d8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The file with .yaml.tpl extension in /conf.d has been expanded environment variable and copied to /etc/datadog-agent/conf.d.


### PR DESCRIPTION
### What does this PR do?

The file with .yaml.tpl extension in /conf.d has been expanded environment variable and copied to /etc/datadog-agent/conf.d.

### Motivation
Some core integrations need to put authentication information such as passwords on config file. (ex: mysql, postgres)

However, since environment variables can not be used in the config file at present, management becomes very difficult with git and k8s configMap

using envsubst we wanted to expand environment variables inside containers so that they could be used safely.

becouse I am not good at English, I use some machine translation. Sorry.
### Additional Notes


