### PR TITLE
[AD]: Moved all integration names into the same file which is always compiled

### DIFF
--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -21,9 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// Consul represents the name of the config provider
-const Consul = "Consul"
-
 // Abstractions for testing
 type consulKVBackend interface {
 	Keys(prefix, separator string, q *consul.QueryOptions) ([]string, *consul.QueryMeta, error)

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -18,9 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
-// Docker represents the name of the config provider
-const Docker = "Docker"
-
 const (
 	dockerADLabelPrefix = "com.datadoghq.ad."
 )

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -17,9 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ECS represents the name of the config provider
-const ECS = "ECS"
-
 const (
 	ecsADLabelPrefix        = "com.datadoghq.ad."
 	metadataURL      string = "http://169.254.170.2/v2/metadata"

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -21,9 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// Etcd represents the name of the config provider
-const Etcd = "etcd"
-
 type etcdBackend interface {
 	Get(ctx context.Context, key string, opts *client.GetOptions) (*client.Response, error)
 }

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -18,9 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// File represents the name of the config provider
-const File = "File"
-
 type configFormat struct {
 	ADIdentifiers []string    `yaml:"ad_identifiers"`
 	InitConfig    interface{} `yaml:"init_config"`

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -18,9 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
-// Kubernetes represents the name of the config provider
-const Kubernetes = "Kubernetes"
-
 const (
 	newPodAnnotationPrefix    = "ad.datadoghq.com/"
 	newPodAnnotationFormat    = newPodAnnotationPrefix + "%s."

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -10,6 +10,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+const (
+	Consul     = "Consul"
+	Docker     = "Docker"
+	ECS        = "ECS"
+	Etcd       = "etcd"
+	File       = "File"
+	Kubernetes = "Kubernetes"
+	Zookeeper  = "Zookeeper"
+)
+
 // ProviderCatalog keeps track of config providers by name
 var ProviderCatalog = make(map[string]ConfigProviderFactory)
 

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -11,13 +11,20 @@ import (
 )
 
 const (
-	Consul     = "Consul"
-	Docker     = "Docker"
-	ECS        = "ECS"
-	Etcd       = "etcd"
-	File       = "File"
+	// Consul represents the name of the Consul config provider
+	Consul = "Consul"
+	// Docker represents the name of the docker config provider
+	Docker = "Docker"
+	// ECS represents the name of the ecs config provider
+	ECS = "ECS"
+	// Etcd represents the name of the etcd config provider
+	Etcd = "etcd"
+	// File represents the name of the file config provider
+	File = "File"
+	// Kubernetes represents the name of the kubernetes config provider
 	Kubernetes = "Kubernetes"
-	Zookeeper  = "Zookeeper"
+	// Zookeeper represents the name of the zookeeper config provider
+	Zookeeper = "Zookeeper"
 )
 
 // ProviderCatalog keeps track of config providers by name

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -21,9 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// Zookeeper represents the name of the config provider
-const Zookeeper = "Zookeeper"
-
 const sessionTimeout = 1 * time.Second
 
 type zkBackend interface {


### PR DESCRIPTION
### What does this PR do?

Moved all integration names into the same file which is always compiled

### Motivation

Ensure constant are always compiled

### Additional Notes

Clients should manage compilation build tags themselves.
