### PR TITLE
Fix the link to integrations-core's changelog in the prelude

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -19,11 +19,11 @@ def add_prelude(ctx, version):
     |
     Release on: {1}
 
-    - Please refer to the `{0} tag on integrations-core <https://github.com/DataDog/integrations-core/releases/tag/{0}>`_ for the list of changes on the Core Checks.
+    - Please refer to the `{0} tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-{2}>`_ for the list of changes on the Core Checks.
 
     - Please refer to the `{0} tag on trace-agent <https://github.com/DataDog/datadog-trace-agent/releases/tag/{0}>`_ for the list of changes on the Trace Agent.
 
-    - Please refer to the `{0} tag on process-agent <https://github.com/DataDog/datadog-process-agent/releases/tag/{0}>`_ for the list of changes on the Process Agent.\n""".format(version, date.today()))
+    - Please refer to the `{0} tag on process-agent <https://github.com/DataDog/datadog-process-agent/releases/tag/{0}>`_ for the list of changes on the Process Agent.\n""".format(version, date.today(), version.replace('.', '')))
 
     ctx.run("git add {}".format(new_releasenote))
     ctx.run("git commit -m \"Add prelude for {} release\"".format(version))


### PR DESCRIPTION
### What does this PR do?

Points the changelog to a new file on integrations-core, `AGENT_CHANGELOG.md` containing the list of checks that changed for each agent release.

### Motivation

Changelog is currently broken

### Additional Notes

We might need to fix the existing entries, waiting for instructions on this side
