### PR TITLE
downgrade AD provider collect message to debug if no change

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -426,7 +426,11 @@ func (ac *AutoConfig) collect(pd *providerDescriptor) ([]integration.Config, []i
 			removedConf = append(removedConf, c)
 		}
 	}
-	log.Infof("%v: collected %d new configurations, removed %d", pd.provider, len(newConf), len(removedConf))
+	if len(newConf) > 0 || len(removedConf) > 0 {
+		log.Infof("%v provider: collected %d new configurations, removed %d", pd.provider, len(newConf), len(removedConf))
+	} else {
+		log.Debugf("%v provider: no configuration change", pd.provider)
+	}
 	return newConf, removedConf
 }
 

--- a/releasenotes/notes/ad-provider-logging-b23f18d4f43c01a2.yaml
+++ b/releasenotes/notes/ad-provider-logging-b23f18d4f43c01a2.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - Kubelet Autodiscovery: reduce logging when no change is detected


### PR DESCRIPTION
### What does this PR do?

When using the `kubelet` configuration provider, the agent prints an `INFO` logline every 10 seconds, stating:
> INFO | (autoconfig.go:429 in collect) | Kubernetes pod annotation: collected 0 new configurations, removed 0

This PR changes the logging logic to:
  - keep the info line if we have an actual change
  - downgrade the line to debug if no change is collected

> INFO | (autoconfig.go:62 in SetupAutoConfig) | Registering kubelet config provider
> DEBUG | (autoconfig.go:432 in collect) | Kubernetes provider: no configuration change
> INFO | (autoconfig.go:430 in collect) | Kubernetes provider: collected 3 new configurations, removed 3
> DEBUG | (autoconfig.go:432 in collect) | Kubernetes provider: no configuration change
> DEBUG | (autoconfig.go:432 in collect) | Kubernetes provider: no configuration change
> INFO | (autoconfig.go:430 in collect) | Kubernetes provider: collected 0 new configurations, removed 4
> DEBUG | (autoconfig.go:432 in collect) | Kubernetes provider: no configuration change
