### PR TITLE
Display wheel version in the status page

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -26,4 +26,5 @@ type Check interface {
 	ID() ID                                              // provide a unique identifier for every check instance
 	GetWarnings() []error                                // return the last warning registered by the check
 	GetMetricStats() (map[string]int64, error)           // get metric stats from the sender
+	Version() string                                     // return the version of the check if available
 }

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -18,6 +18,7 @@ import (
 type TestCheck struct{}
 
 func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Version() string                                    { return "" }
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
 func (c *TestCheck) Interval() time.Duration                            { return 1 }

--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -13,6 +13,7 @@ import (
 // Stats holds basic runtime statistics about check instances
 type Stats struct {
 	CheckName            string
+	CheckVersion         string
 	CheckID              ID
 	TotalRuns            uint64
 	TotalErrors          uint64
@@ -35,8 +36,9 @@ type Stats struct {
 // NewStats returns a new check stats instance
 func NewStats(c Check) *Stats {
 	return &Stats{
-		CheckID:   c.ID(),
-		CheckName: c.String(),
+		CheckID:      c.ID(),
+		CheckName:    c.String(),
+		CheckVersion: c.Version(),
 	}
 }
 

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -42,6 +42,10 @@ func (c *TestCheck) String() string {
 	return "TestCheck"
 }
 
+func (c *TestCheck) Version() string {
+	return ""
+}
+
 func NewCheck() *TestCheck { return &TestCheck{stop: make(chan bool)} }
 func NewCheckUnique(id check.ID, name string) *TestCheck {
 	return &TestCheck{uniqueID: id, name: name, stop: make(chan bool)}

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -79,6 +79,12 @@ func (c *CheckBase) String() string {
 	return c.checkName
 }
 
+// Version returns an empty string as Go check can't be updated independently
+// from the agent
+func (c *CheckBase) Version() string {
+	return ""
+}
+
 // ID returns a unique ID for that check instance
 //
 // For checks that only support one instance, the default value is

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -43,6 +43,10 @@ func (c *APMCheck) String() string {
 	return "APM Agent"
 }
 
+func (c *APMCheck) Version() string {
+	return ""
+}
+
 // Run executes the check with retries
 func (c *APMCheck) Run() error {
 	atomic.StoreUint32(&c.running, 1)

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -60,6 +60,10 @@ func (c *JMXCheck) String() string {
 	return c.name
 }
 
+func (c *JMXCheck) Version() string {
+	return ""
+}
+
 func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data) error {
 	return nil
 }

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -50,6 +50,10 @@ func (c *ProcessAgentCheck) String() string {
 	return "Process Agent"
 }
 
+func (c *ProcessAgentCheck) Version() string {
+	return ""
+}
+
 // Run executes the check with retries
 func (c *ProcessAgentCheck) Run() error {
 	atomic.StoreUint32(&c.running, 1)

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -18,6 +18,7 @@ import (
 type TestCheck struct{}
 
 func (c *TestCheck) String() string                            { return "TestCheck" }
+func (c *TestCheck) Version() string                           { return "" }
 func (c *TestCheck) Run() error                                { return nil }
 func (c *TestCheck) Stop()                                     {}
 func (c *TestCheck) Interval() time.Duration                   { return 1 }

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -30,6 +30,7 @@ import "C"
 // PythonCheck represents a Python check, implements `Check` interface
 type PythonCheck struct {
 	id           check.ID
+	version      string
 	instance     *python.PyObject
 	class        *python.PyObject
 	ModuleName   string
@@ -126,6 +127,11 @@ func (c *PythonCheck) Stop() {}
 // String representation (for debug and logging)
 func (c *PythonCheck) String() string {
 	return c.ModuleName
+}
+
+// Version returns the version of the check if load from a python wheel
+func (c *PythonCheck) Version() string {
+	return c.version
 }
 
 // GetWarnings grabs the last warnings from the struct

--- a/pkg/collector/runner/num_workers_test.go
+++ b/pkg/collector/runner/num_workers_test.go
@@ -35,8 +35,9 @@ type stickyLock struct {
 	locked uint32 // Flag set to 1 if the lock is locked, 0 otherwise
 }
 
-func (nc *NumWorkersCheck) String() string { return nc.name }
-func (nc *NumWorkersCheck) ID() check.ID   { return check.ID(nc.String()) }
+func (nc *NumWorkersCheck) String() string  { return nc.name }
+func (nc *NumWorkersCheck) Version() string { return "" }
+func (nc *NumWorkersCheck) ID() check.ID    { return check.ID(nc.String()) }
 func (nc *NumWorkersCheck) Run() error {
 	if *pythonCheck {
 		e := runPythonCheck() // BUG: this panics occasionally

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -23,6 +23,7 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Version() string                                    { return "" }
 func (c *TestCheck) Stop()                                              {}
 func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
 func (c *TestCheck) Interval() time.Duration                            { return 1 }

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -18,6 +18,7 @@ import (
 type TestCheck struct{ intl time.Duration }
 
 func (c *TestCheck) String() string                                     { return "TestCheck" }
+func (c *TestCheck) Version() string                                    { return "" }
 func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
 func (c *TestCheck) Interval() time.Duration                            { return c.intl }
 func (c *TestCheck) Run() error                                         { return nil }

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -15,8 +15,8 @@ Collector
   {{end -}}
 
   {{- range .Checks}}
-    {{.CheckName}}
-    {{printDashes .CheckName "-"}}
+    {{.CheckName}}{{ if .CheckVersion }} ({{.CheckVersion}}){{ end }}
+    {{printDashes .CheckName "-"}}{{- if .CheckVersion }}{{printDashes .CheckVersion "-"}}---{{ end }}
       Total Runs: {{.TotalRuns}}
       Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: {{.Events}}, Total: {{humanize .TotalEvents}}

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -95,11 +95,7 @@ func FormatUnixTime(unixTime float64) string {
 }
 
 func printDashes(s string, dash string) string {
-	var dashes string
-	for i := 0; i < stringLength(s); i++ {
-		dashes += dash
-	}
-	return dashes
+	return strings.Repeat(dash, stringLength(s))
 }
 
 // MkHuman makes large numbers more readable

--- a/releasenotes/notes/wheel-version-status-page-5d15e8241bbf20e1.yaml
+++ b/releasenotes/notes/wheel-version-status-page-5d15e8241bbf20e1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Display the version for Python checks on the status page.


### PR DESCRIPTION
### What does this PR do?

Display wheel version in the status page
    
We now collect the wheel version from python checks and display it in the status page. This is mandatory to allow user to manually update a wheel and be able to see what is currently installed.
