### PR TITLE
Start reworking container_collect_all

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -6,8 +6,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -15,39 +13,17 @@ import (
 var LogsAgent = config.Datadog
 
 // Build returns logs-agent sources
-func Build() (*LogSources, error) {
-	sources, err := buildLogSources(LogsAgent.GetString("confd_path"), LogsAgent.GetBool("logs_config.container_collect_all"))
-	if err != nil {
-		return nil, err
-	}
-	return sources, nil
+func Build() *LogSources {
+	return buildLogSources(LogsAgent.GetString("confd_path"))
 }
 
 // buildLogSources returns all the logs sources computed from logs configuration files and environment variables
-func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*LogSources, error) {
+func buildLogSources(ddconfdPath string) *LogSources {
 	var sources []*LogSource
 
 	// append sources from all logs config files
 	fileSources := buildLogSourcesFromDirectory(ddconfdPath)
 	sources = append(sources, fileSources...)
 
-	if collectAllLogsFromContainers {
-		// append source to collect all logs from all containers,
-		// this source must be added to the end of the list
-		// to assure sources metadata are not overridden when already defined
-		containersSource := NewLogSource("container_collect_all", &LogsConfig{
-			Type:    DockerType,
-			Service: "docker",
-			Source:  "docker",
-		})
-		sources = append(sources, containersSource)
-	}
-
-	logSources := NewLogSources(sources)
-
-	if len(logSources.GetValidSources()) == 0 {
-		return nil, fmt.Errorf("could not find any valid logs configuration")
-	}
-
-	return logSources, nil
+	return NewLogSources(sources)
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -27,15 +27,9 @@ func TestBuildLogsSources(t *testing.T) {
 	var ddconfdPath string
 	var logsSources *LogSources
 	var source *LogSource
-	var err error
-
-	// should return an error
-	logsSources, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
 
 	// should return the default tail all containers source
-	logsSources, err = buildLogSources(ddconfdPath, true)
-	assert.Nil(t, err)
+	logsSources = buildLogSources(ddconfdPath)
 	assert.Equal(t, 1, len(logsSources.GetValidSources()))
 
 	source = logsSources.GetValidSources()[0]
@@ -45,8 +39,7 @@ func TestBuildLogsSources(t *testing.T) {
 
 	// default tail all containers source should be the last element of the list
 	ddconfdPath = filepath.Join("tests", "any_docker_integration.d")
-	logsSources, err = buildLogSources(ddconfdPath, true)
-	assert.Nil(t, err)
+	logsSources = buildLogSources(ddconfdPath)
 	assert.Equal(t, 3, len(logsSources.GetValidSources()))
 
 	source = logsSources.GetValidSources()[2]

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -23,9 +23,8 @@ func TestAvailableIntegrationConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	allSources, err := buildLogSources(ddconfdPath, false)
+	allSources := buildLogSources(ddconfdPath)
 
-	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allSources.GetSources())-len(allSources.GetValidSources()))
 
 	sources := allSources.GetValidSources()
@@ -121,26 +120,25 @@ func TestCompileProcessingRules(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
 	var ddconfdPath string
-	var err error
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	sources := buildLogSources(ddconfdPath)
+	assert.Equal(t, 0, len(sources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	sources = buildLogSources(ddconfdPath)
+	assert.Equal(t, 0, len(sources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	sources = buildLogSources(ddconfdPath)
+	assert.Equal(t, 0, len(sources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	sources = buildLogSources(ddconfdPath)
+	assert.Equal(t, 0, len(sources.GetValidSources()))
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
-	assert.NotNil(t, err)
+	sources = buildLogSources(ddconfdPath)
+	assert.Equal(t, 0, len(sources.GetValidSources()))
 }
 
 func TestIntegrationName(t *testing.T) {

--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -19,6 +19,7 @@ type LogSources struct {
 func NewLogSources(sources []*LogSource) *LogSources {
 	return &LogSources{
 		sources: sources,
+		lock:    &sync.Mutex{},
 	}
 }
 

--- a/pkg/logs/input/container/kubernetes.go
+++ b/pkg/logs/input/container/kubernetes.go
@@ -31,12 +31,11 @@ type KubeScanner struct {
 	stopped      chan struct{}
 }
 
-func NewKubeScanner(pp pipeline.Provider, auditor *auditor.Auditor) (*KubeScanner, error) {
+func NewKubeScanner(sources *config.LogSources, pp pipeline.Provider, auditor *auditor.Auditor) (*KubeScanner, error) {
 	watcher, err := kubelet.NewPodWatcher(podExpiration)
 	if err != nil {
 		return nil, err
 	}
-	sources := config.NewLogSources(make([]*config.LogSource, 0))
 	scanner := file.New(sources, tailerMaxOpenFiles, pp, auditor, tailerSleepPeriod)
 	return &KubeScanner{
 		scanner:      scanner,

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -21,19 +21,17 @@ var (
 
 // Start starts logs-agent
 func Start() error {
-	sources, err := config.Build()
-	if err != nil {
-		// could not parse the configuration
-		return err
-	}
-	log.Info("Starting logs-agent")
+
+	sources := config.Build()
 
 	// setup and start the agent
-	agent = NewAgent(sources)
+	agent := NewAgent(sources)
+
+	log.Info("Starting logs-agent")
 	agent.Start()
 
 	// setup the status
-	status.Initialize(sources.GetSources())
+	status.Initialize(sources)
 
 	isRunning = true
 

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -37,11 +37,11 @@ type Status struct {
 
 // Builder is used to build the status.
 type Builder struct {
-	sources []*config.LogSource
+	sources *config.LogSources
 }
 
 // Initialize instantiates a builder that holds the sources required to build the current status later on.
-func Initialize(sources []*config.LogSource) {
+func Initialize(sources *config.LogSources) {
 	builder = &Builder{
 		sources: sources,
 	}
@@ -51,7 +51,7 @@ func Initialize(sources []*config.LogSource) {
 func Get() Status {
 	// Sort sources by name (ie. by integration name ~= file name)
 	sources := make(map[string][]*config.LogSource)
-	for _, source := range builder.sources {
+	for _, source := range builder.sources.GetSources() {
 		if _, exists := sources[source.Name]; !exists {
 			sources[source.Name] = []*config.LogSource{}
 		}


### PR DESCRIPTION
### What does this PR do?

Remove container_collect_all from the config, start moving it to scanners.
Properly init and use dynamic sources in the agent status.

### Motivation

### Additional Notes
