### PR TITLE
Add ss from iproute2 in the dockerfile

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -12,7 +12,7 @@ ENV S6_VERSION v1.21.2.2
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz /output/s6.tgz
 ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz.sig /tmp/s6.tgz.sig
 RUN apt-get update \
- && apt-get install --no-install-recommends -y gpg gpg-agent curl ca-certificates \
+ && apt-get install --no-install-recommends -y gpg gpg-agent curl ca-certificates iproute2 \
  && curl https://keybase.io/justcontainers/key.asc | gpg --import \
  && gpg --verify /tmp/s6.tgz.sig /output/s6.tgz
 


### PR DESCRIPTION
### What does this PR do?

Add `ss` to the docker image.

### Motivation

This is required by the network check when we enable the collection of the connection states.

### Additional Notes

Tested locally:
```
which ss
/usr/bin/ss
```

I hope this is fine with the security scan.