### PR TITLE
[forwarder] Fix misleading forwarder startup log message

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -139,8 +139,8 @@ func (f *DefaultForwarder) Start() error {
 		endpointLogs = append(endpointLogs, fmt.Sprintf("\"%s\" (%v api key(s))",
 			domain, len(apiKeys)))
 	}
-	log.Infof("Forwarder started, sending to %v endpoint(s) with %v workers each: %s",
-		f.NumberOfWorkers, len(endpointLogs), strings.Join(endpointLogs, " ; "))
+	log.Infof("Forwarder started, sending to %v endpoint(s) with %v worker(s) each: %s",
+		len(endpointLogs), f.NumberOfWorkers, strings.Join(endpointLogs, " ; "))
 
 	f.healthChecker.Start(f.keysPerDomains)
 	f.internalState = Started


### PR DESCRIPTION
### What does this PR do?

Fixes misleading forwarder startup log message. The number of workers per endpoint and the number of endpoints were switched.

No release note because this wasn't released yet.