### PR TITLE
Fix build tag on jmx test

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/runner_test.go
+++ b/pkg/collector/corechecks/embed/jmx/runner_test.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build jmx
+
 package jmx
 
 import (


### PR DESCRIPTION
### What does this PR do?

Add a `jmx` build tag to the runner test

### Motivation

accessing the `runner` is already behind the flag, the test can't run without it
