### PR TITLE
[kube] Update ServicesMapper logic to be compatible with Kubernetes 1.3.x

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,9 +14,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/spf13/viper"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -199,7 +200,8 @@ func init() {
 	Datadog.SetDefault("kubelet_client_key", "")
 
 	Datadog.SetDefault("kubernetes_collect_metadata_tags", true)
-	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60*5) // 5 min
+	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60*5)    // 5 min
+	BindEnvAndSetDefault("kubernetes_map_services_on_reference", true) // temporary opt-out of the new mapping logic
 
 	// Kube ApiServer
 	Datadog.SetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -200,8 +200,8 @@ func init() {
 	Datadog.SetDefault("kubelet_client_key", "")
 
 	Datadog.SetDefault("kubernetes_collect_metadata_tags", true)
-	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60*5)    // 5 min
-	BindEnvAndSetDefault("kubernetes_map_services_on_reference", true) // temporary opt-out of the new mapping logic
+	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60*5) // 5 min
+	BindEnvAndSetDefault("kubernetes_map_services_on_ip", false)    // temporary opt-out of the new mapping logic
 
 	// Kube ApiServer
 	Datadog.SetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -132,14 +132,14 @@ func (c *APIClient) connect() error {
 // It is updated by mapServices in services.go.
 type MetadataMapperBundle struct {
 	Services ServicesMapper `json:"services,omitempty"`
-	mapOnRef bool           // temporary opt-out of the new mapping logic
+	mapOnIP  bool           // temporary opt-out of the new mapping logic
 	m        sync.RWMutex
 }
 
 func newMetadataMapperBundle() *MetadataMapperBundle {
 	return &MetadataMapperBundle{
 		Services: make(ServicesMapper),
-		mapOnRef: config.Datadog.GetBool("kubernetes_map_services_on_reference"),
+		mapOnIP:  config.Datadog.GetBool("kubernetes_map_services_on_ip"),
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -132,12 +132,14 @@ func (c *APIClient) connect() error {
 // It is updated by mapServices in services.go.
 type MetadataMapperBundle struct {
 	Services ServicesMapper `json:"services,omitempty"`
+	mapOnRef bool           // temporary opt-out of the new mapping logic
 	m        sync.RWMutex
 }
 
 func newMetadataMapperBundle() *MetadataMapperBundle {
 	return &MetadataMapperBundle{
 		Services: make(ServicesMapper),
+		mapOnRef: config.Datadog.GetBool("kubernetes_map_services_on_reference"),
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -134,10 +134,10 @@ func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.Pod
 	defer metaBundle.m.Unlock()
 
 	var err error
-	if metaBundle.mapOnRef {
-		err = metaBundle.Services.mapOnRef(nodeName, endpointList)
-	} else {
+	if metaBundle.mapOnIP {
 		err = metaBundle.Services.mapOnIp(nodeName, pods, endpointList)
+	} else { // Default behaviour
+		err = metaBundle.Services.mapOnRef(nodeName, endpointList)
 	}
 	if err != nil {
 		return err

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -10,8 +10,10 @@ package apiserver
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ServicesMapper maps pod names to the names of the services targeting the pod
@@ -45,7 +47,8 @@ func (m ServicesMapper) Set(ns, podName string, svcs []string) {
 	m[ns][podName] = svcs
 }
 
-func (m ServicesMapper) Map(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {
+// mapOnIp matches pods to services via IP. It supports Kubernetes 1.4+
+func (m ServicesMapper) mapOnIp(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {
 	ipToEndpoints := make(map[string][]string)    // maps the IP address from an endpoint (pod) to associated services ex: "10.10.1.1" : ["service1","service2"]
 	podToIp := make(map[string]map[string]string) // maps pod names to its IP address keyed by the namespace a pod belongs to
 
@@ -56,6 +59,23 @@ func (m ServicesMapper) Map(nodeName string, pods v1.PodList, endpointList v1.En
 		log.Debugf("Service mapper was given an empty node name. Mapping might be incorrect.")
 	}
 
+	for _, svc := range endpointList.Items {
+		for _, endpointsSubsets := range svc.Subsets {
+			if endpointsSubsets.Addresses == nil {
+				log.Tracef("A subset of endpoints from %s could not be evaluated", svc.Name)
+				continue
+			}
+			for _, edpt := range endpointsSubsets.Addresses {
+				if edpt.NodeName == nil {
+					// Kubernetes 1.3+ payload, fallback to mapOnRef
+					return m.mapOnRef(nodeName, pods, endpointList)
+				}
+				if *edpt.NodeName == nodeName {
+					ipToEndpoints[edpt.IP] = append(ipToEndpoints[edpt.IP], svc.Name)
+				}
+			}
+		}
+	}
 	for _, pod := range pods.Items {
 		if pod.Status.PodIP == "" {
 			log.Debugf("PodIP is empty, ignoring pod %s in namespace %s", pod.Name, pod.Namespace)
@@ -65,19 +85,6 @@ func (m ServicesMapper) Map(nodeName string, pods v1.PodList, endpointList v1.En
 			podToIp[pod.Namespace] = make(map[string]string)
 		}
 		podToIp[pod.Namespace][pod.Name] = pod.Status.PodIP
-	}
-	for _, svc := range endpointList.Items {
-		for _, endpointsSubsets := range svc.Subsets {
-			if endpointsSubsets.Addresses == nil {
-				log.Tracef("A subset of endpoints from %s could not be evaluated", svc.Name)
-				continue
-			}
-			for _, edpt := range endpointsSubsets.Addresses {
-				if edpt.NodeName != nil && *edpt.NodeName == nodeName {
-					ipToEndpoints[edpt.IP] = append(ipToEndpoints[edpt.IP], svc.Name)
-				}
-			}
-		}
 	}
 	for ns, pods := range podToIp {
 		for name, ip := range pods {
@@ -89,13 +96,48 @@ func (m ServicesMapper) Map(nodeName string, pods v1.PodList, endpointList v1.En
 	return nil
 }
 
+// mapOnRef matches pods to services via endpoint TargetRef objects. It supports Kubernetes 1.3+
+func (m ServicesMapper) mapOnRef(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {
+	uidToPod := make(map[types.UID]v1.ObjectReference)
+	uidToServices := make(map[types.UID][]string)
+
+	for _, svc := range endpointList.Items {
+		for _, endpointsSubsets := range svc.Subsets {
+			for _, edpt := range endpointsSubsets.Addresses {
+				if edpt.TargetRef == nil {
+					log.Debug("Empty TargetRef on endpoint %s of service %s, skipping", edpt.IP, svc.Name)
+					continue
+				}
+				ref := *edpt.TargetRef
+				if ref.Kind != "Pod" {
+					continue
+				}
+				if ref.Name == "" || ref.Namespace == "" {
+					log.Debug("Incomplete reference for object %s on service %s, skipping", ref.UID, svc.Name)
+					continue
+				}
+				uidToPod[ref.UID] = ref
+				uidToServices[ref.UID] = append(uidToServices[ref.UID], svc.Name)
+			}
+		}
+	}
+	for uid, svcs := range uidToServices {
+		pod, ok := uidToPod[uid]
+		if !ok {
+			continue
+		}
+		m.Set(pod.Namespace, pod.Name, svcs)
+	}
+	return nil
+}
+
 // mapServices maps each pod (endpoint) to the metadata associated with it.
 // It is on a per node basis to avoid mixing up the services pods are actually connected to if all pods of different nodes share a similar subnet, therefore sharing a similar IP.
 func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {
 	metaBundle.m.Lock()
 	defer metaBundle.m.Unlock()
 
-	if err := metaBundle.Services.Map(nodeName, pods, endpointList); err != nil {
+	if err := metaBundle.Services.mapOnIp(nodeName, pods, endpointList); err != nil {
 		return err
 	}
 	log.Tracef("The services matched %q", fmt.Sprintf("%s", metaBundle.Services))

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -93,7 +93,7 @@ func (m ServicesMapper) mapOnIp(nodeName string, pods v1.PodList, endpointList v
 }
 
 // mapOnRef matches pods to services via endpoint TargetRef objects. It supports Kubernetes 1.3+
-func (m ServicesMapper) mapOnRef(nodeName string, pods v1.PodList, endpointList v1.EndpointsList) error {
+func (m ServicesMapper) mapOnRef(nodeName string, endpointList v1.EndpointsList) error {
 	uidToPod := make(map[types.UID]v1.ObjectReference)
 	uidToServices := make(map[types.UID][]string)
 
@@ -135,7 +135,7 @@ func (metaBundle *MetadataMapperBundle) mapServices(nodeName string, pods v1.Pod
 
 	var err error
 	if metaBundle.mapOnRef {
-		err = metaBundle.Services.mapOnRef(nodeName, pods, endpointList)
+		err = metaBundle.Services.mapOnRef(nodeName, endpointList)
 	} else {
 		err = metaBundle.Services.mapOnIp(nodeName, pods, endpointList)
 	}

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -15,40 +15,69 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-type podTest struct {
+type podTestDef struct {
+	uid       string
 	ip        string
 	name      string
 	namespace string
 }
 
-type serviceTest struct {
-	svcName string
-	podIps  []string
+type endPointTestDef struct {
+	name    string
+	subsets [][]addressTestDef
 }
 
-func createSvcList(nodeName string, svcs []serviceTest) v1.EndpointsList {
+type addressTestDef struct {
+	ip          string
+	nodeName    string
+	targetPodId string
+}
+
+func mapPodTestDef(defs []podTestDef) map[string]podTestDef {
+	mapped := make(map[string]podTestDef)
+	for _, d := range defs {
+		mapped[d.uid] = d
+	}
+	return mapped
+}
+
+func createEndpointList(nodeName string, defs []endPointTestDef, pods []podTestDef, legacyKube bool) v1.EndpointsList {
 	var list v1.EndpointsList
+	podsMap := mapPodTestDef(pods)
 
-	for _, svc := range svcs {
-		endpoints := v1.Endpoints{}
-		endpointsSubset := v1.EndpointSubset{}
-		ep := v1.EndpointAddress{}
-		endpoints.Name = svc.svcName
-
-		for _, e := range svc.podIps {
-			ep.NodeName = &nodeName
-			ep.IP = e
-			endpointsSubset.Addresses = append(endpointsSubset.Addresses, ep)
+	for _, epDef := range defs {
+		ep := v1.Endpoints{}
+		ep.Name = epDef.name
+		for _, subsetDef := range epDef.subsets {
+			subset := v1.EndpointSubset{}
+			for _, addrDef := range subsetDef {
+				a := v1.EndpointAddress{}
+				a.IP = addrDef.ip
+				if !legacyKube {
+					a.NodeName = &addrDef.nodeName
+				}
+				pod, found := podsMap[addrDef.targetPodId]
+				if found {
+					a.TargetRef = &v1.ObjectReference{
+						Kind:      "Pod",
+						Namespace: pod.namespace,
+						Name:      pod.name,
+						UID:       types.UID(pod.uid),
+					}
+				}
+				subset.Addresses = append(subset.Addresses, a)
+			}
+			ep.Subsets = append(ep.Subsets, subset)
 		}
-		endpoints.Subsets = append(endpoints.Subsets, endpointsSubset)
-		list.Items = append(list.Items, endpoints)
+		list.Items = append(list.Items, ep)
 	}
 	return list
 }
 
-func createPodList(listPodStructs []podTest) v1.PodList {
+func createPodList(listPodStructs []podTestDef) v1.PodList {
 	var podlist v1.PodList
 	for _, ps := range listPodStructs {
 		var pod v1.Pod
@@ -56,11 +85,13 @@ func createPodList(listPodStructs []podTest) v1.PodList {
 		pod.ObjectMeta = metav1.ObjectMeta{Namespace: ps.namespace}
 		pod.Status.PodIP = ps.ip
 		pod.Name = ps.name
+		pod.UID = types.UID(ps.uid)
 		podlist.Items = append(podlist.Items, pod)
 	}
 
 	return podlist
 }
+
 func createNode(nodeName string) v1.Node {
 	var node v1.Node
 
@@ -69,28 +100,39 @@ func createNode(nodeName string) v1.Node {
 	return node
 }
 
+type serviceMapTestCase struct {
+	caseName        string
+	node            v1.Node
+	pods            []podTestDef
+	endpoints       []endPointTestDef
+	expectedMapping ServicesMapper
+}
+
 func TestMapServices(t *testing.T) {
-	testCases := []struct {
-		caseName        string
-		node            v1.Node
-		pods            []podTest
-		services        []serviceTest
-		expectedMapping ServicesMapper
-	}{
+	testCases := []serviceMapTestCase{
 		{
 			caseName: "1 node, 1 pod, 1 service",
 			node:     createNode("firstNode"),
-			pods: []podTest{
+			pods: []podTestDef{
 				{
+					uid:       "1111",
 					ip:        "1.1.1.1",
 					name:      "pod1_name",
 					namespace: "foo",
 				},
 			},
-			services: []serviceTest{
+			endpoints: []endPointTestDef{
 				{
-					svcName: "svc1",
-					podIps:  []string{"1.1.1.1"},
+					name: "svc1",
+					subsets: [][]addressTestDef{
+						{
+							{
+								ip:          "1.1.1.1",
+								nodeName:    "firstNode",
+								targetPodId: "1111",
+							},
+						},
+					},
 				},
 			},
 			expectedMapping: ServicesMapper{
@@ -100,26 +142,44 @@ func TestMapServices(t *testing.T) {
 		{
 			caseName: "1 node, 2 pods with same name, 2 services",
 			node:     createNode("firstNode"),
-			pods: []podTest{
+			pods: []podTestDef{
 				{
+					uid:       "1111",
 					ip:        "1.1.1.1",
 					name:      "pod_name",
 					namespace: "foo",
 				},
 				{
+					uid:       "2222",
 					ip:        "2.2.2.2",
 					name:      "pod_name",
 					namespace: "bar",
 				},
 			},
-			services: []serviceTest{
+			endpoints: []endPointTestDef{
 				{
-					svcName: "svc1",
-					podIps:  []string{"1.1.1.1"},
+					name: "svc1",
+					subsets: [][]addressTestDef{
+						{
+							{
+								ip:          "1.1.1.1",
+								nodeName:    "firstNode",
+								targetPodId: "1111",
+							},
+						},
+					},
 				},
 				{
-					svcName: "svc2",
-					podIps:  []string{"2.2.2.2"},
+					name: "svc2",
+					subsets: [][]addressTestDef{
+						{
+							{
+								ip:          "2.2.2.2",
+								nodeName:    "firstNode",
+								targetPodId: "2222",
+							},
+						},
+					},
 				},
 			},
 			expectedMapping: ServicesMapper{
@@ -130,46 +190,82 @@ func TestMapServices(t *testing.T) {
 		{
 			caseName: "3 nodes, 4 pods, 3 services",
 			node:     createNode("firstNode"),
-			pods: []podTest{
+			pods: []podTestDef{
 				{
+					uid:       "2222",
 					ip:        "2.2.2.2",
 					name:      "pod2_name",
 					namespace: "foo",
 				},
 				{
+					uid:       "3333",
 					ip:        "3.3.3.3",
 					name:      "pod3_name",
 					namespace: "foo",
 				},
 				{
+					uid:       "4444",
 					ip:        "4.4.4.4",
 					name:      "pod4_name",
 					namespace: "foo",
 				},
 				{
+					uid:       "5555",
 					ip:        "5.5.5.5",
 					name:      "pod5_name",
 					namespace: "foo",
 				},
 			},
-			services: []serviceTest{
+			endpoints: []endPointTestDef{
 				{
-					svcName: "svc2",
-					podIps:  []string{"2.2.2.2"},
-				},
-				{
-					svcName: "svc3",
-					podIps: []string{
-						"2.2.2.2",
-						"5.5.5.5",
-						"1.1.1.1",
+					name: "svc2",
+					subsets: [][]addressTestDef{
+						{
+							{
+								ip:          "2.2.2.2",
+								nodeName:    "firstNode",
+								targetPodId: "2222",
+							},
+						},
 					},
 				},
 				{
-					svcName: "svc4",
-					podIps: []string{
-						"2.2.2.2",
-						"3.3.3.3",
+					name: "svc3",
+					subsets: [][]addressTestDef{
+						{
+							{
+								ip:          "2.2.2.2",
+								nodeName:    "firstNode",
+								targetPodId: "2222",
+							},
+							{
+								ip:          "5.5.5.5",
+								nodeName:    "firstNode",
+								targetPodId: "5555",
+							},
+							{
+								ip:          "1.1.1.1",
+								nodeName:    "firstNode",
+								targetPodId: "1111",
+							},
+						},
+					},
+				},
+				{
+					name: "svc4",
+					subsets: [][]addressTestDef{
+						{
+							{
+								ip:          "2.2.2.2",
+								nodeName:    "firstNode",
+								targetPodId: "2222",
+							},
+							{
+								ip:          "3.3.3.3",
+								nodeName:    "firstNode",
+								targetPodId: "3333",
+							},
+						},
 					},
 				},
 			},
@@ -182,6 +278,9 @@ func TestMapServices(t *testing.T) {
 			},
 		},
 	}
+
+	// Test the final state after all cases run to make
+	// sure mapping does not affect unlisted services
 	expectedAllPodNameToService := ServicesMapper{
 		"foo": {
 			"pod_name":  {"svc1"},
@@ -196,20 +295,30 @@ func TestMapServices(t *testing.T) {
 	}
 	allCasesBundle := newMetadataMapperBundle()
 	allBundleMu := &sync.RWMutex{}
-	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("#%d %s", i, testCase.caseName), func(t *testing.T) {
-			testCaseBundle := newMetadataMapperBundle()
-			podList := createPodList(testCase.pods)
-			nodeName := testCase.node.Name
-			epList := createSvcList(nodeName, testCase.services)
-			testCaseBundle.mapServices(nodeName, podList, epList)
-			assert.Equal(t, testCase.expectedMapping, testCaseBundle.Services)
-			allBundleMu.Lock()
-			allCasesBundle.mapServices(nodeName, podList, epList)
-			allBundleMu.Unlock()
+
+	runCase := func(t *testing.T, tc serviceMapTestCase, legacyKube bool) {
+		testCaseBundle := newMetadataMapperBundle()
+		podList := createPodList(tc.pods)
+		nodeName := tc.node.Name
+		epList := createEndpointList(nodeName, tc.endpoints, tc.pods, legacyKube)
+		testCaseBundle.mapServices(nodeName, podList, epList)
+		assert.Equal(t, tc.expectedMapping, testCaseBundle.Services)
+		allBundleMu.Lock()
+		allCasesBundle.mapServices(nodeName, podList, epList)
+		allBundleMu.Unlock()
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("#%d %s - mapOnIp", i, tc.caseName), func(t *testing.T) {
+			runCase(t, tc, false)
+		})
+		t.Run(fmt.Sprintf("#%d %s - mapOnRef", i, tc.caseName), func(t *testing.T) {
+			runCase(t, tc, true)
 		})
 	}
-	allBundleMu.RLock()
-	defer allBundleMu.RUnlock()
-	assert.Equal(t, expectedAllPodNameToService, allCasesBundle.Services)
+	t.Run("Final state", func(t *testing.T) {
+		allBundleMu.RLock()
+		defer allBundleMu.RUnlock()
+		assert.Equal(t, expectedAllPodNameToService, allCasesBundle.Services)
+	})
 }

--- a/releasenotes/notes/kube-service-mapping-13-f87cc3fb61af3e25.yaml
+++ b/releasenotes/notes/kube-service-mapping-13-f87cc3fb61af3e25.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - This release ships full support of Kubernetes 1.3+
+enhancements:
+  - |
+    The `kube_service` tag is now collected on Kubernetes 1.3.x versions. The matching uses
+    a new logic. If it were to fail, reverting to the previous logic is possible by setting
+    the kubernetes_map_services_on_ip option to true.

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -266,6 +266,12 @@ func (suite *testSuite) TestServiceMapper() {
 					{
 						IP:       pendingPod.Status.PodIP,
 						NodeName: &node.Name,
+						TargetRef: &v1.ObjectReference{
+							Kind:      "Pod",
+							Namespace: pendingPod.Namespace,
+							Name:      pendingPod.Name,
+							UID:       pendingPod.UID,
+						},
 					},
 				},
 				Ports: []v1.EndpointPort{


### PR DESCRIPTION
### What does this PR do?

The current `kube_service` mapping logic relies on the `nodeName` field in the [EndpointAddress objects](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#endpointaddress-v1-core), that was added in Kubernetes 1.4. It matches endpointAddresses to Pods via the (IP, nodeName) tuple.

This PR adds a `ServicesMapper.mapOnRef` method matching pods via the `targetRef` field instead, that is consistently present since 1.3.

Set the new behaviour to default, as it would also allow the servicemapper to avoid querying the podlist, but provide a temporary opt-out option / envvar `kubernetes_map_services_on_reference`, that reverts to the current logic.

Migration plan:
- ship 6.4.0 with the option (`true` by default, `false` to revert)
- if 6.4.x bring no support ticket for the new logic, remove it from 6.5.0, and stop querying the podlist

### Motivation

Kube 1.3 compatibility, reduce apiserver traffic
