### PR TITLE
make the ntp check more resilient

### DIFF
--- a/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default
@@ -9,7 +9,11 @@ instances:
 
     # Optional params:
     #
-    # host: pool.ntp.org
+    # hosts:
+    #  - 0.europe.pool.ntp.org
+    #  - 1.europe.pool.ntp.org
+    #  - 2.europe.pool.ntp.org
+    #  - 3.europe.pool.ntp.org
     # port: ntp
     # version: 3
     # timeout: 5

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -78,18 +78,14 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 
 	c.instance = instance
 	if c.instance.Host != "" {
-		if c.instance.Hosts == nil {
-			c.instance.Hosts = []string{c.instance.Host}
-		} else {
-			hosts := []string{c.instance.Host}
-			// If config contains both host and hosts, we merge both
-			for _, h := range c.instance.Hosts {
-				if h != c.instance.Host {
-					hosts = append(hosts, h)
-				}
+		hosts := []string{c.instance.Host}
+		// If config contains both host and hosts
+		for _, h := range c.instance.Hosts {
+			if h != c.instance.Host {
+				hosts = append(hosts, h)
 			}
-			c.instance.Hosts = hosts
 		}
+		c.instance.Hosts = hosts
 	}
 	if c.instance.Hosts == nil {
 		c.instance.Hosts = defaultHosts

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -189,11 +189,11 @@ func (c *NTPCheck) queryOffset() (float64, error) {
 	var median float64
 
 	sort.Float64s(offsets)
-	lenght := len(offsets)
-	if lenght%2 == 0 {
-		median = (offsets[lenght/2-1] + offsets[lenght/2]) / 2.0
+	length := len(offsets)
+	if length%2 == 0 {
+		median = (offsets[length/2-1] + offsets[length/2]) / 2.0
 	} else {
-		median = offsets[lenght/2]
+		median = offsets[length/2]
 	}
 
 	return median, nil

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -8,7 +8,7 @@ package network
 import (
 	"expvar"
 	"fmt"
-	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -38,12 +38,13 @@ type NTPCheck struct {
 }
 
 type ntpInstanceConfig struct {
-	OffsetThreshold       int    `yaml:"offset_threshold"`
-	Host                  string `yaml:"host"`
-	Port                  string `yaml:"port"`
-	Timeout               int    `yaml:"timeout"`
-	Version               int    `yaml:"version"`
-	MinCollectionInterval int    `yaml:"min_collection_interval"`
+	OffsetThreshold       int      `yaml:"offset_threshold"`
+	Host                  string   `yaml:"host"`
+	Hosts                 []string `yaml:"hosts"`
+	Port                  string   `yaml:"port"`
+	Timeout               int      `yaml:"timeout"`
+	Version               int      `yaml:"version"`
+	MinCollectionInterval int      `yaml:"min_collection_interval"`
 }
 
 type ntpInitConfig struct{}
@@ -65,6 +66,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 	defaultPort := "ntp"
 	defaultOffsetThreshold := 60
 	defaultMinCollectionInterval := 900 // 15 minutes, to follow pool.ntp.org's guidelines on the query rate
+	defaultHosts := []string{"0.datadog.pool.ntp.org", "1.datadog.pool.ntp.org", "2.datadog.pool.ntp.org", "3.datadog.pool.ntp.org"}
 
 	if err := yaml.Unmarshal(data, &instance); err != nil {
 		return err
@@ -74,9 +76,24 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 		return err
 	}
 
+	// TODO : test merging logic
 	c.instance = instance
-	if c.instance.Host == "" {
-		c.instance.Host = fmt.Sprintf("%d.datadog.pool.ntp.org", rand.Intn(3))
+	if c.instance.Host != "" {
+		if c.instance.Hosts == nil {
+			c.instance.Hosts = []string{c.instance.Host}
+		} else {
+			hosts := []string{c.instance.Host}
+			// If config contains both host and hosts, we merge both
+			for _, h := range c.instance.Hosts {
+				if h != c.instance.Host {
+					hosts = append(hosts, h)
+				}
+			}
+			c.instance.Hosts = hosts
+		}
+	}
+	if c.instance.Hosts == nil {
+		c.instance.Hosts = defaultHosts
 	}
 	if c.instance.Port == "" {
 		c.instance.Port = defaultPort
@@ -126,25 +143,23 @@ func (c *NTPCheck) Run() error {
 	}
 
 	var serviceCheckStatus metrics.ServiceCheckStatus
-	var clockOffset int
 	serviceCheckMessage := ""
 	offsetThreshold := c.cfg.instance.OffsetThreshold
 
-	response, err := ntpQuery(c.cfg.instance.Host, c.cfg.instance.Version)
+	clockOffset, err := c.queryOffset()
 	if err != nil {
-		log.Infof("There was an error querying the ntp host: %s", err)
+		log.Info(err)
 		serviceCheckStatus = metrics.ServiceCheckUnknown
 	} else {
-		clockOffset = int(response.ClockOffset.Seconds())
-		if clockOffset > offsetThreshold {
+		if int(clockOffset) > offsetThreshold {
 			serviceCheckStatus = metrics.ServiceCheckCritical
 			serviceCheckMessage = fmt.Sprintf("Offset %v secs higher than offset threshold (%v secs)", clockOffset, offsetThreshold)
 		} else {
 			serviceCheckStatus = metrics.ServiceCheckOK
 		}
 
-		sender.Gauge("ntp.offset", response.ClockOffset.Seconds(), "", nil)
-		ntpExpVar.Set(response.ClockOffset.Seconds())
+		sender.Gauge("ntp.offset", clockOffset, "", nil)
+		ntpExpVar.Set(clockOffset)
 	}
 
 	sender.ServiceCheck("ntp.in_sync", serviceCheckStatus, "", nil, serviceCheckMessage)
@@ -154,6 +169,35 @@ func (c *NTPCheck) Run() error {
 	sender.Commit()
 
 	return nil
+}
+
+func (c *NTPCheck) queryOffset() (float64, error) {
+	offsets := []float64{}
+
+	for _, host := range c.cfg.instance.Hosts {
+		response, err := ntpQuery(host, c.cfg.instance.Version)
+		if err != nil {
+			log.Infof("There was an error querying the ntp host %s: %s", host, err)
+		} else {
+			offsets = append(offsets, response.ClockOffset.Seconds())
+		}
+	}
+
+	if len(offsets) == 0 {
+		return .0, fmt.Errorf("Failed to get clock offset from any ntp host")
+	}
+
+	var median float64
+
+	sort.Float64s(offsets)
+	lenght := len(offsets)
+	if lenght%2 == 0 {
+		median = (offsets[lenght/2-1] + offsets[lenght/2]) / 2.0
+	} else {
+		median = offsets[lenght/2]
+	}
+
+	return median, nil
 }
 
 func ntpFactory() check.Check {

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -76,7 +76,6 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 		return err
 	}
 
-	// TODO : test merging logic
 	c.instance = instance
 	if c.instance.Host != "" {
 		if c.instance.Hosts == nil {

--- a/pkg/collector/corechecks/network/ntp_test.go
+++ b/pkg/collector/corechecks/network/ntp_test.go
@@ -7,10 +7,12 @@ package network
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/beevik/ntp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -123,4 +125,136 @@ func TestNTPError(t *testing.T) {
 	mockSender.AssertNumberOfCalls(t, "Gauge", 0)
 	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 1)
 	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestNTPResiliencyOK(t *testing.T) {
+	var ntpCfg = []byte(`
+hosts:
+  - 1
+  - 400
+  - 2
+`)
+	var ntpInitCfg = []byte("")
+
+	offset = 1
+	ntpQuery = func(host string, version int) (*ntp.Response, error) {
+		o, _ := strconv.Atoi(host)
+		return &ntp.Response{
+			ClockOffset: time.Duration(o) * time.Second,
+		}, nil
+	}
+	defer func() { ntpQuery = ntp.Query }()
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+
+	mockSender := mocksender.NewMockSender(ntpCheck.ID())
+
+	mockSender.On("Gauge", "ntp.offset", float64(2), "", []string(nil)).Return().Times(1)
+	mockSender.On("ServiceCheck",
+		"ntp.in_sync",
+		metrics.ServiceCheckOK,
+		"",
+		[]string(nil),
+		"").Return().Times(1)
+
+	mockSender.On("Commit").Return().Times(1)
+	ntpCheck.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 1)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestNTPResiliencyCritical(t *testing.T) {
+	var ntpCfg = []byte(`
+hosts:
+  - 1
+  - 400
+  - 400
+`)
+	var ntpInitCfg = []byte("")
+
+	offset = 1
+	ntpQuery = func(host string, version int) (*ntp.Response, error) {
+		o, _ := strconv.Atoi(host)
+		return &ntp.Response{
+			ClockOffset: time.Duration(o) * time.Second,
+		}, nil
+	}
+	defer func() { ntpQuery = ntp.Query }()
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+
+	mockSender := mocksender.NewMockSender(ntpCheck.ID())
+
+	mockSender.On("Gauge", "ntp.offset", float64(400), "", []string(nil)).Return().Times(1)
+	mockSender.On("ServiceCheck",
+		"ntp.in_sync",
+		metrics.ServiceCheckCritical,
+		"",
+		[]string(nil),
+		"Offset 400 secs higher than offset threshold (60 secs)").Return().Times(1)
+
+	mockSender.On("Commit").Return().Times(1)
+	ntpCheck.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 1)
+	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestHostConfigsMerge(t *testing.T) {
+
+	expectedHosts := []string{"0.time.dogo", "1.time.dogo", "2.time.dogo"}
+	testedConfig := []byte(`
+host: 0.time.dogo
+hosts:
+  - 1.time.dogo
+  - 2.time.dogo
+`)
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(testedConfig, []byte(""))
+
+	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
+}
+
+func TestHostConfig(t *testing.T) {
+	expectedHosts := []string{"time.dogo"}
+	testedConfig := []byte(`
+host: time.dogo
+`)
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(testedConfig, []byte(""))
+
+	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
+}
+
+func TestHostsConfig(t *testing.T) {
+	expectedHosts := []string{"0.time.dogo", "1.time.dogo"}
+	testedConfig := []byte(`
+hosts:
+  - 0.time.dogo
+  - 1.time.dogo
+`)
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(testedConfig, []byte(""))
+
+	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
+}
+
+func TestDefaultHostConfig(t *testing.T) {
+	expectedHosts := []string{"0.datadog.pool.ntp.org", "1.datadog.pool.ntp.org", "2.datadog.pool.ntp.org", "3.datadog.pool.ntp.org"}
+	testedConfig := []byte(``)
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(testedConfig, []byte(""))
+
+	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }

--- a/pkg/collector/corechecks/network/ntp_test.go
+++ b/pkg/collector/corechecks/network/ntp_test.go
@@ -223,6 +223,23 @@ hosts:
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
 
+func TestHostConfigsMergeNoDuplicate(t *testing.T) {
+
+	expectedHosts := []string{"0.time.dogo", "1.time.dogo", "2.time.dogo"}
+	testedConfig := []byte(`
+host: 0.time.dogo
+hosts:
+  - 0.time.dogo
+  - 1.time.dogo
+  - 2.time.dogo
+`)
+
+	ntpCheck := new(NTPCheck)
+	ntpCheck.Configure(testedConfig, []byte(""))
+
+	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
+}
+
 func TestHostConfig(t *testing.T) {
 	expectedHosts := []string{"time.dogo"}
 	testedConfig := []byte(`

--- a/releasenotes/notes/resilient-ntp-check-daf404a4a4fc61c2.yaml
+++ b/releasenotes/notes/resilient-ntp-check-daf404a4a4fc61c2.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ntp check is now more resilient to npt servers returning wrong offsets

--- a/releasenotes/notes/resilient-ntp-check-daf404a4a4fc61c2.yaml
+++ b/releasenotes/notes/resilient-ntp-check-daf404a4a4fc61c2.yaml
@@ -8,4 +8,7 @@
 ---
 enhancements:
   - |
-    The ntp check is now more resilient to npt servers returning wrong offsets
+    The ntp check will now query multiple servers by default to be more
+    resilient to servers returning wrong offsets. A now config option ``hosts``
+    is now available in the ntp check configuration file to allow users to change
+    the list of ntp servers.


### PR DESCRIPTION
### What does this PR do?

Use multiple ntp servers in the ntp check to be more resilient if a server returns a bad time.

Current implementation simply takes the median of the offsets. With 3+ servers this should make us tolerant to one bad server. With 5+ servers this makes us tolerant to two bad servers. etc..