### PR TITLE
[jmxfetch] bump to 0.20.2

### DIFF
--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -9,8 +9,8 @@ jmxfetch_version = ENV['JMXFETCH_VERSION']
 jmxfetch_hash = ENV['JMXFETCH_HASH']
 
 if jmxfetch_version.nil? || jmxfetch_version.empty?
-  jmxfetch_version = '0.20.1'
-  jmxfetch_hash = "076dc742d158e888bfff914e022bd1e640bde2b27735e27ed47799dd89058752"
+  jmxfetch_version = '0.20.2'
+  jmxfetch_hash = "3551b0c38a5d78f1d78f7ebe83b7b7482a12943e61a1d1178d7b0bd6ac56c6cf"
 end
 
 default_version jmxfetch_version

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	jmxJarName                        = "jmxfetch-0.20.1-jar-with-dependencies.jar"
+	jmxJarName                        = "jmxfetch-0.20.2-jar-with-dependencies.jar"
 	jmxMainClass                      = "org.datadog.jmxfetch.App"
 	defaultJmxCommand                 = "collect"
 	defaultJvmMaxMemoryAllocation     = " -Xmx200m"

--- a/releasenotes/notes/jmxfetch_0.20.2_bump-7f5f115de57e59c6.yaml
+++ b/releasenotes/notes/jmxfetch_0.20.2_bump-7f5f115de57e59c6.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    JMXFetch upgraded to 0.20.2; ships updated FasterXML.


### PR DESCRIPTION
### What does this PR do?

Bumps JMXFetch to the latest 0.20.2

### Motivation

New JMXFetch release.