### PR TITLE
[dogstatsd] Allow appending tags to all received metrics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -184,6 +184,7 @@ func init() {
 	BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
 	BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
 	BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
+	BindEnvAndSetDefault("dogstatsd_tags", []string{})
 	BindEnvAndSetDefault("statsd_forward_host", "")
 	BindEnvAndSetDefault("statsd_forward_port", 0)
 	BindEnvAndSetDefault("statsd_metric_namespace", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -247,6 +247,11 @@ api_key:
 # might change depending on the OS.
 # dogstatsd_so_rcvbuf:
 #
+# Additional tags to append to all metrics received by this server. Useful for
+# tagging all metrics reporting from a single host without resorting to host tags.
+# dogstatsd_tags:
+#   - name:value
+#
 # If you want to forward every packet received by the dogstatsd server
 # to another statsd server, uncomment these lines.
 # WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -55,6 +55,7 @@ type Server struct {
 	defaultHostname  string
 	histToDist       bool
 	histToDistPrefix string
+	extraTags        []string
 }
 
 // NewServer returns a running Dogstatsd server
@@ -108,6 +109,9 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 
 	histToDist := config.Datadog.GetBool("histogram_copy_to_distribution")
 	histToDistPrefix := config.Datadog.GetString("histogram_copy_to_distribution_prefix")
+
+	extraTags := config.Datadog.GetStringSlice("dogstatsd_tags")
+
 	s := &Server{
 		Started:          true,
 		Statistics:       stats,
@@ -120,6 +124,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		defaultHostname:  defaultHostname,
 		histToDist:       histToDist,
 		histToDistPrefix: histToDistPrefix,
+		extraTags:        extraTags,
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
@@ -189,14 +194,15 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 			return
 		case <-s.health.C:
 		case packet := <-s.packetIn:
-			var originTags []string
+			extraTags := s.extraTags
 
 			if packet.Origin != listeners.NoOrigin {
-				var err error
 				log.Tracef("Dogstatsd receive from %s: %s", packet.Origin, packet.Contents)
-				originTags, err = tagger.Tag(packet.Origin, tagger.IsFullCardinality())
+				originTags, err := tagger.Tag(packet.Origin, tagger.IsFullCardinality())
 				if err != nil {
 					log.Errorf(err.Error())
+				} else {
+					extraTags = append(extraTags, originTags...)
 				}
 				log.Tracef("Tags for %s: %s", packet.Origin, originTags)
 			} else {
@@ -220,8 +226,8 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 						dogstatsdServiceCheckParseErrors.Add(1)
 						continue
 					}
-					if len(originTags) > 0 {
-						serviceCheck.Tags = append(serviceCheck.Tags, originTags...)
+					if len(extraTags) > 0 {
+						serviceCheck.Tags = append(serviceCheck.Tags, extraTags...)
 					}
 					dogstatsdServiceCheckPackets.Add(1)
 					serviceCheckOut <- *serviceCheck
@@ -232,8 +238,8 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 						dogstatsdEventParseErrors.Add(1)
 						continue
 					}
-					if len(originTags) > 0 {
-						event.Tags = append(event.Tags, originTags...)
+					if len(extraTags) > 0 {
+						event.Tags = append(event.Tags, extraTags...)
 					}
 					dogstatsdEventPackets.Add(1)
 					eventOut <- *event
@@ -244,8 +250,8 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 						dogstatsdMetricParseErrors.Add(1)
 						continue
 					}
-					if len(originTags) > 0 {
-						sample.Tags = append(sample.Tags, originTags...)
+					if len(extraTags) > 0 {
+						sample.Tags = append(sample.Tags, extraTags...)
 					}
 					dogstatsdMetricPackets.Add(1)
 					metricOut <- sample

--- a/releasenotes/notes/dogstatsd-extra-tags-option-dc29c92ab7a39dd4.yaml
+++ b/releasenotes/notes/dogstatsd-extra-tags-option-dc29c92ab7a39dd4.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Added new dogstatsd_tags variable which can be used to specify
+    additional tags to append to all metrics received by dogstatsd.


### PR DESCRIPTION
### What does this PR do?

Allow appending non-host tags to all metrics received by a dogstatsd server.

### Motivation

When running dogstatsd as a [sidecar container](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/dogstatsd/alpine), only additional _host_ tags can be specified, while normally in such environment no host tags should be reported. This change allows for applying tags to all metrics received by a dogstatsd sidecar container without them being reported as host tags. For example, it can be used to apply a `pod_name` tag to all metrics being reported by the containers in a pod.