### PR TITLE
handle negative offsets in the ntp core check

### DIFF
--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -149,7 +149,7 @@ func (c *NTPCheck) Run() error {
 	} else {
 		if int(math.Abs(clockOffset)) > offsetThreshold {
 			serviceCheckStatus = metrics.ServiceCheckCritical
-			serviceCheckMessage = fmt.Sprintf("Offset %v secs higher than offset threshold (%v secs)", clockOffset, offsetThreshold)
+			serviceCheckMessage = fmt.Sprintf("Offset %v is higher than offset threshold (%v secs)", clockOffset, offsetThreshold)
 		} else {
 			serviceCheckStatus = metrics.ServiceCheckOK
 		}

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -8,6 +8,7 @@ package network
 import (
 	"expvar"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
@@ -146,7 +147,7 @@ func (c *NTPCheck) Run() error {
 		log.Info(err)
 		serviceCheckStatus = metrics.ServiceCheckUnknown
 	} else {
-		if int(clockOffset) > offsetThreshold {
+		if int(math.Abs(clockOffset)) > offsetThreshold {
 			serviceCheckStatus = metrics.ServiceCheckCritical
 			serviceCheckMessage = fmt.Sprintf("Offset %v secs higher than offset threshold (%v secs)", clockOffset, offsetThreshold)
 		} else {

--- a/releasenotes/notes/ntp-handle-negative-150ed17056fc2247.yaml
+++ b/releasenotes/notes/ntp-handle-negative-150ed17056fc2247.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The ntp check now handles negative offsets if the host time is in the
+    future.
+


### PR DESCRIPTION
### What does this PR do?

Offsets can be negative if the node time is in the future.