### PR TITLE
[DCA] Update custom metrics store stats when configmap is updated.

### DIFF
--- a/pkg/clusteragent/custommetrics/README.md
+++ b/pkg/clusteragent/custommetrics/README.md
@@ -16,6 +16,8 @@ Only the leader replica should add or delete metrics from the store. Any replica
 
 ### configMapStore
 
+The `configMapStore` provides simple persistent storage of custom and external metrics. This allows any replica of the Datadog Cluster Agent to serve metrics to the apiserver but still only have the leader replica query Datadog.
+
 The `configMapStore` always performs operations on a local copy of the configmap but `ListAllExternalMetricValues` will always get the most up-to-date configmap from the apiserver before listing the metrics.
 
 #### Summary of apiserver calls

--- a/pkg/clusteragent/custommetrics/status.go
+++ b/pkg/clusteragent/custommetrics/status.go
@@ -30,15 +30,15 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	externalStatus := make(map[string]interface{})
 	status["External"] = externalStatus
 
-	externalMetrics, err := store.ListAllExternalMetricValues()
+	bundle, err := store.GetMetrics()
 	if err != nil {
 		externalStatus["ListError"] = err.Error()
 		return status
 	}
-	externalStatus["Metrics"] = externalMetrics
-	externalStatus["Total"] = len(externalMetrics)
+	externalStatus["Metrics"] = bundle.External
+	externalStatus["Total"] = len(bundle.External)
 	valid := 0
-	for _, metric := range externalMetrics {
+	for _, metric := range bundle.External {
 		if metric.Valid {
 			valid += 1
 		}

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -239,7 +239,6 @@ func setLastUpdatedAnnotation(cm *v1.ConfigMap) {
 		// Don't panic "assignment to entry in nil map" at init
 		cm.Annotations = make(map[string]string)
 	}
-	cm.Annotations[storeLastUpdatedAnnotationKey] = time.Now().String()
 	cm.Annotations[storeLastUpdatedAnnotationKey] = time.Now().Format(time.RFC3339)
 }
 

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -40,6 +40,7 @@ func TestNewConfigMapStore(t *testing.T) {
 	store, err = NewConfigMapStore(client, "default", "bar")
 	require.NoError(t, err)
 	require.NotNil(t, store.(*configMapStore).cm)
+	assert.NotEmpty(t, store.(*configMapStore).cm.Annotations[storeLastUpdatedAnnotationKey])
 }
 
 func TestConfigMapStoreExternalMetrics(t *testing.T) {

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -22,3 +22,7 @@ type ObjectReference struct {
 	Namespace string `json:"namespace"`
 	UID       string `json:"uid"`
 }
+
+type MetricsBundle struct {
+	External []ExternalMetricValue
+}


### PR DESCRIPTION
### What does this PR do?

- Add `MetricsBundle` type
- Add `GetMetrics` to `Store` interface
- Update store stats every time configmap is updated

### Motivation

Incorrect `expvar` stats for `custommetrics`.