### PR TITLE
Fix races in AD

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -46,6 +46,7 @@ type DockerService struct {
 	Ports         []ContainerPort
 	Pid           int
 	Hostname      string
+	sync.RWMutex
 }
 
 func init() {
@@ -344,6 +345,9 @@ func (s *DockerService) GetADIdentifiers() ([]string, error) {
 
 // GetHosts returns the container's hosts
 func (s *DockerService) GetHosts() (map[string]string, error) {
+	s.Lock()
+	defer s.Unlock()
+
 	if s.Hosts != nil {
 		return s.Hosts, nil
 	}

--- a/pkg/autodiscovery/listeners/docker_kubelet.go
+++ b/pkg/autodiscovery/listeners/docker_kubelet.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
@@ -27,6 +28,7 @@ type DockerKubeletService struct {
 	kubeUtil *kubelet.KubeUtil
 	Hosts    map[string]string
 	Ports    []ContainerPort
+	sync.RWMutex
 }
 
 // getPod wraps KubeUtil init and pod lookup for both public methods.
@@ -44,6 +46,9 @@ func (s *DockerKubeletService) getPod() (*kubelet.Pod, error) {
 
 // GetHosts returns the container's hosts
 func (s *DockerKubeletService) GetHosts() (map[string]string, error) {
+	s.Lock()
+	defer s.Unlock()
+
 	if s.Hosts != nil {
 		return s.Hosts, nil
 	}

--- a/releasenotes/notes/fix-race-1d45fe6bed0fabb7.yaml
+++ b/releasenotes/notes/fix-race-1d45fe6bed0fabb7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a possible agent crash due to a race condition in the auto discovery.


### PR DESCRIPTION
### What does this PR do?

* Fix a race in the configresolver services map where the map could be modified while being read.
* Fix a possible race on config resolving with an unsafe map

### Motivation
Fix

```
[ AGENT ] fatal error: concurrent map iteration and map write
[ AGENT ]
[ AGENT ] goroutine 94 [running]:
[ AGENT ] runtime.throw(0x1b4079c, 0x26)
[ AGENT ] 	/root/.gimme/versions/go1.10.2.linux.amd64/src/runtime/panic.go:616 +0x81 fp=0xc4212b7b10 sp=0xc4212b7af0 pc=0x44ccd1
[ AGENT ] runtime.mapiternext(0xc4212b7d80)
[ AGENT ] 	/root/.gimme/versions/go1.10.2.linux.amd64/src/runtime/hashmap.go:747 +0x55c fp=0xc4212b7ba0 sp=0xc4212b7b10 pc=0x42ac4c
[ AGENT ] github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).pollConfigs.func1(0xc4205782c0)
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:419 +0x1c3 fp=0xc4212b7fd8 sp=0xc4212b7ba0 pc=0x131a9c3
[ AGENT ] runtime.goexit()
[ AGENT ] 	/root/.gimme/versions/go1.10.2.linux.amd64/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc4212b7fe0 sp=0xc4212b7fd8 pc=0x47c1f1
[ AGENT ] created by github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).pollConfigs
[ AGENT ] 	/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:407 +0x3f
```