### PR TITLE
[jmx] send check_name to jmxfetch

### DIFF
--- a/cmd/agent/api/agent/agent_jmx.go
+++ b/cmd/agent/api/agent/agent_jmx.go
@@ -69,8 +69,9 @@ func getJMXConfigs(w http.ResponseWriter, r *http.Request) {
 		}
 
 		c["instances"] = instances
-		configs[name] = c
+		c["check_name"] = config.Name
 
+		configs[name] = c
 	}
 	j["configs"] = configs
 	j["timestamp"] = time.Now().Unix()

--- a/releasenotes/notes/jmx_tagging_fix-fdbca83d4acd15c5.yaml
+++ b/releasenotes/notes/jmx_tagging_fix-fdbca83d4acd15c5.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Provide the actual JMX check name as `check_name` in configurations 
+    provided to JMXFetch via the agent API. This addresses a regression
+    in 6.3.0 that broke the `instance:` tag.
+    Due to the nature of the regression, and the fix, this will cause
+    churn on the tag potentially affecting dashboards and monitors.


### PR DESCRIPTION
### What does this PR do?

Sends the name of the check to jmxfetch. We were only sending the config name before that.

Sister PR : 
https://github.com/DataDog/jmxfetch/pull/174
