### PR TITLE
[forwarder] Remove unnecessary Print

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -115,7 +115,6 @@ func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status 
 		apiKey = apiKey[len(apiKey)-5:]
 	}
 	obfuscatedKey := fmt.Sprintf("API key ending in %s for endpoint %s", apiKey, domain)
-	fmt.Println(obfuscatedKey)
 	apiKeyStatus.Set(obfuscatedKey, status)
 }
 


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary Print.

Was probably added during development of https://github.com/DataDog/datadog-agent/pull/2076.

### Motivation

Shouldn't be done on shipped Agents (by default, stdout/stderr usage from a running Agent should pretty much be limited to stack traces when the Agent crashes).

