### PR TITLE
Autodiscovery: retry listeners on failure

### DIFF
--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/collector"
@@ -74,23 +73,10 @@ func SetupAutoConfig(confdPath string) {
 	// Autodiscovery listeners
 	// for now, no need to implement a registry of available listeners since we
 	// have only docker
-	var Listeners []config.Listeners
-	if err = config.Datadog.UnmarshalKey("listeners", &Listeners); err == nil {
-		Listeners = AutoAddListeners(Listeners)
-		for _, l := range Listeners {
-			serviceListenerFactory, ok := listeners.ServiceListenerFactories[l.Name]
-			if !ok {
-				// Factory has not been registered.
-				log.Warnf("Listener %s was not registered", l)
-				continue
-			}
-			serviceListener, err := serviceListenerFactory()
-			if err != nil {
-				log.Errorf("Failed to create a %s listener: %s", l.Name, err)
-			} else {
-				AC.AddListener(serviceListener)
-			}
-		}
+	var listeners []config.Listeners
+	if err = config.Datadog.UnmarshalKey("listeners", &listeners); err == nil {
+		listeners = AutoAddListeners(listeners)
+		AC.AddListeners(listeners)
 	}
 }
 

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -74,9 +74,12 @@ func SetupAutoConfig(confdPath string) {
 	// for now, no need to implement a registry of available listeners since we
 	// have only docker
 	var listeners []config.Listeners
-	if err = config.Datadog.UnmarshalKey("listeners", &listeners); err == nil {
+	err = config.Datadog.UnmarshalKey("listeners", &listeners)
+	if err == nil {
 		listeners = AutoAddListeners(listeners)
 		AC.AddListeners(listeners)
+	} else {
+		log.Errorf("Error while reading 'listeners' settings: %v", err)
 	}
 }
 

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -338,11 +338,7 @@ func (ac *AutoConfig) initListenerCandidates() bool {
 		}
 	}
 
-	if len(ac.listenerCandidates) > 0 {
-		// We have more candidates to try later
-		return true
-	}
-	return false
+	return len(ac.listenerCandidates) > 0
 }
 
 func (ac *AutoConfig) retryListenerCandidates() {

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -12,16 +12,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/tagger"
-
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -23,12 +24,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
 var (
-	configsPollIntl = 10 * time.Second
-	acErrors        *expvar.Map
-	errorStats      = newAcErrorStats()
+	configsPollIntl       = 10 * time.Second
+	listenerCandidateIntl = 30 * time.Second
+	acErrors              *expvar.Map
+	errorStats            = newAcErrorStats()
 )
 
 func init() {
@@ -61,28 +64,32 @@ type providerDescriptor struct {
 // Notice the `AutoConfig` public API speaks in terms of `integration.Config`,
 // meaning that you cannot use it to schedule integrations instances directly.
 type AutoConfig struct {
-	providers         []*providerDescriptor
-	templateCache     *TemplateCache
-	listeners         []listeners.ServiceListener
-	configResolver    *ConfigResolver
-	configsPollTicker *time.Ticker
-	scheduler         scheduler.Scheduler
-	stop              chan bool
-	pollerActive      bool
-	health            *health.Handle
-	store             *store
-	m                 sync.RWMutex
+	providers          []*providerDescriptor
+	templateCache      *TemplateCache
+	listeners          []listeners.ServiceListener
+	listenerCandidates map[string]listeners.ServiceListenerFactory
+	listenerRetryStop  chan struct{}
+	configResolver     *ConfigResolver
+	configsPollTicker  *time.Ticker
+	scheduler          scheduler.Scheduler
+	pollerStop         chan struct{}
+	pollerActive       bool
+	health             *health.Handle
+	store              *store
+	m                  sync.RWMutex
 }
 
 // NewAutoConfig creates an AutoConfig instance.
 func NewAutoConfig(scheduler scheduler.Scheduler) *AutoConfig {
 	ac := &AutoConfig{
-		providers:     make([]*providerDescriptor, 0, 5),
-		templateCache: NewTemplateCache(),
-		stop:          make(chan bool),
-		store:         newStore(),
-		health:        health.Register("ad-autoconfig"),
-		scheduler:     scheduler,
+		providers:          make([]*providerDescriptor, 0, 5),
+		listenerCandidates: make(map[string]listeners.ServiceListenerFactory),
+		listenerRetryStop:  nil, // We'll open it if needed
+		templateCache:      NewTemplateCache(),
+		pollerStop:         make(chan struct{}),
+		store:              newStore(),
+		health:             health.Register("ad-autoconfig"),
+		scheduler:          scheduler,
 	}
 	ac.configResolver = newConfigResolver(ac, ac.templateCache)
 	return ac
@@ -107,7 +114,7 @@ func (ac *AutoConfig) Stop() {
 
 	// stop the poller if running
 	if ac.pollerActive {
-		ac.stop <- true
+		ac.pollerStop <- struct{}{}
 		ac.pollerActive = false
 	}
 
@@ -117,6 +124,11 @@ func (ac *AutoConfig) Stop() {
 	// stop the config resolver
 	if ac.configResolver != nil {
 		ac.configResolver.Stop()
+	}
+
+	// stop the listener retry logic if running
+	if ac.listenerRetryStop != nil {
+		ac.listenerRetryStop <- struct{}{}
 	}
 
 	// stop all the listeners
@@ -269,20 +281,94 @@ func (ac *AutoConfig) resolve(config integration.Config) []integration.Config {
 	return configs
 }
 
-// AddListener adds a service listener to AutoConfig.
-func (ac *AutoConfig) AddListener(listener listeners.ServiceListener) {
+// AddListeners tries to initialise the listeners listed in the given configs. A first
+// try is done synchronously. If a listener fails with a ErrWillRetry, the initialization
+// will be re-triggered later until success or ErrPermaFail.
+func (ac *AutoConfig) AddListeners(listenerConfigs []config.Listeners) {
+	ac.addListenerCandidates(listenerConfigs)
+	remaining := ac.initListenerCandidates()
+	if remaining == false {
+		return
+	}
+
+	// Start the retry logic if we have remaining candidates and it is not already running
+	ac.m.Lock()
+	defer ac.m.Unlock()
+	if ac.listenerRetryStop == nil {
+		ac.listenerRetryStop = make(chan struct{})
+		go ac.retryListenerCandidates()
+	}
+}
+
+func (ac *AutoConfig) addListenerCandidates(listenerConfigs []config.Listeners) {
 	ac.m.Lock()
 	defer ac.m.Unlock()
 
-	for _, l := range ac.listeners {
-		if l == listener {
-			log.Warnf("Listener %s was already added, skipping...", listener)
-			return
+	for _, c := range listenerConfigs {
+		factory, ok := listeners.ServiceListenerFactories[c.Name]
+		if !ok {
+			// Factory has not been registered.
+			log.Warnf("Listener %s was not registered", c.Name)
+			continue
+		}
+		log.Debugf("Listener %s was registered", c.Name)
+		ac.listenerCandidates[c.Name] = factory
+	}
+}
+
+func (ac *AutoConfig) initListenerCandidates() bool {
+	ac.m.Lock()
+	defer ac.m.Unlock()
+
+	for name, factory := range ac.listenerCandidates {
+		listener, err := factory()
+		switch {
+		case err == nil:
+			// Init successful, let's start listening
+			log.Infof("%s listener successfully started", name)
+			ac.listeners = append(ac.listeners, listener)
+			listener.Listen(ac.configResolver.newService, ac.configResolver.delService)
+			delete(ac.listenerCandidates, name)
+		case retry.IsErrWillRetry(err):
+			// Log an info and keep in candidates
+			log.Infof("%s listener cannot start, will retry: %s", name, err)
+		default:
+			// Log an error and remove from candidates
+			log.Errorf("%s listener cannot start: %s", name, err)
+			delete(ac.listenerCandidates, name)
 		}
 	}
 
-	ac.listeners = append(ac.listeners, listener)
-	listener.Listen(ac.configResolver.newService, ac.configResolver.delService)
+	if len(ac.listenerCandidates) > 0 {
+		// We have more candidates to try later
+		return true
+	}
+	return false
+}
+
+func (ac *AutoConfig) retryListenerCandidates() {
+	retryTicker := time.NewTicker(listenerCandidateIntl)
+	defer func() {
+		// Stop ticker
+		retryTicker.Stop()
+		// Cleanup channel before exiting so that we can re-start the routine later
+		ac.m.Lock()
+		defer ac.m.Unlock()
+		close(ac.listenerRetryStop)
+		ac.listenerRetryStop = nil
+	}()
+
+	for {
+		select {
+		case <-ac.listenerRetryStop:
+			return
+		case <-retryTicker.C:
+			remaining := ac.initListenerCandidates()
+			if !remaining {
+				return
+			}
+		}
+	}
 }
 
 func decryptConfig(conf integration.Config) (integration.Config, error) {
@@ -323,7 +409,7 @@ func (ac *AutoConfig) pollConfigs() {
 	go func() {
 		for {
 			select {
-			case <-ac.stop:
+			case <-ac.pollerStop:
 				if ac.configsPollTicker != nil {
 					ac.configsPollTicker.Stop()
 				}

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -228,6 +228,7 @@ func (suite *AutoConfigTestSuite) TestListenerRetry() {
 		{Name: "noerr"},
 		{Name: "fail"},
 		{Name: "retry"},
+		{Name: "invalid"},
 	}
 	ac := NewAutoConfig(scheduler.NewMetaScheduler())
 	assert.Nil(suite.T(), ac.listenerRetryStop)
@@ -277,10 +278,11 @@ func (suite *AutoConfigTestSuite) TestListenerRetry() {
 	// Wait for retryListenerCandidates to close listenerRetryStop and return
 	for i := 0; i < 10; i++ {
 		ac.m.Lock()
-		if ac.listenerRetryStop == nil {
+		nilled := (ac.listenerRetryStop == nil)
+		ac.m.Unlock()
+		if nilled {
 			break
 		}
-		ac.m.Unlock()
 		time.Sleep(10 * time.Millisecond)
 	}
 	ac.m.Lock()

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -6,13 +6,20 @@
 package autodiscovery
 
 import (
+	"errors"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
 type MockProvider struct {
@@ -41,51 +48,246 @@ type MockListener struct {
 	stopReceived bool
 }
 
-func (l *MockListener) Listen(newSvc, delSvc chan<- listeners.Service) { l.ListenCount++ }
-func (l *MockListener) Stop()                                          { l.stopReceived = true }
+func (l *MockListener) Listen(newSvc, delSvc chan<- listeners.Service) {
+	l.ListenCount++
+}
+func (l *MockListener) Stop() {
+	l.stopReceived = true
+}
+func (l *MockListener) fakeFactory() (listeners.ServiceListener, error) {
+	return l, nil
+}
 
-func TestAddProvider(t *testing.T) {
+var mockListenenerConfig = config.Listeners{
+	Name: "mock",
+}
+
+type factoryMock struct {
+	sync.Mutex
+	callCount   int
+	callChan    chan struct{}
+	returnValue listeners.ServiceListener
+	returnError error
+}
+
+func (o *factoryMock) make() (listeners.ServiceListener, error) {
+	o.Lock()
+	defer o.Unlock()
+	if o.callChan != nil {
+		o.callChan <- struct{}{}
+	}
+	o.callCount++
+	return o.returnValue, o.returnError
+}
+
+func (o *factoryMock) waitForCalled(timeout time.Duration) error {
+	select {
+	case <-o.callChan:
+		return nil
+	case <-time.After(timeout):
+		return errors.New("timeout while waiting for call")
+	}
+}
+
+func (o *factoryMock) assertCallNumber(t *testing.T, calls int) bool {
+	o.Lock()
+	defer o.Unlock()
+	return assert.Equal(t, calls, o.callCount)
+}
+
+func (o *factoryMock) resetCallChan() {
+	for {
+		select {
+		case <-o.callChan:
+			continue
+		default:
+			return
+		}
+	}
+}
+
+type AutoConfigTestSuite struct {
+	suite.Suite
+	originalListeners map[string]listeners.ServiceListenerFactory
+}
+
+// SetupSuite saves the original listener registry
+func (suite *AutoConfigTestSuite) SetupSuite() {
+	suite.originalListeners = listeners.ServiceListenerFactories
+	config.SetupLogger(
+		"debug",
+		"",
+		"",
+		false,
+		true,
+		false,
+	)
+}
+
+// TearDownSuite restores the original listener registry
+func (suite *AutoConfigTestSuite) TearDownSuite() {
+	listeners.ServiceListenerFactories = suite.originalListeners
+}
+
+// Empty the listener registry before each test
+func (suite *AutoConfigTestSuite) SetupTest() {
+	listeners.ServiceListenerFactories = make(map[string]listeners.ServiceListenerFactory)
+}
+
+func (suite *AutoConfigTestSuite) TestAddProvider() {
 	ac := NewAutoConfig(scheduler.NewMetaScheduler())
 	ac.StartPolling()
-	assert.Len(t, ac.providers, 0)
+	assert.Len(suite.T(), ac.providers, 0)
 	mp := &MockProvider{}
 	ac.AddProvider(mp, false)
 	ac.AddProvider(mp, false) // this should be a noop
 	ac.AddProvider(&MockProvider2{}, true)
 	ac.LoadAndRun()
-	require.Len(t, ac.providers, 2)
-	assert.Equal(t, 1, mp.collectCounter)
-	assert.False(t, ac.providers[0].poll)
-	assert.True(t, ac.providers[1].poll)
+	require.Len(suite.T(), ac.providers, 2)
+	assert.Equal(suite.T(), 1, mp.collectCounter)
+	assert.False(suite.T(), ac.providers[0].poll)
+	assert.True(suite.T(), ac.providers[1].poll)
 }
 
-func TestAddListener(t *testing.T) {
+func (suite *AutoConfigTestSuite) TestAddListener() {
 	ac := NewAutoConfig(scheduler.NewMetaScheduler())
-	assert.Len(t, ac.listeners, 0)
+	assert.Len(suite.T(), ac.listeners, 0)
+
 	ml := &MockListener{}
-	ac.AddListener(ml)
-	require.Len(t, ac.listeners, 1)
-	assert.Equal(t, 1, ml.ListenCount)
+	listeners.Register("mock", ml.fakeFactory)
+	ac.AddListeners([]config.Listeners{mockListenenerConfig})
+
+	ac.m.Lock()
+	require.Len(suite.T(), ac.listeners, 1)
+	assert.Equal(suite.T(), 1, ml.ListenCount)
+	// Retry goroutine should be started
+	assert.Nil(suite.T(), ac.listenerRetryStop)
+	assert.Len(suite.T(), ac.listenerCandidates, 0)
+	ac.m.Unlock()
 }
 
-func TestContains(t *testing.T) {
+func (suite *AutoConfigTestSuite) TestContains() {
 	c1 := integration.Config{Name: "bar"}
 	c2 := integration.Config{Name: "foo"}
 	pd := providerDescriptor{}
 	pd.configs = append(pd.configs, c1)
-	assert.True(t, pd.contains(&c1))
-	assert.False(t, pd.contains(&c2))
+	assert.True(suite.T(), pd.contains(&c1))
+	assert.False(suite.T(), pd.contains(&c2))
 }
 
-func TestStop(t *testing.T) {
+func (suite *AutoConfigTestSuite) TestStop() {
 	ac := NewAutoConfig(scheduler.NewMetaScheduler())
 	ac.StartPolling() // otherwise Stop would block
 
 	ml := &MockListener{}
-	ac.AddListener(ml)
+	listeners.Register("mock", ml.fakeFactory)
+	ac.AddListeners([]config.Listeners{mockListenenerConfig})
 
 	ac.Stop()
 
-	assert.True(t, ml.stopReceived)
-	assert.True(t, ml.stopReceived)
+	assert.True(suite.T(), ml.stopReceived)
+	assert.True(suite.T(), ml.stopReceived)
+}
+
+func (suite *AutoConfigTestSuite) TestListenerRetry() {
+	// Hack the retry delay to shorten the test run time
+	initialListenerCandidateIntl := listenerCandidateIntl
+	listenerCandidateIntl = 50 * time.Millisecond
+	defer func() { listenerCandidateIntl = initialListenerCandidateIntl }()
+
+	// noErrFactory succeeds on first try
+	noErrListener := &MockListener{}
+	noErrFactory := factoryMock{
+		returnError: nil,
+		returnValue: noErrListener,
+	}
+	listeners.Register("noerr", noErrFactory.make)
+
+	// failFactory does not implement retry, should be discarded on first fail
+	failListener := &MockListener{}
+	failFactory := factoryMock{
+		returnError: errors.New("permafail"),
+		returnValue: failListener,
+	}
+	listeners.Register("fail", failFactory.make)
+
+	// retryFactory implements retry
+	retryListener := &MockListener{}
+	retryFactory := factoryMock{
+		callChan: make(chan struct{}, 3),
+		returnError: &retry.Error{
+			LogicError:    errors.New("will retry"),
+			RessourceName: "mocked",
+			RetryStatus:   retry.FailWillRetry,
+		},
+		returnValue: retryListener,
+	}
+	listeners.Register("retry", retryFactory.make)
+
+	configs := []config.Listeners{
+		{Name: "noerr"},
+		{Name: "fail"},
+		{Name: "retry"},
+	}
+	ac := NewAutoConfig(scheduler.NewMetaScheduler())
+	assert.Nil(suite.T(), ac.listenerRetryStop)
+	ac.AddListeners(configs)
+
+	ac.m.Lock()
+	// First try is synchronous, all factories should be called
+	noErrFactory.assertCallNumber(suite.T(), 1)
+	failFactory.assertCallNumber(suite.T(), 1)
+	retryFactory.assertCallNumber(suite.T(), 1)
+	// We should keep a single candidate
+	assert.Len(suite.T(), ac.listenerCandidates, 1)
+	assert.NotNil(suite.T(), ac.listenerCandidates["retry"])
+	// Listen should be called on the noErrListener, not on the other ones
+	assert.Equal(suite.T(), 1, noErrListener.ListenCount)
+	assert.Equal(suite.T(), 0, failListener.ListenCount)
+	assert.Equal(suite.T(), 0, retryListener.ListenCount)
+	// Retry goroutine should be started
+	assert.NotNil(suite.T(), ac.listenerRetryStop)
+	ac.m.Unlock()
+
+	// Second failure of the retryFactory
+	retryFactory.resetCallChan()
+	err := retryFactory.waitForCalled(500 * time.Millisecond)
+	assert.NoError(suite.T(), err)
+	retryFactory.assertCallNumber(suite.T(), 2)
+	assert.Equal(suite.T(), 0, retryListener.ListenCount)
+	// failFactory should not be called again
+	failFactory.assertCallNumber(suite.T(), 1)
+
+	// Make retryFactory successful now
+	retryFactory.Lock()
+	retryFactory.returnError = nil
+	retryFactory.resetCallChan()
+	retryFactory.Unlock()
+	err = retryFactory.waitForCalled(500 * time.Millisecond)
+	assert.NoError(suite.T(), err)
+
+	// Lock to wait for initListenerCandidates to return
+	// We should start retryListener and have no more candidate
+	ac.m.Lock()
+	retryFactory.assertCallNumber(suite.T(), 3)
+	assert.Equal(suite.T(), 1, retryListener.ListenCount)
+	assert.Len(suite.T(), ac.listenerCandidates, 0)
+	ac.m.Unlock()
+
+	// Wait for retryListenerCandidates to close listenerRetryStop and return
+	for i := 0; i < 10; i++ {
+		ac.m.Lock()
+		if ac.listenerRetryStop == nil {
+			break
+		}
+		ac.m.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	ac.m.Lock()
+	assert.Nil(suite.T(), ac.listenerRetryStop)
+	ac.m.Unlock()
+}
+
+func TestAutoConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(AutoConfigTestSuite))
 }

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -186,7 +186,6 @@ func (suite *AutoConfigTestSuite) TestStop() {
 	ac.Stop()
 
 	assert.True(suite.T(), ml.stopReceived)
-	assert.True(suite.T(), ml.stopReceived)
 }
 
 func (suite *AutoConfigTestSuite) TestListenerRetry() {

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -17,8 +17,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -17,6 +17,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
@@ -54,11 +56,10 @@ func init() {
 }
 
 // NewDockerListener creates a client connection to Docker and instantiate a DockerListener with it
-// TODO: TLS support
 func NewDockerListener() (ServiceListener, error) {
 	d, err := docker.GetDockerUtil()
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Docker, auto discovery will not work: %s", err)
+		return nil, err
 	}
 	return &DockerListener{
 		dockerUtil: d,

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -53,7 +53,7 @@ func init() {
 func NewKubeletListener() (ServiceListener, error) {
 	watcher, err := kubelet.NewPodWatcher(15 * time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to kubelet, Kubernetes listener will not work: %s", err)
+		return nil, err
 	}
 	return &KubeletListener{
 		watcher:  watcher,

--- a/releasenotes/notes/autodiscovery-listeners-retry-34547172d448eeb3.yaml
+++ b/releasenotes/notes/autodiscovery-listeners-retry-34547172d448eeb3.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Autodiscovery: the ``docker`` and ``kubelet`` listeners will retry on error,
+    to support starting the agent before your container runtime (host install)


### PR DESCRIPTION
### What does this PR do?

Allow the agent to start before docker / kubelet by introducing a retry mechanism for AD listeners:
  - move the listener init logic from `cmd/agent` to `pkg/autoconfig`
  - make `NewDockerListener` and `NewKubeletListener` bubble up their retry error
  - start a retry goroutine in `AutoConfig` if at least one listener fails to initialise on first try, don't start it on the nominal case (running in container, starting after the source is available)
  - unit testing

### Additional Notes

ConfigProviders already are resilient to late startup, they fail during `Collect`, not on init

### Tested `datadog/agent-dev:xvello-ad-retry`

- `ecs` listener on ECS Fargate (does not implement retry, should be unaffected)
- `docker` listener, with agent started before and after the docker daemon
- `kubelet` listener on Pupernetes, with agent started before and after the kubelet