### PR TITLE
[Logs]: Fixed registry unmarshalling

### DIFF
--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -213,7 +213,7 @@ func (a *Auditor) unmarshalRegistry(b []byte) (map[string]*RegistryEntry, error)
 	if err != nil {
 		return nil, err
 	}
-	version, exists := r["Version"].(float64)
+	version, exists := r["Version"].(uint64)
 	if !exists {
 		return nil, fmt.Errorf("registry retrieved from disk must have a version number")
 	}


### PR DESCRIPTION
### What does this PR do?

Registry was broken because of wrong cast.

### Motivation

Fix tailer offsets.

### Additional Notes

Happened since we introduce a new JSON library `json "github.com/json-iterator/go"` cc @truthbk 
