### PR TITLE
Add 4 system.fs.file_handles.* metrics

### DIFF
--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -83,7 +83,7 @@ func (c *fhCheck) Run() error {
 	fhInUse := (allocatedFh - allocatedUnusedFh) / maxFh
 	log.Debugf("file handles in use: %f", fhInUse)
 
-	sender.Gauge("system.fs.file_handles.allocated", fhInUse, "", nil)
+	sender.Gauge("system.fs.file_handles.allocated", allocatedFh, "", nil)
 	sender.Gauge("system.fs.file_handles.allocated_unused", allocatedUnusedFh, "", nil)
 	sender.Gauge("system.fs.file_handles.in_use", fhInUse, "", nil)
 	sender.Gauge("system.fs.file_handles.used", allocatedFh-allocatedUnusedFh, "", nil)

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -64,24 +64,20 @@ func (c *fhCheck) Run() error {
 		log.Errorf("Could not gather \"allocated file handle\" value")
 		return err
 	}
-	log.Debugf("allocated file handles: %f", allocatedFh)
 
 	allocatedUnusedFh, err := strconv.ParseFloat(fileNrValues[1], 64)
 	if err != nil {
 		log.Errorf("Could not gather \"allocated unused file handle\" value")
 		return err
 	}
-	log.Debugf("allocated unused file handles: %f", allocatedUnusedFh)
 
 	maxFh, err := strconv.ParseFloat(fileNrValues[2], 64)
 	if err != nil {
 		log.Errorf("Could not parse \"maximum file handle\" value")
 		return err
 	}
-	log.Debugf("maximum file handles: %f", maxFh)
 
 	fhInUse := (allocatedFh - allocatedUnusedFh) / maxFh
-	log.Debugf("file handles in use: %f", fhInUse)
 
 	sender.Gauge("system.fs.file_handles.allocated", allocatedFh, "", nil)
 	sender.Gauge("system.fs.file_handles.allocated_unused", allocatedUnusedFh, "", nil)

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -83,7 +83,11 @@ func (c *fhCheck) Run() error {
 	fhInUse := (allocatedFh - allocatedUnusedFh) / maxFh
 	log.Debugf("file handles in use: %f", fhInUse)
 
+	sender.Gauge("system.fs.file_handles.allocated", fhInUse, "", nil)
+	sender.Gauge("system.fs.file_handles.allocated_unused", allocatedUnusedFh, "", nil)
 	sender.Gauge("system.fs.file_handles.in_use", fhInUse, "", nil)
+	sender.Gauge("system.fs.file_handles.used", allocatedFh-allocatedUnusedFh, "", nil)
+	sender.Gauge("system.fs.file_handles.max", maxFh, "", nil)
 	sender.Commit()
 
 	return nil

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	samplecontent1 = []byte("896\t0\t101478\n") // 0.008829499990145647
-	samplecontent2 = []byte("800\t0\t101478\n") // 0.007883482134058614
+	samplecontent1 = []byte("896\t201\t101478\n") // 0.008829499990145647
+	samplecontent2 = []byte("800\t453\t101478\n") // 0.007883482134058614
 )
 
 func writeSampleFile(f *os.File, content []byte) string {
@@ -50,12 +50,16 @@ func TestFhCheckLinux(t *testing.T) {
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 
-	mock.On("Gauge", "system.fs.file_handles.in_use", 0.008829499990145647, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.allocated", 896.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.allocated_unused", 201.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.in_use", 0.006848775103963421, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.used", 695.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.max", 101478.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
 	fileHandleCheck.Run()
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 1)
+	mock.AssertNumberOfCalls(t, "Gauge", 5)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 
 	tmpFile, err = getFileNr()
@@ -67,11 +71,15 @@ func TestFhCheckLinux(t *testing.T) {
 	fileNrHandle = writeSampleFile(tmpFile, samplecontent2)
 	t.Logf("Testing from file %s", fileNrHandle) // To pass circle ci tests
 
-	mock.On("Gauge", "system.fs.file_handles.in_use", 0.007883482134058614, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.allocated", 800.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.allocated_unused", 453.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.in_use", 0.003419460375647924, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.used", 347.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.fs.file_handles.max", 101478.0, "", []string(nil)).Return().Times(1)
 	mock.On("Commit").Return().Times(1)
 	fileHandleCheck.Run()
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 2)
+	mock.AssertNumberOfCalls(t, "Gauge", 10)
 	mock.AssertNumberOfCalls(t, "Commit", 2)
 }

--- a/releasenotes/notes/more-file_handles-metrics-a2fb71b5ec7b75f2.yaml
+++ b/releasenotes/notes/more-file_handles-metrics-a2fb71b5ec7b75f2.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The file_handle check reports 4 new metrics for feature parity with agent 5


### PR DESCRIPTION
### What does this PR do?

Add :

* `system.fs.file_handles.allocated`
* `system.fs.file_handles.allocated_unused`
* `system.fs.file_handles.used`
* `system.fs.file_handles.max`


### Motivation

These metrics are collected by agent 5
