### PR TITLE
[test][runner] Fix flaky test

### DIFF
--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -62,10 +63,11 @@ type (
 )
 
 var globalUtil *Util
+var initOnce sync.Once
 
 // GetUtil returns a ready to use ecs Util. It is backed by a shared singleton.
 func GetUtil() (*Util, error) {
-	if globalUtil == nil {
+	initOnce.Do(func() {
 		globalUtil = &Util{}
 		globalUtil.initRetry.SetupRetrier(&retry.Config{
 			Name:          "ecsutil",
@@ -74,7 +76,7 @@ func GetUtil() (*Util, error) {
 			RetryCount:    10,
 			RetryDelay:    30 * time.Second,
 		})
-	}
+	})
 	if err := globalUtil.initRetry.TriggerRetry(); err != nil {
 		log.Debugf("ECS init error: %s", err)
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

Should fix flaky test on `collector/runner_test.go`.

This should fix what I think is the root cause of the flakiness:
the 2 checks had the same ID, so with multiple runners, if the check c2
check was run before check c1, c1 could be discarded because c2 (with
the same ID) was already running.

To fix this, give them different IDs.

### Testing

I've run the circleCI `unit_tests` job 4 times on this branch: succeeded 3 times, and failed once on an unrelated and known flake (on `pkg/util/kubernetes/apiserver/metadata_controller_test.go` that's being worked on independently)