### PR TITLE
[docs] Mention that PRs should be opened against master

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -25,7 +25,8 @@ when submitting your PR:
   * preferably make sure that all tests pass locally.
   * summarize your PR with an explanatory title and a message describing your
     changes, cross-referencing any related bugs/PRs.
-  * Use [Reno](#reno) to create a releasenote.
+  * use [Reno](#reno) to create a releasenote.
+  * open your PR against the `master` branch.
 
 Your pull request must pass all CI tests before we will merge it. If you're seeing
 an error and don't think it's your fault, it may not be! [Join us on Slack][slack]


### PR DESCRIPTION
There are no reason for external contributors to open PRs against any other branch unless we explicitly ask them
