### PR TITLE
Update default namespace of go_expvar metrics

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -38,7 +38,7 @@ instances:
   # The following instance pulls the go_expvar metrics of the running datadog-agent
   # Feel free to comment out the instance if you're not interested in these metrics
   - expvar_url: http://localhost:5000/debug/vars  # if you've defined `expvar_port` in datadog.yaml, change the port here to that value
-    namespace: datadog
+    namespace: datadog.agent
     metrics:
       # datadog-agent forwarder monitoring
       - path: forwarder/Transactions/Series


### PR DESCRIPTION
### What does this PR do?

Update the default namespace of the go_expvar metrics reported by the Agents provided configuration to be `datadog.agent.` instead of `datadog.`

### Motivation

Keep the metric names more in line with other metrics coming from the Agent. 

### Additional Notes

Anything else we should know when reviewing?
