### PR TITLE
flare: remove env section of docker inspect

### DIFF
--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -33,6 +33,16 @@ func zipDockerSelfInspect(tempDir, hostname string) error {
 		return err
 	}
 
+	// Remove the envvars section, as we already
+	// dump the whitelisted ones in envvars.log
+	if co.Config != nil {
+		co.Config.Env = []string{
+			"Stripped out",
+			"See runtime_config_dump.yaml for consolidated configuration",
+			"and envvars.log for whitelisted envvars if found",
+		}
+	}
+
 	// Serialise as JSON
 	jsonStats, err := json.Marshal(co)
 	if err != nil {

--- a/releasenotes/notes/flare-inspect-envvars-4091fd662af565c5.yaml
+++ b/releasenotes/notes/flare-inspect-envvars-4091fd662af565c5.yaml
@@ -1,0 +1,2 @@
+enhancements:
+  - The flare command does not collect the agent container's environment variables anymore


### PR DESCRIPTION
### What does this PR do?

When the agent has access to the docker socket, it includes a dump of its container's inspect in the flare, do help diagnose configuration issues (mounts, network, limits...).

We already collect relevant envvars via:
  - [the consolidated viper config in `runtime_config_dump.yaml`](https://github.com/DataDog/datadog-agent/blob/3ac08701eca02a47c831565b42f9aaba6f841b54/pkg/flare/archive.go#L242-L252)
  - [`envvars.log` for non-viper envvars that can affect the agent's behaviour](https://github.com/DataDog/datadog-agent/blob/3ac08701eca02a47c831565b42f9aaba6f841b54/pkg/flare/envvars.go#L15)

To make it explicit for support, I'm replacing the array with this description:

```json
"OpenStdin": false,
"StdinOnce": false,
"Env": [
	"Stripped out",
	"See runtime_config_dump.yaml for consolidated configuration",
	"and envvars.log for whitelisted envvars if found"
],
"Cmd": [
	"/init"
],
```

### Motivation

Avoid collecting more than we need

