### PR TITLE
Add check to make sure mapOnRef for services ignores mappings for other nodes.

### DIFF
--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -120,7 +120,8 @@ func (m ServicesMapper) mapOnRef(_ string, pods v1.PodList, endpointList v1.Endp
 					continue
 				}
 
-				// Check if the referenced pod is from the local pod list we received from the kubelet.
+				// Check if the referenced pod is from the pod list we received from the
+				// kubelet (or apiserver for the DCA).
 				if _, ok := podUIDs[ref.UID]; !ok {
 					continue
 				}

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -99,9 +99,9 @@ func (m ServicesMapper) mapOnRef(_ string, pods v1.PodList, endpointList v1.Endp
 	uidToPod := make(map[types.UID]v1.ObjectReference)
 	uidToServices := make(map[types.UID][]string)
 
-	podUIDs := make(map[types.UID]string)
+	podUIDs := make(map[types.UID]struct{})
 	for _, pod := range pods.Items {
-		podUIDs[pod.UID] = ""
+		podUIDs[pod.UID] = struct{}{}
 	}
 
 	for _, svc := range endpointList.Items {

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -243,6 +243,8 @@ func TestMapServices(t *testing.T) {
 								nodeName:    "firstNode",
 								targetPodId: "5555",
 							},
+							// This endpoint references a pod the is not in the local pod list we
+							// would receive from a kubelet (or apiserver for the DCA).
 							{
 								ip:          "1.1.1.1",
 								nodeName:    "firstNode",

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -243,7 +243,7 @@ func TestMapServices(t *testing.T) {
 								nodeName:    "firstNode",
 								targetPodId: "5555",
 							},
-							// This endpoint references a pod the is not in the local pod list we
+							// This endpoint references a pod the is not in the pod list we
 							// would receive from a kubelet (or apiserver for the DCA).
 							{
 								ip:          "1.1.1.1",


### PR DESCRIPTION
### What does this PR do?

Add check to make sure `mapOnRef` for services ignores mappings for other nodes.

The tests have been completely rewritten to be able to test for this issue. The tests will not pass anymore if the logic that has been added to `mapOnRef` is removed.
