### PR TITLE
[Logs] Handle docker logs without header

### DIFF
--- a/pkg/logs/docker/docker_test.go
+++ b/pkg/logs/docker/docker_test.go
@@ -62,12 +62,6 @@ func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {
 	_, err = ParseMessage(msg)
 	assert.NotNil(t, err)
 
-	// invalid header size
-	msg = []byte{}
-	msg = append(msg, []byte{1, 0, 0, 0, 0, 62, 49, 103}...)
-	msg = append(msg, []byte("INFO_10:26:31 _Loading_settings_from_file:/etc/cassandra/cassandra.yaml")...)
-	_, err = ParseMessage(msg)
-	assert.NotNil(t, err)
 }
 
 func TestParseMessageShouldRemovePartialHeaders(t *testing.T) {

--- a/pkg/logs/docker/docker_test.go
+++ b/pkg/logs/docker/docker_test.go
@@ -15,7 +15,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-const header = "100000002018-06-14T18:27:03.246999277Z"
+var header = string([]byte{1, 0, 0, 0, 0, 0, 0, 0}) + "2018-06-14T18:27:03.246999277Z"
+
+func TestGetStatus(t *testing.T) {
+	assert.Equal(t, message.StatusInfo, getStatus([]byte{1}))
+	assert.Equal(t, message.StatusError, getStatus([]byte{2}))
+	assert.Equal(t, "", getStatus([]byte{3}))
+}
 
 func TestParseMessageShouldSucceedWithValidInput(t *testing.T) {
 	validMessage := header + " " + "anything"
@@ -24,6 +30,26 @@ func TestParseMessageShouldSucceedWithValidInput(t *testing.T) {
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", dockerMsg.Timestamp)
 	assert.Equal(t, message.StatusInfo, dockerMsg.Status)
 	assert.Equal(t, []byte("anything"), dockerMsg.Content)
+}
+
+func TestParseMessageShouldHandleEmptyMessage(t *testing.T) {
+	msg, err := ParseMessage([]byte(header))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(msg.Content))
+}
+
+func TestParseMessageShouldHandleTtyMessage(t *testing.T) {
+	msg, err := ParseMessage([]byte("2018-06-14T18:27:03.246999277Z foo"))
+	assert.Nil(t, err)
+	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", msg.Timestamp)
+	assert.Equal(t, message.StatusInfo, msg.Status)
+	assert.Equal(t, []byte("foo"), msg.Content)
+}
+
+func TestParseMessageShouldHandleEmptyTtyMessage(t *testing.T) {
+	msg, err := ParseMessage([]byte("2018-06-14T18:27:03.246999277Z"))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(msg.Content))
 }
 
 func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {
@@ -39,7 +65,7 @@ func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {
 	// invalid header size
 	msg = []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0, 62, 49, 103}...)
-	msg = append(msg, []byte("INFO_10:26:31_Loading_settings_from_file:/etc/cassandra/cassandra.yaml")...)
+	msg = append(msg, []byte("INFO_10:26:31 _Loading_settings_from_file:/etc/cassandra/cassandra.yaml")...)
 	_, err = ParseMessage(msg)
 	assert.NotNil(t, err)
 }

--- a/pkg/logs/docker/docker_test.go
+++ b/pkg/logs/docker/docker_test.go
@@ -50,6 +50,9 @@ func TestParseMessageShouldHandleEmptyTtyMessage(t *testing.T) {
 	msg, err := ParseMessage([]byte("2018-06-14T18:27:03.246999277Z"))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg.Content))
+	msg, err = ParseMessage([]byte("2018-06-14T18:27:03.246999277Z "))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(msg.Content))
 }
 
 func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {

--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -197,11 +197,13 @@ func (dt *DockerTailer) forwardMessages() {
 			log.Warn(err)
 			continue
 		}
-		origin := message.NewOrigin(dt.source)
-		origin.Offset = dockerMsg.Timestamp
-		origin.Identifier = dt.Identifier()
-		origin.SetTags(dt.containerTags)
-		dt.outputChan <- message.New(dockerMsg.Content, origin, dockerMsg.Status)
+		if len(dockerMsg.Content) > 0 {
+			origin := message.NewOrigin(dt.source)
+			origin.Offset = dockerMsg.Timestamp
+			origin.Identifier = dt.Identifier()
+			origin.SetTags(dt.containerTags)
+			dt.outputChan <- message.New(dockerMsg.Content, origin, dockerMsg.Status)
+		}
 	}
 }
 

--- a/releasenotes/notes/logs-docker-empty-message-5458249c5a4fe54b.yaml
+++ b/releasenotes/notes/logs-docker-empty-message-5458249c5a4fe54b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Detect and handle Docker messages without header.


### PR DESCRIPTION
### What does this PR do?

This PR originally aimed to fix an issue that occurs when tailing Docker logs from a container running with --tty (-t). When this flag is present, logs are not prefixed by the usual 8 byte header, which meant we parsed the log timestamp and content incorrectly.

This also had the side effect of storing incorrect timestamps in the auditor as they were left-trimmed of 8 characters, eg:
```
    "docker:cc360078bf9119ede4db385e4bf1b305a966e63fb42dac234d95bceae16cb10c": {
      "LastUpdated": "2018-07-12T15:33:58.083797546Z",
      "Offset": "12T15:33:58.076572440Z" <-- this is wrong
    },
```
which could possibly result in tailing twice all the container logs if the agent was restarted.

Last of all, I noticed we did not all handle empty messages well, for example when hitting enter in a --interactive (-i) shell. This change now discards messages if no whitespace can be found after the timestamp, instead of logging an error.

### Motivation

Several people have reported occurrences of Logs agent reporting Docker parsing problems.

### Additional Notes
