### PR TITLE
[AD]: Added identifier to config providers

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -169,7 +169,7 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 	for _, pd := range ac.providers {
 		cfgs, err := pd.provider.Collect()
 		if err != nil {
-			log.Debugf("Unexpected error returned when collecting provider %s: %v", pd.provider.String(), err)
+			log.Debugf("Unexpected error returned when collecting configurations from provider %v: %v", pd.provider, err)
 		}
 
 		if fileConfPd, ok := pd.provider.(*providers.FileConfigProvider); ok {
@@ -364,10 +364,10 @@ func (ac *AutoConfig) pollConfigs() {
 					// Check if the CPupdate cache is up to date. Fill it and trigger a Collect() if outdated.
 					upToDate, err := pd.provider.IsUpToDate()
 					if err != nil {
-						log.Errorf("cache processing of %v failed: %v", pd.provider.String(), err)
+						log.Errorf("cache processing of %v configuration provider failed: %v", pd.provider, err)
 					}
 					if upToDate == true {
-						log.Debugf("No modifications in the templates stored in %q ", pd.provider.String())
+						log.Debugf("No modifications in the templates stored in %v configuration provider", pd.provider)
 						continue
 					}
 

--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Consul represents the name of the config provider
-const Consul = "consul"
+const Consul = "Consul"
 
 // Abstractions for testing
 type consulKVBackend interface {

--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -21,6 +21,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+// Consul represents the name of the config provider
+const Consul = "consul"
+
 // Abstractions for testing
 type consulKVBackend interface {
 	Keys(prefix, separator string, q *consul.QueryOptions) ([]string, *consul.QueryMeta, error)
@@ -99,7 +102,7 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 
 // String returns a string representation of the ConsulConfigProvider
 func (p *ConsulConfigProvider) String() string {
-	return "consul Configuration Provider"
+	return Consul
 }
 
 // Collect retrieves templates from consul, builds Config objects and returns them

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -18,6 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
+// Docker represents the name of the config provider
+const Docker = "Docker"
+
 const (
 	dockerADLabelPrefix = "com.datadoghq.ad."
 )
@@ -39,7 +42,7 @@ func NewDockerConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 
 // String returns a string representation of the DockerConfigProvider
 func (d *DockerConfigProvider) String() string {
-	return "Docker container labels"
+	return Docker
 }
 
 // Collect retrieves all running containers and extract AD templates from their labels.

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -17,6 +17,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// ECS represents the name of the config provider
+const ECS = "ECS"
+
 const (
 	ecsADLabelPrefix        = "com.datadoghq.ad."
 	metadataURL      string = "http://169.254.170.2/v2/metadata"
@@ -41,7 +44,7 @@ func NewECSConfigProvider(config config.ConfigurationProviders) (ConfigProvider,
 
 // String returns a string representation of the ECSConfigProvider
 func (p *ECSConfigProvider) String() string {
-	return "ECS container labels"
+	return ECS
 }
 
 // IsUpToDate updates the list of AD templates versions in the Agent's cache and checks the list is up to date compared to ECS' data.

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -21,6 +21,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+// Etcd represents the name of the config provider
+const Etcd = "etcd"
+
 type etcdBackend interface {
 	Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error)
 }
@@ -187,7 +190,7 @@ func (p *EtcdConfigProvider) IsUpToDate() (bool, error) {
 
 // String returns a string representation of the EtcdConfigProvider
 func (p *EtcdConfigProvider) String() string {
-	return "etcd Configuration Provider"
+	return Etcd
 }
 
 // hasTemplateFields verifies that a node array contains

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -18,6 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// File represents the name of the config provider
+const File = "File"
+
 type configFormat struct {
 	ADIdentifiers []string    `yaml:"ad_identifiers"`
 	InitConfig    interface{} `yaml:"init_config"`
@@ -133,7 +136,7 @@ func (c *FileConfigProvider) IsUpToDate() (bool, error) {
 
 // String returns a string representation of the FileConfigProvider
 func (c *FileConfigProvider) String() string {
-	return "File Configuration Provider"
+	return File
 }
 
 // collectEntry collects a file entry and return it's configuration if valid

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -18,6 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
+// Kubernetes represents the name of the config provider
+const Kubernetes = "Kubernetes"
+
 const (
 	newPodAnnotationPrefix    = "ad.datadoghq.com/"
 	newPodAnnotationFormat    = newPodAnnotationPrefix + "%s."
@@ -38,7 +41,7 @@ func NewKubeletConfigProvider(config config.ConfigurationProviders) (ConfigProvi
 
 // String returns a string representation of the KubeletConfigProvider
 func (k *KubeletConfigProvider) String() string {
-	return "Kubernetes pod annotation"
+	return Kubernetes
 }
 
 // Collect retrieves templates from the kubelet's pdolist, builds Config objects and returns them

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -46,6 +46,6 @@ func NewCPCache() *ProviderCache {
 // IsUpToDate checks the local cache of the CP and returns accordingly.
 type ConfigProvider interface {
 	Collect() ([]integration.Config, error)
-	// String() string
+	String() string
 	IsUpToDate() (bool, error)
 }

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -46,6 +46,6 @@ func NewCPCache() *ProviderCache {
 // IsUpToDate checks the local cache of the CP and returns accordingly.
 type ConfigProvider interface {
 	Collect() ([]integration.Config, error)
-	String() string
+	// String() string
 	IsUpToDate() (bool, error)
 }

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -21,6 +21,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+// Zookeeper represents the name of the config provider
+const Zookeeper = "zookeeper"
+
 const sessionTimeout = 1 * time.Second
 
 type zkBackend interface {
@@ -54,7 +57,7 @@ func NewZookeeperConfigProvider(cfg config.ConfigurationProviders) (ConfigProvid
 
 // String returns a string representation of the ZookeeperConfigProvider
 func (z *ZookeeperConfigProvider) String() string {
-	return "zookeeper Configuration Provider"
+	return Zookeeper
 }
 
 // Collect retrieves templates from Zookeeper, builds Config objects and returns them

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Zookeeper represents the name of the config provider
-const Zookeeper = "zookeeper"
+const Zookeeper = "Zookeeper"
 
 const sessionTimeout = 1 * time.Second
 


### PR DESCRIPTION
### What does this PR do?

Added constant identifiers for all configuration providers + cleaned.

### Motivation

Be able to determine the origin of given config.
ex
```
var config integration.Config
...
switch config.Provider {
    case providers.Docker:
       // do something
    default:
      // drop the configuration
}
```

### Additional Notes


