### PR TITLE
Fix unecessary rescheduling + sort tagger list

### DIFF
--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -8,6 +8,7 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
@@ -65,6 +66,10 @@ var taggerListCommand = &cobra.Command{
 			fmt.Fprintln(color.Output, fmt.Sprintf("\n=== Entity %s ===", color.GreenString(entity)))
 
 			fmt.Fprint(color.Output, "Tags: [")
+			// sort tags for easy comparison
+			sort.Slice(tagItem.Tags, func(i, j int) bool {
+				return tagItem.Tags[i] < tagItem.Tags[j]
+			})
 			for i, tag := range tagItem.Tags {
 				tagInfo := strings.Split(tag, ":")
 				fmt.Fprintf(color.Output, fmt.Sprintf("%s:%s", color.BlueString(tagInfo[0]), color.CyanString(strings.Join(tagInfo[1:], ":"))))
@@ -74,6 +79,9 @@ var taggerListCommand = &cobra.Command{
 			}
 			fmt.Fprintln(color.Output, "]")
 			fmt.Fprint(color.Output, "Sources: [")
+			sort.Slice(tagItem.Sources, func(i, j int) bool {
+				return tagItem.Sources[i] < tagItem.Sources[j]
+			})
 			for i, source := range tagItem.Sources {
 				fmt.Fprintf(color.Output, fmt.Sprintf("%s", color.BlueString(source)))
 				if i != len(tagItem.Sources)-1 {

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -344,13 +344,16 @@ func (ac *AutoConfig) pollConfigs() {
 					}
 					currentHash := tagger.GetEntityHash(entityName)
 					if currentHash != previousHash {
-						servicesToRefresh = append(servicesToRefresh, service)
 						ac.store.setTagsHashForService(service.GetID(), currentHash)
+						if previousHash != "" {
+							// only refresh service if we already had a hash to avoid resetting it
+							servicesToRefresh = append(servicesToRefresh, service)
+						}
 					}
 				}
 				ac.configResolver.m.Unlock()
 				for _, service := range servicesToRefresh {
-					log.Debugf("Tags changed for service %s, rescheduling associated checks", string(service.GetID()))
+					log.Debugf("Tags changed for service %s, rescheduling associated checks if any", string(service.GetID()))
 					ac.configResolver.processDelService(service)
 					ac.configResolver.processNewService(service)
 				}

--- a/releasenotes/notes/sort-tagger-list-e72b211262e0e12a.yaml
+++ b/releasenotes/notes/sort-tagger-list-e72b211262e0e12a.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Tags and sources in the tagger-list command are now sorted to ease troubleshooting.
+fixes:
+  - |
+    Fix a verbose debug log caused by rescheduling services with no checks associated with them.


### PR DESCRIPTION
### What does this PR do?

* Fix a verbose debug log caused by rescheduling services with no checks associated with them.
* Tags and sources in the tagger-list command are now sorted to ease troubleshooting.

