### PR TITLE
the install script should respect the dd_url in the agent conf

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -224,6 +224,9 @@ else
       no_start=true
     fi
   fi
+  if [ $dd_url ]; then
+    $sudo_cmd sh -c "sed -i 's/# dd_url:.*/hostname: $dd_url/' $CONF"
+  fi
   if [ $dd_hostname ]; then
     printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: $CONF\n\033[0m\n"
     $sudo_cmd sh -c "sed -i 's/# hostname:.*/hostname: $dd_hostname/' $CONF"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -225,7 +225,7 @@ else
     fi
   fi
   if [ $dd_url ]; then
-    $sudo_cmd sh -c "sed -i 's/# dd_url:.*/hostname: $dd_url/' $CONF"
+    $sudo_cmd sh -c "sed -i 's/# dd_url:.*/dd_url: $dd_url/' $CONF"
   fi
   if [ $dd_hostname ]; then
     printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: $CONF\n\033[0m\n"


### PR DESCRIPTION
### What does this PR do?

The install script should replace the dd_url in the agent conf if dd_url is set

### Motivation

staging but this will be very important when we partition datadog by urls

### Additional Notes

Anything else we should know when reviewing?
