### PR TITLE
[config] Handle `app.datadoghq.eu` similarly to `app.datadoghq.com`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -323,7 +323,9 @@ func BindEnvAndSetDefault(key string, val interface{}) {
 var (
 	ddURLs = map[string]interface{}{
 		"app.datadoghq.com": nil,
+		"app.datadoghq.eu":  nil,
 		"app.datad0g.com":   nil,
+		"app.datad0g.eu":    nil,
 	}
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -153,6 +153,10 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.com", newURL)
 
+	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.eu", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.eu", newURL)
+
 	newURL, err = AddAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://app.myproxy.com", newURL)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -157,6 +157,10 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("app")+".datadoghq.eu", newURL)
 
+	newURL, err = AddAgentVersionToDomain("https://app.datadoghq.eu", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.eu", newURL)
+
 	newURL, err = AddAgentVersionToDomain("https://app.myproxy.com", "app")
 	require.Nil(t, err)
 	assert.Equal(t, "https://app.myproxy.com", newURL)

--- a/releasenotes/notes/add-version-prefix-dd-eu-url-ba254eaab0114ec3.yaml
+++ b/releasenotes/notes/add-version-prefix-dd-eu-url-ba254eaab0114ec3.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When ``dd_url`` is set to ``app.datadoghq.eu``, the infra Agent also sends data
+    to versioned endpoints (similar to ``app.datadoghq.com``)


### PR DESCRIPTION
### What does this PR do?

The `app.datad0g.com`/`app.datadoghq.com` `dd_url`s are "re-written" so that
the Agent forwarder actually sends to versioned endpoints.

Make same transformation to `app.datad0g.eu`/`app.datadoghq.eu`
`dd_url`s.

### Motivation

Improve consistency of setting up `.com`/`.eu` endpoints for the infra Agent in 6.5.0. Other Agent components (logs/trace/process) don't make this kind of transformation.

### Testing

Setting `dd_url: https://app.datadoghq.eu` now works well (all infra data shows up in web app, agent API key validation works well)

### Additional Notes

This agent-side hardcoded url-rewriting isn't a future-proof pattern. I'll investigate how to make things more flexible, depending on what we plan for the future of the `dd_url` option.
