### PR TITLE
Fix logs when errors occurs before initializing the log module

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -383,6 +384,16 @@ func Warnf(format string, params ...interface{}) error {
 func Errorf(format string, params ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.ErrorLvl) {
 		return logger.errorf(format, params...)
+	} else if logger == nil || logger.inner == nil {
+		// We're currently trying to log an error before initializing
+		// the log module. This meant a early error while starting the
+		// agent. We should not silence such error.
+		msg := fmt.Sprintf(format, params...)
+		msgScrubbed, err := CredentialsCleanerBytes([]byte(msg))
+		if err == nil {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", msgScrubbed)
+			return fmt.Errorf(string(msgScrubbed))
+		}
 	}
 	return nil
 }
@@ -391,6 +402,16 @@ func Errorf(format string, params ...interface{}) error {
 func Criticalf(format string, params ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.CriticalLvl) {
 		return logger.criticalf(format, params...)
+	} else if logger == nil || logger.inner == nil {
+		// We're currently trying to log an error before initializing
+		// the log module. This meant a early error while starting the
+		// agent. We should not silence such error.
+		msg := fmt.Sprintf(format, params...)
+		msgScrubbed, err := CredentialsCleanerBytes([]byte(msg))
+		if err == nil {
+			fmt.Fprintf(os.Stderr, "Critical: %s\n", msgScrubbed)
+			return fmt.Errorf(string(msgScrubbed))
+		}
 	}
 	return nil
 }

--- a/releasenotes/notes/log-errors-before-log-init-fb4de945ed5dfa3e.yaml
+++ b/releasenotes/notes/log-errors-before-log-init-fb4de945ed5dfa3e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Errors logged before the agent initialized the log module are now printed
+    on STDERR instead of being silenced.


### PR DESCRIPTION
### What does this PR do?

Errors logged before the agent initialized the `log` module are now printed on STDERR instead of being silenced.

This would happened when the user would set secrets in `datadog.yaml` and `secret_backend_command` would exit with a code different than 0.
It would make troubleshooting `secret_backend_command` very difficult as the traceback/stderr from the binary would not be printed.