### PR TITLE
agent dockerfile: cleanup apt cache

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -72,7 +72,8 @@ RUN apt-get update \
   # https://security-tracker.debian.org/tracker/CVE-2016-2779
   && rm -f /usr/sbin/runuser \
   # https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6954
-  /usr/lib/x86_64-linux-gnu/libdb-5.3.so
+  && rm -f /usr/lib/x86_64-linux-gnu/libdb-5.3.so \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy agent from extract stage
 COPY --from=extract /output/ /


### PR DESCRIPTION
### What does this PR do?

Remove the apt-get cache after running install, to reduce the image size by 13 MB:

![](https://cl.ly/3a473x3C3b0t/Image%2525202018-08-10%252520at%2525202.14.43%252520PM.png)
