### PR TITLE
Don't ignore pause containers in autodiscovery

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -63,7 +63,7 @@ func NewDockerListener() (ServiceListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	filter, err := containers.GetSharedFilter()
+	filter, err := containers.NewFilterFromConfigIncludePause()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -53,7 +53,7 @@ func init() {
 
 // NewECSListener creates an ECSListener
 func NewECSListener() (ServiceListener, error) {
-	filter, err := containers.GetSharedFilter()
+	filter, err := containers.NewFilterFromConfigIncludePause()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -58,7 +58,7 @@ func NewKubeletListener() (ServiceListener, error) {
 	if err != nil {
 		return nil, err
 	}
-	filter, err := containers.GetSharedFilter()
+	filter, err := containers.NewFilterFromConfigIncludePause()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -124,6 +124,15 @@ func NewFilterFromConfig() (*Filter, error) {
 	return NewFilter(whitelist, blacklist)
 }
 
+// NewFilterFromConfigIncludePause creates a new container filter, sourcing patterns
+// from the pkg/config options, but ignoring the exclude_pause_container option, for
+// use in autodiscovery
+func NewFilterFromConfigIncludePause() (*Filter, error) {
+	whitelist := config.Datadog.GetStringSlice("ac_include")
+	blacklist := config.Datadog.GetStringSlice("ac_exclude")
+	return NewFilter(whitelist, blacklist)
+}
+
 // IsExcluded returns a bool indicating if the container should be excluded
 // based on the filters in the containerFilter instance.
 func (cf Filter) IsExcluded(containerName, containerImage string) bool {

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -136,8 +136,6 @@ func TestFilter(t *testing.T) {
 	}
 }
 
-// NewFilterFromConfig creates a new container filter, sourcing patterns
-// from the pkg/config options
 func TestNewFilterFromConfig(t *testing.T) {
 	config.Datadog.SetDefault("exclude_pause_container", true)
 	config.Datadog.SetDefault("ac_include", []string{"image:apache.*"})
@@ -156,6 +154,25 @@ func TestNewFilterFromConfig(t *testing.T) {
 	f, err = NewFilterFromConfig()
 	require.NoError(t, err)
 	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1"))
+
+	config.Datadog.SetDefault("exclude_pause_container", true)
+	config.Datadog.SetDefault("ac_include", []string{})
+	config.Datadog.SetDefault("ac_exclude", []string{})
+}
+
+func TestNewFilterFromConfigIncludePause(t *testing.T) {
+	config.Datadog.SetDefault("exclude_pause_container", true)
+	config.Datadog.SetDefault("ac_include", []string{"image:apache.*"})
+	config.Datadog.SetDefault("ac_exclude", []string{"name:dd-.*"})
+
+	f, err := NewFilterFromConfigIncludePause()
+	require.NoError(t, err)
+
+	assert.True(t, f.IsExcluded("dd-152462", "dummy:latest"))
+	assert.False(t, f.IsExcluded("dd-152462", "apache:latest"))
+	assert.False(t, f.IsExcluded("dummy", "dummy"))
+	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1"))
+	assert.False(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1"))
 
 	config.Datadog.SetDefault("exclude_pause_container", true)
 	config.Datadog.SetDefault("ac_include", []string{})


### PR DESCRIPTION
### What does this PR do?

Mitigate possibly breaking change brought by "Honor ac_exclude / ac_include in autodiscovery" #2302

Some users rely on AD annotations on pause containers to emulate "cluster checks". Let's keep them included in Autodiscovery for 6.5.0.

Documentation explicitly kept as is to avoid new users relying on this behaviour. Our recommendation is to re-tag the pause image under a new name.