### PR TITLE
[stats] allow consuming the channel + test

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -41,7 +41,6 @@ func init() {
 	dogstatsdExpvars.Set("EventPackets", &dogstatsdEventPackets)
 	dogstatsdExpvars.Set("MetricParseErrors", &dogstatsdMetricParseErrors)
 	dogstatsdExpvars.Set("MetricPackets", &dogstatsdMetricPackets)
-	dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 }
 
 // Server represent a Dogstatsd server
@@ -70,6 +69,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 			log.Errorf("Dogstatsd: unable to start statistics facilities")
 		}
 		stats = s
+		dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 	}
 
 	packetChannel := make(chan *listeners.Packet, 100)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -31,6 +31,7 @@ var (
 	dogstatsdEventPackets            = expvar.Int{}
 	dogstatsdMetricParseErrors       = expvar.Int{}
 	dogstatsdMetricPackets           = expvar.Int{}
+	dogstatsdPacketsLastSec          = expvar.Int{}
 )
 
 func init() {
@@ -40,6 +41,7 @@ func init() {
 	dogstatsdExpvars.Set("EventPackets", &dogstatsdEventPackets)
 	dogstatsdExpvars.Set("MetricParseErrors", &dogstatsdMetricParseErrors)
 	dogstatsdExpvars.Set("MetricPackets", &dogstatsdMetricPackets)
+	dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 }
 
 // Server represent a Dogstatsd server
@@ -152,6 +154,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.Event, serviceCheckOut chan<- metrics.ServiceCheck) {
 	if s.Statistics != nil {
 		go s.Statistics.Process()
+		go s.Statistics.Update(&dogstatsdPacketsLastSec)
 	}
 
 	for _, l := range s.listeners {

--- a/pkg/util/stat.go
+++ b/pkg/util/stat.go
@@ -36,7 +36,7 @@ func NewStats(sz uint32) (*Stats, error) {
 		last:       time.Now(),
 		stopped:    make(chan struct{}),
 		incoming:   make(chan int64, sz),
-		Aggregated: make(chan Stat, 3),
+		Aggregated: make(chan Stat, 2),
 	}
 
 	return s, nil

--- a/pkg/util/stat_test.go
+++ b/pkg/util/stat_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"expvar"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStats(t *testing.T) {
+	myStat := expvar.Int{}
+
+	s, err := NewStats(10)
+	require.Nil(t, err)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	require.NotNil(t, ticker)
+
+	go s.Process()
+	go s.Update(&myStat)
+
+	deadline := time.After(2 * time.Second)
+
+loop:
+	for {
+		select {
+		case <-ticker.C:
+			// send a few events per second
+			for i := 0; i < 10; i++ {
+				s.StatEvent(int64(i))
+			}
+		case <-deadline:
+			s.Stop()
+			break loop
+		}
+	}
+
+	assert.NotEqual(t, myStat.Value(), 0)
+}

--- a/releasenotes/notes/dsd-stats-fix-and-expvar-45e2a7ba61a279df.yaml
+++ b/releasenotes/notes/dsd-stats-fix-and-expvar-45e2a7ba61a279df.yaml
@@ -2,7 +2,7 @@
 enhancements:
   - |
     Introduces an expvar reporting the number of dogstatsd
-    packtes per second processed if `dogstatsd_stats_enable`
+    packets per second processed if `dogstatsd_stats_enable`
     is enabled.
 fixes:
   - |

--- a/releasenotes/notes/dsd-stats-fix-and-expvar-45e2a7ba61a279df.yaml
+++ b/releasenotes/notes/dsd-stats-fix-and-expvar-45e2a7ba61a279df.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    Introduces an expvar reporting the number of dogstatsd
+    packtes per second processed if `dogstatsd_stats_enable`
+    is enabled.
+fixes:
+  - |
+    If `dogstatsd_stats_enable` is indeed enabled, we should
+    consume and report on the generated stats. Fixes stagnant
+    channel and misleading debug statement.


### PR DESCRIPTION
### What does this PR do?

The `stats` utility didn't really offer a nice, easy way to consume the aggregated stats. Here we add a simple `update()` method that will periodically update an expvar with the last aggregated value.

### Motivation

When `dogstatsd_stats_enable` was set to `true` (despite being an undocumented feature), the channel was never emptied giving place to a misleading error. This should allow us to a) report legit statistics for dsd packets/sec, b) not err like this.

### Additional Notes

I'm not sure the proposed interface for consumption (ie. an expvar) is ideal, but it provided easy quick integration with the current code. I'm up for any suggestions. 
