### PR TITLE
Add Alibaba instance-id to the host_aliases metadata payload

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/alibaba"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -83,6 +84,13 @@ func GetPythonVersion() string {
 // This should include GCE, Azure, Cloud foundry, kubernetes
 func getHostAliases() []string {
 	aliases := []string{}
+
+	alibabaAlias, err := alibaba.GetHostAlias()
+	if err != nil {
+		log.Debugf("no Alibaba Host Alias: %s", err)
+	} else if alibabaAlias != "" {
+		aliases = append(aliases, alibabaAlias)
+	}
 
 	azureAlias, err := azure.GetHostAlias()
 	if err != nil {

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -44,7 +44,6 @@ func getResponse(url string) (*http.Response, error) {
 		return nil, err
 	}
 
-	req.Header.Add("Metadata", "true")
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package alibaba
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// declare these as vars not const to ease testing
+var (
+	metadataURL = "http://100.100.100.200"
+	timeout     = 300 * time.Millisecond
+)
+
+// GetHostAlias returns the VM ID from the Alibaba Metadata api
+func GetHostAlias() (string, error) {
+	res, err := getResponse(metadataURL + "/latest/meta-data/instance-id")
+	if err != nil {
+		return "", fmt.Errorf("Alibaba HostAliases: unable to query metadata endpoint: %s", err)
+	}
+
+	defer res.Body.Close()
+	all, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error while reading response from alibaba metadata endpoint: %s", err)
+	}
+
+	return string(all), nil
+}
+
+func getResponse(url string) (*http.Response, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Metadata", "true")
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
+	}
+
+	return res, nil
+}

--- a/pkg/util/alibaba/alibaba_test.go
+++ b/pkg/util/alibaba/alibaba_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestGetHostname(t *testing.T) {
-	expected := "5d33a910-a7a0-4443-9f01-6a807801b29b"
+	expected := "i-rj9aql2pwopjn4sm24ix"
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")

--- a/pkg/util/alibaba/alibaba_test.go
+++ b/pkg/util/alibaba/alibaba_test.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package alibaba
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostname(t *testing.T) {
+	expected := "5d33a910-a7a0-4443-9f01-6a807801b29b"
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	val, err := GetHostAlias()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, val)
+	assert.Equal(t, lastRequest.URL.Path, "/latest/meta-data/instance-id")
+}

--- a/pkg/util/alibaba/diagnosis.go
+++ b/pkg/util/alibaba/diagnosis.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package alibaba
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func init() {
+	diagnosis.Register("Alibaba Metadata availability", diagnose)
+}
+
+// diagnose the alibaba metadata API availability
+func diagnose() error {
+	_, err := GetHostAlias()
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}


### PR DESCRIPTION
### What does this PR do?

Add alibaba ecs instance-id to the host_aliases payload if available

Note: I've created a ECS instance but can't connect to google/github/anything so it's impossible to build the agent on the instance. However `curl http://100.100.100.200/latest/meta-data/instance-id` return the expected value. This should work

edit: tested directly on the vm, the agent reports the alias correctly