### PR TITLE
Adding a releasenote for bumping python version

### DIFF
--- a/releasenotes/notes/bump-python-to-2715-7fc6de90afd1f365.yaml
+++ b/releasenotes/notes/bump-python-to-2715-7fc6de90afd1f365.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The embedded Python has been bumped from 2.7.14 to 2.7.15


### PR DESCRIPTION
### What does this PR do?

Adding a releasenote for bumping python version
