### PR TITLE
[Logs]: Fixed an issue with logs status display

### DIFF
--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -17,10 +17,10 @@ var (
 
 // Source provides some information about a logs source.
 type Source struct {
-	Type          string            `json:"type"`
-	Configuration map[string]string `json:"configuration"`
-	Status        string            `json:"status"`
-	Inputs        []string          `json:"inputs"`
+	Type          string                 `json:"type"`
+	Configuration map[string]interface{} `json:"configuration"`
+	Status        string                 `json:"status"`
+	Inputs        []string               `json:"inputs"`
 }
 
 // Integration provides some information about a logs integration.
@@ -86,11 +86,11 @@ func Get() Status {
 }
 
 // toDictionary returns a representation of the configuration
-func toDictionary(c *config.LogsConfig) map[string]string {
-	dictionary := make(map[string]string)
+func toDictionary(c *config.LogsConfig) map[string]interface{} {
+	dictionary := make(map[string]interface{})
 	switch c.Type {
 	case config.TCPType, config.UDPType:
-		dictionary["Port"] = string(c.Port)
+		dictionary["Port"] = c.Port
 	case config.FileType:
 		dictionary["Path"] = c.Path
 	case config.DockerType:


### PR DESCRIPTION
### What does this PR do?

Changed configuration data structure from `map[string]string` to `map[string]interface{}`

### Motivation

The port for UDP and TCP forwarding is not properly displayed when running `agent status`.

### Additional Notes

Got:
```
==========
Logs Agent
==========

  logs
  ----
    Type: udp
    Port: ┕
    Status: OK
```
Expected:
```
==========
Logs Agent
==========

  logs
  ----
    Type: udp
    Port: 9493
    Status: OK
```