### PR TITLE
fix python integration logging with the check subcommand

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -65,6 +65,9 @@ var checkCmd = &cobra.Command{
 			} else {
 				logLevel = "off"
 			}
+		} else {
+			// Python calls config.Datadog.GetString("log_level")
+			config.Datadog.Set("log_level", logLevel)
 		}
 
 		// Setup logger

--- a/releasenotes/notes/fix-log-level-check-command-932b25311f62ac27.yaml
+++ b/releasenotes/notes/fix-log-level-check-command-932b25311f62ac27.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Setting the log level of the ``check`` subcommand using
+    the ``-l`` flag was not setting the log level of python integrations.


### PR DESCRIPTION
### What does this PR do?

Setting the log level of the `datadog-agent check` command using the `-l` flag was not setting the log level of python integrations.

To apply this flag we were only calling `SetupLogger` with it's value. Python integrations are not affected by `SetupLogger` but rather use `config.Datadog.GetString("log_level")` so the flag was not being propagated.
https://github.com/DataDog/integrations-core/blob/d1ce363ef43de4553c0027b8880b10bc621142df/datadog_checks_base/datadog_checks/log.py#L52

Overriding the config value should do the trick.