### PR TITLE
[dsd] support non-docker runtimes for origin detection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@
 /pkg/collector/corechecks/containers/   @DataDog/container-integrations
 /pkg/collector/corechecks/cluster/      @DataDog/container-integrations
 /pkg/tagger/                            @DataDog/container-integrations
+/pkg/util/containers/                   @DataDog/container-integrations
 /pkg/util/docker/                       @DataDog/container-integrations @DataDog/burrito
 /pkg/util/ecs/                          @DataDog/container-integrations @DataDog/burrito
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/burrito

--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -18,8 +19,8 @@ import (
 )
 
 const (
-	// PIDToContainerKeyPrefix holds the name prefix for cache keys
-	PIDToContainerKeyPrefix = "pid_to_container"
+	pidToEntityCacheKeyPrefix = "pid_to_entity"
+	pidToEntityCacheDuration  = time.Minute
 )
 
 // getUDSAncillarySize gets the needed buffer size to retrieve the ancillary data
@@ -64,39 +65,44 @@ func processUDSOrigin(ancillary []byte) (string, error) {
 			"probably to another namespace. Is the agent in host PID mode?")
 	}
 
-	container, err := getContainerForPID(cred.Pid)
+	entity, err := getEntityForPID(cred.Pid)
 	if err != nil {
 		return NoOrigin, err
 	}
-	return container, nil
+	return entity, nil
 }
 
-// getContainerForPID returns the docker container id and caches the value for future lookups
-// As the result is cached and the lookup is really fast (parsing a local file), it can be
+// getEntityForPID returns the container entity name and caches the value for future lookups
+// As the result is cached and the lookup is really fast (parsing local files), it can be
 // called from the intake goroutine.
-func getContainerForPID(pid int32) (string, error) {
-	key := cache.BuildAgentKey(PIDToContainerKeyPrefix, strconv.Itoa(int(pid)))
+func getEntityForPID(pid int32) (string, error) {
+	key := cache.BuildAgentKey(pidToEntityCacheKeyPrefix, strconv.Itoa(int(pid)))
 	if x, found := cache.Cache.Get(key); found {
 		return x.(string), nil
 	}
+
 	id, err := docker.ContainerIDForPID(int(pid))
 	if err != nil {
 		return NoOrigin, err
 	}
-	runtime, err := containers.GetRuntimeForPID(pid)
-	if err != nil {
-		return NoOrigin, err
-	}
-
-	var value string
-	if len(id) == 0 {
+	if id == "" {
 		// If no container is found, it's probably a host process,
 		// cache the `NoOrigin` result for future packets
-		value = NoOrigin
-	} else {
-		value = fmt.Sprintf("%s://%s", runtime, id)
+		cache.Cache.Set(key, NoOrigin, pidToEntityCacheDuration)
+		return NoOrigin, nil
 	}
 
-	cache.Cache.Set(key, value, 0)
-	return value, err
+	runtime, err := containers.GetRuntimeForPID(pid)
+	if err != nil {
+		if err == containers.ErrNoRuntimeMatch {
+			// No runtime detected, cache the `NoOrigin` result
+			cache.Cache.Set(key, NoOrigin, pidToEntityCacheDuration)
+			return NoOrigin, nil
+		}
+		// Other lookup error, retry next time
+		return NoOrigin, err
+	}
+	value := fmt.Sprintf("%s://%s", runtime, id)
+	cache.Cache.Set(key, value, pidToEntityCacheDuration)
+	return value, nil
 }

--- a/pkg/dogstatsd/listeners/uds_linux.go
+++ b/pkg/dogstatsd/listeners/uds_linux.go
@@ -10,9 +10,11 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
 const (
@@ -81,6 +83,10 @@ func getContainerForPID(pid int32) (string, error) {
 	if err != nil {
 		return NoOrigin, err
 	}
+	runtime, err := containers.GetRuntimeForPID(pid)
+	if err != nil {
+		return NoOrigin, err
+	}
 
 	var value string
 	if len(id) == 0 {
@@ -88,7 +94,7 @@ func getContainerForPID(pid int32) (string, error) {
 		// cache the `NoOrigin` result for future packets
 		value = NoOrigin
 	} else {
-		value = fmt.Sprintf("docker://%s", id)
+		value = fmt.Sprintf("%s://%s", runtime, id)
 	}
 
 	cache.Cache.Set(key, value, 0)

--- a/pkg/dogstatsd/listeners/uds_nolinux.go
+++ b/pkg/dogstatsd/listeners/uds_nolinux.go
@@ -8,9 +8,11 @@
 package listeners
 
 import (
-	"fmt"
+	"errors"
 	"net"
 )
+
+var ErrLinuxOnly = errors.New("only implemented on Linux hosts")
 
 // getUDSAncillarySize returns 0 on non-linux hosts
 func getUDSAncillarySize() int {
@@ -19,10 +21,10 @@ func getUDSAncillarySize() int {
 
 // enableUDSPassCred returns a "not implemented" error on non-linux hosts
 func enableUDSPassCred(conn *net.UnixConn) error {
-	return fmt.Errorf("only implemented on Linux hosts")
+	return ErrLinuxOnly
 }
 
 // processUDSOrigin returns a "not implemented" error on non-linux hosts
 func processUDSOrigin(oob []byte) (string, error) {
-	return "", fmt.Errorf("only implemented on Linux hosts")
+	return NoOrigin, ErrLinuxOnly
 }

--- a/pkg/dogstatsd/listeners/uds_nolinux.go
+++ b/pkg/dogstatsd/listeners/uds_nolinux.go
@@ -12,6 +12,7 @@ import (
 	"net"
 )
 
+// ErrLinuxOnly is emitted on non-linux platforms
 var ErrLinuxOnly = errors.New("only implemented on Linux hosts")
 
 // getUDSAncillarySize returns 0 on non-linux hosts

--- a/pkg/util/containers/common_test.go
+++ b/pkg/util/containers/common_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build linux
+
 package containers
 
 import (

--- a/pkg/util/containers/common_test.go
+++ b/pkg/util/containers/common_test.go
@@ -51,17 +51,6 @@ func (f *tempProc) addFile(fileName, contents string) error {
 	return err
 }
 
-func (f *tempProc) addLink(fileName, target string) error {
-	filePath := filepath.Join(f.RootPath, fileName)
-	dirPath := filepath.Dir(filePath)
-	err := os.MkdirAll(dirPath, 0777)
-	if err != nil {
-		return err
-	}
-
-	return os.Symlink(target, filePath)
-}
-
 func (f *tempProc) addDummyStatus(pid string, fields map[string]string) error {
 	var contents string
 	for field, value := range fields {
@@ -71,12 +60,7 @@ func (f *tempProc) addDummyStatus(pid string, fields map[string]string) error {
 }
 
 func (f *tempProc) addDummyProcess(pid, ppid, cmdline string) error {
-	exe := strings.Split(cmdline, " ")[0]
 	err := f.addFile(filepath.Join(pid, "cmdline"), strings.Replace(cmdline, " ", "\u0000", -1))
-	if err != nil {
-		return err
-	}
-	err = f.addLink(filepath.Join(pid, "exe"), exe)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/containers/common_test.go
+++ b/pkg/util/containers/common_test.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package containers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type tempProc struct {
+	RootPath string
+}
+
+func newTempProc(namePrefix string) (*tempProc, error) {
+	path, err := ioutil.TempDir("", namePrefix)
+	if err != nil {
+		return nil, err
+	}
+	os.Setenv("HOST_PROC", path)
+	return &tempProc{path}, nil
+}
+
+func (f *tempProc) delete(fileName string) error {
+	return os.Remove(filepath.Join(f.RootPath, fileName))
+}
+
+func (f *tempProc) removeAll() error {
+	os.Unsetenv("HOST_PROC")
+	return os.RemoveAll(f.RootPath)
+}
+
+func (f *tempProc) addFile(fileName, contents string) error {
+	filePath := filepath.Join(f.RootPath, fileName)
+	dirPath := filepath.Dir(filePath)
+	err := os.MkdirAll(dirPath, 0777)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	_, err = file.WriteString(contents)
+	return err
+}
+
+func (f *tempProc) addLink(fileName, target string) error {
+	filePath := filepath.Join(f.RootPath, fileName)
+	dirPath := filepath.Dir(filePath)
+	err := os.MkdirAll(dirPath, 0777)
+	if err != nil {
+		return err
+	}
+
+	return os.Symlink(target, filePath)
+}
+
+func (f *tempProc) addDummyStatus(pid string, fields map[string]string) error {
+	var contents string
+	for field, value := range fields {
+		contents += fmt.Sprintf("%s:\t%s\n", field, value)
+	}
+	return f.addFile(filepath.Join(pid, "status"), contents)
+}
+
+func (f *tempProc) addDummyProcess(pid, ppid, cmdline string) error {
+	exe := strings.Split(cmdline, " ")[0]
+	err := f.addFile(filepath.Join(pid, "cmdline"), strings.Replace(cmdline, " ", "\u0000", -1))
+	if err != nil {
+		return err
+	}
+	err = f.addLink(filepath.Join(pid, "exe"), exe)
+	if err != nil {
+		return err
+	}
+	err = f.addDummyStatus(pid, map[string]string{"Ppid": ppid})
+	return err
+}

--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -48,7 +48,8 @@ func GetRuntimeForPID(pid int32) (string, error) {
 	}
 
 	for {
-		// Get process cmdline
+		// Get process cmdline and extract cmd name. Not using the `exe`
+		// symlink because we don't always have permissions to read it
 		cmdline, err := currentProcess.CmdlineSlice()
 		if err != nil {
 			return "", err

--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -75,6 +75,7 @@ func GetRuntimeForPID(pid int32) (string, error) {
 		case shimNameContainerd:
 			return RuntimeNameContainerd, nil
 		case daemonNameDockerLegacy1:
+			return RuntimeNameDocker, nil
 		case daemonNameDockerLegacy2:
 			return RuntimeNameDocker, nil
 		case shimNameCRIO:

--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// This code is not tied to docker itself, hence no docker build flag.
+// It could be moved to its own package.
+
+package containers
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/shirou/gopsutil/process"
+)
+
+// Return values per container runtime
+const (
+	RuntimeNameDocker     string = "docker"
+	RuntimeNameContainerd string = "containerd"
+	RuntimeNameCRIO       string = "crio"
+)
+
+// Internal constants
+const (
+	daemonNameDockerLegacy1 string = "dockerd"
+	daemonNameDockerLegacy2 string = "dockerd-current" // Centos
+
+	shimNameContainerd string = "containerd-shim"
+	shimNameCRIO       string = "conmon"
+
+	shimNameContainerdUnsure string = "docker-containerd-shim"
+	shimArgContainerdK8s     string = "-namespace k8s.io"
+	shimArgContainerdDocker  string = "-namespace moby"
+)
+
+// ErrNoRuntimeMatch is returned when no container runtime can be matched
+var ErrNoRuntimeMatch = errors.New("cannot match a container runtime")
+
+// GetRuntimeForPID inspects a PID's parents to detect a container runtime.
+// For now, this assumes we are running on hostPID, as gopsutil looks-up
+// processess in `/proc` or HOST_PROC if set
+func GetRuntimeForPID(pid int32) (string, error) {
+	var currentProcess *process.Process
+	// Inspect given process
+	currentProcess, err := process.NewProcess(pid)
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		// Get process cmdline
+		cmdline, err := currentProcess.CmdlineSlice()
+		if err != nil {
+			return "", err
+		}
+		cmd := cmdline[0]
+		if strings.Contains(cmd, "/") {
+			cmdParts := strings.Split(cmd, "/")
+			cmd = cmdParts[len(cmdParts)-1]
+		}
+		// Match with supported shim names
+		switch cmd {
+		case shimNameContainerdUnsure:
+			// Shim can be used either by k8s for direct containerd
+			// or new docker versions checking arguments
+			args := strings.Join(cmdline[1:], " ")
+			switch {
+			case strings.Contains(args, shimArgContainerdK8s):
+				return RuntimeNameContainerd, nil
+			case strings.Contains(args, shimArgContainerdDocker):
+				return RuntimeNameDocker, nil
+			}
+		case shimNameContainerd:
+			return RuntimeNameContainerd, nil
+		case daemonNameDockerLegacy1:
+		case daemonNameDockerLegacy2:
+			return RuntimeNameDocker, nil
+		case shimNameCRIO:
+			return RuntimeNameCRIO, nil
+		}
+
+		// Didn't match, go up to parent process
+		currentProcess, err = currentProcess.Parent()
+		if err != nil {
+			// Will fail when getting PID 1's parent
+			return "", err
+		}
+	}
+}

--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -19,7 +19,7 @@ import (
 const (
 	RuntimeNameDocker     string = "docker"
 	RuntimeNameContainerd string = "containerd"
-	RuntimeNameCRIO       string = "crio"
+	RuntimeNameCRIO       string = "cri-o"
 )
 
 // Internal constants

--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -6,6 +6,8 @@
 // This code is not tied to docker itself, hence no docker build flag.
 // It could be moved to its own package.
 
+// +build linux
+
 package containers
 
 import (

--- a/pkg/util/containers/runtime_test.go
+++ b/pkg/util/containers/runtime_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+// +build linux
+
 package containers
 
 import (

--- a/pkg/util/containers/runtime_test.go
+++ b/pkg/util/containers/runtime_test.go
@@ -73,6 +73,18 @@ func (s *RuntimeDetectionTestSuite) TestDockerLegacyCentOS7() {
 	assert.Equal(s.T(), RuntimeNameDocker, runtime)
 }
 
+func (s *RuntimeDetectionTestSuite) TestDockerLegacyNominal() {
+	s.proc.addDummyProcess("1", "0", "/usr/lib/systemd/systemd")
+	s.proc.addDummyProcess("10", "1", "/usr/bin/dockerd ...")
+	s.proc.addDummyProcess("25", "10", "docker-containerd ...")
+	s.proc.addDummyProcess("28", "25", "docker-containerd-shim-current 6f82f4e18c89fb10d533303220ce192e3a1b4cb6e0b79b01145ab3c5bfeec804 ...")
+	s.proc.addDummyProcess("444", "28", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), RuntimeNameDocker, runtime)
+}
+
 func TestRuntimeDetectionTestSuite(t *testing.T) {
 	suite.Run(t, new(RuntimeDetectionTestSuite))
 }

--- a/pkg/util/containers/runtime_test.go
+++ b/pkg/util/containers/runtime_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type RuntimeDetectionTestSuite struct {
+	suite.Suite
+	proc *tempProc
+}
+
+func (s *RuntimeDetectionTestSuite) SetupTest() {
+	var err error
+	s.proc, err = newTempProc("runtime-detection")
+	assert.NoError(s.T(), err)
+}
+
+func (s *RuntimeDetectionTestSuite) TearDownTest() {
+	s.proc.removeAll()
+	s.proc = nil
+}
+
+func (s *RuntimeDetectionTestSuite) TestContainerd() {
+	s.proc.addDummyProcess("1", "0", "/sbin/init")
+	s.proc.addDummyProcess("25", "1", "/usr/local/bin/containerd --log-level debug")
+	s.proc.addDummyProcess("28", "25", "containerd-shim -namespace k8s.io ...")
+	s.proc.addDummyProcess("444", "28", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), RuntimeNameContainerd, runtime)
+}
+
+func (s *RuntimeDetectionTestSuite) TestDockerContainerdK8s() {
+	s.proc.addDummyProcess("1", "0", "/sbin/init")
+	s.proc.addDummyProcess("25", "1", "/usr/local/bin/docker-containerd --log-level debug")
+	s.proc.addDummyProcess("28", "25", "docker-containerd-shim -namespace k8s.io ...")
+	s.proc.addDummyProcess("444", "28", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), RuntimeNameContainerd, runtime)
+}
+
+func (s *RuntimeDetectionTestSuite) TestDockerContainerdMoby() {
+	s.proc.addDummyProcess("1", "0", "/sbin/init")
+	s.proc.addDummyProcess("25", "1", "/usr/local/bin/docker-containerd --log-level debug")
+	s.proc.addDummyProcess("28", "25", "docker-containerd-shim -namespace moby ...")
+	s.proc.addDummyProcess("444", "28", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), RuntimeNameDocker, runtime)
+}
+
+func (s *RuntimeDetectionTestSuite) TestDockerLegacyCentOS7() {
+	s.proc.addDummyProcess("1", "0", "/usr/lib/systemd/systemd")
+	s.proc.addDummyProcess("10", "1", "/usr/bin/dockerd-current ...")
+	s.proc.addDummyProcess("25", "10", "/usr/bin/docker-containerd-current ...")
+	s.proc.addDummyProcess("28", "25", "/usr/bin/docker-containerd-shim-current 6f82f4e18c89fb10d533303220ce192e3a1b4cb6e0b79b01145ab3c5bfeec804 ...")
+	s.proc.addDummyProcess("444", "28", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), RuntimeNameDocker, runtime)
+}
+
+func TestRuntimeDetectionTestSuite(t *testing.T) {
+	suite.Run(t, new(RuntimeDetectionTestSuite))
+}

--- a/pkg/util/containers/runtime_test.go
+++ b/pkg/util/containers/runtime_test.go
@@ -95,6 +95,16 @@ func (s *RuntimeDetectionTestSuite) TestCRIO() {
 	assert.Equal(s.T(), RuntimeNameCRIO, runtime)
 }
 
+func (s *RuntimeDetectionTestSuite) TestNoMatch() {
+	s.proc.addDummyProcess("1", "0", "/usr/lib/systemd/systemd")
+	s.proc.addDummyProcess("25", "1", "supervisord ...")
+	s.proc.addDummyProcess("444", "25", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.Equal(s.T(), ErrNoRuntimeMatch, err)
+	assert.Equal(s.T(), "", runtime)
+}
+
 func TestRuntimeDetectionTestSuite(t *testing.T) {
 	suite.Run(t, new(RuntimeDetectionTestSuite))
 }

--- a/pkg/util/containers/runtime_test.go
+++ b/pkg/util/containers/runtime_test.go
@@ -85,6 +85,16 @@ func (s *RuntimeDetectionTestSuite) TestDockerLegacyNominal() {
 	assert.Equal(s.T(), RuntimeNameDocker, runtime)
 }
 
+func (s *RuntimeDetectionTestSuite) TestCRIO() {
+	s.proc.addDummyProcess("1", "0", "/usr/lib/systemd/systemd")
+	s.proc.addDummyProcess("25", "1", "conmon ...")
+	s.proc.addDummyProcess("444", "25", "/opt/datadog-agent/bin/agent/agent start")
+
+	runtime, err := GetRuntimeForPID(444)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), RuntimeNameCRIO, runtime)
+}
+
 func TestRuntimeDetectionTestSuite(t *testing.T) {
 	suite.Run(t, new(RuntimeDetectionTestSuite))
 }

--- a/pkg/util/docker/cgroup.go
+++ b/pkg/util/docker/cgroup.go
@@ -565,6 +565,9 @@ func ScrapeAllCgroups() (map[string]*ContainerCgroup, error) {
 // ContainerIDForPID is a lighter version of CgroupsForPids to only retrieve the
 // container ID for origin detection. Returns container id as a string, empty if
 // the PID is not in a container.
+//
+// Matching also works on containerd and cri-o default cgroups on Kubernetes
+// FIXME: move to the containers package
 func ContainerIDForPID(pid int) (string, error) {
 	cgPath := hostProc(strconv.Itoa(pid), "cgroup")
 	containerID, _, err := readCgroupPaths(cgPath)

--- a/releasenotes/notes/dogstatsd-origin-detection-runtime-d960bee5afc40c21.yaml
+++ b/releasenotes/notes/dogstatsd-origin-detection-runtime-d960bee5afc40c21.yaml
@@ -1,4 +1,4 @@
 features:
   - |
-    Dogstatsd origin detection now supports tagging for Kubernetes clusters
-    running containerd or crio
+    Dogstatsd origin detection now supports container tagging for Kubernetes clusters
+    running containerd or cri-o, in addition to the existing docker support

--- a/releasenotes/notes/dogstatsd-origin-detection-runtime-d960bee5afc40c21.yaml
+++ b/releasenotes/notes/dogstatsd-origin-detection-runtime-d960bee5afc40c21.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Dogstatsd origin detection now supports tagging for Kubernetes clusters
+    running containerd or crio

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -85,8 +85,8 @@ func testUDSOriginDetection(t *testing.T) {
 	select {
 	case packet := <-packetChannel:
 		require.NotNil(t, packet)
-		require.Equal(t, string(packet.Contents), "custom_counter1:1|c")
-		require.Equal(t, packet.Origin, fmt.Sprintf("docker://%s", containerId))
+		require.Equal(t, "custom_counter1:1|c", string(packet.Contents))
+		require.Equal(t, fmt.Sprintf("docker://%s", containerId), packet.Origin)
 		packetPool.Put(packet)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")

--- a/test/integration/dogstatsd/origin_detection_test.go
+++ b/test/integration/dogstatsd/origin_detection_test.go
@@ -5,8 +5,21 @@
 
 package dogstatsd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
 
 func TestUDSOriginDetection(t *testing.T) {
+	config.SetupLogger(
+		"debug",
+		"",
+		"",
+		false,
+		true,
+		false,
+	)
+
 	testUDSOriginDetection(t)
 }


### PR DESCRIPTION
### What does this PR do?

Dogstatsd is able to detect the container ID from the origin PID it receives from the kernel. The current implementation assumes the runtime is docker. This PR adds a `containers.GetRuntimeForPID` function that examines a PID's parents to detect the container runtime running this given container.

Tagging relies on the `kubelet` listener, that already supports containerd and crio.

### Additional Notes

- We currently fallback to no tagging, shall we fallback to `docker://` in case we broke detection in some docker versions?

- Not using gopsutils' `withContext` methods, as they just silently ignore the context anyway. This would add a false expectation of context compatibility. Currently, golang file reads cannot be interrupted by context timeouts.

- We should later move `docker.ContainerIDForPID` and `getEntityForPID` to the `containers` package