### PR TITLE
list envvars we looked for in flare's envvar.log

### DIFF
--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -7,6 +7,7 @@ package flare
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,18 +57,18 @@ func zipEnvvars(tempDir, hostname string) error {
 
 	var b bytes.Buffer
 	if len(envvars) > 0 {
-		b.WriteString("Found the following envvars:\n")
+		fmt.Fprintln(&b, "Found the following envvars:")
 		for _, envvar := range envvars {
-			b.WriteString(envvar)
-			b.WriteString("\n")
+			fmt.Fprintln(&b, " - ", envvar)
 		}
 	} else {
-		b.WriteString("Found no whitelisted envvar\n")
+		fmt.Fprintln(&b, "Found no whitelisted envvar")
 	}
 
-	b.WriteString("\n\nLooked for these envvars:\n")
-	b.WriteString(strings.Join(envvarNameWhitelist, ", "))
-	b.WriteString("\n")
+	fmt.Fprintln(&b, "Looked for these whitelisted envvars:")
+	for _, envvar := range envvarNameWhitelist {
+		fmt.Fprintln(&b, " - ", envvar)
+	}
 
 	f := filepath.Join(tempDir, hostname, "envvars.log")
 	w, err := NewRedactingWriter(f, os.ModePerm, true)


### PR DESCRIPTION
### What does this PR do?

The flare logic has a feature to write whitelisted environment variables to the `envvars.log` file. If no envvar was found, the file was not created. This PR:

- moves the logic from whitelisted prefixes to whitelisted names, to be explicit on individual var whitelisting
- adds the list of whitelisted envvars to the `envvars.log` file, to remind which ones were looked for
- always creates the file, to avoid confusions

Example output with `GOMAXPROCS=4 DD_PROXY_NO_PROXY="dummy" ./bin/agent/agent -c ./bin/agent/dist/ run`:

```
Found the following envvars:
 -  DD_PROXY_NO_PROXY=dummy
 -  GOMAXPROCS=4
Looked for these whitelisted envvars:
 -  DOCKER_API_VERSION
 -  DOCKER_CONFIG
 -  DOCKER_CERT_PATH
 -  DOCKER_HOST
 -  DOCKER_TLS_VERIFY
 -  HTTP_PROXY
 -  HTTPS_PROXY
 -  NO_PROXY
 -  DD_PROXY_HTTP
 -  DD_PROXY_HTTPS
 -  DD_PROXY_NO_PROXY
 -  GOGC
 -  GODEBUG
 -  GOMAXPROCS
 -  GOTRACEBACK
```