### PR TITLE
[oshift] Collect ClusterResourceQuota metrics

### DIFF
--- a/Dockerfiles/manifests/rbac/clusterrole.yaml
+++ b/Dockerfiles/manifests/rbac/clusterrole.yaml
@@ -16,6 +16,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["quota.openshift.io"]
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,7 +15,15 @@
 [[projects]]
   branch = "master"
   name = "github.com/DataDog/gohai"
-  packages = ["cpu","filesystem","memory","network","platform","processes","processes/gops"]
+  packages = [
+    "cpu",
+    "filesystem",
+    "memory",
+    "network",
+    "platform",
+    "processes",
+    "processes/gops"
+  ]
   revision = "60e13eaed98afa238ad6dfc98224c04fbb7b19b1"
 
 [[projects]]
@@ -61,7 +69,34 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/sdkrand","internal/shareddefaults","private/protocol","private/protocol/ec2query","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/ec2","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/ec2query",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ec2",
+    "service/sts"
+  ]
   revision = "bff41fb23b7550368282029f6478819d6a99ae0f"
   version = "v1.12.79"
 
@@ -96,7 +131,20 @@
 
 [[projects]]
   name = "github.com/coreos/etcd"
-  packages = ["auth/authpb","client","clientv3","etcdserver/api/v3rpc/rpctypes","etcdserver/etcdserverpb","mvcc/mvccpb","pkg/pathutil","pkg/srv","pkg/tlsutil","pkg/transport","pkg/types","version"]
+  packages = [
+    "auth/authpb",
+    "client",
+    "clientv3",
+    "etcdserver/api/v3rpc/rpctypes",
+    "etcdserver/etcdserverpb",
+    "mvcc/mvccpb",
+    "pkg/pathutil",
+    "pkg/srv",
+    "pkg/tlsutil",
+    "pkg/transport",
+    "pkg/types",
+    "version"
+  ]
   revision = "c9504f61fc7f29b0ad30bf8bab02d9e1b600e962"
   version = "v3.2.23"
 
@@ -108,7 +156,10 @@
 
 [[projects]]
   name = "github.com/coreos/go-systemd"
-  packages = ["daemon","sdjournal"]
+  packages = [
+    "daemon",
+    "sdjournal"
+  ]
   revision = "40e2722dffead74698ca12a750f64ef313ddce05"
   version = "v16"
 
@@ -126,19 +177,43 @@
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = ["digest","reference"]
+  packages = [
+    "digest",
+    "reference"
+  ]
   revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
   version = "v2.6.2"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/events","api/types/filters","api/types/mount","api/types/network","api/types/reference","api/types/registry","api/types/strslice","api/types/swarm","api/types/time","api/types/versions","api/types/volume","client","pkg/tlsconfig"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/reference",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "pkg/tlsconfig"
+  ]
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
   version = "v1.13.1"
 
 [[projects]]
   name = "github.com/docker/go-connections"
-  packages = ["nat","sockets","tlsconfig"]
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig"
+  ]
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
@@ -151,7 +226,14 @@
 [[projects]]
   branch = "master"
   name = "github.com/dsnet/compress"
-  packages = [".","bzip2","bzip2/internal/sais","internal","internal/errors","internal/prefix"]
+  packages = [
+    ".",
+    "bzip2",
+    "bzip2/internal/sais",
+    "internal",
+    "internal/errors",
+    "internal/prefix"
+  ]
   revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
 
 [[projects]]
@@ -168,7 +250,10 @@
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "3658237ded108b4134956c1b3050349d93e7b895"
   version = "v2.7.1"
 
@@ -216,7 +301,10 @@
 
 [[projects]]
   name = "github.com/go-ole/go-ole"
-  packages = [".","oleutil"]
+  packages = [
+    ".",
+    "oleutil"
+  ]
   revision = "a41e3c4b706f6ae8dfbff342b06e40fa4d2d0506"
   version = "v1.2.1"
 
@@ -246,7 +334,12 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys"]
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys"
+  ]
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
@@ -264,7 +357,14 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
@@ -281,7 +381,11 @@
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions"
+  ]
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
@@ -318,13 +422,27 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
+  packages = [
+    ".",
+    "simplelru"
+  ]
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
@@ -336,7 +454,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/hectane/go-acl"
-  packages = [".","api"]
+  packages = [
+    ".",
+    "api"
+  ]
   revision = "7f56832555fc229dad908c67d65ed3ce6156b70c"
 
 [[projects]]
@@ -380,7 +501,15 @@
 
 [[projects]]
   name = "github.com/kubernetes-incubator/custom-metrics-apiserver"
-  packages = ["pkg/apiserver","pkg/apiserver/installer","pkg/cmd/server","pkg/dynamicmapper","pkg/provider","pkg/registry/custom_metrics","pkg/registry/external_metrics"]
+  packages = [
+    "pkg/apiserver",
+    "pkg/apiserver/installer",
+    "pkg/cmd/server",
+    "pkg/dynamicmapper",
+    "pkg/provider",
+    "pkg/registry/custom_metrics",
+    "pkg/registry/external_metrics"
+  ]
   revision = "e61f72fec56ab519d74ebd396cd3fcf31b084558"
 
 [[projects]]
@@ -404,7 +533,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
@@ -456,14 +589,20 @@
 [[projects]]
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
-  version = "1.0.0"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   branch = "master"
   name = "github.com/nwaples/rardecode"
   packages = ["."]
   revision = "e06696f847aeda6f39a8f0b7cdff193b7690aef6"
+
+[[projects]]
+  name = "github.com/openshift/api"
+  packages = ["quota/v1"]
+  revision = "0d921e363e951d89f583292c60d013c318df64dc"
+  version = "v3.9.0"
 
 [[projects]]
   name = "github.com/patrickmn/go-cache"
@@ -485,7 +624,10 @@
 
 [[projects]]
   name = "github.com/pierrec/lz4"
-  packages = [".","internal/xxh32"]
+  packages = [
+    ".",
+    "internal/xxh32"
+  ]
   revision = "1958fd8fff7f115e79725b1288e0b878b3e06b00"
   version = "v2.0.3"
 
@@ -516,13 +658,22 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","internal/util","nfs","xfs"]
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
   revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
 
 [[projects]]
@@ -539,7 +690,16 @@
 
 [[projects]]
   name = "github.com/shirou/gopsutil"
-  packages = ["cpu","disk","host","internal/common","load","mem","net","process"]
+  packages = [
+    "cpu",
+    "disk",
+    "host",
+    "internal/common",
+    "load",
+    "mem",
+    "net",
+    "process"
+  ]
   revision = "eeb1d38d69593f121e060d24d17f7b1f0936b203"
   version = "v2.18.05"
 
@@ -551,7 +711,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "787d034dfe70e44075ccc060d346146ef53270ad"
   version = "v1.1.1"
 
@@ -593,7 +756,12 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","mock","require","suite"]
+  packages = [
+    "assert",
+    "mock",
+    "require",
+    "suite"
+  ]
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
@@ -604,7 +772,12 @@
 
 [[projects]]
   name = "github.com/ulikunitz/xz"
-  packages = [".","internal/hash","internal/xlog","lzma"]
+  packages = [
+    ".",
+    "internal/hash",
+    "internal/xlog",
+    "lzma"
+  ]
   revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
   version = "v0.5.4"
 
@@ -623,18 +796,54 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http/httpguts","http2","http2/hpack","idna","internal/socks","internal/timeseries","proxy","trace","websocket"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/socks",
+    "internal/timeseries",
+    "proxy",
+    "trace",
+    "websocket"
+  ]
   revision = "97aa3a539ec716117a9d15a4659a911f50d13c3c"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows","windows/registry","windows/svc","windows/svc/debug","windows/svc/eventlog","windows/svc/mgr"]
+  packages = [
+    "unix",
+    "windows",
+    "windows/registry",
+    "windows/svc",
+    "windows/svc/debug",
+    "windows/svc/eventlog",
+    "windows/svc/mgr"
+  ]
   revision = "7138fd3d9dc8335c567ca206f4333fb75eb05d56"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
@@ -647,12 +856,42 @@
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/api/annotations","googleapis/rpc/status"]
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/rpc/status"
+  ]
   revision = "ff3583edef7de132f219f0efc00e097cabcc0ec0"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","encoding/proto","grpclog","health/grpc_health_v1","internal","internal/backoff","internal/channelz","internal/grpcrand","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "health/grpc_health_v1",
+    "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/grpcrand",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
@@ -688,42 +927,378 @@
 [[projects]]
   branch = "master"
   name = "k8s.io/api"
-  packages = ["admission/v1beta1","admissionregistration/v1alpha1","admissionregistration/v1beta1","apps/v1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","events/v1beta1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1alpha1","storage/v1beta1"]
+  packages = [
+    "admission/v1beta1",
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1"
+  ]
   revision = "9e5ffd1f1320950b238cfce291b926411f0af722"
 
 [[projects]]
   branch = "release-1.10"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/api/validation","pkg/api/validation/path","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/internalversion","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1/validation","pkg/apis/meta/v1beta1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/mergepatch","pkg/util/net","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/strategicpatch","pkg/util/uuid","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/waitgroup","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/json","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/equality",
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/api/validation",
+    "pkg/api/validation/path",
+    "pkg/apimachinery",
+    "pkg/apimachinery/announced",
+    "pkg/apimachinery/registered",
+    "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/validation",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/mergepatch",
+    "pkg/util/net",
+    "pkg/util/rand",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/strategicpatch",
+    "pkg/util/uuid",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/waitgroup",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/json",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
 
 [[projects]]
   name = "k8s.io/apiserver"
-  packages = ["pkg/admission","pkg/admission/configuration","pkg/admission/initializer","pkg/admission/metrics","pkg/admission/plugin/initialization","pkg/admission/plugin/namespace/lifecycle","pkg/admission/plugin/webhook/config","pkg/admission/plugin/webhook/config/apis/webhookadmission","pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1","pkg/admission/plugin/webhook/errors","pkg/admission/plugin/webhook/mutating","pkg/admission/plugin/webhook/namespace","pkg/admission/plugin/webhook/request","pkg/admission/plugin/webhook/rules","pkg/admission/plugin/webhook/validating","pkg/admission/plugin/webhook/versioned","pkg/apis/apiserver","pkg/apis/apiserver/install","pkg/apis/apiserver/v1alpha1","pkg/apis/audit","pkg/apis/audit/install","pkg/apis/audit/v1alpha1","pkg/apis/audit/v1beta1","pkg/apis/audit/validation","pkg/audit","pkg/audit/policy","pkg/authentication/authenticator","pkg/authentication/authenticatorfactory","pkg/authentication/group","pkg/authentication/request/anonymous","pkg/authentication/request/bearertoken","pkg/authentication/request/headerrequest","pkg/authentication/request/union","pkg/authentication/request/websocket","pkg/authentication/request/x509","pkg/authentication/serviceaccount","pkg/authentication/token/tokenfile","pkg/authentication/user","pkg/authorization/authorizer","pkg/authorization/authorizerfactory","pkg/authorization/union","pkg/endpoints","pkg/endpoints/discovery","pkg/endpoints/filters","pkg/endpoints/handlers","pkg/endpoints/handlers/negotiation","pkg/endpoints/handlers/responsewriters","pkg/endpoints/metrics","pkg/endpoints/openapi","pkg/endpoints/request","pkg/features","pkg/registry/generic","pkg/registry/generic/registry","pkg/registry/rest","pkg/server","pkg/server/filters","pkg/server/healthz","pkg/server/httplog","pkg/server/mux","pkg/server/options","pkg/server/resourceconfig","pkg/server/routes","pkg/server/routes/data/swagger","pkg/server/storage","pkg/storage","pkg/storage/errors","pkg/storage/etcd","pkg/storage/etcd/metrics","pkg/storage/etcd/util","pkg/storage/etcd3","pkg/storage/etcd3/preflight","pkg/storage/names","pkg/storage/storagebackend","pkg/storage/storagebackend/factory","pkg/storage/value","pkg/util/feature","pkg/util/flag","pkg/util/flushwriter","pkg/util/trace","pkg/util/webhook","pkg/util/wsstream","plugin/pkg/audit/buffered","plugin/pkg/audit/log","plugin/pkg/audit/truncate","plugin/pkg/audit/webhook","plugin/pkg/authenticator/token/webhook","plugin/pkg/authorizer/webhook"]
+  packages = [
+    "pkg/admission",
+    "pkg/admission/configuration",
+    "pkg/admission/initializer",
+    "pkg/admission/metrics",
+    "pkg/admission/plugin/initialization",
+    "pkg/admission/plugin/namespace/lifecycle",
+    "pkg/admission/plugin/webhook/config",
+    "pkg/admission/plugin/webhook/config/apis/webhookadmission",
+    "pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1",
+    "pkg/admission/plugin/webhook/errors",
+    "pkg/admission/plugin/webhook/mutating",
+    "pkg/admission/plugin/webhook/namespace",
+    "pkg/admission/plugin/webhook/request",
+    "pkg/admission/plugin/webhook/rules",
+    "pkg/admission/plugin/webhook/validating",
+    "pkg/admission/plugin/webhook/versioned",
+    "pkg/apis/apiserver",
+    "pkg/apis/apiserver/install",
+    "pkg/apis/apiserver/v1alpha1",
+    "pkg/apis/audit",
+    "pkg/apis/audit/install",
+    "pkg/apis/audit/v1alpha1",
+    "pkg/apis/audit/v1beta1",
+    "pkg/apis/audit/validation",
+    "pkg/audit",
+    "pkg/audit/policy",
+    "pkg/authentication/authenticator",
+    "pkg/authentication/authenticatorfactory",
+    "pkg/authentication/group",
+    "pkg/authentication/request/anonymous",
+    "pkg/authentication/request/bearertoken",
+    "pkg/authentication/request/headerrequest",
+    "pkg/authentication/request/union",
+    "pkg/authentication/request/websocket",
+    "pkg/authentication/request/x509",
+    "pkg/authentication/serviceaccount",
+    "pkg/authentication/token/tokenfile",
+    "pkg/authentication/user",
+    "pkg/authorization/authorizer",
+    "pkg/authorization/authorizerfactory",
+    "pkg/authorization/union",
+    "pkg/endpoints",
+    "pkg/endpoints/discovery",
+    "pkg/endpoints/filters",
+    "pkg/endpoints/handlers",
+    "pkg/endpoints/handlers/negotiation",
+    "pkg/endpoints/handlers/responsewriters",
+    "pkg/endpoints/metrics",
+    "pkg/endpoints/openapi",
+    "pkg/endpoints/request",
+    "pkg/features",
+    "pkg/registry/generic",
+    "pkg/registry/generic/registry",
+    "pkg/registry/rest",
+    "pkg/server",
+    "pkg/server/filters",
+    "pkg/server/healthz",
+    "pkg/server/httplog",
+    "pkg/server/mux",
+    "pkg/server/options",
+    "pkg/server/resourceconfig",
+    "pkg/server/routes",
+    "pkg/server/routes/data/swagger",
+    "pkg/server/storage",
+    "pkg/storage",
+    "pkg/storage/errors",
+    "pkg/storage/etcd",
+    "pkg/storage/etcd/metrics",
+    "pkg/storage/etcd/util",
+    "pkg/storage/etcd3",
+    "pkg/storage/etcd3/preflight",
+    "pkg/storage/names",
+    "pkg/storage/storagebackend",
+    "pkg/storage/storagebackend/factory",
+    "pkg/storage/value",
+    "pkg/util/feature",
+    "pkg/util/flag",
+    "pkg/util/flushwriter",
+    "pkg/util/trace",
+    "pkg/util/webhook",
+    "pkg/util/wsstream",
+    "plugin/pkg/audit/buffered",
+    "plugin/pkg/audit/log",
+    "plugin/pkg/audit/truncate",
+    "plugin/pkg/audit/webhook",
+    "plugin/pkg/authenticator/token/webhook",
+    "plugin/pkg/authorizer/webhook"
+  ]
   revision = "2cf66d2375dce045e1e02e1d7b74a0d1e34fedb3"
   version = "kubernetes-1.10.3"
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","discovery/fake","dynamic","informers","informers/admissionregistration","informers/admissionregistration/v1alpha1","informers/admissionregistration/v1beta1","informers/apps","informers/apps/v1","informers/apps/v1beta1","informers/apps/v1beta2","informers/autoscaling","informers/autoscaling/v1","informers/autoscaling/v2beta1","informers/batch","informers/batch/v1","informers/batch/v1beta1","informers/batch/v2alpha1","informers/certificates","informers/certificates/v1beta1","informers/core","informers/core/v1","informers/events","informers/events/v1beta1","informers/extensions","informers/extensions/v1beta1","informers/internalinterfaces","informers/networking","informers/networking/v1","informers/policy","informers/policy/v1beta1","informers/rbac","informers/rbac/v1","informers/rbac/v1alpha1","informers/rbac/v1beta1","informers/scheduling","informers/scheduling/v1alpha1","informers/settings","informers/settings/v1alpha1","informers/storage","informers/storage/v1","informers/storage/v1alpha1","informers/storage/v1beta1","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/admissionregistration/v1beta1","kubernetes/typed/admissionregistration/v1beta1/fake","kubernetes/typed/apps/v1","kubernetes/typed/apps/v1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/autoscaling/v2beta1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/events/v1beta1","kubernetes/typed/events/v1beta1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1alpha1","kubernetes/typed/storage/v1alpha1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","listers/admissionregistration/v1alpha1","listers/admissionregistration/v1beta1","listers/apps/v1","listers/apps/v1beta1","listers/apps/v1beta2","listers/autoscaling/v1","listers/autoscaling/v2beta1","listers/batch/v1","listers/batch/v1beta1","listers/batch/v2alpha1","listers/certificates/v1beta1","listers/core/v1","listers/events/v1beta1","listers/extensions/v1beta1","listers/networking/v1","listers/policy/v1beta1","listers/rbac/v1","listers/rbac/v1alpha1","listers/rbac/v1beta1","listers/scheduling/v1alpha1","listers/settings/v1alpha1","listers/storage/v1","listers/storage/v1alpha1","listers/storage/v1beta1","pkg/apis/clientauthentication","pkg/apis/clientauthentication/v1alpha1","pkg/version","plugin/pkg/client/auth/exec","rest","rest/watch","testing","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/leaderelection","tools/leaderelection/resourcelock","tools/metrics","tools/pager","tools/record","tools/reference","transport","util/buffer","util/cert","util/flowcontrol","util/homedir","util/integer","util/retry"]
+  packages = [
+    "discovery",
+    "discovery/fake",
+    "dynamic",
+    "informers",
+    "informers/admissionregistration",
+    "informers/admissionregistration/v1alpha1",
+    "informers/admissionregistration/v1beta1",
+    "informers/apps",
+    "informers/apps/v1",
+    "informers/apps/v1beta1",
+    "informers/apps/v1beta2",
+    "informers/autoscaling",
+    "informers/autoscaling/v1",
+    "informers/autoscaling/v2beta1",
+    "informers/batch",
+    "informers/batch/v1",
+    "informers/batch/v1beta1",
+    "informers/batch/v2alpha1",
+    "informers/certificates",
+    "informers/certificates/v1beta1",
+    "informers/core",
+    "informers/core/v1",
+    "informers/events",
+    "informers/events/v1beta1",
+    "informers/extensions",
+    "informers/extensions/v1beta1",
+    "informers/internalinterfaces",
+    "informers/networking",
+    "informers/networking/v1",
+    "informers/policy",
+    "informers/policy/v1beta1",
+    "informers/rbac",
+    "informers/rbac/v1",
+    "informers/rbac/v1alpha1",
+    "informers/rbac/v1beta1",
+    "informers/scheduling",
+    "informers/scheduling/v1alpha1",
+    "informers/settings",
+    "informers/settings/v1alpha1",
+    "informers/storage",
+    "informers/storage/v1",
+    "informers/storage/v1alpha1",
+    "informers/storage/v1beta1",
+    "kubernetes",
+    "kubernetes/fake",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1alpha1/fake",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/admissionregistration/v1beta1/fake",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1/fake",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta1/fake",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/apps/v1beta2/fake",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1/fake",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authentication/v1beta1/fake",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1/fake",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/authorization/v1beta1/fake",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v1/fake",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta1/fake",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1/fake",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v1beta1/fake",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/batch/v2alpha1/fake",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/certificates/v1beta1/fake",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/core/v1/fake",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/events/v1beta1/fake",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/extensions/v1beta1/fake",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1/fake",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/policy/v1beta1/fake",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1/fake",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1alpha1/fake",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/rbac/v1beta1/fake",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1alpha1/fake",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1/fake",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1/fake",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1alpha1/fake",
+    "kubernetes/typed/storage/v1beta1",
+    "kubernetes/typed/storage/v1beta1/fake",
+    "listers/admissionregistration/v1alpha1",
+    "listers/admissionregistration/v1beta1",
+    "listers/apps/v1",
+    "listers/apps/v1beta1",
+    "listers/apps/v1beta2",
+    "listers/autoscaling/v1",
+    "listers/autoscaling/v2beta1",
+    "listers/batch/v1",
+    "listers/batch/v1beta1",
+    "listers/batch/v2alpha1",
+    "listers/certificates/v1beta1",
+    "listers/core/v1",
+    "listers/events/v1beta1",
+    "listers/extensions/v1beta1",
+    "listers/networking/v1",
+    "listers/policy/v1beta1",
+    "listers/rbac/v1",
+    "listers/rbac/v1alpha1",
+    "listers/rbac/v1beta1",
+    "listers/scheduling/v1alpha1",
+    "listers/settings/v1alpha1",
+    "listers/storage/v1",
+    "listers/storage/v1alpha1",
+    "listers/storage/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/version",
+    "plugin/pkg/client/auth/exec",
+    "rest",
+    "rest/watch",
+    "testing",
+    "tools/auth",
+    "tools/cache",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/leaderelection",
+    "tools/leaderelection/resourcelock",
+    "tools/metrics",
+    "tools/pager",
+    "tools/record",
+    "tools/reference",
+    "transport",
+    "util/buffer",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+    "util/retry"
+  ]
   revision = "23781f4d6632d88e869066eaebb743857aa1ef9b"
   version = "v7.0.0"
 
 [[projects]]
   branch = "master"
   name = "k8s.io/kube-openapi"
-  packages = ["pkg/builder","pkg/common","pkg/handler","pkg/util","pkg/util/proto"]
+  packages = [
+    "pkg/builder",
+    "pkg/common",
+    "pkg/handler",
+    "pkg/util",
+    "pkg/util/proto"
+  ]
   revision = "b742be413d0a6f781c123bed504c8fb39264c57d"
 
 [[projects]]
   name = "k8s.io/metrics"
-  packages = ["pkg/apis/custom_metrics","pkg/apis/custom_metrics/install","pkg/apis/custom_metrics/v1beta1","pkg/apis/external_metrics","pkg/apis/external_metrics/install","pkg/apis/external_metrics/v1beta1"]
+  packages = [
+    "pkg/apis/custom_metrics",
+    "pkg/apis/custom_metrics/install",
+    "pkg/apis/custom_metrics/v1beta1",
+    "pkg/apis/external_metrics",
+    "pkg/apis/external_metrics/install",
+    "pkg/apis/external_metrics/v1beta1"
+  ]
   revision = "0d9ea2ac660031c8f2726a735dda29441f396f99"
   version = "kubernetes-1.10.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "11dc3f724c2aa54968db5c215986ab35be03cdd27acd5b0b54eca7116cf3d202"
+  inputs-digest = "bffe02bae14e2474103ba260021e3457f3b58da1ffca85ea97ff2e023e93009e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -14,7 +14,6 @@ core,github.com/docker/distribution,Apache-2.0
 core,github.com/docker/docker,Apache-2.0
 core,github.com/docker/go-connections,Apache-2.0
 core,github.com/docker/go-units,Apache-2.0
-core,github.com/ericchiang/k8s,Apache-2.0
 core,github.com/kubernetes,Apache-2.0
 core,github.com/kubernetes-incubator/custom-metrics-apiserver,Apache-2.0
 core,github.com/json-iterator/go,MIT
@@ -61,6 +60,7 @@ core,github.com/hashicorp/hcl,MPL-2.0
 core,github.com/hectane/go-acl,MIT
 core,github.com/inconshreveable/mousetrap,Apache-2.0
 core,github.com/jquery/jquery,MIT
+core,github.com/juju/ratelimit,LGPL-3+exception
 core,github.com/k-sone/snmpgo,MIT
 core,github.com/lxn/win,BSD-3-Clause
 core,github.com/kardianos/osext,BSD-3-Clause
@@ -69,6 +69,7 @@ core,github.com/mholt/archiver,MIT
 core,github.com/Microsoft/go-winio,MIT
 core,github.com/mitchellh/mapstructure,MIT
 core,github.com/mitchellh/reflectwalk,MIT
+core,github.com/openshift/api,Apache-2.0
 core,github.com/patrickmn/go-cache,MIT
 core,github.com/pelletier/go-toml,MIT
 core,github.com/pkg/errors,BSD-2-Clause

--- a/pkg/collector/corechecks/cluster/kubernetes_openshift.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_openshift.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package cluster
+
+import (
+	"fmt"
+
+	osq "github.com/openshift/api/quota/v1"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// reportClusterQuotas reports metrics on OpenShift ClusterResourceQuota objects
+func (k *KubeASCheck) reportClusterQuotas(quotas []osq.ClusterResourceQuota, sender aggregator.Sender) {
+	for _, quota := range quotas {
+		quotaTags := append(k.instance.Tags, fmt.Sprintf("clusterquota:%s", quota.Name))
+		remaining := computeQuotaRemaining(quota.Status.Total.Used, quota.Status.Total.Hard)
+
+		k.reportQuota(quota.Status.Total.Hard, "openshift.clusterquota", "limit", quotaTags, sender)
+		k.reportQuota(quota.Status.Total.Used, "openshift.clusterquota", "used", quotaTags, sender)
+		k.reportQuota(remaining, "openshift.clusterquota", "remaining", quotaTags, sender)
+
+		for _, nsQuota := range quota.Status.Namespaces {
+			nsTags := append(quotaTags, fmt.Sprintf("kube_namespace:%s", nsQuota.Namespace))
+			k.reportQuota(nsQuota.Status.Hard, "openshift.appliedclusterquota", "limit", nsTags, sender)
+			k.reportQuota(nsQuota.Status.Used, "openshift.appliedclusterquota", "used", nsTags, sender)
+			k.reportQuota(remaining, "openshift.appliedclusterquota", "remaining", nsTags, sender)
+		}
+
+	}
+}
+
+func (k *KubeASCheck) reportQuota(quotas v1.ResourceList, metricPrefix, metricSuffix string, tags []string, sender aggregator.Sender) {
+	for res, qty := range quotas {
+		metricName := fmt.Sprintf("%s.%s.%s", metricPrefix, res, metricSuffix)
+		sender.Gauge(metricName, quantityToFloat64(qty), "", tags)
+	}
+}
+
+func quantityToFloat64(qty resource.Quantity) float64 {
+	return float64(qty.MilliValue()) / 1000
+}
+
+func computeQuotaRemaining(used, limit v1.ResourceList) v1.ResourceList {
+	// Map values are not addressable as pointers, need to create an
+	// intermediate map of custom type to be able to subtract
+	remaining := make(map[v1.ResourceName]*resource.Quantity)
+
+	for res, qty := range limit {
+		remaining[res] = qty.Copy()
+	}
+	for res, qty := range used {
+		ptr := remaining[res]
+		if ptr == nil {
+			log.Debugf("Resource %s: has a usage but no limit, skipping remaining computation", res)
+			continue
+		}
+		ptr.Sub(qty)
+	}
+
+	output := make(v1.ResourceList)
+	for res, ptr := range remaining {
+		if ptr != nil {
+			output[res] = *ptr
+		}
+	}
+	return output
+}

--- a/pkg/collector/corechecks/cluster/kubernetes_openshift.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_openshift.go
@@ -20,16 +20,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	oapiClusterQuotaEndpoint     = "/oapi/v1/clusterresourcequotas/"
+	apiGroupClusterQuotaEndpoint = "/apis/quota.openshift.io/v1/clusterresourcequotas/"
+)
+
 // retrieveOShiftClusterQuotas lists and unmarshalls Openshift
 // ClusterResourceQuota objects from the APIserver
 func (k *KubeASCheck) retrieveOShiftClusterQuotas() ([]osq.ClusterResourceQuota, error) {
 	var url string
 	switch k.oshiftAPILevel {
 	case apiserver.OpenShiftAPIGroup:
-		url = "/apis/quota.openshift.io/v1/clusterresourcequotas/"
+		url = apiGroupClusterQuotaEndpoint
 		break
 	case apiserver.OpenShiftOAPI:
-		url = "/oapi/v1/clusterresourcequotas/"
+		url = oapiClusterQuotaEndpoint
 		break
 	default:
 		return nil, errors.New("OpenShift APIs unavailable")

--- a/pkg/collector/corechecks/cluster/kubernetes_openshift_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_openshift_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	osq "github.com/openshift/api/quota/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+)
+
+func TestReportClusterQuotas(t *testing.T) {
+	raw, err := ioutil.ReadFile("./testdata/oshift_crq_list.json")
+	require.NoError(t, err)
+	list := osq.ClusterResourceQuotaList{}
+	json.Unmarshal(raw, &list)
+	require.Len(t, list.Items, 1)
+
+	var instanceCfg = []byte("tags: [customtag]")
+	var initCfg = []byte("")
+	kubeASCheck := KubernetesASFactory().(*KubeASCheck)
+	err = kubeASCheck.Configure(instanceCfg, initCfg)
+	require.NoError(t, err)
+
+	mocked := mocksender.NewMockSender(kubeASCheck.ID())
+	mocked.SetupAcceptAll()
+	kubeASCheck.reportClusterQuotas(list.Items, mocked)
+	mocked.AssertNumberOfCalls(t, "Gauge", 9*3)
+
+	// Total
+	expectedTags := []string{"customtag", "clusterquota:multiproj-test"}
+
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.cpu.limit", 3.0, "", expectedTags)
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.cpu.used", 0.6, "", expectedTags)
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.cpu.remaining", 2.4, "", expectedTags)
+
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.pods.limit", 10, "", expectedTags)
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.pods.used", 6, "", expectedTags)
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.pods.remaining", 4, "", expectedTags)
+
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.secrets.limit", 30, "", expectedTags)
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.secrets.used", 18, "", expectedTags)
+	mocked.AssertMetric(t, "Gauge", "openshift.clusterquota.secrets.remaining", 12, "", expectedTags)
+
+	// Proj1
+	proj1Tags := append(expectedTags, "kube_namespace:proj1")
+
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.cpu.limit", 3.0, "", proj1Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.cpu.used", 0.6, "", proj1Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.cpu.remaining", 2.4, "", proj1Tags)
+
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.pods.limit", 10, "", proj1Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.pods.used", 6, "", proj1Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.pods.remaining", 4, "", proj1Tags)
+
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.secrets.limit", 30, "", proj1Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.secrets.used", 9, "", proj1Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.secrets.remaining", 12, "", proj1Tags)
+
+	// Proj2
+	proj2Tags := append(expectedTags, "kube_namespace:proj2")
+
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.cpu.limit", 3.0, "", proj2Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.cpu.used", 0, "", proj2Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.cpu.remaining", 2.4, "", proj2Tags)
+
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.pods.limit", 10, "", proj2Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.pods.used", 0, "", proj2Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.pods.remaining", 4, "", proj2Tags)
+
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.secrets.limit", 30, "", proj2Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.secrets.used", 9, "", proj2Tags)
+	mocked.AssertMetric(t, "Gauge", "openshift.appliedclusterquota.secrets.remaining", 12, "", proj2Tags)
+
+	if t.Failed() {
+		// Debug output
+		for i, call := range mocked.Calls {
+			fmt.Printf("Call %d: %+v\n", i, call)
+		}
+	}
+}

--- a/pkg/collector/corechecks/cluster/testdata/oshift_crq_list.json
+++ b/pkg/collector/corechecks/cluster/testdata/oshift_crq_list.json
@@ -1,0 +1,83 @@
+{
+  "kind": "ClusterResourceQuotaList",
+  "apiVersion": "quota.openshift.io/v1",
+  "metadata": {
+    "selfLink": "/apis/quota.openshift.io/v1/clusterresourcequotas/",
+    "resourceVersion": "117107"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "multiproj-test",
+        "selfLink": "/apis/quota.openshift.io/v1/clusterresourcequotas/multiproj-test",
+        "uid": "9fa5ce0c-798d-11e8-b6ca-525400daa710",
+        "resourceVersion": "57492",
+        "creationTimestamp": "2018-06-26T22:09:41Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ClusterResourceQuota\",\"metadata\":{\"annotations\":{},\"name\":\"multiproj-test\",\"namespace\":\"\"},\"spec\":{\"quota\":{\"hard\":{\"cpu\":\"3\",\"pods\":\"10\",\"secrets\":\"30\"}},\"selector\":{\"annotations\":{\"testgroup\":\"one\"}}}}\n"
+        }
+      },
+      "spec": {
+        "selector": {
+          "labels": null,
+          "annotations": {
+            "testgroup": "one"
+          }
+        },
+        "quota": {
+          "hard": {
+            "cpu": "3",
+            "pods": "10",
+            "secrets": "30"
+          }
+        }
+      },
+      "status": {
+        "total": {
+          "hard": {
+            "cpu": "3",
+            "pods": "10",
+            "secrets": "30"
+          },
+          "used": {
+            "cpu": "600m",
+            "pods": "6",
+            "secrets": "18"
+          }
+        },
+        "namespaces": [
+          {
+            "namespace": "proj1",
+            "status": {
+              "hard": {
+                "cpu": "3",
+                "pods": "10",
+                "secrets": "30"
+              },
+              "used": {
+                "cpu": "600m",
+                "pods": "6",
+                "secrets": "9"
+              }
+            }
+          },
+          {
+            "namespace": "proj2",
+            "status": {
+              "hard": {
+                "cpu": "3",
+                "pods": "10",
+                "secrets": "30"
+              },
+              "used": {
+                "cpu": "0",
+                "pods": "0",
+                "secrets": "9"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -52,7 +52,6 @@ type APIClient struct {
 	Cl               kubernetes.Interface
 	timeoutSeconds   int64
 	metadataPollIntl time.Duration
-	isOpenShift      OpenShiftApiLevel
 }
 
 // GetAPIClient returns the shared ApiClient instance.
@@ -61,7 +60,6 @@ func GetAPIClient() (*APIClient, error) {
 		globalAPIClient = &APIClient{
 			timeoutSeconds:   config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
 			metadataPollIntl: time.Duration(config.Datadog.GetInt64("kubernetes_apiserver_poll_freq")) * time.Second,
-			isOpenShift:      OpenShiftUnknown,
 		}
 		globalAPIClient.initRetry.SetupRetrier(&retry.Config{
 			Name:          "apiserver",

--- a/pkg/util/kubernetes/apiserver/diagnosis.go
+++ b/pkg/util/kubernetes/apiserver/diagnosis.go
@@ -19,10 +19,12 @@ func init() {
 // diagnose the API server availability
 func diagnose() error {
 	isConnectVerbose = true
-	_, err := GetAPIClient()
+	c, err := GetAPIClient()
 	isConnectVerbose = false
 	if err != nil {
 		log.Error(err)
+		return err
 	}
-	return err
+	log.Infof("Detecting OpenShift APIs: %s", c.IsOpenShift())
+	return nil
 }

--- a/pkg/util/kubernetes/apiserver/diagnosis.go
+++ b/pkg/util/kubernetes/apiserver/diagnosis.go
@@ -8,9 +8,8 @@
 package apiserver
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func init() {

--- a/pkg/util/kubernetes/apiserver/diagnosis.go
+++ b/pkg/util/kubernetes/apiserver/diagnosis.go
@@ -25,6 +25,6 @@ func diagnose() error {
 		log.Error(err)
 		return err
 	}
-	log.Infof("Detecting OpenShift APIs: %s", c.IsOpenShift())
+	log.Infof("Detecting OpenShift APIs: %s available", c.DetectOpenShiftAPILevel())
 	return nil
 }

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -15,12 +15,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -24,6 +22,8 @@ import (
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -10,7 +10,6 @@ package leaderelection
 import (
 	"encoding/json"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +17,8 @@ import (
 	ld "k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func (le *LeaderEngine) getCurrentLeader() (string, *v1.ConfigMap, error) {

--- a/pkg/util/kubernetes/apiserver/metadata.go
+++ b/pkg/util/kubernetes/apiserver/metadata.go
@@ -10,9 +10,8 @@ package apiserver
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetPodMetadataNames is used when the API endpoint of the DCA to get the metadata of a pod is hit.

--- a/pkg/util/kubernetes/apiserver/openshift.go
+++ b/pkg/util/kubernetes/apiserver/openshift.go
@@ -52,7 +52,7 @@ func (c *APIClient) ListOShiftClusterQuotas() ([]osq.ClusterResourceQuota, error
 		url = "/apis/quota.openshift.io/v1/clusterresourcequotas/"
 		break
 	case OpenShiftOApi:
-		url = "/oapi/v1/appliedclusterresourcequotas/"
+		url = "/oapi/v1/clusterresourcequotas/"
 		break
 	}
 

--- a/pkg/util/kubernetes/apiserver/openshift.go
+++ b/pkg/util/kubernetes/apiserver/openshift.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"errors"
+
+	osq "github.com/openshift/api/quota/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var ErrNotOpenShift = errors.New("not an OpenShift cluster")
+
+// IsOpenShift detects available endpoints to determine of OpenShift APIs are available
+func (c *APIClient) IsOpenShift() OpenShiftApiLevel {
+	if c.isOpenShift != OpenShiftUnknown {
+		return c.isOpenShift
+	}
+	err := c.Cl.CoreV1().RESTClient().Get().AbsPath("/apis/quota.openshift.io").Do().Error()
+	if err == nil {
+		c.isOpenShift = OpenShiftAPIGroup
+		return c.isOpenShift
+	}
+	log.Debugf("Cannot access new OpenShift API: %s", err)
+
+	err = c.Cl.CoreV1().RESTClient().Get().AbsPath("/oapi").Do().Error()
+	if err == nil {
+		c.isOpenShift = OpenShiftOApi
+		return c.isOpenShift
+	}
+	log.Debugf("Cannot access old OpenShift OAPI: %s", err)
+
+	// Fallback to NotOpenShift
+	c.isOpenShift = NotOpenShift
+	return c.isOpenShift
+}
+
+// ListOShiftClusterQuotas retrieves Openshift ClusterResourceQuota objects
+// from the APIserver, returns ErrNotOpenShift if called on a non-Openshift cluster
+func (c *APIClient) ListOShiftClusterQuotas() ([]osq.ClusterResourceQuota, error) {
+	var url string
+	switch c.IsOpenShift() {
+	case NotOpenShift:
+		return nil, ErrNotOpenShift
+	case OpenShiftAPIGroup:
+		url = "/apis/quota.openshift.io/v1/clusterresourcequotas/"
+		break
+	case OpenShiftOApi:
+		url = "/oapi/v1/appliedclusterresourcequotas/"
+		break
+	}
+
+	list := &osq.ClusterResourceQuotaList{}
+	err := c.GetRESTObject(url, list)
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}

--- a/pkg/util/kubernetes/apiserver/openshift_types.go
+++ b/pkg/util/kubernetes/apiserver/openshift_types.go
@@ -8,15 +8,11 @@
 package apiserver
 
 // OpenShiftApiLevel describes what level of OpenShift APIs are available on the apiserver
-type OpenShiftApiLevel int
+type OpenShiftApiLevel string
 
 const (
-	// OpenShiftAPIGroup indicates the new APIGroups are available (3.6+)
-	OpenShiftAPIGroup OpenShiftApiLevel = iota
-	// OpenShiftOApi  indicates the legacy oapi endpoints are available
-	OpenShiftOApi
-	// NotOpenShift indicates neither OShift api is available
-	NotOpenShift
-	// OpenShiftUnknown is set when detection is not yet done
-	OpenShiftUnknown
+	OpenShiftAPIGroup OpenShiftApiLevel = "OpenShift new API is available"
+	OpenShiftOApi                       = "OpenShift legacy oapi is available"
+	NotOpenShift                        = "OpenShift not detected"
+	OpenShiftUnknown                    = "OpenShift status unknown"
 )

--- a/pkg/util/kubernetes/apiserver/openshift_types.go
+++ b/pkg/util/kubernetes/apiserver/openshift_types.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+// OpenShiftApiLevel describes what level of OpenShift APIs are available on the apiserver
+type OpenShiftApiLevel int
+
+const (
+	// OpenShiftAPIGroup indicates the new APIGroups are available (3.6+)
+	OpenShiftAPIGroup OpenShiftApiLevel = iota
+	// OpenShiftOApi  indicates the legacy oapi endpoints are available
+	OpenShiftOApi
+	// NotOpenShift indicates neither OShift api is available
+	NotOpenShift
+	// OpenShiftUnknown is set when detection is not yet done
+	OpenShiftUnknown
+)

--- a/pkg/util/kubernetes/apiserver/openshift_types.go
+++ b/pkg/util/kubernetes/apiserver/openshift_types.go
@@ -7,12 +7,12 @@
 
 package apiserver
 
-// OpenShiftApiLevel describes what level of OpenShift APIs are available on the apiserver
-type OpenShiftApiLevel string
+// OpenShiftAPILevel describes what level of OpenShift APIs are available on the apiserver
+type OpenShiftAPILevel string
 
+// Responses for DetectOpenShiftAPILevel()
 const (
-	OpenShiftAPIGroup OpenShiftApiLevel = "OpenShift new API is available"
-	OpenShiftOApi                       = "OpenShift legacy oapi is available"
-	NotOpenShift                        = "OpenShift not detected"
-	OpenShiftUnknown                    = "OpenShift status unknown"
+	OpenShiftAPIGroup OpenShiftAPILevel = "new apiGroups"
+	OpenShiftOAPI                       = "legacy OAPI"
+	NotOpenShift                        = "no API"
 )

--- a/releasenotes/notes/openshift-clusterquota-metrics-097aa5f94c8a3c44.yaml
+++ b/releasenotes/notes/openshift-clusterquota-metrics-097aa5f94c8a3c44.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    OpenShift ClusterResourceQuotas metrics are now collected by the kube_apiserver check,
+    under the openshift.clusterquota.* and openshift.appliedclusterquota.* names.


### PR DESCRIPTION
### What does this PR do?

OpenShift allows cluster admins to set cluster-wide quotas for a set of namespaces/projects. This PR adds support for the [`ClusterResourceQuota`](https://docs.openshift.org/3.9/rest_api/apis-quota.openshift.io/v1.ClusterResourceQuota.html) custom resource, and code in the `kubernetes_apiserver` to report metrics on it.

For each resource type, the agent will report total and per-namespace gauges. For example with CPU on the [test fixture](https://github.com/DataDog/datadog-agent/blob/22b5bdb26de9f76553fe5917b5acc63253473845/pkg/collector/corechecks/cluster/testdata/oshift_crq_list.json), we will report:

With the tag `clusterquota:multiproj-test`:
- `openshift.clusterquota.cpu.used` = 0.6 (cores)
- `openshift.clusterquota.cpu.limit` = 3 (cores)
- `openshift.clusterquota.cpu.remaining` = 2.4 (cores): computed as `limit - used`

These are to be used per quota object, and for cluster-wide sums

With the tags `clusterquota:multiproj-test kube_namespace:proj2`
- `openshift.appliedclusterquota.cpu.used` = 0 (cores)
- `openshift.appliedclusterquota.cpu.limit` = 3 (cores)
- `openshift.appliedclusterquota.cpu.remaining` = 2.4 (cores): we're using 0, but we already use 0.6 in another namespace

The are only to be used at the namespace level (in a scoped dashboard), the cluster-wide aggregates will be off. If several quotas apply to a given namespace, the min aggregation of `openshift.appliedclusterquota.cpu.remaining` will indicate what can be used before hitting the least permissive one.

### Additional Notes

- Test images `datadog/agent-dev:xvello-oshift-quotas` (and `-jmx`) are pushed on docker hub
- Legacy `OAPI` compatibility mode still needs to be tested. 