### PR TITLE
make AD service identifiers the entity name

### DIFF
--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -16,7 +16,7 @@ type dummyService struct {
 	Hostname      string
 }
 
-// GetID returns the service entity name
+// GetEntity returns the service entity name
 func (s *dummyService) GetEntity() string {
 	return s.ID
 }

--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -8,7 +8,7 @@ package autodiscovery
 import "github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 
 type dummyService struct {
-	ID            listeners.ID
+	ID            string
 	ADIdentifiers []string
 	Hosts         map[string]string
 	Ports         []listeners.ContainerPort
@@ -16,8 +16,8 @@ type dummyService struct {
 	Hostname      string
 }
 
-// GetID returns the service ID
-func (s *dummyService) GetID() listeners.ID {
+// GetID returns the service entity name
+func (s *dummyService) GetEntity() string {
 	return s.ID
 }
 

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -42,9 +42,9 @@ var (
 type ConfigResolver struct {
 	ac              *AutoConfig
 	templates       *TemplateCache
-	services        map[listeners.ID]listeners.Service // Service.ID --> Service
-	adIDToServices  map[string]map[listeners.ID]bool   // AD id --> services that have it
-	configToService map[string]listeners.ID            // config digest --> service ID
+	services        map[string]listeners.Service // Service.ID --> Service
+	adIDToServices  map[string]map[string]bool   // AD id --> services that have it
+	configToService map[string]string            // config digest --> service ID
 	newService      chan listeners.Service
 	delService      chan listeners.Service
 	stop            chan bool
@@ -57,9 +57,9 @@ func newConfigResolver(ac *AutoConfig, tc *TemplateCache) *ConfigResolver {
 	cr := &ConfigResolver{
 		ac:              ac,
 		templates:       tc,
-		services:        make(map[listeners.ID]listeners.Service),
-		adIDToServices:  make(map[string]map[listeners.ID]bool),
-		configToService: make(map[string]listeners.ID),
+		services:        make(map[string]listeners.Service),
+		adIDToServices:  make(map[string]map[string]bool),
+		configToService: make(map[string]string),
 		newService:      make(chan listeners.Service),
 		delService:      make(chan listeners.Service),
 		stop:            make(chan bool),
@@ -186,15 +186,15 @@ func (cr *ConfigResolver) resolve(tpl integration.Config, svc listeners.Service)
 
 	// store resolved configs in the AC
 	cr.ac.store.setLoadedConfig(resolvedConfig)
-	cr.ac.store.addConfigForService(svc.GetID(), resolvedConfig)
-	cr.configToService[resolvedConfig.Digest()] = svc.GetID()
+	cr.ac.store.addConfigForService(svc.GetEntity(), resolvedConfig)
+	cr.configToService[resolvedConfig.Digest()] = svc.GetEntity()
 	// TODO: harmonize service & entities ID
-	entityName := string(svc.GetID())
+	entityName := string(svc.GetEntity())
 	if !strings.Contains(entityName, "://") {
 		entityName = docker.ContainerIDToEntityName(entityName)
 	}
 	cr.ac.store.setTagsHashForService(
-		svc.GetID(),
+		svc.GetEntity(),
 		tagger.GetEntityHash(entityName),
 	)
 
@@ -208,21 +208,21 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 	defer cr.m.Unlock()
 
 	// in any case, register the service and store its tag hash
-	cr.services[svc.GetID()] = svc
+	cr.services[svc.GetEntity()] = svc
 
 	// get all the templates matching service identifiers
 	var templates []integration.Config
 	ADIdentifiers, err := svc.GetADIdentifiers()
 	if err != nil {
-		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetID(), err)
+		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetEntity(), err)
 		return
 	}
 	for _, adID := range ADIdentifiers {
 		// map the AD identifier to this service for reverse lookup
 		if cr.adIDToServices[adID] == nil {
-			cr.adIDToServices[adID] = make(map[listeners.ID]bool)
+			cr.adIDToServices[adID] = make(map[string]bool)
 		}
-		cr.adIDToServices[adID][svc.GetID()] = true
+		cr.adIDToServices[adID][svc.GetEntity()] = true
 		tpls, err := cr.templates.Get(adID)
 		if err != nil {
 			log.Debugf("Unable to fetch templates from the cache: %v", err)
@@ -251,20 +251,20 @@ func (cr *ConfigResolver) processDelService(svc listeners.Service) {
 	cr.m.Lock()
 	defer cr.m.Unlock()
 
-	delete(cr.services, svc.GetID())
-	configs := cr.ac.store.getConfigsForService(svc.GetID())
-	cr.ac.store.removeConfigsForService(svc.GetID())
+	delete(cr.services, svc.GetEntity())
+	configs := cr.ac.store.getConfigsForService(svc.GetEntity())
+	cr.ac.store.removeConfigsForService(svc.GetEntity())
 	cr.ac.processRemovedConfigs(configs)
-	cr.ac.store.removeTagsHashForService(svc.GetID())
+	cr.ac.store.removeTagsHashForService(svc.GetEntity())
 }
 
 func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	hosts, err := svc.GetHosts()
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract IP address for container %s, ignoring it. Source error: %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to extract IP address for container %s, ignoring it. Source error: %s", svc.GetEntity(), err)
 	}
 	if len(hosts) == 0 {
-		return nil, fmt.Errorf("no network found for container %s, ignoring it", svc.GetID())
+		return nil, fmt.Errorf("no network found for container %s, ignoring it", svc.GetEntity())
 	}
 
 	// a network was specified
@@ -277,7 +277,7 @@ func getHost(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	// otherwise use fallback policy
 	ip, err := getFallbackHost(hosts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve IP address for container %s, ignoring it. Source error: %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to resolve IP address for container %s, ignoring it. Source error: %s", svc.GetEntity(), err)
 	}
 
 	return []byte(ip), nil
@@ -306,9 +306,9 @@ func getFallbackHost(hosts map[string]string) (string, error) {
 func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	ports, err := svc.GetPorts()
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract port list for container %s, ignoring it. Source error: %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to extract port list for container %s, ignoring it. Source error: %s", svc.GetEntity(), err)
 	} else if len(ports) == 0 {
-		return nil, fmt.Errorf("no port found for container %s - ignoring it", svc.GetID())
+		return nil, fmt.Errorf("no port found for container %s - ignoring it", svc.GetEntity())
 	}
 
 	if len(tplVar) == 0 {
@@ -323,10 +323,10 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 				return []byte(strconv.Itoa(port.Port)), nil
 			}
 		}
-		return nil, fmt.Errorf("port %s not found, skipping container %s", string(tplVar), svc.GetID())
+		return nil, fmt.Errorf("port %s not found, skipping container %s", string(tplVar), svc.GetEntity())
 	}
 	if len(ports) <= idx {
-		return nil, fmt.Errorf("index given for the port template var is too big, skipping container %s", svc.GetID())
+		return nil, fmt.Errorf("index given for the port template var is too big, skipping container %s", svc.GetEntity())
 	}
 	return []byte(strconv.Itoa(ports[idx].Port)), nil
 }
@@ -335,7 +335,7 @@ func getPort(tplVar []byte, svc listeners.Service) ([]byte, error) {
 func getPid(_ []byte, svc listeners.Service) ([]byte, error) {
 	pid, err := svc.GetPid()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pid for service %s, skipping config - %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to get pid for service %s, skipping config - %s", svc.GetEntity(), err)
 	}
 	return []byte(strconv.Itoa(pid)), nil
 }
@@ -345,7 +345,7 @@ func getPid(_ []byte, svc listeners.Service) ([]byte, error) {
 func getHostname(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	name, err := svc.GetHostname()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get hostname for service %s, skipping config - %s", svc.GetID(), err)
+		return nil, fmt.Errorf("failed to get hostname for service %s, skipping config - %s", svc.GetEntity(), err)
 	}
 	return []byte(name), nil
 }
@@ -353,11 +353,11 @@ func getHostname(tplVar []byte, svc listeners.Service) ([]byte, error) {
 // getEnvvar returns a system environment variable if found
 func getEnvvar(tplVar []byte, svc listeners.Service) ([]byte, error) {
 	if len(tplVar) == 0 {
-		return nil, fmt.Errorf("envvar name is missing, skipping service %s", svc.GetID())
+		return nil, fmt.Errorf("envvar name is missing, skipping service %s", svc.GetEntity())
 	}
 	value, found := os.LookupEnv(string(tplVar))
 	if !found {
-		return nil, fmt.Errorf("failed to retrieve envvar %s, skipping service %s", tplVar, svc.GetID())
+		return nil, fmt.Errorf("failed to retrieve envvar %s, skipping service %s", tplVar, svc.GetEntity())
 	}
 	return []byte(value), nil
 }

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -42,9 +42,9 @@ var (
 type ConfigResolver struct {
 	ac              *AutoConfig
 	templates       *TemplateCache
-	services        map[string]listeners.Service // Service.ID --> Service
+	services        map[string]listeners.Service // entity --> Service
 	adIDToServices  map[string]map[string]bool   // AD id --> services that have it
-	configToService map[string]string            // config digest --> service ID
+	configToService map[string]string            // config digest --> service entity
 	newService      chan listeners.Service
 	delService      chan listeners.Service
 	stop            chan bool

--- a/pkg/autodiscovery/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver_test.go
@@ -431,7 +431,7 @@ func TestResolve(t *testing.T) {
 
 		// Assert the valid configs are stored in the AC and the store
 		assert.Equal(t, validTemplates, len(ac.GetLoadedConfigs()))
-		assert.Equal(t, len(ac.store.getConfigsForService(tc.svc.GetID())), validTemplates)
+		assert.Equal(t, len(ac.store.getConfigsForService(tc.svc.GetEntity())), validTemplates)
 	}
 }
 

--- a/pkg/autodiscovery/listeners/README.md
+++ b/pkg/autodiscovery/listeners/README.md
@@ -15,12 +15,6 @@ Services can only be Docker containers for now.
 
 `DockerListener` first gets current running containers and send these to `ConfigResolver`. Then it starts listening on the Docker event API for container activity and pass by `Services` mentioned in start/stop events to `ConfigResolver` through the corresponding channel.
 
-**TODO**:
-
-- `DockerListener` calls Docker directly. We need a caching layer there.
-- support TLS
-- getHosts, getPorts and getTags need to use a caching layer for docker **and** use the k8s api (also with caching)
-
 ### `ECSListener`
 
 The `ECSListener` relies on the metadata APIs available within the agent container. We're listening on changes on the container list exposed through the API to discover new `Services`.

--- a/pkg/autodiscovery/listeners/common.go
+++ b/pkg/autodiscovery/listeners/common.go
@@ -7,7 +7,6 @@ package listeners
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -17,20 +16,20 @@ const (
 	dockerADTemplateLabelName = "com.datadoghq.ad.instances"
 )
 
-// ComputeContainerServiceIDs takes a container ID, an image (resolved to an actual name) and labels
+// ComputeContainerServiceIDs takes an entity name, an image (resolved to an actual name) and labels
 // and computes the service IDs for this container service.
-func ComputeContainerServiceIDs(cid string, image string, labels map[string]string) []string {
+func ComputeContainerServiceIDs(entity string, image string, labels map[string]string) []string {
 	// ID override label
 	if l, found := labels[newIdentifierLabel]; found {
 		return []string{l}
 	}
 	if l, found := labels[legacyIdentifierLabel]; found {
 		log.Warnf("found legacy %s label for %s, please use the new name %s",
-			legacyIdentifierLabel, cid, newIdentifierLabel)
+			legacyIdentifierLabel, entity, newIdentifierLabel)
 		return []string{l}
 	}
 
-	ids := []string{docker.ContainerIDToEntityName(cid)}
+	ids := []string{entity}
 
 	// AD template in labels, don't add image names
 	if _, found := labels[dockerADTemplateLabelName]; found {

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -145,19 +145,6 @@ func (l *DockerListener) init() {
 	}
 }
 
-// GetServices returns a copy of the current services
-func (l *DockerListener) GetServices() map[string]Service {
-	l.m.RLock()
-	defer l.m.RUnlock()
-
-	ret := make(map[string]Service)
-	for _, v := range l.services {
-		ret[v.GetEntity()] = v
-	}
-
-	return ret
-}
-
 // processEvent takes a ContainerEvent, tries to find a service linked to it, and
 // figure out if the ConfigResolver could be interested to inspect it.
 func (l *DockerListener) processEvent(e *docker.ContainerEvent) {

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -30,7 +30,7 @@ import (
 // match templates against.
 type DockerListener struct {
 	dockerUtil *docker.DockerUtil
-	services   map[ID]Service
+	services   map[string]Service
 	newService chan<- Service
 	delService chan<- Service
 	stop       chan bool
@@ -40,13 +40,13 @@ type DockerListener struct {
 
 // DockerService implements and store results from the Service interface for the Docker listener
 type DockerService struct {
-	ID            ID
-	ADIdentifiers []string
-	Hosts         map[string]string
-	Ports         []ContainerPort
-	Pid           int
-	Hostname      string
 	sync.RWMutex
+	cID           string
+	adIdentifiers []string
+	hosts         map[string]string
+	ports         []ContainerPort
+	pid           int
+	hostname      string
 }
 
 func init() {
@@ -61,7 +61,7 @@ func NewDockerListener() (ServiceListener, error) {
 	}
 	return &DockerListener{
 		dockerUtil: d,
-		services:   make(map[ID]Service),
+		services:   make(map[string]Service),
 		stop:       make(chan bool),
 		health:     health.Register("ad-dockerlistener"),
 	}, nil
@@ -122,38 +122,37 @@ func (l *DockerListener) init() {
 	}
 
 	for _, co := range containers {
-		id := ID(co.ID)
 		var svc Service
 
 		if findKubernetesInLabels(co.Labels) {
 			svc = &DockerKubeletService{
 				DockerService: DockerService{
-					ID:            id,
-					ADIdentifiers: l.getConfigIDFromPs(co),
+					cID:           co.ID,
+					adIdentifiers: l.getConfigIDFromPs(co),
 					// Host and Ports will be looked up when needed
 				},
 			}
 		} else {
 			svc = &DockerService{
-				ID:            id,
-				ADIdentifiers: l.getConfigIDFromPs(co),
-				Hosts:         l.getHostsFromPs(co),
-				Ports:         l.getPortsFromPs(co),
+				cID:           co.ID,
+				adIdentifiers: l.getConfigIDFromPs(co),
+				hosts:         l.getHostsFromPs(co),
+				ports:         l.getPortsFromPs(co),
 			}
 		}
 		l.newService <- svc
-		l.services[id] = svc
+		l.services[co.ID] = svc
 	}
 }
 
 // GetServices returns a copy of the current services
-func (l *DockerListener) GetServices() map[ID]Service {
+func (l *DockerListener) GetServices() map[string]Service {
 	l.m.RLock()
 	defer l.m.RUnlock()
 
-	ret := make(map[ID]Service)
-	for k, v := range l.services {
-		ret[k] = v
+	ret := make(map[string]Service)
+	for _, v := range l.services {
+		ret[v.GetEntity()] = v
 	}
 
 	return ret
@@ -162,7 +161,7 @@ func (l *DockerListener) GetServices() map[ID]Service {
 // processEvent takes a ContainerEvent, tries to find a service linked to it, and
 // figure out if the ConfigResolver could be interested to inspect it.
 func (l *DockerListener) processEvent(e *docker.ContainerEvent) {
-	cID := ID(e.ContainerID)
+	cID := e.ContainerID
 
 	l.m.RLock()
 	_, found := l.services[cID]
@@ -187,12 +186,12 @@ func (l *DockerListener) processEvent(e *docker.ContainerEvent) {
 
 // createService takes a container ID, create a service for it in its cache
 // and tells the ConfigResolver that this service started.
-func (l *DockerListener) createService(cID ID) {
+func (l *DockerListener) createService(cID string) {
 	var svc Service
 
 	// Detect whether that container is managed by Kubernetes
 	var isKube bool
-	cInspect, err := l.dockerUtil.Inspect(string(cID), false)
+	cInspect, err := l.dockerUtil.Inspect(cID, false)
 	if err != nil {
 		log.Errorf("Failed to inspect container %s - %s", cID[:12], err)
 	} else if findKubernetesInLabels(cInspect.Config.Labels) {
@@ -202,12 +201,12 @@ func (l *DockerListener) createService(cID ID) {
 	if isKube {
 		svc = &DockerKubeletService{
 			DockerService: DockerService{
-				ID: cID,
+				cID: cID,
 			},
 		}
 	} else {
 		svc = &DockerService{
-			ID: cID,
+			cID: cID,
 		}
 	}
 
@@ -233,7 +232,7 @@ func (l *DockerListener) createService(cID ID) {
 	}
 
 	l.m.Lock()
-	l.services[ID(cID)] = svc
+	l.services[cID] = svc
 	l.m.Unlock()
 
 	l.newService <- svc
@@ -241,7 +240,7 @@ func (l *DockerListener) createService(cID ID) {
 
 // removeService takes a container ID, removes the related service from its cache
 // and tells the ConfigResolver that this service stopped.
-func (l *DockerListener) removeService(cID ID) {
+func (l *DockerListener) removeService(cID string) {
 	l.m.RLock()
 	svc, ok := l.services[cID]
 	l.m.RUnlock()
@@ -273,7 +272,8 @@ func (l *DockerListener) getConfigIDFromPs(co types.Container) []string {
 	if err != nil {
 		log.Warnf("error while resolving image name: %s", err)
 	}
-	return ComputeContainerServiceIDs(co.ID, image, co.Labels)
+	entity := docker.ContainerIDToEntityName(co.ID)
+	return ComputeContainerServiceIDs(entity, image, co.Labels)
 }
 
 // getHostsFromPs gets the addresss (for now IP address only) of a container on all its networks.
@@ -309,9 +309,9 @@ func (l *DockerListener) getPortsFromPs(co types.Container) []ContainerPort {
 	return ports
 }
 
-// GetID returns the service ID
-func (s *DockerService) GetID() ID {
-	return s.ID
+// GetEntity returns the unique entity name linked to that service
+func (s *DockerService) GetEntity() string {
+	return docker.ContainerIDToEntityName(s.cID)
 }
 
 // GetADIdentifiers returns a set of AD identifiers for a container.
@@ -326,12 +326,12 @@ func (s *DockerService) GetID() ID {
 //   1. Long image name
 //   2. Short image name
 func (s *DockerService) GetADIdentifiers() ([]string, error) {
-	if len(s.ADIdentifiers) == 0 {
+	if len(s.adIdentifiers) == 0 {
 		du, err := docker.GetDockerUtil()
 		if err != nil {
 			return []string{}, err
 		}
-		cj, err := du.Inspect(string(s.ID), false)
+		cj, err := du.Inspect(s.cID, false)
 		if err != nil {
 			return []string{}, err
 		}
@@ -339,10 +339,11 @@ func (s *DockerService) GetADIdentifiers() ([]string, error) {
 		if err != nil {
 			log.Warnf("error while resolving image name: %s", err)
 		}
-		s.ADIdentifiers = ComputeContainerServiceIDs(string(s.ID), image, cj.Config.Labels)
+		entity := docker.ContainerIDToEntityName(s.cID)
+		s.adIdentifiers = ComputeContainerServiceIDs(entity, image, cj.Config.Labels)
 	}
 
-	return s.ADIdentifiers, nil
+	return s.adIdentifiers, nil
 }
 
 // GetHosts returns the container's hosts
@@ -350,8 +351,8 @@ func (s *DockerService) GetHosts() (map[string]string, error) {
 	s.Lock()
 	defer s.Unlock()
 
-	if s.Hosts != nil {
-		return s.Hosts, nil
+	if s.hosts != nil {
+		return s.hosts, nil
 	}
 
 	ips := make(map[string]string)
@@ -359,9 +360,9 @@ func (s *DockerService) GetHosts() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	cInspect, err := du.Inspect(string(s.ID), false)
+	cInspect, err := du.Inspect(s.cID, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inspect container %s", string(s.ID)[:12])
+		return nil, fmt.Errorf("failed to inspect container %s", s.cID[:12])
 	}
 	if cInspect.NetworkSettings != nil {
 		for net, settings := range cInspect.NetworkSettings.Networks {
@@ -376,14 +377,14 @@ func (s *DockerService) GetHosts() (map[string]string, error) {
 		ips["rancher"] = rancherIP
 	}
 
-	s.Hosts = ips
+	s.hosts = ips
 	return ips, nil
 }
 
 // GetPorts returns the container's ports
 func (s *DockerService) GetPorts() ([]ContainerPort, error) {
-	if s.Ports != nil {
-		return s.Ports, nil
+	if s.ports != nil {
+		return s.ports, nil
 	}
 
 	// Make a non-nil array to avoid re-running if we find zero port
@@ -393,9 +394,9 @@ func (s *DockerService) GetPorts() ([]ContainerPort, error) {
 	if err != nil {
 		return ports, err
 	}
-	cInspect, err := du.Inspect(string(s.ID), false)
+	cInspect, err := du.Inspect(s.cID, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inspect container %s", string(s.ID)[:12])
+		return nil, fmt.Errorf("failed to inspect container %s", s.cID[:12])
 	}
 
 	switch {
@@ -409,7 +410,7 @@ func (s *DockerService) GetPorts() ([]ContainerPort, error) {
 			ports = append(ports, out...)
 		}
 	case cInspect.Config != nil && len(cInspect.Config.ExposedPorts) > 0:
-		log.Infof("using ExposedPorts for container %s as no port bindings are listed", string(s.ID)[:12])
+		log.Infof("using ExposedPorts for container %s as no port bindings are listed", s.cID[:12])
 		for p := range cInspect.Config.ExposedPorts {
 			out, err := parseDockerPort(p)
 			if err != nil {
@@ -423,7 +424,7 @@ func (s *DockerService) GetPorts() ([]ContainerPort, error) {
 	sort.Slice(ports, func(i, j int) bool {
 		return ports[i].Port < ports[j].Port
 	})
-	s.Ports = ports
+	s.ports = ports
 	return ports, nil
 }
 
@@ -451,8 +452,7 @@ func parseDockerPort(port nat.Port) ([]ContainerPort, error) {
 
 // GetTags retrieves tags using the Tagger
 func (s *DockerService) GetTags() ([]string, error) {
-	entity := docker.ContainerIDToEntityName(string(s.ID))
-	tags, err := tagger.Tag(entity, tagger.IsFullCardinality())
+	tags, err := tagger.Tag(s.GetEntity(), tagger.IsFullCardinality())
 	if err != nil {
 		return []string{}, err
 	}
@@ -463,44 +463,44 @@ func (s *DockerService) GetTags() ([]string, error) {
 // GetPid inspect the container an return its pid
 func (s *DockerService) GetPid() (int, error) {
 	// Try to inspect container to get the pid if not defined
-	if s.Pid <= 0 {
+	if s.pid <= 0 {
 		du, err := docker.GetDockerUtil()
 		if err != nil {
 			return -1, err
 		}
-		cj, err := du.Inspect(string(s.ID), false)
+		cj, err := du.Inspect(s.cID, false)
 		if err != nil {
 			return -1, err
 		}
-		s.Pid = cj.State.Pid
+		s.pid = cj.State.Pid
 	}
 
-	return s.Pid, nil
+	return s.pid, nil
 }
 
 // GetHostname returns hostname.domainname for the container
 func (s *DockerService) GetHostname() (string, error) {
-	if s.Hostname != "" {
-		return s.Hostname, nil
+	if s.hostname != "" {
+		return s.hostname, nil
 	}
 
 	du, err := docker.GetDockerUtil()
 	if err != nil {
 		return "", err
 	}
-	cInspect, err := du.Inspect(string(s.ID), false)
+	cInspect, err := du.Inspect(s.cID, false)
 	if err != nil {
-		return "", fmt.Errorf("failed to inspect container %s", string(s.ID)[:12])
+		return "", fmt.Errorf("failed to inspect container %s", s.cID[:12])
 	}
 	if cInspect.Config == nil {
-		return "", fmt.Errorf("invalid inspect for container %s", string(s.ID)[:12])
+		return "", fmt.Errorf("invalid inspect for container %s", s.cID[:12])
 	}
 	if cInspect.Config.Hostname == "" {
-		return "", fmt.Errorf("empty hostname for container %s", string(s.ID)[:12])
+		return "", fmt.Errorf("empty hostname for container %s", s.cID[:12])
 	}
 
-	s.Hostname = cInspect.Config.Hostname
-	return s.Hostname, nil
+	s.hostname = cInspect.Config.Hostname
+	return s.hostname, nil
 }
 
 // findKubernetesInLabels traverses a map of container labels and

--- a/pkg/autodiscovery/listeners/docker_kubelet.go
+++ b/pkg/autodiscovery/listeners/docker_kubelet.go
@@ -14,10 +14,8 @@ package listeners
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -40,7 +38,7 @@ func (s *DockerKubeletService) getPod() (*kubelet.Pod, error) {
 			return nil, err
 		}
 	}
-	searchedId := docker.ContainerIDToEntityName(string(s.GetID()))
+	searchedId := s.GetEntity()
 	return s.kubeUtil.GetPodForContainerID(searchedId)
 }
 
@@ -72,10 +70,10 @@ func (s *DockerKubeletService) GetPorts() ([]ContainerPort, error) {
 	if err != nil {
 		return nil, err
 	}
-	searchedId := string(s.GetID())
+	searchedId := s.GetEntity()
 	var searchedContainerName string
 	for _, container := range pod.Status.Containers {
-		if strings.HasSuffix(container.ID, searchedId) {
+		if container.ID == searchedId {
 			searchedContainerName = container.Name
 		}
 	}

--- a/pkg/autodiscovery/listeners/docker_test.go
+++ b/pkg/autodiscovery/listeners/docker_test.go
@@ -168,7 +168,7 @@ func TestGetPortsFromPs(t *testing.T) {
 }
 
 func TestGetADIdentifiers(t *testing.T) {
-	s := DockerService{ID: ID("deadbeef")}
+	s := DockerService{cID: "deadbeef"}
 
 	// Setting mocked data in cache
 	co := types.ContainerJSON{
@@ -184,7 +184,7 @@ func TestGetADIdentifiers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"docker://deadbeef", "org/test", "test"}, ids)
 
-	s = DockerService{ID: ID("deadbeef")}
+	s = DockerService{cID: "deadbeef"}
 	labeledCo := types.ContainerJSON{
 		ContainerJSONBase: &types.ContainerJSONBase{ID: "deadbeef", Image: "test"},
 		Mounts:            make([]types.MountPoint, 0),
@@ -215,7 +215,7 @@ func TestGetHosts(t *testing.T) {
 	cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 	svc := DockerService{
-		ID: ID(id),
+		cID: id,
 	}
 
 	res, _ := svc.GetHosts()
@@ -251,7 +251,7 @@ func TestGetHosts(t *testing.T) {
 	cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 	svc = DockerService{
-		ID: ID(id),
+		cID: id,
 	}
 	hosts, _ := svc.GetHosts()
 
@@ -288,7 +288,7 @@ func TestGetRancherIP(t *testing.T) {
 	cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 	svc := DockerService{
-		ID: ID(id),
+		cID: id,
 	}
 
 	hosts, _ := svc.GetHosts()
@@ -327,7 +327,7 @@ func TestGetPorts(t *testing.T) {
 	cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 	svc := DockerService{
-		ID: ID(id),
+		cID: id,
 	}
 	svcPorts, _ := svc.GetPorts()
 	assert.NotNil(t, svcPorts) // Return array must be non-nil to avoid calling GetPorts again
@@ -361,7 +361,7 @@ func TestGetPorts(t *testing.T) {
 	cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 	svc = DockerService{
-		ID: ID(id),
+		cID: id,
 	}
 
 	pts, _ := svc.GetPorts()
@@ -402,7 +402,7 @@ func TestGetPorts(t *testing.T) {
 	cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 	svc = DockerService{
-		ID: ID(id),
+		cID: id,
 	}
 
 	pts, _ = svc.GetPorts()
@@ -410,7 +410,7 @@ func TestGetPorts(t *testing.T) {
 }
 
 func TestGetPid(t *testing.T) {
-	s := DockerService{ID: ID("foo")}
+	s := DockerService{cID: "foo"}
 
 	// Setting mocked data in cache
 	state := types.ContainerState{Pid: 1337}
@@ -526,7 +526,7 @@ func TestGetHostname(t *testing.T) {
 			cache.Cache.Set(cacheKey, cj, 10*time.Second)
 
 			svc := DockerService{
-				ID: ID(cId),
+				cID: cId,
 			}
 
 			name, err := svc.GetHostname()

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
 
@@ -35,12 +35,11 @@ type ECSListener struct {
 
 // ECSService implements and store results from the Service interface for the ECS listener
 type ECSService struct {
-	ID            ID
+	cID           string
+	runtime       string
 	ADIdentifiers []string
-	Hosts         map[string]string
-	Ports         []int
-	Pid           int
-	Tags          []string
+	hosts         map[string]string
+	tags          []string
 	clusterName   string
 	taskFamily    string
 	taskVersion   string
@@ -138,9 +137,9 @@ func (l *ECSListener) refreshServices() {
 }
 
 func (l *ECSListener) createService(c ecs.Container) (ECSService, error) {
-	cID := ID(c.DockerID)
 	svc := ECSService{
-		ID:          cID,
+		cID:         c.DockerID,
+		runtime:     containers.RuntimeNameDocker,
 		clusterName: l.task.ClusterName,
 		taskFamily:  l.task.Family,
 		taskVersion: l.task.Version,
@@ -149,7 +148,7 @@ func (l *ECSListener) createService(c ecs.Container) (ECSService, error) {
 	// ADIdentifiers
 	image := c.Image
 	labels := c.Labels
-	svc.ADIdentifiers = ComputeContainerServiceIDs(c.DockerID, image, labels)
+	svc.ADIdentifiers = ComputeContainerServiceIDs(svc.GetEntity(), image, labels)
 
 	// Host
 	ips := make(map[string]string)
@@ -159,26 +158,21 @@ func (l *ECSListener) createService(c ecs.Container) (ECSService, error) {
 			ips["awsvpc"] = string(net.IPv4Addresses[0])
 		}
 	}
-	svc.Hosts = ips
+	svc.hosts = ips
 
 	// Tags
-	entity := docker.ContainerIDToEntityName(string(c.DockerID))
-	tags, err := tagger.Tag(entity, tagger.IsFullCardinality())
+	tags, err := tagger.Tag(svc.GetEntity(), tagger.IsFullCardinality())
 	if err != nil {
-		log.Errorf("Failed to extract tags for container %s - %s", cID[:12], err)
+		log.Errorf("Failed to extract tags for container %s - %s", c.DockerID[:12], err)
 	}
-	svc.Tags = tags
-
-	// Ports and Pid
-	svc.Ports = nil
-	svc.Pid = -1
+	svc.tags = tags
 
 	return svc, err
 }
 
-// GetID returns the service ID
-func (s *ECSService) GetID() ID {
-	return s.ID
+// GetEntity returns the unique entity name linked to that service
+func (s *ECSService) GetEntity() string {
+	return containers.BuildEntityName(s.runtime, s.cID)
 }
 
 // GetADIdentifiers returns a set of AD identifiers for a container.
@@ -199,7 +193,7 @@ func (s *ECSService) GetADIdentifiers() ([]string, error) {
 // GetHosts returns the container's hosts
 // TODO: using localhost should usually be enough
 func (s *ECSService) GetHosts() (map[string]string, error) {
-	return s.Hosts, nil
+	return s.hosts, nil
 }
 
 // GetPorts returns nil and an error because port is not supported in Fargate-based ECS
@@ -209,7 +203,7 @@ func (s *ECSService) GetPorts() ([]ContainerPort, error) {
 
 // GetTags retrieves a container's tags
 func (s *ECSService) GetTags() ([]string, error) {
-	return s.Tags, nil
+	return s.tags, nil
 }
 
 // GetPid inspect the container and return its pid

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -29,7 +29,7 @@ const (
 // KubeletListener listen to kubelet pod creation
 type KubeletListener struct {
 	watcher    *kubelet.PodWatcher
-	services   map[ID]Service
+	services   map[string]Service
 	newService chan<- Service
 	delService chan<- Service
 	ticker     *time.Ticker
@@ -38,12 +38,12 @@ type KubeletListener struct {
 	m          sync.RWMutex
 }
 
-// PodContainerService implements and store results from the Service interface for the Kubelet listener
-type PodContainerService struct {
-	ID            ID
-	ADIdentifiers []string
-	Hosts         map[string]string
-	Ports         []ContainerPort
+// KubeContainerService implements and store results from the Service interface for the Kubelet listener
+type KubeContainerService struct {
+	entity        string
+	adIdentifiers []string
+	hosts         map[string]string
+	ports         []ContainerPort
 }
 
 func init() {
@@ -57,7 +57,7 @@ func NewKubeletListener() (ServiceListener, error) {
 	}
 	return &KubeletListener{
 		watcher:  watcher,
-		services: make(map[ID]Service),
+		services: make(map[string]Service),
 		ticker:   time.NewTicker(15 * time.Second),
 		stop:     make(chan bool),
 		health:   health.Register("ad-kubeletlistener"),
@@ -95,8 +95,8 @@ func (l *KubeletListener) Listen(newSvc chan<- Service, delSvc chan<- Service) {
 					log.Error(err)
 					continue
 				}
-				for _, containerID := range expiredContainerList {
-					l.removeService(ID(containerID))
+				for _, entity := range expiredContainerList {
+					l.removeService(entity)
 				}
 			}
 		}
@@ -110,24 +110,24 @@ func (l *KubeletListener) Stop() {
 
 func (l *KubeletListener) processNewPod(pod *kubelet.Pod) {
 	for _, container := range pod.Status.Containers {
-		l.createService(ID(container.ID), pod)
+		l.createService(container.ID, pod)
 	}
 }
 
-func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
-	svc := PodContainerService{
-		ID: id,
+func (l *KubeletListener) createService(entity string, pod *kubelet.Pod) {
+	svc := KubeContainerService{
+		entity: entity,
 	}
 	podName := pod.Metadata.Name
 
 	// AD Identifiers
 	var containerName string
 	for _, container := range pod.Status.Containers {
-		if container.ID == string(svc.ID) {
+		if container.ID == svc.entity {
 			containerName = container.Name
 
 			// Add container uid as ID
-			svc.ADIdentifiers = append(svc.ADIdentifiers, container.ID)
+			svc.adIdentifiers = append(svc.adIdentifiers, container.ID)
 
 			// Stop here if we find an AD template annotation
 			if podHasADTemplate(pod.Metadata.Annotations, containerName) {
@@ -135,13 +135,13 @@ func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
 			}
 
 			// Add other identifiers if no template found
-			svc.ADIdentifiers = append(svc.ADIdentifiers, container.Image)
+			svc.adIdentifiers = append(svc.adIdentifiers, container.Image)
 			_, short, _, err := containers.SplitImageName(container.Image)
 			if err != nil {
 				log.Warnf("Error while spliting image name: %s", err)
 			}
 			if len(short) > 0 && short != container.Image {
-				svc.ADIdentifiers = append(svc.ADIdentifiers, short)
+				svc.adIdentifiers = append(svc.adIdentifiers, short)
 			}
 			break
 		}
@@ -152,7 +152,7 @@ func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
 	if podIp == "" {
 		log.Errorf("Unable to get pod %s IP", podName)
 	}
-	svc.Hosts = map[string]string{"pod": podIp}
+	svc.hosts = map[string]string{"pod": podIp}
 
 	// Ports
 	var ports []ContainerPort
@@ -167,14 +167,14 @@ func (l *KubeletListener) createService(id ID, pod *kubelet.Pod) {
 	sort.Slice(ports, func(i, j int) bool {
 		return ports[i].Port < ports[j].Port
 	})
-	svc.Ports = ports
-	if len(svc.Ports) == 0 {
+	svc.ports = ports
+	if len(svc.ports) == 0 {
 		// Port might not be specified in pod spec
 		log.Debugf("No ports found for pod %s", podName)
 	}
 
 	l.m.Lock()
-	l.services[ID(id)] = &svc
+	l.services[entity] = &svc
 	l.m.Unlock()
 
 	l.newService <- &svc
@@ -193,58 +193,58 @@ func podHasADTemplate(annotations map[string]string, containerName string) bool 
 	return false
 }
 
-func (l *KubeletListener) removeService(cID ID) {
-	if strings.HasPrefix(string(cID), kubelet.KubePodPrefix) {
+func (l *KubeletListener) removeService(entity string) {
+	if strings.HasPrefix(entity, kubelet.KubePodPrefix) {
 		// Ignoring expired pods
 		return
 	}
 
 	l.m.RLock()
-	svc, ok := l.services[cID]
+	svc, ok := l.services[entity]
 	l.m.RUnlock()
 
 	if ok {
 		l.m.Lock()
-		delete(l.services, cID)
+		delete(l.services, entity)
 		l.m.Unlock()
 
 		l.delService <- svc
 	} else {
-		log.Debugf("Container %s not found, not removing", cID)
+		log.Debugf("Entity %s not found, not removing", entity)
 	}
 }
 
-// GetID returns the service ID
-func (s *PodContainerService) GetID() ID {
-	return s.ID
+// GetEntity returns the unique entity name linked to that service
+func (s *KubeContainerService) GetEntity() string {
+	return s.entity
 }
 
 // GetADIdentifiers returns the service AD identifiers
-func (s *PodContainerService) GetADIdentifiers() ([]string, error) {
-	return s.ADIdentifiers, nil
+func (s *KubeContainerService) GetADIdentifiers() ([]string, error) {
+	return s.adIdentifiers, nil
 }
 
 // GetHosts returns the pod hosts
-func (s *PodContainerService) GetHosts() (map[string]string, error) {
-	return s.Hosts, nil
+func (s *KubeContainerService) GetHosts() (map[string]string, error) {
+	return s.hosts, nil
 }
 
 // GetPid is not supported for PodContainerService
-func (s *PodContainerService) GetPid() (int, error) {
+func (s *KubeContainerService) GetPid() (int, error) {
 	return -1, ErrNotSupported
 }
 
 // GetPorts returns the container's ports
-func (s *PodContainerService) GetPorts() ([]ContainerPort, error) {
-	return s.Ports, nil
+func (s *KubeContainerService) GetPorts() ([]ContainerPort, error) {
+	return s.ports, nil
 }
 
 // GetTags retrieves tags using the Tagger
-func (s *PodContainerService) GetTags() ([]string, error) {
-	return tagger.Tag(string(s.ID), tagger.IsFullCardinality())
+func (s *KubeContainerService) GetTags() ([]string, error) {
+	return tagger.Tag(string(s.entity), tagger.IsFullCardinality())
 }
 
 // GetHostname returns nil and an error because port is not supported in Kubelet
-func (s *PodContainerService) GetHostname() (string, error) {
+func (s *KubeContainerService) GetHostname() (string, error) {
 	return "", ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -105,13 +105,13 @@ func TestProcessNewPod(t *testing.T) {
 	services := make(chan Service, 3)
 	listener := KubeletListener{
 		newService: services,
-		services:   make(map[ID]Service),
+		services:   make(map[string]Service),
 	}
 	listener.processNewPod(getMockedPod())
 
 	select {
 	case service := <-services:
-		assert.Equal(t, "docker://foorandomhash", string(service.GetID()))
+		assert.Equal(t, "docker://foorandomhash", string(service.GetEntity()))
 		adIdentifiers, err := service.GetADIdentifiers()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"docker://foorandomhash", "datadoghq.com/foo:latest", "foo"}, adIdentifiers)
@@ -129,7 +129,7 @@ func TestProcessNewPod(t *testing.T) {
 
 	select {
 	case service := <-services:
-		assert.Equal(t, "rkt://bar-random-hash", string(service.GetID()))
+		assert.Equal(t, "rkt://bar-random-hash", string(service.GetEntity()))
 		adIdentifiers, err := service.GetADIdentifiers()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"rkt://bar-random-hash", "datadoghq.com/bar:latest", "bar"}, adIdentifiers)
@@ -147,7 +147,7 @@ func TestProcessNewPod(t *testing.T) {
 
 	select {
 	case service := <-services:
-		assert.Equal(t, "docker://containerid", string(service.GetID()))
+		assert.Equal(t, "docker://containerid", string(service.GetEntity()))
 		adIdentifiers, err := service.GetADIdentifiers()
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"docker://containerid"}, adIdentifiers)

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -24,7 +24,7 @@ type ContainerPort struct {
 // It should be matched with a check template by the ConfigResolver using the
 // ADIdentifiers field.
 type Service interface {
-	GetID() ID                            // unique ID
+	GetEntity() string                    // unique entity name
 	GetADIdentifiers() ([]string, error)  // identifiers on which templates will be matched
 	GetHosts() (map[string]string, error) // network --> IP address
 	GetPorts() ([]ContainerPort, error)   // network ports

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -33,50 +33,50 @@ func newStore() *store {
 }
 
 // getConfigsForService gets config for a specified service
-func (s *store) getConfigsForService(serviceID string) []integration.Config {
+func (s *store) getConfigsForService(serviceEntity string) []integration.Config {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	return s.serviceToConfigs[serviceID]
+	return s.serviceToConfigs[serviceEntity]
 }
 
 // removeConfigsForService removes a config for a specified service
-func (s *store) removeConfigsForService(serviceID string) {
+func (s *store) removeConfigsForService(serviceEntity string) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	delete(s.serviceToConfigs, serviceID)
+	delete(s.serviceToConfigs, serviceEntity)
 }
 
 // addConfigForService adds a config for a specified service
-func (s *store) addConfigForService(serviceID string, config integration.Config) {
+func (s *store) addConfigForService(serviceEntity string, config integration.Config) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	existingConfigs, found := s.serviceToConfigs[serviceID]
+	existingConfigs, found := s.serviceToConfigs[serviceEntity]
 	if found {
-		s.serviceToConfigs[serviceID] = append(existingConfigs, config)
+		s.serviceToConfigs[serviceEntity] = append(existingConfigs, config)
 	} else {
-		s.serviceToConfigs[serviceID] = []integration.Config{config}
+		s.serviceToConfigs[serviceEntity] = []integration.Config{config}
 	}
 }
 
 // getTagsHashForService return the tags hash for a specified service
-func (s *store) getTagsHashForService(serviceID string) string {
+func (s *store) getTagsHashForService(serviceEntity string) string {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	return s.serviceToTagsHash[serviceID]
+	return s.serviceToTagsHash[serviceEntity]
 }
 
 // removeTagsHashForService removes the tags hash for a specified service
-func (s *store) removeTagsHashForService(serviceID string) {
+func (s *store) removeTagsHashForService(serviceEntity string) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	delete(s.serviceToTagsHash, serviceID)
+	delete(s.serviceToTagsHash, serviceEntity)
 }
 
 // setTagsHashForService set the tags hash for a specified service
-func (s *store) setTagsHashForService(serviceID string, hash string) {
+func (s *store) setTagsHashForService(serviceEntity string, hash string) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	s.serviceToTagsHash[serviceID] = hash
+	s.serviceToTagsHash[serviceEntity] = hash
 }
 
 // setLoadedConfig stores a resolved config by its digest

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -9,13 +9,12 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 )
 
 // store holds useful mappings for the AD
 type store struct {
-	serviceToConfigs  map[listeners.ID][]integration.Config
-	serviceToTagsHash map[listeners.ID]string
+	serviceToConfigs  map[string][]integration.Config
+	serviceToTagsHash map[string]string
 	loadedConfigs     map[string]integration.Config
 	nameToJMXMetrics  map[string]integration.Data
 	m                 sync.RWMutex
@@ -24,8 +23,8 @@ type store struct {
 // newStore creates a store
 func newStore() *store {
 	s := store{
-		serviceToConfigs:  make(map[listeners.ID][]integration.Config),
-		serviceToTagsHash: make(map[listeners.ID]string),
+		serviceToConfigs:  make(map[string][]integration.Config),
+		serviceToTagsHash: make(map[string]string),
 		loadedConfigs:     make(map[string]integration.Config),
 		nameToJMXMetrics:  make(map[string]integration.Data),
 	}
@@ -34,21 +33,21 @@ func newStore() *store {
 }
 
 // getConfigsForService gets config for a specified service
-func (s *store) getConfigsForService(serviceID listeners.ID) []integration.Config {
+func (s *store) getConfigsForService(serviceID string) []integration.Config {
 	s.m.RLock()
 	defer s.m.RUnlock()
 	return s.serviceToConfigs[serviceID]
 }
 
 // removeConfigsForService removes a config for a specified service
-func (s *store) removeConfigsForService(serviceID listeners.ID) {
+func (s *store) removeConfigsForService(serviceID string) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	delete(s.serviceToConfigs, serviceID)
 }
 
 // addConfigForService adds a config for a specified service
-func (s *store) addConfigForService(serviceID listeners.ID, config integration.Config) {
+func (s *store) addConfigForService(serviceID string, config integration.Config) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	existingConfigs, found := s.serviceToConfigs[serviceID]
@@ -60,21 +59,21 @@ func (s *store) addConfigForService(serviceID listeners.ID, config integration.C
 }
 
 // getTagsHashForService return the tags hash for a specified service
-func (s *store) getTagsHashForService(serviceID listeners.ID) string {
+func (s *store) getTagsHashForService(serviceID string) string {
 	s.m.RLock()
 	defer s.m.RUnlock()
 	return s.serviceToTagsHash[serviceID]
 }
 
 // removeTagsHashForService removes the tags hash for a specified service
-func (s *store) removeTagsHashForService(serviceID listeners.ID) {
+func (s *store) removeTagsHashForService(serviceID string) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	delete(s.serviceToTagsHash, serviceID)
 }
 
 // setTagsHashForService set the tags hash for a specified service
-func (s *store) setTagsHashForService(serviceID listeners.ID, hash string) {
+func (s *store) setTagsHashForService(serviceID string, hash string) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.serviceToTagsHash[serviceID] = hash

--- a/pkg/autodiscovery/store_test.go
+++ b/pkg/autodiscovery/store_test.go
@@ -8,8 +8,9 @@ package autodiscovery
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 func TestServiceToConfig(t *testing.T) {
@@ -19,10 +20,10 @@ func TestServiceToConfig(t *testing.T) {
 		ADIdentifiers: []string{"redis"},
 		Hosts:         map[string]string{"bridge": "127.0.0.1"},
 	}
-	s.addConfigForService(service.GetID(), integration.Config{Name: "foo"})
-	s.addConfigForService(service.GetID(), integration.Config{Name: "bar"})
-	assert.Equal(t, len(s.getConfigsForService(service.GetID())), 2)
-	s.removeConfigsForService(service.GetID())
-	s.addConfigForService(service.GetID(), integration.Config{Name: "foo"})
-	assert.Equal(t, len(s.getConfigsForService(service.GetID())), 1)
+	s.addConfigForService(service.GetEntity(), integration.Config{Name: "foo"})
+	s.addConfigForService(service.GetEntity(), integration.Config{Name: "bar"})
+	assert.Equal(t, len(s.getConfigsForService(service.GetEntity())), 2)
+	s.removeConfigsForService(service.GetEntity())
+	s.addConfigForService(service.GetEntity(), integration.Config{Name: "foo"})
+	assert.Equal(t, len(s.getConfigsForService(service.GetEntity())), 1)
 }

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -9,8 +9,8 @@ package collectors
 
 import (
 	"io"
-	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -87,9 +87,9 @@ func (c *DockerCollector) Stop() error {
 }
 
 // Fetch inspect a given container to get its tags on-demand (cache miss)
-func (c *DockerCollector) Fetch(container string) ([]string, []string, error) {
-	cID := strings.TrimPrefix(container, docker.DockerEntityPrefix)
-	if cID == container || len(cID) == 0 {
+func (c *DockerCollector) Fetch(entity string) ([]string, []string, error) {
+	runtime, cID := containers.SplitEntityName(entity)
+	if runtime != containers.RuntimeNameDocker || len(cID) == 0 {
 		return nil, nil, nil
 	}
 	return c.fetchForDockerID(cID)

--- a/pkg/util/containers/entity.go
+++ b/pkg/util/containers/entity.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package containers
+
+import (
+	"fmt"
+	"strings"
+)
+
+const entitySeparator = "://"
+
+// BuildEntityName builds a valid entity name for a given container runtime and cid
+func BuildEntityName(runtime, id string) string {
+	if id == "" || runtime == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s%s%s", runtime, entitySeparator, id)
+}
+
+// SplitEntityName returns the runtime and container cid parts of a valid entity name
+func SplitEntityName(name string) (string, string) {
+	if !IsEntityName(name) {
+		return "", ""
+	}
+	parts := strings.SplitN(name, entitySeparator, 2)
+	return parts[0], parts[1]
+}
+
+// RuntimeForEntity extracts the runtime portion of a container entity name
+func RuntimeForEntity(name string) string {
+	r, _ := SplitEntityName(name)
+	return r
+}
+
+// ContainerIDForEntity extracts the container ID portion of a container entity name
+func ContainerIDForEntity(name string) string {
+	_, id := SplitEntityName(name)
+	return id
+}
+
+// IsEntityName tests whether a given entity name is valid
+func IsEntityName(name string) bool {
+	return strings.Contains(name, entitySeparator)
+}

--- a/pkg/util/containers/entity_test.go
+++ b/pkg/util/containers/entity_test.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package containers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildEntityName(t *testing.T) {
+	for nb, tc := range []struct {
+		runtime  string
+		cID      string
+		expected string
+	}{
+		// Empty
+		{"", "", ""},
+		// Empty runtime
+		{"", "5bef08742407ef", ""},
+		// Empty cID
+		{"docker", "", ""},
+		// OK
+		{"docker", "5bef08742407ef", "docker://5bef08742407ef"},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.expected), func(t *testing.T) {
+			out := BuildEntityName(tc.runtime, tc.cID)
+			assert.Equal(t, tc.expected, out)
+		})
+	}
+}
+
+func TestSplitEntityName(t *testing.T) {
+	for nb, tc := range []struct {
+		entity          string
+		expectedRuntime string
+		expectedCID     string
+	}{
+		// OK
+		{"docker://5bef08742407ef", "docker", "5bef08742407ef"},
+		// Invalid
+		{"5bef08742407ef", "", ""},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.entity), func(t *testing.T) {
+			// Test main method
+			r1, c1 := SplitEntityName(tc.entity)
+			assert.Equal(t, tc.expectedRuntime, r1)
+			assert.Equal(t, tc.expectedCID, c1)
+
+			// Test wrapers
+			r2 := RuntimeForEntity(tc.entity)
+			assert.Equal(t, tc.expectedRuntime, r2)
+			c2 := ContainerIDForEntity(tc.entity)
+			assert.Equal(t, tc.expectedCID, c2)
+		})
+	}
+}

--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -12,19 +12,11 @@ package containers
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/shirou/gopsutil/process"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
-)
-
-// Return values per container runtime
-const (
-	RuntimeNameDocker     string = "docker"
-	RuntimeNameContainerd string = "containerd"
-	RuntimeNameCRIO       string = "cri-o"
 )
 
 // Internal constants
@@ -60,8 +52,7 @@ func EntityForPID(pid int32) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	value := fmt.Sprintf("%s://%s", runtime, cID)
-	return value, nil
+	return BuildEntityName(runtime, cID), nil
 }
 
 // GetRuntimeForPID inspects a PID's parents to detect a container runtime.

--- a/pkg/util/containers/types.go
+++ b/pkg/util/containers/types.go
@@ -9,6 +9,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 )
 
+// Known container runtimes
+const (
+	RuntimeNameDocker     string = "docker"
+	RuntimeNameContainerd string = "containerd"
+	RuntimeNameCRIO       string = "cri-o"
+)
+
 // Expose container states
 const (
 	ContainerCreatedState    string = "created"

--- a/pkg/util/docker/util_common.go
+++ b/pkg/util/docker/util_common.go
@@ -7,7 +7,8 @@ package docker
 
 import (
 	"errors"
-	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 const (
@@ -32,8 +33,5 @@ var (
 
 // ContainerIDToEntityName returns a prefixed entity name from a container ID
 func ContainerIDToEntityName(cid string) string {
-	if cid == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s%s", DockerEntityPrefix, cid)
+	return containers.BuildEntityName(containers.RuntimeNameDocker, cid)
 }

--- a/test/integration/autodiscovery/autoconfig_test.go
+++ b/test/integration/autodiscovery/autoconfig_test.go
@@ -1,6 +1,0 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2018 Datadog, Inc.
-
-package autodiscovery


### PR DESCRIPTION
### What does this PR do?

- remove the `listeners.ID` type, move to a string
- rename `Service.GetID()` to `Service.GetEntity()` to make it explicit
- update all three listeners to export entity names
- un-export all fields in the service listener structs
- add some convenience methods to handle entity names in the `containers` package
- update tests
- rename `PodContainerService` to `KubeContainerService` to prepare for `KubePodService` introduction

State of individual listeners:
  - `kubelet` already works with full entities, at that's the format of the podlist
  - `docker` keeps its internal logic in cIDs, converts to entities when exporting only
  - `ecs` keeps cID and runtime, hardcoded to `docker` for now, until ECS supports other runtimes

### Motivation

Harmonise IDs across packages, and make tagger calls easier

### Test image

`datadog/agent-dev:xvello-ad-entity` tested on:
  - ECS Fargate 1.1
  - Pupernetes 1.10, docker and kubelet listeners