### PR TITLE
[packaging] Avoid install failure if enabling systemd service fails

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -68,9 +68,9 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Only supports systemd and upstart
         echo "Enabling service $SERVICE_NAME"
         if command -v systemctl >/dev/null 2>&1; then
-            systemctl enable $SERVICE_NAME || true
-            systemctl enable $SERVICE_NAME-process || true
-            systemctl enable $SERVICE_NAME-trace || true
+            systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
+            systemctl enable $SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with systemctl"
+            systemctl enable $SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with systemctl"
         elif command -v initctl >/dev/null 2>&1; then
             # Nothing to do, this is defined directly in the upstart job file
             :

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -68,9 +68,9 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Only supports systemd and upstart
         echo "Enabling service $SERVICE_NAME"
         if command -v systemctl >/dev/null 2>&1; then
-            systemctl enable $SERVICE_NAME
-            systemctl enable $SERVICE_NAME-process
-            systemctl enable $SERVICE_NAME-trace
+            systemctl enable $SERVICE_NAME || true
+            systemctl enable $SERVICE_NAME-process || true
+            systemctl enable $SERVICE_NAME-trace || true
         elif command -v initctl >/dev/null 2>&1; then
             # Nothing to do, this is defined directly in the upstart job file
             :

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -16,7 +16,7 @@ ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
 
 echo "Enabling service $SERVICE_NAME"
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl enable $SERVICE_NAME || true
+    systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
 elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :

--- a/omnibus/package-scripts/agent/posttrans
+++ b/omnibus/package-scripts/agent/posttrans
@@ -16,7 +16,7 @@ ln -sf $INSTALL_DIR/bin/agent/agent /usr/bin/datadog-agent
 
 echo "Enabling service $SERVICE_NAME"
 if command -v systemctl >/dev/null 2>&1; then
-    systemctl enable $SERVICE_NAME
+    systemctl enable $SERVICE_NAME || true
 elif command -v initctl >/dev/null 2>&1; then
     # start/stop policy is already defined in the upstart job file
     :

--- a/releasenotes/notes/systemd-no-service-enable-failure-c7ac74823b5c1819.yaml
+++ b/releasenotes/notes/systemd-no-service-enable-failure-c7ac74823b5c1819.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Avoid Linux package installation failures when both the ``initctl`` and
+    ``systemctl`` commands are present but upstart is used as the init system


### PR DESCRIPTION
### What does this PR do?

Avoid install failure if enabling systemd service fails.

### Motivation

When `systemctl enable datadog-agent` fails, the package install
currently fails.

The root cause on the dev env where we experienced the issue is the following:
our test for systemd, `command -v systemctl`, tests for the presence of the systemctl
command but not that systemd is used as the init system on the current
system. This can happen for example on Ubuntu 14.04 (-> upstart) when
the `systemd` deb is installed but systemd is not used as the init system.
When that's the case, `systemctl enable` fails.

Unfortunately it seems very hard to reliably determine what the current
init system is across all distros (even the cmdline of PID 1 isn't
always enough). I think the "real" fix would be to ship a different package for
every distro/version tuple, with pkg scripts tailored for that
distro/version.

So for now, let's just ignore these errors. Worst case scenario, on the
few systems where both commands exist, the agent install may not
stop/restart the agent service properly.
