### PR TITLE
use log wrapper in run command

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -16,7 +16,7 @@ import (
 	"os/signal"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/collector/corechecks/system/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu_windows.go
@@ -19,8 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/gohai/cpu"
-	log "github.com/cihub/seelog"
 	"golang.org/x/sys/windows"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"

--- a/pkg/logs/input/windowsevent/launcher.go
+++ b/pkg/logs/input/windowsevent/launcher.go
@@ -6,7 +6,7 @@
 package windowsevent
 
 import (
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"

--- a/pkg/logs/input/windowsevent/launcher_windows.go
+++ b/pkg/logs/input/windowsevent/launcher_windows.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 /*

--- a/pkg/logs/input/windowsevent/tailer.go
+++ b/pkg/logs/input/windowsevent/tailer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/clbanning/mxj"
 )
 

--- a/pkg/logs/input/windowsevent/tailer_nix.go
+++ b/pkg/logs/input/windowsevent/tailer_nix.go
@@ -8,7 +8,7 @@
 package windowsevent
 
 import (
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Start does not do much

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -17,7 +17,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Start starts tailing the event log.

--- a/releasenotes/notes/fix-agent-exit-log-0293d0788c9c6eb8.yaml
+++ b/releasenotes/notes/fix-agent-exit-log-0293d0788c9c6eb8.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue preventing the exit logs of the agent from displaying the correct filename.


### PR DESCRIPTION
### What does this PR do?

Fix an issue creating misleading filename in the agent exit logs (only when using `datadog-agent run`).
Ex:
```
2018-09-04 13:41:11 UTC | INFO | (FileName() error: error during runtime.Caller:-1 in Caller) | Received signal 'terminated', shutting down... 
```

This happens because we configure seelog to pop two level of execution stack so calling it directly will result in a wrong filename or in this case an error since we are at the root of the call stack: 

https://github.com/DataDog/datadog-agent/blob/e2383cb0d9b58f8372b4f54de2fcff6b6f2cbc80/pkg/util/log/log.go#L61