### PR TITLE
[invoke/python] pin python development requirements + use pins everywhere CI/builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: jfullaondo/datadog-agent-runner-circle:latest
+      - image: datadog/datadog-agent-runner-circle:latest
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:latest
+      - image: jfullaondo/datadog-agent-runner-circle:latest
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent
@@ -29,6 +29,10 @@ templates:
           - v2-godeps-{{ .Branch }}-{{ .Revision }}
           - v2-godeps-{{ .Branch }}-
           - v2-godeps-master-
+    - run: &enter_venv
+        name: entering virtual env
+        command: source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate
+
 
 jobs:
   checkout_code:
@@ -46,6 +50,12 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - run:
+          name: setup virtual env
+          command: virtualenv /go/src/github.com/DataDog/datadog-agent/venv
+      - run:
+          name: setup python deps
+          command: source ./venv/bin/activate && pip install -r requirements.txt
+      - run:
           name: grab go deps
           command: inv -e deps
       - run:
@@ -55,6 +65,7 @@ jobs:
           key: v2-godeps-{{ .Branch }}-{{ .Revision }}
           paths:
             - /go/src/github.com/DataDog/datadog-agent/vendor
+            - /go/src/github.com/DataDog/datadog-agent/venv
             - /go/pkg
             - /go/bin
             - /usr/local/lib/python2.7/dist-packages
@@ -64,6 +75,7 @@ jobs:
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
+      - run: *enter_venv
       - run:
           name: run unit tests
           command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 4
@@ -74,6 +86,7 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
+      - run: *enter_venv
       - run:
           name: run integration tests
           command: inv -e integration-tests --race --remote-docker
@@ -87,6 +100,7 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
+      - run: *enter_venv
       - run:
           command: inv -e lint-releasenote
           name: run PR check for release note
@@ -100,6 +114,7 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
+      - run: *enter_venv
       - run:
           name: run filename linting
           command: inv -e lint-filenames
@@ -110,6 +125,7 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
+      - run: *enter_venv
       - run:
           name: run docker image integration tests
           command: inv -e docker.integration-tests
@@ -119,6 +135,7 @@ jobs:
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
+      - run: *enter_venv
       - run:
           name: build dogstatsd
           command: inv -e dogstatsd.build --static
@@ -131,6 +148,7 @@ jobs:
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
+      - run: *enter_venv
       - run:
           name: build puppy
           command: inv -e agent.build --puppy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ templates:
           - v2-godeps-{{ .Branch }}-
           - v2-godeps-master-
     - run: &enter_venv
-        name: entering virtual env
-        command: source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate
+        name: add virtualenv to bashrc 
+        command: echo "source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate" >> $BASH_ENV
 
 
 jobs:
@@ -52,12 +52,13 @@ jobs:
       - run:
           name: setup virtual env
           command: virtualenv /go/src/github.com/DataDog/datadog-agent/venv
+      - run: *enter_venv
       - run:
           name: setup python deps
           command: source ./venv/bin/activate && pip install -r requirements.txt
       - run:
           name: grab go deps
-          command: inv -e deps
+          command: source ./venv/bin/activate && inv deps
       - run:
           name: pre-compile go deps
           command: inv -e agent.build --race --precompile-only

--- a/.circleci/images/builder/Dockerfile
+++ b/.circleci/images/builder/Dockerfile
@@ -70,11 +70,8 @@ ENV BUNDLER_VERSION 1.15.3
 
 RUN gem install bundler --version "$BUNDLER_VERSION"
 
-RUN apt-get update && apt-get install -y python-pip  \
-	&& pip install invoke \
-	&& pip install docker==3.0.1 \
-	&& pip install reno   \
-	&& pip install requests
+RUN apt-get update && apt-get install -y python-pip \
+      && pip install virtualenv==16.0.0
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,7 @@ run_security_scan_test:
     - mkdir -p $GOPATH/src/github.com/DataDog/datadog-agent
     - rsync -azr --delete ./ $GOPATH/src/github.com/DataDog/datadog-agent
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
-    - pip install invoke
+    - pip install -r requirements.txt
     - inv deps
   script:
     - set +x     # don't print the api key to the logs
@@ -815,8 +815,8 @@ build_dogstatsd:
     - apt-get update && apt-get install -y python-pip && pip install awscli
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - pip install invoke
-  dependencies: [] # Don't download Gitlab artifacts
+    - pip install -r requirements.txt
+  dependencies: [] # Don't download Gitlab artefacts
 
 .docker_hub_variables: &docker_hub_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,7 @@ install:
   - 7z x *.zip > NUL
   - set PATH=C:\deps\bin;%GOPATH%\bin;%GOROOT%\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
   - go version
-  - pip install invoke
-  - pip install pyyaml
+  - pip install -r %GOPATH%\src\github.com\DataDog\datadog-agent\requirements.txt
 
 cache:
   - '%GOPATH%\bin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# python development requirements for Agent 6
+invoke==1.0.0
+reno==2.9.2
+docker==3.0.1
+requests==2.19.1


### PR DESCRIPTION
### What does this PR do?

We adds that pin layer for python deps here. This will also allow us to make changes without rebuilding our circle CI images, the pip deps shouldn't take a big deal of time, and we have caching for that as well.

### Motivation

We want to have a reproducible development environment across all layers of the development stack. 

### Additional Notes

Anything else we should know when reviewing?
