### PR TITLE
add snyk for python & go

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,8 +150,11 @@ run_security_scan_test:
     - inv deps
   script:
     - set +x     # don't print the api key to the logs
+    # send the list of the dependencies to snyk
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor # send the list of the dependencies to snyk
+      snyk monitor --project-name=datadog-agent-requirements.txt --file=requirements.txt --package-manager=pip
+    - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
+      snyk monitor --project-name=datadog-agent-gopkg.lock --file=Gopkg.lock
 
 #
 # binary_build


### PR DESCRIPTION
### What does this PR do?

This PRs adds Snyk tests for both Golang and Python

### Motivation

The adding of Python requirements would make `snyk monitor` only monitor Python dependencies
