### PR TITLE
Add options to avoid some kind of payload from being sent to Datadog

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -87,7 +87,7 @@ var checkCmd = &cobra.Command{
 			return err
 		}
 
-		s := &serializer.Serializer{Forwarder: common.Forwarder}
+		s := serializer.NewSerializer(common.Forwarder)
 		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, checkCmdFlushInterval)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 		cs := collector.GetChecksByNameForConfigs(checkName, common.AC.GetAllConfigs())

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -165,7 +165,7 @@ func StartAgent() error {
 	log.Debugf("Forwarder started")
 
 	// setup the aggregator
-	s := &serializer.Serializer{Forwarder: common.Forwarder}
+	s := serializer.NewSerializer(common.Forwarder)
 	agg := aggregator.InitAggregator(s, hostname)
 	agg.AddAgentStartupEvent(version.AgentVersion)
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -143,7 +143,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 	f := forwarder.NewDefaultForwarder(keysPerDomain)
 	f.Start()
-	s := &serializer.Serializer{Forwarder: f}
+	s := serializer.NewSerializer(f)
 
 	aggregatorInstance := aggregator.InitAggregator(s, hostname)
 	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.DCAVersion))

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -136,7 +136,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 	f := forwarder.NewDefaultForwarder(keysPerDomain)
 	f.Start()
-	s := &serializer.Serializer{Forwarder: f}
+	s := serializer.NewSerializer(f)
 
 	hname, err := util.GetHostname()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,6 +155,13 @@ func init() {
 	Datadog.SetDefault("use_v2_api.series", false)
 	Datadog.SetDefault("use_v2_api.events", false)
 	Datadog.SetDefault("use_v2_api.service_checks", false)
+	// Serializer: allow user to blacklist any kind of payload to be sent
+	BindEnvAndSetDefault("enable_payloads.events", true)
+	BindEnvAndSetDefault("enable_payloads.series", true)
+	BindEnvAndSetDefault("enable_payloads.service_checks", true)
+	BindEnvAndSetDefault("enable_payloads.sketches", true)
+	BindEnvAndSetDefault("enable_payloads.json_to_v1_intake", true)
+
 	// Forwarder
 	Datadog.SetDefault("forwarder_timeout", 20)
 	Datadog.SetDefault("forwarder_retry_queue_max_size", 30)

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 func TestNewScheduler(t *testing.T) {
 	fwd := forwarder.NewDefaultForwarder(nil)
 	fwd.Start()
-	s := &serializer.Serializer{Forwarder: fwd}
+	s := serializer.NewSerializer(fwd)
 	c := NewScheduler(s, "hostname")
 	assert.Equal(t, fwd, c.srl.Forwarder)
 	assert.Equal(t, "hostname", c.hostname)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -73,6 +73,30 @@ func initExtraHeaders() {
 // Serializer serializes metrics to the correct format and routes the payloads to the correct endpoint in the Forwarder
 type Serializer struct {
 	Forwarder forwarder.Forwarder
+
+	// Those variables allow users to blacklist any kind of payload
+	// from being sent by the agent. This was introduced for
+	// environment where, for example, events or serviceChecks
+	// might collect data considered too sensitive (database IP and
+	// such). By default every kind of payload is enabled since
+	// almost every user won't fall into this use case.
+	enableEvents         bool
+	enableSeries         bool
+	enableServiceChecks  bool
+	enableSketches       bool
+	enableJSONToV1Intake bool
+}
+
+// NewSerializer returns a new Serializer initialized
+func NewSerializer(forwarder forwarder.Forwarder) *Serializer {
+	return &Serializer{
+		Forwarder:            forwarder,
+		enableEvents:         config.Datadog.GetBool("enable_payloads.events"),
+		enableSeries:         config.Datadog.GetBool("enable_payloads.series"),
+		enableServiceChecks:  config.Datadog.GetBool("enable_payloads.service_checks"),
+		enableSketches:       config.Datadog.GetBool("enable_payloads.sketches"),
+		enableJSONToV1Intake: config.Datadog.GetBool("enable_payloads.json_to_v1_intake"),
+	}
 }
 
 func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool, useV1API bool) (forwarder.Payloads, http.Header, error) {
@@ -106,6 +130,10 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 
 // SendEvents serializes a list of event and sends the payload to the forwarder
 func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
+	if !s.enableEvents {
+		return nil
+	}
+
 	useV1API := !config.Datadog.GetBool("use_v2_api.events")
 
 	compress := true
@@ -122,6 +150,10 @@ func (s *Serializer) SendEvents(e marshaler.Marshaler) error {
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
+	if !s.enableServiceChecks {
+		return nil
+	}
+
 	useV1API := !config.Datadog.GetBool("use_v2_api.service_checks")
 
 	compress := true
@@ -138,6 +170,10 @@ func (s *Serializer) SendServiceChecks(sc marshaler.Marshaler) error {
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
+	if !s.enableSeries {
+		return nil
+	}
+
 	useV1API := !config.Datadog.GetBool("use_v2_api.series")
 
 	compress := true
@@ -154,6 +190,10 @@ func (s *Serializer) SendSeries(series marshaler.Marshaler) error {
 
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder
 func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
+	if !s.enableSketches {
+		return nil
+	}
+
 	compress := false // TODO: enable compression once the backend supports it on this endpoint
 	useV1API := false // Sketches only have a v2 endpoint
 	splitSketches, extraHeaders, err := s.serializePayload(sketches, compress, useV1API)
@@ -185,6 +225,10 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 // SendJSONToV1Intake serializes a payload and sends it to the forwarder. Some code sends
 // arbitrary payload the v1 API.
 func (s *Serializer) SendJSONToV1Intake(data interface{}) error {
+	if !s.enableJSONToV1Intake {
+		return nil
+	}
+
 	payload, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("could not serialize v1 payload: %s", err)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -129,7 +129,7 @@ func TestSendV1Events(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitV1Intake", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendEvents(payload)
@@ -147,7 +147,7 @@ func TestSendEvents(t *testing.T) {
 	config.Datadog.Set("use_v2_api.events", true)
 	defer config.Datadog.Set("use_v2_api.events", nil)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendEvents(payload)
@@ -163,7 +163,7 @@ func TestSendV1ServiceChecks(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitV1CheckRuns", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendServiceChecks(payload)
@@ -181,7 +181,7 @@ func TestSendServiceChecks(t *testing.T) {
 	config.Datadog.Set("use_v2_api.service_checks", true)
 	defer config.Datadog.Set("use_v2_api.service_checks", nil)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendServiceChecks(payload)
@@ -197,7 +197,7 @@ func TestSendV1Series(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitV1Series", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendSeries(payload)
@@ -215,7 +215,7 @@ func TestSendSeries(t *testing.T) {
 	config.Datadog.Set("use_v2_api.series", true)
 	defer config.Datadog.Set("use_v2_api.series", nil)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendSeries(payload)
@@ -232,7 +232,7 @@ func TestSendSketch(t *testing.T) {
 	payloads, _ := mkPayloads(protobufString, false)
 	f.On("SubmitSketchSeries", payloads, protobufExtraHeaders).Return(nil).Times(1)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendSketch(payload)
@@ -249,7 +249,7 @@ func TestSendMetadata(t *testing.T) {
 	payloads, _ := mkPayloads(jsonString, false)
 	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(nil).Times(1)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	payload := &testPayload{}
 	err := s.SendMetadata(payload)
@@ -272,7 +272,7 @@ func TestSendJSONToV1Intake(t *testing.T) {
 	payloads, _ := mkPayloads(payload, false)
 	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(nil).Times(1)
 
-	s := Serializer{Forwarder: f}
+	s := NewSerializer(f)
 
 	err := s.SendJSONToV1Intake("test")
 	require.Nil(t, err)
@@ -286,4 +286,46 @@ func TestSendJSONToV1Intake(t *testing.T) {
 	errPayload := &testErrorPayload{}
 	err = s.SendJSONToV1Intake(errPayload)
 	require.NotNil(t, err)
+}
+
+func TestSendWithDisabledKind(t *testing.T) {
+	config.Datadog.Set("enable_payloads.events", false)
+	config.Datadog.Set("enable_payloads.series", false)
+	config.Datadog.Set("enable_payloads.service_checks", false)
+	config.Datadog.Set("enable_payloads.sketches", false)
+	config.Datadog.Set("enable_payloads.json_to_v1_intake", false)
+
+	//restore default values
+	defer func() {
+		config.Datadog.Set("enable_payloads.events", true)
+		config.Datadog.Set("enable_payloads.series", true)
+		config.Datadog.Set("enable_payloads.service_checks", true)
+		config.Datadog.Set("enable_payloads.sketches", true)
+		config.Datadog.Set("enable_payloads.json_to_v1_intake", true)
+	}()
+
+	f := &forwarder.MockedForwarder{}
+	s := NewSerializer(f)
+
+	payload := &testPayload{}
+	payloads, _ := mkPayloads(jsonString, false)
+
+	s.SendEvents(payload)
+	s.SendSeries(payload)
+	s.SendSketch(payload)
+	s.SendServiceChecks(payload)
+	s.SendJSONToV1Intake("test")
+
+	f.AssertNotCalled(t, "SubmitV1Intake")
+	f.AssertNotCalled(t, "SubmitEvents")
+	f.AssertNotCalled(t, "SubmitV1CheckRuns")
+	f.AssertNotCalled(t, "SubmitServiceChecks")
+	f.AssertNotCalled(t, "SubmitV1Series")
+	f.AssertNotCalled(t, "SubmitSeries")
+	f.AssertNotCalled(t, "SubmitSketchSeries")
+
+	// We never disable metadata
+	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(nil).Times(1)
+	s.SendMetadata(payload)
+	f.AssertNumberOfCalls(t, "SubmitV1Intake", 1) // called once for the metadata
 }

--- a/releasenotes/notes/blacklist-payload-by-kind-65831a4a56776b32.yaml
+++ b/releasenotes/notes/blacklist-payload-by-kind-65831a4a56776b32.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add options to exclude specific payloads from being sent to Datadog. In
+    some environments, some of the gathered information is considered too
+    sensitive to be sent to Datadog (i.e. IP addresses in events or service
+    checks). This feature adds to option to exclude specific payload types from
+    being sent to the backend.

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -209,7 +209,7 @@ func main() {
 	util.SetHostname("foo")
 
 	f := &forwarderBenchStub{}
-	s := &serializer.Serializer{Forwarder: f}
+	s := serializer.NewSerializer(f)
 
 	agg = aggregator.InitAggregatorWithFlushInterval(s, "hostname", time.Duration(*flushIval)*time.Second)
 

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -224,7 +224,7 @@ func main() {
 
 	config.Datadog.Set("dogstatsd_stats_enable", true)
 	config.Datadog.Set("dogstatsd_stats_buffer", 100)
-	s := &serializer.Serializer{Forwarder: f}
+	s := serializer.NewSerializer(f)
 	aggr := aggregator.InitAggregator(s, "localhost")
 	statsd, err := dogstatsd.NewServer(aggr.GetChannels())
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

For some user, basic information gathered by a check can be too sensitive
to be sent to Datadog (ex: IP addresses in events or service_check). We
now have options to blacklist any kind of payload from being sent to the
backend.