### PR TITLE
[changelog] Remove entry that shouldn't be in 6.4.0 + fix title typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,9 +12,6 @@ Release Notes
 Prelude
 -------
 
-Defer process orchestration to the operating system where supported.
-
-
 Release on: 2018-07-31
 
 - Please refer to the `6.4.0 tag on integrations-core <https://github.com/DataDog/integrations-core/releases/tag/6.4.0>`_ for the list of changes on the Core Checks.
@@ -52,17 +49,12 @@ New Features
 - OpenShift ClusterResourceQuotas metrics are now collected by the kube_apiserver check,
   under the openshift.clusterquota.* and openshift.appliedclusterquota.* names.
 
-- Adds support for OS-level process orchestration of the agents on linux.
-  Specifically, this adds support for upstart on systemd which should cover
-  most modern debian/rhel based distros. Changes enable a more resilient 
-  process management for the infrastructure, process and trace agents.
-
 - Display the version for Python checks on the status page.
 
 
 .. _Release Notes_6.4.0_Enhancements Notes:
 
-Enhancements Notes
+Enhancement Notes
 ------------------
 
 - Adding DD_EXPVAR_PORT to the configuration environment variables.

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -42,7 +42,7 @@ template: |
 sections:
   # The prelude section is implicitly included.
   - [features, New Features]
-  - [enhancements, Enhancements Notes]
+  - [enhancements, Enhancement Notes]
   - [issues, Known Issues]
   - [upgrade, Upgrade Notes]
   - [deprecations, Deprecation Notes]

--- a/releasenotes/notes/os-level-orchestration-4e96f65bf856c628.yaml
+++ b/releasenotes/notes/os-level-orchestration-4e96f65bf856c628.yaml
@@ -1,9 +1,0 @@
----
-prelude: >
-    Defer process orchestration to the operating system where supported.
-features:
-  - |
-    Adds support for OS-level process orchestration of the agents on linux.
-    Specifically, this adds support for upstart on systemd which should cover
-    most modern debian/rhel based distros. Changes enable a more resilient 
-    process management for the infrastructure, process and trace agents.


### PR DESCRIPTION
### What does this PR do?

* Remove changelog entry that shouldn't be in 6.4.0
* remove the related `releasenotes/` file
* fix changelog title typo

### Motivation

This old release note was originally put in the wrong directory so not
used, but it was recently moved back to the correct `releasenotes/`
directory (in the otherwise unrelated PR https://github.com/DataDog/datadog-agent/pull/2045) so reno started picking it up.
