### PR TITLE
Make agent status page human readable

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -16,7 +16,7 @@ Collector
       Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: {{.Events}}, Total: {{humanize .TotalEvents}}
       Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
-      Average Execution Time : {{.AverageExecutionTime}}ms
+      Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
       {{if .LastError -}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/forwarder.tmpl
@@ -3,7 +3,7 @@ Forwarder
 =========
 {{ if .Transactions }}
   {{- range $key, $value := .Transactions }}
-  {{$key}}: {{$value}}
+  {{$key}}: {{humanize $value}}
   {{- end }}
   {{- if .Transactions.DroppedOnInput }}
 

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -11,10 +11,10 @@
           <span class="stat_subtitle">{{.CheckName}}{{ if .CheckVersion }} ({{.CheckVersion}}){{ end }}</span>
           <span class="stat_subdata">
               Total Runs: {{.TotalRuns}}<br>
-              Metric Samples: {{.MetricSamples}}, Total: {{humanizeF .TotalMetricSamples}}<br>
-              Events: {{.Events}}, Total: {{humanizeF .TotalEvents}}<br>
-              Service Checks: {{.ServiceChecks}}, Total: {{humanizeF .TotalServiceChecks}}<br>
-              Average Execution Time : {{.AverageExecutionTime}}ms<br>
+              Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
+              Events: {{.Events}}, Total: {{humanize .TotalEvents}}<br>
+              Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+              Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
             {{- if .LastError}}
               <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
                     {{lastErrorTraceback .LastError -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -22,7 +22,7 @@
     <span class="stat_data">
       System UTC Time: {{.time}}
       {{- if .ntpOffset}}
-        <br>NTP Offset: {{.ntpOffset}}s
+        <br>NTP Offset: {{ humanizeDuration .ntpOffset "s"}}
       {{end}}
       <br>Go Version: {{.platform.goV}}
       <br>Python Version: {{.platform.pythonV}}
@@ -37,8 +37,9 @@
           {{- if ne $type "hostid" -}}
             {{if $value}}
               {{formatTitle $type}}: {{if eq $type "bootTime" -}}{{- formatUnixTime $value -}}
+                              {{- else -}}{{- if eq $type "uptime" -}}{{- humanizeDuration $value "s" -}}
                               {{- else -}}{{- $value -}}
-                              {{- end -}}<br>
+                              {{- end -}}{{- end -}}<br>
             {{end -}}
           {{end -}}
         {{end -}}
@@ -115,7 +116,7 @@
       {{- with .forwarderStats -}}
         {{- if .TransactionsCreated -}}
           {{- range $key, $value := .TransactionsCreated}}
-            {{formatTitle $key}}: {{$value}}<br>
+            {{formatTitle $key}}: {{humanize $value}}<br>
           {{- end -}}
         {{- end}}
         {{- if .APIKeyStatus}}
@@ -164,34 +165,34 @@
     <span class="stat_data">
       {{- with .aggregatorStats -}}
         {{- if .ChecksMetricSample}}
-          Checks Metric Sample: {{.ChecksMetricSample}}<br>
+          Checks Metric Sample: {{humanize .ChecksMetricSample}}<br>
         {{- end -}}
         {{- if .Event}}
-          Event: {{.Event}}<br>
+          Event: {{humanize .Event}}<br>
         {{- end -}}
         {{- if .EventsFlushed}}
-          Events Flushed: {{.EventsFlushed}}<br>
+          Events Flushed: {{humanize .EventsFlushed}}<br>
         {{- end -}}
         {{- if .NumberOfFlush}}
-          Number Of Flushes: {{.NumberOfFlush}}<br>
+          Number Of Flushes: {{humanize .NumberOfFlush}}<br>
         {{- end -}}
         {{- if .SeriesFlushed}}
-          Series Flushed: {{.SeriesFlushed}}<br>
+          Series Flushed: {{humanize .SeriesFlushed}}<br>
         {{- end -}}
         {{- if .ServiceCheck}}
-          Service Check: {{.ServiceCheck}}<br>
+          Service Check: {{humanize .ServiceCheck}}<br>
         {{- end -}}
         {{- if .ServiceCheckFlushed}}
-          Service Checks Flushed: {{.ServiceCheckFlushed}}<br>
+          Service Checks Flushed: {{humanize .ServiceCheckFlushed}}<br>
         {{- end -}}
         {{- if .SketchesFlushed}}
-          Sketches Flushed: {{.SketchesFlushed}}<br>
+          Sketches Flushed: {{humanize .SketchesFlushed}}<br>
         {{- end -}}
         {{- if .HostnameUpdate}}
-          Hostname Update: {{.HostnameUpdate}}<br>
+          Hostname Update: {{humanize .HostnameUpdate}}<br>
         {{- end -}}
         {{- if .DogstatsdMetricSample}}
-          Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}<br>
+          Dogstatsd Metric Sample: {{humanize .DogstatsdMetricSample}}<br>
         {{- end}}
       {{- end -}}
     </span>

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -4,9 +4,9 @@
   <span class="stat_subtitle">Instance {{add $i 1}}</span>
     <span class="stat_data">
         Total Runs: {{.TotalRuns}}<br>
-        Metric Samples: {{.MetricSamples}}, Total: {{humanizeI .TotalMetricSamples}}<br>
-        Events: {{.Events}}, Total: {{humanizeI .TotalEvents}}<br>
-        Service Checks: {{.ServiceChecks}}, Total: {{humanizeI .TotalServiceChecks}}<br>
+        Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
+        Events: {{.Events}}, Total: {{humanize .TotalEvents}}<br>
+        Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
       {{- if .LastError}}
         <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
               {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -21,7 +21,7 @@ Collector
       Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: {{.Events}}, Total: {{humanize .TotalEvents}}
       Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
-      Average Execution Time : {{.AverageExecutionTime}}ms
+      Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
       {{if .LastError -}}
       Error: {{lastErrorMessage .LastError}}
       {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/dogstatsd.tmpl
+++ b/pkg/status/dist/templates/dogstatsd.tmpl
@@ -5,32 +5,32 @@ NOTE: Changes made to this template should be reflected on the following templat
 DogStatsD
 =========
 {{ if .ChecksMetricSample }}
-  Checks Metric Sample: {{.ChecksMetricSample}}
+  Checks Metric Sample: {{humanize .ChecksMetricSample}}
 {{- end -}}
 {{- if .Event}}
-  Event: {{.Event}}
+  Event: {{humanize .Event}}
 {{- end -}}
 {{- if .EventsFlushed}}
-  Events Flushed: {{.EventsFlushed}}
+  Events Flushed: {{humanize .EventsFlushed}}
 {{- end -}}
 {{- if .NumberOfFlush}}
-  Number Of Flushes: {{.NumberOfFlush}}
+  Number Of Flushes: {{humanize .NumberOfFlush}}
 {{- end -}}
 {{- if .SeriesFlushed}}
-  Series Flushed: {{.SeriesFlushed}}
+  Series Flushed: {{humanize .SeriesFlushed}}
 {{- end -}}
 {{- if .ServiceCheck}}
-  Service Check: {{.ServiceCheck}}
+  Service Check: {{humanize .ServiceCheck}}
 {{- end -}}
 {{- if .ServiceCheckFlushed}}
-  Service Checks Flushed: {{.ServiceCheckFlushed}}
+  Service Checks Flushed: {{humanize .ServiceCheckFlushed}}
 {{- end -}}
 {{- if .SketchesFlushed}}
-  Sketches Flushed: {{.SketchesFlushed}}
+  Sketches Flushed: {{humanize .SketchesFlushed}}
 {{- end -}}
 {{- if .HostnameUpdate}}
-  Hostname Update: {{.HostnameUpdate}}
+  Hostname Update: {{humanize .HostnameUpdate}}
 {{- end -}}
 {{- if .DogstatsdMetricSample}}
-  Dogstatsd Metric Sample: {{.DogstatsdMetricSample}}
+  Dogstatsd Metric Sample: {{humanize .DogstatsdMetricSample}}
 {{- end}}

--- a/pkg/status/dist/templates/forwarder.tmpl
+++ b/pkg/status/dist/templates/forwarder.tmpl
@@ -7,7 +7,7 @@ Forwarder
 =========
 {{ if .Transactions }}
   {{- range $key, $value := .Transactions }}
-  {{$key}}: {{$value}}
+  {{$key}}: {{humanize $value}}
   {{- end }}
   {{- if .Transactions.DroppedOnInput }}
 

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -24,7 +24,7 @@ NOTE: Changes made to this template should be reflected on the following templat
   Clocks
   ======
     {{- if .ntpOffset }}
-    NTP offset: {{.ntpOffset}} s
+    NTP offset: {{ humanizeDuration .ntpOffset "s"}}
     {{- end }}
     System UTC time: {{.time}}
 
@@ -32,7 +32,7 @@ NOTE: Changes made to this template should be reflected on the following templat
   =========
   {{- range $name, $value := .hostinfo -}}
     {{- if and (ne $name "hostname") (ne $name "hostid") ($value) }}
-    {{$name}}: {{if eq $name "bootTime" }}{{ formatUnixTime $value }}{{ else }}{{ $value }}{{ end }}
+    {{$name}}: {{if eq $name "bootTime" }}{{ formatUnixTime $value }}{{ else }}{{if eq $name "uptime" }}{{ humanizeDuration $value "s"}}{{ else }}{{ $value }}{{ end }}{{ end }}
     {{- end }}
   {{- end }}
 

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -11,22 +11,28 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
+	"github.com/dustin/go-humanize"
 	json "github.com/json-iterator/go"
 	"golang.org/x/text/unicode/norm"
 )
 
-func init() {
-	fmap = template.FuncMap{
+// Fmap return a fresh copy of a map of utility functions for templating
+func Fmap() template.FuncMap {
+	return template.FuncMap{
 		"doNotEscape":        doNotEscape,
 		"lastError":          lastError,
 		"lastErrorTraceback": lastErrorTraceback,
-		"lastErrorMessage":   LastErrorMessage,
+		"lastErrorMessage":   lastErrorMessage,
 		"configError":        configError,
 		"printDashes":        printDashes,
-		"formatUnixTime":     FormatUnixTime,
-		"humanize":           MkHuman,
+		"formatUnixTime":     formatUnixTime,
+		"humanize":           mkHuman,
+		"humanizeDuration":   mkHumanDuration,
 		"toUnsortedList":     toUnsortedList,
+		"formatTitle":        formatTitle,
+		"add":                add,
 	}
 }
 
@@ -54,8 +60,8 @@ func lastErrorTraceback(value string) template.HTML {
 	return template.HTML(lastErrorArray[0]["traceback"])
 }
 
-// LastErrorMessage converts the last error message to html
-func LastErrorMessage(value string) template.HTML {
+// lastErrorMessage converts the last error message to html
+func lastErrorMessage(value string) template.HTML {
 	var lastErrorArray []map[string]string
 	err := json.Unmarshal([]byte(value), &lastErrorArray)
 	if err == nil && len(lastErrorArray) > 0 {
@@ -66,8 +72,8 @@ func LastErrorMessage(value string) template.HTML {
 	return template.HTML(value)
 }
 
-// FormatUnixTime formats the unix time to make it more readable
-func FormatUnixTime(unixTime float64) string {
+// formatUnixTime formats the unix time to make it more readable
+func formatUnixTime(unixTime float64) string {
 	var (
 		sec  int64
 		nsec int64
@@ -94,18 +100,28 @@ func toUnsortedList(s map[string]interface{}) string {
 	return fmt.Sprintf("%s", res)
 }
 
-// MkHuman makes large numbers more readable
-func MkHuman(f float64) string {
-	i := int64(f)
-	str := fmt.Sprintf("%d", i)
-
-	if i > 1000000 {
-		str = "over 1M"
-	} else if i > 100000 {
-		str = "over 100K"
+// mkHuman makes large numbers more readable
+func mkHuman(f float64) string {
+	var str string
+	if f > 1000000.0 {
+		str = humanize.SIWithDigits(f, 1, "")
+	} else {
+		str = humanize.Commaf(f)
 	}
 
 	return str
+}
+
+// mkHumanDuration makes time values more readable
+func mkHumanDuration(f float64, unit string) string {
+	var duration time.Duration
+	if unit != "" {
+		duration, _ = time.ParseDuration(fmt.Sprintf("%f%s", f, unit))
+	} else {
+		duration = time.Duration(int64(f)) * time.Second
+	}
+
+	return duration.String()
 }
 
 func stringLength(s string) int {
@@ -123,4 +139,32 @@ func stringLength(s string) int {
 		ia.Next()
 	}
 	return nc
+}
+
+// add two integer together
+func add(x, y int) int {
+	return x + y
+}
+
+// formatTitle split a camel case string into space-separated words
+func formatTitle(title string) string {
+	if title == "os" {
+		return "OS"
+	}
+
+	// Split camel case words
+	var words []string
+	var l int
+
+	for s := title; s != ""; s = s[l:] {
+		l = strings.IndexFunc(s[1:], unicode.IsUpper) + 1
+		if l <= 0 {
+			l = len(s)
+		}
+		words = append(words, s[:l])
+	}
+	title = strings.Join(words, " ")
+
+	// Capitalize the first letter
+	return strings.Title(title)
 }

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	here, _        = executable.Folder()
-	fmap           template.FuncMap
+	fmap           = Fmap()
 	templateFolder string
 )
 

--- a/releasenotes/notes/Make-agent-status-page-human-readable-95eb75a95aa16821.yaml
+++ b/releasenotes/notes/Make-agent-status-page-human-readable-95eb75a95aa16821.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make all numbers on the status page more human readable (using unit and SI prefix when appropriate)


### PR DESCRIPTION
Agent Status prints unreadable numbers

### What does this PR do?

Format all numbers to be human friendly
- Durations are displayed with a proper unit (ms, s, h) depending on their value
- All numbers are comma separated
- Above 100k, numbers are displayed with an SI prefix
- Make some function between cli and gui templating in common (We can't make them all common because of HTML stuff)


### Motivation

All numbers in expvar are unmarshalled as float because of the JSON standard. When a number is too large go will display it with an exponent and it is rendered terribly on the status page.
