### PR TITLE
[gopkg] fix insane gopkg situation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1172,8 +1172,7 @@
   version = "v2.8.6"
 
 [[projects]]
-  branch = "master"
-  digest = "1:063b0970fabddacc03f0e07e1d0193460d050f2048d3244a3071cf2e0509a187"
+  digest = "1:532516d37bfedc99c6b137148ef7a9690f6a18130644484fbb0e289d4613a690"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -1207,11 +1206,11 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "9e5ffd1f1320950b238cfce291b926411f0af722"
+  revision = "feb48db456a5912850dcccbd42a3535382ba76de"
+  version = "kubernetes-1.10.3"
 
 [[projects]]
-  branch = "release-1.10"
-  digest = "1:33bcc98ed218289d68aeac0799649844075ee7a2fb1e686040b605b5b5a1523c"
+  digest = "1:3050702e54022945c9eb8b9716ef0cfb738fc440a57bda81cd801d103203a87e"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1267,7 +1266,8 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
+  revision = "31dade610c053669d8054bfd847da657251e8c1a"
+  version = "kubernetes-1.10.3"
 
 [[projects]]
   digest = "1:988f8eb584fb05903205e095e950cb3e51b5cdf2a511446a088f4c8a90bccb9e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,19 +39,37 @@
   version = "~v1.0.0"
 
 [[override]]
+  name = "github.com/kubernetes/client-go"
+  version = "~v7.0.0"
+
+[[override]]
+  name = "k8s.io/client-go"
+  version = "~v7.0.0"
+
+[[override]]
   name = "github.com/kubernetes/apimachinery"
   # branch = "release-1.11"
   #        + pinning to commit in branch above
   version = "kubernetes-1.10.3"
-
+  # branch = "release-1.10"
+  # revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
+  #
 [[override]]
-  name = "github.com/kubernetes/client-go"
-  version = "~v7.0.0"
+  name = "k8s.io/apimachinery"
+  # branch = "release-1.11"
+  #        + pinning to commit in branch above
+  version = "kubernetes-1.10.3"
+  # branch = "release-1.10"
+  # revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
 
 [[override]]
   name = "github.com/kubernetes/api"
   # branch = "release-1.11"
   #        + pinning to commit in branch above
+  version = "kubernetes-1.10.3"
+
+[[override]]
+  name = "k8s.io/api"
   version = "kubernetes-1.10.3"
 
 [[override]]


### PR DESCRIPTION
### What does this PR do?

Fixes `gopkg.lock` generation, in the previous state generating a `gopkg.lock` off a fresh `gopkg.toml` would fail during dependency resolution. The changes introduced allow us to actually compile the lockfile.

### Motivation

Not being able to recreate a `gopkg.lock` from a `gopkg.toml` is a bad thing. Not being able to safely add new dependencies with guarantees of a being able to compile the updated `gopkg.lock` may be worse. To make things worse, changes upstream in dependencies, etc.... might also break the `dep ensure` process. 

The goal is to get us back to a sane state where we can manipulate `gopkg.{toml,lock}` safely. 

### Additional Notes

There are multiple version changes with an added risk of adding regressions. Maybe we should add additional pins wherever necessary, maybe this is fine. Let's attempt to merge this early in the `6.6.0` cycle.
