### PR TITLE
Added a support for configuring logs TCP forwarding by env var

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -248,6 +248,7 @@ func init() {
 	BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 	BindEnvAndSetDefault("logs_config.container_collect_all", false)
 	BindEnvAndSetDefault("logs_config.frame_size", 9000)
+	BindEnvAndSetDefault("logs_config.tcp_forward_port", -1)
 
 	// Tagger full cardinality mode
 	// Undocumented opt-in feature for now

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -15,7 +15,11 @@ var LogsAgent = config.Datadog
 
 // Build returns logs-agent sources
 func Build() (*LogSources, error) {
-	sources, err := buildLogSources(LogsAgent.GetString("confd_path"), LogsAgent.GetBool("logs_config.container_collect_all"))
+	sources, err := buildLogSources(
+		LogsAgent.GetString("confd_path"),
+		LogsAgent.GetBool("logs_config.container_collect_all"),
+		LogsAgent.GetInt("logs_config.tcp_forward_port"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +27,7 @@ func Build() (*LogSources, error) {
 }
 
 // buildLogSources returns all the logs sources computed from logs configuration files and environment variables
-func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*LogSources, error) {
+func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool, tcpForwardPort int) (*LogSources, error) {
 	var sources []*LogSource
 
 	// append sources from all logs config files
@@ -31,9 +35,7 @@ func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*Lo
 	sources = append(sources, fileSources...)
 
 	if collectAllLogsFromContainers {
-		// append source to collect all logs from all containers,
-		// this source must be added to the end of the list
-		// to assure sources metadata are not overridden when already defined
+		// append source to collect all logs from all containers.
 		containersSource := NewLogSource("container_collect_all", &LogsConfig{
 			Type:    DockerType,
 			Service: "docker",
@@ -42,11 +44,18 @@ func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool) (*Lo
 		sources = append(sources, containersSource)
 	}
 
-	logSources := &LogSources{sources}
+	if tcpForwardPort > 0 {
+		// append source to collect all logs forwarded by TCP on a given port.
+		tcpForwardSource := NewLogSource("tcp_forward", &LogsConfig{
+			Type: TCPType,
+			Port: tcpForwardPort,
+		})
+		sources = append(sources, tcpForwardSource)
+	}
 
+	logSources := &LogSources{sources}
 	if len(logSources.GetValidSources()) == 0 {
 		return nil, fmt.Errorf("could not find any valid logs configuration")
 	}
-
 	return logSources, nil
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +21,7 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, true, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
 	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.open_files_limit"))
 	assert.Equal(t, 9000, LogsAgent.GetInt("logs_config.frame_size"))
+	assert.Equal(t, -1, LogsAgent.GetInt("logs_config.tcp_forward_port"))
 }
 
 func TestBuildLogsSources(t *testing.T) {
@@ -31,27 +31,25 @@ func TestBuildLogsSources(t *testing.T) {
 	var err error
 
 	// should return an error
-	logsSources, err = buildLogSources(ddconfdPath, false)
+	logsSources, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)
 
 	// should return the default tail all containers source
-	logsSources, err = buildLogSources(ddconfdPath, true)
+	logsSources, err = buildLogSources(ddconfdPath, true, -1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(logsSources.GetValidSources()))
-
 	source = logsSources.GetValidSources()[0]
 	assert.Equal(t, "container_collect_all", source.Name)
+	assert.Equal(t, DockerType, source.Config.Type)
 	assert.Equal(t, "docker", source.Config.Service)
 	assert.Equal(t, "docker", source.Config.Source)
 
-	// default tail all containers source should be the last element of the list
-	ddconfdPath = filepath.Join("tests", "any_docker_integration.d")
-	logsSources, err = buildLogSources(ddconfdPath, true)
+	// should return the tcp forward source
+	logsSources, err = buildLogSources(ddconfdPath, false, 1234)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(logsSources.GetValidSources()))
-
-	source = logsSources.GetValidSources()[2]
-	assert.Equal(t, "container_collect_all", source.Name)
-	assert.Equal(t, "docker", source.Config.Service)
-	assert.Equal(t, "docker", source.Config.Source)
+	assert.Equal(t, 1, len(logsSources.GetValidSources()))
+	source = logsSources.GetValidSources()[0]
+	assert.Equal(t, "tcp_forward", source.Name)
+	assert.Equal(t, TCPType, source.Config.Type)
+	assert.Equal(t, 1234, source.Config.Port)
 }

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -23,7 +23,7 @@ func TestAvailableIntegrationConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	allSources, err := buildLogSources(ddconfdPath, false)
+	allSources, err := buildLogSources(ddconfdPath, false, -1)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allSources.GetSources())-len(allSources.GetValidSources()))
@@ -123,23 +123,23 @@ func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
 	var ddconfdPath string
 	var err error
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
-	_, err = buildLogSources(ddconfdPath, false)
+	_, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_2", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
+	_, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_3", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
+	_, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_4", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
+	_, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)
 
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_5", "conf.d")
-	_, err = buildLogSources(ddconfdPath, false)
+	_, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)
 }
 


### PR DESCRIPTION
### What does this PR do?

Added the possibility to setup the logs-TCP-forwarding through a var env.

### Motivation

Easily set up the agent as log-tcp-forwarder.