### PR TITLE
Revert "Fix API_KEY validation for 'additional_endpoints'"

### DIFF
--- a/releasenotes/notes/api-key-validation-per-domain-891ebd73ab300a6c.yaml
+++ b/releasenotes/notes/api-key-validation-per-domain-891ebd73ab300a6c.yaml
@@ -1,5 +1,0 @@
----
-fixes:
-  - |
-    Fix API_KEY validation for 'additional_endpoints' by using their respective
-    endpoint instead of the main one all the time.


### PR DESCRIPTION
### What does this PR do?

This reverts PR #1890.

### Motivation

We noticed this was breaking the API key validation logic because it hits the validation endpoint on an
`.agent.app.<datadog_top_level_domain>` domain (which doesn't expose a full API) instead of the correct `app.<datadog_top_level_domain>` domain.

Let's revert for 6.4.0 since the original PR touches a sensitive part of the Agent, and is only useful on our internal environments.
