### PR TITLE
Changed the docker and k8 config providers to return logs config as well 

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -192,7 +192,7 @@ func (ac *AutoConfig) GetChecksByName(checkName string) []check.Check {
 	return checks
 }
 
-// GetAllConfigs queries all the providers and returns all the check
+// GetAllConfigs queries all the providers and returns all the integration
 // configurations found, resolving the ones it can
 func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 	resolvedConfigs := []integration.Config{}
@@ -244,6 +244,10 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 func (ac *AutoConfig) getChecksFromConfigs(configs []integration.Config, populateCache bool) []check.Check {
 	allChecks := []check.Check{}
 	for _, config := range configs {
+		if config.MetricConfig == nil && len(config.Instances) == 0 {
+			// skip non check configs.
+			continue
+		}
 		configDigest := config.Digest()
 		checks, err := ac.getChecks(config)
 		if err != nil {
@@ -390,6 +394,10 @@ func (ac *AutoConfig) pollConfigs() {
 					// Process removed configs first to handle the case where a
 					// container churn would result in the same configuration hash.
 					for _, config := range removedConfigs {
+						if config.MetricConfig == nil && len(config.Instances) == 0 {
+							// skip non check configs.
+							continue
+						}
 						// unschedule all the checks corresponding to this config
 						digest := config.Digest()
 						ids := ac.config2checks[digest]

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -244,7 +244,7 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 func (ac *AutoConfig) getChecksFromConfigs(configs []integration.Config, populateCache bool) []check.Check {
 	allChecks := []check.Check{}
 	for _, config := range configs {
-		if config.MetricConfig == nil && len(config.Instances) == 0 {
+		if isCheckConfig(config) {
 			// skip non check configs.
 			continue
 		}
@@ -265,6 +265,12 @@ func (ac *AutoConfig) getChecksFromConfigs(configs []integration.Config, populat
 	}
 
 	return allChecks
+}
+
+// isCheckConfig returns true if the config is a check configuration,
+// this method should be moved to pkg/collector/check while removing the check related-code from the autodiscovery package.
+func isCheckConfig(config integration.Config) bool {
+	return config.MetricConfig == nil && len(config.Instances) == 0
 }
 
 // schedule takes a slice of checks and schedule them
@@ -394,7 +400,7 @@ func (ac *AutoConfig) pollConfigs() {
 					// Process removed configs first to handle the case where a
 					// container churn would result in the same configuration hash.
 					for _, config := range removedConfigs {
-						if config.MetricConfig == nil && len(config.Instances) == 0 {
+						if isCheckConfig(config) {
 							// skip non check configs.
 							continue
 						}

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	Instances     []Data   `json:"instances"`      // array of Yaml configurations
 	InitConfig    Data     `json:"init_config"`    // the init_config in Yaml (python check only)
 	MetricConfig  Data     `json:"metric_config"`  // the metric config in Yaml (jmx check only)
-	LogsConfig    Data     `json:"log_config"`     // the logs config in Yaml (logs-agent only)
+	LogsConfig    Data     `json:"logs"`           // the logs config in Yaml (logs-agent only)
 	ADIdentifiers []string `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
 	Provider      string   `json:"provider"`       // the provider that issued the config
 }

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -227,7 +227,7 @@ func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) c
 				continue
 			}
 			// determine if a check has to be run by default by
-			// searching for integratio.yaml.default files
+			// searching for integration.yaml.default files
 			if entry.isDefault {
 				defaultConfigs = append(defaultConfigs, entry.conf)
 			} else if entry.isMetric || entry.isLogsOnly {

--- a/pkg/autodiscovery/providers/file_test.go
+++ b/pkg/autodiscovery/providers/file_test.go
@@ -13,32 +13,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetCheckConfig(t *testing.T) {
+func TestGetIntegrationConfig(t *testing.T) {
 	// file does not exist
-	config, err := GetCheckConfigFromFile("foo", "")
+	config, err := GetIntegrationConfigFromFile("foo", "")
 	assert.NotNil(t, err)
 
 	// file contains invalid Yaml
-	config, err = GetCheckConfigFromFile("foo", "tests/invalid.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/invalid.yaml")
 	assert.NotNil(t, err)
 
 	// valid yaml, invalid configuration file
-	config, err = GetCheckConfigFromFile("foo", "tests/notaconfig.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/notaconfig.yaml")
 	assert.NotNil(t, err)
 	assert.Equal(t, len(config.Instances), 0)
 
 	// valid metric file
-	config, err = GetCheckConfigFromFile("foo", "tests/metrics.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/metrics.yaml")
 	assert.Nil(t, err)
 	assert.NotNil(t, config.MetricConfig)
 
 	// valid logs-agent file
-	config, err = GetCheckConfigFromFile("foo", "tests/logs-agent_only.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/logs-agent_only.yaml")
 	assert.Nil(t, err)
 	assert.NotNil(t, config.LogsConfig)
 
 	// valid configuration file
-	config, err = GetCheckConfigFromFile("foo", "tests/testcheck.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/testcheck.yaml")
 	require.Nil(t, err)
 	assert.Equal(t, config.Name, "foo")
 	assert.Equal(t, []byte(config.InitConfig), []byte("- test: 21\n"))
@@ -46,14 +46,15 @@ func TestGetCheckConfig(t *testing.T) {
 	assert.Equal(t, []byte(config.Instances[0]), []byte("foo: bar\n"))
 	assert.Len(t, config.ADIdentifiers, 0)
 	assert.Nil(t, config.MetricConfig)
+	assert.Nil(t, config.LogsConfig)
 
 	// autodiscovery
-	config, err = GetCheckConfigFromFile("foo", "tests/ad.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/ad.yaml")
 	require.Nil(t, err)
 	assert.Equal(t, config.ADIdentifiers, []string{"foo_id", "bar_id"})
 
 	// autodiscovery: check if we correctly refuse to load if a 'docker_images' section is present
-	config, err = GetCheckConfigFromFile("foo", "tests/ad_deprecated.yaml")
+	config, err = GetIntegrationConfigFromFile("foo", "tests/ad_deprecated.yaml")
 	assert.NotNil(t, err)
 }
 
@@ -109,11 +110,17 @@ func TestCollect(t *testing.T) {
 	// metric files don't override default files
 	assert.Equal(t, 2, len(get("qux")))
 
+	// logs files don't override default files
+	assert.Equal(t, 2, len(get("corge")))
+
 	// metric files not collected in root directory
 	assert.Equal(t, 0, len(get("metrics")))
 
+	// logs files collected in root directory
+	assert.Equal(t, 1, len(get("logs-agent_only")))
+
 	// total number of configurations found
-	assert.Equal(t, 11, len(configs))
+	assert.Equal(t, 14, len(configs))
 
 	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml & ad_deprecated.yaml)
 	assert.Equal(t, 3, len(provider.Errors))

--- a/pkg/autodiscovery/providers/tests/corge.d/conf.yaml.default
+++ b/pkg/autodiscovery/providers/tests/corge.d/conf.yaml.default
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar

--- a/pkg/autodiscovery/providers/tests/corge.d/logs.yaml
+++ b/pkg/autodiscovery/providers/tests/corge.d/logs.yaml
@@ -1,0 +1,3 @@
+logs:
+  - type: file
+    name: /foo/bar.log

--- a/pkg/autodiscovery/providers/tests/logs-agent_only.yaml
+++ b/pkg/autodiscovery/providers/tests/logs-agent_only.yaml
@@ -1,7 +1,3 @@
-init_config:
-
-instances:
-
 logs:
   - type: file
     name: /foo/bar/*.log

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -150,7 +150,8 @@ func extractCheckTemplatesFromMap(key string, input map[string]string, prefix st
 	return buildTemplates(key, checkNames, initConfigs, instances), nil
 }
 
-// extractLogsTemplatesFromMap returns the first logs configuration from a given map.
+// extractLogsTemplatesFromMap returns the first logs configuration from a given map
+// if none are found return an empty list.
 func extractLogsTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+logsConfigPath]
 	if !found {

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -105,13 +105,13 @@ func extractTemplatesFromMap(key string, input map[string]string, prefix string)
 
 	checksConfigs, err := extractCheckTemplatesFromMap(key, input, prefix)
 	if err != nil {
-		return []integration.Config{}, err
+		return configs, err
 	}
 	configs = append(configs, checksConfigs...)
 
 	logsConfigs, err := extractLogsTemplatesFromMap(key, input, prefix)
 	if err != nil {
-		return []integration.Config{}, err
+		return configs, err
 	}
 	configs = append(configs, logsConfigs...)
 

--- a/pkg/legacy/docker.go
+++ b/pkg/legacy/docker.go
@@ -69,7 +69,7 @@ func ImportDockerConf(src, dst string, overwrite bool) error {
 	fmt.Printf("%s\n", warningNewCheck)
 
 	// read docker_daemon.yaml
-	c, err := providers.GetCheckConfigFromFile("docker_daemon", src)
+	c, err := providers.GetIntegrationConfigFromFile("docker_daemon", src)
 	if err != nil {
 		return fmt.Errorf("Could not load %s: %s", src, err)
 	}

--- a/pkg/legacy/kubernetes.go
+++ b/pkg/legacy/kubernetes.go
@@ -94,7 +94,7 @@ func importKubernetesConfWithDeprec(src, dst string, overwrite bool) (kubeDeprec
 	deprecations := make(kubeDeprecations)
 
 	// read kubernetes.yaml
-	c, err := providers.GetCheckConfigFromFile("kubernetes", src)
+	c, err := providers.GetIntegrationConfigFromFile("kubernetes", src)
 	if err != nil {
 		return deprecations, fmt.Errorf("Could not load %s: %s", src, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Updated the utils method to extract config from docker labels and kubernetes annotations to return logs config.

### Motivation

Share a common logic to extract configs from docker labels and k8 annotations.