### PR TITLE
Add circle check that requires a label of `team/*` on the PR before

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,8 @@ jobs:
           name: run integration tests
           command: inv  -e integration-tests --race --remote-docker
 
-  # general linting for PR health
+  # general linting for PR health  These checks are so short there doesn't seem
+  # to be a point in spinning up separate images to run them
   pr_linting:
     <<: *job_template
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,17 +79,20 @@ jobs:
           command: inv  -e integration-tests --race --remote-docker
 
   # general linting for PR health  These checks are so short there doesn't seem
-  # to be a point in spinning up separate images to run them
-  pr_linting:
+  # to be a point in spinning up separate images to run them.  Leave it named
+  # `reno_linting`, as that's what the github job expects.
+  reno_linting:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
       - run:
-          name: run PR linting
           command: inv -e lint-releasenote
+          name: run PR check for release note
+      - run:
           command: inv -e lint-teamassignment
+          name: run PR check for team assignment
 
   filename_linting:
     <<: *job_template
@@ -149,7 +152,7 @@ workflows:
       - integration_tests:
           requires:
             - dependencies
-      - pr_linting:
+      - reno_linting:
           requires:
             - dependencies
       - filename_linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,15 +78,17 @@ jobs:
           name: run integration tests
           command: inv  -e integration-tests --race --remote-docker
 
-  reno_linting:
+  # general linting for PR health
+  pr_linting:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
       - run:
-          name: run reno linting
+          name: run PR linting
           command: inv -e lint-releasenote
+          command: inv -e lint-teamassignment
 
   filename_linting:
     <<: *job_template
@@ -146,7 +148,7 @@ workflows:
       - integration_tests:
           requires:
             - dependencies
-      - reno_linting:
+      - pr_linting:
           requires:
             - dependencies
       - filename_linting:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,7 +7,7 @@ from invoke import Collection
 from . import agent, android, benchmarks, docker, dogstatsd, pylauncher, cluster_agent, systray, release
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
-from .test import test, integration_tests, version, lint_releasenote, lint_filenames, e2e_tests
+from .test import test, integration_tests, version, lint_teamassignment, lint_releasenote, lint_filenames, e2e_tests
 from .build_tags import audit_tag_impact
 
 # the root namespace
@@ -25,6 +25,7 @@ ns.add_task(integration_tests)
 ns.add_task(deps)
 ns.add_task(reset)
 ns.add_task(version)
+ns.add_task(lint_teamassignment)
 ns.add_task(lint_releasenote)
 ns.add_task(lint_filenames)
 ns.add_task(audit_tag_impact)


### PR DESCRIPTION
accepting for merge.  This simplifies test assignment for releases,
since multiple teams check into this repo

### Motivation

trying to do a release

