### PR TITLE
[gitlab] add DEPPROJECTROOT to get around dep `0.5.0` limitation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ stages:
 
 variables:
   SRC_PATH: /src/github.com/DataDog/datadog-agent
+  DEPPROJECTROOT: /src/github.com/DataDog/datadog-agent
   OMNIBUS_BASE_DIR: $CI_PROJECT_DIR/.omnibus/
   OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/.omnibus/pkg/
   # make sure the types of RPM packages are kept separate


### PR DESCRIPTION
### What does this PR do?

There appears to be a tiny behavioral change/bug in `0.5.0` by which `GOPATH` being set to `/` doesn't appear to be playing well. Setting `DEPPROJECTROOT`, helped me pull the vendored deps in a container environment.

### Motivation

Broken gitlab pipeline.

