### PR TITLE
[android] fixes to reflect how gomobile works

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -346,10 +346,19 @@ build_windows_msi_x64:
 agent_android_apk:
   allow_failure: true
   stage: package_build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/android_builder:v513248-e1d6f02
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/android_builder:v538460-2b07be3
   tags: [ "runner:main", "size:large" ]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+  before_script:
+    # We need to install go deps from within the GOPATH, which we set to / on builder images; that's because pointing
+    # GOPATH to the project folder would be too complex (we'd need to replicate the `src/github/project` scheme).
+    # So we copy the agent sources to / and bootstrap from there the vendor dependencies before running any job.
+    - echo running default before_script
+    - rsync -azr --delete ./ $SRC_PATH
+    - cd $SRC_PATH
+    - pip install -U pip
+    - inv -e deps --android
   script:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf $OMNIBUS_PACKAGE_DIR/*

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,7 +24,7 @@
     "processes",
     "processes/gops"
   ]
-  revision = "60e13eaed98afa238ad6dfc98224c04fbb7b19b1"
+  revision = "508b4f7bfc834501c944ab00e99b6f0e760f5ea7"
 
 [[projects]]
   branch = "master"
@@ -1299,6 +1299,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bffe02bae14e2474103ba260021e3457f3b58da1ffca85ea97ff2e023e93009e"
+  inputs-digest = "93591a49081406a09997ccc0a20a961d4c95330a07255af743b88e2a6e8067ea"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -6,7 +6,8 @@
             "github.com/fzipp/gocyclo",
             "github.com/gordonklaus/ineffassign",
             "github.com/client9/misspell/cmd/misspell",
-            "github.com/golang/dep/cmd/dep"
+            "github.com/golang/dep/cmd/dep",
+            "golang.org/x/mobile/cmd/gomobile"
         ],
         "mercurial": {
             "version": "4.6.2",
@@ -29,6 +30,10 @@
             "type": "go"
         },
         "github.com/client9/misspell/cmd/misspell": {
+            "version": "master",
+            "type": "go"
+        },
+        "golang.org/x/mobile/cmd/gomobile": {
             "version": "master",
             "type": "go"
         }

--- a/cmd/agent/android/main_android.go
+++ b/cmd/agent/android/main_android.go
@@ -10,6 +10,7 @@ package ddandroid
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 
 	ddapp "github.com/DataDog/datadog-agent/cmd/agent/app"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -52,19 +53,17 @@ func readAsset(name string) ([]byte, error) {
 }
 
 func AndroidMain() {
-	//readAsset("android.yaml")
+	readAsset("android.yaml")
 	// read the android-specific config in `assets`, which allows us
 	// to override config rather than using environment variables
 
-	/*
-		var ae androidEnv
-		ae.read()
-		if len(ae.Cfgpath) != 0 {
-			log.Printf("Setting config path to %s", ae.Cfgpath)
-			ddapp.SetCfgPath(ae.Cfgpath)
-		}
-	*/
-	ddapp.SetCfgPath("/data/datadog-agent")
+	var ae androidEnv
+	ae.read()
+	if len(ae.Cfgpath) != 0 {
+		log.Printf("Setting config path to %s", ae.Cfgpath)
+		ddapp.SetCfgPath(ae.Cfgpath)
+	}
+	//ddapp.SetCfgPath("/data/datadog-agent")
 	ddapp.StartAgent()
 }
 

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -104,8 +104,8 @@ def install(ctx, rebuild=False, race=False, build_include=None, build_exclude=No
     """
     if not skip_build:
         build(ctx, rebuild, race, build_include, build_exclude)
-        sign_apk(ctx)
 
+    sign_apk(ctx)
     cmd = "adb install -r bin/agent/ddagent-release-signed.apk"
     ctx.run(cmd)
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -219,6 +219,13 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
         print("Removing PSUTIL on Windows")
         ctx.run("rd /s/q vendor\\github.com\\shirou\\gopsutil")
 
+    # Make sure that golang.org/x/mobile is deleted.  It will get vendored in
+    # because we use it, and there's no way to exclude; however, we must use
+    # the version from $GOPATH
+    if os.path.exists('vendor/golang.org/x/mobile'):
+        print("Removing vendored golang.org/x/mobile")
+        shutil.rmtree('vendor/golang.org/x/mobile')
+
     if not no_checks:
         verbosity = 'v' if verbose else 'q'
         core_dir = core_dir or os.getenv('DD_CORE_DIR')

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -3,6 +3,7 @@ Golang related tasks go here
 """
 from __future__ import print_function
 import os
+import shutil
 import sys
 
 from invoke import task
@@ -200,6 +201,16 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
         tool = deps.get(dependency)
         process_deps(ctx, dependency, tool.get('version'), tool.get('type'), 'install', verbose=verbose)
 
+    if android:
+        ndkhome = os.environ.get('ANDROID_NDK_HOME')
+        if not ndkhome:
+            print("set ANDROID_NDK_HOME to build android")
+            raise Exit(code=1)
+
+        cmd = "gomobile init -ndk {}". format(ndkhome)
+        print("gomobile command {}". format(cmd))
+        ctx.run(cmd)
+
     # source level deps
     ctx.run("dep ensure{}".format(verbosity))
     # make sure PSUTIL is gone on windows; the dep ensure above will vendor it
@@ -207,7 +218,6 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
     if not android and sys.platform == 'win32':
         print("Removing PSUTIL on Windows")
         ctx.run("rd /s/q vendor\\github.com\\shirou\\gopsutil")
-
 
     if not no_checks:
         verbosity = 'v' if verbose else 'q'


### PR DESCRIPTION
Update gopkg.lock to the merged gohai
UPdate tasks to reflect that gomobile should be initialized during the
build

Update build image to matching datadog-agent-builders result

### What does this PR do?

changes build to only include `golang/x/mobile` from `$(GOROOT)` instead of vendoring it in

### Motivation

THere is an open issue with `gomobile` that you must have `gomobile` not vendored in; the same gomobile must be used to build the compiler exe as the target image

