### PR TITLE
Align docker agent's kubernetes liveness probe timeout with docker healthcheck (5s)

### DIFF
--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -53,6 +53,7 @@ spec:
             - ./probe.sh
           initialDelaySeconds: 15
           periodSeconds: 5
+          timeoutSeconds: 5
       volumes:
         - hostPath:
             path: /var/run/docker.sock

--- a/releasenotes/notes/k8s-liveness-probe-timeout-70dc4483152cddc9.yaml
+++ b/releasenotes/notes/k8s-liveness-probe-timeout-70dc4483152cddc9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Align docker agent's kubernetes liveness probe timeout with docker healthcheck (5s) to avoid too many container restarts.


### PR DESCRIPTION
### What does this PR do?

Default timeout for kubernetes liveness probes is 1s: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes

This apparently is too short and triggers container restarts too often.

This PR aligns the timeout to the one declared for docker: https://github.com/DataDog/datadog-agent/commit/45af2f8163154dee7386de67d88b0a1edbac307d#diff-c0e62e43e3f3ef321994872f8fef948dR74

### Motivation

Reduce the number of restarts of datadog agent containers.

### Additional Notes

N/A