### PR TITLE
[log][flare] scrub regular domain passwords too. URIs cannot contain literal spaces.

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -35,8 +35,8 @@ func init() {
 		Repl:  []byte(`***************************$1`),
 	}
 	uriPasswordReplacer = Replacer{
-		Regex: regexp.MustCompile(`\:\/\/([A-Za-z0-9_]+)\:(.+)\@`),
-		Repl:  []byte(`://$1:********@`),
+		Regex: regexp.MustCompile(`([A-Za-z]+\:\/\/|\b)([A-Za-z0-9_]+)\:([^\s-]+)\@`),
+		Repl:  []byte(`$1$2:********@`),
 	}
 	passwordReplacer = Replacer{
 		Regex: matchYAMLKeyPart(`pass(word)?`),

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -71,7 +71,7 @@ func TestConfigStripURLPassword(t *testing.T) {
 		`random_url_key: http://user:p@ssw0r)@host:port`,
 		`random_url_key: http://user:********@host:port`)
 	assertClean(t,
-		`random_url_key: http://user:🔑 🔒 🔐 🔓@host:port`,
+		`random_url_key: http://user:🔑🔒🔐🔓@host:port`,
 		`random_url_key: http://user:********@host:port`)
 	assertClean(t,
 		`random_url_key: http://user:password@host`,
@@ -85,6 +85,9 @@ func TestConfigStripURLPassword(t *testing.T) {
 	assertClean(t,
 		`random_url_key: 'http://user:password@host:port'`,
 		`random_url_key: 'http://user:********@host:port'`)
+	assertClean(t,
+		`random_domain_key: 'user:password@host:port'`,
+		`random_domain_key: 'user:********@host:port'`)
 	assertClean(t,
 		`random_url_key: |
 			http://user:password@host:port`,


### PR DESCRIPTION
### What does this PR do?

Tweaks the regex for password detection in URIs/domains

### Motivation

We weren't detecting passwords in domains (not in URI format). Also, URI encoded format for username, passwords cannot contain literal spaces, so tweaked the unicode test. 
