### PR TITLE
Return an error when the GCE metadata API responds with an empty body (#1721)

### DIFF
--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -88,6 +88,11 @@ func getResponse(url string) (string, error) {
 		return "", fmt.Errorf("GCE hostname, error reading response body: %s", err)
 	}
 
+	// Some cloud platforms will respond with an empty body, causing the agent to assume a faulty hostname
+	if len(all) <= 0 {
+		return "", fmt.Errorf("empty response body")
+	}
+
 	return string(all), nil
 }
 

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -28,7 +28,22 @@ func TestGetHostname(t *testing.T) {
 	val, err := GetHostname()
 	assert.Nil(t, err)
 	assert.Equal(t, expected, val)
-	assert.Equal(t, lastRequest.URL.Path, "/instance/hostname")
+	assert.Equal(t, "/instance/hostname", lastRequest.URL.Path)
+}
+
+func TestGetHostnameEmptyBody(t *testing.T) {
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetHostname()
+	assert.Error(t, err)
+	assert.Empty(t, val)
+	assert.Equal(t, "/instance/hostname", lastRequest.URL.Path)
 }
 
 func TestGetHostAliases(t *testing.T) {

--- a/releasenotes/notes/return-an-error-when-the-GCE-metadata-API-responds-with-an-empty-body-eab83cb87cbfa848.yaml
+++ b/releasenotes/notes/return-an-error-when-the-GCE-metadata-API-responds-with-an-empty-body-eab83cb87cbfa848.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Prevent an empty response body from being marked as a "successfull call to the GCE metadata api".
+    Fixes a bug where hostnames became an empty string when using docker swarm and a non GCE environment.


### PR DESCRIPTION
### What does this PR do?

Return an error when the GCE metadata API responds with an empty body

### Additional Notes

This was release with `6.2.1` but never cherry-picked on master
