### PR TITLE
Maxime/fix io check

### DIFF
--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4
+FROM golang:1.10.3
 
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
     && sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list \

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -64,6 +64,10 @@ func ioSampler(names ...string) (map[string]disk.IOCountersStat, error) {
 }
 
 func TestIOCheck(t *testing.T) {
+	startNow := time.Now().UnixNano()
+	nowNano = func() int64 { return startNow } // time of the first run
+	defer func() { nowNano = time.Now().UnixNano }()
+
 	ioCounters = ioSampler
 	ioCheck := new(IOCheck)
 	ioCheck.Configure(nil, nil)
@@ -92,8 +96,8 @@ func TestIOCheck(t *testing.T) {
 	mock.AssertNumberOfCalls(t, "Rate", expectedRates)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 
-	// sleep for a second, for delta
-	time.Sleep(time.Second)
+	// simulate a 1s interval
+	nowNano = func() int64 { return startNow + int64(1*time.Second) } // time of the second run
 
 	switch os := runtime.GOOS; os {
 	case "windows":
@@ -110,7 +114,7 @@ func TestIOCheck(t *testing.T) {
 		mock.On("Gauge", "system.io.await", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.r_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.w_await", 0.0, "", []string{"device:sda"}).Return().Times(1)
-		mock.On("Gauge", "system.io.avg_q_sz", 0.028, "", []string{"device:sda"}).Return().Times(1)
+		mock.On("Gauge", "system.io.avg_q_sz", 0.03, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.util", 2.8, "", []string{"device:sda"}).Return().Times(1)
 		mock.On("Gauge", "system.io.svctm", 0.0, "", []string{"device:sda"}).Return().Times(1)
 		expectedRates += 4

--- a/releasenotes/notes/fix-io-check-06189c108da09495.yaml
+++ b/releasenotes/notes/fix-io-check-06189c108da09495.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix the IO check behavior on unix based on 'iostat' tool:
+    - Most metrics are an average time, so we don't need to divide again by
+      'delta' (ex: number of read/time doing read operations)
+    - time is based on the millisecond and not the second


### PR DESCRIPTION
### What does this PR do?

Fix the IO check behavior based on 'iostat' tool:

Most metrics are an average time, so we don't need to divide again by 'delta' (ex: number of read/time doing read operations)
time is based on the millisecond and not the second

PS: reopen from #1933 to fix `avg_q_sz`