### PR TITLE
Use tag rather than revision sha

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,6 +11,7 @@
   name = "github.com/DataDog/agent-payload"
   packages = ["gogen"]
   revision = "c76e9d5be7457cafb7b3e056c6e8ae127b1f0431"
+  version = "4.7.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/DataDog/agent-payload"
-  revision = "c76e9d5be7457cafb7b3e056c6e8ae127b1f0431"
+  version = "4.7.1"
 
 [[constraint]]
   name = "github.com/DataDog/gohai"


### PR DESCRIPTION
### What does this PR do?

Set the version to a tag rather than using the revision sha

### Motivation

Fixes overall agent version reporting
