### PR TITLE
[DCA] Status output cleanup for custom metrics

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/custommetricsprovider.tmpl
@@ -1,30 +1,31 @@
-Custom Metrics Provider
-=======================
-External Metrics
-================
-  {{- if .hpaExternal -}}
-  {{- if .hpaExternal.Error }}
-  Error while trying to serve external metrics: {{ .hpaExternal.Error }}
+Custom Metrics Server
+=====================
+  {{- if .custommetrics.Error }}
+  Error: {{ .custommetrics.Error }}
   {{ else }}
-  {{- if .hpaExternal.ErrorStore }}
-  Internal Error while processing the External Metrics : {{ .hpaExternal.ErrorStore }}
+  ConfigMap name: {{ .custommetrics.Cmname }}
+  {{ if .custommetrics.StoreError }}
+  Error: {{ .custommetrics.StoreError }}
   {{ else }}
-  ConfigMap name: {{ .hpaExternal.Cmname }}
-  Number of external metrics detected: {{ .hpaExternal.Number }}
-  {{- end -}}
-  {{- end -}}
-  {{ range $metric := .hpaExternal.Metrics }}
-  {{ range $name, $value := $metric}}
-  {{- if or (eq $name "hpa") (eq $name "labels")}}
-  {{$name}}:
-  {{- range $k, $v := $value}}
-  - {{$k}}: {{$v}}
-  {{- end -}}
-  {{else}}
-  {{$name}}: {{$value}}
+  External Metrics
+  ----------------
+    {{- if .custommetrics.External.ListError }}
+    Error: {{ .custommetrics.External.ListError }}
+    {{ else }}
+    Total: {{ .custommetrics.External.Total }}
+    Valid: {{ .custommetrics.External.Valid }}
+    {{ range $metric := .custommetrics.External.Metrics }}
+    {{- range $name, $value := $metric }}
+    {{- if or (eq $name "hpa") (eq $name "labels") }}
+    {{$name}}:
+    {{- range $k, $v := $value }}
+    - {{$k}}: {{$v}}
+    {{- end -}}
+    {{else}}
+    {{$name}}: {{$value}}
+    {{- end }}
+    {{- end }}
+    {{ end }}
+    {{- end }}
   {{- end }}
   {{- end }}
-  {{- end -}}
-  {{ else }}
-  The External Metrics Provider is not enabled
-  {{- end -}}

--- a/Dockerfiles/cluster-agent/dist/templates/header.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/header.tmpl
@@ -51,22 +51,23 @@
     {{- end}}
     {{- end}}
 
-  Custom Metrics Provider
-  =======================
-  External Metrics
-  ================
-    {{- if .hpaExternal -}}
-    {{- if .hpaExternal.Error }}
-    Error while trying to serve external metrics: {{ .hpaExternal.Error }}
+  Custom Metrics Server
+  =====================
+    {{- if .custommetrics.Error }}
+    Error: {{ .custommetrics.Error }}
     {{ else }}
-    {{- if .hpaExternal.ErrorStore }}
-    Internal Error while processing the External Metrics : {{ .hpaExternal.ErrorStore }}
+    ConfigMap name: {{ .custommetrics.Cmname }}
+    {{ if .custommetrics.StoreError }}
+    Error: {{ .custommetrics.StoreError }}
     {{ else }}
-    ConfigMap name: {{ .hpaExternal.Cmname }}
-    Number of external metrics detected: {{ .hpaExternal.Number }}
-    {{- end -}}
-    {{- end -}}
-    {{ else }}
-    The External Metrics Provider is not enabled
-    {{- end -}}
+    External Metrics
+    ----------------
+      {{- if .custommetrics.External.ListError }}
+      Error: {{ .custommetrics.External.ListError }}
+      {{ else }}
+      Total: {{ .custommetrics.External.Total }}
+      Valid: {{ .custommetrics.External.Valid }}
+      {{ end -}}
+    {{- end }}
+    {{- end }}
 {{/* this line intentionally left blank */}}

--- a/pkg/clusteragent/custommetrics/status.go
+++ b/pkg/clusteragent/custommetrics/status.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package custommetrics
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+// GetStatus returns status info for the Custom Metrics Server.
+func GetStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+	apiCl, err := apiserver.GetAPIClient()
+	if err != nil {
+		status["Error"] = err.Error()
+		return status
+	}
+
+	configMapName := GetConfigmapName()
+	configMapNamespace := apiserver.GetResourcesNamespace()
+	status["Cmname"] = fmt.Sprintf("%s/%s", configMapNamespace, configMapName)
+
+	store, err := NewConfigMapStore(apiCl.Cl, configMapNamespace, configMapName)
+	if err != nil {
+		status["StoreError"] = err.Error()
+		return status
+	}
+
+	externalStatus := make(map[string]interface{})
+	status["External"] = externalStatus
+
+	externalMetrics, err := store.ListAllExternalMetricValues()
+	if err != nil {
+		externalStatus["ListError"] = err.Error()
+		return status
+	}
+	externalStatus["Metrics"] = externalMetrics
+	externalStatus["Total"] = len(externalMetrics)
+	valid := 0
+	for _, metric := range externalMetrics {
+		if metric.Valid {
+			valid += 1
+		}
+	}
+	externalStatus["Valid"] = valid
+
+	return status
+}

--- a/pkg/clusteragent/custommetrics/status_no_apiserver.go
+++ b/pkg/clusteragent/custommetrics/status_no_apiserver.go
@@ -5,18 +5,11 @@
 
 // +build !kubeapiserver
 
-package status
+package custommetrics
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
-func getLeaderElectionDetails() map[string]string {
-	log.Info("Not implemented")
-	return nil
-}
-
-func getDCAStatus() map[string]string {
-	log.Info("Not implemented")
-	return nil
+// GetStatus returns the status info of the Custom Metrics Server.
+func GetStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+	status["Error"] = "The Custom Metrics Server is not enabled"
+	return status
 }

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/mholt/archiver"
 
@@ -190,7 +191,7 @@ func zipMetadataMap(tempDir, hostname string) error {
 func zipHPAStatus(tempDir, hostname string) error {
 	// Grab the full content of the HPA configmap
 	stats := make(map[string]interface{})
-	stats["hpaExternal"] = status.GetHorizontalPodAutoscalingStatus()
+	stats["custommetrics"] = custommetrics.GetStatus()
 	statsBytes, err := json.Marshal(stats)
 	if err != nil {
 		log.Infof("Error while marshalling the cluster level metadata: %q", err)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -128,7 +129,7 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	now := time.Now()
 	stats["time"] = now.Format(timeFormat)
 	stats["leaderelection"] = getLeaderElectionDetails()
-	stats["hpaExternal"] = GetHorizontalPodAutoscalingStatus()
+	stats["custommetrics"] = custommetrics.GetStatus()
 
 	return stats, nil
 }

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -9,11 +9,10 @@ package status
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
-	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 )
 
 func getLeaderElectionDetails() map[string]string {
@@ -50,30 +49,4 @@ func getDCAStatus() map[string]string {
 	}
 	clusterAgentDetails["Version"] = ver
 	return clusterAgentDetails
-}
-
-// GetHorizontalPodAutoscalingStatus fetches the content of the ConfigMap storing the state of the HPA metrics provider
-func GetHorizontalPodAutoscalingStatus() map[string]interface{} {
-	horizontalPodAutoscalingStatus := make(map[string]interface{})
-
-	apiCl, err := apiserver.GetAPIClient()
-	if err != nil {
-		horizontalPodAutoscalingStatus["Error"] = err.Error()
-		return horizontalPodAutoscalingStatus
-	}
-
-	datadogHPAConfigMap := custommetrics.GetConfigmapName()
-	horizontalPodAutoscalingStatus["Cmname"] = datadogHPAConfigMap
-
-	store, err := custommetrics.NewConfigMapStore(apiCl.Cl, apiserver.GetResourcesNamespace(), datadogHPAConfigMap)
-	externalMetrics, err := store.ListAllExternalMetricValues()
-	if err != nil {
-		horizontalPodAutoscalingStatus["ErrorStore"] = err.Error()
-		return horizontalPodAutoscalingStatus
-	}
-
-	horizontalPodAutoscalingStatus["Number"] = len(externalMetrics)
-	horizontalPodAutoscalingStatus["Metrics"] = externalMetrics
-
-	return horizontalPodAutoscalingStatus
 }


### PR DESCRIPTION
### What does this PR do?

- Move `GetHorizontalPodAutoscalingStatus` to `custommetrics.GetStatus`
- Handle `StoreError` and `ListError` errors in `custommetrics.GetStatus`
- Always display `Cmname` name if we can connect to apiserver.
- Changed title from `Custom Metrics Provider` to `Custom Metrics Server`

Here is sample output for each state

```
--- FAIL: TestFormatHPAStatus (0.00s)
	render_test.go:98: Rendering "error"...
		
		Custom Metrics Server
		=====================
		  Error: This is an error
		  
	render_test.go:98: Rendering "store error"...
		
		Custom Metrics Server
		=====================
		  ConfigMap name: default/datadog-custom-metrics
		  
		  Error: This is an error
		  
	render_test.go:98: Rendering "list error"...
		
		Custom Metrics Server
		=====================
		  ConfigMap name: default/datadog-custom-metrics
		  
		  External Metrics
		  ----------------
		    Error: This is an error
		    
	render_test.go:98: Rendering "no metrics"...
		
		Custom Metrics Server
		=====================
		  ConfigMap name: default/datadog-custom-metrics
		  
		  External Metrics
		  ----------------
		    Total: 2
		    Valid: 1
		    
	render_test.go:98: Rendering "one metric"...
		
		Custom Metrics Server
		=====================
		  ConfigMap name: default/datadog-custom-metrics
		  
		  External Metrics
		  ----------------
		    Total: 2
		    Valid: 1
		    
		    hpa:
		    - name: hpa
		    - namespace: default
		    labels:
		    - foo: bar
		    metricName: metric1
		    ts: 1.533262651e&#43;09
		    valid: true
		    value: 10
		    
	render_test.go:98: Rendering "multiple metrics"...
		
		Custom Metrics Server
		=====================
		  ConfigMap name: default/datadog-custom-metrics
		  
		  External Metrics
		  ----------------
		    Total: 2
		    Valid: 1
		    
		    hpa:
		    - name: hpa
		    - namespace: default
		    labels:
		    - foo: bar
		    metricName: metric1
		    ts: 1.533262651e&#43;09
		    valid: true
		    value: 10
		    
		    hpa:
		    - name: hpa
		    - namespace: default
		    labels:
		    - foo: bar
		    metricName: metric2
		    ts: 1.533262651e&#43;09
		    valid: false
		    value: 10
```