### PR TITLE
Add healthcheck debug logging + warning on exit

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
@@ -30,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -183,6 +183,10 @@ func getFormattedStatus(w http.ResponseWriter, r *http.Request) {
 
 func getHealth(w http.ResponseWriter, r *http.Request) {
 	h := health.GetStatus()
+
+	if len(h.Unhealthy) > 0 {
+		log.Debugf("Healthcheck failed on: %v", h.Unhealthy)
+	}
 
 	jsonHealth, err := json.Marshal(h)
 	if err != nil {

--- a/releasenotes/notes/healthcheck-fail-log-8d6d3a817cdab8e5.yaml
+++ b/releasenotes/notes/healthcheck-fail-log-8d6d3a817cdab8e5.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - The Agent will log failed healthchecks on query and during exit


### PR DESCRIPTION
### What does this PR do?

To make support easier, add logging when a component is unhealthy:

- `debug` line when `agent health` is called and one component is unhealthy:

> 2018-07-20 12:59:18 UTC | DEBUG | (agent.go:189 in getHealth) | Healthcheck failed on: [forwarder]

- `warning` line on agent exit if one component is unhealthy

> 2018-07-20 12:59:21 UTC | WARN | (start.go:259 in StopAgent) | Some components were unhealthy: [forwarder]
> 2018-07-20 12:59:21 UTC | DEBUG | (scheduler.go:171 in Stop) | Waiting for the scheduler to shutdown
> 2018-07-20 12:59:21 UTC | DEBUG | (scheduler.go:144 in func1) | Exited Scheduler loop, shutting down queues...
> 2018-07-20 12:59:21 UTC | DEBUG | (scheduler.go:185 in stopQueues) | Stopping 1 queue(s)
> 2018-07-20 12:59:21 UTC | DEBUG | (scheduler.go:192 in stopQueues) | Stopped queue 15s
> 2018-07-20 12:59:21 UTC | INFO | (runner.go:149 in Stop) | Runner is shutting down...
> 2018-07-20 12:59:21 UTC | INFO | (domain_forwarder.go:185 in Stop) | domainForwarder stopped
> 2018-07-20 12:59:21 UTC | INFO | (start.go:279 in StopAgent) | See ya!

- `health.GetStatus()` should not block, but as an added safety measure, I'm wrapping its call with a 100ms timeout. If that were to happen, the agent would log this:

> 2018-07-20 13:02:34 UTC | WARN | (start.go:257 in StopAgent) | Agent health unknown: timeout when getting health status