### PR TITLE
K8s host port updates

### DIFF
--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -17,9 +17,11 @@ spec:
         name: datadog-agent
         ports:
           - containerPort: 8125
+            hostPort: 8125
             name: dogstatsdport
             protocol: UDP
           - containerPort: 8126
+            hostPort: 8126
             name: traceport
             protocol: TCP
         env:


### PR DESCRIPTION
If the hostPort is not set, you cannot use APM or StatsD. This has caused several challenges with customers as of late.

### What does this PR do?
Adds hostPort variables to K8s manifest.

### Motivation

Several frustrated customers. 

### Additional Notes

May want to validate that we're OK to do this per: https://trello.com/c/AAUqncjh/1139-workaround-when-using-kubernetes-network-provider-not-supported-by-cni 
