### PR TITLE
Fixing k8s host aliasing issues through a cluster-name option

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -137,7 +137,7 @@ For more information about the container's lifecycle, see [SUPERVISION.md](SUPER
 To deploy the Agent in your Kubernetes cluster, you can use the manifest in [manifests](../manifests/cluster-agent/cluster-agent.yaml). Firstly, make sure you have the correct [RBAC](#rbac) in place. You can use the files in manifests/rbac that contain the minimal requirements to run the Kubernetes Cluster level checks and perform the leader election.
 `kubectl create -f manifests/rbac`
 
-Please note that with the above RBAC, every agent will have access to the API Server, to list the pods, services ...  
+Please note that with the above RBAC, every agent will have access to the API Server, to list the pods, services ...
 These accesses vanish when using the Datadog Cluster Agent.
 Indeed, the agents will only have access to the local kubelet and only the Cluster Agent will be able to access cluster level insight (nodes, services...).
 
@@ -155,7 +155,7 @@ See details in [Event Collection](#event-collection).
 
 **This sub-section is only valid for agent versions > 6.3.2 and when using the Datadog Cluster Agent.**
 
-Event collection is handled by the cluster agent and the RBAC for the agent is slimmed down to the kubelet's API access. There is now a dedicated Clusterrole for the agent which should be as follows: 
+Event collection is handled by the cluster agent and the RBAC for the agent is slimmed down to the kubelet's API access. There is now a dedicated Clusterrole for the agent which should be as follows:
 
 ```
 apiVersion: rbac.authorization.k8s.io/v1
@@ -184,7 +184,7 @@ Similarly to Agent 5, Agent 6 collects events from the Kubernetes API server.
 1/ Set the `collect_kubernetes_events` variable to `true` in the `datadog.yaml` file, you can use the environment variable `DD_COLLECT_KUBERNETES_EVENTS` for this.
 2/ Give the agents proper RBACs to activate this feature. See the [RBAC](#rbac) section.
 3/ A ConfigMap can be used to store the `event.tokenKey` and the `event.tokenTimestamp`. It has to be deployed in the `default` namespace and be named `datadogtoken`.
-   Run `kubectl create configmap datadogtoken --from-literal="event.tokenKey"="0"` . 
+   Run `kubectl create configmap datadogtoken --from-literal="event.tokenKey"="0"` .
    You can also use the example in [manifests/datadog_configmap.yaml][https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/manifests/datadog_configmap.yaml].
 
 Note: When the ConfigMap is used, if the agent in charge (via the [Leader election](#leader-election)) of collecting the events dies, the next leader elected will use the ConfigMap to identify the last events pulled.
@@ -225,6 +225,11 @@ This will create the Service Account in the default namespace, a Cluster Role wi
 ### Node label collection
 
 The agent can collect node labels from the APIserver and report them as host tags. This feature is disabled by default, as it is usually redundant with cloud provider host tags. If you need to do so, you can provide a node label -> host tag mapping in the `DD_KUBERNETES_NODE_LABELS_AS_TAGS` environment variable. The format is the inline JSON described in the [tagging section](#Tagging).
+
+### Kubernetes node name as aliases
+
+By default, the agent is using the kubernetes _node name_ as an alias that can be used to forward metrics and events. This allows to submit events and metrics from remote hosts.
+However, if you have several clusters where some nodes could have similar node names, some host alias collisions could occur. To prevent those, the agent supports the use of a cluster-unique identifier (such as the actual cluster name), through the environment variable `DD_CLUSTERNAME`. That identifier will be added to the node name as a host alias, and avoid collision issues altogether.
 
 ### Legacy Kubernetes Versions
 

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -19,6 +19,7 @@
 PyObject* GetVersion(PyObject *self, PyObject *args);
 PyObject* Headers(PyObject *self, PyObject *args);
 PyObject* GetHostname(PyObject *self, PyObject *args);
+PyObject* GetClustername(PyObject *self, PyObject *args);
 PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 PyObject* GetSubprocessOutput(char **args, int argc, int raise);
@@ -234,6 +235,7 @@ static PyMethodDef datadogAgentMethods[] = {
   {"get_config", get_config, METH_VARARGS, "Get value from the agent configuration."},
   {"headers", Headers, METH_VARARGS | METH_KEYWORDS, "Get basic HTTP headers with the right UserAgent."},
   {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
+  {"get_clustername", GetClustername, METH_VARARGS, "Get the agent clustername."},
   {"log", log_message, METH_VARARGS, "Log a message through the agent logger."},
   {"set_external_tags", set_external_tags, METH_VARARGS, "Send external host tags."},
   {NULL, NULL}

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -19,7 +19,7 @@
 PyObject* GetVersion(PyObject *self, PyObject *args);
 PyObject* Headers(PyObject *self, PyObject *args);
 PyObject* GetHostname(PyObject *self, PyObject *args);
-PyObject* GetClustername(PyObject *self, PyObject *args);
+PyObject* GetClusterName(PyObject *self, PyObject *args);
 PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 PyObject* GetSubprocessOutput(char **args, int argc, int raise);
@@ -235,7 +235,7 @@ static PyMethodDef datadogAgentMethods[] = {
   {"get_config", get_config, METH_VARARGS, "Get value from the agent configuration."},
   {"headers", Headers, METH_VARARGS | METH_KEYWORDS, "Get basic HTTP headers with the right UserAgent."},
   {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
-  {"get_clustername", GetClustername, METH_VARARGS, "Get the agent clustername."},
+  {"get_clustername", GetClusterName, METH_VARARGS, "Get the agent cluster name."},
   {"log", log_message, METH_VARARGS, "Log a message through the agent logger."},
   {"set_external_tags", set_external_tags, METH_VARARGS, "Send external host tags."},
   {NULL, NULL}

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -64,11 +64,11 @@ func GetHostname(self *C.PyObject, args *C.PyObject) *C.PyObject {
 // GetClustername exposes the current clustername (if it exists) of the agent to Python checks.
 // Used as a PyCFunction of type METH_VARARGS mapped to `datadog_agent.get_clustername`.
 // `self` is the module object.
-//export GetClustername
-func GetClustername(self *C.PyObject, args *C.PyObject) *C.PyObject {
-	clustername := clustername.GetClustername()
+//export GetClusterName
+func GetClusterName(self *C.PyObject, args *C.PyObject) *C.PyObject {
+	clusterName := clustername.GetClusterName()
 
-	cStr := C.CString(clustername)
+	cStr := C.CString(clusterName)
 	pyStr := C.PyString_FromString(cStr)
 	C.free(unsafe.Pointer(cStr))
 	return pyStr

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -55,6 +56,19 @@ func GetHostname(self *C.PyObject, args *C.PyObject) *C.PyObject {
 	}
 
 	cStr := C.CString(hostname)
+	pyStr := C.PyString_FromString(cStr)
+	C.free(unsafe.Pointer(cStr))
+	return pyStr
+}
+
+// GetClustername exposes the current clustername (if it exists) of the agent to Python checks.
+// Used as a PyCFunction of type METH_VARARGS mapped to `datadog_agent.get_clustername`.
+// `self` is the module object.
+//export GetClustername
+func GetClustername(self *C.PyObject, args *C.PyObject) *C.PyObject {
+	clustername := clustername.GetClustername()
+
+	cStr := C.CString(clustername)
 	pyStr := C.PyString_FromString(cStr)
 	C.free(unsafe.Pointer(cStr))
 	return pyStr

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,6 +111,7 @@ func init() {
 	BindEnvAndSetDefault("auth_token_file_path", "")
 	BindEnvAndSetDefault("bind_host", "localhost")
 	BindEnvAndSetDefault("hostname_fqdn", false)
+	BindEnvAndSetDefault("cluster_name", "")
 
 	// secrets backend
 	Datadog.BindEnv("secret_backend_command")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -532,6 +532,9 @@ api_key:
 # kubernetes_node_labels_as_tags:
 #   kubernetes.io/hostname: nodename
 #   beta.kubernetes.io/os: os
+#
+# Kubernetes cluster identifier used to avoid host alias collisions. Empty by default.
+# clustername: cluster_identifier
 {{ end -}}
 
 {{- if .ProcessAgent }}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -22,6 +22,7 @@ func autoDiscoverClustername() {
 	// TODO
 }
 
+// GetClustername returns a k8s cluster name if it exists, either directly specified or autodiscovered
 func GetClustername() string {
 	mutex.Lock()
 	defer mutex.Unlock()

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -18,19 +18,19 @@ var (
 	mutex       = &sync.Mutex{}
 )
 
-func autoDiscoverClustername() {
+func autoDiscoverClusterName() {
 	// TODO
 }
 
-// GetClustername returns a k8s cluster name if it exists, either directly specified or autodiscovered
-func GetClustername() string {
+// GetClusterName returns a k8s cluster name if it exists, either directly specified or autodiscovered
+func GetClusterName() string {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	if !initDone {
 		clusterName = config.Datadog.GetString("cluster_name")
 		if clusterName == "" {
-			autoDiscoverClustername()
+			autoDiscoverClusterName()
 		}
 		initDone = true
 	}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -6,7 +6,6 @@
 package clustername
 
 import (
-	// "fmt"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/config"

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package clustername
+
+import (
+	// "fmt"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var (
+	clusterName string
+	initDone    = false
+	mutex       = &sync.Mutex{}
+)
+
+func autoDiscoverClustername() {
+	// TODO
+}
+
+func GetClustername() string {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if !initDone {
+		clusterName = config.Datadog.GetString("cluster_name")
+		if clusterName == "" {
+			autoDiscoverClustername()
+		}
+		initDone = true
+	}
+	return clusterName
+}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -35,3 +35,10 @@ func GetClusterName() string {
 	}
 	return clusterName
 }
+
+// ResetClusterName resets the clustername, which allows it to be detected again. Used for tests
+func ResetClusterName() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	initDone = false
+}

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -18,11 +18,7 @@ type clusterNameData struct {
 }
 
 func newClusterNameData() *clusterNameData {
-	return &clusterNameData{
-		clusterName: "",
-		initDone:    false,
-		mutex:       &sync.Mutex{},
-	}
+	return &clusterNameData{}
 }
 
 var defaultClusterNameData *clusterNameData
@@ -48,9 +44,13 @@ func GetClusterName() string {
 	return getClusterName(defaultClusterNameData)
 }
 
+func resetClusterName(data *clusterNameData) {
+	data.mutex.Lock()
+	defer data.mutex.Unlock()
+	data.initDone = false
+}
+
 // ResetClusterName resets the clustername, which allows it to be detected again. Used for tests
 func ResetClusterName() {
-	defaultClusterNameData.mutex.Lock()
-	defer defaultClusterNameData.mutex.Unlock()
-	defaultClusterNameData.initDone = false
+	resetClusterName(defaultClusterNameData)
 }

--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -14,7 +14,7 @@ import (
 type clusterNameData struct {
 	clusterName string
 	initDone    bool
-	mutex       *sync.Mutex
+	mutex       sync.Mutex
 }
 
 func newClusterNameData() *clusterNameData {

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package clustername
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestGetClusterName(t *testing.T) {
+	var testClusterName = "Laika"
+	config.Datadog.Set("cluster_name", testClusterName)
+	defer config.Datadog.Set("cluster_name", nil)
+
+	assert.Equal(t, testClusterName, GetClusterName())
+	assert.Equal(t, initDone, true)
+}

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -19,5 +19,11 @@ func TestGetClusterName(t *testing.T) {
 	defer config.Datadog.Set("cluster_name", nil)
 
 	assert.Equal(t, testClusterName, GetClusterName())
-	assert.Equal(t, initDone, true)
+
+	// Test caching and reset
+	var newClusterName = "Youri"
+	config.Datadog.Set("cluster_name", newClusterName)
+	assert.Equal(t, testClusterName, GetClusterName())
+	ResetClusterName()
+	assert.Equal(t, newClusterName, GetClusterName())
 }

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -17,6 +17,7 @@ func TestGetClusterName(t *testing.T) {
 	var testClusterName = "Laika"
 	config.Datadog.Set("cluster_name", testClusterName)
 	defer config.Datadog.Set("cluster_name", nil)
+	defer ResetClusterName()
 
 	assert.Equal(t, testClusterName, GetClusterName())
 

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGetClusterName(t *testing.T) {
-	data := &clusterNameData{}
+	data := newClusterNameData()
 
 	var testClusterName = "Laika"
 	config.Datadog.Set("cluster_name", testClusterName)
@@ -26,6 +26,6 @@ func TestGetClusterName(t *testing.T) {
 	var newClusterName = "Youri"
 	config.Datadog.Set("cluster_name", newClusterName)
 	assert.Equal(t, testClusterName, getClusterName(data))
-	freshData := &clusterNameData{}
+	freshData := newClusterNameData()
 	assert.Equal(t, newClusterName, getClusterName(freshData))
 }

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -14,17 +14,18 @@ import (
 )
 
 func TestGetClusterName(t *testing.T) {
+	data := &clusterNameData{}
+
 	var testClusterName = "Laika"
 	config.Datadog.Set("cluster_name", testClusterName)
 	defer config.Datadog.Set("cluster_name", nil)
-	defer ResetClusterName()
 
-	assert.Equal(t, testClusterName, GetClusterName())
+	assert.Equal(t, testClusterName, getClusterName(data))
 
 	// Test caching and reset
 	var newClusterName = "Youri"
 	config.Datadog.Set("cluster_name", newClusterName)
-	assert.Equal(t, testClusterName, GetClusterName())
-	ResetClusterName()
-	assert.Equal(t, newClusterName, GetClusterName())
+	assert.Equal(t, testClusterName, getClusterName(data))
+	freshData := &clusterNameData{}
+	assert.Equal(t, newClusterName, getClusterName(freshData))
 }

--- a/pkg/util/kubernetes/hostinfo/host_alias.go
+++ b/pkg/util/kubernetes/hostinfo/host_alias.go
@@ -20,5 +20,5 @@ func GetHostAlias() (string, error) {
 	if err == nil && util.ValidHostname(name) == nil {
 		return name, nil
 	}
-	return "", fmt.Errorf("Couldn't extract a host alias from the kubelet")
+	return "", fmt.Errorf("Couldn't extract a host alias from the kubelet: %s", err)
 }

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -121,14 +121,14 @@ func (ku *KubeUtil) GetNodeInfo() (string, string, error) {
 	return "", "", fmt.Errorf("failed to get node info, pod list length: %d", len(pods))
 }
 
-// GetHostname builds a k8s from a hostname and an optional cluster-name
+// GetHostname builds a hostname from the kubernetes nodename and an optional cluster-name
 func (ku *KubeUtil) GetHostname() (string, error) {
 	nodeName, err := ku.getNodename()
 	if err != nil {
 		return "", fmt.Errorf("couldn't fetch the host nodename from the kubelet: %s", err)
 	}
 
-	clusterName := clustername.GetClustername()
+	clusterName := clustername.GetClusterName()
 	if clusterName == "" {
 		log.Debugf("Now using plain kubernetes nodename as an alias: no cluster name was set and none could be autodiscovered")
 		return nodeName, nil

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -125,7 +125,6 @@ func (ku *KubeUtil) GetNodeInfo() (string, string, error) {
 func (ku *KubeUtil) GetHostname() (string, error) {
 	nodeName, err := ku.getNodename()
 	if err != nil {
-	} else {
 		return "", fmt.Errorf("couldn't fetch the host nodename from the kubelet: %s", err)
 	}
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 
@@ -120,8 +121,25 @@ func (ku *KubeUtil) GetNodeInfo() (string, string, error) {
 	return "", "", fmt.Errorf("failed to get node info, pod list length: %d", len(pods))
 }
 
-// GetHostname returns the hostname of the first pod.spec.nodeName in the PodList
+// GetHostname builds a k8s from a hostname and an optional cluster-name
 func (ku *KubeUtil) GetHostname() (string, error) {
+	nodeName, err := ku.getNodename()
+	if err != nil {
+	} else {
+		return "", fmt.Errorf("couldn't fetch the host nodename from the kubelet: %s", err)
+	}
+
+	clusterName := clustername.GetClustername()
+	if clusterName == "" {
+		log.Debugf("Now using plain kubernetes nodename as an alias: no cluster name was set and none could be autodiscovered")
+		return nodeName, nil
+	} else {
+		return (nodeName + "-" + clusterName), nil
+	}
+}
+
+// getNodename returns the nodename of the first pod.spec.nodeName in the PodList
+func (ku *KubeUtil) getNodename() (string, error) {
 	pods, err := ku.GetLocalPodList()
 	if err != nil {
 		return "", fmt.Errorf("error getting pod list from kubelet: %s", err)
@@ -134,7 +152,7 @@ func (ku *KubeUtil) GetHostname() (string, error) {
 		return pod.Spec.NodeName, nil
 	}
 
-	return "", fmt.Errorf("failed to get hostname, pod list length: %d", len(pods))
+	return "", fmt.Errorf("failed to get the kubernetes nodename, pod list length: %d", len(pods))
 }
 
 // GetLocalPodList returns the list of pods running on the node

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 )
 
 const (
@@ -273,6 +274,17 @@ func (suite *KubeletTestSuite) TestGetHostname() {
 	hostname, err := kubeutil.GetHostname()
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), "my-node-name", hostname)
+
+	// Testing hostname when a cluster name is set
+	var testClusterName = "Laika"
+	config.Datadog.Set("cluster_name", testClusterName)
+	defer config.Datadog.Set("cluster_name", nil)
+
+	clustername.ResetClusterName() // reset state as clustername was already read
+	hostname, err = kubeutil.GetHostname()
+	require.Nil(suite.T(), err)
+	require.Equal(suite.T(), "my-node-name-"+testClusterName, hostname)
+	clustername.ResetClusterName() // reset state so that future hostname fetches are not impacted
 
 	select {
 	case r := <-kubelet.Requests:

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -278,13 +278,15 @@ func (suite *KubeletTestSuite) TestGetHostname() {
 	// Testing hostname when a cluster name is set
 	var testClusterName = "Laika"
 	config.Datadog.Set("cluster_name", testClusterName)
-	defer config.Datadog.Set("cluster_name", nil)
-
 	clustername.ResetClusterName() // reset state as clustername was already read
+
+	// defer a reset of the state so that future hostname fetches are not impacted
+	defer config.Datadog.Set("cluster_name", nil)
+	defer clustername.ResetClusterName()
+
 	hostname, err = kubeutil.GetHostname()
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), "my-node-name-"+testClusterName, hostname)
-	clustername.ResetClusterName() // reset state so that future hostname fetches are not impacted
 
 	select {
 	case r := <-kubelet.Requests:

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -281,7 +281,7 @@ func (suite *KubeletTestSuite) TestGetHostname() {
 	clustername.ResetClusterName() // reset state as clustername was already read
 
 	// defer a reset of the state so that future hostname fetches are not impacted
-	defer config.Datadog.Set("cluster_name", nil)
+	defer config.Datadog.Set("cluster_name", "")
 	defer clustername.ResetClusterName()
 
 	hostname, err = kubeutil.GetHostname()

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "master",
+		"INTEGRATIONS_CORE_VERSION": "antoine/add-clustername-suffix-to-nodenames-in-kubernetes-state",
 		"TRACE_AGENT_VERSION": "master",
 		"PROCESS_AGENT_VERSION": "master",
 		"OMNIBUS_SOFTWARE_VERSION": "master",

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
 	"nightly": {
-		"INTEGRATIONS_CORE_VERSION": "antoine/add-clustername-suffix-to-nodenames-in-kubernetes-state",
+		"INTEGRATIONS_CORE_VERSION": "master",
 		"TRACE_AGENT_VERSION": "master",
 		"PROCESS_AGENT_VERSION": "master",
 		"OMNIBUS_SOFTWARE_VERSION": "master",

--- a/releasenotes/notes/cluster-name-option-9eda598b1c68fa9f.yaml
+++ b/releasenotes/notes/cluster-name-option-9eda598b1c68fa9f.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a cluster-name attribute in the agent, to be used in kubernetes clusters so that host aliases are unique.

--- a/releasenotes/notes/cluster-name-option-9eda598b1c68fa9f.yaml
+++ b/releasenotes/notes/cluster-name-option-9eda598b1c68fa9f.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add a cluster-name attribute in the agent, to be used in kubernetes clusters so that host aliases are unique.
+    Kubernetes: to avoid hostname collisions between clusters, a new ``cluster_name`` option is available. It will be added as a suffix to the host alias detected from the kubelet in order to make these aliases unique across different clusters.


### PR DESCRIPTION
### What does this PR do?

Add a cluster-name attribute in the agent, to be used in kubernetes clusters so that host aliases are unique. It will be most useful in the kubernetes_state check and in kubernetes events.

### Motivation

The kubernetes API do not reference a cluster identifier from inside the cluster. This causes issues when submitting metrics from distant hosts as we rely on using node names as aliases, and they can be identical across different clusters.
The cluster name will be used as a suffix on the node name when a hostname will be needed.

### Additional Notes

Sister/child PRs:
- in kubernetes_state https://github.com/DataDog/integrations-core/pull/2069
- for events https://github.com/DataDog/datadog-agent/pull/1739