### PR TITLE
Adding logging in dogstatsd-uds when not in host proc mode

### DIFF
--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -56,6 +56,12 @@ func processUDSOrigin(ancillary []byte) (string, error) {
 	if err != nil {
 		return NoOrigin, err
 	}
+
+	if cred.Pid == 0 {
+		return NoOrigin, fmt.Errorf("matched PID for the process is 0, it belongs " +
+			"probably to another namespace. Is the agent in host PID mode?")
+	}
+
 	container, err := getContainerForPID(cred.Pid)
 	if err != nil {
 		return NoOrigin, err

--- a/releasenotes/notes/dogstatsd-uds-log-when-not-in-host-proc-mode-9db3cd23d0abcb3b.yaml
+++ b/releasenotes/notes/dogstatsd-uds-log-when-not-in-host-proc-mode-9db3cd23d0abcb3b.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Adding logging for when the agent fails to detect the origin of a packet in dogstatsd socket mode because of namespace issues.


### PR DESCRIPTION
### What does this PR do?

Adding logging for when the agent fails to detect the origin of a packet in dogstatsd socket mode because of namespace issues. Most probably the user forgot to run the agent container in host PID mode.

### Motivation
Support case. Prior to this, the user would have no clue that host PID mode would be missing, as no logs would be shown.