### PR TITLE
fix hostPID operations

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -82,9 +82,6 @@ COPY s6-services /etc/services.d/
 COPY entrypoint /etc/cont-init.d/
 COPY probe.sh initlog.sh /
 
-# Override the exit script by ours to fix --pid=host operations
-COPY init-stage3 /etc/s6/init/init-stage3
-
 # Extract s6-overlay
 # Done in 2 steps to avoid overriding the /bin --> /usr/bin symlink
 # FIXME: copying it from the extract stage does not work
@@ -100,6 +97,9 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod 755 /probe.sh /initlog.sh
+
+# Override the exit script by ours to fix --pid=host operations
+COPY init-stage3 /etc/s6/init/init-stage3
 
 # Expose DogStatsD and trace-agent ports
 EXPOSE 8125/udp 8126/tcp

--- a/releasenotes/notes/docker-hostpid-69a79f1c0ac8a245.yaml
+++ b/releasenotes/notes/docker-hostpid-69a79f1c0ac8a245.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Docker image: fix hostPID operations


### PR DESCRIPTION
### What does this PR do?

On all 6.3.x versions, our override of `/etc/s6/init/init-stage3` is not picked up by s6, making it kill all processes in its namespace on some scenarios of container exit.

Test image on master: `datadog/agent-dev:xvello-s6kill`