### PR TITLE
[DCA] Change resources checked by the DCA.

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -132,7 +132,7 @@ func (c *APIClient) connect() error {
 	}
 	log.Debugf("Connected to kubernetes apiserver, version %s", APIversion.Version)
 
-	err = c.checkResources(metav1.NamespaceAll)
+	err = c.checkResources()
 	if err != nil {
 		return err
 	}
@@ -406,7 +406,7 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	return result.Into(output)
 }
 
-// maybeListResources checks that we can query resources from the Kubernetes apiserver.
+// maybeListResources checks that we have can query resources from the Kubernetes apiserver.
 func (c *APIClient) maybeListResources(listers map[string]ListFunc) error {
 	options := metav1.ListOptions{Limit: 1, TimeoutSeconds: &c.timeoutSeconds}
 	var errorMessages []string

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -45,6 +45,9 @@ const (
 	metadataMapperCachePrefix = "KubernetesMetadataMapping"
 )
 
+// ListFunc knows how to list resources
+type ListFunc func(options metav1.ListOptions) (runtime.Object, error)
+
 // APIClient provides authenticated access to the
 // apiserver endpoints. Use the shared instance via GetApiClient.
 type APIClient struct {
@@ -129,7 +132,7 @@ func (c *APIClient) connect() error {
 	}
 	log.Debugf("Connected to kubernetes apiserver, version %s", APIversion.Version)
 
-	err = c.checkResourcesAuth()
+	err = c.checkResources(metav1.NamespaceAll)
 	if err != nil {
 		return err
 	}
@@ -233,47 +236,6 @@ func aggregateCheckResourcesErrors(errorMessages []string) error {
 		return nil
 	}
 	return fmt.Errorf("check resources failed: %s", strings.Join(errorMessages, ", "))
-}
-
-// checkResourcesAuth is meant to check that we can query resources from the API server.
-// Depending on the user's config we only trigger an error if necessary.
-// The Event check requires getting Events data.
-// The MetadataMapper case, requires access to Services, Nodes and Pods.
-func (c *APIClient) checkResourcesAuth() error {
-	var errorMessages []string
-
-	// We always want to collect events
-	_, err := c.Cl.CoreV1().Events("").List(metav1.ListOptions{Limit: 1, TimeoutSeconds: &c.timeoutSeconds})
-	if err != nil {
-		errorMessages = append(errorMessages, fmt.Sprintf("event collection: %q", err.Error()))
-		if !isConnectVerbose {
-			return aggregateCheckResourcesErrors(errorMessages)
-		}
-	}
-
-	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") == false {
-		return aggregateCheckResourcesErrors(errorMessages)
-	}
-	_, err = c.Cl.CoreV1().Services("").List(metav1.ListOptions{Limit: 1, TimeoutSeconds: &c.timeoutSeconds})
-	if err != nil {
-		errorMessages = append(errorMessages, fmt.Sprintf("service collection: %q", err.Error()))
-		if !isConnectVerbose {
-			return aggregateCheckResourcesErrors(errorMessages)
-		}
-	}
-	_, err = c.Cl.CoreV1().Pods("").List(metav1.ListOptions{Limit: 1, TimeoutSeconds: &c.timeoutSeconds})
-	if err != nil {
-		errorMessages = append(errorMessages, fmt.Sprintf("pod collection: %q", err.Error()))
-		if !isConnectVerbose {
-			return aggregateCheckResourcesErrors(errorMessages)
-		}
-	}
-	_, err = c.Cl.CoreV1().Nodes().List(metav1.ListOptions{Limit: 1, TimeoutSeconds: &c.timeoutSeconds})
-
-	if err != nil {
-		errorMessages = append(errorMessages, fmt.Sprintf("node collection: %q", err.Error()))
-	}
-	return aggregateCheckResourcesErrors(errorMessages)
 }
 
 // ComponentStatuses returns the component status list from the APIServer
@@ -442,4 +404,20 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	}
 
 	return result.Into(output)
+}
+
+// maybeListResources checks that we can query resources from the Kubernetes apiserver.
+func (c *APIClient) maybeListResources(listers map[string]ListFunc) error {
+	options := metav1.ListOptions{Limit: 1, TimeoutSeconds: &c.timeoutSeconds}
+	var errorMessages []string
+	for kind, lister := range listers {
+		_, err := lister(options)
+		if err != nil {
+			errorMessages = append(errorMessages, fmt.Sprintf("%s collection: %q", kind, err.Error()))
+			if !isConnectVerbose {
+				return aggregateCheckResourcesErrors(errorMessages)
+			}
+		}
+	}
+	return aggregateCheckResourcesErrors(errorMessages)
 }

--- a/pkg/util/kubernetes/apiserver/resources.go
+++ b/pkg/util/kubernetes/apiserver/resources.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver,!dca
+
+package apiserver
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (c *APIClient) checkResources(namespace string) error {
+	resources := make(map[string]ListFunc)
+	resources["events"] = func(options metav1.ListOptions) (runtime.Object, error) {
+		return c.Cl.CoreV1().Events(namespace).List(options)
+	}
+	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
+		resources["services"] = func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.Cl.CoreV1().Services(namespace).List(options)
+		}
+		resources["pods"] = func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.Cl.CoreV1().Pods(namespace).List(options)
+		}
+		resources["nodes"] = func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.Cl.CoreV1().Nodes().List(options)
+		}
+	}
+	return c.maybeListResources(resources)
+}

--- a/pkg/util/kubernetes/apiserver/resources.go
+++ b/pkg/util/kubernetes/apiserver/resources.go
@@ -14,17 +14,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (c *APIClient) checkResources(namespace string) error {
+// checkResources checks that we can query resources from the Kubernetes apiserver required
+// by the Datadog Agent.
+func (c *APIClient) checkResources() error {
 	resources := make(map[string]ListFunc)
 	resources["events"] = func(options metav1.ListOptions) (runtime.Object, error) {
-		return c.Cl.CoreV1().Events(namespace).List(options)
+		return c.Cl.CoreV1().Events("").List(options)
 	}
 	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
 		resources["services"] = func(options metav1.ListOptions) (runtime.Object, error) {
-			return c.Cl.CoreV1().Services(namespace).List(options)
+			return c.Cl.CoreV1().Services("").List(options)
 		}
 		resources["pods"] = func(options metav1.ListOptions) (runtime.Object, error) {
-			return c.Cl.CoreV1().Pods(namespace).List(options)
+			return c.Cl.CoreV1().Pods("").List(options)
 		}
 		resources["nodes"] = func(options metav1.ListOptions) (runtime.Object, error) {
 			return c.Cl.CoreV1().Nodes().List(options)

--- a/pkg/util/kubernetes/apiserver/resources_dca.go
+++ b/pkg/util/kubernetes/apiserver/resources_dca.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver,dca
+
+package apiserver
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func (c *APIClient) checkResources() error {
+	resources := make(map[string]ListFunc)
+	resources["events"] = func(options metav1.ListOptions) (runtime.Object, error) {
+		return c.Cl.CoreV1().Events(namespace).List(options)
+	}
+	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
+		resources["endpoints"] = func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.Cl.CoreV1().Endpoints(namespace).List(options)
+		}
+		resources["nodes"] = func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.Cl.CoreV1().Nodes().List(options)
+		}
+	}
+	return c.maybeListResources(resources)
+}

--- a/pkg/util/kubernetes/apiserver/resources_dca.go
+++ b/pkg/util/kubernetes/apiserver/resources_dca.go
@@ -14,14 +14,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// checkResources checks that we can query resources from the Kubernetes apiserver required
+// by the Datadog Cluster Agent.
 func (c *APIClient) checkResources() error {
 	resources := make(map[string]ListFunc)
 	resources["events"] = func(options metav1.ListOptions) (runtime.Object, error) {
-		return c.Cl.CoreV1().Events(namespace).List(options)
+		return c.Cl.CoreV1().Events("").List(options)
 	}
 	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
 		resources["endpoints"] = func(options metav1.ListOptions) (runtime.Object, error) {
-			return c.Cl.CoreV1().Endpoints(namespace).List(options)
+			return c.Cl.CoreV1().Endpoints("").List(options)
 		}
 		resources["nodes"] = func(options metav1.ListOptions) (runtime.Object, error) {
 			return c.Cl.CoreV1().Nodes().List(options)

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -19,8 +19,8 @@ BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
+    "dca",
 ]
-
 
 @task
 def build(ctx, rebuild=False, race=False, use_embedded_libs=False):


### PR DESCRIPTION
### What does this PR do?

The DCA does not need to list pods or services with the addition of `MetadataController`. 

- Changes the `checkResourcesAuth` to only check for the resources required for DCA/Agent.
- Introduce the `dca` build tag