### PR TITLE
make all the fields of the check status human readable

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/collector.tmpl
@@ -15,10 +15,10 @@ Collector
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
         Instance ID: {{.CheckID}} {{status .}}
-        Total Runs: {{.TotalRuns}}
-        Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
-        Events: {{.Events}}, Total: {{humanize .TotalEvents}}
-        Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+        Total Runs: {{humanize .TotalRuns}}
+        Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+        Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+        Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
         Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
         {{if .LastError -}}
         Error: {{lastErrorMessage .LastError}}

--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -12,10 +12,10 @@
           {{- range $CheckInstances }}
             <span class="stat_subdata">
                 Instance ID: {{.CheckID}} {{status .}}<br>
-                Total Runs: {{.TotalRuns}}<br>
-                Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
-                Events: {{.Events}}, Total: {{humanize .TotalEvents}}<br>
-                Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+                Total Runs: {{humanize .TotalRuns}}<br>
+                Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
+                Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
+                Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
                 Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}<br>
               {{- if .LastError}}
                 <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -4,10 +4,10 @@
   <span class="stat_subtitle">Instance {{add $i 1}}</span>
     <span class="stat_data">
         Instance ID: {{.CheckID}}<br>
-        Total Runs: {{.TotalRuns}}<br>
-        Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
-        Events: {{.Events}}, Total: {{humanize .TotalEvents}}<br>
-        Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
+        Total Runs: {{humanize .TotalRuns}}<br>
+        Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
+        Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>
+        Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}<br>
       {{- if .LastError}}
         <span class="error">Error</span>: {{lastErrorMessage .LastError}}<br>
               {{lastErrorTraceback .LastError -}}

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -20,10 +20,10 @@ Collector
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
         Instance ID: {{.CheckID}} {{status .}}
-        Total Runs: {{.TotalRuns}}
-        Metric Samples: {{.MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
-        Events: {{.Events}}, Total: {{humanize .TotalEvents}}
-        Service Checks: {{.ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
+        Total Runs: {{humanize .TotalRuns}}
+        Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
+        Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}
+        Service Checks: {{humanize .ServiceChecks}}, Total: {{humanize .TotalServiceChecks}}
         Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
         {{if .LastError -}}
         Error: {{lastErrorMessage .LastError}}


### PR DESCRIPTION
### What does this PR do?

We were not calling humanize on some field leading to some inconsistency:

```
    uptime
    ------
        Instance ID: uptime [OK]
        Total Runs: 9686
        Metric Samples: 1, Total: 9,686
        Events: 0, Total: 0
        Service Checks: 0, Total: 0
        Average Execution Time : 0s
```