### PR TITLE
[Logs]: Properly handling UDPListener stop

### DIFF
--- a/pkg/logs/input/listener/udp.go
+++ b/pkg/logs/input/listener/udp.go
@@ -75,7 +75,7 @@ func (l *UDPListener) read(tailer *Tailer) ([]byte, error) {
 	inBuf := make([]byte, 4096)
 	n, err := tailer.conn.Read(inBuf)
 	switch {
-	case l.isClosedConnError(err):
+	case err != nil && l.isClosedConnError(err):
 		return nil, err
 	case err != nil:
 		go l.resetTailer()

--- a/pkg/logs/input/listener/udp_test.go
+++ b/pkg/logs/input/listener/udp_test.go
@@ -38,6 +38,6 @@ func TestUDPShouldReceiveMessage(t *testing.T) {
 
 func TestIsConnectionClosedError(t *testing.T) {
 	listener := NewUDPListener(nil, nil)
-	assert.True(t, errors.New("use of closed network connection"))
-	assert.False(t, io.EOF)
+	assert.True(t, listener.isClosedConnError(errors.New("use of closed network connection")))
+	assert.False(t, listener.isClosedConnError(io.EOF))
 }

--- a/pkg/logs/input/listener/udp_test.go
+++ b/pkg/logs/input/listener/udp_test.go
@@ -6,14 +6,15 @@
 package listener
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
-	// "github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
 )
 
@@ -33,4 +34,10 @@ func TestUDPShouldReceiveMessage(t *testing.T) {
 	assert.Equal(t, "hello world", string(msg.Content()))
 
 	listener.Stop()
+}
+
+func TestIsConnectionClosedError(t *testing.T) {
+	listener := NewUDPListener(nil, nil)
+	assert.True(t, errors.New("use of closed network connection"))
+	assert.False(t, io.EOF)
 }


### PR DESCRIPTION
### What does this PR do?

Don't reopen a UDP connection when `close()` has been called.

### Motivation

Properly stop the agent

### Additional Notes

see here for more context about the solution chosen: https://golang.org/src/internal/poll/fd.go#L18
