### PR TITLE
Chmod bin in the Dockerfile

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update \
 COPY entrypoint.sh .
 
 RUN chmod 755 /entrypoint.sh \
-    && chmod g+r,g+w,g+X -R /etc/datadog-agent/
+    && chmod g+r,g+w,g+X -R /etc/datadog-agent/ \
+    && chmod +x /opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -17,7 +17,6 @@ if [[ -z "$DD_DD_URL" ]]; then
     export DD_DD_URL="https://app.datadoghq.com"
 fi
 
-chmod +x /opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
 sync	# Fix for 'Text file busy' error
 
 ##### Starting up #####

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -17,8 +17,6 @@ if [[ -z "$DD_DD_URL" ]]; then
     export DD_DD_URL="https://app.datadoghq.com"
 fi
 
-sync	# Fix for 'Text file busy' error
-
 ##### Starting up #####
 export PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH
 


### PR DESCRIPTION
### What does this PR do?

The datadog-cluster-agent binary should be chmoded in the Dockerfile to allow for a override of the entrypoint.sh.

### Additional Notes

Per @JulienBalestra's feedback
