### PR TITLE
[proxy] Add support of `DD_` prefixed env vars

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -29,14 +29,12 @@ The agent is highly customizable, here are the most used environment variables:
 
 #### Proxies
 
-The agent proxy settings can be overridden with the standard `*_PROXY`
+Starting with Agent v6.4.0, the agent proxy settings can be overridden with the following
 environment variables:
 
-- `HTTP_PROXY`: an http URL to use as a proxy for `http` requests.
-- `HTTPS_PROXY`: an http URL to use as a proxy for `https` requests.
-- `NO_PROXY`: a comma-separated list of URLs for which no proxy should be used.
-
-Notice: these variables don't use the `DD_` prefix.
+- `DD_PROXY_HTTP`: an http URL to use as a proxy for `http` requests.
+- `DD_PROXY_HTTPS`: an http URL to use as a proxy for `https` requests.
+- `DD_PROXY_NO_PROXY`: a space-separated list of URLs for which no proxy should be used.
 
 For more information: https://docs.datadoghq.com/agent/proxy/#agent-v6
 

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -36,6 +36,10 @@ environment variables:
 - `DD_PROXY_HTTPS`: an http URL to use as a proxy for `https` requests.
 - `DD_PROXY_NO_PROXY`: a space-separated list of URLs for which no proxy should be used.
 
+Note: At the moment, the trace-agent only supports setting a proxy in `datadog.yaml`, and does not
+support these proxy environment variables. If you wish to set a proxy for trace-agent, please refer
+to the [section on mounting a custom datadog.yaml](#others).
+
 For more information: https://docs.datadoghq.com/agent/proxy/#agent-v6
 
 #### Optional collection agents

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -101,7 +101,8 @@ environment variables:
 
 The standard environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are
 supported in both the Agent 5 and the Agent 6. However, with the Agent 6, using the new
-`DD_PROXY_*` environment variables listed above is recommended.
+`DD_PROXY_*` environment variables listed above is recommended, and they have precedence over
+the standard environment variables.
 
 **The precedence order of the Agent 6 proxy options is different from Agent 5**:
 

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -92,25 +92,27 @@ To not miss some specific configuration details, if you are currently using envi
 
 #### Proxies
 
-The agent proxy settings can be overridden with the standard `*_PROXY`
+Starting with v6.4.0, the agent proxy settings can be overridden with the following
 environment variables:
 
-- `HTTP_PROXY`: an http URL to use as a proxy for `http` requests.
-- `HTTPS_PROXY`: an http URL to use as a proxy for `https` requests.
-- `NO_PROXY`: a comma-separated list of URLs for which no proxy should be used.
+- `DD_PROXY_HTTP`: an http URL to use as a proxy for `http` requests.
+- `DD_PROXY_HTTPS`: an http URL to use as a proxy for `https` requests.
+- `DD_PROXY_NO_PROXY`: a space-separated list of URLs for which no proxy should be used.
 
-Notice: these variables don't use the `DD_` prefix.
+The standard environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are
+supported in both the Agent 5 and the Agent 6. However, with the Agent 6, using the new
+`DD_PROXY_*` environment variables listed above is recommended.
 
-**The behaviour of the Agent 6 is different from Agent 5**:
+**The precedence order of the Agent 6 proxy options is different from Agent 5**:
 
-The Agent 6 will first use the environment variables and the configuration file
+The Agent 6 will first use the environment variables and then the configuration file
 (as for every other setting available through environment variables). This is
 the opposite of Agent 5, which would always use the proxy from the configuration
 file if set.
 
 For proxies, the Agent 6 will override the values from the configuration file
-with the ones in the environment. This means that if both a `HTTP` and `HTTPS`
-proxy are set in the configuration file but only the `HTTPS_PROXY` is set in
+with the ones in the environment. This means that if both `proxy.http` and `proxy.https`
+are set in the configuration file but only `DD_PROXY_HTTPS` is set in
 the environment, the agent will use the `HTTPS` value from the environment and
 the `HTTP` value from the configuration file.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -369,6 +369,16 @@ func loadProxyFromEnv() {
 		return os.Getenv(strings.ToLower(key))
 	}
 
+	// getEnvDDPrecedence pulls the value of the `DD_`-prefixed env var first, and
+	// if not found or empty, the value of the env var without the prefix (case-insensitive)
+	getEnvDDPrecedence := func(key string) string {
+		value := os.Getenv("DD_" + key)
+		if value == "" {
+			value = getEnvCaseInsensitive(key)
+		}
+		return value
+	}
+
 	var isSet bool
 	p := &Proxy{}
 	if isSet = Datadog.IsSet("proxy"); isSet {
@@ -378,15 +388,15 @@ func loadProxyFromEnv() {
 		}
 	}
 
-	if HTTP := getEnvCaseInsensitive("HTTP_PROXY"); HTTP != "" {
+	if HTTP := getEnvDDPrecedence("HTTP_PROXY"); HTTP != "" {
 		isSet = true
 		p.HTTP = HTTP
 	}
-	if HTTPS := getEnvCaseInsensitive("HTTPS_PROXY"); HTTPS != "" {
+	if HTTPS := getEnvDDPrecedence("HTTPS_PROXY"); HTTPS != "" {
 		isSet = true
 		p.HTTPS = HTTPS
 	}
-	if noProxy := getEnvCaseInsensitive("NO_PROXY"); noProxy != "" {
+	if noProxy := getEnvDDPrecedence("NO_PROXY"); noProxy != "" {
 		isSet = true
 		p.NoProxy = strings.Split(noProxy, ",")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -367,6 +367,7 @@ func loadProxyFromEnv() {
 			value, found = os.LookupEnv(strings.ToLower(key))
 		}
 		if found {
+			// FIXME: this doesn't log anything because the logger isn't initialized yet
 			log.Infof("Found '%v' env var, using it for the Agent proxy settings", key)
 		}
 		return value, found
@@ -375,6 +376,7 @@ func loadProxyFromEnv() {
 	lookupEnv := func(key string) (string, bool) {
 		value, found := os.LookupEnv(key)
 		if found {
+			// FIXME: this doesn't log anything because the logger isn't initialized yet
 			log.Infof("Found '%v' env var, using it for the Agent proxy settings", key)
 		}
 		return value, found
@@ -385,6 +387,7 @@ func loadProxyFromEnv() {
 	if isSet = Datadog.IsSet("proxy"); isSet {
 		if err := Datadog.UnmarshalKey("proxy", p); err != nil {
 			isSet = false
+			// FIXME: this doesn't log anything because the logger isn't initialized yet
 			log.Errorf("Could not load proxy setting from the configuration (ignoring): %s", err)
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -369,12 +369,12 @@ func loadProxyFromEnv() {
 		return os.Getenv(strings.ToLower(key))
 	}
 
-	// getEnvDDPrecedence pulls the value of the `DD_`-prefixed env var first, and
-	// if not found or empty, the value of the env var without the prefix (case-insensitive)
-	getEnvDDPrecedence := func(key string) string {
-		value := os.Getenv("DD_" + key)
+	// getEnvDDPrecedence pulls the value of the DD-specific proxy env var first (case-sensitive), and
+	// if not found or empty, the value of the standard env var (case-insensitive)
+	getEnvDDPrecedence := func(DDkey, standardKey string) string {
+		value := os.Getenv(DDkey)
 		if value == "" {
-			value = getEnvCaseInsensitive(key)
+			value = getEnvCaseInsensitive(standardKey)
 		}
 		return value
 	}
@@ -388,15 +388,15 @@ func loadProxyFromEnv() {
 		}
 	}
 
-	if HTTP := getEnvDDPrecedence("HTTP_PROXY"); HTTP != "" {
+	if HTTP := getEnvDDPrecedence("DD_PROXY_HTTP", "HTTP_PROXY"); HTTP != "" {
 		isSet = true
 		p.HTTP = HTTP
 	}
-	if HTTPS := getEnvDDPrecedence("HTTPS_PROXY"); HTTPS != "" {
+	if HTTPS := getEnvDDPrecedence("DD_PROXY_HTTPS", "HTTPS_PROXY"); HTTPS != "" {
 		isSet = true
 		p.HTTPS = HTTPS
 	}
-	if noProxy := getEnvDDPrecedence("NO_PROXY"); noProxy != "" {
+	if noProxy := getEnvDDPrecedence("DD_PROXY_NO_PROXY", "NO_PROXY"); noProxy != "" {
 		isSet = true
 		p.NoProxy = strings.Split(noProxy, ",")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,23 +363,19 @@ func loadProxyFromEnv() {
 
 	lookupEnvCaseInsensitive := func(key string) (string, bool) {
 		value, found := os.LookupEnv(key)
-		if found {
-			return value, found
+		if !found {
+			value, found = os.LookupEnv(strings.ToLower(key))
 		}
-		return os.LookupEnv(strings.ToLower(key))
+		if found {
+			log.Infof("Found '%v' env var, using it for the Agent proxy settings", key)
+		}
+		return value, found
 	}
 
-	// lookupEnvDDPrecedence pulls the value of the DD-specific proxy env var first (case-sensitive), and
-	// if not found, the value of the standard env var (case-insensitive)
-	lookupEnvDDPrecedence := func(DDkey, standardKey string) (string, bool) {
-		value, found := os.LookupEnv(DDkey)
-		if !found {
-			value, found = lookupEnvCaseInsensitive(standardKey)
-			if found {
-				log.Infof("Found '%v' env var, using it for the Agent proxy settings", standardKey)
-			}
-		} else {
-			log.Infof("Found '%v' env var, using it for the Agent proxy settings", DDkey)
+	lookupEnv := func(key string) (string, bool) {
+		value, found := os.LookupEnv(key)
+		if found {
+			log.Infof("Found '%v' env var, using it for the Agent proxy settings", key)
 		}
 		return value, found
 	}
@@ -393,17 +389,28 @@ func loadProxyFromEnv() {
 		}
 	}
 
-	if HTTP, found := lookupEnvDDPrecedence("DD_PROXY_HTTP", "HTTP_PROXY"); found {
+	if HTTP, found := lookupEnv("DD_PROXY_HTTP"); found {
+		isSet = true
+		p.HTTP = HTTP
+	} else if HTTP, found := lookupEnvCaseInsensitive("HTTP_PROXY"); found {
 		isSet = true
 		p.HTTP = HTTP
 	}
-	if HTTPS, found := lookupEnvDDPrecedence("DD_PROXY_HTTPS", "HTTPS_PROXY"); found {
+
+	if HTTPS, found := lookupEnv("DD_PROXY_HTTPS"); found {
+		isSet = true
+		p.HTTPS = HTTPS
+	} else if HTTPS, found := lookupEnvCaseInsensitive("HTTPS_PROXY"); found {
 		isSet = true
 		p.HTTPS = HTTPS
 	}
-	if noProxy, found := lookupEnvDDPrecedence("DD_PROXY_NO_PROXY", "NO_PROXY"); found {
+
+	if noProxy, found := lookupEnv("DD_PROXY_NO_PROXY"); found {
 		isSet = true
-		p.NoProxy = strings.Split(noProxy, ",")
+		p.NoProxy = strings.Split(noProxy, " ") // space-separated list, consistent with viper
+	} else if noProxy, found := lookupEnvCaseInsensitive("NO_PROXY"); found {
+		isSet = true
+		p.NoProxy = strings.Split(noProxy, ",") // comma-separated list, consistent with other tools that use the NO_PROXY env var
 	}
 
 	// We have to set each value individually so both Datadog.Get("proxy")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -11,8 +11,8 @@ api_key:
 # disabled). You can use the 'no_proxy' list to specify hosts that should
 # bypass the proxy. These settings might impact your checks requests, please
 # refer to the specific check documentation for more details. Environment
-# variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (coma-separated string) will
-# override the values set here. See https://docs.datadoghq.com/agent/proxy/.
+# variables DD_PROXY_HTTP, DD_PROXY_HTTPS and DD_PROXY_NO_PROXY (space-separated string)
+# will override the values set here. See https://docs.datadoghq.com/agent/proxy/.
 #
 # proxy:
 #   http: http://user:password@proxy_for_http:port

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -317,3 +317,30 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 			NoProxy: []string{"d", "e", "f"}},
 		proxies)
 }
+
+func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
+	os.Setenv("DD_PROXY_HTTP", "")
+	os.Setenv("DD_PROXY_NO_PROXY", "a,b,c")
+	os.Setenv("HTTP_PROXY", "env_http_url")
+	os.Setenv("HTTPS_PROXY", "")
+	os.Setenv("NO_PROXY", "")
+	Datadog.Set("proxy.https", "https_conf")
+
+	loadProxyFromEnv()
+
+	proxies := GetProxies()
+	assert.Equal(t,
+		&Proxy{
+			HTTP:    "",
+			HTTPS:   "",
+			NoProxy: []string{"a", "b", "c"}},
+		proxies)
+
+	os.Unsetenv("NO_PROXY")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
+	Datadog.Set("proxy", nil)
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -199,7 +199,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	// uppercase
 	os.Setenv("HTTP_PROXY", "http_url")
 	os.Setenv("HTTPS_PROXY", "https_url")
-	os.Setenv("NO_PROXY", "a,b,c")
+	os.Setenv("NO_PROXY", "a,b,c") // comma-separated list
 
 	loadProxyFromEnv()
 
@@ -219,7 +219,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	// lowercase
 	os.Setenv("http_proxy", "http_url2")
 	os.Setenv("https_proxy", "https_url2")
-	os.Setenv("no_proxy", "1,2,3")
+	os.Setenv("no_proxy", "1,2,3") // comma-separated list
 
 	loadProxyFromEnv()
 	proxies = GetProxies()
@@ -239,7 +239,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "http_url")
 	os.Setenv("DD_PROXY_HTTPS", "https_url")
-	os.Setenv("DD_PROXY_NO_PROXY", "a b c")
+	os.Setenv("DD_PROXY_NO_PROXY", "a b c") // space-separated list
 
 	loadProxyFromEnv()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -166,7 +166,7 @@ func TestEnvNestedConfig(t *testing.T) {
 	os.Unsetenv("DD_FOO_BAR_NESTED")
 }
 
-func TestLoadProxyFromEnvNoValue(t *testing.T) {
+func TestLoadProxyFromStdEnvNoValue(t *testing.T) {
 	// circleCI set some proxy setting
 	ciValue := os.Getenv("NO_PROXY")
 	os.Unsetenv("NO_PROXY")
@@ -195,7 +195,7 @@ func TestLoadProxyConfOnly(t *testing.T) {
 	assert.Equal(t, p, proxies)
 }
 
-func TestLoadProxyEnvOnly(t *testing.T) {
+func TestLoadProxyStdEnvOnly(t *testing.T) {
 	// uppercase
 	os.Setenv("HTTP_PROXY", "http_url")
 	os.Setenv("HTTPS_PROXY", "https_url")
@@ -236,10 +236,10 @@ func TestLoadProxyEnvOnly(t *testing.T) {
 	Datadog.Set("proxy", nil)
 }
 
-func TestLoadProxyDDPrefixedEnvOnly(t *testing.T) {
-	os.Setenv("DD_HTTP_PROXY", "http_url")
-	os.Setenv("DD_HTTPS_PROXY", "https_url")
-	os.Setenv("DD_NO_PROXY", "a,b,c")
+func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
+	os.Setenv("DD_PROXY_HTTP", "http_url")
+	os.Setenv("DD_PROXY_HTTPS", "https_url")
+	os.Setenv("DD_PROXY_NO_PROXY", "a,b,c")
 
 	loadProxyFromEnv()
 
@@ -251,16 +251,16 @@ func TestLoadProxyDDPrefixedEnvOnly(t *testing.T) {
 			NoProxy: []string{"a", "b", "c"}},
 		proxies)
 
-	os.Unsetenv("DD_HTTP_PROXY")
-	os.Unsetenv("DD_HTTPS_PROXY")
-	os.Unsetenv("DD_NO_PROXY")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
 	Datadog.Set("proxy", nil)
 }
 
-func TestLoadProxyDDPrefixedEnvPrecedenceOverEnv(t *testing.T) {
-	os.Setenv("DD_HTTP_PROXY", "dd_http_url")
-	os.Setenv("DD_HTTPS_PROXY", "dd_https_url")
-	os.Setenv("DD_NO_PROXY", "a,b,c")
+func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
+	os.Setenv("DD_PROXY_HTTP", "dd_http_url")
+	os.Setenv("DD_PROXY_HTTPS", "dd_https_url")
+	os.Setenv("DD_PROXY_NO_PROXY", "a,b,c")
 	os.Setenv("HTTP_PROXY", "env_http_url")
 	os.Setenv("HTTPS_PROXY", "env_https_url")
 	os.Setenv("NO_PROXY", "d,e,f")
@@ -278,13 +278,13 @@ func TestLoadProxyDDPrefixedEnvPrecedenceOverEnv(t *testing.T) {
 	os.Unsetenv("NO_PROXY")
 	os.Unsetenv("HTTPS_PROXY")
 	os.Unsetenv("HTTP_PROXY")
-	os.Unsetenv("DD_HTTP_PROXY")
-	os.Unsetenv("DD_HTTPS_PROXY")
-	os.Unsetenv("DD_NO_PROXY")
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+	os.Unsetenv("DD_PROXY_NO_PROXY")
 	Datadog.Set("proxy", nil)
 }
 
-func TestLoadProxyEnvAndConf(t *testing.T) {
+func TestLoadProxyStdEnvAndConf(t *testing.T) {
 	os.Setenv("HTTP_PROXY", "http_env")
 	Datadog.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	Datadog.Set("proxy.http", "http_conf")
@@ -301,11 +301,11 @@ func TestLoadProxyEnvAndConf(t *testing.T) {
 		proxies)
 }
 
-func TestLoadProxyDDPrefixedEnvAndConf(t *testing.T) {
-	os.Setenv("DD_HTTP_PROXY", "http_env")
+func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
+	os.Setenv("DD_PROXY_HTTP", "http_env")
 	Datadog.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	Datadog.Set("proxy.http", "http_conf")
-	defer os.Unsetenv("DD_HTTP_PROXY")
+	defer os.Unsetenv("DD_PROXY_HTTP")
 	defer Datadog.Set("proxy", nil)
 
 	loadProxyFromEnv()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -239,7 +239,7 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "http_url")
 	os.Setenv("DD_PROXY_HTTPS", "https_url")
-	os.Setenv("DD_PROXY_NO_PROXY", "a,b,c")
+	os.Setenv("DD_PROXY_NO_PROXY", "a b c")
 
 	loadProxyFromEnv()
 
@@ -260,7 +260,7 @@ func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "dd_http_url")
 	os.Setenv("DD_PROXY_HTTPS", "dd_https_url")
-	os.Setenv("DD_PROXY_NO_PROXY", "a,b,c")
+	os.Setenv("DD_PROXY_NO_PROXY", "a b c")
 	os.Setenv("HTTP_PROXY", "env_http_url")
 	os.Setenv("HTTPS_PROXY", "env_https_url")
 	os.Setenv("NO_PROXY", "d,e,f")
@@ -320,7 +320,7 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 
 func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	os.Setenv("DD_PROXY_HTTP", "")
-	os.Setenv("DD_PROXY_NO_PROXY", "a,b,c")
+	os.Setenv("DD_PROXY_NO_PROXY", "a b c")
 	os.Setenv("HTTP_PROXY", "env_http_url")
 	os.Setenv("HTTPS_PROXY", "")
 	os.Setenv("NO_PROXY", "")

--- a/releasenotes/notes/dd-specific-proxy-env-vars-e9fa931c8041c842.yaml
+++ b/releasenotes/notes/dd-specific-proxy-env-vars-e9fa931c8041c842.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    Proxy settings can be configured through the environment variables ``DD_PROXY_HTTP``,
+    ``DD_PROXY_HTTPS`` and ``DD_PROXY_NO_PROXY``. These environment variables take precedence over
+    the ``proxy`` options configured in ``datadog.yaml``, and behave exactly the same way as these
+    options. The standard ``HTTP_PROXY``, ``HTTPS_PROXY`` and ``NO_PROXY`` are still honored but have
+    known side effects on integrations, for simplicity we recommended using the new environment variables.
+    For more information, please refer to our `proxy docs`_
+
+    .. _proxy docs: https://docs.datadoghq.com/agent/proxy/

--- a/releasenotes/notes/dd-specific-proxy-env-vars-e9fa931c8041c842.yaml
+++ b/releasenotes/notes/dd-specific-proxy-env-vars-e9fa931c8041c842.yaml
@@ -9,3 +9,9 @@ enhancements:
     For more information, please refer to our `proxy docs`_
 
     .. _proxy docs: https://docs.datadoghq.com/agent/proxy/
+upgrade:
+  - |
+    If the environment variables that can be used to configure a proxy (``DD_PROXY_HTTP``, ``DD_PROXY_HTTPS``,
+    ``DD_PROXY_NO_PROXY``, ``HTTP_PROXY``, ``HTTPS_PROXY`` and ``NO_PROXY``) are present with an empty value
+    (e.g. ``HTTP_PROXY=""``), the Agent now uses this empty value instead of ignoring it and using
+    lower-precedence options.


### PR DESCRIPTION
Update:
* using env var naming that's closer to Agent 6 convention
* use empty env var values when they're present
* use space-separated list for `DD_PROXY_NO_PROXY`

### What does this PR do?

Add support of `DD_PROXY_HTTP`, `DD_PROXY_HTTPS` and `DD_PROXY_NO_PROXY` env vars.

They take precedence respectively over the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` env vars, which themselves take precedence over the `proxy` settings defined directly in `datadog.yaml`.

So overall: `DD_`-env > standard env > `datadog.yaml`

Also, the proxy env vars with empty values are now used instead of being ignored. This is a minor breaking change, but should allow users to meaningfully set an env var to an empty value when they actually want the value used by the Agent to be empty.

### Motivation

The `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` env vars are "standards" that are used automatically by many libs and tools (for example the `requests` python lib).

When users use `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` to set up the Agent proxy, many integrations (e.g. `kubelet`) that use `requests` without passing explicit `proxies` settings will also end up using these proxy settings. That's a breaking and undesirable change because, before 6.3.0, these integrations didn't use proxies when the Agent was set up to use a proxy, and these integrations are generally not meant to be used with proxies (they hit internal domains/IPs).

So let's introduce these new DD-specific env vars that have the exact same effect as setting `proxy` in `datadog.yaml`: they will only be used by the Agent and the integrations that want to use the Agent's proxy settings, but will not make the other integrations use them.

We keep support of the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` env vars to be consistent with the "standard" (i.e. what any other tool would do) and with what the Agent 5 does.

### Additional Notes

~**Open questions**:~ _Questions answered, see update at top of PR description._

~1. Should we rather use `DD_PROXY_HTTP`, `DD_PROXY_HTTPS` and `DD_PROXY_NO_PROXY` as the new env var keys? It would be consistent with the naming of the other `DD_` env vars (which is based on the `datadog.yaml` name). I'd be in favor of using them for consistency.~
~2. When an env var is present and set to `""`, should we use its empty value or should we discard it? Currently we discard it (and continue reading the option with less precedence), but it may not be desirable as a user may want to explicitly set `DD_HTTP_PROXY` to `""` while `HTTP_PROXY` is set to a non-empty value in order to override the latter.~

TODO:

* [x] add release note
* [x] update `datadog-agent` docs:
  - https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md
  - https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#L98
  - https://github.com/DataDog/datadog-agent/blob/6.3.3/pkg/config/config_template.yaml#L14
* [x] Make sure `process-agent` and `trace-agent` aren't impacted/are consistent.