### PR TITLE
[jmxfetch] single source of truth + build time version assignment

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -5,12 +5,14 @@
 
 name "jmxfetch"
 
+jmxfetch_version_default = '0.20.1'
+jmxfetch_hash_default = '076dc742d158e888bfff914e022bd1e640bde2b27735e27ed47799dd89058752'
 jmxfetch_version = ENV['JMXFETCH_VERSION']
 jmxfetch_hash = ENV['JMXFETCH_HASH']
 
 if jmxfetch_version.nil? || jmxfetch_version.empty?
-  jmxfetch_version = '0.20.1'
-  jmxfetch_hash = "076dc742d158e888bfff914e022bd1e640bde2b27735e27ed47799dd89058752"
+  jmxfetch_version = jmxfetch_version_default
+  jmxfetch_hash = jmxfetch_hash_default 
 end
 
 default_version jmxfetch_version

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -23,10 +23,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const (
-	jmxJarName                        = "jmxfetch-0.20.1-jar-with-dependencies.jar"
 	jmxMainClass                      = "org.datadog.jmxfetch.App"
 	defaultJmxCommand                 = "collect"
 	defaultJvmMaxMemoryAllocation     = " -Xmx200m"
@@ -37,6 +37,7 @@ const (
 )
 
 var (
+	jmxJarName     = fmt.Sprintf("jmxfetch-%s-jar-with-dependencies.jar", version.JMXFetchVersion)
 	jmxLogLevelMap = map[string]string{
 		"trace":    "TRACE",
 		"debug":    "DEBUG",

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -13,11 +13,17 @@ var AgentVersion string
 // DCAVersion contains the version of the Datatog Cluster Agent
 var DCAVersion string
 
+// JMXFetchVersion contains the version of the JMXFetch artifact
+var JMXFetchVersion string
+
 // Commit is populated with the short commit hash from which the Agent was built
 var Commit string
 
-var agentVersionDefault = "6.0.0"
-var clusterAgentVersionDefault = "1.0.0"
+var (
+	agentVersionDefault        = "6.0.0"
+	clusterAgentVersionDefault = "1.0.0"
+	jmxFetchVersionDefault     = "0.20.1"
+)
 
 func init() {
 	if AgentVersion == "" {
@@ -25,5 +31,8 @@ func init() {
 	}
 	if DCAVersion == "" {
 		DCAVersion = clusterAgentVersionDefault
+	}
+	if JMXFetchVersion == "" {
+		JMXFetchVersion = jmxFetchVersionDefault
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Single source of truth for the JMXFetch version. Either environment variable (set from the `release.json` and then honored in the JMXFetch omnibus software definition), or the default value described in the JMXFetch honored. In actuality it's still a dual source of truth because there's two places we might get this from, but in practice this guarantees a good build as the version used by omnibus will be the version used by the agent, and that's the most important aspect to this PR.


### Motivation

Previous approach was error prone.

### Additional Notes

Tested with and without environment variables, seems to work nicely.