### PR TITLE
Removed log in windows event laucher

### DIFF
--- a/pkg/logs/input/windowsevent/launcher.go
+++ b/pkg/logs/input/windowsevent/launcher.go
@@ -40,7 +40,6 @@ func New(sources []*config.LogSource, pipelineProvider pipeline.Provider, audito
 
 // Start starts new tailers.
 func (l *Launcher) Start() {
-	log.Info("Start tailing windows event log")
 	availableChannels, err := EnumerateChannels()
 	if err != nil {
 		log.Debug("Could not list windows event log channels: ", err)


### PR DESCRIPTION
### What does this PR do?

Removed log in windows event laucher

### Motivation

`Start tailing windows event log` log message appears all the time, let's remove it and just keep `Starting windows event log tailing for channel %s query %s` for each tailer.
