### PR TITLE
make the pupernetes-tags step manual

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1074,6 +1074,7 @@ pupernetes-master:
 pupernetes-tags:
   <<: *pupernetes_template
   <<: *run_when_triggered_on_tag
+  when: manual
   script:
   # note: it's not the agent-dev
   - inv -e e2e-tests --image=datadog/agent:$CI_COMMIT_TAG


### PR DESCRIPTION
### What does this PR do?

make the pupernetes-tags step manual as it currently depends on tag_release that is currently manual. This removes the false-positive on RCs
