### PR TITLE
Allow omitting GCE metadata from host tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,6 +236,9 @@ func init() {
 	BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
 	BindEnvAndSetDefault("collect_ec2_tags", false)
 
+	// GCE
+	BindEnvAndSetDefault("collect_gce_tags", true)
+
 	// Cloud Foundry
 	BindEnvAndSetDefault("cloud_foundry", false)
 	BindEnvAndSetDefault("bosh_id", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -97,6 +97,9 @@ api_key:
 
 # Collect AWS EC2 custom tags as agent tags
 # collect_ec2_tags: false
+
+# Collect Google Cloud Engine metadata as agent tags
+# collect_gce_tags: true
 {{ end }}
 {{- if .Agent }}
 # The path containing check configuration files

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -75,12 +75,15 @@ func getHostTags() *tags {
 		hostTags = appendToHostTags(hostTags, dockerTags)
 	}
 
-	rawGceTags, err := gce.GetTags()
-	if err != nil {
-		log.Debugf("No GCE host tags %v", err)
+	gceTags := []string{}
+	if config.Datadog.GetBool("collect_gce_tags") {
+		rawGceTags, err := gce.GetTags()
+		if err != nil {
+			log.Debugf("No GCE host tags %v", err)
+		} else {
+			gceTags = appendToHostTags(gceTags, rawGceTags)
+		}
 	}
-	var gceTags []string
-	gceTags = appendToHostTags(gceTags, rawGceTags)
 
 	return &tags{
 		System:              hostTags,

--- a/releasenotes/notes/allow-excluding-gce-metadata-tags-2252cbb728c7da70.yaml
+++ b/releasenotes/notes/allow-excluding-gce-metadata-tags-2252cbb728c7da70.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Tags generated from GCE metadata may now be omitted by using
+    ``collect_gce_tags`` configuration option.


### PR DESCRIPTION
### What does this PR do?

A new setting was introduced that allows preventing the behavior of
automatically generating host tags from GCE metadata.

### Motivation

GCE metadata may contain confidential information (as it does in our
case) and that must not be sent outside the execution environment.

### Additional Notes

Similar logic already exists for EC2: When collect_ec2_tags is set to
false, no extra tags are generated based on EC2 metadata. This unifies
the behavior so that GCE tags can also be excluded (though default
value for the new setting is different from the existing EC2 setting to
avoid changing existing behavior).

This also allows making the agent work like it did with version 5: With
version 5 if metadata collection was off but custom host tags were
specified, the tags got associated with the metrics. With version 6 the
tags are only ever sent when metadata collection is enabled, which also
sends the undesired GCE tags.