### PR TITLE
Install expvar handler in the DCA.

### DIFF
--- a/Dockerfiles/cluster-agent/README.md
+++ b/Dockerfiles/cluster-agent/README.md
@@ -16,6 +16,7 @@ The following environment variables are supported:
 - `DD_CLUSTER_AGENT_AUTH_TOKEN`: 32 characters long token that needs to be shared between the node agent and the DCA.
 - `DD_KUBE_RESOURCES_NAMESPACE`: configures the namespace where the Cluster Agent creates the configmaps required for the Leader Election, the Event Collection (optional) and the Horizontal Pod Autoscaling.
 - `DD_KUBERNETES_METADATA_RESYNC_PERIOD`: frequency in seconds to query the API Server to reprocess the cluster metadata. The default is 5 minutes.
+- `DD_EXPVAR_PORT`: change the port for fetching [expvar](https://golang.org/pkg/expvar/) public variables from the Datadog Cluster Agent. The default is port 5000.
 
 For a more detailed usage please [refer to the official Docker Hub](https://hub.docker.com/r/datadog/cluster-agent/) documentation.
 

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"os"
 
+	_ "expvar"
+
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system"


### PR DESCRIPTION
### What does this PR do?

Install the `expvar` HTTP handler

```
$ curl http://127.0.0.1:5000/debug/vars
{
"CheckScheduler": {"LoaderErrors": {}, "RunErrors": {}},
"Event": {},
"ServiceCheck": {},
"aggregator": {"ChecksMetricSample": 8, "DogstatsdMetricSample": 0, "Event": 1, "EventsFlushErrors": 0, "EventsFlushed": 1, "Flush": {"ChecksMetricSampleFlushTime":{"Flushes":[2379268,156128500,1102855,1059848,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":3,"LastFlush":1059848,"Name":"ChecksMetricSampleFlushTime"},"EventFlushTime":{"Flushes":[623606,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":0,"LastFlush":623606,"Name":"EventFlushTime"},"MainFlushTime":{"Flushes":[73322,43435,57407,43093,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":3,"LastFlush":43093,"Name":"MainFlushTime"},"MetricSketchFlushTime":{"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":-1,"LastFlush":0,"Name":"MetricSketchFlushTime"},"ServiceCheckFlushTime":{"Flushes":[2799170,155356990,482960,456071,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":3,"LastFlush":456071,"Name":"ServiceCheckFlushTime"}}, "FlushCount": {"Events":{"Flushes":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":0,"LastFlush":1,"Name":"Events"},"Series":{"Flushes":[1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":3,"LastFlush":1,"Name":"Series"},"ServiceChecks":{"Flushes":[1,2,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":3,"LastFlush":2,"Name":"ServiceChecks"},"Sketches":{"Flushes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FlushIndex":3,"LastFlush":0,"Name":"Sketches"}}, "HostnameUpdate": 0, "NumberOfFlush": 4, "SeriesFlushErrors": 0, "SeriesFlushed": 4, "ServiceCheck": 4, "ServiceCheckFlushErrors": 0, "ServiceCheckFlushed)": 7, "SketchesFlushErrors": 0, "SketchesFlushed": 0},
"autoconfig": {"ConfigErrors": {}, "ResolveWarnings": {}},
"cmdline": ["datadog-cluster-agent","start"],
"dogstatsd": {"EventPackets": 0, "EventParseErrors": 0, "MetricPackets": 0, "MetricParseErrors": 0, "ServiceCheckPackets": 0, "ServiceCheckParseErrors": 0},
"dogstatsd-udp": {"PacketReadingErrors": 0},
"dogstatsd-uds": {"OriginDetectionErrors": 0, "PacketReadingErrors": 0},
"forwarder": {"APIKeyStatus": {"API key ending by 33a36 on endpoint https://6-4-1-app.agent.datadoghq.com": "API Key valid"}, "Transactions": {"CheckRunsV1": 4, "Dropped": 0, "DroppedOnInput": 0, "Errors": 0, "Events": 0, "HostMetadata": 0, "IntakeV1": 1, "Metadata": 0, "Requeued": 0, "Retried": 0, "RetryQueueSize": 0, "Series": 0, "ServiceChecks": 0, "SketchSeries": 0, "Success": 9, "TimeseriesV1": 4}},
"memstats": {"Alloc":5987792,"TotalAlloc":37651120,"Sys":43547772,"Lookups":1390,"Mallocs":546846,"Frees":497425,"HeapAlloc":5987792,"HeapSys":11894784,"HeapIdle":3260416,"HeapInuse":8634368,"HeapReleased":0,"HeapObjects":49421,"StackInuse":688128,"StackSys":688128,"MSpanInuse":75256,"MSpanSys":98304,"MCacheInuse":868,"MCacheSys":16384,"BuckHashSys":731487,"GCSys":29440000,"OtherSys":678685,"NextGC":10032160,"LastGC":1533222749972322811,"PauseTotalNs":527186,"PauseNs":[38655,37832,30518,30233,25502,26442,66324,32082,37595,31718,133248,37037,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"PauseEnd":[1533222700947929928,1533222700977729979,1533222701769561271,1533222702131332416,1533222702181954018,1533222702223191583,1533222702597647247,1533222703288202205,1533222704479198573,1533222705555915629,1533222706931888122,1533222749972322811,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"NumGC":12,"NumForcedGC":0,"GCCPUFraction":0.0013653964513282001,"EnableGC":true,"DebugGC":false,"BySize":[{"Size":0,"Mallocs":0,"Frees":0},{"Size":8,"Mallocs":105738,"Frees":96318},{"Size":16,"Mallocs":158304,"Frees":138583},{"Size":32,"Mallocs":62360,"Frees":54032},{"Size":48,"Mallocs":19384,"Frees":17522},{"Size":64,"Mallocs":17038,"Frees":13771},{"Size":80,"Mallocs":4732,"Frees":3957},{"Size":96,"Mallocs":4380,"Frees":3772},{"Size":112,"Mallocs":2936,"Frees":2369},{"Size":128,"Mallocs":3476,"Frees":3228},{"Size":144,"Mallocs":26911,"Frees":25632},{"Size":160,"Mallocs":2937,"Frees":2662},{"Size":176,"Mallocs":1410,"Frees":1189},{"Size":192,"Mallocs":509,"Frees":440},{"Size":208,"Mallocs":220,"Frees":190},{"Size":224,"Mallocs":615,"Frees":407},{"Size":240,"Mallocs":135,"Frees":113},{"Size":256,"Mallocs":12320,"Frees":12247},{"Size":288,"Mallocs":7164,"Frees":6086},{"Size":320,"Mallocs":135,"Frees":106},{"Size":352,"Mallocs":154,"Frees":113},{"Size":384,"Mallocs":900,"Frees":859},{"Size":416,"Mallocs":158,"Frees":71},{"Size":448,"Mallocs":103,"Frees":55},{"Size":480,"Mallocs":16,"Frees":14},{"Size":512,"Mallocs":2205,"Frees":2184},{"Size":576,"Mallocs":806,"Frees":676},{"Size":640,"Mallocs":187,"Frees":141},{"Size":704,"Mallocs":876,"Frees":693},{"Size":768,"Mallocs":91,"Frees":48},{"Size":896,"Mallocs":451,"Frees":349},{"Size":1024,"Mallocs":494,"Frees":380},{"Size":1152,"Mallocs":393,"Frees":289},{"Size":1280,"Mallocs":213,"Frees":195},{"Size":1408,"Mallocs":257,"Frees":228},{"Size":1536,"Mallocs":375,"Frees":326},{"Size":1792,"Mallocs":397,"Frees":363},{"Size":2048,"Mallocs":500,"Frees":476},{"Size":2304,"Mallocs":80,"Frees":75},{"Size":2688,"Mallocs":199,"Frees":181},{"Size":3072,"Mallocs":49,"Frees":25},{"Size":3200,"Mallocs":20,"Frees":15},{"Size":3456,"Mallocs":10,"Frees":7},{"Size":4096,"Mallocs":361,"Frees":294},{"Size":4864,"Mallocs":643,"Frees":629},{"Size":5376,"Mallocs":30,"Frees":22},{"Size":6144,"Mallocs":11,"Frees":5},{"Size":6528,"Mallocs":1,"Frees":1},{"Size":6784,"Mallocs":1,"Frees":0},{"Size":6912,"Mallocs":0,"Frees":0},{"Size":8192,"Mallocs":57,"Frees":45},{"Size":9472,"Mallocs":25,"Frees":18},{"Size":9728,"Mallocs":20,"Frees":16},{"Size":10240,"Mallocs":0,"Frees":0},{"Size":10880,"Mallocs":21,"Frees":18},{"Size":12288,"Mallocs":10,"Frees":0},{"Size":13568,"Mallocs":0,"Frees":0},{"Size":14336,"Mallocs":0,"Frees":0},{"Size":16384,"Mallocs":43,"Frees":30},{"Size":18432,"Mallocs":2,"Frees":0},{"Size":19072,"Mallocs":17,"Frees":12}]},
"ntpOffset": 0,
"runner": {"Checks": {"kubernetes_apiserver":{"CheckName":"kubernetes_apiserver","CheckVersion":"","CheckID":"kubernetes_apiserver","TotalRuns":4,"TotalErrors":0,"TotalWarnings":0,"MetricSamples":0,"Events":0,"ServiceChecks":0,"TotalMetricSamples":0,"TotalEvents":0,"TotalServiceChecks":0,"ExecutionTimes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"AverageExecutionTime":0,"LastExecutionTime":0,"LastError":"","LastWarnings":[],"UpdateTimestamp":1533222762}}, "RunningChecks": 0, "Runs": 4, "Workers": 1},
"scheduler": {"ChecksEntered": 1, "Queues": [{"Interval":15,"Size":1}], "QueuesCount": 1},
"series": {},
"splitter": {"NotTooBig": 9, "TooBig": 0, "TotalLoops": 0}
}
```