### PR TITLE
[proxy] Improve `no_proxy` matching logic

### DIFF
--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -1,102 +1,17 @@
 package util
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"gopkg.in/yaml.v2"
 )
-
-func TestEmptyProxy(t *testing.T) {
-	r, err := http.NewRequest("GET", "https://test.com", nil)
-	require.Nil(t, err)
-
-	proxies := &config.Proxy{}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-}
-
-func TestHTTPProxy(t *testing.T) {
-	rHTTP, _ := http.NewRequest("GET", "http://test.com/api/v1?arg=21", nil)
-	rHTTPS, _ := http.NewRequest("GET", "https://test.com/api/v1?arg=21", nil)
-
-	proxies := &config.Proxy{
-		HTTP: "https://user:pass@proxy.com:3128",
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(rHTTP)
-	assert.Nil(t, err)
-	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
-
-	proxyURL, err = proxyFunc(rHTTPS)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-}
-
-func TestNoProxy(t *testing.T) {
-	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
-	r2, _ := http.NewRequest("GET", "http://test_http.com/api/v1?arg=21", nil)
-	r3, _ := http.NewRequest("GET", "https://test_https.com/api/v1?arg=21", nil)
-
-	proxies := &config.Proxy{
-		HTTP:    "https://user:pass@proxy.com:3128",
-		HTTPS:   "https://user:pass@proxy_https.com:3128",
-		NoProxy: []string{"test_no_proxy.com", "test.org"},
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-
-	proxyURL, err = proxyFunc(r2)
-	assert.Nil(t, err)
-	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
-
-	proxyURL, err = proxyFunc(r3)
-	assert.Nil(t, err)
-	assert.Equal(t, "https://user:pass@proxy_https.com:3128", proxyURL.String())
-}
-
-func TestErrorParse(t *testing.T) {
-	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
-
-	proxies := &config.Proxy{
-		HTTP: "21://test.com",
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r1)
-	assert.NotNil(t, err)
-	assert.Nil(t, proxyURL)
-}
-
-func TestBadScheme(t *testing.T) {
-	r1, _ := http.NewRequest("GET", "ftp://test.com", nil)
-
-	proxies := &config.Proxy{
-		HTTP: "http://test.com",
-	}
-	proxyFunc := GetProxyTransportFunc(proxies)
-
-	proxyURL, err := proxyFunc(r1)
-	assert.Nil(t, err)
-	assert.Nil(t, proxyURL)
-}
 
 func TestJSONConverter(t *testing.T) {
 
@@ -133,27 +48,4 @@ func TestJSONConverter(t *testing.T) {
 	//json encode
 	_, err := json.Marshal(GetJSONSerializableMap(j))
 	assert.Nil(t, err)
-}
-
-func TestCreateHTTPTransport(t *testing.T) {
-	skipSSL := config.Datadog.GetBool("skip_ssl_validation")
-	forceTLS := config.Datadog.GetBool("force_tls_12")
-	defer config.Datadog.Set("skip_ssl_validation", skipSSL)
-	defer config.Datadog.Set("force_tls_12", forceTLS)
-
-	config.Datadog.Set("skip_ssl_validation", false)
-	config.Datadog.Set("force_tls_12", false)
-	transport := CreateHTTPTransport()
-	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
-
-	config.Datadog.Set("skip_ssl_validation", true)
-	transport = CreateHTTPTransport()
-	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
-
-	config.Datadog.Set("force_tls_12", true)
-	transport = CreateHTTPTransport()
-	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
 }

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,6 +1,16 @@
 package util
 
-import "regexp"
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
 
 const (
 	apiKeyReplacement = "api_key=*************************$1"
@@ -13,4 +23,81 @@ var apiKeyRegExp = regexp.MustCompile("api_key=*\\w+(\\w{5})")
 // For now, it obfuscates the API key.
 func SanitizeURL(message string) string {
 	return apiKeyRegExp.ReplaceAllString(message, apiKeyReplacement)
+}
+
+// HTTPHeaders returns a http headers including various basic information (User-Agent, Content-Type...).
+func HTTPHeaders() map[string]string {
+	av, _ := version.New(version.AgentVersion, version.Commit)
+	return map[string]string{
+		"User-Agent":   fmt.Sprintf("Datadog Agent/%s", av.GetNumber()),
+		"Content-Type": "application/x-www-form-urlencoded",
+		"Accept":       "text/html, */*",
+	}
+}
+
+// GetProxyTransportFunc return a proxy function for a http.Transport that
+// would return the right proxy depending on the configuration.
+func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error) {
+	return func(r *http.Request) (*url.URL, error) {
+		// check no_proxy list first
+		for _, host := range p.NoProxy {
+			if r.URL.Host == host {
+				log.Debugf("URL match no_proxy list item '%s': not using any proxy", host)
+				return nil, nil
+			}
+		}
+
+		// check proxy by scheme
+		confProxy := ""
+		if r.URL.Scheme == "http" {
+			confProxy = p.HTTP
+		} else if r.URL.Scheme == "https" {
+			confProxy = p.HTTPS
+		} else {
+			log.Warnf("Proxy configuration do not support scheme '%s'", r.URL.Scheme)
+		}
+
+		if confProxy != "" {
+			proxyURL, err := url.Parse(confProxy)
+			if err != nil {
+				err := fmt.Errorf("Could not parse the proxy URL for scheme %s from configuration: %s", r.URL.Scheme, err)
+				log.Error(err.Error())
+				return nil, err
+			}
+			userInfo := ""
+			if proxyURL.User != nil {
+				if _, isSet := proxyURL.User.Password(); isSet {
+					userInfo = "*****:*****@"
+				} else {
+					userInfo = "*****@"
+				}
+			}
+
+			log.Debugf("Using proxy %s://%s%s for URL '%s'", proxyURL.Scheme, userInfo, proxyURL.Host, SanitizeURL(r.URL.String()))
+			return proxyURL, nil
+		}
+
+		// no proxy set for this request
+		return nil, nil
+	}
+}
+
+// CreateHTTPTransport creates an *http.Transport for use in the agent
+func CreateHTTPTransport() *http.Transport {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: config.Datadog.GetBool("skip_ssl_validation"),
+	}
+
+	if config.Datadog.GetBool("force_tls_12") {
+		tlsConfig.MinVersion = tls.VersionTLS12
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	if proxies := config.GetProxies(); proxies != nil {
+		transport.Proxy = GetProxyTransportFunc(proxies)
+	}
+	return transport
 }

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,0 +1,116 @@
+package util
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestEmptyProxy(t *testing.T) {
+	r, err := http.NewRequest("GET", "https://test.com", nil)
+	require.Nil(t, err)
+
+	proxies := &config.Proxy{}
+	proxyFunc := GetProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestHTTPProxy(t *testing.T) {
+	rHTTP, _ := http.NewRequest("GET", "http://test.com/api/v1?arg=21", nil)
+	rHTTPS, _ := http.NewRequest("GET", "https://test.com/api/v1?arg=21", nil)
+
+	proxies := &config.Proxy{
+		HTTP: "https://user:pass@proxy.com:3128",
+	}
+	proxyFunc := GetProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(rHTTP)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
+
+	proxyURL, err = proxyFunc(rHTTPS)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestNoProxy(t *testing.T) {
+	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
+	r2, _ := http.NewRequest("GET", "http://test_http.com/api/v1?arg=21", nil)
+	r3, _ := http.NewRequest("GET", "https://test_https.com/api/v1?arg=21", nil)
+
+	proxies := &config.Proxy{
+		HTTP:    "https://user:pass@proxy.com:3128",
+		HTTPS:   "https://user:pass@proxy_https.com:3128",
+		NoProxy: []string{"test_no_proxy.com", "test.org"},
+	}
+	proxyFunc := GetProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r1)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+
+	proxyURL, err = proxyFunc(r2)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://user:pass@proxy.com:3128", proxyURL.String())
+
+	proxyURL, err = proxyFunc(r3)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://user:pass@proxy_https.com:3128", proxyURL.String())
+}
+
+func TestErrorParse(t *testing.T) {
+	r1, _ := http.NewRequest("GET", "http://test_no_proxy.com/api/v1?arg=21", nil)
+
+	proxies := &config.Proxy{
+		HTTP: "21://test.com",
+	}
+	proxyFunc := GetProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r1)
+	assert.NotNil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestBadScheme(t *testing.T) {
+	r1, _ := http.NewRequest("GET", "ftp://test.com", nil)
+
+	proxies := &config.Proxy{
+		HTTP: "http://test.com",
+	}
+	proxyFunc := GetProxyTransportFunc(proxies)
+
+	proxyURL, err := proxyFunc(r1)
+	assert.Nil(t, err)
+	assert.Nil(t, proxyURL)
+}
+
+func TestCreateHTTPTransport(t *testing.T) {
+	skipSSL := config.Datadog.GetBool("skip_ssl_validation")
+	forceTLS := config.Datadog.GetBool("force_tls_12")
+	defer config.Datadog.Set("skip_ssl_validation", skipSSL)
+	defer config.Datadog.Set("force_tls_12", forceTLS)
+
+	config.Datadog.Set("skip_ssl_validation", false)
+	config.Datadog.Set("force_tls_12", false)
+	transport := CreateHTTPTransport()
+	assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
+
+	config.Datadog.Set("skip_ssl_validation", true)
+	transport = CreateHTTPTransport()
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(0))
+
+	config.Datadog.Set("force_tls_12", true)
+	transport = CreateHTTPTransport()
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+	assert.Equal(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
+}

--- a/releasenotes/notes/no-proxy-setting-improvement-4117bf203635f21b.yaml
+++ b/releasenotes/notes/no-proxy-setting-improvement-4117bf203635f21b.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The logic that matches the ``no_proxy`` entries with the request's host has been
+    improved to more closely match the behavior of other network utilities (``curl``
+    for example).


### PR DESCRIPTION
### What does this PR do?

Before this commit, the `no_proxy` entries would only match hosts exactly. This adds support for a lot of cases where `no_proxy` entries should match the request's host, for example:
* a no_proxy entry that's a suffix of the target host now matches
* the port of the target host is now cleaned up before matching it with
  no_proxy entries
* [logic that might be golang-specific] localhost and loopback addresses
  never use proxies

(see the tests that were added for examples of target hosts that would stop using the configured http/https proxies)

### Motivation

Make the behavior of the `no_proxy` setting closer to what other programs (typically, `curl`) would do.

### Additional Notes

See second commit for the logic changes, the first commit only moves code around.

The code itself is mostly copied from `net/http/transport.go` of go's stdlib, with a few minor tweaks for our needs (see inline comments). Unfortunately the logic there isn't usable through exported functions.
