### PR TITLE
pass the generated datadog-cluster.yaml file as artifact

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,6 +205,7 @@ cluster_agent-build:
   script:
     - inv -e cluster-agent.build
     - $S3_CP_CMD $SRC_PATH/$CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $S3_ARTEFACTS_URI/datadog-cluster-agent
+    - $S3_CP_CMD $SRC_PATH/Dockerfiles/cluster-agent/datadog-cluster.yaml $S3_ARTEFACTS_URI/datadog-cluster.yaml
 
 #
 # integration_test


### PR DESCRIPTION
### What does this PR do?

pass the generated datadog-cluster.yaml file as gitlab artifact

### Motivation

fix image build: `datadog/cluster-agent-dev:xvello-dca-image` pushed to the hub
