### PR TITLE
[reno] edit an old release note that was using an outdated section

### DIFF
--- a/releasenotes/notes/win-iostats-8f3eeb57a3d9e905.yaml
+++ b/releasenotes/notes/win-iostats-8f3eeb57a3d9e905.yaml
@@ -1,9 +1,8 @@
 ---
-critical:
-  - |
-    ".pdh" suffix was added to `system.io` metrics on windows for side-by-side 
-    testing when changed the collection mechanism, and inadvertently left.
 fixes:
   - |
-    remove `.pdh` suffix from system.io.wkb_s, system.io_w_s, system.io.rkb_s, 
+    remove `.pdh` suffix from system.io.wkb_s, system.io_w_s, system.io.rkb_s,
     system.io.r_s, system.io.avg_q_sz
+  - |
+    ".pdh" suffix was added to `system.io` metrics on windows for side-by-side
+    testing when changed the collection mechanism, and inadvertently left.


### PR DESCRIPTION
reno-lint was failing because of that

appveyor failure is unrelated 