### PR TITLE
use a regexp to validate "connection refused" test

### DIFF
--- a/test/integration/util/kubelet/securekubelet_test.go
+++ b/test/integration/util/kubelet/securekubelet_test.go
@@ -85,7 +85,7 @@ func (suite *SecureTestSuite) TestTLSWithoutCA() {
 	_, err := kubelet.GetKubeUtil()
 	require.NotNil(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), "Get https://127.0.0.1:10250/pods: x509: ")
-	assert.Contains(suite.T(), err.Error(), "Get http://127.0.0.1:10255/pods: dial tcp 127.0.0.1:10255: getsockopt: connection refused")
+	assert.Regexp(suite.T(), "10255: \\w+: connection refused", err.Error())
 }
 
 // TestTLSWithCACertificate with:


### PR DESCRIPTION
Remove flakyness: depending on the go version, the failing module is either `connect` or `getsockopt`