### PR TITLE
kubelet tag collector: use taglist for all tags

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -36,6 +36,34 @@ func TestParsePods(t *testing.T) {
 		},
 	}
 
+	dockerEntityID2 := "docker://ff242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f"
+	dockerTwoContainersStatus := kubelet.Status{
+		Containers: []kubelet.ContainerStatus{
+			{
+				ID:    dockerEntityID,
+				Image: "datadog/docker-dd-agent:latest5",
+				Name:  "dd-agent",
+			},
+			{
+				ID:    dockerEntityID2,
+				Image: "datadog/docker-filter:latest",
+				Name:  "filter",
+			},
+		},
+	}
+	dockerTwoContainersSpec := kubelet.Spec{
+		Containers: []kubelet.ContainerSpec{
+			{
+				Name:  "dd-agent",
+				Image: "datadog/docker-dd-agent:latest5",
+			},
+			{
+				Name:  "filter",
+				Image: "datadog/docker-filter:latest",
+			},
+		},
+	}
+
 	criEntityId := "cri-containerd://acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1"
 	criContainerStatus := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
@@ -60,7 +88,7 @@ func TestParsePods(t *testing.T) {
 		pod               *kubelet.Pod
 		labelsAsTags      map[string]string
 		annotationsAsTags map[string]string
-		expectedInfo      *TagInfo
+		expectedInfo      []*TagInfo
 	}{
 		{
 			desc:         "empty pod",
@@ -86,24 +114,94 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: dockerEntityID,
-				LowCardTags: []string{
-					"kube_namespace:default",
-					"kube_container_name:dd-agent",
-					"kube_daemon_set:dd-agent-rc",
-					"image_tag:latest5",
-					"image_name:datadog/docker-dd-agent",
-					"short_image:docker-dd-agent",
-				},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					"pod_name:dd-agent-rc-qd876",
-					"display_container_name:dd-agent_dd-agent-rc-qd876",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_namespace:default",
+						"kube_container_name:dd-agent",
+						"kube_daemon_set:dd-agent-rc",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"pod_name:dd-agent-rc-qd876",
+						"display_container_name:dd-agent_dd-agent-rc-qd876",
+					},
 				},
 			},
 		},
+		{
+			desc: "two containers + pod",
+			pod: &kubelet.Pod{
+				Metadata: kubelet.PodMetadata{
+					Name:      "dd-agent-rc-qd876",
+					Namespace: "default",
+					UID:       "5e8e05",
+					Owners: []kubelet.PodOwner{
+						{
+							Kind: "DaemonSet",
+							Name: "dd-agent-rc",
+							ID:   "6a76e51c-88d7-11e7-9a0f-42010a8401cc",
+						},
+					},
+				},
+				Status: dockerTwoContainersStatus,
+				Spec:   dockerTwoContainersSpec,
+			},
+			labelsAsTags: map[string]string{},
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: "kubernetes_pod://5e8e05",
+					LowCardTags: []string{
+						"kube_namespace:default",
+						"kube_daemon_set:dd-agent-rc",
+					},
+					HighCardTags: []string{
+						"pod_name:dd-agent-rc-qd876",
+					},
+				},
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_namespace:default",
+						"kube_container_name:dd-agent",
+						"kube_daemon_set:dd-agent-rc",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"pod_name:dd-agent-rc-qd876",
+						"display_container_name:dd-agent_dd-agent-rc-qd876",
+					},
+				},
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID2,
+					LowCardTags: []string{
+						"kube_namespace:default",
+						"kube_container_name:filter",
+						"kube_daemon_set:dd-agent-rc",
+						"image_tag:latest",
+						"image_name:datadog/docker-filter",
+						"short_image:docker-filter",
+					},
+					HighCardTags: []string{
+						"container_id:ff242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"pod_name:dd-agent-rc-qd876",
+						"display_container_name:filter_dd-agent-rc-qd876",
+					},
+				},
+			},
+		},
+
 		{
 			desc: "standalone replicaset",
 			pod: &kubelet.Pod{
@@ -119,18 +217,20 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: dockerEntityID,
-				LowCardTags: []string{
-					"kube_container_name:dd-agent",
-					"kube_replica_set:kubernetes-dashboard",
-					"image_tag:latest5",
-					"image_name:datadog/docker-dd-agent",
-					"short_image:docker-dd-agent",
-				},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_container_name:dd-agent",
+						"kube_replica_set:kubernetes-dashboard",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					},
 				},
 			},
 		},
@@ -149,19 +249,21 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: dockerEntityID,
-				LowCardTags: []string{
-					"kube_container_name:dd-agent",
-					"kube_deployment:frontend",
-					"image_tag:latest5",
-					"image_name:datadog/docker-dd-agent",
-					"short_image:docker-dd-agent",
-				},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					"kube_replica_set:frontend-2891696001",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_container_name:dd-agent",
+						"kube_deployment:frontend",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"kube_replica_set:frontend-2891696001",
+					},
 				},
 			},
 		},
@@ -180,19 +282,21 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: dockerEntityID,
-				LowCardTags: []string{
-					"kube_container_name:dd-agent",
-					"kube_deployment:front-end",
-					"image_tag:latest5",
-					"image_name:datadog/docker-dd-agent",
-					"short_image:docker-dd-agent",
-				},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					"kube_replica_set:front-end-768dd754b7",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_container_name:dd-agent",
+						"kube_deployment:front-end",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"kube_replica_set:front-end-768dd754b7",
+					},
 				},
 			},
 		},
@@ -218,21 +322,23 @@ func TestParsePods(t *testing.T) {
 				"gitcommit": "+GitCommit",
 				"tier":      "tier",
 			},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: dockerEntityID,
-				LowCardTags: []string{
-					"kube_container_name:dd-agent",
-					"team:Kenafeh",
-					"component:kube-proxy",
-					"tier:node",
-					"image_tag:latest5",
-					"image_name:datadog/docker-dd-agent",
-					"short_image:docker-dd-agent",
-				},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_container_name:dd-agent",
+						"team:Kenafeh",
+						"component:kube-proxy",
+						"tier:node",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
+					},
 				},
 			},
 		},
@@ -263,21 +369,23 @@ func TestParsePods(t *testing.T) {
 				"ownerteam": "team",
 				"gitcommit": "+GitCommit",
 			},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: dockerEntityID,
-				LowCardTags: []string{
-					"kube_container_name:dd-agent",
-					"team:Kenafeh",
-					"component:kube-proxy",
-					"tier:node",
-					"image_tag:latest5",
-					"image_name:datadog/docker-dd-agent",
-					"short_image:docker-dd-agent",
-				},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: dockerEntityID,
+					LowCardTags: []string{
+						"kube_container_name:dd-agent",
+						"team:Kenafeh",
+						"component:kube-proxy",
+						"tier:node",
+						"image_tag:latest5",
+						"image_name:datadog/docker-dd-agent",
+						"short_image:docker-dd-agent",
+					},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
+					},
 				},
 			},
 		},
@@ -294,13 +402,15 @@ func TestParsePods(t *testing.T) {
 				Status: dockerContainerStatus,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: &TagInfo{
-				Source:      "kubelet",
-				Entity:      dockerEntityID,
-				LowCardTags: []string{"kube_container_name:dd-agent", "oshift_deployment_config:gitlab-ce"},
-				HighCardTags: []string{
-					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					"oshift_deployment:gitlab-ce-1",
+			expectedInfo: []*TagInfo{
+				{
+					Source:      "kubelet",
+					Entity:      dockerEntityID,
+					LowCardTags: []string{"kube_container_name:dd-agent", "oshift_deployment_config:gitlab-ce"},
+					HighCardTags: []string{
+						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+						"oshift_deployment:gitlab-ce-1",
+					},
 				},
 			},
 		},
@@ -320,21 +430,23 @@ func TestParsePods(t *testing.T) {
 				Spec:   criContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: &TagInfo{
-				Source: "kubelet",
-				Entity: criEntityId,
-				LowCardTags: []string{
-					"kube_container_name:redis-master",
-					"kube_deployment:redis-master",
-					"image_name:gcr.io/google_containers/redis",
-					"image_tag:e2e",
-					"short_image:redis",
-				},
-				HighCardTags: []string{
-					"pod_name:redis-master-bpnn6",
-					"display_container_name:redis-master_redis-master-bpnn6",
-					"container_id:acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1",
-					"kube_replica_set:redis-master-546dc4865f",
+			expectedInfo: []*TagInfo{
+				{
+					Source: "kubelet",
+					Entity: criEntityId,
+					LowCardTags: []string{
+						"kube_container_name:redis-master",
+						"kube_deployment:redis-master",
+						"image_name:gcr.io/google_containers/redis",
+						"image_tag:e2e",
+						"short_image:redis",
+					},
+					HighCardTags: []string{
+						"pod_name:redis-master-bpnn6",
+						"display_container_name:redis-master_redis-master-bpnn6",
+						"container_id:acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1",
+						"kube_replica_set:redis-master-546dc4865f",
+					},
 				},
 			},
 		},
@@ -350,8 +462,7 @@ func TestParsePods(t *testing.T) {
 			if tc.expectedInfo == nil {
 				assert.Len(t, infos, 0)
 			} else {
-				assert.Len(t, infos, 1)
-				assertTagInfoEqual(t, tc.expectedInfo, infos[0])
+				assertTagInfoListEqual(t, tc.expectedInfo, infos)
 			}
 		})
 	}

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -114,25 +114,23 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: dockerEntityID,
-					LowCardTags: []string{
-						"kube_namespace:default",
-						"kube_container_name:dd-agent",
-						"kube_daemon_set:dd-agent-rc",
-						"image_tag:latest5",
-						"image_name:datadog/docker-dd-agent",
-						"short_image:docker-dd-agent",
-					},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-						"pod_name:dd-agent-rc-qd876",
-						"display_container_name:dd-agent_dd-agent-rc-qd876",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_namespace:default",
+					"kube_container_name:dd-agent",
+					"kube_daemon_set:dd-agent-rc",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
-			},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"pod_name:dd-agent-rc-qd876",
+					"display_container_name:dd-agent_dd-agent-rc-qd876",
+				},
+			}},
 		},
 		{
 			desc: "two containers + pod",
@@ -201,7 +199,6 @@ func TestParsePods(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			desc: "standalone replicaset",
 			pod: &kubelet.Pod{
@@ -217,22 +214,20 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: dockerEntityID,
-					LowCardTags: []string{
-						"kube_container_name:dd-agent",
-						"kube_replica_set:kubernetes-dashboard",
-						"image_tag:latest5",
-						"image_name:datadog/docker-dd-agent",
-						"short_image:docker-dd-agent",
-					},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"kube_replica_set:kubernetes-dashboard",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
-			},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+				},
+			}},
 		},
 		{
 			desc: "replicaset to daemonset < 1.8",
@@ -249,23 +244,21 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: dockerEntityID,
-					LowCardTags: []string{
-						"kube_container_name:dd-agent",
-						"kube_deployment:frontend",
-						"image_tag:latest5",
-						"image_name:datadog/docker-dd-agent",
-						"short_image:docker-dd-agent",
-					},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-						"kube_replica_set:frontend-2891696001",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"kube_deployment:frontend",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
-			},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"kube_replica_set:frontend-2891696001",
+				},
+			}},
 		},
 		{
 			desc: "replicaset to daemonset 1.8+",
@@ -282,23 +275,21 @@ func TestParsePods(t *testing.T) {
 				Spec:   dockerContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: dockerEntityID,
-					LowCardTags: []string{
-						"kube_container_name:dd-agent",
-						"kube_deployment:front-end",
-						"image_tag:latest5",
-						"image_name:datadog/docker-dd-agent",
-						"short_image:docker-dd-agent",
-					},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-						"kube_replica_set:front-end-768dd754b7",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"kube_deployment:front-end",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
-			},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"kube_replica_set:front-end-768dd754b7",
+				},
+			}},
 		},
 		{
 			desc: "pod labels",
@@ -322,25 +313,23 @@ func TestParsePods(t *testing.T) {
 				"gitcommit": "+GitCommit",
 				"tier":      "tier",
 			},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: dockerEntityID,
-					LowCardTags: []string{
-						"kube_container_name:dd-agent",
-						"team:Kenafeh",
-						"component:kube-proxy",
-						"tier:node",
-						"image_tag:latest5",
-						"image_name:datadog/docker-dd-agent",
-						"short_image:docker-dd-agent",
-					},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-						"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"team:Kenafeh",
+					"component:kube-proxy",
+					"tier:node",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
-			},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
+				},
+			}},
 		},
 		{
 			desc: "pod labels + annotations",
@@ -369,25 +358,23 @@ func TestParsePods(t *testing.T) {
 				"ownerteam": "team",
 				"gitcommit": "+GitCommit",
 			},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: dockerEntityID,
-					LowCardTags: []string{
-						"kube_container_name:dd-agent",
-						"team:Kenafeh",
-						"component:kube-proxy",
-						"tier:node",
-						"image_tag:latest5",
-						"image_name:datadog/docker-dd-agent",
-						"short_image:docker-dd-agent",
-					},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-						"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: dockerEntityID,
+				LowCardTags: []string{
+					"kube_container_name:dd-agent",
+					"team:Kenafeh",
+					"component:kube-proxy",
+					"tier:node",
+					"image_tag:latest5",
+					"image_name:datadog/docker-dd-agent",
+					"short_image:docker-dd-agent",
 				},
-			},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"GitCommit:ea38b55f07e40b68177111a2bff1e918132fd5fb",
+				},
+			}},
 		},
 		{
 			desc: "openshift deploymentconfig",
@@ -402,17 +389,15 @@ func TestParsePods(t *testing.T) {
 				Status: dockerContainerStatus,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: []*TagInfo{
-				{
-					Source:      "kubelet",
-					Entity:      dockerEntityID,
-					LowCardTags: []string{"kube_container_name:dd-agent", "oshift_deployment_config:gitlab-ce"},
-					HighCardTags: []string{
-						"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
-						"oshift_deployment:gitlab-ce-1",
-					},
+			expectedInfo: []*TagInfo{{
+				Source:      "kubelet",
+				Entity:      dockerEntityID,
+				LowCardTags: []string{"kube_container_name:dd-agent", "oshift_deployment_config:gitlab-ce"},
+				HighCardTags: []string{
+					"container_id:d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f",
+					"oshift_deployment:gitlab-ce-1",
 				},
-			},
+			}},
 		},
 		{
 			desc: "CRI pod",
@@ -430,25 +415,23 @@ func TestParsePods(t *testing.T) {
 				Spec:   criContainerSpec,
 			},
 			labelsAsTags: map[string]string{},
-			expectedInfo: []*TagInfo{
-				{
-					Source: "kubelet",
-					Entity: criEntityId,
-					LowCardTags: []string{
-						"kube_container_name:redis-master",
-						"kube_deployment:redis-master",
-						"image_name:gcr.io/google_containers/redis",
-						"image_tag:e2e",
-						"short_image:redis",
-					},
-					HighCardTags: []string{
-						"pod_name:redis-master-bpnn6",
-						"display_container_name:redis-master_redis-master-bpnn6",
-						"container_id:acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1",
-						"kube_replica_set:redis-master-546dc4865f",
-					},
+			expectedInfo: []*TagInfo{{
+				Source: "kubelet",
+				Entity: criEntityId,
+				LowCardTags: []string{
+					"kube_container_name:redis-master",
+					"kube_deployment:redis-master",
+					"image_name:gcr.io/google_containers/redis",
+					"image_tag:e2e",
+					"short_image:redis",
 				},
-			},
+				HighCardTags: []string{
+					"pod_name:redis-master-bpnn6",
+					"display_container_name:redis-master_redis-master-bpnn6",
+					"container_id:acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1",
+					"kube_replica_set:redis-master-546dc4865f",
+				},
+			}},
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.desc), func(t *testing.T) {

--- a/pkg/tagger/utils/taglist.go
+++ b/pkg/tagger/utils/taglist.go
@@ -84,3 +84,20 @@ func (l *TagList) Compute() ([]string, []string) {
 	}
 	return low, high
 }
+
+// Copy creates a deep copy of the taglist object for reuse
+func (l *TagList) Copy() *TagList {
+	return &TagList{
+		lowCardTags:  deepCopyMap(l.lowCardTags),
+		highCardTags: deepCopyMap(l.highCardTags),
+		splitList:    l.splitList, // constant, can be shared
+	}
+}
+
+func deepCopyMap(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/pkg/tagger/utils/taglist_test.go
+++ b/pkg/tagger/utils/taglist_test.go
@@ -110,3 +110,43 @@ func TestCompute(t *testing.T) {
 	require.Contains(t, high, "foo:bar")
 	require.Contains(t, high, "high:yes-high")
 }
+
+func TestCopy(t *testing.T) {
+	list := NewTagList()
+	list.AddHigh("foo", "bar")
+	list.AddLow("faa", "baz")
+	list.AddLow("low", "yes")
+
+	list2 := list.Copy()
+	list2.AddHigh("foo2", "bar2")
+	list2.AddLow("faa2", "baz2")
+
+	list3 := list.Copy()
+	list3.AddHigh("foo3", "bar3")
+	list3.AddLow("faa3", "baz3")
+
+	low, high := list.Compute()
+	require.Len(t, low, 2)
+	require.Contains(t, low, "faa:baz")
+	require.Contains(t, low, "low:yes")
+	require.Len(t, high, 1)
+	require.Contains(t, high, "foo:bar")
+
+	low2, high2 := list2.Compute()
+	require.Len(t, low2, 3)
+	require.Contains(t, low2, "faa:baz")
+	require.Contains(t, low2, "low:yes")
+	require.Contains(t, low2, "faa2:baz2")
+	require.Len(t, high2, 2)
+	require.Contains(t, high2, "foo:bar")
+	require.Contains(t, high2, "foo2:bar2")
+
+	low3, high3 := list3.Compute()
+	require.Len(t, low3, 3)
+	require.Contains(t, low3, "faa:baz")
+	require.Contains(t, low3, "low:yes")
+	require.Contains(t, low3, "faa3:baz3")
+	require.Len(t, high3, 2)
+	require.Contains(t, high3, "foo:bar")
+	require.Contains(t, high3, "foo3:bar3")
+}


### PR DESCRIPTION
### What does this PR do?

As a follow-up to https://github.com/DataDog/datadog-agent/pull/2122 , modify the `kubelet` tag collector to use the `TagList` class for all of its tags. This ensures consistent behavior for all tags.

### Motivation

Avoid user confusion
