### PR TITLE
[config] Bind `skip_ssl_validation` option to related env var

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,7 +82,7 @@ func init() {
 	Datadog.SetDefault("dd_url", "https://app.datadoghq.com")
 	Datadog.SetDefault("app_key", "")
 	Datadog.SetDefault("proxy", nil)
-	Datadog.SetDefault("skip_ssl_validation", false)
+	BindEnvAndSetDefault("skip_ssl_validation", false)
 	Datadog.SetDefault("hostname", "")
 	Datadog.SetDefault("tags", []string{})
 	Datadog.SetDefault("conf_path", ".")

--- a/releasenotes/notes/env-skip-ssl-validation-6186cb822894af12.yaml
+++ b/releasenotes/notes/env-skip-ssl-validation-6186cb822894af12.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - The ``skip_ssl_validation`` configuration option can now be set through the
+    related ``DD_SKIP_SSL_VALIDATION`` env var


### PR DESCRIPTION
### What does this PR do?

Binds `skip_ssl_validation` option to related env var

### Motivation

Customer request, to be able to simply set the option on the dockerized agent

### Additional Notes

We should do this for all config option, we have a card in our backlog for this, for which we'll bump the priority
