### PR TITLE
[Logs]: Autodiscovery - Docker Label fix

### DIFF
--- a/pkg/logs/input/docker/container.go
+++ b/pkg/logs/input/docker/container.go
@@ -50,14 +50,6 @@ func (c *Container) FindSource(sources []*config.LogSource) *config.LogSource {
 			bestMatch = source
 		}
 	}
-	if bestMatch == nil {
-		// no source found for this container
-		return nil
-	}
-	if c.ContainsADLabel() && !c.isIdentifierMatch(bestMatch.Config.Identifier) {
-		// containers with an autodiscovery label must have the same identifier as the source it matches with
-		return nil
-	}
 	return bestMatch
 }
 
@@ -78,7 +70,7 @@ func (c *Container) computeScore(source *config.LogSource) int {
 
 // IsMatch returns true if the source matches with the container.
 func (c *Container) IsMatch(source *config.LogSource) bool {
-	if source.Config.Identifier != "" && !c.isIdentifierMatch(source.Config.Identifier) {
+	if (source.Config.Identifier != "" || c.ContainsADIdentifier()) && !c.isIdentifierMatch(source.Config.Identifier) {
 		return false
 	}
 	if source.Config.Image != "" && !c.isImageMatch(source.Config.Image) {
@@ -160,8 +152,8 @@ func (c *Container) isLabelMatch(labelFilter string) bool {
 // this feature is commonly named 'ad' or 'autodicovery'.
 const configPath = "com.datadoghq.ad.logs"
 
-// ContainsADLabel returns true if the container contains an autodiscovery label.
-func (c *Container) ContainsADLabel() bool {
-	_, exists := c.container.Labels[configPath]
+// ContainsADIdentifier returns true if the container contains an autodiscovery identifier.
+func (c *Container) ContainsADIdentifier() bool {
+	_, exists := container.Labels[configPath]
 	return exists
 }

--- a/pkg/logs/input/docker/container.go
+++ b/pkg/logs/input/docker/container.go
@@ -154,6 +154,6 @@ const configPath = "com.datadoghq.ad.logs"
 
 // ContainsADIdentifier returns true if the container contains an autodiscovery identifier.
 func (c *Container) ContainsADIdentifier() bool {
-	_, exists := container.Labels[configPath]
+	_, exists := c.container.Labels[configPath]
 	return exists
 }

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -127,6 +127,11 @@ func (l *Launcher) run() {
 // startTailer starts a new tailer for the container.
 func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 	containerID := container.service.Identifier
+	if _, isTailed := l.tailers[containerID]; isTailed {
+		log.Warnf("Can't tail twice the same container: %v", ShortContainerID(containerID))
+		return
+	}
+
 	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan())
 
 	since, err := Since(l.registry, tailer.Identifier(), container.service.CreationTime)


### PR DESCRIPTION
### What does this PR do?

Fixed a bug that would occur at agent restart when a container contains an ad config and that the agent is configured to tail all containers.
The ad config would not be chosen by the strategy and the logs would not have the right attributes.

### Motivation

Be able to override a logs config with a an ad config.

### Additional Notes

To merge for the RC2.
