### PR TITLE
Fix invalid json in log

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -107,7 +107,7 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 
 	configTemplate += fmt.Sprintf(`</outputs>
 	<formats>
-		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%File&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
+		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%File&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%QuoteMsg&quot;}%%n"/>
 		<format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n"/>
 		<format id="syslog-json" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
 		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%RelFile:%%Line) | %%Msg%%n" />
@@ -304,7 +304,14 @@ func (s *SyslogReceiver) Close() error {
 	return nil
 }
 
+func createQuoteMsgFormatter(params string) seelog.FormatterFunc {
+	return func(message string, level seelog.LogLevel, context seelog.LogContextInterface) interface{} {
+		return strconv.Quote(message)
+	}
+}
+
 func init() {
+	seelog.RegisterCustomFormatter("QuoteMsg", createQuoteMsgFormatter)
 	seelog.RegisterCustomFormatter("CustomSyslogHeader", createSyslogHeaderFormatter)
 	seelog.RegisterReceiver("syslog", &SyslogReceiver{})
 }

--- a/releasenotes/notes/fix-invalid-json-f5a3e8b4f8ee75e5.yaml
+++ b/releasenotes/notes/fix-invalid-json-f5a3e8b4f8ee75e5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix invalid JSON in log


### PR DESCRIPTION
### What does this PR do?

Fix invalid json in log.

https://github.com/DataDog/datadog-agent/blob/6.4.1/pkg/forwarder/transaction.go#L140 uses `%q` for log URL, which uses `"` in the log message. However, the message is just passed to seelog without escape.

See cihub/seelog#161 - all changes are from it.

### Motivation

It breaks JSON parsing in Logstash :(