### PR TITLE
[gui/DCA] Add check version in gui/DCA status pages

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -10,8 +10,8 @@ Collector
   {{end -}}
 
   {{- range .Checks}}
-    {{.CheckName}}
-    {{printDashes .CheckName "-"}}
+    {{.CheckName}}{{ if .CheckVersion }} ({{.CheckVersion}}){{ end }}
+    {{printDashes .CheckName "-"}}{{- if .CheckVersion }}{{printDashes .CheckVersion "-"}}---{{ end }}
       Total Runs: {{.TotalRuns}}
       Metrics: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: {{.Events}}, Total: {{humanize .TotalEvents}}

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -8,10 +8,10 @@
         {{end -}}
 
         {{- range .Checks}}
-          <span class="stat_subtitle">{{.CheckName}}</span>
+          <span class="stat_subtitle">{{.CheckName}}{{ if .CheckVersion }} ({{.CheckVersion}}){{ end }}</span>
           <span class="stat_subdata">
               Total Runs: {{.TotalRuns}}<br>
-              Metrics: {{.MetricSamples}}, Total: {{humanizeF .TotalMetricSamples}}<br>
+              Metric Samples: {{.MetricSamples}}, Total: {{humanizeF .TotalMetricSamples}}<br>
               Events: {{.Events}}, Total: {{humanizeF .TotalEvents}}<br>
               Service Checks: {{.ServiceChecks}}, Total: {{humanizeF .TotalServiceChecks}}<br>
               Average Execution Time : {{.AverageExecutionTime}}ms<br>

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -1,10 +1,10 @@
 <div id="check_run_results">
-  <span class="stat_title">{{formatTitle .Name}} run result: </span>
+  <span class="stat_title">{{formatTitle .Name}}{{ if .CheckVersion }} ({{.CheckVersion}}){{ end }} run result: </span>
   {{- range $i, $e := .CheckStats}}
   <span class="stat_subtitle">Instance {{add $i 1}}</span>
     <span class="stat_data">
         Total Runs: {{.TotalRuns}}<br>
-        Metrics: {{.MetricSamples}}, Total: {{humanizeI .TotalMetricSamples}}<br>
+        Metric Samples: {{.MetricSamples}}, Total: {{humanizeI .TotalMetricSamples}}<br>
         Events: {{.Events}}, Total: {{humanizeI .TotalEvents}}<br>
         Service Checks: {{.ServiceChecks}}, Total: {{humanizeI .TotalServiceChecks}}<br>
       {{- if .LastError}}


### PR DESCRIPTION
### What does this PR do?

Reflects changes done on Agent status page in https://github.com/DataDog/datadog-agent/pull/1861

Also, reflects the renaming of `Metrics` into `Metric Samples` on the GUI.

### Motivation

Keep things consistent :)