### PR TITLE
[install script] split DD_URL config options

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -224,7 +224,7 @@ else
       no_start=true
     fi
   fi
-  if [ $DD_URL ]; then
+  if [ -n "$DD_URL" ]; then
     $sudo_cmd sh -c "sed -i 's/# dd_url:.*/dd_url: $DD_URL/' $CONF"
   fi
   if [ $dd_hostname ]; then

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -64,10 +64,10 @@ if [ -n "$DD_HOST_TAGS" ]; then
     host_tags=$DD_HOST_TAGS
 fi
 
-if [ -n "$DD_URL" ]; then
-  dd_url=$DD_URL
+if [ -n "$REPO_URL" ]; then
+  repo_url=$REPO_URL
 else
-  dd_url="datadoghq.com"
+  repo_url="datadoghq.com"
 fi
 
 dd_upgrade=
@@ -127,7 +127,7 @@ if [ $OS = "RedHat" ]; then
         ARCHI="x86_64"
     fi
 
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${dd_url}/stable/6/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public\n       https://yum.${dd_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/stable/6/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean metadata
@@ -143,7 +143,7 @@ elif [ $OS = "Debian" ]; then
       $sudo_cmd apt-get install -y dirmngr
     fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
-    $sudo_cmd sh -c "echo 'deb https://apt.${dd_url}/ stable 6' > /etc/apt/sources.list.d/datadog.list"
+    $sudo_cmd sh -c "echo 'deb https://apt.${repo_url}/ stable 6' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"
@@ -173,10 +173,10 @@ elif [ $OS = "SUSE" ]; then
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
-  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${dd_url}/suse/stable/6/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${dd_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog.repo"
+  $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.${repo_url}/suse/stable/6/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog.repo"
 
   echo -e "\033[34m\n* Importing the Datadog GPG Key\n\033[0m"
-  $sudo_cmd rpm --import https://yum.${dd_url}/DATADOG_RPM_KEY.public
+  $sudo_cmd rpm --import https://yum.${repo_url}/DATADOG_RPM_KEY.public
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
   $sudo_cmd zypper --non-interactive --no-gpg-check refresh datadog

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -224,8 +224,8 @@ else
       no_start=true
     fi
   fi
-  if [ $dd_url ]; then
-    $sudo_cmd sh -c "sed -i 's/# dd_url:.*/dd_url: $dd_url/' $CONF"
+  if [ $DD_URL ]; then
+    $sudo_cmd sh -c "sed -i 's/# dd_url:.*/dd_url: $DD_URL/' $CONF"
   fi
   if [ $dd_hostname ]; then
     printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: $CONF\n\033[0m\n"

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -49,9 +49,9 @@ end
 execute 'run agent install script' do
   cwd wrk_dir
   command <<-EOF
-    sed -i '1iDD_API_KEY=#{node['dd-agent-install-script']['api_key']}' install-script
-    sed -i '1iREPO_URL="datad0g.com"' install-script
-    sed -i '1iDD_URL="datad0g.com"' install-script
+    sed -i '1aDD_API_KEY=#{node['dd-agent-install-script']['api_key']}' install-script
+    sed -i '1aREPO_URL="datad0g.com"' install-script
+    sed -i '1aDD_URL="datad0g.com"' install-script
     bash install-script
     sleep 10
   EOF

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -50,7 +50,7 @@ execute 'run agent install script' do
   cwd wrk_dir
   command <<-EOF
     sed -i '1iDD_API_KEY=#{node['dd-agent-install-script']['api_key']}' install-script
-    sed -i '1iDD_URL="datad0g.com"' install-script
+    sed -i '1iREPO_URL="datad0g.com"' install-script
     bash install-script
     sleep 10
   EOF

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -51,6 +51,7 @@ execute 'run agent install script' do
   command <<-EOF
     sed -i '1iDD_API_KEY=#{node['dd-agent-install-script']['api_key']}' install-script
     sed -i '1iREPO_URL="datad0g.com"' install-script
+    sed -i '1iDD_URL="datad0g.com"' install-script
     bash install-script
     sleep 10
   EOF


### PR DESCRIPTION
### What does this PR do?

The `DD_URL` env var was configuring two things:
1. the address of the package repo 
1. the agent `DD_URL` config option

This PR moves 1. behavior to the `REPO_URL` env var.
