### PR TITLE
Fix API_KEY validation for 'additional_endpoints'

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -38,14 +37,12 @@ type forwarderHealth struct {
 	health  *health.Handle
 	stop    chan bool
 	stopped chan struct{}
-	ddURL   string
 	timeout time.Duration
 }
 
 func (fh *forwarderHealth) init(keysPerDomains map[string][]string) {
 	fh.stop = make(chan bool, 1)
 	fh.stopped = make(chan struct{})
-	fh.ddURL = config.Datadog.GetString("dd_url")
 
 	// Since timeout is the maximum duration we can wait, we need to divide it
 	// by the total number of api keys to obtain the max duration for each key
@@ -114,7 +111,7 @@ func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status 
 }
 
 func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
-	url := fmt.Sprintf("%s%s?api_key=%s", fh.ddURL, v1ValidateEndpoint, apiKey)
+	url := fmt.Sprintf("%s%s?api_key=%s", domain, v1ValidateEndpoint, apiKey)
 
 	transport := util.CreateHTTPTransport()
 

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -6,64 +6,65 @@
 package forwarder
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestHasValidAPIKey(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ddURL := config.Datadog.Get("dd_url")
-	config.Datadog.Set("dd_url", ts.URL)
-	defer ts.Close()
-	defer func() { config.Datadog.Set("dd_url", ddURL) }()
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts1.Close()
+	defer ts2.Close()
 
 	keysPerDomains := map[string][]string{
-		"domain1": {"api_key1", "api_key2"},
-		"domain2": {"key3"},
+		ts1.URL: {"api_key1", "api_key2"},
+		ts2.URL: {"api_key3"},
 	}
 
 	fh := forwarderHealth{}
 	fh.init(keysPerDomains)
 	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
 
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain1,*************************_key1"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain1,*************************_key2"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain2,*************************"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get(ts1.URL+",*************************_key1"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get(ts1.URL+",*************************_key2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get(ts2.URL+",*************************_key3"))
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 		if r.Form.Get("api_key") == "api_key1" {
 			w.WriteHeader(http.StatusForbidden)
 		} else if r.Form.Get("api_key") == "api_key2" {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
-			w.WriteHeader(http.StatusOK)
+			assert.Fail(t, fmt.Sprintf("Unknown api key received: %v", r.Form.Get("api_key")))
 		}
 	}))
-	ddURL := config.Datadog.Get("dd_url")
-	config.Datadog.Set("dd_url", ts.URL)
-	defer ts.Close()
-	defer func() { config.Datadog.Set("dd_url", ddURL) }()
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts1.Close()
+	defer ts2.Close()
 
 	keysPerDomains := map[string][]string{
-		"domain1": {"api_key1", "api_key2"},
-		"domain2": {"key3"},
+		ts1.URL: {"api_key1", "api_key2"},
+		ts2.URL: {"api_key3"},
 	}
 
 	fh := forwarderHealth{}
 	fh.init(keysPerDomains)
 	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
 
-	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("domain1,*************************_key1"))
-	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("domain1,*************************_key2"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain2,*************************"))
+	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get(ts1.URL+",*************************_key1"))
+	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get(ts1.URL+",*************************_key2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get(ts2.URL+",*************************_key3"))
 }

--- a/releasenotes/notes/api-key-validation-per-domain-891ebd73ab300a6c.yaml
+++ b/releasenotes/notes/api-key-validation-per-domain-891ebd73ab300a6c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix API_KEY validation for 'additional_endpoints' by using their respective
+    endpoint instead of the main one all the time.


### PR DESCRIPTION
### What does this PR do?

We now use the endpoint linked to the API_KEY to validate it instead of
the main one from the configuration.