### PR TITLE
Move APM to dd-agent-user as well

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -250,7 +250,8 @@
                             Type="ownProcess"
                             Vital="yes"
                             Interactive="no"
-                            Account="LocalSystem"
+                          Account=".\ddagentuser"
+                          Password="[DDAGENTUSER_PASSWORD]"
                             Arguments="--config=c:\programdata\datadog\datadog.yaml" >
               <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
               <util:ServiceConfig


### PR DESCRIPTION
### What does this PR do?

Installs the APM agent as running as dd-agent-user rather than LOCAL_SERVICE

### Motivation

migrate all services to dd-agent-user

