### PR TITLE
Add metric about number of payload dropped because they can't be split

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -127,3 +127,5 @@ instances:
         type: rate
       - path: splitter/TotalLoops
         type: rate
+      - path: splitter/PayloadDrops
+        type: rate

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/serializer/split"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -321,6 +322,15 @@ func (agg *BufferedAggregator) flushSeries() {
 	series = append(series, &metrics.Serie{
 		Name:           "datadog.agent.running",
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
+		Host:           agg.hostname,
+		MType:          metrics.APIGaugeType,
+		SourceTypeName: "System",
+	})
+
+	// Send along a metric that counts the number of times we dropped some payloads because we couldn't split them.
+	series = append(series, &metrics.Serie{
+		Name:           "n_o_i_n_d_e_x.datadog.agent.payload.dropped",
+		Points:         []metrics.Point{{Value: float64(split.GetPayloadDrops()), Ts: float64(start.Unix())}},
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",

--- a/pkg/serializer/split/split.go
+++ b/pkg/serializer/split/split.go
@@ -28,16 +28,18 @@ const (
 )
 
 var (
-	splitterExpvars    = expvar.NewMap("splitter")
-	splitterNotTooBig  = expvar.Int{}
-	splitterTooBig     = expvar.Int{}
-	splitterTotalLoops = expvar.Int{}
+	splitterExpvars      = expvar.NewMap("splitter")
+	splitterNotTooBig    = expvar.Int{}
+	splitterTooBig       = expvar.Int{}
+	splitterTotalLoops   = expvar.Int{}
+	splitterPayloadDrops = expvar.Int{}
 )
 
 func init() {
 	splitterExpvars.Set("NotTooBig", &splitterNotTooBig)
 	splitterExpvars.Set("TooBig", &splitterTooBig)
 	splitterExpvars.Set("TotalLoops", &splitterTotalLoops)
+	splitterExpvars.Set("PayloadDrops", &splitterPayloadDrops)
 
 }
 
@@ -94,6 +96,8 @@ func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarde
 			chunks, err := toSplit.SplitPayload(numChunks)
 			log.Debugf("payload was split into %f chunks", len(chunks))
 			if err != nil {
+				log.Warnf("Some payloads could not be splitted, dropping them")
+				splitterPayloadDrops.Add(1)
 				return smallEnoughPayloads, err
 			}
 			// after the payload has been split, loop through the chunks
@@ -122,6 +126,10 @@ func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarde
 			log.Debug("marshallers was not empty, running around the loop again")
 			loops++
 		}
+	}
+	if len(marshallers) != 0 {
+		log.Warnf("Some payloads could not be splitted enough, dropping them")
+		splitterPayloadDrops.Add(1)
 	}
 
 	return smallEnoughPayloads, nil
@@ -162,4 +170,9 @@ func marshal(m marshaler.Marshaler, mType MarshalType) ([]byte, error) {
 	default:
 		return m.MarshalJSON()
 	}
+}
+
+// GetPayloadDrops returns the number of times we dropped some payloads because we couldn't split them.
+func GetPayloadDrops() int64 {
+	return splitterPayloadDrops.Value()
 }


### PR DESCRIPTION
### What does this PR do?

Count the number of dropped payloads that couldn't be splitted, expose it through expvar and send it to datadog

### Motivation

All data points of the same metric need to be sent in one payload otherwise we drop then. We need to know when this problem will arise, because it will.
