### PR TITLE
Add UID to pod metadata when converting from kubelet pod.

### DIFF
--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
@@ -118,6 +119,7 @@ func (c *KubeMetadataCollector) addToCacheMetadataMapping(kubeletPodList []*kube
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      p.Metadata.Name,
 				Namespace: p.Metadata.Namespace,
+				UID:       types.UID(p.Metadata.UID),
 			},
 			Status: v1.PodStatus{
 				PodIP: p.Status.PodIP,

--- a/releasenotes/notes/missing-kube-service-tags-bugfix-47da1c20da553149.yaml
+++ b/releasenotes/notes/missing-kube-service-tags-bugfix-47da1c20da553149.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug causing kube_service tags to be missing when kubernetes_map_services_on_ip is false.


### PR DESCRIPTION
### What does this PR do?

This will fix a bug related to missing `UID` during conversion from `kubelet.Pod` to `v1.Pod`. 

e2e fails with `agent:latest`
```
 └---✖ find-metrics-redis-tagged  argo-datadog-agent-mzx4q-2782533555  3m   Pod was active on the node longer than the specified deadline
```

e2e passes with `agent-dev:devon-missing-uid-pod-conversion`
```
 ├---✔ find-metrics-redis-tagged  argo-datadog-agent-w66w2-2386073837  28s   
```

test image: `datadog/agent-dev:devon-missing-uid-pod-conversion`

### Motivation

Bug fix.

### To Do

- [x] Make sure e2e tests pass