### PR TITLE
Properly set default hostname on metrics with no tags

### DIFF
--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -255,7 +255,7 @@ func parseMetricMessage(message []byte, namespace string) (*metrics.MetricSample
 
 	// Metadata
 	var metricTags []string
-	var host string
+	host := defaultHostname
 	var rawMetadataField []byte
 	sampleRate := 1.0
 

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -221,6 +221,21 @@ func TestParseGaugeWithNoHostTag(t *testing.T) {
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
+func TestParseGaugeWithNoTags(t *testing.T) {
+	defaultHostname = "test-hostname"
+	defer func() { defaultHostname = "" }()
+
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "daemon", parsed.Name)
+	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
+	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
+	assert.Empty(t, parsed.Tags)
+	assert.Equal(t, "test-hostname", parsed.Host)
+	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+}
+
 func TestParseGaugeWithSampleRate(t *testing.T) {
 	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "")
 


### PR DESCRIPTION
### What does this PR do?

Fixes regression introduced in https://github.com/DataDog/datadog-agent/pull/1806

### Motivation

Dogstatsd metrics with no tags at all wouldn't get properly associated with the Agent hostname anymore.