### PR TITLE
Corrected readme run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ care of adjusting paths and run the binary in foreground.
 You need to provide a valid API key. You can either use the config file or
 overwrite it with the environment variable like:
 ```
-DD_API_KEY=12345678990 ./bin/agent/agent -c bin/agent/dist/datadog.yaml
+DD_API_KEY=12345678990 ./bin/agent/agent run -c bin/agent/dist/datadog.yaml
 ```
 
 ## Contributing code


### PR DESCRIPTION
### What does this PR do?

The command for running the agent was missing "run" By using the command as is, users will see the datadog agent help information rather than starting the agent. This PR corrects the command so that it will actually start the agent.

### Motivation

I was following your documentation to use the agent and noticed a typo

### Additional Notes

Anything else we should know when reviewing?
