### PR TITLE
Maxime/update gitlab trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,40 @@ before_script:
   - pip install -U pip
   - inv -e deps
 
+#
+# Trigger conditions
+#
+
+# run job only when triggered by an external tool (ex: Jenkins). This is used
+# for jobs that run both on nightlies and tags
+.run_when_triggered: &run_when_triggered
+  only:
+    - triggers
+
+# run job only when triggered by an external tool (ex: Jenkins) and when
+# RELEASE_VERSION is NOT "nightly". In this setting we are building either a
+# new tagged version of the agent (an RC for example). In both cases the
+# artifacts should be uploaded to our staging repository.
+
+.run_when_triggered_on_tag: &run_when_triggered_on_tag
+  only:
+    refs:
+      - triggers
+  except: # we have to use except since gitlab doens't handle '!=' operator
+    variables:
+      - $RELEASE_VERSION == "nightly"
+      - $RELEASE_VERSION == "" # no  RELEASE_VERSION means a nightly build for omnibus
+
+# run job only when triggered by an external tool (ex: Jenkins) and when
+# RELEASE_VERSION is "nightly". In this setting we build from master and update
+# the nightly build for windows, linux and docker.
+
+.run_when_triggered_on_nightly: &run_when_triggered_on_nightly
+  only:
+    refs:
+      - triggers
+    variables:
+      - $RELEASE_VERSION == "nightly"
 
 #
 # source_test
@@ -402,9 +436,7 @@ deploy_deb_testing:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
+  <<: *run_when_triggered
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -426,13 +458,11 @@ deploy_deb_testing:
 
 # deploy rpm packages to yum staging repo
 deploy_rpm_testing:
+  <<: *run_when_triggered
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -445,14 +475,12 @@ deploy_rpm_testing:
 
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing:
+  <<: *run_when_triggered
   allow_failure: true
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -465,14 +493,12 @@ deploy_suse_rpm_testing:
 
 # deploy windows packages to our testing bucket
 deploy_windows_testing:
+  <<: *run_when_triggered
   allow_failure: true
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_TESTING_S3_BUCKET/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -485,6 +511,7 @@ kitchen_windows:
   only:
     - master
     - tags
+    - triggers
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -511,6 +538,7 @@ kitchen_centos:
   only:
     - master
     - tags
+    - triggers
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -535,6 +563,7 @@ kitchen_ubuntu:
   only:
     - master
     - tags
+    - triggers
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -560,6 +589,7 @@ kitchen_suse:
   only:
     - master
     - tags
+    - triggers
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -584,6 +614,7 @@ kitchen_debian:
   only:
     - master
     - tags
+    - triggers
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -607,6 +638,7 @@ testkitchen_cleanup_s3:
   only:
     - master
     - tags
+    - triggers
   tags: [ "runner:main", "size:large" ]
   before_script:
     - ls
@@ -628,6 +660,7 @@ testkitchen_cleanup_azure:
   only:
     - master
     - tags
+    - triggers
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true
   when: always
@@ -737,7 +770,7 @@ dev_branch_docker_hub:
 dev_master_docker_hub:
   <<: *docker_tag_job_definition
   only:
-    - master
+    master
   variables:
     <<: *docker_hub_variables
   script:
@@ -757,8 +790,7 @@ dca_dev_branch_docker_hub:
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
-  only:
-    - master
+  <<: *run_when_triggered_on_nightly
   variables:
     <<: *docker_hub_variables
   script:
@@ -769,8 +801,7 @@ dca_dev_master_docker_hub:
 # to run security scans on them
 dev_master_quay:
   <<: *docker_tag_job_definition
-  only:
-    - master
+  <<: *run_when_triggered_on_nightly
   variables:
     <<: *quay_variables
   script:
@@ -785,13 +816,11 @@ dev_master_quay:
 
 # deploy debian packages to apt staging repo
 deploy_deb:
+  <<: *run_when_triggered
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -820,8 +849,7 @@ deploy_windows_master:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
+  <<: *run_when_triggered_on_nightly
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -833,8 +861,7 @@ deploy_windows_tags:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - tags
+  <<: *run_when_triggered_on_tag
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
@@ -842,13 +869,11 @@ deploy_windows_tags:
 
 # deploy rpm packages to yum staging repo
 deploy_rpm:
+  <<: *run_when_triggered
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -865,14 +890,12 @@ deploy_rpm:
 
 # deploy suse rpm packages to yum staging repo
 deploy_suse_rpm:
+  <<: *run_when_triggered
   allow_failure: true
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -889,13 +912,11 @@ deploy_suse_rpm:
 
 # deploy dsd binary to staging bucket
 deploy_dsd:
+  <<: *run_when_triggered
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
@@ -904,13 +925,11 @@ deploy_dsd:
 
 # deploy dsd binary to staging bucket
 deploy_puppy:
+  <<: *run_when_triggered
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/puppy/agent ./agent
@@ -923,10 +942,9 @@ deploy_puppy:
 
 tag_release:
   <<: *docker_tag_job_definition
+  <<: *run_when_triggered_on_tag
   stage: deploy
   when: manual
-  only:
-    - tags
   variables:
     <<: *docker_hub_variables
   script:
@@ -936,10 +954,9 @@ tag_release:
 
 latest_release:
   <<: *docker_tag_job_definition
+  <<: *run_when_triggered_on_tag
   stage: deploy
   when: manual
-  only:
-    - tags
   variables:
     <<: *docker_hub_variables
   script:
@@ -949,10 +966,9 @@ latest_release:
 
 dca_tag_release:
   <<: *docker_tag_job_definition
+  <<: *run_when_triggered_on_tag
   stage: deploy
   when: manual
-  only:
-    - tags
   variables:
     <<: *docker_hub_variables
   script:
@@ -961,10 +977,9 @@ dca_tag_release:
 
 dca_latest_release:
   <<: *docker_tag_job_definition
+  <<: *run_when_triggered_on_tag
   stage: deploy
   when: manual
-  only:
-    - tags
   variables:
     <<: *docker_hub_variables
   script:
@@ -972,13 +987,11 @@ dca_latest_release:
 
 # invalidate cloudfront cache
 deploy_cloudfront_invalidate:
+  <<: *run_when_triggered
   stage: deploy_invalidate
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  only:
-    - master
-    - tags
   tags: [ "runner:main", "size:large" ]
   script:
     - cd /deploy_scripts/cloudfront-invalidation
@@ -1007,14 +1020,13 @@ pupernetes-dev:
 pupernetes-master:
   <<: *pupernetes_template
   only:
-    - master
+    master
   script:
   - inv -e e2e-tests --image=datadog/agent-dev:master
 
 pupernetes-tags:
   <<: *pupernetes_template
-  only:
-    - tags
+  <<: *run_when_triggered_on_tag
   script:
   # note: it's not the agent-dev
   - inv -e e2e-tests --image=datadog/agent:$CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -865,7 +865,10 @@ deploy_windows_tags:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    # By default we update the "latest" artifacts on our s3 bucket so the
+    # staging box can pick it up. Allow the job to skip this step if needed
+    # (when building a custom beta for example).
+    - if [ "WINDOWS_DO_NOT_UPDATE_LATEST" != "true" ]; then $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-*-x86_64.msi s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/datadog-agent-6-latest.amd64.msi --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732; fi
 
 # deploy rpm packages to yum staging repo
 deploy_rpm:


### PR DESCRIPTION
### What does this PR do?

-  Move release jobs to run only when the pipeline it triggered. All release jobs (i.e. jobs run when producing a nightly or building a tag) are now only run when the pipeline is triggered. This avoids building a version named after a tag but with the nightly versions from release.json inside.

- Avoid updating the latest build when needed. This is useful when building a custom beta for example.