### PR TITLE
Update status page working for API Keys status

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -113,10 +113,10 @@ func (fh *forwarderHealth) healthCheckLoop(keysPerDomains map[string][]string) {
 }
 
 func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status expvar.Var) {
-	obfuscatedKey := fmt.Sprintf("%s,*************************", domain)
 	if len(apiKey) > 5 {
-		obfuscatedKey += apiKey[len(apiKey)-5:]
+		apiKey = apiKey[len(apiKey)-5:]
 	}
+	obfuscatedKey := fmt.Sprintf("API key ending by %s on endpoint %s", apiKey, domain)
 	apiKeyStatus.Set(obfuscatedKey, status)
 }
 

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -33,9 +33,9 @@ func TestHasValidAPIKey(t *testing.T) {
 	fh.init(keysPerDomains)
 	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
 
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain1,*************************_key1"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain1,*************************_key2"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain2,*************************"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by _key1 on endpoint domain1"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by _key2 on endpoint domain1"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by key3 on endpoint domain2"))
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {
@@ -63,7 +63,7 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	fh.init(keysPerDomains)
 	assert.True(t, fh.hasValidAPIKey(keysPerDomains))
 
-	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("domain1,*************************_key1"))
-	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("domain1,*************************_key2"))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("domain2,*************************"))
+	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending by _key1 on endpoint domain1"))
+	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending by _key2 on endpoint domain1"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending by key3 on endpoint domain2"))
 }


### PR DESCRIPTION
### What does this PR do?

The old wording was confusing for new users.

Old wording:
```
    a,*************************55555: Unable to validate API Key
    https://app.datadoghq.com,*************************22222: API Key invalid
    https://app.datadoghq.com,*************************c0b75: API Key valid
```

New wording:
```
    API key ending by 55555 on endpoint a: Unable to validate API Key
    API key ending by 22222 on endpoint https://app.datadoghq.com: API Key invalid
    API key ending by c0b75 on endpoint https://app.datadoghq.com: API Key valid
```