### PR TITLE
Add twistlock scan to pipeline for all docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -788,6 +788,27 @@ build_dogstatsd:
 # Docker dev image deployments
 #
 
+twistlock_scan:
+  stage: image_deploy
+  tags: [ "runner:docker", "size:large" ]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/twistlock-cli:2.5.121
+  dependencies: [] # Don't download Gitlab artefacts
+  allow_failure: true # Don't block the pipeline
+  variables:
+    SRC_AGENT: *agent_ecr
+    SRC_DSD: *dogstatsd_ecr
+    SRC_DCA: *cluster-agent_ecr
+  before_script:
+    - export SRC_TAG=v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
+    - export DOCKER_CLIENT_ADDRESS=$DOCKER_HOST
+    - TWISTLOCK_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.twistlock_password --with-decryption --query "Parameter.Value" --out text)
+    - scan () { echo -e "\n==== Scanning $1 ====\n"; docker pull $1 > /dev/null; /twistcli images scan --address="$TWISTLOCK_URL" --user="$TWISTLOCK_USER" --password="$TWISTLOCK_PASS" --vulnerability-threshold=$THRESHOLD --details $1; }
+  script:
+    - scan ${SRC_AGENT}:${SRC_TAG}
+    - scan ${SRC_AGENT}:${SRC_TAG}-jmx
+    - scan ${SRC_DSD}:${SRC_TAG}
+    - scan ${SRC_DCA}:${SRC_TAG}
+
 .docker_tag_job_definition: &docker_tag_job_definition
   stage: image_deploy
   tags: [ "runner:docker", "size:large" ]


### PR DESCRIPTION
### What does this PR do?

Introduce the the twistlock image vulnerability scan in the gitlab pipeline. It scans all four images in a single step to conserve resources (disposable docker runners), and avoid crowding the pipeline.

Our vulnerability threshold is set to `high`, which means the step will soft-fail for `high` and `critical` vulnerabilities, but leave `low` and `medium` vulns alone. The step will not make the pipeline fail, to avoid blocking the release on potential false positives.