### PR TITLE
[DCA] Add more expvars for custom metrics, and api request rates.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -612,6 +612,12 @@
   version = "v2.1.0"
 
 [[projects]]
+  name = "github.com/paulbellamy/ratecounter"
+  packages = ["."]
+  revision = "524851a93235ac051e3540563ed7909357fe24ab"
+  version = "v0.2.0"
+
+[[projects]]
   name = "github.com/pborman/uuid"
   packages = ["."]
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
@@ -1267,7 +1273,8 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
-    "util/retry"
+    "util/retry",
+    "util/workqueue"
   ]
   revision = "23781f4d6632d88e869066eaebb743857aa1ef9b"
   version = "v7.0.0"
@@ -1300,6 +1307,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "93591a49081406a09997ccc0a20a961d4c95330a07255af743b88e2a6e8067ea"
+  inputs-digest = "5a9127e88f491e8b090e9053c32bd9093cceaf268c57fc6774e5958816dc5311"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -94,3 +94,4 @@ core,golang.org/x/sys,BSD-3-Clause
 core,golang.org/x/text,BSD-3-Clause
 core,gopkg.in/yaml.v2,Apache-2.0
 core,gopkg.in/zorkian/go-datadog-api.v2,"BSD-3-Clause"
+core,github.com/paulbellamy/ratecounter,MIT

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -7,17 +7,35 @@ package v1
 
 import (
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/paulbellamy/ratecounter"
 
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/gorilla/mux"
 )
 
-// eventChecks are checks that send events and are supported by the DCA
-var eventChecks = []string{
-	"kubernetes",
+var (
+	// eventChecks are checks that send events and are supported by the DCA
+	eventChecks = []string{
+		"kubernetes",
+	}
+
+	apiStats                  = expvar.NewMap("apiv1")
+	metadataStats             = new(expvar.Map).Init()
+	metadataErrors            = &expvar.Int{}
+	metadataRequestsPerSecond = &expvar.Int{}
+	metadataRequestsCounter   = ratecounter.NewRateCounter(1 * time.Second)
+)
+
+func init() {
+	apiStats.Set("Metadata", metadataStats)
+	metadataStats.Set("Errors", metadataErrors)
+	metadataStats.Set("RequestsPerSecond", metadataRequestsPerSecond)
 }
 
 // Install registers v1 API endpoints
@@ -61,6 +79,10 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 			Returns: string
 			Example: "no cached metadata found for the pod my-nginx-5d69 on the node localhost"
 	*/
+
+	metadataRequestsCounter.Incr(1)
+	metadataRequestsPerSecond.Set(metadataRequestsCounter.Rate())
+
 	vars := mux.Vars(r)
 	var metaBytes []byte
 	nodeName := vars["nodeName"]
@@ -70,6 +92,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	if errMetaList != nil {
 		log.Errorf("Could not retrieve the metadata of: %s from the cache", podName)
 		http.Error(w, errMetaList.Error(), http.StatusInternalServerError)
+		metadataErrors.Add(1)
 		return
 	}
 
@@ -77,6 +100,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Errorf("Could not process the list of services for: %s", podName)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		metadataErrors.Add(1)
 		return
 	}
 	if len(metaBytes) != 0 {
@@ -86,7 +110,6 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNotFound)
 	w.Write([]byte(fmt.Sprintf("Could not find associated metadata mapped to the pod: %s on node: %s", podName, nodeName)))
-
 }
 
 // getNodeMetadata has the same signature as getAllMetadata, but is only scoped on one node.

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -12,11 +12,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/paulbellamy/ratecounter"
 
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/gorilla/mux"
 )
 
 var (

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2017 Datadog, Inc.
+// Copyright 2018 Datadog, Inc.
 
 // +build kubeapiserver
 

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2017 Datadog, Inc.
+// Copyright 2018 Datadog, Inc.
 
 // +build kubeapiserver
 

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2017 Datadog, Inc.
+// Copyright 2018 Datadog, Inc.
 
 // +build kubeapiserver
 

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/paulbellamy/ratecounter"
-
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -23,7 +22,7 @@ import (
 )
 
 var (
-	datadogStats          = expvar.NewMap("datadog")
+	datadogStats          = expvar.NewMap("datadog-api")
 	datadogErrors         = &expvar.Int{}
 	datadogQueriesPerHour = &expvar.Int{}
 	datadogQueriesCounter = ratecounter.NewRateCounter(1 * time.Hour)

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -9,15 +9,30 @@ package hpa
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/paulbellamy/ratecounter"
 
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var (
+	datadogStats          = expvar.NewMap("datadog")
+	datadogErrors         = &expvar.Int{}
+	datadogQueriesPerHour = &expvar.Int{}
+	datadogQueriesCounter = ratecounter.NewRateCounter(1 * time.Hour)
+)
+
+func init() {
+	datadogStats.Set("Errors", datadogErrors)
+	datadogStats.Set("QueriesPerHour", datadogQueriesPerHour)
+}
 
 // queryDatadogExternal converts the metric name and labels from the HPA format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,
@@ -36,11 +51,16 @@ func (hpa *HPAWatcherClient) queryDatadogExternal(metricName string, tags map[st
 	// TODO: offer other aggregations than avg.
 	query := fmt.Sprintf("avg:%s{%s}", metricName, tagString)
 
+	datadogQueriesCounter.Incr(1)
+	datadogQueriesPerHour.Set(datadogQueriesCounter.Rate())
+
 	seriesSlice, err := hpa.datadogClient.QueryMetrics(time.Now().Unix()-bucketSize, time.Now().Unix(), query)
 
 	if err != nil {
+		datadogErrors.Add(1)
 		return 0, log.Errorf("Error while executing metric query %s: %s", query, err)
 	}
+
 	if len(seriesSlice) == 0 {
 		return 0, log.Errorf("Returned series slice empty")
 	}

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -96,7 +96,7 @@ func (c *HPAWatcherClient) run(res string) (added, modified, deleted []*autoscal
 				added = append(added, currHPA)
 			}
 			if rcvdHPA.Type == watch.Modified {
-				log.Debugf("Updated HPA: %s/%s", currHPA.Namespace, currHPA.Name)
+				log.Tracef("Updated HPA: %s/%s", currHPA.Namespace, currHPA.Name)
 				modified = append(modified, currHPA)
 			}
 			if rcvdHPA.Type == watch.Deleted {

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -92,11 +92,11 @@ func (c *HPAWatcherClient) run(res string) (added, modified, deleted []*autoscal
 				continue
 			}
 			if rcvdHPA.Type == watch.Added {
-				log.Debugf("Adding this manifest: %s", currHPA)
+				log.Debugf("Added HPA: %s/%s", currHPA.Namespace, currHPA.Name)
 				added = append(added, currHPA)
 			}
 			if rcvdHPA.Type == watch.Modified {
-				log.Debugf("Modifying this manifest: %s", currHPA)
+				log.Debugf("Updated HPA: %s/%s", currHPA.Namespace, currHPA.Name)
 				modified = append(modified, currHPA)
 			}
 			if rcvdHPA.Type == watch.Deleted {


### PR DESCRIPTION
### What does this PR do?

Add more expvars for custom metrics, and api request rates.

```
"apiv1": {"Metadata": {"Errors": 0, "RequestsPerSecond": 8}},
"custommetrics": {"External": {"Total": 1, "Valid": 0}},
"datadog-api": {"Errors": 2, "QueriesPerHour": 2},
```

### Motivation

More visibility into potential problems.

### Additional Notes

This adds `github.com/paulbellamy/ratecounter` as a dependency.
