### PR TITLE
Fixing apiserver polling frequency

### DIFF
--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -14,6 +14,7 @@ The following environment variables are supported:
 - `DD_LEADER_ELECTION`: activates the [leader election](#leader-election). You must set `DD_COLLECT_KUBERNETES_EVENTS` to `true` to activate this feature. Default value is `false`.
 - `DD_LEADER_LEASE_DURATION`: used only if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds, is 60 by default. 
 - `DD_CLUSTER_AGENT_AUTH_TOKEN`: 32 characters long token that needs to be shared between the node agent and the DCA.
+- `DD_KUBERNETES_APISERVER_POLL_FREQ`: frequency in second at which the DCA (or every agent if the DCA is not enabled) will query the API Server to refresh the cluster metadata map.
 
 For a more detailed usage please [refer to the official Docker Hub](https://hub.docker.com/r/datadog/cluster-agent/) documentation.
 

--- a/docs/cluster-agent/GETTING_STARTED.md
+++ b/docs/cluster-agent/GETTING_STARTED.md
@@ -120,8 +120,8 @@ To do so, add the following environment variables to the agent's manifest:
                 name: datadog-auth-token
                 key: token 
 #            value: "<32_CHARACTERS_LONG_TOKEN>" # If you are not using the secret, just set the string.                
-          - name: DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ # Optional
-            value: '15'
+          - name: DD_KUBERNETES_APISERVER_POLL_FREQ # Optional
+            value: '60'
 ```
 
 **Step 8** - Create the Daemonsets for your agents:

--- a/docs/cluster-agent/HORIZONTAL_POD_AUTOSCALING.md
+++ b/docs/cluster-agent/HORIZONTAL_POD_AUTOSCALING.md
@@ -1,4 +1,4 @@
-# Datadog Cluster Agent (DCA) | Getting Started
+# Datadog Cluster Agent - DCA | Horizontal Pod Autoscaling
 
 The DCA is a **beta** feature, if you are facing any issues please reach out to our [support team](http://docs.datadoghq.com/help)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -200,8 +200,9 @@ func init() {
 	Datadog.SetDefault("kubelet_client_key", "")
 
 	Datadog.SetDefault("kubernetes_collect_metadata_tags", true)
-	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60*5) // 5 min
+	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
+	BindEnvAndSetDefault("kubernetes_apiserver_poll_freq", 30)   // Polling frequency of the DCA (or the agent if the DCA is disabled) to the API Server in seconds
 	BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 
 	// Kube ApiServer

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -491,9 +491,9 @@ api_key:
 # You can disable this option or set how often (in seconds) the agent refreshes the internal mapping of services to
 # ContainerIDs with the following options:
 # kubernetes_collect_metadata_tags: true
-# kubernetes_metadata_tag_update_freq: 300
+# kubernetes_metadata_tag_update_freq: 60
 # kubernetes_apiserver_client_timeout: 10
-#
+# kubernetes_apiserver_poll_freq: 30
 #
 # To collect Kubernetes events, leader election must be enabled and collect_kubernetes_events set to true.
 # Only the leader will collect events. More details about events [here](https://github.com/DataDog/datadog-agent/blob/master/Dockerfilesagent/README.md#event-collection).

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -56,7 +56,7 @@ func GetAPIClient() (*APIClient, error) {
 	if globalAPIClient == nil {
 		globalAPIClient = &APIClient{
 			timeoutSeconds:   config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
-			metadataPollIntl: config.Datadog.GetDuration("kubernetes_metadata_tag_update_freq"),
+			metadataPollIntl: time.Duration(config.Datadog.GetInt64("kubernetes_apiserver_poll_freq")) * time.Second,
 		}
 		globalAPIClient.initRetry.SetupRetrier(&retry.Config{
 			Name:          "apiserver",

--- a/releasenotes/notes/fix-kubernetes-apiserver-poll-freq-9432990a84c7ccfb.yaml
+++ b/releasenotes/notes/fix-kubernetes-apiserver-poll-freq-9432990a84c7ccfb.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Kubernetes API Server's polling frequency is now customisable.
+


### PR DESCRIPTION
### What does this PR do?

The polling frequency of the Node Agent against the DCA is set with `kubernetes_metadata_tag_update_freq`. This value is used [here](https://github.com/DataDog/datadog-agent/blob/866cbc5fa21fb1919587d421fbedf37637a9cabb/pkg/tagger/collectors/kubernetes_main.go#L65), we expect an int64 (from the Viper conf).
This value was also used to specify the polling frequency of the DCA against the API Server.
but it was never used until https://github.com/DataDog/datadog-agent/pull/1976 was introduced.
The issue is that it was expecting a [Duration](https://github.com/DataDog/datadog-agent/blob/b524de4eada5c4a702f671885da53f1984c06bdf/pkg/util/kubernetes/apiserver/apiserver.go#L59)

Because of this line https://github.com/DataDog/datadog-agent/blob/866cbc5fa21fb1919587d421fbedf37637a9cabb/pkg/config/config.go#L66

Setting `kubernetes_metadata_tag_update_freq` to `1m` for instance would cause a panic.
Setting it to `1` would set the polling frequency to 1 ns. 

This PR introduces `apiserver_polling_freq`. It speficies the frequency at which the DCA queries the API Server. The Agent's polling frequency is still specified by `kubernetes_metadata_tag_update_freq`.
This is not a breaking change as the APIServer polling frequency was set to 20 seconds and not customisable prior to #1976, but this has not been released in a stable version.

Therefore, starting from 6.4, the user will be able to configure how often the agent/DCA query the API Server.

### Motivation

#1976 helped uncover a bug, this PR aims at fixing the underlying problem.
