### PR TITLE
[DCA] Fix a spammy error log in services mapper.

### DIFF
--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -28,16 +28,16 @@ import (
 // }
 type ServicesMapper map[string]map[string][]string
 
-func (m ServicesMapper) Get(ns, podName string) ([]string, error) {
+func (m ServicesMapper) Get(ns, podName string) ([]string, bool) {
 	pods, ok := m[ns]
 	if !ok {
-		return nil, fmt.Errorf("no mapping for namespace %s", ns)
+		return nil, false
 	}
 	svcs, ok := pods[podName]
 	if !ok {
-		return nil, fmt.Errorf("no mapping for pod %s in namespace %s", podName, ns)
+		return nil, false
 	}
-	return svcs, nil
+	return svcs, true
 }
 
 func (m ServicesMapper) Set(ns, podName string, svcs []string) {
@@ -152,9 +152,9 @@ func (metaBundle *MetadataMapperBundle) ServicesForPod(ns, podName string) ([]st
 	metaBundle.m.RLock()
 	defer metaBundle.m.RUnlock()
 
-	svcs, err := metaBundle.Services.Get(ns, podName)
-	if err != nil {
-		log.Errorf("could not get services: %s", err)
+	svcs, ok := metaBundle.Services.Get(ns, podName)
+	if !ok {
+		log.Debugf("could not get services for pod %s in namespace %s", podName, ns)
 		return nil, false
 	}
 	return svcs, true

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -28,6 +28,7 @@ import (
 // }
 type ServicesMapper map[string]map[string][]string
 
+// Get returns the list of services for a given namespace and pod name.
 func (m ServicesMapper) Get(ns, podName string) ([]string, bool) {
 	pods, ok := m[ns]
 	if !ok {
@@ -40,6 +41,7 @@ func (m ServicesMapper) Get(ns, podName string) ([]string, bool) {
 	return svcs, true
 }
 
+// Set updates the list of services for a given namespace and pod name.
 func (m ServicesMapper) Set(ns, podName string, svcs []string) {
 	if _, ok := m[ns]; !ok {
 		m[ns] = make(map[string][]string)
@@ -152,10 +154,5 @@ func (metaBundle *MetadataMapperBundle) ServicesForPod(ns, podName string) ([]st
 	metaBundle.m.RLock()
 	defer metaBundle.m.RUnlock()
 
-	svcs, ok := metaBundle.Services.Get(ns, podName)
-	if !ok {
-		log.Debugf("could not get services for pod %s in namespace %s", podName, ns)
-		return nil, false
-	}
-	return svcs, true
+	return metaBundle.Services.Get(ns, podName)
 }


### PR DESCRIPTION
### What does this PR do?

This error log is a bit spammy and probably shouldn't be logged at the error level.

```
2018-07-12 09:22:30 UTC | ERROR | (services.go:113 in ServicesForPod) | could not get services: no mapping for pod omsagent-wx97z in namespace kube-system
2018-07-12 09:22:30 UTC | ERROR | (services.go:113 in ServicesForPod) | could not get services: no mapping for pod redis-77689f7578-fvvvt in namespace default
````
