### PR TITLE
[Logs]: Refactored sources to be dynamic

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -48,13 +48,12 @@ func NewAgent(sources *config.LogSources) *Agent {
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, connectionManager, messageChan)
 
 	// setup the inputs
-	validSources := sources.GetValidSources()
 	inputs := []restart.Restartable{
-		docker.NewScanner(validSources, pipelineProvider, auditor),
-		listener.New(validSources, pipelineProvider),
-		file.New(validSources, config.LogsAgent.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
-		journald.New(validSources, pipelineProvider, auditor),
-		windowsevent.New(validSources, pipelineProvider, auditor),
+		docker.NewScanner(sources, pipelineProvider, auditor),
+		listener.New(sources, pipelineProvider),
+		file.New(sources, config.LogsAgent.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
+		journald.New(sources, pipelineProvider, auditor),
+		windowsevent.New(sources, pipelineProvider, auditor),
 	}
 
 	return &Agent{

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -53,9 +53,10 @@ func buildLogSources(ddconfdPath string, collectAllLogsFromContainers bool, tcpF
 		sources = append(sources, tcpForwardSource)
 	}
 
-	logSources := &LogSources{sources}
+	logSources := NewLogSources(sources)
 	if len(logSources.GetValidSources()) == 0 {
 		return nil, fmt.Errorf("could not find any valid logs configuration")
 	}
+
 	return logSources, nil
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -25,30 +25,29 @@ func TestDefaultDatadogConfig(t *testing.T) {
 }
 
 func TestBuildLogsSources(t *testing.T) {
-	var ddconfdPath string
-	var logsSources *LogSources
+	var sources *LogSources
 	var source *LogSource
 	var err error
 
 	// should return an error
-	logsSources, err = buildLogSources(ddconfdPath, false, -1)
+	sources, err = buildLogSources("", false, -1)
 	assert.NotNil(t, err)
 
 	// should return the default tail all containers source
-	logsSources, err = buildLogSources(ddconfdPath, true, -1)
+	sources, err = buildLogSources("", true, -1)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(logsSources.GetValidSources()))
-	source = logsSources.GetValidSources()[0]
+	assert.Equal(t, 1, len(sources.GetValidSources()))
+	source = sources.GetValidSources()[0]
 	assert.Equal(t, "container_collect_all", source.Name)
 	assert.Equal(t, DockerType, source.Config.Type)
 	assert.Equal(t, "docker", source.Config.Service)
 	assert.Equal(t, "docker", source.Config.Source)
 
 	// should return the tcp forward source
-	logsSources, err = buildLogSources(ddconfdPath, false, 1234)
+	sources, err = buildLogSources("", false, 1234)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(logsSources.GetValidSources()))
-	source = logsSources.GetValidSources()[0]
+	assert.Equal(t, 1, len(sources.GetValidSources()))
+	source = sources.GetValidSources()[0]
 	assert.Equal(t, "tcp_forward", source.Name)
 	assert.Equal(t, TCPType, source.Config.Type)
 	assert.Equal(t, 1234, source.Config.Port)

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -23,8 +23,8 @@ func TestAvailableIntegrationConfigs(t *testing.T) {
 
 func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 	ddconfdPath := filepath.Join(testsPath, "complete", "conf.d")
-	allSources, err := buildLogSources(ddconfdPath, false, -1)
 
+	allSources, err := buildLogSources(ddconfdPath, false, -1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allSources.GetSources())-len(allSources.GetValidSources()))
 
@@ -122,6 +122,7 @@ func TestCompileProcessingRules(t *testing.T) {
 func TestBuildLogsAgentIntegrationConfigsWithMisconfiguredFile(t *testing.T) {
 	var ddconfdPath string
 	var err error
+
 	ddconfdPath = filepath.Join(testsPath, "misconfigured_1")
 	_, err = buildLogSources(ddconfdPath, false, -1)
 	assert.NotNil(t, err)

--- a/pkg/logs/config/sources_test.go
+++ b/pkg/logs/config/sources_test.go
@@ -9,32 +9,69 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type LogSourcesSuite struct {
-	suite.Suite
-	sources *LogSources
+func TestAddSource(t *testing.T) {
+	sources := NewEmptyLogSources()
+	assert.Equal(t, 0, len(sources.GetSources()))
+	sources.AddSource(NewLogSource("foo", nil))
+	assert.Equal(t, 1, len(sources.GetSources()))
+	sources.AddSource(NewLogSource("bar", nil))
+	assert.Equal(t, 2, len(sources.GetSources()))
 }
 
-func (s *LogSourcesSuite) TestGetSources() {
-	s.sources = newLogSources([]*LogSource{})
-	s.Equal(0, len(s.sources.GetSources()))
-	s.sources = newLogSources([]*LogSource{NewLogSource("", nil)})
-	s.Equal(1, len(s.sources.GetSources()))
+func TestRemoveSource(t *testing.T) {
+	source1 := NewLogSource("foo", nil)
+	source2 := NewLogSource("bar", nil)
+	sources := NewLogSources([]*LogSource{source1, source2})
+	assert.Equal(t, 2, len(sources.GetSources()))
+	sources.RemoveSource(source1)
+	assert.Equal(t, 1, len(sources.GetSources()))
+	assert.Equal(t, source2, sources.GetSources()[0])
+	sources.RemoveSource(source2)
+	assert.Equal(t, 0, len(sources.GetSources()))
 }
 
-func (s *LogSourcesSuite) TestGetValidSources() {
-	source1 := NewLogSource("", nil)
-	source2 := NewLogSource("", nil)
-	s.sources = newLogSources([]*LogSource{source1, source2})
-	s.Equal(2, len(s.sources.GetValidSources()))
+func TestGetSources(t *testing.T) {
+	sources := NewEmptyLogSources()
+	assert.Equal(t, 0, len(sources.GetSources()))
+	sources.AddSource(NewLogSource("", nil))
+	assert.Equal(t, 1, len(sources.GetSources()))
+}
+
+func TestGetValidSources(t *testing.T) {
+	source1 := NewLogSource("foo", nil)
+	source2 := NewLogSource("bar", nil)
+	sources := NewLogSources([]*LogSource{source1, source2})
+	assert.Equal(t, 2, len(sources.GetValidSources()))
 	source1.Status.Error(errors.New("invalid"))
-	s.Equal(1, len(s.sources.GetValidSources()))
+	assert.Equal(t, 1, len(sources.GetValidSources()))
 	source1.Status.Success()
-	s.Equal(2, len(s.sources.GetValidSources()))
+	assert.Equal(t, 2, len(sources.GetValidSources()))
 }
 
-func TestLogSourcesSuite(t *testing.T) {
-	suite.Run(t, new(LogSourcesSuite))
+func TestGetSourcesWithType(t *testing.T) {
+	source1 := NewLogSource("foo", nil)
+	source2 := NewLogSource("bar", &LogsConfig{})
+	source3 := NewLogSource("baz", &LogsConfig{Type: "foo"})
+	source4 := NewLogSource("qux", &LogsConfig{Type: "foo"})
+	source4.Status.Error(errors.New("test"))
+	sources := NewLogSources([]*LogSource{source1, source2, source3, source4})
+	assert.Equal(t, 2, len(sources.GetSourcesWithType("foo")))
+}
+
+func TestGetValidSourcesWithType(t *testing.T) {
+	source1 := NewLogSource("foo", nil)
+	source2 := NewLogSource("bar", &LogsConfig{})
+	source3 := NewLogSource("baz", &LogsConfig{Type: "foo"})
+	source4 := NewLogSource("qux", &LogsConfig{Type: "foo"})
+	source4.Status.Error(errors.New("test"))
+	sources := NewLogSources([]*LogSource{source1, source2, source3, source4})
+	assert.Equal(t, 1, len(sources.GetValidSourcesWithType("foo")))
+}
+
+// NewEmptyLogSources creates a new log sources with no initial entries.
+func NewEmptyLogSources() *LogSources {
+	return NewLogSources(make([]*LogSource, 0))
 }

--- a/pkg/logs/input/docker/scanner_nodocker.go
+++ b/pkg/logs/input/docker/scanner_nodocker.go
@@ -17,7 +17,7 @@ import (
 type Scanner struct{}
 
 // NewScanner returns a new Scanner
-func NewScanner(sources []*config.LogSource, pp pipeline.Provider, auditor *auditor.Auditor) *Scanner {
+func NewScanner(sources *config.LogSources, pp pipeline.Provider, auditor *auditor.Auditor) *Scanner {
 	return &Scanner{}
 }
 

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -32,13 +32,13 @@ func NewFile(path string, source *config.LogSource) *File {
 
 // Provider implements the logic to retrieve at most filesLimit Files defined in sources
 type Provider struct {
-	sources         []*config.LogSource
+	sources         *config.LogSources
 	filesLimit      int
 	shouldLogErrors bool
 }
 
 // NewProvider returns a new Provider
-func NewProvider(sources []*config.LogSource, filesLimit int) *Provider {
+func NewProvider(sources *config.LogSources, filesLimit int) *Provider {
 	return &Provider{
 		sources:         sources,
 		filesLimit:      filesLimit,
@@ -51,12 +51,13 @@ func NewProvider(sources []*config.LogSource, filesLimit int) *Provider {
 // For now, there is no way to prioritize specific Files over others,
 // they are just returned in alphabetical order
 func (p *Provider) FilesToTail() []*File {
-	filesToTail := []*File{}
+	var filesToTail []*File
 	shouldLogErrors := p.shouldLogErrors
 	p.shouldLogErrors = false // Let's log errors on first run only
 
-	for i := 0; i < len(p.sources) && len(filesToTail) < p.filesLimit; i++ {
-		source := p.sources[i]
+	sources := p.sources.GetSourcesWithType(config.FileType)
+	for i := 0; i < len(sources) && len(filesToTail) < p.filesLimit; i++ {
+		source := sources[i]
 		sourcePath := source.Config.Path
 		if p.exists(sourcePath) {
 			// no need to traverse the file system here as we found a file
@@ -67,7 +68,7 @@ func (p *Provider) FilesToTail() []*File {
 		pattern := sourcePath
 		paths, err := filepath.Glob(pattern)
 		if err != nil {
-			err := fmt.Errorf("Malformed pattern, could not find any file: %s", pattern)
+			err := fmt.Errorf("malformed pattern, could not find any file: %s", pattern)
 			source.Status.Error(err)
 			if shouldLogErrors {
 				log.Error(err)
@@ -77,13 +78,13 @@ func (p *Provider) FilesToTail() []*File {
 		if len(paths) == 0 {
 			// no file was found, its parent directories might have wrong permissions or it just does not exist
 			if p.containsWildcard(pattern) {
-				err := fmt.Errorf("Could not find any file matching pattern %s, check that all its subdirectories are exectutable", pattern)
+				err := fmt.Errorf("could not find any file matching pattern %s, check that all its subdirectories are exectutable", pattern)
 				source.Status.Error(err)
 				if shouldLogErrors {
 					log.Error(err)
 				}
 			} else {
-				err := fmt.Errorf("File %s does not exist", sourcePath)
+				err := fmt.Errorf("file %s does not exist", sourcePath)
 				source.Status.Error(err)
 				if shouldLogErrors {
 					log.Error(err)

--- a/pkg/logs/input/file/file_provider_test.go
+++ b/pkg/logs/input/file/file_provider_test.go
@@ -26,7 +26,7 @@ type ProviderTestSuite struct {
 
 // newProvider returns a new Provider initialized with the right configuration
 func (suite *ProviderTestSuite) newProvider(path string) *Provider {
-	sources := []*config.LogSource{config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})}
+	sources := config.NewLogSources([]*config.LogSource{config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})})
 	return NewProvider(sources, suite.filesLimit)
 }
 

--- a/pkg/logs/input/file/scanner_test.go
+++ b/pkg/logs/input/file/scanner_test.go
@@ -32,16 +32,16 @@ type ScannerTestSuite struct {
 	testRotatedPath string
 	testRotatedFile *os.File
 
-	outputChan     chan message.Message
-	pp             pipeline.Provider
-	sources        []*config.LogSource
-	openFilesLimit int
-	s              *Scanner
+	outputChan       chan message.Message
+	pipelineProvider pipeline.Provider
+	sources          []*config.LogSource
+	openFilesLimit   int
+	s                *Scanner
 }
 
 func (suite *ScannerTestSuite) SetupTest() {
-	suite.pp = mock.NewMockProvider()
-	suite.outputChan = suite.pp.NextPipelineChan()
+	suite.pipelineProvider = mock.NewMockProvider()
+	suite.outputChan = suite.pipelineProvider.NextPipelineChan()
 
 	var err error
 	suite.testDir, err = ioutil.TempDir("", "log-scanner-test-")
@@ -60,7 +60,7 @@ func (suite *ScannerTestSuite) SetupTest() {
 	suite.openFilesLimit = 100
 	suite.sources = []*config.LogSource{config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: suite.testPath})}
 	sleepDuration := 20 * time.Millisecond
-	suite.s = New(suite.sources, suite.openFilesLimit, suite.pp, auditor.New(nil, ""), sleepDuration)
+	suite.s = New(config.NewLogSources(suite.sources), suite.openFilesLimit, suite.pipelineProvider, auditor.New(nil, ""), sleepDuration)
 	suite.s.setup()
 }
 
@@ -209,7 +209,7 @@ func TestScannerScanStartNewTailer(t *testing.T) {
 	sources := []*config.LogSource{config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})}
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
-	scanner := New(sources, openFilesLimit, mock.NewMockProvider(), auditor.New(nil, ""), sleepDuration)
+	scanner := New(config.NewLogSources(sources), openFilesLimit, mock.NewMockProvider(), auditor.New(nil, ""), sleepDuration)
 
 	// setup scanner
 	scanner.setup()
@@ -261,7 +261,7 @@ func TestScannerScanWithTooManyFiles(t *testing.T) {
 	sources := []*config.LogSource{config.NewLogSource("", &config.LogsConfig{Type: config.FileType, Path: path})}
 	openFilesLimit := 2
 	sleepDuration := 20 * time.Millisecond
-	scanner := New(sources, openFilesLimit, mock.NewMockProvider(), auditor.New(nil, ""), sleepDuration)
+	scanner := New(config.NewLogSources(sources), openFilesLimit, mock.NewMockProvider(), auditor.New(nil, ""), sleepDuration)
 
 	// test at setup
 	scanner.setup()

--- a/pkg/logs/input/journald/launcher.go
+++ b/pkg/logs/input/journald/launcher.go
@@ -15,22 +15,16 @@ import (
 
 // Launcher is in charge of starting and stopping new journald tailers
 type Launcher struct {
-	sources          []*config.LogSource
+	sources          *config.LogSources
 	pipelineProvider pipeline.Provider
 	auditor          *auditor.Auditor
 	tailers          map[string]*Tailer
 }
 
 // New returns a new Launcher.
-func New(sources []*config.LogSource, pipelineProvider pipeline.Provider, auditor *auditor.Auditor) *Launcher {
-	journaldSources := []*config.LogSource{}
-	for _, source := range sources {
-		if source.Config.Type == config.JournaldType {
-			journaldSources = append(journaldSources, source)
-		}
-	}
+func New(sources *config.LogSources, pipelineProvider pipeline.Provider, auditor *auditor.Auditor) *Launcher {
 	return &Launcher{
-		sources:          journaldSources,
+		sources:          sources,
 		pipelineProvider: pipelineProvider,
 		auditor:          auditor,
 		tailers:          make(map[string]*Tailer),
@@ -39,7 +33,7 @@ func New(sources []*config.LogSource, pipelineProvider pipeline.Provider, audito
 
 // Start starts new tailers.
 func (l *Launcher) Start() {
-	for _, source := range l.sources {
+	for _, source := range l.sources.GetValidSourcesWithType(config.JournaldType) {
 		identifier := source.Config.Path
 		if _, exists := l.tailers[identifier]; exists {
 			// set up only one tailer per journal

--- a/pkg/logs/input/journald/launcher_test.go
+++ b/pkg/logs/input/journald/launcher_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 func TestShouldStartOnlyOneTailerPerJournal(t *testing.T) {
-	sources := []*config.LogSource{
+	sources := config.NewLogSources([]*config.LogSource{
 		config.NewLogSource("", &config.LogsConfig{Type: config.JournaldType}),
 		config.NewLogSource("", &config.LogsConfig{Type: config.JournaldType}),
-	}
+	})
 	launcher := New(sources, pipeline.NewMockProvider(), auditor.New(nil, ""))
 
 	// expect two new tailers

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -23,23 +23,23 @@ const defaultTimeout = time.Minute
 
 // A TCPListener listens and accepts TCP connections and delegates the read operations to a tailer.
 type TCPListener struct {
-	pp        pipeline.Provider
-	source    *config.LogSource
-	frameSize int
-	listener  net.Listener
-	tailers   []*Tailer
-	mu        sync.Mutex
-	stop      chan struct{}
+	pipelineProvider pipeline.Provider
+	source           *config.LogSource
+	frameSize        int
+	listener         net.Listener
+	tailers          []*Tailer
+	mu               sync.Mutex
+	stop             chan struct{}
 }
 
 // NewTCPListener returns an initialized TCPListener
-func NewTCPListener(pp pipeline.Provider, source *config.LogSource, frameSize int) *TCPListener {
+func NewTCPListener(pipelineProvider pipeline.Provider, source *config.LogSource, frameSize int) *TCPListener {
 	return &TCPListener{
-		pp:        pp,
-		source:    source,
-		frameSize: frameSize,
-		tailers:   []*Tailer{},
-		stop:      make(chan struct{}, 1),
+		pipelineProvider: pipelineProvider,
+		source:           source,
+		frameSize:        frameSize,
+		tailers:          []*Tailer{},
+		stop:             make(chan struct{}, 1),
 	}
 }
 
@@ -128,7 +128,7 @@ func (l *TCPListener) read(tailer *Tailer) ([]byte, error) {
 func (l *TCPListener) startNewTailer(conn net.Conn) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	tailer := NewTailer(l.source, conn, l.pp.NextPipelineChan(), l.read)
+	tailer := NewTailer(l.source, conn, l.pipelineProvider.NextPipelineChan(), l.read)
 	l.tailers = append(l.tailers, tailer)
 	tailer.Start()
 }

--- a/pkg/logs/input/listener/udp.go
+++ b/pkg/logs/input/listener/udp.go
@@ -28,18 +28,18 @@ import (
 
 // A UDPListener opens a new UDP connection, keeps it alive and delegates the read operations to a tailer.
 type UDPListener struct {
-	pp        pipeline.Provider
-	source    *config.LogSource
-	frameSize int
-	tailer    *Tailer
+	pipelineProvider pipeline.Provider
+	source           *config.LogSource
+	frameSize        int
+	tailer           *Tailer
 }
 
 // NewUDPListener returns an initialized UDPListener
-func NewUDPListener(pp pipeline.Provider, source *config.LogSource, frameSize int) *UDPListener {
+func NewUDPListener(pipelineProvider pipeline.Provider, source *config.LogSource, frameSize int) *UDPListener {
 	return &UDPListener{
-		pp:        pp,
-		source:    source,
-		frameSize: frameSize,
+		pipelineProvider: pipelineProvider,
+		source:           source,
+		frameSize:        frameSize,
 	}
 }
 
@@ -67,7 +67,7 @@ func (l *UDPListener) startNewTailer() error {
 	if err != nil {
 		return err
 	}
-	l.tailer = NewTailer(l.source, conn, l.pp.NextPipelineChan(), l.read)
+	l.tailer = NewTailer(l.source, conn, l.pipelineProvider.NextPipelineChan(), l.read)
 	l.tailer.Start()
 	return nil
 }

--- a/pkg/logs/input/windowsevent/launcher.go
+++ b/pkg/logs/input/windowsevent/launcher.go
@@ -16,22 +16,16 @@ import (
 
 // Launcher is in charge of starting and stopping windows event logs tailers
 type Launcher struct {
-	sources          []*config.LogSource
+	sources          *config.LogSources
 	pipelineProvider pipeline.Provider
 	auditor          *auditor.Auditor
 	tailers          map[string]*Tailer
 }
 
 // New returns a new Launcher.
-func New(sources []*config.LogSource, pipelineProvider pipeline.Provider, auditor *auditor.Auditor) *Launcher {
-	windowsEventSources := []*config.LogSource{}
-	for _, source := range sources {
-		if source.Config.Type == config.WindowsEventType {
-			windowsEventSources = append(windowsEventSources, source)
-		}
-	}
+func New(sources *config.LogSources, pipelineProvider pipeline.Provider, auditor *auditor.Auditor) *Launcher {
 	return &Launcher{
-		sources:          windowsEventSources,
+		sources:          sources,
 		pipelineProvider: pipelineProvider,
 		auditor:          auditor,
 		tailers:          make(map[string]*Tailer),
@@ -47,7 +41,7 @@ func (l *Launcher) Start() {
 		log.Debug("Found available windows event log channels: ", availableChannels)
 	}
 
-	for _, source := range l.sources {
+	for _, source := range l.sources.GetValidSourcesWithType(config.WindowsEventType) {
 		identifier := Identifier(source.Config.ChannelPath, source.Config.Query)
 		if _, exists := l.tailers[identifier]; exists {
 			// tailer already setup

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -33,7 +33,7 @@ func Start() error {
 	agent.Start()
 
 	// setup the status
-	status.Initialize(sources.GetSources())
+	status.Initialize(sources)
 
 	isRunning = true
 

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -37,11 +37,11 @@ type Status struct {
 
 // Builder is used to build the status.
 type Builder struct {
-	sources []*config.LogSource
+	sources *config.LogSources
 }
 
 // Initialize instantiates a builder that holds the sources required to build the current status later on.
-func Initialize(sources []*config.LogSource) {
+func Initialize(sources *config.LogSources) {
 	builder = &Builder{
 		sources: sources,
 	}
@@ -51,7 +51,7 @@ func Initialize(sources []*config.LogSource) {
 func Get() Status {
 	// Sort sources by name (ie. by integration name ~= file name)
 	sources := make(map[string][]*config.LogSource)
-	for _, source := range builder.sources {
+	for _, source := range builder.sources.GetSources() {
 		if _, exists := sources[source.Name]; !exists {
 			sources[source.Name] = []*config.LogSource{}
 		}

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestSourceAreGroupedByIntegrations(t *testing.T) {
-	sources := []*config.LogSource{
+	sources := config.NewLogSources([]*config.LogSource{
 		config.NewLogSource("foo", &config.LogsConfig{}),
 		config.NewLogSource("bar", &config.LogsConfig{}),
 		config.NewLogSource("foo", &config.LogsConfig{}),
-	}
+	})
 	Initialize(sources)
 	status := Get()
 	assert.Equal(t, true, status.IsRunning)


### PR DESCRIPTION
### What does this PR do?

Refactored sources to be added and removed dynamically. Moved away this refactoring from https://github.com/DataDog/datadog-agent/pull/1956.

### Motivation

Split Kubernetes integration into smaller PRs.

### Additional Notes

This refactoring will ease the plug to autodiscovery.
