### PR TITLE
Changed the docker and k8 config providers to return logs config as well

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -709,8 +709,9 @@ func (ac *AutoConfig) processDelService(svc listeners.Service) {
 	// FIXME: unschedule remove services as well
 	ac.unschedule([]integration.Config{
 		{
-			LogsConfig: integration.Data{},
-			Entity:     svc.GetEntity(),
+			LogsConfig:   integration.Data{},
+			Entity:       svc.GetEntity(),
+			CreationTime: svc.GetCreationTime(),
 		},
 	})
 }

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -688,9 +688,7 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 		// ask the Collector to schedule the checks
 		ac.schedule([]integration.Config{resolvedConfig})
 	}
-	// FIXME: send all the new services to the logs package for now because the logs package is still
-	// responsible for filtering out containers, as soon as we drop the docker filters in logs configs,
-	// we'll only use `logs_config.container_collect_all` to filer on services.
+	// FIXME: schedule new services as well
 	ac.schedule([]integration.Config{
 		{
 			LogsConfig:   integration.Data{},
@@ -708,8 +706,7 @@ func (ac *AutoConfig) processDelService(svc listeners.Service) {
 	ac.store.removeConfigsForService(svc.GetEntity())
 	ac.processRemovedConfigs(configs)
 	ac.store.removeTagsHashForService(svc.GetEntity())
-	// FIXME: as soon as we have deprecated the filter parameters in the logs configuration,
-	// we'll need to check first if `logs_config.container_collect_all` is enabled.
+	// FIXME: unschedule remove services as well
 	ac.unschedule([]integration.Config{
 		{
 			LogsConfig: integration.Data{},

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -700,8 +700,9 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 	// we'll only use `logs_config.container_collect_all` to filer on services.
 	ac.schedule([]integration.Config{
 		{
-			LogsConfig: integration.Data{},
-			Entity:     svc.GetEntity(),
+			LogsConfig:   integration.Data{},
+			Entity:       svc.GetEntity(),
+			CreationTime: svc.GetCreationTime(),
 		},
 	})
 

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -254,6 +254,11 @@ func (ac *AutoConfig) schedule(configs []integration.Config) {
 	ac.scheduler.Schedule(configs)
 }
 
+// unschedule takes a slice of configs and unschedule them
+func (ac *AutoConfig) unschedule(configs []integration.Config) {
+	ac.scheduler.Unschedule(configs)
+}
+
 // processNewConfig store (in template cache) and resolves a given config into a slice of resolved configs
 func (ac *AutoConfig) processNewConfig(config integration.Config) []integration.Config {
 	var configs []integration.Config
@@ -709,4 +714,12 @@ func (ac *AutoConfig) processDelService(svc listeners.Service) {
 	ac.store.removeConfigsForService(svc.GetEntity())
 	ac.processRemovedConfigs(configs)
 	ac.store.removeTagsHashForService(svc.GetEntity())
+	// FIXME: as soon as we have deprecated the filter parameters in the logs configuration,
+	// we'll need to check first if `logs_config.container_collect_all` is enabled.
+	ac.unschedule([]integration.Config{
+		{
+			LogsConfig: integration.Data{},
+			Entity:     svc.GetEntity(),
+		},
+	})
 }

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -238,9 +238,7 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 
 		// resolve configs if needed
 		for _, config := range cfgs {
-			// set config's provider and origin
 			config.Provider = pd.provider.String()
-			config.Origin = integration.NewConfig
 			rc := ac.processNewConfig(config)
 			resolvedConfigs = append(resolvedConfigs, rc...)
 		}
@@ -509,9 +507,7 @@ func (ac *AutoConfig) pollConfigs() {
 					ac.processRemovedConfigs(removedConfigs)
 
 					for _, config := range newConfigs {
-						// set config's provider and origin
 						config.Provider = pd.provider.String()
-						config.Origin = integration.NewConfig
 						resolvedConfigs := ac.processNewConfig(config)
 						ac.schedule(resolvedConfigs)
 					}
@@ -688,9 +684,6 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 		if err != nil {
 			continue
 		}
-
-		// set the config origin
-		resolvedConfig.Origin = integration.NewService
 
 		// ask the Collector to schedule the checks
 		ac.schedule([]integration.Config{resolvedConfig})

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -518,7 +518,7 @@ func (ac *AutoConfig) pollConfigs() {
 }
 
 func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
-	ac.scheduler.Unschedule(configs)
+	ac.unschedule(configs)
 	for _, c := range configs {
 		ac.store.removeLoadedConfig(c)
 		// if the config is a template, remove it from the cache

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -681,6 +681,7 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 		}
 		templates = append(templates, tpls...)
 	}
+
 	for _, template := range templates {
 		// resolve the template
 		resolvedConfig, err := ac.resolveTemplateForService(template, svc)
@@ -694,17 +695,16 @@ func (ac *AutoConfig) processNewService(svc listeners.Service) {
 		// ask the Collector to schedule the checks
 		ac.schedule([]integration.Config{resolvedConfig})
 	}
-	if len(templates) == 0 {
-		ac.schedule([]integration.Config{
-			// FIXME: send all the new services to the logs package for now because the logs package is still
-			// responsible for filtering out containers, as soon as we drop the docker filters in logs configs,
-			// we'll only use `logs_config.container_collect_all` to filer on services.
-			{
-				LogsConfig: integration.Data{},
-				Entity:     svc.GetEntity(),
-			},
-		})
-	}
+	// FIXME: send all the new services to the logs package for now because the logs package is still
+	// responsible for filtering out containers, as soon as we drop the docker filters in logs configs,
+	// we'll only use `logs_config.container_collect_all` to filer on services.
+	ac.schedule([]integration.Config{
+		{
+			LogsConfig: integration.Data{},
+			Entity:     svc.GetEntity(),
+		},
+	})
+
 }
 
 // processDelService takes a service, stops its associated checks, and updates the cache

--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -5,7 +5,10 @@
 
 package autodiscovery
 
-import "github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
+import (
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
+)
 
 type dummyService struct {
 	ID            string
@@ -14,6 +17,7 @@ type dummyService struct {
 	Ports         []listeners.ContainerPort
 	Pid           int
 	Hostname      string
+	CreationTime  integration.CreationTime
 }
 
 // GetEntity returns the service entity name
@@ -49,4 +53,9 @@ func (s *dummyService) GetPid() (int, error) {
 // GetHostname return a dummy hostname
 func (s *dummyService) GetHostname() (string, error) {
 	return s.Hostname, nil
+}
+
+// GetCreationTime return a dummy creation time
+func (s *dummyService) GetCreationTime() integration.CreationTime {
+	return s.CreationTime
 }

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -38,8 +38,10 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		Instances:     make([]integration.Data, len(tpl.Instances)),
 		InitConfig:    make(integration.Data, len(tpl.InitConfig)),
 		MetricConfig:  tpl.MetricConfig,
+		LogsConfig:    tpl.LogsConfig,
 		ADIdentifiers: tpl.ADIdentifiers,
 		Provider:      tpl.Provider,
+		Entity:        svc.GetEntity(),
 	}
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -42,6 +42,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		ADIdentifiers: tpl.ADIdentifiers,
 		Provider:      tpl.Provider,
 		Entity:        svc.GetEntity(),
+		CreationTime:  svc.GetCreationTime(),
 	}
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -27,6 +27,7 @@ type dummyService struct {
 	Ports         []listeners.ContainerPort
 	Pid           int
 	Hostname      string
+	CreationTime  integration.CreationTime
 }
 
 // GetEntity returns the service entity name
@@ -62,6 +63,11 @@ func (s *dummyService) GetPid() (int, error) {
 // GetHostname return a dummy hostname
 func (s *dummyService) GetHostname() (string, error) {
 	return s.Hostname, nil
+}
+
+// GetCreationTime return a dummy creation time
+func (s *dummyService) GetCreationTime() integration.CreationTime {
+	return s.CreationTime
 }
 
 func TestParseTemplateVar(t *testing.T) {

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -135,6 +135,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: 127.0.0.1")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -153,6 +154,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: 127.0.0.2")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -171,6 +173,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: 127.0.0.5")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -189,6 +192,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: 127.0.0.3")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -207,6 +211,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: 127.0.0.4")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -220,6 +225,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: %%host%%")},
+				Entity:        "a5901276aed1",
 			},
 			errorString: "no network found for container a5901276aed1, ignoring it",
 		},
@@ -240,6 +246,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("port: 3")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -258,6 +265,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("port: 1")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -276,6 +284,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("port: 2")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -337,6 +346,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("test: test_value")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		{
@@ -383,6 +393,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("test: imhere")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		//// other tags testing
@@ -402,6 +413,7 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("pid: 1337\ntags:\n- foo\n")},
+				Entity:        "a5901276aed1",
 			},
 		},
 		//// unknown tag

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -37,18 +37,29 @@ const (
 	NewConfig
 )
 
+// CreationTime represents the moment when the service was launched compare to the agent start.
+type CreationTime int
+
+const (
+	// Before indicates the service was launched before the agent start
+	Before CreationTime = iota
+	// After indicates the service was launched after the agent start
+	After
+)
+
 // Config is a generic container for configuration files
 type Config struct {
-	Name          string   `json:"check_name"`     // the name of the check
-	Instances     []Data   `json:"instances"`      // array of Yaml configurations
-	InitConfig    Data     `json:"init_config"`    // the init_config in Yaml (python check only)
-	MetricConfig  Data     `json:"metric_config"`  // the metric config in Yaml (jmx check only)
-	LogsConfig    Data     `json:"logs"`           // the logs config in Yaml (logs-agent only)
-	ADIdentifiers []string `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
-	Provider      string   `json:"provider"`       // the provider that issued the config
-	Entity        string   `json:"-"`              // the id of the entity (optional)
-	ClusterCheck  bool     `json:"-"`              // cluster-check configuration flag, don't expose in JSON
-	Origin        Origin   `json:"-"`              // configuration's origin
+	Name          string       `json:"check_name"`     // the name of the check
+	Instances     []Data       `json:"instances"`      // array of Yaml configurations
+	InitConfig    Data         `json:"init_config"`    // the init_config in Yaml (python check only)
+	MetricConfig  Data         `json:"metric_config"`  // the metric config in Yaml (jmx check only)
+	LogsConfig    Data         `json:"logs"`           // the logs config in Yaml (logs-agent only)
+	ADIdentifiers []string     `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
+	Provider      string       `json:"provider"`       // the provider that issued the config
+	Entity        string       `json:"-"`              // the id of the entity (optional)
+	ClusterCheck  bool         `json:"-"`              // cluster-check configuration flag, don't expose in JSON
+	Origin        Origin       `json:"-"`              // configuration's origin
+	CreationTime  CreationTime `json:"-"`              // creation time of service
 }
 
 // Equal determines whether the passed config is the same

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -27,16 +27,6 @@ type RawMap map[interface{}]interface{}
 // JSONMap is the generic type to hold JSON configurations
 type JSONMap map[string]interface{}
 
-// Origin is the origin of the config
-type Origin int
-
-const (
-	// NewService indicates the config was created from a service event
-	NewService Origin = iota
-	// NewConfig indicates the config was created from a config event
-	NewConfig
-)
-
 // CreationTime represents the moment when the service was launched compare to the agent start.
 type CreationTime int
 
@@ -58,7 +48,6 @@ type Config struct {
 	Provider      string       `json:"provider"`       // the provider that issued the config
 	Entity        string       `json:"-"`              // the id of the entity (optional)
 	ClusterCheck  bool         `json:"-"`              // cluster-check configuration flag, don't expose in JSON
-	Origin        Origin       `json:"-"`              // configuration's origin
 	CreationTime  CreationTime `json:"-"`              // creation time of service
 }
 

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	LogsConfig    Data     `json:"logs"`           // the logs config in Yaml (logs-agent only)
 	ADIdentifiers []string `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
 	Provider      string   `json:"provider"`       // the provider that issued the config
+	Entity        string   `json:"-"`              // the id of the entity (optional)
 	ClusterCheck  bool     `json:"-"`              // cluster-check configuration flag, don't expose in JSON
 	Origin        Origin   `json:"-"`              // configuration's origin
 }

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -89,7 +89,7 @@ func (l *ECSListener) Stop() {
 // refreshServices queries the task metadata endpoint for fresh info
 // compares the container list to the local cache and sends new/dead services
 // over newService and delService accordingly
-func (l *ECSListener) refreshServices(start bool) {
+func (l *ECSListener) refreshServices(firstRun bool) {
 	meta, err := ecs.GetTaskMetadata()
 	if err != nil {
 		log.Errorf("failed to get task metadata, not refreshing services - %s", err)
@@ -116,7 +116,7 @@ func (l *ECSListener) refreshServices(start bool) {
 			log.Debugf("container %s is in status %s - skipping", c.DockerID, c.KnownStatus)
 			continue
 		}
-		s, err := l.createService(c, start)
+		s, err := l.createService(c, firstRun)
 		if err != nil {
 			log.Errorf("couldn't create a service out of container %s - Auto Discovery will ignore it", c.DockerID)
 			continue
@@ -138,9 +138,9 @@ func (l *ECSListener) refreshServices(start bool) {
 	}
 }
 
-func (l *ECSListener) createService(c ecs.Container, start bool) (ECSService, error) {
+func (l *ECSListener) createService(c ecs.Container, firstRun bool) (ECSService, error) {
 	var crTime integration.CreationTime
-	if start {
+	if firstRun {
 		crTime = integration.Before
 	} else {
 		crTime = integration.After

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -42,6 +43,7 @@ type ECSService struct {
 	clusterName   string
 	taskFamily    string
 	taskVersion   string
+	creationTime  integration.CreationTime
 }
 
 func init() {
@@ -65,6 +67,7 @@ func (l *ECSListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 	l.delService = delSvc
 
 	go func() {
+		l.refreshServices(true)
 		for {
 			select {
 			case <-l.stop:
@@ -72,7 +75,7 @@ func (l *ECSListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 				return
 			case <-l.health.C:
 			case <-l.t.C:
-				l.refreshServices()
+				l.refreshServices(false)
 			}
 		}
 	}()
@@ -86,7 +89,7 @@ func (l *ECSListener) Stop() {
 // refreshServices queries the task metadata endpoint for fresh info
 // compares the container list to the local cache and sends new/dead services
 // over newService and delService accordingly
-func (l *ECSListener) refreshServices() {
+func (l *ECSListener) refreshServices(start bool) {
 	meta, err := ecs.GetTaskMetadata()
 	if err != nil {
 		log.Errorf("failed to get task metadata, not refreshing services - %s", err)
@@ -113,7 +116,7 @@ func (l *ECSListener) refreshServices() {
 			log.Debugf("container %s is in status %s - skipping", c.DockerID, c.KnownStatus)
 			continue
 		}
-		s, err := l.createService(c)
+		s, err := l.createService(c, start)
 		if err != nil {
 			log.Errorf("couldn't create a service out of container %s - Auto Discovery will ignore it", c.DockerID)
 			continue
@@ -135,13 +138,20 @@ func (l *ECSListener) refreshServices() {
 	}
 }
 
-func (l *ECSListener) createService(c ecs.Container) (ECSService, error) {
+func (l *ECSListener) createService(c ecs.Container, start bool) (ECSService, error) {
+	var crTime integration.CreationTime
+	if start {
+		crTime = integration.Before
+	} else {
+		crTime = integration.After
+	}
 	svc := ECSService{
-		cID:         c.DockerID,
-		runtime:     containers.RuntimeNameDocker,
-		clusterName: l.task.ClusterName,
-		taskFamily:  l.task.Family,
-		taskVersion: l.task.Version,
+		cID:          c.DockerID,
+		runtime:      containers.RuntimeNameDocker,
+		clusterName:  l.task.ClusterName,
+		taskFamily:   l.task.Family,
+		taskVersion:  l.task.Version,
+		creationTime: crTime,
 	}
 
 	// ADIdentifiers
@@ -214,4 +224,9 @@ func (s *ECSService) GetPid() (int, error) {
 // GetHostname returns nil and an error because port is not supported in Fargate-based ECS
 func (s *ECSService) GetHostname() (string, error) {
 	return "", ErrNotSupported
+}
+
+// GetCreationTime returns the creation time of the container compare to the agent start.
+func (s *ECSService) GetCreationTime() integration.CreationTime {
+	return s.creationTime
 }

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -44,6 +45,7 @@ type KubeContainerService struct {
 	adIdentifiers []string
 	hosts         map[string]string
 	ports         []ContainerPort
+	creationTime  integration.CreationTime
 }
 
 func init() {
@@ -71,6 +73,13 @@ func (l *KubeletListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 
 	go func() {
 		for {
+			pods, err := l.watcher.PullChanges()
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			l.processNewPods(pods, true)
+
 			select {
 			case <-l.stop:
 				l.health.Deregister()
@@ -83,12 +92,7 @@ func (l *KubeletListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 					log.Error(err)
 					continue
 				}
-				for _, pod := range updatedPods {
-					// Ignore pending/failed/succeeded/unknown states
-					if pod.Status.Phase == "Running" {
-						l.processNewPod(pod)
-					}
-				}
+				l.processNewPods(updatedPods, false)
 				// Compute deleted pods
 				expiredContainerList, err := l.watcher.Expire()
 				if err != nil {
@@ -108,15 +112,27 @@ func (l *KubeletListener) Stop() {
 	l.stop <- true
 }
 
-func (l *KubeletListener) processNewPod(pod *kubelet.Pod) {
-	for _, container := range pod.Status.Containers {
-		l.createService(container.ID, pod)
+func (l *KubeletListener) processNewPods(pods []*kubelet.Pod, start bool) {
+	for _, pod := range pods {
+		// Ignore pending/failed/succeeded/unknown states
+		if pod.Status.Phase == "Running" {
+			for _, container := range pod.Status.Containers {
+				l.createService(container.ID, pod, start)
+			}
+		}
 	}
 }
 
-func (l *KubeletListener) createService(entity string, pod *kubelet.Pod) {
+func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, start bool) {
+	var crTime integration.CreationTime
+	if start {
+		crTime = integration.Before
+	} else {
+		crTime = integration.After
+	}
 	svc := KubeContainerService{
-		entity: entity,
+		entity:       entity,
+		creationTime: crTime,
 	}
 	podName := pod.Metadata.Name
 
@@ -247,4 +263,9 @@ func (s *KubeContainerService) GetTags() ([]string, error) {
 // GetHostname returns nil and an error because port is not supported in Kubelet
 func (s *KubeContainerService) GetHostname() (string, error) {
 	return "", ErrNotSupported
+}
+
+// GetCreationTime returns the creation time of the container compare to the agent start.
+func (s *KubeContainerService) GetCreationTime() integration.CreationTime {
+	return s.creationTime
 }

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
-func getMockedPod() *kubelet.Pod {
+func getMockedPods() []*kubelet.Pod {
 	containerSpecs := []kubelet.ContainerSpec{
 		{
 			Name:  "foo",
@@ -89,13 +89,15 @@ func getMockedPod() *kubelet.Pod {
 		HostIP:     "127.0.0.2",
 		Containers: containerStatuses,
 	}
-	return &kubelet.Pod{
-		Spec:   kubeletSpec,
-		Status: kubeletStatus,
-		Metadata: kubelet.PodMetadata{
-			Name: "mock-pod",
-			Annotations: map[string]string{
-				"ad.datadoghq.com/baz.instances": "[]",
+	return []*kubelet.Pod{
+		{
+			Spec:   kubeletSpec,
+			Status: kubeletStatus,
+			Metadata: kubelet.PodMetadata{
+				Name: "mock-pod",
+				Annotations: map[string]string{
+					"ad.datadoghq.com/baz.instances": "[]",
+				},
 			},
 		},
 	}
@@ -107,7 +109,7 @@ func TestProcessNewPod(t *testing.T) {
 		newService: services,
 		services:   make(map[string]Service),
 	}
-	listener.processNewPod(getMockedPod())
+	listener.processNewPods(getMockedPods(), false)
 
 	select {
 	case service := <-services:

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -8,6 +8,7 @@ package listeners
 import (
 	"errors"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -24,13 +25,14 @@ type ContainerPort struct {
 // It should be matched with a check template by the ConfigResolver using the
 // ADIdentifiers field.
 type Service interface {
-	GetEntity() string                    // unique entity name
-	GetADIdentifiers() ([]string, error)  // identifiers on which templates will be matched
-	GetHosts() (map[string]string, error) // network --> IP address
-	GetPorts() ([]ContainerPort, error)   // network ports
-	GetTags() ([]string, error)           // tags
-	GetPid() (int, error)                 // process identifier
-	GetHostname() (string, error)         // hostname.domainname for the entity
+	GetEntity() string                         // unique entity name
+	GetADIdentifiers() ([]string, error)       // identifiers on which templates will be matched
+	GetHosts() (map[string]string, error)      // network --> IP address
+	GetPorts() ([]ContainerPort, error)        // network ports
+	GetTags() ([]string, error)                // tags
+	GetPid() (int, error)                      // process identifier
+	GetHostname() (string, error)              // hostname.domainname for the entity
+	GetCreationTime() integration.CreationTime // creation time of the service
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -32,7 +32,7 @@ type Service interface {
 	GetTags() ([]string, error)                // tags
 	GetPid() (int, error)                      // process identifier
 	GetHostname() (string, error)              // hostname.domainname for the entity
-	GetCreationTime() integration.CreationTime // creation time of the service
+	GetCreationTime() integration.CreationTime // created before or after the agent start
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -163,6 +163,11 @@ func extractLogsTemplatesFromMap(key string, input map[string]string, prefix str
 	if err != nil {
 		return []integration.Config{}, fmt.Errorf("in %s: %s", logsConfigPath, err)
 	}
-	logsConfig, _ := json.Marshal(data)
-	return []integration.Config{{LogsConfig: logsConfig, ADIdentifiers: []string{key}}}, nil
+	switch data.(type) {
+	case []interface{}:
+		logsConfig, _ := json.Marshal(data)
+		return []integration.Config{{LogsConfig: logsConfig, ADIdentifiers: []string{key}}}, nil
+	default:
+		return []integration.Config{}, fmt.Errorf("invalid format, expected an array, got: '%v'", data)
+	}
 }

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -21,6 +21,7 @@ const (
 	instancePath   string = "instances"
 	checkNamePath  string = "check_names"
 	initConfigPath string = "init_configs"
+	logsConfigPath string = "logs"
 )
 
 func init() {
@@ -101,6 +102,25 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []in
 // extractTemplatesFromMap looks for autodiscovery configurations in a given map
 // (either docker labels or kubernetes annotations) and returns them if found.
 func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
+	configs := make([]integration.Config, 0)
+
+	checksConfigs, err := extractCheckTemplatesFromMap(key, input, prefix)
+	if err != nil {
+		return configs, err
+	}
+	configs = append(configs, checksConfigs...)
+
+	logsConfigs, err := extractLogsTemplatesFromMap(key, input, prefix)
+	if err != nil {
+		return configs, err
+	}
+	configs = append(configs, logsConfigs...)
+
+	return configs, nil
+}
+
+// extractCheckTemplatesFromMap returns all the check configurations from a given map.
+func extractCheckTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+checkNamePath]
 	if !found {
 		return []integration.Config{}, nil
@@ -129,4 +149,18 @@ func extractTemplatesFromMap(key string, input map[string]string, prefix string)
 	}
 
 	return buildTemplates(key, checkNames, initConfigs, instances), nil
+}
+
+// extractLogsTemplatesFromMap returns the first logs configuration from a given map
+// if none are found return an empty list.
+func extractLogsTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
+	value, found := input[prefix+logsConfigPath]
+	if !found {
+		return []integration.Config{}, nil
+	}
+	logsConfigs, err := parseJSONValue(value)
+	if err != nil || len(logsConfigs) < 1 {
+		return []integration.Config{}, fmt.Errorf("in %s: %s", logsConfigPath, err)
+	}
+	return []integration.Config{{LogsConfig: logsConfigs[0], ADIdentifiers: []string{key}}}, nil
 }

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -151,16 +151,18 @@ func extractCheckTemplatesFromMap(key string, input map[string]string, prefix st
 	return buildTemplates(key, checkNames, initConfigs, instances), nil
 }
 
-// extractLogsTemplatesFromMap returns the first logs configuration from a given map
+// extractLogsTemplatesFromMap returns the logs configuration from a given map,
 // if none are found return an empty list.
 func extractLogsTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	value, found := input[prefix+logsConfigPath]
 	if !found {
 		return []integration.Config{}, nil
 	}
-	logsConfigs, err := parseJSONValue(value)
-	if err != nil || len(logsConfigs) < 1 {
+	var data interface{}
+	err := json.Unmarshal([]byte(value), &data)
+	if err != nil {
 		return []integration.Config{}, fmt.Errorf("in %s: %s", logsConfigPath, err)
 	}
-	return []integration.Config{{LogsConfig: logsConfigs[0], ADIdentifiers: []string{key}}}, nil
+	logsConfig, _ := json.Marshal(data)
+	return []integration.Config{{LogsConfig: logsConfig, ADIdentifiers: []string{key}}}, nil
 }

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -267,7 +267,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			adIdentifier: "id",
 			prefix:       "prefix.",
 			output:       []integration.Config{},
-			err:          errors.New("in logs: Failed to unmarshal JSON"),
+			err:          errors.New("invalid format, expected an array, got: "),
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -278,6 +278,10 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 				expectedCfg := getConfigByName(tc.output, config.Name, []string{tc.adIdentifier})
 				require.NotNil(t, expectedCfg)
 
+				if expectedCfg.LogsConfig != nil {
+					assert.JSONEq(string(expectedCfg.LogsConfig), string(config.LogsConfig))
+					continue
+				}
 				assert.Equal(expectedCfg.Name, config.Name)
 				assert.EqualValues(expectedCfg.ADIdentifiers, []string{tc.adIdentifier})
 				assert.JSONEq(string(expectedCfg.InitConfig), string(config.InitConfig))

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -198,7 +198,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			prefix:       "prefix.",
 			output: []integration.Config{
 				{
-					LogsConfig:    integration.Data("{\"service\":\"any_service\",\"source\":\"any_source\"}"),
+					LogsConfig:    integration.Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 					ADIdentifiers: []string{"id"},
 				},
 			},
@@ -221,7 +221,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 					ADIdentifiers: []string{"id"},
 				},
 				{
-					LogsConfig:    integration.Data("{\"service\":\"any_service\",\"source\":\"any_source\"}"),
+					LogsConfig:    integration.Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 					ADIdentifiers: []string{"id"},
 				},
 			},

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -190,6 +190,43 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 		},
 		{
+			// Logs config
+			source: map[string]string{
+				"prefix.logs": "[{\"service\":\"any_service\",\"source\":\"any_source\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output: []integration.Config{
+				{
+					LogsConfig:    integration.Data("{\"service\":\"any_service\",\"source\":\"any_source\"}"),
+					ADIdentifiers: []string{"id"},
+				},
+			},
+		},
+		{
+			// Check + logs
+			source: map[string]string{
+				"prefix.check_names":  "[\"apache\"]",
+				"prefix.init_configs": "[{}]",
+				"prefix.instances":    "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}]",
+				"prefix.logs":         "[{\"service\":\"any_service\",\"source\":\"any_source\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output: []integration.Config{
+				{
+					Name:          "apache",
+					Instances:     []integration.Data{integration.Data("{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}")},
+					InitConfig:    integration.Data("{}"),
+					ADIdentifiers: []string{"id"},
+				},
+				{
+					LogsConfig:    integration.Data("{\"service\":\"any_service\",\"source\":\"any_source\"}"),
+					ADIdentifiers: []string{"id"},
+				},
+			},
+		},
+		{
 			// Missing check_names, silently ignore map
 			source: map[string]string{
 				"prefix.init_configs": "[{}]",
@@ -221,6 +258,16 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			prefix:       "prefix.",
 			output:       []integration.Config{},
 			err:          errors.New("in instances: Failed to unmarshal JSON"),
+		},
+		{
+			// Invalid logs json
+			source: map[string]string{
+				"prefix.logs": "{\"service\":\"any_service\",\"source\":\"any_source\"}",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			output:       []integration.Config{},
+			err:          errors.New("in logs: Failed to unmarshal JSON"),
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Updated the utils method to extract config from docker labels and kubernetes annotations to return logs config.

### Motivation

Share a common logic to extract configs from docker labels and k8 annotations.