### PR TITLE
Honor ac_exclude / ac_include in autodiscovery

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -132,8 +132,7 @@ func (l *DockerListener) init() {
 
 	for _, co := range containers {
 		if l.isExcluded(co) {
-			log.Debugf("container %s is filtered out", co.ID)
-			continue
+			continue // helper method already logs
 		}
 		var svc Service
 
@@ -202,7 +201,7 @@ func (l *DockerListener) createService(cID string) {
 			image = ""
 		}
 		if l.filter.IsExcluded(cInspect.Name, image) {
-			log.Debugf("container %s is filtered out", cInspect.ID)
+			log.Debugf("container %s filtered out: name %q image %q", cID[:12], cInspect.Name, image)
 			return
 		}
 		if findKubernetesInLabels(cInspect.Config.Labels) {
@@ -335,6 +334,7 @@ func (l *DockerListener) isExcluded(co types.Container) bool {
 	}
 	for _, name := range co.Names {
 		if l.filter.IsExcluded(name, image) {
+			log.Debugf("container %s filtered out: name %q image %q", co.ID[:12], name, image)
 			return true
 		}
 	}

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -123,7 +123,7 @@ func (l *ECSListener) refreshServices(firstRun bool) {
 			continue
 		}
 		if l.filter.IsExcluded(c.DockerName, c.Image) {
-			log.Debugf("container %s is filtered out", c.DockerID)
+			log.Debugf("container %s filtered out: name %q image %q", c.DockerID[:12], c.DockerName, c.Image)
 			continue
 		}
 		s, err := l.createService(c, firstRun)

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -24,6 +24,7 @@ import (
 // new containers to monitor, and old containers to stop monitoring
 type ECSListener struct {
 	task       ecs.TaskMetadata
+	filter     *containers.Filter
 	services   map[string]Service // maps container IDs to services
 	newService chan<- Service
 	delService chan<- Service
@@ -52,9 +53,14 @@ func init() {
 
 // NewECSListener creates an ECSListener
 func NewECSListener() (ServiceListener, error) {
+	filter, err := containers.GetSharedFilter()
+	if err != nil {
+		return nil, err
+	}
 	return &ECSListener{
 		services: make(map[string]Service),
 		stop:     make(chan bool),
+		filter:   filter,
 		t:        time.NewTicker(2 * time.Second),
 		health:   health.Register("ad-ecslistener"),
 	}, nil
@@ -114,6 +120,10 @@ func (l *ECSListener) refreshServices(firstRun bool) {
 		}
 		if c.KnownStatus != "RUNNING" {
 			log.Debugf("container %s is in status %s - skipping", c.DockerID, c.KnownStatus)
+			continue
+		}
+		if l.filter.IsExcluded(c.DockerName, c.Image) {
+			log.Debugf("container %s is filtered out", c.DockerID)
 			continue
 		}
 		s, err := l.createService(c, firstRun)

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -146,7 +146,7 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 	for _, container := range pod.Status.Containers {
 		if container.ID == svc.entity {
 			if l.filter.IsExcluded(container.Name, container.Image) {
-				log.Debugf("container %s is filtered out", container.ID)
+				log.Debugf("container %s filtered out: name %q image %q", container.ID, container.Name, container.Image)
 				return
 			}
 			containerName = container.Name

--- a/releasenotes/notes/autodiscovery-ac-exclude-dd681caf9c8809b3.yaml
+++ b/releasenotes/notes/autodiscovery-ac-exclude-dd681caf9c8809b3.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    Autodiscovery now enforces the ac_exclude and ac_include filtering options
+    for all listeners. Please double-check your exclusion patterns before upgrading
+    and add inclusion patterns if some autodiscovered containers match these.
+fixes:
+  - |
+    All Autodiscovery listeners now enforce the ac_exclude and ac_include filtering
+    options, as described in the documentation.

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -69,9 +69,7 @@ spec:
                     cpu: "5m"
               - name: redis-sidecar
                 image: redis
-                ports:
-                - name: redis
-                  containerPort: 6380
+                command: ["sleep", "1000d"]
                 resources:
                   requests:
                     memory: "32Mi"
@@ -833,6 +831,7 @@ spec:
           sleep(2000);
         }
 
+        // Make sure we don't collect metrics for the excluded redis sidecar.
         // Wait a whole collector cycle as bucket scheduling might delay the run
         sleep(15000);
         var nb = db.series.find({

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -62,21 +62,11 @@ spec:
                   containerPort: 6379
                 resources:
                   requests:
-                    memory: "32Mi"
-                    cpu: "5m"
+                    memory: "64Mi"
+                    cpu: "50m"
                   limits:
-                    memory: "32Mi"
-                    cpu: "5m"
-              - name: redis-sidecar
-                image: redis
-                command: ["sleep", "1000d"]
-                resources:
-                  requests:
-                    memory: "32Mi"
-                    cpu: "5m"
-                  limits:
-                    memory: "32Mi"
-                    cpu: "5m"
+                    memory: "128Mi"
+                    cpu: "100m"
 
     - name: cpu-stress
       value: |
@@ -193,7 +183,6 @@ spec:
               polling: true
             leader_election: true
             kubernetes_metadata_tag_update_freq: 20
-            ac_exclude: ["name:redis-sidecar"]
 
           kubelet.yaml: |
             init_config:
@@ -822,24 +811,13 @@ spec:
         while (1) {
           var nb = db.series.find({
             metric: {$regex: "redis*"},
-            tags: {$all: ["kube_service:redis", "kube_container_name:redis"]}
+            tags: "kube_service:redis"
           }).count();
           print("find: " + nb)
           if (nb != 0) {
             break;
           }
           sleep(2000);
-        }
-
-        // Make sure we don't collect metrics for the excluded redis sidecar.
-        // Wait a whole collector cycle as bucket scheduling might delay the run
-        sleep(15000);
-        var nb = db.series.find({
-          metric: {$regex: "redis*"},
-          tags: {$all: ["kube_service:redis", "kube_container_name:redis-sidecar"]}
-        }).count();
-        if (nb != 0) {
-          throw new Error("Detected metrics for excluded container redis-sidecar");
         }
 
   - name: find-metrics-cpu-kubelet

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -62,11 +62,23 @@ spec:
                   containerPort: 6379
                 resources:
                   requests:
-                    memory: "64Mi"
-                    cpu: "50m"
+                    memory: "32Mi"
+                    cpu: "5m"
                   limits:
-                    memory: "128Mi"
-                    cpu: "100m"
+                    memory: "32Mi"
+                    cpu: "5m"
+              - name: redis-sidecar
+                image: redis
+                ports:
+                - name: redis
+                  containerPort: 6380
+                resources:
+                  requests:
+                    memory: "32Mi"
+                    cpu: "5m"
+                  limits:
+                    memory: "32Mi"
+                    cpu: "5m"
 
     - name: cpu-stress
       value: |
@@ -183,6 +195,7 @@ spec:
               polling: true
             leader_election: true
             kubernetes_metadata_tag_update_freq: 20
+            ac_exclude: ["name:redis-sidecar"]
 
           kubelet.yaml: |
             init_config:
@@ -811,13 +824,23 @@ spec:
         while (1) {
           var nb = db.series.find({
             metric: {$regex: "redis*"},
-            tags: "kube_service:redis"
+            tags: {$all: ["kube_service:redis", "kube_container_name:redis"]}
           }).count();
           print("find: " + nb)
           if (nb != 0) {
             break;
           }
           sleep(2000);
+        }
+
+        // Wait a whole collector cycle as bucket scheduling might delay the run
+        sleep(15000);
+        var nb = db.series.find({
+          metric: {$regex: "redis*"},
+          tags: {$all: ["kube_service:redis", "kube_container_name:redis-sidecar"]}
+        }).count();
+        if (nb != 0) {
+          throw new Error("Detected metrics for excluded container redis-sidecar");
         }
 
   - name: find-metrics-cpu-kubelet

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -37,6 +37,10 @@ type DockerListenerTestSuite struct {
 }
 
 func (suite *DockerListenerTestSuite) SetupSuite() {
+	config.Datadog.SetDefault("ac_include", []string{"name:.*redis.*"})
+	config.Datadog.SetDefault("ac_exclude", []string{"image:datadog/docker-library:redis.*"})
+	containers.ResetSharedFilter()
+
 	tagger.Init()
 
 	config.SetupLogger(
@@ -58,11 +62,13 @@ func (suite *DockerListenerTestSuite) SetupSuite() {
 	}
 }
 
-func (suite *DockerListenerTestSuite) SetupTest() {
-	config.Datadog.SetDefault("ac_include", []string{"name:.*redis.*"})
-	config.Datadog.SetDefault("ac_exclude", []string{"image:datadog/docker-library:redis.*"})
+func (suite *DockerListenerTestSuite) TearDownSuite() {
+	config.Datadog.SetDefault("ac_include", []string{})
+	config.Datadog.SetDefault("ac_exclude", []string{})
 	containers.ResetSharedFilter()
+}
 
+func (suite *DockerListenerTestSuite) SetupTest() {
 	dl, err := listeners.NewDockerListener()
 	if err != nil {
 		panic(err)
@@ -74,10 +80,6 @@ func (suite *DockerListenerTestSuite) SetupTest() {
 }
 
 func (suite *DockerListenerTestSuite) TearDownTest() {
-	config.Datadog.SetDefault("ac_include", []string{})
-	config.Datadog.SetDefault("ac_exclude", []string{})
-	containers.ResetSharedFilter()
-
 	suite.listener.Stop()
 	suite.listener = nil
 	suite.stopContainers()

--- a/test/integration/listeners/docker/testdata/redis.yaml
+++ b/test/integration/listeners/docker/testdata/redis.yaml
@@ -6,3 +6,5 @@ services:
     image: "datadog/docker-library:redis_3_2_11-alpine"
     labels:
       com.datadoghq.ad.check.id: "custom-id"
+  excluded:
+    image: "datadog/docker-library:redis_3_2_11-alpine"


### PR DESCRIPTION
### What does this PR do?

Make the three AD listeners honor the container filter settings

### Motivation

Causes a regression in logs container discovery

### Testing

Image `datadog/agent-dev:xvello-ac-exclude` tested on vanilla docker, fargate and gke