### PR TITLE
Add doc and improve the status page

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -10,27 +10,27 @@ Collector
   {{end -}}
 
   {{- range $CheckName, $CheckInstances := .Checks}}
-    {{ $version := version $CheckInstances}}
+    {{ $version := version $CheckInstances }}
     {{$CheckName}}{{ if $version }} ({{$version}}){{ end }}
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
-        Instance ID: {{.CheckID}} {{status .}}
-        Total Runs: {{humanize .TotalRuns}}
-        Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
-        Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
-        Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
-        Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
-        {{if .LastError -}}
-        Error: {{lastErrorMessage .LastError}}
-        {{lastErrorTraceback .LastError -}}
-        {{- end }}
-        {{- if .LastWarnings -}}
-          {{- range .LastWarnings }}
-        Warning: {{.}}
-          {{ end -}}
-        {{- end }}
-    {{ end }}
-  {{ end }}
+      Instance ID: {{.CheckID}} {{status .}}
+      Total Runs: {{humanize .TotalRuns}}
+      Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+      Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+      Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+      Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
+      {{if .LastError -}}
+      Error: {{lastErrorMessage .LastError}}
+      {{lastErrorTraceback .LastError -}}
+      {{- end }}
+      {{- if .LastWarnings -}}
+        {{- range .LastWarnings }}
+      Warning: {{.}}
+        {{ end -}}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- with .AutoConfigStats }}

--- a/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
@@ -11,9 +11,8 @@ Forwarder
   {{- end}}
   {{- if .Transactions.DroppedOnInput }}
 
-    Warning: the forwarder dropped transactions because all workers were busy.
-    You should review your network performance, and tune the forwarder_num_workers
-    and forwarder_timeout options.
+    Warning: the forwarder dropped transactions, there is probably an issue with your network
+    More info at https://github.com/DataDog/datadog-agent/tree/master/docs/agent/status.md
   {{- end}}
   {{- if .Transactions.Errors }}
 

--- a/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
@@ -6,7 +6,7 @@ Forwarder
   ============
   {{- range $key, $value := .Transactions }}
     {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode")}}
-  {{$key}}: {{humanize $value}}
+    {{$key}}: {{humanize $value}}
     {{- end}}
   {{- end}}
   {{- if .Transactions.DroppedOnInput }}
@@ -23,7 +23,7 @@ Forwarder
     Errors By Type:
           {{- range $type, $count := .Transactions.ErrorsByType }}
             {{- if $count }}
-      {{$type}}: {{$count}}
+      {{$type}}: {{humanize $count}}
             {{- end}}
           {{- end}}
   {{- end}}
@@ -34,7 +34,7 @@ Forwarder
     Total number: {{.Transactions.HTTPErrors}}
     HTTP Errors By Code:
       {{- range $code, $count := .Transactions.HTTPErrorsByCode }}
-      {{$code}}: {{$count}}
+      {{$code}}: {{humanize $count}}
       {{- end}}
   {{- end}}
 {{- end}}

--- a/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
@@ -2,6 +2,8 @@
 Forwarder
 =========
 {{ if .Transactions }}
+  Transactions
+  ============
   {{- range $key, $value := .Transactions }}
     {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode")}}
   {{$key}}: {{humanize $value}}
@@ -9,9 +11,9 @@ Forwarder
   {{- end}}
   {{- if .Transactions.DroppedOnInput }}
 
-  Warning: the forwarder dropped transactions because all workers were busy.
-  You should review your network performance, and tune the forwarder_num_workers
-  and forwarder_timeout options.
+    Warning: the forwarder dropped transactions because all workers were busy.
+    You should review your network performance, and tune the forwarder_num_workers
+    and forwarder_timeout options.
   {{- end}}
   {{- if .Transactions.Errors }}
 

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -249,7 +249,33 @@
         {{- if .HostnameUpdate}}
           Hostname Update: {{humanize .HostnameUpdate}}<br>
         {{- end }}
+      {{- end -}}
+    </span>
+  </div>
+
+  <div class="stat">
+    <span class="stat_title">DogStatsD</span>
+    <span class="stat_data">
+      {{- with .dogstatsdStats -}}
+        {{ if .EventPackets}}
+          Event Packets: {{.EventPackets}}<br>
+        {{ end -}}
+        {{- if .EventParseErrors}}
+          Event Parse Errors: {{.EventParseErrors}}<br>
         {{- end -}}
+        {{- if .MetricPackets}}
+          Metric Packets: {{.MetricPackets}}<br>
+        {{- end -}}
+        {{- if .MetricParseErrors}}
+          Metric Parse Errors: {{.MetricParseErrors}}<br>
+        {{- end -}}
+        {{- if .ServiceCheckPackets}}
+          Service Check Packets: {{.ServiceCheckPackets}}<br>
+        {{- end -}}
+        {{- if .ServiceCheckParseErrors}}
+          Service Check Parse Errors: {{.ServiceCheckParseErrors}}<br>
+        {{- end }}
+      {{- end -}}
     </span>
   </div>
 {{- end -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -134,7 +134,7 @@
               Errors By Type:<br>
               <span class="stat_subdata">
                 {{- range $type, $count := .Transactions.ErrorsByType }}
-                    {{$type}}: {{$count}}<br>
+                    {{$type}}: {{humanize $count}}<br>
                 {{- end}}
               </span>
             </span>
@@ -147,7 +147,7 @@
               HTTP Errors By Code:<br>
               <span class="stat_subdata">
                 {{- range $code, $count := .Transactions.HTTPErrorsByCode }}
-                    {{$code}}: {{$count}}<br>
+                    {{$code}}: {{humanize $count}}<br>
                 {{- end}}
               </span>
             </span>
@@ -257,23 +257,8 @@
     <span class="stat_title">DogStatsD</span>
     <span class="stat_data">
       {{- with .dogstatsdStats -}}
-        {{ if .EventPackets}}
-          Event Packets: {{.EventPackets}}<br>
-        {{ end -}}
-        {{- if .EventParseErrors}}
-          Event Parse Errors: {{.EventParseErrors}}<br>
-        {{- end -}}
-        {{- if .MetricPackets}}
-          Metric Packets: {{.MetricPackets}}<br>
-        {{- end -}}
-        {{- if .MetricParseErrors}}
-          Metric Parse Errors: {{.MetricParseErrors}}<br>
-        {{- end -}}
-        {{- if .ServiceCheckPackets}}
-          Service Check Packets: {{.ServiceCheckPackets}}<br>
-        {{- end -}}
-        {{- if .ServiceCheckParseErrors}}
-          Service Check Parse Errors: {{.ServiceCheckParseErrors}}<br>
+        {{- range $key, $value := .}}
+          {{formatTitle $key}}: {{humanize $value}}<br>
         {{- end }}
       {{- end -}}
     </span>

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -204,17 +204,23 @@
   </div>
 
   <div class="stat">
-    <span class="stat_title">DogStatsD</span>
+    <span class="stat_title">Aggregator</span>
     <span class="stat_data">
       {{- with .aggregatorStats -}}
         {{- if .ChecksMetricSample}}
           Checks Metric Sample: {{humanize .ChecksMetricSample}}<br>
         {{- end -}}
+        {{- if .DogstatsdMetricSample}}
+          Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}<br>
+        {{- end}}
         {{- if .Event}}
           Event: {{humanize .Event}}<br>
         {{- end -}}
         {{- if .EventsFlushed}}
           Events Flushed: {{humanize .EventsFlushed}}<br>
+        {{- end -}}
+        {{- if .EventsFlushErrors}}
+          Events Flush Errors: {{.EventsFlushErrors}}<br>
         {{- end -}}
         {{- if .NumberOfFlush}}
           Number Of Flushes: {{humanize .NumberOfFlush}}<br>
@@ -222,22 +228,28 @@
         {{- if .SeriesFlushed}}
           Series Flushed: {{humanize .SeriesFlushed}}<br>
         {{- end -}}
+        {{- if .SeriesFlushErrors}}
+          Series Flush Errors: {{.SeriesFlushErrors}}<br>
+        {{- end -}}
         {{- if .ServiceCheck}}
           Service Check: {{humanize .ServiceCheck}}<br>
         {{- end -}}
         {{- if .ServiceCheckFlushed}}
           Service Checks Flushed: {{humanize .ServiceCheckFlushed}}<br>
         {{- end -}}
+        {{- if .ServiceCheckFlushErrors}}
+          Service Checks Flush Errors: {{.ServiceCheckFlushErrors}}<br>
+        {{- end -}}
         {{- if .SketchesFlushed}}
           Sketches Flushed: {{humanize .SketchesFlushed}}<br>
         {{- end -}}
+        {{- if .SketchesFlushErrors}}
+          Sketches Flush Errors: {{.SketchesFlushErrors}}<br>
+        {{- end -}}
         {{- if .HostnameUpdate}}
           Hostname Update: {{humanize .HostnameUpdate}}<br>
+        {{- end }}
         {{- end -}}
-        {{- if .DogstatsdMetricSample}}
-          Dogstatsd Metric Sample: {{humanize .DogstatsdMetricSample}}<br>
-        {{- end}}
-      {{- end -}}
     </span>
   </div>
 {{- end -}}

--- a/docs/agent/status.md
+++ b/docs/agent/status.md
@@ -1,0 +1,36 @@
+# Status page
+
+The agent status page, `datadog-agent status` or `Status` -> `General` on the gui display information about the running services.
+
+## Collector
+
+### Running Checks
+
+List of running check instances.
+
+- Total Runs: total number of times this instance has run
+- Metric Samples: Number of fetched metrics
+- Events: Number of triggered events
+- Service Checks: Number of service checks reported
+    - Last Run: during the last check run
+    - Total: since the agent has started
+
+
+## JMX Fetch
+
+## Forwarder
+
+## Aggregator
+
+Flush: the aggregator stores metrics, events, etc sent to it in a queue. The queue is emptied once per flush interval and the data is sent to the forwarder
+
+- Checks Metric Sample: Total number of metrics sent from the checks to the aggregator
+- Dogstatsd Metric Sample: Total number of metrics sent from the dogstatsd server to the aggregator
+- Event: Total number of events sent to the aggregator
+- Service Check: Total number of service checks sent to the agrregator
+
+
+## Logs Agent
+
+## DogStatsD
+

--- a/docs/agent/status.md
+++ b/docs/agent/status.md
@@ -8,19 +8,67 @@ The agent status page, `datadog-agent status` or `Status` -> `General` on the gu
 
 List of running check instances.
 
+example:
+
+```
+    load
+    ----
+      Total Runs: 4
+      Metric Samples: Last Run: 6, Total: 24
+      Events: Last Run: 0, Total: 0
+      Service Checks: Last Run: 0, Total: 0
+      Average Execution Time : 6ms
+```
+
 - Total Runs: total number of times this instance has run
 - Metric Samples: Number of fetched metrics
 - Events: Number of triggered events
-- Service Checks: Number of service checks reported
-    - Last Run: during the last check run
-    - Total: since the agent has started
+- Service Checks: Number of service checks reported (OK|WARNING|ERROR)
+- Last Run: during the last check run
+- Total: since the agent has started
 
 
 ## JMX Fetch
 
 ## Forwarder
 
+example:
+```
+=========
+Forwarder
+=========
+
+  CheckRunsV1: 3
+  IntakeV1: 2
+  TimeseriesV1: 3
+  Errors: 1
+```
+
+CheckRunsV1: Number of sent service check payloads
+IntakeV1: Number of sent event payloads
+TimeseriesV1: Number of sent metrics payloads
+Errors: Number of errors during payload sending
+
+
+
+
 ## Aggregator
+
+example:
+
+```
+=========
+Aggregator
+=========
+
+  Checks Metric Sample: 145
+  Event: 1
+  Events Flushed: 1
+  Number Of Flushes: 3
+  Series Flushed: 80
+  Service Check: 26
+  Service Checks Flushed: 24
+```
 
 Flush: the aggregator stores metrics, events, etc sent to it in a queue. The queue is emptied once per flush interval and the data is sent to the forwarder
 

--- a/docs/agent/status.md
+++ b/docs/agent/status.md
@@ -48,6 +48,10 @@ example:
 
 ## JMX Fetch
 
+
+List of loaded and failed JMX-based checks
+
+
 ## Forwarder
 
 example:

--- a/docs/agent/status.md
+++ b/docs/agent/status.md
@@ -44,11 +44,13 @@ Forwarder
   Errors: 1
 ```
 
-CheckRunsV1: Number of sent service check payloads
-IntakeV1: Number of sent event payloads
-TimeseriesV1: Number of sent metrics payloads
-Errors: Number of errors during payload sending
+- CheckRunsV1: Number of sent service check payloads
+- IntakeV1: Number of sent event payloads
+- TimeseriesV1: Number of sent metrics payloads
+- Errors: Number of errors during payload sending
 
+The forwarder uses a number of workers to send the payloads to the backend.
+If you see a warning like this `the forwarder dropped transactions, there is probably an issue with your network`, this means that all the workers were busy. You should review your network performance, and tune the `forwarder_num_workers` and `forwarder_timeout options`.
 
 
 

--- a/docs/agent/status.md
+++ b/docs/agent/status.md
@@ -27,6 +27,24 @@ example:
 - Last Run: during the last check run
 - Total: since the agent has started
 
+### Loading Errors
+
+List of checks that were not loaded successfully
+
+example:
+
+```
+    apm
+    ---
+      Core Check Loader:
+        Could not configure check APM Agent: APM agent disabled through main configuration file
+
+      JMX Check Loader:
+        check is not a jmx check, or unable to determine if it's so
+
+      Python Check Loader:
+        No module named apm
+```
 
 ## JMX Fetch
 
@@ -52,7 +70,9 @@ Forwarder
 The forwarder uses a number of workers to send the payloads to the backend.
 If you see a warning like this `the forwarder dropped transactions, there is probably an issue with your network`, this means that all the workers were busy. You should review your network performance, and tune the `forwarder_num_workers` and `forwarder_timeout options`.
 
+## Logs Agent
 
+TODO
 
 ## Aggregator
 
@@ -80,7 +100,20 @@ Flush: the aggregator stores metrics, events, etc sent to it in a queue. The que
 - Service Check: Total number of service checks sent to the agrregator
 
 
-## Logs Agent
-
 ## DogStatsD
 
+example:
+
+```
+=========
+DogStatsD
+=========
+  Event Packets: 12
+  Event Parse Errors: 0
+  Metric Packets: 433
+  Metric Parse Errors: 0
+  Service Check Packets: 3
+  Service Check Parse Errors: 0
+  ```
+
+Number of packets received by the DogStatsD server for each type of data (metrics, events and service checks) and associated errors

--- a/pkg/status/dist/templates/aggregator.tmpl
+++ b/pkg/status/dist/templates/aggregator.tmpl
@@ -2,16 +2,22 @@
 NOTE: Changes made to this template should be reflected on the following templates, if applicable:
 * cmd/agent/gui/views/templates/generalStatus.tmpl
 */}}=========
-DogStatsD
+Aggregator
 =========
 {{ if .ChecksMetricSample }}
   Checks Metric Sample: {{humanize .ChecksMetricSample}}
 {{- end -}}
+{{- if .DogstatsdMetricSample}}
+  Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}
+{{- end}}
 {{- if .Event}}
   Event: {{humanize .Event}}
 {{- end -}}
 {{- if .EventsFlushed}}
   Events Flushed: {{humanize .EventsFlushed}}
+{{- end -}}
+{{- if .EventsFlushErrors}}
+  Events Flush Errors: {{.EventsFlushErrors}}
 {{- end -}}
 {{- if .NumberOfFlush}}
   Number Of Flushes: {{humanize .NumberOfFlush}}
@@ -19,18 +25,24 @@ DogStatsD
 {{- if .SeriesFlushed}}
   Series Flushed: {{humanize .SeriesFlushed}}
 {{- end -}}
+{{- if .SeriesFlushErrors}}
+  Series Flush Errors: {{.SeriesFlushErrors}}
+{{- end -}}
 {{- if .ServiceCheck}}
   Service Check: {{humanize .ServiceCheck}}
 {{- end -}}
 {{- if .ServiceCheckFlushed}}
   Service Checks Flushed: {{humanize .ServiceCheckFlushed}}
 {{- end -}}
+{{- if .ServiceCheckFlushErrors}}
+  Service Checks Flush Errors: {{.ServiceCheckFlushErrors}}
+{{- end -}}
 {{- if .SketchesFlushed}}
   Sketches Flushed: {{humanize .SketchesFlushed}}
+{{- end -}}
+{{- if .SketchesFlushErrors}}
+  Sketches Flush Errors: {{.SketchesFlushErrors}}
 {{- end -}}
 {{- if .HostnameUpdate}}
   Hostname Update: {{humanize .HostnameUpdate}}
 {{- end -}}
-{{- if .DogstatsdMetricSample}}
-  Dogstatsd Metric Sample: {{humanize .DogstatsdMetricSample}}
-{{- end}}

--- a/pkg/status/dist/templates/aggregator.tmpl
+++ b/pkg/status/dist/templates/aggregator.tmpl
@@ -4,45 +4,46 @@ NOTE: Changes made to this template should be reflected on the following templat
 */}}=========
 Aggregator
 =========
-{{ if .ChecksMetricSample }}
+{{- if .ChecksMetricSample }}
   Checks Metric Sample: {{humanize .ChecksMetricSample}}
-{{- end -}}
+{{- end }}
 {{- if .DogstatsdMetricSample}}
-  Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}
-{{- end}}
+  Dogstatsd Metric Sample: {{humanize .DogstatsdMetricSample}}
+{{- end }}
 {{- if .Event}}
   Event: {{humanize .Event}}
-{{- end -}}
+{{- end }}
 {{- if .EventsFlushed}}
   Events Flushed: {{humanize .EventsFlushed}}
-{{- end -}}
+{{- end }}
 {{- if .EventsFlushErrors}}
-  Events Flush Errors: {{.EventsFlushErrors}}
-{{- end -}}
+  Events Flush Errors: {{humanize .EventsFlushErrors}}
+{{- end }}
 {{- if .NumberOfFlush}}
   Number Of Flushes: {{humanize .NumberOfFlush}}
-{{- end -}}
+{{- end }}
 {{- if .SeriesFlushed}}
   Series Flushed: {{humanize .SeriesFlushed}}
-{{- end -}}
+{{- end }}
 {{- if .SeriesFlushErrors}}
-  Series Flush Errors: {{.SeriesFlushErrors}}
-{{- end -}}
+  Series Flush Errors: {{humanize .SeriesFlushErrors}}
+{{- end }}
 {{- if .ServiceCheck}}
   Service Check: {{humanize .ServiceCheck}}
-{{- end -}}
+{{- end }}
 {{- if .ServiceCheckFlushed}}
   Service Checks Flushed: {{humanize .ServiceCheckFlushed}}
-{{- end -}}
+{{- end }}
 {{- if .ServiceCheckFlushErrors}}
-  Service Checks Flush Errors: {{.ServiceCheckFlushErrors}}
-{{- end -}}
+  Service Checks Flush Errors: {{humanize .ServiceCheckFlushErrors}}
+{{- end }}
 {{- if .SketchesFlushed}}
   Sketches Flushed: {{humanize .SketchesFlushed}}
-{{- end -}}
+{{- end }}
 {{- if .SketchesFlushErrors}}
-  Sketches Flush Errors: {{.SketchesFlushErrors}}
-{{- end -}}
+  Sketches Flush Errors: {{humanize .SketchesFlushErrors}}
+{{- end }}
 {{- if .HostnameUpdate}}
   Hostname Update: {{humanize .HostnameUpdate}}
-{{- end -}}
+{{- end }}
+

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -19,21 +19,21 @@ Collector
     {{$CheckName}}{{ if $version }} ({{$version}}){{ end }}
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
-        Instance ID: {{.CheckID}} {{status .}}
-        Total Runs: {{humanize .TotalRuns}}
-        Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
-        Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
-        Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
-        Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
-        {{if .LastError -}}
-        Error: {{lastErrorMessage .LastError}}
-        {{lastErrorTraceback .LastError -}}
-        {{- end }}
-        {{- if .LastWarnings -}}
-          {{- range .LastWarnings }}
-        Warning: {{.}}
-          {{ end -}}
-        {{- end }}
+      Instance ID: {{.CheckID}} {{status .}}
+      Total Runs: {{humanize .TotalRuns}}
+      Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+      Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+      Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+      Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
+      {{if .LastError -}}
+      Error: {{lastErrorMessage .LastError}}
+      {{lastErrorTraceback .LastError -}}
+      {{- end }}
+      {{- if .LastWarnings -}}
+        {{- range .LastWarnings }}
+      Warning: {{.}}
+        {{ end -}}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -21,9 +21,9 @@ Collector
     {{- range $CheckInstances }}
         Instance ID: {{.CheckID}} {{status .}}
         Total Runs: {{humanize .TotalRuns}}
-        Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
-        Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
-        Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+        Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+        Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+        Service Checks: Last Run: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
         Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
         {{if .LastError -}}
         Error: {{lastErrorMessage .LastError}}

--- a/pkg/status/dist/templates/dogstatsd.tmpl
+++ b/pkg/status/dist/templates/dogstatsd.tmpl
@@ -1,0 +1,24 @@
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}=========
+DogStatsD
+=========
+{{ if .EventPackets}}
+  Event Packets: {{.EventPackets}}
+{{ end -}}
+{{- if .EventParseErrors}}
+  Event Parse Errors: {{.EventParseErrors}}
+{{- end -}}
+{{- if .MetricPackets}}
+  Metric Packets: {{.MetricPackets}}
+{{- end -}}
+{{- if .MetricParseErrors}}
+  Metric Parse Errors: {{.MetricParseErrors}}
+{{- end -}}
+{{- if .ServiceCheckPackets}}
+  Service Check Packets: {{.ServiceCheckPackets}}
+{{- end -}}
+{{- if .ServiceCheckParseErrors}}
+  Service Check Parse Errors: {{.ServiceCheckParseErrors}}
+{{- end }}

--- a/pkg/status/dist/templates/dogstatsd.tmpl
+++ b/pkg/status/dist/templates/dogstatsd.tmpl
@@ -4,21 +4,6 @@ NOTE: Changes made to this template should be reflected on the following templat
 */}}=========
 DogStatsD
 =========
-{{ if .EventPackets}}
-  Event Packets: {{.EventPackets}}
-{{ end -}}
-{{- if .EventParseErrors}}
-  Event Parse Errors: {{.EventParseErrors}}
-{{- end -}}
-{{- if .MetricPackets}}
-  Metric Packets: {{.MetricPackets}}
-{{- end -}}
-{{- if .MetricParseErrors}}
-  Metric Parse Errors: {{.MetricParseErrors}}
-{{- end -}}
-{{- if .ServiceCheckPackets}}
-  Service Check Packets: {{.ServiceCheckPackets}}
-{{- end -}}
-{{- if .ServiceCheckParseErrors}}
-  Service Check Parse Errors: {{.ServiceCheckParseErrors}}
+{{- range $key, $value := .}}
+  {{formatTitle $key}}: {{humanize $value}}
 {{- end }}

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -10,7 +10,7 @@ Forwarder
   ============
   {{- range $key, $value := .Transactions }}
     {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode")}}
-  {{$key}}: {{humanize $value}}
+    {{$key}}: {{humanize $value}}
     {{- end}}
   {{- end}}
   {{- if .Transactions.DroppedOnInput }}
@@ -27,7 +27,7 @@ Forwarder
     Errors By Type:
           {{- range $type, $count := .Transactions.ErrorsByType }}
             {{- if $count }}
-      {{$type}}: {{$count}}
+      {{$type}}: {{humanize $count}}
             {{- end}}
           {{- end}}
   {{- end}}
@@ -38,7 +38,7 @@ Forwarder
     Total number: {{.Transactions.HTTPErrors}}
     HTTP Errors By Code:
       {{- range $code, $count := .Transactions.HTTPErrorsByCode }}
-      {{$code}}: {{$count}}
+      {{$code}}: {{humanize $count}}
       {{- end}}
   {{- end}}
 {{- end}}

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -6,6 +6,8 @@ NOTE: Changes made to this template should be reflected on the following templat
 Forwarder
 =========
 {{ if .Transactions }}
+  Transactions
+  ============
   {{- range $key, $value := .Transactions }}
     {{- if and (ne $key "Errors") (ne $key "ErrorsByType") (ne $key "HTTPErrors") (ne $key "HTTPErrorsByCode")}}
   {{$key}}: {{humanize $value}}
@@ -13,9 +15,9 @@ Forwarder
   {{- end}}
   {{- if .Transactions.DroppedOnInput }}
 
-  Warning: the forwarder dropped transactions because all workers were busy.
-  You should review your network performance, and tune the forwarder_num_workers
-  and forwarder_timeout options.
+    Warning: the forwarder dropped transactions because all workers were busy.
+    You should review your network performance, and tune the forwarder_num_workers
+    and forwarder_timeout options.
   {{- end}}
   {{- if .Transactions.Errors }}
 

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -15,9 +15,8 @@ Forwarder
   {{- end}}
   {{- if .Transactions.DroppedOnInput }}
 
-    Warning: the forwarder dropped transactions because all workers were busy.
-    You should review your network performance, and tune the forwarder_num_workers
-    and forwarder_timeout options.
+    Warning: the forwarder dropped transactions, there is probably an issue with your network
+    More info at https://github.com/DataDog/datadog-agent/tree/master/docs/agent/status.md
   {{- end}}
   {{- if .Transactions.Errors }}
 

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -40,6 +40,7 @@ func FormatStatus(data []byte) (string, error) {
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
 	aggregatorStats := stats["aggregatorStats"]
+	dogstatsdStats := stats["dogstatsdStats"]
 	jmxStats := stats["JMXStatus"]
 	logsStats := stats["logsStats"]
 	dcaStats := stats["clusterAgentStatus"]
@@ -51,7 +52,7 @@ func FormatStatus(data []byte) (string, error) {
 	renderForwarderStatus(b, forwarderStats)
 	renderLogsStatus(b, logsStats)
 	renderAggregatorStatus(b, aggregatorStats)
-	// renderDogstatsdStatus(b, aggregatorStats)
+	renderDogstatsdStatus(b, dogstatsdStats)
 	if config.Datadog.GetBool("cluster_agent.enabled") {
 		renderDatadogClusterAgentStatus(b, dcaStats)
 	}
@@ -117,9 +118,9 @@ func renderAggregatorStatus(w io.Writer, aggregatorStats interface{}) {
 	}
 }
 
-func renderDogstatsdStatus(w io.Writer, aggregatorStats interface{}) {
+func renderDogstatsdStatus(w io.Writer, dogstatsdStats interface{}) {
 	t := template.Must(template.New("dogstatsd.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "dogstatsd.tmpl")))
-	err := t.Execute(w, aggregatorStats)
+	err := t.Execute(w, dogstatsdStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -50,7 +50,8 @@ func FormatStatus(data []byte) (string, error) {
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
 	renderLogsStatus(b, logsStats)
-	renderDogstatsdStatus(b, aggregatorStats)
+	renderAggregatorStatus(b, aggregatorStats)
+	// renderDogstatsdStatus(b, aggregatorStats)
 	if config.Datadog.GetBool("cluster_agent.enabled") {
 		renderDatadogClusterAgentStatus(b, dcaStats)
 	}
@@ -103,6 +104,14 @@ func FormatMetadataMapCLI(data []byte) (string, error) {
 func renderHeader(w io.Writer, stats map[string]interface{}) {
 	t := template.Must(template.New("header.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "header.tmpl")))
 	err := t.Execute(w, stats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderAggregatorStatus(w io.Writer, aggregatorStats interface{}) {
+	t := template.Must(template.New("aggregator.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "aggregator.tmpl")))
+	err := t.Execute(w, aggregatorStats)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -211,6 +211,11 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	json.Unmarshal(aggregatorStatsJSON, &aggregatorStats)
 	stats["aggregatorStats"] = aggregatorStats
 
+	dogstatsdStatsJSON := []byte(expvar.Get("dogstatsd").String())
+	dogstatsdStats := make(map[string]interface{})
+	json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats)
+	stats["dogstatsdStats"] = aggregatorStats
+
 	pyLoaderData := expvar.Get("pyLoader")
 	if pyLoaderData != nil {
 		pyLoaderStatsJSON := []byte(pyLoaderData.String())

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -214,7 +214,7 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	dogstatsdStatsJSON := []byte(expvar.Get("dogstatsd").String())
 	dogstatsdStats := make(map[string]interface{})
 	json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats)
-	stats["dogstatsdStats"] = aggregatorStats
+	stats["dogstatsdStats"] = dogstatsdStats
 
 	pyLoaderData := expvar.Get("pyLoader")
 	if pyLoaderData != nil {


### PR DESCRIPTION
### What does this PR do?

- [x] Display aggregator stats in a new "Aggregator" section, not the "DogStatsD" section
- [x] Display dogstatsd stats in the "DogStatsD" section
- [x] Fix "Forwarder" section on the gui
- [x] Detail check status
- [x] Docs on the figures displayed on the status

### Motivation

Questions where asked on how to interpret the status page of agent 6

We should write a doc explaining what is everything: what is a sample, a flush, Metrics Samples vs Total Sample, how metrics samples are reset at each run where dogstatsd is not ... 
