### PR TITLE
[Logs]: Fixed default frame size overriding for tcp/udp log collection

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -45,7 +45,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, serverConf
 
 	// setup the inputs
 	inputs := []restart.Restartable{
-		listener.NewListener(sources, pipelineProvider),
+		listener.NewListener(sources, config.LogsAgent.GetInt("logs_config.frame_size"), pipelineProvider),
 		file.NewScanner(sources, config.LogsAgent.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
 		journald.NewLauncher(sources, pipelineProvider, auditor),
 		windowsevent.NewLauncher(sources, pipelineProvider),

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -45,7 +45,7 @@ func NewTCPListener(pipelineProvider pipeline.Provider, source *config.LogSource
 
 // Start starts the listener to accepts new incoming connections.
 func (l *TCPListener) Start() {
-	log.Infof("Starting TCP forwarder on port %d", l.source.Config.Port)
+	log.Infof("Starting TCP forwarder on port %d, with read buffer size: %d", l.source.Config.Port, l.frameSize)
 	err := l.startListener()
 	if err != nil {
 		log.Errorf("Can't start TCP forwarder on port %d: %v", l.source.Config.Port, err)

--- a/pkg/logs/input/listener/tcp_test.go
+++ b/pkg/logs/input/listener/tcp_test.go
@@ -23,7 +23,7 @@ const tcpTestPort = 10512
 func TestTCPShouldReceivesMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewTCPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: tcpTestPort}), defaultFrameSize)
+	listener := NewTCPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: tcpTestPort}), 9000)
 	listener.Start()
 
 	conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", tcpTestPort))

--- a/pkg/logs/input/listener/udp.go
+++ b/pkg/logs/input/listener/udp.go
@@ -45,7 +45,7 @@ func NewUDPListener(pipelineProvider pipeline.Provider, source *config.LogSource
 
 // Start opens a new UDP connection and starts a tailer.
 func (l *UDPListener) Start() {
-	log.Infof("Starting UDP forwarder on port: %d", l.source.Config.Port)
+	log.Infof("Starting UDP forwarder on port: %d, with read buffer size: %d", l.source.Config.Port, l.frameSize)
 	err := l.startNewTailer()
 	if err != nil {
 		log.Errorf("Can't start UDP forwarder on port %d: %v", l.source.Config.Port, err)

--- a/pkg/logs/input/listener/udp_nix_test.go
+++ b/pkg/logs/input/listener/udp_nix_test.go
@@ -25,7 +25,8 @@ const maxUDPFrameLen = 65535
 func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), defaultFrameSize)
+	frameSize := 9000
+	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
 	listener.Start()
 
 	conn, err := net.Dial("udp", fmt.Sprintf("localhost:%d", udpTestPort))
@@ -33,17 +34,17 @@ func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 
 	var msg message.Message
 
-	fmt.Fprintf(conn, strings.Repeat("a", defaultFrameSize-100)+"\n")
+	fmt.Fprintf(conn, strings.Repeat("a", frameSize-100)+"\n")
 	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", defaultFrameSize-100), string(msg.Content()))
+	assert.Equal(t, strings.Repeat("a", frameSize-100), string(msg.Content()))
 
-	fmt.Fprintf(conn, strings.Repeat("a", defaultFrameSize)+"\n")
+	fmt.Fprintf(conn, strings.Repeat("a", frameSize)+"\n")
 	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", defaultFrameSize), string(msg.Content()))
+	assert.Equal(t, strings.Repeat("a", frameSize), string(msg.Content()))
 
-	fmt.Fprintf(conn, strings.Repeat("a", defaultFrameSize-200)+"\n")
+	fmt.Fprintf(conn, strings.Repeat("a", frameSize-200)+"\n")
 	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", defaultFrameSize-200), string(msg.Content()))
+	assert.Equal(t, strings.Repeat("a", frameSize-200), string(msg.Content()))
 
 	listener.Stop()
 }

--- a/pkg/logs/input/listener/udp_test.go
+++ b/pkg/logs/input/listener/udp_test.go
@@ -22,7 +22,7 @@ const udpTestPort = 10513
 func TestUDPShouldReceiveMessage(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), defaultFrameSize)
+	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)
 	listener.Start()
 
 	conn, err := net.Dial("udp", fmt.Sprintf("localhost:%d", udpTestPort))

--- a/releasenotes/notes/logs-fix-frame-size-override-ceaa202ba1048d4a.yaml
+++ b/releasenotes/notes/logs-fix-frame-size-override-ceaa202ba1048d4a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed "logs_config.frame_size" override that would not be taken into account.


### PR DESCRIPTION
### What does this PR do?

Fixed an issue with `logs_config.frame_size` override that would not be taken into account.

### Motivation

Be able to override the read buffer size.

### Additional Notes

https://github.com/DataDog/datadog-agent/issues/2271
