### PR TITLE
[DCA] Add store abstraction for custom metrics storage.

### DIFF
--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"time"
 
+	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd/server"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/dynamicmapper"
 	"github.com/spf13/pflag"

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -28,6 +28,10 @@ import (
 var options *server.CustomMetricsAdapterServerOptions
 var stopCh chan struct{}
 
+const (
+	datadogHPAConfigMap = "datadog-hpa"
+)
+
 func init() {
 	// FIXME: log to seelog
 	options = server.NewCustomMetricsAdapterServerOptions(os.Stdout, os.Stdout)
@@ -78,7 +82,7 @@ func StartServer() error {
 		return err
 	}
 
-	store, err := custommetrics.NewConfigMapStore(client.Cl, as.GetResourcesNamespace(), "datadog-hpa")
+	store, err := custommetrics.NewConfigMapStore(client.Cl, as.GetResourcesNamespace(), datadogHPAConfigMap)
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -87,8 +87,13 @@ func StartServer() error {
 		return err
 	}
 
+	datadogCl, err := hpa.NewDatadogClient()
+	if err != nil {
+		return err
+	}
+
 	// HPA watcher
-	hpaClient, err := hpa.NewHPAWatcherClient(client.Cl, store)
+	hpaClient, err := hpa.NewHPAWatcherClient(client.Cl, datadogCl, store)
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -77,7 +77,10 @@ func StartServer() error {
 		return err
 	}
 
-	store := custommetrics.NewConfigMapStore(client.Cl, as.GetResourcesNamespace(), "datadog-hpa")
+	store, err := custommetrics.NewConfigMapStore(client.Cl, as.GetResourcesNamespace(), "datadog-hpa")
+	if err != nil {
+		return err
+	}
 
 	// HPA watcher
 	hpaClient, err := hpa.NewHPAWatcherClient(client.Cl, store)

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -10,6 +10,7 @@ package custommetrics
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -19,9 +20,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type externalMetric struct {
@@ -36,16 +34,16 @@ type datadogProvider struct {
 	values          map[provider.CustomMetricInfo]int64
 	externalMetrics []externalMetric
 	resVersion      string
-	hpaClient       *hpa.HPAWatcherClient
+	store           Store
 }
 
 // NewDatadogProvider creates a Custom Metrics and External Metrics Provider.
-func NewDatadogProvider(client dynamic.ClientPool, mapper apimeta.RESTMapper, hpaCl *hpa.HPAWatcherClient) provider.MetricsProvider {
+func NewDatadogProvider(client dynamic.ClientPool, mapper apimeta.RESTMapper, store Store) provider.MetricsProvider {
 	return &datadogProvider{
-		client:    client,
-		mapper:    mapper,
-		values:    make(map[provider.CustomMetricInfo]int64),
-		hpaClient: hpaCl,
+		client: client,
+		mapper: mapper,
+		values: make(map[provider.CustomMetricInfo]int64),
+		store:  store,
 	}
 }
 
@@ -80,7 +78,11 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsInfoList []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
-	rawMetrics := p.hpaClient.ReadConfigMap()
+	rawMetrics, err := p.store.ListAllExternalMetrics()
+	if err != nil {
+		log.Errorf("Could not list the external metrics in the store: %s", err.Error())
+		return externalMetricsInfoList
+	}
 
 	for _, metric := range rawMetrics {
 		// Only metrics that exist in Datadog and available are eligible to be evaluated in the HPA process.
@@ -89,18 +91,18 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 		}
 		var extMetric externalMetric
 		extMetric.info = provider.ExternalMetricInfo{
-			Metric: metric.Name,
+			Metric: metric.MetricName,
 			Labels: metric.Labels,
 		}
 		extMetric.value = external_metrics.ExternalMetricValue{
-			MetricName:   metric.Name,
+			MetricName:   metric.MetricName,
 			MetricLabels: metric.Labels,
 			Value:        *resource.NewQuantity(metric.Value, resource.DecimalSI),
 		}
 		externalMetricsList = append(externalMetricsList, extMetric)
 
 		externalMetricsInfoList = append(externalMetricsInfoList, provider.ExternalMetricInfo{
-			Metric: metric.Name,
+			Metric: metric.MetricName,
 			Labels: metric.Labels,
 		})
 	}

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -78,7 +78,7 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsInfoList []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
-	rawMetrics, err := p.store.ListAllExternalMetrics()
+	rawMetrics, err := p.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Errorf("Could not list the external metrics in the store: %s", err.Error())
 		return externalMetricsInfoList

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -54,7 +54,7 @@ func NewConfigMapStore(client kubernetes.Interface, ns, name string) (Store, err
 		return nil, err
 	}
 
-	log.Infof("The configmap %s not dot exist, trying to create it", name)
+	log.Infof("The configmap %s does not exist, trying to create it", name)
 	cm = &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -100,7 +100,7 @@ func (c *configMapStore) DeleteExternalMetric(hpaNamespace, hpaName, metricName 
 		return nil
 	}
 	delete(c.cm.Data, key)
-	log.Debugf("Deleted external metric %#v from the configmap %s", metricName, c.cm.Name)
+	log.Debugf("Deleted external metric %#v from the configmap %s", metricName, c.name)
 	return nil
 }
 

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -36,14 +37,14 @@ type configMapStore struct {
 
 // NewConfigMapStore returns a new store backed by a configmap. The configmap will be created
 // in the specified namespace if it does not exist.
-func NewConfigMapStore(client corev1.CoreV1Interface, ns, name string) (Store, error) {
-	cm, err := client.ConfigMaps(ns).Get(name, metav1.GetOptions{})
+func NewConfigMapStore(client kubernetes.Interface, ns, name string) (Store, error) {
+	cm, err := client.CoreV1().ConfigMaps(ns).Get(name, metav1.GetOptions{})
 	if err == nil {
 		log.Infof("Retrieved the configmap %s", name)
 		return &configMapStore{
 			namespace: ns,
 			name:      name,
-			client:    client,
+			client:    client.CoreV1(),
 			cm:        cm,
 		}, nil
 	}
@@ -61,14 +62,14 @@ func NewConfigMapStore(client corev1.CoreV1Interface, ns, name string) (Store, e
 		},
 	}
 	// FIXME: distinguish RBAC error
-	cm, err = client.ConfigMaps(ns).Create(cm)
+	cm, err = client.CoreV1().ConfigMaps(ns).Create(cm)
 	if err != nil {
 		return nil, err
 	}
 	return &configMapStore{
 		namespace: ns,
 		name:      name,
-		client:    client,
+		client:    client.CoreV1(),
 		cm:        cm,
 	}, nil
 }

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package custommetrics
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type Store interface {
+	UpdateExternalMetrics(updated []ExternalMetricValue) error
+	DeleteExternalMetrics(metricNames []string) error
+	ListAllExternalMetrics() ([]ExternalMetricValue, error)
+}
+
+// configMapStore provides persistent storage for custom and external metrics using a configmap.
+type configMapStore struct {
+	namespace string
+	name      string
+	client    corev1.CoreV1Interface
+	cm        *v1.ConfigMap
+}
+
+// NewConfigMapStore returns a new store backed by a configmap. The configmap will be created
+// in the specified namespace if it does not exist.
+func NewConfigMapStore(client corev1.CoreV1Interface, ns, name string) (Store, error) {
+	cm, err := client.ConfigMaps(ns).Get(name, metav1.GetOptions{})
+	if err == nil {
+		log.Infof("Retrieved the configmap %s", name)
+		return &configMapStore{
+			namespace: ns,
+			name:      name,
+			client:    client,
+			cm:        cm,
+		}, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		log.Infof("Error while attempting to fetch the configmap %s: %s", name, err)
+		return nil, err
+	}
+
+	log.Infof("The configmap %s not dot exist, trying to create it", name)
+	cm = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+	// FIXME: distinguish RBAC error
+	cm, err = client.ConfigMaps(ns).Create(cm)
+	if err != nil {
+		return nil, err
+	}
+	return &configMapStore{
+		namespace: ns,
+		name:      name,
+		client:    client,
+		cm:        cm,
+	}, nil
+}
+
+// UpdateExternalMetrics updates the specified external metrics in the configmap. Only the
+// leader replica should call this function.
+func (c *configMapStore) UpdateExternalMetrics(updated []ExternalMetricValue) error {
+	if c.cm == nil {
+		return fmt.Errorf("configmap not initialized")
+	}
+	if len(updated) == 0 {
+		return nil
+	}
+	for _, m := range updated {
+		key := fmt.Sprintf("external_metric.%s", m.MetricName)
+		toStore, _ := json.Marshal(m)
+		if c.cm.Data == nil {
+			// Don't panic "assignment to entry in nil map" at init
+			c.cm.Data = make(map[string]string)
+		}
+		c.cm.Data[key] = string(toStore)
+	}
+	return c.updateConfigMap()
+}
+
+// DeleteExternalMetrics delete specified external metrics from the configmap. Only the
+// leader replica should call this function.
+func (c *configMapStore) DeleteExternalMetrics(metricNames []string) error {
+	if c.cm == nil {
+		return fmt.Errorf("configmap not initialized")
+	}
+	if len(metricNames) == 0 {
+		return nil
+	}
+	for _, metricName := range metricNames {
+		key := fmt.Sprintf("external_metric.%s", metricName)
+		if c.cm.Data[key] == "" {
+			log.Debugf("No data for external metric %s", metricName)
+			continue
+		}
+		delete(c.cm.Data, key)
+		log.Debugf("Removed external metric %#v from the configmap %s", metricName, c.name)
+	}
+	return c.updateConfigMap()
+}
+
+// ListAllExternalMetrics returns the most up-to-date list of external metrics from the configmap.
+// Any replica can safely call this function.
+func (c *configMapStore) ListAllExternalMetrics() ([]ExternalMetricValue, error) {
+	var metrics []ExternalMetricValue
+	var err error
+	c.cm, err = c.client.ConfigMaps(c.namespace).Get(c.name, metav1.GetOptions{})
+	if err != nil {
+		log.Infof("Could not get the configmap %s: %s", c.name, err.Error())
+		return nil, err
+	}
+	for _, d := range c.cm.Data {
+		cm := &ExternalMetricValue{}
+		json.Unmarshal([]byte(d), &cm)
+		metrics = append(metrics, *cm)
+	}
+	return metrics, nil
+}
+
+func (c *configMapStore) updateConfigMap() error {
+	var err error
+	c.cm, err = c.client.ConfigMaps(c.namespace).Update(c.cm)
+	if err != nil {
+		log.Infof("Could not update the configmap %s: %s", c.name, err.Error())
+		return err
+	}
+	return nil
+}

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -21,9 +21,9 @@ import (
 
 // Store is an interface for persistent storage of custom and external metrics.
 type Store interface {
-	SetExternalMetrics([]ExternalMetricValue) error
-	DeleteExternalMetrics([]ExternalMetricInfo) error
-	ListAllExternalMetrics() ([]ExternalMetricValue, error)
+	SetExternalMetricValues([]ExternalMetricValue) error
+	DeleteExternalMetricValues([]ExternalMetricInfo) error
+	ListAllExternalMetricValues() ([]ExternalMetricValue, error)
 }
 
 // configMapStore provides persistent storage of custom and external metrics using a configmap.
@@ -73,8 +73,8 @@ func NewConfigMapStore(client kubernetes.Interface, ns, name string) (Store, err
 	}, nil
 }
 
-// SetExternalMetrics updates the external metrics in the configmap.
-func (c *configMapStore) SetExternalMetrics(added []ExternalMetricValue) error {
+// SetExternalMetricValues updates the external metrics in the configmap.
+func (c *configMapStore) SetExternalMetricValues(added []ExternalMetricValue) error {
 	if c.cm == nil {
 		return fmt.Errorf("configmap not initialized")
 	}
@@ -93,8 +93,8 @@ func (c *configMapStore) SetExternalMetrics(added []ExternalMetricValue) error {
 	return c.updateConfigMap()
 }
 
-// DeleteExternalMetrics deletes the external metric from the configmap associated with the hpas.
-func (c *configMapStore) DeleteExternalMetrics(deleted []ExternalMetricInfo) error {
+// DeleteExternalMetricValues deletes the external metrics from the configmap.
+func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricInfo) error {
 	if c.cm == nil {
 		return fmt.Errorf("configmap not initialized")
 	}
@@ -113,9 +113,9 @@ func (c *configMapStore) DeleteExternalMetrics(deleted []ExternalMetricInfo) err
 	return c.updateConfigMap()
 }
 
-// ListAllExternalMetrics returns the most up-to-date list of external metrics from the configmap.
+// ListAllExternalMetricValues returns the most up-to-date list of external metrics from the configmap.
 // Any replica can safely call this function.
-func (c *configMapStore) ListAllExternalMetrics() ([]ExternalMetricValue, error) {
+func (c *configMapStore) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
 	var metrics []ExternalMetricValue
 	var err error
 	c.cm, err = c.client.ConfigMaps(c.namespace).Get(c.name, metav1.GetOptions{})

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -145,10 +145,10 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, store.(*configMapStore).cm)
 
-			err = store.SetExternalMetrics(tt.metrics)
+			err = store.SetExternalMetricValues(tt.metrics)
 			require.NoError(t, err)
 
-			allMetrics, err := store.ListAllExternalMetrics()
+			allMetrics, err := store.ListAllExternalMetricValues()
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, allMetrics)
 
@@ -162,7 +162,7 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				infos = append(infos, info)
 			}
 
-			err = store.DeleteExternalMetrics(infos)
+			err = store.DeleteExternalMetricValues(infos)
 			require.NoError(t, err)
 			assert.Zero(t, len(store.(*configMapStore).cm.Data))
 		})

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -56,24 +56,24 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{"bar", "default"},
+					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{"bar", "default"},
+					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 		},
@@ -83,24 +83,24 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"bar", "default"},
+					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"bar", "default"},
+					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 		},
@@ -110,19 +110,19 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{"foo", "default"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 			},
 		},

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -141,12 +141,12 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, allMetrics)
 
-			refs := make([]ObjectReference, 0)
+			objectRefs := make([]ObjectReference, 0)
 			for _, m := range tt.metrics {
-				refs = append(refs, m.HPA)
+				objectRefs = append(objectRefs, m.HPA)
 			}
 
-			err = store.DeleteExternalMetricValues(refs)
+			err = store.Delete(objectRefs)
 			require.NoError(t, err)
 			assert.Zero(t, len(store.(*configMapStore).cm.Data))
 		})

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -26,8 +26,8 @@ func TestNewConfigMapStore(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset().CoreV1()
-	_, err := client.ConfigMaps("default").Create(cm)
+	client := fake.NewSimpleClientset()
+	_, err := client.CoreV1().ConfigMaps("default").Create(cm)
 	require.NoError(t, err)
 
 	// configmap already exists

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -54,30 +54,26 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			"same metric with different hpas and labels",
 			[]ExternalMetricValue{
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "backend"},
-					HPAName:      "bar",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "backend"},
+					HPA:        ObjectReference{"bar", "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "backend"},
-					HPAName:      "bar",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "backend"},
+					HPA:        ObjectReference{"bar", "default"},
 				},
 			},
 		},
@@ -85,30 +81,26 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			"same metric with different owners and same labels",
 			[]ExternalMetricValue{
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "bar",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"bar", "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "bar",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"bar", "default"},
 				},
 			},
 		},
@@ -116,24 +108,21 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			"same metric with same owners and different labels",
 			[]ExternalMetricValue{
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "frontend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "frontend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "backend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "backend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
-					MetricName:   "requests_per_s",
-					Labels:       map[string]string{"role": "backend"},
-					HPAName:      "foo",
-					HPANamespace: "default",
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"role": "backend"},
+					HPA:        ObjectReference{"foo", "default"},
 				},
 			},
 		},
@@ -152,17 +141,12 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, allMetrics)
 
-			infos := make([]ExternalMetricInfo, 0)
+			refs := make([]ObjectReference, 0)
 			for _, m := range tt.metrics {
-				info := ExternalMetricInfo{
-					MetricName:   m.MetricName,
-					HPAName:      m.HPAName,
-					HPANamespace: m.HPANamespace,
-				}
-				infos = append(infos, info)
+				refs = append(refs, m.HPA)
 			}
 
-			err = store.DeleteExternalMetricValues(infos)
+			err = store.DeleteExternalMetricValues(refs)
 			require.NoError(t, err)
 			assert.Zero(t, len(store.(*configMapStore).cm.Data))
 		})

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -42,7 +42,7 @@ func TestNewConfigMapStore(t *testing.T) {
 }
 
 func TestConfigMapStoreExternalMetrics(t *testing.T) {
-	client := fake.NewSimpleClientset().CoreV1()
+	client := fake.NewSimpleClientset()
 
 	tests := []struct {
 		desc     string

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -1,0 +1,118 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package custommetrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newMockConfigMap(t *testing.T, name, metricName string, labels map[string]string) *v1.ConfigMap {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+	if metricName == "" || len(labels) == 0 {
+		return cm
+	}
+	em := ExternalMetricValue{
+		OwnerRef:   ObjectReference{Name: "foo"},
+		MetricName: metricName,
+		Labels:     labels,
+		Timestamp:  12,
+		Value:      1,
+		Valid:      false,
+	}
+	cm.Data = make(map[string]string)
+	b, err := json.Marshal(em)
+	require.NoError(t, err)
+	cm.Data[metricName] = string(b)
+	return cm
+}
+
+func newMockExternalMetricValue(name string, labels map[string]string) ExternalMetricValue {
+	return ExternalMetricValue{
+		OwnerRef:   ObjectReference{Name: "foo"},
+		MetricName: name,
+		Labels:     labels,
+		Timestamp:  12,
+		Value:      1,
+	}
+}
+
+func TestNewConfigMapStore(t *testing.T) {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+	}
+
+	client := fake.NewSimpleClientset().CoreV1()
+	_, err := client.ConfigMaps("default").Create(cm)
+	require.NoError(t, err)
+
+	// configmap already exists
+	store, err := NewConfigMapStore(client, "default", "foo")
+	require.NoError(t, err)
+	require.NotNil(t, store.(*configMapStore).cm)
+
+	// configmap doesn't exist
+	store, err = NewConfigMapStore(client, "default", "bar")
+	require.NoError(t, err)
+	require.NotNil(t, store.(*configMapStore).cm)
+}
+
+func TestConfigMapStoreListAllExternalMetrics(t *testing.T) {
+	testCases := []struct {
+		caseName       string
+		configmap      *v1.ConfigMap
+		expectedResult []ExternalMetricValue
+	}{
+		{
+			caseName:       "No correct metrics",
+			configmap:      newMockConfigMap(t, "foo", "requests_per_sec", nil),
+			expectedResult: nil,
+		},
+		{
+			caseName:       "Metric has the expected format",
+			configmap:      newMockConfigMap(t, "bar", "requests_per_sec", map[string]string{"bar": "baz"}),
+			expectedResult: []ExternalMetricValue{newMockExternalMetricValue("requests_per_sec", map[string]string{"bar": "baz"})},
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("#%d %s", i, testCase.caseName), func(t *testing.T) {
+			client := fake.NewSimpleClientset().CoreV1()
+
+			// create configmap populated with mock data
+			cm, err := client.ConfigMaps("default").Create(testCase.configmap)
+			require.NoError(t, err)
+
+			store := &configMapStore{
+				namespace: "default",
+				name:      testCase.configmap.Name,
+				client:    client,
+				cm:        cm,
+			}
+
+			allMetrics, err := store.ListAllExternalMetrics()
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedResult, allMetrics)
+		})
+	}
+}

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -7,23 +7,12 @@
 
 package custommetrics
 
-import (
-	"k8s.io/apimachinery/pkg/types"
-)
-
 type ExternalMetricValue struct {
-	OwnerRef   ObjectReference   `json:"ownerRef"`
-	MetricName string            `json:"metricName"`
-	Labels     map[string]string `json:"labels"`
-	Timestamp  int64             `json:"ts"`
-	Value      int64             `json:"value"`
-	Valid      bool              `json:"valid"`
-}
-
-type ObjectReference struct {
-	Kind       string    `json:"kind"`
-	Namespace  string    `json:"namespace"`
-	Name       string    `json:"name"`
-	UID        types.UID `json:"uid"`
-	APIVersion string    `json:"apiVersion"`
+	MetricName   string            `json:"metricName"`
+	Labels       map[string]string `json:"labels"`
+	Timestamp    int64             `json:"ts"`
+	HPAName      string            `json:"hpa_name"`
+	HPANamespace string            `json:"hpa_namespace"`
+	Value        int64             `json:"value"`
+	Valid        bool              `json:"valid"`
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package custommetrics
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ExternalMetricValue struct {
+	OwnerRef   ObjectReference   `json:"ownerRef"`
+	MetricName string            `json:"metricName"`
+	Labels     map[string]string `json:"labels"`
+	Timestamp  int64             `json:"ts"`
+	Value      int64             `json:"value"`
+	Valid      bool              `json:"valid"`
+}
+
+type ObjectReference struct {
+	Kind       string    `json:"kind"`
+	Namespace  string    `json:"namespace"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uid"`
+	APIVersion string    `json:"apiVersion"`
+}

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -8,17 +8,16 @@
 package custommetrics
 
 type ExternalMetricValue struct {
-	MetricName   string            `json:"metricName"`
-	Labels       map[string]string `json:"labels"`
-	Timestamp    int64             `json:"ts"`
-	HPAName      string            `json:"hpa_name"`
-	HPANamespace string            `json:"hpa_namespace"`
-	Value        int64             `json:"value"`
-	Valid        bool              `json:"valid"`
+	MetricName string            `json:"metricName"`
+	Labels     map[string]string `json:"labels"`
+	Timestamp  int64             `json:"ts"`
+	HPA        ObjectReference   `json:"hpa"`
+	Value      int64             `json:"value"`
+	Valid      bool              `json:"valid"`
 }
 
-type ExternalMetricInfo struct {
-	MetricName   string
-	HPAName      string
-	HPANamespace string
+// ObjectReference contains enough information to let you identify the referred resource.
+type ObjectReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -16,3 +16,9 @@ type ExternalMetricValue struct {
 	Value        int64             `json:"value"`
 	Valid        bool              `json:"valid"`
 }
+
+type ExternalMetricInfo struct {
+	MetricName   string
+	HPAName      string
+	HPANamespace string
+}

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -167,7 +167,7 @@ func (c *HPAWatcherClient) Start() {
 func (c *HPAWatcherClient) updateExternalMetrics() {
 	maxAge := int64(c.externalMaxAge.Seconds())
 
-	emList, err := c.store.ListAllExternalMetrics()
+	emList, err := c.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Infof("Error while retrieving external metrics from the store: %s", err)
 		return
@@ -191,7 +191,7 @@ func (c *HPAWatcherClient) updateExternalMetrics() {
 		}
 		log.Debugf("Updated the custom metric %#v", em)
 	}
-	if err = c.store.SetExternalMetrics(emList); err != nil {
+	if err = c.store.SetExternalMetricValues(emList); err != nil {
 		log.Errorf("Could not update the external metrics in the store: %s", err.Error())
 	}
 }
@@ -225,7 +225,7 @@ func (c *HPAWatcherClient) processHPAs(added, modified []*autoscalingv2.Horizont
 			}
 		}
 	}
-	return c.store.SetExternalMetrics(external)
+	return c.store.SetExternalMetricValues(external)
 }
 
 func (c *HPAWatcherClient) removeEntryFromStore(deleted []*autoscalingv2.HorizontalPodAutoscaler) error {
@@ -238,7 +238,7 @@ func (c *HPAWatcherClient) removeEntryFromStore(deleted []*autoscalingv2.Horizon
 			switch metricSpec.Type {
 			case autoscalingv2.ExternalMetricSourceType:
 				info := custommetrics.ExternalMetricInfo{
-					MetricName:   metricName,
+					MetricName:   metricSpec.External.MetricName,
 					HPANamespace: hpa.Namespace,
 					HPAName:      hpa.Name,
 				}
@@ -248,7 +248,7 @@ func (c *HPAWatcherClient) removeEntryFromStore(deleted []*autoscalingv2.Horizon
 			}
 		}
 	}
-	return c.store.DeleteExternalMetrics(external)
+	return c.store.DeleteExternalMetricValues(external)
 }
 
 // validateExternalMetric queries Datadog to validate the availability of an external metric

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -8,22 +8,18 @@
 package hpa
 
 import (
-	"encoding/json"
-	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 	"k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/core/v1"
-	apiMachineryErr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -32,20 +28,6 @@ var (
 	expectedHPAType = reflect.TypeOf(v2beta1.HorizontalPodAutoscaler{})
 )
 
-const (
-	datadogHPAConfigMap = "datadog-hpa"
-)
-
-type CustomExternalMetric struct {
-	Name         string            `json:"name"`
-	Labels       map[string]string `json:"labels"`
-	Timestamp    int64             `json:"ts"`
-	HPAName      string            `json:"hpa_name"`
-	HPANamespace string            `json:"hpa_namespace"`
-	Value        int64             `json:"value"`
-	Valid        bool              `json:"valid"`
-}
-
 // HPAWatcherClient embeds the API Server client and the configuration to refresh metrics from Datadog and watch the HPA Objects' activities
 type HPAWatcherClient struct {
 	clientSet      kubernetes.Interface
@@ -53,25 +35,42 @@ type HPAWatcherClient struct {
 	refreshItl     *time.Ticker
 	pollItl        *time.Ticker
 	externalMaxAge time.Duration
-	ns             string
 	datadogClient  *datadog.Client
+	store          custommetrics.Store
+}
+
+// NewHPAWatcherClient returns a new HPAWatcherClient
+func NewHPAWatcherClient(clientSet kubernetes.Interface, store custommetrics.Store) (*HPAWatcherClient, error) {
+	datadogCl, err := NewDatadogClient()
+	if err != nil {
+		return nil, err
+	}
+	pollInterval := config.Datadog.GetInt("hpa_watcher_polling_freq")
+	refreshInterval := config.Datadog.GetInt("hpa_external_metrics_polling_freq")
+	externalMaxAge := config.Datadog.GetInt("hpa_external_metrics_max_age")
+	return &HPAWatcherClient{
+		clientSet:      clientSet,
+		readTimeout:    100 * time.Millisecond,
+		pollItl:        time.NewTicker(time.Duration(pollInterval) * time.Second),
+		refreshItl:     time.NewTicker(time.Duration(refreshInterval) * time.Second),
+		externalMaxAge: time.Duration(externalMaxAge) * time.Second,
+		datadogClient:  datadogCl,
+		store:          store,
+	}, nil
 }
 
 func (c *HPAWatcherClient) run(res string) (new []*v2beta1.HorizontalPodAutoscaler, modified []*v2beta1.HorizontalPodAutoscaler, deleted []*v2beta1.HorizontalPodAutoscaler, resVer string, err error) {
-	hpaInterface := c.clientSet.AutoscalingV2beta1()
-
 	metaOptions := metav1.ListOptions{Watch: true, ResourceVersion: res}
-
-	hpaWatcher, err := hpaInterface.HorizontalPodAutoscalers(metav1.NamespaceAll).Watch(metaOptions)
+	watcher, err := c.clientSet.AutoscalingV2beta1().HorizontalPodAutoscalers(metav1.NamespaceAll).Watch(metaOptions)
 	if err != nil {
 		log.Infof("Failed to watch %v: %v", expectedHPAType, err)
 	}
-	defer hpaWatcher.Stop()
+	defer watcher.Stop()
 
 	watcherTimeout := time.NewTimer(c.readTimeout)
 	for {
 		select {
-		case rcvdHPA, ok := <-hpaWatcher.ResultChan():
+		case rcvdHPA, ok := <-watcher.ResultChan():
 			if !ok {
 				log.Debugf("Unexpected watch close")
 				return nil, nil, nil, "0", err
@@ -111,45 +110,12 @@ func (c *HPAWatcherClient) run(res string) (new []*v2beta1.HorizontalPodAutoscal
 	}
 }
 
-// NewHPAWatcherClient returns the HPAWatcherClient
-func NewHPAWatcherClient() (*HPAWatcherClient, error) {
-	namespace := as.GetResourcesNamespace()
-	clientAPI, err := as.GetAPIClient()
-	datadogCl, err := NewDatadogClient()
-	if err != nil {
-		return nil, err
-	}
-	if err != nil {
-		log.Errorf("Error creating Client for the HPA: %s", err.Error())
-		return nil, err
-	}
-	pollInterval := config.Datadog.GetInt("hpa_watcher_polling_freq")
-	refreshInterval := config.Datadog.GetInt("hpa_external_metrics_polling_freq")
-	externalMaxAge := config.Datadog.GetInt("hpa_external_metrics_max_age")
-	return &HPAWatcherClient{
-		clientSet:      clientAPI.Cl,
-		readTimeout:    100 * time.Millisecond,
-		pollItl:        time.NewTicker(time.Duration(pollInterval) * time.Second),
-		refreshItl:     time.NewTicker(time.Duration(refreshInterval) * time.Second),
-		externalMaxAge: time.Duration(externalMaxAge) * time.Second,
-		ns:             namespace,
-		datadogClient:  datadogCl,
-	}, nil
-}
-
 // Start runs a watch process of the various HPA objects' activities to process and store the relevant info.
 // Refreshes the custom metrics stored as well.
 func (c *HPAWatcherClient) Start() {
 	log.Info("Starting HPA Process ...")
 	tickerHPAWatchProcess := c.pollItl
 	tickerHPARefreshProcess := c.refreshItl
-
-	var resversion string
-	err := c.createConfigMapHPA()
-	if err != nil {
-		log.Errorf("Could not retrieve the ConfigMap %s to run the HPA process, stopping: %s", datadogHPAConfigMap, err.Error())
-		return
-	}
 
 	// Creating a leader election engine to make sure only the leader writes the metrics in the configmap and queries Datadog.
 	leaderEngine, err := leaderelection.GetLeaderEngine()
@@ -159,6 +125,8 @@ func (c *HPAWatcherClient) Start() {
 	}
 	leaderEngine.EnsureLeaderElectionRuns()
 
+	var resversion string
+
 	go func() {
 		for {
 			select {
@@ -167,21 +135,22 @@ func (c *HPAWatcherClient) Start() {
 				if !leaderEngine.IsLeader() {
 					continue
 				}
-				newHPA, modified, deleted, res, err := c.run(resversion)
+				added, modified, deleted, res, err := c.run(resversion)
 				if err != nil {
 					log.Errorf("Error while watching HPA Objects' activities: %s", err)
 					return
 				}
 				if res != resversion && res != "" {
 					resversion = res
-					if len(newHPA) > 0 {
-						c.storeHPA(newHPA)
+					if len(added) > 0 {
+						c.processHPAs(added)
 					}
 					if len(modified) > 0 {
-						c.storeHPA(modified)
+						c.processHPAs(modified)
 					}
 					if len(deleted) > 0 {
-						c.removeEntryFromConfigMap(deleted)
+						log.Infof("deleting if resver is diff")
+						c.removeEntryFromStore(deleted)
 					}
 				}
 			// Ticker to run the refresh process for the stored external metrics
@@ -191,186 +160,117 @@ func (c *HPAWatcherClient) Start() {
 				}
 				// Updating the metrics against Datadog should not affect the HPA pipeline.
 				// If metrics are temporarily unavailable for too long, they will become `Valid=false` and won't be evaluated.
-				c.updateCustomMetrics()
+				c.updateExternalMetrics()
 			}
 		}
 	}()
 }
 
-func (c *HPAWatcherClient) updateCustomMetrics() {
+func (c *HPAWatcherClient) updateExternalMetrics() {
 	maxAge := int64(c.externalMaxAge.Seconds())
-	configMap, err := c.clientSet.CoreV1().ConfigMaps(c.ns).Get(datadogHPAConfigMap, metav1.GetOptions{})
+
+	emList, err := c.store.ListAllExternalMetrics()
 	if err != nil {
-		log.Infof("Error while retrieving the Config Map %s", datadogHPAConfigMap)
+		log.Infof("Error while retrieving external metrics from the store: %s", err)
 		return
 	}
 
-	data := configMap.Data
-	if len(data) == 0 {
+	if len(emList) == 0 {
 		log.Debugf("No External Metrics to evaluate at the moment")
 		return
 	}
 
-	for _, d := range data {
-		cm := CustomExternalMetric{}
-		err := json.Unmarshal([]byte(d), &cm)
-		if err != nil {
-			log.Errorf("Could not unmarshal %#v", d)
+	for _, em := range emList {
+		if metav1.Now().Unix()-em.Timestamp <= maxAge && em.Valid {
 			continue
 		}
-		if metav1.Now().Unix()-cm.Timestamp > maxAge || !cm.Valid {
-			cm.Valid = false
-			cm.Timestamp = metav1.Now().Unix()
-			cm.Value, cm.Valid, err = c.validate(cm)
-			if err != nil {
-				log.Debugf("Could not update the metric %s from Datadog: %s", cm.Name, err.Error())
-				continue
-			}
 
-			c, err := json.Marshal(cm)
-			if err != nil {
-				log.Errorf("Error while marshalling the custom metric %s: %s", cm.Name, err.Error())
-				continue
-			}
-			key := fmt.Sprintf("external.metrics.%s.%s-%s", cm.HPANamespace, cm.HPAName, cm.Name)
-			data[key] = string(c)
-			log.Debugf("Updated the custom metric %#v", cm)
+		em.Valid = false
+		em.Timestamp = metav1.Now().Unix()
+
+		em.Value, em.Valid, err = c.validateExternalMetric(em)
+		if err != nil {
+			log.Debugf("Could not update the metric %s from Datadog: %s", em.MetricName, err.Error())
+			continue
 		}
 
+		log.Debugf("Updated the custom metric %#v", em)
 	}
-	_, err = c.clientSet.CoreV1().ConfigMaps(c.ns).Update(configMap)
-	if err != nil {
-		log.Errorf("Could not update because: %s", err)
+
+	if err := c.store.UpdateExternalMetrics(emList); err != nil {
+		log.Errorf("Could not store the custom metrics in the store: %s", err.Error())
 	}
 }
 
-func (c *HPAWatcherClient) createConfigMapHPA() error {
-	_, err := c.clientSet.CoreV1().ConfigMaps(c.ns).Get(datadogHPAConfigMap, metav1.GetOptions{})
-	// There is an error if the ConfigMap does not exist so we attempt to create it.
-	if err == nil {
-		log.Infof("Retrieving the Config Map %s", datadogHPAConfigMap)
-		return nil
+// processHPAs transforms HPA data into structures to be stored upon validation that they are available in Datadog
+func (c *HPAWatcherClient) processHPAs(hpas []*v2beta1.HorizontalPodAutoscaler) error {
+	var external []custommetrics.ExternalMetricValue
+	var err error
+
+	for _, hpa := range hpas {
+		ownerRef := custommetrics.ObjectReference{
+			Kind:       hpa.Kind,
+			Name:       hpa.Name,
+			Namespace:  hpa.Namespace,
+			UID:        hpa.UID,
+			APIVersion: hpa.APIVersion,
+		}
+		for _, metricSpec := range hpa.Spec.Metrics {
+			switch metricSpec.Type {
+			case v2beta1.ExternalMetricSourceType:
+				em := custommetrics.ExternalMetricValue{
+					OwnerRef:   ownerRef,
+					MetricName: metricSpec.External.MetricName,
+					Timestamp:  metav1.Now().Unix(),
+					Labels:     metricSpec.External.MetricSelector.MatchLabels,
+				}
+				em.Value, em.Valid, err = c.validateExternalMetric(em)
+				if err != nil {
+					log.Debugf("Not able to process external metric %#v: %s", em, err)
+					continue
+				}
+				external = append(external, em)
+			default:
+				log.Debugf("Unsupported metric type %s", metricSpec.Type)
+			}
+		}
 	}
-	// We do not need to attempt to create the Config Map if we face an error when trying to get it that is different from "not found"
-	if !apiMachineryErr.IsNotFound(err) {
-		log.Infof("Error while attempting to fetch the Config Map %s: %s", datadogHPAConfigMap, err.Error())
+	if err := c.store.UpdateExternalMetrics(external); err != nil {
+		log.Infof("Could not update external metrics in the store: %s", err)
 		return err
 	}
-
-	log.Infof("Could not get the Config Map to run the HPA, trying to create it: %s", err.Error())
-	cm := &v1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      datadogHPAConfigMap,
-			Namespace: c.ns,
-		},
-	}
-	// FIXME: distinguish RBAC error
-	_, err = c.clientSet.CoreV1().ConfigMaps(c.ns).Create(cm)
-	return err
+	return nil
 }
 
-// processHPA transforms HPA data into structures to be stored upon validation that they are available in Datadog
-// TODO Distinguish custom and external
-func (hpa *HPAWatcherClient) processHPA(list []*v2beta1.HorizontalPodAutoscaler) []CustomExternalMetric {
-	var cmList []CustomExternalMetric
-	var err error
-	for _, e := range list {
-		for _, m := range e.Spec.Metrics {
-			var cm CustomExternalMetric
-			cm.Name = m.External.MetricName
-			cm.Timestamp = metav1.Now().Unix()
-			cm.Labels = m.External.MetricSelector.MatchLabels
-			cm.HPAName = e.Name
-			cm.HPANamespace = e.Namespace
-			cm.Value, cm.Valid, err = hpa.validate(cm)
-			if err != nil {
-				log.Debugf("Not able to process %#v: %s", cm, err)
-			}
-			cmList = append(cmList, cm)
-		}
-	}
-	return cmList
-}
-
-// validate queries Datadog to validate the availability of a metric
-func (hpa *HPAWatcherClient) validate(cm CustomExternalMetric) (value int64, valid bool, err error) {
-	val, err := hpa.queryDatadogExternal(cm.Name, cm.Labels)
+// validateExternalMetric queries Datadog to validate the availability of an external metric
+func (c *HPAWatcherClient) validateExternalMetric(em custommetrics.ExternalMetricValue) (value int64, valid bool, err error) {
+	val, err := c.queryDatadogExternal(em.MetricName, em.Labels)
 	if err != nil {
-		return cm.Value, false, err
+		return em.Value, false, err
 	}
 	return val, true, nil
 }
 
-// storeHPA processes the data collected from the HPA object watch to be validated and stored in the datadogHPAConfigMap ConfigMap.
-func (c *HPAWatcherClient) storeHPA(hpaList []*v2beta1.HorizontalPodAutoscaler) error {
-	listCustomMetrics := c.processHPA(hpaList)
-	cm, err := c.clientSet.CoreV1().ConfigMaps(c.ns).Get(datadogHPAConfigMap, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("Could not store the custom metrics data in the ConfigMap %s: %s", datadogHPAConfigMap, err.Error())
-		return err
-	}
-	for _, n := range listCustomMetrics {
-		toStore, _ := json.Marshal(n)
-		if cm.Data == nil {
-			// Don't panic "assignment to entry in nil map" at init
-			cm.Data = make(map[string]string)
-		}
-		// We use a specific key to avoid conflicting when processing several HPA manifests with the same name but in different namespaces.
-		key := fmt.Sprintf("external.metrics.%s.%s-%s", n.HPANamespace, n.HPAName, n.Name)
-		cm.Data[key] = string(toStore)
-	}
-
-	_, err = c.clientSet.CoreV1().ConfigMaps(c.ns).Update(cm)
-	if err != nil {
-		log.Infof("Could not update the ConfigMap: %s", err)
-	}
-	return err
-}
-
-// removeEntryFromConfigMap will remove an External Custom Metric from removeEntryFromConfigMap if the corresponding HPA manifest is deleted.
-func (c *HPAWatcherClient) removeEntryFromConfigMap(deleted []*v2beta1.HorizontalPodAutoscaler) error {
-	cm, err := c.clientSet.CoreV1().ConfigMaps(c.ns).Get(datadogHPAConfigMap, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("Could not remove the custom metrics data in the ConfigMap %s: %s", datadogHPAConfigMap, err.Error())
-		return err
-	}
+// removeEntryFromStore will remove an External Custom Metric from removeEntryFromStore if the corresponding HPA manifest is deleted.
+func (c *HPAWatcherClient) removeEntryFromStore(deleted []*v2beta1.HorizontalPodAutoscaler) error {
+	metricNames := make([]string, 0)
 	for _, d := range deleted {
-		for _, m := range d.Spec.Metrics {
-			metricName := m.External.MetricName
-			key := fmt.Sprintf("external.metrics.%s.%s-%s", d.Namespace, d.Name, metricName)
-			if cm.Data[key] != "" {
-				delete(cm.Data, key)
-				log.Debugf("Removed entry %#v from the ConfigMap %s", key, datadogHPAConfigMap)
+		for _, metricSpec := range d.Spec.Metrics {
+			var metricName string
+			switch metricSpec.Type {
+			case v2beta1.ExternalMetricSourceType:
+				metricName = metricSpec.External.MetricName
+			default:
+				log.Debugf("Unsupported metric type %s", metricSpec.Type)
 			}
+			metricNames = append(metricNames, metricName)
 		}
 	}
-	_, err = c.clientSet.CoreV1().ConfigMaps(c.ns).Update(cm)
-	if err != nil {
-		log.Infof("Could not update because: %s", err)
+	if err := c.store.DeleteExternalMetrics(metricNames); err != nil {
+		log.Infof("Could not delete external metrics in the store: %s", err.Error())
+		return err
 	}
-	return err
-}
-
-// ReadConfigMap is used by any replica of the DCA serving the request by Kubernetes to ListExternalMetrics.
-// Called every 30 seconds (configurable on Kubernetes's end) by default.
-// Just list the content of the ConfigMap `datadogHPAConfigMap`.
-func (c *HPAWatcherClient) ReadConfigMap() []CustomExternalMetric {
-	var list []CustomExternalMetric
-	cm, err := c.clientSet.CoreV1().ConfigMaps(c.ns).Get(datadogHPAConfigMap, metav1.GetOptions{})
-	if err != nil {
-		log.Errorf("Could not store the custom metrics data in the ConfigMap %s: %s", datadogHPAConfigMap, err.Error())
-		return nil
-	}
-	data := cm.Data
-	for _, d := range data {
-		cm := &CustomExternalMetric{}
-		json.Unmarshal([]byte(d), &cm)
-		list = append(list, *cm)
-	}
-	return list
+	return nil
 }
 
 // Stop sends a signal to the HPAWatcher to stop it.

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -211,7 +211,7 @@ func (c *HPAWatcherClient) processHPAs(added, modified []*autoscalingv2.Horizont
 				em := custommetrics.ExternalMetricValue{
 					MetricName: metricSpec.External.MetricName,
 					Timestamp:  metav1.Now().Unix(),
-					HPA:        custommetrics.ObjectReference{hpa.Name, hpa.Namespace},
+					HPA:        custommetrics.ObjectReference{Name: hpa.Name, Namespace: hpa.Namespace},
 					Labels:     metricSpec.External.MetricSelector.MatchLabels,
 				}
 				em.Value, em.Valid, err = c.validateExternalMetric(em)
@@ -233,7 +233,7 @@ func (c *HPAWatcherClient) removeEntryFromStore(deleted []*autoscalingv2.Horizon
 	}
 	toDelete := []custommetrics.ObjectReference{}
 	for _, hpa := range deleted {
-		toDelete = append(toDelete, custommetrics.ObjectReference{hpa.Name, hpa.Namespace})
+		toDelete = append(toDelete, custommetrics.ObjectReference{Name: hpa.Name, Namespace: hpa.Namespace})
 	}
 	return c.store.DeleteExternalMetricValues(toDelete)
 }

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -189,7 +189,7 @@ func (c *HPAWatcherClient) updateExternalMetrics() {
 		if err != nil {
 			log.Debugf("Could not fetch the external metric %s from Datadog, metric is no longer valid: %s", em.MetricName, err)
 		}
-		log.Debugf("Updated the custom metric %#v", em)
+		log.Debugf("Updated the external metric %#v", em)
 		updated = append(updated, em)
 	}
 	if err = c.store.SetExternalMetricValues(updated); err != nil {

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -35,7 +35,8 @@ func (s *mockStore) SetExternalMetricValues(added []custommetrics.ExternalMetric
 		s.externalMetrics = make(map[string]custommetrics.ExternalMetricValue)
 	}
 	for _, em := range added {
-		s.externalMetrics[fmt.Sprintf("%s.%s.%s", em.HPA.Namespace, em.HPA.Name, em.MetricName)] = em
+		key := strings.Join([]string{em.HPA.Namespace, em.HPA.Name, em.MetricName}, ".")
+		s.externalMetrics[key] = em
 	}
 	return nil
 }
@@ -43,7 +44,8 @@ func (s *mockStore) SetExternalMetricValues(added []custommetrics.ExternalMetric
 func (s *mockStore) DeleteExternalMetricValues(deleted []custommetrics.ObjectReference) error {
 	for _, obj := range deleted {
 		for k := range s.externalMetrics {
-			if !strings.HasPrefix(k, fmt.Sprintf("%s.%s", obj.Namespace, obj.Name)) {
+			parts := strings.Split(k, ".")
+			if parts[0] != obj.Namespace || parts[1] != obj.Name {
 				continue
 			}
 			delete(s.externalMetrics, k)

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -34,11 +34,11 @@ func newMockStore(metricName string, labels map[string]string) *mockStore {
 		Value:        1,
 		Valid:        false,
 	}
-	_ = s.SetExternalMetrics([]custommetrics.ExternalMetricValue{em})
+	_ = s.SetExternalMetricValues([]custommetrics.ExternalMetricValue{em})
 	return s
 }
 
-func (s *mockStore) SetExternalMetrics(added []custommetrics.ExternalMetricValue) error {
+func (s *mockStore) SetExternalMetricValues(added []custommetrics.ExternalMetricValue) error {
 	if s.externalMetrics == nil {
 		s.externalMetrics = make(map[string]custommetrics.ExternalMetricValue)
 	}
@@ -48,14 +48,14 @@ func (s *mockStore) SetExternalMetrics(added []custommetrics.ExternalMetricValue
 	return nil
 }
 
-func (s *mockStore) DeleteExternalMetrics(deleted []custommetrics.ExternalMetricInfo) error {
+func (s *mockStore) DeleteExternalMetricValues(deleted []custommetrics.ExternalMetricInfo) error {
 	for _, info := range deleted {
 		delete(s.externalMetrics, info.MetricName)
 	}
 	return nil
 }
 
-func (s *mockStore) ListAllExternalMetrics() ([]custommetrics.ExternalMetricValue, error) {
+func (s *mockStore) ListAllExternalMetricValues() ([]custommetrics.ExternalMetricValue, error) {
 	allMetrics := make([]custommetrics.ExternalMetricValue, 0)
 	for _, cm := range s.externalMetrics {
 		allMetrics = append(allMetrics, cm)

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -62,7 +62,7 @@ func TestRemoveEntryFromStore(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{"foo", "default"},
+					HPA:        custommetrics.ObjectReference{Name: "foo", Namespace: "default"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,
@@ -78,7 +78,7 @@ func TestRemoveEntryFromStore(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{"bar", "default"},
+					HPA:        custommetrics.ObjectReference{Name: "bar", Namespace: "default"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,
@@ -90,7 +90,7 @@ func TestRemoveEntryFromStore(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{"bar", "default"},
+					HPA:        custommetrics.ObjectReference{Name: "bar", Namespace: "default"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -34,20 +34,24 @@ func newMockStore(metricName string, labels map[string]string) *mockStore {
 		Value:        1,
 		Valid:        false,
 	}
-	_ = s.SetExternalMetric(em)
+	_ = s.SetExternalMetrics([]custommetrics.ExternalMetricValue{em})
 	return s
 }
 
-func (s *mockStore) SetExternalMetric(em custommetrics.ExternalMetricValue) error {
+func (s *mockStore) SetExternalMetrics(added []custommetrics.ExternalMetricValue) error {
 	if s.externalMetrics == nil {
 		s.externalMetrics = make(map[string]custommetrics.ExternalMetricValue)
 	}
-	s.externalMetrics[em.MetricName] = em
+	for _, em := range added {
+		s.externalMetrics[em.MetricName] = em
+	}
 	return nil
 }
 
-func (s *mockStore) DeleteExternalMetric(hpaNamespace, hpaName, metricName string) error {
-	delete(s.externalMetrics, metricName)
+func (s *mockStore) DeleteExternalMetrics(deleted []custommetrics.ExternalMetricInfo) error {
+	for _, info := range deleted {
+		delete(s.externalMetrics, info.MetricName)
+	}
 	return nil
 }
 

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -99,7 +99,7 @@ func TestRemoveEntryFromStore(t *testing.T) {
 			store:    newMockStore("foobar", map[string]string{"bar": "baz"}),
 			hpa:      newMockHPAExternalMetricSource("foo", map[string]string{"bar": "baz"}),
 			expectedMetrics: map[string]custommetrics.ExternalMetricValue{
-				"foobar": custommetrics.ExternalMetricValue{
+				"foobar": {
 					MetricName:   "foobar",
 					Labels:       map[string]string{"bar": "baz"},
 					HPANamespace: "default",


### PR DESCRIPTION
### What does this PR do?

This PR continues the work to support the Custom Metrics API by abstracting out the logic of storing metrics from the `HPAWatcherClient` into another type so its easier to write unit tests and add the logic to `HPAWatcherClient` for `ObjectMetricSourceType` and `PodsMetricSourceType` custom metrics coming soon.

**I will change the target branch to `master` once https://github.com/DataDog/datadog-agent/pull/1883 is merged.**
