### PR TITLE
Add ECS pause containers to the default docker exclusion list

### DIFF
--- a/pkg/util/docker/filter.go
+++ b/pkg/util/docker/filter.go
@@ -25,6 +25,7 @@ const (
 	pauseContainerGCR        = `image:(.*)gcr\.io(/google_containers/|/)pause(.*)`
 	pauseContainerOpenshift  = "image:openshift/origin-pod"
 	pauseContainerKubernetes = "image:kubernetes/pause"
+	pauseContainerECS        = "image:amazon/amazon-ecs-pause"
 	// pauseContainerAzure regex matches:
 	// - k8s-gcrio.azureedge.net/pause-amd64
 	// - gcrio.azureedge.net/google_containers/pause-amd64
@@ -92,7 +93,13 @@ func NewFilterFromConfig() (*Filter, error) {
 	blacklist := config.Datadog.GetStringSlice("ac_exclude")
 
 	if config.Datadog.GetBool("exclude_pause_container") {
-		blacklist = append(blacklist, pauseContainerGCR, pauseContainerOpenshift, pauseContainerKubernetes, pauseContainerAzure)
+		blacklist = append(blacklist,
+			pauseContainerGCR,
+			pauseContainerOpenshift,
+			pauseContainerKubernetes,
+			pauseContainerAzure,
+			pauseContainerECS,
+		)
 	}
 	return NewFilter(whitelist, blacklist)
 }

--- a/releasenotes/notes/docker-ecs-pause-container-04bda11f1ceb87e1.yaml
+++ b/releasenotes/notes/docker-ecs-pause-container-04bda11f1ceb87e1.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Added ECS pause containers to the default docker exclusion list


### PR DESCRIPTION
### What does this PR do?

When running ECS tasks in [awsvpc mode](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html), the ecs-agent creates pause containers with the `amazon/amazon-ecs-pause` image name to hold the network interface. Adding them to the default docker container blacklist
