### PR TITLE
Don’t collect gohai network information when agent running in container.

### DIFF
--- a/pkg/metadata/gohai/gohai.go
+++ b/pkg/metadata/gohai/gohai.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/gohai/network"
 	"github.com/DataDog/gohai/platform"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -23,7 +24,6 @@ func GetPayload() *Payload {
 }
 
 func getGohaiInfo() *gohai {
-
 	res := new(gohai)
 
 	cpuPayload, err := new(cpu.Cpu).Collect()
@@ -47,11 +47,13 @@ func getGohaiInfo() *gohai {
 		log.Errorf("Failed to retrieve memory metadata: %s", err)
 	}
 
-	networkPayload, err := new(network.Network).Collect()
-	if err == nil {
-		res.Network = networkPayload
-	} else {
-		log.Errorf("Failed to retrieve network metadata: %s", err)
+	if !config.IsContainerized() {
+		networkPayload, err := new(network.Network).Collect()
+		if err == nil {
+			res.Network = networkPayload
+		} else {
+			log.Errorf("Failed to retrieve network metadata: %s", err)
+		}
 	}
 
 	platformPayload, err := new(platform.Platform).Collect()

--- a/pkg/metadata/gohai/gohai_test.go
+++ b/pkg/metadata/gohai/gohai_test.go
@@ -6,8 +6,10 @@
 package gohai
 
 import (
-	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPayload(t *testing.T) {
@@ -17,5 +19,18 @@ func TestGetPayload(t *testing.T) {
 	assert.NotNil(t, gohai.Gohai.FileSystem)
 	assert.NotNil(t, gohai.Gohai.Memory)
 	assert.NotNil(t, gohai.Gohai.Network)
+	assert.NotNil(t, gohai.Gohai.Platform)
+}
+
+func TestGetPayloadContainerized(t *testing.T) {
+	os.Setenv("DOCKER_DD_AGENT", "yes")
+	defer os.Unsetenv("DOCKER_DD_AGENT")
+
+	gohai := GetPayload()
+
+	assert.NotNil(t, gohai.Gohai.CPU)
+	assert.NotNil(t, gohai.Gohai.FileSystem)
+	assert.NotNil(t, gohai.Gohai.Memory)
+	assert.Nil(t, gohai.Gohai.Network)
 	assert.NotNil(t, gohai.Gohai.Platform)
 }

--- a/releasenotes/notes/no-network-info-containerized-883f53b53dcca8ea.yaml
+++ b/releasenotes/notes/no-network-info-containerized-883f53b53dcca8ea.yaml
@@ -1,0 +1,5 @@
+other:
+  - |
+  The system information collected from gohai no longer includes network information
+  when the agent is running in a container since the network information is for the
+  the container and not the host itself.

--- a/releasenotes/notes/no-network-info-containerized-883f53b53dcca8ea.yaml
+++ b/releasenotes/notes/no-network-info-containerized-883f53b53dcca8ea.yaml
@@ -1,5 +1,5 @@
 other:
   - |
-  The system information collected from gohai no longer includes network information
-  when the agent is running in a container since the network information is for the
-  the container and not the host itself.
+    The system information collected from gohai no longer includes network information
+    when the agent is running in a container since the network information is for the
+    the container and not the host itself.


### PR DESCRIPTION
### What does this PR do?

The system information collected from gohai no longer includes network information when the agent is running in a container since the network information is for the the container and not the host itself.

The UI seems to be able to handle missing network information just fine.

<img width="692" alt="screen shot 2018-07-02 at 12 22 27 pm" src="https://user-images.githubusercontent.com/5367914/42175205-c306b7e2-7df2-11e8-830e-dd582c10f570.png">

### Motivation

It can be misleading to show the container IP addresses as system information.

### To Do

- [x] Sanity check to make sure UI is not broken if no network information is collected from the agent