### PR TITLE
[DCA] Set store stats when configmap is updated and revamp store interface.

### DIFF
--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -16,6 +16,8 @@ Only the leader replica should add or delete metrics from the store. Any replica
 
 ### configMapStore
 
+The `configMapStore` store provides simple persistent storage of custom and external metrics. This allows any replica of the Datadog Cluster Agent to serve metrics to the apiserver but still only have the leader replica query Datadog.
+
 The `configMapStore` always performs operations on a local copy of the configmap but `ResyncAndDump` will always get the most up-to-date configmap from the apiserver before returning the metrics.
 
 #### Summary of apiserver calls

--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -6,21 +6,22 @@ This package is a part of the Datadog Cluster Agent and is responsible for provi
 
 The `DatadogProvider` currently only implements the External Metrics Provider interface by providing external metrics from Datadog.
 
-There is no guarantee that every replica returns the exact same list of metrics for `ListAllExternalMetrics`. It is possible for the leader to mutate the store between calls to `ListAllExternalMetricValues` from different replicas. This is the tradeoff of using a `ConfigMap` for persistent storage instead of a transactional store.
+There is no guarantee that every replica returns the exact same list of metrics for `DatadogProvider.ListAllExternalMetrics`. It is possible for the leader to mutate the store between calls to `ResyncAndDump` from different replicas. This is the tradeoff of using a `ConfigMap` for persistent storage instead of a transactional store.
 
 ## Store
 
 The `Store` interface provides persistent storage of custom and external metrics. The default implementation stores metric values in a `ConfigMap`.
 
-Only the leader replica should add or delete metrics from the store. Any replica is able to call `ListAllExternalMetricValues` to return the most up-to-date values for metrics.
+Only the leader replica should add or delete metrics from the store. Any replica is able to call `ResyncAndDump` to return the most up-to-date values for metrics.
 
 ### configMapStore
 
-The `configMapStore` always performs operations on a local copy of the configmap but `ListAllExternalMetricValues` will always get the most up-to-date configmap from the apiserver before listing the metrics.
+The `configMapStore` always performs operations on a local copy of the configmap but `ResyncAndDump` will always get the most up-to-date configmap from the apiserver before returning the metrics.
 
 #### Summary of apiserver calls
 
 - `NewConfigMapStore`: between 1 and 2 calls
-- `SetExternalMetricValues`: 1 call to update configmap
-- `DeleteExternalMetricValues`: 1 call to update configmap
-- `ListAllExternalMetricValues`: 1 call to get configmap
+- `Add`: 1 call to update configmap
+- `Delete`: 1 call to update configmap
+- `Dump`: 0 calls
+- `ResyncAndDump`: 1 call to get configmap

--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -16,7 +16,7 @@ Only the leader replica should add or delete metrics from the store. Any replica
 
 ### configMapStore
 
-The `configMapStore` store provides simple persistent storage of custom and external metrics. This allows any replica of the Datadog Cluster Agent to serve metrics to the apiserver but still only have the leader replica query Datadog.
+The `configMapStore` provides simple persistent storage of custom and external metrics. This allows any replica of the Datadog Cluster Agent to serve metrics to the apiserver but still only have the leader replica query Datadog.
 
 The `configMapStore` always performs operations on a local copy of the configmap but `ResyncAndDump` will always get the most up-to-date configmap from the apiserver before returning the metrics.
 

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -78,13 +78,13 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsInfoList []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
-	rawMetrics, err := p.store.ListAllExternalMetricValues()
+	bundle, err := p.store.ResyncAndDump()
 	if err != nil {
 		log.Errorf("Could not list the external metrics in the store: %s", err.Error())
 		return externalMetricsInfoList
 	}
 
-	for _, metric := range rawMetrics {
+	for _, metric := range bundle.External {
 		// Only metrics that exist in Datadog and available are eligible to be evaluated in the HPA process.
 		if !metric.Valid {
 			continue

--- a/pkg/clusteragent/custommetrics/status.go
+++ b/pkg/clusteragent/custommetrics/status.go
@@ -35,15 +35,15 @@ func GetStatus() map[string]interface{} {
 	externalStatus := make(map[string]interface{})
 	status["External"] = externalStatus
 
-	externalMetrics, err := store.ListAllExternalMetricValues()
+	bundle, err := store.Dump()
 	if err != nil {
 		externalStatus["ListError"] = err.Error()
 		return status
 	}
-	externalStatus["Metrics"] = externalMetrics
-	externalStatus["Total"] = len(externalMetrics)
+	externalStatus["Metrics"] = bundle.External
+	externalStatus["Total"] = len(bundle.External)
 	valid := 0
-	for _, metric := range externalMetrics {
+	for _, metric := range bundle.External {
 		if metric.Valid {
 			valid += 1
 		}

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -98,7 +98,7 @@ func NewConfigMapStore(client kubernetes.Interface, ns, name string) (Store, err
 	return store, nil
 }
 
-// Add adds metrics in the bundle to the configmap.
+// Add adds metrics in the bundle to the configmap. Only the leader should call this function.
 func (c *configMapStore) Add(bundle *MetricsBundle) error {
 	if bundle.Len() == 0 {
 		return nil
@@ -126,7 +126,7 @@ func (c *configMapStore) Add(bundle *MetricsBundle) error {
 	return c.updateConfigMap()
 }
 
-// Delete deletes metrics in the bundle from the configmap.
+// Delete deletes metrics in the bundle from the configmap. Only the leader should call this function.
 func (c *configMapStore) Delete(bundle *MetricsBundle) error {
 	if bundle.Len() == 0 {
 		return nil
@@ -173,8 +173,8 @@ func (c *configMapStore) doDump() (*MetricsBundle, error) {
 	return bundle, nil
 }
 
-// ResyncAndDump returns an up-to-date bundle of metrics from the configmap.
-// Any replica can safely call this function.
+// ResyncAndDump syncs the local configmap with the apiserver and returns bundle of all
+// metrics in the configmap. Any replica can safely call this function.
 func (c *configMapStore) ResyncAndDump() (*MetricsBundle, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -44,11 +44,10 @@ func init() {
 
 // Store is an interface for persistent storage of custom and external metrics.
 type Store interface {
-	SetExternalMetricValues([]ExternalMetricValue) error
-
-	DeleteExternalMetricValues([]ExternalMetricValue) error
-
-	ListAllExternalMetricValues() ([]ExternalMetricValue, error)
+	Add(*MetricsBundle) error
+	Delete(*MetricsBundle) error
+	Dump() (*MetricsBundle, error)
+	ResyncAndDump() (*MetricsBundle, error)
 }
 
 // configMapStore provides persistent storage of custom and external metrics using a configmap.
@@ -99,9 +98,9 @@ func NewConfigMapStore(client kubernetes.Interface, ns, name string) (Store, err
 	return store, nil
 }
 
-// SetExternalMetricValues updates the external metrics in the configmap.
-func (c *configMapStore) SetExternalMetricValues(added []ExternalMetricValue) error {
-	if len(added) == 0 {
+// Add adds metrics in the bundle to the configmap.
+func (c *configMapStore) Add(bundle *MetricsBundle) error {
+	if bundle.Len() == 0 {
 		return nil
 	}
 
@@ -115,7 +114,7 @@ func (c *configMapStore) SetExternalMetricValues(added []ExternalMetricValue) er
 		// Don't panic "assignment to entry in nil map" at init
 		c.cm.Data = make(map[string]string)
 	}
-	for _, m := range added {
+	for _, m := range bundle.External {
 		key := externalMetricValueKeyFunc(m)
 		toStore, err := json.Marshal(m)
 		if err != nil {
@@ -124,28 +123,12 @@ func (c *configMapStore) SetExternalMetricValues(added []ExternalMetricValue) er
 		}
 		c.cm.Data[key] = string(toStore)
 	}
-	if err := c.updateConfigMap(); err != nil {
-		return err
-	}
-
-	total := int64(len(added))
-	externalTotal.Set(total)
-
-	valid := int64(0)
-	for _, metric := range added {
-		if metric.Valid {
-			valid += 1
-		}
-	}
-
-	externalValid.Set(valid)
-
-	return nil
+	return c.updateConfigMap()
 }
 
-// Delete deletes all metrics in the configmap that refer to any of the given object references.
-func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricValue) error {
-	if len(deleted) == 0 {
+// Delete deletes metrics in the bundle from the configmap.
+func (c *configMapStore) Delete(bundle *MetricsBundle) error {
+	if bundle.Len() == 0 {
 		return nil
 	}
 
@@ -155,7 +138,7 @@ func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricValu
 	if c.cm == nil {
 		return errNotInitialized
 	}
-	for _, m := range deleted {
+	for _, m := range bundle.External {
 		key := externalMetricValueKeyFunc(m)
 		delete(c.cm.Data, key)
 		log.Debugf("Deleted metric %s for HPA %s/%s from the configmap %s", m.MetricName, m.HPA.Namespace, m.HPA.Name, c.name)
@@ -163,16 +146,19 @@ func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricValu
 	return c.updateConfigMap()
 }
 
-// ListAllExternalMetricValues returns the most up-to-date list of external metrics from the configmap.
-// Any replica can safely call this function.
-func (c *configMapStore) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// Dump returns a bundle of all metrics in the configmap.
+func (c *configMapStore) Dump() (*MetricsBundle, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
-	if err := c.getConfigMap(); err != nil {
-		return nil, err
+	return c.doDump()
+}
+
+func (c *configMapStore) doDump() (*MetricsBundle, error) {
+	if c.cm == nil {
+		return nil, errNotInitialized
 	}
-	var metrics []ExternalMetricValue
+	bundle := &MetricsBundle{}
 	for k, v := range c.cm.Data {
 		if !isExternalMetricValueKey(k) {
 			continue
@@ -182,9 +168,21 @@ func (c *configMapStore) ListAllExternalMetricValues() ([]ExternalMetricValue, e
 			log.Debugf("Could not unmarshal the external metric for key %s: %v", k, err)
 			continue
 		}
-		metrics = append(metrics, m)
+		bundle.External = append(bundle.External, m)
 	}
-	return metrics, nil
+	return bundle, nil
+}
+
+// ResyncAndDump returns an up-to-date bundle of metrics from the configmap.
+// Any replica can safely call this function.
+func (c *configMapStore) ResyncAndDump() (*MetricsBundle, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.getConfigMap(); err != nil {
+		return nil, err
+	}
+	return c.doDump()
 }
 
 func (c *configMapStore) getConfigMap() error {
@@ -204,6 +202,7 @@ func (c *configMapStore) updateConfigMap() error {
 		log.Infof("Could not update the configmap %s: %v", c.name, err)
 		return err
 	}
+	setStoreStats(c)
 	return nil
 }
 
@@ -223,4 +222,22 @@ func externalMetricValueKeyFunc(val ExternalMetricValue) string {
 
 func isExternalMetricValueKey(key string) bool {
 	return strings.HasPrefix(key, "external_metric")
+}
+
+func setStoreStats(store *configMapStore) {
+	bundle, err := store.doDump()
+	if err != nil {
+		return
+	}
+
+	total := int64(len(bundle.External))
+	externalTotal.Set(total)
+
+	valid := int64(0)
+	for _, metric := range bundle.External {
+		if metric.Valid {
+			valid += 1
+		}
+	}
+	externalValid.Set(valid)
 }

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -253,5 +253,5 @@ func setLastUpdatedAnnotation(cm *v1.ConfigMap) {
 		// Don't panic "assignment to entry in nil map" at init
 		cm.Annotations = make(map[string]string)
 	}
-	cm.Annotations[storeLastUpdatedAnnotationKey] = time.Now().String()
+	cm.Annotations[storeLastUpdatedAnnotationKey] = time.Now().Format(time.RFC3339)
 }

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -40,6 +40,7 @@ func TestNewConfigMapStore(t *testing.T) {
 	store, err = NewConfigMapStore(client, "default", "bar")
 	require.NoError(t, err)
 	require.NotNil(t, store.(*configMapStore).cm)
+	assert.NotEmpty(t, store.(*configMapStore).cm.Annotations[storeLastUpdatedAnnotationKey])
 }
 
 func TestConfigMapStoreExternalMetrics(t *testing.T) {

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -134,19 +134,20 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, store.(*configMapStore).cm)
 
-			err = store.SetExternalMetricValues(tt.metrics)
+			bundle := &MetricsBundle{External: tt.metrics}
+			err = store.Add(bundle)
 			require.NoError(t, err)
 
-			list, err := store.ListAllExternalMetricValues()
+			bundle, err = store.Dump()
 			require.NoError(t, err)
-			assert.ElementsMatch(t, tt.expected, list)
+			assert.ElementsMatch(t, tt.expected, bundle.External)
 
-			err = store.DeleteExternalMetricValues(list)
+			err = store.Delete(bundle)
 			require.NoError(t, err)
 
-			list, err = store.ListAllExternalMetricValues()
+			bundle, err = store.Dump()
 			require.NoError(t, err)
-			assert.Empty(t, list)
+			assert.Empty(t, bundle)
 		})
 	}
 }

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -7,6 +7,15 @@
 
 package custommetrics
 
+type MetricsBundle struct {
+	External []ExternalMetricValue
+}
+
+func (b *MetricsBundle) Len() int {
+	return len(b.External)
+}
+
+// ExternalMetricValue is the value of a metric from Datadog.
 type ExternalMetricValue struct {
 	MetricName string            `json:"metricName"`
 	Labels     map[string]string `json:"labels"`


### PR DESCRIPTION
### What does this PR do?

The `storeStats` expvar was only being updated in `SetExternalMetricValues` instead of every time the store is updated, so the metrics were misleading.

This also changes the `custommetrics.Store` interface to better reflect the simplicity of the data storage model and allow for `setStoreStats` to dump the entire store.

### To Do

- [x] Make sure e2e tests pass locally