### PR TITLE
remove debug println left behind

### DIFF
--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -182,7 +182,6 @@ func status(check map[string]interface{}) string {
 }
 
 func getVersion(instances map[string]interface{}) string {
-	fmt.Println(instances)
 	if len(instances) == 0 {
 		return ""
 	}
@@ -196,7 +195,6 @@ func getVersion(instances map[string]interface{}) string {
 		if !ok {
 			return ""
 		}
-		fmt.Println(str)
 		return str
 	}
 	return ""


### PR DESCRIPTION
### What does this PR do?

A few `fmt.Println` used for debug were left behind in https://github.com/DataDog/datadog-agent/pull/2111