### PR TITLE
[DCA] Add namespace to metadata routes to uniquely identify pods by name.

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
@@ -15,10 +15,13 @@ Warnings:
 {{- range $index, $meta_type := .Nodes }}
 Node detected: {{ $index -}}
 {{- range $m := $meta_type }}
-   {{ range $pod, $svc := $m }}
- -  Pod name: {{ $pod }}
-    Services list: {{ $svc -}}
-   {{ end -}}
+  {{ range $ns, $pods := $m }}
+  -  Namespace: {{ $ns }}
+    {{ range $pod, $svc := $pods }}
+      - Pod name: {{ $pod }}
+        Services list: {{ $svc -}}
+    {{ end -}}
+  {{ end -}}
 {{- end -}}
 {{- end }}
 {{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
@@ -1,7 +1,6 @@
-
-==============
-Service Mapper
-==============
+===============
+Metadata Mapper
+===============
 {{- if .Errors -}}
 Could not run the service mapper: {{.Errors}}
 {{else}}
@@ -11,18 +10,18 @@ Warnings:
    - {{.}}
 {{ end -}}
 {{- end -}}
-{{- if .Nodes}}
+{{- if .Nodes }}
 {{- range $index, $meta_type := .Nodes }}
 Node detected: {{ $index -}}
 {{- range $m := $meta_type }}
   {{ range $ns, $pods := $m }}
-  -  Namespace: {{ $ns }}
-    {{ range $pod, $svc := $pods }}
-      - Pod name: {{ $pod }}
-        Services list: {{ $svc -}}
-    {{ end -}}
+  - Namespace: {{ $ns -}}
+    {{- range $pod, $svc := $pods }}
+      - Pod: {{ $pod }}
+        Services: {{ $svc -}}
+    {{ end }}
   {{ end -}}
 {{- end -}}
-{{- end }}
 {{- end -}}
-{{- end }}
+{{- end -}}
+{{- end -}}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -18,12 +18,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
-	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -39,10 +38,9 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/flare", makeFlare).Methods("POST")
 	r.HandleFunc("/stop", stopAgent).Methods("POST")
 	r.HandleFunc("/status", getStatus).Methods("GET")
-	r.HandleFunc("/api/v1/metadata/{nodeName}/{podName}", getPodMetadata).Methods("GET")
-	r.HandleFunc("/api/v1/metadata/{nodeName}", getNodeMetadata).Methods("GET")
-	r.HandleFunc("/api/v1/metadata", getAllMetadata).Methods("GET")
-	r.HandleFunc("/api/v1/{check}/events", getCheckLatestEvents).Methods("GET")
+
+	// Install versioned apis
+	v1.Install(r.PathPrefix("/api/v1").Subrouter())
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
@@ -117,138 +115,4 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 	}
 	w.Write([]byte(filePath))
-}
-
-// TODO: complete it
-func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	check := vars["check"]
-	supportedCheck := false
-	for _, c := range EventChecks {
-		if c == check {
-			supportedCheck = true
-			break
-		}
-	}
-	if supportedCheck {
-		// TODO
-		w.Write([]byte("[OK] TODO"))
-	} else {
-		err := fmt.Errorf("[FAIL] TODO")
-		log.Errorf("%s", err.Error())
-		http.Error(w, err.Error(), 404)
-	}
-}
-
-// getPodMetadata is only used when the node agent hits the DCA for the tags list.
-// It returns a list of all the tags that can be directly used in the tagger of the agent.
-func getPodMetadata(w http.ResponseWriter, r *http.Request) {
-	/*
-		Input
-			localhost:5001/api/v1/metadata/localhost/my-nginx-5d69
-		Outputs
-			Status: 200
-			Returns: []string
-			Example: ["kube_service:my-nginx-service"]
-
-			Status: 404
-			Returns: string
-			Example: 404 page not found
-
-			Status: 500
-			Returns: string
-			Example: "no cached metadata found for the pod my-nginx-5d69 on the node localhost"
-	*/
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
-		return
-	}
-	vars := mux.Vars(r)
-	var metaBytes []byte
-	nodeName := vars["nodeName"]
-	podName := vars["podName"]
-	metaList, errMetaList := as.GetPodMetadataNames(nodeName, podName)
-	if errMetaList != nil {
-		log.Errorf("Could not retrieve the metadata of: %s from the cache", podName)
-		http.Error(w, errMetaList.Error(), 500)
-		return
-	}
-
-	metaBytes, err := json.Marshal(metaList)
-	if err != nil {
-		log.Errorf("Could not process the list of services for: %s", podName)
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	if len(metaBytes) != 0 {
-		w.WriteHeader(200)
-		w.Write(metaBytes)
-		return
-	}
-	w.WriteHeader(404)
-	w.Write([]byte(fmt.Sprintf("Could not find associated metadata mapped to the pod: %s on node: %s", podName, nodeName)))
-
-}
-
-// getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.
-func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	nodeName := vars["nodeName"]
-	log.Infof("Fetching metadata map on all pods of the node %s", nodeName)
-	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
-	if errNodes != nil {
-		log.Errorf("Could not collect the service map for %s", nodeName)
-	}
-	slcB, err := json.Marshal(metaList)
-	if err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-
-	if len(slcB) != 0 {
-		w.WriteHeader(200)
-		w.Write(slcB)
-		return
-	}
-	w.WriteHeader(404)
-	return
-}
-
-// getAllMetadata is used by the svcmap command.
-func getAllMetadata(w http.ResponseWriter, r *http.Request) {
-	/*
-		Input
-			localhost:5001/api/v1/metadata
-		Outputs
-			Status: 200
-			Returns: map[string][]string
-			Example: ["Node1":["pod1":["svc1"],"pod2":["svc2"]],"Node2":["pod3":["svc1"]], "Error":"the key KubernetesMetadataMapping/Node3 not found in the cache"]
-
-			Status: 404
-			Returns: string
-			Example: 404 page not found
-
-			Status: 503
-			Returns: map[string]string
-			Example: "["Error":"could not collect the service map for all nodes: List services is not permitted at the cluster scope."]
-	*/
-	log.Info("Computing metadata map on all nodes")
-	metaList, errAPIServer := as.GetMetadataMapBundleOnAllNodes()
-	// If we hit an error at this point, it is because we don't have access to the API server.
-	if errAPIServer != nil {
-		w.WriteHeader(503)
-		log.Errorf("There was an error querying the nodes from the API: %s", errAPIServer.Error())
-	} else {
-		w.WriteHeader(200)
-	}
-	metaListBytes, err := json.Marshal(metaList)
-	if err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	if len(metaListBytes) != 0 {
-		w.Write(metaListBytes)
-		return
-	}
-	w.WriteHeader(404)
-	return
 }

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -26,11 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-// EventChecks are checks that send events and are supported by the DCA
-var EventChecks = []string{
-	"kubernetes",
-}
-
 // SetupHandlers adds the specific handlers for cluster agent endpoints
 func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/version", getVersion).Methods("GET")

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -16,6 +16,7 @@ var eventChecks = []string{
 	"kubernetes",
 }
 
+// Install registers v1 API endpoints
 func Install(r *mux.Router) {
 	r.HandleFunc("metadata/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")
 	r.HandleFunc("metadata/{nodeName}", getNodeMetadata).Methods("GET")

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -18,10 +18,10 @@ var eventChecks = []string{
 
 // Install registers v1 API endpoints
 func Install(r *mux.Router) {
-	r.HandleFunc("metadata/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")
-	r.HandleFunc("metadata/{nodeName}", getNodeMetadata).Methods("GET")
-	r.HandleFunc("metadata", getAllMetadata).Methods("GET")
-	r.HandleFunc("events/{check}", getCheckLatestEvents).Methods("GET")
+	r.HandleFunc("/metadata/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")
+	r.HandleFunc("/metadata/{nodeName}", getNodeMetadata).Methods("GET")
+	r.HandleFunc("/metadata", getAllMetadata).Methods("GET")
+	r.HandleFunc("/events/{check}", getCheckLatestEvents).Methods("GET")
 }
 
 func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package v1
 
 import (

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -10,8 +10,8 @@ import (
 )
 
 func Install(r *mux.Router) {
-	r.HandleFunc("metadata/nodes/{nodeName}/namespaces/{ns}/pods/{podName}", getPodMetadata).Methods("GET")
-	r.HandleFunc("metadata/nodes/{nodeName}", getNodeMetadata).Methods("GET")
+	r.HandleFunc("metadata/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")
+	r.HandleFunc("metadata/{nodeName}", getNodeMetadata).Methods("GET")
 	r.HandleFunc("metadata", getAllMetadata).Methods("GET")
 	r.HandleFunc("{check}/events", getCheckLatestEvents).Methods("GET")
 }
@@ -35,7 +35,7 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	/*
 		Input
-			localhost:5001/api/v1/metadata/nodes/localhost/namespaces/default/pods/my-nginx-5d69
+			localhost:5001/api/v1/metadata/localhost/default/my-nginx-5d69
 		Outputs
 			Status: 200
 			Returns: []string

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -16,7 +16,6 @@ func Install(r *mux.Router) {
 	r.HandleFunc("{check}/events", getCheckLatestEvents).Methods("GET")
 }
 
-// TODO: complete it
 func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	check := vars["check"]
@@ -28,7 +27,6 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if supportedCheck {
-		// TODO
 		w.Write([]byte("[OK] TODO"))
 	} else {
 		err := fmt.Errorf("[FAIL] TODO")
@@ -42,7 +40,7 @@ func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	/*
 		Input
-			localhost:5001/api/v1/metadata/localhost/my-nginx-5d69
+			localhost:5001/api/v1/metadata/nodes/localhost/namespaces/default/pods/my-nginx-5d69
 		Outputs
 			Status: 200
 			Returns: []string

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -19,20 +19,15 @@ func Install(r *mux.Router) {
 func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	check := vars["check"]
-	supportedCheck := false
 	for _, c := range EventChecks {
 		if c == check {
-			supportedCheck = true
-			break
+			w.Write([]byte("[OK] TODO"))
+			return
 		}
 	}
-	if supportedCheck {
-		w.Write([]byte("[OK] TODO"))
-	} else {
-		err := fmt.Errorf("[FAIL] TODO")
-		log.Errorf("%s", err.Error())
-		http.Error(w, err.Error(), http.StatusNotFound)
-	}
+	err := fmt.Errorf("[FAIL] TODO")
+	log.Errorf("%s", err.Error())
+	http.Error(w, err.Error(), http.StatusNotFound)
 }
 
 // getPodMetadata is only used when the node agent hits the DCA for the tags list.

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -5,9 +5,16 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/DataDog/dd-go/log"
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
 )
+
+// EventChecks are checks that send events and are supported by the DCA
+var EventChecks = []string{
+	"kubernetes",
+}
 
 func Install(r *mux.Router) {
 	r.HandleFunc("metadata/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -1,0 +1,152 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/dd-go/log"
+	"github.com/gorilla/mux"
+)
+
+func Install(r *mux.Router) {
+	r.HandleFunc("metadata/nodes/{nodeName}/namespaces/{ns}/pods/{podName}", getPodMetadata).Methods("GET")
+	r.HandleFunc("metadata/nodes/{nodeName}", getNodeMetadata).Methods("GET")
+	r.HandleFunc("metadata", getAllMetadata).Methods("GET")
+	r.HandleFunc("{check}/events", getCheckLatestEvents).Methods("GET")
+}
+
+// TODO: complete it
+func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	check := vars["check"]
+	supportedCheck := false
+	for _, c := range EventChecks {
+		if c == check {
+			supportedCheck = true
+			break
+		}
+	}
+	if supportedCheck {
+		// TODO
+		w.Write([]byte("[OK] TODO"))
+	} else {
+		err := fmt.Errorf("[FAIL] TODO")
+		log.Errorf("%s", err.Error())
+		http.Error(w, err.Error(), http.StatusNotFound)
+	}
+}
+
+// getPodMetadata is only used when the node agent hits the DCA for the tags list.
+// It returns a list of all the tags that can be directly used in the tagger of the agent.
+func getPodMetadata(w http.ResponseWriter, r *http.Request) {
+	/*
+		Input
+			localhost:5001/api/v1/metadata/localhost/my-nginx-5d69
+		Outputs
+			Status: 200
+			Returns: []string
+			Example: ["kube_service:my-nginx-service"]
+
+			Status: 404
+			Returns: string
+			Example: 404 page not found
+
+			Status: 500
+			Returns: string
+			Example: "no cached metadata found for the pod my-nginx-5d69 on the node localhost"
+	*/
+	if err := apiutil.ValidateDCARequest(w, r); err != nil {
+		return
+	}
+	vars := mux.Vars(r)
+	var metaBytes []byte
+	nodeName := vars["nodeName"]
+	podName := vars["podName"]
+	ns := vars["ns"]
+	metaList, errMetaList := as.GetPodMetadataNames(nodeName, ns, podName)
+	if errMetaList != nil {
+		log.Errorf("Could not retrieve the metadata of: %s from the cache", podName)
+		http.Error(w, errMetaList.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	metaBytes, err := json.Marshal(metaList)
+	if err != nil {
+		log.Errorf("Could not process the list of services for: %s", podName)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(metaBytes) != 0 {
+		w.WriteHeader(http.StatusOK)
+		w.Write(metaBytes)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+	w.Write([]byte(fmt.Sprintf("Could not find associated metadata mapped to the pod: %s on node: %s", podName, nodeName)))
+
+}
+
+// getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.
+func getNodeMetadata(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	nodeName := vars["nodeName"]
+	log.Infof("Fetching metadata map on all pods of the node %s", nodeName)
+	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
+	if errNodes != nil {
+		log.Errorf("Could not collect the service map for %s", nodeName)
+	}
+	slcB, err := json.Marshal(metaList)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if len(slcB) != 0 {
+		w.WriteHeader(http.StatusOK)
+		w.Write(slcB)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+	return
+}
+
+// getAllMetadata is used by the svcmap command.
+func getAllMetadata(w http.ResponseWriter, r *http.Request) {
+	/*
+		Input
+			localhost:5001/api/v1/metadata
+		Outputs
+			Status: 200
+			Returns: map[string][]string
+			Example: ["Node1":["pod1":["svc1"],"pod2":["svc2"]],"Node2":["pod3":["svc1"]], "Error":"the key KubernetesMetadataMapping/Node3 not found in the cache"]
+
+			Status: 404
+			Returns: string
+			Example: 404 page not found
+
+			Status: 503
+			Returns: map[string]string
+			Example: "["Error":"could not collect the service map for all nodes: List services is not permitted at the cluster scope."]
+	*/
+	log.Info("Computing metadata map on all nodes")
+	metaList, errAPIServer := as.GetMetadataMapBundleOnAllNodes()
+	// If we hit an error at this point, it is because we don't have access to the API server.
+	if errAPIServer != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		log.Errorf("There was an error querying the nodes from the API: %s", errAPIServer.Error())
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	metaListBytes, err := json.Marshal(metaList)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(metaListBytes) != 0 {
+		w.Write(metaListBytes)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+	return
+}

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// EventChecks are checks that send events and are supported by the DCA
-var EventChecks = []string{
+// eventChecks are checks that send events and are supported by the DCA
+var eventChecks = []string{
 	"kubernetes",
 }
 
@@ -20,13 +20,13 @@ func Install(r *mux.Router) {
 	r.HandleFunc("metadata/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")
 	r.HandleFunc("metadata/{nodeName}", getNodeMetadata).Methods("GET")
 	r.HandleFunc("metadata", getAllMetadata).Methods("GET")
-	r.HandleFunc("{check}/events", getCheckLatestEvents).Methods("GET")
+	r.HandleFunc("events/{check}", getCheckLatestEvents).Methods("GET")
 }
 
 func getCheckLatestEvents(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	check := vars["check"]
-	for _, c := range EventChecks {
+	for _, c := range eventChecks {
 		if c == check {
 			w.Write([]byte("[OK] TODO"))
 			return

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -53,7 +53,7 @@ func getMetadataMap(nodeName string) error {
 	if nodeName == "" {
 		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata", config.Datadog.GetInt("cluster_agent_cmd_port"))
 	} else {
-		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/%s", config.Datadog.GetInt("cluster_agent_cmd_port"), nodeName)
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/nodes/%s", config.Datadog.GetInt("cluster_agent_cmd_port"), nodeName)
 	}
 
 	// Set session token

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -53,7 +53,7 @@ func getMetadataMap(nodeName string) error {
 	if nodeName == "" {
 		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata", config.Datadog.GetInt("cluster_agent_cmd_port"))
 	} else {
-		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/nodes/%s", config.Datadog.GetInt("cluster_agent_cmd_port"), nodeName)
+		urlstr = fmt.Sprintf("https://localhost:%v/api/v1/metadata/%s", config.Datadog.GetInt("cluster_agent_cmd_port"), nodeName)
 	}
 
 	// Set session token

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -47,13 +47,13 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 
 		tagList := utils.NewTagList()
 		if !config.Datadog.GetBool("cluster_agent") {
-			metadataNames, err = apiserver.GetPodMetadataNames(po.Spec.NodeName, po.Metadata.Name)
+			metadataNames, err = apiserver.GetPodMetadataNames(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
 			if err != nil {
 				log.Errorf("Could not fetch cluster level tags for the pod %s: %s", po.Metadata.Name, err.Error())
 				continue
 			}
 		} else {
-			metadataNames, err = c.dcaClient.GetKubernetesMetadataNames(po.Spec.NodeName, po.Metadata.Name)
+			metadataNames, err = c.dcaClient.GetKubernetesMetadataNames(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
 			if err != nil {
 				log.Tracef("Could not pull the metadata map of po %s on node %s from the Datadog Cluster Agent: %s", po.Metadata.Name, po.Spec.NodeName, err.Error())
 			}

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -166,7 +166,7 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]
 	req := &http.Request{
 		Header: *c.clusterAgentAPIRequestHeaders,
 	}
-	// https://host:port/api/v1/metadata/nodes/{nodeName}/pods/{pod-[0-9a-z]+}
+	// https://host:port/api/v1/metadata/nodes/{nodeName}/namespaces/{ns}/pods/{pod-[0-9a-z]+}
 	rawURL := fmt.Sprintf("%s/%s/nodes/%s/namespaces/%s/pods/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
 	req.URL, err = url.Parse(rawURL)
 	if err != nil {

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -166,8 +166,8 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]
 	req := &http.Request{
 		Header: *c.clusterAgentAPIRequestHeaders,
 	}
-	// https://host:port/api/v1/metadata/nodes/{nodeName}/namespaces/{ns}/pods/{pod-[0-9a-z]+}
-	rawURL := fmt.Sprintf("%s/%s/nodes/%s/namespaces/%s/pods/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
+	// https://host:port/api/v1/metadata/{nodeName}/{ns}/{pod-[0-9a-z]+}
+	rawURL := fmt.Sprintf("%s/%s/%s/%s/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
 	req.URL, err = url.Parse(rawURL)
 	if err != nil {
 		return metadataNames, err

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -151,7 +151,7 @@ func getClusterAgentEndpoint() (string, error) {
 
 // GetKubernetesMetadataNames queries the datadog cluster agent to get nodeName/podName registered
 // Kubernetes metadata.
-func (c *DCAClient) GetKubernetesMetadataNames(nodeName, podName string) ([]string, error) {
+func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error) {
 	const dcaMetadataPath = "api/v1/metadata"
 	var metadataNames metadataNames
 	var err error
@@ -159,11 +159,15 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, podName string) ([]stri
 	if c == nil {
 		return nil, fmt.Errorf("cluster agent's client is not properly initialized")
 	}
+	if ns == "" {
+		return nil, fmt.Errorf("namespace is empty")
+	}
+
 	req := &http.Request{
 		Header: *c.clusterAgentAPIRequestHeaders,
 	}
-	// https://host:port /api/v1/metadata/ {nodeName}/ {pod-[0-9a-z]+}
-	rawURL := fmt.Sprintf("%s/%s/%s/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, podName)
+	// https://host:port/api/v1/metadata/nodes/{nodeName}/pods/{pod-[0-9a-z]+}
+	rawURL := fmt.Sprintf("%s/%s/nodes/%s/namespaces/%s/pods/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
 	req.URL, err = url.Parse(rawURL)
 	if err != nil {
 		return metadataNames, err

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -58,14 +58,14 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// path should be like: /api/v1/metadata/nodes/{nodeName}/namespaces/{ns}/pods/{pod-[0-9a-z]+}
+	// path should be like: /api/v1/metadata/{nodeName}/{ns}/{pod-[0-9a-z]+}
 	s := strings.Split(r.URL.Path, "/")
-	if len(s) != 10 {
+	if len(s) != 7 {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Errorf("unexpected len 10 != %d", len(s))
+		log.Errorf("unexpected len 7 != %d", len(s))
 		return
 	}
-	nodeName, ns, podName := s[5], s[7], s[9]
+	nodeName, ns, podName := s[4], s[5], s[6]
 	key := fmt.Sprintf("%s/%s/%s", nodeName, ns, podName)
 
 	d.RLock()

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -303,7 +303,7 @@ func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 	for _, testCase := range testSuite {
 		suite.T().Run("", func(t *testing.T) {
 			svc, err := ca.GetKubernetesMetadataNames(testCase.nodeName, testCase.namespace, testCase.podName)
-			fmt.Println("svc: ", svc)
+			t.Logf("svc: %s", svc)
 			require.Nil(t, err, fmt.Sprintf("%v", err))
 			require.Equal(t, len(testCase.expectedSvc), len(svc))
 			for _, elt := range testCase.expectedSvc {

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -37,12 +37,12 @@ type dummyClusterAgent struct {
 func newDummyClusterAgent() (*dummyClusterAgent, error) {
 	dca := &dummyClusterAgent{
 		responses: map[string][]string{
-			"node1/pod-00001": {"kube_service:svc1"},
-			"node1/pod-00002": {"kube_service:svc1", "kube_service:svc2"},
-			"node1/pod-00003": {"kube_service:svc1"},
-			"node2/pod-00004": {"kube_service:svc2"},
-			"node2/pod-00005": {"kube_service:svc3"},
-			"node2/pod-00006": {},
+			"node1/foo/pod-00001": {"kube_service:svc1"},
+			"node1/foo/pod-00002": {"kube_service:svc1", "kube_service:svc2"},
+			"node1/foo/pod-00003": {"kube_service:svc1"},
+			"node2/bar/pod-00004": {"kube_service:svc2"},
+			"node2/bar/pod-00005": {"kube_service:svc3"},
+			"node2/bar/pod-00006": {},
 		},
 		token: config.Datadog.GetString("cluster_agent.auth_token"),
 	}
@@ -54,18 +54,21 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	token := r.Header.Get("Authorization")
 	if token != fmt.Sprintf("Bearer %s", d.token) {
 		log.Errorf("wrong token %s", token)
-		w.WriteHeader(403)
+		w.WriteHeader(http.StatusForbidden)
 		return
 	}
-	// path should be like: /api/v1/metadata/{nodeName}/{pod-[0-9a-z]+}
+
+	// path should be like: /api/v1/metadata/nodes/{nodeName}/namespaces/{ns}/pods/{pod-[0-9a-z]+}
 	s := strings.Split(r.URL.Path, "/")
-	if len(s) != 6 {
+	if len(s) != 10 {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Errorf("unexpected len 6 != %d", len(s))
+		log.Errorf("unexpected len 10 != %d", len(s))
 		return
 	}
-	nodeName, podName := s[4], s[5]
-	key := fmt.Sprintf("%s/%s", nodeName, podName)
+	fmt.Println(s, len(s))
+
+	nodeName, ns, podName := s[5], s[7], s[9]
+	key := fmt.Sprintf("%s/%s/%s", nodeName, ns, podName)
 
 	d.RLock()
 	defer d.RUnlock()
@@ -259,42 +262,49 @@ func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 	testSuite := []struct {
 		nodeName    string
 		podName     string
+		namespace   string
 		expectedSvc []string
 	}{
 		{
 			nodeName:    "node1",
 			podName:     "pod-00001",
+			namespace:   "foo",
 			expectedSvc: []string{"kube_service:svc1"},
 		},
 		{
 			nodeName:    "node1",
 			podName:     "pod-00002",
+			namespace:   "foo",
 			expectedSvc: []string{"kube_service:svc1", "kube_service:svc2"},
 		},
 		{
 			nodeName:    "node1",
 			podName:     "pod-00003",
+			namespace:   "foo",
 			expectedSvc: []string{"kube_service:svc1"},
 		},
 		{
 			nodeName:    "node2",
 			podName:     "pod-00004",
+			namespace:   "bar",
 			expectedSvc: []string{"kube_service:svc2"},
 		},
 		{
 			nodeName:    "node2",
 			podName:     "pod-00005",
+			namespace:   "bar",
 			expectedSvc: []string{"kube_service:svc3"},
 		},
 		{
 			nodeName:    "node2",
 			podName:     "pod-00006",
+			namespace:   "bar",
 			expectedSvc: []string{},
 		},
 	}
 	for _, testCase := range testSuite {
 		suite.T().Run("", func(t *testing.T) {
-			svc, err := ca.GetKubernetesMetadataNames(testCase.nodeName, testCase.podName)
+			svc, err := ca.GetKubernetesMetadataNames(testCase.nodeName, testCase.namespace, testCase.podName)
 			fmt.Println("svc: ", svc)
 			require.Nil(t, err, fmt.Sprintf("%v", err))
 			require.Equal(t, len(testCase.expectedSvc), len(svc))

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -65,8 +65,6 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("unexpected len 10 != %d", len(s))
 		return
 	}
-	fmt.Println(s, len(s))
-
 	nodeName, ns, podName := s[5], s[7], s[9]
 	key := fmt.Sprintf("%s/%s/%s", nodeName, ns, podName)
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -127,14 +127,17 @@ func (c *APIClient) connect() error {
 	return nil
 }
 
-// MetadataMapperBundle maps the podNames to the metadata they are associated with.
-// ex: services.
-// It is updated by mapServices in services.go
+// MetadataMapperBundle maps Pod names to associated metadata like the names of
+// the Services targeting the Pod.
+//
+// The data is stored in the following schema:
 // {
 // 	"namespace": [
 // 		"pod": [ "svc1", "svc2", "svc3" ]
 // 	]
 // }
+//
+// It is updated by mapServices in services.go.
 type MetadataMapperBundle struct {
 	Services map[string]map[string][]string `json:"services,omitempty"`
 	m        sync.RWMutex

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -130,15 +130,19 @@ func (c *APIClient) connect() error {
 // MetadataMapperBundle maps the podNames to the metadata they are associated with.
 // ex: services.
 // It is updated by mapServices in services.go
-// example: [ "pod" : ["svc1","svc2"]]
+// {
+// 	"namespace": [
+// 		"pod": [ "svc1", "svc2", "svc3" ]
+// 	]
+// }
 type MetadataMapperBundle struct {
-	PodNameToService map[string][]string `json:"services,omitempty"`
-	m                sync.RWMutex
+	Services map[string]map[string][]string `json:"services,omitempty"`
+	m        sync.RWMutex
 }
 
 func newMetadataMapperBundle() *MetadataMapperBundle {
 	return &MetadataMapperBundle{
-		PodNameToService: make(map[string][]string),
+		Services: make(map[string]map[string][]string),
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -127,25 +127,17 @@ func (c *APIClient) connect() error {
 	return nil
 }
 
-// MetadataMapperBundle maps Pod names to associated metadata like the names of
-// the Services targeting the Pod.
-//
-// The data is stored in the following schema:
-// {
-// 	"namespace": [
-// 		"pod": [ "svc1", "svc2", "svc3" ]
-// 	]
-// }
+// MetadataMapperBundle maps pod names to associated metadata.
 //
 // It is updated by mapServices in services.go.
 type MetadataMapperBundle struct {
-	Services map[string]map[string][]string `json:"services,omitempty"`
+	Services ServicesMapper `json:"services,omitempty"`
 	m        sync.RWMutex
 }
 
 func newMetadataMapperBundle() *MetadataMapperBundle {
 	return &MetadataMapperBundle{
-		Services: make(map[string]map[string][]string),
+		Services: make(ServicesMapper),
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -9,7 +9,6 @@ package apiserver
 
 import (
 	"errors"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -24,10 +23,7 @@ var (
 type APIClient struct{}
 
 // MetadataMapperBundle maps the podNames to the metadata they are associated with.
-type MetadataMapperBundle struct {
-	Services map[string]map[string][]string
-	m        sync.RWMutex
-}
+type MetadataMapperBundle struct{}
 
 // GetPodMetadataNames is used when the API endpoint of the DCA to get the services of a pod is hit.
 func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -25,12 +25,12 @@ type APIClient struct{}
 
 // MetadataMapperBundle maps the podNames to the metadata they are associated with.
 type MetadataMapperBundle struct {
-	PodNameToService map[string][]string
-	m                sync.RWMutex
+	Services map[string]map[string][]string
+	m        sync.RWMutex
 }
 
 // GetPodMetadataNames is used when the API endpoint of the DCA to get the services of a pod is hit.
-func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
+func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 	log.Errorf("GetPodMetadataNames not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }

--- a/pkg/util/kubernetes/apiserver/metadata.go
+++ b/pkg/util/kubernetes/apiserver/metadata.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GetPodMetadataNames is used when the API endpoint of the DCA to get the metadata of a pod is hit.
-func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
+func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 	var metaList []string
 	cacheKey := cache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
 
@@ -32,7 +32,7 @@ func GetPodMetadataNames(nodeName string, podName string) ([]string, error) {
 	}
 	// The list of metadata collected in the metaBundle is extensible and is handled here.
 	// If new cluster level tags need to be collected by the agent, only this needs to be modified.
-	serviceList, foundServices := metaBundle.ServicesForPod(podName)
+	serviceList, foundServices := metaBundle.ServicesForPod(ns, podName)
 	if !foundServices {
 		log.Tracef("no cached services list found for the pod %s on the node %s", podName, nodeName)
 		return nil, nil

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -57,14 +57,14 @@ func (m ServicesMapper) Map(nodeName string, pods v1.PodList, endpointList v1.En
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Status.PodIP != "" {
-			if _, ok := podToIp[pod.Namespace]; !ok {
-				podToIp[pod.Namespace] = make(map[string]string)
-			}
-			podToIp[pod.Namespace][pod.Name] = pod.Status.PodIP
-		} else {
+		if pod.Status.PodIP == "" {
 			log.Debugf("PodIP is empty, ignoring pod %s in namespace %s", pod.Name, pod.Namespace)
+			continue
 		}
+		if _, ok := podToIp[pod.Namespace]; !ok {
+			podToIp[pod.Namespace] = make(map[string]string)
+		}
+		podToIp[pod.Namespace][pod.Name] = pod.Status.PodIP
 	}
 	for _, svc := range endpointList.Items {
 		for _, endpointsSubsets := range svc.Subsets {

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -63,7 +63,7 @@ func (m ServicesMapper) Map(nodeName string, pods v1.PodList, endpointList v1.En
 			}
 			podToIp[pod.Namespace][pod.Name] = pod.Status.PodIP
 		} else {
-			log.Debugf("PodIP is empty, ignoring pod %s in namespace", pod.Name, pod.Namespace)
+			log.Debugf("PodIP is empty, ignoring pod %s in namespace %s", pod.Name, pod.Namespace)
 		}
 	}
 	for _, svc := range endpointList.Items {

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -14,13 +14,22 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+/*
+Service mapper for a node
+{
+	"foo": [
+		"name": [ "svc1" "svc2" "svc3" ]
+	]
+}
+*/
+
 // mapServices maps each pod (endpoint) to the metadata associated with it.
 // It is on a per node basis to avoid mixing up the services pods are actually connected to if all pods of different nodes share a similar subnet, therefore sharing a similar IP.
 func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {
 	metaBundle.m.Lock()
 	defer metaBundle.m.Unlock()
-	ipToEndpoints := make(map[string][]string) // maps the IP address from an endpoint (pod) to associated services ex: "10.10.1.1" : ["service1","service2"]
-	podToIp := make(map[string]string)         // maps the pods of the currently evaluated node to their IP.
+	ipToEndpoints := make(map[string][]string)    // maps the IP address from an endpoint (pod) to associated services ex: "10.10.1.1" : ["service1","service2"]
+	podToIp := make(map[string]map[string]string) // maps the pods of the currently evaluated node to their IP.
 
 	if pods.Items == nil {
 		return fmt.Errorf("empty podlist received for nodeName %q", nodeName)
@@ -31,7 +40,10 @@ func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.Pod
 
 	for _, pod := range pods.Items {
 		if pod.Status.PodIP != "" {
-			podToIp[pod.Name] = pod.Status.PodIP
+			if podToIp[pod.Namespace] == nil {
+				podToIp[pod.Namespace] = make(map[string]string)
+			}
+			podToIp[pod.Namespace][pod.Name] = pod.Status.PodIP
 		}
 	}
 	for _, svc := range endpointList.Items {
@@ -47,20 +59,26 @@ func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.Pod
 			}
 		}
 	}
-	for name, ip := range podToIp {
-		if svc, found := ipToEndpoints[ip]; found {
-			metaBundle.PodNameToService[name] = svc
+	for ns, pods := range podToIp {
+		for name, ip := range pods {
+			if svc, found := ipToEndpoints[ip]; found {
+				if metaBundle.Services[ns] == nil {
+					metaBundle.Services[ns] = make(map[string][]string)
+				}
+				metaBundle.Services[ns][name] = svc
+			}
 		}
 	}
-	log.Tracef("The services matched %q", fmt.Sprintf("%s", metaBundle.PodNameToService))
+	log.Tracef("The services matched %q", fmt.Sprintf("%s", metaBundle.Services))
 	return nil
 }
 
-// ServicesForPod returns the services mapped to a given pod.
+// ServicesForPod returns the services mapped to a given pod and namespace.
 // If nothing is found, the boolean is false. This call is thread-safe.
-func (metaBundle *MetadataMapperBundle) ServicesForPod(podName string) ([]string, bool) {
+func (metaBundle *MetadataMapperBundle) ServicesForPod(ns, podName string) ([]string, bool) {
 	metaBundle.m.RLock()
-	svc, found := metaBundle.PodNameToService[podName]
-	metaBundle.m.RUnlock()
+	defer metaBundle.m.RUnlock()
+
+	svc, found := metaBundle.Services[ns][podName]
 	return svc, found
 }

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -14,15 +14,6 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-/*
-Service mapper for a node
-{
-	"foo": [
-		"name": [ "svc1" "svc2" "svc3" ]
-	]
-}
-*/
-
 // mapServices maps each pod (endpoint) to the metadata associated with it.
 // It is on a per node basis to avoid mixing up the services pods are actually connected to if all pods of different nodes share a similar subnet, therefore sharing a similar IP.
 func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 type podTest struct {
-	ip   string
-	name string
+	ip        string
+	name      string
+	namespace string
 }
 
 type serviceTest struct {
@@ -52,7 +53,7 @@ func createPodList(listPodStructs []podTest) v1.PodList {
 	for _, ps := range listPodStructs {
 		var pod v1.Pod
 		pod.Status = v1.PodStatus{}
-		pod.ObjectMeta = metav1.ObjectMeta{}
+		pod.ObjectMeta = metav1.ObjectMeta{Namespace: ps.namespace}
 		pod.Status.PodIP = ps.ip
 		pod.Name = ps.name
 		podlist.Items = append(podlist.Items, pod)
@@ -74,15 +75,16 @@ func TestMapServices(t *testing.T) {
 		node            v1.Node
 		pods            []podTest
 		services        []serviceTest
-		expectedMapping map[string][]string
+		expectedMapping map[string]map[string][]string
 	}{
 		{
 			caseName: "1 node, 1 pod, 1 service",
 			node:     createNode("firstNode"),
 			pods: []podTest{
 				{
-					ip:   "1.1.1.1",
-					name: "pod1_name",
+					ip:        "1.1.1.1",
+					name:      "pod1_name",
+					namespace: "foo",
 				},
 			},
 			services: []serviceTest{
@@ -91,8 +93,38 @@ func TestMapServices(t *testing.T) {
 					podIps:  []string{"1.1.1.1"},
 				},
 			},
-			expectedMapping: map[string][]string{
-				"pod1_name": {"svc1"},
+			expectedMapping: map[string]map[string][]string{
+				"foo": {"pod1_name": {"svc1"}},
+			},
+		},
+		{
+			caseName: "1 node, 2 pods with same name, 2 services",
+			node:     createNode("firstNode"),
+			pods: []podTest{
+				{
+					ip:        "1.1.1.1",
+					name:      "pod_name",
+					namespace: "foo",
+				},
+				{
+					ip:        "2.2.2.2",
+					name:      "pod_name",
+					namespace: "bar",
+				},
+			},
+			services: []serviceTest{
+				{
+					svcName: "svc1",
+					podIps:  []string{"1.1.1.1"},
+				},
+				{
+					svcName: "svc2",
+					podIps:  []string{"2.2.2.2"},
+				},
+			},
+			expectedMapping: map[string]map[string][]string{
+				"foo": {"pod_name": {"svc1"}},
+				"bar": {"pod_name": {"svc2"}},
 			},
 		},
 		{
@@ -100,20 +132,24 @@ func TestMapServices(t *testing.T) {
 			node:     createNode("firstNode"),
 			pods: []podTest{
 				{
-					ip:   "2.2.2.2",
-					name: "pod2_name",
+					ip:        "2.2.2.2",
+					name:      "pod2_name",
+					namespace: "foo",
 				},
 				{
-					ip:   "3.3.3.3",
-					name: "pod3_name",
+					ip:        "3.3.3.3",
+					name:      "pod3_name",
+					namespace: "foo",
 				},
 				{
-					ip:   "4.4.4.4",
-					name: "pod4_name",
+					ip:        "4.4.4.4",
+					name:      "pod4_name",
+					namespace: "foo",
 				},
 				{
-					ip:   "5.5.5.5",
-					name: "pod5_name",
+					ip:        "5.5.5.5",
+					name:      "pod5_name",
+					namespace: "foo",
 				},
 			},
 			services: []serviceTest{
@@ -137,18 +173,26 @@ func TestMapServices(t *testing.T) {
 					},
 				},
 			},
-			expectedMapping: map[string][]string{
-				"pod2_name": {"svc2", "svc3", "svc4"},
-				"pod3_name": {"svc4"},
-				"pod5_name": {"svc3"},
+			expectedMapping: map[string]map[string][]string{
+				"foo": {
+					"pod2_name": {"svc2", "svc3", "svc4"},
+					"pod3_name": {"svc4"},
+					"pod5_name": {"svc3"},
+				},
 			},
 		},
 	}
-	expectedAllPodNameToService := map[string][]string{
-		"pod1_name": {"svc1"},
-		"pod2_name": {"svc2", "svc3", "svc4"},
-		"pod3_name": {"svc4"},
-		"pod5_name": {"svc3"},
+	expectedAllPodNameToService := map[string]map[string][]string{
+		"foo": {
+			"pod_name":  {"svc1"},
+			"pod1_name": {"svc1"},
+			"pod2_name": {"svc2", "svc3", "svc4"},
+			"pod3_name": {"svc4"},
+			"pod5_name": {"svc3"},
+		},
+		"bar": {
+			"pod_name": {"svc2"},
+		},
 	}
 	allCasesBundle := newMetadataMapperBundle()
 	allBundleMu := &sync.RWMutex{}
@@ -159,7 +203,7 @@ func TestMapServices(t *testing.T) {
 			nodeName := testCase.node.Name
 			epList := createSvcList(nodeName, testCase.services)
 			testCaseBundle.mapServices(nodeName, podList, epList)
-			assert.Equal(t, testCase.expectedMapping, testCaseBundle.PodNameToService)
+			assert.Equal(t, testCase.expectedMapping, testCaseBundle.Services)
 			allBundleMu.Lock()
 			allCasesBundle.mapServices(nodeName, podList, epList)
 			allBundleMu.Unlock()
@@ -167,5 +211,5 @@ func TestMapServices(t *testing.T) {
 	}
 	allBundleMu.RLock()
 	defer allBundleMu.RUnlock()
-	assert.Equal(t, expectedAllPodNameToService, allCasesBundle.PodNameToService)
+	assert.Equal(t, expectedAllPodNameToService, allCasesBundle.Services)
 }

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -75,7 +75,7 @@ func TestMapServices(t *testing.T) {
 		node            v1.Node
 		pods            []podTest
 		services        []serviceTest
-		expectedMapping map[string]map[string][]string
+		expectedMapping ServicesMapper
 	}{
 		{
 			caseName: "1 node, 1 pod, 1 service",
@@ -93,7 +93,7 @@ func TestMapServices(t *testing.T) {
 					podIps:  []string{"1.1.1.1"},
 				},
 			},
-			expectedMapping: map[string]map[string][]string{
+			expectedMapping: ServicesMapper{
 				"foo": {"pod1_name": {"svc1"}},
 			},
 		},
@@ -122,7 +122,7 @@ func TestMapServices(t *testing.T) {
 					podIps:  []string{"2.2.2.2"},
 				},
 			},
-			expectedMapping: map[string]map[string][]string{
+			expectedMapping: ServicesMapper{
 				"foo": {"pod_name": {"svc1"}},
 				"bar": {"pod_name": {"svc2"}},
 			},
@@ -173,7 +173,7 @@ func TestMapServices(t *testing.T) {
 					},
 				},
 			},
-			expectedMapping: map[string]map[string][]string{
+			expectedMapping: ServicesMapper{
 				"foo": {
 					"pod2_name": {"svc2", "svc3", "svc4"},
 					"pod3_name": {"svc4"},
@@ -182,7 +182,7 @@ func TestMapServices(t *testing.T) {
 			},
 		},
 	}
-	expectedAllPodNameToService := map[string]map[string][]string{
+	expectedAllPodNameToService := ServicesMapper{
 		"foo": {
 			"pod_name":  {"svc1"},
 			"pod1_name": {"svc1"},

--- a/releasenotes/notes/add-namespace-to-service-mapper-c550314965636890.yaml
+++ b/releasenotes/notes/add-namespace-to-service-mapper-c550314965636890.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    The service mapper now groups the mappings of pods to services by namespace.
+    This prevents `kube_service` tags from being erroneously applied to metrics
+    for a pod not targeted by a service but has the same name as a pod in a different
+    namespace targeted by that service.

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -206,6 +206,9 @@ func (suite *testSuite) TestServiceMapper() {
 	require.Nil(suite.T(), err)
 
 	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+		},
 		Spec: v1.PodSpec{
 			NodeName: node.Name,
 			Containers: []v1.Container{
@@ -284,7 +287,7 @@ func (suite *testSuite) TestServiceMapper() {
 	err = apiClient.ClusterMetadataMapping()
 	require.Nil(suite.T(), err)
 
-	metadataNames, err := apiserver.GetPodMetadataNames(node.Name, pod.Name)
+	metadataNames, err := apiserver.GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
 	require.Nil(suite.T(), err)
 	assert.Len(suite.T(), metadataNames, 1)
 	assert.Contains(suite.T(), metadataNames, "kube_service:nginx-1")
@@ -301,7 +304,7 @@ func (suite *testSuite) TestServiceMapper() {
 	err = apiClient.ClusterMetadataMapping()
 	require.Nil(suite.T(), err)
 
-	metadataNames, err = apiserver.GetPodMetadataNames(node.Name, pod.Name)
+	metadataNames, err = apiserver.GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
 	require.Nil(suite.T(), err)
 	assert.Len(suite.T(), metadataNames, 2)
 	assert.Contains(suite.T(), metadataNames, "kube_service:nginx-1")
@@ -312,7 +315,7 @@ func (suite *testSuite) TestServiceMapper() {
 	list := fullmapper["Nodes"]
 	assert.Contains(suite.T(), list, "ip-172-31-119-125")
 	fullMap := list.(map[string]*apiserver.MetadataMapperBundle)
-	services, found := fullMap["ip-172-31-119-125"].ServicesForPod("nginx")
+	services, found := fullMap["ip-172-31-119-125"].ServicesForPod(metav1.NamespaceDefault, "nginx")
 	assert.True(suite.T(), found)
 	assert.Contains(suite.T(), services, "nginx-1")
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds `namespace` to `api/v1/metadata` routes of the DCA.

```bash
$ datadog-cluster-agent metamap

===============
Metadata Mapper
===============
Warnings:
   - Node gke-devon-test-default-pool-068cb9c0-sf1w could not be added to the service map bundle: the key agent/KubernetesMetadataMapping/gke-devon-test-default-pool-068cb9c0-sf1w was not found in the cache

   - Node gke-devon-test-default-pool-068cb9c0-wntj could not be added to the service map bundle: the key agent/KubernetesMetadataMapping/gke-devon-test-default-pool-068cb9c0-wntj was not found in the cache

Node detected: gke-devon-test-default-pool-068cb9c0-sf1w
Node detected: gke-devon-test-default-pool-068cb9c0-wntj
```

```bash
$ datadog-cluster-agent metamap

===============
Metadata Mapper
===============

Node detected: gke-devon-test-default-pool-068cb9c0-sf1w
  
  - Namespace: kube-system
      - Pod: kube-dns-788979dc8f-hzbj5
        Services: [kube-dns]
      - Pod: kube-state-metrics-5587867c9f-xllnm
        Services: [kube-state-metrics]
      - Pod: kubernetes-dashboard-598d75cb96-5khmj
        Services: [kubernetes-dashboard]
  
Node detected: gke-devon-test-default-pool-068cb9c0-wntj
  
  - Namespace: default
      - Pod: datadog-cluster-agent-7dd6bd75bf-vgflp
        Services: [datadog-cluster-hpa dca]
  
  - Namespace: kube-system
      - Pod: heapster-v1.5.2-6d59ff54cf-g7q4h
        Services: [heapster]
      - Pod: kube-dns-788979dc8f-q9qkt
        Services: [kube-dns]
      - Pod: l7-default-backend-5d5b9874d5-b2lts
        Services: [default-http-backend]
      - Pod: metrics-server-v0.2.1-7486f5bd67-v827f
        Services: [metrics-server]

```
### Motivation

Pod names are unique inside a given namespace, not a given cluster.

The servicemapper / DCA identifies pods per (nodeName, podName) pair, without prefixing this podName by the namespace. Although frequency is low, that could lead to hard to debug issues.

### To Do

- [x] Sanity check DCA CLI