### PR TITLE
[DCA] Use the same informer factory instance to start controllers.

### DIFF
--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -23,8 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
 )
 
 var options *server.CustomMetricsAdapterServerOptions
@@ -83,19 +81,6 @@ func StartServer() error {
 	store, err := custommetrics.NewConfigMapStore(client.Cl, common.GetResourcesNamespace(), datadogHPAConfigMap)
 	if err != nil {
 		return err
-	}
-	dogCl, err := hpa.NewDatadogClient()
-	if err != nil {
-		return err
-	}
-	stopHPA := make(chan struct{})
-	le, err := leaderelection.GetLeaderEngine()
-	if err != nil {
-		return err
-	}
-	errHPAController := as.StartAutoscalersController(le, dogCl, stopHPA)
-	if errHPAController != nil {
-		return errHPAController
 	}
 	emProvider := custommetrics.NewDatadogProvider(clientPool, dynamicMapper, store)
 	// As the Custom Metrics Provider is introduced, change the first emProvider to a cmProvider.

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+var controllerCatalog = map[string]func(controllerContext) error{
+	"metadata":    startMetadataController,
+	"autoscalers": startMetadataController,
+}
+
+type controllerContext struct {
+	InformerFactory informers.SharedInformerFactory
+	Client          kubernetes.Interface
+	LeaderElector   LeaderElectorInterface
+	StopCh          chan struct{}
+}
+
+// StartControllers runs the Kubernetes controllers for the Datadog Cluster Agent. This is
+// only called once, when we have confirmed we could correctly connect to the API server.
+func StartControllers(le LeaderElectorInterface, stopCh chan struct{}) error {
+	timeoutSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_restclient_timeout"))
+	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
+	client, err := getKubeClient(timeoutSeconds * time.Second)
+	if err != nil {
+		log.Infof("Could not get apiserver client: %v", err)
+		return err
+	}
+
+	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriodSeconds*time.Second)
+	informerFactory.Start(stopCh)
+
+	ctx := controllerContext{
+		InformerFactory: informerFactory,
+		Client:          client,
+		LeaderElector:   le,
+		StopCh:          stopCh,
+	}
+
+	enabledControllers := sets.NewString("metadata") // always enabled
+	if config.Datadog.GetBool("external_metrics_provider.enabled") {
+		enabledControllers.Insert("autoscalers")
+	}
+
+	for name, controllerFn := range controllerCatalog {
+		if !enabledControllers.Has(name) {
+			log.Infof("%q is disabled", name)
+			continue
+		}
+		err := controllerFn(ctx)
+		if err != nil {
+			log.Errorf("Error starting %q", name)
+		}
+	}
+
+	return nil
+}
+
+func startMetadataController(ctx controllerContext) error {
+	metaController := NewMetadataController(
+		ctx.InformerFactory.Core().V1().Nodes(),
+		ctx.InformerFactory.Core().V1().Endpoints(),
+	)
+	go metaController.Run(ctx.StopCh)
+
+	return nil
+}
+
+func startAutoscalersController(ctx controllerContext) error {
+	dogCl, err := hpa.NewDatadogClient()
+	if err != nil {
+		return err
+	}
+	autoscalersController, err := NewAutoscalersController(
+		ctx.Client,
+		ctx.LeaderElector,
+		dogCl,
+		ctx.InformerFactory.Autoscaling().V2beta1().HorizontalPodAutoscalers(),
+	)
+	if err != nil {
+		return err
+	}
+	go autoscalersController.Run(ctx.StopCh)
+
+	return nil
+}

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -41,7 +41,7 @@ type controllerContext struct {
 	stopCh          chan struct{}
 }
 
-// StartControllers runs the Kubernetes controllers for the Datadog Cluster Agent. This is
+// StartControllers runs the enabled Kubernetes controllers for the Datadog Cluster Agent. This is
 // only called once, when we have confirmed we could correctly connect to the API server.
 func StartControllers(le LeaderElectorInterface, stopCh chan struct{}) error {
 	timeoutSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_restclient_timeout"))
@@ -62,12 +62,12 @@ func StartControllers(le LeaderElectorInterface, stopCh chan struct{}) error {
 		stopCh:          stopCh,
 	}
 
-	for name, controllerFuncs := range controllerCatalog {
-		if !controllerFuncs.enabled() {
+	for name, cntrlFuncs := range controllerCatalog {
+		if !cntrlFuncs.enabled() {
 			log.Infof("%q is disabled", name)
 			continue
 		}
-		err := controllerFuncs.start(ctx)
+		err := cntrlFuncs.start(ctx)
 		if err != nil {
 			log.Errorf("Error starting %q", name)
 		}

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -52,7 +52,10 @@ func StartControllers(le LeaderElectorInterface, stopCh chan struct{}) error {
 		stopCh:          stopCh,
 	}
 
-	enabledControllers := sets.NewString("metadata") // always enabled
+	enabledControllers := sets.NewString()
+	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") {
+		enabledControllers.Insert("metadata")
+	}
 	if config.Datadog.GetBool("external_metrics_provider.enabled") {
 		enabledControllers.Insert("autoscalers")
 	}


### PR DESCRIPTION
### What does this PR do?

Small refactoring to allow all controllers to use the same `SharedInformerFactory` instance.