### PR TITLE
[windows] fix imports such that version library will be properly loaded

### DIFF
--- a/pkg/util/winutil/winver.go
+++ b/pkg/util/winutil/winver.go
@@ -14,14 +14,14 @@ import (
 )
 
 var (
-	k32     = syscall.NewLazyDLL("kernel32.dll")
-	apicore = syscall.NewLazyDLL("api-ms-win-core-version-l1-1-0.dll")
+	k32        = syscall.NewLazyDLL("kernel32.dll")
+	versiondll = syscall.NewLazyDLL("version.dll")
 
 	procGetModuleHandle          = k32.NewProc("GetModuleHandleW")
 	procGetModuleFileName        = k32.NewProc("GetModuleFileNameW")
-	procGetFileVersionInfoSizeEx = apicore.NewProc("GetFileVersionInfoSizeExW")
-	procGetFileVersionInfoEx     = apicore.NewProc("GetFileVersionInfoExW")
-	procVerQueryValue            = apicore.NewProc("VerQueryValueW")
+	procGetFileVersionInfoSizeEx = versiondll.NewProc("GetFileVersionInfoSizeExW")
+	procGetFileVersionInfoEx     = versiondll.NewProc("GetFileVersionInfoExW")
+	procVerQueryValue            = versiondll.NewProc("VerQueryValueW")
 )
 
 // GetWindowsBuildString retrieves the windows build version by querying

--- a/releasenotes/notes/fixserver2008-9e7867cb19c82625.yaml
+++ b/releasenotes/notes/fixserver2008-9e7867cb19c82625.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes problem in 6.3.0 in which agent wouldn't start on Windows
+    Server 2008r2.


### PR DESCRIPTION
on server 2008

### What does this PR do?

changes the import description to the generic file (version.dll) that should be available on each platform.

### Motivation

significant impact bug.

### testing
verify agent installs and properly starts on server 2008, server 2012, server 2016.
and servercore.