### PR TITLE
[Logs]: Fixed kubernetes ingtegration to tail logs from beginning

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -70,6 +70,8 @@ type LogsConfig struct {
 func (c *LogsConfig) Validate() error {
 	switch {
 	case c.Type == "":
+		// a logs-config must have a type to be forwarded to the right input,
+		// otherwise it's dropped.
 		return fmt.Errorf("a config must have a type")
 	case c.Type == FileType && c.Path == "":
 		return fmt.Errorf("file source must have a path")

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -69,6 +69,8 @@ type LogsConfig struct {
 // Validate returns an error if the config is misconfigured
 func (c *LogsConfig) Validate() error {
 	switch {
+	case c.Type == "":
+		return fmt.Errorf("a config must have a type")
 	case c.Type == FileType && c.Path == "":
 		return fmt.Errorf("file source must have a path")
 	case c.Type == TCPType && c.Port == 0:

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -70,8 +70,9 @@ type LogsConfig struct {
 func (c *LogsConfig) Validate() error {
 	switch {
 	case c.Type == "":
-		// a logs-config must have a type to be forwarded to the right input,
-		// otherwise it's dropped.
+		// user don't have to specify a logs-config type when defining
+		// an autodiscovery label because so we must override it at some point,
+		// this check is mostly used for sanity purposed to detect an override miss.
 		return fmt.Errorf("a config must have a type")
 	case c.Type == FileType && c.Path == "":
 		return fmt.Errorf("file source must have a path")

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -30,6 +30,7 @@ func TestValidateShouldSucceedWithValidConfigs(t *testing.T) {
 
 func TestValidateShouldFailWithInvalidConfigs(t *testing.T) {
 	invalidConfigs := []*LogsConfig{
+		{},
 		{Type: FileType},
 		{Type: TCPType},
 		{Type: UDPType},

--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -166,6 +166,8 @@ func (s *Scanner) launchTailers(source *config.LogSource) {
 		}
 		tailFromBeginning := false
 		if source.Config.Identifier != "" {
+			// this is a dynamic source that has been created after discovering a new service (most likely a new container),
+			// so all logs will be collected.
 			tailFromBeginning := true
 		}
 		s.startNewTailer(file, tailFromBeginning)

--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -164,7 +164,11 @@ func (s *Scanner) launchTailers(source *config.LogSource) {
 		if _, isTailed := s.tailers[file.Path]; isTailed {
 			continue
 		}
-		s.startNewTailer(file, false)
+		tailFromBeginning := false
+		if source.Config.Identifier != "" {
+			tailFromBeginning := true
+		}
+		s.startNewTailer(file, tailFromBeginning)
 	}
 }
 

--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -164,11 +164,11 @@ func (s *Scanner) launchTailers(source *config.LogSource) {
 		if _, isTailed := s.tailers[file.Path]; isTailed {
 			continue
 		}
-		tailFromBeginning := false
+		var tailFromBeginning bool
 		if source.Config.Identifier != "" {
 			// this is a dynamic source that has been created after discovering a new service (most likely a new container),
 			// so all logs will be collected.
-			tailFromBeginning := true
+			tailFromBeginning = true
 		}
 		s.startNewTailer(file, tailFromBeginning)
 	}

--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -166,8 +166,9 @@ func (s *Scanner) launchTailers(source *config.LogSource) {
 		}
 		var tailFromBeginning bool
 		if source.Config.Identifier != "" {
-			// this is a dynamic source that has been created after discovering a new service (most likely a new container),
-			// so all logs will be collected.
+			// only sources generated from a service discovery will contain a config identifier,
+			// in which case we want to collect all logs.
+			// FIXME: better detect a source that has been generated from a service discovery.
 			tailFromBeginning = true
 		}
 		s.startNewTailer(file, tailFromBeginning)

--- a/pkg/logs/input/kubernetes/scanner.go
+++ b/pkg/logs/input/kubernetes/scanner.go
@@ -128,6 +128,8 @@ func (s *Scanner) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus)
 			return nil, fmt.Errorf("could not parse kubernetes annotation %v", annotation)
 		}
 		cfg = configs[0]
+		cfg.Type = config.FileType
+		cfg.Path = s.getPath(pod, container)
 		if err := cfg.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
 		}
@@ -136,12 +138,13 @@ func (s *Scanner) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus)
 		}
 	} else {
 		cfg = &config.LogsConfig{
+			Type: config.FileType,
+			Path: s.getPath(pod, container)
 			Source:  kubernetesIntegration,
 			Service: kubernetesIntegration,
 		}
 	}
-	cfg.Type = config.FileType
-	cfg.Path = s.getPath(pod, container)
+	cfg.Identifier = container.ID
 	cfg.Tags = append(cfg.Tags, s.getTags(container)...)
 	return config.NewLogSource(s.getSourceName(pod, container), cfg), nil
 }

--- a/pkg/logs/input/kubernetes/scanner.go
+++ b/pkg/logs/input/kubernetes/scanner.go
@@ -128,24 +128,22 @@ func (s *Scanner) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus)
 			return nil, fmt.Errorf("could not parse kubernetes annotation %v", annotation)
 		}
 		cfg = configs[0]
-		cfg.Type = config.FileType
-		cfg.Path = s.getPath(pod, container)
-		if err := cfg.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
-		}
-		if err := cfg.Compile(); err != nil {
-			return nil, fmt.Errorf("could not compile kubernetes annotation: %v", err)
-		}
 	} else {
 		cfg = &config.LogsConfig{
-			Type: config.FileType,
-			Path: s.getPath(pod, container)
 			Source:  kubernetesIntegration,
 			Service: kubernetesIntegration,
 		}
 	}
+	cfg.Type = config.FileType
+	cfg.Path = s.getPath(pod, container)
 	cfg.Identifier = container.ID
 	cfg.Tags = append(cfg.Tags, s.getTags(container)...)
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
+	}
+	if err := cfg.Compile(); err != nil {
+		return nil, fmt.Errorf("could not compile kubernetes annotation: %v", err)
+	}
 	return config.NewLogSource(s.getSourceName(pod, container), cfg), nil
 }
 

--- a/pkg/logs/input/kubernetes/scanner_test.go
+++ b/pkg/logs/input/kubernetes/scanner_test.go
@@ -39,6 +39,7 @@ func TestGetSource(t *testing.T) {
 	assert.Equal(t, config.FileType, source.Config.Type)
 	assert.Equal(t, "buu/fuz/foo", source.Name)
 	assert.Equal(t, "/var/log/pods/baz/foo/*.log", source.Config.Path)
+	assert.Equal(t, "boo", source.Config.Identifier)
 	assert.Equal(t, "kubernetes", source.Config.Source)
 	assert.Equal(t, "kubernetes", source.Config.Service)
 }
@@ -69,6 +70,7 @@ func TestGetSourceShouldBeOverridenByAutoDiscoveryAnnotation(t *testing.T) {
 	assert.Equal(t, config.FileType, source.Config.Type)
 	assert.Equal(t, "buu/fuz/foo", source.Name)
 	assert.Equal(t, "/var/log/pods/baz/foo/*.log", source.Config.Path)
+	assert.Equal(t, "boo", source.Config.Identifier)
 	assert.Equal(t, "any_source", source.Config.Source)
 	assert.Equal(t, "any_service", source.Config.Service)
 	assert.True(t, contains(source.Config.Tags, "tag1", "tag2"))

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -108,7 +108,7 @@ func (s *Scheduler) toSources(integrationConfig integration.Config) ([]*config.L
 		return nil, err
 	}
 
-	var service *Service
+	var service *service.Service
 	if integrationConfig.Entity != "" {
 		var err error
 		service, err = s.toService(integrationConfig)

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -108,29 +108,31 @@ func (s *Scheduler) toSources(integrationConfig integration.Config) ([]*config.L
 		return nil, err
 	}
 
+	var service *Service
+	if integrationConfig.Entity != "" {
+		var err error
+		service, err = s.toService(integrationConfig)
+		if err != nil {
+			log.Warnf("Invalid service: %v", err)
+		}
+	}
+
 	var sources []*config.LogSource
 	for _, cfg := range configs {
 		integrationName := integrationConfig.Name
-		if integrationConfig.Entity != "" {
-			service, identifier, err := s.parseEntity(integrationConfig.Entity)
-			if err != nil {
-				log.Warnf("Invalid service: %v", err)
-				continue
-			}
-			cfg.Type = service
-			cfg.Identifier = identifier
-			integrationName = service
+		if cfg.Type == "" && service != nil {
+			cfg.Type = service.Type
+			cfg.Identifier = service.Identifier
+			integrationName = service.Type
 		}
 
 		source := config.NewLogSource(integrationName, cfg)
 		sources = append(sources, source)
-
 		if err := cfg.Validate(); err != nil {
 			log.Warnf("Invalid logs configuration: %v", err)
 			source.Status.Error(err)
 			continue
 		}
-
 		if err := cfg.Compile(); err != nil {
 			log.Warnf("Could not compile logs configuration: %v", err)
 			source.Status.Error(err)


### PR DESCRIPTION
### What does this PR do?

Fixed kubernetes integration that would lead to tail all containers from the end.

### Motivation

Collect all logs from beginning.

### Additional Notes

Kubernetes scanner is likely to change since we plugged the logs-agent to autodiscovery.
