### PR TITLE
Initial Logs SOCKS5 Proxy Support

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -43,6 +43,7 @@ func NewAgent(sources *config.LogSources) *Agent {
 		config.LogsAgent.GetString("logs_config.dd_url"),
 		config.LogsAgent.GetInt("logs_config.dd_port"),
 		config.LogsAgent.GetBool("logs_config.dev_mode_no_ssl"),
+		config.LogsAgent.GetString("logs_config.socks5"),
 	)
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, connectionManager, messageChan)
 

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -43,7 +43,7 @@ func NewAgent(sources *config.LogSources) *Agent {
 		config.LogsAgent.GetString("logs_config.dd_url"),
 		config.LogsAgent.GetInt("logs_config.dd_port"),
 		config.LogsAgent.GetBool("logs_config.dev_mode_no_ssl"),
-		config.LogsAgent.GetString("logs_config.socks5"),
+		config.LogsAgent.GetString("logs_config.socks5_proxy_address"),
 	)
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, connectionManager, messageChan)
 

--- a/pkg/logs/sender/connection_manager.go
+++ b/pkg/logs/sender/connection_manager.go
@@ -72,9 +72,9 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 		var err error
 
 		if cm.socksProxy != "" {
-			proxyDialer, err := proxy.SOCKS5("tcp", cm.socksProxy, nil, proxy.Direct)
-			if err != nil {
-				log.Warn(err)
+			proxyDialer, proxyErr := proxy.SOCKS5("tcp", cm.socksProxy, nil, proxy.Direct)
+			if proxyErr != nil {
+				log.Warn(proxyErr)
 				cm.backoff()
 				continue
 			}

--- a/pkg/logs/sender/connection_manager.go
+++ b/pkg/logs/sender/connection_manager.go
@@ -28,7 +28,7 @@ type ConnectionManager struct {
 	connectionString string
 	serverName       string
 	devModeNoSSL     bool
-	socksProxy		 string
+	socksProxy       string
 
 	mutex   sync.Mutex
 	retries int
@@ -42,7 +42,7 @@ func NewConnectionManager(serverName string, serverPort int, devModeNoSSL bool, 
 		connectionString: fmt.Sprintf("%s:%d", serverName, serverPort),
 		serverName:       serverName,
 		devModeNoSSL:     devModeNoSSL,
-		socksProxy:		  socksProxy,
+		socksProxy:       socksProxy,
 
 		mutex: sync.Mutex{},
 

--- a/pkg/logs/sender/connection_manager.go
+++ b/pkg/logs/sender/connection_manager.go
@@ -58,7 +58,11 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 
 	for {
 		if cm.firstConn {
-			log.Info("Connecting to the backend: ", cm.connectionString)
+			if cm.socksProxy != "" {
+				log.Info("Connecting to the backend: ", cm.connectionString, " via socks5:", cm.socksProxy)
+			} else {
+				log.Info("Connecting to the backend: ", cm.connectionString)
+			}
 			cm.firstConn = false
 		}
 
@@ -68,7 +72,6 @@ func (cm *ConnectionManager) NewConnection() net.Conn {
 		var err error
 
 		if cm.socksProxy != "" {
-			log.Info("Connecting to logs intake via socks5://", cm.socksProxy)
 			proxyDialer, err := proxy.SOCKS5("tcp", cm.socksProxy, nil, proxy.Direct)
 			if err != nil {
 				log.Warn(err)

--- a/releasenotes/notes/socks5-proxy-support-660616930b474a29.yaml
+++ b/releasenotes/notes/socks5-proxy-support-660616930b474a29.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Logs Agent: Added SOCKS5 proxy support. Use ``logs_config: socks5_proxy_address: fqdn.example.com:port`` to set the proxy.
+


### PR DESCRIPTION
### What does this PR do?

Allows the agent to connect to the logging ingestion endpoint via a SOCKS5-compatible proxy. Configure using:

```
logs_config:
  socks5_proxy_address: fqdn.example.com:port
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
