### PR TITLE
[windows] Fix io metrics collection for mountpoints

### DIFF
--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -25,7 +25,8 @@ var (
 	procGetLogicalDriveStringsW = modkernel32.NewProc("GetLogicalDriveStringsW")
 	procGetDriveType            = modkernel32.NewProc("GetDriveTypeW")
 
-	drivePattern = regexp.MustCompile(`[A-Za-z]:`)
+	driveLetterPattern    = regexp.MustCompile(`[A-Za-z]:`)
+	unmountedDrivePattern = regexp.MustCompile(`HarddiskVolume([0-9])+`)
 )
 
 const (
@@ -44,7 +45,10 @@ type IOCheck struct {
 }
 
 func isDrive(instance string) bool {
-	if !drivePattern.MatchString(instance) {
+	if unmountedDrivePattern.MatchString(instance) {
+		return true
+	}
+	if !driveLetterPattern.MatchString(instance) {
 		return false
 	}
 	instance += "\\"

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 )
 
@@ -36,8 +35,6 @@ const (
 	DRIVE_FIXED          = 3
 )
 
-var drivelist []string
-
 // IOCheck doesn't need additional fields
 type IOCheck struct {
 	core.CheckBase
@@ -46,35 +43,11 @@ type IOCheck struct {
 	counternames map[string]string
 }
 
-func init() {
-	drivebuf := make([]uint16, 256)
-
-	// Windows API GetLogicalDriveStrings returns all of the assigned drive letters
-	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa364975(v=vs.85).aspx
-	r, _, _ := procGetLogicalDriveStringsW.Call(
-		uintptr(len(drivebuf)),
-		uintptr(unsafe.Pointer(&drivebuf[0])))
-	if r == 0 {
-		return
-	}
-	drivelist = winutil.ConvertWindowsStringList(drivebuf)
-}
-
 func isDrive(instance string) bool {
-	found := false
 	if !drivePattern.MatchString(instance) {
 		return false
 	}
 	instance += "\\"
-	for _, driveletter := range drivelist {
-		if instance == driveletter {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return false
-	}
 	r, _, _ := procGetDriveType.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(instance))))
 	if r != DRIVE_FIXED {
 		return false

--- a/releasenotes/notes/Fix-io-metrics-collection-for-mountpoints-c775bcab80daff9b.yaml
+++ b/releasenotes/notes/Fix-io-metrics-collection-for-mountpoints-c775bcab80daff9b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    collect io metrics for drives with path only (like: C:\C0) on Windows


### PR DESCRIPTION
Currently Agent 6 only collects io metrics for:
 - drive letters (like C:)
but not for: 
- drive paths (like a drive mounted in C:\C0)
- unmounted drives (shown as harddiskvolumeX by windows).

Agent 5 collects io metrics for all these kinds of drives

### What does this PR do?

Make agent 6 have the same behavior as agent 5.

Note: Agent 5 only removes the "_Total" fake drive from the metrics, Agent 6 filtering is more complicated so we might be still discarded some other useful types of drive.

### Motivation

Ease upgrade process. Collect missing metrics

