### PR TITLE
move OMNIBUS_BASE for windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ variables:
   # make sure the types of RPM packages are kept separate
   OMNIBUS_BASE_DIR_SUSE: $CI_PROJECT_DIR/.omnibus/suse/
   OMNIBUS_PACKAGE_DIR_SUSE: $CI_PROJECT_DIR/.omnibus/suse/pkg/
+  OMNIBUS_BASE_DIR_WIN: c:\omni-base\$CI_RUNNER_ID
   DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/test/kitchen
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
@@ -341,11 +342,10 @@ agent_suse-x64:
 
 # build Agent package for Windows
 build_windows_msi_x64:
-  # FIXME to be removed
-  allow_failure: true
   before_script:
     - if exist .omnibus rd /s/q .omnibus
     - if exist \omnibus-ruby rd /s/q \omnibus-ruby
+    - if exist %OMNIBUS_BASE_DIR_WIN% rd /s/q %OMNIBUS_BASE_DIR_WIN%
     - if exist \opt\datadog-agent rd /s/q \opt\datadog-agent
     - if exist %GOPATH%\src\github.com\DataDog\datadog-agent rd /s/q %GOPATH%\src\github.com\DataDog\datadog-agent
     - mkdir %GOPATH%\src\github.com\DataDog\datadog-agent
@@ -361,7 +361,7 @@ build_windows_msi_x64:
     # remove artifacts from previous pipelines that may come from the cache
     - rm -rf .omnibus/pkg/
     - cd %GOPATH%\src\github.com\DataDog\datadog-agent
-    - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache
+    - inv agent.omnibus-build --release-version %RELEASE_VERSION% --omnibus-s3-cache --base-dir %OMNIBUS_BASE_DIR_WIN%
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -341,6 +341,8 @@ agent_suse-x64:
 
 # build Agent package for Windows
 build_windows_msi_x64:
+  # FIXME to be removed
+  allow_failure: true
   before_script:
     - if exist .omnibus rd /s/q .omnibus
     - if exist \omnibus-ruby rd /s/q \omnibus-ruby

--- a/Dockerfiles/agent/entrypoint/50-cri.sh
+++ b/Dockerfiles/agent/entrypoint/50-cri.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ -z "${DD_CRI_SOCKET_PATH}" ]]; then
+    exit 0
+fi
+
+# Set a default config for the CRI check
+# Don't override it if it exists
+if [[ ! -e /etc/datadog-agent/conf.d/cri.d/conf.yaml.default ]]; then
+    mv /etc/datadog-agent/conf.d/cri.d/conf.yaml.example \
+    /etc/datadog-agent/conf.d/cri.d/conf.yaml.default
+fi

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1542,6 +1542,14 @@
   revision = "b742be413d0a6f781c123bed504c8fb39264c57d"
 
 [[projects]]
+  digest = "1:13614139aef760b502fe057a8d34e9c4257d1581fb85498b0053267596e0514c"
+  name = "k8s.io/kubernetes"
+  packages = ["pkg/kubelet/apis/cri/runtime/v1alpha2"]
+  pruneopts = ""
+  revision = "bb9ffb1654d4a729bb4cec18ff088eacc153c239"
+  version = "v1.11.2"
+
+[[projects]]
   digest = "1:f25f07a85862183de4ac853ef22fe8b7fd9fb08f7e26c21577e6e7133ecbd540"
   name = "k8s.io/metrics"
   packages = [
@@ -1638,6 +1646,7 @@
     "golang.org/x/sys/windows/svc/eventlog",
     "golang.org/x/sys/windows/svc/mgr",
     "golang.org/x/text/unicode/norm",
+    "google.golang.org/grpc",
     "gopkg.in/yaml.v2",
     "gopkg.in/zorkian/go-datadog-api.v2",
     "k8s.io/api/autoscaling/v2beta1",
@@ -1670,6 +1679,7 @@
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/workqueue",
+    "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2",
     "k8s.io/metrics/pkg/apis/custom_metrics",
     "k8s.io/metrics/pkg/apis/external_metrics",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -152,3 +152,7 @@
 [[constraint]]
   name = "github.com/clbanning/mxj"
   version = "1.8.0"
+
+[[constraint]]
+  name = "k8s.io/kubernetes"
+  version = "1.11.2"

--- a/cmd/agent/dist/conf.d/cri.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/cri.d/conf.yaml.example
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+  - ## Tagging
+    ##
+
+    # You can add extra tags to your Docker metrics with the tags list option.
+    # Example: ["extra_tag", "env:testing"]
+    #
+    # tags: []

--- a/cmd/agent/dist/conf.d/cri.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/cri.d/conf.yaml.example
@@ -1,10 +1,10 @@
 init_config:
 
 instances:
-  - ## Tagging
-    ##
 
-    # You can add extra tags to your Docker metrics with the tags list option.
-    # Example: ["extra_tag", "env:testing"]
+    ## @param tags  - list of key:value elements - optional
+    ## List of tags to attach to every metrics, events and service checks emitted by this integration.
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
     #
-    # tags: []
+    # - tags:
+    #   - <KEY_1>:<VALUE_1>,<KEY_2>:<VALUE_3>

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -23,8 +23,7 @@ const (
 
 // CRIConfig holds the config of the check
 type CRIConfig struct {
-	RuntimeEndpoint string   `yaml:"runtime_endpoint"`
-	Tags            []string `yaml:"tags"`
+	Tags []string `yaml:"tags"`
 }
 
 // CRICheck grabs CRI metrics

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build linux
+// +build cri
 
 package containers
 

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -63,6 +63,10 @@ func (c *CRICheck) Run() error {
 	}
 
 	stats, err := util.ListContainerStats()
+	if err != nil {
+		c.Warnf("Cannot get containers from the CRI: %s", err)
+		return err
+	}
 	for cid, stats := range stats {
 		entityID := containers.BuildEntityName(util.Runtime, cid)
 		tags, err := tagger.Tag(entityID, true)

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build linux
+
+package containers
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	criCheckName = "cri"
+)
+
+// CRIConfig holds the config of the check
+type CRIConfig struct {
+	RuntimeEndpoint string   `yaml:"runtime_endpoint"`
+	Tags            []string `yaml:"tags"`
+}
+
+// CRICheck grabs CRI metrics
+type CRICheck struct {
+	core.CheckBase
+	instance *CRIConfig
+}
+
+// CRIFactory is exported for integration testing
+func CRIFactory() check.Check {
+	return &CRICheck{
+		CheckBase: core.NewCheckBase(criCheckName),
+		instance:  &CRIConfig{},
+	}
+}
+
+// Configure parses the check configuration and init the check
+func (c *CRICheck) Configure(config, initConfig integration.Data) error {
+	return nil
+}
+
+func init() {
+	core.RegisterCheck("cri", CRIFactory)
+}
+
+// Run executes the check
+func (c *CRICheck) Run() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	util, err := containers.GetCRIUtil()
+	if err != nil {
+		c.Warnf("Error initialising check: %s", err)
+		return err
+	}
+
+	stats, err := util.ListContainerStats()
+	for cid, stats := range stats {
+		entityID := containers.BuildEntityName(util.Runtime, cid)
+		tags, err := tagger.Tag(entityID, true)
+		if err != nil {
+			log.Errorf("Could not collect tags for container %s: %s", cid[:12], err)
+		}
+		tags = append(tags, "runtime:"+util.Runtime)
+		tags = append(tags, c.instance.Tags...)
+		sender.Gauge("cri.mem.rss", float64(stats.GetMemory().GetWorkingSetBytes().GetValue()), "", tags)
+		sender.Gauge("cri.disk.used", float64(stats.GetWritableLayer().GetUsedBytes().GetValue()), "", tags)
+		sender.Gauge("cri.disk.inodes", float64(stats.GetWritableLayer().GetInodesUsed().GetValue()), "", tags)
+		// Cumulative CPU usage (sum across all cores) since object creation.
+		sender.Rate("cri.cpu.usage", float64(stats.GetCpu().GetUsageCoreNanoSeconds().GetValue()), "", tags)
+	}
+	sender.Commit()
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -208,6 +208,10 @@ func init() {
 	BindEnvAndSetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
 	BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 
+	// CRI
+	BindEnvAndSetDefault("cri_socket_path", "") // empty is disabled
+	BindEnvAndSetDefault("cri_query_timeout", int64(5))
+
 	// Kubernetes
 	BindEnvAndSetDefault("kubernetes_kubelet_host", "")
 	BindEnvAndSetDefault("kubernetes_http_kubelet_port", 10255)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -209,8 +209,8 @@ func init() {
 	BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 
 	// CRI
-	BindEnvAndSetDefault("cri_socket_path", "") // empty is disabled
-	BindEnvAndSetDefault("cri_query_timeout", int64(5))
+	BindEnvAndSetDefault("cri_socket_path", "")         // empty is disabled
+	BindEnvAndSetDefault("cri_query_timeout", int64(1)) // in seconds
 
 	// Kubernetes
 	BindEnvAndSetDefault("kubernetes_kubelet_host", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -210,7 +210,7 @@ func init() {
 
 	// CRI
 	BindEnvAndSetDefault("cri_socket_path", "")         // empty is disabled
-	BindEnvAndSetDefault("cri_query_timeout", int64(1)) // in seconds
+	BindEnvAndSetDefault("cri_query_timeout", int64(5)) // in seconds
 
 	// Kubernetes
 	BindEnvAndSetDefault("kubernetes_kubelet_host", "")

--- a/pkg/util/containers/cri.go
+++ b/pkg/util/containers/cri.go
@@ -46,7 +46,7 @@ func (c *CRIUtil) init() error {
 	socketPath := config.Datadog.GetString("cri_socket_path")
 
 	if socketPath == "" {
-		return fmt.Errorf("no cri_socket_path path was set")
+		return fmt.Errorf("no cri_socket_path was set")
 	}
 
 	dialer := func(socketPath string, timeout time.Duration) (net.Conn, error) {

--- a/pkg/util/containers/cri.go
+++ b/pkg/util/containers/cri.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build linux
+
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+	"google.golang.org/grpc"
+	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+var (
+	globalCRIUtil *CRIUtil
+	once          sync.Once
+)
+
+// CRIUtil wraps interactions with the CRI
+// see https://github.com/kubernetes/kubernetes/blob/release-1.12/pkg/kubelet/apis/cri/runtime/v1alpha2/api.proto
+type CRIUtil struct {
+	// used to setup the CRIUtil
+	initRetry retry.Retrier
+
+	sync.Mutex
+	client         pb.RuntimeServiceClient
+	Runtime        string
+	RuntimeVersion string
+	queryTimeout   time.Duration
+}
+
+// init makes an empty CRIUtil bootstrap itself.
+// This is not exposed as public API but is called by the retrier embed.
+func (c *CRIUtil) init() error {
+	// TODO config?
+	c.queryTimeout = 5 * time.Second
+
+	addr := "/var/run/containerd/containerd.sock"
+	dialer := func(addr string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout("unix", addr, timeout)
+	}
+
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(c.queryTimeout), grpc.WithDialer(dialer))
+	if err != nil {
+		return fmt.Errorf("failed to dial: %v", err)
+	}
+
+	c.client = pb.NewRuntimeServiceClient(conn)
+	// validating the connection fetching the version
+	request := &pb.VersionRequest{}
+	r, err := c.client.Version(context.Background(), request)
+	if err != nil {
+		return err
+	}
+	c.Runtime = r.RuntimeName
+	c.RuntimeVersion = r.RuntimeVersion
+
+	return nil
+}
+
+// GetCRIUtil returns a ready to use CRIUtil. It is backed by a shared singleton.
+func GetCRIUtil() (*CRIUtil, error) {
+	once.Do(func() {
+		globalCRIUtil = &CRIUtil{}
+		globalCRIUtil.initRetry.SetupRetrier(&retry.Config{
+			Name:          "criutil",
+			AttemptMethod: globalCRIUtil.init,
+			Strategy:      retry.RetryCount,
+			RetryCount:    10,
+			RetryDelay:    30 * time.Second,
+		})
+	})
+
+	if err := globalCRIUtil.initRetry.TriggerRetry(); err != nil {
+		log.Debugf("CRI init error: %s", err)
+		return nil, err
+	}
+	return globalCRIUtil, nil
+}
+
+// Version sends a VersionRequest to the server, and parses the returned VersionResponse.
+func (c *CRIUtil) ListContainerStats() (map[string]*pb.ContainerStats, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
+	defer cancel()
+	filter := &pb.ContainerStatsFilter{}
+	request := &pb.ListContainerStatsRequest{Filter: filter}
+	r, err := c.client.ListContainerStats(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make(map[string]*pb.ContainerStats)
+	for _, s := range r.GetStats() {
+		stats[s.Attributes.Id] = s
+	}
+	return stats, nil
+}

--- a/pkg/util/containers/cri.go
+++ b/pkg/util/containers/cri.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build linux
+// +build cri
 
 package containers
 

--- a/pkg/util/containers/cri.go
+++ b/pkg/util/containers/cri.go
@@ -43,17 +43,17 @@ type CRIUtil struct {
 // This is not exposed as public API but is called by the retrier embed.
 func (c *CRIUtil) init() error {
 	c.queryTimeout = config.Datadog.GetDuration("cri_query_timeout") * time.Second
-	socket_path := config.Datadog.GetString("cri_socket_path")
+	socketPath := config.Datadog.GetString("cri_socket_path")
 
-	if socket_path == "" {
+	if socketPath == "" {
 		return fmt.Errorf("no cri_socket_path path was set")
 	}
 
-	dialer := func(socket_path string, timeout time.Duration) (net.Conn, error) {
-		return net.DialTimeout("unix", socket_path, timeout)
+	dialer := func(socketPath string, timeout time.Duration) (net.Conn, error) {
+		return net.DialTimeout("unix", socketPath, timeout)
 	}
 
-	conn, err := grpc.Dial(socket_path, grpc.WithInsecure(), grpc.WithTimeout(c.queryTimeout), grpc.WithDialer(dialer))
+	conn, err := grpc.Dial(socketPath, grpc.WithInsecure(), grpc.WithTimeout(c.queryTimeout), grpc.WithDialer(dialer))
 	if err != nil {
 		return fmt.Errorf("failed to dial: %v", err)
 	}
@@ -91,7 +91,7 @@ func GetCRIUtil() (*CRIUtil, error) {
 	return globalCRIUtil, nil
 }
 
-// Version sends a VersionRequest to the server, and parses the returned VersionResponse.
+// ListContainerStats sends a ListContainerStatsRequest to the server, and parses the returned response
 func (c *CRIUtil) ListContainerStats() (map[string]*pb.ContainerStats, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
 	defer cancel()

--- a/pkg/util/containers/cri_host_metadata.go
+++ b/pkg/util/containers/cri_host_metadata.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build linux
+
+package containers
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
+)
+
+func init() {
+	container.RegisterMetadataProvider("cri", getMetadata)
+}
+
+func getMetadata() (map[string]string, error) {
+	metadata := make(map[string]string)
+	cu, err := GetCRIUtil()
+	if err != nil {
+		return metadata, err
+	}
+	metadata["cri_name"] = cu.Runtime
+	metadata["cri_version"] = cu.RuntimeVersion
+
+	return metadata, nil
+}

--- a/pkg/util/containers/cri_host_metadata.go
+++ b/pkg/util/containers/cri_host_metadata.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build linux
+// +build cri
 
 package containers
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -25,6 +25,7 @@ DEFAULT_BUILD_TAGS = [
     "apm",
     "consul",
     "cpython",
+    "cri",
     "docker",
     "ec2",
     "etcd",

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -11,6 +11,7 @@ ALL_TAGS = set([
     "clusterchecks",
     "consul",
     "cpython",
+    "cri",
     "docker",
     "ec2",
     "etcd",
@@ -35,6 +36,7 @@ LINUX_ONLY_TAGS = [
     "docker",
     "kubelet",
     "kubeapiserver",
+    "cri",
 ]
 
 DEBIAN_ONLY_TAGS = [


### PR DESCRIPTION
### What does this PR do?

On windows builds, move the omnibus base dir closer to the root rather than relative to the gitlab build dir.  mitigates (but `doesn't solve`) long filename issue.  

### Motivation

builds breaking due to vendored package with long path name

### Additional Notes

Sometimes, having an OS with a 30 year old legacy isn't the best thing in the world.
