### PR TITLE
Remove noisy and useless debug log line from contextResolver

### DIFF
--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -9,9 +9,6 @@ import (
 	// stdlib
 	"fmt"
 
-	// 3p
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -76,7 +76,6 @@ func (cr *ContextResolver) expireContexts(expireTimestamp float64) []ckey.Contex
 	for contextKey, lastSeen := range cr.lastSeenByKey {
 		if lastSeen < expireTimestamp {
 			expiredContextKeys = append(expiredContextKeys, contextKey)
-			log.Debugf("Context key '%s' expired", contextKey)
 		}
 	}
 

--- a/releasenotes/notes/remove-debug-log-0ed15ae9c10a2105.yaml
+++ b/releasenotes/notes/remove-debug-log-0ed15ae9c10a2105.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Remove noisy and useless debug log line from contextResolver


### PR DESCRIPTION
### What does this PR do?

Title

### Motivation

Had a look a flare and it was flooded with these lines. (Really large vSphere environment, with long metric collection intervals)

### Additional Notes

Anything else we should know when reviewing?
