### PR TITLE
[runner][scheduler] fix check stoppage + stat reporting

### DIFF
--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -137,7 +137,7 @@ func (c *Collector) ReloadCheck(id check.ID, config, initConfig integration.Data
 	// unschedule the instance
 	err := c.scheduler.Cancel(id)
 	if err != nil {
-		return fmt.Errorf("an error occurred while cancelling the check schedule: %s", err)
+		return fmt.Errorf("an error occurred while canceling the check schedule: %s", err)
 	}
 
 	// stop the instance
@@ -172,7 +172,7 @@ func (c *Collector) StopCheck(id check.ID) error {
 	// unschedule the instance
 	err := c.scheduler.Cancel(id)
 	if err != nil {
-		return fmt.Errorf("an error occurred while cancelling the check schedule: %s", err)
+		return fmt.Errorf("an error occurred while canceling the check schedule: %s", err)
 	}
 
 	// stop the instance, this might time out

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -176,13 +176,21 @@ func (c *Collector) StopCheck(id check.ID) error {
 	}
 
 	// stop the instance, this might time out
+	log.Errorf("Before StopCheck %s", string(id))
+	c.scheduler.PrintQueues()
+
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
 	}
+	log.Errorf("After StopCheck %s", string(id))
+	c.scheduler.PrintQueues()
 
 	// remove the check from the stats map
 	runner.RemoveCheckStats(id)
+
+	log.Errorf("After RemoveCheck %s", string(id))
+	c.scheduler.PrintQueues()
 
 	// vaporize the check
 	c.delete(id)

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -175,22 +175,13 @@ func (c *Collector) StopCheck(id check.ID) error {
 		return fmt.Errorf("an error occurred while canceling the check schedule: %s", err)
 	}
 
-	// stop the instance, this might time out
-	log.Errorf("Before StopCheck %s", string(id))
-	c.scheduler.PrintQueues()
-
 	err = c.runner.StopCheck(id)
 	if err != nil {
 		return fmt.Errorf("an error occurred while stopping the check: %s", err)
 	}
-	log.Errorf("After StopCheck %s", string(id))
-	c.scheduler.PrintQueues()
 
 	// remove the check from the stats map
 	runner.RemoveCheckStats(id)
-
-	log.Errorf("After RemoveCheck %s", string(id))
-	c.scheduler.PrintQueues()
 
 	// vaporize the check
 	c.delete(id)

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -275,7 +275,7 @@ func (r *Runner) work() {
 		if doLog {
 			log.Infof("Running check %s", check)
 		} else {
-			log.Infof("Running check %s", check)
+			log.Debugf("Running check %s", check)
 		}
 
 		// run the check
@@ -389,7 +389,7 @@ func addWorkStats(c check.Check, execTime time.Duration, err error, warnings []e
 	var found bool
 
 	checkStats.M.Lock()
-	log.Errorf("Add stats for %s", string(c.ID()))
+	log.Debugf("Add stats for %s", string(c.ID()))
 	stats, found := checkStats.Stats[c.String()]
 	if !found {
 		stats = make(map[check.ID]*check.Stats)
@@ -424,7 +424,7 @@ func GetCheckStats() map[string]map[check.ID]*check.Stats {
 func RemoveCheckStats(checkID check.ID) {
 	checkStats.M.Lock()
 	defer checkStats.M.Unlock()
-	log.Errorf("Remove stats for %s", string(checkID))
+	log.Debugf("Remove stats for %s", string(checkID))
 
 	checkName := strings.Split(string(checkID), ":")[0]
 	stats, found := checkStats.Stats[checkName]

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -209,14 +209,14 @@ func (r *Runner) StopCheck(id check.ID) error {
 	// mark checks as stopped even if it's not yet running - might get scheduled
 	r.stoppedChecks[id] = struct{}{}
 	if c, isRunning := r.runningChecks[id]; isRunning {
-		log.Errorf("Stopping check %s %s", string(id), c)
+		log.Debugf("Stopping check %s %s", string(id), c)
 		go func() {
 			// Remember that the check was stopped so that even if it runs we can discard its stats
 			c.Stop()
 			close(done)
 		}()
 	} else {
-		log.Errorf("check %s is not running", string(id))
+		log.Debugf("check %s is not running", string(id))
 		return nil
 	}
 

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -392,6 +392,9 @@ func RemoveCheckStats(checkID check.ID) {
 	stats, found := checkStats.Stats[checkName]
 	if found {
 		delete(stats, checkID)
+		if len(stats) == 0 {
+			delete(checkStats.Stats, checkName)
+		}
 	}
 }
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -84,7 +84,6 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 		for _, id := range ids {
 			// `StopCheck` might time out so we don't risk to block
 			// the polling loop forever
-			log.Debugf("Stop check instance id: %s", string(id))
 			err := s.collector.StopCheck(id)
 			if err != nil {
 				log.Errorf("Error stopping check %s: %s", id, err)

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -84,7 +84,7 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 		for _, id := range ids {
 			// `StopCheck` might time out so we don't risk to block
 			// the polling loop forever
-			log.Errorf("Stop check instance id: %s", string(id))
+			log.Debugf("Stop check instance id: %s", string(id))
 			err := s.collector.StopCheck(id)
 			if err != nil {
 				log.Errorf("Error stopping check %s: %s", id, err)

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -84,6 +84,7 @@ func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 		for _, id := range ids {
 			// `StopCheck` might time out so we don't risk to block
 			// the polling loop forever
+			log.Errorf("Stop check instance id: %s", string(id))
 			err := s.collector.StopCheck(id)
 			if err != nil {
 				log.Errorf("Error stopping check %s: %s", id, err)

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -143,11 +143,11 @@ func (jq *jobQueue) stats() map[string]interface{} {
 // run schedules the checks in the queue by posting them to the
 // execution pipeline.
 // Not blocking, runs in a new goroutine.
-func (jq *jobQueue) run(out chan<- check.Check) {
+func (jq *jobQueue) run(s *Scheduler) {
 
 	go func() {
 		log.Debugf("Job queue is running...")
-		for jq.process(out) {
+		for jq.process(s) {
 			// empty
 		}
 		jq.stopped <- true
@@ -156,7 +156,7 @@ func (jq *jobQueue) run(out chan<- check.Check) {
 
 // process  enqueues the checks at a tick, and returns whether the queue
 // should listen to the following tick (or stop)
-func (jq *jobQueue) process(out chan<- check.Check) bool {
+func (jq *jobQueue) process(s *Scheduler) bool {
 
 	select {
 	case <-jq.stop:
@@ -177,18 +177,18 @@ func (jq *jobQueue) process(out chan<- check.Check) bool {
 		// blocking could interfere with scheduling new jobs
 		jobs := []check.Check{}
 		jobs = append(jobs, bucket.jobs...)
-		log.Errorf("job queue")
-		for _, job := range jobs {
-			log.Errorf(string(job.ID()))
-		}
 		bucket.mu.RUnlock()
 
 		log.Tracef("Jobs in bucket: %v", jobs)
 
 		for _, check := range jobs {
+			if !s.isCheckScheduled(check.ID()) {
+				continue
+			}
+
 			select {
 			// blocking, we'll be here as long as it takes
-			case out <- check:
+			case s.checksPipe <- check:
 			case <-jq.stop:
 				jq.health.Deregister()
 				return false

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -177,6 +177,10 @@ func (jq *jobQueue) process(out chan<- check.Check) bool {
 		// blocking could interfere with scheduling new jobs
 		jobs := []check.Check{}
 		jobs = append(jobs, bucket.jobs...)
+		log.Errorf("job queue")
+		for _, job := range jobs {
+			log.Errorf(string(job.ID()))
+		}
 		bucket.mu.RUnlock()
 
 		log.Tracef("Jobs in bucket: %v", jobs)

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -93,17 +93,6 @@ func (s *Scheduler) Enter(check check.Check) error {
 	return nil
 }
 
-// PrintQueues print
-func (s *Scheduler) PrintQueues() {
-	for _, queue := range s.jobQueues {
-		for _, job := range queue.buckets {
-			for _, check := range job.jobs {
-				fmt.Println(string(check.ID()))
-			}
-		}
-	}
-}
-
 // Cancel remove a Check from the scheduled queue. If the check is not
 // in the scheduler, this is a noop.
 func (s *Scheduler) Cancel(id check.ID) error {

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -93,13 +93,24 @@ func (s *Scheduler) Enter(check check.Check) error {
 	return nil
 }
 
+// PrintQueues print
+func (s *Scheduler) PrintQueues() {
+	for _, queue := range s.jobQueues {
+		for _, job := range queue.buckets {
+			for _, check := range job.jobs {
+				fmt.Println(string(check.ID()))
+			}
+		}
+	}
+}
+
 // Cancel remove a Check from the scheduled queue. If the check is not
 // in the scheduler, this is a noop.
 func (s *Scheduler) Cancel(id check.ID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Infof("Unscheduling check %v ", check.IDToCheckName(id))
+	log.Errorf("Unscheduling %s check %v ", string(id), check.IDToCheckName(id))
 
 	if _, ok := s.checkToQueue[id]; !ok {
 		return nil

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -99,7 +99,7 @@ func (s *Scheduler) Cancel(id check.ID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	log.Errorf("Unscheduling %s check %v ", string(id), check.IDToCheckName(id))
+	log.Infof("Unscheduling %s check %v ", string(id), check.IDToCheckName(id))
 
 	if _, ok := s.checkToQueue[id]; !ok {
 		return nil

--- a/pkg/collector/scheduler/scheduler.go
+++ b/pkg/collector/scheduler/scheduler.go
@@ -187,6 +187,15 @@ func (s *Scheduler) Stop() error {
 	}
 }
 
+// isCheckScheduled returns whether a check is in the schedule or not
+func (s *Scheduler) isCheckScheduled(id check.ID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, found := s.checkToQueue[id]
+	return found
+}
+
 // stopQueues shuts down the timers for each active queue
 // Blocks until all the queues have fully stopped
 func (s *Scheduler) stopQueues() {
@@ -220,7 +229,7 @@ func (s *Scheduler) startQueues() {
 // startQueue starts a queue (non-blocking operation) if it's not running yet
 func (s *Scheduler) startQueue(q *jobQueue) {
 	if !q.running {
-		q.run(s.checksPipe)
+		q.run(s)
 		q.running = true
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR attempts to provide fix for the multiple race conditions to actually label a check as stopped, unscheduling it, and removing from the stat reporting. 

Due to the fact we make a copy of checks-to-schedule (we make this copy to avoid interfering with the scheduler), but then have to wait on runners to be available to execute these checks, there's an arbitrary time between the moment we stop a check, and the last time we might schedule it despite removing it from the scheduler:
 - we might remove it, and is currently being executed by a runner, so we know that's the last time (we know this in the runner). 
 - we might remove it, and have to wait an arbitrary amount of time until a runner becomes available (we don't know this in the runner).
 - we might remove it, and since it's on an unrelated bucket to the current iteration then it has already run for the last time (we don't know this in the runner).

The two bottom cases make tracking necessary.

* Book-keeping is done to avoid a potential small leak. We can debate whether it's necessary. 

* If a check remains in the `runner.stoppedChecks` map, and the instance comes back up, we would fail to report it in its first run.

### Motivation

We were still running checks one last time after actually stopping them, this presented a problem with auto-config as check targets (containers) were already gone. This made troubleshooting complicated and misleading, as well as reporting stats (or rather, errors) for checks that had been stopped. 

### Additional Information

This might deserve a release note, though it is a side-effect from concurrent runners.