### PR TITLE
fetch GOPATH from 'go env' command if env var is not set

### DIFF
--- a/tasks/bootstrap.py
+++ b/tasks/bootstrap.py
@@ -42,7 +42,14 @@ def process_deps(ctx, target, version, kind, step, verbose=False):
     if kind == "go":
         if step == "checkout":
             # download tools
-            path = os.path.join(os.environ.get('GOPATH'), 'src', target)
+            gopath = os.environ.get("GOPATH")
+            if not gopath:
+                for line in ctx.run("go env", hide=True).stdout.splitlines():
+                    [name, value] = line.split("=", 1)
+                    if name == "GOPATH":
+                        gopath = value
+                        break
+            path = os.path.join(gopath, 'src', target)
             if not os.path.exists(path):
                 ctx.run("go get{} -d -u {}".format(verbosity, target))
 


### PR DESCRIPTION
### What does this PR do?

Try to get GOPATH from $GOPATH environment variable then fallback to `go env` command

### Motivation

One can have a valid go environment without setting $GOPATH, the default is then simply $HOME/go and we can get it through `go env`. With this change we don't force people to set $GOPATH explicitly anymore. It simplifies the setup process to contribute