### PR TITLE
fix panic when log_level >= error

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -160,14 +160,18 @@ func StartAgent() error {
 	if pidfilePath != "" {
 		err = pidfile.WritePID(pidfilePath)
 		if err != nil {
-			return log.Errorf("Error while writing PID file, exiting: %v", err)
+			err := fmt.Errorf("Error while writing PID file, exiting: %v", err)
+			log.Error(err)
+			return err
 		}
 		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), pidfilePath)
 	}
 
 	hostname, err := util.GetHostname()
 	if err != nil {
-		return log.Errorf("Error while getting hostname, exiting: %v", err)
+		err := fmt.Errorf("Error while getting hostname, exiting: %v", err)
+		log.Error(err)
+		return err
 	}
 	log.Infof("Hostname is: %s", hostname)
 
@@ -180,7 +184,9 @@ func StartAgent() error {
 
 	// start the cmd HTTP server
 	if err = api.StartServer(); err != nil {
-		return log.Errorf("Error while starting api server, exiting: %v", err)
+		err := fmt.Errorf("Error while starting api server, exiting: %v", err)
+		log.Error(err)
+		return err
 	}
 
 	// start the GUI server
@@ -282,11 +288,15 @@ func setupMetadataCollection(s *serializer.Serializer, hostname string) error {
 	// Should be always true, except in some edge cases (multiple agents per host)
 	err = common.MetadataScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
 	if err != nil {
-		return log.Error("Host metadata is supposed to be always available in the catalog!")
+		err := fmt.Errorf("Host metadata is supposed to be always available in the catalog")
+		log.Error(err)
+		return err
 	}
 	err = common.MetadataScheduler.AddCollector("agent_checks", agentChecksMetadataCollectorInterval*time.Second)
 	if err != nil {
-		return log.Error("Agent Checks metadata is supposed to be always available in the catalog!")
+		err := fmt.Errorf("Agent Checks metadata is supposed to be always available in the catalog")
+		log.Error(err)
+		return err
 	}
 	if addDefaultResourcesCollector && runtime.GOOS == "linux" {
 		err = common.MetadataScheduler.AddCollector("resources", defaultResourcesMetadataCollectorInterval*time.Second)

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -127,13 +127,17 @@ func start(cmd *cobra.Command, args []string) error {
 	// get hostname
 	hostname, err := util.GetHostname()
 	if err != nil {
-		return log.Errorf("Error while getting hostname, exiting: %v", err)
+		err = fmt.Errorf("Error while getting hostname, exiting: %v", err)
+		log.Error(err)
+		return err
 	}
 	log.Infof("Hostname is: %s", hostname)
 
 	// start the cmd HTTPS server
 	if err = api.StartServer(); err != nil {
-		return log.Errorf("Error while starting api server, exiting: %v", err)
+		err = fmt.Errorf("Error while starting api server, exiting: %v", err)
+		log.Error(err)
+		return err
 	}
 
 	// setup the forwarder

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -155,7 +155,9 @@ func start(cmd *cobra.Command, args []string) error {
 		err = metaScheduler.AddCollector("host", hostMetadataCollectorInterval*time.Second)
 		if err != nil {
 			metaScheduler.Stop()
-			return log.Error("Host metadata is supposed to be always available in the catalog!")
+			err = fmt.Errorf("Host metadata is supposed to be always available in the catalog")
+			log.Error(err)
+			return err
 		}
 	} else {
 		log.Warnf("Metadata collection disabled, only do that if another agent/dogstatsd is running on this host")

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -50,7 +50,8 @@ func (c *CheckBase) BuildID(instance, initConfig integration.Data) {
 
 // Warn sends an integration warning to logs + agent status.
 func (c *CheckBase) Warn(v ...interface{}) error {
-	w := log.Warn(v)
+	log.Warn(v)
+	w := fmt.Errorf(fmt.Sprint(v...))
 	c.latestWarnings = append(c.latestWarnings, w)
 
 	return w
@@ -58,7 +59,9 @@ func (c *CheckBase) Warn(v ...interface{}) error {
 
 // Warnf sends an integration warning to logs + agent status.
 func (c *CheckBase) Warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
+	log.Warnf(format, params)
+	w := fmt.Errorf(format, params)
+
 	c.latestWarnings = append(c.latestWarnings, w)
 
 	return w

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -347,7 +347,9 @@ func (c *APIClient) GetTokenFromConfigmap(token string, tokenTimeout int64) (str
 
 	tokenTime, err := time.Parse(time.RFC822, tokenTimeStr)
 	if err != nil {
-		return "", found, log.Errorf("could not convert the timestamp associated with %s from the ConfigMap %s", token, configMapDCAToken)
+		err = fmt.Errorf("could not convert the timestamp associated with %s from the ConfigMap %s", token, configMapDCAToken)
+		log.Error(err)
+		return "", found, err
 	}
 	tokenAge := time.Now().Unix() - tokenTime.Unix()
 

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -39,15 +39,21 @@ func (hpa *HPAWatcherClient) queryDatadogExternal(metricName string, tags map[st
 	seriesSlice, err := hpa.datadogClient.QueryMetrics(time.Now().Unix()-bucketSize, time.Now().Unix(), query)
 
 	if err != nil {
-		return 0, log.Errorf("Error while executing metric query %s: %s", query, err)
+		err = fmt.Errorf("Error while executing metric query %s: %s", query, err)
+		log.Error(err)
+		return 0, err
 	}
 	if len(seriesSlice) == 0 {
-		return 0, log.Errorf("Returned series slice empty")
+		err = fmt.Errorf("Returned series slice empty")
+		log.Error(err)
+		return 0, err
 	}
 	points := seriesSlice[0].Points
 
 	if len(points) == 0 {
-		return 0, log.Errorf("No points in series")
+		err = fmt.Errorf("No points in series")
+		log.Error(err)
+		return 0, err
 	}
 	lastValue := int64(points[len(points)-1][1])
 	return lastValue, nil

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -154,48 +154,42 @@ func (sw *DatadogLogger) info(s string) {
 }
 
 //warn logs at the warn level
-func (sw *DatadogLogger) warn(s string) error {
+func (sw *DatadogLogger) warn(s string) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
 
 	scrubbed := sw.scrub(s)
-	err := sw.inner.Warn(scrubbed)
+	sw.inner.Warn(scrubbed)
 
 	for _, l := range sw.extra {
 		l.Warn(scrubbed)
 	}
-
-	return err
 }
 
 //error logs at the error level
-func (sw *DatadogLogger) error(s string) error {
+func (sw *DatadogLogger) error(s string) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
 
 	scrubbed := sw.scrub(s)
-	err := sw.inner.Error(scrubbed)
+	sw.inner.Error(scrubbed)
 
 	for _, l := range sw.extra {
 		l.Error(scrubbed)
 	}
-
-	return err
 }
 
 //critical logs at the critical level
-func (sw *DatadogLogger) critical(s string) error {
+func (sw *DatadogLogger) critical(s string) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
 
 	scrubbed := sw.scrub(s)
-	err := sw.inner.Critical(scrubbed)
+	sw.inner.Critical(scrubbed)
 
 	for _, l := range sw.extra {
 		l.Critical(scrubbed)
 	}
-
-	return err
 }
 
 //tracef logs with format at the trace level
@@ -238,48 +232,42 @@ func (sw *DatadogLogger) infof(format string, params ...interface{}) {
 }
 
 //warnf logs with format at the warn level
-func (sw *DatadogLogger) warnf(format string, params ...interface{}) error {
+func (sw *DatadogLogger) warnf(format string, params ...interface{}) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
 
 	scrubbed := sw.scrub(fmt.Sprintf(format, params...))
-	err := sw.inner.Warn(scrubbed)
+	sw.inner.Warn(scrubbed)
 
 	for _, l := range sw.extra {
 		l.Warn(scrubbed)
 	}
-
-	return err
 }
 
 //errorf logs with format at the error level
-func (sw *DatadogLogger) errorf(format string, params ...interface{}) error {
+func (sw *DatadogLogger) errorf(format string, params ...interface{}) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
 
 	scrubbed := sw.scrub(fmt.Sprintf(format, params...))
-	err := sw.inner.Error(scrubbed)
+	sw.inner.Error(scrubbed)
 
 	for _, l := range sw.extra {
 		l.Error(scrubbed)
 	}
-
-	return err
 }
 
 //criticalf logs with format at the critical level
-func (sw *DatadogLogger) criticalf(format string, params ...interface{}) error {
+func (sw *DatadogLogger) criticalf(format string, params ...interface{}) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
 
 	scrubbed := sw.scrub(fmt.Sprintf(format, params...))
-	err := sw.inner.Critical(scrubbed)
+	sw.inner.Critical(scrubbed)
 
 	for _, l := range sw.extra {
 		l.Critical(scrubbed)
 	}
-
-	return err
 }
 
 func buildLogEntry(v ...interface{}) string {
@@ -318,30 +306,27 @@ func Info(v ...interface{}) {
 }
 
 //Warn logs at the warn level
-func Warn(v ...interface{}) error {
+func Warn(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.WarnLvl) {
 		s := buildLogEntry(v...)
-		return logger.warn(logger.scrub(s))
+		logger.warn(logger.scrub(s))
 	}
-	return nil
 }
 
 //Error logs at the error level
-func Error(v ...interface{}) error {
+func Error(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.ErrorLvl) {
 		s := buildLogEntry(v...)
-		return logger.error(logger.scrub(s))
+		logger.error(logger.scrub(s))
 	}
-	return nil
 }
 
 //Critical logs at the critical level
-func Critical(v ...interface{}) error {
+func Critical(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.CriticalLvl) {
 		s := buildLogEntry(v...)
-		return logger.critical(logger.scrub(s))
+		logger.critical(logger.scrub(s))
 	}
-	return nil
 }
 
 //Flush flushes the underlying inner log
@@ -373,17 +358,16 @@ func Infof(format string, params ...interface{}) {
 }
 
 //Warnf logs with format at the warn level
-func Warnf(format string, params ...interface{}) error {
+func Warnf(format string, params ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.WarnLvl) {
-		return logger.warnf(format, params...)
+		logger.warnf(format, params...)
 	}
-	return nil
 }
 
 //Errorf logs with format at the error level
-func Errorf(format string, params ...interface{}) error {
+func Errorf(format string, params ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.ErrorLvl) {
-		return logger.errorf(format, params...)
+		logger.errorf(format, params...)
 	} else if logger == nil || logger.inner == nil {
 		// We're currently trying to log an error before initializing
 		// the log module. This meant a early error while starting the
@@ -392,16 +376,14 @@ func Errorf(format string, params ...interface{}) error {
 		msgScrubbed, err := CredentialsCleanerBytes([]byte(msg))
 		if err == nil {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", msgScrubbed)
-			return fmt.Errorf(string(msgScrubbed))
 		}
 	}
-	return nil
 }
 
 //Criticalf logs with format at the critical level
-func Criticalf(format string, params ...interface{}) error {
+func Criticalf(format string, params ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.CriticalLvl) {
-		return logger.criticalf(format, params...)
+		logger.criticalf(format, params...)
 	} else if logger == nil || logger.inner == nil {
 		// We're currently trying to log an error before initializing
 		// the log module. This meant a early error while starting the
@@ -410,10 +392,8 @@ func Criticalf(format string, params ...interface{}) error {
 		msgScrubbed, err := CredentialsCleanerBytes([]byte(msg))
 		if err == nil {
 			fmt.Fprintf(os.Stderr, "Critical: %s\n", msgScrubbed)
-			return fmt.Errorf(string(msgScrubbed))
 		}
 	}
-	return nil
 }
 
 //ReplaceLogger allows replacing the internal logger, returns old logger

--- a/releasenotes/notes/panic-log-level-error-bee8cbd4b4224c3d.yaml
+++ b/releasenotes/notes/panic-log-level-error-bee8cbd4b4224c3d.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug that led the agent to panic in some cases if
+    the ``log_level`` configuration option was set to ``error``.
+
+
+


### PR DESCRIPTION
### What does this PR do?

Fixes an issue that was making the agent panic when the log_level was >= error and a check was reporting a warning.

The recent refactoring to the logging system implemented the same interface as `seelog` to act as a drop-in replacement. 
We failed to identify some weirdness in the `seelog` API and changed the behavior of a few methods : 

https://github.com/DataDog/datadog-agent/blob/4ab39da9332d4520cbcb7db0e2dd3a610a4c1a88/pkg/util/log/log.go#L321-L345

`seelog` does not actually return a real error for this methods. Instead it returns the formatted log line encapsulated in an error. The returned value would never be nil.

We were using this behavior in a few places and particularly here : 

https://github.com/DataDog/datadog-agent/blob/4ab39da9332d4520cbcb7db0e2dd3a610a4c1a88/pkg/collector/corechecks/checkbase.go#L51-L65

When the `log_level` was above warning, calling `log.Warnf` would return `nil`. This `nil` would be added to a slice that would later be used by a method and would trigger a panic : 

https://github.com/DataDog/datadog-agent/blob/1739a162fbb0340ade38e764abbf635a54833d89/pkg/collector/check/stats.go#L69-L74

```
[ AGENT ] github.com/DataDog/datadog-agent/pkg/collector/check.(*Stats).Add(0xc4202de1c0, 0x3ce1, 0x0, 0x0, 0xc420a8a800, 0x1, 0x1, 0xc42060a6f0) 
[ AGENT ] /go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/check/stats.go:72 +0x204 
[ AGENT ] github.com/DataDog/datadog-agent/pkg/collector/runner.addWorkStats(0x1cb91c0, 0xc420256070, 0x3ce1, 0x0, 0x0, 0xc420a8a800, 0x1, 0x1, 0xc42060a6f0) 
[ AGENT ] /go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:356 +0x10e 
[ AGENT ] github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).work(0xc420229ef0) 
[ AGENT ] /go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:301 +0x942 
[ AGENT ] created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).AddWorker 
[ AGENT ] /go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:100 +0x8a 
```