### PR TITLE
Improve Config.Digest

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -541,7 +541,6 @@ func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 // resolver at this moment.
 func (ac *AutoConfig) resolveTemplate(tpl integration.Config) []integration.Config {
 	// use a map to dedupe configurations
-	// FIXME: the config digest as the key is currently not reliable
 	resolvedSet := map[string]integration.Config{}
 
 	// go through the AD identifiers provided by the template

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"regexp"
+	"sort"
 	"strconv"
 
 	yaml "gopkg.in/yaml.v2"
@@ -191,7 +192,19 @@ func (c *Config) Digest() string {
 	h := fnv.New64()
 	h.Write([]byte(c.Name))
 	for _, i := range c.Instances {
-		h.Write([]byte(i))
+		inst := RawMap{}
+		err := yaml.Unmarshal(i, &inst)
+		if err != nil {
+			continue
+		}
+		tagList, _ := inst["tags"].([]string)
+		sort.Strings(tagList)
+		inst["tags"] = tagList
+		out, err := yaml.Marshal(&inst)
+		if err != nil {
+			continue
+		}
+		h.Write(out)
 	}
 	h.Write([]byte(c.InitConfig))
 	for _, i := range c.ADIdentifiers {

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -197,6 +197,7 @@ func (c *Config) Digest() string {
 	for _, i := range c.ADIdentifiers {
 		h.Write([]byte(i))
 	}
+	h.Write([]byte(c.LogsConfig))
 
 	return strconv.FormatUint(h.Sum64(), 16)
 }

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -90,8 +90,21 @@ func TestMergeAdditionalTags(t *testing.T) {
 }
 
 func TestDigest(t *testing.T) {
-	config := &Config{}
-	assert.Equal(t, 16, len(config.Digest()))
+	emptyConfig := &Config{}
+	assert.Equal(t, "cbf29ce484222325", emptyConfig.Digest())
+	simpleConfig := &Config{
+		Name:       "foo",
+		InitConfig: Data(""),
+		Instances:  []Data{Data("foo:bar")},
+	}
+	assert.Equal(t, "126b7a7a3ef3b734", simpleConfig.Digest())
+	simpleConfigWithLogs := &Config{
+		Name:       "foo",
+		InitConfig: Data(""),
+		Instances:  []Data{Data("foo:bar")},
+		LogsConfig: Data("bar:foo"),
+	}
+	assert.Equal(t, "66ba0a850883b699", simpleConfigWithLogs.Digest())
 }
 
 // this is here to prevent compiler optimization on the benchmarking code

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -41,6 +41,20 @@ func TestConfigEqual(t *testing.T) {
 	assert.True(t, config.Equal(another))
 	another.ADIdentifiers = []string{"bar", "foo"}
 	assert.False(t, config.Equal(another))
+
+	checkConfigWithOrderedTags := &Config{
+		Name:       "test",
+		InitConfig: Data("foo"),
+		// Instances:  []Data{Data("tags: [\"bar:foo\", \"foo:bar\"]")},
+		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
+	}
+	checkConfigWithUnorderedTags := &Config{
+		Name:       "test",
+		InitConfig: Data("foo"),
+		// Instances:  []Data{Data("tags: [\"foo:bar\", \"bar:foo\"]")},
+		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
+	}
+	assert.Equal(t, checkConfigWithOrderedTags.Digest(), checkConfigWithUnorderedTags.Digest())
 }
 
 func TestString(t *testing.T) {
@@ -102,9 +116,9 @@ func TestDigest(t *testing.T) {
 		Name:       "foo",
 		InitConfig: Data(""),
 		Instances:  []Data{Data("foo:bar")},
-		LogsConfig: Data("bar:foo"),
+		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
-	assert.Equal(t, "66ba0a850883b699", simpleConfigWithLogs.Digest())
+	assert.Equal(t, "d315dd2bad449674", simpleConfigWithLogs.Digest())
 }
 
 // this is here to prevent compiler optimization on the benchmarking code

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -25,12 +25,12 @@ func TestConfigEqual(t *testing.T) {
 	config.Name = another.Name
 	assert.True(t, config.Equal(another))
 
-	another.InitConfig = Data("fooBarBaz")
+	another.InitConfig = Data("{fooBarBaz}")
 	assert.False(t, config.Equal(another))
 	config.InitConfig = another.InitConfig
 	assert.True(t, config.Equal(another))
 
-	another.Instances = []Data{Data("justFoo")}
+	another.Instances = []Data{Data("{justFoo}")}
 	assert.False(t, config.Equal(another))
 	config.Instances = another.Instances
 	assert.True(t, config.Equal(another))
@@ -44,14 +44,14 @@ func TestConfigEqual(t *testing.T) {
 
 	checkConfigWithOrderedTags := &Config{
 		Name:       "test",
-		InitConfig: Data("foo"),
-		// Instances:  []Data{Data("tags: [\"bar:foo\", \"foo:bar\"]")},
+		InitConfig: Data("{foo}"),
+		Instances:  []Data{Data("tags: [\"bar:foo\", \"foo:bar\"]")},
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
 	checkConfigWithUnorderedTags := &Config{
 		Name:       "test",
-		InitConfig: Data("foo"),
-		// Instances:  []Data{Data("tags: [\"foo:bar\", \"bar:foo\"]")},
+		InitConfig: Data("{foo}"),
+		Instances:  []Data{Data("tags: [\"foo:bar\", \"bar:foo\"]")},
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
 	assert.Equal(t, checkConfigWithOrderedTags.Digest(), checkConfigWithUnorderedTags.Digest())
@@ -109,16 +109,16 @@ func TestDigest(t *testing.T) {
 	simpleConfig := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
-		Instances:  []Data{Data("foo:bar")},
+		Instances:  []Data{Data("{foo:bar}")},
 	}
-	assert.Equal(t, "126b7a7a3ef3b734", simpleConfig.Digest())
+	assert.Equal(t, "d8cbc7186ba13533", simpleConfig.Digest())
 	simpleConfigWithLogs := &Config{
 		Name:       "foo",
 		InitConfig: Data(""),
-		Instances:  []Data{Data("foo:bar")},
+		Instances:  []Data{Data("{foo:bar}")},
 		LogsConfig: Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
 	}
-	assert.Equal(t, "d315dd2bad449674", simpleConfigWithLogs.Digest())
+	assert.Equal(t, "6253da85b1624771", simpleConfigWithLogs.Digest())
 }
 
 // this is here to prevent compiler optimization on the benchmarking code

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -128,7 +128,11 @@ func BenchmarkID(b *testing.B) {
 	var id string // store return value to avoid the compiler to strip the function call
 	config := &Config{}
 	config.InitConfig = make([]byte, 32000)
+	config.Instances = []Data{make([]byte, 32000)}
+	config.LogsConfig = make([]byte, 32000)
 	rand.Read(config.InitConfig)
+	rand.Read(config.Instances[0])
+	rand.Read(config.LogsConfig)
 	for n := 0; n < b.N; n++ {
 		id = config.Digest()
 	}

--- a/releasenotes/notes/make-config.Digest-stable-on-unsorted-tags-acda4e96abf5d3dc.yaml
+++ b/releasenotes/notes/make-config.Digest-stable-on-unsorted-tags-acda4e96abf5d3dc.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixes config.Digest that was not stable depending on the oder of tags in the instance.
+    It also did not take into account LogsConfig, this is fixed as well.


### PR DESCRIPTION
### What does this PR do?

Config.Digest is now idempotent wrt tag order. It also takes into account LogsConfig which it did not before.
Tests were also updated.

### Motivation

We need the hash to stay the same if tags change order as this happens in some cases during autodiscovery.
It should also consider LogsConfig because otherwise we'll miss some template updates.

### Additional Notes

Anything else we should know when reviewing?
