### PR TITLE
[docs] Support go 1.10.2+ only

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and development, is located under [the docs directory](docs) of the present repo
 ## Getting started
 
 To build the Agent you need:
- * [Go](https://golang.org/doc/install) 1.9.4 or later.
+ * [Go](https://golang.org/doc/install) 1.10.2 or later.
  * Python 2.7 along with development libraries.
  * [Invoke](http://www.pyinvoke.org/installing.html), you can install it via
    `pip install invoke` or via [Homebrew](https://brew.sh) on OSX/macOS with

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -23,7 +23,7 @@ variables (see Invoke docs for more details).
 
 ## Golang
 
-You must install [go](https://golang.org/doc/install) version 1.9.2 or above. Make
+You must install [go](https://golang.org/doc/install) version 1.10.2 or above. Make
 sure that `$GOPATH/bin` is in your `$PATH` otherwise Invoke cannot use any
 additional tool it might need.
 


### PR DESCRIPTION
### What does this PR do?

Document that we only support go 1.10.2+. We use it for our packaged builds since v6.3.0. Let's drop any documented support for go 1.9, although at the moment and AFAIK we don't use any 1.10-specific features in `datadog-agent`.
