### PR TITLE
overwrite default `before_script` for cloudfront invalidation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1082,6 +1082,7 @@ deploy_cloudfront_invalidate:
   only:
     - master
     - tags
+    - arbll/overwrite-cf-invalidation-before-script
   tags: [ "runner:main", "size:large" ]
   script:
     - cd /deploy_scripts/cloudfront-invalidation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,10 +41,14 @@ variables:
   S3_DSD6_URI: s3://dsd6-staging/linux
   RELEASE_VERSION: nightly
 
+
+# Default before_script for all the jobs. If you create a new job and don't want this to execute
+# you NEED to overwrite it.
 before_script:
   # We need to install go deps from within the GOPATH, which we set to / on builder images; that's because pointing
   # GOPATH to the project folder would be too complex (we'd need to replicate the `src/github/project` scheme).
   # So we copy the agent sources to / and bootstrap from there the vendor dependencies before running any job.
+  - echo running default before_script
   - rsync -azr --delete ./ $SRC_PATH
   - cd $SRC_PATH
   - pip install -U pip

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1082,7 +1082,6 @@ deploy_cloudfront_invalidate:
   only:
     - master
     - tags
-    - arbll/overwrite-cf-invalidation-before-script
   tags: [ "runner:main", "size:large" ]
   script:
     - cd /deploy_scripts/cloudfront-invalidation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1077,6 +1077,8 @@ latest_dsd_push:
 deploy_cloudfront_invalidate:
   stage: deploy_invalidate
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
   only:
     - master
     - tags


### PR DESCRIPTION
### What does this PR do?

We need to add a dummy `before_script` to the `deploy_cloudfront_invalidate` job to avoid running the default `before_script` :

https://github.com/DataDog/datadog-agent/blob/05a65517e9f1ca803dcf8fcf594bf6cb4b57a6f8/.gitlab-ci.yml#L44-L51

We use the same kind of overwriting for every other `deploy` jobs.

Relevant gitlab doc : https://docs.gitlab.com/ee/ci/yaml/#before_script-and-after_script