### PR TITLE
Add expvar on number of packets per listener

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -79,7 +79,11 @@ instances:
 
 
       # datadog-agent dogstatsd monitoring
+      - path: dogstatsd-udp/Packets
+        type: rate
       - path: dogstatsd-udp/PacketReadingErrors
+        type: rate
+      - path: dogstatsd-uds/Packets
         type: rate
       - path: dogstatsd-uds/PacketReadingErrors
         type: rate

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -19,10 +19,12 @@ import (
 var (
 	udpExpvars             = expvar.NewMap("dogstatsd-udp")
 	udpPacketReadingErrors = expvar.Int{}
+	udpPackets             = expvar.Int{}
 )
 
 func init() {
 	udpExpvars.Set("PacketReadingErrors", &udpPacketReadingErrors)
+	udpExpvars.Set("Packets", &udpPackets)
 }
 
 // UDPListener implements the StatsdListener interface for UDP protocol.
@@ -74,6 +76,7 @@ func (l *UDPListener) Listen() {
 	log.Infof("dogstatsd-udp: starting to listen on %s", l.conn.LocalAddr())
 	for {
 		packet := l.packetPool.Get()
+		udpPackets.Add(1)
 		n, _, err := l.conn.ReadFrom(packet.buffer)
 		if err != nil {
 			// connection has been closed

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -22,11 +22,13 @@ var (
 	udsExpvars               = expvar.NewMap("dogstatsd-uds")
 	udsOriginDetectionErrors = expvar.Int{}
 	udsPacketReadingErrors   = expvar.Int{}
+	udsPackets               = expvar.Int{}
 )
 
 func init() {
 	udsExpvars.Set("OriginDetectionErrors", &udsOriginDetectionErrors)
 	udsExpvars.Set("PacketReadingErrors", &udsPacketReadingErrors)
+	udsExpvars.Set("Packets", &udsPackets)
 
 }
 
@@ -117,7 +119,7 @@ func (l *UDSListener) Listen() {
 		var n int
 		var err error
 		packet := l.packetPool.Get()
-
+		udsPackets.Add(1)
 		if l.OriginDetection {
 			// Read datagram + credentials in ancilary data
 			oob := l.oobPool.Get().([]byte)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -212,8 +212,20 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	stats["aggregatorStats"] = aggregatorStats
 
 	dogstatsdStatsJSON := []byte(expvar.Get("dogstatsd").String())
+	dogstatsdUdsStatsJSON := []byte(expvar.Get("dogstatsd-uds").String())
+	dogstatsdUDPStatsJSON := []byte(expvar.Get("dogstatsd-udp").String())
 	dogstatsdStats := make(map[string]interface{})
 	json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats)
+	dogstatsdUdsStats := make(map[string]interface{})
+	json.Unmarshal(dogstatsdUdsStatsJSON, &dogstatsdUdsStats)
+	for name, value := range dogstatsdUdsStats {
+		dogstatsdStats["Uds"+name] = value
+	}
+	dogstatsdUDPStats := make(map[string]interface{})
+	json.Unmarshal(dogstatsdUDPStatsJSON, &dogstatsdUDPStats)
+	for name, value := range dogstatsdUDPStats {
+		dogstatsdStats["Udp"+name] = value
+	}
 	stats["dogstatsdStats"] = dogstatsdStats
 
 	pyLoaderData := expvar.Get("pyLoader")

--- a/releasenotes/notes/expvars-dogstatsd-listeners-5b4aefe7f494964b.yaml
+++ b/releasenotes/notes/expvars-dogstatsd-listeners-5b4aefe7f494964b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    expose number of packets received for each dogstatsd listeners through expvar

--- a/releasenotes/notes/expvars-dogstatsd-listeners-5b4aefe7f494964b.yaml
+++ b/releasenotes/notes/expvars-dogstatsd-listeners-5b4aefe7f494964b.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    expose number of packets received for each dogstatsd listeners through expvar
+    Expose number of packets received for each dogstatsd listeners through expvar


### PR DESCRIPTION
### What does this PR do?

Create expvars for the number of packets received by each listeners

### Motivation

Useful when both UDP and UDS listeners are in use
