### PR TITLE
[circleci] split reno and team assignment linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           name: run integration tests
           command: inv  -e integration-tests --race --remote-docker
 
-  release_note_linting:
+  release_note:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
@@ -88,7 +88,7 @@ jobs:
           command: inv -e lint-releasenote
           name: run PR check for release note
 
-  team_assignment_label_linting:
+  team_label:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
@@ -156,10 +156,10 @@ workflows:
       - integration_tests:
           requires:
             - dependencies
-      - release_note_linting:
+      - release_note:
           requires:
             - dependencies
-      - team_assignment_label_linting:
+      - team_label:
           requires:
             - dependencies
       - filename_linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           name: run PR check for release note
 
   team_assignment_label_linting:
-     <<: *job_template
+    <<: *job_template
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,10 @@ workflows:
       - integration_tests:
           requires:
             - dependencies
-      - reno_linting:
+      - release_note_linting:
+          requires:
+            - dependencies
+      - team_assignment_label_linting:
           requires:
             - dependencies
       - filename_linting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,7 @@ jobs:
           name: run integration tests
           command: inv  -e integration-tests --race --remote-docker
 
-  # general linting for PR health  These checks are so short there doesn't seem
-  # to be a point in spinning up separate images to run them.  Leave it named
-  # `reno_linting`, as that's what the github job expects.
-  reno_linting:
+  release_note_linting:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
@@ -90,9 +87,16 @@ jobs:
       - run:
           command: inv -e lint-releasenote
           name: run PR check for release note
+
+  team_assignment_label_linting:
+     <<: *job_template
+    steps:
+      - restore_cache: *restore_source
+      - restore_cache: *restore_deps
+      - setup_remote_docker
       - run:
           command: inv -e lint-teamassignment
-          name: run PR check for team assignment
+          name: run PR check for team assignment labels
 
   filename_linting:
     <<: *job_template


### PR DESCRIPTION
### What does this PR do?

Split reno and team assignment linters to avoid confusion.

Also using this opportunity to rename `reno_linting` to `release_note_linting` to make it clearer for external contributors.

### Note

Not sure if I need to edit something on github side - testing it with this PR