### PR TITLE
[Logs]: Fixed wrong log status values

### DIFF
--- a/pkg/logs/message/status.go
+++ b/pkg/logs/message/status.go
@@ -5,14 +5,13 @@
 
 package message
 
-// Status values,
-// for more information check https://en.wikipedia.org/wiki/Syslog#Severity_level.
+// Status values
 const (
-	StatusEmergency = "emerg"
+	StatusEmergency = "emergency"
 	StatusAlert     = "alert"
 	StatusCritical  = "critical"
 	StatusError     = "error"
-	StatusWarning   = "warning"
+	StatusWarning   = "warn"
 	StatusNotice    = "notice"
 	StatusInfo      = "info"
 	StatusDebug     = "debug"


### PR DESCRIPTION
### What does this PR do?

Fixed status value for `warning` and `emergency`

### Motivation

Status was not properly displayed on the platform

