### PR TITLE
handle swarm in docker tag extracts

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -8,6 +8,7 @@
 package collectors
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -17,17 +18,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// Allows to pass the dockerutil resolving method to
+// dockerExtractImage while using a mock for tests
+type resolveHook func(image string) (string, error)
+
 // extractFromInspect extract tags for a container inspect JSON
 func (c *DockerCollector) extractFromInspect(co types.ContainerJSON) ([]string, []string, error) {
 	tags := utils.NewTagList()
 
-	//TODO: remove when Inspect returns resolved image names
-	dockerImage, err := c.dockerUtil.ResolveImageName(co.Image)
-	if err != nil {
-		log.Debugf("Error resolving image %s: %s", co.Image, err)
-	} else {
-		dockerExtractImage(tags, dockerImage)
-	}
+	dockerExtractImage(tags, co, c.dockerUtil.ResolveImageName)
 	dockerExtractLabels(tags, co.Config.Labels, c.labelsAsTags)
 	dockerExtractEnvironmentVariables(tags, co.Config.Env, c.envAsTags)
 
@@ -38,7 +37,27 @@ func (c *DockerCollector) extractFromInspect(co types.ContainerJSON) ([]string, 
 	return low, high, nil
 }
 
-func dockerExtractImage(tags *utils.TagList, dockerImage string) {
+func dockerExtractImage(tags *utils.TagList, co types.ContainerJSON, resolve resolveHook) {
+	// Swarm / Compose will store the full image with tag and sha in co.Config.Image
+	// while co.Image will miss the tag. Handle this case first before using the sha
+	// and inspecting the image.
+	if co.Config != nil && strings.Contains(co.Config.Image, "@sha256") {
+		imageName, shortImage, imageTag, err := containers.SplitImageName(co.Config.Image)
+		if err == nil && imageName != "" && imageTag != "" {
+			tags.AddLow("docker_image", fmt.Sprintf("%s:%s", imageName, imageTag))
+			tags.AddLow("image_name", imageName)
+			tags.AddLow("short_image", shortImage)
+			tags.AddLow("image_tag", imageTag)
+			return
+		}
+	}
+
+	// Resolve sha to image repotag for orchestrators that pin the image by sha
+	dockerImage, err := resolve(co.Image)
+	if err != nil {
+		log.Debugf("Error resolving image %s: %s", co.Image, err)
+	} else {
+	}
 	tags.AddLow("docker_image", dockerImage)
 	imageName, shortImage, imageTag, err := containers.SplitImageName(dockerImage)
 	if err != nil {
@@ -53,7 +72,6 @@ func dockerExtractImage(tags *utils.TagList, dockerImage string) {
 // dockerExtractLabels contain hard-coded labels from:
 // - Docker swarm
 func dockerExtractLabels(tags *utils.TagList, containerLabels map[string]string, labelsAsTags map[string]string) {
-
 	for labelName, labelValue := range containerLabels {
 		switch labelName {
 		// Docker swarm

--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -56,7 +56,7 @@ func dockerExtractImage(tags *utils.TagList, co types.ContainerJSON, resolve res
 	dockerImage, err := resolve(co.Image)
 	if err != nil {
 		log.Debugf("Error resolving image %s: %s", co.Image, err)
-	} else {
+		return
 	}
 	tags.AddLow("docker_image", dockerImage)
 	imageName, shortImage, imageTag, err := containers.SplitImageName(dockerImage)

--- a/pkg/util/containers/image_test.go
+++ b/pkg/util/containers/image_test.go
@@ -43,6 +43,9 @@ func TestSplitImageName(t *testing.T) {
 		// Custom registry, most insane form possible
 		{"myregistry.local:5000/testing/test-image:version@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
 			"myregistry.local:5000/testing/test-image", "test-image", "version", nil},
+		// Test swarm image
+		{"dockercloud/haproxy:1.6.7@sha256:8c4ed4049f55de49cbc8d03d057a5a7e8d609c264bb75b59a04470db1d1c5121",
+			"dockercloud/haproxy", "haproxy", "1.6.7", nil},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {
 			assert := assert.New(t)

--- a/releasenotes/notes/swarm-image-tag-fix-6197b77e54fa4fbc.yaml
+++ b/releasenotes/notes/swarm-image-tag-fix-6197b77e54fa4fbc.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    More accurate tag extraction logic for Docker Swarm


### PR DESCRIPTION
### What does this PR do?

Images pulled by Swarm worker nodes show an empty `RepoTags` array in the image inspect, and the `RepoDigests` value does not hold the image tag:
```
  {
    "Id": "sha256:3199480a61205f9ebe93672d0125a05f88eec656c8ab78de893edeafe2db4eb1",
    "RepoTags": [    
    ],
    "RepoDigests": [
"dockercloud/haproxy@sha256:8c4ed4049f55de49cbc8d03d057a5a7e8d609c264bb75b59a04470db1d1c5121"
    ],
```

The desired tag is only accessible in the `container.Config.Image` field:
```
{
  "Id": "d2a8a270e306c67946aa014f867641319892b50b8d2caf484c1656d62b3670fd",
  "Image": "sha256:3199480a61205f9ebe93672d0125a05f88eec656c8ab78de893edeafe2db4eb1",
  ...
  "Config": {
    "Image": "dockercloud/haproxy:1.6.7@sha256:8c4ed4049f55de49cbc8d03d057a5a7e8d609c264bb75b59a04470db1d1c5121",
```

This leads to Swarm containers missing their `image_tag` tag, as it is not exposed in the fields our current logic is looking at.

This PR adds a new logic trying to extract image informations from the `container.Config.Image` field, and defaulting to the current logic if it fails.

Instead of modifying `docker.ResolveImageName` or `docker.Inspect` to add a special case, I went with a tagger-only fix, as other uses of the image name in the product (Autodiscovery ID matching, container filtering) are not affected by the tag being off, and this allows to significantly reduce the impact of that change.
