### PR TITLE
Ship a readsecret helper script in the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ templates:
           - v2-godeps-{{ .Branch }}-
           - v2-godeps-master-
     - run: &enter_venv
-        name: add virtualenv to bashrc 
+        name: add virtualenv to bashrc
         command: echo "source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate" >> $BASH_ENV
 
 jobs:
@@ -124,13 +124,16 @@ jobs:
           name: run filename linting
           command: inv -e lint-filenames
 
-  docker_integration_tests:
+  docker_tests:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - setup_remote_docker
       - run: *enter_venv
+      - run:
+          name: run docker image tests
+          command: inv -e docker.test
       - run:
           name: run docker image integration tests
           command: inv -e docker.integration-tests
@@ -184,16 +187,16 @@ workflows:
       - filename_linting:
           requires:
             - dependencies
-      - docker_integration_tests:
+      - docker_tests:
           requires:
             - dependencies
       - build_binaries:
           requires:
             - unit_tests
             - integration_tests
-            - docker_integration_tests
+            - docker_tests
       - build_puppy:
           requires:
             - unit_tests
             - integration_tests
-            - docker_integration_tests
+            - docker_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           name: run filename linting
           command: inv -e lint-filenames
 
-  docker_tests:
+  docker_integration_tests:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
@@ -187,16 +187,16 @@ workflows:
       - filename_linting:
           requires:
             - dependencies
-      - docker_tests:
+      - docker_integration_tests:
           requires:
             - dependencies
       - build_binaries:
           requires:
             - unit_tests
             - integration_tests
-            - docker_tests
+            - docker_integration_tests
       - build_puppy:
           requires:
             - unit_tests
             - integration_tests
-            - docker_tests
+            - docker_integration_tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ Dockerfiles/dogstatsd/alpine/dogstatsd
 vendor/
 bin/
 /dev/
+__pycache__
+.pytest_cache
 
 **/*.tmp
 **/debug.test

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -81,7 +81,7 @@ COPY --from=extract /output/ /
 # S6 entrypoint, service definitions, healthcheck probe
 COPY s6-services /etc/services.d/
 COPY entrypoint /etc/cont-init.d/
-COPY probe.sh initlog.sh /
+COPY probe.sh initlog.sh secrets-helper/readsecret.py /
 
 # Extract s6-overlay
 # Done in 2 steps to avoid overriding the /bin --> /usr/bin symlink
@@ -97,7 +97,9 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
  && rm /var/run && mkdir -p /var/run/s6 \
  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
- && chmod 755 /probe.sh /initlog.sh
+ && chmod 755 /probe.sh /initlog.sh \
+ && chown root:root /readsecret.py \
+ && chmod 500 /readsecret.py
 
 # Override the exit script by ours to fix --pid=host operations
 COPY init-stage3 /etc/s6/init/init-stage3

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -76,6 +76,10 @@ DD_KUBERNETES_POD_LABELS_AS_TAGS='{"app":"kube_app","release":"helm_release"}'
 DD_DOCKER_LABELS_AS_TAGS='{"com.docker.compose.service":"service_name"}'
 ```
 
+#### Using secret files (BETA)
+
+Integration credentials can be stored in Docker / Kubernetes secrets and used in Autodiscovery templates. See the [setup instructions for the helper script](secrets-helper/README.md) and the [agent documentation](https://github.com/DataDog/datadog-agent/blob/6.4.x/docs/agent/secrets.md) for more information.
+
 #### Ignore containers
 
 You can exclude containers from the metrics collection and autodiscovery, if these are not useful for you. We already exclude Kubernetes and OpenShift `pause` containers by default. See the `datadog.yaml.example` file for more documentation, and examples.

--- a/Dockerfiles/agent/secrets-helper/README.md
+++ b/Dockerfiles/agent/secrets-helper/README.md
@@ -1,0 +1,41 @@
+# Helper script to access secret files (BETA)
+
+
+**This feature is in beta and its options or behaviour might break between minor or bugfix releases of the Agent.**
+
+Many of our integrations require credentials to retrieve metrics. To avoid hardcoding these credentials in the [Autodiscovery templates](https://docs.datadoghq.com/agent/autodiscovery/), you can use this feature to separate them from the template itself.
+
+This script is available in the docker image as `/readsecret.py` and is intended
+to be used with [the agent's external secret feature](https://github.com/DataDog/datadog-agent/blob/6.4.x/docs/agent/secrets.md). Please refer to this feature's documentation for usage examples.
+
+## Script usage
+
+- The script requires a folder passed as argument. Secret handles will be interpreted as file names, relative to this folder. The script will refuse to access any file out of this root folder (including symbolic link targets), in order to avoid leaking sensitive information.
+
+- For now, this script is incompatible with [OpenShift restricted SCC operations](https://github.com/DataDog/datadog-agent/blob/6.4.x/Dockerfiles/agent/OPENSHIFT.md#restricted-scc-operations) and requires that the Agent runs as the `root` user.
+
+- `ENV[]` tokens found in `datadog.yaml` and in Autodiscovery templates will be replaced, but replacing `ENV[]` tokens in config values passed as enviroment variables is not supported as of 6.5.0
+
+## Setup examples
+
+### Docker Swarm Secrets
+
+[Docker secrets](https://docs.docker.com/engine/swarm/secrets/) are mounted in the `/run/secrets` folder. You need to pass the following environment variables to your agent container:
+
+- `DD_SECRET_BACKEND_COMMAND=/readsecret.py`
+- `DD_SECRET_BACKEND_ARGUMENTS=/run/secrets`
+
+To use the `db_prod_password` secret value, exposed in the `/run/secrets/db_prod_password` file, just insert `ENC[db_prod_password]` in your template.
+
+### Kubernetes secrets
+
+Kubernetes supports [exposing secrets as files](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume) inside a pod.
+
+If your secrets are mounted in `/etc/secret-volume`, just use the following environment variables:
+
+- `DD_SECRET_BACKEND_COMMAND=/readsecret.py`
+- `DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume`
+
+Following the linked example, the password field will be stored in the `/etc/secret-volume/password` file, and accessible via the `ENC[password]` token.
+
+**Note:** We recommend using a dedicated folder instead of `/var/run/secrets`, as the script will be able to access all subfolders, including the sensitive `/var/run/secrets/kubernetes.io/serviceaccount/token` file.

--- a/Dockerfiles/agent/secrets-helper/README.md
+++ b/Dockerfiles/agent/secrets-helper/README.md
@@ -14,7 +14,7 @@ to be used with [the agent's external secret feature](https://github.com/DataDog
 
 - For now, this script is incompatible with [OpenShift restricted SCC operations](https://github.com/DataDog/datadog-agent/blob/6.4.x/Dockerfiles/agent/OPENSHIFT.md#restricted-scc-operations) and requires that the Agent runs as the `root` user.
 
-- `ENV[]` tokens found in `datadog.yaml` and in Autodiscovery templates will be replaced, but replacing `ENV[]` tokens in config values passed as enviroment variables is not supported as of 6.5.0
+- `ENC[]` tokens found in `datadog.yaml` and in Autodiscovery templates will be replaced, but replacing `ENC[]` tokens in config values passed as enviroment variables is not supported as of 6.5.0
 
 ## Setup examples
 

--- a/Dockerfiles/agent/secrets-helper/readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/readsecret.py
@@ -8,8 +8,9 @@ import sys
 
 def list_secret_names(input_json):
     query = json.loads(input_json)
-    if query["version"] != "1.0":
-        raise ValueError("unknown protocol version {}".format(query["version"]))
+    version = query["version"].split(".")
+    if version[0] != "1":
+        raise ValueError("incompatible protocol version {}".format(query["version"]))
 
     names = query["secrets"]
     if type(names) is not list:

--- a/Dockerfiles/agent/secrets-helper/readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/readsecret.py
@@ -1,0 +1,74 @@
+#!/opt/datadog-agent/embedded/bin/python
+
+import argparse
+import json
+import os.path
+import sys
+
+
+def list_secret_names(input_json):
+    query = json.loads(input_json)
+    if query["version"] != "1.0":
+        raise ValueError("unknown protocol version {}".format(query["version"]))
+
+    names = query["secrets"]
+    if type(names) is not list:
+        raise ValueError("the secrets field should be an array: {}".format(names))
+
+    return names
+
+
+def read_file(root_folder, filename):
+    path = os.path.join(root_folder, filename)
+    realpath = os.path.realpath(path)
+
+    if not realpath.startswith(root_folder):
+        raise ValueError("file {} is outside of the specified folder {}".format(realpath, root_folder))
+
+    with open(realpath, "r") as f:
+        return f.read()
+
+
+def is_valid_folder(arg):
+    if not os.path.isdir(arg):
+        raise argparse.ArgumentTypeError('The folder {} does not exist'.format(arg))
+    else:
+        return arg
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='''
+            Helper script to extract values from secret files.
+            It implements the secrets protocol 1.0 as specified in Agent 6.3.0.
+            To avoid leaking information, this script refuses to read files
+            outside of its specified root folder.
+        ''',
+        epilog='''
+            See https://github.com/DataDog/datadog-agent/blob/6.4.x/docs/agent/secrets.md
+            for more information on the secrets protocol.
+        '''
+    )
+    parser.add_argument(
+        "root_folder",
+        help="folder where secrets are mounted, eg. /run/secrets",
+        default="/run/secrets",
+        type=is_valid_folder
+    )
+
+    args = parser.parse_args()
+    input_json = sys.stdin.read()
+    try:
+        secret_names = list_secret_names(input_json)
+    except ValueError as e:
+        sys.exit('Cannot parse input: ' + str(e))
+
+    output = {}
+    for s in secret_names:
+        try:
+            contents = read_file(args.root_folder, s)
+            output[s] = {"value": contents}
+        except (ValueError, IOError) as e:
+            output[s] = {"error": str(e)}
+
+    print json.dumps(output)

--- a/Dockerfiles/agent/secrets-helper/readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/readsecret.py
@@ -5,6 +5,8 @@ import json
 import os.path
 import sys
 
+MAX_FILE_SIZE_BYTES = 1024
+
 
 def list_secret_names(input_json):
     query = json.loads(input_json)
@@ -27,7 +29,7 @@ def read_file(root_folder, filename):
         raise ValueError("file {} is outside of the specified folder {}".format(realpath, root_folder))
 
     with open(realpath, "r") as f:
-        return f.read()
+        return f.read(MAX_FILE_SIZE_BYTES)
 
 
 def is_valid_folder(arg):

--- a/Dockerfiles/agent/secrets-helper/test_readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/test_readsecret.py
@@ -14,7 +14,7 @@ class TestListSecretNames(unittest.TestCase):
             list_secret_names("")
 
     def test_invalid_version(self):
-        with self.assertRaisesRegexp(ValueError, "unknown protocol version 2.0"):
+        with self.assertRaisesRegexp(ValueError, "incompatible protocol version 2.0"):
             list_secret_names('{"version": "2.0"}')
 
     def test_not_list(self):

--- a/Dockerfiles/agent/secrets-helper/test_readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/test_readsecret.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import argparse
+import shutil
+import tempfile
+import unittest
+
+from readsecret import *
+
+
+class TestListSecretNames(unittest.TestCase):
+    def test_invalid_output(self):
+        with self.assertRaisesRegexp(ValueError, "No JSON object could be decoded"):
+            list_secret_names("")
+
+    def test_invalid_version(self):
+        with self.assertRaisesRegexp(ValueError, "unknown protocol version 2.0"):
+            list_secret_names('{"version": "2.0"}')
+
+    def test_not_list(self):
+        with self.assertRaisesRegexp(ValueError, "should be an array"):
+            list_secret_names('{"version": "1.0", "secrets": "one"}')
+
+    def test_valid(self):
+        names = list_secret_names('{"version": "1.0", "secrets": ["one", "two"]}')
+        self.assertEqual(names, ["one", "two"])
+
+
+class TestReadFile(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.mkdtemp(prefix="tmp-readsecret-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.folder, True)
+        self.folder = None
+
+    def test_path_escape(self):
+        with self.assertRaisesRegexp(ValueError, "outside of the specified folder"):
+            read_file(self.folder, "a/../../outside/file")
+
+    def test_file_not_found(self):
+        with self.assertRaisesRegexp(IOError, "No such file or directory"):
+            read_file(self.folder, "file/not/found")
+
+    def test_file_ok(self):
+        filename = "ok_file"
+        with open(os.path.join(self.folder, filename), "w") as f:
+            f.write("ok_contents")
+        contents = read_file(self.folder, filename)
+        self.assertEqual(contents, "ok_contents")
+
+
+class TestIsValidFolder(unittest.TestCase):
+    def setUp(self):
+        self.folder = tempfile.mkdtemp(prefix="tmp-readsecret-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.folder, True)
+        self.folder = None
+
+    def test_ok(self):
+        self.assertEqual(self.folder, is_valid_folder(self.folder))
+
+    def test_nok(self):
+        foldername = os.path.join(self.folder, "not_found")
+        with self.assertRaisesRegexp(argparse.ArgumentTypeError, "does not exist"):
+            is_valid_folder(foldername)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Dockerfiles/agent/secrets-helper/test_readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/test_readsecret.py
@@ -38,6 +38,23 @@ class TestReadFile(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, "outside of the specified folder"):
             read_file(self.folder, "a/../../outside/file")
 
+    def test_path_escape_symlink(self):
+        sensitive_path = os.path.join(self.folder, "sensitive")
+        os.mkdir(sensitive_path)
+        allowed_path = os.path.join(self.folder, "allowed")
+        os.mkdir(allowed_path)
+
+        # Create a sensitive file and symlink it in the allowed folder
+        with open(os.path.join(sensitive_path, "target"), "w") as f:
+            f.write("sensitive")
+        os.symlink(
+            os.path.join(sensitive_path, "target"),
+            os.path.join(allowed_path, "target"),
+        )
+
+        with self.assertRaisesRegexp(ValueError, "outside of the specified folder"):
+            read_file(allowed_path, "target")
+
     def test_file_not_found(self):
         with self.assertRaisesRegexp(IOError, "No such file or directory"):
             read_file(self.folder, "file/not/found")

--- a/Dockerfiles/agent/secrets-helper/test_readsecret.py
+++ b/Dockerfiles/agent/secrets-helper/test_readsecret.py
@@ -66,6 +66,14 @@ class TestReadFile(unittest.TestCase):
         contents = read_file(self.folder, filename)
         self.assertEqual(contents, "ok_contents")
 
+    def test_file_size_limit(self):
+        filename = "big_file"
+        with open(os.path.join(self.folder, filename), "w") as f:
+            for i in range(0, 2048):
+                f.write("big")
+        contents = read_file(self.folder, filename)
+        self.assertEqual(len(contents), 1024)
+
 
 class TestIsValidFolder(unittest.TestCase):
     def setUp(self):

--- a/releasenotes/notes/docker-image-secrets-script-efabab863b28ff5c.yaml
+++ b/releasenotes/notes/docker-image-secrets-script-efabab863b28ff5c.yaml
@@ -1,0 +1,2 @@
+features:
+  - Docker image: handle docker/kubernetes secret files with a helper script

--- a/releasenotes/notes/docker-image-secrets-script-efabab863b28ff5c.yaml
+++ b/releasenotes/notes/docker-image-secrets-script-efabab863b28ff5c.yaml
@@ -1,2 +1,3 @@
 features:
-  - Docker image: handle docker/kubernetes secret files with a helper script
+  -|
+   Docker image: handle docker/kubernetes secret files with a helper script

--- a/releasenotes/notes/docker-image-secrets-script-efabab863b28ff5c.yaml
+++ b/releasenotes/notes/docker-image-secrets-script-efabab863b28ff5c.yaml
@@ -1,3 +1,3 @@
 features:
-  -|
+  - |
    Docker image: handle docker/kubernetes secret files with a helper script

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -15,6 +15,14 @@ from .dogstatsd import DOGSTATSD_TAG
 
 
 @task
+def test(ctx):
+    """
+    Run docker tests
+    """
+    ctx.run("python ./Dockerfiles/agent/secrets-helper/test_readsecret.py")
+
+
+@task
 def integration_tests(ctx, skip_image_build=False, skip_build=False):
     """
     Run docker integration tests


### PR DESCRIPTION
### What does this PR do?

In order to make using docker / kubernetes secrets more accessible, ship a helper script to use the agent's [external secret feature](https://github.com/DataDog/datadog-agent/blob/6.4.x/docs/agent/secrets.md).

This script allows to read secrets exposed as files, to avoid setting credentials in AD templates stored as docker labels / kubernetes annotations. It is disabled by default to avoid unknowingly exposing secrets, but setup instructions are provided in the `README.md`.

Security considerations:
  - has to be explicitly enabled
  - refuses to read files outside of a given root folder, to avoid exposing sensitive information stored in host volumes
  - script is chmod-ed `500`, as per the agent's security recommendations. That means we don't support running in random-uid mode for this feature

### Motivation

Make the external secrets feature easier to use

### Additional Notes

- For now, the agent does not support replacing `ENC` tokens in envvar values, one cannot use `DD_API_KEY=ENC[apikey]` for now, until viper allows for overrides: https://github.com/spf13/viper/pull/555
