### PR TITLE
[DCA] Add descriptors for Pods and Object metrics to custom metrics store.

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
@@ -1,41 +1,18 @@
 Custom Metrics Provider
 =======================
+  {{- if .hpaExternal -}}
   {{- if .hpaExternal.Error }}
   Error while trying to list external metrics: {{ .hpaExternal.Error }}
   {{ else }}
   ConfigMap name: {{ .hpaExternal.ConfigMapName }}
-  {{- end -}}
-
-  External Metrics
-  ================
-  {{- if .hpaExternal.External.ErrorStore }}
-  Error while processing external metrics: {{ .hpaExternal.External.ErrorStore }}
-  {{ else }}
-  Number of external metrics detected: {{ .hpaExternal.External.Number }}
-
-  Values
-  ------
-  {{ range $metric := .hpaExternal.External.Metrics }}
-  {{ range $name, $value := $metric}}
-  {{- if or (eq $name "hpaRef") (eq $name "labels")}}
-  {{$name}}:
-  {{- range $k, $v := $value}}
-  - {{$k}}: {{$v}}
-  {{- end -}}
-  {{else}}
-  {{$name}}: {{$value}}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-
-  {{- end -}}
 
   Detected Metrics
-  ================
+  ----------------
     {{- if .hpaExternal.Descriptors.ErrorStore }}
-    Error while processing descriptors: {{ .hpaExternal.Descriptors.ErrorStore }}
+    Internal Error while processing descriptors: {{ .hpaExternal.Descriptors.ErrorStore }}
     {{ else }}
     Number of descriptors detected: {{ .hpaExternal.Descriptors.Number }}
+    {{- end -}}
 
     Pods Metrics
     ------------
@@ -48,9 +25,9 @@ Custom Metrics Provider
     {{- end -}}
     {{else}}
     {{$name}}: {{$value}}
-    {{- end }}
-    {{- end }}
     {{- end -}}
+    {{- end -}}
+    {{- end }}
 
     Object Metrics
     --------------
@@ -63,8 +40,30 @@ Custom Metrics Provider
     {{- end -}}
     {{else}}
     {{$name}}: {{$value}}
-    {{- end }}
-    {{- end }}
     {{- end -}}
+    {{- end -}}
+    {{- end }}
 
+  External Metrics
+  ----------------
+    {{- if .hpaExternal.External.ErrorStore }}
+    Internal Error while processing the External Metrics: {{ .hpaExternal.External.ErrorStore }}
+    {{ else }}
+    Number of external metrics detected: {{ .hpaExternal.External.Number }}
     {{- end -}}
+    {{ range $metric := .hpaExternal.External.Metrics }}
+    {{ range $name, $value := $metric}}
+    {{- if (eq $name "hpaRef")}}
+    {{$name}}:
+    {{- range $k, $v := $value}}
+    - {{$k}}: {{$v}}
+    {{- end -}}
+    {{else}}
+    {{$name}}: {{$value}}
+    {{- end -}}
+    {{- end -}}
+    {{- end }}
+  {{- end -}}
+  {{ else }}
+  The Custom Metrics Provider is not enabled.
+  {{ end }}

--- a/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
@@ -15,7 +15,7 @@ External Metrics
   {{- end -}}
   {{ range $metric := .hpaExternal.Metrics }}
   {{ range $name, $value := $metric}}
-  {{- if or (eq $name "hpa") (eq $name "labels")}}
+  {{- if or (eq $name "hpaRef") (eq $name "labels")}}
   {{$name}}:
   {{- range $k, $v := $value}}
   - {{$k}}: {{$v}}

--- a/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
@@ -1,19 +1,19 @@
 Custom Metrics Provider
 =======================
-External Metrics
-================
+  ConfigMap name: {{ .hpaExternal.ConfigMapName }}
   {{- if .hpaExternal -}}
   {{- if .hpaExternal.Error }}
-  Error while trying to serve external metrics: {{ .hpaExternal.Error }}
+  Error while trying to list external metrics: {{ .hpaExternal.Error }}
   {{ else }}
-  {{- if .hpaExternal.ErrorStore }}
-  Internal Error while processing the External Metrics : {{ .hpaExternal.ErrorStore }}
+
+  External Metrics
+  ================
+  {{- if .hpaExternal.External.ErrorStore }}
+  Error while processing external metrics: {{ .hpaExternal.External.ErrorStore }}
   {{ else }}
-  ConfigMap name: {{ .hpaExternal.Cmname }}
-  Number of external metrics detected: {{ .hpaExternal.Number }}
-  {{- end -}}
-  {{- end -}}
-  {{ range $metric := .hpaExternal.Metrics }}
+  Number of external metrics detected: {{ .hpaExternal.External.Number }}
+
+  {{ range $metric := .hpaExternal.External.Metrics }}
   {{ range $name, $value := $metric}}
   {{- if or (eq $name "hpaRef") (eq $name "labels")}}
   {{$name}}:
@@ -24,7 +24,49 @@ External Metrics
   {{$name}}: {{$value}}
   {{- end }}
   {{- end }}
+  {{- end }}
+
   {{- end -}}
+
+  Descriptors
+  ============
+    {{- if .hpaExternal.Descriptors.ErrorStore }}
+    Error while processing descriptors: {{ .hpaExternal.Descriptors.ErrorStore }}
+    {{ else }}
+    Number of descriptors detected: {{ .hpaExternal.Descriptors.Number }}
+
+    Pods
+    ====
+    {{ range $metric := .hpaExternal.Descriptors.Pods }}
+    {{ range $name, $value := $metric}}
+    {{- if (eq $name "hpaRef")}}
+    {{$name}}:
+    {{- range $k, $v := $value}}
+    - {{$k}}: {{$v}}
+    {{- end -}}
+    {{else}}
+    {{$name}}: {{$value}}
+    {{- end }}
+    {{- end }}
+    {{- end -}}
+
+    Object
+    ======
+    {{ range $metric := .hpaExternal.Descriptors.Object }}
+    {{ range $name, $value := $metric}}
+    {{- if (eq $name "hpaRef")}}
+    {{$name}}:
+    {{- range $k, $v := $value}}
+    - {{$k}}: {{$v}}
+    {{- end -}}
+    {{else}}
+    {{$name}}: {{$value}}
+    {{- end }}
+    {{- end }}
+    {{- end -}}
+
+    {{- end -}}
+
   {{ else }}
-  The External Metrics Provider is not enabled
+  The Custom Metrics Provider is not enabled.
   {{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
@@ -1,10 +1,10 @@
 Custom Metrics Provider
 =======================
-  ConfigMap name: {{ .hpaExternal.ConfigMapName }}
-  {{- if .hpaExternal -}}
   {{- if .hpaExternal.Error }}
   Error while trying to list external metrics: {{ .hpaExternal.Error }}
   {{ else }}
+  ConfigMap name: {{ .hpaExternal.ConfigMapName }}
+  {{- end -}}
 
   External Metrics
   ================
@@ -13,6 +13,8 @@ Custom Metrics Provider
   {{ else }}
   Number of external metrics detected: {{ .hpaExternal.External.Number }}
 
+  Values
+  ------
   {{ range $metric := .hpaExternal.External.Metrics }}
   {{ range $name, $value := $metric}}
   {{- if or (eq $name "hpaRef") (eq $name "labels")}}
@@ -28,15 +30,15 @@ Custom Metrics Provider
 
   {{- end -}}
 
-  Descriptors
-  ============
+  Detected Metrics
+  ================
     {{- if .hpaExternal.Descriptors.ErrorStore }}
     Error while processing descriptors: {{ .hpaExternal.Descriptors.ErrorStore }}
     {{ else }}
     Number of descriptors detected: {{ .hpaExternal.Descriptors.Number }}
 
-    Pods
-    ====
+    Pods Metrics
+    ------------
     {{ range $metric := .hpaExternal.Descriptors.Pods }}
     {{ range $name, $value := $metric}}
     {{- if (eq $name "hpaRef")}}
@@ -50,8 +52,8 @@ Custom Metrics Provider
     {{- end }}
     {{- end -}}
 
-    Object
-    ======
+    Object Metrics
+    --------------
     {{ range $metric := .hpaExternal.Descriptors.Object }}
     {{ range $name, $value := $metric}}
     {{- if (eq $name "hpaRef")}}
@@ -66,7 +68,3 @@ Custom Metrics Provider
     {{- end -}}
 
     {{- end -}}
-
-  {{ else }}
-  The Custom Metrics Provider is not enabled.
-  {{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/header.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/header.tmpl
@@ -45,20 +45,29 @@
 
   Custom Metrics Provider
   =======================
-  External Metrics
-  ================
     {{- if .hpaExternal -}}
     {{- if .hpaExternal.Error }}
-    Error while trying to serve external metrics: {{ .hpaExternal.Error }}
+    Error while trying to list external metrics: {{ .hpaExternal.Error }}
     {{ else }}
-    {{- if .hpaExternal.ErrorStore }}
-    Internal Error while processing the External Metrics : {{ .hpaExternal.ErrorStore }}
-    {{ else }}
-    ConfigMap name: {{ .hpaExternal.Cmname }}
-    Number of external metrics detected: {{ .hpaExternal.Number }}
+    ConfigMap name: {{ .hpaExternal.ConfigMapName }}
+
+    Detected Metrics
+    ----------------
+      {{- if .hpaExternal.Descriptors.ErrorStore }}
+      Internal Error while processing descriptors: {{ .hpaExternal.Descriptors.ErrorStore }}
+      {{ else }}
+      Number of descriptors detected: {{ .hpaExternal.Descriptors.Number }}
+      {{- end }}
+
+    External Metrics
+    ----------------
+      {{- if .hpaExternal.External.ErrorStore }}
+      Internal Error while processing the External Metrics: {{ .hpaExternal.External.ErrorStore }}
+      {{ else }}
+      Number of external metrics detected: {{ .hpaExternal.External.Number }}
+      {{- end -}}
     {{- end -}}
-    {{- end -}}
     {{ else }}
-    The External Metrics Provider is not enabled
+    The Custom Metrics Provider is not enabled.
     {{- end -}}
 {{/* this line intentionally left blank */}}

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	keyDelimeter = "-"
+	numKeyParts  = 5
 )
 
 // Store is an interface for persistent storage of custom and external metrics.
@@ -114,14 +115,14 @@ func (c *configMapStore) SetMetricDescriptors(podsMetrics []PodsMetricDescriptor
 		if err = c.set(key, desc); err == nil {
 			continue
 		}
-		log.Debugf("Could not marshal the pods metric descriptor %v: %s", desc, err)
+		log.Debugf("Could not marshal the pods metric descriptor %v: %v", desc, err)
 	}
 	for _, desc := range objectMetrics {
 		key := strings.Join([]string{"descriptor", "object", desc.HPARef.Namespace, desc.HPARef.Name, desc.MetricName}, keyDelimeter)
 		if err = c.set(key, desc); err == nil {
 			continue
 		}
-		log.Debugf("Could not marshal the object metric descriptor %v: %s", desc, err)
+		log.Debugf("Could not marshal the object metric descriptor %v: %v", desc, err)
 	}
 	return c.updateConfigMap()
 }
@@ -138,7 +139,7 @@ func (c *configMapStore) Purge(deleted []ObjectReference) error {
 		// Delete all metrics from the configmap that reference this object.
 		for k := range c.cm.Data {
 			parts := strings.Split(k, keyDelimeter)
-			if len(parts) < 5 {
+			if len(parts) < numKeyParts {
 				log.Debugf("Deleting malformed key %s", k)
 				delete(c.cm.Data, k)
 				continue
@@ -160,7 +161,7 @@ func (c *configMapStore) ListAllExternalMetricValues() (externalMetrics []Extern
 	}
 	for k, v := range c.cm.Data {
 		parts := strings.Split(k, keyDelimeter)
-		if len(parts) < 4 {
+		if len(parts) < numKeyParts {
 			continue
 		}
 		if parts[0] != "value" && parts[1] != "external" {
@@ -183,7 +184,7 @@ func (c *configMapStore) ListAllMetricDescriptors() (podsMetrics []PodsMetricDes
 	}
 	for k, v := range c.cm.Data {
 		parts := strings.Split(k, keyDelimeter)
-		if len(parts) < 4 {
+		if len(parts) < numKeyParts {
 			continue
 		}
 		if parts[0] != "descriptor" {

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -30,10 +30,10 @@ type Store interface {
 	SetExternalMetricValues([]ExternalMetricValue) error
 	SetMetricDescriptors([]PodsMetricDescriptor, []ObjectMetricDescriptor) error
 
+	Purge([]ObjectReference) error
+
 	ListAllExternalMetricValues() ([]ExternalMetricValue, error)
 	ListAllMetricDescriptors() ([]PodsMetricDescriptor, []ObjectMetricDescriptor, error)
-
-	Purge([]ObjectReference) error
 }
 
 // configMapStore provides persistent storage of custom and external metrics using a configmap.

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -30,10 +30,10 @@ type Store interface {
 	SetExternalMetricValues([]ExternalMetricValue) error
 	SetMetricDescriptors([]PodsMetricDescriptor, []ObjectMetricDescriptor) error
 
-	Purge([]ObjectReference) error
-
 	ListAllExternalMetricValues() ([]ExternalMetricValue, error)
 	ListAllMetricDescriptors() ([]PodsMetricDescriptor, []ObjectMetricDescriptor, error)
+
+	Purge([]ObjectReference) error
 }
 
 // configMapStore provides persistent storage of custom and external metrics using a configmap.
@@ -126,7 +126,7 @@ func (c *configMapStore) SetMetricDescriptors(podsMetrics []PodsMetricDescriptor
 	return c.updateConfigMap()
 }
 
-// Purge purges all data in the configmap that refer to any of the given object references.
+// Purge deletes all data in the configmap that refers to any of the given object references.
 func (c *configMapStore) Purge(deleted []ObjectReference) error {
 	if c.cm == nil {
 		return fmt.Errorf("configmap not initialized")

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -148,6 +148,7 @@ func TestConfigMapStorePurge(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	store, err := NewConfigMapStore(client, "default", "bag-o-things")
+	require.NoError(t, err)
 
 	fooRef := ObjectReference{
 		Namespace: "foo",

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -56,24 +56,24 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 		},
@@ -83,24 +83,24 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "bar", Namespace: "default"},
 				},
 			},
 		},
@@ -110,19 +110,19 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 			},
 			[]ExternalMetricValue{
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
-					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     ObjectReference{Name: "foo", Namespace: "default"},
 				},
 			},
 		},
@@ -143,10 +143,10 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 
 			objectRefs := make([]ObjectReference, 0)
 			for _, m := range tt.metrics {
-				objectRefs = append(objectRefs, m.HPA)
+				objectRefs = append(objectRefs, m.HPARef)
 			}
 
-			err = store.Delete(objectRefs)
+			err = store.Purge(objectRefs)
 			require.NoError(t, err)
 			assert.Zero(t, len(store.(*configMapStore).cm.Data))
 		})

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -7,31 +7,28 @@
 
 package custommetrics
 
-import "k8s.io/apimachinery/pkg/types"
-
 type ExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`
 	Timestamp  int64             `json:"ts"`
-	HPA        ObjectReference   `json:"hpa"`
+	HPARef     ObjectReference   `json:"hpaRef"`
 	Value      int64             `json:"value"`
 	Valid      bool              `json:"valid"`
 }
 
 // ObjectReference contains enough information to let you identify the referred resource.
 type ObjectReference struct {
-	Name      string    `json:"name"`
-	Namespace string    `json:"namespace"`
-	UID       types.UID `json:"uid"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 type PodsMetricDescriptor struct {
 	MetricName string          `json:"metricName"`
-	HPA        ObjectReference `json:"hpa"`
+	HPARef     ObjectReference `json:"hpaRef"`
 }
 
 type ObjectMetricDescriptor struct {
 	MetricName      string          `json:"metricName"`
-	HPA             ObjectReference `json:"hpa"`
+	HPARef          ObjectReference `json:"hpaRef"`
 	DescribedObject ObjectReference `json:"describedObject"`
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -16,12 +16,6 @@ type ExternalMetricValue struct {
 	Valid      bool              `json:"valid"`
 }
 
-// ObjectReference contains enough information to let you identify the referred resource.
-type ObjectReference struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}
-
 type PodsMetricDescriptor struct {
 	MetricName string          `json:"metricName"`
 	HPARef     ObjectReference `json:"hpaRef"`
@@ -31,4 +25,10 @@ type ObjectMetricDescriptor struct {
 	MetricName      string          `json:"metricName"`
 	HPARef          ObjectReference `json:"hpaRef"`
 	DescribedObject ObjectReference `json:"describedObject"`
+}
+
+// ObjectReference contains enough information to let you identify the referred resource.
+type ObjectReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -7,6 +7,8 @@
 
 package custommetrics
 
+import "k8s.io/apimachinery/pkg/types"
+
 type ExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`
@@ -18,6 +20,18 @@ type ExternalMetricValue struct {
 
 // ObjectReference contains enough information to let you identify the referred resource.
 type ObjectReference struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	UID       types.UID `json:"uid"`
+}
+
+type PodsMetricDescriptor struct {
+	MetricName string          `json:"metricName"`
+	HPA        ObjectReference `json:"hpa"`
+}
+
+type ObjectMetricDescriptor struct {
+	MetricName      string          `json:"metricName"`
+	HPA             ObjectReference `json:"hpa"`
+	DescribedObject ObjectReference `json:"describedObject"`
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -29,6 +29,8 @@ type ObjectMetricDescriptor struct {
 
 // ObjectReference contains enough information to let you identify the referred resource.
 type ObjectReference struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	APIVersion string `json:"apiVersion"`
 }

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -68,24 +68,28 @@ func GetHorizontalPodAutoscalingStatus() map[string]interface{} {
 
 	store, err := custommetrics.NewConfigMapStore(apiCl.Cl, apiserver.GetResourcesNamespace(), datadogHPAConfigMap)
 
-	status["External"] := make(map[string]interface{})
+	externalStatus := make(map[string]interface{})
 	externalMetrics, err := store.ListAllExternalMetricValues()
 	if err != nil {
 		externalStatus["ErrorStore"] = err.Error()
 		return status
 	}
-	status["External"]["Number"] = len(externalMetrics)
-	status["External"]["Metrics"] = externalMetrics
+	externalStatus["Number"] = len(externalMetrics)
+	externalStatus["Metrics"] = externalMetrics
 
-	status["Descriptors"] := make(map[string]interface{})
+	status["External"] = externalStatus
+
+	descStatus := make(map[string]interface{})
 	podsDescs, objectDescs, err := store.ListAllMetricDescriptors()
 	if err != nil {
-		status["Descriptors"]["ErrorStore"] = err.Error()
+		descStatus["ErrorStore"] = err.Error()
 		return status
 	}
-	status["Descriptors"]["Number"] = len(podsDescs) + len(objectDescs)
-	status["Descriptors"]["Pods"] = podsDescs
-	status["Descriptors"]["Object"] = objectDescs
+	descStatus["Number"] = len(podsDescs) + len(objectDescs)
+	descStatus["Pods"] = podsDescs
+	descStatus["Object"] = objectDescs
+
+	status["Descriptors"] = descStatus
 
 	return status
 }

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -230,8 +230,10 @@ func (c *HPAWatcherClient) removeEntryFromStore(deleted []*autoscalingv2.Horizon
 	hpaRefs := []custommetrics.ObjectReference{}
 	for _, hpa := range deleted {
 		hpaRef := custommetrics.ObjectReference{
-			Name:      hpa.Name,
-			Namespace: hpa.Namespace,
+			Kind:       hpa.Kind,
+			Name:       hpa.Name,
+			Namespace:  hpa.Namespace,
+			APIVersion: hpa.APIVersion,
 		}
 		hpaRefs = append(hpaRefs, hpaRef)
 	}
@@ -262,8 +264,10 @@ func parseHPAs(hpas ...*autoscalingv2.HorizontalPodAutoscaler) (
 
 	for _, hpa := range hpas {
 		hpaRef := custommetrics.ObjectReference{
-			Name:      hpa.Name,
-			Namespace: hpa.Namespace,
+			Kind:       hpa.Kind,
+			Name:       hpa.Name,
+			Namespace:  hpa.Namespace,
+			APIVersion: hpa.APIVersion,
 		}
 		for _, metricSpec := range hpa.Spec.Metrics {
 			switch metricSpec.Type {
@@ -283,8 +287,10 @@ func parseHPAs(hpas ...*autoscalingv2.HorizontalPodAutoscaler) (
 					MetricName: metricSpec.Object.MetricName,
 					HPARef:     hpaRef,
 					DescribedObject: custommetrics.ObjectReference{
-						Name:      metricSpec.Object.Target.Name,
-						Namespace: hpa.Namespace,
+						Kind:       metricSpec.Object.Target.Kind,
+						Name:       metricSpec.Object.Target.Name,
+						Namespace:  hpa.Namespace,
+						APIVersion: metricSpec.Object.Target.APIVersion,
 					},
 				})
 			default:

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -201,13 +201,14 @@ func (c *HPAWatcherClient) processHPAs(added, modified []*autoscalingv2.Horizont
 	}
 	externalMetrics, podsDescs, objectDescs := parseHPAs(added...)
 
+	var err error
+
 	if err = c.store.SetMetricDescriptors(podsDescs, objectDescs); err != nil {
 		log.Errorf("Could not store metric descriptors: %v", err)
 	}
 
 	// We can query Datadog immediately for external metric values since they do not
 	// originate from within the cluster.
-	var err error
 	for i, metric := range externalMetrics {
 		metric.Value, metric.Valid, err = c.validateExternalMetric(metric.MetricName, metric.Labels)
 		if err != nil {

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/zorkian/go-datadog-api.v2"
-	"k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -39,17 +39,17 @@ func newFakeConfigMapStore(t *testing.T, ns, name string, metrics []custommetric
 	return store
 }
 
-func newMockHPAExternalMetricSource(name, ns, metricName string, labels map[string]string) *v2beta1.HorizontalPodAutoscaler {
-	return &v2beta1.HorizontalPodAutoscaler{
+func newMockHPAExternalMetricSource(name, ns, metricName string, labels map[string]string) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
-		Spec: v2beta1.HorizontalPodAutoscalerSpec{
-			Metrics: []v2beta1.MetricSpec{
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			Metrics: []autoscalingv2.MetricSpec{
 				{
-					Type: v2beta1.ExternalMetricSourceType,
-					External: &v2beta1.ExternalMetricSource{
+					Type: autoscalingv2.ExternalMetricSourceType,
+					External: &autoscalingv2.ExternalMetricSource{
 						MetricName: metricName,
 						MetricSelector: &metav1.LabelSelector{
 							MatchLabels: labels,
@@ -65,7 +65,7 @@ func TestHPAWatcherRemoveEntryFromStore(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		metrics  []custommetrics.ExternalMetricValue
-		hpa      *v2beta1.HorizontalPodAutoscaler
+		hpa      *autoscalingv2.HorizontalPodAutoscaler
 		expected []custommetrics.ExternalMetricValue
 	}{
 		{
@@ -116,7 +116,7 @@ func TestHPAWatcherRemoveEntryFromStore(t *testing.T) {
 			store := newFakeConfigMapStore(t, "default", fmt.Sprintf("test-%d", i), testCase.metrics)
 			hpaCl := &HPAWatcherClient{store: store}
 
-			err := hpaCl.removeEntryFromStore([]*v2beta1.HorizontalPodAutoscaler{testCase.hpa})
+			err := hpaCl.removeEntryFromStore([]*autoscalingv2.HorizontalPodAutoscaler{testCase.hpa})
 			require.NoError(t, err)
 
 			allMetrics, err := store.ListAllExternalMetricValues()
@@ -189,4 +189,77 @@ func TestHPAWatcherUpdateExternalMetrics(t *testing.T) {
 			assert.ElementsMatch(t, tt.expected, strippedTs)
 		})
 	}
+}
+
+func TestParseHPAs(t *testing.T) {
+	test := struct {
+		hpa             *autoscalingv2.HorizontalPodAutoscaler
+		externalMetrics []custommetrics.ExternalMetricValue
+		podsMetrics     []custommetrics.PodsMetricDescriptor
+		objectMetrics   []custommetrics.ObjectMetricDescriptor
+	}{
+		&autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				Metrics: []autoscalingv2.MetricSpec{
+					{
+						Type: autoscalingv2.ExternalMetricSourceType,
+						External: &autoscalingv2.ExternalMetricSource{
+							MetricName: "requests_per_s",
+							MetricSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"availability_zone": "us-east-1"},
+							},
+						},
+					},
+					{
+						Type: autoscalingv2.PodsMetricSourceType,
+						Pods: &autoscalingv2.PodsMetricSource{
+							MetricName: "conn_opened_per_s",
+						},
+					},
+					{
+						Type: autoscalingv2.ObjectMetricSourceType,
+						Object: &autoscalingv2.ObjectMetricSource{
+							MetricName: "connections",
+							Target: autoscalingv2.CrossVersionObjectReference{
+								Kind: "Deployment",
+								Name: "nginx",
+							},
+						},
+					},
+				},
+			},
+		},
+		[]custommetrics.ExternalMetricValue{
+			{
+				MetricName: "requests_per_s",
+				Labels:     map[string]string{"availability_zone": "us-east-1"},
+				HPARef:     custommetrics.ObjectReference{Name: "foo", Namespace: "default"},
+			},
+		},
+		[]custommetrics.PodsMetricDescriptor{
+			{
+				MetricName: "conn_opened_per_s",
+				HPARef:     custommetrics.ObjectReference{Name: "foo", Namespace: "default"},
+			},
+		},
+		[]custommetrics.ObjectMetricDescriptor{
+			{
+				MetricName: "connections",
+				HPARef:     custommetrics.ObjectReference{Name: "foo", Namespace: "default"},
+				DescribedObject: custommetrics.ObjectReference{
+					Name:      "nginx",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+
+	externalMetrics, podsMetrics, objectMetrics := parseHPAs(test.hpa)
+	assert.ElementsMatch(t, externalMetrics, test.externalMetrics)
+	assert.ElementsMatch(t, podsMetrics, test.podsMetrics)
+	assert.ElementsMatch(t, objectMetrics, test.objectMetrics)
 }

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -74,7 +74,7 @@ func TestHPAWatcherRemoveEntryFromStore(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{Name: "foo", Namespace: "default"},
+					HPARef:     custommetrics.ObjectReference{Name: "foo", Namespace: "default"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,
@@ -90,7 +90,7 @@ func TestHPAWatcherRemoveEntryFromStore(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{Name: "bar", Namespace: "default"},
+					HPARef:     custommetrics.ObjectReference{Name: "bar", Namespace: "default"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,
@@ -102,7 +102,7 @@ func TestHPAWatcherRemoveEntryFromStore(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{Name: "bar", Namespace: "default"},
+					HPARef:     custommetrics.ObjectReference{Name: "bar", Namespace: "default"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,


### PR DESCRIPTION
### What does this PR do?

This PR continues the work on custom metrics to additionally parse HPAs for Pods and Object metrics.

```
$ datadog-cluster-agent status

  Custom Metrics Provider
  =======================
    ConfigMap name: datadog-hpa

    Detected Metrics
    ----------------
      Number of descriptors detected: 3

    External Metrics
    ----------------
      Number of external metrics detected: 1
```