### PR TITLE
Rename circleci docker_integration_tests step to more accurate docker_tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           name: run filename linting
           command: inv -e lint-filenames
 
-  docker_integration_tests:
+  docker_tests:
     <<: *job_template
     steps:
       - restore_cache: *restore_source
@@ -187,16 +187,16 @@ workflows:
       - filename_linting:
           requires:
             - dependencies
-      - docker_integration_tests:
+      - docker_tests:
           requires:
             - dependencies
       - build_binaries:
           requires:
             - unit_tests
             - integration_tests
-            - docker_integration_tests
+            - docker_tests
       - build_puppy:
           requires:
             - unit_tests
             - integration_tests
-            - docker_integration_tests
+            - docker_tests


### PR DESCRIPTION
### What does this PR do?

Change was not made in https://github.com/DataDog/datadog-agent/pull/2163 to avoid pipeline changes on the day of the freeze. To merge when re-opening `master`.

Will require changes to the github required statuses.
