### PR TITLE
remove unwanted ) in aggregator/ServiceCheckFlushed expvar

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -109,7 +109,7 @@ func init() {
 	aggregatorExpvars.Set("SeriesFlushed", &aggregatorSeriesFlushed)
 	aggregatorExpvars.Set("SeriesFlushErrors", &aggregatorSeriesFlushErrors)
 	aggregatorExpvars.Set("ServiceCheckFlushErrors", &aggregatorServiceCheckFlushErrors)
-	aggregatorExpvars.Set("ServiceCheckFlushed)", &aggregatorServiceCheckFlushed)
+	aggregatorExpvars.Set("ServiceCheckFlushed", &aggregatorServiceCheckFlushed)
 	aggregatorExpvars.Set("SketchesFlushErrors", &aggregatorSketchesFlushErrors)
 	aggregatorExpvars.Set("SketchesFlushed", &aggregatorSketchesFlushed)
 	aggregatorExpvars.Set("EventsFlushErrors", &aggregatorEventsFlushErrors)

--- a/releasenotes/notes/fix-aggregator-service-check-flushed-expvar-name-a507a94643b37b6f.yaml
+++ b/releasenotes/notes/fix-aggregator-service-check-flushed-expvar-name-a507a94643b37b6f.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Change the name of the agent expvar from ``aggregator/ServiceCheckFlushed)``
+    to ``aggregator/ServiceCheckFlushed``


### PR DESCRIPTION
### What does this PR do?

An unwanted `)` slipped in https://github.com/DataDog/datadog-agent/pull/1929