### PR TITLE
Fix API_KEY validation for 'additional_endpoints'

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,7 +47,7 @@ additional_endpoints:
 		"https://foo.datadoghq.com": {
 			"someapikey",
 		},
-		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
+		"https://app.datadoghq.com": {
 			"fakeapikey",
 			"fakeapikey2",
 			"fakeapikey3",
@@ -69,7 +69,7 @@ api_key: fakeapikey
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
-		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
+		"https://app.datadoghq.com": {
 			"fakeapikey",
 		},
 	}
@@ -97,7 +97,7 @@ additional_endpoints:
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
-		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
+		"https://app.datadoghq.com": {
 			"fakeapikey",
 			"fakeapikey2",
 		},
@@ -130,7 +130,7 @@ additional_endpoints:
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
-		"https://" + getDomainPrefix("app") + ".datadoghq.com": {
+		"https://app.datadoghq.com": {
 			"fakeapikey",
 			"fakeapikey2",
 		},
@@ -145,15 +145,15 @@ additional_endpoints:
 }
 
 func TestAddAgentVersionToDomain(t *testing.T) {
-	newURL, err := addAgentVersionToDomain("https://app.datadoghq.com", "app")
+	newURL, err := AddAgentVersionToDomain("https://app.datadoghq.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.com", newURL)
 
-	newURL, err = addAgentVersionToDomain("https://app.datadoghq.com", "flare")
+	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.com", "flare")
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.com", newURL)
 
-	newURL, err = addAgentVersionToDomain("https://app.myproxy.com", "app")
+	newURL, err = AddAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://app.myproxy.com", newURL)
 }

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -113,12 +113,13 @@ func NewDefaultForwarder(keysPerDomains map[string][]string) *DefaultForwarder {
 		domainForwarders: map[string]*domainForwarder{},
 		keysPerDomains:   map[string][]string{},
 		internalState:    Stopped,
-		healthChecker:    &forwarderHealth{},
+		healthChecker:    &forwarderHealth{keysPerDomains: keysPerDomains},
 	}
 	numWorkers := config.Datadog.GetInt("forwarder_num_workers")
 	retryQueueMaxSize := config.Datadog.GetInt("forwarder_retry_queue_max_size")
 
 	for domain, keys := range keysPerDomains {
+		domain, _ := config.AddAgentVersionToDomain(domain, "app")
 		if keys == nil || len(keys) == 0 {
 			log.Errorf("No API keys for domain '%s', dropping domain ", domain)
 		} else {
@@ -153,7 +154,7 @@ func (f *DefaultForwarder) Start() error {
 	log.Infof("Forwarder started, sending to %v endpoint(s) with %v worker(s) each: %s",
 		len(endpointLogs), f.NumberOfWorkers, strings.Join(endpointLogs, " ; "))
 
-	f.healthChecker.Start(f.keysPerDomains)
+	f.healthChecker.Start()
 	f.internalState = Started
 	return nil
 }

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -42,22 +41,21 @@ func initForwarderHealthExpvars() {
 // unhealthy if the API keys are not longer valid or if to many transactions
 // were dropped
 type forwarderHealth struct {
-	health  *health.Handle
-	stop    chan bool
-	stopped chan struct{}
-	ddURL   string
-	timeout time.Duration
+	health         *health.Handle
+	stop           chan bool
+	stopped        chan struct{}
+	timeout        time.Duration
+	keysPerDomains map[string][]string
 }
 
-func (fh *forwarderHealth) init(keysPerDomains map[string][]string) {
+func (fh *forwarderHealth) init() {
 	fh.stop = make(chan bool, 1)
 	fh.stopped = make(chan struct{})
-	fh.ddURL = config.Datadog.GetString("dd_url")
 
 	// Since timeout is the maximum duration we can wait, we need to divide it
 	// by the total number of api keys to obtain the max duration for each key
 	apiKeyCount := 0
-	for _, apiKeys := range keysPerDomains {
+	for _, apiKeys := range fh.keysPerDomains {
 		apiKeyCount += len(apiKeys)
 	}
 
@@ -67,10 +65,10 @@ func (fh *forwarderHealth) init(keysPerDomains map[string][]string) {
 	}
 }
 
-func (fh *forwarderHealth) Start(keysPerDomains map[string][]string) {
+func (fh *forwarderHealth) Start() {
 	fh.health = health.Register("forwarder")
-	fh.init(keysPerDomains)
-	go fh.healthCheckLoop(keysPerDomains)
+	fh.init()
+	go fh.healthCheckLoop()
 }
 
 func (fh *forwarderHealth) Stop() {
@@ -79,14 +77,14 @@ func (fh *forwarderHealth) Stop() {
 	<-fh.stopped
 }
 
-func (fh *forwarderHealth) healthCheckLoop(keysPerDomains map[string][]string) {
+func (fh *forwarderHealth) healthCheckLoop() {
 	log.Debug("Waiting for APIkey validity to be confirmed.")
 
 	validateTicker := time.NewTicker(time.Hour * 1)
 	defer validateTicker.Stop()
 	defer close(fh.stopped)
 
-	valid := fh.hasValidAPIKey(keysPerDomains)
+	valid := fh.hasValidAPIKey()
 	// If no key is valid, no need to keep checking, they won't magicaly become valid
 	if !valid {
 		log.Errorf("No valid api key found, reporting the forwarder as unhealthy.")
@@ -98,7 +96,7 @@ func (fh *forwarderHealth) healthCheckLoop(keysPerDomains map[string][]string) {
 		case <-fh.stop:
 			return
 		case <-validateTicker.C:
-			valid := fh.hasValidAPIKey(keysPerDomains)
+			valid := fh.hasValidAPIKey()
 			if !valid {
 				log.Errorf("No valid api key found, reporting the forwarder as unhealthy.")
 				return
@@ -117,11 +115,12 @@ func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status 
 		apiKey = apiKey[len(apiKey)-5:]
 	}
 	obfuscatedKey := fmt.Sprintf("API key ending by %s on endpoint %s", apiKey, domain)
+	fmt.Println(obfuscatedKey)
 	apiKeyStatus.Set(obfuscatedKey, status)
 }
 
 func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
-	url := fmt.Sprintf("%s%s?api_key=%s", fh.ddURL, v1ValidateEndpoint, apiKey)
+	url := fmt.Sprintf("%s%s?api_key=%s", domain, v1ValidateEndpoint, apiKey)
 
 	transport := util.CreateHTTPTransport()
 
@@ -150,18 +149,21 @@ func (fh *forwarderHealth) validateAPIKey(apiKey, domain string) (bool, error) {
 	return false, fmt.Errorf("Unexpected response code from the apikey validation endpoint: %v", resp.StatusCode)
 }
 
-func (fh *forwarderHealth) hasValidAPIKey(keysPerDomains map[string][]string) bool {
+func (fh *forwarderHealth) hasValidAPIKey() bool {
 	validKey := false
 	apiError := false
 
-	for domain, apiKeys := range keysPerDomains {
+	for domain, apiKeys := range fh.keysPerDomains {
 		for _, apiKey := range apiKeys {
 			v, err := fh.validateAPIKey(apiKey, domain)
 			if err != nil {
 				log.Debug(err)
 				apiError = true
 			} else if v {
+				log.Debugf("api_key '%s' for domain %s is valid", apiKey, domain)
 				validKey = true
+			} else {
+				log.Debugf("api_key '%s' for domain %s is invalid", apiKey, domain)
 			}
 		}
 	}

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -6,64 +6,65 @@
 package forwarder
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestHasValidAPIKey(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	ddURL := config.Datadog.Get("dd_url")
-	config.Datadog.Set("dd_url", ts.URL)
-	defer ts.Close()
-	defer func() { config.Datadog.Set("dd_url", ddURL) }()
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts1.Close()
+	defer ts2.Close()
 
 	keysPerDomains := map[string][]string{
-		"domain1": {"api_key1", "api_key2"},
-		"domain2": {"key3"},
+		ts1.URL: {"api_key1", "api_key2"},
+		ts2.URL: {"key3"},
 	}
 
-	fh := forwarderHealth{}
-	fh.init(keysPerDomains)
-	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
+	fh := forwarderHealth{keysPerDomains: keysPerDomains}
+	fh.init()
+	assert.True(t, fh.hasValidAPIKey())
 
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by _key1 on endpoint domain1"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by _key2 on endpoint domain1"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by key3 on endpoint domain2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by _key1 on endpoint "+ts1.URL))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by _key2 on endpoint "+ts1.URL))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by key3 on endpoint "+ts2.URL))
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 		if r.Form.Get("api_key") == "api_key1" {
 			w.WriteHeader(http.StatusForbidden)
 		} else if r.Form.Get("api_key") == "api_key2" {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
-			w.WriteHeader(http.StatusOK)
+			assert.Fail(t, fmt.Sprintf("Unknown api key received: %v", r.Form.Get("api_key")))
 		}
 	}))
-	ddURL := config.Datadog.Get("dd_url")
-	config.Datadog.Set("dd_url", ts.URL)
-	defer ts.Close()
-	defer func() { config.Datadog.Set("dd_url", ddURL) }()
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts1.Close()
+	defer ts2.Close()
 
 	keysPerDomains := map[string][]string{
-		"domain1": {"api_key1", "api_key2"},
-		"domain2": {"key3"},
+		ts1.URL: {"api_key1", "api_key2"},
+		ts2.URL: {"key3"},
 	}
 
-	fh := forwarderHealth{}
-	fh.init(keysPerDomains)
-	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
+	fh := forwarderHealth{keysPerDomains: keysPerDomains}
+	fh.init()
+	assert.True(t, fh.hasValidAPIKey())
 
-	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending by _key1 on endpoint domain1"))
-	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending by _key2 on endpoint domain1"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by key3 on endpoint domain2"))
+	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending by _key1 on endpoint "+ts1.URL))
+	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending by _key2 on endpoint "+ts1.URL))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by key3 on endpoint "+ts2.URL))
 }

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -20,15 +20,17 @@ import (
 )
 
 var (
-	monoKeysDomains = map[string][]string{
-		"datadog.foo": {"monokey"},
+	testDomain           = "http://app.datadoghq.com"
+	testVersionDomain, _ = config.AddAgentVersionToDomain(testDomain, "app")
+	monoKeysDomains      = map[string][]string{
+		testVersionDomain: {"monokey"},
 	}
 	keysPerDomains = map[string][]string{
-		"datadog.foo": {"api-key-1", "api-key-2"},
+		testDomain:    {"api-key-1", "api-key-2"},
 		"datadog.bar": nil,
 	}
 	validKeysPerDomain = map[string][]string{
-		"datadog.foo": {"api-key-1", "api-key-2"},
+		testVersionDomain: {"api-key-1", "api-key-2"},
 	}
 )
 
@@ -95,10 +97,10 @@ func TestCreateHTTPTransactions(t *testing.T) {
 
 	transactions := forwarder.createHTTPTransactions(endpoint, payloads, false, headers)
 	require.Len(t, transactions, 4)
-	assert.Equal(t, "datadog.foo", transactions[0].Domain)
-	assert.Equal(t, "datadog.foo", transactions[1].Domain)
-	assert.Equal(t, "datadog.foo", transactions[2].Domain)
-	assert.Equal(t, "datadog.foo", transactions[3].Domain)
+	assert.Equal(t, testVersionDomain, transactions[0].Domain)
+	assert.Equal(t, testVersionDomain, transactions[1].Domain)
+	assert.Equal(t, testVersionDomain, transactions[2].Domain)
+	assert.Equal(t, testVersionDomain, transactions[3].Domain)
 	assert.Equal(t, endpoint, transactions[0].Endpoint)
 	assert.Equal(t, endpoint, transactions[1].Endpoint)
 	assert.Equal(t, endpoint, transactions[2].Endpoint)
@@ -147,7 +149,7 @@ func TestSubmitV1Intake(t *testing.T) {
 	// DefaultForwarder correctly create HTTPTransaction, set the headers
 	// and send them to the correct domainForwarder.
 	inputQueue := make(chan Transaction, 1)
-	df := forwarder.domainForwarders["datadog.foo"]
+	df := forwarder.domainForwarders[testVersionDomain]
 	bk := df.highPrio
 	df.highPrio = inputQueue
 	defer func() { df.highPrio = bk }()

--- a/releasenotes/notes/api-key-validation-per-domain-891ebd73ab300a6c.yaml
+++ b/releasenotes/notes/api-key-validation-per-domain-891ebd73ab300a6c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix API_KEY validation for 'additional_endpoints' by using their respective
+    endpoint instead of the main one all the time.


### PR DESCRIPTION
### What does this PR do?

We now use the endpoint linked to the API_KEY to validate it instead of
the main one from the configuration. The forwarder is now in charge of
prefixing the endpoints with the agent version.