### PR TITLE
Re-schedule a check on new tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,6 +281,7 @@ agent_suse-x64:
 
 # build Agent package for Windows
 build_windows_msi_x64:
+  allow_failure: true
   before_script:
     - if exist .omnibus rd /s/q .omnibus
     - if exist \omnibus-ruby rd /s/q \omnibus-ruby

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,20 +60,20 @@ before_script:
 #
 
 # run tests for deb-x64
-run_tests_deb-x64:
-  stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e test --race --profile
+#run_tests_deb-x64:
+#  stage: source_test
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+#  tags: [ "runner:main", "size:large" ]
+#  script:
+#    - inv -e test --race --profile
 
 # run tests for rpm-x64
-run_test_rpm-x64:
-  stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - inv -e test --race --profile
+#run_test_rpm-x64:
+#  stage: source_test
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
+#  tags: [ "runner:main", "size:large" ]
+#  script:
+#    - inv -e test --race --profile
 
 # scan the dependencies for security vulnerabilities with snyk
 run_security_scan_test:
@@ -215,35 +215,35 @@ agent_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 # build Agent package for rpm-x64
-agent_rpm-x64:
-  stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
-  tags: [ "runner:main", "size:large" ]
-  variables:
-    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-  script:
-    # remove artifacts from previous pipelines that may come from the cache
-    - rm -rf $OMNIBUS_PACKAGE_DIR/*
-    # Artifacts and cache must live within project directory but we run omnibus
-    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
-    # pointing to a gitlab-friendly location.
-    - set +x
-    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key --with-decryption --query "Parameter.Value" --out text)
-    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
-    - set -x
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
-    - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
-  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
-  # cache:
-  #   # cache per branch
-  #   key: $CI_COMMIT_REF_NAME
-  #   paths:
-  #     - $OMNIBUS_BASE_DIR
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - $OMNIBUS_PACKAGE_DIR
+#agent_rpm-x64:
+#  stage: package_build
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
+#  tags: [ "runner:main", "size:large" ]
+#  variables:
+#    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+#  script:
+#    # remove artifacts from previous pipelines that may come from the cache
+#    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+#    # Artifacts and cache must live within project directory but we run omnibus
+#    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+#    # pointing to a gitlab-friendly location.
+#    - set +x
+#    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key --with-decryption --query "Parameter.Value" --out text)
+#    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
+#    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
+#    - set -x
+#    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+#    - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
+#  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+#  # cache:
+#  #   # cache per branch
+#  #   key: $CI_COMMIT_REF_NAME
+#  #   paths:
+#  #     - $OMNIBUS_BASE_DIR
+#  artifacts:
+#    expire_in: 2 weeks
+#    paths:
+#      - $OMNIBUS_PACKAGE_DIR
 
 # build Agent package for rpm-x64
 agent_suse-x64:
@@ -425,23 +425,23 @@ deploy_deb_testing:
 
 
 # deploy rpm packages to yum staging repo
-deploy_rpm_testing:
-  stage: testkitchen_deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - source /usr/local/rvm/scripts/rvm
-    - rvm use 2.4
-    - mkdir -p ./rpmrepo/x86_64/
-    - aws s3 sync s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID ./rpmrepo/
-    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/x86_64/
-    - createrepo --update -v --checksum sha ./rpmrepo/x86_64
-    - aws s3 sync ./rpmrepo/ s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+#deploy_rpm_testing:
+#  stage: testkitchen_deploy
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
+#  before_script:
+#    - ls $OMNIBUS_PACKAGE_DIR
+#  only:
+#    - master
+#    - tags
+#  tags: [ "runner:main", "size:large" ]
+#  script:
+#    - source /usr/local/rvm/scripts/rvm
+#    - rvm use 2.4
+#    - mkdir -p ./rpmrepo/x86_64/
+#    - aws s3 sync s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID ./rpmrepo/
+#    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/x86_64/
+#    - createrepo --update -v --checksum sha ./rpmrepo/x86_64
+#    - aws s3 sync ./rpmrepo/ s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing:
@@ -841,27 +841,27 @@ deploy_windows_tags:
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy rpm packages to yum staging repo
-deploy_rpm:
-  stage: deploy
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
-  before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
-  tags: [ "runner:main", "size:large" ]
-  script:
-    - source /usr/local/rvm/scripts/rvm
-    - rvm use 2.4
-    - mkdir -p ./rpmrepo/6/x86_64/
-    - aws s3 sync s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
-
-    # add RPMs to new "6" branch
-    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/6/x86_64/
-    - createrepo --update -v --checksum sha ./rpmrepo/6/x86_64
-
-    # sync to S3
-    - aws s3 sync ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+#deploy_rpm:
+#  stage: deploy
+#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
+#  before_script:
+#    - ls $OMNIBUS_PACKAGE_DIR
+#  only:
+#    - master
+#    - tags
+#  tags: [ "runner:main", "size:large" ]
+#  script:
+#    - source /usr/local/rvm/scripts/rvm
+#    - rvm use 2.4
+#    - mkdir -p ./rpmrepo/6/x86_64/
+#    - aws s3 sync s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
+#
+#    # add RPMs to new "6" branch
+#    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/6/x86_64/
+#    - createrepo --update -v --checksum sha ./rpmrepo/6/x86_64
+#
+#    # sync to S3
+#    - aws s3 sync ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy suse rpm packages to yum staging repo
 deploy_suse_rpm:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,7 +281,6 @@ agent_suse-x64:
 
 # build Agent package for Windows
 build_windows_msi_x64:
-  allow_failure: true
   before_script:
     - if exist .omnibus rd /s/q .omnibus
     - if exist \omnibus-ruby rd /s/q \omnibus-ruby

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,20 +60,20 @@ before_script:
 #
 
 # run tests for deb-x64
-#run_tests_deb-x64:
-#  stage: source_test
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
-#  tags: [ "runner:main", "size:large" ]
-#  script:
-#    - inv -e test --race --profile
+run_tests_deb-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --race --profile
 
 # run tests for rpm-x64
-#run_test_rpm-x64:
-#  stage: source_test
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
-#  tags: [ "runner:main", "size:large" ]
-#  script:
-#    - inv -e test --race --profile
+run_test_rpm-x64:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - inv -e test --race --profile
 
 # scan the dependencies for security vulnerabilities with snyk
 run_security_scan_test:
@@ -215,35 +215,35 @@ agent_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 # build Agent package for rpm-x64
-#agent_rpm-x64:
-#  stage: package_build
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
-#  tags: [ "runner:main", "size:large" ]
-#  variables:
-#    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
-#  script:
-#    # remove artifacts from previous pipelines that may come from the cache
-#    - rm -rf $OMNIBUS_PACKAGE_DIR/*
-#    # Artifacts and cache must live within project directory but we run omnibus
-#    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
-#    # pointing to a gitlab-friendly location.
-#    - set +x
-#    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key --with-decryption --query "Parameter.Value" --out text)
-#    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
-#    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
-#    - set -x
-#    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
-#    - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
-#  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
-#  # cache:
-#  #   # cache per branch
-#  #   key: $CI_COMMIT_REF_NAME
-#  #   paths:
-#  #     - $OMNIBUS_BASE_DIR
-#  artifacts:
-#    expire_in: 2 weeks
-#    paths:
-#      - $OMNIBUS_PACKAGE_DIR
+agent_rpm-x64:
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
+  tags: [ "runner:main", "size:large" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    # Artifacts and cache must live within project directory but we run omnibus
+    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+    # pointing to a gitlab-friendly location.
+    - set +x
+    - RPM_GPG_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_private_key --with-decryption --query "Parameter.Value" --out text)
+    - printf -- "$RPM_GPG_KEY" | gpg --import --batch
+    - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
+    - set -x
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
+  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
+  # cache:
+  #   # cache per branch
+  #   key: $CI_COMMIT_REF_NAME
+  #   paths:
+  #     - $OMNIBUS_BASE_DIR
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
 
 # build Agent package for rpm-x64
 agent_suse-x64:
@@ -425,23 +425,23 @@ deploy_deb_testing:
 
 
 # deploy rpm packages to yum staging repo
-#deploy_rpm_testing:
-#  stage: testkitchen_deploy
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
-#  before_script:
-#    - ls $OMNIBUS_PACKAGE_DIR
-#  only:
-#    - master
-#    - tags
-#  tags: [ "runner:main", "size:large" ]
-#  script:
-#    - source /usr/local/rvm/scripts/rvm
-#    - rvm use 2.4
-#    - mkdir -p ./rpmrepo/x86_64/
-#    - aws s3 sync s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID ./rpmrepo/
-#    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/x86_64/
-#    - createrepo --update -v --checksum sha ./rpmrepo/x86_64
-#    - aws s3 sync ./rpmrepo/ s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+deploy_rpm_testing:
+  stage: testkitchen_deploy
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  only:
+    - master
+    - tags
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - source /usr/local/rvm/scripts/rvm
+    - rvm use 2.4
+    - mkdir -p ./rpmrepo/x86_64/
+    - aws s3 sync s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID ./rpmrepo/
+    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/x86_64/
+    - createrepo --update -v --checksum sha ./rpmrepo/x86_64
+    - aws s3 sync ./rpmrepo/ s3://$RPM_TESTING_S3_BUCKET/pipeline-$CI_PIPELINE_ID --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing:
@@ -841,27 +841,27 @@ deploy_windows_tags:
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy rpm packages to yum staging repo
-#deploy_rpm:
-#  stage: deploy
-#  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
-#  before_script:
-#    - ls $OMNIBUS_PACKAGE_DIR
-#  only:
-#    - master
-#    - tags
-#  tags: [ "runner:main", "size:large" ]
-#  script:
-#    - source /usr/local/rvm/scripts/rvm
-#    - rvm use 2.4
-#    - mkdir -p ./rpmrepo/6/x86_64/
-#    - aws s3 sync s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
-#
-#    # add RPMs to new "6" branch
-#    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/6/x86_64/
-#    - createrepo --update -v --checksum sha ./rpmrepo/6/x86_64
-#
-#    # sync to S3
-#    - aws s3 sync ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+deploy_rpm:
+  stage: deploy
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  only:
+    - master
+    - tags
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - source /usr/local/rvm/scripts/rvm
+    - rvm use 2.4
+    - mkdir -p ./rpmrepo/6/x86_64/
+    - aws s3 sync s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ ./rpmrepo/6/
+
+    # add RPMs to new "6" branch
+    - cp $OMNIBUS_PACKAGE_DIR/*x86_64.rpm ./rpmrepo/6/x86_64/
+    - createrepo --update -v --checksum sha ./rpmrepo/6/x86_64
+
+    # sync to S3
+    - aws s3 sync ./rpmrepo/6/ s3://$RPM_S3_BUCKET/$DEB_RPM_BUCKET_BRANCH/6/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy suse rpm packages to yum staging repo
 deploy_suse_rpm:

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -439,14 +439,17 @@ func (ac *AutoConfig) pollConfigs() {
 					// retrieve the list of newly added configurations as well
 					// as removed configurations
 					newConfigs, removedConfigs := ac.collect(pd)
-
+					log.Infof("evaluating provider %s, removing %s, adding %s", pd.provider.String(), removedConfigs, newConfigs)
 					ac.processRemovedConfigs(removedConfigs)
 
 					// TODO: move to check scheduler
 					for _, config := range newConfigs {
+						log.Infof("processing the new config %s", config)
 						config.Provider = pd.provider.String()
 						resolvedConfigs := ac.resolve(config)
+						log.Infof("resolved to %s", resolvedConfigs)
 						checks := ac.getChecksFromConfigs(resolvedConfigs, true)
+						log.Infof("collected the checks %s", checks)
 						ac.schedule(checks)
 					}
 				}
@@ -461,6 +464,7 @@ func (ac *AutoConfig) processRemovedConfigs(removedConfigs []integration.Config)
 	// Process removed configs first to handle the case where a
 	// container churn would result in the same configuration hash.
 	for _, config := range removedConfigs {
+		log.Infof("Started removing %s", config)
 		if !isCheckConfig(config) {
 			// skip non check configs.
 			continue
@@ -500,8 +504,10 @@ func (ac *AutoConfig) processRemovedConfigs(removedConfigs []integration.Config)
 
 		// if the config is a template, remove it from the cache
 		if config.IsTemplate() {
+			log.Infof("Config %s is template, deleting", config)
 			ac.templateCache.Del(config)
 		}
+		log.Infof("Finished removing %s", config)
 	}
 }
 

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 )
 
 var (
@@ -516,11 +517,16 @@ func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []integratio
 	}
 
 	for _, c := range fetched {
+		log.Infof("c.ADIdentifiers is %s", c.ADIdentifiers) // REMOVE
 		if !pd.contains(&c) {
 			new = append(new, c)
+			continue
+		}
+		// Check the freshness of c. Reschedule if necessary.
+		if tagger.OutdatedTags(c.ADIdentifiers) {
+			ac.reschedule(c)
 		}
 	}
-
 	old := pd.configs
 	pd.configs = fetched
 
@@ -533,6 +539,19 @@ func (ac *AutoConfig) collect(pd *providerDescriptor) (new, removed []integratio
 	log.Infof("%v: collected %d new configurations, removed %d", pd.provider, len(new), len(removed))
 
 	return
+}
+
+// reschedule is used when a check has started with a template that is not up to date anymore.
+func (ac *AutoConfig) reschedule(c integration.Config) {
+	log.Infof("Starting rescheduling for %s", c)
+	ac.processRemovedConfigs([]integration.Config{c})
+	log.Infof("Processed remove configs for %s", c)
+	resolvedConfigs := ac.resolve(c)
+	log.Infof("Resolved configs %s", resolvedConfigs)
+	checks := ac.getChecksFromConfigs(resolvedConfigs, true)
+	log.Infof("Preparing scheduling for %s", checks)
+	ac.schedule(checks)
+	log.Infof("Rescheduled the checks %s", checks)
 }
 
 // getChecks takes a check configuration and returns a slice of Check instances

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -428,15 +428,8 @@ func (ac *AutoConfig) pollConfigs() {
 						entityName = docker.ContainerIDToEntityName(entityName)
 					}
 					currentHash := tagger.GetEntityHash(entityName)
-					if previousHash == "" {
-						// hash init
-						ac.store.setTagsHashForService(
-							service.GetID(),
-							currentHash,
-						)
-					} else if currentHash != previousHash {
-						log.Infof("%s != %s", previousHash, currentHash)
-						log.Infof("Tags changed for service %s, rescheduling associated checks", string(service.GetID()))
+					if currentHash != previousHash {
+						log.Debugf("Tags changed for service %s, rescheduling associated checks", string(service.GetID()))
 						ac.configResolver.processDelService(service)
 						ac.configResolver.processNewService(service)
 						ac.store.setTagsHashForService(service.GetID(), currentHash)

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -349,9 +349,7 @@ func (ac *AutoConfig) resolve(config integration.Config) []integration.Config {
 	configs = append(configs, config)
 
 	// store non template configs in the AC
-	ac.m.Lock()
 	ac.loadedConfigs[config.Digest()] = config
-	ac.m.Unlock()
 	return configs
 }
 

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -186,9 +186,7 @@ func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service)
 	}
 
 	// store resolved configs in the AC
-	cr.ac.m.Lock()
-	defer cr.ac.m.Unlock()
-	cr.ac.loadedConfigs[resolvedConfig.Digest()] = resolvedConfig
+	cr.ac.store.setLoadedConfig(resolvedConfig)
 	cr.ac.store.addConfigForService(svc.GetID(), resolvedConfig)
 	cr.configToService[resolvedConfig.Digest()] = svc.GetID()
 	cr.ac.store.setTagsHashForService(

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -253,10 +253,11 @@ func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	}
 
 	// a network was specified
-	if ip, ok := hosts[string(tplVar)]; ok {
+	tplVarStr := string(tplVar)
+	if ip, ok := hosts[tplVarStr]; ok {
 		return []byte(ip), nil
 	}
-	log.Warnf("network %s not found, trying bridge IP instead", string(tplVar))
+	log.Warnf("network %q not found, trying bridge IP instead", tplVarStr)
 
 	// otherwise use fallback policy
 	ip, err := getFallbackHost(hosts)

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -145,7 +145,7 @@ func (cr *ConfigResolver) ResolveTemplate(tpl integration.Config) []integration.
 
 // resolve takes a template and a service and generates a config with
 // valid connection info and relevant tags.
-// method is not thread safe and needs a lock realized by the caller
+// this method is not thread safe and needs a lock managed by the caller
 func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service) (integration.Config, error) {
 	// Copy original template
 	resolvedConfig := integration.Config{
@@ -257,7 +257,7 @@ func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	if ip, ok := hosts[tplVarStr]; ok {
 		return []byte(ip), nil
 	}
-	log.Warnf("network %q not found, trying bridge IP instead", tplVarStr)
+	log.Warnf("Network %q not found, trying bridge IP instead", tplVarStr)
 
 	// otherwise use fallback policy
 	ip, err := getFallbackHost(hosts)

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -227,6 +227,9 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 			continue
 		}
 		errorStats.removeResolveWarnings(config.Name)
+		digest := template.Digest()
+		log.Infof("Scheduling done with digest %s: 1", digest)
+		cr.ac.templateToConfig[digest] = []integration.Config{config}
 
 		// load the checks for this config using Autoconfig
 		checks := cr.ac.getChecksFromConfigs([]integration.Config{config}, true)

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -184,7 +184,7 @@ func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service)
 		}
 	}
 
-	// store resolved configs in the AC, this method is NOT thread safe at this point
+	// store resolved configs in the AC
 	cr.ac.loadedConfigs[resolvedConfig.Digest()] = resolvedConfig
 	cr.ac.store.addConfigForService(svc.GetID(), resolvedConfig)
 	cr.configToService[resolvedConfig.Digest()] = svc.GetID()

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -147,7 +147,6 @@ func (cr *ConfigResolver) ResolveTemplate(tpl integration.Config) []integration.
 
 // resolve takes a template and a service and generates a config with
 // valid connection info and relevant tags.
-// this method is not thread safe and needs a lock managed by the caller
 func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service) (integration.Config, error) {
 	// Copy original template
 	resolvedConfig := integration.Config{
@@ -187,6 +186,8 @@ func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service)
 	}
 
 	// store resolved configs in the AC
+	cr.ac.m.Lock()
+	defer cr.ac.m.Unlock()
 	cr.ac.loadedConfigs[resolvedConfig.Digest()] = resolvedConfig
 	cr.ac.store.addConfigForService(svc.GetID(), resolvedConfig)
 	cr.configToService[resolvedConfig.Digest()] = svc.GetID()

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"unicode"
 
@@ -190,9 +191,14 @@ func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service)
 	cr.ac.store.setLoadedConfig(resolvedConfig)
 	cr.ac.store.addConfigForService(svc.GetID(), resolvedConfig)
 	cr.configToService[resolvedConfig.Digest()] = svc.GetID()
+	// TODO: harmonize service & entities ID
+	entityName := string(svc.GetID())
+	if !strings.Contains(entityName, "://") {
+		entityName = docker.ContainerIDToEntityName(entityName)
+	}
 	cr.ac.store.setTagsHashForService(
 		svc.GetID(),
-		tagger.GetEntityHash(docker.ContainerIDToEntityName(string(svc.GetID()))),
+		tagger.GetEntityHash(entityName),
 	)
 
 	return resolvedConfig, nil

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -41,7 +41,7 @@ type ConfigResolver struct {
 	ac              *AutoConfig
 	collector       *collector.Collector
 	templates       *TemplateCache
-	services        map[listeners.ID]listeners.Service // Service.ID --> []Service
+	services        map[listeners.ID]listeners.Service // Service.ID --> Service
 	adIDToServices  map[string][]listeners.ID          // AD id --> services that have it
 	configToService map[string]listeners.ID            // config digest --> service ID
 	newService      chan listeners.Service
@@ -227,9 +227,6 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 			continue
 		}
 		errorStats.removeResolveWarnings(config.Name)
-		digest := template.Digest()
-		log.Infof("Scheduling done with digest %s: 1", digest)
-		cr.ac.templateToConfig[digest] = []integration.Config{config}
 
 		// load the checks for this config using Autoconfig
 		checks := cr.ac.getChecksFromConfigs([]integration.Config{config}, true)

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -411,8 +411,7 @@ func TestResolve(t *testing.T) {
 		},
 	}
 	ac := &AutoConfig{
-		loadedConfigs: make(map[string]integration.Config),
-		store:         newStore(),
+		store: newStore(),
 	}
 	cr := newConfigResolver(nil, ac, NewTemplateCache())
 	validTemplates := 0
@@ -434,7 +433,7 @@ func TestResolve(t *testing.T) {
 		})
 
 		// Assert the valid configs are stored in the AC and the store
-		assert.Equal(t, validTemplates, len(ac.loadedConfigs))
+		assert.Equal(t, validTemplates, len(ac.GetLoadedConfigs()))
 		assert.Equal(t, len(ac.store.getConfigsForService(tc.svc.GetID())), validTemplates)
 	}
 }

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -8,10 +8,10 @@ package integration
 import (
 	"fmt"
 	"hash/fnv"
-	"log"
 	"regexp"
 	"strconv"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -64,7 +64,7 @@ func (c *Config) String() string {
 
 	buffer, err := yaml.Marshal(&rawConfig)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
 	}
 
 	return string(buffer)

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -43,6 +43,7 @@ func (s *store) removeConfigsForService(serviceID listeners.ID) {
 	delete(s.serviceToConfigs, serviceID)
 }
 
+// addConfigForService adds a config for a specified service
 func (s *store) addConfigForService(serviceID listeners.ID, config integration.Config) {
 	s.m.Lock()
 	defer s.m.Unlock()
@@ -54,18 +55,21 @@ func (s *store) addConfigForService(serviceID listeners.ID, config integration.C
 	}
 }
 
+// getTagsHashForService return the tags hash for a specified service
 func (s *store) getTagsHashForService(serviceID listeners.ID) string {
-	s.m.Lock()
-	defer s.m.Unlock()
+	s.m.RLock()
+	defer s.m.RUnlock()
 	return s.serviceToTagsHash[serviceID]
 }
 
+// removeTagsHashForService removes the tags hash for a specified service
 func (s *store) removeTagsHashForService(serviceID listeners.ID) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	delete(s.serviceToTagsHash, serviceID)
 }
 
+// setTagsHashForService set the tags hash for a specified service
 func (s *store) setTagsHashForService(serviceID listeners.ID, hash string) {
 	s.m.Lock()
 	defer s.m.Unlock()

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -14,14 +14,16 @@ import (
 
 // store holds useful mappings for the AD
 type store struct {
-	serviceToConfigs map[listeners.ID][]integration.Config
-	m                sync.RWMutex
+	serviceToConfigs  map[listeners.ID][]integration.Config
+	serviceToTagsHash map[listeners.ID]string
+	m                 sync.RWMutex
 }
 
 // newStore creates a store
 func newStore() *store {
 	s := store{
-		serviceToConfigs: make(map[listeners.ID][]integration.Config),
+		serviceToConfigs:  make(map[listeners.ID][]integration.Config),
+		serviceToTagsHash: make(map[listeners.ID]string),
 	}
 
 	return &s
@@ -50,4 +52,22 @@ func (s *store) addConfigForService(serviceID listeners.ID, config integration.C
 	} else {
 		s.serviceToConfigs[serviceID] = []integration.Config{config}
 	}
+}
+
+func (s *store) getTagsHashForService(serviceID listeners.ID) string {
+	s.m.Lock()
+	defer s.m.Unlock()
+	return s.serviceToTagsHash[serviceID]
+}
+
+func (s *store) removeTagsHashForService(serviceID listeners.ID) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	delete(s.serviceToTagsHash, serviceID)
+}
+
+func (s *store) setTagsHashForService(serviceID listeners.ID, hash string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.serviceToTagsHash[serviceID] = hash
 }

--- a/pkg/autodiscovery/templatecache.go
+++ b/pkg/autodiscovery/templatecache.go
@@ -7,7 +7,6 @@ package autodiscovery
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"strings"
 	"sync"
 
@@ -90,8 +89,6 @@ func (cache *TemplateCache) GetUnresolvedTemplates() map[string]integration.Conf
 func (cache *TemplateCache) Del(tpl integration.Config) error {
 	// compute the digest once
 	d := tpl.Digest()
-	log.Infof("Digest is %s", d)
-	log.Infof("Fake rerun of the Digest is %s", tpl.Digest())
 	cache.m.Lock()
 	defer cache.m.Unlock()
 
@@ -100,22 +97,17 @@ func (cache *TemplateCache) Del(tpl integration.Config) error {
 		return fmt.Errorf("template not found in cache")
 	}
 
-	log.Infof("Current digest in the cache %s", cache.digest2ids)
 	// remove the template
 	delete(cache.digest2ids, d)
 	delete(cache.digest2template, d)
-	log.Infof("Post removal of the id %s in the cache %s", d, cache.digest2ids)
 
 	// iterate through the AD identifiers for this config
 	for _, id := range tpl.ADIdentifiers {
-		log.Infof("Evaluating %s for ADID tpl %s", id, tpl.ADIdentifiers)
 		digests := cache.id2digests[id]
 		// remove the template from id2templates
 		for i, digest := range digests {
 			if digest == d {
-				log.Infof("i is %s, digest is %s and id2digests %s", i, digest, cache.id2digests[id])
 				cache.id2digests[id] = append(digests[:i], digests[i+1:]...)
-				log.Infof("cache is now %s", cache.id2digests[id])
 				break
 			}
 		}

--- a/pkg/autodiscovery/templatecache.go
+++ b/pkg/autodiscovery/templatecache.go
@@ -7,6 +7,7 @@ package autodiscovery
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"strings"
 	"sync"
 
@@ -89,7 +90,8 @@ func (cache *TemplateCache) GetUnresolvedTemplates() map[string]integration.Conf
 func (cache *TemplateCache) Del(tpl integration.Config) error {
 	// compute the digest once
 	d := tpl.Digest()
-
+	log.Infof("Digest is %s", d)
+	log.Infof("Fake rerun of the Digest is %s", tpl.Digest())
 	cache.m.Lock()
 	defer cache.m.Unlock()
 
@@ -98,17 +100,22 @@ func (cache *TemplateCache) Del(tpl integration.Config) error {
 		return fmt.Errorf("template not found in cache")
 	}
 
+	log.Infof("Current digest in the cache %s", cache.digest2ids)
 	// remove the template
 	delete(cache.digest2ids, d)
 	delete(cache.digest2template, d)
+	log.Infof("Post removal of the id %s in the cache %s", d, cache.digest2ids)
 
 	// iterate through the AD identifiers for this config
 	for _, id := range tpl.ADIdentifiers {
+		log.Infof("Evaluating %s for ADID tpl %s", id, tpl.ADIdentifiers)
 		digests := cache.id2digests[id]
 		// remove the template from id2templates
 		for i, digest := range digests {
 			if digest == d {
+				log.Infof("i is %s, digest is %s and id2digests %s", i, digest, cache.id2digests[id])
 				cache.id2digests[id] = append(digests[:i], digests[i+1:]...)
+				log.Infof("cache is now %s", cache.id2digests[id])
 				break
 			}
 		}

--- a/pkg/autodiscovery/templatecache_test.go
+++ b/pkg/autodiscovery/templatecache_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestNew(t *testing.T) {
 	cache := NewTemplateCache()
-	assert.Len(t, cache.id2digests, 0)
-	assert.Len(t, cache.digest2ids, 0)
-	assert.Len(t, cache.digest2template, 0)
+	assert.Len(t, cache.adIDToDigests, 0)
+	assert.Len(t, cache.digestToADId, 0)
+	assert.Len(t, cache.digestToTemplate, 0)
 }
 
 func TestSet(t *testing.T) {
@@ -30,21 +30,21 @@ func TestSet(t *testing.T) {
 	err = cache.Set(tpl1)
 	require.Nil(t, err)
 
-	assert.Len(t, cache.id2digests, 2)
-	assert.Len(t, cache.id2digests["foo"], 1)
-	assert.Len(t, cache.id2digests["bar"], 1)
-	assert.Len(t, cache.digest2ids, 1)
-	assert.Len(t, cache.digest2template, 1)
+	assert.Len(t, cache.adIDToDigests, 2)
+	assert.Len(t, cache.adIDToDigests["foo"], 1)
+	assert.Len(t, cache.adIDToDigests["bar"], 1)
+	assert.Len(t, cache.digestToADId, 1)
+	assert.Len(t, cache.digestToTemplate, 1)
 
 	tpl2 := integration.Config{ADIdentifiers: []string{"foo"}}
 	err = cache.Set(tpl2)
 
 	require.Nil(t, err)
-	assert.Len(t, cache.id2digests, 2)
-	assert.Len(t, cache.id2digests["foo"], 2)
-	assert.Len(t, cache.id2digests["bar"], 1)
-	assert.Len(t, cache.digest2ids, 2)
-	assert.Len(t, cache.digest2template, 2)
+	assert.Len(t, cache.adIDToDigests, 2)
+	assert.Len(t, cache.adIDToDigests["foo"], 2)
+	assert.Len(t, cache.adIDToDigests["bar"], 1)
+	assert.Len(t, cache.digestToADId, 2)
+	assert.Len(t, cache.digestToTemplate, 2)
 
 	// no identifiers at all
 	tpl3 := integration.Config{ADIdentifiers: []string{}}
@@ -62,11 +62,11 @@ func TestDel(t *testing.T) {
 	err = cache.Del(tpl)
 	require.Nil(t, err)
 
-	require.Len(t, cache.id2digests, 2)
-	assert.Len(t, cache.id2digests["foo"], 0)
-	assert.Len(t, cache.id2digests["bar"], 0)
-	assert.Len(t, cache.digest2ids, 0)
-	assert.Len(t, cache.digest2template, 0)
+	require.Len(t, cache.adIDToDigests, 2)
+	assert.Len(t, cache.adIDToDigests["foo"], 0)
+	assert.Len(t, cache.adIDToDigests["bar"], 0)
+	assert.Len(t, cache.digestToADId, 0)
+	assert.Len(t, cache.digestToTemplate, 0)
 
 	// delete for an unknown identifier
 	err = cache.Del(integration.Config{ADIdentifiers: []string{"baz"}})

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -51,7 +51,7 @@ func List(highCard bool) response.TaggerListResponse {
 	return defaultTagger.List(highCard)
 }
 
-// GetEntityHash returns the hash of an entity
+// GetEntityHash returns the hash for the tags associated with the given entity
 func GetEntityHash(entity string) string {
 	return defaultTagger.GetEntityHash(entity)
 }

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -51,6 +51,11 @@ func List(highCard bool) response.TaggerListResponse {
 	return defaultTagger.List(highCard)
 }
 
+// OutdatedTags returns a boolean based on high cards tags.
+func OutdatedTags(ADIdentifiers []string) bool {
+	return defaultTagger.OutdatedTags(ADIdentifiers)
+}
+
 func init() {
 	defaultTagger = newTagger()
 }

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -51,9 +51,9 @@ func List(highCard bool) response.TaggerListResponse {
 	return defaultTagger.List(highCard)
 }
 
-// OutdatedTags returns a boolean based on high cards tags.
-func OutdatedTags(ADIdentifiers []string) bool {
-	return defaultTagger.OutdatedTags(ADIdentifiers)
+// GetEntityHash returns the hash of an entity
+func GetEntityHash(entity string) string {
+	return defaultTagger.GetEntityHash(entity)
 }
 
 func init() {

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -213,17 +213,9 @@ func (t *Tagger) Stop() error {
 	return nil
 }
 
-// GetEntityHash returns the hash of an entity
+// GetEntityHash returns the tags hash of an entity
 func (t *Tagger) GetEntityHash(entity string) string {
-	t.tagStore.storeMutex.Lock()
-	defer t.tagStore.storeMutex.Unlock()
-	var tagsHash string
-	log.Infof("HASH GET entity %s", entity)
-	entityTags, ok := t.tagStore.store[entity]
-	if ok {
-		tagsHash = entityTags.tagsHash
-	}
-	return tagsHash
+	return t.tagStore.getEntityHash(entity)
 }
 
 // Tag returns tags for a given entity. If highCard is false, high
@@ -232,7 +224,7 @@ func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {
 	if entity == "" {
 		return nil, fmt.Errorf("empty entity ID")
 	}
-	cachedTags, sources := t.tagStore.lookup(entity, highCard)
+	cachedTags, sources, _ := t.tagStore.lookup(entity, highCard)
 
 	if len(sources) == len(t.fetchers) {
 		// All sources sent data to cache
@@ -288,7 +280,7 @@ func (t *Tagger) List(highCard bool) response.TaggerListResponse {
 	defer t.tagStore.storeMutex.RUnlock()
 	for entityID, et := range t.tagStore.store {
 		entity := response.TaggerListEntity{}
-		tags, sources := et.get(highCard)
+		tags, sources, _ := et.get(highCard)
 		entity.Tags = copyArray(tags)
 		entity.Sources = copyArray(sources)
 		r.Entities[entityID] = entity

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -7,7 +7,6 @@ package tagger
 
 import (
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
@@ -214,32 +213,17 @@ func (t *Tagger) Stop() error {
 	return nil
 }
 
-// OutdatedTags returns true if an ADIdentifiers contains is not up to date
-func (t *Tagger) OutdatedTags(ADIdentifiers []string) bool {
+// GetEntityHash returns the hash of an entity
+func (t *Tagger) GetEntityHash(entity string) string {
 	t.tagStore.storeMutex.Lock()
 	defer t.tagStore.storeMutex.Unlock()
-	for _, entity := range ADIdentifiers {
-		log.Infof("Lookup for outdated tags for entity %q", entity)
-		entityTags, ok := t.tagStore.store[entity]
-		if !ok || entityTags == nil {
-			// We might be trying to evaluate a EntityID that was removed
-			log.Infof("Entity %q does not have any tags", entity)
-			continue
-		}
-		if !entityTags.outdatedTags {
-			log.Infof("Entity %q has are up to date tags", entity)
-			continue
-		}
-		if entityTags.tagsHash == "" {
-			log.Infof("Entity %q has an empty tagsHash", entity)
-			continue
-		}
-		log.Infof("Entity %q has outdated tags with tagsHash %q", entity, entityTags.tagsHash)
-		entityTags.outdatedTags = false
-		t.tagStore.store[entity] = entityTags
-		return true
+	var tagsHash string
+	log.Infof("HASH GET entity %s", entity)
+	entityTags, ok := t.tagStore.store[entity]
+	if ok {
+		tagsHash = entityTags.tagsHash
 	}
-	return false
+	return tagsHash
 }
 
 // Tag returns tags for a given entity. If highCard is false, high
@@ -318,7 +302,6 @@ func (t *Tagger) List(highCard bool) response.TaggerListResponse {
 // contents to a new slice. As strings are references, the size of
 // the new array is small enough.
 func copyArray(source []string) []string {
-	sort.Strings(source) // TODO I'm not sure
 	copied := make([]string, len(source))
 	copy(copied, source)
 	return copied

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -22,7 +22,7 @@ import (
 
 // Tagger is the entry class for entity tagging. It holds collectors, memory store
 // and handles the query logic. One can use the package methods to use the default
-// tagger instead of instanciating one.
+// tagger instead of instantiating one.
 type Tagger struct {
 	sync.RWMutex
 	tagStore    *tagStore
@@ -217,29 +217,26 @@ func (t *Tagger) Stop() error {
 func (t *Tagger) OutdatedTags(ADIdentifiers []string) bool {
 	t.tagStore.storeMutex.Lock()
 	defer t.tagStore.storeMutex.Unlock()
-	for _, ad := range ADIdentifiers {
-		log.Infof("Lookup for outdated tags for %s", ad)
-		entityTags, ok := t.tagStore.store[ad]
+	for _, entity := range ADIdentifiers {
+		log.Debugf("Lookup for outdated tags for entity %q", entity)
+		entityTags, ok := t.tagStore.store[entity]
 		if !ok || entityTags == nil {
 			// We might be trying to evaluate a EntityID that was removed
-			log.Infof("No entityTags found for %s", ad)
+			log.Debugf("Entity %q does not have any tags", entity)
 			continue
 		}
 		if !entityTags.outdatedTags {
-			log.Infof("EntityTags for %s are up to date", ad)
+			log.Debugf("Entity %q has are up to date tags", entity)
 			continue
 		}
-		if entityTags.freshnessHash == "" {
-			log.Infof("EntityTags for %s got an empty freshnessHash", ad)
+		if entityTags.tagsHash == "" {
+			log.Infof("Entity %q has an empty tagsHash", entity)
 			continue
 		}
-		if entityTags.freshnessHash != "" {
-			log.Infof("EntityTags %s got outdated tags with freshnessHash %q, %d highCard tags %d lowCard tags", ad, entityTags.freshnessHash, len(entityTags.highCardTags), len(entityTags.lowCardTags))
-			entityTags.outdatedTags = false
-			t.tagStore.store[ad] = entityTags
-			return true
-		}
-		log.Infof("EntityTags %s is marked as outdated but its freshnessHash is %q", ad, entityTags.freshnessHash)
+		log.Infof("Entity %q has outdated tags with tagsHash %q", entity, entityTags.tagsHash)
+		entityTags.outdatedTags = false
+		t.tagStore.store[entity] = entityTags
+		return true
 	}
 	return false
 }

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -7,6 +7,7 @@ package tagger
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -218,15 +219,15 @@ func (t *Tagger) OutdatedTags(ADIdentifiers []string) bool {
 	t.tagStore.storeMutex.Lock()
 	defer t.tagStore.storeMutex.Unlock()
 	for _, entity := range ADIdentifiers {
-		log.Debugf("Lookup for outdated tags for entity %q", entity)
+		log.Infof("Lookup for outdated tags for entity %q", entity)
 		entityTags, ok := t.tagStore.store[entity]
 		if !ok || entityTags == nil {
 			// We might be trying to evaluate a EntityID that was removed
-			log.Debugf("Entity %q does not have any tags", entity)
+			log.Infof("Entity %q does not have any tags", entity)
 			continue
 		}
 		if !entityTags.outdatedTags {
-			log.Debugf("Entity %q has are up to date tags", entity)
+			log.Infof("Entity %q has are up to date tags", entity)
 			continue
 		}
 		if entityTags.tagsHash == "" {
@@ -317,6 +318,7 @@ func (t *Tagger) List(highCard bool) response.TaggerListResponse {
 // contents to a new slice. As strings are references, the size of
 // the new array is small enough.
 func copyArray(source []string) []string {
+	sort.Strings(source) // TODO I'm not sure
 	copied := make([]string, len(source))
 	copy(copied, source)
 	return copied

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -222,8 +222,9 @@ func (t *Tagger) OutdatedTags(ADIdentifiers []string) bool {
 			// We might be trying to evaluate a EntityID that was removed
 			continue
 		}
-		if id.outdatedTags {
-			log.Infof("Outdated tags")
+		if id.outdatedTags && t.tagStore.store[ad].freshnessHash != "" {
+			log.Infof("Outdated tags %s", t.tagStore.store[ad].freshnessHash)
+			t.tagStore.store[ad].outdatedTags = false
 			return true
 		}
 	}

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -213,6 +213,23 @@ func (t *Tagger) Stop() error {
 	return nil
 }
 
+// OutdatedTags returns true if an ADIdentifiers contains is not up to date
+func (t *Tagger) OutdatedTags(ADIdentifiers []string) bool {
+	log.Infof("ADIdentifiers are %s", ADIdentifiers) // REMOVE
+	for _, ad := range ADIdentifiers {
+		id := t.tagStore.store[ad]
+		if id == nil {
+			// We might be trying to evaluate a EntityID that was removed
+			continue
+		}
+		if id.outdatedTags {
+			log.Infof("Outdated tags")
+			return true
+		}
+	}
+	return false
+}
+
 // Tag returns tags for a given entity. If highCard is false, high
 // cardinality tags are left out.
 func (t *Tagger) Tag(entity string, highCard bool) ([]string, error) {

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -215,7 +215,8 @@ func (t *Tagger) Stop() error {
 
 // GetEntityHash returns the tags hash of an entity
 func (t *Tagger) GetEntityHash(entity string) string {
-	return t.tagStore.getEntityHash(entity)
+	_, _, tagsHash := t.tagStore.lookup(entity, true)
+	return tagsHash
 }
 
 // Tag returns tags for a given entity. If highCard is false, high

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -2,10 +2,13 @@ package tagger
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"hash/fnv"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
@@ -13,12 +16,14 @@ import (
 // entityTags holds the tag information for a given entity
 type entityTags struct {
 	sync.RWMutex
-	lowCardTags  map[string][]string
-	highCardTags map[string][]string
-	cacheValid   bool
-	cachedSource []string
-	cachedAll    []string // Low + high
-	cachedLow    []string // Sub-slice of cachedAll
+	lowCardTags   map[string][]string
+	highCardTags  map[string][]string
+	cacheValid    bool
+	cachedSource  []string
+	cachedAll     []string // Low + high
+	cachedLow     []string // Sub-slice of cachedAll
+	freshnessHash string
+	outdatedTags  bool
 }
 
 // tagStore stores entity tags in memory and handles search and collation.
@@ -69,6 +74,7 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	storedTags.lowCardTags[info.Source] = info.LowCardTags
 	storedTags.highCardTags[info.Source] = info.HighCardTags
 	storedTags.cacheValid = false
+	storedTags.outdatedTags = false
 	storedTags.Unlock()
 
 	if exist == false {
@@ -77,7 +83,31 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 		s.storeMutex.Unlock()
 	}
 
+	digestInfo := digest(info)
+
+	storedTags.Lock()
+	defer storedTags.Unlock()
+	if storedTags.freshnessHash == "" || storedTags.freshnessHash != digestInfo {
+		log.Infof("freshHash is %s and digestInfo %s", storedTags.freshnessHash, digestInfo) // REMOVE
+		log.Infof("highcards is %s and low is %s", info.HighCardTags, info.LowCardTags)      // REMOVE
+		storedTags.freshnessHash = digestInfo
+		storedTags.outdatedTags = true
+		log.Infof("NEW freshHash is %s and digestInfo %s", storedTags.freshnessHash, digestInfo) // REMOVE
+	}
+
 	return nil
+}
+
+func digest(info *collectors.TagInfo) string {
+	log.Infof("digesting %s containing low %s and high %s", info.Entity, info.LowCardTags, info.HighCardTags)
+	h := fnv.New64()
+	for _, i := range info.HighCardTags {
+		h.Write([]byte(i))
+	}
+	for _, i := range info.LowCardTags {
+		h.Write([]byte(i))
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 // prune will lock the store and delete tags for the entity previously

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -60,9 +60,9 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	}
 
 	// TODO: check if real change
-	s.storeMutex.RLock()
+	s.storeMutex.Lock()
+	defer s.storeMutex.Unlock()
 	storedTags, exist := s.store[info.Entity]
-	s.storeMutex.RUnlock()
 	if exist == false {
 		storedTags = &entityTags{
 			lowCardTags:  make(map[string][]string),
@@ -77,9 +77,7 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	storedTags.cacheValid = false
 
 	if exist == false {
-		s.storeMutex.Lock()
 		s.store[info.Entity] = storedTags
-		s.storeMutex.Unlock()
 	}
 
 	tagsHash := computeTagsHash(info)

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -23,7 +23,6 @@ type entityTags struct {
 	cachedAll    []string // Low + high
 	cachedLow    []string // Sub-slice of cachedAll
 	tagsHash     string
-	outdatedTags bool
 }
 
 // tagStore stores entity tags in memory and handles search and collation.
@@ -80,7 +79,6 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	tagsHash := computeTagsHash(info)
 	if storedTags.tagsHash != tagsHash {
 		storedTags.tagsHash = tagsHash
-		storedTags.outdatedTags = true
 	}
 	return nil
 }

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -63,11 +63,12 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	s.storeMutex.Lock()
 	defer s.storeMutex.Unlock()
 	storedTags, exist := s.store[info.Entity]
-	if exist == false {
+	if !exist {
 		storedTags = &entityTags{
 			lowCardTags:  make(map[string][]string),
 			highCardTags: make(map[string][]string),
 		}
+		s.store[info.Entity] = storedTags
 	}
 
 	storedTags.Lock()
@@ -75,10 +76,6 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	storedTags.lowCardTags[info.Source] = info.LowCardTags
 	storedTags.highCardTags[info.Source] = info.HighCardTags
 	storedTags.cacheValid = false
-
-	if exist == false {
-		s.store[info.Entity] = storedTags
-	}
 
 	tagsHash := computeTagsHash(info)
 	if storedTags.tagsHash != tagsHash {

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -2,15 +2,13 @@ package tagger
 
 import (
 	"fmt"
+	"hash/fnv"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"hash/fnv"
-
-	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
@@ -177,8 +175,8 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 		insertWithPriority(tagPrioMapper, tags, source, true)
 	}
 
-	lowCardTags := []string{}
-	highCardTags := []string{}
+	var lowCardTags []string
+	var highCardTags []string
 	for _, tags := range tagPrioMapper {
 		for i := 0; i < len(tags); i++ {
 			insert := true
@@ -189,13 +187,14 @@ func (e *entityTags) get(highCard bool) ([]string, []string) {
 					break
 				}
 			}
-			if insert {
-				if tags[i].isHighCard {
-					highCardTags = append(highCardTags, tags[i].tag)
-				} else {
-					lowCardTags = append(lowCardTags, tags[i].tag)
-				}
+			if !insert {
+				continue
 			}
+			if tags[i].isHighCard {
+				highCardTags = append(highCardTags, tags[i].tag)
+				continue
+			}
+			lowCardTags = append(lowCardTags, tags[i].tag)
 		}
 	}
 

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -87,7 +87,6 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 
 func computeTagsHash(info *collectors.TagInfo) string {
 	h := fnv.New64()
-	h.Write([]byte(info.Source)) // TODO do we need this ?
 	highTags := info.HighCardTags
 	sort.Strings(highTags)
 	for _, i := range highTags {

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -93,7 +93,7 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 	digestInfo := digest(info)
 	if storedTags.freshnessHash == "" || storedTags.freshnessHash != digestInfo {
 		log.Infof("freshHash is %s and digestInfo %s", storedTags.freshnessHash, digestInfo)                        // REMOVE
-		log.Infof("highcards is %s analoprs d low is %s from %s", info.HighCardTags, info.LowCardTags, info.Source) // REMOVE
+		log.Infof("highcards is %s and low is %s from %s", info.HighCardTags, info.LowCardTags, info.Source) // REMOVE
 		storedTags.freshnessHash = digestInfo
 		storedTags.outdatedTags = true
 		log.Infof("NEW freshHash is %s and digestInfo %s", storedTags.freshnessHash, digestInfo) // REMOVE

--- a/pkg/tagger/tagstore.go
+++ b/pkg/tagger/tagstore.go
@@ -81,9 +81,9 @@ func (s *tagStore) processTagInfo(info *collectors.TagInfo) error {
 
 func computeTagsHash(tags []string) string {
 	hash := ""
-	// do not sort original slice
-	tags = copyArray(tags)
 	if len(tags) > 0 {
+		// do not sort original slice
+		tags = copyArray(tags)
 		h := fnv.New64()
 		sort.Strings(tags)
 		for _, i := range tags {
@@ -118,9 +118,10 @@ func (s *tagStore) prune() error {
 	return nil
 }
 
-// lookup gets tags from the store and returns them concatenated in a []string
-// array. It returns the source names in the second []string to allow the
-// client to trigger manual lookups on missing sources.
+// lookup gets tags from the store and returns them concatenated in a string
+// slice. It returns the source names in the second slice to allow the
+// client to trigger manual lookups on missing sources, the last string
+// is the tags hash to have a snapshot digest of all the tags.
 func (s *tagStore) lookup(entity string, highCard bool) ([]string, []string, string) {
 	s.storeMutex.RLock()
 	defer s.storeMutex.RUnlock()
@@ -130,12 +131,6 @@ func (s *tagStore) lookup(entity string, highCard bool) ([]string, []string, str
 		return nil, nil, ""
 	}
 	return storedTags.get(highCard)
-}
-
-func (s *tagStore) getEntityHash(entity string) string {
-	// the hash is always computed for high card
-	_, _, tagsHash := s.lookup(entity, true)
-	return tagsHash
 }
 
 type tagPriority struct {

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -275,10 +275,10 @@ func TestDigest(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			for i := 0; i < 100; i++ {
-				beforeShuffle := digest(tc.tagInfo)
+				beforeShuffle := computeTagsHash(tc.tagInfo)
 				shuffleTags(tc.tagInfo.LowCardTags)
 				shuffleTags(tc.tagInfo.HighCardTags)
-				assert.Equal(t, beforeShuffle, digest(tc.tagInfo))
+				assert.Equal(t, beforeShuffle, computeTagsHash(tc.tagInfo))
 			}
 		})
 	}

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -261,6 +261,8 @@ func TestDigest(t *testing.T) {
 	tags := []string{
 		"high2:b",
 		"high1:a",
+		"high1:b",
+		"high1:aa",
 		"high3:c",
 		"low2:b",
 		"low1:a",

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -58,8 +58,8 @@ func (s *StoreTestSuite) TestLookup() {
 		LowCardTags: []string{"tag"},
 	})
 
-	tagsHigh, sourcesHigh := s.store.lookup("test", true)
-	tagsLow, sourcesLow := s.store.lookup("test", false)
+	tagsHigh, sourcesHigh, hashHigh := s.store.lookup("test", true)
+	tagsLow, sourcesLow, hashLow := s.store.lookup("test", false)
 
 	assert.Len(s.T(), tagsHigh, 3)
 	assert.Len(s.T(), tagsLow, 2)
@@ -71,10 +71,13 @@ func (s *StoreTestSuite) TestLookup() {
 	assert.Len(s.T(), sourcesLow, 2)
 	assert.Contains(s.T(), sourcesLow, "source1")
 	assert.Contains(s.T(), sourcesHigh, "source2")
+
+	assert.Equal(s.T(), hashHigh, hashLow)
+	assert.Equal(s.T(), "a974197fffce859b", hashHigh)
 }
 
 func (s *StoreTestSuite) TestLookupNotPresent() {
-	tags, sources := s.store.lookup("test", false)
+	tags, sources, _ := s.store.lookup("test", false)
 	assert.Nil(s.T(), tags)
 	assert.Nil(s.T(), sources)
 }
@@ -115,12 +118,14 @@ func (s *StoreTestSuite) TestPrune() {
 	s.store.toDeleteMutex.RUnlock()
 
 	// Data should still be in the store
-	tagsHigh, sourcesHigh := s.store.lookup("test1", true)
+	tagsHigh, sourcesHigh, hashHigh := s.store.lookup("test1", true)
 	assert.Len(s.T(), tagsHigh, 3)
 	assert.Len(s.T(), sourcesHigh, 2)
-	tagsHigh, sourcesHigh = s.store.lookup("test2", true)
+	assert.Equal(s.T(), "a974197fffce859b", hashHigh)
+	tagsHigh, sourcesHigh, hashHigh = s.store.lookup("test2", true)
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
+	assert.Equal(s.T(), "c84d937037763631", hashHigh)
 
 	s.store.prune()
 
@@ -130,21 +135,23 @@ func (s *StoreTestSuite) TestPrune() {
 	s.store.toDeleteMutex.RUnlock()
 
 	// test1 should be removed, test2 still present
-	tagsHigh, sourcesHigh = s.store.lookup("test1", true)
+	tagsHigh, sourcesHigh, hashHigh = s.store.lookup("test1", true)
 	assert.Nil(s.T(), tagsHigh)
 	assert.Nil(s.T(), sourcesHigh)
-	tagsHigh, sourcesHigh = s.store.lookup("test2", true)
+	assert.Empty(s.T(), hashHigh)
+	tagsHigh, sourcesHigh, hashHigh = s.store.lookup("test2", true)
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
+	assert.Equal(s.T(), "c84d937037763631", hashHigh)
 
 	err := s.store.prune()
 	assert.Nil(s.T(), err)
 
 	// No impact if nothing is queued
-	tagsHigh, sourcesHigh = s.store.lookup("test1", true)
+	tagsHigh, sourcesHigh, _ = s.store.lookup("test1", true)
 	assert.Nil(s.T(), tagsHigh)
 	assert.Nil(s.T(), sourcesHigh)
-	tagsHigh, sourcesHigh = s.store.lookup("test2", true)
+	tagsHigh, sourcesHigh, _ = s.store.lookup("test2", true)
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
 
@@ -163,30 +170,34 @@ func TestGetEntityTags(t *testing.T) {
 	assert.False(t, etags.cacheValid)
 
 	// Get empty tags and make sure cache is now set to valid
-	tags, sources := etags.get(true)
+	tags, sources, hash := etags.get(true)
 	assert.Len(t, tags, 0)
 	assert.Len(t, sources, 0)
 	assert.True(t, etags.cacheValid)
+	assert.Empty(t, hash)
 
 	// Add tags but don't invalidate the cache, we should return empty arrays
 	etags.lowCardTags["source"] = []string{"low1", "low2"}
 	etags.highCardTags["source"] = []string{"high1", "high2"}
-	tags, sources = etags.get(true)
+	tags, sources, hash = etags.get(true)
 	assert.Len(t, tags, 0)
 	assert.Len(t, sources, 0)
 	assert.True(t, etags.cacheValid)
+	assert.Empty(t, hash)
 
 	// Invalidate the cache, we should now get the tags
 	etags.cacheValid = false
-	tags, sources = etags.get(true)
+	tags, sources, hash = etags.get(true)
 	assert.Len(t, tags, 4)
 	assert.ElementsMatch(t, tags, []string{"low1", "low2", "high1", "high2"})
 	assert.Len(t, sources, 1)
 	assert.True(t, etags.cacheValid)
-	tags, sources = etags.get(false)
+	assert.Equal(t, "27554d1171230c5b", hash)
+	tags, sources, _ = etags.get(false)
 	assert.Len(t, tags, 2)
 	assert.ElementsMatch(t, tags, []string{"low1", "low2"})
 	assert.Len(t, sources, 1)
+	assert.Equal(t, "27554d1171230c5b", hash)
 }
 
 func TestDuplicateSourceTags(t *testing.T) {
@@ -198,10 +209,11 @@ func TestDuplicateSourceTags(t *testing.T) {
 	assert.False(t, etags.cacheValid)
 
 	// Get empty tags and make sure cache is now set to valid
-	tags, sources := etags.get(true)
+	tags, sources, hash := etags.get(true)
 	assert.Len(t, tags, 0)
 	assert.Len(t, sources, 0)
 	assert.True(t, etags.cacheValid)
+	assert.Empty(t, hash)
 
 	// Mock collector priorities
 	collectors.CollectorPriorities = map[string]collectors.CollectorPriority{
@@ -217,22 +229,25 @@ func TestDuplicateSourceTags(t *testing.T) {
 	etags.highCardTags["sourceNodeOrchestrator"] = []string{"tag3:sourceHigh", "tag4:sourceHigh"}
 	etags.highCardTags["sourceClusterOrchestrator"] = []string{"tag4:sourceClusterLow"}
 	etags.lowCardTags["sourceClusterOrchestrator"] = []string{"tag3:sourceClusterHigh", "tag1:sourceClusterLow"}
-	tags, sources = etags.get(true)
+	tags, sources, hash = etags.get(true)
 	assert.Len(t, tags, 0)
 	assert.Len(t, sources, 0)
 	assert.True(t, etags.cacheValid)
+	assert.Empty(t, hash)
 
 	// Invalidate the cache, we should now get the tags
 	etags.cacheValid = false
-	tags, sources = etags.get(true)
+	tags, sources, hash = etags.get(true)
 	assert.Len(t, tags, 7)
 	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh", "tag4:sourceClusterLow", "tag5:sourceLow"})
 	assert.Len(t, sources, 3)
 	assert.True(t, etags.cacheValid)
-	tags, sources = etags.get(false)
+	assert.Equal(t, "b4e89f91534288c8", hash)
+	tags, sources, hash = etags.get(false)
 	assert.Len(t, sources, 3)
 	assert.Len(t, tags, 5)
 	assert.ElementsMatch(t, tags, []string{"foo", "bar", "tag1:sourceClusterLow", "tag2:sourceHigh", "tag3:sourceClusterHigh"})
+	assert.Equal(t, "b4e89f91534288c8", hash)
 }
 
 func shuffleTags(tags []string) {
@@ -243,43 +258,17 @@ func shuffleTags(tags []string) {
 }
 
 func TestDigest(t *testing.T) {
-	for _, tc := range []struct {
-		tagInfo *collectors.TagInfo
-	}{
-		{
-			tagInfo: &collectors.TagInfo{
-				Source: "source-a",
-				Entity: "docker://4bf586f5309008b9822d3a7aa819cb123b23959f6ce63446dd2a97523b531dfe",
-				HighCardTags: []string{
-					"high2:b",
-					"high1:a",
-					"high3:c",
-				},
-				LowCardTags: []string{
-					"low2:b",
-					"low1:a",
-					"low3:c",
-				},
-			},
-		},
-		{
-			tagInfo: &collectors.TagInfo{
-				Source:       "source-b",
-				Entity:       "docker://4bf586f5309008b9822d3a7aa819cb123b23959f6ce63446dd2a97523b531dfe",
-				HighCardTags: []string{},
-				LowCardTags: []string{
-					"low3:c",
-				},
-			},
-		},
-	} {
-		t.Run("", func(t *testing.T) {
-			for i := 0; i < 100; i++ {
-				beforeShuffle := computeTagsHash(tc.tagInfo)
-				shuffleTags(tc.tagInfo.LowCardTags)
-				shuffleTags(tc.tagInfo.HighCardTags)
-				assert.Equal(t, beforeShuffle, computeTagsHash(tc.tagInfo))
-			}
-		})
+	tags := []string{
+		"high2:b",
+		"high1:a",
+		"high3:c",
+		"low2:b",
+		"low1:a",
+		"low3:c",
+	}
+	for i := 0; i < 50; i++ {
+		beforeShuffle := computeTagsHash(tags)
+		shuffleTags(tags)
+		assert.Equal(t, beforeShuffle, computeTagsHash(tags))
 	}
 }

--- a/pkg/tagger/tagstore_test.go
+++ b/pkg/tagger/tagstore_test.go
@@ -193,7 +193,7 @@ func TestGetEntityTags(t *testing.T) {
 	assert.Len(t, sources, 1)
 	assert.True(t, etags.cacheValid)
 	assert.Equal(t, "27554d1171230c5b", hash)
-	tags, sources, _ = etags.get(false)
+	tags, sources, hash = etags.get(false)
 	assert.Len(t, tags, 2)
 	assert.ElementsMatch(t, tags, []string{"low1", "low2"})
 	assert.Len(t, sources, 1)

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -893,7 +893,7 @@ spec:
         }
 
   - name: no-more-metrics-redis
-    activeDeadlineSeconds: 200
+    activeDeadlineSeconds: 300
     script:
       image: mongo:3.6.3
       command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
@@ -903,6 +903,20 @@ spec:
           var nb = db.series.find({
             metric: {$regex: "redis*"}
           }).count();
+
+          print("prev-find: " + prevNb)
+          print("find: " + nb)
+          if (nb == prevNb) {
+            break;
+          }
+          prevNb = nb;
+          sleep(30000);
+        }
+        var prevNb = -1
+        while (1) {
+          var nb = db.check_run.find({check: "datadog.agent.check_status",
+          tags: "check:redisdb",
+          status: {$ne: 0}}).count();
 
           print("prev-find: " + prevNb)
           print("find: " + nb)

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -463,6 +463,7 @@ spec:
   - name: main
     inputs:
       parameters:
+      - name: cpu-stress
       - name: redis-service
       - name: redis-deployment
       - name: agent-configmap
@@ -487,6 +488,7 @@ spec:
         withItems:
         - "{{inputs.parameters.fake-datadog-deployment}}"
         - "{{inputs.parameters.fake-datadog-service}}"
+
       - name: redis-deployment-setup
         template: manifest
         arguments:
@@ -563,6 +565,7 @@ spec:
 
       - name: find-metrics-cpu-system
         template: find-metrics-cpu-system
+
     - - name: redis-service-setup
         template: manifest
         arguments:
@@ -574,7 +577,7 @@ spec:
         withItems:
         - "{{inputs.parameters.redis-service}}"
 
-      - name: find-metrics-redis-tagged
+    - - name: find-metrics-redis-tagged
         template: find-metrics-redis-tagged
 
     - - name: delete-redis
@@ -777,25 +780,6 @@ spec:
           sleep(2000);
         }
 
-  - name: find-metrics-redis-tagged
-    activeDeadlineSeconds: 200
-    script:
-      image: mongo:3.6.3
-      command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
-      source: |
-        while (1) {
-          var nb = db.series.find({
-            metric: {$regex: "redis*"},
-            tags: "kube_service:redis"
-          }).count();
-          print("find: " + nb)
-          if (nb != 0) {
-            break;
-          }
-          sleep(2000);
-        }
-
-
   - name: find-metrics-cpu-docker
     activeDeadlineSeconds: 200
     script:
@@ -810,6 +794,24 @@ spec:
           print("find: " + nb)
           if (nb != 0) {
             print("cpu value in target range")
+            break;
+          }
+          sleep(2000);
+        }
+
+  - name: find-metrics-redis-tagged
+    activeDeadlineSeconds: 200
+    script:
+      image: mongo:3.6.3
+      command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
+      source: |
+        while (1) {
+          var nb = db.series.find({
+            metric: {$regex: "redis*"},
+            tags: "kube_service:redis"
+          }).count();
+          print("find: " + nb)
+          if (nb != 0) {
             break;
           }
           sleep(2000);

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -7,7 +7,24 @@ spec:
   #onExit: delete # call argo submit --entrypoint delete instead
   arguments:
     parameters:
-    - name: redis
+    - name: redis-service
+      value: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: redis
+          namespace: default
+        spec:
+          ports:
+          - port: 6379
+            protocol: TCP
+            targetPort: 6379
+            name: redis
+          selector:
+            app: redis
+          type: ClusterIP
+
+    - name: redis-deployment
       value: |
         apiVersion: extensions/v1beta1
         kind: Deployment
@@ -41,7 +58,8 @@ spec:
               - name: redis
                 image: redis
                 ports:
-                - containerPort: 6379
+                - name: redis
+                  containerPort: 6379
                 resources:
                   requests:
                     memory: "64Mi"
@@ -164,6 +182,7 @@ spec:
             - name: kubelet
               polling: true
             leader_election: true
+            kubernetes_metadata_tag_update_freq: 20
 
           kubelet.yaml: |
             init_config:
@@ -209,7 +228,7 @@ spec:
               serviceAccount: datadog-agent
               containers:
               - name: agent
-                image: datadog/agent:latest # TODO provide the ECR PR image
+                image: datadog/agent-dev:master
                 command:
                 - /opt/datadog-agent/bin/agent/agent
                 - start
@@ -444,8 +463,8 @@ spec:
   - name: main
     inputs:
       parameters:
-      - name: redis
-      - name: cpu-stress
+      - name: redis-service
+      - name: redis-deployment
       - name: agent-configmap
       - name: agent-service-account
       - name: agent-cluster-role
@@ -468,8 +487,7 @@ spec:
         withItems:
         - "{{inputs.parameters.fake-datadog-deployment}}"
         - "{{inputs.parameters.fake-datadog-service}}"
-
-      - name: redis-setup
+      - name: redis-deployment-setup
         template: manifest
         arguments:
           parameters:
@@ -478,7 +496,7 @@ spec:
           - name: manifest
             value: "{{item}}"
         withItems:
-        - "{{inputs.parameters.redis}}"
+        - "{{inputs.parameters.redis-deployment}}"
 
       - name: cpu-stress-setup
         template: manifest
@@ -545,6 +563,19 @@ spec:
 
       - name: find-metrics-cpu-system
         template: find-metrics-cpu-system
+    - - name: redis-service-setup
+        template: manifest
+        arguments:
+          parameters:
+          - name: action
+            value: "apply"
+          - name: manifest
+            value: "{{item}}"
+        withItems:
+        - "{{inputs.parameters.redis-service}}"
+
+      - name: find-metrics-redis-tagged
+        template: find-metrics-redis-tagged
 
     - - name: delete-redis
         template: manifest
@@ -555,7 +586,8 @@ spec:
           - name: manifest
             value: "{{item}}"
         withItems:
-        - "{{inputs.parameters.redis}}"
+        - "{{inputs.parameters.redis-deployment}}"
+        - "{{inputs.parameters.redis-service}}"
 
     - - name: no-more-redis
         template: no-more-metrics-redis
@@ -574,7 +606,8 @@ spec:
   - name: delete
     inputs:
       parameters:
-      - name: redis
+      - name: redis-service
+      - name: redis-deployment
       - name: cpu-stress
       - name: agent-configmap
       - name: agent-service-account
@@ -596,7 +629,8 @@ spec:
           - name: manifest
             value: "{{item}}"
         withItems:
-        - "{{inputs.parameters.redis}}"
+        - "{{inputs.parameters.redis-service}}"
+        - "{{inputs.parameters.redis-deployment}}"
         - "{{inputs.parameters.cpu-stress}}"
         - "{{inputs.parameters.agent-configmap}}"
         - "{{inputs.parameters.agent-service-account}}"
@@ -742,6 +776,25 @@ spec:
           }
           sleep(2000);
         }
+
+  - name: find-metrics-redis-tagged
+    activeDeadlineSeconds: 200
+    script:
+      image: mongo:3.6.3
+      command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
+      source: |
+        while (1) {
+          var nb = db.series.find({
+            metric: {$regex: "redis*"},
+            tags: "kube_service:redis"
+          }).count();
+          print("find: " + nb)
+          if (nb != 0) {
+            break;
+          }
+          sleep(2000);
+        }
+
 
   - name: find-metrics-cpu-docker
     activeDeadlineSeconds: 200


### PR DESCRIPTION
### What does this PR do?

When the Autodiscovery was created for the Agent 6, it was assumed that templates are static.
This is now an issue as a template that is created for a check will only be tagged with the tags found when the template for it is created.
Therefore, if another tag is collected later on, it will not be associated to the metrics for the check.

Once the config is resolved the tags added are static.
After this, if you create a k8s service that matches the pod you’ll never get the kube_service tags because tags are injected as instance tags when the check is launched and are never refreshed.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
