### PR TITLE
Display python exception from '__init__' method in the status page

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -13,10 +13,11 @@ Collector
     {{.CheckName}}{{ if .CheckVersion }} ({{.CheckVersion}}){{ end }}
     {{printDashes .CheckName "-"}}{{- if .CheckVersion }}{{printDashes .CheckVersion "-"}}---{{ end }}
       Total Runs: {{.TotalRuns}}
-      Metrics: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+      Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: {{.Events}}, Total: {{humanize .TotalEvents}}
       Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
-      {{- if .LastError -}}
+      Average Execution Time : {{.AverageExecutionTime}}ms
+      {{if .LastError -}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}
       {{- end }}

--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -51,7 +51,7 @@ Collector
       {{- range $kind, $err := $errors -}}
         {{- if eq $kind "Python Check Loader" }}
       {{$kind}}:
-        {{ pythonLoaderError $err }}
+        {{ doNotEscape $err }}
         {{ else }}
       {{$kind}}:
         {{ doNotEscape $err }}

--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -114,17 +114,10 @@ func fillTemplate(w io.Writer, data Data, request string) error {
 /****** Helper functions for the template formatting ******/
 
 func pythonLoaderError(value string) template.HTML {
-	value = strings.Replace(value, "', '", "", -1)
-	value = strings.Replace(value, "['", "", -1)
-	value = strings.Replace(value, "\\n']", "", -1)
-	value = strings.Replace(value, "']", "", -1)
-
 	value = template.HTMLEscapeString(value)
 
-	value = strings.Replace(value, "\\n", "<br>", -1)
+	value = strings.Replace(value, "\n", "<br>", -1)
 	value = strings.Replace(value, "  ", "&nbsp;&nbsp;&nbsp;", -1)
-	var loaderErrorArray []string
-	json.Unmarshal([]byte(value), &loaderErrorArray)
 	return template.HTML(value)
 }
 

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -30,6 +30,27 @@
       <span/>
   </div>
 
+  {{- with .pyLoaderStats }}
+    {{- if .ConfigureErrors }}
+    <div class="stat">
+      <span class="stat_title">Check Initialization Errors</span>
+      <span class="stat_data">
+      {{ range $checkname, $errors :=  .ConfigureErrors }}
+          <span class="stat_subtitle">{{$checkname}}</span>
+          <span class="stat_subdata">
+            {{- range $idx, $err := $errors}}
+              <span class="stat_subtitle">Instance {{$idx}}</span>
+              <span class="stat_subdata">
+                {{ pythonLoaderError $err }}
+              </span>
+            {{- end }}
+          </span>
+      {{- end}}
+      </span>
+    </div>
+    {{- end }}
+  {{- end }}
+
   {{- with .autoConfigStats -}}
     {{- if .ConfigErrors}}
       <div class="stat">

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -55,9 +55,9 @@
             <span class="stat_subdata">
               {{- range $kind, $err := $errors -}}
                 {{- if eq $kind "Python Check Loader"}}
-                  {{$kind}}: {{ pythonLoaderError $err -}}<br>
+                  <b>{{$kind}}</b>: {{ pythonLoaderError $err -}}<br>
                 {{- else}}
-                  {{$kind}}: {{ $err -}}<br>
+                  <b>{{$kind}}</b>: {{ $err -}}<br>
                 {{end -}}
               {{end -}}
             </span>

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -123,8 +123,7 @@ func TestInitNewSignatureCheck(t *testing.T) {
 func TestInitException(t *testing.T) {
 	_, err := getCheckInstance("init_exception", "TestCheck")
 
-	assert.Contains(t, err.Error(), "could not invoke python check constructor: ['Traceback (most recent call last):\\n")
-	assert.Contains(t, err.Error(), "raise RuntimeError(\"unexpected error\")\\n', 'RuntimeError: unexpected error\\n']")
+	assert.Regexp(t, "could not invoke python check constructor: Traceback \\(most recent call last\\):\n  File \"[\\S]+(\\/|\\\\)init_exception\\.py\", line 11, in __init__\n    raise RuntimeError\\(\"unexpected error\"\\)\nRuntimeError: unexpected error", err.Error())
 }
 
 func TestInitNoTracebackException(t *testing.T) {

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -9,7 +9,9 @@ package py
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -18,6 +20,23 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var (
+	pyLoaderStats   *expvar.Map
+	configureErrors map[string][]string
+	statsLock       sync.RWMutex
+)
+
+func init() {
+	factory := func() (check.Loader, error) {
+		return NewPythonCheckLoader()
+	}
+	loaders.RegisterLoader(10, factory)
+
+	configureErrors = map[string][]string{}
+	pyLoaderStats = expvar.NewMap("pyLoader")
+	pyLoaderStats.Set("ConfigureErrors", expvar.Func(expvarConfigureErrors))
+}
 
 // const things
 const agentCheckClassName = "AgentCheck"
@@ -146,11 +165,13 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 	// Get an AgentCheck for each configuration instance and add it to the registry
 	for _, i := range config.Instances {
 		check := NewPythonCheck(moduleName, checkClass)
+
 		// The GIL should be unlocked at this point, `check.Configure` uses its own stickyLock and stickyLocks must not be nested
 		if err := check.Configure(i, config.InitConfig); err != nil {
-			log.Errorf("py.loader: could not configure check '%s': %s", moduleName, err)
+			addExpvarConfigureError(fmt.Sprintf("%s (%s)", moduleName, wheelVersion), err.Error())
 			continue
 		}
+
 		check.version = wheelVersion
 		checks = append(checks, check)
 	}
@@ -166,10 +187,22 @@ func (cl *PythonCheckLoader) String() string {
 	return "Python Check Loader"
 }
 
-func init() {
-	factory := func() (check.Loader, error) {
-		return NewPythonCheckLoader()
-	}
+func expvarConfigureErrors() interface{} {
+	statsLock.RLock()
+	defer statsLock.RUnlock()
 
-	loaders.RegisterLoader(10, factory)
+	return configureErrors
+}
+
+func addExpvarConfigureError(check string, errMsg string) {
+	log.Errorf("py.loader: could not configure check '%s': %s", check, errMsg)
+
+	statsLock.Lock()
+	defer statsLock.Unlock()
+
+	if errors, ok := configureErrors[check]; ok {
+		configureErrors[check] = append(errors, errMsg)
+	} else {
+		configureErrors[check] = []string{errMsg}
+	}
 }

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -101,6 +101,7 @@ func (sl *stickyLock) getPythonError() (string, error) {
 	if ptraceback != nil && ptraceback.GetCPointer() != nil {
 		// There's a traceback, try to format it nicely
 		traceback := python.PyImport_ImportModule("traceback")
+		defer traceback.DecRef()
 		formatExcFn := traceback.GetAttrString("format_exception")
 		if formatExcFn != nil {
 			defer formatExcFn.DecRef()

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -107,11 +107,13 @@ func (sl *stickyLock) getPythonError() (string, error) {
 			pyFormattedExc := formatExcFn.CallFunction(ptype, pvalue, ptraceback)
 			if pyFormattedExc != nil {
 				defer pyFormattedExc.DecRef()
-				pyStringExc := pyFormattedExc.Str()
-				if pyStringExc != nil {
-					defer pyStringExc.DecRef()
-					return python.PyString_AsString(pyStringExc), nil
+
+				tracebackString := ""
+				// "format_exception" return a list of strings (one per line)
+				for i := 0; i < python.PyList_Size(pyFormattedExc); i++ {
+					tracebackString = tracebackString + python.PyString_AsString(python.PyList_GetItem(pyFormattedExc, i))
 				}
+				return tracebackString, nil
 			}
 		}
 

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -34,6 +34,24 @@ Collector
   {{ end }}
 {{- end }}
 
+{{- with .pyLoaderStats }}
+  {{- if .ConfigureErrors }}
+  Check Initialization Errors
+  ===========================
+
+    {{ range $CheckName, $errors :=  .ConfigureErrors }}
+      {{ $CheckName }}
+      {{printDashes $CheckName "-"}}
+      {{- range $idx, $err := $errors}}
+
+      instance {{$idx}}:
+
+        {{ doNotEscape $err }}
+      {{- end }}
+    {{- end}}
+  {{- end }}
+{{- end }}
+
 {{- with .AutoConfigStats }}
   {{- if .ConfigErrors}}
   Config Errors

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -56,7 +56,7 @@ Collector
       {{- range $kind, $err := $errors -}}
         {{- if eq $kind "Python Check Loader" }}
       {{$kind}}:
-        {{ pythonLoaderError $err }}
+        {{ doNotEscape $err }}
         {{ else }}
       {{$kind}}:
         {{ doNotEscape $err }}

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -22,7 +22,6 @@ func init() {
 		"lastError":          lastError,
 		"lastErrorTraceback": lastErrorTraceback,
 		"lastErrorMessage":   LastErrorMessage,
-		"pythonLoaderError":  pythonLoaderError,
 		"configError":        configError,
 		"printDashes":        printDashes,
 		"formatUnixTime":     FormatUnixTime,
@@ -31,18 +30,6 @@ func init() {
 }
 
 func doNotEscape(value string) template.HTML {
-	return template.HTML(value)
-}
-
-func pythonLoaderError(value string) template.HTML {
-	value = strings.Replace(value, "', '", "", -1)
-	value = strings.Replace(value, "['", "", -1)
-	value = strings.Replace(value, "\\n']", "", -1)
-	value = strings.Replace(value, "']", "", -1)
-	value = strings.Replace(value, "\\n", "\n      ", -1)
-	value = strings.TrimRight(value, "\n\t ")
-	var loaderErrorArray []string
-	json.Unmarshal([]byte(value), &loaderErrorArray)
 	return template.HTML(value)
 }
 

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -36,6 +36,7 @@ func FormatStatus(data []byte) (string, error) {
 	json.Unmarshal(data, &stats)
 	forwarderStats := stats["forwarderStats"]
 	runnerStats := stats["runnerStats"]
+	pyLoaderStats := stats["pyLoaderStats"]
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
 	aggregatorStats := stats["aggregatorStats"]
@@ -45,7 +46,7 @@ func FormatStatus(data []byte) (string, error) {
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, autoConfigStats, checkSchedulerStats, "")
+	renderChecksStats(b, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
 	renderLogsStatus(b, logsStats)
@@ -70,7 +71,7 @@ func FormatDCAStatus(data []byte) (string, error) {
 	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, autoConfigStats, checkSchedulerStats, "")
+	renderChecksStats(b, runnerStats, nil, autoConfigStats, checkSchedulerStats, "")
 	renderForwarderStatus(b, forwarderStats)
 
 	return b.String(), nil
@@ -139,9 +140,10 @@ func renderHPAStats(w io.Writer, hpaStats interface{}) {
 	}
 }
 
-func renderChecksStats(w io.Writer, runnerStats interface{}, autoConfigStats interface{}, checkSchedulerStats interface{}, onlyCheck string) {
+func renderChecksStats(w io.Writer, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats interface{}, onlyCheck string) {
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
+	checkStats["pyLoaderStats"] = pyLoaderStats
 	checkStats["AutoConfigStats"] = autoConfigStats
 	checkStats["CheckSchedulerStats"] = checkSchedulerStats
 	checkStats["OnlyCheck"] = onlyCheck
@@ -159,9 +161,10 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	stats := make(map[string]interface{})
 	json.Unmarshal(data, &stats)
 	runnerStats := stats["runnerStats"]
+	pyLoaderStats := stats["pyLoaderStats"]
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
-	renderChecksStats(b, runnerStats, autoConfigStats, checkSchedulerStats, checkName)
+	renderChecksStats(b, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats, checkName)
 
 	return b.String(), nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -199,6 +199,16 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	json.Unmarshal(aggregatorStatsJSON, &aggregatorStats)
 	stats["aggregatorStats"] = aggregatorStats
 
+	pyLoaderData := expvar.Get("pyLoader")
+	if pyLoaderData != nil {
+		pyLoaderStatsJSON := []byte(pyLoaderData.String())
+		pyLoaderStats := make(map[string]interface{})
+		json.Unmarshal(pyLoaderStatsJSON, &pyLoaderStats)
+		stats["pyLoaderStats"] = pyLoaderStats
+	} else {
+		stats["pyLoaderStats"] = nil
+	}
+
 	if expvar.Get("ntpOffset").String() != "" {
 		stats["ntpOffset"], err = strconv.ParseFloat(expvar.Get("ntpOffset").String(), 64)
 	}

--- a/releasenotes/notes/display-configure-errors-status-page-dff9f92a97e5a95e.yaml
+++ b/releasenotes/notes/display-configure-errors-status-page-dff9f92a97e5a95e.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The 'status' command and 'status' page (in the GUI) now displays errors
+    raised by the '__init__' method of a Python check.


### PR DESCRIPTION
### What does this PR do?

- Display python check configure errors in the status page
    
  Python check can fail at 3 stages: importing the check, initialising it
  and running the check. The status page was missing errors from the
  second stage.

- Fix python traceback in status page
    
  The CPython function "format_exception" returns a list of strings.
  Instead of manually replacing the python representation of a list to a
  string we directly concatenate the traceback when we received it from
  CPython. This simplifies the status page and print readable python
  tracebacks in the log.

- Updating the GUI and DCA status page to be up to date with the agent

### Additional Notes

The PR is easier to review commit by commit.

Example of check with 2 instances raising when configured (aka during `__init__()`):
```
  Check Initialization Errors
  ===========================

    
      max_raise_init (unversioned)
      ----------------------------

      instance 0:

        could not invoke python check constructor: Traceback (most recent call last):
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max_raise_init.py", line 9, in __init__
    test()
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max_raise_init.py", line 4, in test
    raise Exception("error raised !")
Exception: error raised !


      instance 1:

        could not invoke python check constructor: Traceback (most recent call last):
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max_raise_init.py", line 9, in __init__
    test()
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max_raise_init.py", line 4, in test
    raise Exception("error raised !")
Exception: error raised !
```

Same in the GUI: 
![2018-07-19-172933_911x405_scrot](https://user-images.githubusercontent.com/311563/42971182-6695b1d6-8b79-11e8-9b1e-54bc8eddc1c5.png)


Example a check raising when run (aka during `check()`):
```
=========
Collector
=========

  Running Checks
  ==============

    max_raise_check (unversioned)
    -----------------------------
      Total Runs: 1
      Metric Samples: 0, Total: 0
      Events: 0, Total: 0
      Service Checks: 0, Total: 0
      Average Execution Time : 0ms
      Error: error raised !
      Traceback (most recent call last):
        File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/venv/local/lib/python2.7/site-packages/datadog_checks/checks/base.py", line 303, in run
          self.check(copy.deepcopy(self.instances[0]))
        File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max_raise_check.py", line 9, in check
          test()
        File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/max_raise_check.py", line 4, in test
          raise Exception("error raised !")
      Exception: error raised !
 ```

Same in the GUI:
![2018-07-19-172926_1150x328_scrot](https://user-images.githubusercontent.com/311563/42971172-5ee466e4-8b79-11e8-8d56-9a1dc68c83b0.png)
