### PR TITLE
Update color used in the version command.

### DIFF
--- a/cmd/agent/app/version.go
+++ b/cmd/agent/app/version.go
@@ -35,7 +35,7 @@ var versionCmd = &cobra.Command{
 		fmt.Fprintln(
 			color.Output,
 			fmt.Sprintf("Agent %s %s- Commit: %s - Serialization version: %s",
-				color.BlueString(av.GetNumberAndPre()),
+				color.CyanString(av.GetNumberAndPre()),
 				meta,
 				color.GreenString(av.Commit),
 				color.MagentaString(serializer.AgentPayloadVersion),


### PR DESCRIPTION
### What does this PR do?

The blue color is too dark for terminal with dark background, making it
impossible to read.

Example:
![2018-06-12-141619_708x61_scrot](https://user-images.githubusercontent.com/311563/41308927-3ae74cfc-6e4b-11e8-8ceb-5c5549ea32bb.png)

New color:
![2018-06-12-141932_206x28_scrot](https://user-images.githubusercontent.com/311563/41309068-a74f3fd0-6e4b-11e8-9296-e811fac9f3c1.png)
