### PR TITLE
[runners] bump default to 4

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,7 +107,7 @@ func init() {
 	BindEnvAndSetDefault("default_integration_http_timeout", 9)
 	BindEnvAndSetDefault("enable_metadata_collection", true)
 	BindEnvAndSetDefault("enable_gohai", true)
-	BindEnvAndSetDefault("check_runners", int64(1))
+	BindEnvAndSetDefault("check_runners", int64(4))
 	BindEnvAndSetDefault("auth_token_file_path", "")
 	BindEnvAndSetDefault("bind_host", "localhost")
 	BindEnvAndSetDefault("hostname_fqdn", false)

--- a/releasenotes/notes/bump-check-runners-4-4ec46f9d8a2cae3e.yaml
+++ b/releasenotes/notes/bump-check-runners-4-4ec46f9d8a2cae3e.yaml
@@ -6,14 +6,17 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-prelude:
+upgrade:
   - |
-    The introduction of multiple runners for checks imples check
+    The introduction of multiple runners for checks implies check
     instances may now run concurrently. This will affect checks which
     are not thread-safe as they may, depending on the scheduling, access
     unsynchronized structures concurrently with the corresponding data
-    race ensuing. Please be cautious and feel free to reach out to us
-    if you wish to change the number of runners.
+    race ensuing. Please be cautious. If you wish to run checks in a fully
+    sequential fashion, you may set the `check_runners` option in your
+    `datadog.yaml` config or via the `DD_CHECK_RUNNERS` to 1. Also, please
+    feel free to reach out to us if you need more information or help
+    with the new multiple runner/concurrency model.
 features:
   - |
     Bump the default number of check runners to 4. This has some

--- a/releasenotes/notes/bump-check-runners-4-4ec46f9d8a2cae3e.yaml
+++ b/releasenotes/notes/bump-check-runners-4-4ec46f9d8a2cae3e.yaml
@@ -1,0 +1,21 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+prelude:
+  - |
+    The introduction of multiple runners for checks imples check
+    instances may now run concurrently. This will affect checks which
+    are not thread-safe as they may, depending on the scheduling, access
+    unsynchronized structures concurrently with the corresponding data
+    race ensuing. Please be cautious and feel free to reach out to us
+    if you wish to change the number of runners.
+features:
+  - |
+    Bump the default number of check runners to 4. This has some
+    concurrency implications as we will now run multiple checks in
+    parallel.


### PR DESCRIPTION
### What does this PR do?

Bumps the default number of check runners to 4.

### Motivation

The new scheduler is begging for multiple runners :) We have circumstances where slow checks may slow down the entire check collection, so some more runners should help us the problem, allow for some concurrency.