### PR TITLE
Revert "[Logs] Handle docker logs without header"

### DIFF
--- a/pkg/logs/docker/docker.go
+++ b/pkg/logs/docker/docker.go
@@ -36,57 +36,32 @@ func ParseMessage(msg []byte) (Message, error) {
 	// [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 	// If we don't have at the very least 8 bytes we can consider this message can't be parsed.
 	if len(msg) < dockerHeaderLength {
-		return Message{}, errors.New("can't parse docker message: expected a 8 bytes header")
+		return Message{}, errors.New("Can't parse docker message: expected a 8 bytes header")
 	}
 
-	// Read the first byte to get the status
-	status := getStatus(msg)
-	if status == "" {
-
-		// When tailing logs coming from a container running with a tty, docker
-		// does not add the header. In that case, the message only contains
-		// the timestamp followed by whatever comes from what is running in the
-		// container (and maybe stdin). As a fallback, set the status to info.
-		status = message.StatusInfo
-
-	} else {
-
-		// remove partial headers that are added by docker when the message gets too long
-		if len(msg) > dockerBufferSize {
-			msg = removePartialDockerMetadata(msg)
-		}
-
-		// remove the header as we don't need it anymore
-		msg = msg[dockerHeaderLength:]
-
+	// remove partial headers that are added by docker when the message gets too long.
+	if len(msg) > dockerBufferSize {
+		msg = removePartialDockerMetadata(msg)
 	}
 
-	// timestamp goes till first space
-	idx := bytes.Index(msg, []byte{' '})
-	if idx == -1 {
-		// Nothing after the timestamp: empty message
-		return Message{}, nil
+	// First byte is 1 for stdout and 2 for stderr
+	status := message.StatusInfo
+	if msg[0] == 2 {
+		status = message.StatusError
 	}
+
+	// timestamp goes from byte 8 till first space
+	metadataLen := GetDockerMetadataLength(msg)
+	if metadataLen == 0 {
+		return Message{}, errors.New("Can't parse docker message: expected a whitespace after header")
+	}
+	timestamp := string(msg[dockerHeaderLength : metadataLen-1])
 
 	return Message{
-		Content:   msg[idx+1:],
+		Content:   msg[metadataLen:],
 		Status:    status,
-		Timestamp: string(msg[:idx]),
+		Timestamp: timestamp,
 	}, nil
-}
-
-// getStatus returns the status of the message based on the value of the
-// STREAM_TYPE byte in the header. STREAM_TYPE can be 1 for stdout and 2 for
-// stderr. If it doesn't match either of these, return an empty string.
-func getStatus(msg []byte) string {
-	switch msg[0] {
-	case 1:
-		return message.StatusInfo
-	case 2:
-		return message.StatusError
-	default:
-		return ""
-	}
 }
 
 // removePartialDockerMetadata removes the 8 byte header, timestamp, and space that occurs between 16Kb section of a log.

--- a/pkg/logs/docker/docker_test.go
+++ b/pkg/logs/docker/docker_test.go
@@ -15,13 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-var header = string([]byte{1, 0, 0, 0, 0, 0, 0, 0}) + "2018-06-14T18:27:03.246999277Z"
-
-func TestGetStatus(t *testing.T) {
-	assert.Equal(t, message.StatusInfo, getStatus([]byte{1}))
-	assert.Equal(t, message.StatusError, getStatus([]byte{2}))
-	assert.Equal(t, "", getStatus([]byte{3}))
-}
+const header = "100000002018-06-14T18:27:03.246999277Z"
 
 func TestParseMessageShouldSucceedWithValidInput(t *testing.T) {
 	validMessage := header + " " + "anything"
@@ -30,26 +24,6 @@ func TestParseMessageShouldSucceedWithValidInput(t *testing.T) {
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", dockerMsg.Timestamp)
 	assert.Equal(t, message.StatusInfo, dockerMsg.Status)
 	assert.Equal(t, []byte("anything"), dockerMsg.Content)
-}
-
-func TestParseMessageShouldHandleEmptyMessage(t *testing.T) {
-	msg, err := ParseMessage([]byte(header))
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(msg.Content))
-}
-
-func TestParseMessageShouldHandleTtyMessage(t *testing.T) {
-	msg, err := ParseMessage([]byte("2018-06-14T18:27:03.246999277Z foo"))
-	assert.Nil(t, err)
-	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", msg.Timestamp)
-	assert.Equal(t, message.StatusInfo, msg.Status)
-	assert.Equal(t, []byte("foo"), msg.Content)
-}
-
-func TestParseMessageShouldHandleEmptyTtyMessage(t *testing.T) {
-	msg, err := ParseMessage([]byte("2018-06-14T18:27:03.246999277Z"))
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(msg.Content))
 }
 
 func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {
@@ -65,7 +39,7 @@ func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {
 	// invalid header size
 	msg = []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0, 62, 49, 103}...)
-	msg = append(msg, []byte("INFO_10:26:31 _Loading_settings_from_file:/etc/cassandra/cassandra.yaml")...)
+	msg = append(msg, []byte("INFO_10:26:31_Loading_settings_from_file:/etc/cassandra/cassandra.yaml")...)
 	_, err = ParseMessage(msg)
 	assert.NotNil(t, err)
 }

--- a/pkg/logs/docker/docker_test.go
+++ b/pkg/logs/docker/docker_test.go
@@ -62,6 +62,12 @@ func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {
 	_, err = ParseMessage(msg)
 	assert.NotNil(t, err)
 
+	// invalid header size
+	msg = []byte{}
+	msg = append(msg, []byte{1, 0, 0, 0, 0, 62, 49, 103}...)
+	msg = append(msg, []byte("INFO_10:26:31 _Loading_settings_from_file:/etc/cassandra/cassandra.yaml")...)
+	_, err = ParseMessage(msg)
+	assert.NotNil(t, err)
 }
 
 func TestParseMessageShouldRemovePartialHeaders(t *testing.T) {

--- a/pkg/logs/docker/docker_test.go
+++ b/pkg/logs/docker/docker_test.go
@@ -50,9 +50,6 @@ func TestParseMessageShouldHandleEmptyTtyMessage(t *testing.T) {
 	msg, err := ParseMessage([]byte("2018-06-14T18:27:03.246999277Z"))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg.Content))
-	msg, err = ParseMessage([]byte("2018-06-14T18:27:03.246999277Z "))
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(msg.Content))
 }
 
 func TestParseMessageShouldFailWithInvalidInput(t *testing.T) {

--- a/pkg/logs/input/container/docker.go
+++ b/pkg/logs/input/container/docker.go
@@ -197,13 +197,11 @@ func (dt *DockerTailer) forwardMessages() {
 			log.Warn(err)
 			continue
 		}
-		if len(dockerMsg.Content) > 0 {
-			origin := message.NewOrigin(dt.source)
-			origin.Offset = dockerMsg.Timestamp
-			origin.Identifier = dt.Identifier()
-			origin.SetTags(dt.containerTags)
-			dt.outputChan <- message.New(dockerMsg.Content, origin, dockerMsg.Status)
-		}
+		origin := message.NewOrigin(dt.source)
+		origin.Offset = dockerMsg.Timestamp
+		origin.Identifier = dt.Identifier()
+		origin.SetTags(dt.containerTags)
+		dt.outputChan <- message.New(dockerMsg.Content, origin, dockerMsg.Status)
 	}
 }
 

--- a/releasenotes/notes/logs-docker-empty-message-5458249c5a4fe54b.yaml
+++ b/releasenotes/notes/logs-docker-empty-message-5458249c5a4fe54b.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Detect and handle Docker messages without header.


### PR DESCRIPTION
Reverts DataDog/datadog-agent#1985 as I used rebase-merge instead of squashing.