### PR TITLE
Consistently install python dev deps in gitlab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ before_script:
   - rsync -azr --delete ./ $SRC_PATH
   - cd $SRC_PATH
   - pip install -U pip
+  - pip install -r requirements.txt
   - inv -e deps
 
 #
@@ -388,6 +389,7 @@ agent_android_apk:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $SRC_PATH
     - pip install -U pip
+    - pip install -r requirements.txt
     - inv -e deps --android
   script:
     # remove artifacts from previous pipelines that may come from the cache

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -275,7 +275,11 @@ def lint_licenses(ctx):
     go_deps = set()
     gopkg_lock = toml.load('Gopkg.lock')
     for project in gopkg_lock['projects']:
-        go_deps.add(project['name'])
+        # FIXME: this conditional is necessary because of the issue introduced by DEPPROJECTROOT
+        # (for some reason `datadog-agent` gets added to Gopkg.lock and vendored), see comment in `deps`
+        # task for details
+        if project['name'] != 'github.com/DataDog/datadog-agent':
+            go_deps.add(project['name'])
 
     deps = go_deps | NON_GO_DEPS
 


### PR DESCRIPTION
### What does this PR do?

Consistently installs the python dev deps in gitlab jobs

### Motivation

So that adding a python dev dep is as simple as adding it to
`requirements.txt`. Should fix the gitlab build failures introduced
by https://github.com/DataDog/datadog-agent/pull/2268

### Additional Notes

I'm a bit sad about the lack of consistency of our pip deps management (some are installed in the test/build docker images, others are installed in `requirements.txt`, others pulled from `bootstrap.json`, and there's some overlap between the 3 of them).

Will follow up with a couple of PRs to try and make this more consistent and well-defined.