### PR TITLE
[scheduler] bucketed scheduler - single ticker implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -802,6 +802,15 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/mobile"
+  packages = [
+    "asset",
+    "internal/mobileinit"
+  ]
+  revision = "bceb7ef27cc623473a5b664d2a3450576dddff0f"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -4,6 +4,8 @@
 // Copyright 2018 Datadog, Inc.
 
 // +build !windows
+// +build kubeapiserver
+
 //go:generate go run ../../pkg/config/render_config.go dca ../../pkg/config/config_template.yaml ../../Dockerfiles/cluster-agent/datadog-cluster.yaml
 
 package main

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -25,7 +25,7 @@ type TestCheck struct {
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
 func (c *TestCheck) Configure(a, b integration.Data) error     { return nil }
-func (c *TestCheck) Interval() time.Duration                   { return 5 * time.Second }
+func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -25,7 +25,7 @@ type TestCheck struct {
 
 func (c *TestCheck) Stop()                                     { c.stop <- true }
 func (c *TestCheck) Configure(a, b integration.Data) error     { return nil }
-func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
+func (c *TestCheck) Interval() time.Duration                   { return 5 * time.Second }
 func (c *TestCheck) Run() error                                { <-c.stop; return nil }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -7,61 +7,24 @@ package scheduler
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
-)
-
-const (
-	oCHAN = 0
-	hCHAN = 1
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type jobBucket struct {
-	idx     uint
-	starter *time.Timer
-	ticker  *time.Ticker
-	halt    chan bool // to stop this bucket
-	jobs    []check.Check
-	mu      sync.RWMutex // to protect critical sections in struct's fields
+	jobs []check.Check
+	mu   sync.RWMutex // to protect critical sections in struct's fields
 }
 
-func newJobBucket(idx uint, interval, start time.Duration) *jobBucket {
-	bucket := &jobBucket{
-		idx:  idx,
-		halt: make(chan bool),
-	}
-
-	// ticker starts after start duration
-	bucket.starter = time.AfterFunc(start, func() {
-		bucket.mu.Lock()
-		defer bucket.mu.Unlock()
-
-		bucket.ticker = time.NewTicker(interval)
-		log.Debugf("Bucket %d ticker started at interval %s", idx, interval)
-	})
-
-	return bucket
-}
-
-func (jb *jobBucket) stop() {
-	select {
-	case jb.halt <- true:
-	default:
-	}
-
+func (jb *jobBucket) size() int {
 	jb.mu.RLock()
 	defer jb.mu.RUnlock()
 
-	jb.starter.Stop()
-	if jb.ticker != nil {
-		jb.ticker.Stop()
-	}
+	return len(jb.jobs)
 }
 
 func (jb *jobBucket) addJob(c check.Check) {
@@ -74,24 +37,27 @@ func (jb *jobBucket) addJob(c check.Check) {
 // jobQueue contains a list of checks (called jobs) that need to be
 // scheduled at a certain interval.
 type jobQueue struct {
-	interval        time.Duration
-	stop            chan bool // to stop this queue
-	stopped         chan bool // signals that this queue has stopped
-	buckets         []*jobBucket
-	nextBucket      uint
-	bucketScheduled uint
-	running         bool
-	health          *health.Handle
-	mu              sync.RWMutex // to protect critical sections in struct's fields
+	interval            time.Duration
+	stop                chan bool // to stop this queue
+	stopped             chan bool // signals that this queue has stopped
+	buckets             []*jobBucket
+	bucketTicker        *time.Ticker
+	sparseStep          uint
+	currentBucketIdx    uint
+	schedulingBucketIdx uint
+	running             bool
+	health              *health.Handle
+	mu                  sync.RWMutex // to protect critical sections in struct's fields
 }
 
 // newJobQueue creates a new jobQueue instance
 func newJobQueue(interval time.Duration) *jobQueue {
 	jq := &jobQueue{
-		interval: interval,
-		stop:     make(chan bool),
-		stopped:  make(chan bool),
-		health:   health.Register("collector-queue"),
+		interval:     interval,
+		stop:         make(chan bool),
+		stopped:      make(chan bool),
+		health:       health.Register("collector-queue"),
+		bucketTicker: time.NewTicker(time.Second),
 	}
 
 	var nb int
@@ -101,8 +67,22 @@ func newJobQueue(interval time.Duration) *jobQueue {
 		nb = int(interval.Truncate(time.Second).Seconds())
 	}
 	for i := 0; i < nb; i++ {
-		bucket := newJobBucket(uint(i), interval, time.Duration(time.Duration(i)*time.Second))
+		bucket := &jobBucket{}
 		jq.buckets = append(jq.buckets, bucket)
+	}
+
+	// compute step for sparse scheduling
+	switch nb % 2 {
+	case 0:
+		step := nb / 2
+		switch step % 2 {
+		case 0:
+			jq.sparseStep = uint(step - 1)
+		case 1:
+			jq.sparseStep = uint(step - 2)
+		}
+	case 1:
+		jq.sparseStep = uint(nb / 2)
 	}
 
 	return jq
@@ -113,9 +93,9 @@ func (jq *jobQueue) addJob(c check.Check) {
 	jq.mu.Lock()
 	defer jq.mu.Unlock()
 
-	// Checks scheduled to buckets scheduled in round-robin
-	jq.buckets[jq.nextBucket].addJob(c)
-	jq.nextBucket = (jq.nextBucket + 1) % uint(len(jq.buckets))
+	// Checks scheduled to buckets scheduled with sparse round-robin
+	jq.buckets[jq.schedulingBucketIdx].addJob(c)
+	jq.schedulingBucketIdx = (jq.schedulingBucketIdx + jq.sparseStep) % uint(len(jq.buckets))
 }
 
 func (jq *jobQueue) removeJob(id check.ID) error {
@@ -137,117 +117,75 @@ func (jq *jobQueue) removeJob(id check.ID) error {
 	return fmt.Errorf("check with id %s is not in this Job Queue", id)
 }
 
+func (jq *jobQueue) stats() map[string]interface{} {
+	jq.mu.RLock()
+	defer jq.mu.RUnlock()
+
+	nJobs := 0
+	nBuckets := 0
+	for _, bucket := range jq.buckets {
+		nJobs += bucket.size()
+		nBuckets++
+	}
+
+	return map[string]interface{}{
+		"Interval": jq.interval / time.Second,
+		"Buckets":  nBuckets,
+		"Size":     nJobs,
+	}
+}
+
 // run schedules the checks in the queue by posting them to the
 // execution pipeline.
 // Not blocking, runs in a new goroutine.
 func (jq *jobQueue) run(out chan<- check.Check) {
 
-	time.Sleep(time.Second) // wait for one ticker
-
 	go func() {
-		cases := make([]reflect.SelectCase, 2+len(jq.buckets))
-		cases[oCHAN] = reflect.SelectCase{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(jq.stop),
-		}
-		cases[hCHAN] = reflect.SelectCase{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(jq.health.C),
-		}
-
-		ready := true
-		for i, bucket := range jq.buckets {
-
-			bucket.mu.RLock()
-			if bucket.ticker != nil {
-				cases[2+i] = reflect.SelectCase{
-					Dir:  reflect.SelectRecv,
-					Chan: reflect.ValueOf(bucket.ticker.C),
-				}
-			} else {
-				ready = false
-				cases[2+i] = reflect.SelectCase{
-					Dir:  reflect.SelectRecv,
-					Chan: reflect.ValueOf(nil),
-				}
-			}
-			bucket.mu.RUnlock()
-		}
-
-		for jq.waitForTick(cases, out) {
-			if ready {
-				continue
-			}
-
-			log.Debugf("Not all buckets are ticking")
-
-			ready = true
-			for i, bucket := range jq.buckets {
-				bucket.mu.RLock()
-				if bucket.ticker == nil {
-					ready = false
-				} else if bucket.ticker != nil && (!cases[2+i].Chan.IsValid() || cases[2+i].Chan.IsNil()) {
-					log.Debugf("Adding ticker to select case")
-					cases[2+i].Chan = reflect.ValueOf(bucket.ticker.C)
-				}
-				bucket.mu.RUnlock()
-			}
+		log.Debugf("Job queue is running...")
+		for jq.process(out) {
+			// empty
 		}
 		jq.stopped <- true
 	}()
 }
 
-// waitForTicks enqueues the checks at a tick, and returns whether the queue
+// process  enqueues the checks at a tick, and returns whether the queue
 // should listen to the following tick (or stop)
-func (jq *jobQueue) waitForTick(cases []reflect.SelectCase, out chan<- check.Check) bool {
+func (jq *jobQueue) process(out chan<- check.Check) bool {
 
-	chosen, _, ok := reflect.Select(cases)
-	if !ok {
-		// The chosen channel has been closed, so zero out the channel to disable the case
-		// should never really happen: we use the stop channel.
-		cases[chosen].Chan = reflect.ValueOf(nil)
-		return true
-	}
-
-	switch chosen {
-	case oCHAN:
-		// someone asked to stop this queue
-		jq.mu.RLock()
-		defer jq.mu.RUnlock()
-
-		for _, bucket := range jq.buckets {
-			bucket.stop()
-		}
+	select {
+	case <-jq.stop:
 		jq.health.Deregister()
 		return false
-	case hCHAN:
-	default:
-		// normal case, (re)schedule the queue
-		idx := chosen - 2
-		log.Debugf("Processing checks in queue %s and bucket %d", jq.interval, idx)
+	case <-jq.bucketTicker.C:
+		log.Debugf("Bucket ticked... current index: %v", jq.currentBucketIdx)
+		jq.mu.RLock()
+		bucket := jq.buckets[jq.currentBucketIdx]
+		jq.mu.RUnlock()
 
-		bucket := jq.buckets[idx]
 		bucket.mu.RLock()
+		// we have to copy to avoid blocking the bucket :(
+		// blocking could interfere with scheduling new jobs
+		jobs := []check.Check{}
+		jobs = append(jobs, bucket.jobs...)
+		bucket.mu.RUnlock()
 
-		for _, check := range bucket.jobs {
-			// sending to `out` is blocking, we need to constantly check that someone
-			// isn't asking to stop this queue
+		log.Debugf("Jobs in bucket: %v", jobs)
+
+		for _, check := range jobs {
 			select {
+			// blocking, we'll be here as long as it takes
+			case out <- check:
 			case <-jq.stop:
-				bucket.mu.RUnlock()
-				jq.mu.RLock()
-				defer jq.mu.RUnlock()
-
-				for _, bucket := range jq.buckets {
-					bucket.stop()
-				}
 				jq.health.Deregister()
 				return false
-			case out <- check:
-				log.Debugf("Enqueuing check %s for queue %s", check, jq.interval)
 			}
 		}
-		bucket.mu.RUnlock()
+		jq.mu.Lock()
+		jq.currentBucketIdx = (jq.currentBucketIdx + 1) % uint(len(jq.buckets))
+		jq.mu.Unlock()
+	case <-jq.health.C:
+		// nothing
 	}
 
 	return true

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -237,18 +237,8 @@ func expQueues(s *Scheduler) func() interface{} {
 	return func() interface{} {
 		queues := make([]map[string]interface{}, 0)
 
-		for interval, queue := range s.jobQueues {
-			nJobs := 0
-			// FIXME: this is not threadsafe
-			for _, bucket := range queue.buckets {
-				nJobs += len(bucket.jobs)
-			}
-			queueStats := map[string]interface{}{
-				"Interval": interval / time.Second,
-				"Buckets":  len(queue.buckets),
-				"Size":     nJobs,
-			}
-			queues = append(queues, queueStats)
+		for _, queue := range s.jobQueues {
+			queues = append(queues, queue.stats())
 		}
 		return queues
 	}

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -238,9 +238,15 @@ func expQueues(s *Scheduler) func() interface{} {
 		queues := make([]map[string]interface{}, 0)
 
 		for interval, queue := range s.jobQueues {
+			nJobs := 0
+			// FIXME: this is not threadsafe
+			for _, bucket := range queue.buckets {
+				nJobs += len(bucket.jobs)
+			}
 			queueStats := map[string]interface{}{
 				"Interval": interval / time.Second,
-				"Size":     len(queue.jobs),
+				"Buckets":  len(queue.buckets),
+				"Size":     nJobs,
 			}
 			queues = append(queues, queueStats)
 		}

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -107,11 +107,11 @@ func TestEnter(t *testing.T) {
 
 	// schedule again the previous plus another with different interval
 	s.Enter(c)
-	c = &TestCheck{intl: 10 * time.Second}
+	c = &TestCheck{intl: 20 * time.Second}
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 2)
 	assert.Len(t, s.jobQueues[1*time.Second].buckets[0].jobs, 3)
-	assert.Len(t, s.jobQueues[c.intl].buckets, 10)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 20)
 	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 1)
 
 	stop <- true
@@ -153,13 +153,13 @@ func TestRun(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	s := getScheduler()
-	s.Enter(&TestCheck{intl: 5 * time.Second})
+	s.Enter(&TestCheck{intl: 10 * time.Second})
 	s.Run()
 
 	err := s.Stop()
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), s.running)
-	assert.False(t, s.jobQueues[5*time.Second].running)
+	assert.False(t, s.jobQueues[10*time.Second].running)
 
 	// stopping again should be non blocking, noop and return nil
 	assert.Nil(t, s.Stop())

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -43,6 +43,17 @@ func consistently(f func() bool) bool {
 	return false
 }
 
+func consume(c chan check.Check, stop chan bool) {
+	for {
+		select {
+		case <-c:
+			continue
+		case <-stop:
+			return
+		}
+	}
+}
+
 func resetMinAllowedInterval() {
 	minAllowedInterval = initialMinAllowedInterval
 }
@@ -54,6 +65,7 @@ func getScheduler() *Scheduler {
 func TestNewScheduler(t *testing.T) {
 	c := make(chan<- check.Check)
 	s := NewScheduler(c)
+
 	assert.Equal(t, c, s.checksPipe)
 	assert.Equal(t, len(s.jobQueues), 0)
 	assert.Equal(t, s.running, uint32(0))
@@ -61,7 +73,12 @@ func TestNewScheduler(t *testing.T) {
 
 func TestEnter(t *testing.T) {
 	c := &TestCheck{}
-	s := getScheduler()
+	ch := make(chan check.Check)
+	stop := make(chan bool)
+	s := NewScheduler(ch)
+
+	// consume the enqueued checks
+	go consume(ch, stop)
 
 	// schedule passing a wrong interval value
 	c.intl = -1
@@ -78,32 +95,46 @@ func TestEnter(t *testing.T) {
 	c.intl = 1 * time.Second
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 1)
-	assert.Len(t, s.jobQueues[c.intl].jobs, 1)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 1)
+	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 1)
 
 	// schedule another, same interval
 	c = &TestCheck{intl: c.intl}
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 1)
-	assert.Len(t, s.jobQueues[c.intl].jobs, 2)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 1)
+	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 2)
 
 	// schedule again the previous plus another with different interval
 	s.Enter(c)
-	c = &TestCheck{intl: 20 * time.Second}
+	c = &TestCheck{intl: 10 * time.Second}
 	s.Enter(c)
 	assert.Len(t, s.jobQueues, 2)
-	assert.Len(t, s.jobQueues[1*time.Second].jobs, 3)
-	assert.Len(t, s.jobQueues[c.intl].jobs, 1)
+	assert.Len(t, s.jobQueues[1*time.Second].buckets[0].jobs, 3)
+	assert.Len(t, s.jobQueues[c.intl].buckets, 10)
+	assert.Len(t, s.jobQueues[c.intl].buckets[0].jobs, 1)
+
+	stop <- true
 }
 
 func TestCancel(t *testing.T) {
-	c := &TestCheck{intl: 1 * time.Second}
-	s := getScheduler()
+	c := make(chan check.Check)
+	stop := make(chan bool)
+	chk := &TestCheck{intl: 1 * time.Second}
+
+	// consume the enqueued checks
+	go consume(c, stop)
+	defer func() {
+		stop <- true
+	}()
+
+	s := NewScheduler(c)
 	defer s.Stop()
 
-	s.Enter(c)
+	s.Enter(chk)
 	s.Run()
-	s.Cancel(c.ID())
-	assert.Len(t, s.jobQueues[c.intl].jobs, 0)
+	s.Cancel(chk.ID())
+	assert.Len(t, s.jobQueues[chk.intl].buckets[0].jobs, 0)
 }
 
 func TestRun(t *testing.T) {
@@ -122,20 +153,26 @@ func TestRun(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	s := getScheduler()
-	s.Enter(&TestCheck{intl: 10 * time.Second})
+	s.Enter(&TestCheck{intl: 5 * time.Second})
 	s.Run()
 
 	err := s.Stop()
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(0), s.running)
-	assert.False(t, s.jobQueues[10*time.Second].running)
+	assert.False(t, s.jobQueues[5*time.Second].running)
 
 	// stopping again should be non blocking, noop and return nil
 	assert.Nil(t, s.Stop())
 }
 
 func TestStopCancelsProducers(t *testing.T) {
-	s := getScheduler()
+	ch := make(chan check.Check)
+	stop := make(chan bool)
+	s := NewScheduler(ch)
+
+	// consume the enqueued checks
+	go consume(ch, stop)
+
 	minAllowedInterval = time.Millisecond // for the purpose of this test, so that the scheduler actually schedules the checks
 	defer resetMinAllowedInterval()
 
@@ -145,10 +182,13 @@ func TestStopCancelsProducers(t *testing.T) {
 	time.Sleep(2 * time.Millisecond) // wait for the scheduler to actually schedule the check
 
 	s.Stop()
+	// stop check consumer routine
+	stop <- true
 	// once the scheduler is stopped, it should be safe to close this channel. Otherwise, this should panic
 	close(s.checksPipe)
 	// sleep to make the runtime schedule the hanging producer goroutines, if there are any left
 	time.Sleep(time.Millisecond)
+
 }
 
 func TestTinyInterval(t *testing.T) {

--- a/releasenotes/notes/bucketed_scheduler-d4eca4b9e20edc67.yaml
+++ b/releasenotes/notes/bucketed_scheduler-d4eca4b9e20edc67.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Introduction of a new bucketed scheduler to enable multiple 
+    check workers to increase concurrency while spreading the load
+    over the collection interval.

--- a/releasenotes/notes/bucketed_scheduler-d4eca4b9e20edc67.yaml
+++ b/releasenotes/notes/bucketed_scheduler-d4eca4b9e20edc67.yaml
@@ -6,7 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-features:
+enhancements:
   - |
     Introduction of a new bucketed scheduler to enable multiple 
     check workers to increase concurrency while spreading the load

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -21,7 +21,6 @@ DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
 ]
 
-
 @task
 def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
     """
@@ -32,6 +31,7 @@ def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
     """
 
     build_tags = get_build_tags(DEFAULT_BUILD_TAGS, [])
+
     # We rely on the go libs embedded in the debian stretch image to build dynamically
     ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs)
 
@@ -56,9 +56,9 @@ def build(ctx, rebuild=False, race=False, use_embedded_libs=False):
         "GOOS": "",
         "GOARCH": "",
     })
-    cmd = "go generate {}/cmd/cluster-agent"
 
-    ctx.run(cmd.format(REPO_PATH), env=env)
+    cmd = "go generate -tags '{build_tags}' {repo_path}/cmd/cluster-agent"
+    ctx.run(cmd.format(build_tags=" ".join(build_tags), repo_path=REPO_PATH), env=env)
 
 @task
 def clean(ctx):


### PR DESCRIPTION
### What does this PR do?

Introduces the bucketed scheduler with a simpler single ticker implementation. It will not enforce deadlines and will stay at a bucket until all checks in it have been correctly enqueued. We lose some flexibility in unlikely scenarios where we might be running low on runners, but gain predictability.

### Motivation

We want to spread the load during collection intervals, hence the buckets. The single ticker is aimed at providing a simple, predictable approach to the scheduling of the checks in these buckets. 

### Additional Notes

Anything else we should know when reviewing?
