### PR TITLE
Fix io check on *nix

### DIFF
--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4
+FROM golang:1.10.3
 
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
     && sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list \

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -9,6 +9,7 @@ package system
 
 import (
 	"bytes"
+	"math"
 	"regexp"
 	"time"
 
@@ -16,15 +17,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/xc"
 	"github.com/shirou/gopsutil/disk"
 )
 
 // For testing purpose
-var ioCounters = disk.IOCounters
+var (
+	ioCounters = disk.IOCounters
 
-// kernel ticks / sec
-var hz int64
+	// for test purpose
+	nowNano = func() int64 { return time.Now().UnixNano() }
+)
 
 // IOCheck doesn't need additional fields
 type IOCheck struct {
@@ -39,6 +41,12 @@ func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data) 
 	err := c.commonConfigure(data, initConfig)
 	return err
 }
+
+// round a float64 with 2 decimal precision
+func roundFloat(val float64) float64 {
+	return math.Round(val*100) / 100
+}
+
 func (c *IOCheck) nixIO() error {
 	sender, err := aggregator.GetSender(c.ID())
 	if err != nil {
@@ -52,8 +60,10 @@ func (c *IOCheck) nixIO() error {
 		return err
 	}
 
-	now := time.Now().Unix()
+	// tick in millisecond
+	now := nowNano() / 1000000
 	delta := float64(now - c.ts)
+	deltaSecond := delta / 1000
 
 	var tagbuff bytes.Buffer
 	for device, ioStats := range iomap {
@@ -85,8 +95,9 @@ func (c *IOCheck) nixIO() error {
 			continue
 		}
 
-		rkbs := float64(ioStats.ReadBytes-lastIOStats.ReadBytes) / kB
-		wkbs := float64(ioStats.WriteBytes-lastIOStats.WriteBytes) / kB
+		// computing kB/s
+		rkbs := float64(ioStats.ReadBytes-lastIOStats.ReadBytes) / kB / deltaSecond
+		wkbs := float64(ioStats.WriteBytes-lastIOStats.WriteBytes) / kB / deltaSecond
 		avgqusz := float64(ioStats.WeightedIO-lastIOStats.WeightedIO) / 1000
 
 		rAwait := 0.0
@@ -108,28 +119,29 @@ func (c *IOCheck) nixIO() error {
 			aWait = float64(ioStats.ReadTime-lastIOStats.ReadTime+ioStats.WriteTime-lastIOStats.WriteTime) / diffNIO
 		}
 
-		tput := diffNIO * float64(hz)
-		util := float64(ioStats.IoTime - lastIOStats.IoTime)
+		// we are aligning ourselves with the metric reported by
+		// sysstat, so itv is a time interval in 1/100th of a second
+		itv := delta / 10
+		tput := diffNIO * 100 / itv
+		util := float64(ioStats.IoTime-lastIOStats.IoTime) / itv * 100
 		svctime := 0.0
 		if tput != 0 {
 			svctime = util / tput
 		}
 
-		sender.Gauge("system.io.rkb_s", rkbs/delta, "", tags)
-		sender.Gauge("system.io.wkb_s", wkbs/delta, "", tags)
-		sender.Gauge("system.io.avg_rq_sz", avgrqsz/delta, "", tags)
-		sender.Gauge("system.io.await", aWait/delta, "", tags)
-		sender.Gauge("system.io.r_await", rAwait/delta, "", tags)
-		sender.Gauge("system.io.w_await", wAwait/delta, "", tags)
-		sender.Gauge("system.io.avg_q_sz", avgqusz/delta, "", tags)
-		if hz > 0 { // only send if we were able to collect HZ
-			sender.Gauge("system.io.svctm", svctime/delta, "", tags)
-		}
+		sender.Gauge("system.io.rkb_s", roundFloat(rkbs), "", tags)
+		sender.Gauge("system.io.wkb_s", roundFloat(wkbs), "", tags)
+		sender.Gauge("system.io.avg_rq_sz", roundFloat(avgrqsz), "", tags)
+		sender.Gauge("system.io.await", roundFloat(aWait), "", tags)
+		sender.Gauge("system.io.r_await", roundFloat(rAwait), "", tags)
+		sender.Gauge("system.io.w_await", roundFloat(wAwait), "", tags)
+		sender.Gauge("system.io.avg_q_sz", roundFloat(avgqusz), "", tags)
+		sender.Gauge("system.io.svctm", roundFloat(svctime), "", tags)
 
 		// Stats should be per device no device groups.
 		// If device groups ever become a thing - util / 10.0 / n_devs_in_group
 		// See more: (https://github.com/sysstat/sysstat/blob/v11.5.6/iostat.c#L1033-L1040)
-		sender.Gauge("system.io.util", (util / 10.0 / delta), "", tags)
+		sender.Gauge("system.io.util", roundFloat(util/10.0), "", tags)
 
 	}
 
@@ -150,17 +162,4 @@ func (c *IOCheck) Run() error {
 		sender.Commit()
 	}
 	return err
-}
-
-func init() {
-	var err error
-	hz, err = xc.GetSystemFreq()
-	if err != nil {
-		hz = 0
-	}
-
-	if hz <= 0 {
-		log.Errorf("Unable to grab HZ: perhaps unavailable in your architecture" +
-			"(svctm will not be available)")
-	}
 }

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -64,6 +64,10 @@ func ioSampler(names ...string) (map[string]disk.IOCountersStat, error) {
 }
 
 func TestIOCheck(t *testing.T) {
+	startNow := time.Now().UnixNano()
+	nowNano = func() int64 { return startNow } // time of the first run
+	defer func() { nowNano = time.Now().UnixNano }()
+
 	ioCounters = ioSampler
 	ioCheck := new(IOCheck)
 	ioCheck.Configure(nil, nil)
@@ -92,8 +96,8 @@ func TestIOCheck(t *testing.T) {
 	mock.AssertNumberOfCalls(t, "Rate", expectedRates)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 
-	// sleep for a second, for delta
-	time.Sleep(time.Second)
+	// simulate a 1s interval
+	nowNano = func() int64 { return startNow + int64(1*time.Second) } // time of the second run
 
 	switch os := runtime.GOOS; os {
 	case "windows":
@@ -110,7 +114,7 @@ func TestIOCheck(t *testing.T) {
 		mock.On("Gauge", "system.io.await", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.r_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.w_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
-		mock.On("Gauge", "system.io.avg_q_sz", 0.028, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.avg_q_sz", 0.03, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.util", 2.8, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.svctm", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		expectedRates += 4

--- a/releasenotes/notes/fix-io-check-06189c108da09495.yaml
+++ b/releasenotes/notes/fix-io-check-06189c108da09495.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix the IO check behavior on unix based on 'iostat' tool:
+    - Most metrics are an average time, so we don't need to divide again by
+      'delta' (ex: number of read/time doing read operations)
+    - time is based on the millisecond and not the second


### PR DESCRIPTION
### What does this PR do?

Fix the IO check behavior based on 'iostat' tool:

- Most metrics are an average time, so we don't need to divide again by 'delta' (ex: number of read/time doing read operations)
- time is based on the millisecond and not the second
