### PR TITLE
Increase memory limits of agent

### DIFF
--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -33,10 +33,10 @@ spec:
                 fieldPath: status.hostIP
         resources:
           requests:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "200m"
           limits:
-            memory: "256Mi"
+            memory: "512Mi"
             cpu: "200m"
         volumeMounts:
           - name: dockersocket


### PR DESCRIPTION
### What does this PR do?

Increase memory limits and request for avoiding OOM killer.

### Motivation

I got such as error when some container are deployed to same cluster.

```
Name:           datadog-agent-mwht5
Namespace:      default
Node:           ********
Start Time:     Thu, 20 Sep 2018 13:12:29 +0900
Labels:         app=datadog-agent
                controller-revision-hash=1875514103
                pod-template-generation=2
Annotations:    <none>
Status:         Running
IP:             ********
Controlled By:  DaemonSet/datadog-agent
Containers:
  datadog-agent:
    Container ID:   docker://b1496f37b5474f6546a5697d7da5fc2d11773ad24aa9fd5f12958d98e95dbd12
    Image:          datadog/agent:latest
    Image ID:       docker-pullable://datadog/agent@sha256:e8f17e9c87cc6e9f0b654a36b21390337a48589cabffa40c4bd897dd9030fe90
    Ports:          8125/UDP, 8126/TCP
    Host Ports:     8125/UDP, 8126/TCP
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    0
      Started:      Thu, 20 Sep 2018 14:14:27 +0900
      Finished:     Thu, 20 Sep 2018 14:16:46 +0900
    Ready:          False
    Restart Count:  11
```

It was solved if increasing the memory limits for testing.
I think that the memory limits is not enough.
