### PR TITLE
Added a support for container tags collection on journald integration

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -62,8 +62,9 @@ type LogsConfig struct {
 	Port int    // Network
 	Path string // File, Journald
 
-	IncludeUnits []string `mapstructure:"include_units" json:"include_units"` // Journald
-	ExcludeUnits []string `mapstructure:"exclude_units" json:"exclude_units"` // Journald
+	IncludeUnits         []string `mapstructure:"include_units" json:"include_units"`                   // Journald
+	ExcludeUnits         []string `mapstructure:"exclude_units" json:"exclude_units"`                   // Journald
+	CollectContainerTags bool     `mapstructure:"collect_container_tags" json:"collect_container_tags"` // Journald
 
 	Image string // Docker
 	Label string // Docker

--- a/pkg/logs/input/journald/docker_test.go
+++ b/pkg/logs/input/journald/docker_test.go
@@ -32,3 +32,15 @@ func TestIsContainerEntry(t *testing.T) {
 	entry = &sdjournal.JournalEntry{}
 	assert.False(t, tailer.isContainerEntry(entry))
 }
+
+func TestGetContainerID(t *testing.T) {
+	source := config.NewLogSource("", &config.LogsConfig{})
+	tailer := NewTailer(source, nil)
+
+	entry := &sdjournal.JournalEntry{
+		Fields: map[string]string{
+			containerIDKey: "0123456789",
+		},
+	}
+	assert.Equal(t, "0123456789", tailer.getContainerID(entry))
+}


### PR DESCRIPTION
### What does this PR do?

Use tagger inside the journald integration to collect container tags.

### Motivation

Enrich logs

### Additional Notes

I am not sure it's worth using a flag for this feature.

