### PR TITLE
[android] disable logs; logs got enabled by default, and is now

### DIFF
--- a/cmd/agent/android/app/src/main/assets/datadog.yaml
+++ b/cmd/agent/android/app/src/main/assets/datadog.yaml
@@ -90,7 +90,7 @@ logs_config:
   dev_mode_use_proto: false
   open_files_limit: 100
   run_path: ""
-logs_enabled: true
+logs_enabled: false
 logset: ""
 metadata_collectors:
 - interval: 60


### PR DESCRIPTION
continuously logging (expected) failures to the android log

### What does this PR do?

