### PR TITLE
Don't display stats of stopped checks

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -176,20 +176,20 @@ func (c *Collector) StopCheck(id check.ID) error {
 	}
 
 	// stop the instance, this might time out
-	fmt.Println("Before StopCheck")
+	log.Errorf("Before StopCheck %s", string(id))
 	c.scheduler.PrintQueues()
 
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
 	}
-	fmt.Println("After StopCheck")
+	log.Errorf("After StopCheck %s", string(id))
 	c.scheduler.PrintQueues()
 
 	// remove the check from the stats map
 	runner.RemoveCheckStats(id)
 
-	fmt.Println("After RemoveCheck")
+	log.Errorf("After RemoveCheck %s", string(id))
 	c.scheduler.PrintQueues()
 
 	// vaporize the check

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -176,13 +176,21 @@ func (c *Collector) StopCheck(id check.ID) error {
 	}
 
 	// stop the instance, this might time out
+	fmt.Println("Before StopCheck")
+	c.scheduler.PrintQueues()
+
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
 	}
+	fmt.Println("After StopCheck")
+	c.scheduler.PrintQueues()
 
 	// remove the check from the stats map
 	runner.RemoveCheckStats(id)
+
+	fmt.Println("After RemoveCheck")
+	c.scheduler.PrintQueues()
 
 	// vaporize the check
 	c.delete(id)

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -372,7 +372,7 @@ func addWorkStats(c check.Check, execTime time.Duration, err error, warnings []e
 	var found bool
 
 	checkStats.M.Lock()
-	log.Errorf("Remove stats for %s", string(c.ID()))
+	log.Errorf("Add stats for %s", string(c.ID()))
 	stats, found := checkStats.Stats[c.String()]
 	if !found {
 		stats = make(map[check.ID]*check.Stats)

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -392,6 +392,9 @@ func RemoveCheckStats(checkID check.ID) {
 	stats, found := checkStats.Stats[checkName]
 	if found {
 		delete(stats, checkID)
+		if len(stats) == 0 {
+			delete(checkStats.Stats, checkName)
+		}
 	}
 }
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -84,6 +84,7 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 		for _, id := range ids {
 			// `StopCheck` might time out so we don't risk to block
 			// the polling loop forever
+			log.Errorf("Stop check instance id: %s", string(id))
 			err := s.collector.StopCheck(id)
 			if err != nil {
 				log.Errorf("Error stopping check %s: %s", id, err)

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -177,6 +177,10 @@ func (jq *jobQueue) process(out chan<- check.Check) bool {
 		// blocking could interfere with scheduling new jobs
 		jobs := []check.Check{}
 		jobs = append(jobs, bucket.jobs...)
+		log.Errorf("job queue")
+		for _, job := range jobs {
+			log.Errorf(string(job.ID()))
+		}
 		bucket.mu.RUnlock()
 
 		log.Tracef("Jobs in bucket: %v", jobs)

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -99,7 +99,7 @@ func (s *Scheduler) Cancel(id check.ID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Infof("Unscheduling check %v ", check.IDToCheckName(id))
+	log.Errorf("Unscheduling %s check %v ", string(id), check.IDToCheckName(id))
 
 	if _, ok := s.checkToQueue[id]; !ok {
 		return nil

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -93,6 +93,17 @@ func (s *Scheduler) Enter(check check.Check) error {
 	return nil
 }
 
+// PrintQueues print
+func (s *Scheduler) PrintQueues() {
+	for _, queue := range s.jobQueues {
+		for _, job := range queue.buckets {
+			for _, check := range job.jobs {
+				fmt.Println(string(check.ID()))
+			}
+		}
+	}
+}
+
 // Cancel remove a Check from the scheduled queue. If the check is not
 // in the scheduler, this is a noop.
 func (s *Scheduler) Cancel(id check.ID) error {


### PR DESCRIPTION
### What does this PR do?

- If all instances of a check have stopped, don't display an empty check name
- fix for some concurrency issue where stats of stopped checks are display in the status (needs testing)
