### PR TITLE
Recover from crashing docker socket

### DIFF
--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -189,7 +189,6 @@ func (l *Launcher) stopTailer(containerID string) {
 func (l *Launcher) restartTailer(containerID string) {
 	backoffDuration := backoffInitialDuration
 	cumulatedBackoff := 0 * time.Second
-	var tailer *Tailer
 	var source *config.LogSource
 
 	oldTailer, exists := l.tailers[containerID]
@@ -199,7 +198,7 @@ func (l *Launcher) restartTailer(containerID string) {
 		l.removeTailer(containerID)
 	}
 
-	tailer = NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
+	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), service.Before)

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -195,7 +195,7 @@ func (l *Launcher) restartTailer(containerID string) {
 
 	for {
 		if backoffDuration > backoffMaxDuration {
-			log.Warnf("Could not restart container %v. Stop tailing", ShortContainerID(containerID))
+			log.Warnf("Could not resume tailing container %v", ShortContainerID(containerID))
 			return
 		}
 
@@ -211,7 +211,7 @@ func (l *Launcher) restartTailer(containerID string) {
 		// compute the offset to prevent from missing or duplicating logs
 		since, err := Since(l.registry, tailer.Identifier(), service.Before)
 		if err != nil {
-			log.Warnf("Could not recover tailing from last committed offset, start tailing from now for container %v: %v", ShortContainerID(containerID), err)
+			log.Warnf("Could not recover last committed offset for container %v: %v", ShortContainerID(containerID), err)
 		}
 
 		// start the tailer

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -179,6 +179,7 @@ func (l *Launcher) stopTailer(containerID string) {
 }
 
 func (l *Launcher) restartTailer(containerID string) {
+	log.Warnf("Tailing will restart for %v", ShortContainerID(containerID))
 	backoffDuration := 1 * time.Second
 	backoffMax := 60 * time.Second
 	var tailer *Tailer

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -200,13 +200,13 @@ func (l *Launcher) restartTailer(containerID string) {
 		// compute the offset to prevent from missing or duplicating logs
 		since, err := Since(l.registry, tailer.Identifier(), service.Before)
 		if err != nil {
-			log.Warnf("Could not recover tailing from last committed offset, start tailing from now for container: %v", ShortContainerID(containerID), err)
+			log.Warnf("Could not recover tailing from last committed offset, start tailing from now for container %v: %v", ShortContainerID(containerID), err)
 		}
 
 		// start the tailer
 		err = tailer.Start(since)
 		if err != nil {
-			log.Warnf("Could not start tailer for container: %v", containerID, err)
+			log.Warnf("Could not start tailer for container %v: %v", containerID, err)
 			time.Sleep(backoffDuration)
 			backoffDuration *= 2
 			continue

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -200,16 +200,13 @@ func (l *Launcher) restartTailer(containerID string) {
 		// compute the offset to prevent from missing or duplicating logs
 		since, err := Since(l.registry, tailer.Identifier(), service.Before)
 		if err != nil {
-			log.Warnf("Could not recover tailing from last committed offset: %v", ShortContainerID(containerID), err)
-			time.Sleep(backoffDuration)
-			backoffDuration *= 2
-			continue
+			log.Warnf("Could not recover tailing from last committed offset, start tailing from now for container: %v", ShortContainerID(containerID), err)
 		}
 
 		// start the tailer
 		err = tailer.Start(since)
 		if err != nil {
-			log.Warnf("Could not start tailer: %v", containerID, err)
+			log.Warnf("Could not start tailer for container: %v", containerID, err)
 			time.Sleep(backoffDuration)
 			backoffDuration *= 2
 			continue

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -47,7 +47,7 @@ func NewLauncher(sources *config.LogSources, services *service.Services, pipelin
 		pendingContainers:  make(map[string]*Container),
 		registry:           registry,
 		stop:               make(chan struct{}),
-		erroredContainerID: make(chan string, 1),
+		erroredContainerID: make(chan string),
 	}
 	err := launcher.setup()
 	if err != nil {
@@ -136,7 +136,7 @@ func (l *Launcher) run() {
 			l.stopTailer(containerID)
 			delete(l.pendingContainers, containerID)
 		case containerId := <-l.erroredContainerID:
-			l.restartTailer(containerId)
+			go l.restartTailer(containerId)
 		case <-l.stop:
 			// no docker container should be tailed anymore
 			return

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -206,7 +206,7 @@ func (l *Launcher) restartTailer(containerID string) {
 		// start the tailer
 		err = tailer.Start(since)
 		if err != nil {
-			log.Warnf("Could not start tailer for container %v: %v", containerID, err)
+			log.Warnf("Could not start tailer for container %v: %v", ShortContainerID(containerID), err)
 			time.Sleep(backoffDuration)
 			backoffDuration *= 2
 			continue

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -144,7 +144,6 @@ func (t *Tailer) readForever() {
 				}
 				if err == io.ErrUnexpectedEOF {
 					log.Warn("Unexpected EOF: The tailer of container ", ShortContainerID(t.ContainerID), " will restart")
-					t.wait() // TODO: Implement a better retry policy
 					t.unexpectedEOF <- t.ContainerID
 				}
 				return

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -148,7 +148,7 @@ func (t *Tailer) readForever() {
 					return
 				default:
 					t.source.Status.Error(err)
-					log.Errorf("Error reading logs for container %v: %v", ShortContainerID(t.ContainerID), err)
+					log.Errorf("Could not tail logs for container %v: %v", ShortContainerID(t.ContainerID), err)
 					t.erroredContainerID <- t.ContainerID
 					return
 				}
@@ -222,5 +222,4 @@ func (t *Tailer) wait() {
 // for more details, see: https://golang.org/src/internal/poll/fd.go#L18.
 func isClosedConnError(err error) bool {
 	return strings.Contains(err.Error(), "use of closed network connection")
-
 }

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -141,9 +141,7 @@ func (t *Tailer) readForever() {
 				if err != io.EOF {
 					t.source.Status.Error(err)
 					log.Error("Err: ", err)
-				}
-				if err == io.ErrUnexpectedEOF { // TODO: Catch the networking errors instead of just the Unexpected EOF
-					log.Warn("Unexpected EOF: The tailer of container ", ShortContainerID(t.ContainerID), " will restart")
+					log.Warn("The tailer of container ", ShortContainerID(t.ContainerID), " will restart")
 					t.erroredContainerID <- t.ContainerID
 				}
 				return

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -143,7 +143,8 @@ func (t *Tailer) readForever() {
 					// This error is raised when the agent is stopping
 					return
 				case err == io.EOF:
-					// This error is raised when the agent is stopping
+					// This error is raised when the container is stopping
+					t.source.RemoveInput(t.ContainerID)
 					return
 				default:
 					t.source.Status.Error(err)

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -125,13 +125,6 @@ func (t *Tailer) tail(since string) error {
 	return nil
 }
 
-// isConnClosedError returns true if the error is related to a closed connection,
-// for more details, see: https://golang.org/src/internal/poll/fd.go#L18.
-func isClosedConnError(err error) bool {
-	return strings.Contains(err.Error(), "use of closed network connection")
-
-}
-
 // readForever reads from the reader as fast as it can,
 // and sleeps when there is nothing to read
 func (t *Tailer) readForever() {
@@ -152,8 +145,7 @@ func (t *Tailer) readForever() {
 				// an error occurred, stop from reading new logs
 				if err != io.EOF {
 					t.source.Status.Error(err)
-					log.Error("Err: ", err)
-					log.Warn("The tailer of container ", ShortContainerID(t.ContainerID), " will restart")
+					log.Errorf("Error reading logs for container %v: %v", ShortContainerID(t.ContainerID), err)
 					t.erroredContainerID <- t.ContainerID
 				}
 				return
@@ -221,4 +213,11 @@ func (t *Tailer) checkForNewDockerTags() {
 // wait lets the reader sleep for a bit
 func (t *Tailer) wait() {
 	time.Sleep(t.sleepDuration)
+}
+
+// isConnClosedError returns true if the error is related to a closed connection,
+// for more details, see: https://golang.org/src/internal/poll/fd.go#L18.
+func isClosedConnError(err error) bool {
+	return strings.Contains(err.Error(), "use of closed network connection")
+
 }

--- a/releasenotes/notes/restart-tailer-when-docker-socket-is-lost-7f211a63f9158fd9.yaml
+++ b/releasenotes/notes/restart-tailer-when-docker-socket-is-lost-7f211a63f9158fd9.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Recover from errors when connection to the docker socket is lost to continue tailing containers.


### PR DESCRIPTION
### What does this PR do?

It restarts the docker tailers to reopen a connection to the docker socket

### Motivation

When the docker socket is killed, the log ingestion for container fails because the reader isn't properly closed

