### PR TITLE
Speedup unit tests when coverage is on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - restore_cache: *restore_deps
       - run:
           name: run unit tests
-          command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 2
+          command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 4
 
   integration_tests:
     <<: *job_template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - restore_cache: *restore_deps
       - run:
           name: grab go deps
-          command: invoke deps
+          command: inv -e deps
       - run:
           name: pre-compile go deps
           command: inv -e agent.build --race --precompile-only
@@ -76,7 +76,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: run integration tests
-          command: inv  -e integration-tests --race --remote-docker
+          command: inv -e integration-tests --race --remote-docker
 
   # general linting for PR health  These checks are so short there doesn't seem
   # to be a point in spinning up separate images to run them.  Leave it named

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - restore_cache: *restore_deps
       - run:
           name: run unit tests
-          command: inv -e test --coverage --race --profile --fail-on-fmt
+          command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 2
 
   integration_tests:
     <<: *job_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ run_tests_deb-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --race --profile
+    - inv -e test --race --profile --cpus 4
 
 # run tests for rpm-x64
 run_test_rpm-x64:
@@ -108,7 +108,7 @@ run_test_rpm-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:large" ]
   script:
-    - inv -e test --race --profile
+    - inv -e test --race --profile --cpus 4
 
 # scan the dependencies for security vulnerabilities with snyk
 run_security_scan_test:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -22,17 +22,6 @@ from .cluster_agent import integration_tests as dca_integration_tests
 
 PROFILE_COV = "profile.cov"
 
-# List of packages to ignore when running tests on Windows platform
-WIN_PKG_BLACKLIST = [
-    "./pkg\\util\\xc",
-    "./pkg\\util\\container",
-    "./pkg\\util\\kubernetes",
-]
-
-NOTWIN_PKG_BLACKLIST = [
-    "./pkg/util/winutil",
-    "./pkg/util/winutil/pdhutil",
-]
 DEFAULT_TOOL_TARGETS = [
     "./pkg",
     "./cmd",

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -45,7 +45,8 @@ DEFAULT_TEST_TARGETS = [
 
 @task()
 def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=None,
-    race=False, profile=False, use_embedded_libs=False, fail_on_fmt=False, timeout=120):
+    race=False, profile=False, use_embedded_libs=False, fail_on_fmt=False,
+    cpus=0, timeout=120):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -94,6 +95,9 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
 
     race_opt = ""
     covermode_opt = ""
+    build_cpus_opt = ""
+    if cpus:
+        build_cpus_opt = "-p {}".format(cpus)
     if race:
         race_opt = "-race"
     if coverage:
@@ -112,12 +116,13 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     if coverage:
         coverprofile = "-coverprofile={}".format(PROFILE_COV)
     cmd = 'go test -vet=off -timeout {timeout}s -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" '
-    cmd += '{race_opt} -short {covermode_opt} {coverprofile} {pkg_folder}'
+    cmd += '{build_cpus} {race_opt} -short {covermode_opt} {coverprofile} {pkg_folder}'
     args = {
         "go_build_tags": " ".join(build_tags),
         "gcflags": gcflags,
         "ldflags": ldflags,
         "race_opt": race_opt,
+        "build_cpus": build_cpus_opt,
         "covermode_opt": covermode_opt,
         "coverprofile": coverprofile,
         "pkg_folder": ' '.join(matches),

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -105,28 +105,13 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
         else:
             covermode_opt = "-covermode=count"
 
-    if coverage:
-        matches = []
-        for target in test_targets:
-            for root, _, filenames in os.walk(target):
-                if not fnmatch.filter(filenames, "*.go"):
-                    continue
-                if sys.platform == 'win32' and root in WIN_PKG_BLACKLIST:
-                    print("Skipping blacklisted directory {}\n".format(root))
-                    continue
-                if sys.platform != 'win32' and root in NOTWIN_PKG_BLACKLIST:
-                    print("Skipping blacklisted directory {}\n".format(root))
-                    continue
-                matches.append(root)
-
-    else:
-        matches = ["{}/...".format(t) for t in test_targets]
+    matches = ["{}/...".format(t) for t in test_targets]
     print("\n--- Running unit tests:")
 
     coverprofile = ""
     if coverage:
         coverprofile = "-coverprofile={}".format(PROFILE_COV)
-    cmd = 'go test -timeout {timeout}s -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" '
+    cmd = 'go test -vet=off -timeout {timeout}s -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" '
     cmd += '{race_opt} -short {covermode_opt} {coverprofile} {pkg_folder}'
     args = {
         "go_build_tags": " ".join(build_tags),


### PR DESCRIPTION
### What does this PR do?

Take advantage of [go 1.10's ability to run coverage on multiple packages at once](https://github.com/golang/go/issues/6909) to speed up tests on CircleCI:

- disable the built-in `go vet` done by `go test`, as it uses a partial vet check list. We want to keep our vetting with the full list
- Call `go test` once with only the target (`./pkg/...` by default)
- Remove the whole package filtering logic, as `go test` is faster than `invoke` for that

### Motivation

Unit test step in circleci (which includes lint/vet and co) goes down from an [average of 8 minutes](https://circleci.com/gh/DataDog/datadog-agent/55738) to an [average of 3 minutes](https://circleci.com/gh/DataDog/datadog-agent/59319)

Appveyor and gitlab not affected as we removed code coverage to speed them up in the past.

Now the slowest step in integration tests, but running them in parallel might create flakes. We'd need to allow parallel builds, but only run one test at a time (create a locking mechanism in `dockerize_test`?

### Additional Notes

Go test compiles/tests as many packages in parallel as there are CPUs. This is OK on VM runners, but leads to OOM on circleci, as the runner hosts are huge, but the container only has 4GB memory. Added the `--cpus` option to `inv test` for that, set it to 4 on CCI. Also set it on gitlab to be future proof