### PR TITLE
[ntp] Run the check every 15 minutes by default

### DIFF
--- a/releasenotes/notes/ntp-check-15-min-cc70949271bf62c1.yaml
+++ b/releasenotes/notes/ntp-check-15-min-cc70949271bf62c1.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    The ntp check now runs every 15 minutes by default to avoid over-loading
+    the NTP server pools


### PR DESCRIPTION
### What does this PR do?

Runs the check every 15 minutes by default instead of every 15 seconds.

### Motivation

Avoid over-loading the NTP server pools, the value of 4 times an hour comes from [pool.ntp.org's guidelines](https://www.ntppool.org/en/vendors.html)

### Additional Notes

The natural way to implement this would be to set the check's `Interval` to 15 minutes. Unfortunately with the current collector architecture this would mean that the check would run for the first time 15 minutes after the Agent has started, which is not acceptable for the ntp check. Modifying the collector to schedule the first run of checks differently would be a significant change that we can't make for 6.4.0, so I've decided to implement the logic directly in the check for now.

I've added a card in our backlog to eventually improve the collector's behavior.
