### PR TITLE
Update the status page to display hostname errors and provider

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/header.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/header.tmpl
@@ -28,6 +28,14 @@
     {{$name}}: {{$value}}
     {{- end }}
   {{- end }}
+      hostname provider: {{.hostnameStats.provider}}
+  {{- range $name, $value := .hostnameStats.errors -}}
+    {{- if ne $name "all" }}
+    error: {{$name}}: {{$value}}
+    {{- else }}
+    error: {{$value}}
+    {{- end}}
+  {{- end }}
 
   Leader Election
   ===============

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -52,6 +52,17 @@
             {{end -}}
           {{- end -}}
         {{- end}}
+        Hostname Provider: {{.hostnameStats.provider}}<br>
+        {{- if .hostnameStats.error }}
+          <span class="error">Error</span>: {{.hostnameStats.error}}<br>
+        {{- end }}
+        {{- range $name, $value := .hostnameStats.errors -}}
+          {{- if ne $name "all" }}
+          <span class="error">Error</span>: {{$name}}: {{$value}}<br>
+          {{- else }}
+          <span class="error">Error</span>: {{$value}}<br>
+          {{- end}}
+        {{- end }}
       </span>
     </span>
   </div>

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -43,4 +43,12 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{$name}}: {{$value}}
     {{- end }}
   {{- end }}
+    hostname provider: {{.hostnameStats.provider}}
+  {{- range $name, $value := .hostnameStats.errors -}}
+    {{- if ne $name "all" }}
+    error: {{$name}}: {{$value}}
+    {{- else }}
+    error: {{$value}}
+    {{- end}}
+  {{- end }}
 {{/* this line intentionally left blank */}}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -209,6 +209,11 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 		stats["pyLoaderStats"] = nil
 	}
 
+	hostnameStatsJSON := []byte(expvar.Get("hostname").String())
+	hostnameStats := make(map[string]interface{})
+	json.Unmarshal(hostnameStatsJSON, &hostnameStats)
+	stats["hostnameStats"] = hostnameStats
+
 	if expvar.Get("ntpOffset").String() != "" {
 		stats["ntpOffset"], err = strconv.ParseFloat(expvar.Get("ntpOffset").String(), 64)
 	}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -88,5 +88,6 @@ func HostnameProvider(hostName string) (string, error) {
 		log.Debug("GetHostname trying EC2 metadata...")
 		return GetInstanceID()
 	}
-	return "", nil
+	// If we arrive here, we are probably not on an EC2 instance
+	return "", fmt.Errorf("The host is not an EC2 instance")
 }

--- a/releasenotes/notes/Update-the-status-page-to-display-hostname-errors-and-provider-0be5f02e09f473c4.yaml
+++ b/releasenotes/notes/Update-the-status-page-to-display-hostname-errors-and-provider-0be5f02e09f473c4.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Display hostname provider and errors on the status page


### PR DESCRIPTION
### What does this PR do?

Add hostname provider and errors when choosing the hostname on the status page.

### Motivation

This is useful to debug situations where the hostname appears to not have been correctly determined.
