### PR TITLE
[docs] Suggest sane value for http/https proxy settings

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -15,8 +15,8 @@ api_key:
 # override the values set here. See https://docs.datadoghq.com/agent/proxy/.
 #
 # proxy:
-#   http: http(s)://user:password@proxy_for_http:port
-#   https: http(s)://user:password@proxy_for_https:port
+#   http: http://user:password@proxy_for_http:port
+#   https: http://user:password@proxy_for_https:port
 #   no_proxy:
 #     - host1
 #     - host2


### PR DESCRIPTION
### What does this PR do?

Suggests "sane" value for http/https proxy settings

### Motivation

All known users of proxies with the Agent use a regular HTTP proxy,
let's make this "sane" setting more obvious in our config template docs.

### Additional Notes

Related to https://github.com/DataDog/documentation/pull/2806. The docs there
will be improved soon to explain a bit more what kind of other values are possible,
and what they do.
