### PR TITLE
avoid logging hostname fqdn deprecation notice if we fail to grab it

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -171,7 +171,7 @@ func GetHostname() (string, error) {
 
 	// REMOVEME: This should be removed in 6.5
 	h, err := os.Hostname()
-	if err == nil && !config.Datadog.GetBool("hostname_fqdn") && hostName == h && h != fqdn {
+	if err == nil && !config.Datadog.GetBool("hostname_fqdn") && fqdn != "" && hostName == h && h != fqdn {
 		log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as '%s'. However starting from version 6.5, it will be resolved as '%s' by default. To enable the behavior of 6.5+, please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
 	}
 


### PR DESCRIPTION
### What does this PR do?

If we failed to grab the fqdn using `hostname -f` (on windows for ex.) we would still log the deprecation notice : 

`The agent resolved your hostname as 'an-hostname'. However starting from version 6.4, it will be resolved as '' by default. `

