### PR TITLE
Auto detect some potential kubelet hosts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -250,6 +250,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
+	config.BindEnvAndSetDefault("kubernetes_kubelet_host_autodetect", true)
 
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/util/kubernetes/kubelet/init.go
+++ b/pkg/util/kubernetes/kubelet/init.go
@@ -8,8 +8,16 @@
 package kubelet
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -22,10 +30,6 @@ func isCertificatesConfigured() bool {
 
 func isTokenPathConfigured() bool {
 	return config.Datadog.GetString("kubelet_auth_token_path") != ""
-}
-
-func isConfiguredTLSVerify() bool {
-	return config.Datadog.GetBool("kubelet_tls_verify")
 }
 
 func buildTLSConfig(verifyTLS bool, caPath string) (*tls.Config, error) {
@@ -48,4 +52,110 @@ func buildTLSConfig(verifyTLS bool, caPath string) (*tls.Config, error) {
 	tlsConfig.RootCAs = caPool
 	tlsConfig.BuildNameToCertificate()
 	return tlsConfig, nil
+}
+
+func getIPAddressesFromHostname(hostname string) ([]string, error) {
+	if net.ParseIP(hostname) != nil {
+		log.Debugf("This is already a resolved IP address: %s", hostname)
+		return nil, fmt.Errorf("already a resolved IP address")
+	}
+
+	log.Debug("Trying to resolve the hostname provided %q")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		log.Debugf("Cannot LookupIP hostname %s: %v", hostname, err)
+		return nil, err
+	}
+	var ipAddresses []string
+	for _, elt := range ips {
+		log.Debugf("Potential kubelet host: %q resolved from %q", elt.String(), hostname)
+		ipAddresses = append(ipAddresses, elt.String())
+	}
+	return ipAddresses, nil
+}
+
+// potentialKubeletHostsFilter remove duplicates and returns IP addresses first
+func potentialKubeletHostsFilter(potentialKubeletHosts []string) []string {
+	potentialKubeletHostsSet := make(map[string]struct{})
+	var ips []string
+	var hostnames []string
+
+	for _, elt := range potentialKubeletHosts {
+		if _, ok := potentialKubeletHostsSet[elt]; ok {
+			continue
+		}
+		potentialKubeletHostsSet[elt] = struct{}{}
+		if net.ParseIP(elt) == nil {
+			hostnames = append(hostnames, elt)
+			continue
+		}
+		ips = append(ips, elt)
+	}
+	return append(ips, hostnames...)
+}
+
+func getKubeletPotentialHosts() []string {
+	var potentialKubeletHosts []string
+
+	// from configuration
+	configuredKubeletHost := config.Datadog.GetString("kubernetes_kubelet_host")
+	if configuredKubeletHost != "" {
+		log.Infof("Potential kubelet host: %q provided by configuration kubernetes_kubelet_host", configuredKubeletHost)
+		potentialKubeletHosts = append(potentialKubeletHosts, configuredKubeletHost)
+		if !config.Datadog.GetBool("kubernetes_kubelet_host_autodetect") {
+			log.Debugf("Skipping the discovery of potential kubelet hosts: kubernetes_kubelet_host_autodetect == false")
+			return potentialKubeletHosts
+		}
+		potentialIPs, err := getIPAddressesFromHostname(configuredKubeletHost)
+		if err == nil {
+			potentialKubeletHosts = append(potentialKubeletHosts, potentialIPs...)
+		}
+	} else {
+		log.Debugf("Empty configuration for kubernetes_kubelet_host")
+	}
+
+	// docker detection
+	dockerHost, err := docker.HostnameProvider()
+	if err == nil {
+		log.Infof("Potential kubelet host: %q provided by docker", dockerHost)
+		potentialKubeletHosts = append(potentialKubeletHosts, dockerHost)
+		potentialIPs, err := getIPAddressesFromHostname(dockerHost)
+		if err == nil {
+			potentialKubeletHosts = append(potentialKubeletHosts, potentialIPs...)
+		}
+	} else {
+		log.Debugf("Cannot use docker host as potential kubelet host: %v", err)
+	}
+
+	// ec2 detection
+	ec2Host, err := ec2.GetHostname()
+	if err == nil {
+		log.Infof("Potential kubelet host: %q provided by ec2 metadata", ec2Host)
+		potentialKubeletHosts = append(potentialKubeletHosts, ec2Host)
+		potentialIPs, err := getIPAddressesFromHostname(ec2Host)
+		if err == nil {
+			potentialKubeletHosts = append(potentialKubeletHosts, potentialIPs...)
+		}
+	} else {
+		log.Debugf("Cannot use ec2 host as potential kubelet host: %v", err)
+	}
+
+	// gce detection
+	gceHost, err := gce.GetHostname()
+	if err == nil {
+		log.Infof("Potential kubelet host: %q provided by gce metadata", gceHost)
+		potentialKubeletHosts = append(potentialKubeletHosts, gceHost)
+		potentialIPs, err := getIPAddressesFromHostname(gceHost)
+		if err == nil {
+			potentialKubeletHosts = append(potentialKubeletHosts, potentialIPs...)
+		}
+	} else {
+		log.Debugf("Cannot use gce host as potential kubelet host: %v", err)
+	}
+
+	potentialKubeletHosts = potentialKubeletHostsFilter(potentialKubeletHosts)
+	log.Infof("Potential kubelet detected hosts are: %s", strings.Join(potentialKubeletHosts, ", "))
+	return potentialKubeletHosts
 }

--- a/pkg/util/kubernetes/kubelet/init_test.go
+++ b/pkg/util/kubernetes/kubelet/init_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubelet
+
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/docker/docker/pkg/testutil/assert"
+)
+
+//func TestSortWithIPFirst()
+
+func TestSortWithIPFirst(t *testing.T) {
+	for _, tc := range []struct {
+		given    []string
+		expected []string
+	}{
+		{
+			[]string{
+				"host",
+				"192.168.1.1",
+			},
+			[]string{
+				"192.168.1.1",
+				"host",
+			},
+		},
+		{
+			[]string{
+				"host",
+				"192.168.1.1",
+				"192.168.1.2",
+			},
+			[]string{
+				"192.168.1.1",
+				"192.168.1.2",
+				"host",
+			},
+		},
+		{
+			[]string{
+				"host-a",
+				"host-b",
+				"192.168.1.1",
+				"192.168.1.2",
+			},
+			[]string{
+				"192.168.1.1",
+				"192.168.1.2",
+				"host-a",
+				"host-b",
+			},
+		},
+		{
+			[]string{
+				"host-a",
+				"host-b",
+				"host-a",
+				"192.168.1.1",
+				"192.168.1.2",
+			},
+			[]string{
+				"192.168.1.1",
+				"192.168.1.2",
+				"host-a",
+				"host-b",
+			},
+		},
+		{
+			[]string{
+				"192.168.1.2",
+				"host-a",
+				"host-b",
+				"host-a",
+				"192.168.1.1",
+				"192.168.1.1",
+				"192.168.1.2",
+			},
+			[]string{
+				"192.168.1.2",
+				"192.168.1.1",
+				"host-a",
+				"host-b",
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			current := potentialKubeletHostsFilter(tc.given)
+			assert.EqualStringSlice(t, current, tc.expected)
+		})
+	}
+}

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -189,6 +189,7 @@ func (suite *KubeletTestSuite) SetupTest() {
 	mockConfig.Set("kubernetes_kubelet_host", "")
 	mockConfig.Set("kubernetes_http_kubelet_port", 10250)
 	mockConfig.Set("kubernetes_https_kubelet_port", 10255)
+	mockConfig.Set("kubernetes_kubelet_host_autodetect", false)
 }
 
 func (suite *KubeletTestSuite) TestLocateKubeletHTTP() {
@@ -267,7 +268,7 @@ func (suite *KubeletTestSuite) TestGetNodeInfo() {
 	defer ts.Close()
 	require.Nil(suite.T(), err)
 
-	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
 	mockConfig.Set("kubelet_tls_verify", false)
 	mockConfig.Set("kubelet_auth_token_path", "")
@@ -300,7 +301,7 @@ func (suite *KubeletTestSuite) TestGetHostname() {
 	defer ts.Close()
 	require.Nil(suite.T(), err)
 
-	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
 	mockConfig.Set("kubelet_tls_verify", false)
 	mockConfig.Set("kubelet_auth_token_path", "")
@@ -345,7 +346,7 @@ func (suite *KubeletTestSuite) TestHostnameProvider() {
 	defer ts.Close()
 	require.Nil(suite.T(), err)
 
-	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
 	mockConfig.Set("kubelet_tls_verify", false)
 	mockConfig.Set("kubelet_auth_token_path", "")
@@ -364,7 +365,7 @@ func (suite *KubeletTestSuite) TestPodlistCache() {
 	defer ts.Close()
 	require.Nil(suite.T(), err)
 
-	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
 
 	kubeutil, err := GetKubeUtil()
@@ -404,7 +405,7 @@ func (suite *KubeletTestSuite) TestGetPodForContainerID() {
 	defer ts.Close()
 	require.Nil(suite.T(), err)
 
-	mockConfig.Set("kubernetes_kubelet_host", "localhost")
+	mockConfig.Set("kubernetes_kubelet_host", "127.0.0.1")
 	mockConfig.Set("kubernetes_http_kubelet_port", kubeletPort)
 
 	kubeutil, err := GetKubeUtil()


### PR DESCRIPTION
### What does this PR do?

This PR will solve multiple issues:
- support escalation on Kubelet TLS
- Autodetection on IP address first, no DNS DDoS
- TLSBootstrap Kubernetes 1.11 ready [see](https://github.com/kubernetes/kubernetes/blob/1ca851baec6a245bbb2bd3aea284e6cb4f364348/pkg/kubelet/kubelet.go#L760-L775)
  Before, there is only the `hostname` in the TLSBootstrap CSR subject alternative name

### Motivation

Reduce the escalations, avoid any DNS DDoS if possible.

The autodetection try to resolve (with timeout) any potential kubelet host.
These IPAddresses are tested before any hostname.

I needed to refactor the kubelet detection logic to be able to loop over potential kubelet hosts.

I created a new configuration value to let to the users the ability to disable the autodetection and stay on the previous behaviour.

### Additional Notes

More testing to come ... (AWS, GCE at least).

We should cover all cloud providers. There are also some AWS routes to grab the IP address too. [see](https://github.com/DataDog/pupernetes/blob/master/pkg/setup/hostname.go#L102-L111)

[pupernetes](https://github.com/DataDog/pupernetes) environment:
```text 
agent start
2018-06-29 17:17:12 UTC | INFO | (start.go:154 in StartAgent) | Starting Datadog Agent v6.3.0-test-cloudfront-invalidation+git.31.b78a869
2018-06-29 17:17:12 UTC | INFO | (start.go:172 in StartAgent) | Hostname is: v1704
2018-06-29 17:17:13 UTC | INFO | (start.go:189 in StartAgent) | GUI server port -1 specified: not starting the GUI.
2018-06-29 17:17:13 UTC | INFO | (forwarder.go:142 in Start) | Forwarder started, sending to 1 endpoint(s) with 1 worker(s) each: "http://fake-datadog.default.svc.cluster.local" (1 api key(s))
2018-06-29 17:17:13 UTC | INFO | (start.go:229 in StartAgent) | logs-agent disabled
2018-06-29 17:17:13 UTC | INFO | (tagger.go:79 in Init) | starting the tagging system
2018-06-29 17:17:13 UTC | INFO | (init.go:105 in getKubeletPotentialHosts) | Potential kubelet host: "192.168.128.162" provided by configuration kubernetes_kubelet_host
2018-06-29 17:17:13 UTC | INFO | (udp.go:69 in Listen) | dogstatsd-udp: starting to listen on 127.0.0.1:8125
2018-06-29 17:17:13 UTC | INFO | (init.go:122 in getKubeletPotentialHosts) | Potential kubelet host: "v1704" provided by docker
2018-06-29 17:17:15 UTC | INFO | (init.go:159 in getKubeletPotentialHosts) | Potential kubelet detected hosts are: 192.168.128.162, v1704
2018-06-29 17:17:15 UTC | INFO | (kubelet.go:421 in init) | Host 1/2, trying to use host 192.168.128.162 with HTTPS and HTTP settings
2018-06-29 17:17:15 UTC | INFO | (kubelet.go:433 in init) | Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods
2018-06-29 17:17:15 UTC | INFO | (kubelet.go:437 in init) | Successfully connected securely on kubelet endpoint https://192.168.128.162:10250/pods
2018-06-29 17:17:15 UTC | INFO | (kubelet.go:440 in init) | Successfully authorized to query the kubelet on https://192.168.128.162:10250/pods: 200, using https://192.168.128.162:10250 as kubelet endpoint
```

Diagnose:
```text
agent diagnose
=== Running Kubelet availability diagnosis ===
[INFO] infof: Potential kubelet host: "192.168.128.162" provided by configuration kubernetes_kubelet_host - 1530292717244695539
2018-06-29 17:18:37 UTC | ERROR | (diagnosis.go:21 in diagnose) | unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
2018-06-29 17:18:37 UTC | INFO | (init.go:105 in getKubeletPotentialHosts) | Potential kubelet host: "192.168.128.162" provided by configuration kubernetes_kubelet_host
[INFO] infof: Potential kubelet host: "v1704" provided by docker - 1530292717275592368
2018-06-29 17:18:37 UTC | INFO | (init.go:122 in getKubeletPotentialHosts) | Potential kubelet host: "v1704" provided by docker
[INFO] infof: Potential kubelet detected hosts are: 192.168.128.162, v1704 - 1530292719677918675
2018-06-29 17:18:39 UTC | INFO | (init.go:159 in getKubeletPotentialHosts) | Potential kubelet detected hosts are: 192.168.128.162, v1704
[INFO] infof: Host 1/2, trying to use host 192.168.128.162 with HTTPS and HTTP settings - 1530292719678467025
2018-06-29 17:18:39 UTC | INFO | (kubelet.go:421 in init) | Host 1/2, trying to use host 192.168.128.162 with HTTPS and HTTP settings
[INFO] infof: Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods - 1530292719689101003
2018-06-29 17:18:39 UTC | INFO | (kubelet.go:433 in init) | Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods
[INFO] infof: Successfully connected securely on kubelet endpoint https://192.168.128.162:10250/pods - 1530292719714082418
[INFO] infof: Successfully authorized to query the kubelet on https://192.168.128.162:10250/pods: 200, using https://192.168.128.162:10250 as kubelet endpoint - 1530292719714196457
===> PASS
```

Debug diagnose:
```text
DD_LOG_LEVEL=debug agent diagnose
=== Running Kubelet availability diagnosis ===
2018-06-29 17:19:36 UTC | ERROR | (diagnosis.go:21 in diagnose) | unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
[INFO] infof: Potential kubelet host: "192.168.128.162" provided by configuration kubernetes_kubelet_host - 1530292776211041313
2018-06-29 17:19:36 UTC | INFO | (init.go:105 in getKubeletPotentialHosts) | Potential kubelet host: "192.168.128.162" provided by configuration kubernetes_kubelet_host
[DEBUG] debugf: This is already a resolved IP address: 192.168.128.162 - 1530292776211490698
2018-06-29 17:19:36 UTC | DEBUG | (init.go:59 in getIPAddressesFromHostname) | This is already a resolved IP address: 192.168.128.162
[INFO] infof: Potential kubelet host: "v1704" provided by docker - 1530292776237115838
2018-06-29 17:19:36 UTC | INFO | (init.go:122 in getKubeletPotentialHosts) | Potential kubelet host: "v1704" provided by docker
[DEBUG] debug: Trying to resolve the hostname provided %q - 1530292776237994408
2018-06-29 17:19:36 UTC | DEBUG | (init.go:63 in getIPAddressesFromHostname) | Trying to resolve the hostname provided %q
[DEBUG] debugf: Cannot LookupIP hostname v1704: lookup v1704 on 192.168.254.2:53: no such host - 1530292776281822501
2018-06-29 17:19:36 UTC | DEBUG | (init.go:68 in getIPAddressesFromHostname) | Cannot LookupIP hostname v1704: lookup v1704 on 192.168.254.2:53: no such host
[DEBUG] debugf: Cannot use ec2 host as potential kubelet host: unable to fetch EC2 API, Get http://169.254.169.254/latest/meta-data/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) - 1530292776384321265
2018-06-29 17:19:36 UTC | DEBUG | (init.go:142 in getKubeletPotentialHosts) | Cannot use ec2 host as potential kubelet host: unable to fetch EC2 API, Get http://169.254.169.254/latest/meta-data/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
[DEBUG] debugf: Cannot use gce host as potential kubelet host: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) - 1530292776686005350
2018-06-29 17:19:36 UTC | DEBUG | (init.go:155 in getKubeletPotentialHosts) | Cannot use gce host as potential kubelet host: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
[INFO] infof: Potential kubelet detected hosts are: 192.168.128.162, v1704 - 1530292776686340197
2018-06-29 17:19:36 UTC | INFO | (init.go:159 in getKubeletPotentialHosts) | Potential kubelet detected hosts are: 192.168.128.162, v1704
[DEBUG] debugf: Potential kubelet hosts are: 192.168.128.162, v1704 - 1530292776686607999
[INFO] infof: Host 1/2, trying to use host 192.168.128.162 with HTTPS and HTTP settings - 1530292776686777672
2018-06-29 17:19:36 UTC | DEBUG | (kubelet.go:414 in init) | Potential kubelet hosts are: 192.168.128.162, v1704
2018-06-29 17:19:36 UTC | INFO | (kubelet.go:421 in init) | Host 1/2, trying to use host 192.168.128.162 with HTTPS and HTTP settings
[DEBUG] debug: Using HTTPS with service account bearer token - 1530292776688205725
2018-06-29 17:19:36 UTC | DEBUG | (kubelet.go:285 in setupKubeletApiClient) | Using HTTPS with service account bearer token
[DEBUG] debugf: Trying to query the kubelet endpoint https://192.168.128.162:10250 ... - 1530292776688510326
2018-06-29 17:19:36 UTC | DEBUG | (kubelet.go:430 in init) | Trying to query the kubelet endpoint https://192.168.128.162:10250 ...
[INFO] infof: Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods - 1530292776696400196
2018-06-29 17:19:36 UTC | INFO | (kubelet.go:433 in init) | Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods
[INFO] infof: Successfully connected securely on kubelet endpoint https://192.168.128.162:10250/pods - 1530292776707756343
[INFO] infof: Successfully authorized to query the kubelet on https://192.168.128.162:10250/pods: 200, using https://192.168.128.162:10250 as kubelet endpoint - 1530292776707819665
===> PASS
```

### Failure injections

Setup:
* `kubernetes_kubelet_host: 172.17.0.1`
  This IP address isn't in the Kubelet server certificate SAN
* docker will provide `v1704` host hostname
   This host is resolved to `192.168.128.162`

```
=== Running Kubelet availability diagnosis ===
[INFO] infof: Potential kubelet host: "172.17.0.1" provided by configuration kubernetes_kubelet_host - 1530293181652714630
2018-06-29 17:26:21 UTC | INFO | (init.go:105 in getKubeletPotentialHosts) | Potential kubelet host: "172.17.0.1" provided by configuration kubernetes_kubelet_host
[DEBUG] debugf: This is already a resolved IP address: 172.17.0.1 - 1530293181653083460
2018-06-29 17:26:21 UTC | DEBUG | (init.go:59 in getIPAddressesFromHostname) | This is already a resolved IP address: 172.17.0.1
[DEBUG] debugf: Successfully connected to Docker server version 18.01.0-ce - 1530293181656137799
2018-06-29 17:26:21 UTC | DEBUG | (docker_util.go:106 in connectToDocker) | Successfully connected to Docker server version 18.01.0-ce
[INFO] infof: Potential kubelet host: "v1704" provided by docker - 1530293181699611974
[DEBUG] debug: Trying to resolve the hostname provided %q - 1530293181699713170
[DEBUG] debugf: Potential kubelet host: "192.168.128.162" resolved from "v1704" - 1530293181699964184
2018-06-29 17:26:21 UTC | INFO | (init.go:122 in getKubeletPotentialHosts) | Potential kubelet host: "v1704" provided by docker
2018-06-29 17:26:21 UTC | DEBUG | (init.go:63 in getIPAddressesFromHostname) | Trying to resolve the hostname provided %q
2018-06-29 17:26:21 UTC | DEBUG | (init.go:73 in getIPAddressesFromHostname) | Potential kubelet host: "192.168.128.162" resolved from "v1704"
[DEBUG] debugf: Cannot use ec2 host as potential kubelet host: unable to fetch EC2 API, Get http://169.254.169.254/latest/meta-data/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) - 1530293181801355269
2018-06-29 17:26:21 UTC | DEBUG | (init.go:142 in getKubeletPotentialHosts) | Cannot use ec2 host as potential kubelet host: unable to fetch EC2 API, Get http://169.254.169.254/latest/meta-data/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
[DEBUG] debugf: Cannot use gce host as potential kubelet host: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) - 1530293182102888177
2018-06-29 17:26:22 UTC | DEBUG | (init.go:155 in getKubeletPotentialHosts) | Cannot use gce host as potential kubelet host: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
[INFO] infof: Potential kubelet detected hosts are: 172.17.0.1, 192.168.128.162, v1704 - 1530293182103304606
2018-06-29 17:26:22 UTC | INFO | (init.go:159 in getKubeletPotentialHosts) | Potential kubelet detected hosts are: 172.17.0.1, 192.168.128.162, v1704
[DEBUG] debugf: Potential kubelet hosts are: 172.17.0.1, 192.168.128.162, v1704 - 1530293182103482217
[INFO] infof: Host 1/3, trying to use host 172.17.0.1 with HTTPS and HTTP settings - 1530293182103619220
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:414 in init) | Potential kubelet hosts are: 172.17.0.1, 192.168.128.162, v1704
2018-06-29 17:26:22 UTC | INFO | (kubelet.go:421 in init) | Host 1/3, trying to use host 172.17.0.1 with HTTPS and HTTP settings
[DEBUG] debug: Using HTTPS with service account bearer token - 1530293182104597015
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:285 in setupKubeletApiClient) | Using HTTPS with service account bearer token
[DEBUG] debugf: Trying to query the kubelet endpoint https://172.17.0.1:10250 ... - 1530293182104835173
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:430 in init) | Trying to query the kubelet endpoint https://172.17.0.1:10250 ...
[INFO] infof: Successfully queried to https://172.17.0.1:10250/ without any security settings, adding security transport settings to query https://172.17.0.1:10250/pods - 1530293182113742344
2018-06-29 17:26:22 UTC | INFO | (kubelet.go:433 in init) | Successfully queried to https://172.17.0.1:10250/ without any security settings, adding security transport settings to query https://172.17.0.1:10250/pods
[DEBUG] debugf: Cannot request https://172.17.0.1:10250/pods: Get https://172.17.0.1:10250/pods: x509: certificate is valid for 127.0.0.1, 192.168.128.162, 192.168.254.1, not 172.17.0.1 - 1530293182118477192
[DEBUG] debugf: Invalid x509 settings, the kubelet server certificate is not valid for this subject alternative name: 172.17.0.1, Get https://172.17.0.1:10250/pods: x509: certificate is valid for 127.0.0.1, 192.168.128.162, 192.168.254.1, not 172.17.0.1, Please check the SAN of the kubelet server certificate with "openssl x509 -in ${KUBELET_CERTIFICATE} -text -noout".  - 1530293182118592415
[DEBUG] debugf: Cannot use the HTTPS endpoint: https://172.17.0.1:10250, trying through HTTP - 1530293182118635181
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:355 in doKubeletRequest) | Cannot request https://172.17.0.1:10250/pods: Get https://172.17.0.1:10250/pods: x509: certificate is valid for 127.0.0.1, 192.168.128.162, 192.168.254.1, not 172.17.0.1
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:455 in init) | Invalid x509 settings, the kubelet server certificate is not valid for this subject alternative name: 172.17.0.1, Get https://172.17.0.1:10250/pods: x509: certificate is valid for 127.0.0.1, 192.168.128.162, 192.168.254.1, not 172.17.0.1, Please check the SAN of the kubelet server certificate with "openssl x509 -in ${KUBELET_CERTIFICATE} -text -noout". 
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:466 in init) | Cannot use the HTTPS endpoint: https://172.17.0.1:10250, trying through HTTP
[DEBUG] debugf: Trying to query the kubelet endpoint http://172.17.0.1:10255 ... - 1530293182118748707
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:470 in init) | Trying to query the kubelet endpoint http://172.17.0.1:10255 ...
[DEBUG] debugf: Cannot request http://172.17.0.1:10255/: Get http://172.17.0.1:10255/: dial tcp 172.17.0.1:10255: connect: connection refused - 1530293182119812969
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:355 in doKubeletRequest) | Cannot request http://172.17.0.1:10255/: Get http://172.17.0.1:10255/: dial tcp 172.17.0.1:10255: connect: connection refused
[INFO] infof: Cannot use the HTTP endpoint: http://172.17.0.1:10255: Get http://172.17.0.1:10255/: dial tcp 172.17.0.1:10255: connect: connection refused - 1530293182119904466
[INFO] infof: Host 1/3, cannot use host 172.17.0.1 with HTTPS and HTTP settings - 1530293182119947623
[INFO] infof: Host 2/3, trying to use host 192.168.128.162 with HTTPS and HTTP settings - 1530293182119974630
[DEBUG] debug: Using HTTPS with service account bearer token - 1530293182120290467
[DEBUG] debugf: Trying to query the kubelet endpoint https://192.168.128.162:10250 ... - 1530293182120359623
2018-06-29 17:26:22 UTC | INFO | (kubelet.go:476 in init) | Cannot use the HTTP endpoint: http://172.17.0.1:10255: Get http://172.17.0.1:10255/: dial tcp 172.17.0.1:10255: connect: connection refused
2018-06-29 17:26:22 UTC | INFO | (kubelet.go:477 in init) | Host 1/3, cannot use host 172.17.0.1 with HTTPS and HTTP settings
2018-06-29 17:26:22 UTC | INFO | (kubelet.go:421 in init) | Host 2/3, trying to use host 192.168.128.162 with HTTPS and HTTP settings
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:285 in setupKubeletApiClient) | Using HTTPS with service account bearer token
2018-06-29 17:26:22 UTC | DEBUG | (kubelet.go:430 in init) | Trying to query the kubelet endpoint https://192.168.128.162:10250 ...
[INFO] infof: Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods - 1530293182125289942
2018-06-29 17:26:22 UTC | INFO | (kubelet.go:433 in init) | Successfully queried to https://192.168.128.162:10250/ without any security settings, adding security transport settings to query https://192.168.128.162:10250/pods
[INFO] infof: Successfully connected securely on kubelet endpoint https://192.168.128.162:10250/pods - 1530293182148490297
[INFO] infof: Successfully authorized to query the kubelet on https://192.168.128.162:10250/pods: 200, using https://192.168.128.162:10250 as kubelet endpoint - 1530293182148568402
===> PASS
```