### PR TITLE
Use the default number of runners for agent containers

### DIFF
--- a/Dockerfiles/agent/datadog-docker.yaml
+++ b/Dockerfiles/agent/datadog-docker.yaml
@@ -8,10 +8,6 @@ config_providers:
   - name: docker
     polling: true
 
-# Run two runners by default, this needs to be adjusted depending
-# on the number of checks (static + AD) expected to run.
-check_runners: 2
-
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
   enabled: false

--- a/Dockerfiles/agent/datadog-ecs.yaml
+++ b/Dockerfiles/agent/datadog-ecs.yaml
@@ -8,10 +8,6 @@ config_providers:
   - name: ecs
     polling: true
 
-# Run two runners by default, this needs to be adjusted depending
-# on the number of checks (static + AD) expected to run.
-check_runners: 2
-
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
   enabled: false

--- a/Dockerfiles/agent/datadog-kubernetes.yaml
+++ b/Dockerfiles/agent/datadog-kubernetes.yaml
@@ -8,10 +8,6 @@ config_providers:
   - name: kubelet
     polling: true
 
-# Run two runners by default, this needs to be adjusted depending
-# on the number of checks (static + AD) expected to run.
-check_runners: 2
-
 # Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
 apm_config:
   enabled: false


### PR DESCRIPTION
### What does this PR do?

Remove the `check_runners` in the agent containers

follow-up of #2246 