### PR TITLE
[proc] Adding the network tracer, for eBPF-based network collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ agentmsg.h
 
 # go-generated files
 datadog.yaml
+network-tracer.yaml
 dogstatsd.yaml
 Dockerfiles/cluster-agent/datadog-cluster.yaml
 

--- a/Dockerfiles/agent/SUPERVISION.md
+++ b/Dockerfiles/agent/SUPERVISION.md
@@ -1,10 +1,11 @@
 # Embedded supervisor for the agent6 image
 
-The Datadog Agent is currently split in three binaries running cooperatively:
+The Datadog Agent is currently split in four binaries running cooperatively:
 
   - the main `agent`, collecting metrics, events and logs
   - the `trace-agent`, collecting APM traces
   - the `process-agent`, collecting live container and process data
+  - the `network-tracer`, collecting network data, accessible by the process-agent
 
 In order to provide an all-in-one image, we are including a process supervisor.
 We are using [`s6`](https://skarnet.org/software/s6/s6-svc.html) via the
@@ -13,7 +14,6 @@ We are using [`s6`](https://skarnet.org/software/s6/s6-svc.html) via the
 - it is light and customisable
 - it correctly handles signals and process reaping
 - it has been battle tested in docker containers since 2015
-
 
 ## Entrypoint scripts
 
@@ -36,8 +36,8 @@ The supported way to pass envvars to the agent is to set container envvars.
 The image starts three services:
 
 - `agent` is the main agent. The container will exit if it stops.
-- `trace-agent` and `process-agent` are auxiliary services. They will be
-restarted after crashing, but not if exiting normally (for example, the
+- `trace-agent`, `process-agent`, and `network-tracer` are auxiliary services.
+They will be restarted after crashing, but not if exiting normally (for example, the
 `trace-agent` will disable itself if `DD_APM_ENABLED` is false).
 
 ## Useful commands
@@ -46,7 +46,6 @@ Each agent runs as a separate service. You can use the
 [`s6-svstat`](https://skarnet.org/software/s6/s6-svstat.html) and
 [`s6-svc`](https://skarnet.org/software/s6/s6-svc.html)
 commands to manage them:
-
 
 #### Get the process-agent status
 ```

--- a/Dockerfiles/agent/SUPERVISION.md
+++ b/Dockerfiles/agent/SUPERVISION.md
@@ -33,7 +33,7 @@ The supported way to pass envvars to the agent is to set container envvars.
 
 ## Services
 
-The image starts three services:
+The image starts four services:
 
 - `agent` is the main agent. The container will exit if it stops.
 - `trace-agent`, `process-agent`, and `network-tracer` are auxiliary services.

--- a/Dockerfiles/agent/s6-services/network/finish
+++ b/Dockerfiles/agent/s6-services/network/finish
@@ -1,0 +1,15 @@
+#!/usr/bin/execlineb -S1
+
+# Disable the service it it exit(0), else wait 2 seconds before restarting it
+
+ifthenelse
+    { s6-test ${1} -eq 0 }
+    {
+        foreground { /initlog.sh "network-tracer exited with code ${1}, disabling" }
+        foreground { /bin/s6-svc -d /var/run/s6/services/network/ }
+        foreground { /bin/s6-svc -d /var/run/s6/services/network/log }
+    }
+    {
+        foreground { /initlog.sh "network-tracer exited with code ${1}, signal ${2}, restarting in 2 seconds" }
+        foreground { s6-sleep 2 }
+    }

--- a/Dockerfiles/agent/s6-services/network/finish
+++ b/Dockerfiles/agent/s6-services/network/finish
@@ -1,6 +1,6 @@
 #!/usr/bin/execlineb -S1
 
-# Disable the service it it exit(0), else wait 2 seconds before restarting it
+# Disable the service if it exit(0), else wait 2 seconds before restarting it
 
 ifthenelse
     { s6-test ${1} -eq 0 }

--- a/Dockerfiles/agent/s6-services/network/log/run
+++ b/Dockerfiles/agent/s6-services/network/log/run
@@ -1,0 +1,3 @@
+#!/usr/bin/execlineb -P
+
+s6-format-filter "[NETWORK] %s"

--- a/Dockerfiles/agent/s6-services/network/run
+++ b/Dockerfiles/agent/s6-services/network/run
@@ -1,0 +1,5 @@
+#!/usr/bin/execlineb -P
+
+foreground { /initlog.sh "starting network-tracer" }
+fdmove -c 2 1
+network-tracer --config=/etc/datadog-agent/network-tracer.yaml

--- a/Dockerfiles/agent/s6-services/process/finish
+++ b/Dockerfiles/agent/s6-services/process/finish
@@ -10,6 +10,6 @@ ifthenelse
         foreground { /bin/s6-svc -d /var/run/s6/services/process/log }
     }
     {
-        foreground { /initlog.sh "trace-agent exited with code ${1}, signal ${2}, restarting in 2 seconds" }
+        foreground { /initlog.sh "process-agent exited with code ${1}, signal ${2}, restarting in 2 seconds" }
         foreground { s6-sleep 2 }
     }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -6,6 +6,7 @@
 // +build !windows,!android
 
 //go:generate go run ../../pkg/config/render_config.go agent ../../pkg/config/config_template.yaml ./dist/datadog.yaml
+//go:generate go run ../../pkg/config/render_config.go network-tracer ../../pkg/config/config_template.yaml ./dist/network-tracer.yaml
 
 package main
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -125,7 +125,7 @@ dependency 'jmxfetch'
 
 # External agents
 dependency 'datadog-trace-agent'
-dependency 'datadog-process-agent'
+dependency 'datadog-process-agent' # Includes network-tracer
 
 if osx?
   dependency 'datadog-agent-mac-app'
@@ -152,6 +152,7 @@ dependency 'datadog-agent-finalize'
 if linux?
   extra_package_file '/etc/init/datadog-agent.conf'
   extra_package_file '/etc/init/datadog-agent-process.conf'
+  extra_package_file '/etc/init/datadog-agent-network.conf'
   extra_package_file '/etc/init/datadog-agent-trace.conf'
   systemd_directory = "/usr/lib/systemd/system"
   if debian?
@@ -163,6 +164,7 @@ if linux?
   end
   extra_package_file "#{systemd_directory}/datadog-agent.service"
   extra_package_file "#{systemd_directory}/datadog-agent-process.service"
+  extra_package_file "#{systemd_directory}/datadog-agent-network.service"
   extra_package_file "#{systemd_directory}/datadog-agent-trace.service"
   extra_package_file '/etc/datadog-agent/'
   extra_package_file '/usr/bin/dd-agent'

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -46,6 +46,7 @@ build do
             move "#{install_dir}/scripts/datadog-agent.conf", "/etc/init"
             move "#{install_dir}/scripts/datadog-agent-trace.conf", "/etc/init"
             move "#{install_dir}/scripts/datadog-agent-process.conf", "/etc/init"
+            move "#{install_dir}/scripts/datadog-agent-network.conf", "/etc/init"
             systemd_directory = "/usr/lib/systemd/system"
             if debian?
                 # debian recommends using a different directory for systemd unit files
@@ -61,11 +62,13 @@ build do
             move "#{install_dir}/scripts/datadog-agent.service", systemd_directory
             move "#{install_dir}/scripts/datadog-agent-trace.service", systemd_directory
             move "#{install_dir}/scripts/datadog-agent-process.service", systemd_directory
+            move "#{install_dir}/scripts/datadog-agent-network.service", systemd_directory
 
             # Move checks and configuration files
             mkdir "/etc/datadog-agent"
             move "#{install_dir}/bin/agent/dd-agent", "/usr/bin/dd-agent"
             move "#{install_dir}/etc/datadog-agent/datadog.yaml.example", "/etc/datadog-agent"
+            move "#{install_dir}/etc/datadog-agent/network-tracer.yaml.example", "/etc/datadog-agent"
             move "#{install_dir}/etc/datadog-agent/conf.d", "/etc/datadog-agent", :force=>true
 
             # Create empty directories so that they're owned by the package

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -57,6 +57,7 @@ build do
                 move "#{install_dir}/scripts/datadog-agent", "/etc/init.d"
                 move "#{install_dir}/scripts/datadog-agent-trace", "/etc/init.d"
                 move "#{install_dir}/scripts/datadog-agent-process", "/etc/init.d"
+                move "#{install_dir}/scripts/datadog-agent-network", "/etc/init.d"
             end
             mkdir systemd_directory
             move "#{install_dir}/scripts/datadog-agent.service", systemd_directory

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -59,7 +59,7 @@ build do
 
   # move around bin and config files
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
-
+  move 'bin/agent/dist/network-tracer.yaml', "#{conf_dir}/network-tracer.yaml.example"
   move 'bin/agent/dist/conf.d', "#{conf_dir}/"
 
   copy 'bin', install_dir
@@ -72,6 +72,10 @@ build do
           vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_debian.process.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent-process.conf",
+          mode: 0644,
+          vars: { install_dir: install_dir, etc_dir: etc_dir }
+      erb source: "upstart_debian.network.conf.erb",
+          dest: "#{install_dir}/scripts/datadog-agent-network.conf",
           mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_debian.trace.conf.erb",
@@ -101,6 +105,10 @@ build do
           dest: "#{install_dir}/scripts/datadog-agent-process.conf",
           mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
+      erb source: "upstart_redhat.network.conf.erb",
+          dest: "#{install_dir}/scripts/datadog-agent-network.conf",
+          mode: 0644,
+          vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "upstart_redhat.trace.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent-trace.conf",
           mode: 0644,
@@ -113,6 +121,10 @@ build do
         vars: { install_dir: install_dir, etc_dir: etc_dir }
     erb source: "systemd.process.service.erb",
         dest: "#{install_dir}/scripts/datadog-agent-process.service",
+        mode: 0644,
+        vars: { install_dir: install_dir, etc_dir: etc_dir }
+    erb source: "systemd.network.service.erb",
+        dest: "#{install_dir}/scripts/datadog-agent-network.service",
         mode: 0644,
         vars: { install_dir: install_dir, etc_dir: etc_dir }
     erb source: "systemd.trace.service.erb",

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -90,6 +90,10 @@ build do
           dest: "#{install_dir}/scripts/datadog-agent-process",
           mode: 0755,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
+      erb source: "sysvinit_debian.network.erb",
+          dest: "#{install_dir}/scripts/datadog-agent-network",
+          mode: 0755,
+          vars: { install_dir: install_dir, etc_dir: etc_dir }
       erb source: "sysvinit_debian.trace.erb",
           dest: "#{install_dir}/scripts/datadog-agent-trace",
           mode: 0755,

--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -13,19 +13,29 @@ if process_agent_version.nil? || process_agent_version.empty?
 end
 default_version process_agent_version
 
+url = "https://s3.amazonaws.com/datad0g-process-agent/"
+
 build do
+  ship_license "https://raw.githubusercontent.com/DataDog/datadog-process-agent/#{version}/LICENSE"
   if windows?
     binary = "process-agent-windows-#{version}.exe"
     target_binary = "process-agent.exe"
-    url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
-    curl_cmd = "powershell -Command wget -OutFile #{binary} #{url}"
+    curl_cmd = "powershell -Command wget -OutFile #{binary} #{url}#{binary}"
     command curl_cmd
     command "mv #{binary} #{install_dir}/bin/agent/#{target_binary}"
   else
     binary = "process-agent-amd64-#{version}"
     target_binary = "process-agent"
-    url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
-    curl_cmd = "curl -f #{url} -o #{binary}"
+    curl_cmd = "curl -f #{url}#{binary} -o #{binary}"
+    command curl_cmd
+    command "chmod +x #{binary}"
+    command "mv #{binary} #{install_dir}/embedded/bin/#{target_binary}"
+
+    # network-tracer versions will always be the same on both process-agent and network-tracer
+    ship_license "https://raw.githubusercontent.com/DataDog/tcptracer-bpf/#{version}/LICENSE.network-tracer"
+    binary = "network-tracer-amd64-#{version}"
+    target_binary = "network-tracer"
+    curl_cmd = "curl -f #{url}#{binary} -o #{binary}"
     command curl_cmd
     command "chmod +x #{binary}"
     command "mv #{binary} #{install_dir}/embedded/bin/#{target_binary}"

--- a/omnibus/config/templates/datadog-agent/systemd.network.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.network.service.erb
@@ -1,0 +1,14 @@
+[Unit]
+Description="Datadog Network Tracer"
+After=network.target
+StartLimitIntervalSec=10
+StartLimitBurst=5
+
+[Service]
+Type=simple
+PIDFile=<%= install_dir %>/run/network-tracer.pid
+Restart=on-failure
+ExecStart=<%= install_dir %>/embedded/bin/network-tracer --config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/network-tracer.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/systemd.network.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.network.service.erb
@@ -9,6 +9,3 @@ Type=simple
 PIDFile=<%= install_dir %>/run/network-tracer.pid
 Restart=on-failure
 ExecStart=<%= install_dir %>/embedded/bin/network-tracer --config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/network-tracer.pid
-
-[Install]
-WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.process.service.erb
@@ -10,7 +10,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
-ExecStart=<%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --pid=<%= install_dir %>/run/process-agent.pid
+ExecStart=<%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --network-config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/process-agent.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.network.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.network.erb
@@ -1,0 +1,162 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: datadog-agent-network
+# Short-Description: Start and stop datadog network-tracer agent
+# Description: Datadog Network Tracer Agent
+# Required-Start: $remote_fs
+# Required-Stop: $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+ETC_DIR="/etc/datadog-agent"
+INSTALL_DIR="/opt/datadog-agent"
+AGENTPATH="$INSTALL_DIR/embedded/bin/network-tracer"
+PIDFILE="$INSTALL_DIR/run/network-tracer.pid"
+AGENT_ARGS="--config=$ETC_DIR/network-tracer.yaml --pid=$PIDFILE"
+NAME="datadog-agent-network"
+DESC="Datadog Network Tracer Agent"
+
+
+
+if [ ! -x $AGENTPATH ]; then
+	echo "$AGENTPATH not found. Exiting."
+	exit 0
+fi
+
+if [ -r "/etc/default/${NAME}" ]; then
+	. "/etc/default/${NAME}"
+fi
+
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --background --quiet --pidfile $PIDFILE --exec $AGENTPATH -- \
+		$AGENT_ARGS \
+		|| return 2
+	# Add code here, if necessary, that waits for the process to be ready
+	# to handle requests from services started subsequently which depend
+	# on this one.  As a last resort, sleep for some time.
+}
+
+
+#
+# Start the agent and wait for it to be up
+#
+start_and_wait()
+{
+	log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		1) log_end_msg 0 ;;
+		2) log_end_msg 1 ;;
+		*)
+			# check if the agent is running once per second for 5 seconds
+			retries=5
+			while [ $retries -gt 1 ]; do
+				start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $AGENTPATH --test
+				if [ "$?" -eq "1" ]; then
+					# We've started up successfully. Exit cleanly
+					log_end_msg 0
+					return 0
+				else
+					retries=$(($retries - 1))
+					sleep 1
+				fi
+			done
+			# After 5 tries the agent didn't start. Report an error
+			log_end_msg 1
+
+		;;
+	esac
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=30 --pidfile $PIDFILE --exec $AGENTPATH
+	RETVAL="$?"
+	rm -f $PIDFILE
+	return $RETVAL
+}
+
+#
+# Stop the agent and wait for it to be down
+#
+stop_and_wait()
+{
+	log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) log_end_msg 0 ;;
+		*) log_end_msg 1 ;; # Failed to stop
+	esac
+}
+
+# Action to take
+case "$1" in
+	start)
+		if init_is_upstart; then
+			exit 1
+		fi
+		if [ "$DATADOG_ENABLED" = "no" ]; then
+			echo "Disabled via /etc/default/$NAME. Exiting."
+			exit 0
+		fi
+
+		start_and_wait
+
+		;;
+
+	stop)
+		if init_is_upstart; then
+			exit 0
+		fi
+
+		stop_and_wait
+
+		;;
+
+	status)
+		status_of_proc -p $PIDFILE $AGENTPATH $NAME && exit 0 || exit $?
+		;;
+
+	restart|force-reload)
+		if init_is_upstart; then
+			exit 1
+		fi
+
+		echo "Restarting $DESC"
+
+		stop_and_wait
+		start_and_wait
+
+		;;
+
+	*)
+		N=/etc/init.d/$NAME
+		echo "Usage: $N {start|stop|restart|status}"
+		exit 1
+		;;
+esac
+
+exit $?

--- a/omnibus/config/templates/datadog-agent/upstart_debian.network.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.network.conf.erb
@@ -1,4 +1,4 @@
-description "Datadog Process Agent"
+description "Datadog Network Tracer"
 
 start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
@@ -13,12 +13,10 @@ normal exit 0
 console log
 env DD_LOG_TO_CONSOLE=false
 
-setuid dd-agent
-
 script
-  exec <%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --network-config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/process-agent.pid
+  exec <%= install_dir %>/embedded/bin/network-tracer --config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/network-tracer.pid
 end script
 
 post-stop script
-  rm -f <%= install_dir %>/run/process-agent.pid
+  rm -f <%= install_dir %>/run/network-tracer.pid
 end script

--- a/omnibus/config/templates/datadog-agent/upstart_debian.network.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.network.conf.erb
@@ -1,6 +1,5 @@
 description "Datadog Network Tracer"
 
-start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.network.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.network.conf.erb
@@ -1,0 +1,30 @@
+description "Datadog Network Tracer"
+
+start on started datadog-agent
+stop on (runlevel [!2345] or stopping datadog-agent)
+
+respawn
+respawn limit 10 5
+normal exit 0
+
+console output
+
+script
+  # Logging to console from the agent is disabled since the agent already logs using file or
+  # syslog depending on its configuration. We then redirect the stdout/stderr of the agent process
+  # to log panic/crashes.
+  exec <%= install_dir %>/embedded/bin/network-tracer --config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/network-tracer.pid &>> /var/log/datadog/network-tracer-errors.log
+end script
+
+pre-start script
+  # Manual rotation of errors log
+  log_file_size=`du -b /var/log/datadog/network-tracer-errors.log | cut -f1`
+  if [ -n "$log_file_size" ] && [ $log_file_size -gt 5242880 ]; then
+    # Rotate log file if it's larger than 5MB
+    mv /var/log/datadog/network-tracer-errors.log /var/log/datadog/network-tracer-errors.log.1
+  fi
+end script
+
+post-stop script
+  rm -f <%= install_dir %>/run/network-tracer.pid
+end script

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.network.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.network.conf.erb
@@ -1,6 +1,5 @@
 description "Datadog Network Tracer"
 
-start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.process.conf.erb
@@ -16,7 +16,7 @@ script
   #
   # setuid is not available in versions of upstart before 1.4. CentOS/RHEL6 use an earlier version of upstart.
   # This is the best way to set the user in the absence of setuid.
-  exec su -s /bin/sh -c 'DD_LOG_TO_CONSOLE=false exec "$0" "$@"' dd-agent -- <%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --pid=<%= install_dir %>/run/process-agent.pid &>> /var/log/datadog/process-errors.log
+  exec su -s /bin/sh -c 'DD_LOG_TO_CONSOLE=false exec "$0" "$@"' dd-agent -- <%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --network-config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/process-agent.pid &>> /var/log/datadog/process-errors.log
 end script
 
 pre-start script

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -62,6 +62,12 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     chown -R dd-agent:dd-agent ${LOG_DIR}
     chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
+    # Make network tracer configs read-only
+    if [ -f "$CONFIG_DIR/network-tracer.yaml" ] || [ -f "$CONFIG_DIR/network-tracer.example.yaml" ]; then
+      chmod 0440 ${CONFIG_DIR}/network-tracer.yaml || true
+      chmod 0440 ${CONFIG_DIR}/network-tracer.example.yaml || true
+    fi
+
     # Enable and restart the agent service here on Debian platforms
     # On RHEL, this is done in the posttrans script
     if [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -63,10 +63,11 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
     # Make network tracer configs read-only
-    if [ -f "$CONFIG_DIR/network-tracer.yaml" ] || [ -f "$CONFIG_DIR/network-tracer.example.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/network-tracer.yaml.example || true
+    if [ -f "$CONFIG_DIR/network-tracer.yaml" ]; then
       chmod 0440 ${CONFIG_DIR}/network-tracer.yaml || true
-      chmod 0440 ${CONFIG_DIR}/network-tracer.example.yaml || true
     fi
+
 
     # Enable and restart the agent service here on Debian platforms
     # On RHEL, this is done in the posttrans script

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -23,10 +23,12 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Only supports systemd and upstart
         if command -v systemctl >/dev/null 2>&1; then
             systemctl stop $SERVICE_NAME-process || true
+            systemctl stop $SERVICE_NAME-network || true
             systemctl stop $SERVICE_NAME-trace || true
             systemctl stop $SERVICE_NAME || true
         elif command -v initctl >/dev/null 2>&1; then
             initctl stop $SERVICE_NAME-process || true
+            initctl stop $SERVICE_NAME-network || true
             initctl stop $SERVICE_NAME-trace || true
             initctl stop $SERVICE_NAME || true
         elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -33,8 +33,9 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
             initctl stop $SERVICE_NAME || true
         elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
             if command -v service >/dev/null 2>&1; then
-                service $SERVICE_NAME-process stop|| true
-                service $SERVICE_NAME-trace stop|| true
+                service $SERVICE_NAME-process stop || true
+                service $SERVICE_NAME-network stop || true
+                service $SERVICE_NAME-trace stop || true
                 service $SERVICE_NAME stop || true
             else
                 echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -21,10 +21,12 @@ stop_agent()
     # Only supports systemd and upstart
     if command -v systemctl >/dev/null 2>&1; then
         systemctl stop $SERVICE_NAME-process || true
+        systemctl stop $SERVICE_NAME-network || true
         systemctl stop $SERVICE_NAME-trace || true
         systemctl stop $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         initctl stop $SERVICE_NAME-process || true
+        initctl stop $SERVICE_NAME-network || true
         initctl stop $SERVICE_NAME-trace || true
         initctl stop $SERVICE_NAME || true
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
@@ -47,6 +49,7 @@ deregister_agent()
     if command -v systemctl >/dev/null 2>&1; then
         # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-network || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
@@ -55,6 +58,7 @@ deregister_agent()
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         if command -v update-rc.d >/dev/null 2>&1; then
             update-rc.d -f $SERVICE_NAME-process remove || true
+            update-rc.d -f $SERVICE_NAME-network remove || true
             update-rc.d -f $SERVICE_NAME-trace remove || true
             update-rc.d -f $SERVICE_NAME remove || true
         else

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -31,8 +31,9 @@ stop_agent()
         initctl stop $SERVICE_NAME || true
     elif [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
         if command -v service >/dev/null 2>&1; then
-            service $SERVICE_NAME-process stop|| true
-            service $SERVICE_NAME-trace stop|| true
+            service $SERVICE_NAME-process stop || true
+            service $SERVICE_NAME-network stop || true
+            service $SERVICE_NAME-trace stop || true
             service $SERVICE_NAME stop || true
         else
             echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -641,6 +641,18 @@ api_key:
 #   dd_agent_bin:
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
+{{ end -}} 
+
+{{- if .NetworkTracer }}
+#   Network tracer specific settings
+#
+# network_tracer_config:
+#   A string indicating the enabled state of the network tracer.
+#   network_tracing_enabled: "true"
+#   The full path to the location of the unix socket where network traces will be accessed
+#   nettracer_socket: /opt/datadog-agent/run/nettracer.sock
+#   The full path to the file where network-tracer logs will be written.
+#   log_file: /var/log/datadog/network-tracer.log
 {{ end -}}
 
 {{- if .TraceAgent }}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -644,11 +644,11 @@ api_key:
 {{ end -}} 
 
 {{- if .NetworkTracer }}
-#   Network tracer specific settings
+# Network tracer specific settings
 #
 # network_tracer_config:
-#   A string indicating the enabled state of the network tracer.
-#   network_tracing_enabled: "true"
+#   A boolean indicating the enabled state of the network tracer.
+#   enabled: true
 #   The full path to the location of the unix socket where network traces will be accessed
 #   nettracer_socket: /opt/datadog-agent/run/nettracer.sock
 #   The full path to the file where network-tracer logs will be written.

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -32,6 +32,7 @@ type context struct {
 	ECS               bool
 	CRI               bool
 	ProcessAgent      bool
+	NetworkTracer     bool
 	KubeApiServer     bool
 	TraceAgent        bool
 }
@@ -59,6 +60,10 @@ func mkContext(buildType string) context {
 			TraceAgent:        true,
 			Kubelet:           true,
 			KubeApiServer:     true, // TODO: remove when phasing out from node-agent
+		}
+	case "network-tracer":
+		return context{
+			NetworkTracer: true,
 		}
 	case "dogstatsd":
 		return context{

--- a/releasenotes/notes/adding-bpf-network-tracer-998cb72e5a8562e9.yaml
+++ b/releasenotes/notes/adding-bpf-network-tracer-998cb72e5a8562e9.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds eBPF-based network collection component called network-tracer.
+

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -174,6 +174,7 @@ def refresh_assets(ctx, build_tags, development=True, puppy=False):
         bin_ddagent = os.path.join(BIN_PATH, "dd-agent")
         shutil.move(os.path.join(dist_folder, "dd-agent"), bin_ddagent)
     shutil.copy("./cmd/agent/dist/datadog.yaml", os.path.join(dist_folder, "datadog.yaml"))
+    shutil.copy("./cmd/agent/dist/network-tracer.yaml", os.path.join(dist_folder, "network-tracer.yaml"))
 
     for check in AGENT_CORECHECKS if not puppy else PUPPY_CORECHECKS:
         check_dir = os.path.join(dist_folder, "conf.d/{}.d/".format(check))

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -173,8 +173,11 @@ def refresh_assets(ctx, build_tags, development=True, puppy=False):
         # copy the dd-agent placeholder to the bin folder
         bin_ddagent = os.path.join(BIN_PATH, "dd-agent")
         shutil.move(os.path.join(dist_folder, "dd-agent"), bin_ddagent)
+
+    # Network tracer not supported on windows
+    if sys.platform != 'win32':
+      shutil.copy("./cmd/agent/dist/network-tracer.yaml", os.path.join(dist_folder, "network-tracer.yaml"))
     shutil.copy("./cmd/agent/dist/datadog.yaml", os.path.join(dist_folder, "datadog.yaml"))
-    shutil.copy("./cmd/agent/dist/network-tracer.yaml", os.path.join(dist_folder, "network-tracer.yaml"))
 
     for check in AGENT_CORECHECKS if not puppy else PUPPY_CORECHECKS:
         check_dir = os.path.join(dist_folder, "conf.d/{}.d/".format(check))

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -175,7 +175,7 @@ def refresh_assets(ctx, build_tags, development=True, puppy=False):
         shutil.move(os.path.join(dist_folder, "dd-agent"), bin_ddagent)
 
     # Network tracer not supported on windows
-    if sys.platform != 'win32':
+    if sys.platform.startswith('linux'):
       shutil.copy("./cmd/agent/dist/network-tracer.yaml", os.path.join(dist_folder, "network-tracer.yaml"))
     shutil.copy("./cmd/agent/dist/datadog.yaml", os.path.join(dist_folder, "datadog.yaml"))
 


### PR DESCRIPTION
### What does this PR do?

This PR bundles the datadog-agent with a new component that we've been working on: [network-tracer](https://github.com/DataDog/tcptracer-bpf/tree/dd/agent).

This allows for eBPF-based collection of network data (TCP + UDP connections) on a per-process level.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
