### PR TITLE
[jmxfetch] bumping to 0.20.1

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -9,8 +9,8 @@ jmxfetch_version = ENV['JMXFETCH_VERSION']
 jmxfetch_hash = ENV['JMXFETCH_HASH']
 
 if jmxfetch_version.nil? || jmxfetch_version.empty?
-  jmxfetch_version = '0.20.0'
-  jmxfetch_hash = "5aad61dfec602ad536f855a12e6c47289515a10808422fc984a57c6a59964c04"
+  jmxfetch_version = '0.20.1'
+  jmxfetch_hash = "076dc742d158e888bfff914e022bd1e640bde2b27735e27ed47799dd89058752"
 end
 
 default_version jmxfetch_version

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	jmxJarName                        = "jmxfetch-0.20.0-jar-with-dependencies.jar"
+	jmxJarName                        = "jmxfetch-0.20.1-jar-with-dependencies.jar"
 	jmxMainClass                      = "org.datadog.jmxfetch.App"
 	defaultJmxCommand                 = "collect"
 	defaultJvmMaxMemoryAllocation     = " -Xmx200m"

--- a/releasenotes/notes/jmxfetch_0.20.1_bump-f9996230f3f7585a.yaml
+++ b/releasenotes/notes/jmxfetch_0.20.1_bump-f9996230f3f7585a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    JMXFetch upgraded to 0.20.1; ships tagging bugfixes.


### PR DESCRIPTION
### What does this PR do?

Fix in jmxfetch 0.20.1 required for https://github.com/DataDog/datadog-agent/pull/1889.

### Motivation

Broken tagging with JMXFetch 0.20.0 and agent 6.

### Additional Notes

Anything else we should know when reviewing?
