### PR TITLE
[bootstrap] some changes to the bootstrap schema, introducing order + python

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,6 @@ before_script:
   - rsync -azr --delete ./ $SRC_PATH
   - cd $SRC_PATH
   - pip install -U pip
-  - pip install mercurial
   - inv -e deps
 
 #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,7 +120,6 @@ run_security_scan_test:
     - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
     - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
-    - pip install mercurial
     - dep ensure
   script:
     - set +x     # don't print the api key to the logs
@@ -324,7 +323,6 @@ build_windows_msi_x64:
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
     - xcopy /q/h/e/s * %GOPATH%\src\github.com\DataDog\datadog-agent
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - pip install mercurial
     - inv -e deps
   stage: package_build
   variables:

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,11 +1,36 @@
 {
-    "post-deps": {
-    },
     "deps": {
-        "github.com/golang/dep/cmd/dep": "v0.4.1",
-        "golang.org/x/lint/golint": "master",
-        "github.com/fzipp/gocyclo": "master",
-        "github.com/gordonklaus/ineffassign": "master",
-        "github.com/client9/misspell/cmd/misspell": "master"
+        "order": [
+            "mercurial",
+            "golang.org/x/lint/golint",
+            "github.com/fzipp/gocyclo",
+            "github.com/gordonklaus/ineffassign",
+            "github.com/client9/misspell/cmd/misspell",
+            "github.com/golang/dep/cmd/dep"
+        ],
+        "mercurial": {
+            "version": "4.6.2",
+            "type": "python"
+        },
+        "github.com/golang/dep/cmd/dep": {
+            "version": "v0.4.1",
+            "type": "go"
+        },
+        "golang.org/x/lint/golint": {
+            "version": "master",
+            "type": "go"
+        },
+        "github.com/fzipp/gocyclo": {
+            "version": "master",
+            "type": "go"
+        },
+        "github.com/gordonklaus/ineffassign": {
+            "version": "master",
+            "type": "go"
+        },
+        "github.com/client9/misspell/cmd/misspell": {
+            "version": "master",
+            "type": "go"
+        }
     }
 }

--- a/tasks/bootstrap.py
+++ b/tasks/bootstrap.py
@@ -1,0 +1,58 @@
+"""
+Boostrapping related logic goes here
+"""
+import os
+import json
+
+# Bootstrap dependencies description
+BOOTSTRAP_DEPS = "bootstrap.json"
+BOOTSTRAP_ORDER_KEY = "order"
+BOOTSTRAP_SUPPORTED_KINDS = ["go", "python"]
+BOOTSTRAP_SUPPORTED_STEPS = ["checkout", "install"]
+
+
+def get_deps(key):
+    """
+    Load dependency file, return specific key
+    """
+    here = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(here, '..', BOOTSTRAP_DEPS)) as depfile:
+        deps = json.load(depfile)
+
+    return deps.get(key, {})
+
+def process_deps(ctx, target, version, kind, step, verbose=False):
+    """
+    Process a dependency target.
+
+    Keyword arguments:
+    target -- the package name
+    version -- the target version
+    kind -- go, python
+    step -- checkout, install
+    verbose -- boolean
+    """
+    if kind not in BOOTSTRAP_SUPPORTED_KINDS:
+        raise Exception("Unknown dependency kind: {} for {}".format(kind, target))
+
+    if step not in BOOTSTRAP_SUPPORTED_STEPS:
+        raise Exception("Unknown bootstrap step: {} for {}".format(step, target))
+
+    verbosity = ' -v' if verbose else ''
+    if kind == "go":
+        if step == "checkout":
+            # download tools
+            path = os.path.join(os.environ.get('GOPATH'), 'src', target)
+            if not os.path.exists(path):
+                ctx.run("go get{} -d -u {}".format(verbosity, target))
+
+            with ctx.cd(path):
+                # checkout versions
+                ctx.run("git fetch")
+                ctx.run("git checkout {}".format(version))
+        elif step == "install":
+            ctx.run("go install{} {}".format(verbosity, target))
+    elif kind == "python":
+        # no checkout needed for python deps
+        if step == "install":
+            ctx.run("pip install{} {}=={}".format(verbosity, target, version))

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -4,12 +4,12 @@ Golang related tasks go here
 from __future__ import print_function
 import os
 import sys
-import json
 
 from invoke import task
 from invoke.exceptions import Exit
 from .build_tags import get_default_build_tags
 from .utils import pkg_config_path, get_build_flags
+from .bootstrap import get_deps, process_deps
 
 
 # List of modules to ignore when running lint on Windows platform
@@ -27,18 +27,6 @@ MISSPELL_IGNORED_TARGETS = [
     os.path.join("cmd", "agent", "dist", "checks", "prometheus_check"),
     os.path.join("cmd", "agent", "gui", "views", "private"),
 ]
-
-# Bootstrap dependencies description
-BOOTSTRAP_DEPS = "bootstrap.json"
-
-
-def get_deps(key):
-    here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, '..', BOOTSTRAP_DEPS)) as f:
-        deps = json.load(f)
-
-    return deps.get(key, {})
-
 
 @task
 def fmt(ctx, targets, fail_on_fmt=False):
@@ -198,32 +186,19 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False):
     """
     verbosity = ' -v' if verbose else ''
     deps = get_deps('deps')
-    for tool, version in deps.iteritems():
-        # download tools
-        path = os.path.join(os.environ.get('GOPATH'), 'src', tool)
-        if not os.path.exists(path):
-            ctx.run("go get{} -d -u {}".format(verbosity, tool))
+    order = deps.get("order", deps.keys())
+    for dependency in order:
+        tool = deps.get(dependency)
+        if not tool:
+            print("Malformed bootstrap JSON, dependency {} not found". format(dependency))
+            raise Exit(code=1)
 
-        with ctx.cd(path):
-            # checkout versions
-            ctx.run("git fetch")
-            ctx.run("git checkout {}".format(version))
+        process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'checkout', verbose=verbose)
 
-    postdeps = get_deps('post-deps')
-    for tool, version in postdeps.iteritems():
-        # download tools
-        path = os.path.join(os.environ.get('GOPATH'), 'src', tool)
-        if not os.path.exists(path):
-            ctx.run("go get{} -d -u {}".format(verbosity, tool))
-
-        with ctx.cd(path):
-            # checkout versions
-            ctx.run("git fetch")
-            ctx.run("git checkout {}".format(version))
-
-    for tool, version in deps.iteritems():
-        # install tools
-        ctx.run("go install{} {}".format(verbosity, tool))
+    order = deps.get("order", deps.keys())
+    for dependency in order:
+        tool = deps.get(dependency)
+        process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'install', verbose=verbose)
 
     # source level deps
     ctx.run("dep ensure{}".format(verbosity))


### PR DESCRIPTION
### What does this PR do?

It does a couple of things: 
1) it introduces support for python bootstrap deps (as we now have mercurial as a dependency).
2) it introduces ordering so we can ensure the necessary stuff is checked out, installed in the right order if so needed. The ordering should also allow us to do stuff like the previous "post-deps" stuff.

### Motivation

Mercurial was introduced as a new bootstrap dependency for some of the go packages stored in bitbucket, so while working on solving that I added some of the "new" features.