### PR TITLE
fix security scan in the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,13 +120,15 @@ run_security_scan_test:
     - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
     - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
-    - dep ensure
+    - pip install invoke
+    - inv deps
   script:
     - set +x     # don't print the api key to the logs
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor # send the list of the dependencies to snyk
   only:
     - master
+    - arbll/fix-snyk
 
 #
 # binary_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,6 @@ run_security_scan_test:
       snyk monitor # send the list of the dependencies to snyk
   only:
     - master
-    - arbll/fix-snyk
 
 #
 # binary_build


### PR DESCRIPTION
### What does this PR do?

Fix the security scan step in the CI. It was calling `dep ensure` without having mercurial installed. This PR makes it use `inv deps` instead to fix this issue and align with the rest of the pipeline.

