### PR TITLE
dsd-static: disable cgo to allow running on musl

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -68,7 +68,8 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
 
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
-        #env["CGO_ENABLED"] = "0"
+        # Disable cgo in order to allow running on musl
+        env["CGO_ENABLED"] = "0"
     elif use_embedded_libs:
         embedded_lib_path = ctx.run("pkg-config --variable=libdir python-2.7",
                                     env=env, hide=True).stdout.strip()

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -67,7 +67,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
 
     if static:
-        ldflags += "-s -w -linkmode=external '-extldflags=-static' "
+        ldflags += "-s -w '-extldflags=-static' "
         # Disable cgo in order to allow running on musl
         env["CGO_ENABLED"] = "0"
     elif use_embedded_libs:


### PR DESCRIPTION
As discussed in cafe, for usage in the docker dsd alpine image

```
$ inv -e dogstatsd.build -s && file bin/static/dogstatsd && ./bin/static/dogstatsd version
go build   -tags 'kubelet docker zlib' -o ./bin/static/dogstatsd -gcflags="" -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.Commit=73df5f0 -X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=6.3.0-test-cloudfront-invalidation+git.139.73df5f0 -X github.com/DataDog/datadog-agent/pkg/serializer.AgentPayloadVersion=None -s -w '-extldflags=-static' " github.com/DataDog/datadog-agent/cmd/dogstatsd
go generate github.com/DataDog/datadog-agent/cmd/dogstatsd
Successfully wrote /git/datadog-agent/cmd/dogstatsd/dist/dogstatsd.yaml
file ./bin/static/dogstatsd
./bin/static/dogstatsd: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
bin/static/dogstatsd: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
DogStatsD from Agent 6.3.0 - Codename: git.139.73df5f0 - Commit: 73df5f0 - Serialization version: None
```