### PR TITLE
Introducing the HPA Status & verbose in flare

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
@@ -1,0 +1,30 @@
+Custom Metrics Provider
+=======================
+External Metrics
+================
+  {{- if .hpaExternal -}}
+  {{- if .hpaExternal.Error }}
+  Error while trying to serve external metrics: {{ .hpaExternal.Error }}
+  {{ else }}
+  {{- if .hpaExternal.ErrorStore }}
+  Internal Error while processing the External Metrics : {{ .hpaExternal.ErrorStore }}
+  {{ else }}
+  ConfigMap name: {{ .hpaExternal.Cmname }}
+  Number of external metrics detected: {{ .hpaExternal.Number }}
+  {{- end -}}
+  {{- end -}}
+  {{ range $metric := .hpaExternal.Metrics }}
+  {{ range $name, $value := $metric}}
+  {{- if or (eq $name "hpa") (eq $name "labels")}}
+  {{$name}}:
+  {{- range $k, $v := $value}}
+  - {{$k}}: {{$v}}
+  {{- end -}}
+  {{else}}
+  {{$name}}: {{$value}}
+  {{- end }}
+  {{- end }}
+  {{- end -}}
+  {{ else }}
+  The External Metrics Provider is not enabled
+  {{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/header.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/header.tmpl
@@ -42,5 +42,23 @@
     Number of leader transitions: {{.leaderelection.transitions}}
     {{- end}}
     {{- end}}
-{{/* this line intentionally left blank */}}
 
+  Custom Metrics Provider
+  =======================
+  External Metrics
+  ================
+    {{- if .hpaExternal -}}
+    {{- if .hpaExternal.Error }}
+    Error while trying to serve external metrics: {{ .hpaExternal.Error }}
+    {{ else }}
+    {{- if .hpaExternal.ErrorStore }}
+    Internal Error while processing the External Metrics : {{ .hpaExternal.ErrorStore }}
+    {{ else }}
+    ConfigMap name: {{ .hpaExternal.Cmname }}
+    Number of external metrics detected: {{ .hpaExternal.Number }}
+    {{- end -}}
+    {{- end -}}
+    {{ else }}
+    The External Metrics Provider is not enabled
+    {{- end -}}
+{{/* this line intentionally left blank */}}

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -28,10 +28,6 @@ import (
 var options *server.CustomMetricsAdapterServerOptions
 var stopCh chan struct{}
 
-const (
-	datadogHPAConfigMap = "datadog-hpa"
-)
-
 func init() {
 	// FIXME: log to seelog
 	options = server.NewCustomMetricsAdapterServerOptions(os.Stdout, os.Stdout)
@@ -81,7 +77,7 @@ func StartServer() error {
 	if err != nil {
 		return err
 	}
-
+	datadogHPAConfigMap := custommetrics.GetHPAConfigmapName()
 	store, err := custommetrics.NewConfigMapStore(client.Cl, as.GetResourcesNamespace(), datadogHPAConfigMap)
 	if err != nil {
 		return err

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +40,11 @@ type configMapStore struct {
 	name      string
 	client    corev1.CoreV1Interface
 	cm        *v1.ConfigMap
+}
+
+// GetHPAConfigmapName returns the name of the ConfigMap used to store the state of the Custom Metrics Provider
+func GetHPAConfigmapName() string {
+	return config.Datadog.GetString("hpa_configmap_name")
 }
 
 // NewConfigMapStore returns a new store backed by a configmap. The configmap will be created

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -307,6 +307,7 @@ func init() {
 	Datadog.BindEnv("cluster_agent.cmd_port")
 	Datadog.BindEnv("cluster_agent.kubernetes_service_name")
 	BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
+	BindEnvAndSetDefault("hpa_configmap_name", "datadog-hpa")
 	BindEnvAndSetDefault("external_metrics_provider.polling_freq", 30)
 	BindEnvAndSetDefault("external_metrics_provider.max_age", 60)
 	BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -102,6 +102,13 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		return "", err
 	}
 
+	if config.Datadog.GetBool("external_metrics_provider.enabled") {
+		err = zipHPAStatus(tempDir, hostname)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	err = archiver.Zip.Make(zipFilePath, []string{filepath.Join(tempDir, hostname)})
 	if err != nil {
 		return "", err
@@ -162,6 +169,37 @@ func zipMetadataMap(tempDir, hostname string) error {
 	sByte := []byte(str)
 	f := filepath.Join(tempDir, hostname, "cluster-agent-metadatamapper.log")
 	log.Infof("Flare metadata mapper made at %s", tempDir)
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(f, sByte, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func zipHPAStatus(tempDir, hostname string) error {
+	// Grab the full content of the HPA configmap
+	stats := make(map[string]interface{})
+	stats["hpaExternal"] = status.GetHorizontalPodAutoscalingStatus()
+	statsBytes, err := json.Marshal(stats)
+	if err != nil {
+		log.Infof("Error while marshalling the cluster level metadata: %q", err)
+		return err
+	}
+
+	str, err := status.FormatHPAStatus(statsBytes)
+	if err != nil {
+		return err
+	}
+	sByte := []byte(str)
+
+	f := filepath.Join(tempDir, hostname, "custommetricsprovider.log")
+	log.Infof("Flare hpa status made at %s", tempDir)
+
 	err = ensureParentDirsExist(f)
 	if err != nil {
 		return err

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -74,6 +74,15 @@ func FormatDCAStatus(data []byte) (string, error) {
 	return b.String(), nil
 }
 
+// FormatHPAStatus takes a json bytestring and prints out the formatted statuspage
+func FormatHPAStatus(data []byte) (string, error) {
+	var b = new(bytes.Buffer)
+	stats := make(map[string]interface{})
+	json.Unmarshal(data, &stats)
+	renderHPAStats(b, stats)
+	return b.String(), nil
+}
+
 // FormatMetadataMapCLI builds the rendering in the metadataMapper template.
 func FormatMetadataMapCLI(data []byte) (string, error) {
 	var b = new(bytes.Buffer)
@@ -115,6 +124,14 @@ func renderForwarderStatus(w io.Writer, forwarderStats interface{}) {
 func renderDatadogClusterAgentStatus(w io.Writer, dcaStats interface{}) {
 	t := template.Must(template.New("clusteragent.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "clusteragent.tmpl")))
 	err := t.Execute(w, dcaStats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderHPAStats(w io.Writer, hpaStats interface{}) {
+	t := template.Must(template.New("custommetricsprovider.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "custommetricsprovider.tmpl")))
+	err := t.Execute(w, hpaStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -128,6 +128,7 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	now := time.Now()
 	stats["time"] = now.Format(timeFormat)
 	stats["leaderelection"] = getLeaderElectionDetails()
+	stats["hpaExternal"] = GetHorizontalPodAutoscalingStatus()
 
 	return stats, nil
 }

--- a/pkg/status/status_no_apiserver.go
+++ b/pkg/status/status_no_apiserver.go
@@ -20,3 +20,9 @@ func getDCAStatus() map[string]string {
 	log.Info("Not implemented")
 	return nil
 }
+
+// GetHorizontalPodAutoscalingStatus fetches the content of the ConfigMap storing the state of the HPA metrics provider
+func GetHorizontalPodAutoscalingStatus() map[string]interface{} {
+	log.Info("Not implemented")
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

In the output of the `datadog-cluster-agent status` we can see the state of the Custom Metrics Provider process:
<img width="611" alt="image 2018-07-19 at 7 39 31 pm" src="https://user-images.githubusercontent.com/7433560/42975679-7960c938-8b8b-11e8-8a4d-c65e20e9ebf8.png">

And the verbose version is embedded in the flare as a log file:
<img width="569" alt="image 2018-07-19 at 7 40 09 pm" src="https://user-images.githubusercontent.com/7433560/42975704-9d27ff30-8b8b-11e8-994c-567dff448f65.png">

### Motivation

Easier to investigate what the Datadog Cluster Agent is serving and has detected.