### PR TITLE
[release notes] Clarify what `upgrade` section should contain

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -25,6 +25,8 @@ template: |
           upgrade:
             - |
               List upgrade notes here, or remove this section.
+              Only list known/potential breaking changes, or behavior changes
+              that users should absolutely know about before upgrading.
           deprecations:
             - |
               List deprecations notes here, or remove this section.
@@ -37,7 +39,7 @@ template: |
           other:
             - |
               Add here every other information you want in the CHANGELOG that
-              don't feat in any other section. This section should rarely be
+              don't fit in any other section. This section should rarely be
               used.
 sections:
   # The prelude section is implicitly included.


### PR DESCRIPTION
### What does this PR do?

Clarifies what `upgrade` section should contain. Follow-up to https://github.com/DataDog/datadog-agent/pull/2269

### Motivation

To provide maximum value to users, this section should list known/potential breaking changes only.
