### PR TITLE
[DCA] Add gc goroutine to HPAWatcher to handle deleted hpas.

### DIFF
--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -20,7 +20,7 @@ The `configMapStore` always performs operations on a local copy of the configmap
 
 #### Summary of apiserver calls
 
-`NewConfigMapStore`: between 1 and 2 calls
-`SetExternalMetricValues`: 1 call to update configmap
-`DeleteExternalMetricValues`: 1 call to update configmap
-`ListAllExternalMetricValues`: 1 call to get configmap
+- `NewConfigMapStore`: between 1 and 2 calls
+- `SetExternalMetricValues`: 1 call to update configmap
+- `DeleteExternalMetricValues`: 1 call to update configmap
+- `ListAllExternalMetricValues`: 1 call to get configmap

--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -16,7 +16,7 @@ Only the leader replica should add or delete metrics from the store. Any replica
 
 ### configMapStore
 
-The `configMapStore` always performs operations a local copy of the configmap but `ListAllExternalMetricValues` will always get the most up-to-date configmap from the apiserver before listing the metrics.
+The `configMapStore` always performs operations on a local copy of the configmap but `ListAllExternalMetricValues` will always get the most up-to-date configmap from the apiserver before listing the metrics.
 
 #### Summary of apiserver calls
 

--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -1,0 +1,26 @@
+# package `custommetrics`
+
+This package is a part of the Datadog Cluster Agent and is responsible for providing custom metrics to the Kubernetes apiserver for Horizontal Pod Autoscalers.
+
+## DatadogProvider
+
+The `DatadogProvider` currently only implements the External Metrics Provider interface by providing external metrics from Datadog.
+
+There is no guarantee that every replica returns the exact same list of metrics for `ListAllExternalMetrics`. It is possible for the leader to mutate the store between calls to `ListAllExternalMetricValues` from different replicas. This is the tradeoff of using a `ConfigMap` for persistent storage instead of a transactional store.
+
+## Store
+
+The `Store` interface provides persistent storage of custom and external metrics. The default implementation stores metric values in a `ConfigMap`.
+
+Only the leader replica should add or delete metrics from the store. Any replica is able to call `ListAllExternalMetricValues` to return the most up-to-date values for metrics.
+
+### configMapStore
+
+The `configMapStore` always performs operations a local copy of the configmap but `ListAllExternalMetricValues` will always get the most up-to-date configmap from the apiserver before listing the metrics.
+
+#### apiserver requests
+
+`NewConfigMapStore`: between 1 and 2 requests
+`SetExternalMetricValues`: 1 request
+`DeleteExternalMetricValues`: 1 request
+`ListAllExternalMetricValues`: 1 request

--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -18,9 +18,9 @@ Only the leader replica should add or delete metrics from the store. Any replica
 
 The `configMapStore` always performs operations a local copy of the configmap but `ListAllExternalMetricValues` will always get the most up-to-date configmap from the apiserver before listing the metrics.
 
-#### apiserver requests
+#### Summary of apiserver calls
 
-`NewConfigMapStore`: between 1 and 2 requests
-`SetExternalMetricValues`: 1 request
-`DeleteExternalMetricValues`: 1 request
-`ListAllExternalMetricValues`: 1 request
+`NewConfigMapStore`: between 1 and 2 calls
+`SetExternalMetricValues`: 1 call to update configmap
+`DeleteExternalMetricValues`: 1 call to update configmap
+`ListAllExternalMetricValues`: 1 call to get configmap

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -78,10 +78,14 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsInfoList []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
+	if err := p.store.Resync(); err != nil {
+		log.Errorf("Could not list the external metrics in the store: %v", err)
+		return nil
+	}
 	rawMetrics, err := p.store.ListAllExternalMetricValues()
 	if err != nil {
-		log.Errorf("Could not list the external metrics in the store: %s", err.Error())
-		return externalMetricsInfoList
+		log.Errorf("Could not list the external metrics in the store: %v", err)
+		return nil
 	}
 
 	for _, metric := range rawMetrics {

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -80,8 +80,8 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 
 	rawMetrics, err := p.store.ListAllExternalMetricValues()
 	if err != nil {
-		log.Errorf("Could not list the external metrics in the store: %v", err)
-		return nil
+		log.Errorf("Could not list the external metrics in the store: %s", err.Error())
+		return externalMetricsInfoList
 	}
 
 	for _, metric := range rawMetrics {

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -78,10 +78,6 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsInfoList []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
-	if err := p.store.Resync(); err != nil {
-		log.Errorf("Could not list the external metrics in the store: %v", err)
-		return nil
-	}
 	rawMetrics, err := p.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Errorf("Could not list the external metrics in the store: %v", err)

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -104,8 +104,10 @@ func (c *configMapStore) SetExternalMetricValues(added []ExternalMetricValue) er
 	if len(added) == 0 {
 		return nil
 	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	if c.cm == nil {
 		return errNotInitialized
 	}
@@ -146,8 +148,10 @@ func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricValu
 	if len(deleted) == 0 {
 		return nil
 	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	if c.cm == nil {
 		return errNotInitialized
 	}
@@ -163,16 +167,11 @@ func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricValu
 // Any replica can safely call this function.
 func (c *configMapStore) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
 	c.mu.Lock()
-	err := c.getConfigMap()
-	c.mu.Unlock()
+	defer c.mu.Unlock()
 
-	if err != nil {
+	if err := c.getConfigMap(); err != nil {
 		return nil, err
 	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	var metrics []ExternalMetricValue
 	for k, v := range c.cm.Data {
 		if !isExternalMetricValueKey(k) {

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -141,12 +141,7 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			require.NoError(t, err)
 			assert.ElementsMatch(t, tt.expected, allMetrics)
 
-			objectRefs := make([]ObjectReference, 0)
-			for _, m := range tt.metrics {
-				objectRefs = append(objectRefs, m.HPA)
-			}
-
-			err = store.Delete(objectRefs)
+			err = store.DeleteExternalMetricValues(allMetrics)
 			require.NoError(t, err)
 			assert.Zero(t, len(store.(*configMapStore).cm.Data))
 		})

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -137,13 +137,16 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			err = store.SetExternalMetricValues(tt.metrics)
 			require.NoError(t, err)
 
-			allMetrics, err := store.ListAllExternalMetricValues()
+			list, err := store.ListAllExternalMetricValues()
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tt.expected, allMetrics)
+			assert.ElementsMatch(t, tt.expected, list)
 
-			err = store.DeleteExternalMetricValues(allMetrics)
+			err = store.DeleteExternalMetricValues(list)
 			require.NoError(t, err)
-			assert.Zero(t, len(store.(*configMapStore).cm.Data))
+
+			list, err = store.ListAllExternalMetricValues()
+			require.NoError(t, err)
+			assert.Empty(t, list)
 		})
 	}
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -20,4 +20,5 @@ type ExternalMetricValue struct {
 type ObjectReference struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
+	UID       string `json:"uid"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -313,7 +313,7 @@ func init() {
 	Datadog.BindEnv("cluster_agent.cmd_port")
 	Datadog.BindEnv("cluster_agent.kubernetes_service_name")
 	BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
-	BindEnvAndSetDefault("hpa_watcher_gc_period", 30) // 30 seconds
+	BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
 	BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	BindEnvAndSetDefault("external_metrics_provider.polling_freq", 30)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -313,7 +313,7 @@ func init() {
 	Datadog.BindEnv("cluster_agent.cmd_port")
 	Datadog.BindEnv("cluster_agent.kubernetes_service_name")
 	BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
-
+	BindEnvAndSetDefault("hpa_watcher_gc_period", 30) // 30 seconds
 	BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	BindEnvAndSetDefault("external_metrics_provider.polling_freq", 30)

--- a/pkg/util/kubernetes/hpa/README.md
+++ b/pkg/util/kubernetes/hpa/README.md
@@ -9,3 +9,4 @@ The watcher starts a single loop to perform the following tasks:
 - Start a watch for changes to HPAs and process the changes
 - Query Datadog to update external metric values
 - Garbage collect external metrics values in the store that reference deleted HPAs
+    - The purpose of the garbage collection is to be able to clean deleted metric values from the store if an hpa was deleted while the Datadog Cluster Agent was not running. This can't be done with a watch alone.

--- a/pkg/util/kubernetes/hpa/README.md
+++ b/pkg/util/kubernetes/hpa/README.md
@@ -1,0 +1,11 @@
+# package `hpa`
+
+This package is a part of the Datadog Cluster Agent and is responsible for watching the `HorizontalPodAutoscaler` resource and querying Datadog for external metrics specified by HPAs.
+
+## HPAWatcherClient
+
+The watcher starts a single loop to perform the following tasks:
+
+- Start a watch for changes to HPAs and process the changes
+- Query Datadog to update external metric values
+- Garbage collect external metrics values in the store that reference deleted HPAs

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -169,7 +169,8 @@ func (c *HPAWatcherClient) Start() {
 	}()
 }
 
-// gc checks if any hpas have been deleted to clean the store.
+// gc checks if any hpas have been deleted (possibly while the Datadog Cluster Agent was
+// not running) to clean the store.
 func (c *HPAWatcherClient) gc() {
 	log.Debugf("Starting gc run")
 


### PR DESCRIPTION
### What does this PR do?

Added
- `gc` in `HPAWatcherClient` to delete HPAs configured by `hpa_watcher_gc_period`
- Added a lock to functions in `configMapStore` since the `DatadogProvider` can try to read while the `HPAWatcherClient` updates and the `configMapStore` functions always work on a local copy.

### Motivation

The previous delete logic relied on splitting the keys of the data stored in the configmap to figure out what to delete. This was error prone because there is no safe way to split the key and parse the parts since the key components like `MetricName` and `Namespace` can contain the key delimeter.

This also solves the problem of HPAs being deleted while the DCA is not running.

### TODO

- [x] Run e2e test for locally
- [x] Sanity check that deletes happen