### PR TITLE
remove Cryptodome.SelfTest from agent docker image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -31,6 +31,8 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
     opt/datadog-agent/embedded/lib/libcurl.so.4.4.0 \
     # ditto for this older libsystemd
     usr/lib/x86_64-linux-gnu/libsystemd.so.0.21.0 \
+    # self-test certificates that are detected (false positive) as private keys
+    opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest \
  && find opt/datadog-agent/ -iname "*.a" -delete \
  && if [ -z "$WITH_JMX" ]; then rm -rf opt/datadog-agent/bin/agent/dist/jmx; fi \
  && ln -s /opt/datadog-agent/embedded/ssl etc/ssl \


### PR DESCRIPTION
### What does this PR do?

Delete `SelfTest` module of the `Cryptodome` python library. It triggers a false-positive on twistlock scanner:

> Private keys stored in image
> --
> Found:  /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private.pem,   /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private_enc_aes128.pem,   /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private_enc_aes192.pem,   /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private_enc_aes256_gcm.pem,   /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private_enc_des3.pem,   /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private_p8.pem,   /opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/PublicKey/test_vectors/ECC/ecc_p256_private_p8_clear.pem

### Motivation

From my investigation, it is not required at runtime, but can be invoked with `python -m Crypto.SelfTest` to verify the installation.

