### PR TITLE
Trim new line on API Key

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -434,7 +434,13 @@ func Load() error {
 	}
 
 	loadProxyFromEnv()
+	sanitizeAPIKey()
 	return nil
+}
+
+// Avoid log ingestion breaking because of a newline in the API key
+func sanitizeAPIKey() {
+	Datadog.Set("api_key", strings.TrimSpace(Datadog.GetString("api_key")))
 }
 
 // GetMultipleEndpoints returns the api keys per domain specified in the main agent config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -344,3 +344,21 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	os.Unsetenv("DD_PROXY_NO_PROXY")
 	Datadog.Set("proxy", nil)
 }
+
+func TestSanitizeAPIKey(t *testing.T) {
+	Datadog.Set("api_key", "foo")
+	sanitizeAPIKey()
+	assert.Equal(t, "foo", Datadog.GetString("api_key"))
+
+	Datadog.Set("api_key", "foo\n")
+	sanitizeAPIKey()
+	assert.Equal(t, "foo", Datadog.GetString("api_key"))
+
+	Datadog.Set("api_key", "foo\n\n")
+	sanitizeAPIKey()
+	assert.Equal(t, "foo", Datadog.GetString("api_key"))
+
+	Datadog.Set("api_key", " \n  foo   \n")
+	sanitizeAPIKey()
+	assert.Equal(t, "foo", Datadog.GetString("api_key"))
+}

--- a/releasenotes/notes/fix-issue-with-newline-in-api-key-56123e5a861729a2.yaml
+++ b/releasenotes/notes/fix-issue-with-newline-in-api-key-56123e5a861729a2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an issue where logs wouldn't be ingested if the API key contains a trailing
+    new line


### PR DESCRIPTION
### What does this PR do?

Trim new line on API key

### Motivation

Sometime, we receive API key with trailing new line and it breaks silently break the log ingestion.
