### PR TITLE
Build a static dependency environment from core

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -22,6 +22,10 @@ whitelist_file "embedded/lib/python2.7"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 
+PIPTOOLS_VERSION "2.0.2"
+PYMPLER_VERSION "0.5"
+WHEELS_VERSION "0.30.0"
+
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?
   integrations_core_version = 'master'
@@ -79,14 +83,14 @@ build do
 
     # Install all the build requirements
     if windows?
-      pip_args = "install wheel==0.30.0 pympler==0.5 pip-tools==2.0.2"
+      pip_args = "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION} pip-tools==#{PIPTOOLS_VERSION}"
       command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
-      pip "install wheel==0.30.0 pympler==0.5 pip-tools==2.0.2", :env => build_env
+      pip "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION} pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
     end
 
     # Windows pip workaround to support globs

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -31,6 +31,7 @@ default_version integrations_core_version
 
 blacklist = [
   'datadog_checks_base',  # namespacing package for wheels (NOT AN INTEGRATION)
+  'datadog_checks_dev',   # Development package, (NOT AN INTEGRATION)
   'agent_metrics',
   'docker_daemon',
   'kubernetes',
@@ -48,13 +49,6 @@ build do
 
   # Install the checks and generate the global requirements file
   block do
-    all_reqs_file = File.open("#{project_dir}/check_requirements.txt", 'w+')
-    # FIX THIS these dependencies have to be grabbed from somewhere
-    all_reqs_file.puts "pympler==0.5 --hash=sha256:7d16c4285f01dcc647f69fb6ed4635788abc7a7cb7caa0065d763f4ce3d21c0f"
-    all_reqs_file.puts "wheel==0.30.0 --hash=sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"\
-        " --hash=sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8"
-
-    all_reqs_file.close
 
     # required by TUF for meta
     if windows?
@@ -83,47 +77,36 @@ build do
       copy windows_safe_path("#{project_dir}/.tuf-root.json"), windows_safe_path("#{tuf_repo_meta}/current/root.json")
     end
 
-    # Install all the requirements
+    # Install all the build requirements
     if windows?
-      pip_args = "install  -r #{project_dir}/check_requirements.txt"
+      pip_args = "install wheel==0.30.0 pympler==0.5 pip-tools==2.0.2"
       command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
-      pip "install -r #{project_dir}/check_requirements.txt", :env => build_env
+      pip "install wheel==0.30.0 pympler==0.5 pip-tools==2.0.2", :env => build_env
     end
-
-    # Set frozen requirements
-    pip "freeze > #{install_dir}/agent_requirements.txt"
 
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
-    python_pip = "pip install -c #{windows_safe_path(install_dir)}\\agent_requirements.txt #{windows_safe_path(project_dir)}"
-    python_pip_req = "pip install -c #{windows_safe_path(install_dir)}\\agent_requirements.txt -r #{windows_safe_path(project_dir)}"
+    python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
+    python_pip_req = "pip install --require-hashes -r #{windows_safe_path(project_dir)}"
 
-    pinned_requirements = "#{project_dir}/datadog_checks_base/requirements.in"
     if windows?
-      command("#{python_bin} -m #{python_pip}\\datadog_checks_base")
-      if File.exist? pinned_requirements
-        command("#{python_bin} -m #{python_pip_req}\\datadog_checks_base\\requirements.in")
-      end
+      command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
+      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\agent_requirements.in")
+      command("#{python_bin} -m #{python_pip_req}\\#{windows_safe_path(project_dir)}\\static_requirements.txt")
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
-      pip "wheel --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      pip "install -c #{install_dir}/agent_requirements.txt *.whl", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      if File.exist? pinned_requirements
-        pip "install -c #{install_dir}/agent_requirements.txt -rrequirements.in", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      end
+      pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
+      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/agent_requirements.in")
+      pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
-
-    # Set frozen requirements post `datadog_checks_base` - constraints file will be used by
-    # pip to ensure all other integrations dependency sanity.
-    pip "freeze > #{install_dir}/agent_requirements.txt"
 
     Dir.glob("#{project_dir}/*").each do |check_dir|
       check = check_dir.split('/').last
@@ -177,21 +160,14 @@ build do
       end
 
       File.file?("#{check_dir}/setup.py") || next
-      pinned_requirements = "#{check_dir}/requirements.in"
       if windows?
-        command("#{python_bin} -m #{python_pip}\\#{check}")
-        if File.exist? pinned_requirements
-          command("#{python_bin} -m #{python_pip_req}\\#{check}\\requirements.in")
-        end
+        command("#{python_bin} -m #{python_pip_no_deps}\\#{check}")
       else
         build_env = {
           "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
           "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
         }
-        pip "wheel --no-deps .", :env => build_env, :cwd => "#{project_dir}/#{check}"
-        if File.exist? pinned_requirements
-          pip "install -c #{install_dir}/agent_requirements.txt *.whl -rrequirements.in", :env => build_env, :cwd => "#{project_dir}/#{check}"
-        end
+        pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/#{check}"
       end
     end
   end

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -23,8 +23,6 @@ whitelist_file "embedded/lib/python2.7"
 source git: 'https://github.com/DataDog/integrations-core.git'
 
 PIPTOOLS_VERSION = "2.0.2"
-PYMPLER_VERSION = "0.5"
-WHEELS_VERSION = "0.30.0"
 UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'six', 'pip-tools']
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
@@ -82,20 +80,29 @@ build do
       copy windows_safe_path("#{project_dir}/.tuf-root.json"), windows_safe_path("#{tuf_repo_meta}/current/root.json")
     end
 
+    ll_reqs_file = File.open("#{project_dir}/check_requirements.txt", 'w+')
+    # FIX THIS these dependencies have to be grabbed from somewhere
+    all_reqs_file.puts "pympler==0.5 --hash=sha256:7d16c4285f01dcc647f69fb6ed4635788abc7a7cb7caa0065d763f4ce3d21c0f"
+    all_reqs_file.puts "wheel==0.30.0 --hash=sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"\
+    " --hash=sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8"
+    
+    all_reqs_file.close
+
+    # Install all the requirements
     # Install all the build requirements
-    if windows?
-      pip_args = "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION}"
-      command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
-    else
-      build_env = {
-        "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-        "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
-      }
-      pip "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION}", :env => build_env
-    end
+     if windows?
+       pip_args = "install --require-hashes -r #{project_dir}/check_requirements.txt"
+       command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
+     else
+       build_env = {
+         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+       }
+       pip "install --require-hashes -r #{project_dir}/check_requirements.txt", :env => build_env
+     end
 
     # Set frozen requirements without pip-tools 
-    pip "freeze > #{install_dir}/check_requirements.txt"
+    pip "freeze > #{install_dir}/constraint_requirements.txt"
 
     # Install all the build requirements
     if windows?
@@ -111,8 +118,8 @@ build do
 
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
-    python_pip_no_deps = "pip install -c #{windows_safe_path(install_dir)}\\check_requirements.txt --no-deps #{windows_safe_path(project_dir)}"
-    python_pip_req = "pip install -c #{windows_safe_path(install_dir)}\\check_requirements.txt --require-hashes -r #{windows_safe_path(project_dir)}"
+    python_pip_no_deps = "pip install -c #{windows_safe_path(install_dir)}\\constraint_requirements.txt --no-deps #{windows_safe_path(project_dir)}"
+    python_pip_req = "pip install -c #{windows_safe_path(install_dir)}\\constraint_requirements.txt --require-hashes -r #{windows_safe_path(project_dir)}"
     python_pip_uninstall = "pip uninstall -y"
 
     if windows?
@@ -130,7 +137,7 @@ build do
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
-      pip "install -c #{install_dir}/check_requirements.txt --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
+      pip "install -c #{install_dir}/constraint_requirements.txt --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
@@ -138,7 +145,7 @@ build do
         pip "uninstall -y #{dep}"
       end
 
-      pip "install -c #{install_dir}/check_requirements.txt--require-hashes -r #{project_dir}/static_requirements.txt"
+      pip "install -c #{install_dir}/constraint_requirements.txt--require-hashes -r #{project_dir}/static_requirements.txt"
     end
 
     Dir.glob("#{project_dir}/*").each do |check_dir|

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -94,8 +94,20 @@ build do
       pip "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION} pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
     end
 
-    # Set frozen requirements
+    # Set frozen requirements without pip-tools 
     pip "freeze > #{install_dir}/check_requirements.txt"
+
+    # Install all the build requirements
+    if windows?
+      pip_args = "install pip-tools==#{PIPTOOLS_VERSION}"
+      command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
+    else
+      build_env = {
+        "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+        "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+      }
+      pip "install pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
+    end
 
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -22,9 +22,9 @@ whitelist_file "embedded/lib/python2.7"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 
-PIPTOOLS_VERSION "2.0.2"
-PYMPLER_VERSION "0.5"
-WHEELS_VERSION "0.30.0"
+PIPTOOLS_VERSION = "2.0.2"
+PYMPLER_VERSION = "0.5"
+WHEELS_VERSION = "0.30.0"
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -23,7 +23,7 @@ whitelist_file "embedded/lib/python2.7"
 source git: 'https://github.com/DataDog/integrations-core.git'
 
 PIPTOOLS_VERSION = "2.0.2"
-UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'six', 'pip-tools']
+UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'pip-tools']
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?
@@ -145,7 +145,7 @@ build do
         pip "uninstall -y #{dep}"
       end
 
-      pip "install -c #{install_dir}/constraint_requirements.txt--require-hashes -r #{project_dir}/static_requirements.txt"
+      pip "install -c #{install_dir}/constraint_requirements.txt --require-hashes -r #{project_dir}/static_requirements.txt"
     end
 
     Dir.glob("#{project_dir}/*").each do |check_dir|

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -84,14 +84,14 @@ build do
 
     # Install all the build requirements
     if windows?
-      pip_args = "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION} pip-tools==#{PIPTOOLS_VERSION}"
+      pip_args = "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION}"
       command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
-      pip "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION} pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
+      pip "install wheel==#{WHEELS_VERSION} pympler==#{PYMPLER_VERSION}", :env => build_env
     end
 
     # Set frozen requirements without pip-tools 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -127,7 +127,7 @@ build do
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
 
       # Uninstall pip
-      freeze_file = File.read("#{windows_safe_path(project_dir)}\\agent_requirements.txt")
+      freeze_file = File.read("#{windows_safe_path(project_dir)}\\constraint_requirements.txt")
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
           pip "uninstall -y #{dep}"
@@ -144,7 +144,7 @@ build do
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
       
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      freeze_file = File.read("#{project_dir}/agent_requirements.txt")
+      freeze_file = File.read("#{project_dir}/constraint_requirements.txt")
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
            pip "uninstall -y #{dep}"

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -80,7 +80,7 @@ build do
       copy windows_safe_path("#{project_dir}/.tuf-root.json"), windows_safe_path("#{tuf_repo_meta}/current/root.json")
     end
 
-    ll_reqs_file = File.open("#{project_dir}/check_requirements.txt", 'w+')
+    all_reqs_file = File.open("#{project_dir}/check_requirements.txt", 'w+')
     # FIX THIS these dependencies have to be grabbed from somewhere
     all_reqs_file.puts "pympler==0.5 --hash=sha256:7d16c4285f01dcc647f69fb6ed4635788abc7a7cb7caa0065d763f4ce3d21c0f"
     all_reqs_file.puts "wheel==0.30.0 --hash=sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"\

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -23,7 +23,7 @@ whitelist_file "embedded/lib/python2.7"
 source git: 'https://github.com/DataDog/integrations-core.git'
 
 PIPTOOLS_VERSION = "2.0.2"
-UNINSTALL_PIPTOOLS_DEPS = ['click', 'six', 'pip-tools']
+UNINSTALL_PIPTOOLS_DEPS = ['click', 'first', 'pip-tools']
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -23,7 +23,7 @@ whitelist_file "embedded/lib/python2.7"
 source git: 'https://github.com/DataDog/integrations-core.git'
 
 PIPTOOLS_VERSION = "2.0.2"
-UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'pip-tools']
+UNINSTALL_PIPTOOLS_DEPS = ['pip-tools']
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?
@@ -119,19 +119,22 @@ build do
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install -c #{windows_safe_path(install_dir)}\\constraint_requirements.txt --no-deps #{windows_safe_path(project_dir)}"
-    python_pip_req = "pip install -c #{windows_safe_path(install_dir)}\\constraint_requirements.txt --require-hashes -r #{windows_safe_path(project_dir)}"
+    python_pip_req = "pip install -c #{windows_safe_path(install_dir)}\\constraint_requirements.txt --require-hashes -r"
     python_pip_uninstall = "pip uninstall -y"
 
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
 
-      # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      for dep in UNINSTALL_PIPTOOLS_DEPS
-        command("#{python_bin} -m #{python_pip_uninstall} #{dep}")
+      # Uninstall pip
+      freeze_file = File.read("#{windows_safe_path(project_dir)}\\agent_requirements.txt")
+      UNINSTALL_PIPTOOLS_DEPS.each do |dep|
+        if not freeze_file.include? dep
+          pip "uninstall -y #{dep}"
+        end
       end
 
-      command("#{python_bin} -m #{python_pip_req}\\static_requirements.txt")
+      command("#{python_bin} -m #{python_pip_req} #{windows_safe_path(project_dir)}\\static_requirements.txt")
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
@@ -139,10 +142,13 @@ build do
       }
       pip "install -c #{install_dir}/constraint_requirements.txt --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
-
+      
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      for dep in UNINSTALL_PIPTOOLS_DEPS
-        pip "uninstall -y #{dep}"
+      freeze_file = File.read("#{project_dir}/agent_requirements.txt")
+      UNINSTALL_PIPTOOLS_DEPS.each do |dep|
+        if not freeze_file.include? dep
+           pip "uninstall -y #{dep}"
+        end
       end
 
       pip "install -c #{install_dir}/constraint_requirements.txt --require-hashes -r #{project_dir}/static_requirements.txt"

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -98,7 +98,7 @@ build do
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
     python_pip_req = "pip install --require-hashes -r #{windows_safe_path(project_dir)}"
-    python_pip_uninstall = "pip uninstall"
+    python_pip_uninstall = "pip uninstall -y"
 
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
@@ -120,7 +120,7 @@ build do
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
       for dep in UNINSTALL_PIPTOOLS_DEPS
-        pip "uninstall #{dep}"
+        pip "uninstall -y #{dep}"
       end
 
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -127,7 +127,8 @@ build do
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
 
       # Uninstall pip
-      freeze_file = File.read("#{windows_safe_path(install_dir)}\\constraint_requirements.txt")
+
+      freeze_file = File.read(File.readlink("#{windows_safe_path(install_dir)}\\constraint_requirements.txt"))
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
           pip "uninstall -y #{dep}"
@@ -144,7 +145,7 @@ build do
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
       
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      freeze_file = File.read("#{install_dir}/constraint_requirements.txt")
+      freeze_file = File.read(File.readlink("#{install_dir}/constraint_requirements.txt"))
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
            pip "uninstall -y #{dep}"

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -100,7 +100,7 @@ build do
 
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\agent_requirements.in")
+      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
       command("#{python_bin} -m #{python_pip_req}\\#{windows_safe_path(project_dir)}\\static_requirements.txt")
     else
       build_env = {
@@ -108,7 +108,7 @@ build do
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/agent_requirements.in")
+      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -106,7 +106,7 @@ build do
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
       for dep in UNINSTALL_PIPTOOLS_DEPS
-        command("#{python_bin} -m #{python_pip_uninstall} dep")
+        command("#{python_bin} -m #{python_pip_uninstall} #{dep}")
       end
 
       command("#{python_bin} -m #{python_pip_req}\\static_requirements.txt")
@@ -122,7 +122,7 @@ build do
       for dep in UNINSTALL_PIPTOOLS_DEPS
         pip "uninstall #{dep}"
       end
-      
+
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -101,7 +101,7 @@ build do
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
-      command("#{python_bin} -m #{python_pip_req}\\#{windows_safe_path(project_dir)}\\static_requirements.txt")
+      command("#{python_bin} -m #{python_pip_req}\\static_requirements.txt")
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -25,6 +25,7 @@ source git: 'https://github.com/DataDog/integrations-core.git'
 PIPTOOLS_VERSION = "2.0.2"
 PYMPLER_VERSION = "0.5"
 WHEELS_VERSION = "0.30.0"
+UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'pip-tools']
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?
@@ -97,11 +98,17 @@ build do
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
     python_pip_req = "pip install --require-hashes -r #{windows_safe_path(project_dir)}"
+    python_pip_uninstall = "pip uninstall"
 
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
       command("#{python_bin} -m #{python_pip_req}\\static_requirements.txt")
+
+      # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
+      for dep in UNINSTALL_PIPTOOLS_DEPS
+        command("#{python_bin} -m #{python_pip_uninstall} dep")
+      end
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
@@ -109,6 +116,11 @@ build do
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
+
+      # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
+      for dep in UNINSTALL_PIPTOOLS_DEPS
+        pip "uninstall #{dep}"
+      end
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -25,7 +25,7 @@ source git: 'https://github.com/DataDog/integrations-core.git'
 PIPTOOLS_VERSION = "2.0.2"
 PYMPLER_VERSION = "0.5"
 WHEELS_VERSION = "0.30.0"
-UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'pip-tools']
+UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'six', 'pip-tools']
 
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?
@@ -103,12 +103,13 @@ build do
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
-      command("#{python_bin} -m #{python_pip_req}\\static_requirements.txt")
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
       for dep in UNINSTALL_PIPTOOLS_DEPS
         command("#{python_bin} -m #{python_pip_uninstall} dep")
       end
+
+      command("#{python_bin} -m #{python_pip_req}\\static_requirements.txt")
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
@@ -121,6 +122,7 @@ build do
       for dep in UNINSTALL_PIPTOOLS_DEPS
         pip "uninstall #{dep}"
       end
+      
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -127,7 +127,7 @@ build do
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
 
       # Uninstall pip
-      freeze_file = File.read("#{windows_safe_path(project_dir)}\\constraint_requirements.txt")
+      freeze_file = File.read("#{windows_safe_path(install_dir)}\\constraint_requirements.txt")
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
           pip "uninstall -y #{dep}"
@@ -144,7 +144,7 @@ build do
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
       
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      freeze_file = File.read("#{project_dir}/constraint_requirements.txt")
+      freeze_file = File.read("#{install_dir}/constraint_requirements.txt")
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
            pip "uninstall -y #{dep}"


### PR DESCRIPTION
### What does this PR do?

Uses pip-compile to generate the list of dependencies required by integrations core using the integration core agent_requirements.in file. 

### Motivation

Keep a static environment of dependencies and keep things up to date with the changes in integrations-core

### Additional Notes

Anything else we should know when reviewing?
