### PR TITLE
Kill jmxfetch on agent exit

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
@@ -270,6 +271,7 @@ func StopAgent() {
 		common.MetadataScheduler.Stop()
 	}
 	api.StopServer()
+	jmx.StopJmxfetch()
 	if common.Forwarder != nil {
 		common.Forwarder.Stop()
 	}

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -45,7 +45,7 @@ func (c *JMXCheck) Run() error {
 	case <-state.runnerError:
 		return fmt.Errorf("jmxfetch exited, stopping %s : %s", c.name, err)
 	case <-c.stop:
-		log.Debugf("jmx check %s stopped", c.name)
+		log.Infof("jmx check %s stopped", c.name)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -45,7 +45,7 @@ func (c *JMXCheck) Run() error {
 	case <-state.runnerError:
 		return fmt.Errorf("jmxfetch exited, stopping %s : %s", c.name, err)
 	case <-c.stop:
-		log.Debug("jmx check %s stopped", c.name)
+		log.Debugf("jmx check %s stopped", c.name)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -108,3 +108,10 @@ func (r *runner) configureRunner(instance, initConfig integration.Data) error {
 
 	return nil
 }
+
+func (r *runner) stopRunner() error {
+	if r.jmxfetch != nil && r.started {
+		return r.jmxfetch.Kill()
+	}
+	return nil
+}

--- a/pkg/collector/corechecks/embed/jmx/state.go
+++ b/pkg/collector/corechecks/embed/jmx/state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type jmxState struct {
@@ -81,4 +82,11 @@ func GetScheduledConfigs() map[string]integration.Config {
 // the list of scheduled configuration got updated.
 func GetScheduledConfigsModificationTimestamp() int64 {
 	return state.getScheduledConfigsModificationTimestamp()
+}
+
+func StopJmxfetch() {
+	err := state.runner.stopRunner()
+	if err != nil {
+		log.Errorf("failure to kill jmxfetch process: %s", err)
+	}
 }

--- a/pkg/collector/corechecks/embed/jmx/state.go
+++ b/pkg/collector/corechecks/embed/jmx/state.go
@@ -84,6 +84,7 @@ func GetScheduledConfigsModificationTimestamp() int64 {
 	return state.getScheduledConfigsModificationTimestamp()
 }
 
+// StopJmxfetch stops the jmxfetch process if it is running
 func StopJmxfetch() {
 	err := state.runner.stopRunner()
 	if err != nil {

--- a/pkg/collector/corechecks/embed/jmx/state_nojmx.go
+++ b/pkg/collector/corechecks/embed/jmx/state_nojmx.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !jmx
+
+package jmx
+
+// StopJmxfetch does nothing when the agent does not ship jmx
+func StopJmxfetch() {
+
+}

--- a/releasenotes/notes/kill-jmxfetch-exit-63cf18e7f8f8687c.yaml
+++ b/releasenotes/notes/kill-jmxfetch-exit-63cf18e7f8f8687c.yaml
@@ -1,0 +1,35 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List enhancements (new behavior that is too small to be
+    considered a new feature), or remove this section.
+issues:
+  - |
+    List known issues here, or remove this section.
+upgrade:
+  - |
+    List upgrade notes here, or remove this section.
+deprecations:
+  - |
+    List deprecations notes here, or remove this section.
+security:
+  - |
+    Add security notes here, or remove this section.
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't feat in any other section. This section should rarely be
+    used.

--- a/releasenotes/notes/kill-jmxfetch-exit-63cf18e7f8f8687c.yaml
+++ b/releasenotes/notes/kill-jmxfetch-exit-63cf18e7f8f8687c.yaml
@@ -6,30 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-features:
-  - |
-    List new features here, or remove this section.
-enhancements:
-  - |
-    List enhancements (new behavior that is too small to be
-    considered a new feature), or remove this section.
-issues:
-  - |
-    List known issues here, or remove this section.
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.
-deprecations:
-  - |
-    List deprecations notes here, or remove this section.
-security:
-  - |
-    Add security notes here, or remove this section.
 fixes:
   - |
-    Add normal bug fixes here, or remove this section.
-other:
-  - |
-    Add here every other information you want in the CHANGELOG that
-    don't feat in any other section. This section should rarely be
-    used.
+    Fixed an issue with jmxfetch not being killed on agent exit.


### PR DESCRIPTION
### What does this PR do?

The JMXFetch process was not being killed by the agent since `6.3`. Most supervisors automatically kill child processes which might explain why this was not noticed.