### PR TITLE
Go's syscall package FreeBSD is missing S_IRWXG and S_IRWXO

### DIFF
--- a/pkg/secrets/check_right_freebsd.go
+++ b/pkg/secrets/check_right_freebsd.go
@@ -3,9 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build !windows,!freebsd
+// +build freebsd
 
 package secrets
+
+// temporary fix until go gets S_IRWXG and S_IRWXO
+
+/*
+#include <sys/stat.h>
+*/
+import "C"
 
 import (
 	"fmt"
@@ -20,7 +27,7 @@ func checkRights(path string) error {
 	}
 
 	// checking that group and others don't have any rights
-	if stat.Mode&(syscall.S_IRWXG|syscall.S_IRWXO) != 0 {
+	if stat.Mode&(C.S_IRWXG|C.S_IRWXO) != 0 {
 		return fmt.Errorf("invalid executable '%s', 'groups' or 'others' have rights on it", path)
 	}
 

--- a/releasenotes/notes/Go's-syscall-package-FreeBSD-is-missing-S_IRWXG-and-S_IRWXO-7274fcfefaba26f3.yaml
+++ b/releasenotes/notes/Go's-syscall-package-FreeBSD-is-missing-S_IRWXG-and-S_IRWXO-7274fcfefaba26f3.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix build on FreeBSD where Go’s syscall is missing S_IRWXG and S_IRWXO


### PR DESCRIPTION
This patch adds a _freebsd.go file that builds instead of the regular
one *only* on Freebsd (to the best of my cross-platform Go abilities).

It imports the C constants S_IRWXG and S_IRWXO and uses them instead
of syscall.S_IRWXG and syscall.S_IRWXO.

Closes #2078

The relevant diff is:

```diff
--- pkg/secrets/check_right.go	2018-07-29 16:56:36.000000000 +0200
+++ pkg/secrets/check_right_freebsd.go	2018-07-29 16:56:36.000000000 +0200
@@ -3,10 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build !windows,!freebsd
+// +build freebsd
 
 package secrets
 
+// temporary fix until go gets S_IRWXG and S_IRWXO
+
+/*
+#include <sys/stat.h>
+*/
+import "C"
+
 import (
 	"fmt"
 	"os/user"
@@ -20,7 +27,7 @@
 	}
 
 	// checking that group and others don't have any rights
-	if stat.Mode&(syscall.S_IRWXG|syscall.S_IRWXO) != 0 {
+	if stat.Mode&(C.S_IRWXG|C.S_IRWXO) != 0 {
 		return fmt.Errorf("invalid executable '%s', 'groups' or 'others' have rights on it", path)
 	}
 ```