### PR TITLE
[e2e] add docker/kubernetes/system cpu usage e2e test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -678,16 +678,6 @@
   revision = "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1"
 
 [[projects]]
-  branch = "master"
-  name = "golang.org/x/tools"
-  packages = [
-    "go/ast/astutil",
-    "go/buildutil",
-    "go/loader"
-  ]
-  revision = "95b47aa5df4eda9bfbc0133f77c0e320f0275eba"
-
-[[projects]]
   name = "gopkg.in/Knetic/govaluate.v3"
   packages = ["."]
   revision = "d216395917cc49052c7c7094cf57f09657ca08a8"
@@ -826,6 +816,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "55624c688dd0881de84d5ed5c959d065b3426181fc4f6fcad06fb254b7c6d135"
+  inputs-digest = "a073b6e2360cb042ec37d7aafb94ee3ff307f0abb5892b85d939f2123f09c377"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -168,7 +168,7 @@ spec:
           kubelet.yaml: |
             init_config:
             instances:
-            - cadvisor_port: 4194
+            - {}
 
           apiserver.yaml: |
             init_configs:

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -650,7 +650,7 @@ spec:
 
           // Get the user CPU usage, make sure it's above 39% non-normalized
           var point = db.series.find({
-            metric: "system.cpu.usage",
+            metric: "system.cpu.user",
             host: hostname
           }).limit(1).sort({$natural:-1})[0];
           if (!point) {

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -605,7 +605,8 @@ spec:
           if (point) {
             value = point.points[0][1] / 10e6
             print("cpu value: " + value)
-            if (value > 39 && value < 41) {
+            // Sampling is less accurate than cgroups, widening the acceptable range
+            if (value > 35 && value < 45) {
               print("cpu value in target range")
               break;
             }

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -50,6 +50,34 @@ spec:
                     memory: "128Mi"
                     cpu: "100m"
 
+    - name: cpu-stress
+      value: |
+        apiVersion: extensions/v1beta1
+        kind: Deployment
+        metadata:
+          name: cpu-stress
+          namespace: default
+        spec:
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                app: cpu-stress
+            spec:
+              containers:
+              - name: cpu-stress
+                image: datadog/docker-library:progrium_stress
+                args:
+                - "--cpu"
+                - "2"
+                resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "400m"
+                  limits:
+                    memory: "64Mi"
+                    cpu: "400m"
+
     - name: agent-service-account
       value: |
         kind: ServiceAccount
@@ -140,7 +168,7 @@ spec:
           kubelet.yaml: |
             init_config:
             instances:
-            - {}
+            - cadvisor_port: 4194
 
           apiserver.yaml: |
             init_configs:
@@ -299,6 +327,7 @@ spec:
     inputs:
       parameters:
       - name: redis
+      - name: cpu-stress
       - name: agent-configmap
       - name: agent-service-account
       - name: agent-cluster-role
@@ -318,6 +347,7 @@ spec:
         withItems:
         - "{{inputs.parameters.fake-datadog-deployment}}"
         - "{{inputs.parameters.fake-datadog-service}}"
+
       - name: redis-setup
         template: manifest
         arguments:
@@ -328,6 +358,17 @@ spec:
             value: "{{item}}"
         withItems:
         - "{{inputs.parameters.redis}}"
+
+      - name: cpu-stress-setup
+        template: manifest
+        arguments:
+          parameters:
+          - name: action
+            value: "apply"
+          - name: manifest
+            value: "{{item}}"
+        withItems:
+        - "{{inputs.parameters.cpu-stress}}"
 
     - - name: fake-dd-reset
         template: fake-dd-reset
@@ -358,6 +399,15 @@ spec:
 
       - name: find-metrics-redis
         template: find-metrics-redis
+
+      - name: find-metrics-cpu-docker
+        template: find-metrics-cpu-docker
+
+      - name: find-metrics-cpu-kubelet
+        template: find-metrics-cpu-kubelet
+
+      - name: find-metrics-cpu-system
+        template: find-metrics-cpu-system
 
     - - name: delete-redis
         template: manifest
@@ -512,6 +562,106 @@ spec:
             break;
           }
           sleep(2000);
+        }
+
+  - name: find-metrics-cpu-docker
+    activeDeadlineSeconds: 200
+    script:
+      image: mongo:3.6.3
+      command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
+      source: |
+        while (1) {
+          var point = db.series.find({
+            metric: "docker.cpu.usage",
+            tags: {$all: ["kube_deployment:cpu-stress", "kube_container_name:cpu-stress"]}
+          }).limit(1).sort({$natural:-1})[0];
+
+          if (point) {
+            value = point.points[0][1]
+            print("cpu value: " + value)
+            if (value > 39 && value < 41) {
+              print("cpu value in target range")
+              break;
+            }
+          } else {
+              print("no docker.cpu.usage metric reported")
+          }
+
+          sleep(2000);
+        }
+
+  - name: find-metrics-cpu-kubelet
+    activeDeadlineSeconds: 200
+    script:
+      image: mongo:3.6.3
+      command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
+      source: |
+        while (1) {
+          var point = db.series.find({
+            metric: "kubernetes.cpu.usage.total",
+            tags: {$all: ["kube_deployment:cpu-stress", "kube_container_name:cpu-stress"]}
+          }).limit(1).sort({$natural:-1})[0];
+
+          if (point) {
+            value = point.points[0][1] / 10e6
+            print("cpu value: " + value)
+            if (value > 39 && value < 41) {
+              print("cpu value in target range")
+              break;
+            }
+          } else {
+              print("no kubernetes.cpu.usage.total metric reported")
+          }
+
+          sleep(2000);
+        }
+
+  - name: find-metrics-cpu-system
+    activeDeadlineSeconds: 200
+    script:
+      image: mongo:3.6.3
+      command: [mongo, "fake-datadog.default.svc.cluster.local/datadog"]
+      source: |
+        while (1) {
+          sleep(2000);
+
+          // Determine the hostname the cpu-stress pod is running on
+          var point = db.series.find({
+            metric: "kubernetes.cpu.usage.total",
+            tags: {$all: ["kube_deployment:cpu-stress", "kube_container_name:cpu-stress"]}
+          }).limit(1).sort({$natural:-1})[0];
+          if (!point) {
+            print("cannot get hostname for pod");
+            continue;
+          }
+          hostname = point.host;
+
+          // Get the number of CPUs on that host
+          var point = db.series.find({
+            metric: "kubernetes.cpu.capacity",
+            host: hostname
+          }).limit(1).sort({$natural:-1})[0];
+          if (!point) {
+            print("cannot get cpu capacity for host " + hostname);
+            continue;
+          }
+          cpucount = point.points[0][1];
+
+          // Get the user CPU usage, make sure it's above 39% non-normalized
+          var point = db.series.find({
+            metric: "system.cpu.usage",
+            host: hostname
+          }).limit(1).sort({$natural:-1})[0];
+          if (!point) {
+            print("no system.cpu.usage metric reported for host " + hostname)
+            continue;
+          }
+          value = point.points[0][1] * cpucount;
+          print("cpu value: " + value)
+          if (value > 39) {
+            print("cpu value in target range");
+            break;
+          }
         }
 
   - name: no-more-metrics-redis

--- a/test/e2e/scripts/run-instance/22-argo-submit.sh
+++ b/test/e2e/scripts/run-instance/22-argo-submit.sh
@@ -78,7 +78,9 @@ spec:
         - name: datadog-config
           mountPath: /etc/datadog-agent/conf.d/network.d/conf.yaml.default
           subPath: network.yaml
-
+        - name: datadog-config
+          mountPath: /etc/datadog-agent/conf.d/docker.d/conf.yaml.default
+          subPath: docker.yaml
         - name: proc
           mountPath: /host/proc
           readOnly: true

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -34,7 +34,8 @@ done
 
 _ssh git clone https://github.com/DataDog/datadog-agent.git /home/core/datadog-agent || {
     # To be able to retry
-    echo "Already cloned ?"
+    echo "Already cloned, fetching new changes"
+    _ssh git -C /home/core/datadog-agent fetch
 }
 _ssh git -C /home/core/datadog-agent checkout ${COMMIT_ID}
 


### PR DESCRIPTION
### What does this PR do?

- Start a `stress` container limited to 40% over two threads, and make sure the following is true:

  - `docker.cpu.usage` is between 39 and 41% for the `cpu-stress` deployment
  - `kubernetes.cpu.usage.total` is between 35 and 45% (wider range due to the cadvisor sampling time being variable) for the `cpu-stress` deployment
  - `system.cpu.user` is higher than 39% (de-normalized) for the host running this pod

- Allow e2e on sandbox to fetch new commits to allow faster iteration

### What's next

Would be great to enable the kubelet's 4194 port and test two `kubelet` instances, separated by instance tags (one in prom mode, the other in legacy cadvisor) 
