### PR TITLE
Dockerfiles/agent: update README to reflect recent trace-agent changes.

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -36,9 +36,7 @@ environment variables:
 - `DD_PROXY_HTTPS`: an http URL to use as a proxy for `https` requests.
 - `DD_PROXY_NO_PROXY`: a space-separated list of URLs for which no proxy should be used.
 
-Note: At the moment, the trace-agent only supports setting a proxy in `datadog.yaml`, and does not
-support these proxy environment variables. If you wish to set a proxy for trace-agent, please refer
-to the [section on mounting a custom datadog.yaml](#others).
+Note: at the moment, the trace agent only supports the above proxy environment variables starting from version 6.5.0
 
 For more information: https://docs.datadoghq.com/agent/proxy/#agent-v6
 


### PR DESCRIPTION
This change removes a section from the README saying that proxy
environment variables are not supported in the trace agent. This
functionality has been added recently in 6.5.0
