### PR TITLE
[Logs]: Autodiscovery - Pod Annotation fix

### DIFF
--- a/pkg/logs/input/docker/ad_identifier.go
+++ b/pkg/logs/input/docker/ad_identifier.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker,!kubelet
+
+package docker
+
+import (
+	"github.com/docker/docker/api/types"
+)
+
+// configPath refers to the configuration that can be passed over a docker label,
+// this feature is commonly named 'ad' or 'autodicovery'.
+const configPath = "com.datadoghq.ad.logs"
+
+// ContainsADIdentifier returns true if the container contains an autodiscovery identifier.
+func ContainsADIdentifier(c *Container) bool {
+	_, exists := container.Labels[configPath]
+	return exists
+}

--- a/pkg/logs/input/docker/ad_identifier_kubelet.go
+++ b/pkg/logs/input/docker/ad_identifier_kubelet.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker,kubelet
+
+package docker
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+// configPath refers to the configuration that can be passed over a docker label or a pod annotation,
+// this feature is commonly named 'ad' or 'autodicovery'.
+const (
+	labelConfigPath            = "com.datadoghq.ad.logs"
+	annotationConfigPathPrefix = "ad.datadoghq.com"
+	annotationConfigPathSuffix = "logs"
+)
+
+// ContainsADIdentifier returns true if the container contains an autodiscovery identifier.
+func ContainsADIdentifier(c *Container) bool {
+	var exists bool
+	_, exists = c.container.Labels[labelConfigPath]
+	if exists {
+		return true
+	}
+	kubeutil, err := kubelet.GetKubeUtil()
+	if err != nil {
+		return false
+	}
+	entityID := c.service.GetEntityID()
+	pod, err := kubeutil.GetPodForEntityID(entityID)
+	if err != nil {
+		return false
+	}
+	for _, container := range pod.Status.Containers {
+		if container.ID == entityID {
+			// looks for the container name specified in the pod manifest as its different from the name of the container
+			// returns by the docker socket which is a concatenation of the container name specified in the pod manifest and a hash
+			_, exists = pod.Metadata.Annotations[annotationConfigPath(container.Name)]
+			return exists
+		}
+	}
+	return false
+}
+
+// annotationConfigPath returns the path of a logs-config passed in a pod annotation.
+func annotationConfigPath(containerName string) string {
+	return fmt.Sprintf("%s/%s.%s", annotationConfigPathPrefix, containerName, annotationConfigPathSuffix)
+}

--- a/pkg/logs/input/docker/container.go
+++ b/pkg/logs/input/docker/container.go
@@ -154,6 +154,5 @@ const configPath = "com.datadoghq.ad.logs"
 
 // ContainsADIdentifier returns true if the container contains an autodiscovery identifier.
 func (c *Container) ContainsADIdentifier() bool {
-	_, exists := c.container.Labels[configPath]
-	return exists
+	return ContainsADIdentifier(c)
 }

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -130,7 +130,7 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 	configName := s.configName(config)
 	var sources []*logsConfig.LogSource
 	for _, cfg := range configs {
-		if cfg.Type == "" && service != nil {
+		if service != nil {
 			cfg.Type = service.Type
 			cfg.Identifier = service.Identifier
 		}

--- a/pkg/logs/service/service.go
+++ b/pkg/logs/service/service.go
@@ -5,6 +5,10 @@
 
 package service
 
+import (
+	"fmt"
+)
+
 // CreationTime represents the moment when the service was created compared to the agent start.
 type CreationTime int
 
@@ -29,4 +33,9 @@ func NewService(provider string, identifier string, createdTime CreationTime) *S
 		Identifier:   identifier,
 		CreationTime: createdTime,
 	}
+}
+
+// GetEntityID return the entity identifier of the service
+func (s *Service) GetEntityID() string {
+	return fmt.Sprintf("%s://%s", s.Type, s.Identifier)
 }


### PR DESCRIPTION
### What does this PR do?

Fix a bug that would lead a pod annotation config not to be taken into account when `logs_config.container_collect_all` is enabled.

### Motivation

Be able to override logs attributes with pod annotation ad identifier

### Additional Notes

Need to merge this first https://github.com/DataDog/datadog-agent/pull/2277
This should fix https://github.com/DataDog/datadog-agent/issues/2267
