### PR TITLE
[DCA] Fix validation middleware to allow for namespace in metadata paths.

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -104,7 +104,7 @@ func StopServer() {
 func validateToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.String()
-		if strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 6 {
+		if strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 {
 			if err := util.ValidateDCARequest(w, r); err != nil {
 				return
 			}

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -88,7 +88,6 @@ func StartServer() error {
 
 	go srv.Serve(tlsListener)
 	return nil
-
 }
 
 // StopServer closes the connection and the server

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTokenMiddleware(t *testing.T) {
+	config.Datadog.Set("cluster_agent.auth_token", "abc123")
+	util.SetDCAAuthToken()
+
+	tests := []struct {
+		path               string
+		expectedStatusCode int
+	}{
+		{
+			"/api/v1/metadata",
+			http.StatusForbidden,
+		},
+		{
+			"/api/v1/metadata/node/namespace/pod",
+			http.StatusOK,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			req, err := http.NewRequest("GET", tt.path, nil)
+			require.NoError(t, err)
+
+			req.Header.Add("Authorization", "Bearer abc123")
+
+			rr := httptest.NewRecorder()
+
+			nopHandler := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}
+
+			handler := validateToken(http.HandlerFunc(nopHandler))
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.expectedStatusCode, rr.Code)
+		})
+	}
+}

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -22,16 +22,23 @@ func TestValidateTokenMiddleware(t *testing.T) {
 	util.SetDCAAuthToken()
 
 	tests := []struct {
-		path               string
+		path, authToken    string
 		expectedStatusCode int
 	}{
 		{
 			"/api/v1/metadata",
+			"abc123",
 			http.StatusForbidden,
 		},
 		{
 			"/api/v1/metadata/node/namespace/pod",
+			"abc123",
 			http.StatusOK,
+		},
+		{
+			"/api/v1/metadata/node/namespace/pod",
+			"imposter",
+			http.StatusForbidden,
 		},
 	}
 
@@ -40,7 +47,7 @@ func TestValidateTokenMiddleware(t *testing.T) {
 			req, err := http.NewRequest("GET", tt.path, nil)
 			require.NoError(t, err)
 
-			req.Header.Add("Authorization", "Bearer abc123")
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tt.authToken))
 
 			rr := httptest.NewRecorder()
 

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
 package api
 
 import (

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 
-	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
@@ -62,9 +61,6 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: string
 			Example: "no cached metadata found for the pod my-nginx-5d69 on the node localhost"
 	*/
-	if err := apiutil.ValidateDCARequest(w, r); err != nil {
-		return
-	}
 	vars := mux.Vars(r)
 	var metaBytes []byte
 	nodeName := vars["nodeName"]


### PR DESCRIPTION
### What does this PR do?

Fix validation middleware to allow for namespace in metadata paths.

### Motivation

The `validateToken` middleware asserts a specific paths which were changed in [this PR](https://github.com/DataDog/datadog-agent/pull/1892).