### PR TITLE
Set service and source values to "docker" by default for container entries

### DIFF
--- a/pkg/logs/input/journald/docker.go
+++ b/pkg/logs/input/journald/docker.go
@@ -11,8 +11,8 @@ import (
 	"github.com/coreos/go-systemd/sdjournal"
 )
 
-// containerIDKey represents the key of the short identifier of a container in a journal entry.
-const containerIDKey = "CONTAINER_ID"
+// containerIDKey represents the key of the container identifier in a journal entry.
+const containerIDKey = "CONTAINER_ID_FULL"
 
 // isContainerEntry returns true if the entry comes from a docker container.
 func isContainerEntry(entry *sdjournal.JournalEntry) bool {

--- a/pkg/logs/input/journald/docker.go
+++ b/pkg/logs/input/journald/docker.go
@@ -15,7 +15,7 @@ import (
 const containerIDKey = "CONTAINER_ID_FULL"
 
 // isContainerEntry returns true if the entry comes from a docker container.
-func isContainerEntry(entry *sdjournal.JournalEntry) bool {
+func (t *Tailer) isContainerEntry(entry *sdjournal.JournalEntry) bool {
 	_, exists := entry.Fields[containerIDKey]
 	return exists
 }

--- a/pkg/logs/input/journald/docker.go
+++ b/pkg/logs/input/journald/docker.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build systemd
+
+package journald
+
+import (
+	"github.com/coreos/go-systemd/sdjournal"
+)
+
+// containerIDKey represents the key of the short identifier of a container in a journal entry.
+const containerIDKey = "CONTAINER_ID"
+
+// isContainerEntry returns true if the entry comes from a docker container.
+func isContainerEntry(entry *sdjournal.JournalEntry) bool {
+	_, exists := entry.Fields[containerIDKey]
+	return exists
+}

--- a/pkg/logs/input/journald/docker_test.go
+++ b/pkg/logs/input/journald/docker_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build systemd
+
+package journald
+
+import (
+	"testing"
+
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContainerEntry(t *testing.T) {
+	var entry *sdjournal.JournalEntry
+
+	entry = &sdjournal.JournalEntry{
+		Fields: map[string]string{
+			containerIDKey: "0123456789",
+		},
+	}
+	assert.True(t, isContainerEntry(entry))
+
+	entry = &sdjournal.JournalEntry{}
+	assert.False(t, isContainerEntry(entry))
+}

--- a/pkg/logs/input/journald/docker_test.go
+++ b/pkg/logs/input/journald/docker_test.go
@@ -12,9 +12,14 @@ import (
 
 	"github.com/coreos/go-systemd/sdjournal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
 func TestIsContainerEntry(t *testing.T) {
+	source := config.NewLogSource("", &config.LogsConfig{})
+	tailer := NewTailer(source, nil)
+
 	var entry *sdjournal.JournalEntry
 
 	entry = &sdjournal.JournalEntry{
@@ -22,8 +27,8 @@ func TestIsContainerEntry(t *testing.T) {
 			containerIDKey: "0123456789",
 		},
 	}
-	assert.True(t, isContainerEntry(entry))
+	assert.True(t, tailer.isContainerEntry(entry))
 
 	entry = &sdjournal.JournalEntry{}
-	assert.False(t, isContainerEntry(entry))
+	assert.False(t, tailer.isContainerEntry(entry))
 }

--- a/pkg/logs/input/journald/tailer_systemd.go
+++ b/pkg/logs/input/journald/tailer_systemd.go
@@ -203,6 +203,9 @@ var applicationKeys = []string{
 
 // getApplicationName returns the name of the application from where the entry is from.
 func (t *Tailer) getApplicationName(entry *sdjournal.JournalEntry) string {
+	if isContainerEntry(entry) {
+		return "docker"
+	}
 	for _, key := range applicationKeys {
 		if value, exists := entry.Fields[key]; exists {
 			return value

--- a/pkg/logs/input/journald/tailer_systemd.go
+++ b/pkg/logs/input/journald/tailer_systemd.go
@@ -203,7 +203,7 @@ var applicationKeys = []string{
 
 // getApplicationName returns the name of the application from where the entry is from.
 func (t *Tailer) getApplicationName(entry *sdjournal.JournalEntry) string {
-	if isContainerEntry(entry) {
+	if t.isContainerEntry(entry) {
 		return "docker"
 	}
 	for _, key := range applicationKeys {

--- a/pkg/logs/input/journald/tailer_systemd_test.go
+++ b/pkg/logs/input/journald/tailer_systemd_test.go
@@ -49,12 +49,6 @@ func TestApplicationName(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
 	tailer := NewTailer(source, nil)
 
-	var err error
-	err = tailer.setup()
-	assert.Nil(t, err)
-	err = tailer.seek("")
-	assert.Nil(t, err)
-
 	assert.Equal(t, "foo", tailer.getApplicationName(
 		&sdjournal.JournalEntry{
 			Fields: map[string]string{
@@ -89,12 +83,6 @@ func TestContent(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
 	tailer := NewTailer(source, nil)
 
-	var err error
-	err = tailer.setup()
-	assert.Nil(t, err)
-	err = tailer.seek("")
-	assert.Nil(t, err)
-
 	assert.Equal(t, []byte(`{"journald":{"_A":"foo.service"},"message":"bar"}`), tailer.getContent(
 		&sdjournal.JournalEntry{
 			Fields: map[string]string{
@@ -120,12 +108,6 @@ func TestSeverity(t *testing.T) {
 	source := config.NewLogSource("", &config.LogsConfig{})
 	tailer := NewTailer(source, nil)
 
-	var err error
-	err = tailer.setup()
-	assert.Nil(t, err)
-	err = tailer.seek("")
-	assert.Nil(t, err)
-
 	priorityValues := []string{"0", "1", "2", "3", "4", "5", "6", "7", "foo"}
 	statuses := []string{message.StatusEmergency, message.StatusAlert, message.StatusCritical, message.StatusError, message.StatusWarning, message.StatusNotice, message.StatusInfo, message.StatusDebug, message.StatusInfo}
 
@@ -137,4 +119,19 @@ func TestSeverity(t *testing.T) {
 				},
 			}))
 	}
+}
+
+func TestApplicationNameShouldBeDockerForContainerEntries(t *testing.T) {
+	source := config.NewLogSource("", &config.LogsConfig{})
+	tailer := NewTailer(source, nil)
+
+	assert.Equal(t, "docker", tailer.getApplicationName(
+		&sdjournal.JournalEntry{
+			Fields: map[string]string{
+				sdjournal.SD_JOURNAL_FIELD_SYSLOG_IDENTIFIER: "foo",
+				sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT:      "foo.service",
+				sdjournal.SD_JOURNAL_FIELD_COMM:              "foo.sh",
+				containerIDKey:                               "bar",
+			},
+		}))
 }


### PR DESCRIPTION
### What does this PR do?

Changed the application name method to always return "docker" if the journal entry is container log.

### Motivation

Otherwise we would return the short container identifier and assign it to the service and the source.