### PR TITLE
[DCA] Check watch errors before processing event in HPA watcher.

### DIFF
--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	expectedHPAType = reflect.TypeOf(&autoscalingv2.HorizontalPodAutoscaler{})
+	expectedHPAType = reflect.TypeOf(autoscalingv2.HorizontalPodAutoscaler{})
 )
 
 type DatadogClient interface {


### PR DESCRIPTION
### What does this PR do?

Check for `event.Type == watch.Error` before trying to cast the `event.Object`.

This `HPAWatcherClient` still keeps trying to create watches so long as the most recent `resourceVersion` is expired but at least this handles the error correctly and the logs should indicate exactly what is happening.

This is an edge case that only occurs if no HPA in the cluster is modified for a long enough period of time (unlikely since the `Status` should get updated often for an HPA that is actually autoscaling).