### PR TITLE
Add an option to split tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,7 +85,7 @@ func init() {
 	BindEnvAndSetDefault("skip_ssl_validation", false)
 	BindEnvAndSetDefault("hostname", "")
 	BindEnvAndSetDefault("tags", []string{})
-	Datadog.SetDefault("split_tags", map[string]string{})
+	BindEnvAndSetDefault("split_tags", map[string]string{})
 	BindEnvAndSetDefault("conf_path", ".")
 	BindEnvAndSetDefault("confd_path", defaultConfdPath)
 	BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,7 +85,7 @@ func init() {
 	BindEnvAndSetDefault("skip_ssl_validation", false)
 	BindEnvAndSetDefault("hostname", "")
 	BindEnvAndSetDefault("tags", []string{})
-	BindEnvAndSetDefault("split_tags", map[string]string{})
+	BindEnvAndSetDefault("tag_value_split_separator", map[string]string{})
 	BindEnvAndSetDefault("conf_path", ".")
 	BindEnvAndSetDefault("confd_path", defaultConfdPath)
 	BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,6 +85,7 @@ func init() {
 	BindEnvAndSetDefault("skip_ssl_validation", false)
 	BindEnvAndSetDefault("hostname", "")
 	BindEnvAndSetDefault("tags", []string{})
+	Datadog.SetDefault("split_tags", map[string]string{})
 	BindEnvAndSetDefault("conf_path", ".")
 	BindEnvAndSetDefault("confd_path", defaultConfdPath)
 	BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -55,7 +55,7 @@ api_key:
 #  With a raw collected tag "foo:1;2;3
 #  Using the following configuration:
 #
-#    split_tags:
+#    tag_value_split_separator:
 #      foo: ;
 #
 #  will result in the raw tag being transformed into "foo:1", "foo:2", "foo:3" tags

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -45,9 +45,10 @@ api_key:
 #   - env:prod
 #   - role:database
 
-# Split tags according to given string.
-# Supports host tags, container tags, excludes tags collected by the integration
-# themselves.
+# Split tag values according to a given separator.
+# Only applies to host tags, tags coming from container integrations.
+# Does not apply to tags on dogstatsd metrics, and tags collected by other
+# integrations.
 # This option is useful when the native tags do not support repeating multiple
 # tags with the same name and different values.
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -46,8 +46,9 @@ api_key:
 #   - role:database
 
 # Split tags according to given string.
+# Supported only for tags handled by the Tagger (Kubernetes, Docker, AWS ECS, ...)
 # This option is useful when the native tags do not support repeating multiple
-# tags with the same name but different values.
+# tags with the same name and different values.
 #
 # Example use-case:
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -52,7 +52,7 @@ api_key:
 #
 # Example use-case:
 #
-#  With a raw collected tag "foo:1;2;3
+#  With a raw collected tag "foo:1;2;3"
 #  Using the following configuration:
 #
 #    tag_value_split_separator:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -46,7 +46,8 @@ api_key:
 #   - role:database
 
 # Split tags according to given string.
-# Supported only for tags handled by the Tagger (Kubernetes, Docker, AWS ECS, ...)
+# Supports host tags, container tags, excludes tags collected by the integration
+# themselves.
 # This option is useful when the native tags do not support repeating multiple
 # tags with the same name and different values.
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -45,6 +45,20 @@ api_key:
 #   - env:prod
 #   - role:database
 
+# Split tags according to given string.
+# This option is useful when the native tags do not support repeating multiple
+# tags with the same name but different values.
+#
+# Example use-case:
+#
+#  With a raw collected tag "foo:1;2;3
+#  Using the following configuration:
+#
+#    split_tags:
+#      foo: ;
+#
+#  will result in the raw tag being transformed into "foo:1", "foo:2", "foo:3" tags
+
 # Histogram and Historate configuration
 #
 # Configure which aggregated value to compute. Possible values are: min, max,

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -11,11 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
@@ -68,43 +66,6 @@ func GetMeta() *Meta {
 		return x.(*Meta)
 	}
 	return getMeta()
-}
-
-func getHostTags() *tags {
-	hostTags := config.Datadog.GetStringSlice("tags")
-
-	if config.Datadog.GetBool("collect_ec2_tags") {
-		ec2Tags, err := ec2.GetTags()
-		if err != nil {
-			log.Debugf("No EC2 host tags %v", err)
-		} else {
-			hostTags = append(hostTags, ec2Tags...)
-		}
-	}
-
-	k8sTags, err := k8s.GetTags()
-	if err != nil {
-		log.Debugf("No Kubernetes host tags %v", err)
-	} else {
-		hostTags = append(hostTags, k8sTags...)
-	}
-
-	dockerTags, err := docker.GetTags()
-	if err != nil {
-		log.Debugf("No Docker host tags %v", err)
-	} else {
-		hostTags = append(hostTags, dockerTags...)
-	}
-
-	gceTags, err := gce.GetTags()
-	if err != nil {
-		log.Debugf("No GCE host tags %v", err)
-	}
-
-	return &tags{
-		System:              hostTags,
-		GoogleCloudPlatform: gceTags,
-	}
 }
 
 // getPythonVersion returns the version string as provided by the embedded Python

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -1,0 +1,89 @@
+package host
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/gce"
+	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// this is a "low-tech" version of tagger/utils/taglist.go
+// but host tags are handled separately here for now
+func appendAndSplitTags(target []string, tags []string, splits map[string]string) []string {
+	if len(splits) == 0 {
+		return append(target, tags...)
+	}
+
+	for _, tag := range tags {
+		tagParts := strings.SplitN(tag, ":", 2)
+		if len(tagParts) != 2 {
+			target = append(target, tag)
+			continue
+		}
+		name := tagParts[0]
+		value := tagParts[1]
+
+		sep, ok := splits[name]
+		if !ok {
+			target = append(target, tag)
+			continue
+		}
+
+		for _, elt := range strings.Split(value, sep) {
+			target = append(target, fmt.Sprintf("%s:%s", name, elt))
+		}
+	}
+
+	return target
+}
+
+func getHostTags() *tags {
+	splits := config.Datadog.GetStringMapString("split_tags")
+	appendToHostTags := func(old, new []string) []string {
+		return appendAndSplitTags(old, new, splits)
+	}
+
+	rawHostTags := config.Datadog.GetStringSlice("tags")
+	hostTags := make([]string, 0, len(rawHostTags))
+	hostTags = appendToHostTags(hostTags, rawHostTags)
+
+	if config.Datadog.GetBool("collect_ec2_tags") {
+		ec2Tags, err := ec2.GetTags()
+		if err != nil {
+			log.Debugf("No EC2 host tags %v", err)
+		} else {
+			hostTags = appendToHostTags(hostTags, ec2Tags)
+		}
+	}
+
+	k8sTags, err := k8s.GetTags()
+	if err != nil {
+		log.Debugf("No Kubernetes host tags %v", err)
+	} else {
+		hostTags = appendToHostTags(hostTags, k8sTags)
+	}
+
+	dockerTags, err := docker.GetTags()
+	if err != nil {
+		log.Debugf("No Docker host tags %v", err)
+	} else {
+		hostTags = appendToHostTags(hostTags, dockerTags)
+	}
+
+	rawGceTags, err := gce.GetTags()
+	if err != nil {
+		log.Debugf("No GCE host tags %v", err)
+	}
+	var gceTags []string
+	gceTags = appendToHostTags(gceTags, rawGceTags)
+
+	return &tags{
+		System:              hostTags,
+		GoogleCloudPlatform: gceTags,
+	}
+}

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -43,7 +43,7 @@ func appendAndSplitTags(target []string, tags []string, splits map[string]string
 }
 
 func getHostTags() *tags {
-	splits := config.Datadog.GetStringMapString("split_tags")
+	splits := config.Datadog.GetStringMapString("tag_value_split_separator")
 	appendToHostTags := func(old, new []string) []string {
 		return appendAndSplitTags(old, new, splits)
 	}

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -1,0 +1,44 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostTags(t *testing.T) {
+	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
+	defer config.Datadog.Set("tags", nil)
+
+	hostTags := getHostTags()
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3"}, hostTags.System)
+}
+
+func TestGetEmptyHostTags(t *testing.T) {
+	// getHostTags should never return a nil value under System even when there are no host tags
+	hostTags := getHostTags()
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{}, hostTags.System)
+}
+
+func TestGetHostTagsWithSplits(t *testing.T) {
+	config.Datadog.Set("split_tags", map[string]string{"kafka_partition": ","})
+	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
+	defer config.Datadog.Set("tags", nil)
+
+	hostTags := getHostTags()
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0", "kafka_partition:1", "kafka_partition:2"}, hostTags.System)
+}
+
+func TestGetHostTagsWithoutSplits(t *testing.T) {
+	config.Datadog.Set("split_tags", map[string]string{"kafka_partition": ";"})
+	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
+	defer config.Datadog.Set("tags", nil)
+
+	hostTags := getHostTags()
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"}, hostTags.System)
+}

--- a/pkg/metadata/host/host_tags_test.go
+++ b/pkg/metadata/host/host_tags_test.go
@@ -24,7 +24,7 @@ func TestGetEmptyHostTags(t *testing.T) {
 }
 
 func TestGetHostTagsWithSplits(t *testing.T) {
-	config.Datadog.Set("split_tags", map[string]string{"kafka_partition": ","})
+	config.Datadog.Set("tag_value_split_separator", map[string]string{"kafka_partition": ","})
 	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
 	defer config.Datadog.Set("tags", nil)
 
@@ -34,7 +34,7 @@ func TestGetHostTagsWithSplits(t *testing.T) {
 }
 
 func TestGetHostTagsWithoutSplits(t *testing.T) {
-	config.Datadog.Set("split_tags", map[string]string{"kafka_partition": ";"})
+	config.Datadog.Set("tag_value_split_separator", map[string]string{"kafka_partition": ";"})
 	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
 	defer config.Datadog.Set("tags", nil)
 

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/shirou/gopsutil/cpu"
@@ -68,22 +67,6 @@ func TestGetMeta(t *testing.T) {
 	assert.NotEmpty(t, meta.SocketHostname)
 	assert.NotEmpty(t, meta.Timezones)
 	assert.NotEmpty(t, meta.SocketFqdn)
-}
-
-func TestGetHostTags(t *testing.T) {
-	config.Datadog.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
-	defer config.Datadog.Set("tags", nil)
-
-	hostTags := getHostTags()
-	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, hostTags.System, []string{"tag1:value1", "tag2", "tag3"})
-}
-
-func TestGetEmptyHostTags(t *testing.T) {
-	// getHostTags should never return a nil value under System even when there are no host tags
-	hostTags := getHostTags()
-	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, hostTags.System, []string{})
 }
 
 func TestBuildKey(t *testing.T) {

--- a/pkg/tagger/utils/taglist.go
+++ b/pkg/tagger/utils/taglist.go
@@ -8,6 +8,8 @@ package utils
 import (
 	"fmt"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // TagList allows collector to incremental build a tag list
@@ -15,6 +17,7 @@ import (
 type TagList struct {
 	lowCardTags  map[string]bool
 	highCardTags map[string]bool
+	splitList    map[string]string
 }
 
 // NewTagList creates a new object ready to use
@@ -22,23 +25,35 @@ func NewTagList() *TagList {
 	return &TagList{
 		lowCardTags:  make(map[string]bool),
 		highCardTags: make(map[string]bool),
+		splitList:    config.Datadog.GetStringMapString("split_tags"),
+	}
+}
+
+func addTags(target map[string]bool, name string, value string, splits map[string]string) {
+	if name == "" || value == "" {
+		return
+	}
+	sep, ok := splits[name]
+	if !ok {
+		target[fmt.Sprintf("%s:%s", name, value)] = true
+		return
+	}
+
+	for _, elt := range strings.Split(value, sep) {
+		target[fmt.Sprintf("%s:%s", name, elt)] = true
 	}
 }
 
 // AddHigh adds a new high cardinality tag to the map, or replace if already exists.
 // It will skip empty values/names, so it's safe to use without verifying the value is not empty.
 func (l *TagList) AddHigh(name string, value string) {
-	if name != "" && value != "" {
-		l.highCardTags[fmt.Sprintf("%s:%s", name, value)] = true
-	}
+	addTags(l.highCardTags, name, value, l.splitList)
 }
 
 // AddLow adds a new low cardinality tag to the list, or replace if already exists.
 // It will skip empty values/names, so it's safe to use without verifying the value is not empty.
 func (l *TagList) AddLow(name string, value string) {
-	if name != "" && value != "" {
-		l.lowCardTags[fmt.Sprintf("%s:%s", name, value)] = true
-	}
+	addTags(l.lowCardTags, name, value, l.splitList)
 }
 
 // AddAuto determine the tag cardinality and will call the proper method AddLow or AddHigh

--- a/pkg/tagger/utils/taglist.go
+++ b/pkg/tagger/utils/taglist.go
@@ -25,7 +25,7 @@ func NewTagList() *TagList {
 	return &TagList{
 		lowCardTags:  make(map[string]bool),
 		highCardTags: make(map[string]bool),
-		splitList:    config.Datadog.GetStringMapString("split_tags"),
+		splitList:    config.Datadog.GetStringMapString("tag_value_split_separator"),
 	}
 }
 

--- a/pkg/tagger/utils/taglist_test.go
+++ b/pkg/tagger/utils/taglist_test.go
@@ -25,6 +25,10 @@ func TestNewTagList(t *testing.T) {
 
 func TestAddLow(t *testing.T) {
 	list := NewTagList()
+	list.splitList = map[string]string{
+		"values":  ",",
+		"missing": " ",
+	}
 	list.AddLow("foo", "bar")
 	list.AddLow("faa", "baz")
 	list.AddLow("empty", "")
@@ -35,10 +39,21 @@ func TestAddLow(t *testing.T) {
 
 	require.False(t, list.lowCardTags["empty:"])
 	require.False(t, list.lowCardTags["empty"])
+
+	list.AddLow("values", "1")
+	require.Contains(t, list.lowCardTags, "values:1")
+	list.AddLow("values", "2,3")
+	require.Contains(t, list.lowCardTags, "values:1")
+	require.Contains(t, list.lowCardTags, "values:2")
+	require.Contains(t, list.lowCardTags, "values:3")
 }
 
 func TestAddHigh(t *testing.T) {
 	list := NewTagList()
+	list.splitList = map[string]string{
+		"values":  ",",
+		"missing": " ",
+	}
 	list.AddHigh("foo", "bar")
 	list.AddHigh("faa", "baz")
 	list.AddHigh("empty", "")
@@ -49,6 +64,13 @@ func TestAddHigh(t *testing.T) {
 
 	require.False(t, list.highCardTags["empty:"])
 	require.False(t, list.highCardTags["empty"])
+
+	list.AddHigh("values", "1")
+	require.Contains(t, list.highCardTags, "values:1")
+	list.AddHigh("values", "2,3")
+	require.Contains(t, list.highCardTags, "values:1")
+	require.Contains(t, list.highCardTags, "values:2")
+	require.Contains(t, list.highCardTags, "values:3")
 }
 
 func TestAddHighOrLow(t *testing.T) {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -8,10 +8,10 @@
 package hostinfo
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
@@ -46,13 +46,14 @@ func GetTags() ([]string, error) {
 }
 
 func extractTags(nodeLabels, labelsToTags map[string]string) []string {
-	var tags []string
+	tagList := utils.NewTagList()
 
 	for labelName, labelValue := range nodeLabels {
 		if tagName, found := labelsToTags[strings.ToLower(labelName)]; found {
-			tags = append(tags, fmt.Sprintf("%s:%s", tagName, labelValue))
+			tagList.AddLow(tagName, labelValue)
 		}
 	}
 
+	tags, _ := tagList.Compute()
 	return tags
 }

--- a/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
+++ b/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
@@ -2,4 +2,4 @@
 enhancements:
   - |
     Add a new configuration option, named `tag_value_split_separator`, allowing the specified list of raw tags to have its value split by a given separator.
-    Supports host tags, container tags, excludes tags collected by the integration themselves.
+    Only applies to host tags, tags coming from container integrations. Does not apply to tags on dogstatsd metrics, and tags collected by other integrations.

--- a/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
+++ b/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add a new configuration option, named `tag_value_split_separator`, allowing the specified list of raw tags to be split by a given string.
-    This feature is limited to tags handled by the Tagger and does not process host tags, external host tags or check instance tags.
+    Add a new configuration option, named `tag_value_split_separator`, allowing the specified list of raw tags to have its value split by a given separator.
+    This feature is limited to tags handled by the Tagger and host tags (config, AWS, GCE, docker).

--- a/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
+++ b/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
@@ -2,3 +2,4 @@
 enhancements:
   - |
     Add a new configuration option, named `split_tags`, allowing the specified list of raw tags to be split by a given string.
+    This feature is limited to tags handled by the Tagger and does not process host tags, external host tags or check instance tags.

--- a/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
+++ b/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add a new configuration option, named `split_tags`, allowing the specified list of raw tags to be split by a given string.

--- a/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
+++ b/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
@@ -2,4 +2,4 @@
 enhancements:
   - |
     Add a new configuration option, named `tag_value_split_separator`, allowing the specified list of raw tags to have its value split by a given separator.
-    This feature is limited to tags handled by the Tagger and host tags (config, AWS, GCE, docker).
+    Supports host tags, container tags, excludes tags collected by the integration themselves.

--- a/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
+++ b/releasenotes/notes/tagger-split-tags-734494f661b4db45.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add a new configuration option, named `split_tags`, allowing the specified list of raw tags to be split by a given string.
+    Add a new configuration option, named `tag_value_split_separator`, allowing the specified list of raw tags to be split by a given string.
     This feature is limited to tags handled by the Tagger and does not process host tags, external host tags or check instance tags.


### PR DESCRIPTION
This PR adds a new config entry, named `split_tags`, that takes a `map[string]string`, listing the names of the tags to split with the associated string.


The primary use-case for this is the ability for Kubernetes labels, annotations to be split using a string. Since Kubernetes does not allow to repeat the same tag with different values, this feature allows one user to label pods using `foo:1-2-3`, then add an entry in `split_tags` that tells the Agent to split all the `foo` tag: `foo: "-"`. Following this example would lead to the pods being tagged with `foo:1`, `foo:2`, `foo:3` instead of `foo:1-2-3`.


This feature is not limited to Kubernetes, this feature can be applied to any tag collected by the Agent.