### PR TITLE
Fix TCP listener stop that would cause the agent stop to be stuck

### DIFF
--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -37,7 +37,7 @@ func NewTCPListener(pp pipeline.Provider, source *config.LogSource) *TCPListener
 		pp:      pp,
 		source:  source,
 		tailers: []*Tailer{},
-		stop:    make(chan struct{}),
+		stop:    make(chan struct{}, 1),
 	}
 }
 

--- a/pkg/logs/input/listener/tcp_test.go
+++ b/pkg/logs/input/listener/tcp_test.go
@@ -32,4 +32,6 @@ func TestTCPShouldReceivesMessages(t *testing.T) {
 	msg := <-msgChan
 	assert.Equal(t, "hello world", string(msg.Content()))
 	assert.Equal(t, 1, len(listener.tailers))
+
+	listener.Stop()
 }


### PR DESCRIPTION
### What does this PR do?

Changed the stop channel to prevent the producer to be stuck if the event is never consumed.

### Motivation

Fix agent stop

