### PR TITLE
[Logs]: Fixed a deadlock that could occur when the container launcher setup fails

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -45,13 +45,11 @@ func NewAgent(sources *config.LogSources, services *service.Services, serverConf
 
 	// setup the inputs
 	inputs := []restart.Restartable{
+		container.NewLauncher(sources, services, pipelineProvider, auditor),
 		listener.NewListener(sources, config.LogsAgent.GetInt("logs_config.frame_size"), pipelineProvider),
 		file.NewScanner(sources, config.LogsAgent.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
 		journald.NewLauncher(sources, pipelineProvider, auditor),
 		windowsevent.NewLauncher(sources, pipelineProvider),
-	}
-	if input, err := container.NewScanner(sources, services, pipelineProvider, auditor); err == nil {
-		inputs = append(inputs, input)
 	}
 
 	return &Agent{

--- a/pkg/logs/input/container/noop.go
+++ b/pkg/logs/input/container/noop.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package container
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/restart"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+)
+
+// noopLauncher consumes docker sources and services to ensure that no deadlock occurs when
+// the docker launcher or the kubernetes scanner could not be set up properly and autodiscovery
+// emits new valid docker integration configs, see [logs-scheduler](https://github.com/DataDog/datadog-agent/blob/master/pkg/logs/scheduler/scheduler.go).
+type noopLauncher struct {
+	sources  *config.LogSources
+	services *service.Services
+	stop     chan struct{}
+}
+
+// NewNoopLauncher returns a new noopLauncher.
+func NewNoopLauncher(sources *config.LogSources, services *service.Services) restart.Restartable {
+	return &noopLauncher{
+		sources:  sources,
+		services: services,
+		stop:     make(chan struct{}),
+	}
+}
+
+// Start does nothing
+func (l *noopLauncher) Start() {
+	go l.run()
+}
+
+// Stop stops the noopLauncher scanner.
+func (l *noopLauncher) Stop() {
+	l.stop <- struct{}{}
+}
+
+// run consumes docker sources and services and drop them directly.
+func (l *noopLauncher) run() {
+	for {
+		select {
+		case <-l.services.GetAddedServices(service.Docker):
+			continue
+		case <-l.services.GetRemovedServices(service.Docker):
+			continue
+		case <-l.sources.GetSourceStreamForType(config.DockerType):
+			continue
+		case <-l.stop:
+			return
+		}
+	}
+}

--- a/pkg/logs/input/docker/launcher_nodocker.go
+++ b/pkg/logs/input/docker/launcher_nodocker.go
@@ -8,6 +8,8 @@
 package docker
 
 import (
+	"errors"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -16,39 +18,15 @@ import (
 
 // Launcher is not supported on non docker environment
 type Launcher struct {
-	sources  *config.LogSources
-	services *service.Services
-	stop     chan struct{}
 }
 
 // NewLauncher returns a new Launcher
 func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) (*Launcher, error) {
-	return &Launcher{
-		sources:  sources,
-		services: services,
-		stop:     make(chan struct{}),
-	}, nil
+	return &Launcher{}, errors.New("the docker integration is not available on your system")
 }
 
 // Start does nothing
-func (l *Launcher) Start() {
-	go func() {
-		for {
-			select {
-			case <-l.services.GetAddedServices(service.Docker):
-				continue
-			case <-l.sources.GetSourceStreamForType(config.DockerType):
-				continue
-			case <-l.services.GetRemovedServices(service.Docker):
-				continue
-			case <-l.stop:
-				return
-			}
-		}
-	}()
-}
+func (l *Launcher) Start() {}
 
 // Stop does nothing
-func (l *Launcher) Stop() {
-	l.stop <- struct{}{}
-}
+func (l *Launcher) Stop() {}

--- a/pkg/logs/input/kubernetes/scanner_nokubelet.go
+++ b/pkg/logs/input/kubernetes/scanner_nokubelet.go
@@ -8,15 +8,18 @@
 package kubernetes
 
 import (
+	"errors"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
 )
 
 // Scanner is not supported on no kubelet environment
 type Scanner struct{}
 
 // NewScanner returns a new scanner
-func NewScanner(sources *config.LogSources) (*Scanner, error) {
-	return &Scanner{}, nil
+func NewScanner(sources *config.LogSources, services *service.Services) (*Scanner, error) {
+	return &Scanner{}, errors.New("the kubernetes integration is not available on your system")
 }
 
 // Start does nothing


### PR DESCRIPTION
### What does this PR do?

Ensure we always have a component consuming docker sources and services to prevent having any deadlock.

### Motivation

Fix possible deadlocks that could occur when new docker sources and services are pushed and:
- the docker socket is closed at agent setup
- the docker socket is not mounted
- the kubernetes integration is enabled

### Additional Notes

This needs to be merged for the `6.5.1`
