### PR TITLE
Enhance Agent Status CLI with Cluster Agent status

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -103,7 +103,7 @@ func StopServer() {
 func validateToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.String()
-		if strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 {
+		if strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 || path == "/version" {
 			if err := util.ValidateDCARequest(w, r); err != nil {
 				return
 			}

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -40,6 +40,16 @@ func TestValidateTokenMiddleware(t *testing.T) {
 			"imposter",
 			http.StatusForbidden,
 		},
+		{
+			"/version",
+			"abc123",
+			http.StatusOK,
+		},
+		{
+			"/version",
+			"bandit!",
+			http.StatusForbidden,
+		},
 	}
 
 	for i, tt := range tests {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,6 +305,7 @@ func init() {
 	Datadog.BindEnv("cluster_agent.url")
 	Datadog.BindEnv("cluster_agent.auth_token")
 	Datadog.BindEnv("cluster_agent.cmd_port")
+	Datadog.BindEnv("cluster_agent.kubernetes_service_name")
 	BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	BindEnvAndSetDefault("external_metrics_provider.polling_freq", 30)
 	BindEnvAndSetDefault("external_metrics_provider.max_age", 60)

--- a/pkg/status/dist/templates/clusteragent.tmpl
+++ b/pkg/status/dist/templates/clusteragent.tmpl
@@ -1,0 +1,8 @@
+=====================
+Datadog Cluster Agent
+=====================
+{{- if .Error -}}
+Could not reach the Datadog Cluster Agent: {{ .Error }}
+{{else}}
+Datadog Cluster Agent available at: {{ .Endpoint }}
+{{- end -}}

--- a/pkg/status/dist/templates/clusteragent.tmpl
+++ b/pkg/status/dist/templates/clusteragent.tmpl
@@ -2,9 +2,8 @@
 =====================
 Datadog Cluster Agent
 =====================
-
-{{- if .Error }}
+{{ if .Error }}
   Could not reach the Datadog Cluster Agent: {{ .Error }}
-{{else}}
-  Datadog Cluster Agent available at: {{ .Endpoint }}
+{{ else }}
+  Datadog Cluster Agent endpoint detected: {{ .Endpoint }}
 {{- end }}

--- a/pkg/status/dist/templates/clusteragent.tmpl
+++ b/pkg/status/dist/templates/clusteragent.tmpl
@@ -2,8 +2,17 @@
 =====================
 Datadog Cluster Agent
 =====================
-{{ if .Error }}
-  Could not reach the Datadog Cluster Agent: {{ .Error }}
+{{ if .DetectionError }}
+  - Could not detect the Datadog Cluster Agent's endpoint: {{ .DetectionError }}
 {{ else }}
-  Datadog Cluster Agent endpoint detected: {{ .Endpoint }}
+  - Datadog Cluster Agent endpoint detected: {{ .Endpoint }}
+{{- end }}
+{{- if .ConnectionError }}
+  - Could not reach the Datadog Cluster Agent: {{ .ConnectionError }}
+{{- end }}
+{{-  if not .Version }}
+  - Could not retrieve the version of the Datadog Cluster Agent.
+{{ else }}
+  Successfully connected to the Datadog Cluster Agent.
+  - Running: {{ .Version }}
 {{- end }}

--- a/pkg/status/dist/templates/clusteragent.tmpl
+++ b/pkg/status/dist/templates/clusteragent.tmpl
@@ -1,8 +1,10 @@
+
 =====================
 Datadog Cluster Agent
 =====================
-{{- if .Error -}}
-Could not reach the Datadog Cluster Agent: {{ .Error }}
+
+{{- if .Error }}
+  Could not reach the Datadog Cluster Agent: {{ .Error }}
 {{else}}
-Datadog Cluster Agent available at: {{ .Endpoint }}
-{{- end -}}
+  Datadog Cluster Agent available at: {{ .Endpoint }}
+{{- end }}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 )
 
@@ -48,7 +49,9 @@ func FormatStatus(data []byte) (string, error) {
 	renderForwarderStatus(b, forwarderStats)
 	renderLogsStatus(b, logsStats)
 	renderDogstatsdStatus(b, aggregatorStats)
-	renderDatadogClusterAgentStatus(b, dcaStats)
+	if config.Datadog.GetBool("cluster_agent.enabled") {
+		renderDatadogClusterAgentStatus(b, dcaStats)
+	}
 
 	return b.String(), nil
 }

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -39,6 +39,7 @@ func FormatStatus(data []byte) (string, error) {
 	aggregatorStats := stats["aggregatorStats"]
 	jmxStats := stats["JMXStatus"]
 	logsStats := stats["logsStats"]
+	dcaStats := stats["clusterAgentStatus"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
@@ -47,6 +48,7 @@ func FormatStatus(data []byte) (string, error) {
 	renderForwarderStatus(b, forwarderStats)
 	renderLogsStatus(b, logsStats)
 	renderDogstatsdStatus(b, aggregatorStats)
+	renderDatadogClusterAgentStatus(b, dcaStats)
 
 	return b.String(), nil
 }
@@ -102,6 +104,14 @@ func renderDogstatsdStatus(w io.Writer, aggregatorStats interface{}) {
 func renderForwarderStatus(w io.Writer, forwarderStats interface{}) {
 	t := template.Must(template.New("forwarder.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "forwarder.tmpl")))
 	err := t.Execute(w, forwarderStats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderDatadogClusterAgentStatus(w io.Writer, dcaStats interface{}) {
+	t := template.Must(template.New("clusteragent.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "clusteragent.tmpl")))
+	err := t.Execute(w, dcaStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -58,7 +58,7 @@ func GetStatus() (map[string]interface{}, error) {
 
 	stats["logsStats"] = logs.GetStatus()
 
-	if config.Datadog.GetBool("cluster_agent") {
+	if config.Datadog.GetBool("cluster_agent.enabled") {
 		stats["clusterAgentStatus"] = getDCAStatus()
 	}
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -58,6 +58,10 @@ func GetStatus() (map[string]interface{}, error) {
 
 	stats["logsStats"] = logs.GetStatus()
 
+	if config.Datadog.GetBool("cluster_agent") {
+		stats["clusterAgentStatus"] = getDCAStatus()
+	}
+
 	return stats, nil
 }
 

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -42,7 +42,7 @@ func getDCAStatus() map[string]string {
 	}
 	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint
 
-	ver, err := dcaCl.GetClusterAgentVersion()
+	ver, err := dcaCl.GetVersion()
 	if err != nil {
 		clusterAgentDetails["ConnectionError"] = err.Error()
 		return clusterAgentDetails

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -34,11 +34,19 @@ func getLeaderElectionDetails() map[string]string {
 
 func getDCAStatus() map[string]string {
 	clusterAgentDetails := make(map[string]string)
+
 	dcaCl, err := clusteragent.GetClusterAgentClient()
 	if err != nil {
-		clusterAgentDetails["Error"] = err.Error()
+		clusterAgentDetails["DetectionError"] = err.Error()
 		return clusterAgentDetails
 	}
 	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint
+
+	ver, err := dcaCl.GetClusterAgentVersion()
+	if err != nil {
+		clusterAgentDetails["ConnectionError"] = err.Error()
+		return clusterAgentDetails
+	}
+	clusterAgentDetails["Version"] = ver
 	return clusterAgentDetails
 }

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 )
 
@@ -29,4 +30,15 @@ func getLeaderElectionDetails() map[string]string {
 	leaderElectionStats["transitions"] = fmt.Sprintf("%d transitions", record.LeaderTransitions)
 	leaderElectionStats["status"] = "Running"
 	return leaderElectionStats
+}
+
+func getDCAStatus() map[string]string {
+	clusterAgentDetails := make(map[string]string)
+	dcaCl, err := clusteragent.GetClusterAgentClient()
+	if err != nil {
+		clusterAgentDetails["Error"] = err.Error()
+		return clusterAgentDetails
+	}
+	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint
+	return clusterAgentDetails
 }

--- a/pkg/status/status_no_apiserver.go
+++ b/pkg/status/status_no_apiserver.go
@@ -15,3 +15,8 @@ func getLeaderElectionDetails() map[string]string {
 	log.Info("Not implemented")
 	return nil
 }
+
+func getDCADetails() map[string]string {
+	log.Info("Not implemented")
+	return nil
+}

--- a/pkg/status/status_no_apiserver.go
+++ b/pkg/status/status_no_apiserver.go
@@ -16,7 +16,7 @@ func getLeaderElectionDetails() map[string]string {
 	return nil
 }
 
-func getDCADetails() map[string]string {
+func getDCAStatus() map[string]string {
 	log.Info("Not implemented")
 	return nil
 }

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -59,7 +59,7 @@ func GetClusterAgentClient() (*DCAClient, error) {
 		})
 	}
 	if err := globalClusterAgentClient.initRetry.TriggerRetry(); err != nil {
-		log.Debugf("Cluster Agent init error: %s", err)
+		log.Debugf("Cluster Agent init error: %s", err.Error())
 		return nil, err
 	}
 	return globalClusterAgentClient, nil
@@ -121,7 +121,7 @@ func getClusterAgentEndpoint() (string, error) {
 	dcaSvc := config.Datadog.GetString(configDcaSvcName)
 	log.Debugf("Identified service for the Datadog Cluster Agent: %s", dcaSvc)
 	if dcaSvc == "" {
-		return "", fmt.Errorf("cannot get a cluster agent endpoint, both %q and %q are empty", configDcaURL, configDcaSvcName)
+		return "", fmt.Errorf("cannot get a cluster agent endpoint, both %s and %s are empty", configDcaURL, configDcaSvcName)
 	}
 
 	dcaSvc = strings.ToUpper(dcaSvc)
@@ -131,13 +131,13 @@ func getClusterAgentEndpoint() (string, error) {
 	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)
 	dcaSvcHost := os.Getenv(dcaSvcHostEnv)
 	if dcaSvcHost == "" {
-		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %q, env %q is empty", dcaSvc, dcaSvcHostEnv)
+		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %s, env %s is empty", dcaSvc, dcaSvcHostEnv)
 	}
 
 	// port
 	dcaSvcPort := os.Getenv(fmt.Sprintf("%s_SERVICE_PORT", dcaSvc))
 	if dcaSvcPort == "" {
-		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %q, env %q is empty", dcaSvc, dcaSvcPort)
+		return "", fmt.Errorf("cannot get a cluster agent endpoint for kubernetes service %s, env %s is empty", dcaSvc, dcaSvcPort)
 	}
 
 	// validate the URL

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -150,8 +150,8 @@ func getClusterAgentEndpoint() (string, error) {
 	return u.String(), nil
 }
 
-// GetClusterAgentVersion fetches the version of the Cluster Agent. Used in the agent status command.
-func (c *DCAClient) GetClusterAgentVersion() (string, error) {
+// GetVersion fetches the version of the Cluster Agent. Used in the agent status command.
+func (c *DCAClient) GetVersion() (string, error) {
 	const dcaVersionPath = "/version"
 	var version string
 	var err error
@@ -179,9 +179,7 @@ func (c *DCAClient) GetClusterAgentVersion() (string, error) {
 	if err != nil {
 		return version, err
 	}
-
-	err = json.Unmarshal(b, &version)
-	return version, err
+	return string(b), err
 }
 
 // GetKubernetesMetadataNames queries the datadog cluster agent to get nodeName/podName registered

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -59,7 +59,7 @@ func GetClusterAgentClient() (*DCAClient, error) {
 		})
 	}
 	if err := globalClusterAgentClient.initRetry.TriggerRetry(); err != nil {
-		log.Debugf("Cluster Agent init error: %s", err.Error())
+		log.Debugf("Cluster Agent init error: %v", err)
 		return nil, err
 	}
 	return globalClusterAgentClient, nil
@@ -149,6 +149,8 @@ func getClusterAgentEndpoint() (string, error) {
 
 	return u.String(), nil
 }
+
+// GetClusterAgentVersion fetches the version of the Cluster Agent. Used in the agent status command.
 func (c *DCAClient) GetClusterAgentVersion() (string, error) {
 	const dcaVersionPath = "/version"
 	var version string
@@ -165,6 +167,7 @@ func (c *DCAClient) GetClusterAgentVersion() (string, error) {
 	}
 
 	resp, err := c.clusterAgentAPIClient.Do(req)
+	defer resp.Body.Close()
 	if err != nil {
 		return version, err
 	}

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -149,6 +149,38 @@ func getClusterAgentEndpoint() (string, error) {
 
 	return u.String(), nil
 }
+func (c *DCAClient) GetClusterAgentVersion() (string, error) {
+	const dcaVersionPath = "/version"
+	var version string
+	var err error
+
+	req := &http.Request{
+		Header: *c.clusterAgentAPIRequestHeaders,
+	}
+	// https://host:port/version
+	rawURL := fmt.Sprintf("%s/%s", c.ClusterAgentAPIEndpoint, dcaVersionPath)
+	req.URL, err = url.Parse(rawURL)
+	if err != nil {
+		return version, err
+	}
+
+	resp, err := c.clusterAgentAPIClient.Do(req)
+	if err != nil {
+		return version, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return version, fmt.Errorf("unexpected status code from cluster agent: %d", resp.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return version, err
+	}
+
+	err = json.Unmarshal(b, &version)
+	return version, err
+}
 
 // GetKubernetesMetadataNames queries the datadog cluster agent to get nodeName/podName registered
 // Kubernetes metadata.

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -41,7 +41,7 @@ type DCAClient struct {
 	// used to setup the DCAClient
 	initRetry retry.Retrier
 
-	clusterAgentAPIEndpoint       string // ${SCHEME}://${clusterAgentHost}:${PORT}
+	ClusterAgentAPIEndpoint       string // ${SCHEME}://${clusterAgentHost}:${PORT}
 	clusterAgentAPIClient         *http.Client
 	clusterAgentAPIRequestHeaders *http.Header
 }
@@ -68,7 +68,7 @@ func GetClusterAgentClient() (*DCAClient, error) {
 func (c *DCAClient) init() error {
 	var err error
 
-	c.clusterAgentAPIEndpoint, err = getClusterAgentEndpoint()
+	c.ClusterAgentAPIEndpoint, err = getClusterAgentEndpoint()
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]
 		Header: *c.clusterAgentAPIRequestHeaders,
 	}
 	// https://host:port/api/v1/metadata/{nodeName}/{ns}/{pod-[0-9a-z]+}
-	rawURL := fmt.Sprintf("%s/%s/%s/%s/%s", c.clusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
+	rawURL := fmt.Sprintf("%s/%s/%s/%s/%s", c.ClusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
 	req.URL, err = url.Parse(rawURL)
 	if err != nil {
 		return metadataNames, err

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -125,6 +125,7 @@ func getClusterAgentEndpoint() (string, error) {
 	}
 
 	dcaSvc = strings.ToUpper(dcaSvc)
+	dcaSvc = strings.Replace(dcaSvc, "-", "_", -1) // Kubernetes replaces "-" with "_" in the service names injected in the env var.
 
 	// host
 	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -106,7 +106,7 @@ type clusterAgentSuite struct {
 }
 
 const (
-	clusterAgentServiceName = "DATADOG-CLUSTER-AGENT"
+	clusterAgentServiceName = "DATADOG_CLUSTER_AGENT"
 	clusterAgentServiceHost = clusterAgentServiceName + "_SERVICE_HOST"
 	clusterAgentServicePort = clusterAgentServiceName + "_SERVICE_PORT"
 	clusterAgentTokenValue  = "01234567890123456789012345678901"

--- a/releasenotes/notes/status-command-cluster-agent-status-33cf9eaf381d0281.yaml
+++ b/releasenotes/notes/status-command-cluster-agent-status-33cf9eaf381d0281.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Adding the status of the DCA (If enabled) in the Agent status command.

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -60,25 +60,6 @@ def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
 
     ctx.run(cmd.format(REPO_PATH), env=env)
 
-
-@task
-def run(ctx, rebuild=False, race=False, skip_build=False, development=True):
-    """
-    Run the Cluster Agent's binary. Build the binary before executing, unless
-    --skip-build was passed.
-    """
-    if not skip_build:
-        print("Building the Cluster Agent...")
-        build(ctx, rebuild=rebuild, race=race)
-
-    target = os.path.join(BIN_PATH, bin_name("datadog-cluster-agent"))
-    cfgPath = ""
-    if development:
-        cfgPath = "-c dev/dist/datadog-cluster.yaml"
-
-    ctx.run("{0} start {1}".format(target, cfgPath))
-
-
 @task
 def clean(ctx):
     """


### PR DESCRIPTION
### What does this PR do?

If the Cluster Agent is enabled, it greatly helps to know that an agent can indeed reach it and furthermore know the endpoint or the reason why it's failing.

### Motivation

Troubleshoot cases with the Cluster Agent.
