### PR TITLE
Fix kube node labels retrieval

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetTags gets the tags from the kubernetes apiserver
@@ -32,10 +31,15 @@ func GetTags() ([]string, error) {
 		labelsToTags[strings.ToLower(label)] = value
 	}
 
-	nodeName, err := kubelet.HostnameProvider("")
+	ku, err := kubelet.GetKubeUtil()
 	if err != nil {
 		return nil, err
 	}
+	nodeName, err := ku.GetNodename()
+	if err != nil {
+		return nil, err
+	}
+
 	var nodeLabels map[string]string
 	if config.Datadog.GetBool("cluster_agent.enabled") {
 		cl, err := clusteragent.GetClusterAgentClient()

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -40,7 +40,7 @@ func GetTags() ([]string, error) {
 	if config.Datadog.GetBool("cluster_agent.enabled") {
 		cl, err := clusteragent.GetClusterAgentClient()
 		if err != nil {
-			log.Errorf("Could not connect to the Cluster Agent to collect node labels for %s: %v", nodeName, err)
+			return nil, err
 		}
 		nodeLabels, err = cl.GetNodeLabels(nodeName)
 		if err != nil {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -122,7 +122,7 @@ func (ku *KubeUtil) GetNodeInfo() (string, string, error) {
 
 // GetHostname builds a hostname from the kubernetes nodename and an optional cluster-name
 func (ku *KubeUtil) GetHostname() (string, error) {
-	nodeName, err := ku.getNodename()
+	nodeName, err := ku.GetNodename()
 	if err != nil {
 		return "", fmt.Errorf("couldn't fetch the host nodename from the kubelet: %s", err)
 	}
@@ -136,8 +136,8 @@ func (ku *KubeUtil) GetHostname() (string, error) {
 	}
 }
 
-// getNodename returns the nodename of the first pod.spec.nodeName in the PodList
-func (ku *KubeUtil) getNodename() (string, error) {
+// GetNodename returns the nodename of the first pod.spec.nodeName in the PodList
+func (ku *KubeUtil) GetNodename() (string, error) {
 	pods, err := ku.GetLocalPodList()
 	if err != nil {
 		return "", fmt.Errorf("error getting pod list from kubelet: %s", err)


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs in the logic:

- `nil` pointer exception when the agent is configured to use the cluster-agent, but the latter is unavailable
- incompatibility with the new `cluster_name` option, as we used the suffixed hostname instead of the "pure" nodename for the query

Test image: `xvellodatadog/agent-dev:nodefix`
