### PR TITLE
[subprocess] don't block on get_subprocess_output calls

### DIFF
--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -82,6 +82,22 @@ func TestSubprocessRun(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestSubprocessRunConcurrent(t *testing.T) {
+
+	instances := make([]*PythonCheck, 30)
+	for i := range instances {
+		check, _ := getCheckInstance("testsubprocess", "TestSubprocessCheck")
+		instances[i] = check
+	}
+
+	for _, check := range instances {
+		go func(c *PythonCheck) {
+			err := c.Run()
+			assert.Nil(t, err)
+		}(check)
+	}
+}
+
 func TestWarning(t *testing.T) {
 	check, _ := getCheckInstance("testwarnings", "TestCheck")
 	err := check.Run()

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+
 	python "github.com/sbinet/go-python"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -71,6 +72,12 @@ func TestNewPythonCheck(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	check, _ := getCheckInstance("testcheck", "TestCheck")
+	err := check.Run()
+	assert.Nil(t, err)
+}
+
+func TestSubprocessRun(t *testing.T) {
+	check, _ := getCheckInstance("testsubprocess", "TestSubprocessCheck")
 	err := check.Run()
 	assert.Nil(t, err)
 }

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -155,7 +155,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
 	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
 
-	threadState := C.PyEval_SaveThread()
+	threadState := SaveThreadState()
 
 	length := int(argc)
 	subprocessArgs := make([]string, length-1)

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -163,9 +163,6 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 	}
 	cmd := exec.Command(subprocessCmd, subprocessArgs...)
 
-	glock := C.PyGILState_Ensure()
-	defer C.PyGILState_Release(glock)
-
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cErr := C.CString(fmt.Sprintf("internal error creating stdout pipe: %v", err))
@@ -209,6 +206,9 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 			retCode = status.ExitStatus()
 		}
 	}
+
+	glock := C.PyGILState_Ensure()
+	defer C.PyGILState_Release(glock)
 
 	if raise > 0 {
 		// raise on error

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -142,3 +142,14 @@ func setPythonHome() {
 	pPythonHome := C.CString(pythonHome)
 	C.Py_SetPythonHome(pPythonHome)
 }
+
+func RestoreThreadStateAndLock(state *C.PyThreadState) C.PyGILState_STATE {
+	C.PyEval_RestoreThread(state)
+
+	//Note: Technically the GIL is already acquired here, but we want
+	//      a reference to the GIL, so lets just reacquire it (NOP),
+	//      and return get the glock reference to release at will.
+	glock := C.PyGILState_Ensure()
+
+	return glock
+}

--- a/pkg/collector/py/py.go
+++ b/pkg/collector/py/py.go
@@ -143,6 +143,16 @@ func setPythonHome() {
 	C.Py_SetPythonHome(pPythonHome)
 }
 
+// SaveThreadState is a wrapper around the Python C-API PyEval_SaveThread
+// call. It releases the GIL, and resets the python thread state to NULL.
+// The previous thread state is returned.
+func SaveThreadState() *C.PyThreadState {
+	return C.PyEval_SaveThread()
+}
+
+// RestoreThreadStateAndLock is a wrapper around the Python C-API PyEval_RestoreThread
+// call. It acquires the GIL, and restores the thread state we pass as a parameter.
+// The GIL lock state is returned.
 func RestoreThreadStateAndLock(state *C.PyThreadState) C.PyGILState_STATE {
 	C.PyEval_RestoreThread(state)
 

--- a/pkg/collector/py/tests/testsubprocess.py
+++ b/pkg/collector/py/tests/testsubprocess.py
@@ -3,12 +3,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2018 Datadog, Inc.
 
-import logging
-
 from checks import AgentCheck
 import _util
-
-log = logging.getLogger(__name__)
 
 
 class TestSubprocessCheck(AgentCheck):
@@ -17,4 +13,4 @@ class TestSubprocessCheck(AgentCheck):
         Do not interact with the Aggregator during
         unit tests. Doing anything is ok here.
         """
-        _util.get_subprocess_output(['sleep', '10'], log)
+        _util.get_subprocess_output(['sleep', '10'], False)

--- a/pkg/collector/py/tests/testsubprocess.py
+++ b/pkg/collector/py/tests/testsubprocess.py
@@ -1,0 +1,20 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2018 Datadog, Inc.
+
+import logging
+
+from checks import AgentCheck
+import _util
+
+log = logging.getLogger(__name__)
+
+
+class TestSubprocessCheck(AgentCheck):
+    def check(self, instance):
+        """
+        Do not interact with the Aggregator during
+        unit tests. Doing anything is ok here.
+        """
+        _util.get_subprocess_output(['sleep', '10'], log)

--- a/releasenotes/notes/subprocess-no-GIL-block-3ab15993e448e70b.yaml
+++ b/releasenotes/notes/subprocess-no-GIL-block-3ab15993e448e70b.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    To allow concurrent execution of subprocess calls from python, we now 
+    save the thread state and release the GIL to unblock the interpreter . We
+    can reaquire the GIL and restore the thread state when the subprocess call
+    returns.


### PR DESCRIPTION
### What does this PR do?

While on the C-extension (go-land in practice) end, we can actually save the thread-state, release the GIL, and do our thing until we return from the subprocess call, or need to interact again with the python API. At that point we can restore the thread-state, and reacquire the GIL.

### Motivation

Slow check runs as calls to `get_subprocess_output` would hold the GIL until these completed execution all through-out its call. This basically froze our agent check-execution concurrent abilities for the duration of the call. 
