### PR TITLE
[DCA] Set leader identity on start leading and add a test.

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -50,12 +50,13 @@ type LeaderEngine struct {
 	LeaseDuration   time.Duration
 	LeaseName       string
 	LeaderNamespace string
-	coreClient      *corev1.CoreV1Client
+	coreClient      corev1.CoreV1Interface
 
-	currentHolderMutex sync.RWMutex
-	leaderElector      *leaderelection.LeaderElector
+	leaderIdentityMutex sync.RWMutex
+	leaderElector       *leaderelection.LeaderElector
 
-	currentHolderIdentity string
+	// leaderIdentity is the HolderIdentity of the current leader.
+	leaderIdentity string
 }
 
 func newLeaderEngine() *LeaderEngine {
@@ -190,10 +191,10 @@ func (le *LeaderEngine) runLeaderElection() {
 // GetLeader returns the identity of the last observed leader or returns the empty string if
 // no leader has yet been observed.
 func (le *LeaderEngine) GetLeader() string {
-	le.currentHolderMutex.RLock()
-	defer le.currentHolderMutex.RUnlock()
+	le.leaderIdentityMutex.RLock()
+	defer le.leaderIdentityMutex.RUnlock()
 
-	return le.currentHolderIdentity
+	return le.leaderIdentity
 }
 
 // IsLeader returns true if the last observed leader was this client else returns false.

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -72,19 +72,29 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 
 	callbacks := ld.LeaderCallbacks{
 		OnNewLeader: func(identity string) {
-			le.currentHolderMutex.Lock()
-			le.currentHolderIdentity = identity
-			le.currentHolderMutex.Unlock()
+			le.leaderIdentityMutex.Lock()
+			defer le.leaderIdentityMutex.Unlock()
+
+			le.leaderIdentity = identity
+
 			log.Infof("New leader %q", identity)
 		},
 		OnStartedLeading: func(stop <-chan struct{}) {
-			log.Infof("Started leading as %q ...", le.HolderIdentity)
+			le.leaderIdentityMutex.Lock()
+			defer le.leaderIdentityMutex.Unlock()
+
+			le.leaderIdentity = le.HolderIdentity
+
+			log.Infof("Started leading as %q...", le.HolderIdentity)
 		},
-		// OnStoppedLeading shouldn't be called unless the election is lost
+		// OnStoppedLeading shouldn't be called unless the election is lost. This could happen if
+		// we lose connection to the apiserver for the duration of the lease.
 		OnStoppedLeading: func() {
-			le.currentHolderMutex.Lock()
-			le.currentHolderIdentity = ""
-			le.currentHolderMutex.Unlock()
+			le.leaderIdentityMutex.Lock()
+			defer le.leaderIdentityMutex.Unlock()
+
+			le.leaderIdentity = ""
+
 			log.Infof("Stopped leading %q", le.HolderIdentity)
 		},
 	}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -73,17 +73,15 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 	callbacks := ld.LeaderCallbacks{
 		OnNewLeader: func(identity string) {
 			le.leaderIdentityMutex.Lock()
-			defer le.leaderIdentityMutex.Unlock()
-
 			le.leaderIdentity = identity
+			le.leaderIdentityMutex.Unlock()
 
 			log.Infof("New leader %q", identity)
 		},
 		OnStartedLeading: func(stop <-chan struct{}) {
 			le.leaderIdentityMutex.Lock()
-			defer le.leaderIdentityMutex.Unlock()
-
 			le.leaderIdentity = le.HolderIdentity
+			le.leaderIdentityMutex.Unlock()
 
 			log.Infof("Started leading as %q...", le.HolderIdentity)
 		},
@@ -91,9 +89,8 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 		// we lose connection to the apiserver for the duration of the lease.
 		OnStoppedLeading: func() {
 			le.leaderIdentityMutex.Lock()
-			defer le.leaderIdentityMutex.Unlock()
-
 			le.leaderIdentity = ""
+			le.leaderIdentityMutex.Unlock()
 
 			log.Infof("Stopped leading %q", le.HolderIdentity)
 		},

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -8,11 +8,33 @@
 package leaderelection
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 )
+
+func newFakeLockObject(namespace, name, leaderIdentity string) *v1.ConfigMap {
+	return &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Annotations: map[string]string{
+				rl.LeaderElectionRecordAnnotationKey: fmt.Sprintf(`{"holderIdentity":"%s"}`, leaderIdentity),
+			},
+		},
+	}
+}
 
 type testSuite struct {
 	suite.Suite
@@ -26,4 +48,50 @@ func (s *testSuite) TestError() {
 func TestSuite(t *testing.T) {
 	s := &testSuite{}
 	suite.Run(t, s)
+}
+
+func TestStoppedLeading(t *testing.T) {
+	const leaseName = "datadog-leader-election"
+
+	client := fake.NewSimpleClientset()
+
+	lock := newFakeLockObject("default", leaseName, "foo")
+	_, err := client.CoreV1().ConfigMaps("default").Create(lock)
+	require.NoError(t, err)
+
+	le := &LeaderEngine{
+		HolderIdentity:  "foo",
+		LeaseName:       leaseName,
+		LeaderNamespace: "default",
+		LeaseDuration:   1 * time.Second,
+
+		coreClient: client.CoreV1(),
+	}
+
+	le.leaderElector, err = le.newElection()
+	require.NoError(t, err)
+
+	le.EnsureLeaderElectionRuns()
+
+	require.True(t, le.IsLeader())
+
+	lock = newFakeLockObject("default", leaseName, "bar")
+	_, err = client.CoreV1().ConfigMaps("default").Update(lock)
+	require.NoError(t, err)
+
+	// poll until election is lost
+	err = wait.Poll(1*time.Second, 10*time.Second, func() (done bool, err error) {
+		return le.IsLeader() == false, nil
+	})
+	require.NoError(t, err, "Should not be leader")
+
+	lock = newFakeLockObject("default", leaseName, "foo")
+	_, err = client.CoreV1().ConfigMaps("default").Update(lock)
+	require.NoError(t, err)
+
+	// poll until leader again
+	err = wait.Poll(1*time.Second, 10*time.Second, func() (done bool, err error) {
+		return le.IsLeader(), nil
+	})
+	require.NoError(t, err, "Should be leader")
 }


### PR DESCRIPTION
### What does this PR do?

When the DCA leader election is lost, we set `currentHolderIdentity` to an empty string. The `OnStartedLeading` handler is then called which does not set `currentHolderIdentity` again.

This causes `IsLeader()` to incorrectly return false.

### Motivation

Bug
