### PR TITLE
Make the Kubernetes event collection timeout configurable

### DIFF
--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -11,3 +11,7 @@ instances:
     # You can specify a filter over the event types you want the check to ignore.
     # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20
     # filtered_event_types: ["MissingClusterDNS"]
+    #
+    # If the API Server is slow to respond under load, the event collection might fail. You can increate the read timeout here.
+    # To account for slow starts, the timeout for the first message will be the double of this.
+    # kubernetes_event_read_timeout_ms: 100

--- a/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -12,6 +12,5 @@ instances:
     # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20
     # filtered_event_types: ["MissingClusterDNS"]
     #
-    # If the API Server is slow to respond under load, the event collection might fail. You can increate the read timeout here.
-    # To account for slow starts, the timeout for the first message will be the double of this.
+    # If the API Server is slow to respond under load, the event collection might fail. You can increase the read timeout here.
     # kubernetes_event_read_timeout_ms: 100

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -72,6 +72,7 @@ func (k *KubeASCheck) Configure(config, initConfig integration.Data) error {
 		log.Error("could not parse the config for the API server")
 		return err
 	}
+	k.eventCollectionTimeout = time.Duration(k.instance.EventCollectionTimeoutMs) * time.Millisecond
 
 	log.Debugf("Running config %s", config)
 	return nil
@@ -117,7 +118,6 @@ func (k *KubeASCheck) Run() error {
 		if k.instance.CollectOShiftQuotas {
 			k.oshiftAPILevel = k.ac.DetectOpenShiftAPILevel()
 		}
-		k.eventCollectionTimeout = time.Duration(k.instance.EventCollectionTimeoutMs) * time.Millisecond
 	}
 
 	// Running the Control Plane status check.

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -11,7 +11,6 @@ package apiserver
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -21,10 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
-var (
-	expectedType = reflect.TypeOf(v1.Event{})
 )
 
 // LatestEvents retrieves all the cluster events happening after a given token.
@@ -44,11 +39,11 @@ func (c *APIClient) LatestEvents(since string, eventReadTimeout time.Duration) (
 		since = "0"
 	}
 
-	log.Tracef("Starting watch of %v with resourceVersion %s", expectedType, since)
+	log.Tracef("Starting watch of events with resourceVersion %s", since)
 
 	eventWatcher, err := c.Cl.CoreV1().Events(metav1.NamespaceAll).Watch(metav1.ListOptions{Watch: true, ResourceVersion: since})
 	if err != nil {
-		return nil, nil, "0", fmt.Errorf("Failed to watch %v: %v", expectedType, err)
+		return nil, nil, "0", fmt.Errorf("Failed to watch events: %v", err)
 	}
 	defer eventWatcher.Stop()
 
@@ -81,7 +76,7 @@ func (c *APIClient) LatestEvents(since string, eventReadTimeout time.Duration) (
 
 			currEvent, ok := rcvdEv.Object.(*v1.Event)
 			if !ok {
-				log.Debugf("The event object cannot be safely converted to %v: %v", expectedType, rcvdEv.Object)
+				log.Debugf("The event object cannot be safely converted to event: %v", rcvdEv.Object)
 				continue
 			}
 

--- a/releasenotes/notes/kubernetes-event-collection-timeout-89d6af8575f92751.yaml
+++ b/releasenotes/notes/kubernetes-event-collection-timeout-89d6af8575f92751.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - The Kubernetes event collection timeout is now configurable


### PR DESCRIPTION
### What does this PR do?

As the API Server does not allow to stream events, then stop at a given timestamp, we detect the end of the event stream via a `100ms` read timeout on the event stream. Under heavy load, the API Server can take longer than that to serialise events.

This PR makes this timeout configurable in the `kubernetes_apiserver.yaml` integration config. To account for slow starts, the timeout for the first event read is the double of the rest. Side effect is that a run check collecting zero event would run for 100ms longer. But given the apiserver verbosity, that's not a common case.

Set the timeout to 500ms in the integration test, hoping that might help with this test's flakiness (no events are collected when they should be).
