### PR TITLE
use true/false rather than yes/no in the config template

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -48,7 +48,7 @@ COPY datadog*.yaml etc/datadog-agent/
 FROM debian:buster-slim
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
-ENV DOCKER_DD_AGENT=yes \
+ENV DOCKER_DD_AGENT=true \
     PATH=/opt/datadog-agent/bin/agent/:/opt/datadog-agent/embedded/bin/:$PATH \
     CURL_CA_BUNDLE=/opt/datadog-agent/embedded/ssl/certs/cacert.pem \
     # Pass envvar variables to agents

--- a/Dockerfiles/manifests/agent-kubelet-only.yaml
+++ b/Dockerfiles/manifests/agent-kubelet-only.yaml
@@ -23,7 +23,7 @@ spec:
           - name: DD_LEADER_ELECTION
             value: "true"
           - name: KUBERNETES
-            value: "yes"
+            value: "true"
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:
               fieldRef:

--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -26,7 +26,7 @@ spec:
           - name: DD_API_KEY
             value: <YOUR_API_KEY>
           - name: KUBERNETES
-            value: "yes"
+            value: "true"
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:
               fieldRef:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -564,7 +564,7 @@ func getMultipleEndpoints(config *viper.Viper) (map[string][]string, error) {
 
 // IsContainerized returns whether the Agent is running on a Docker container
 func IsContainerized() bool {
-	return os.Getenv("DOCKER_DD_AGENT") == "yes"
+	return os.Getenv("DOCKER_DD_AGENT") != ""
 }
 
 // FileUsedDir returns the absolute path to the folder containing the config

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -342,14 +342,14 @@ api_key:
 #
 # Change the root directory to look at to get cgroup statistics. Useful when running inside a
 # container with host directories mounted on a different folder.
-# Default if environment variable "DOCKER_DD_AGENT" is set to "true"
+# Default if environment variable "DOCKER_DD_AGENT" is set
 # "/host/sys/fs/cgroup" and "/sys/fs/cgroup" if not.
 #
 # container_cgroup_root: /host/sys/fs/cgroup/
 #
 # Change the root directory to look at to get proc statistics. Useful when running inside a
 # container with host directories mounted on a different folder.
-# Default if environment variable "DOCKER_DD_AGENT" is set to "true"
+# Default if environment variable "DOCKER_DD_AGENT" is set
 # "/host/proc" and "/proc" if not.
 #
 # container_proc_root: /host/proc

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -21,14 +21,14 @@ api_key:
 #     - host1
 #     - host2
 
-# Setting this option to "yes" will tell the agent to skip validation of SSL/TLS certificates.
+# Setting this option to "true" will tell the agent to skip validation of SSL/TLS certificates.
 # This may be necessary if the agent is running behind a proxy. See this page for details:
 # https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-haproxy-as-a-proxy
-# skip_ssl_validation: no
+# skip_ssl_validation: false
 
-# Setting this option to "yes" will force the agent to only use TLS 1.2 when
+# Setting this option to "true" will force the agent to only use TLS 1.2 when
 # pushing data to the url specified in "dd_url".
-# force_tls_12: no
+# force_tls_12: false
 
 # Force the hostname to whatever you want. (default: auto-detected)
 # hostname: mymachine.mydomain
@@ -167,8 +167,8 @@ api_key:
 {{- if .Dogstatsd }}
 # DogStatsd
 #
-# If you don't want to enable the DogStatsd server, set this option to no
-# use_dogstatsd: yes
+# If you don't want to enable the DogStatsd server, set this option to false
+# use_dogstatsd: true
 #
 # Make sure your client is sending to the same UDP port
 # dogstatsd_port: 8125
@@ -190,10 +190,10 @@ api_key:
 # dogstatsd_buffer_size: 1024
 #
 # Whether dogstatsd should listen to non local UDP traffic
-# dogstatsd_non_local_traffic: no
+# dogstatsd_non_local_traffic: false
 #
 # Publish dogstatsd's internal stats as Go expvars
-# dogstatsd_stats_enable: no
+# dogstatsd_stats_enable: false
 #
 # How many items in the dogstatsd's stats circular buffer
 # dogstatsd_stats_buffer: 10
@@ -303,26 +303,26 @@ api_key:
 # log_level: info
 # log_file: /var/log/datadog/agent.log
 
-# Set to 'yes' to output logs in JSON format
-# log_format_json: no
+# Set to 'true' to output logs in JSON format
+# log_format_json: false
 
-# Set to 'no' to disable logging to stdout
-# log_to_console: yes
+# Set to 'false' to disable logging to stdout
+# log_to_console: true
 
-# Set to 'yes' to disable logging to the log file
-# disable_file_logging: no
+# Set to 'true' to disable logging to the log file
+# disable_file_logging: false
 
-# Set to 'yes' to enable logging to syslog.
+# Set to 'true' to enable logging to syslog.
 #
-# log_to_syslog: no
+# log_to_syslog: false
 #
 # If 'syslog_uri' is left undefined/empty, a local domain socket connection will be attempted
 #
 # syslog_uri:
 #
-# Set to 'yes' to output in an RFC 5424-compliant format
+# Set to 'true' to output in an RFC 5424-compliant format
 #
-# syslog_rfc: no
+# syslog_rfc: false
 #
 # If TLS enabled, you must specify a path to a PEM certificate here
 #
@@ -334,7 +334,7 @@ api_key:
 #
 # If TLS enabled, you may enforce TLS verification here (defaults to true)
 #
-# syslog_tls_verify: yes
+# syslog_tls_verify: true
 #
 {{ end -}}
 {{- if .Autodiscovery }}
@@ -342,14 +342,14 @@ api_key:
 #
 # Change the root directory to look at to get cgroup statistics. Useful when running inside a
 # container with host directories mounted on a different folder.
-# Default if environment variable "DOCKER_DD_AGENT" is set to "yes"
+# Default if environment variable "DOCKER_DD_AGENT" is set to "true"
 # "/host/sys/fs/cgroup" and "/sys/fs/cgroup" if not.
 #
 # container_cgroup_root: /host/sys/fs/cgroup/
 #
 # Change the root directory to look at to get proc statistics. Useful when running inside a
 # container with host directories mounted on a different folder.
-# Default if environment variable "DOCKER_DD_AGENT" is set to "yes"
+# Default if environment variable "DOCKER_DD_AGENT" is set to "true"
 # "/host/proc" and "/proc" if not.
 #
 # container_proc_root: /host/proc

--- a/pkg/metadata/gohai/gohai_test.go
+++ b/pkg/metadata/gohai/gohai_test.go
@@ -23,7 +23,7 @@ func TestGetPayload(t *testing.T) {
 }
 
 func TestGetPayloadContainerized(t *testing.T) {
-	os.Setenv("DOCKER_DD_AGENT", "yes")
+	os.Setenv("DOCKER_DD_AGENT", "true")
 	defer os.Unsetenv("DOCKER_DD_AGENT")
 
 	gohai := GetPayload()

--- a/pkg/util/docker/global.go
+++ b/pkg/util/docker/global.go
@@ -109,5 +109,5 @@ func (cfg *ContainerListConfig) GetCacheKey() string {
 
 // IsContainerized returns True if we're running in the docker-dd-agent container.
 func IsContainerized() bool {
-	return os.Getenv("DOCKER_DD_AGENT") == "yes"
+	return os.Getenv("DOCKER_DD_AGENT") != ""
 }

--- a/pkg/util/docker/global.go
+++ b/pkg/util/docker/global.go
@@ -8,7 +8,6 @@
 package docker
 
 import (
-	"os"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -105,9 +104,4 @@ func (cfg *ContainerListConfig) GetCacheKey() string {
 	}
 
 	return cacheKey
-}
-
-// IsContainerized returns True if we're running in the docker-dd-agent container.
-func IsContainerized() bool {
-	return os.Getenv("DOCKER_DD_AGENT") != ""
 }

--- a/pkg/util/docker/global_nodocker.go
+++ b/pkg/util/docker/global_nodocker.go
@@ -12,11 +12,6 @@ func HostnameProvider(hostName string) (string, error) {
 	return "", ErrDockerNotCompiled
 }
 
-// IsContainerized returns True if we're running in the docker-dd-agent container.
-func IsContainerized() bool {
-	return false
-}
-
 // GetTags returns tags that are automatically added to metrics and events on a
 // host that is running docker.
 func GetTags() ([]string, error) {


### PR DESCRIPTION
### What does this PR do?

Changes all `yes` to `true` and `no` to `false` in the config template.

### Motivation

Stay consistent across the config file and avoid confusion with environment variables (`yes` and `no` won't work with env vars).