### PR TITLE
buffer log line before the log package is initialized

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -367,7 +367,6 @@ func loadProxyFromEnv() {
 			value, found = os.LookupEnv(strings.ToLower(key))
 		}
 		if found {
-			// FIXME: this doesn't log anything because the logger isn't initialized yet
 			log.Infof("Found '%v' env var, using it for the Agent proxy settings", key)
 		}
 		return value, found
@@ -376,7 +375,6 @@ func loadProxyFromEnv() {
 	lookupEnv := func(key string) (string, bool) {
 		value, found := os.LookupEnv(key)
 		if found {
-			// FIXME: this doesn't log anything because the logger isn't initialized yet
 			log.Infof("Found '%v' env var, using it for the Agent proxy settings", key)
 		}
 		return value, found
@@ -387,7 +385,6 @@ func loadProxyFromEnv() {
 	if isSet = Datadog.IsSet("proxy"); isSet {
 		if err := Datadog.UnmarshalKey("proxy", p); err != nil {
 			isSet = false
-			// FIXME: this doesn't log anything because the logger isn't initialized yet
 			log.Errorf("Could not load proxy setting from the configuration (ignoring): %s", err)
 		}
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -18,7 +18,7 @@ import (
 
 var logger *DatadogLogger
 
-//DatadogLogger wrapper structure for seelog
+// DatadogLogger wrapper structure for seelog
 type DatadogLogger struct {
 	inner seelog.LoggerInterface
 	level seelog.LogLevel
@@ -26,7 +26,7 @@ type DatadogLogger struct {
 	l     sync.Mutex
 }
 
-//SetupDatadogLogger configure logger singleton with seelog interface
+// SetupDatadogLogger configure logger singleton with seelog interface
 func SetupDatadogLogger(l seelog.LoggerInterface, level string) {
 	logger = &DatadogLogger{
 		inner: l,
@@ -39,13 +39,13 @@ func SetupDatadogLogger(l seelog.LoggerInterface, level string) {
 	}
 	logger.level = lvl
 
-	//We're not going to call DatadogLogger directly, but using the
-	//exported functions, that will give us two frames in the stack
-	//trace that should be skipped to get to the original caller.
+	// We're not going to call DatadogLogger directly, but using the
+	// exported functions, that will give us two frames in the stack
+	// trace that should be skipped to get to the original caller.
 	//
-	//The fact we need a constant "additional depth" means some
-	//theoretical refactor to avoid duplication in the functions
-	//below cannot be performed.
+	// The fact we need a constant "additional depth" means some
+	// theoretical refactor to avoid duplication in the functions
+	// below cannot be performed.
 	logger.inner.SetAdditionalStackDepth(2)
 }
 
@@ -114,7 +114,7 @@ func (sw *DatadogLogger) scrub(s string) string {
 	return s
 }
 
-//trace logs at the trace level
+// trace logs at the trace level
 func (sw *DatadogLogger) trace(s string) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -127,7 +127,7 @@ func (sw *DatadogLogger) trace(s string) {
 	}
 }
 
-//debug logs at the debug level
+// debug logs at the debug level
 func (sw *DatadogLogger) debug(s string) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -140,7 +140,7 @@ func (sw *DatadogLogger) debug(s string) {
 	}
 }
 
-//info logs at the info level
+// info logs at the info level
 func (sw *DatadogLogger) info(s string) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -153,7 +153,7 @@ func (sw *DatadogLogger) info(s string) {
 	}
 }
 
-//warn logs at the warn level
+// warn logs at the warn level
 func (sw *DatadogLogger) warn(s string) error {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -168,7 +168,7 @@ func (sw *DatadogLogger) warn(s string) error {
 	return err
 }
 
-//error logs at the error level
+// error logs at the error level
 func (sw *DatadogLogger) error(s string) error {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -183,7 +183,7 @@ func (sw *DatadogLogger) error(s string) error {
 	return err
 }
 
-//critical logs at the critical level
+// critical logs at the critical level
 func (sw *DatadogLogger) critical(s string) error {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -198,7 +198,7 @@ func (sw *DatadogLogger) critical(s string) error {
 	return err
 }
 
-//tracef logs with format at the trace level
+// tracef logs with format at the trace level
 func (sw *DatadogLogger) tracef(format string, params ...interface{}) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -211,7 +211,7 @@ func (sw *DatadogLogger) tracef(format string, params ...interface{}) {
 	}
 }
 
-//debugf logs with format at the debug level
+// debugf logs with format at the debug level
 func (sw *DatadogLogger) debugf(format string, params ...interface{}) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -224,7 +224,7 @@ func (sw *DatadogLogger) debugf(format string, params ...interface{}) {
 	}
 }
 
-//infof logs with format at the info level
+// infof logs with format at the info level
 func (sw *DatadogLogger) infof(format string, params ...interface{}) {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -237,7 +237,7 @@ func (sw *DatadogLogger) infof(format string, params ...interface{}) {
 	}
 }
 
-//warnf logs with format at the warn level
+// warnf logs with format at the warn level
 func (sw *DatadogLogger) warnf(format string, params ...interface{}) error {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -252,7 +252,7 @@ func (sw *DatadogLogger) warnf(format string, params ...interface{}) error {
 	return err
 }
 
-//errorf logs with format at the error level
+// errorf logs with format at the error level
 func (sw *DatadogLogger) errorf(format string, params ...interface{}) error {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -267,7 +267,7 @@ func (sw *DatadogLogger) errorf(format string, params ...interface{}) error {
 	return err
 }
 
-//criticalf logs with format at the critical level
+// criticalf logs with format at the critical level
 func (sw *DatadogLogger) criticalf(format string, params ...interface{}) error {
 	sw.l.Lock()
 	defer sw.l.Unlock()
@@ -311,7 +311,7 @@ func formatError(v ...interface{}) error {
 	return errors.New(msg)
 }
 
-//Trace logs at the trace level
+// Trace logs at the trace level
 func Trace(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.TraceLvl) {
 		s := buildLogEntry(v...)
@@ -319,7 +319,7 @@ func Trace(v ...interface{}) {
 	}
 }
 
-//Debug logs at the debug level
+// Debug logs at the debug level
 func Debug(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.DebugLvl) {
 		s := buildLogEntry(v...)
@@ -327,7 +327,7 @@ func Debug(v ...interface{}) {
 	}
 }
 
-//Info logs at the info level
+// Info logs at the info level
 func Info(v ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.InfoLvl) {
 		s := buildLogEntry(v...)
@@ -335,7 +335,7 @@ func Info(v ...interface{}) {
 	}
 }
 
-//Warn logs at the warn level and returns an error containing the formated log message
+// Warn logs at the warn level and returns an error containing the formated log message
 func Warn(v ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.WarnLvl) {
 		s := buildLogEntry(v...)
@@ -344,7 +344,7 @@ func Warn(v ...interface{}) error {
 	return formatError(v...)
 }
 
-//Error logs at the error level and returns an error containing the formated log message
+// Error logs at the error level and returns an error containing the formated log message
 func Error(v ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.ErrorLvl) {
 		s := buildLogEntry(v...)
@@ -355,7 +355,7 @@ func Error(v ...interface{}) error {
 	return err
 }
 
-//Critical logs at the critical level and returns an error containing the formated log message
+// Critical logs at the critical level and returns an error containing the formated log message
 func Critical(v ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.CriticalLvl) {
 		s := buildLogEntry(v...)
@@ -366,35 +366,35 @@ func Critical(v ...interface{}) error {
 	return err
 }
 
-//Flush flushes the underlying inner log
+// Flush flushes the underlying inner log
 func Flush() {
 	if logger != nil && logger.inner != nil {
 		logger.inner.Flush()
 	}
 }
 
-//Tracef logs with format at the trace level
+// Tracef logs with format at the trace level
 func Tracef(format string, params ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.TraceLvl) {
 		logger.tracef(format, params...)
 	}
 }
 
-//Debugf logs with format at the debug level
+// Debugf logs with format at the debug level
 func Debugf(format string, params ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.DebugLvl) {
 		logger.debugf(format, params...)
 	}
 }
 
-//Infof logs with format at the info level
+// Infof logs with format at the info level
 func Infof(format string, params ...interface{}) {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.InfoLvl) {
 		logger.infof(format, params...)
 	}
 }
 
-//Warnf logs with format at the warn level and returns an error containing the formated log message
+// Warnf logs with format at the warn level and returns an error containing the formated log message
 func Warnf(format string, params ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.WarnLvl) {
 		return logger.warnf(format, params...)
@@ -402,7 +402,7 @@ func Warnf(format string, params ...interface{}) error {
 	return formatErrorf(format, params...)
 }
 
-//Errorf logs with format at the error level and returns an error containing the formated log message
+// Errorf logs with format at the error level and returns an error containing the formated log message
 func Errorf(format string, params ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.ErrorLvl) {
 		return logger.errorf(format, params...)
@@ -412,7 +412,7 @@ func Errorf(format string, params ...interface{}) error {
 	return err
 }
 
-//Criticalf logs with format at the critical level and returns an error containing the formated log message
+// Criticalf logs with format at the critical level and returns an error containing the formated log message
 func Criticalf(format string, params ...interface{}) error {
 	if logger != nil && logger.inner != nil && logger.shouldLog(seelog.CriticalLvl) {
 		return logger.criticalf(format, params...)
@@ -422,7 +422,7 @@ func Criticalf(format string, params ...interface{}) error {
 	return err
 }
 
-//ReplaceLogger allows replacing the internal logger, returns old logger
+// ReplaceLogger allows replacing the internal logger, returns old logger
 func ReplaceLogger(l seelog.LoggerInterface) seelog.LoggerInterface {
 	if logger != nil && logger.inner != nil {
 		return logger.replaceInnerLogger(l)
@@ -431,7 +431,7 @@ func ReplaceLogger(l seelog.LoggerInterface) seelog.LoggerInterface {
 	return nil
 }
 
-//RegisterAdditionalLogger registers an additional logger for logging
+// RegisterAdditionalLogger registers an additional logger for logging
 func RegisterAdditionalLogger(n string, l seelog.LoggerInterface) error {
 	if logger != nil && logger.inner != nil {
 		return logger.registerAdditionalLogger(n, l)
@@ -440,7 +440,7 @@ func RegisterAdditionalLogger(n string, l seelog.LoggerInterface) error {
 	return errors.New("cannot register: logger not initialized")
 }
 
-//UnregisterAdditionalLogger unregisters additional logger with name n
+// UnregisterAdditionalLogger unregisters additional logger with name n
 func UnregisterAdditionalLogger(n string) error {
 	if logger != nil && logger.inner != nil {
 		return logger.unregisterAdditionalLogger(n)

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -45,6 +45,34 @@ func TestBasicLogging(t *testing.T) {
 	assert.Equal(t, strings.Count(b.String(), "bar"), 5)
 }
 
+func TestLogBuffer(t *testing.T) {
+	// reset buffer state
+	logsBuffer = []func(){}
+	bufferLogsBeforeInit = true
+	logger = nil
+
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+
+	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
+	assert.Nil(t, err)
+
+	Tracef("%s", "foo")
+	Debugf("%s", "foo")
+	Infof("%s", "foo")
+	Warnf("%s", "foo")
+	Errorf("%s", "foo")
+	Criticalf("%s", "foo")
+
+	SetupDatadogLogger(l, "debug")
+	assert.NotNil(t, logger)
+
+	w.Flush()
+
+	// Trace will not be logged, Error and Critical will directly be logged to Stderr
+	assert.Equal(t, strings.Count(b.String(), "foo"), 5)
+}
+
 func TestCredentialScrubbingLogging(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)

--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-//Replacer structure to store regex matching and replacement functions
+// Replacer structure to store regex matching and replacement functions
 type Replacer struct {
 	Regex    *regexp.Regexp
 	Hints    []string // If any of these hints do not exist in the line, then we know the regex wont match either
@@ -68,7 +68,7 @@ func matchYAMLKey(key string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:).+`, key))
 }
 
-//CredentialsCleanerFile scrubs credentials from file in path
+// CredentialsCleanerFile scrubs credentials from file in path
 func CredentialsCleanerFile(filePath string) ([]byte, error) {
 	file, err := os.Open(filePath)
 	defer file.Close()
@@ -78,7 +78,7 @@ func CredentialsCleanerFile(filePath string) ([]byte, error) {
 	return credentialsCleaner(file)
 }
 
-//CredentialsCleanerBytes scrubs credentials from slice of bytes
+// CredentialsCleanerBytes scrubs credentials from slice of bytes
 func CredentialsCleanerBytes(file []byte) ([]byte, error) {
 	r := bytes.NewReader(file)
 	return credentialsCleaner(r)


### PR DESCRIPTION
### What does this PR do?

Buffer log line until we initialized the logger. This allows us to log important information message while we load the config.