### PR TITLE
[lint] Add a basic 3rd-party license linter

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -65,10 +65,8 @@ core,github.com/inconshreveable/mousetrap,Apache-2.0
 core,github.com/jmespath/go-jmespath,Apache-2.0
 core,github.com/jquery/jquery,MIT
 core,github.com/json-iterator/go,MIT
-core,github.com/juju/ratelimit,LGPL-3+exception
 core,github.com/k-sone/snmpgo,MIT
 core,github.com/kardianos/osext,BSD-3-Clause
-core,github.com/kubernetes,Apache-2.0
 core,github.com/kubernetes-incubator/custom-metrics-apiserver,Apache-2.0
 core,github.com/lxn/walk,BSD-3-Clause
 core,github.com/lxn/win,BSD-3-Clause

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ reno==2.9.2
 docker==3.0.1
 requests==2.19.1
 PyYAML==3.13
+toml==0.9.4

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -6,7 +6,7 @@ from invoke import Collection
 
 from . import agent, android, benchmarks, customaction, docker, dogstatsd, pylauncher, cluster_agent, systray, release
 
-from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, reset
+from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, lint_licenses, reset
 from .test import test, integration_tests, version, lint_teamassignment, lint_releasenote, lint_filenames, e2e_tests
 from .build_tags import audit_tag_impact
 
@@ -23,6 +23,7 @@ ns.add_task(misspell)
 ns.add_task(test)
 ns.add_task(integration_tests)
 ns.add_task(deps)
+ns.add_task(lint_licenses)
 ns.add_task(reset)
 ns.add_task(version)
 ns.add_task(lint_teamassignment)

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -257,6 +257,43 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
 
 
 @task
+def lint_licenses(ctx):
+    """
+    Checks that the LICENSE-3rdparty.csv file is up-to-date with contents of Gopkg.lock
+    """
+    import csv
+    import toml
+
+    # non-go deps that should be listed in the license file, but not in Gopkg.lock
+    NON_GO_DEPS = set([
+        'github.com/codemirror/CodeMirror',
+        'github.com/FortAwesome/Font-Awesome',
+        'github.com/jquery/jquery',
+    ])
+
+    # Read all dep names from Gopkg.lock
+    go_deps = set()
+    gopkg_lock = toml.load('Gopkg.lock')
+    for project in gopkg_lock['projects']:
+        go_deps.add(project['name'])
+
+    deps = go_deps | NON_GO_DEPS
+
+    # Read all dep names listed in LICENSE-3rdparty
+    licenses = csv.DictReader(open('LICENSE-3rdparty.csv'))
+    license_deps = set()
+    for entry in licenses:
+        if len(entry['License']) == 0:
+            raise Exit(message="LICENSE-3rdparty entry '{}' has an empty license".format(entry['Origin']), code=1)
+        license_deps.add(entry['Origin'])
+
+    if deps != license_deps:
+        raise Exit(message="LICENSE-3rdparty.csv is outdated compared to deps listed in Gopkg.lock:\n" +
+                           "missing from LICENSE-3rdparty.csv: {}\n".format(deps - license_deps) +
+                           "listed in LICENSE-3rdparty.csv but not in Gopkg.lock: {}".format(license_deps - deps),
+                   code=1)
+
+@task
 def reset(ctx):
     """
     Clean everything and remove vendoring

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -14,7 +14,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .utils import get_build_flags, get_version, pkg_config_path
-from .go import fmt, lint, vet, misspell, ineffassign
+from .go import fmt, lint, vet, misspell, ineffassign, lint_licenses
 from .build_tags import get_default_build_tags, get_build_tags
 from .agent import integration_tests as agent_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
@@ -65,6 +65,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     lint_filenames(ctx)
     fmt(ctx, targets=tool_targets, fail_on_fmt=fail_on_fmt)
     lint(ctx, targets=tool_targets)
+    lint_licenses(ctx)
     print("--- Vetting:")
     vet(ctx, targets=tool_targets, use_embedded_libs=use_embedded_libs)
     print("--- Misspelling:")


### PR DESCRIPTION
### What does this PR do?

Adds a basic 3rd-party license linter (part of regular `inv test` command) that simply checks that the `LICENSE-3rdparty.csv` file is up-to-date with contents of `Gopkg.lock`.

Follow-up to https://github.com/DataDog/datadog-agent/pull/2264

### Motivation

Basic linter to at least make sure we update the license file when we add/remove deps.

### Additional Notes

Baklava will soon work on generating the license file automatically, the present task is only a stopgap until that's ready.
