### PR TITLE
add a flag to use hostname -f instead of os.Hostname() on *nix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,6 +106,7 @@ func init() {
 	Datadog.SetDefault("check_runners", int64(1))
 	Datadog.SetDefault("auth_token_file_path", "")
 	Datadog.SetDefault("bind_host", "localhost")
+	BindEnvAndSetDefault("hostname_fqdn", false)
 
 	// secrets backend
 	Datadog.BindEnv("secret_backend_command")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -33,6 +33,9 @@ api_key:
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 
+# Force the agent to use
+# hostname_fqdn: false
+
 # Set the host's tags (optional)
 # tags:
 #   - mytag
@@ -112,10 +115,10 @@ api_key:
 # IPC api server timeout in seconds
 # server_timeout: 15
 
-# Some environments may have the procfs file system mounted in a miscellaneous 
-# location. The procfs_path configuration parameter provides a mechanism to 
-# override the standard default location: '/proc' - this setting will trickle 
-# down to integrations and affect their behavior if they rely on the psutil 
+# Some environments may have the procfs file system mounted in a miscellaneous
+# location. The procfs_path configuration parameter provides a mechanism to
+# override the standard default location: '/proc' - this setting will trickle
+# down to integrations and affect their behavior if they rely on the psutil
 # python package.
 # procfs_path: /proc
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -33,7 +33,9 @@ api_key:
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 
-# Force the agent to use
+# Make the agent use "hostname -f" on unix based systems as a last resort
+# way of determining the hostname instead of Golang "os.Hostname()"
+# This will be enabled by default in version 6.4
 # hostname_fqdn: false
 
 # Set the host's tags (optional)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -33,7 +33,7 @@ api_key:
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
 
-# Make the agent use "hostname -f" on unix based systems as a last resort
+# Make the agent use "hostname -f" on unix-based systems as a last resort
 # way of determining the hostname instead of Golang "os.Hostname()"
 # This will be enabled by default in version 6.4
 # hostname_fqdn: false

--- a/pkg/legacy/converter.go
+++ b/pkg/legacy/converter.go
@@ -164,6 +164,8 @@ func FromAgentConfig(agentConfig Config) error {
 		config.Datadog.Set("apm_config.ignore_resources", strings.Split(agentConfig["resource"], ","))
 	}
 
+	config.Datadog.Set("hostname_fqdn", true)
+
 	return nil
 }
 

--- a/pkg/legacy/converter_test.go
+++ b/pkg/legacy/converter_test.go
@@ -198,6 +198,13 @@ func TestBuildHistogramPercentiles(t *testing.T) {
 	assert.Equal(t, expectedBoth, actualBoth)
 }
 
+func TestDefaultValues(t *testing.T) {
+	agentConfig := make(Config)
+	FromAgentConfig(agentConfig)
+
+	assert.Equal(t, true, config.Datadog.GetBool("hostname_fqdn"))
+}
+
 func TestExtractURLAPIKeys(t *testing.T) {
 	defer func() {
 		config.Datadog.Set("dd_url", "")

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -130,11 +130,12 @@ func GetHostname() (string, error) {
 	name, err = getSystemFQDN()
 	if err == nil {
 		if config.Datadog.GetBool("hostname_fqdn") {
-			return name, nil
-		}
-		h, err := os.Hostname()
-		if err == nil && h != name {
-			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as %s. However starting from version 6.4, it will be resolved as %s by default. To enable the behavior of 6.4+, please enable the `hostname_fqdn` flag in the configuration.", h, name)
+			hostName = name
+		} else {
+			h, err := os.Hostname()
+			if err == nil && h != name {
+				log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as '%s'. However starting from version 6.4, it will be resolved as '%s' by default. To enable the behavior of 6.4+, please enable the `hostname_fqdn` flag in the configuration.", h, name)
+			}
 		}
 	} else {
 		log.Debug("Unable to get FQDN from system: ", err)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -134,7 +134,7 @@ func GetHostname() (string, error) {
 		}
 		h, err := os.Hostname()
 		if err == nil && h != name {
-			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as %s. However starting from version 6.4, it will be resolved as %s by default. To enable the behavior of 6.4+, please enable the `hostname_fqdn` flag in the configuration.")
+			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as %s. However starting from version 6.4, it will be resolved as %s by default. To enable the behavior of 6.4+, please enable the `hostname_fqdn` flag in the configuration.", h, name)
 		}
 	} else {
 		log.Debug("Unable to get FQDN from system: ", err)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -126,11 +126,17 @@ func GetHostname() (string, error) {
 	}
 
 	// FQDN
-	if config.Datadog.GetBool("hostname_fqdn") {
-		name, err = getSystemFQDN()
-		if err == nil {
+	log.Debug("GetHostname trying FQDN/`hostname -f`...")
+	name, err = getSystemFQDN()
+	if err == nil {
+		if config.Datadog.GetBool("hostname_fqdn") {
 			return name, nil
 		}
+		h, err := os.Hostname()
+		if err == nil && h != name {
+			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as %s. However starting from version 6.4, it will be resolved as %s by default. To enable the behavior of 6.4+, please enable the `hostname_fqdn` flag in the configuration.")
+		}
+	} else {
 		log.Debug("Unable to get FQDN from system: ", err)
 	}
 

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -125,6 +125,15 @@ func GetHostname() (string, error) {
 		log.Debug("Unable to get hostname from GCE: ", err)
 	}
 
+	// FQDN
+	if config.Datadog.GetBool("hostname_fqdn") {
+		name, err = getSystemFQDN()
+		if err == nil {
+			return name, nil
+		}
+		log.Debug("Unable to get FQDN from system: ", err)
+	}
+
 	isContainerized, name := getContainerHostname()
 	if isContainerized && name != "" {
 		hostName = name

--- a/pkg/util/hostname_nix.go
+++ b/pkg/util/hostname_nix.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package util
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+func getSystemFQDN() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "hostname", "-f")
+
+	out, err := cmd.Output()
+	return string(out), err
+}

--- a/pkg/util/hostname_nix.go
+++ b/pkg/util/hostname_nix.go
@@ -17,7 +17,7 @@ func getSystemFQDN() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "hostname", "-f")
+	cmd := exec.CommandContext(ctx, "/bin/hostname", "-f")
 
 	out, err := cmd.Output()
 	return string(out), err

--- a/pkg/util/hostname_nix.go
+++ b/pkg/util/hostname_nix.go
@@ -10,6 +10,7 @@ package util
 import (
 	"context"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -20,5 +21,5 @@ func getSystemFQDN() (string, error) {
 	cmd := exec.CommandContext(ctx, "/bin/hostname", "-f")
 
 	out, err := cmd.Output()
-	return string(out), err
+	return strings.TrimSpace(string(out)), err
 }

--- a/pkg/util/hostname_windows.go
+++ b/pkg/util/hostname_windows.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package util
+
+import "os"
+
+func getSystemFQDN() (string, error) {
+	return os.Hostname()
+}

--- a/pkg/util/hostname_windows.go
+++ b/pkg/util/hostname_windows.go
@@ -5,8 +5,10 @@
 
 package util
 
-import "os"
+import (
+	"fmt"
+)
 
 func getSystemFQDN() (string, error) {
-	return os.Hostname()
+	return "", fmt.Errorf("getSystemFQDN is not implemented on windows")
 }

--- a/releasenotes/notes/hostname-fqdn-flag-6ee403d385f36997.yaml
+++ b/releasenotes/notes/hostname-fqdn-flag-6ee403d385f36997.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     To match the behavior of Agent 5, a flag has been introduced to make the
-    agent use ``hostname -f`` on unix based system before trying ``os.Hostname()``.
-    This flag is turrned off by default for 6.3 and will be enabled by default in 6.4.
+    agent use ``hostname -f`` on unix-based systems before trying ``os.Hostname()``.
+    This flag is turned off by default for 6.3 and will be enabled by default in 6.4.

--- a/releasenotes/notes/hostname-fqdn-flag-6ee403d385f36997.yaml
+++ b/releasenotes/notes/hostname-fqdn-flag-6ee403d385f36997.yaml
@@ -4,3 +4,5 @@ fixes:
     To match the behavior of Agent 5, a flag has been introduced to make the
     agent use ``hostname -f`` on unix-based systems before trying ``os.Hostname()``.
     This flag is turned off by default for 6.3 and will be enabled by default in 6.4.
+    The import command used to upgrade from the Agent5 to the Agent6 will enable
+    this flag in the config.

--- a/releasenotes/notes/hostname-fqdn-flag-6ee403d385f36997.yaml
+++ b/releasenotes/notes/hostname-fqdn-flag-6ee403d385f36997.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    To match the behavior of Agent 5, a flag has been introduced to make the
+    agent use ``hostname -f`` on unix based system before trying ``os.Hostname()``.
+    This flag is turrned off by default for 6.3 and will be enabled by default in 6.4.


### PR DESCRIPTION
### What does this PR do?

Adds a flag to use `hostname -f` instead of os.Hostname() on unix based platforms.

### Motivation

Behavior changed between agent 5 and 6