### PR TITLE
[DCA] Rename pod metadata endpoint to tags endpoint.

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -103,7 +103,7 @@ func StopServer() {
 func validateToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.String()
-		if strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 || path == "/version" {
+		if strings.HasPrefix(path, "/api/v1/tags/") && len(strings.Split(path, "/")) == 7 || path == "/version" {
 			if err := util.ValidateDCARequest(w, r); err != nil {
 				return
 			}

--- a/cmd/cluster-agent/api/server_test.go
+++ b/cmd/cluster-agent/api/server_test.go
@@ -31,12 +31,12 @@ func TestValidateTokenMiddleware(t *testing.T) {
 			http.StatusForbidden,
 		},
 		{
-			"/api/v1/metadata/node/namespace/pod",
+			"/api/v1/tags/node/namespace/pod",
 			"abc123",
 			http.StatusOK,
 		},
 		{
-			"/api/v1/metadata/node/namespace/pod",
+			"/api/v1/tags/node/namespace/pod",
 			"imposter",
 			http.StatusForbidden,
 		},

--- a/docs/cluster-agent/GETTING_STARTED.md
+++ b/docs/cluster-agent/GETTING_STARTED.md
@@ -71,7 +71,7 @@ Create the ConfigMap accordingly:
 
 **Step 4** - Once the secret is created, create the Datadog Cluster Agent along with its service.
 Don't forget to add your `<DD_API_KEY>` in the manifest of the Datadog Cluster Agent. Both manifests can be found in the [manifest/cluster-agent directory](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/manifests)
-Run: 
+Run:
 
 `kubectl apply -f Dockerfiles/manifests/cluster-agent/datadog-cluster-agent_service.yaml`
 
@@ -148,7 +148,7 @@ Then, Kubernetes events should start to flow in your Datadog account, and releva
 
 To execute the following commands, you will first need to be inside the pod of the Cluster Agent or the Node Agent.
 You can use `kubectl exec -it <datadog-cluster-agent pod name> bash`
-  
+
 #### On the Datadog Cluster Agent side
 
 To see what cluster level metadata is served by the Datadog Cluster Agent exec in the pod and run:
@@ -191,8 +191,8 @@ To verify that the Datadog Cluster Agent is being queried, look for:
 
 ```
 root@datadog-cluster-agent-8568545574-x9tc9:/# tail -f /var/log/datadog/cluster-agent.log
-2018-06-11 09:37:20 UTC | DEBUG | (metadata.go:40 in GetPodMetadataNames) | CacheKey: agent/KubernetesMetadataMapping/ip-192-168-226-77.ec2.internal, with 1 services
-2018-06-11 09:37:20 UTC | DEBUG | (metadata.go:40 in GetPodMetadataNames) | CacheKey: agent/KubernetesMetadataMapping/ip-192-168-226-77.ec2.internal, with 1 services
+2018-06-11 09:37:20 UTC | DEBUG | (metadata.go:40 in GetPodClusterTags) | CacheKey: agent/KubernetesMetadataMapping/ip-192-168-226-77.ec2.internal, with 1 services
+2018-06-11 09:37:20 UTC | DEBUG | (metadata.go:40 in GetPodClusterTags) | CacheKey: agent/KubernetesMetadataMapping/ip-192-168-226-77.ec2.internal, with 1 services
 ```
 
 If you are not collecting events properly, make sure to have those environment variables set to true:

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -56,8 +56,7 @@ Secondly, it will start serving the `DD_CLUSTER_AGENT.CMD_PORT` if set or 5005 b
 ```
 - /hostname
 - /version
-- /api/v1/{check}/checks (available for Kubernetes only in 6.0.0)
-- /api/v1/metadata/{host}/{container:[0-9a-z]{64}} (returning the metadata of the said source available in the API Server)
+- /api/v1/tags/{nodeName}/{namespace}{container:[0-9a-z]{64}} (returning the cluster-level tags of the said source available in the API Server)
 - /flare
 - /stop
 - /status

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -48,13 +48,13 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 
 		tagList := utils.NewTagList()
 		if !config.Datadog.GetBool("cluster_agent.enabled") {
-			metadataNames, err = apiserver.GetPodMetadataNames(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
+			metadataNames, err = apiserver.GetPodClusterTags(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
 			if err != nil {
 				log.Errorf("Could not fetch cluster level tags for the pod %s: %s", po.Metadata.Name, err.Error())
 				continue
 			}
 		} else {
-			metadataNames, err = c.dcaClient.GetKubernetesMetadataNames(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
+			metadataNames, err = c.dcaClient.GetPodClusterTags(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
 			if err != nil {
 				log.Debugf("Could not pull the metadata map of po %s on node %s from the Datadog Cluster Agent: %s", po.Metadata.Name, po.Spec.NodeName, err.Error())
 				continue

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -191,10 +191,10 @@ func (c *DCAClient) GetVersion() (string, error) {
 	return dcaVersion, nil
 }
 
-// GetKubernetesMetadataNames queries the datadog cluster agent to get nodeName/podName registered
-// Kubernetes metadata.
-func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error) {
-	const dcaMetadataPath = "api/v1/metadata"
+// GetPodClusterTags queries the Datadog Cluster Agent to get nodeName/podName registered
+// cluster-level tags.
+func (c *DCAClient) GetPodClusterTags(nodeName, ns, podName string) ([]string, error) {
+	const dcaMetadataPath = "api/v1/tags"
 	var metadataNames metadataNames
 	var err error
 
@@ -205,7 +205,7 @@ func (c *DCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]
 		return nil, fmt.Errorf("namespace is empty")
 	}
 
-	// https://host:port/api/v1/metadata/{nodeName}/{ns}/{pod-[0-9a-z]+}
+	// https://host:port/api/v1/tags/{nodeName}/{ns}/{pod-[0-9a-z]+}
 	rawURL := fmt.Sprintf("%s/%s/%s/%s/%s", c.ClusterAgentAPIEndpoint, dcaMetadataPath, nodeName, ns, podName)
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -244,7 +244,7 @@ func (suite *clusterAgentSuite) TestGetClusterAgentEndpointFromKubernetesSvcEmpt
 	require.NotNil(suite.T(), err, fmt.Sprintf("%v", err))
 }
 
-func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
+func (suite *clusterAgentSuite) TestGetPodClusterTags() {
 	dca, err := newDummyClusterAgent()
 	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
 
@@ -302,7 +302,7 @@ func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 	}
 	for _, testCase := range testSuite {
 		suite.T().Run("", func(t *testing.T) {
-			svc, err := ca.GetKubernetesMetadataNames(testCase.nodeName, testCase.namespace, testCase.podName)
+			svc, err := ca.GetPodClusterTags(testCase.nodeName, testCase.namespace, testCase.podName)
 			t.Logf("svc: %s", svc)
 			require.Nil(t, err, fmt.Sprintf("%v", err))
 			require.Equal(t, len(testCase.expectedSvc), len(svc))

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -413,7 +413,7 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	return result.Into(output)
 }
 
-// StartMetadataController runs the controller to collect cluster-level tags. This is
+// StartMetadataController runs the metadata controller to collect cluster metadata. This is
 // only called once, when we have confirmed we could correctly connect to the API server.
 func StartMetadataController(stopCh chan struct{}) error {
 	var (

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -120,9 +120,8 @@ func (c *APIClient) connect() error {
 	return nil
 }
 
-// MetadataMapperBundle maps pod names to associated metadata.
-//
-// It is updated by mapServices in services.go.
+// MetadataMapperBundle contains cluster-level metadata for a node that maps pod names to metadata
+// about the pod. This is used to add cluster-level tags to metrics like the `kube_service` tag.
 type MetadataMapperBundle struct {
 	Services ServicesMapper `json:"services,omitempty"`
 	mapOnIP  bool           // temporary opt-out of the new mapping logic
@@ -414,7 +413,7 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	return result.Into(output)
 }
 
-// StartMetadataController runs the metadata controller to collect cluster metadata. This is
+// StartMetadataController runs the controller to collect cluster-level tags. This is
 // only called once, when we have confirmed we could correctly connect to the API server.
 func StartMetadataController(stopCh chan struct{}) error {
 	var (

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -31,9 +31,9 @@ func GetAPIClient() (*APIClient, error) {
 	return nil, nil
 }
 
-// GetPodMetadataNames is used when the API endpoint of the DCA to get the services of a pod is hit.
-func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
-	log.Errorf("GetPodMetadataNames not implemented %s", ErrNotCompiled.Error())
+// GetPodClusterTags returns a list of cluster-level tags for the specified pod, namespace, and node.
+func GetPodClusterTags(nodeName, ns, podName string) ([]string, error) {
+	log.Errorf("GetPodClusterTags not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }
 
@@ -47,10 +47,4 @@ func GetMetadataMapBundleOnNode(nodeName string) (map[string]interface{}, error)
 func GetMetadataMapBundleOnAllNodes(_ *APIClient) (map[string]interface{}, error) {
 	log.Errorf("GetMetadataMapBundleOnAllNodes not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
-}
-
-// StartClusterMetadataMapping is only called once, when we have confirmed we could correctly connect to the API server.
-func (c *APIClient) StartClusterMetadataMapping(_ chan struct{}) {
-	log.Errorf("StartClusterMetadataMapping not implemented %s", ErrNotCompiled.Error())
-	return
 }

--- a/pkg/util/kubernetes/apiserver/metadata.go
+++ b/pkg/util/kubernetes/apiserver/metadata.go
@@ -266,8 +266,8 @@ func (m *MetadataController) deleteMappedEndpoints(namespace, svc string) error 
 	return nil
 }
 
-// GetPodMetadataNames is used when the API endpoint of the DCA to get the metadata of a pod is hit.
-func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
+// GetPodClusterTags returns a list of cluster-level tags for the specified pod, namespace, and node.
+func GetPodClusterTags(nodeName, ns, podName string) ([]string, error) {
 	var metaList []string
 	cacheKey := agentcache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
 

--- a/pkg/util/kubernetes/apiserver/metadata_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_test.go
@@ -428,7 +428,7 @@ func TestMetadataController(t *testing.T) {
 		require.FailNow(t, "Timeout waiting for endpoints to sync")
 	}
 
-	metadataNames, err := GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
+	metadataNames, err := GetPodClusterTags(node.Name, pod.Namespace, pod.Name)
 	require.NoError(t, err)
 	assert.Len(t, metadataNames, 1)
 	assert.Contains(t, metadataNames, "kube_service:nginx-1")
@@ -451,7 +451,7 @@ func TestMetadataController(t *testing.T) {
 		require.FailNow(t, "Timeout waiting for endpoints to sync")
 	}
 
-	metadataNames, err = GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
+	metadataNames, err = GetPodClusterTags(node.Name, pod.Namespace, pod.Name)
 	require.NoError(t, err)
 	assert.Len(t, metadataNames, 2)
 	assert.Contains(t, metadataNames, "kube_service:nginx-1")


### PR DESCRIPTION
### What does this PR do?

Rename the following:

- `GetPodMetadataNames` -> `GetPodClusterTags`
- `/api/v1/metadata/{nodeName}/{ns}/{podName}` -> `/api/v1/tags/{nodeName}/{ns}/{podName}`
- `DCAClient.GetKubernetesMetadataNames` -> `DCAClient.GetPodClusterTags`

### Additional Information

This changes the `DCAClient` and will only work with Agent version 6.5.0 after this is merged.

### To Do

- [ ] Run DCA e2e tests locally to sanity check that the API still works