### PR TITLE
Add wildcard support to label to tag mappings for containers.

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -69,11 +69,25 @@ We automatically collect common tags from [Docker](https://github.com/DataDog/da
 - `DD_KUBERNETES_POD_LABELS_AS_TAGS` : extract pod labels
 - `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS` : extract pod annotations
 
-You can either define them in your custom `datadog.yaml`, or set them as JSON maps in these envvars. The map key is the source (label/envvar) name, and the map value the datadog tag name.
+You can either define them in your custom `datadog.yaml`, or set them as JSON maps in these envvars. The map key is the source (label/envvar) name, and the map value the Datadog tag name.
 
 ```shell
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app","release":"helm_release"}'
 DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
+```
+
+You can use shell patterns in label names to define simple rules for mapping labels to Datadog tag names using the same simple template system used by Autodiscovery. This is only supported by `DD_KUBERNETES_POD_LABELS_AS_TAGS`.
+
+To add all pod labels as tags to your metrics where tags names are prefixed by `kube_`, you can use the following:
+
+```shell
+DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"kube_%%label%%"}'
+```
+
+To add only pod labels as tags to your metrics that start with `app`, you can use the following:
+
+```shell
+DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app*":"kube_%%label%%"}'
 ```
 
 #### Ignore containers
@@ -137,7 +151,7 @@ For more information about the container's lifecycle, see [SUPERVISION.md](SUPER
 To deploy the Agent in your Kubernetes cluster, you can use the manifest in [manifests](../manifests/cluster-agent/cluster-agent.yaml). Firstly, make sure you have the correct [RBAC](#rbac) in place. You can use the files in manifests/rbac that contain the minimal requirements to run the Kubernetes Cluster level checks and perform the leader election.
 `kubectl create -f manifests/rbac`
 
-Please note that with the above RBAC, every agent will have access to the API Server, to list the pods, services ...  
+Please note that with the above RBAC, every agent will have access to the API Server, to list the pods, services ...
 These accesses vanish when using the Datadog Cluster Agent.
 Indeed, the agents will only have access to the local kubelet and only the Cluster Agent will be able to access cluster level insight (nodes, services...).
 
@@ -155,7 +169,7 @@ See details in [Event Collection](#event-collection).
 
 **This sub-section is only valid for agent versions > 6.3.2 and when using the Datadog Cluster Agent.**
 
-Event collection is handled by the cluster agent and the RBAC for the agent is slimmed down to the kubelet's API access. There is now a dedicated Clusterrole for the agent which should be as follows: 
+Event collection is handled by the cluster agent and the RBAC for the agent is slimmed down to the kubelet's API access. There is now a dedicated Clusterrole for the agent which should be as follows:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1
@@ -184,7 +198,7 @@ Similarly to Agent 5, Agent 6 collects events from the Kubernetes API server.
 1/ Set the `collect_kubernetes_events` variable to `true` in the `datadog.yaml` file, you can use the environment variable `DD_COLLECT_KUBERNETES_EVENTS` for this.
 2/ Give the agents proper RBACs to activate this feature. See the [RBAC](#rbac) section.
 3/ A ConfigMap can be used to store the `event.tokenKey` and the `event.tokenTimestamp`. It has to be deployed in the `default` namespace and be named `datadogtoken`.
-   Run `kubectl create configmap datadogtoken --from-literal="event.tokenKey"="0"` . 
+   Run `kubectl create configmap datadogtoken --from-literal="event.tokenKey"="0"` .
    You can also use the example in [manifests/datadog_configmap.yaml][https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/datadog_configmap.yaml].
 
 Note: When the ConfigMap is used, if the agent in charge (via the [Leader election](#leader-election)) of collecting the events dies, the next leader elected will use the ConfigMap to identify the last events pulled.

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -52,28 +52,6 @@ func TestResolveTemplate(t *testing.T) {
 	assert.Len(t, res, 1)
 }
 
-func TestParseTemplateVar(t *testing.T) {
-	name, key := parseTemplateVar([]byte("%%host%%"))
-	assert.Equal(t, "host", string(name))
-	assert.Equal(t, "", string(key))
-
-	name, key = parseTemplateVar([]byte("%%host_0%%"))
-	assert.Equal(t, "host", string(name))
-	assert.Equal(t, "0", string(key))
-
-	name, key = parseTemplateVar([]byte("%%host 0%%"))
-	assert.Equal(t, "host0", string(name))
-	assert.Equal(t, "", string(key))
-
-	name, key = parseTemplateVar([]byte("%%host_0_1%%"))
-	assert.Equal(t, "host", string(name))
-	assert.Equal(t, "0_1", string(key))
-
-	name, key = parseTemplateVar([]byte("%%host_network_name%%"))
-	assert.Equal(t, "host", string(name))
-	assert.Equal(t, "network_name", string(key))
-}
-
 func TestGetFallbackHost(t *testing.T) {
 	ip, err := getFallbackHost(map[string]string{"bridge": "172.17.0.1"})
 	assert.Equal(t, "172.17.0.1", ip)

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -8,14 +8,12 @@ package integration
 import (
 	"fmt"
 	"hash/fnv"
-	"regexp"
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 	yaml "gopkg.in/yaml.v2"
 )
-
-var tplVarRegex = regexp.MustCompile(`%%.+?%%`)
 
 // Data contains YAML code
 type Data []byte
@@ -126,11 +124,11 @@ func (c *Config) AddMetrics(metrics Data) error {
 
 // GetTemplateVariablesForInstance returns a slice of raw template variables
 // it found in a config instance template.
-func (c *Config) GetTemplateVariablesForInstance(i int) (vars [][]byte) {
+func (c *Config) GetTemplateVariablesForInstance(i int) []tmplvar.TemplateVar {
 	if len(c.Instances) < i {
-		return vars
+		return nil
 	}
-	return tplVarRegex.FindAll(c.Instances[i], -1)
+	return tmplvar.Parse(c.Instances[i])
 }
 
 // MergeAdditionalTags merges additional tags to possible existing config tags

--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -13,7 +13,7 @@ import (
 )
 
 var templateVariables = map[string]struct{}{
-	"label": struct{}{},
+	"label": {},
 }
 
 // retrieveMappingFromConfig gets a stringmapstring config key and

--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -9,7 +9,12 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 )
+
+var templateVariables = map[string]struct{}{
+	"label": struct{}{},
+}
 
 // retrieveMappingFromConfig gets a stringmapstring config key and
 // lowercases all map keys to make envvar and yaml sources consistent
@@ -21,4 +26,17 @@ func retrieveMappingFromConfig(configKey string) map[string]string {
 	}
 
 	return labelsList
+}
+
+func resolveTag(tmpl, label string) string {
+	vars := tmplvar.ParseString(tmpl)
+	tagName := tmpl
+	for _, v := range vars {
+		if _, ok := templateVariables[string(v.Name)]; ok {
+			tagName = strings.Replace(tagName, string(v.Raw), label, -1)
+			continue
+		}
+		tagName = strings.Replace(tagName, string(v.Raw), "", -1)
+	}
+	return tagName
 }

--- a/pkg/tagger/collectors/common_test.go
+++ b/pkg/tagger/collectors/common_test.go
@@ -1,6 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package collectors
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -47,5 +53,34 @@ func assertTagInfoListEqual(t *testing.T, expectedUpdates []*TagInfo, updates []
 	assert.Equal(t, len(expectedUpdates), len(updates))
 	for i := 0; i < len(expectedUpdates); i++ {
 		assertTagInfoEqual(t, expectedUpdates[i], updates[i])
+	}
+}
+
+func TestResolveTag(t *testing.T) {
+	testCases := []struct {
+		tmpl, label, expected string
+	}{
+		{
+			"kube_%%label%%", "app", "kube_app",
+		},
+		{
+			"foo_%%label%%_bar", "app", "foo_app_bar",
+		},
+		{
+			"%%label%%%%label%%", "app", "appapp",
+		},
+		{
+			"kube_", "app", "kube_", // no template variable
+		},
+		{
+			"kube_%%foo%%", "app", "kube_", // unsupported template variable
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			tagName := resolveTag(testCase.tmpl, testCase.label)
+			assert.Equal(t, testCase.expected, tagName)
+		})
 	}
 }

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -9,6 +9,7 @@ package collectors
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -38,8 +39,10 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 
 		// Pod labels
 		for name, value := range pod.Metadata.Labels {
-			if tagName, found := c.labelsAsTags[strings.ToLower(name)]; found {
-				tags.AddAuto(tagName, value)
+			for pattern, tmpl := range c.labelsAsTags {
+				if ok, _ := filepath.Match(pattern, strings.ToLower(name)); ok {
+					tags.AddAuto(resolveTag(tmpl, name), value)
+				}
 			}
 		}
 

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -311,6 +311,42 @@ func TestParsePods(t *testing.T) {
 				HighCardTags: []string{"kube_replica_set:redis-master-546dc4865f"},
 			},
 		},
+		{
+			desc: "pod labels as tags with wildcards",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Labels: map[string]string{
+						"component":         "kube-proxy",
+						"tier":              "node",
+						"k8s-app":           "kubernetes-dashboard",
+						"pod-template-hash": "490794276",
+					},
+				},
+				Status: dockerContainerStatus,
+				Spec:   dockerContainerSpec,
+			},
+			labelsAsTags: map[string]string{
+				"*":         "foo_%%label%%",
+				"component": "component",
+			},
+			annotationsAsTags: map[string]string{},
+			expectedInfo: &TagInfo{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"foo_component:kube-proxy",
+					"component:kube-proxy",
+					"foo_tier:node",
+					"foo_k8s-app:kubernetes-dashboard",
+					"foo_pod-template-hash:490794276",
+					"image_name:datadog/docker-dd-agent",
+					"image_tag:latest5",
+					"kube_container_name:dd-agent",
+					"short_image:docker-dd-agent",
+				},
+				HighCardTags: []string{},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {
 			collector := &KubeletCollector{

--- a/pkg/util/tmplvar/parse.go
+++ b/pkg/util/tmplvar/parse.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package tmplvar
+
+import (
+	"bytes"
+	"regexp"
+	"unicode"
+)
+
+var tmplVarRegex = regexp.MustCompile(`%%.+?%%`)
+
+// TemplateVar is the info for a parsed template variable.
+type TemplateVar struct {
+	Raw, Name, Key []byte
+}
+
+// ParseString returns parsed template variables found in the input string.
+func ParseString(s string) []TemplateVar {
+	return Parse([]byte(s))
+}
+
+// Parse returns parsed template variables found in the input data.
+func Parse(b []byte) []TemplateVar {
+	var parsed []TemplateVar
+	vars := tmplVarRegex.FindAll(b, -1)
+	for _, v := range vars {
+		name, key := parseTemplateVar(v)
+		parsed = append(parsed, TemplateVar{v, name, key})
+	}
+	return parsed
+}
+
+// parseTemplateVar extracts the name of the var and the key (or index if it can be
+// cast to an int)
+func parseTemplateVar(v []byte) (name, key []byte) {
+	stripped := bytes.Map(func(r rune) rune {
+		if unicode.IsSpace(r) || r == '%' {
+			return -1
+		}
+		return r
+	}, v)
+	split := bytes.SplitN(stripped, []byte("_"), 2)
+	name = split[0]
+	if len(split) == 2 {
+		key = split[1]
+	} else {
+		key = []byte("")
+	}
+	return name, key
+}

--- a/pkg/util/tmplvar/parse_test.go
+++ b/pkg/util/tmplvar/parse_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package tmplvar
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTemplateVar(t *testing.T) {
+	testCases := []struct {
+		tmpl, name, key string
+	}{
+		{
+			"%%host%%",
+			"host",
+			"",
+		},
+		{
+			"%%host_0%%",
+			"host",
+			"0",
+		},
+		{
+			"%%host 0%%",
+			"host0",
+			"",
+		},
+		{
+			"%%host_0_1%%",
+			"host",
+			"0_1",
+		},
+		{
+			"%%host_network_name%%",
+			"host",
+			"network_name",
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			name, key := parseTemplateVar([]byte(testCase.tmpl))
+			assert.Equal(t, testCase.name, string(name))
+			assert.Equal(t, testCase.key, string(key))
+		})
+	}
+}

--- a/releasenotes/notes/support-wildcards-pod-labels-as-tags-45b873f7a94be498.yaml
+++ b/releasenotes/notes/support-wildcards-pod-labels-as-tags-45b873f7a94be498.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    Added support for wildcards to `DD_KUBERNETES_POD_LABELS_AS_TAGS`. For example,
+    `DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"kube_%%label%%"}'` will all pod labels as
+    tags to your metrics with tags names prefixed by `kube_`.


### PR DESCRIPTION
### What does this PR do?

We currently have the env var `DD_KUBERNETES_POD_LABELS_AS_TAGS` in Agent 6, which allows people to map a pod label to any tag name. This gives users a lot more freedom than a blacklist and label-to-tag prefix (like Agent 5) and I wanted to keep this freedom. 

This PR allows wildcards in `DD_KUBERNETES_POD_LABELS_AS_TAGS`, for example `{"app*","kube_%%label%%"}` would resolve to the tag name `kube_application` for the label `application`. More interestingly `{"*", "kube_%%label%%"}` would add all pod labels as tags prefixed with `kube_`.

### Potential problems

- This feature would have to continue to be maintained and supported
- This could potentially add a lot more tags to Kubernetes metrics if wildcards are used recklessly
- This feature may not always give "clean" tag names, for example, a rule like `{"com.docker.swarm.*":"swarm_%%label%%"}` would resolve this label `com.docker.swarm.node.id`  to `swarm_com.docker.swarm.node.id`
- **This could potentially result in a lot of tags for metrics if people are using `*` recklessly**

### Other solutions

- We could add env vars like `DD_KUBERNETES_EXCLUDE_POD_LABELS_AS_TAGS` and `DD_KUBERNETES_LABEL_TO_TAG_PREFIX` to give the same behaviour as Agent 5. The problem is that users have much less freedom for how a label name is mapped to a tag name and the issue I previously mentioned about "clean" tag names still exists here.

### Motivation

Agent 5 supported the ability to easily add all pod labels as tags. This adds a similar feature to Agent 6 with a bit more freedom for the user.

### Additional Notes

This feature could also be added for all of 

- `DD_DOCKER_LABELS_AS_TAGS`
- `DD_DOCKER_ENV_AS_TAGS`
- `DD_KUBERNETES_POD_LABELS_AS_TAGS`
- `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS`
