### PR TITLE
stop jmxfetch gracefully

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -111,7 +111,7 @@ func (r *runner) configureRunner(instance, initConfig integration.Data) error {
 
 func (r *runner) stopRunner() error {
 	if r.jmxfetch != nil && r.started {
-		return r.jmxfetch.Kill()
+		return r.jmxfetch.Stop()
 	}
 	return nil
 }

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -230,9 +230,6 @@ func (j *JMXFetch) Start() error {
 // Stop stops the JMXFetch process
 func (j *JMXFetch) Stop() error {
 	if j.JmxExitFile == "" {
-		graceTimer := time.NewTimer(500 * time.Millisecond)
-		defer graceTimer.Stop()
-
 		stopped := make(chan struct{})
 
 		// Unix
@@ -247,7 +244,7 @@ func (j *JMXFetch) Stop() error {
 		}()
 
 		select {
-		case <-graceTimer.C:
+		case <-time.After(time.Millisecond * 500):
 			log.Warnf("Jmxfetch did not exit during it's grace period, killing it")
 			err = j.cmd.Process.Signal(os.Kill)
 			if err != nil {

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -251,7 +251,7 @@ func (j *JMXFetch) Stop() error {
 			log.Warnf("Jmxfetch did not exit during it's grace period, killing it")
 			err = j.cmd.Process.Signal(os.Kill)
 			if err != nil {
-				return err
+				log.Warnf("Could not kill jmxfetch: %v", err)
 			}
 		case <-stopped:
 		}


### PR DESCRIPTION
### What does this PR do?

Use `SIGTERM` instead of `SIGKILL`. If jmxfetch takes more than half a second to exit, `SIGKILL` it.