### PR TITLE
fix flaky windows packging by unpining pre-deps

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,7 +1,6 @@
 {
     "post-deps": {
-        "golang.org/x/tools/go/internal/gcimporter": "02fcd6aaf1349bf6a3f24ef1b62ca07ff618ff59",
-        "golang.org/x/tools/go/ast/astutil": "02fcd6aaf1349bf6a3f24ef1b62ca07ff618ff59"
+
     },
     "deps": {
         "github.com/golang/dep/cmd/dep": "v0.4.1",

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,6 +1,5 @@
 {
     "post-deps": {
-
     },
     "deps": {
         "github.com/golang/dep/cmd/dep": "v0.4.1",


### PR DESCRIPTION
### What does this PR do

Pinning seems to have introduced an issue with windows packaging and the issue we pinned for seems to have been resolved.

Context for the previous pin : https://github.com/DataDog/datadog-agent/pull/1832