### PR TITLE
Blacklist tests helper package from agent release

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -33,8 +33,9 @@ default_version integrations_core_version
 
 
 blacklist = [
-  'datadog_checks_base',  # namespacing package for wheels (NOT AN INTEGRATION)
-  'datadog_checks_dev',   # Development package, (NOT AN INTEGRATION)
+  'datadog_checks_base',           # namespacing package for wheels (NOT AN INTEGRATION)
+  'datadog_checks_dev',            # Development package, (NOT AN INTEGRATION)
+  'datadog_checks_tests_helper',   # Testing and Development package, (NOT AN INTEGRATION)
   'agent_metrics',
   'docker_daemon',
   'kubernetes',


### PR DESCRIPTION
### What does this PR do?

Don't ship the datadog_checks_tests_helper package with the Agent. 

### Motivation

Its only used for dev and testing, not for a functioning agent. 
### Additional Notes

Anything else we should know when reviewing?
