### PR TITLE
[status/gui] Fix display of check loader errors

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -38,7 +38,9 @@ Collector
       {{ configError $error }}
     {{- end }}
   {{- end}}
+{{- end }}
 
+{{- with .CheckSchedulerStats }}
   {{- if .LoaderErrors}}
   Loading Errors
   ==============

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -44,6 +44,8 @@
         </span>
       </div>
     {{- end}}
+  {{- end}}
+  {{- with .checkSchedulerStats }}
     {{- if .LoaderErrors}}
       <div class="stat">
         <span class="stat_title">Loading Errors</span>

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -44,7 +44,9 @@ Collector
       {{ configError $error }}
     {{- end }}
   {{- end}}
+{{- end }}
 
+{{- with .CheckSchedulerStats }}
   {{- if .LoaderErrors}}
   Loading Errors
   ==============

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -37,6 +37,7 @@ func FormatStatus(data []byte) (string, error) {
 	forwarderStats := stats["forwarderStats"]
 	runnerStats := stats["runnerStats"]
 	autoConfigStats := stats["autoConfigStats"]
+	checkSchedulerStats := stats["checkSchedulerStats"]
 	aggregatorStats := stats["aggregatorStats"]
 	jmxStats := stats["JMXStatus"]
 	logsStats := stats["logsStats"]
@@ -44,7 +45,7 @@ func FormatStatus(data []byte) (string, error) {
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, autoConfigStats, "")
+	renderChecksStats(b, runnerStats, autoConfigStats, checkSchedulerStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
 	renderLogsStatus(b, logsStats)
@@ -65,10 +66,11 @@ func FormatDCAStatus(data []byte) (string, error) {
 	forwarderStats := stats["forwarderStats"]
 	runnerStats := stats["runnerStats"]
 	autoConfigStats := stats["autoConfigStats"]
+	checkSchedulerStats := stats["checkSchedulerStats"]
 	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, autoConfigStats, "")
+	renderChecksStats(b, runnerStats, autoConfigStats, checkSchedulerStats, "")
 	renderForwarderStatus(b, forwarderStats)
 
 	return b.String(), nil
@@ -137,10 +139,11 @@ func renderHPAStats(w io.Writer, hpaStats interface{}) {
 	}
 }
 
-func renderChecksStats(w io.Writer, runnerStats interface{}, autoConfigStats interface{}, onlyCheck string) {
+func renderChecksStats(w io.Writer, runnerStats interface{}, autoConfigStats interface{}, checkSchedulerStats interface{}, onlyCheck string) {
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
 	checkStats["AutoConfigStats"] = autoConfigStats
+	checkStats["CheckSchedulerStats"] = checkSchedulerStats
 	checkStats["OnlyCheck"] = onlyCheck
 	t := template.Must(template.New("collector.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "collector.tmpl")))
 
@@ -157,7 +160,8 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	json.Unmarshal(data, &stats)
 	runnerStats := stats["runnerStats"]
 	autoConfigStats := stats["autoConfigStats"]
-	renderChecksStats(b, runnerStats, autoConfigStats, checkName)
+	checkSchedulerStats := stats["checkSchedulerStats"]
+	renderChecksStats(b, runnerStats, autoConfigStats, checkSchedulerStats, checkName)
 
 	return b.String(), nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -189,6 +189,11 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	json.Unmarshal(autoConfigStatsJSON, &autoConfigStats)
 	stats["autoConfigStats"] = autoConfigStats
 
+	checkSchedulerStatsJSON := []byte(expvar.Get("CheckScheduler").String())
+	checkSchedulerStats := make(map[string]interface{})
+	json.Unmarshal(checkSchedulerStatsJSON, &checkSchedulerStats)
+	stats["checkSchedulerStats"] = checkSchedulerStats
+
 	aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
 	aggregatorStats := make(map[string]interface{})
 	json.Unmarshal(aggregatorStatsJSON, &aggregatorStats)


### PR DESCRIPTION
### What does this PR do?

Fixes display of check loader errors from status and GUI (broken since the AD refactor in https://github.com/DataDog/datadog-agent/pull/1936)

### Motivation

🛠 

### Additional Notes

The `status`package deserves a revamp, a lot of implicit mappings going on there...
