### PR TITLE
Use builder to reduce the size of the fake-datadog image

### DIFF
--- a/test/e2e/containers/fake_datadog/Dockerfile
+++ b/test/e2e/containers/fake_datadog/Dockerfile
@@ -1,16 +1,17 @@
-FROM python:3.7-rc as builder
+FROM python:3.6-alpine as builder
 
 COPY app /usr/local/fake_datadog/app
 
-RUN apt-get update
-RUN apt-get install -y python-virtualenv
+RUN apk update
+RUN apk add py-pip python3-dev py-virtualenv gcc musl-dev
+
 RUN virtualenv /usr/local/fake_datadog/venv -p python3 --no-site-packages --system-site-packages
 RUN /usr/local/fake_datadog/venv/bin/pip install -r /usr/local/fake_datadog/app/requirements.txt
+RUN mkdir -pv /usr/local/fake_datadog/recorded
 
-FROM python:3.7-rc-slim
+FROM python:3.6-alpine
 
 COPY --from=builder /usr/local/fake_datadog /usr/local/fake_datadog
-RUN mkdir -pv /usr/local/fake_datadog/recorded
 
 VOLUME /usr/local/fake_datadog/recorded
 

--- a/test/e2e/containers/fake_datadog/Dockerfile
+++ b/test/e2e/containers/fake_datadog/Dockerfile
@@ -1,11 +1,19 @@
-FROM python:3.6
+FROM python:3.7-rc as builder
 
 COPY app /usr/local/fake_datadog/app
 
-RUN pip install -r /usr/local/fake_datadog/app/requirements.txt && mkdir -pv /usr/local/fake_datadog/recorded
+RUN apt-get update
+RUN apt-get install -y python-virtualenv
+RUN virtualenv /usr/local/fake_datadog/venv -p python3 --no-site-packages --system-site-packages
+RUN /usr/local/fake_datadog/venv/bin/pip install -r /usr/local/fake_datadog/app/requirements.txt
+
+FROM python:3.7-rc-slim
+
+COPY --from=builder /usr/local/fake_datadog /usr/local/fake_datadog
+RUN mkdir -pv /usr/local/fake_datadog/recorded
 
 VOLUME /usr/local/fake_datadog/recorded
 
 ENV prometheus_multiproc_dir "/var/lib/prometheus"
 
-CMD ["gunicorn", "--bind", "0.0.0.0:80", "--pythonpath", "/usr/local/fake_datadog/app", "api:app"]
+CMD ["/usr/local/fake_datadog/venv/bin/gunicorn", "--bind", "0.0.0.0:80", "--pythonpath", "/usr/local/fake_datadog/app", "api:app"]


### PR DESCRIPTION
### What does this PR do?

Using this new way to build it drops the size from `705MB` to `162MB` with debian slim.
It dropped to `108MB`with alpine.

### Motivation

Reduce the size of the image.