### PR TITLE
Make more precise the doc comments for capped metrics in the docker check yaml

### DIFF
--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.example
@@ -59,7 +59,7 @@ instances:
     #
     # collect_exit_codes: true
 
-    # Allows ad-hoc spike filtering if the system reports incorrect metrics.
+    # Allows ad-hoc spike filtering in some rare cases when the system happen to report incorrect metrics.
     # This will drop points if the computed rate is higher than the cap value
     # capped_metrics:
     #   docker.cpu.user: 1000


### PR DESCRIPTION
### What does this PR do?

Make more precise the doc comments for capped metrics in the docker check yaml

### Motivation

This can lead the user to think that this option would be legitimate for some uses, when it's only a workaround.