### PR TITLE
Add upgrade note on `https://` proxy URL behavior change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -158,6 +158,17 @@ New Features
   from our private TUF repository. Please note any third party dependencies will
   still be downloaded from PyPI with no additional security validation.
 
+Upgrade Notes
+-------------
+
+- If your Agent is configured to use a web proxy through the ``proxy`` config option
+  or one of the ``*_PROXY``  environment variables, and the configured proxy URL
+  starts with the ``https://`` scheme, the Agent will now attempt to connect to
+  your proxy using HTTPS, whereas it would previously connect to your proxy using
+  HTTP. If you have a working proxy configuration, please make sure your proxy URL(s)
+  start with the  ``http://`` scheme before upgrading to v6.3+. This has no impact on the
+  security of the data sent to Datadog, since the payloads are always secured with
+  HTTPS between your Agents and Datadog whatever ``proxy`` configuration you may use.
 
 Bug Fixes
 ---------


### PR DESCRIPTION
### What does this PR do?

Add upgrade note on `https://` proxy URL behavior change.

### Motivation

The Go 1.10 upgrade led to a "silent" breaking change between pre-6.3 and post-6.3 Agents when using a proxy URL starting with `https://`.

Reason: Go 1.10 now supports connecting to http proxies using HTTPS whereas it previously only supported connecting using HTTP. On top of that, previous versions of Go would silently use HTTP instead of HTTPS to connect to a proxy with an `https://` URL.

So for someone using:

```
proxy:
  https: https://proxy.mydomain.com
```

pre-6.3 Agents would silently connect to the `http://proxy.mydomain.com` proxy instead (which generally works), whereas post-6.3 Agents now actually attempt an HTTPS connection to the proxy (which generally doesn't work for regular proxies).

Note that this doesn't affect the protocol that's used between the Agent and Datadog (which is always HTTPS)