### PR TITLE
Store configuration origin

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -211,7 +211,9 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 
 		// resolve configs if needed
 		for _, config := range cfgs {
+			// set config's provider and origin
 			config.Provider = pd.provider.String()
+			config.Origin = integration.NewConfig
 			rc := ac.resolve(config)
 			resolvedConfigs = append(resolvedConfigs, rc...)
 		}
@@ -479,7 +481,9 @@ func (ac *AutoConfig) pollConfigs() {
 					ac.processRemovedConfigs(removedConfigs)
 
 					for _, config := range newConfigs {
+						// set config's provider and origin
 						config.Provider = pd.provider.String()
+						config.Origin = integration.NewConfig
 						resolvedConfigs := ac.resolve(config)
 						ac.schedule(resolvedConfigs)
 					}

--- a/pkg/autodiscovery/configresolver.go
+++ b/pkg/autodiscovery/configresolver.go
@@ -241,6 +241,9 @@ func (cr *ConfigResolver) processNewService(svc listeners.Service) {
 		}
 		errorStats.removeResolveWarnings(config.Name)
 
+		// set the config origin
+		config.Origin = integration.NewService
+
 		// ask the Collector to schedule the checks
 		cr.ac.schedule([]integration.Config{config})
 	}

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -27,6 +27,16 @@ type RawMap map[interface{}]interface{}
 // JSONMap is the generic type to hold JSON configurations
 type JSONMap map[string]interface{}
 
+// Origin is the origin of the config
+type Origin int
+
+const (
+	// NewService indicates the config was created from a service event
+	NewService Origin = iota
+	// NewConfig indicates the config was created from a config event
+	NewConfig
+)
+
 // Config is a generic container for configuration files
 type Config struct {
 	Name          string   `json:"check_name"`     // the name of the check
@@ -37,6 +47,7 @@ type Config struct {
 	ADIdentifiers []string `json:"ad_identifiers"` // the list of AutoDiscovery identifiers (optional)
 	Provider      string   `json:"provider"`       // the provider that issued the config
 	ClusterCheck  bool     `json:"-"`              // cluster-check configuration flag, don't expose in JSON
+	Origin        Origin   `json:"-"`              // configuration's origin
 }
 
 // Equal determines whether the passed config is the same


### PR DESCRIPTION
### What does this PR do?

Add the configuration origin (coming from the config or service listening)

### Motivation

This is needed for the log's team to know if they have to tail from the start or the end
