### PR TITLE
Collecting the container size less often in the docker check

### DIFF
--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.example
@@ -29,6 +29,9 @@ instances:
     # Defaults to false.
     #
     # collect_container_size: true
+    #
+    # Set the frequency of collection of disk user per container metrics, default is once every 5 check runs
+    # collect_container_size_frequency: 5
 
     # Collect images stats
     # Number of available active images and intermediate images as gauges.

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -169,6 +169,8 @@ func (d *DockerCheck) Run() error {
 		return err
 	}
 
+	collectingContainerSizeDuringThisRun := d.instance.CollectContainerSize && d.collectContainerSizeCounter == 0
+
 	images := map[string]*containerPerImage{}
 	for _, c := range containers {
 		updateContainerRunningCount(images, c)
@@ -226,7 +228,7 @@ func (d *DockerCheck) Run() error {
 			}
 		}
 
-		if d.instance.CollectContainerSize && d.collectContainerSizeCounter == 0 {
+		if collectingContainerSizeDuringThisRun {
 			info, err := du.Inspect(c.ID, true)
 			if err != nil {
 				log.Errorf("Failed to inspect container %s - %s", c.ID[:12], err)

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -239,9 +239,11 @@ func (d *DockerCheck) Run() error {
 		}
 	}
 
-	// Update the container size counter, used to collect them less often as they are costly
-	d.collectContainerSizeCounter =
-		(d.collectContainerSizeCounter + 1) % d.instance.CollectContainerSizeFreq
+	if d.instance.CollectContainerSize {
+		// Update the container size counter, used to collect them less often as they are costly
+		d.collectContainerSizeCounter =
+			(d.collectContainerSizeCounter + 1) % d.instance.CollectContainerSizeFreq
+	}
 
 	var totalRunning, totalStopped int64
 	for _, image := range images {

--- a/pkg/legacy/docker_test.go
+++ b/pkg/legacy/docker_test.go
@@ -55,6 +55,7 @@ instances:
 
 	dockerNewConf string = `instances:
 - collect_container_size: true
+  collect_container_size_frequency: 5
   collect_exit_codes: true
   collect_images_stats: false
   collect_image_size: true

--- a/releasenotes/notes/collect-container-disk-metrics-less-often-2ea2de0d82f51046.yaml
+++ b/releasenotes/notes/collect-container-disk-metrics-less-often-2ea2de0d82f51046.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Collect container disk metrics less often in the docker check, decreasing its effect on performance when enabled.


### PR DESCRIPTION
### What does this PR do?

Adding a counter in the docker check so that the container size is collected less often.

### Motivation

Collecting the container size is quite heavy in performance due to the way it is collected through the docker API. Agent 5 was already collecting it less often, it's porting back this feature in the new docker check.

### Additional Notes
Retro-compatibility-wise, it changes the default frequency from 1 every check run to 5 every check runs, as it should cause few issues in graphs or monitors, and improve the agent performance for most users.

Not sure if it is worth writing additional tests: we already test the presence of the container size metrics in an integration test, but not the frequency itself, which is harder to test with the current tools.