### PR TITLE
Change wording of hostname providers in the status

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/header.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/header.tmpl
@@ -28,13 +28,17 @@
     {{$name}}: {{$value}}
     {{- end }}
   {{- end }}
-      hostname provider: {{.hostnameStats.provider}}
+    hostname provider: {{.hostnameStats.provider}}
+  {{- if gt (len .hostnameStats.errors) 0 }}
+    unused hostname providers:
+  {{- end }}
   {{- range $name, $value := .hostnameStats.errors -}}
-    {{- if ne $name "all" }}
-    error: {{$name}}: {{$value}}
-    {{- else }}
-    error: {{$value}}
-    {{- end}}
+      {{- if ne $name "all" }}
+      {{$name}}: {{$value}}
+      {{- end}}
+  {{- end }}
+  {{- if .hostnameStats.errors.all }}
+    error: {{.hostnameStats.errors.all}}
   {{- end }}
 
   Leader Election

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -44,27 +44,35 @@
           {{end -}}
         {{end -}}
       {{- end}}
-      <span class="stat_subtitle">Hostnames</span>
-      <span class="stat_subdata">
-        {{- range $type, $value := .metadata.meta -}}
-          {{- if ne $type "timezones" -}}
-            {{- if $value}}
-              {{formatTitle $type}}: {{$value -}}<br>
-            {{end -}}
-          {{- end -}}
-        {{- end}}
-        Hostname Provider: {{.hostnameStats.provider}}<br>
-        {{- if .hostnameStats.error }}
-          <span class="error">Error</span>: {{.hostnameStats.error}}<br>
-        {{- end }}
-        {{- range $name, $value := .hostnameStats.errors -}}
-          {{- if ne $name "all" }}
-          <span class="error">Error</span>: {{$name}}: {{$value}}<br>
-          {{- else }}
-          <span class="error">Error</span>: {{$value}}<br>
-          {{- end}}
-        {{- end }}
-      </span>
+    </span>
+  </div>
+
+  <div class="stat">
+    <span class="stat_title">Hostnames</span>
+    <span class="stat_data">
+      {{- range $type, $value := .metadata.meta -}}
+        {{- if ne $type "timezones" -}}
+          {{- if $value}}
+            {{formatTitle $type}}: {{$value -}}<br>
+          {{end -}}
+        {{- end -}}
+      {{- end}}
+      Hostname Provider: {{.hostnameStats.provider}}<br>
+      {{- if gt (len .hostnameStats.errors) 0 }}
+        <span>Unused Hostname Providers: <br>
+          <span class="stat_subdata">
+            {{- range $name, $value := .hostnameStats.errors -}}
+              {{- if ne $name "all" }}
+                {{formatTitle $name}}: {{$value}}<br>
+              {{- end}}
+            {{- end }}
+          </span>
+        </span>
+      {{- if .hostnameStats.errors.all }}
+        <span class="error">Error</span>: {{.hostnameStats.errors.all}}<br>
+      {{- end }}
+      {{- end }}
+
     </span>
   </div>
 

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -44,11 +44,15 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{- end }}
   {{- end }}
     hostname provider: {{.hostnameStats.provider}}
+  {{- if gt (len .hostnameStats.errors) 0 }}
+    unused hostname providers:
+  {{- end }}
   {{- range $name, $value := .hostnameStats.errors -}}
-    {{- if ne $name "all" }}
-    error: {{$name}}: {{$value}}
-    {{- else }}
-    error: {{$value}}
-    {{- end}}
+      {{- if ne $name "all" }}
+      {{$name}}: {{$value}}
+      {{- end}}
+  {{- end }}
+  {{- if .hostnameStats.errors.all }}
+    error: {{.hostnameStats.errors.all}}
   {{- end }}
 {{/* this line intentionally left blank */}}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -88,6 +88,6 @@ func HostnameProvider(hostName string) (string, error) {
 		log.Debug("GetHostname trying EC2 metadata...")
 		return GetInstanceID()
 	}
-	// If we arrive here, we are probably not on an EC2 instance
-	return "", fmt.Errorf("The host is not an EC2 instance")
+
+	return "", fmt.Errorf("not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames")
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -47,7 +47,7 @@ func init() {
 // In case it's not, the returned error contains the details of the failure.
 func ValidHostname(hostname string) error {
 	if hostname == "" {
-		return fmt.Errorf("host name is empty")
+		return fmt.Errorf("hostname is empty")
 	} else if isLocal(hostname) {
 		return fmt.Errorf("%s is a local hostname", hostname)
 	} else if len(hostname) > maxLength {


### PR DESCRIPTION
### What does this PR do?

Change wording of hostname providers in the status

### Motivation

We’re showing as `error`s things that are completely expected (for example: `error: configuration/environment: host name is empty` or `error: gce: unable to retrieve hostname from GCE: Get http://169.254.169.254/computeMetadata/v1/instance/hostname: dial tcp 169.254.169.254:80: connect: no route to host`) which can be misleading. Show them as `unused hostname providers` instead
