### PR TITLE
Normalize and document handling of config options setting through env vars

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -8,6 +8,18 @@ might mean:
  * The option refers to a feature that's currently under development
  * The option refers to a feature that's scheduled but will come later
 
+## Environment variables
+
+All options supported by the Infrastructure Agent in the configuration file can also be set through environment variables;
+ * Option names should be put in uppercase with the `DD_` prefix. (example: `hostname` -> `DD_HOSTNAME`)
+ * Nested variables should be specified with an underscore. (example: `DD_CLUSTER_AGENT_CMD_PORT` -> `cluster_agent.cmd_port`)
+ * List of values should be separated by spaces. (example: `DD_AC_INCLUDE="image:cp-kafka image:k8szk"`)
+ * Any map structure but the proxy settings should be json-formatted. (example: `DD_DOCKER_ENV_AS_TAGS='{ "ENVVAR_NAME": "tag_name" }'`)
+
+Notes:
+ * Specifying nested variables with an environment variable overrides all the others nested variables of the parameter specified in the corresponding configuration file.
+ * The above note doesn't apply for the proxy setting. [Refer to the dedicated Agent proxy documentation](https://docs.datadoghq.com/agent/proxy/#agent-v6) to learn more.
+
 ## Orchestration + Agent Management
 
 Orchestration has now been deferred to OS facilities wherever possible. To this purpose

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,35 +79,36 @@ func init() {
 
 	// Configuration defaults
 	// Agent
-	Datadog.SetDefault("dd_url", "https://app.datadoghq.com")
-	Datadog.SetDefault("app_key", "")
+	BindEnvAndSetDefault("dd_url", "https://app.datadoghq.com")
+	BindEnvAndSetDefault("app_key", "")
 	Datadog.SetDefault("proxy", nil)
 	BindEnvAndSetDefault("skip_ssl_validation", false)
-	Datadog.SetDefault("hostname", "")
-	Datadog.SetDefault("tags", []string{})
-	Datadog.SetDefault("conf_path", ".")
-	Datadog.SetDefault("confd_path", defaultConfdPath)
-	Datadog.SetDefault("additional_checksd", defaultAdditionalChecksPath)
-	Datadog.SetDefault("log_payloads", false)
-	Datadog.SetDefault("log_level", "info")
-	Datadog.SetDefault("log_to_syslog", false)
-	Datadog.SetDefault("log_to_console", true)
-	Datadog.SetDefault("logging_frequency", int64(20))
-	Datadog.SetDefault("disable_file_logging", false)
-	Datadog.SetDefault("syslog_uri", "")
-	Datadog.SetDefault("syslog_rfc", false)
-	Datadog.SetDefault("syslog_pem", "")
-	Datadog.SetDefault("syslog_key", "")
-	Datadog.SetDefault("syslog_tls_verify", true)
-	Datadog.SetDefault("cmd_host", "localhost")
-	Datadog.SetDefault("cmd_port", 5001)
-	Datadog.SetDefault("cluster_agent.cmd_port", 5005)
-	Datadog.SetDefault("default_integration_http_timeout", 9)
-	Datadog.SetDefault("enable_metadata_collection", true)
-	Datadog.SetDefault("enable_gohai", true)
-	Datadog.SetDefault("check_runners", int64(1))
-	Datadog.SetDefault("auth_token_file_path", "")
-	Datadog.SetDefault("bind_host", "localhost")
+	BindEnvAndSetDefault("hostname", "")
+	BindEnvAndSetDefault("tags", []string{})
+	BindEnvAndSetDefault("conf_path", ".")
+	BindEnvAndSetDefault("confd_path", defaultConfdPath)
+	BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)
+	BindEnvAndSetDefault("log_payloads", false)
+	BindEnvAndSetDefault("log_file", "")
+	BindEnvAndSetDefault("log_level", "info")
+	BindEnvAndSetDefault("log_to_syslog", false)
+	BindEnvAndSetDefault("log_to_console", true)
+	BindEnvAndSetDefault("logging_frequency", int64(20))
+	BindEnvAndSetDefault("disable_file_logging", false)
+	BindEnvAndSetDefault("syslog_uri", "")
+	BindEnvAndSetDefault("syslog_rfc", false)
+	BindEnvAndSetDefault("syslog_pem", "")
+	BindEnvAndSetDefault("syslog_key", "")
+	BindEnvAndSetDefault("syslog_tls_verify", true)
+	BindEnvAndSetDefault("cmd_host", "localhost")
+	BindEnvAndSetDefault("cmd_port", 5001)
+	BindEnvAndSetDefault("cluster_agent.cmd_port", 5005)
+	BindEnvAndSetDefault("default_integration_http_timeout", 9)
+	BindEnvAndSetDefault("enable_metadata_collection", true)
+	BindEnvAndSetDefault("enable_gohai", true)
+	BindEnvAndSetDefault("check_runners", int64(1))
+	BindEnvAndSetDefault("auth_token_file_path", "")
+	BindEnvAndSetDefault("bind_host", "localhost")
 	BindEnvAndSetDefault("hostname_fqdn", false)
 
 	// secrets backend
@@ -117,11 +118,11 @@ func init() {
 	BindEnvAndSetDefault("secret_backend_timeout", 5)
 
 	// Retry settings
-	Datadog.SetDefault("forwarder_backoff_factor", 2)
-	Datadog.SetDefault("forwarder_backoff_base", 2)
-	Datadog.SetDefault("forwarder_backoff_max", 64)
-	Datadog.SetDefault("forwarder_recovery_interval", DefaultForwarderRecoveryInterval)
-	Datadog.SetDefault("forwarder_recovery_reset", false)
+	BindEnvAndSetDefault("forwarder_backoff_factor", 2)
+	BindEnvAndSetDefault("forwarder_backoff_base", 2)
+	BindEnvAndSetDefault("forwarder_backoff_max", 64)
+	BindEnvAndSetDefault("forwarder_recovery_interval", DefaultForwarderRecoveryInterval)
+	BindEnvAndSetDefault("forwarder_recovery_reset", false)
 
 	// Use to output logs in JSON format
 	BindEnvAndSetDefault("log_format_json", false)
@@ -133,7 +134,7 @@ func init() {
 	BindEnvAndSetDefault("force_tls_12", false)
 
 	// Agent GUI access port
-	Datadog.SetDefault("GUI_port", defaultGuiPort)
+	BindEnvAndSetDefault("GUI_port", defaultGuiPort)
 	if IsContainerized() {
 		Datadog.SetDefault("procfs_path", "/host/proc")
 		Datadog.SetDefault("container_proc_root", "/host/proc")
@@ -148,13 +149,18 @@ func init() {
 			Datadog.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")
 		}
 	}
-	Datadog.SetDefault("proc_root", "/proc")
-	Datadog.SetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
-	Datadog.SetDefault("histogram_percentiles", []string{"0.95"})
+
+	Datadog.BindEnv("procfs_path")
+	Datadog.BindEnv("container_proc_root")
+	Datadog.BindEnv("container_cgroup_root")
+
+	BindEnvAndSetDefault("proc_root", "/proc")
+	BindEnvAndSetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
+	BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})
 	// Serializer
-	Datadog.SetDefault("use_v2_api.series", false)
-	Datadog.SetDefault("use_v2_api.events", false)
-	Datadog.SetDefault("use_v2_api.service_checks", false)
+	BindEnvAndSetDefault("use_v2_api.series", false)
+	BindEnvAndSetDefault("use_v2_api.events", false)
+	BindEnvAndSetDefault("use_v2_api.service_checks", false)
 	// Serializer: allow user to blacklist any kind of payload to be sent
 	BindEnvAndSetDefault("enable_payloads.events", true)
 	BindEnvAndSetDefault("enable_payloads.series", true)
@@ -163,83 +169,85 @@ func init() {
 	BindEnvAndSetDefault("enable_payloads.json_to_v1_intake", true)
 
 	// Forwarder
-	Datadog.SetDefault("forwarder_timeout", 20)
-	Datadog.SetDefault("forwarder_retry_queue_max_size", 30)
+	BindEnvAndSetDefault("forwarder_timeout", 20)
+	BindEnvAndSetDefault("forwarder_retry_queue_max_size", 30)
 	BindEnvAndSetDefault("forwarder_num_workers", 1)
 	// Dogstatsd
-	Datadog.SetDefault("use_dogstatsd", true)
-	Datadog.SetDefault("dogstatsd_port", 8125)          // Notice: 0 means UDP port closed
-	Datadog.SetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
-	Datadog.SetDefault("dogstatsd_non_local_traffic", false)
-	Datadog.SetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
-	Datadog.SetDefault("dogstatsd_stats_port", 5000)
-	Datadog.SetDefault("dogstatsd_stats_enable", false)
-	Datadog.SetDefault("dogstatsd_stats_buffer", 10)
-	Datadog.SetDefault("dogstatsd_expiry_seconds", 300)
-	Datadog.SetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
-	Datadog.SetDefault("dogstatsd_so_rcvbuf", 0)
-	Datadog.SetDefault("statsd_forward_host", "")
-	Datadog.SetDefault("statsd_forward_port", 0)
+	BindEnvAndSetDefault("use_dogstatsd", true)
+	BindEnvAndSetDefault("dogstatsd_port", 8125)          // Notice: 0 means UDP port closed
+	BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
+	BindEnvAndSetDefault("dogstatsd_non_local_traffic", false)
+	BindEnvAndSetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
+	BindEnvAndSetDefault("dogstatsd_stats_port", 5000)
+	BindEnvAndSetDefault("dogstatsd_stats_enable", false)
+	BindEnvAndSetDefault("dogstatsd_stats_buffer", 10)
+	BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
+	BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
+	BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
+	BindEnvAndSetDefault("statsd_forward_host", "")
+	BindEnvAndSetDefault("statsd_forward_port", 0)
 	BindEnvAndSetDefault("statsd_metric_namespace", "")
 	// Autoconfig
-	Datadog.SetDefault("autoconf_template_dir", "/datadog/check_configs")
-	Datadog.SetDefault("exclude_pause_container", true)
-	Datadog.SetDefault("ac_include", []string{})
-	Datadog.SetDefault("ac_exclude", []string{})
+	BindEnvAndSetDefault("autoconf_template_dir", "/datadog/check_configs")
+	BindEnvAndSetDefault("exclude_pause_container", true)
+	BindEnvAndSetDefault("ac_include", []string{})
+	BindEnvAndSetDefault("ac_exclude", []string{})
 
 	// Docker
 	BindEnvAndSetDefault("docker_query_timeout", int64(5))
-	Datadog.SetDefault("docker_labels_as_tags", map[string]string{})
-	Datadog.SetDefault("docker_env_as_tags", map[string]string{})
-	Datadog.SetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
-	Datadog.SetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
-	Datadog.SetDefault("kubernetes_node_labels_as_tags", map[string]string{})
+	BindEnvAndSetDefault("docker_labels_as_tags", map[string]string{})
+	BindEnvAndSetDefault("docker_env_as_tags", map[string]string{})
+	BindEnvAndSetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
+	BindEnvAndSetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
+	BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 
 	// Kubernetes
-	Datadog.SetDefault("kubernetes_http_kubelet_port", 10255)
-	Datadog.SetDefault("kubernetes_https_kubelet_port", 10250)
+	BindEnvAndSetDefault("kubernetes_kubelet_host", "")
+	BindEnvAndSetDefault("kubernetes_http_kubelet_port", 10255)
+	BindEnvAndSetDefault("kubernetes_https_kubelet_port", 10250)
 
-	Datadog.SetDefault("kubelet_tls_verify", true)
-	Datadog.SetDefault("kubelet_client_ca", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	BindEnvAndSetDefault("kubelet_tls_verify", true)
+	BindEnvAndSetDefault("collect_kubernetes_events", false)
+	BindEnvAndSetDefault("kubelet_client_ca", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 
-	Datadog.SetDefault("kubelet_auth_token_path", "")
-	Datadog.SetDefault("kubelet_client_crt", "")
-	Datadog.SetDefault("kubelet_client_key", "")
+	BindEnvAndSetDefault("kubelet_auth_token_path", "")
+	BindEnvAndSetDefault("kubelet_client_crt", "")
+	BindEnvAndSetDefault("kubelet_client_key", "")
 
-	Datadog.SetDefault("kubernetes_collect_metadata_tags", true)
-	Datadog.SetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
+	BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
+	BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 
 	// Kube ApiServer
-	Datadog.SetDefault("kubernetes_kubeconfig_path", "")
-	Datadog.SetDefault("leader_lease_duration", "60")
-	Datadog.SetDefault("leader_election", false)
-	Datadog.SetDefault("kube_resources_namespace", "")
+	BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")
+	BindEnvAndSetDefault("leader_lease_duration", "60")
+	BindEnvAndSetDefault("leader_election", false)
+	BindEnvAndSetDefault("kube_resources_namespace", "")
 
 	// Datadog cluster agent
-	Datadog.SetDefault("cluster_agent.enabled", false)
-	Datadog.SetDefault("cluster_agent.auth_token", "")
-	Datadog.SetDefault("cluster_agent.url", "")
-	Datadog.SetDefault("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
+	BindEnvAndSetDefault("cluster_agent.enabled", false)
+	BindEnvAndSetDefault("cluster_agent.auth_token", "")
+	BindEnvAndSetDefault("cluster_agent.url", "")
+	BindEnvAndSetDefault("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
 
 	// ECS
-	Datadog.SetDefault("ecs_agent_url", "") // Will be autodetected
-	Datadog.SetDefault("collect_ec2_tags", false)
+	BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
+	BindEnvAndSetDefault("collect_ec2_tags", false)
 
 	// Cloud Foundry
-	Datadog.SetDefault("cloud_foundry", false)
-	Datadog.SetDefault("bosh_id", "")
+	BindEnvAndSetDefault("cloud_foundry", false)
+	BindEnvAndSetDefault("bosh_id", "")
 
 	// JMXFetch
 	BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 
 	// Go_expvar server port
-	Datadog.SetDefault("expvar_port", "5000")
+	BindEnvAndSetDefault("expvar_port", "5000")
 
 	// Trace agent
-	Datadog.SetDefault("apm_config.enabled", true)
+	BindEnvAndSetDefault("apm_config.enabled", true)
 
 	// Logs Agent
 	BindEnvAndSetDefault("logs_enabled", false)
@@ -262,56 +270,8 @@ func init() {
 	BindEnvAndSetDefault("histogram_copy_to_distribution", false)
 	BindEnvAndSetDefault("histogram_copy_to_distribution_prefix", "")
 
-	// ENV vars bindings
 	Datadog.BindEnv("api_key")
-	Datadog.BindEnv("dd_url")
-	Datadog.BindEnv("app_key")
-	Datadog.BindEnv("hostname")
-	Datadog.BindEnv("tags")
-	Datadog.BindEnv("cmd_port")
-	Datadog.BindEnv("conf_path")
-	Datadog.BindEnv("enable_metadata_collection")
-	Datadog.BindEnv("enable_gohai")
-	Datadog.BindEnv("dogstatsd_port")
-	Datadog.BindEnv("bind_host")
-	Datadog.BindEnv("proc_root")
-	Datadog.BindEnv("procfs_path")
-	Datadog.BindEnv("container_proc_root")
-	Datadog.BindEnv("container_cgroup_root")
-	Datadog.BindEnv("dogstatsd_socket")
-	Datadog.BindEnv("dogstatsd_stats_port")
-	Datadog.BindEnv("dogstatsd_non_local_traffic")
-	Datadog.BindEnv("dogstatsd_origin_detection")
-	Datadog.BindEnv("dogstatsd_so_rcvbuf")
-	Datadog.BindEnv("check_runners")
-	Datadog.BindEnv("expvar_port")
 
-	Datadog.BindEnv("log_file")
-	Datadog.BindEnv("log_level")
-	Datadog.BindEnv("log_to_console")
-
-	Datadog.BindEnv("kubernetes_kubelet_host")
-	Datadog.BindEnv("kubernetes_http_kubelet_port")
-	Datadog.BindEnv("kubernetes_https_kubelet_port")
-	Datadog.BindEnv("kubelet_client_crt")
-	Datadog.BindEnv("kubelet_client_key")
-	Datadog.BindEnv("kubelet_tls_verify")
-	Datadog.BindEnv("collect_kubernetes_events")
-	Datadog.BindEnv("kubernetes_collect_metadata_tags")
-	Datadog.BindEnv("kubernetes_metadata_tag_update_freq")
-	Datadog.BindEnv("docker_labels_as_tags")
-	Datadog.BindEnv("docker_env_as_tags")
-	Datadog.BindEnv("kubernetes_pod_labels_as_tags")
-	Datadog.BindEnv("kubernetes_pod_annotations_as_tags")
-	Datadog.BindEnv("kubernetes_node_labels_as_tags")
-	Datadog.BindEnv("ac_include")
-	Datadog.BindEnv("ac_exclude")
-
-	Datadog.BindEnv("cluster_agent.enabled")
-	Datadog.BindEnv("cluster_agent.url")
-	Datadog.BindEnv("cluster_agent.auth_token")
-	Datadog.BindEnv("cluster_agent.cmd_port")
-	Datadog.BindEnv("cluster_agent.kubernetes_service_name")
 	BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
 	BindEnvAndSetDefault("external_metrics_provider.enabled", false)
@@ -321,19 +281,6 @@ func init() {
 	BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)
 	BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)    // 5 minutes
 	BindEnvAndSetDefault("kubernetes_informers_restclient_timeout", 60) // 1 minute
-
-	Datadog.BindEnv("forwarder_timeout")
-	Datadog.BindEnv("forwarder_retry_queue_max_size")
-	Datadog.BindEnv("cloud_foundry")
-	Datadog.BindEnv("bosh_id")
-	Datadog.BindEnv("histogram_aggregates")
-	Datadog.BindEnv("histogram_percentiles")
-	Datadog.BindEnv("kubernetes_kubeconfig_path")
-	Datadog.BindEnv("leader_election")
-	Datadog.BindEnv("leader_lease_duration")
-	Datadog.BindEnv("kube_resources_namespace")
-
-	Datadog.BindEnv("collect_ec2_tags")
 
 	setAssetFs()
 }

--- a/releasenotes/notes/Normalize-and-document-handling-of-config-options-setting-through-env-vars-bf2217d7b591dace.yaml
+++ b/releasenotes/notes/Normalize-and-document-handling-of-config-options-setting-through-env-vars-bf2217d7b591dace.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enable all configuration options to be set with env vars


### PR DESCRIPTION
### What does this PR do?

Enable all configuration options to be set with env vars.

### Motivation

The goal is to make the configuration more consistent: All main options can be set either by the `datadog.yml` file or env vars. Env binding is done with default setting to avoid duplication.

### Additional Notes


