### PR TITLE
[DCA] Update Gitlab pipeline for DCA releases.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,6 +91,28 @@ before_script:
       - $RELEASE_VERSION == "nightly"
 
 #
+# Job conditions
+#
+
+# run job when building Datadog Cluster Agent release tag
+
+.run_on_cluster_agent_tag: &run_on_cluster_agent_tag
+  only:
+    refs:
+      - tags
+    variables:
+      - $CI_COMMIT_TAG =~ /^dca-([\d.-]|rc)+$/
+
+# skip job when building Datadog Cluster Agent release tag
+
+.skip_on_cluster_agent_tag: &skip_on_cluster_agent_tag
+  except:
+    refs:
+      - tags
+    variables:
+      - $CI_COMMIT_TAG =~ /^dca-([\d.-]|rc)+$/
+
+#
 # source_test
 #
 
@@ -115,6 +137,9 @@ run_security_scan_test:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:latest
   tags: ["runner:main", "size:large"]
+  only:
+    - master
+  <<: *skip_on_cluster_agent_tag
   before_script:
     # this image isn't built in the datadog-agent-builders repo
     # it doesn't have invoke so we install the dependencies without invoke
@@ -127,8 +152,6 @@ run_security_scan_test:
     - set +x     # don't print the api key to the logs
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor # send the list of the dependencies to snyk
-  only:
-    - master
 
 #
 # binary_build
@@ -137,6 +160,7 @@ run_security_scan_test:
 
 # build dogstatsd static for deb-x64
 build_dogstatsd_static-deb_x64:
+  <<: *skip_on_cluster_agent_tag
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -146,6 +170,7 @@ build_dogstatsd_static-deb_x64:
 
 # build puppy agent for deb-x64, to make sure the build is not broken because of build flags
 build_puppy_agent-deb_x64:
+  <<: *skip_on_cluster_agent_tag
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -155,6 +180,7 @@ build_puppy_agent-deb_x64:
 
 # build puppy agent for ARM, to make sure the build is not broken because of build targets
 build_puppy_agent-deb_x64_arm:
+  <<: *skip_on_cluster_agent_tag
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -163,6 +189,7 @@ build_puppy_agent-deb_x64_arm:
 
 # build dogstatsd for deb-x64
 build_dogstatsd-deb_x64:
+  <<: *skip_on_cluster_agent_tag
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -208,6 +235,7 @@ cluster_agent-build:
 
 # check the size of the static dogstatsd binary
 run_dogstatsd_size_test:
+  <<: *skip_on_cluster_agent_tag
   stage: integration_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -225,6 +253,7 @@ run_dogstatsd_size_test:
 
 # build Agent package for deb-x64
 agent_deb-x64:
+  <<: *skip_on_cluster_agent_tag
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -252,6 +281,7 @@ agent_deb-x64:
 
 # build Agent package for rpm-x64
 agent_rpm-x64:
+  <<: *skip_on_cluster_agent_tag
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -283,6 +313,7 @@ agent_rpm-x64:
 
 # build Agent package for rpm-x64
 agent_suse-x64:
+  <<: *skip_on_cluster_agent_tag
   allow_failure: true
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:latest
@@ -317,6 +348,7 @@ agent_suse-x64:
 
 # build Agent package for Windows
 build_windows_msi_x64:
+  <<: *skip_on_cluster_agent_tag
   before_script:
     - if exist .omnibus rd /s/q .omnibus
     - if exist \omnibus-ruby rd /s/q \omnibus-ruby
@@ -344,6 +376,7 @@ build_windows_msi_x64:
 
 # build Agent package for android
 agent_android_apk:
+  <<: *skip_on_cluster_agent_tag
   allow_failure: true
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/android_builder:v538460-2b07be3
@@ -374,6 +407,7 @@ agent_android_apk:
 
 # build Dogstastd package for deb-x64
 dogstatsd_deb-x64:
+  <<: *skip_on_cluster_agent_tag
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -401,6 +435,7 @@ dogstatsd_deb-x64:
 
 # build Dogstastd package for rpm-x64
 dogstatsd_rpm-x64:
+  <<: *skip_on_cluster_agent_tag
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
@@ -433,6 +468,7 @@ dogstatsd_rpm-x64:
 
 # build Dogstastd package for rpm-x64
 dogstatsd_suse-x64:
+  <<: *skip_on_cluster_agent_tag
   allow_failure: true
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:latest
@@ -545,6 +581,7 @@ kitchen_windows:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -572,6 +609,7 @@ kitchen_centos:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -597,6 +635,7 @@ kitchen_ubuntu:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -623,6 +662,7 @@ kitchen_suse:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -648,6 +688,7 @@ kitchen_debian:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -672,6 +713,7 @@ testkitchen_cleanup_s3:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   tags: [ "runner:main", "size:large" ]
   before_script:
     - ls
@@ -694,6 +736,7 @@ testkitchen_cleanup_azure:
     - master
     - tags
     - triggers
+  <<: *skip_on_cluster_agent_tag
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true
   when: always
@@ -715,7 +758,7 @@ testkitchen_cleanup_azure:
   services:
     - 486234852809.dkr.ecr.us-east-1.amazonaws.com/remote-docker:latest
   before_script: [ "# noop" ] # Override top level entry
-  dependencies: [] # Don't download Gitlab artefacts
+  dependencies: [] # Don't download Gitlab artifacts
   script:
     - apt-get update && apt-get install -y python-pip && pip install awscli
     - aws s3 sync --only-show-errors "s3://dd-ci-artefacts-build-stable/datadog-agent/$CI_PIPELINE_ID" $BUILD_CONTEXT
@@ -727,6 +770,7 @@ testkitchen_cleanup_azure:
 # build the agent6 image
 build_agent6:
   <<: *docker_build_job_definition
+  <<: *skip_on_cluster_agent_tag
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -734,6 +778,7 @@ build_agent6:
 # build the agent6 jmx image
 build_agent6_jmx:
   <<: *docker_build_job_definition
+  <<: *skip_on_cluster_agent_tag
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
@@ -750,6 +795,7 @@ build_cluster_agent:
 # build the dogstatsd image
 build_dogstatsd:
   <<: *docker_build_job_definition
+  <<: *skip_on_cluster_agent_tag
   variables:
     IMAGE: &dogstatsd_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
     BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
@@ -770,7 +816,7 @@ build_dogstatsd:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - pip install invoke
-  dependencies: [] # Don't download Gitlab artefacts
+  dependencies: [] # Don't download Gitlab artifacts
 
 .docker_hub_variables: &docker_hub_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
@@ -802,6 +848,7 @@ dev_master_docker_hub:
   <<: *docker_tag_job_definition
   only:
     - master
+  <<: *skip_on_cluster_agent_tag
   variables:
     <<: *docker_hub_variables
   script:
@@ -845,10 +892,11 @@ dev_master_quay:
 #
 
 # Check that the current version hasn't already been deployed (we don't want to
-# overwrite a public package). To update a erroneous package, first remove it
+# overwrite a public package). To update an erroneous package, first remove it
 # from our S3 bucket.
 check_already_deployed_version:
   <<: *run_when_triggered
+  <<: *skip_on_cluster_agent_tag
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
@@ -1013,24 +1061,23 @@ latest_release:
 
 dca_tag_release:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_on_cluster_agent_tag
   stage: deploy
   when: manual
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent-dev:${CI_COMMIT_TAG}
-
+    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:${CI_COMMIT_TAG#$(echo "dca-")}
 
 dca_latest_release:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_tag
+  <<: *run_on_cluster_agent_tag
   stage: deploy
   when: manual
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent-dev:latest
+    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:latest
 
 # invalidate cloudfront cache
 deploy_cloudfront_invalidate:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -153,7 +153,7 @@ def query_version(ctx, git_sha_length=7):
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
     described_version = ctx.run("git describe --tags", hide=True).stdout.strip()
     # For the tag 6.0.0-beta.0, this will match 6.0.0
-    version_match = re.findall(r"^v?(\d+\.\d+\.\d+)", described_version)
+    version_match = re.findall(r"^(?:dca-)?v?(\d+\.\d+\.\d+)", described_version)
 
     if version_match and version_match[0]:
         version = version_match[0]
@@ -174,9 +174,9 @@ def query_version(ctx, git_sha_length=7):
     # if there have been no commits since, it will be just 6.0.0-beta.0,
     # and it will match beta.0
     if commits_since_version == 0:
-        pre_regex = r"^v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)$"
+        pre_regex = r"^(?:dca-)?v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)$"
     else:
-        pre_regex = r"^v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)-\d+-g[0-9a-f]+$"
+        pre_regex = r"^(?:dca-)?v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)-\d+-g[0-9a-f]+$"
 
     pre_match = re.findall(pre_regex, described_version)
     pre = ""


### PR DESCRIPTION
### What does this PR do?

Tags for DCA releases must start with `dca`, like `dca-1.0.0`.

- Add `releasenotes/cluster-agent` directory in root of project.

### Limitations/Hacks

- The proposed solution uses git tags that have the prefix `dca-` which means that the git tag doesn't conform to semantic versioning unless this prefix is ignored or removed.
- All jobs in the pipeline for the agent need to have an `except` condition to not run for DCA release tags since the omnibus build for the agent fails because the git tag doesn't conform to semantic versioning.
- Gitlab does not support running a job for a specific tag so the best we can do is exclude jobs for any git ref (branches or tags) matching the regex for dca releases.
- When creating `releasenotes` for the DCA you must use the `-d releasenotes/cluster-agent` flag for reno.
- The DCA image tag names will include the `dca-` prefix too.
### Motivation

Prepare for DCA 1.0.0 release.