### PR TITLE
Moving internal API start prior to blocking call

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -169,6 +169,13 @@ func start(cmd *cobra.Command, args []string) error {
 
 	// Start the cluster-check discovery if configured
 	clusterCheckHandler := setupClusterCheck()
+	// start the cmd HTTPS server
+	sc := clusteragent.ServerContext{
+		ClusterCheckHandler: clusterCheckHandler,
+	}
+	if err = api.StartServer(sc); err != nil {
+		return log.Errorf("Error while starting api server, exiting: %v", err)
+	}
 
 	// HPA Process
 	if config.Datadog.GetBool("external_metrics_provider.enabled") {
@@ -183,14 +190,6 @@ func start(cmd *cobra.Command, args []string) error {
 				log.Errorf("Could not start the custom metrics API server: %s", err.Error())
 			}
 		}
-	}
-
-	// start the cmd HTTPS server
-	sc := clusteragent.ServerContext{
-		ClusterCheckHandler: clusterCheckHandler,
-	}
-	if err = api.StartServer(sc); err != nil {
-		return log.Errorf("Error while starting api server, exiting: %v", err)
 	}
 
 	// Block here until we receive the interrupt signal


### PR DESCRIPTION
### What does this PR do?

Regression introduced when implementing the cluster level checks.
We [attempted to start](https://github.com/DataDog/datadog-agent/commit/e1ae7c704caa3ac34cfb96cad29f5f65c398dd1d#diff-5474a8acab62e3264d69daf4870ee0a9L136) the internal API Server after a blocking call happening when enabling the the custom metrics server.

### Motivation

Fix the internal API.