### PR TITLE
[scheduler] bucketed scheduler enabling multiple runners

### DIFF
--- a/Dockerfiles/cluster-agent/datadog-cluster.yaml
+++ b/Dockerfiles/cluster-agent/datadog-cluster.yaml
@@ -7,8 +7,37 @@ dd_url: https://app.datadoghq.com
 # https://app.datadoghq.com/account/settings
 api_key:
 
+# If you need a proxy to connect to the Internet, provide it here (default:
+# disabled). You can use the 'no_proxy' list to specify hosts that should
+# bypass the proxy. These settings might impact your checks requests, please
+# refer to the specific check documentation for more details. Environment
+# variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (coma-separated string) will
+# override the values set here. See https://docs.datadoghq.com/agent/proxy/.
+#
+# proxy:
+#   http: http(s)://user:password@proxy_for_http:port
+#   https: http(s)://user:password@proxy_for_https:port
+#   no_proxy:
+#     - host1
+#     - host2
+
+# Setting this option to "yes" will tell the agent to skip validation of SSL/TLS certificates.
+# This may be necessary if the agent is running behind a proxy. See this page for details:
+# https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-haproxy-as-a-proxy
+# skip_ssl_validation: no
+
+# Setting this option to "yes" will force the agent to only use TLS 1.2 when
+# pushing data to the url specified in "dd_url".
+# force_tls_12: no
+
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
+
+# Make the agent use "hostname -f" on unix-based systems as a last resort
+# way of determining the hostname instead of Golang "os.Hostname()"
+# This will be enabled by default in version 6.4
+# More information at  https://dtdg.co/flag-hostname-fqdn
+# hostname_fqdn: false
 
 # Set the host's tags (optional)
 # tags:
@@ -16,10 +45,80 @@ api_key:
 #   - env:prod
 #   - role:database
 
+# Histogram and Historate configuration
+#
+# Configure which aggregated value to compute. Possible values are: min, max,
+# median, avg, sum and count.
+#
+# histogram_aggregates: ["max", "median", "avg", "count"]
+#
+# Configure which percentiles will be computed. Must be a list of float
+# between 0 and 1.
+# Warning: percentiles must be specified as yaml strings
+#
+# histogram_percentiles: ["0.95"]
+#
+# Copy histogram values to distributions for true global distributions (in beta)
+# This will increase the number of custom metrics created
+# histogram_copy_to_distribution: false
+#
+# A prefix to add to distribution metrics created when histogram_copy_to_distributions is true
+# histogram_copy_to_distribution_prefix: ""
+
+# Forwarder timeout in seconds
+# forwarder_timeout: 20
+
+# The forwarder retries failed requests. Use this setting to change the
+# maximum length of the forwarder's retry queue (each request in the queue
+# takes no more than 2MB in memory)
+# forwarder_retry_queue_max_size: 30
+
+# The number of workers used by the forwarder. Please note each worker will
+# open an outbound HTTP connection towards Datadog's metrics intake at every
+# flush.
+# forwarder_num_workers: 1
+
+# Collect AWS EC2 custom tags as agent tags
+# collect_ec2_tags: false
+
 # Logging
 #
 # log_level: info
 # log_file: /var/log/datadog/agent.log
+
+# Set to 'yes' to output logs in JSON format
+# log_format_json: no
+
+# Set to 'no' to disable logging to stdout
+# log_to_console: yes
+
+# Set to 'yes' to disable logging to the log file
+# disable_file_logging: no
+
+# Set to 'yes' to enable logging to syslog.
+#
+# log_to_syslog: no
+#
+# If 'syslog_uri' is left undefined/empty, a local domain socket connection will be attempted
+#
+# syslog_uri:
+#
+# Set to 'yes' to output in an RFC 5424-compliant format
+#
+# syslog_rfc: no
+#
+# If TLS enabled, you must specify a path to a PEM certificate here
+#
+# syslog_pem: /path/to/certificate.pem
+#
+# If TLS enabled, you must specify a path to a private key here
+#
+# syslog_key: /path/to/key.pem
+# 
+# If TLS enabled, you may enforce TLS verification here (defaults to true) 
+#
+# syslog_tls_verify: yes 
+#
 
 # Kubernetes apiserver integration
 #
@@ -32,7 +131,7 @@ api_key:
 #
 # In order to collect Kubernetes service names, the agent needs certain rights (see RBAC documentation in
 # [docker readme](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#kubernetes)).
-# You can disable this option or set how often (in seconds) the agent refreshes the internal mapping of metadata (including service names) to
+# You can disable this option or set how often (in seconds) the agent refreshes the internal mapping of services to
 # ContainerIDs with the following options:
 # kubernetes_collect_metadata_tags: true
 # kubernetes_metadata_tag_update_freq: 300
@@ -48,3 +147,11 @@ api_key:
 # leader_election: false
 # The leader election lease is an integer in seconds.
 # leader_lease_duration: 60
+#
+# Node labels that should be collected and their name in host tags. Off by default.
+# Some of these labels are redundant with metadata collected by
+# cloud provider crawlers (AWS, GCE, Azure)
+#
+# kubernetes_node_labels_as_tags:
+#   kubernetes.io/hostname: nodename
+#   beta.kubernetes.io/os: os

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -4,6 +4,8 @@
 // Copyright 2018 Datadog, Inc.
 
 // +build !windows
+// +build kubeapiserver
+
 //go:generate go run ../../pkg/config/render_config.go dca ../../pkg/config/config_template.yaml ../../Dockerfiles/cluster-agent/datadog-cluster.yaml
 
 package main

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -24,7 +24,7 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
-func (c *TestCheck) Configure(a, b check.ConfigData) error     { return nil }
+func (c *TestCheck) Configure(a, b integration.Data) error     { return nil }
 func (c *TestCheck) Interval() time.Duration                   { return 5 * time.Second }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -24,8 +24,8 @@ type TestCheck struct {
 }
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
-func (c *TestCheck) Configure(a, b integration.Data) error     { return nil }
-func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
+func (c *TestCheck) Configure(a, b check.ConfigData) error     { return nil }
+func (c *TestCheck) Interval() time.Duration                   { return 5 * time.Second }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -285,6 +285,7 @@ func (jq *jobQueue) waitForTick(cases []reflect.SelectCase, out chan<- check.Che
 			jIdx := jq.rand.Intn(nJobs)
 			jobs := append(bucket.jobs[jIdx:nJobs], bucket.jobs[0:jIdx]...)
 
+		jobloop:
 			for _, check := range jobs {
 				// sending to `out` is blocking, we need to constantly check that someone
 				// isn't asking to stop this queue
@@ -298,7 +299,7 @@ func (jq *jobQueue) waitForTick(cases []reflect.SelectCase, out chan<- check.Che
 					log.Debugf("Enqueuing check %s for queue %s", check, jq.interval)
 				case <-deadline:
 					log.Infof("Bucket[%d] deadline reached not enough runners were available - skipping runs", idx)
-					break
+					break jobloop
 				}
 			}
 		}

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -16,29 +17,73 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 )
 
+type jobBucket struct {
+	idx     uint
+	starter *time.Timer
+	ticker  *time.Ticker
+	cue     chan uint
+	halt    chan bool // to stop this bucket
+	jobs    []check.Check
+}
+
+func newJobBucket(idx uint, interval, start time.Duration) *jobBucket {
+	bucket := &jobBucket{idx: idx}
+
+	// ticker starts after start duration
+	bucket.starter = time.AfterFunc(start, func() {
+		bucket.ticker = time.NewTicker(interval)
+	})
+
+	// start ticker bucket cue processor
+	go func() {
+		for {
+			select {
+			case <-bucket.ticker.C:
+				bucket.cue <- bucket.idx
+			case <-bucket.halt:
+				return
+			}
+		}
+	}()
+
+	return bucket
+}
+
+func (jb *jobBucket) stop() {
+	jb.ticker.Stop()
+	jb.halt <- true
+}
+
 // jobQueue contains a list of checks (called jobs) that need to be
 // scheduled at a certain interval.
 type jobQueue struct {
-	interval time.Duration
-	stop     chan bool // to stop this queue
-	stopped  chan bool // signals that this queue has stopped
-	ticker   *time.Ticker
-	jobs     []check.Check
-	running  bool
-	health   *health.Handle
-	mu       sync.RWMutex // to protect critical sections in struct's fields
+	interval        time.Duration
+	stop            chan bool // to stop this queue
+	stopped         chan bool // signals that this queue has stopped
+	buckets         []*jobBucket
+	nextBucket      uint
+	bucketScheduled uint
+	running         bool
+	health          *health.Handle
+	mu              sync.RWMutex // to protect critical sections in struct's fields
 }
 
 // newJobQueue creates a new jobQueue instance
 func newJobQueue(interval time.Duration) *jobQueue {
-	return &jobQueue{
+	jq := &jobQueue{
 		interval: interval,
-		ticker:   time.NewTicker(time.Duration(interval)),
 		stop:     make(chan bool),
 		stopped:  make(chan bool),
 		health:   health.Register("collector-queue"),
 	}
 
+	nBuckets := int(interval.Truncate(time.Second).Seconds())
+	for i := 0; i < nBuckets; i++ {
+		bucket := newJobBucket(uint(i), interval, time.Duration(time.Duration(i)*time.Second))
+		jq.buckets = append(jq.buckets, bucket)
+	}
+
+	return jq
 }
 
 // addJob is a convenience method to add a check to a queue
@@ -46,17 +91,21 @@ func (jq *jobQueue) addJob(c check.Check) {
 	jq.mu.Lock()
 	defer jq.mu.Unlock()
 
-	jq.jobs = append(jq.jobs, c)
+	// Checks scheduled to buckets scheduled in round-robin
+	jq.buckets[jq.nextBucket].jobs = append(jq.buckets[jq.nextBucket].jobs, c)
+	jq.nextBucket = (jq.nextBucket + 1) % uint(len(jq.buckets))
 }
 
 func (jq *jobQueue) removeJob(id check.ID) error {
 	jq.mu.Lock()
 	defer jq.mu.Unlock()
 
-	for i, c := range jq.jobs {
-		if c.ID() == id {
-			jq.jobs = append(jq.jobs[:i], jq.jobs[i+1:]...)
-			return nil
+	for i, bucket := range jq.buckets {
+		for j, c := range bucket.jobs {
+			if c.ID() == id {
+				jq.buckets[i].jobs = append(bucket.jobs[:j], bucket.jobs[j+1:]...)
+				return nil
+			}
 		}
 	}
 
@@ -68,7 +117,15 @@ func (jq *jobQueue) removeJob(id check.ID) error {
 // Not blocking, runs in a new goroutine.
 func (jq *jobQueue) run(out chan<- check.Check) {
 	go func() {
-		for jq.waitForTick(out) {
+		cases := make([]reflect.SelectCase, len(jq.buckets))
+		for i, bucket := range jq.buckets {
+			cases[i] = reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(bucket.cue),
+			}
+		}
+
+		for jq.waitForTick(cases, out) {
 		}
 		jq.stopped <- true
 	}()
@@ -76,23 +133,37 @@ func (jq *jobQueue) run(out chan<- check.Check) {
 
 // waitForTicks enqueues the checks at a tick, and returns whether the queue
 // should listen to the following tick (or stop)
-func (jq *jobQueue) waitForTick(out chan<- check.Check) bool {
+func (jq *jobQueue) waitForTick(cases []reflect.SelectCase, out chan<- check.Check) bool {
+
 	select {
 	case <-jq.stop:
 		// someone asked to stop this queue
-		jq.ticker.Stop()
+		for _, bucket := range jq.buckets {
+			bucket.stop()
+		}
 		jq.health.Deregister()
 		return false
 	case <-jq.health.C:
-	case <-jq.ticker.C:
+	default:
 		// normal case, (re)schedule the queue
 		jq.mu.RLock()
-		for _, check := range jq.jobs {
+		chosen, idx, ok := reflect.Select(cases)
+		if !ok {
+			// The chosen channel has been closed, so zero out the channel to disable the case
+			// should never really happen: we use the stop channel.
+			cases[chosen].Chan = reflect.ValueOf(nil)
+			jq.mu.RUnlock()
+			return true
+		}
+
+		for _, check := range jq.buckets[idx.Uint()].jobs {
 			// sending to `out` is blocking, we need to constantly check that someone
 			// isn't asking to stop this queue
 			select {
 			case <-jq.stop:
-				jq.ticker.Stop()
+				for _, bucket := range jq.buckets {
+					bucket.stop()
+				}
 				jq.health.Deregister()
 				jq.mu.RUnlock()
 				return false

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -233,18 +233,8 @@ func expQueues(s *Scheduler) func() interface{} {
 	return func() interface{} {
 		queues := make([]map[string]interface{}, 0)
 
-		for interval, queue := range s.jobQueues {
-			nJobs := 0
-			// FIXME: this is not threadsafe
-			for _, bucket := range queue.buckets {
-				nJobs += len(bucket.jobs)
-			}
-			queueStats := map[string]interface{}{
-				"Interval": interval / time.Second,
-				"Buckets":  len(queue.buckets),
-				"Size":     nJobs,
-			}
-			queues = append(queues, queueStats)
+		for _, queue := range s.jobQueues {
+			queues = append(queues, queue.stats())
 		}
 		return queues
 	}

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -234,9 +234,14 @@ func expQueues(s *Scheduler) func() interface{} {
 		queues := make([]map[string]interface{}, 0)
 
 		for interval, queue := range s.jobQueues {
+			nJobs := 0
+			for _, bucket := range queue.buckets {
+				nJobs += len(bucket.jobs)
+			}
 			queueStats := map[string]interface{}{
 				"Interval": interval / time.Second,
-				"Size":     len(queue.jobs),
+				"Buckets":  len(queue.buckets),
+				"Size":     nJobs,
 			}
 			queues = append(queues, queueStats)
 		}

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -235,6 +235,7 @@ func expQueues(s *Scheduler) func() interface{} {
 
 		for interval, queue := range s.jobQueues {
 			nJobs := 0
+			// FIXME: this is not threadsafe
 			for _, bucket := range queue.buckets {
 				nJobs += len(bucket.jobs)
 			}

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -43,6 +43,17 @@ func consistently(f func() bool) bool {
 	return false
 }
 
+func consume(c chan check.Check, stop chan bool) {
+	for {
+		select {
+		case <-c:
+			continue
+		case <-stop:
+			return
+		}
+	}
+}
+
 func resetMinAllowedInterval() {
 	minAllowedInterval = initialMinAllowedInterval
 }
@@ -54,6 +65,7 @@ func getScheduler() *Scheduler {
 func TestNewScheduler(t *testing.T) {
 	c := make(chan<- check.Check)
 	s := NewScheduler(c)
+
 	assert.Equal(t, c, s.checksPipe)
 	assert.Equal(t, len(s.jobQueues), 0)
 	assert.Equal(t, s.running, uint32(0))
@@ -61,7 +73,12 @@ func TestNewScheduler(t *testing.T) {
 
 func TestEnter(t *testing.T) {
 	c := &TestCheck{}
-	s := getScheduler()
+	ch := make(chan check.Check)
+	stop := make(chan bool)
+	s := NewScheduler(ch)
+
+	// consume the enqueued checks
+	go consume(ch, stop)
 
 	// schedule passing a wrong interval value
 	c.intl = -1
@@ -78,32 +95,46 @@ func TestEnter(t *testing.T) {
 	c.intl = 1 * time.Second
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 1)
-	assert.Len(t, s.jobQueues[c.intl].jobs, 1)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 1)
+	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 1)
 
 	// schedule another, same interval
 	c = &TestCheck{intl: c.intl}
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 1)
-	assert.Len(t, s.jobQueues[c.intl].jobs, 2)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 1)
+	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 2)
 
 	// schedule again the previous plus another with different interval
 	s.Enter(c)
-	c = &TestCheck{intl: 20 * time.Second}
+	c = &TestCheck{intl: 10 * time.Second}
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 2)
-	assert.Len(t, s.jobQueues[1*time.Second].jobs, 3)
-	assert.Len(t, s.jobQueues[c.intl].jobs, 1)
+	assert.Len(t, s.jobQueues[1*time.Second].buckets[0].jobs, 3)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 10)
+	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 1)
+
+	stop <- true
 }
 
 func TestCancel(t *testing.T) {
-	c := &TestCheck{intl: 1 * time.Second}
-	s := getScheduler()
+	c := make(chan check.Check)
+	stop := make(chan bool)
+	chk := &TestCheck{intl: 1 * time.Second}
+
+	// consume the enqueued checks
+	go consume(c, stop)
+	defer func() {
+		stop <- true
+	}()
+
+	s := NewScheduler(c)
 	defer s.Stop()
 
-	s.Enter(c)
+	s.Enter(chk)
 	s.Run()
-	s.Cancel(c.ID())
-	assert.Len(t, s.jobQueues[c.intl].jobs, 0)
+	s.Cancel(chk.ID())
+	assert.Len(t, s.jobQueues[chk.intl].buckets[0].jobs, 0)
 }
 
 func TestRun(t *testing.T) {
@@ -122,20 +153,26 @@ func TestRun(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	s := getScheduler()
-	s.Enter(&TestCheck{intl: 10 * time.Second})
+	s.Enter(&TestCheck{intl: 5 * time.Second})
 	s.Run()
 
 	err := s.Stop()
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), s.running)
-	assert.False(t, s.jobQueues[10*time.Second].running)
+	assert.False(t, s.jobQueues[5*time.Second].running)
 
 	// stopping again should be non blocking, noop and return nil
 	assert.Nil(t, s.Stop())
 }
 
 func TestStopCancelsProducers(t *testing.T) {
-	s := getScheduler()
+	ch := make(chan check.Check)
+	stop := make(chan bool)
+	s := NewScheduler(ch)
+
+	// consume the enqueued checks
+	go consume(ch, stop)
+
 	minAllowedInterval = time.Millisecond // for the purpose of this test, so that the scheduler actually schedules the checks
 	defer resetMinAllowedInterval()
 
@@ -145,10 +182,13 @@ func TestStopCancelsProducers(t *testing.T) {
 	time.Sleep(2 * time.Millisecond) // wait for the scheduler to actually schedule the check
 
 	s.Stop()
+	// stop check consumer routine
+	stop <- true
 	// once the scheduler is stopped, it should be safe to close this channel. Otherwise, this should panic
 	close(s.checksPipe)
 	// sleep to make the runtime schedule the hanging producer goroutines, if there are any left
 	time.Sleep(time.Millisecond)
+
 }
 
 func TestTinyInterval(t *testing.T) {

--- a/releasenotes/notes/bucketed_scheduler-d4eca4b9e20edc67.yaml
+++ b/releasenotes/notes/bucketed_scheduler-d4eca4b9e20edc67.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Introduction of a new bucketed scheduler to enable multiple 
+    check workers to increase concurrency while spreading the load
+    over the collection interval.

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -21,7 +21,6 @@ DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
 ]
 
-
 @task
 def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
     """
@@ -32,6 +31,7 @@ def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
     """
 
     build_tags = get_build_tags(DEFAULT_BUILD_TAGS, [])
+
     # We rely on the go libs embedded in the debian stretch image to build dynamically
     ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs)
 
@@ -56,9 +56,9 @@ def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
         "GOOS": "",
         "GOARCH": "",
     })
-    cmd = "go generate {}/cmd/cluster-agent"
 
-    ctx.run(cmd.format(REPO_PATH), env=env)
+    cmd = "go generate -tags '{build_tags}' {repo_path}/cmd/cluster-agent"
+    ctx.run(cmd.format(build_tags=" ".join(build_tags), repo_path=REPO_PATH), env=env)
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new bucketed scheduler. The scheduler introduces a bucket per second for every interval and assigns the running checks in round-robin fashion over the entire collection interval. The idea is this should mitigate the effects on CPU load in scenarios with increased concurrency (ie. multiple check runners).

### Motivation

Help spread the load when running concurrent checks over the entire collection intervals.

### Additional Notes

Anything else we should know when reviewing?
