### PR TITLE
e2e: fix the pupernetes wait race

### DIFF
--- a/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
+++ b/test/e2e/scripts/run-instance/10-pupernetes-wait.sh
@@ -21,5 +21,16 @@ _wait_binary() {
 
 _wait_binary pupernetes
 
-set -ex
-sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --timeout 20m
+# Binary is here, so setup-pupernetes has completed
+# pupernetes.service should start soon because it contains the constraint After=setup-pupernetes.service
+
+set -x
+sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --timeout 20m || {
+    # Here pupernetes.service may not be started yet and be considered as dead by go-systemd
+    # A single retry is enough
+    # https://github.com/DataDog/pupernetes/issues/46
+    sleep 10
+    sudo -kE pupernetes wait --unit-to-watch pupernetes.service --logging-since 2h --timeout 20m
+}
+
+exit $?


### PR DESCRIPTION
### What does this PR do?

See https://github.com/DataDog/pupernetes/issues/46

### Motivation

Avoid any failure in gitlab pipelines.
