### PR TITLE
Fix ECS tag collector lifecycle issue causing missing tags

### DIFF
--- a/pkg/tagger/collectors/ecs_extract_test.go
+++ b/pkg/tagger/collectors/ecs_extract_test.go
@@ -11,14 +11,14 @@ import (
 	"testing"
 	"time"
 
-	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
-	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	ecsutil "github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
 
-func TestECSMetadata(t *testing.T) {
-	assert := assert.New(t)
+func TestECSParseTasks(t *testing.T) {
 	ecsExpireFreq := 5 * time.Minute
 	expiretest, _ := taggerutil.NewExpire(ecsExpireFreq)
 	ecsCollector := &ECSCollector{
@@ -77,7 +77,7 @@ func TestECSMetadata(t *testing.T) {
 		},
 	} {
 		t.Logf("test case %d", nb)
-		infos, err := ecsCollector.parseTasks(tc.input)
+		infos, err := ecsCollector.parseTasks(tc.input, "")
 		if len(infos) > 0 {
 			require.Len(t, infos, 2)
 		}
@@ -86,10 +86,58 @@ func TestECSMetadata(t *testing.T) {
 			require.True(t, requireMatchInfo(t, tc.expected, item))
 		}
 		if tc.err == nil {
-			assert.Nil(err)
+			assert.Nil(t, err)
 		} else {
-			assert.NotNil(err)
-			assert.Equal(tc.err.Error(), err.Error())
+			assert.NotNil(t, err)
+			assert.Equal(t, tc.err.Error(), err.Error())
 		}
 	}
+}
+
+func TestECSParseTasksTargetting(t *testing.T) {
+	ecsExpireFreq := 5 * time.Minute
+	expiretest, _ := taggerutil.NewExpire(ecsExpireFreq)
+	ecsCollector := &ECSCollector{
+		expire: expiretest,
+	}
+
+	input := ecsutil.TasksV1Response{
+		Tasks: []ecsutil.TaskV1{
+			{
+				Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+				DesiredStatus: "RUNNING",
+				KnownStatus:   "RUNNING",
+				Family:        "hello_world",
+				Version:       "8",
+				Containers: []ecsutil.ContainerV1{
+					{
+						DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+						DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+						Name:       "mysql",
+					},
+					{
+						DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+						DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+						Name:       "wordpress",
+					},
+				},
+			},
+		},
+	}
+
+	// First run, collect all
+	infos, err := ecsCollector.parseTasks(input, "")
+	assert.NoError(t, err)
+	assert.Len(t, infos, 2)
+
+	// Second run, collect none (all already seen)
+	infos, err = ecsCollector.parseTasks(input, "")
+	assert.NoError(t, err)
+	assert.Len(t, infos, 0)
+
+	// Force a target container ID
+	infos, err = ecsCollector.parseTasks(input, "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15")
+	assert.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "docker://bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15", infos[0].Entity)
 }

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -8,12 +8,11 @@
 package collectors
 
 import (
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 )
 
@@ -53,9 +52,8 @@ func (c *ECSCollector) Detect(out chan<- []*TagInfo) (CollectionMode, error) {
 
 // Fetch fetches ECS tags
 func (c *ECSCollector) Fetch(container string) ([]string, []string, error) {
-	// FIXME: move to containers.SplitEntityName when rebasing
-	cID := strings.TrimPrefix(container, docker.DockerEntityPrefix)
-	if cID == container || len(cID) == 0 {
+	runtime, cID := containers.SplitEntityName(container)
+	if runtime != containers.RuntimeNameDocker || len(cID) == 0 {
 		return nil, nil, nil
 	}
 

--- a/releasenotes/notes/ecs-missing-tags-86fad4214787023e.yaml
+++ b/releasenotes/notes/ecs-missing-tags-86fad4214787023e.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Fix missing ECS tags under some conditions


### PR DESCRIPTION
### What does this PR do?

The ECS tag collector only collects tags for containers it has not parsed yet, in order to reduce CPU usage. Combined to the tagstore's asynchronous behaviour, this is prone to a race condition where a container might have empty ECS tasks:

- Containers A and B are running
- User class retrieves tags for A
- The tagstore does not have tags for A yet -> cache miss -> call to `ECSCollector.Fetch`
- `ECSCollector.parseTasks` parses both A and B as new containers
- `ECSCollector.Fetch` sends both A and B's tags to the tagstore's intake channel
- before the tags for B are ingested by the tagstore, user class retrieves tags for B
- cache miss -> `ECSCollector.Fetch` -> `ECSCollector.parseTasks` ignores B as it has already been parsed -> empty tags

The fix is to make `parseTasks` always parse the container `Fetch` is asked for, in order to ensure tags are returned for containers.

Same lifecycle issue as https://github.com/DataDog/datadog-agent/pull/2102 (Fargate tagging)