### PR TITLE
Fix instance ID on configcheck for autodiscovery

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -11,10 +11,10 @@ Collector
 
   {{- range $CheckName, $CheckInstances := .Checks}}
     {{ $version := version $CheckInstances}}
-    {{$CheckName}} {{ if $version }} ({{$version}}){{ end }}
+    {{$CheckName}}{{ if $version }} ({{$version}}){{ end }}
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
-        Instance ID: {{- if eq (len $CheckInstances) 1 }} {{$CheckName}}{{else}} {{.CheckID}}{{end}} {{status .}}
+        Instance ID: {{.CheckID}} {{status .}}
         Total Runs: {{.TotalRuns}}
         Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
         Events: {{.Events}}, Total: {{humanize .TotalEvents}}

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -11,7 +11,7 @@
           <span class="stat_subtitle">{{$CheckName}}{{ if $version }} ({{$version}}){{ end }}</span>
           {{- range $CheckInstances }}
             <span class="stat_subdata">
-                Instance ID: {{- if eq (len $CheckInstances) 1 }} {{$CheckName}}{{else}} {{.CheckID}}{{end}} {{status .}}<br>
+                Instance ID: {{.CheckID}} {{status .}}<br>
                 Total Runs: {{.TotalRuns}}<br>
                 Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
                 Events: {{.Events}}, Total: {{humanize .TotalEvents}}<br>

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -94,13 +94,8 @@ func PrintConfig(w io.Writer, c integration.Config) {
 		fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Source"), color.RedString("Unknown provider")))
 	}
 	for _, inst := range c.Instances {
-		var ID string
-		if len(c.Instances) > 1 || len(c.ADIdentifiers) > 0 {
-			ID = string(check.BuildID(c.Name, inst, c.InitConfig))
-		} else {
-			ID = c.Name
-		}
-		fmt.Fprintln(w, fmt.Sprintf("%s: %s:", color.BlueString("Instance ID"), color.CyanString(ID)))
+		ID := string(check.BuildID(c.Name, inst, c.InitConfig))
+		fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("Instance ID"), color.CyanString(ID)))
 		fmt.Fprint(w, fmt.Sprintf("%s", inst))
 		fmt.Fprintln(w, "~")
 	}

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -95,10 +95,10 @@ func PrintConfig(w io.Writer, c integration.Config) {
 	}
 	for _, inst := range c.Instances {
 		var ID string
-		if len(c.Instances) == 1 {
-			ID = c.Name
+		if len(c.Instances) > 1 || len(c.ADIdentifiers) > 0 {
+			ID = string(check.BuildID(c.Name, inst, c.InitConfig))
 		} else {
-			ID = string(check.BuildID(c.Name, c.InitConfig, inst))
+			ID = c.Name
 		}
 		fmt.Fprintln(w, fmt.Sprintf("%s: %s:", color.BlueString("Instance ID"), color.CyanString(ID)))
 		fmt.Fprint(w, fmt.Sprintf("%s", inst))

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -16,10 +16,10 @@ Collector
 
   {{- range $CheckName, $CheckInstances := .Checks}}
     {{ $version := version $CheckInstances }}
-    {{$CheckName}} {{ if $version }} ({{$version}}){{ end }}
+    {{$CheckName}}{{ if $version }} ({{$version}}){{ end }}
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
-        Instance ID: {{- if eq (len $CheckInstances) 1 }} {{$CheckName}}{{else}} {{.CheckID}}{{end}} {{status .}}
+        Instance ID: {{.CheckID}} {{status .}}
         Total Runs: {{.TotalRuns}}
         Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
         Events: {{.Events}}, Total: {{humanize .TotalEvents}}


### PR DESCRIPTION
### What does this PR do?

Always show the instance ID in case of autodiscovery

### Motivation

We only show the ID when there is several instances of a check to match what `datadog-agent status` show

For file configurations, all instances are in one `integration.Config` struct, so we just check the length of the integration slice. However for autodiscovery, each instance is in its one `integration.Config` struct so we have to always show the ID for autodiscovery.

At this point we could also show the ID for all instances inconditionally.
