### PR TITLE
Cleanup logs tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin/
 /dev/
 __pycache__
 .pytest_cache
+venv/
 
 **/*.tmp
 **/debug.test

--- a/pkg/logs/README.md
+++ b/pkg/logs/README.md
@@ -4,12 +4,12 @@ logs-agent collects logs and submits them to datadog's infrastructure.
 
 ## Structure
 
-`logs` reads the config files, and instanciates what's needed.
-Each log line comes from a source (e.g. file, network, docker), and then enters one of the available _pipeline - decoder -> processor -> sender -> auditor_
+`logs` reads the config files, and instantiates what's needed.
+Each log line comes from a source (e.g. file, network, docker), and then enters one of the available _pipeline - tailer|listener|container -> decoder -> processor -> sender -> auditor_
 
 `Tailer` tails a file and submits data to the processors
 
-`Listener` listens on local network and submits data to the processors
+`Listener` listens on local network (TCP, UDP, Unix) and submits data to the processors
 
 `Container` scans docker logs from stdout/stderr and submits data to the processors
 
@@ -17,6 +17,6 @@ Each log line comes from a source (e.g. file, network, docker), and then enters 
 
 `Processor` updates the messages, filtering, redacting or adding metadata, and submits to the forwarder
 
-`Forwarder` submits the messages to the intake, and notifies the auditor
+`Sender` submits the messages to the intake, and notifies the auditor
 
 `Auditor` notes that messages were properly submitted, stores offsets for agent restarts

--- a/pkg/logs/README.md
+++ b/pkg/logs/README.md
@@ -20,3 +20,11 @@ Each log line comes from a source (e.g. file, network, docker), and then enters 
 `Sender` submits the messages to the intake, and notifies the auditor
 
 `Auditor` notes that messages were properly submitted, stores offsets for agent restarts
+
+## Tests
+
+```
+# Run the unit tests
+inv test --targets=./pkg/logs --timeout=10
+
+```

--- a/pkg/logs/input/listener/tcp_test.go
+++ b/pkg/logs/input/listener/tcp_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
 )
 
-
 // FIXME: Use a randomly assigned port, but this means allowing '0' in the config.
 const tcpTestPort = 10512
 

--- a/pkg/logs/input/listener/tcp_test.go
+++ b/pkg/logs/input/listener/tcp_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
 )
 
+
+// FIXME: Use a randomly assigned port, but this means allowing '0' in the config.
 const tcpTestPort = 10512
 
 func TestTCPShouldReceivesMessages(t *testing.T) {

--- a/pkg/logs/input/listener/udp_darwin_test.go
+++ b/pkg/logs/input/listener/udp_darwin_test.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build darwin
+
+package listener
+
+// TODO: Get it from `sysctl sys.inet.udp.maxdgram`
+const maxUDPFrameLen = 9216

--- a/pkg/logs/input/listener/udp_default_test.go
+++ b/pkg/logs/input/listener/udp_default_test.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !darwin,!linux
+
+package listener
+
+const maxUDPFrameLen = -1

--- a/pkg/logs/input/listener/udp_linux_test.go
+++ b/pkg/logs/input/listener/udp_linux_test.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build linux
+
+package listener
+
+const maxUDPFrameLen = 65535

--- a/pkg/logs/input/listener/udp_nix_test.go
+++ b/pkg/logs/input/listener/udp_nix_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
 )
 
-const maxUDPFrameLen = 65535
-
 func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
@@ -50,6 +48,11 @@ func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 }
 
 func TestUDPShoulDropTooBigMessages(t *testing.T) {
+	// Skip if we can't detect the max UDP frame length (currently only linux/darwin).
+	if maxUDPFrameLen <= 0 {
+		return
+	}
+
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
 	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), maxUDPFrameLen)


### PR DESCRIPTION
### What does this PR do?

This PR only cleanups quirks that one might find when trying to run unit tests on pkg/logs.

### Additional Notes

This is the first test before additional work on `pkgs/logs/input/listerners`.