### PR TITLE
remove container_name from kubelet tag collector

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
@@ -104,11 +103,6 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			highC := append(high, fmt.Sprintf("container_id:%s", kubelet.TrimRuntimeFromCID(container.ID)))
 			if container.Name != "" && pod.Metadata.Name != "" {
 				highC = append(highC, fmt.Sprintf("display_container_name:%s_%s", container.Name, pod.Metadata.Name))
-			}
-
-			// REMOVEME: remove when live view / map handles `display_container_name`
-			if !strings.HasPrefix(container.ID, docker.DockerEntityPrefix) {
-				highC = append(highC, fmt.Sprintf("container_name:%s_%s", container.Name, pod.Metadata.Name))
 			}
 
 			// check image tag in spec

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -332,7 +332,6 @@ func TestParsePods(t *testing.T) {
 				},
 				HighCardTags: []string{
 					"pod_name:redis-master-bpnn6",
-					"container_name:redis-master_redis-master-bpnn6", // Temporary for non-docker containers
 					"display_container_name:redis-master_redis-master-bpnn6",
 					"container_id:acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1",
 					"kube_replica_set:redis-master-546dc4865f",


### PR DESCRIPTION
The app now supports the new display_container_name as
an override

`noreno` as the tag was not released yet
