### PR TITLE
Fix panic on event watcher

### DIFF
--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -10,6 +10,7 @@ package apiserver
 //// Covered by test/integration/util/kube_apiserver/events_test.go
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"time"
@@ -48,7 +49,7 @@ func (c *APIClient) LatestEvents(since string) ([]*v1.Event, []*v1.Event, string
 
 	eventWatcher, err := c.Client.Events(metav1.NamespaceAll).Watch(metav1.ListOptions{Watch: true, ResourceVersion: since})
 	if err != nil {
-		log.Debugf("Failed to watch %v: %v", expectedType, err)
+		return nil, nil, "0", fmt.Errorf("Failed to watch %v: %v", expectedType, err)
 	}
 	defer eventWatcher.Stop()
 

--- a/releasenotes/notes/fix-panic-event-37279e4ac70b61a4.yaml
+++ b/releasenotes/notes/fix-panic-event-37279e4ac70b61a4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a possible panic in the kubernetes event watcher.


### PR DESCRIPTION
### What does this PR do?

Return early if we can't get the event watcher

### Motivation

Fixes a possible panic
```
[ AGENT ] panic: runtime error: invalid memory address or nil pointer dereference
[ AGENT ] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xec5699]
[ AGENT ]
[ AGENT ] goroutine 73 [running]:
[ AGENT ] github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver.(*APIClient).LatestEvents(0xc420403100, 0xc4205399d0, 0x7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/events.go:53 +0x449
[ AGENT ] github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster.(*KubeASCheck).eventCollectionCheck(0xc4206f89a0, 0x1cbad58, 0xc420b67d40, 0xc4206cc310, 0x0, 0x0, 0xc420745d18, 0x44c0e4, 0x1baecb8)
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetes_apiserver.go:200 +0x59
[ AGENT ] github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster.(*KubeASCheck).Run(0xc4206f89a0, 0x0, 0x0)
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetes_apiserver.go:126 +0x2c3
[ AGENT ] github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).work(0xc420264420)
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:255 +0x422
[ AGENT ] created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).AddWorker
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:100 +0x8a
```
