### PR TITLE
Add keys process_config.scrub_args && process_config.custom_sensitive…

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -547,6 +547,10 @@ api_key:
 #   dd_agent_bin:
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
+#   Hide sensitive data on the Live Processes page, default value: true  
+#   scrub_args: true
+#   Define your own list of sensitive data to be merged with the default one 
+#   custom_sensitive_words: ['personal_key', '*token', 'sql*', *pass*d*']
 {{ end -}}
 
 {{- if .TraceAgent }}


### PR DESCRIPTION


### What does this PR do?

Add configuration keys process_config.scrub_args && process_config.custom_sensitive_words for more clarity
come from https://github.com/DataDog/datadog-process-agent/commit/55180242799a30f271997f916382a5d9ac16f75e
documented here: https://docs.datadoghq.com/graphing/infrastructure/process/#process-arguments-scrubbing


### Motivation

all possible configuration keys in one place

### Additional Notes

N/A