### PR TITLE
Clean up embedded python libs when Agent installation changes

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -32,6 +32,10 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         fi
     fi
 
+    if [ -d "$INSTALL_DIR/embedded/lib/python2.7" ]; then
+        rm -rf $INSTALL_DIR/embedded/lib/python2.7
+    fi
+
     if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
         # Nothing specific on Debian
         :

--- a/releasenotes/notes/Clean-up-embedded-python-libs-on-agent-installation-595bbd8a1c2085df.yaml
+++ b/releasenotes/notes/Clean-up-embedded-python-libs-on-agent-installation-595bbd8a1c2085df.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Remove all not-preinstalled python modules on agent installation/upgrade in the embedded environment


### PR DESCRIPTION
### What does this PR do?

Remove all custom python modules on upgrade

Tested on Ubuntu and Fedora
