### PR TITLE
[Logs] Replace invalid utf-8 characters by a placeholder

### DIFF
--- a/pkg/logs/processor/encoder_test.go
+++ b/pkg/logs/processor/encoder_test.go
@@ -181,8 +181,18 @@ func TestProtoEncoderEmpty(t *testing.T) {
 
 }
 
-func TestProtoEncoderInvalidUTF8(t *testing.T) {
-	msg, err := protoEncoder.encode(nil, []byte("\xde\xea\xca\xfe"))
-	assert.Nil(t, msg)
-	assert.Error(t, err)
+func TestProtoEncoderHandleInvalidUTF8(t *testing.T) {
+	cfg := &config.LogsConfig{}
+	src := config.NewLogSource("", cfg)
+	msg := newMessage([]byte(""), src, "")
+	encoded, err := protoEncoder.encode(msg, []byte("a\xfez"))
+	assert.NotNil(t, encoded)
+	assert.Nil(t, err)
+}
+
+func TestProtoEncoderToValidUTF8(t *testing.T) {
+	assert.Equal(t, "a�z", protoEncoder.toValidUtf8([]byte("a\xfez")))
+	assert.Equal(t, "a��z", protoEncoder.toValidUtf8([]byte("a\xc0\xafz")))
+	assert.Equal(t, "a���z", protoEncoder.toValidUtf8([]byte("a\xed\xa0\x80z")))
+	assert.Equal(t, "a����z", protoEncoder.toValidUtf8([]byte("a\xf0\x8f\xbf\xbfz")))
 }

--- a/releasenotes/notes/logs-replace-invalid-utf8-ea99e671f5c0ab39.yaml
+++ b/releasenotes/notes/logs-replace-invalid-utf8-ea99e671f5c0ab39.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Replace invalid utf-8 characters by the standard replacement char.


### PR DESCRIPTION
### What does this PR do?

This is a workaround to handle invalid utf-8 characters in the agent logs.

Previously, we would drop the message and log an error. This error had the unintended side-effect of creating another message with invalid characters, as it contained the original message. If the agent was tailing its own logs, this would create another message to be sent, which would again cause an error and so on in a loop. 

Instead of dropping the message, this PR replaces all invalid utf-8 characters in it with the replacement character `�`.

### Motivation

https://github.com/DataDog/datadog-agent/issues/1906

### Additional Notes

