### PR TITLE
fix dogstatsd version

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -47,7 +47,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
 
     # NOTE: consider stripping symbols to reduce binary size
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
-    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd/"
+    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd"
     args = {
         "race_opt": "-race" if race else "",
         "build_type": "-a" if rebuild else "",

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -47,7 +47,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
 
     # NOTE: consider stripping symbols to reduce binary size
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
-    cmd += "-gcflags=\"{gcflags}\" -ldflags=all=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd/"
+    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd"
     args = {
         "race_opt": "-race" if race else "",
         "build_type": "-a" if rebuild else "",

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -47,7 +47,7 @@ def build(ctx, rebuild=False, race=False, static=False, build_include=None,
 
     # NOTE: consider stripping symbols to reduce binary size
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
-    cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd"
+    cmd += "-gcflags=\"{gcflags}\" -ldflags=all=\"{ldflags}\" {REPO_PATH}/cmd/dogstatsd/"
     args = {
         "race_opt": "-race" if race else "",
         "build_type": "-a" if rebuild else "",

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -65,7 +65,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
 
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
-        env["CGO_ENABLED"] = "0"
+        #env["CGO_ENABLED"] = "0"
     elif use_embedded_libs:
         embedded_lib_path = ctx.run("pkg-config --variable=libdir python-2.7",
                                     env=env, hide=True).stdout.strip()


### PR DESCRIPTION
### What does this PR do?

Found that removing the trailing `/` fixes the issue where dogstatsd was not getting tagged with any version. 

Not 100% sure why honestly 🤔. There were changes on `ldflag` with go `1.10` but from what I understand, it should not affect us (and it has not on other flavors of the agent). It might just be some kind of bug on go side.
