### PR TITLE
[Logs]: Isolated the server configuration to a dedicated structure

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -39,12 +39,12 @@ func NewAgent(sources *config.LogSources) *Agent {
 	auditor := auditor.New(messageChan, config.LogsAgent.GetString("logs_config.run_path"))
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	connectionManager := sender.NewConnectionManager(
+	serverConfig := sender.NewServerConfig(
 		config.LogsAgent.GetString("logs_config.dd_url"),
 		config.LogsAgent.GetInt("logs_config.dd_port"),
-		config.LogsAgent.GetBool("logs_config.dev_mode_no_ssl"),
-		config.LogsAgent.GetString("logs_config.socks5_proxy_address"),
+		!config.LogsAgent.GetBool("logs_config.dev_mode_no_ssl"),
 	)
+	connectionManager := sender.NewConnectionManager(serverConfig, config.LogsAgent.GetString("logs_config.socks5_proxy_address"))
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, connectionManager, messageChan)
 
 	// setup the inputs

--- a/pkg/logs/sender/server_config.go
+++ b/pkg/logs/sender/server_config.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package sender
+
+import (
+	"fmt"
+)
+
+// ServerConfig holds the network configuration of the server to send logs to.
+type ServerConfig struct {
+	Name   string
+	Port   int
+	UseSSL bool
+}
+
+// NewServerConfig returns a new server config.
+func NewServerConfig(name string, port int, useSSL bool) ServerConfig {
+	return ServerConfig{
+		Name:   name,
+		Port:   port,
+		UseSSL: useSSL,
+	}
+}
+
+// Address returns the address of the server to send logs to.
+func (c ServerConfig) Address() string {
+	return fmt.Sprintf("%s:%d", c.Name, c.Port)
+}

--- a/pkg/logs/sender/server_config_test.go
+++ b/pkg/logs/sender/server_config_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package sender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddress(t *testing.T) {
+	config := NewServerConfig("foo", 12345, false)
+	assert.Equal(t, "foo", config.Name)
+	assert.Equal(t, 12345, config.Port)
+	assert.False(t, config.UseSSL)
+	assert.Equal(t, "foo:12345", config.Address())
+}


### PR DESCRIPTION
### What does this PR do?

Isolated the server configuration to a dedicated structure

### Motivation

Simplify the connection manager.

### Additional Notes

Need to rebase https://github.com/DataDog/datadog-agent/pull/2075
