### PR TITLE
[e2e] Add e2e tests for agents using DCA service mapper.

### DIFF
--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -1,4 +1,4 @@
-# Datadog Cluster Agent | Containerized environments 
+# Datadog Cluster Agent | Containerized environments
 
 This is how the official Datadog Cluster Agent (also known as `DCA`) image, available [here](https://hub.docker.com/r/datadog/cluster-agent/), is built.
 
@@ -6,13 +6,13 @@ This is how the official Datadog Cluster Agent (also known as `DCA`) image, avai
 
 The following environment variables are supported:
 
-- `DD_API_KEY` - **required** - your [Datadog API key][https://app.datadoghq.com/account/settings#api].
+- `DD_API_KEY` - **required** - your [Datadog API key](https://app.datadoghq.com/account/settings#api).
 - `DD_HOSTNAME`: hostname to use for the DCA.
 - `DD_CLUSTER_AGENT_CMD_PORT`: port for the DCA to serve, default is `5005`.
 - `DD_USE_METADATA_MAPPER`: enables the cluster level metadata mapping, default is `true`.
 - `DD_COLLECT_KUBERNETES_EVENTS` - configures the agent to collect Kubernetes events. Default to `false`. See the [Event collection section](#event-collection) for more details.
 - `DD_LEADER_ELECTION`: activates the [leader election](#leader-election). You must set `DD_COLLECT_KUBERNETES_EVENTS` to `true` to activate this feature. Default value is `false`.
-- `DD_LEADER_LEASE_DURATION`: used only if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds, is 60 by default. 
+- `DD_LEADER_LEASE_DURATION`: used only if the leader election is activated. See the details [here](#leader-election-lease). The expected value is a number of seconds, is 60 by default.
 - `DD_CLUSTER_AGENT_AUTH_TOKEN`: 32 characters long token that needs to be shared between the node agent and the DCA.
 - `DD_KUBE_RESOURCES_NAMESPACE`: configures the namespace where the Cluster Agent creates the configmaps required for the Leader Election, the Event Collection (optional) and the Horizontal Pod Autoscaling.
 - `DD_KUBERNETES_APISERVER_POLL_FREQ`: frequency in second at which the DCA will query the API Server to refresh the cluster metadata map.
@@ -34,10 +34,10 @@ Then from the current folder, run `inv -e cluster-agent.image-build`.
 ### Security premise
 <a name="security-premise"></a>
 
-You should create the secret that is be used for your Agents to communicate with the DCA. 
+You should create the secret that is be used for your Agents to communicate with the DCA.
 You must modify the value in [the dca-secret.yaml](/manifests/cluster-agent/dca-secret.yaml) then create it:
 
-`kubectl create -f manifests/cluster-agent/dca-secret.yaml` 
+`kubectl create -f manifests/cluster-agent/dca-secret.yaml`
 
 Will yield:
 
@@ -143,7 +143,7 @@ You can disable the kubernetes metadata tag collection with `DD_KUBERNETES_COLLE
 
 #### HPA
 
-To enable the HPA: 
+To enable the HPA:
 - Set `DD_EXTERNAL_METRICS_PROVIDER_ENABLED` to `true` in the Deployment of the DCA.
 - Configure the `<DD_APP_KEY>` as well as the `<DD_API_KEY>` in the Deployment of the DCA.
 - Create a service exposing the port 443 and register it as an APIService for External Metrics.

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -9,7 +9,7 @@
 ##### Core config #####
 
 if [[ -z "$DD_API_KEY" ]]; then
-    echo "You must set an DD_API_KEY environment variable to run the Datadog Agent container"
+    echo "You must set an DD_API_KEY environment variable to run the Datadog Cluster Agent container"
     exit 1
 fi
 

--- a/test/e2e/argo-workflows/cluster-agent.yaml
+++ b/test/e2e/argo-workflows/cluster-agent.yaml
@@ -328,15 +328,7 @@ spec:
             port: 8090
             targetPort: 80
 
-    - name: agent-service-account
-      value: |
-        kind: ServiceAccount
-        apiVersion: v1
-        metadata:
-          name: datadog-agent
-          namespace: default
-
-    - name: agent-cluster-role
+    - name: agent-rbac
       value: |
         apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRole
@@ -351,9 +343,7 @@ spec:
           - nodes/proxy
           verbs:
           - get
-
-    - name: agent-cluster-role-binding
-      value: |
+        ---
         apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRoleBinding
         metadata:
@@ -364,6 +354,12 @@ spec:
           name: datadog-agent
         subjects:
         - kind: ServiceAccount
+          name: datadog-agent
+          namespace: default
+        ---
+        kind: ServiceAccount
+        apiVersion: v1
+        metadata:
           name: datadog-agent
           namespace: default
 
@@ -378,6 +374,7 @@ spec:
           datadog.yaml: |
             api_key: "123er"
             dd_url: "http://fake-datadog.default.svc.cluster.local"
+            cluster_agent: true
             listeners:
             - name: kubelet
             config_providers:
@@ -414,8 +411,6 @@ spec:
                 - /opt/datadog-agent/bin/agent/agent
                 - start
                 env:
-                - name: DD_CLUSTER_AGENT
-                  value: "true"
                 - name: DD_CLUSTER_AGENT_AUTH_TOKEN
                   value: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
                 - name: DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ
@@ -527,14 +522,12 @@ spec:
       parameters:
       - name: nginx
       - name: agent-configmap
-      - name: agent-service-account
-      - name: agent-cluster-role
-      - name: agent-cluster-role-binding
+      - name: agent-rbac
       - name: agent-daemonset
       - name: cluster-agent-rbac
       - name: cluster-agent-deployment
-      - name: cluster-agent-hpa-svc
       - name: cluster-agent-svc
+      - name: cluster-agent-hpa-svc
       - name: custom-metrics-server-rbac
       - name: fake-datadog-deployment
       - name: fake-datadog-service
@@ -591,9 +584,7 @@ spec:
             value: "{{item}}"
         withItems:
         - "{{inputs.parameters.agent-configmap}}"
-        - "{{inputs.parameters.agent-service-account}}"
-        - "{{inputs.parameters.agent-cluster-role}}"
-        - "{{inputs.parameters.agent-cluster-role-binding}}"
+        - "{{inputs.parameters.agent-rbac}}"
         - "{{inputs.parameters.agent-daemonset}}"
 
     - - name: nginx-hpa-setup
@@ -635,9 +626,7 @@ spec:
       parameters:
       - name: nginx
       - name: agent-configmap
-      - name: agent-service-account
-      - name: agent-cluster-role
-      - name: agent-cluster-role-binding
+      - name: agent-rbac
       - name: agent-daemonset
       - name: fake-datadog-deployment
       - name: fake-datadog-service
@@ -660,9 +649,7 @@ spec:
         withItems:
         - "{{inputs.parameters.nginx}}"
         - "{{inputs.parameters.agent-configmap}}"
-        - "{{inputs.parameters.agent-service-account}}"
-        - "{{inputs.parameters.agent-cluster-role}}"
-        - "{{inputs.parameters.agent-cluster-role-binding}}"
+        - "{{inputs.parameters.agent-rbac}}"
         - "{{inputs.parameters.agent-daemonset}}"
         - "{{inputs.parameters.fake-datadog-service}}"
         - "{{inputs.parameters.fake-datadog-deployment}}"

--- a/test/e2e/argo-workflows/cluster-agent.yaml
+++ b/test/e2e/argo-workflows/cluster-agent.yaml
@@ -1,13 +1,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: argo-datadog-cluster-agent-hpa
+  generateName: argo-datadog-cluster-agent-
 spec:
   entrypoint: main
   #onExit: delete # call argo submit --entrypoint delete instead
   arguments:
     parameters:
-    - name: cluster-agent-rbac-cluster-role
+    - name: cluster-agent-rbac
       value: |
         apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRole
@@ -40,6 +40,7 @@ spec:
           - configmaps
           resourceNames:
           - datadogtoken
+          - datadog-leader-election
           verbs:
           - get
           - update
@@ -51,31 +52,27 @@ spec:
           - get
           - update
           - create
-
-    - name: cluster-agent-rbac-sa
-      value: |
-        kind: ServiceAccount
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: dca
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: dca
+        subjects:
+        - kind: ServiceAccount
+          name: dca
+          namespace: default
+        ---
         apiVersion: v1
+        kind: ServiceAccount
         metadata:
           name: dca
           namespace: default
 
-    - name: cluster-agent-rbac-cluster-role-binding
-      value: |
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: ClusterRoleBinding
-          metadata:
-            name: dca
-          roleRef:
-            apiGroup: rbac.authorization.k8s.io
-            kind: ClusterRole
-            name: dca
-          subjects:
-          - kind: ServiceAccount
-            name: dca
-            namespace: default
-
-    - name: external-custom-metric-rbac
+    - name: custom-metrics-server-rbac
       value: |
         apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRoleBinding
@@ -164,7 +161,7 @@ spec:
               containers:
               - name: datadog-cluster-agent
                 image: datadog/cluster-agent-dev:master
-                imagePullPolicy: IfNotPresent
+                imagePullPolicy: Always
                 env:
                 - name: DD_API_KEY
                   value: "123er"
@@ -182,6 +179,8 @@ spec:
                   value: "true"
                 - name: DD_LEADER_ELECTION
                   value: "true"
+                - name: DD_KUBERNETES_APISERVER_POLL_FREQ
+                  value: "20"
                 livenessProbe:
                   exec:
                     command:
@@ -207,7 +206,7 @@ spec:
            app: datadog-cluster-agent
         spec:
          ports:
-         - port: 5001
+         - port: 5005
            protocol: TCP
          selector:
            app: datadog-cluster-agent
@@ -226,7 +225,7 @@ spec:
             port: 443
             targetPort: 443
 
-    - name: hpa-manifest
+    - name: nginx-hpa
       value: |
         apiVersion: autoscaling/v2beta1
         kind: HorizontalPodAutoscaler
@@ -288,6 +287,10 @@ spec:
 
         ---
         apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: nginxconfig
+          namespace: default
         data:
           nginx.conf: |+
             worker_processes  5;
@@ -310,11 +313,6 @@ spec:
                     }
                 }
             }
-
-        kind: ConfigMap
-        metadata:
-          name: nginxconfig
-          namespace: default
         ---
         apiVersion: v1
         kind: Service
@@ -416,6 +414,12 @@ spec:
                 - /opt/datadog-agent/bin/agent/agent
                 - start
                 env:
+                - name: DD_CLUSTER_AGENT
+                  value: "true"
+                - name: DD_CLUSTER_AGENT_AUTH_TOKEN
+                  value: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
+                - name: DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ
+                  value: "20"
                 - name: DD_KUBERNETES_KUBELET_HOST
                   valueFrom:
                     fieldRef:
@@ -457,7 +461,6 @@ spec:
                 - name: dockersocket
                   mountPath: /var/run/docker.sock
                   readOnly: true
-
               volumes:
               - name: datadog-config
                 configMap:
@@ -528,16 +531,14 @@ spec:
       - name: agent-cluster-role
       - name: agent-cluster-role-binding
       - name: agent-daemonset
-      - name: external-custom-metric-rbac
-      - name: cluster-agent-rbac-cluster-role
-      - name: cluster-agent-rbac-sa
-      - name: cluster-agent-rbac-cluster-role-binding
+      - name: cluster-agent-rbac
       - name: cluster-agent-deployment
       - name: cluster-agent-hpa-svc
       - name: cluster-agent-svc
-      - name: hpa-manifest
+      - name: custom-metrics-server-rbac
       - name: fake-datadog-deployment
       - name: fake-datadog-service
+      - name: nginx-hpa
     steps:
     - - name: fake-dd-setup
         template: manifest
@@ -565,6 +566,21 @@ spec:
     - - name: fake-dd-reset
         template: fake-dd-reset
 
+    - - name: cluster-agent-setup
+        template: manifest
+        arguments:
+          parameters:
+          - name: action
+            value: "apply"
+          - name: manifest
+            value: "{{item}}"
+        withItems:
+        - "{{inputs.parameters.cluster-agent-rbac}}"
+        - "{{inputs.parameters.cluster-agent-deployment}}"
+        - "{{inputs.parameters.cluster-agent-svc}}"
+        - "{{inputs.parameters.cluster-agent-hpa-svc}}"
+        - "{{inputs.parameters.custom-metrics-server-rbac}}"
+
     - - name: agent-setup
         template: manifest
         arguments:
@@ -580,7 +596,7 @@ spec:
         - "{{inputs.parameters.agent-cluster-role-binding}}"
         - "{{inputs.parameters.agent-daemonset}}"
 
-    - - name: cluster-agent-setup
+    - - name: nginx-hpa-setup
         template: manifest
         arguments:
           parameters:
@@ -589,24 +605,7 @@ spec:
           - name: manifest
             value: "{{item}}"
         withItems:
-        - "{{inputs.parameters.cluster-agent-rbac-cluster-role}}"
-        - "{{inputs.parameters.cluster-agent-rbac-sa}}"
-        - "{{inputs.parameters.cluster-agent-rbac-cluster-role-binding}}"
-        - "{{inputs.parameters.cluster-agent-deployment}}"
-        - "{{inputs.parameters.cluster-agent-svc}}"
-        - "{{inputs.parameters.cluster-agent-hpa-svc}}"
-
-    - - name: hpa
-        template: manifest
-        arguments:
-          parameters:
-          - name: action
-            value: "apply"
-          - name: manifest
-            value: "{{item}}"
-        withItems:
-        - "{{inputs.parameters.external-custom-metric-rbac}}"
-        - "{{inputs.parameters.hpa-manifest}}"
+        - "{{inputs.parameters.nginx-hpa}}"
 
     - - name: find-metrics-nginx
         template: find-metrics-nginx
@@ -631,17 +630,6 @@ spec:
     - - name: no-more-nginx
         template: no-more-metrics-nginx
 
-  - name: query-job
-    activeDeadlineSeconds: 120
-    inputs:
-      parameters:
-      - name: manifest
-    resource:
-      action: create
-      successCondition: status.succeeded > 0
-      failureCondition: status.failed > 10
-      manifest: "{{inputs.parameters.manifest}}"
-
   - name: delete
     inputs:
       parameters:
@@ -653,14 +641,12 @@ spec:
       - name: agent-daemonset
       - name: fake-datadog-deployment
       - name: fake-datadog-service
-      - name: external-custom-metric-rbac
-      - name: cluster-agent-rbac-cluster-role
-      - name: cluster-agent-rbac-sa
-      - name: cluster-agent-rbac-cluster-role-binding
+      - name: cluster-agent-rbac
       - name: cluster-agent-deployment
       - name: cluster-agent-hpa-svc
       - name: cluster-agent-svc
-      - name: hpa-manifest
+      - name: custom-metrics-server-rbac
+      - name: nginx-hpa
 
     steps:
     - - name: delete-manifest
@@ -680,13 +666,12 @@ spec:
         - "{{inputs.parameters.agent-daemonset}}"
         - "{{inputs.parameters.fake-datadog-service}}"
         - "{{inputs.parameters.fake-datadog-deployment}}"
-        - "{{inputs.parameters.cluster-agent-rbac-cluster-role}}"
-        - "{{inputs.parameters.cluster-agent-rbac-sa}}"
-        - "{{inputs.parameters.cluster-agent-rbac-cluster-role-binding}}"
+        - "{{inputs.parameters.cluster-agent-rbac}}"
         - "{{inputs.parameters.cluster-agent-deployment}}"
         - "{{inputs.parameters.cluster-agent-svc}}"
         - "{{inputs.parameters.cluster-agent-hpa-svc}}"
-        - "{{inputs.parameters.hpa-manifest}}"
+        - "{{inputs.parameters.custom-metrics-server-rbac}}"
+        - "{{inputs.parameters.nginx-hpa}}"
 
     - - name: remove-maps
         template: delete-cm-datadog-hpa
@@ -709,7 +694,7 @@ spec:
         set -x
         set -o pipefail
 
-        # Verify the DCA has written in the CM
+        # Verify the DCA has written in the configmap
         until kubectl get cm datadog-hpa -o json -n default | jq -re .data[]
         do
          sleep 1
@@ -767,7 +752,7 @@ spec:
         while (1) {
           var nb = db.series.find({
             metric: {$regex: "nginx*"},
-            tags: {$all: ["image_name:nginx"]}
+            tags: {$all: ["image_name:nginx", "kube_service:nginx"]}
           }).count();
           print("find: " + nb)
           if (nb != 0) {

--- a/test/e2e/argo-workflows/cluster-agent.yaml
+++ b/test/e2e/argo-workflows/cluster-agent.yaml
@@ -143,6 +143,21 @@ spec:
           name: horizontal-pod-autoscaler
           namespace: kube-system
 
+    - name: cluster-agent-configmap
+      value: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: datadog-cluster
+          namespace: default
+        data:
+          datadog.yaml: |
+            dd_url: "http://fake-datadog.default.svc.cluster.local"
+            cluster_agent:
+              auth_token: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
+            external_metrics_provider:
+              enabled: true
+
     - name: cluster-agent-deployment
       value: |
         apiVersion: extensions/v1beta1
@@ -167,16 +182,10 @@ spec:
                   value: "123er"
                 - name: DD_APP_KEY
                   value: "123er1"
-                - name: DATADOG_HOST
-                  value: "http://fake-datadog.default.svc.cluster.local"
-                - name: DD_DD_URL
+                - name: DATADOG_HOST # used by https://github.com/zorkian/go-datadog-api
                   value: "http://fake-datadog.default.svc.cluster.local"
                 - name: DD_LOG_LEVEL
                   value: "debug"
-                - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-                  value: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
-                - name: DD_EXTERNAL_METRICS_PROVIDER_ENABLED
-                  value: "true"
                 - name: DD_LEADER_ELECTION
                   value: "true"
                 - name: DD_KUBERNETES_APISERVER_POLL_FREQ
@@ -195,6 +204,14 @@ spec:
                     - status
                   failureThreshold: 5
                   initialDelaySeconds: 20
+                volumeMounts:
+                - name: datadog-config
+                  mountPath: /etc/datadog-agent/datadog.yaml
+                  subPath: datadog.yaml
+              volumes:
+              - name: datadog-config
+                configMap:
+                  name: datadog-cluster
 
     - name: cluster-agent-svc
       value: |
@@ -374,7 +391,10 @@ spec:
           datadog.yaml: |
             api_key: "123er"
             dd_url: "http://fake-datadog.default.svc.cluster.local"
-            cluster_agent: true
+            cluster_agent:
+              enabled: true
+              kubernetes_service_name: "dca"
+              auth_token: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
             listeners:
             - name: kubelet
             config_providers:
@@ -407,12 +427,11 @@ spec:
               containers:
               - name: agent
                 image: datadog/agent-dev:master # TODO provide the ECR PR image
+                imagePullPolicy: Always
                 command:
                 - /opt/datadog-agent/bin/agent/agent
                 - start
                 env:
-                - name: DD_CLUSTER_AGENT_AUTH_TOKEN
-                  value: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
                 - name: DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ
                   value: "20"
                 - name: DD_KUBERNETES_KUBELET_HOST
@@ -524,6 +543,7 @@ spec:
       - name: agent-configmap
       - name: agent-rbac
       - name: agent-daemonset
+      - name: cluster-agent-configmap
       - name: cluster-agent-rbac
       - name: cluster-agent-deployment
       - name: cluster-agent-svc
@@ -568,6 +588,7 @@ spec:
           - name: manifest
             value: "{{item}}"
         withItems:
+        - "{{inputs.parameters.cluster-agent-configmap}}"
         - "{{inputs.parameters.cluster-agent-rbac}}"
         - "{{inputs.parameters.cluster-agent-deployment}}"
         - "{{inputs.parameters.cluster-agent-svc}}"
@@ -630,6 +651,7 @@ spec:
       - name: agent-daemonset
       - name: fake-datadog-deployment
       - name: fake-datadog-service
+      - name: cluster-agent-configmap
       - name: cluster-agent-rbac
       - name: cluster-agent-deployment
       - name: cluster-agent-hpa-svc
@@ -653,6 +675,7 @@ spec:
         - "{{inputs.parameters.agent-daemonset}}"
         - "{{inputs.parameters.fake-datadog-service}}"
         - "{{inputs.parameters.fake-datadog-deployment}}"
+        - "{{inputs.parameters.cluster-agent-configmap}}"
         - "{{inputs.parameters.cluster-agent-rbac}}"
         - "{{inputs.parameters.cluster-agent-deployment}}"
         - "{{inputs.parameters.cluster-agent-svc}}"

--- a/test/e2e/argo-workflows/cluster-agent.yaml
+++ b/test/e2e/argo-workflows/cluster-agent.yaml
@@ -153,6 +153,8 @@ spec:
         data:
           datadog.yaml: |
             dd_url: "http://fake-datadog.default.svc.cluster.local"
+            kubernetes_apiserver_poll_freq: 20
+            leader_election: true
             cluster_agent:
               auth_token: "c9e21a248434a400b1de021dbdd554d790983a1212a5eac0ba36e79346ec52fd"
             external_metrics_provider:
@@ -186,10 +188,6 @@ spec:
                   value: "http://fake-datadog.default.svc.cluster.local"
                 - name: DD_LOG_LEVEL
                   value: "debug"
-                - name: DD_LEADER_ELECTION
-                  value: "true"
-                - name: DD_KUBERNETES_APISERVER_POLL_FREQ
-                  value: "20"
                 livenessProbe:
                   exec:
                     command:
@@ -391,6 +389,7 @@ spec:
           datadog.yaml: |
             api_key: "123er"
             dd_url: "http://fake-datadog.default.svc.cluster.local"
+            kubernetes_metadata_tag_update_freq: 20
             cluster_agent:
               enabled: true
               kubernetes_service_name: "dca"
@@ -432,8 +431,6 @@ spec:
                 - /opt/datadog-agent/bin/agent/agent
                 - start
                 env:
-                - name: DD_KUBERNETES_METADATA_TAG_UPDATE_FREQ
-                  value: "20"
                 - name: DD_KUBERNETES_KUBELET_HOST
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
### What does this PR do?

This generalizes the `dca-hpa` argo workflow to also test that the node agents use the DCA service mapper. I also renamed a few parameters and steps for clarity.

This mainly changes the `find-nginx-metrics` step to also look for the `kube_service:nginx` tag and adds the env vars necessary to enable DCA service mapper.

**Currently this workflow does not run in CI.**
