### PR TITLE
[release notes] Move JMXFetch upgrade to `other` section

### DIFF
--- a/releasenotes/notes/jmxfetch_0.20.2_bump-7f5f115de57e59c6.yaml
+++ b/releasenotes/notes/jmxfetch_0.20.2_bump-7f5f115de57e59c6.yaml
@@ -6,6 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-upgrade:
+other:
   - |
     JMXFetch upgraded to 0.20.2; ships updated FasterXML.


### PR DESCRIPTION
### What does this PR do?

Moves JMXFetch upgrade release note to `other` section

### Motivation

The `upgrade` section should only list potentially breaking
changes/changes that users should absolutely double-check before they
upgrade. So this JMXFetch upgrade doesn't fit in this section, let's
move it to `other`.

### Additional Notes

I'll follow up with another PR to clarify what the `upgrade` section is about.