### PR TITLE
ecs: allow to setup the ecs-agent container name 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -240,6 +240,7 @@ func init() {
 
 	// ECS
 	BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
+	BindEnvAndSetDefault("ecs_agent_name", "ecs-agent")
 	BindEnvAndSetDefault("collect_ec2_tags", false)
 
 	// GCE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -240,7 +240,7 @@ func init() {
 
 	// ECS
 	BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
-	BindEnvAndSetDefault("ecs_agent_name", "ecs-agent")
+	BindEnvAndSetDefault("ecs_agent_container_name", "ecs-agent")
 	BindEnvAndSetDefault("collect_ec2_tags", false)
 
 	// GCE

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -492,6 +492,9 @@ api_key:
 # URL where the ECS agent can be found. Standard cases will be autodetected.
 # ecs_agent_url: http://localhost:51678
 #
+# Name of the ecs-agent docker container, for autodetection.
+# ecs_agent_name: ecs-agent
+#
 {{ end -}}
 {{- if .Kubelet }}
 # Kubernetes kubelet connectivity

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -487,13 +487,15 @@ api_key:
 #
 {{ end -}}
 {{- if .ECS }}
-# ECS integration
+# ECS integration 
 #
-# URL where the ECS agent can be found. Standard cases will be autodetected.
+# The ECS agent container should be autodetected when running with the
+# default (ecs-agent) name. Else, you can change the container name the
+# agent will look for, or force a fixed url:
+# ecs_agent_container_name: ecs-agent
 # ecs_agent_url: http://localhost:51678
 #
-# Name of the ecs-agent docker container, for autodetection.
-# ecs_agent_name: ecs-agent
+# Fargate clusters use other endpoints and are not affected by these options.
 #
 {{ end -}}
 {{- if .Kubelet }}

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -26,8 +26,6 @@ import (
 const (
 	// DefaultAgentPort is the default port used by the ECS Agent.
 	DefaultAgentPort = 51678
-	// DefaultECSContainer is the default container used by ECS.
-	DefaultECSContainer = "ecs-agent"
 	// Cache the fact we're running on ECS Fargate
 	isFargateInstanceCacheKey = "IsFargateInstanceCacheKey"
 )
@@ -229,7 +227,7 @@ func getAgentContainerURLS() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	ecsConfig, err := du.Inspect(config.Datadog.GetString("ecs_agent_name"), false)
+	ecsConfig, err := du.Inspect(config.Datadog.GetString("ecs_agent_container_name"), false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -178,7 +178,7 @@ func detectAgentURL() (string, error) {
 		}
 
 		// Try all networks available on the ecs container.
-		ecsConfig, err := du.Inspect(DefaultECSContainer, false)
+		ecsConfig, err := du.Inspect(config.Datadog.GetString("ecs_agent_name"), false)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -172,30 +172,17 @@ func detectAgentURL() (string, error) {
 	}
 
 	if config.IsContainerized() {
-		du, err := docker.GetDockerUtil()
+		// List all interfaces for the ecs-agent container
+		agentURLS, err := getAgentContainerURLS()
 		if err != nil {
-			return "", err
+			log.Debugf("could inspect ecs-agent container: ", err)
+		} else {
+			urls = append(urls, agentURLS...)
 		}
-
-		// Try all networks available on the ecs container.
-		ecsConfig, err := du.Inspect(config.Datadog.GetString("ecs_agent_name"), false)
-		if err != nil {
-			return "", err
-		}
-
-		for _, network := range ecsConfig.NetworkSettings.Networks {
-			ip := network.IPAddress
-			if ip != "" {
-				urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
-			}
-		}
-
 		// Try the default gateway
 		gw, err := docker.DefaultGateway()
 		if err != nil {
-			// "expected" errors are handled in DefaultGateway so only
-			// unexpected errors are bubbled up, so we keep bubbling.
-			return "", err
+			log.Debugf("could not get docker default gateway: ", err)
 		}
 		if gw != nil {
 			urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))
@@ -204,6 +191,7 @@ func detectAgentURL() (string, error) {
 
 	// Always try the localhost URL.
 	urls = append(urls, fmt.Sprintf("http://localhost:%d/", DefaultAgentPort))
+
 	detected := testURLs(urls, 1*time.Second)
 	if detected != "" {
 		return detected, nil
@@ -232,4 +220,25 @@ func testURLs(urls []string, timeout time.Duration) string {
 		}
 	}
 	return ""
+}
+
+func getAgentContainerURLS() ([]string, error) {
+	var urls []string
+
+	du, err := docker.GetDockerUtil()
+	if err != nil {
+		return nil, err
+	}
+	ecsConfig, err := du.Inspect(config.Datadog.GetString("ecs_agent_name"), false)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, network := range ecsConfig.NetworkSettings.Networks {
+		ip := network.IPAddress
+		if ip != "" {
+			urls = append(urls, fmt.Sprintf("http://%s:%d/", ip, DefaultAgentPort))
+		}
+	}
+	return urls, nil
 }

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -163,8 +163,8 @@ func TestLocateECSHTTP(t *testing.T) {
 }
 
 func TestGetAgentContainerURLS(t *testing.T) {
-	config.Datadog.SetDefault("ecs_agent_name", "ecs-agent-custom")
-	defer config.Datadog.SetDefault("ecs_agent_name", "ecs-agent")
+	config.Datadog.SetDefault("ecs_agent_container_name", "ecs-agent-custom")
+	defer config.Datadog.SetDefault("ecs_agent_container_name", "ecs-agent")
 
 	// Setting mocked data in cache
 	nets := make(map[string]*network.EndpointSettings)

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -17,10 +17,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/docker"
 )
 
 // dummyECS allows tests to mock a ECS's responses
@@ -45,6 +49,7 @@ func (d *dummyECS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}
 }
+
 func (d *dummyECS) Start() (*httptest.Server, int, error) {
 	ts := httptest.NewServer(d)
 	ecs_agent_url, err := url.Parse(ts.URL)
@@ -57,6 +62,7 @@ func (d *dummyECS) Start() (*httptest.Server, int, error) {
 	}
 	return ts, ecs_agent_port, nil
 }
+
 func TestLocateECSHTTP(t *testing.T) {
 	assert := assert.New(t)
 	ecsinterface, err := newDummyECS()
@@ -154,4 +160,29 @@ func TestLocateECSHTTP(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		assert.FailNow("Timeout on receive channel")
 	}
+}
+
+func TestGetAgentContainerURLS(t *testing.T) {
+	config.Datadog.SetDefault("ecs_agent_name", "ecs-agent-custom")
+	defer config.Datadog.SetDefault("ecs_agent_name", "ecs-agent")
+
+	// Setting mocked data in cache
+	nets := make(map[string]*network.EndpointSettings)
+	nets["bridge"] = &network.EndpointSettings{IPAddress: "172.17.0.2"}
+	nets["foo"] = &network.EndpointSettings{IPAddress: "172.17.0.3"}
+
+	co := types.ContainerJSON{
+		ContainerJSONBase: &types.ContainerJSONBase{},
+		NetworkSettings: &types.NetworkSettings{
+			Networks: nets,
+		},
+	}
+	cacheKey := docker.GetInspectCacheKey("ecs-agent-custom", false)
+	cache.Cache.Set(cacheKey, co, 10*time.Second)
+
+	agentURLS, err := getAgentContainerURLS()
+	assert.NoError(t, err)
+	assert.Len(t, agentURLS, 2)
+	assert.Contains(t, agentURLS, "http://172.17.0.2:51678/")
+	assert.Contains(t, agentURLS, "http://172.17.0.3:51678/")
 }

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -177,6 +177,7 @@ func TestGetAgentContainerURLS(t *testing.T) {
 			Networks: nets,
 		},
 	}
+	docker.EnableTestingMode()
 	cacheKey := docker.GetInspectCacheKey("ecs-agent-custom", false)
 	cache.Cache.Set(cacheKey, co, 10*time.Second)
 

--- a/releasenotes/notes/ecs-container-name-d627c0f0df230079.yaml
+++ b/releasenotes/notes/ecs-container-name-d627c0f0df230079.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    The ecs-agent's docker container name can now be set via the ``ecs_agent_name``
-    option or the ``DD_ECS_AGENT_NAME`` envvar for autodetection.
+    The ecs-agent's docker container name can now be set via the ``ecs_agent_container_name``
+    option or the ``DD_ECS_AGENT_CONTAINER_NAME`` envvar for autodetection.

--- a/releasenotes/notes/ecs-container-name-d627c0f0df230079.yaml
+++ b/releasenotes/notes/ecs-container-name-d627c0f0df230079.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The ecs-agent's docker container name can now be set via the ``ecs_agent_name``
+    option or the ``DD_ECS_AGENT_NAME`` envvar for autodetection.


### PR DESCRIPTION
### What does this PR do?

Update the ecs-agent detection logic:
  - Read the `ecs_agent_name` option, to allow customizing the container name we look for
  - Don't error out if we cannot inspect the container, to allow us to try connecting to other urls, including `ecs_agent_url`

Fixes https://github.com/DataDog/datadog-agent/issues/2167