### PR TITLE
Upgrading viper, updating logic

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -96,7 +96,7 @@
 
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "~v1.0.2"
+  version = "=v1.0.2"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,9 +90,13 @@
   name = "github.com/spf13/cobra"
   version = "~v0.0.1"
 
+[[override]]
+  name = "github.com/json-iterator/go"
+  revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
+
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "~v1.0.0"
+  version = "~v1.0.2"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -112,9 +112,9 @@ func buildLogSourcesFromDirectory(ddconfdPath string) []*LogSource {
 			config := logSourceConfigIterator
 
 			// Users can specify tags as comma separated string, or as YAML array. Handle the first case here
-			if len(config.Tags) == 1 {
+			if len(config.Tags) > 1 {
 				newSlice := []string{}
-				for _, splitted := range strings.Split(config.Tags[0], ",") {
+				for _, splitted := range config.Tags {
 					newSlice = append(newSlice, strings.TrimSpace(splitted))
 				}
 				config.Tags = newSlice

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -26,8 +26,8 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	allSources, err := buildLogSources(ddconfdPath, false)
 
 	assert.Nil(t, err)
-	assert.Equal(t, 7, len(allSources.GetValidSources()))
-	assert.Equal(t, 8, len(allSources.GetSources()))
+	assert.Equal(t, 8, len(allSources.GetValidSources()))
+	assert.Equal(t, 9, len(allSources.GetSources()))
 
 	sources := allSources.GetValidSources()
 
@@ -55,6 +55,7 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 
 	assert.Equal(t, []string{"env:prod", "foo:bar"}, sources[5].Config.Tags)
 	assert.Equal(t, []string{"env:prod", "foo:bar"}, sources[6].Config.Tags)
+	assert.Equal(t, []string{"env:prod", "foo:bar"}, sources[7].Config.Tags)
 
 	// processing
 	assert.Equal(t, 0, len(sources[0].Config.ProcessingRules))

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -26,8 +26,7 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	allSources, err := buildLogSources(ddconfdPath, false)
 
 	assert.Nil(t, err)
-	assert.Equal(t, 8, len(allSources.GetValidSources()))
-	assert.Equal(t, 9, len(allSources.GetSources()))
+	assert.Equal(t, 1, len(allSources.GetSources())-len(allSources.GetValidSources()))
 
 	sources := allSources.GetValidSources()
 

--- a/pkg/logs/config/tests/complete/conf.d/integration.d/integration4.yaml
+++ b/pkg/logs/config/tests/complete/conf.d/integration.d/integration4.yaml
@@ -12,6 +12,13 @@ logs:
     sourcecategory: http_access
     tags: env:prod, foo:bar
 
+  - type: file
+    path: /var/log/access.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_access
+    tags: env:prod,foo:bar
+
   # test for tags as array
   - type: file
     path: /var/log/access.log

--- a/releasenotes/notes/upgrade-viper-49c2f99455aa1636.yaml
+++ b/releasenotes/notes/upgrade-viper-49c2f99455aa1636.yaml
@@ -1,0 +1,6 @@
+upgrade:
+  - |
+    Upgrade the version of spf13/viper from v1.0.0 to v1.0.2
+fixes:
+  - |
+    Change the tag parsing logic of the log agent's configuration reader as a result of upgrading viper

--- a/releasenotes/notes/upgrade-viper-49c2f99455aa1636.yaml
+++ b/releasenotes/notes/upgrade-viper-49c2f99455aa1636.yaml
@@ -1,6 +1,0 @@
-upgrade:
-  - |
-    Upgrade the version of spf13/viper from v1.0.0 to v1.0.2
-fixes:
-  - |
-    Change the tag parsing logic of the log agent's configuration reader as a result of upgrading viper


### PR DESCRIPTION
### What does this PR do?

I investigated and realised that viper modified the behavior of their lib.
1.0.0: `tags: key:val, key:val` is a string
1.0.2: `tags: key:val, key:val` is an array
https://github.com/spf13/viper/compare/v1.0.0...v1.0.2#diff-38f1012180f40493dcf780c312a40ec3R779
### Motivation

proactively fix the change. 

### Additional Notes

@DataDog/ramen-intake This is just a suggestion, I figured I'd raise the flag in case someone mistakenly upgrade viper and this breaks our tags parsing.