### PR TITLE
fix possible index out of range error in origin detection

### DIFF
--- a/pkg/util/containers/runtime.go
+++ b/pkg/util/containers/runtime.go
@@ -82,6 +82,9 @@ func GetRuntimeForPID(pid int32) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if len(cmdline) == 0 {
+			return "", errors.New("empty command line")
+		}
 		cmd := cmdline[0]
 		if strings.Contains(cmd, "/") {
 			cmdParts := strings.Split(cmd, "/")
@@ -92,6 +95,9 @@ func GetRuntimeForPID(pid int32) (string, error) {
 		case shimNameContainerdUnsure:
 			// Shim can be used either by k8s for direct containerd
 			// or new docker versions, checking arguments
+			if len(cmdline) < 2 {
+				break
+			}
 			args := strings.Join(cmdline[1:], " ")
 			switch {
 			case strings.Contains(args, shimArgContainerdK8s):

--- a/releasenotes/notes/origin-detection-index-range-1f65c0684524821b.yaml
+++ b/releasenotes/notes/origin-detection-index-range-1f65c0684524821b.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix a possible index out of range panic in Dogstatsd origin detection


### PR DESCRIPTION
### What does this PR do?

Fix a possible index out of range panic in Dogstatsd origin detection.

In some cases (process currently stopping?) [gopsutil can return `nil, nil`](https://github.com/DataDog/datadog-agent/blob/master/pkg/util/containers/runtime.go#L81-L85), making us panic. Check the length of the returned slice before accessing items.
