### PR TITLE
[dogstatsd] Fix hostname applied to metrics when tags metadata field is empty

### DIFF
--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -59,11 +59,12 @@ func nextField(slice, sep []byte) ([]byte, []byte) {
 
 // parseTags parses `rawTags` and returns a slice of tags and the value of the `host:` tag if found
 func parseTags(rawTags []byte, extractHost bool) ([]string, string) {
+	host := defaultHostname
+
 	if len(rawTags) == 0 {
-		return nil, ""
+		return nil, host
 	}
 
-	host := defaultHostname
 	tagsList := make([]string, 0, bytes.Count(rawTags, tagSeparator)+1)
 	remainder := rawTags
 

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -57,23 +57,21 @@ func nextField(slice, sep []byte) ([]byte, []byte) {
 	return slice[:sepIndex], slice[sepIndex+1:]
 }
 
-// parseTags parses `rawTags` and returns a slice of tags, and, if extractHost is true,
-// whether it found the `host:` tag and its value
-func parseTags(rawTags []byte, extractHost bool) ([]string, bool, string) {
+// parseTags parses `rawTags` and returns a slice of tags,
+// and, if extractHost is true, the extracted hostname
+func parseTags(rawTags []byte, extractHost bool, defaultHostname string) ([]string, string) {
 	if len(rawTags) == 0 {
-		return nil, false, ""
+		return nil, defaultHostname
 	}
 
 	tagsList := make([]string, 0, bytes.Count(rawTags, tagSeparator)+1)
-	var foundHost bool
-	var host string
+	host := defaultHostname
 	remainder := rawTags
 
 	var tag []byte
 	for {
 		tag, remainder = nextField(remainder, tagSeparator)
 		if extractHost && bytes.HasPrefix(tag, []byte("host:")) {
-			foundHost = true
 			host = string(tag[5:])
 		} else {
 			tagsList = append(tagsList, string(tag))
@@ -83,7 +81,7 @@ func parseTags(rawTags []byte, extractHost bool) ([]string, bool, string) {
 			break
 		}
 	}
-	return tagsList, foundHost, host
+	return tagsList, host
 }
 
 func parseServiceCheckMessage(message []byte) (*metrics.ServiceCheck, error) {
@@ -130,7 +128,7 @@ func parseServiceCheckMessage(message []byte) (*metrics.ServiceCheck, error) {
 		} else if bytes.HasPrefix(rawMetadataField, []byte("h:")) {
 			service.Host = string(rawMetadataField[2:])
 		} else if bytes.HasPrefix(rawMetadataField, []byte("#")) {
-			service.Tags, _, _ = parseTags(rawMetadataField[1:], false)
+			service.Tags, _ = parseTags(rawMetadataField[1:], false, "")
 		} else if bytes.HasPrefix(rawMetadataField, []byte("m:")) {
 			service.Message = string(rawMetadataField[2:])
 		} else {
@@ -225,7 +223,7 @@ func parseEventMessage(message []byte) (*metrics.Event, error) {
 			} else if bytes.HasPrefix(rawMetadataFields[i], []byte("s:")) {
 				event.SourceTypeName = string(rawMetadataFields[i][2:])
 			} else if bytes.HasPrefix(rawMetadataFields[i], []byte("#")) {
-				event.Tags, _, _ = parseTags(rawMetadataFields[i][1:], false)
+				event.Tags, _ = parseTags(rawMetadataFields[i][1:], false, "")
 			} else {
 				log.Warnf("unknown metadata type: '%s'", rawMetadataFields[i])
 			}
@@ -258,8 +256,7 @@ func parseMetricMessage(message []byte, namespace string, defaultHostname string
 
 	// Metadata
 	var metricTags []string
-	var foundHost bool
-	var host string
+	host := defaultHostname
 	var rawMetadataField []byte
 	sampleRate := 1.0
 
@@ -267,7 +264,7 @@ func parseMetricMessage(message []byte, namespace string, defaultHostname string
 		rawMetadataField, remainder = nextField(remainder, fieldSeparator)
 
 		if bytes.HasPrefix(rawMetadataField, []byte("#")) {
-			metricTags, foundHost, host = parseTags(rawMetadataField[1:], true)
+			metricTags, host = parseTags(rawMetadataField[1:], true, defaultHostname)
 		} else if bytes.HasPrefix(rawMetadataField, []byte("@")) {
 			rawSampleRate := rawMetadataField[1:]
 			var err error
@@ -285,10 +282,6 @@ func parseMetricMessage(message []byte, namespace string, defaultHostname string
 	metricName := string(rawName)
 	if namespace != "" {
 		metricName = namespace + metricName
-	}
-
-	if !foundHost && host == "" {
-		host = defaultHostname
 	}
 
 	metricType, ok := metricTypes[string(rawType)]

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -65,7 +65,7 @@ func TestGaugePacketCounter(t *testing.T) {
 }
 
 func TestParseGauge(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -74,11 +74,12 @@ func TestParseGauge(t *testing.T) {
 	assert.Equal(t, "666", parsed.RawValue)
 	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseCounter(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -86,11 +87,12 @@ func TestParseCounter(t *testing.T) {
 	assert.Equal(t, 21.0, parsed.Value)
 	assert.Equal(t, metrics.CounterType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseCounterWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "")
+	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -100,11 +102,12 @@ func TestParseCounterWithTags(t *testing.T) {
 	assert.Equal(t, 2, len(parsed.Tags))
 	assert.Equal(t, "protocol:http", parsed.Tags[0])
 	assert.Equal(t, "bench", parsed.Tags[1])
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseHistogram(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -112,11 +115,12 @@ func TestParseHistogram(t *testing.T) {
 	assert.Equal(t, 21.0, parsed.Value)
 	assert.Equal(t, metrics.HistogramType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseTimer(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -125,10 +129,11 @@ func TestParseTimer(t *testing.T) {
 	assert.Equal(t, metrics.HistogramType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+	assert.Equal(t, "default-hostname", parsed.Host)
 }
 
 func TestParseSet(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -136,22 +141,24 @@ func TestParseSet(t *testing.T) {
 	assert.Equal(t, "abc", parsed.RawValue)
 	assert.Equal(t, metrics.SetType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseDistribution(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
 	assert.Equal(t, 3.5, parsed.Value)
 	assert.Equal(t, metrics.DistributionType, parsed.Mtype)
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, 0, len(parsed.Tags))
 }
 
 func TestParseSetUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -159,11 +166,12 @@ func TestParseSetUnicode(t *testing.T) {
 	assert.Equal(t, "♬†øU†øU¥ºuT0♪", parsed.RawValue)
 	assert.Equal(t, metrics.SetType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseGaugeWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -173,11 +181,12 @@ func TestParseGaugeWithTags(t *testing.T) {
 	require.Equal(t, 2, len(parsed.Tags))
 	assert.Equal(t, "sometag1:somevalue1", parsed.Tags[0])
 	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -191,7 +200,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithEmptyHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -204,40 +213,20 @@ func TestParseGaugeWithEmptyHostTag(t *testing.T) {
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
-func TestParseGaugeWithNoHostTag(t *testing.T) {
-	defaultHostname = "test-hostname"
-	defer func() { defaultHostname = "" }()
-
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "")
-	assert.NoError(t, err)
-
-	assert.Equal(t, "daemon", parsed.Name)
-	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
-	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
-	require.Equal(t, 2, len(parsed.Tags))
-	assert.Equal(t, "sometag1:somevalue1", parsed.Tags[0])
-	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
-	assert.Equal(t, "test-hostname", parsed.Host)
-	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
-}
-
 func TestParseGaugeWithNoTags(t *testing.T) {
-	defaultHostname = "test-hostname"
-	defer func() { defaultHostname = "" }()
-
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
 	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
 	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
 	assert.Empty(t, parsed.Tags)
-	assert.Equal(t, "test-hostname", parsed.Host)
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseGaugeWithSampleRate(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -245,11 +234,12 @@ func TestParseGaugeWithSampleRate(t *testing.T) {
 	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
 	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 0.21, parsed.SampleRate, epsilon)
 }
 
 func TestParseGaugeWithPoundOnly(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -257,11 +247,12 @@ func TestParseGaugeWithPoundOnly(t *testing.T) {
 	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
 	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseGaugeWithUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "")
+	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -270,48 +261,48 @@ func TestParseGaugeWithUnicode(t *testing.T) {
 	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
 	require.Equal(t, 1, len(parsed.Tags))
 	assert.Equal(t, "intitulé:T0µ", parsed.Tags[0])
+	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
 func TestParseMetricError(t *testing.T) {
 	// not enough information
-	_, err := parseMetricMessage([]byte("daemon:666"), "")
+	_, err := parseMetricMessage([]byte("daemon:666"), "", "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:666|"), "")
+	_, err = parseMetricMessage([]byte("daemon:666|"), "", "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:|g"), "")
+	_, err = parseMetricMessage([]byte("daemon:|g"), "", "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte(":666|g"), "")
+	_, err = parseMetricMessage([]byte(":666|g"), "", "default-hostname")
 	assert.Error(t, err)
 
 	// too many value
-	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "")
+	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "", "default-hostname")
 	assert.Error(t, err)
 
 	// unknown metadata prefix
-	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "")
+	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	// invalid value
-	_, err = parseMetricMessage([]byte("daemon:abc|g"), "")
+	_, err = parseMetricMessage([]byte("daemon:abc|g"), "", "default-hostname")
 	assert.Error(t, err)
 
 	// invalid metric type
-	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "")
+	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "", "default-hostname")
 	assert.Error(t, err)
 
 	// invalid sample rate
-	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "")
+	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "", "default-hostname")
 	assert.Error(t, err)
 }
 
 func TestParseMonokeyBatching(t *testing.T) {
-	// parsed, err := parseMetricMessage([]byte("test_gauge:1.5|g|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g"))
-
-	// TODO: implement test
+	// TODO: not implemented
+	// parsed, err := parseMetricMessage([]byte("test_gauge:1.5|g|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g"), "default-hostname")
 }
 
 func TestEnsureUTF8(t *testing.T) {
@@ -679,9 +670,10 @@ func TestEventMetadataMultiple(t *testing.T) {
 }
 
 func TestNamespace(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.")
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.", "default-hostname")
 
 	assert.NoError(t, err)
 
 	assert.Equal(t, "testNamespace.daemon", parsed.Name)
+	assert.Equal(t, "default-hostname", parsed.Host)
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -88,7 +88,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 
 	defaultHostname, err := util.GetHostname()
 	if err != nil {
-		log.Error(err.Error())
+		log.Errorf("Dogstatsd: unable to determine default hostname: %s", err.Error())
 	}
 
 	histToDist := config.Datadog.GetBool("histogram_copy_to_distribution")

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -26,11 +25,6 @@ import (
 
 var (
 	dogstatsdExpvar = expvar.NewMap("dogstatsd")
-
-	// The default hostname to enforce on metrics, assumed to not change in the
-	// Agent's lifetime
-	defaultHostname = ""
-	initHostname    sync.Once
 )
 
 // Server represent a Dogstatsd server
@@ -43,6 +37,7 @@ type Server struct {
 	stopChan         chan bool
 	health           *health.Handle
 	metricPrefix     string
+	defaultHostname  string
 	histToDist       bool
 	histToDistPrefix string
 }
@@ -58,12 +53,6 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		}
 		stats = s
 	}
-
-	// We enforce the defaultHostname on metrics when none is set. To avoid checking
-	// the cache on every metrics, save it once and for all in a package variable.
-	initHostname.Do(func() {
-		defaultHostname, _ = util.GetHostname()
-	})
 
 	packetChannel := make(chan *listeners.Packet, 100)
 	packetPool := listeners.NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
@@ -97,6 +86,11 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		metricPrefix = metricPrefix + "."
 	}
 
+	defaultHostname, err := util.GetHostname()
+	if err != nil {
+		log.Error(err.Error())
+	}
+
 	histToDist := config.Datadog.GetBool("histogram_copy_to_distribution")
 	histToDistPrefix := config.Datadog.GetString("histogram_copy_to_distribution_prefix")
 	s := &Server{
@@ -108,6 +102,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		stopChan:         make(chan bool),
 		health:           health.Register("dogstatsd-main"),
 		metricPrefix:     metricPrefix,
+		defaultHostname:  defaultHostname,
 		histToDist:       histToDist,
 		histToDistPrefix: histToDistPrefix,
 	}
@@ -228,7 +223,7 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 					dogstatsdExpvar.Add("EventPackets", 1)
 					eventOut <- *event
 				} else {
-					sample, err := parseMetricMessage(message, s.metricPrefix)
+					sample, err := parseMetricMessage(message, s.metricPrefix, s.defaultHostname)
 					if err != nil {
 						log.Errorf("Dogstatsd: error parsing metrics: %s", err)
 						dogstatsdExpvar.Add("MetricParseErrors", 1)

--- a/releasenotes/notes/dogstatsd-hostname-single-pound-tags-638cb5886c2d9b03.yaml
+++ b/releasenotes/notes/dogstatsd-hostname-single-pound-tags-638cb5886c2d9b03.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a bug in dogstatsd metrics parsing where the Agent would leave the host tag
+    empty instead of applying its hostname on metrics with a tag metadata
+    field but no tags (i.e. the tags field is only one `#` character).
+    Regression introduced in 6.3.0


### PR DESCRIPTION
### What does this PR do?

Fixes the hostname that's applied to metrics when tags metadata field is present but empty (i.e. when it's a single `#`): in that case it should be the Agent's hostname instead of an empty hostname.

Regression introduced in https://github.com/DataDog/datadog-agent/pull/1806 and still present after https://github.com/DataDog/datadog-agent/pull/1850 

### Motivation

This should be regarded as a regression from earlier Agent versions.

### Additional Notes

Look at first commit for actual fix, and second commit for what I regard as a cleaner fix (see commit message for more info) 