### PR TITLE
[DCA] Create informer factory in APIClient so its usable for all apiserver calls

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -157,10 +157,7 @@ func start(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-
 		stopCh := make(chan struct{})
-		apiCl.InformerFactory.Start(stopCh)
-
 		ctx := apiserver.ControllerContext{
 			InformerFactory: apiCl.InformerFactory,
 			Client:          apiCl.Cl,

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -52,6 +52,12 @@ func StartControllers(ctx ControllerContext) error {
 			log.Errorf("Error starting %q", name)
 		}
 	}
+
+	// we must start the informer factory after starting the controllers because the informer
+	// factory uses lazy initialization (delays the creation of an informer until the first
+	// time it's needed).
+	ctx.InformerFactory.Start(ctx.StopCh)
+
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Create informer factory in APIClient so its usable for all apiserver calls.

### Motivation

DCA can now use the nodes in the local store (shared with the `MetadataController`) to provide node labels to agents.

