### PR TITLE
Add configuration/environment hostname errors on the status page

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -51,8 +51,10 @@ func ValidHostname(hostname string) error {
 	} else if isLocal(hostname) {
 		return fmt.Errorf("%s is a local hostname", hostname)
 	} else if len(hostname) > maxLength {
+		log.Errorf("ValidHostname: name exceeded the maximum length of %d characters", maxLength)
 		return fmt.Errorf("name exceeded the maximum length of %d characters", maxLength)
 	} else if !validHostnameRfc1123.MatchString(hostname) {
+		log.Errorf("ValidHostname: %s is not RFC1123 compliant", hostname)
 		return fmt.Errorf("%s is not RFC1123 compliant", hostname)
 	}
 	return nil

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -118,6 +118,10 @@ func GetHostname() (string, error) {
 		return name, err
 	}
 
+	expErr := new(expvar.String)
+	expErr.Set(err.Error())
+	hostnameErrors.Set("configuration/environment", expErr)
+
 	log.Debugf("Unable to get the hostname from the config file: %s", err)
 	log.Debug("Trying to determine a reliable host name automatically...")
 


### PR DESCRIPTION
### What does this PR do?

Add configuration/environment hostname errors on the status page

### Motivation

Since #2103 we display hostname errors on the status page
