### PR TITLE
Fixed a null pointer exception caused by logs docker launcher

### DIFF
--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -172,6 +172,7 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 	err = tailer.Start(since)
 	if err != nil {
 		log.Warnf("Could not start tailer: %v", containerID, err)
+		return
 	}
 
 	// keep the tailer in track to stop it later on

--- a/releasenotes/notes/fix-logs-docker-launcher-crash-bec5a4ff7e21be0a.yaml
+++ b/releasenotes/notes/fix-logs-docker-launcher-crash-bec5a4ff7e21be0a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a crash in the logs package that could occur when a docker tailer initialization failed.


### PR DESCRIPTION
### What does this PR do?

Added an early return when the tailer start fails.

### Motivation

Fix crash in logs docker launcher.

### Additional Notes

This should fix https://github.com/DataDog/datadog-agent/issues/2337
