### PR TITLE
add readwrite volumes to agent Dockerfile

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -56,7 +56,9 @@ ENV DOCKER_DD_AGENT=true \
     # Direct all agent logs to stdout
     S6_LOGGING=0 \
     # Exit container if entrypoint fails
-    S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    # Allow readonlyrootfs
+    S6_READ_ONLY_ROOT=1
 
 # Install openjdk-8-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then apt-get update \
@@ -107,5 +109,8 @@ EXPOSE 8125/udp 8126/tcp
 
 HEALTHCHECK --interval=2m --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
+
+# Leave following directories RW to allow use of kubernetes readonlyrootfs flag
+VOLUME ["/var/run/s6", "/etc/datadog-agent", "/var/log/datadog", "/tmp"]
 
 CMD ["/init"]

--- a/releasenotes/notes/support-read-only-fs-c4ddeb97bfd6dc3e.yaml
+++ b/releasenotes/notes/support-read-only-fs-c4ddeb97bfd6dc3e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Docker image: running with a read-only root filesystem is now supported


### PR DESCRIPTION
### What does this PR do?

Declares readwrite directories as volumes.

### Motivation

Allows use of kubernetes `readonlyrootfs` flag

### Additional Notes

Anything else we should know when reviewing?
