### PR TITLE
Add %%hostname%% AD tag for docker listener

### DIFF
--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -13,6 +13,7 @@ type dummyService struct {
 	Hosts         map[string]string
 	Ports         []listeners.ContainerPort
 	Pid           int
+	Hostname      string
 }
 
 // GetID returns the service ID
@@ -43,4 +44,9 @@ func (s *dummyService) GetTags() ([]string, error) {
 // GetPid return a dummy pid
 func (s *dummyService) GetPid() (int, error) {
 	return s.Pid, nil
+}
+
+// GetHostname return a dummy hostname
+func (s *dummyService) GetHostname() (string, error) {
+	return s.Hostname, nil
 }

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -322,7 +322,7 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 func getPid(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	pid, err := svc.GetPid()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
 	}
 	return []byte(strconv.Itoa(pid)), nil
 }
@@ -332,7 +332,7 @@ func getPid(tplVar []byte, svc listeners.Service) ([]byte, error) {
 func getHostname(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	name, err := svc.GetHostname()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get hostname for service %s, skipping config - %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to get hostname for service %s, skipping config - %s", svc.GetID(), err)
 	}
 	return []byte(name), nil
 }

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -26,10 +26,11 @@ type variableGetter func(key []byte, svc listeners.Service) ([]byte, error)
 
 var (
 	templateVariables = map[string]variableGetter{
-		"host": getHost,
-		"pid":  getPid,
-		"port": getPort,
-		"env":  getEnvvar,
+		"host":     getHost,
+		"pid":      getPid,
+		"port":     getPort,
+		"env":      getEnvvar,
+		"hostname": getHostname,
 	}
 )
 
@@ -324,6 +325,16 @@ func getPid(tplVar []byte, svc listeners.Service) ([]byte, error) {
 		return nil, fmt.Errorf("Failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
 	}
 	return []byte(strconv.Itoa(pid)), nil
+}
+
+// getHostname returns the hostname of the service, to be used
+// when the IP is unavailable or erroneous
+func getHostname(tplVar []byte, svc listeners.Service) ([]byte, error) {
+	name, err := svc.GetHostname()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get hostname for service %s, skipping config - %s", svc.GetID(), err)
+	}
+	return []byte(name), nil
 }
 
 // getEnvvar returns a system environment variable if found

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -363,7 +363,7 @@ func TestResolve(t *testing.T) {
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
-				Hostname:      "i.m.here",
+				Hostname:      "imhere",
 			},
 			tpl: integration.Config{
 				Name:          "cpu",
@@ -373,7 +373,7 @@ func TestResolve(t *testing.T) {
 			out: integration.Config{
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
-				Instances:     []integration.Data{integration.Data("test: i.m.here")},
+				Instances:     []integration.Data{integration.Data("test: imhere")},
 			},
 		},
 		//// other tags testing

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -357,6 +357,25 @@ func TestResolve(t *testing.T) {
 			},
 			errorString: "envvar name is missing, skipping service a5901276aed1",
 		},
+		//// hostname
+		{
+			testName: "simple %%hostname%%",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hostname:      "i.m.here",
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("test: %%hostname%%")},
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("test: i.m.here")},
+			},
+		},
 		//// other tags testing
 		{
 			testName: "simple %%pid%%",

--- a/pkg/autodiscovery/listeners/README.md
+++ b/pkg/autodiscovery/listeners/README.md
@@ -33,8 +33,8 @@ The `KubeletListener` relies on the Kubelet API. We're listening on changes on t
 
 ### Template variable support
 
-| Listener | AD identifiers | Host | Port | Tag | Pid | Env
+| Listener | AD identifiers | Host | Port | Tag | Pid | Env | Hostname
 |---|---|---|---|---|---|---|
-| Docker | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| ECS | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
-| Kubelet | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Docker | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| ECS | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| Kubelet | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -493,12 +493,7 @@ func (s *DockerService) GetHostname() (string, error) {
 		return "", fmt.Errorf("empty hostname for container %s", string(s.ID)[:12])
 	}
 
-	if cInspect.Config.Domainname == "" {
-		s.Hostname = cInspect.Config.Hostname
-	} else {
-		s.Hostname = fmt.Sprintf("%s.%s", cInspect.Config.Hostname, cInspect.Config.Domainname)
-	}
-
+	s.Hostname = cInspect.Config.Hostname
 	return s.Hostname, nil
 }
 

--- a/pkg/autodiscovery/listeners/docker_test.go
+++ b/pkg/autodiscovery/listeners/docker_test.go
@@ -474,3 +474,72 @@ func TestParseDockerPort(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHostname(t *testing.T) {
+	cId := "12345678901234567890123456789012"
+	cBase := types.ContainerJSONBase{
+		ID:    cId,
+		Image: "test",
+	}
+
+	testCases := []struct {
+		hostname      string
+		domainname    string
+		expected      string
+		expectedError error
+	}{
+		{
+			hostname:      "",
+			domainname:    "",
+			expected:      "",
+			expectedError: errors.New("empty hostname for container 123456789012"),
+		},
+		{
+			hostname:      "host",
+			domainname:    "",
+			expected:      "host",
+			expectedError: nil,
+		},
+		{
+			hostname:      "host",
+			domainname:    "domain",
+			expected:      "host.domain",
+			expectedError: nil,
+		},
+		{
+			hostname:      "",
+			domainname:    "domain",
+			expected:      "",
+			expectedError: errors.New("empty hostname for container 123456789012"),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s.%s", i, tc.hostname, tc.domainname), func(t *testing.T) {
+			cj := types.ContainerJSON{
+				ContainerJSONBase: &cBase,
+				Config: &container.Config{
+					Hostname:   tc.hostname,
+					Domainname: tc.domainname,
+				},
+			}
+			// add cj to the cache so svc.GetPorts finds it
+			cacheKey := docker.GetInspectCacheKey(cId, false)
+			cache.Cache.Set(cacheKey, cj, 10*time.Second)
+
+			svc := DockerService{
+				ID: ID(cId),
+			}
+
+			name, err := svc.GetHostname()
+			assert.Equal(t, tc.expected, name)
+
+			if tc.expectedError == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+			}
+
+		})
+	}
+}

--- a/pkg/autodiscovery/listeners/docker_test.go
+++ b/pkg/autodiscovery/listeners/docker_test.go
@@ -503,7 +503,7 @@ func TestGetHostname(t *testing.T) {
 		{
 			hostname:      "host",
 			domainname:    "domain",
-			expected:      "host.domain",
+			expected:      "host",
 			expectedError: nil,
 		},
 		{

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -217,3 +217,8 @@ func (s *ECSService) GetTags() ([]string, error) {
 func (s *ECSService) GetPid() (int, error) {
 	return -1, ErrNotSupported
 }
+
+// GetHostname returns nil and an error because port is not supported in Fargate-based ECS
+func (s *ECSService) GetHostname() (string, error) {
+	return "", ErrNotSupported
+}

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -244,3 +244,8 @@ func (s *PodContainerService) GetPorts() ([]ContainerPort, error) {
 func (s *PodContainerService) GetTags() ([]string, error) {
 	return tagger.Tag(string(s.ID), tagger.IsFullCardinality())
 }
+
+// GetHostname returns nil and an error because port is not supported in Kubelet
+func (s *PodContainerService) GetHostname() (string, error) {
+	return "", ErrNotSupported
+}

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -30,6 +30,7 @@ type Service interface {
 	GetPorts() ([]ContainerPort, error)   // network ports
 	GetTags() ([]string, error)           // tags
 	GetPid() (int, error)                 // process identifier
+	GetHostname() (string, error)         // hostname.domainname for the entity
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/releasenotes/notes/docker-ad-hostname-9ef32e6777bdd439.yaml
+++ b/releasenotes/notes/docker-ad-hostname-9ef32e6777bdd439.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Autodiscovery now supports the %%hostname%% tag on the docker listener
+    This tag will resolve to the containers' hostname.domainname value if
+    present in the container inspect. It is useful if the container IP
+    is not available or erroneous.

--- a/releasenotes/notes/docker-ad-hostname-9ef32e6777bdd439.yaml
+++ b/releasenotes/notes/docker-ad-hostname-9ef32e6777bdd439.yaml
@@ -2,6 +2,6 @@
 features:
   - |
     Autodiscovery now supports the %%hostname%% tag on the docker listener
-    This tag will resolve to the containers' hostname.domainname value if
-    present in the container inspect. It is useful if the container IP
-    is not available or erroneous.
+    This tag will resolve to the containers' hostname value if present in
+    the container inspect. It is useful if the container IP is not available
+    or erroneous.


### PR DESCRIPTION
### What does this PR do?

Autodiscovery now supports the %%hostname%% tag on the docker listener.

This tag will resolve to the containers' hostname value if present in the container inspect. It is useful if the container IP is not available or erroneous.

Sister doc PR: https://github.com/DataDog/documentation/pull/2680