### PR TITLE
fix `hostname -f` vs `os.Hostname()` logging

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -36,6 +36,7 @@ api_key:
 # Make the agent use "hostname -f" on unix-based systems as a last resort
 # way of determining the hostname instead of Golang "os.Hostname()"
 # This will be enabled by default in version 6.4
+# More information at  https://dtdg.co/flag-hostname-fqdn
 # hostname_fqdn: false
 
 # Set the host's tags (optional)


### PR DESCRIPTION
We were logging the deprecation notice before being sure that `os.Hostname()` was going to be used