### PR TITLE
use buster-slim for docker cluster-agent image

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 


### PR DESCRIPTION
### Motivation

Brings updated packages with less CVEs
