### PR TITLE
Fix dogstatsd static build with go 1.10

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -21,7 +21,7 @@ from .go import deps
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 15 * 1024
+MAX_BINARY_SIZE = 20 * 1024
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 DEFAULT_BUILD_TAGS = [
     "zlib",
@@ -45,6 +45,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
     if static:
         bin_path = STATIC_BIN_PATH
 
+    # NOTE: consider stripping symbols to reduce binary size 
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd/"
     args = {
@@ -57,14 +58,6 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
         "REPO_PATH": REPO_PATH,
     }
     ctx.run(cmd.format(**args), env=env)
-
-    # Manually strip the binary as go 1.10 does not pass the ldflag correctly
-    if static:
-        cmd = "strip {bin_name} "
-        args = {
-            "bin_name": os.path.join(bin_path, bin_name("dogstatsd")),
-        }
-        ctx.run(cmd.format(**args), env=env)
 
     # Render the configuration file template
     #

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -21,7 +21,7 @@ from .go import deps
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 20 * 1024
+MAX_BINARY_SIZE = 15 * 1024
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 DEFAULT_BUILD_TAGS = [
     "zlib",
@@ -57,6 +57,14 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
         "REPO_PATH": REPO_PATH,
     }
     ctx.run(cmd.format(**args), env=env)
+
+    # Manually strip the binary as go 1.10 does not pass the ldflag correctly
+    if static:
+        cmd = "strip {bin_name} "
+        args = {
+            "bin_name": os.path.join(bin_path, bin_name("dogstatsd")),
+        }
+        ctx.run(cmd.format(**args), env=env)
 
     # Render the configuration file template
     #

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -64,7 +64,8 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
 
     if static:
-        ldflags += "-s -w -linkmode external -extldflags '-static' "
+        ldflags += "-s -w -linkmode=external '-extldflags=-static' "
+        env["CGO_ENABLED"] = "0"
     elif use_embedded_libs:
         embedded_lib_path = ctx.run("pkg-config --variable=libdir python-2.7",
                                     env=env, hide=True).stdout.strip()

--- a/test/integration/docker/dsd_listening.py
+++ b/test/integration/docker/dsd_listening.py
@@ -69,7 +69,24 @@ def isUDSListening(container, retries=10):
     return SOCKET_PATH in out
 
 
-class DSDTest(unittest.TestCase):
+class DSDStaticTest(unittest.TestCase):
+    def setUp(self):
+        self.assertIsNotNone(os.environ.get('DOCKER_IMAGE'), "DOCKER_IMAGE envvar needed")
+
+    def test_static_binary(self):
+        '''Fails if /dogstatsd is not a static binary, build options are likely broken'''
+        global client
+        fileOutput = client.containers.run(
+            os.environ.get('DOCKER_IMAGE'),
+            environment=COMMON_ENVIRONMENT,
+            auto_remove=True,
+            stdout=True,
+            command='sh -c "apk add --no-cache file && file /dogstatsd"'
+        )
+        self.assertIn("statically linked", fileOutput)
+
+
+class DSDListeningTest(unittest.TestCase):
     def setUp(self):
         self.assertIsNotNone(os.environ.get('DOCKER_IMAGE'), "DOCKER_IMAGE envvar needed")
 


### PR DESCRIPTION
### What does this PR do?

Cherry pick the go110 changes that didn't make it into `master`:

- fix ldflags to enable static build
- force binary strip as go 1.10 does not handle it itself
- add a "is binary static" check to the `inv docker.integration-tests` tests
- revert max dsd size to 15MB

### Motivation

`datadog/dogstatsd:6.3.0` does not start because the binary is glibc-dynamic
