### PR TITLE
handle empty_default_hostname in python and go checks

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -66,6 +66,16 @@ in any way.
 || `syslog_key`  | Syslog configuration client private key for TLS client validation |
 
 
+## Integrations instance configuration
+
+In addition to integration-specific options, the agent supports the following
+advanced options in the `instance` section:
+
+* `min_collection_interval`: set a different run interval in seconds, for checks
+that should run less frequently than the default 15 seconds interval
+* `empty_default_hostname`: submit metrics, events and service checks with no
+hostname when set to `true`
+
 ## Removed options
 
 This is the list of configuration options that were removed in the new Agent

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -51,6 +51,12 @@ type Config struct {
 	CreationTime  CreationTime `json:"-"`              // creation time of service
 }
 
+// CommonInstanceConfig holds the reserved fields for the yaml instance data
+type CommonInstanceConfig struct {
+	MinCollectionInterval int  `yaml:"min_collection_interval"`
+	EmptyDefaultHostname  bool `yaml:"empty_default_hostname"`
+}
+
 // Equal determines whether the passed config is the same
 func (c *Config) Equal(cfg *Config) bool {
 	if cfg == nil {

--- a/pkg/collector/corechecks/checkbase_test.go
+++ b/pkg/collector/corechecks/checkbase_test.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package corechecks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+)
+
+var (
+	defaultsInstance = `foo_init: bar_init`
+	customInstance   = `
+foo_init: bar_init
+min_collection_interval: 60
+empty_default_hostname: true
+`
+)
+
+type dummyCheck struct {
+	CheckBase
+}
+
+func TestCommonConfigure(t *testing.T) {
+	checkName := "test"
+	mycheck := &dummyCheck{
+		CheckBase: NewCheckBase(checkName),
+	}
+	mockSender := mocksender.NewMockSender(mycheck.ID())
+
+	err := mycheck.CommonConfigure([]byte(defaultsInstance))
+	assert.NoError(t, err)
+	assert.Equal(t, check.DefaultCheckInterval, mycheck.Interval())
+	mockSender.AssertNumberOfCalls(t, "DisableDefaultHostname", 0)
+
+	mockSender.On("DisableDefaultHostname", true).Return().Once()
+	err = mycheck.CommonConfigure([]byte(customInstance))
+	assert.NoError(t, err)
+	assert.Equal(t, 60*time.Second, mycheck.Interval())
+	mockSender.AssertExpectations(t)
+}
+
+func TestCommonConfigureCustomID(t *testing.T) {
+	checkName := "test"
+	mycheck := &dummyCheck{
+		CheckBase: NewCheckBase(checkName),
+	}
+	mycheck.BuildID([]byte(customInstance), nil)
+	assert.NotEqual(t, checkName, string(mycheck.ID()))
+	mockSender := mocksender.NewMockSender(mycheck.ID())
+
+	mockSender.On("DisableDefaultHostname", true).Return().Once()
+	err := mycheck.CommonConfigure([]byte(customInstance))
+	assert.NoError(t, err)
+	assert.Equal(t, 60*time.Second, mycheck.Interval())
+	mockSender.AssertExpectations(t)
+}

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -66,8 +66,13 @@ func (c *KubeASConfig) parse(data []byte) error {
 
 // Configure parses the check configuration and init the check.
 func (k *KubeASCheck) Configure(config, initConfig integration.Data) error {
+	err := k.CommonConfigure(config)
+	if err != nil {
+		return err
+	}
+
 	// Check connectivity to the APIServer
-	err := k.instance.parse(config)
+	err = k.instance.parse(config)
 	if err != nil {
 		log.Error("could not parse the config for the API server")
 		return err

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -343,13 +343,17 @@ func (d *DockerCheck) Run() error {
 
 // Configure parses the check configuration and init the check
 func (d *DockerCheck) Configure(config, initConfig integration.Data) error {
+	err := d.CommonConfigure(config)
+	if err != nil {
+		return err
+	}
+
 	d.instance.Parse(config)
 
 	if len(d.instance.FilteredEventType) == 0 {
 		d.instance.FilteredEventType = []string{"top", "exec_create", "exec_start", "exec_die"}
 	}
 
-	var err error
 	// Use the same hostname as the agent so that host tags (like `availability-zone:us-east-1b`)
 	// are attached to Docker events from this host. The hostname from the docker api may be
 	// different than the agent hostname depending on the environment (like EC2 or GCE).

--- a/pkg/collector/corechecks/network/ntp.go
+++ b/pkg/collector/corechecks/network/ntp.go
@@ -12,15 +12,15 @@ import (
 	"sort"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
-	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/beevik/ntp"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const ntpCheckName = "ntp"
@@ -113,8 +113,12 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 
 // Configure configure the data from the yaml
 func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data) error {
+	err := c.CommonConfigure(data)
+	if err != nil {
+		return err
+	}
 	cfg := new(ntpConfig)
-	err := cfg.parse(data, initConfig)
+	err = cfg.parse(data, initConfig)
 	if err != nil {
 		log.Criticalf("Error parsing configuration file: %s", err)
 		return err

--- a/pkg/collector/corechecks/network/snmp.go
+++ b/pkg/collector/corechecks/network/snmp.go
@@ -31,15 +31,15 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/k-sone/snmpgo"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/k-sone/snmpgo"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -644,9 +644,13 @@ func (c *SNMPCheck) getSNMP() error {
 
 // Configure the check from YAML data
 func (c *SNMPCheck) Configure(data integration.Data, initConfig integration.Data) error {
+	err := c.CommonConfigure(data)
+	if err != nil {
+		return err
+	}
 
 	cfg := new(snmpConfig)
-	err := cfg.parse(data, initConfig)
+	err = cfg.parse(data, initConfig)
 	if err != nil {
 		log.Criticalf("Error parsing configuration file: %s ", err)
 		return err

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -9,13 +9,13 @@ package system
 import (
 	"fmt"
 
+	"github.com/shirou/gopsutil/cpu"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/shirou/gopsutil/cpu"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 const cpuCheckName = "cpu"
@@ -77,9 +77,12 @@ func (c *CPUCheck) Run() error {
 	return nil
 }
 
-// Configure the CPU check doesn't need configuration
+// Configure the CPU check
 func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// do nothing
+	err := c.CommonConfigure(data)
+	if err != nil {
+		return err
+	}
 	// NOTE: This runs before the python checks, so we should be good, but cpuInfo()
 	//       on windows initializes COM to the multithreaded model. Therefore,
 	//       if a python check has run on this native windows thread prior and

--- a/pkg/collector/corechecks/system/disk.go
+++ b/pkg/collector/corechecks/system/disk.go
@@ -10,10 +10,11 @@ import (
 	"regexp"
 	"strings"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -78,7 +79,7 @@ func (c *DiskCheck) excludeDisk(mountpoint, device, fstype string) bool {
 	return false
 }
 
-func (c *DiskCheck) commonConfigure(data integration.Data) error {
+func (c *DiskCheck) instanceConfigure(data integration.Data) error {
 	conf := make(map[interface{}]interface{})
 	c.cfg = &diskConfig{}
 	err := yaml.Unmarshal([]byte(data), &conf)

--- a/pkg/collector/corechecks/system/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk_nix.go
@@ -10,11 +10,12 @@ package system
 import (
 	"fmt"
 
+	"github.com/shirou/gopsutil/disk"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/shirou/gopsutil/disk"
 )
 
 // for testing
@@ -142,6 +143,9 @@ func (c *DiskCheck) sendDiskMetrics(sender aggregator.Sender, ioCounter disk.IOC
 
 // Configure the disk check
 func (c *DiskCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.commonConfigure(data)
-	return err
+	err := c.CommonConfigure(data)
+	if err != nil {
+		return err
+	}
+	return c.instanceConfigure(data)
 }

--- a/pkg/collector/corechecks/system/file_handles.go
+++ b/pkg/collector/corechecks/system/file_handles.go
@@ -12,12 +12,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 const fileHandlesCheckName = "file_handle"
@@ -86,12 +84,6 @@ func (c *fhCheck) Run() error {
 	sender.Gauge("system.fs.file_handles.max", maxFh, "", nil)
 	sender.Commit()
 
-	return nil
-}
-
-// The check doesn't need configuration
-func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// do nothing
 	return nil
 }
 

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -9,12 +9,13 @@ package system
 import (
 	"fmt"
 
+	"github.com/shirou/gopsutil/load"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/shirou/gopsutil/load"
 )
 
 const loadCheckName = "load"
@@ -53,9 +54,12 @@ func (c *LoadCheck) Run() error {
 	return nil
 }
 
-// Configure the CPU check doesn't need configuration
+// Configure the CPU check
 func (c *LoadCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// do nothing
+	err := c.CommonConfigure(data)
+	if err != nil {
+		return err
+	}
 	// NOTE: This check is disabled on windows - so the following doesn't apply
 	//       currently:
 	//

--- a/pkg/collector/corechecks/system/memory.go
+++ b/pkg/collector/corechecks/system/memory.go
@@ -6,18 +6,11 @@
 package system
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
 
 const memCheckName = "memory"
-
-// Configure the Python check from YAML data
-func (c *MemoryCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// do nothing
-	return nil
-}
 
 func memFactory() check.Check {
 	return &MemoryCheck{

--- a/pkg/collector/corechecks/system/uptime.go
+++ b/pkg/collector/corechecks/system/uptime.go
@@ -6,12 +6,10 @@
 package system
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 const uptimeCheckName = "uptime"
@@ -37,12 +35,6 @@ func (c *UptimeCheck) Run() error {
 	sender.Gauge("system.uptime", float64(t), "", nil)
 	sender.Commit()
 
-	return nil
-}
-
-// Configure the CPU check doesn't need configuration
-func (c *UptimeCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// do nothing
 	return nil
 }
 

--- a/pkg/collector/corechecks/system/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc_windows.go
@@ -24,7 +24,6 @@ type processChk struct {
 
 // Run executes the check
 func (c *processChk) Run() error {
-
 	sender, err := aggregator.GetSender(c.ID())
 	if err != nil {
 		return err
@@ -40,7 +39,12 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(data integration.Data, initConfig integration.Data) (err error) {
+func (c *processChk) Configure(data integration.Data, initConfig integration.Data) error {
+	err := c.CommonConfigure(data)
+	if err != nil {
+		return err
+	}
+
 	c.numprocs, err = pdhutil.GetCounterSet("System", "Processes", "", nil)
 	if err != nil {
 		return err

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -83,7 +83,6 @@ func TestSubprocessRun(t *testing.T) {
 }
 
 func TestSubprocessRunConcurrent(t *testing.T) {
-
 	instances := make([]*PythonCheck, 30)
 	for i := range instances {
 		check, _ := getCheckInstance("testsubprocess", "TestSubprocessCheck")

--- a/releasenotes/notes/handle-empty-hostname-0d530fcc86cba056.yaml
+++ b/releasenotes/notes/handle-empty-hostname-0d530fcc86cba056.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    All python and go checks support the new ``empty_default_hostname`` option
+    to send metrics with no hostname. This is used for cluster-level checks

--- a/releasenotes/notes/handle-empty-hostname-0d530fcc86cba056.yaml
+++ b/releasenotes/notes/handle-empty-hostname-0d530fcc86cba056.yaml
@@ -3,3 +3,6 @@ enhancements:
   - |
     All python and go checks support the new ``empty_default_hostname`` option
     to send metrics with no hostname. This is used for cluster-level checks
+  - |
+    All go checks now support the ``min_collection_interval`` option, as python
+    check already do

--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -230,10 +230,20 @@ spec:
             instances:
             - {}
 
+          memory.yaml: |
+            # Test go check handling of empty_default_hostname
+            instances:
+            - empty_default_hostname: true
+
           network.yaml: |
             init_config:
             instances:
             - collect_connection_state: false
+              excluded_interfaces:
+                - lo
+                - lo0
+            - collect_connection_state: false
+              empty_default_hostname: true
               excluded_interfaces:
                 - lo
                 - lo0
@@ -306,6 +316,9 @@ spec:
                 - name: datadog-config
                   mountPath: /etc/datadog-agent/conf.d/network.d/conf.yaml.default
                   subPath: network.yaml
+                - name: datadog-config
+                  mountPath: /etc/datadog-agent/conf.d/memory.d/conf.yaml.default
+                  subPath: memory.yaml
                 - name: proc
                   mountPath: /host/proc
                   readOnly: true
@@ -1019,13 +1032,39 @@ spec:
         while (1) {
           sleep(2000);
 
-          // Gauges
+          // Go memory check
           var nb = db.series.find({
-            metric: "system.cpu.user",
+            metric: "system.cpu.idle",
             host: "e2e-test"
           }).count();
           if (nb == 0) {
-            print("no system.cpu.user metric with nominal hostname");
+            print("no system.cpu.idle metric with nominal hostname");
+            continue;
+          }
+          var nb = db.series.find({
+            metric: "system.mem.free",
+            host: ""
+          }).count();
+          if (nb == 0) {
+            print("no system.mem.free metric with empty hostname");
+            continue;
+          }
+
+          // Python network check
+          var nb = db.series.find({
+            metric: "system.net.bytes_sent",
+            host: "e2e-test"
+          }).count();
+          if (nb == 0) {
+            print("no system.net.bytes_sent metric with nominal hostname");
+            continue;
+          }
+          var nb = db.series.find({
+            metric: "system.net.bytes_sent",
+            host: ""
+          }).count();
+          if (nb == 0) {
+            print("no system.net.bytes_sent metric with empty hostname");
             continue;
           }
 

--- a/test/e2e/scripts/run-instance/22-argo-submit.sh
+++ b/test/e2e/scripts/run-instance/22-argo-submit.sh
@@ -81,6 +81,9 @@ spec:
         - name: datadog-config
           mountPath: /etc/datadog-agent/conf.d/docker.d/conf.yaml.default
           subPath: docker.yaml
+        - name: datadog-config
+          mountPath: /etc/datadog-agent/conf.d/memory.d/conf.yaml.default
+          subPath: memory.yaml
         - name: proc
           mountPath: /host/proc
           readOnly: true


### PR DESCRIPTION
### What does this PR do?

Building on top of https://github.com/DataDog/datadog-agent/pull/2334 , make python and go checks look for the `empty_default_hostname` option in `instance`, to selectively disable default hostname injection in cluster-level checks:

* PythonCheck.Configure: rework `min_collection_interval` handling code to also look for `empty_default_hostname`. Serialise in a new `integration.CommonInstanceConfig` struct type to avoid brittle manual casting and factor code in the golang checks
* CheckBase: add a new `CommonConfigure` method handling these two options, provide a default `Configure` method that calls it when check need no specific configuration
* Go checks: update the `Configure` methods to call `CheckBase.CommonConfigure` or remove them when they were empty
* Update documentation
