### PR TITLE
Fix log Trace method

### DIFF
--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -296,7 +296,7 @@ func buildLogEntry(v ...interface{}) string {
 //Trace logs at the trace level
 func Trace(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.TraceLvl) {
-		s := buildLogEntry(v)
+		s := buildLogEntry(v...)
 		logger.trace(logger.scrub(s))
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Methods used for other log levels all use `s := buildLogEntry(v...)`.

Not sure how `Sprintf` reacts when fed with a slice but let's be consistent anyway.