### PR TITLE
HPA Support for EKS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ templates:
           # use master's cache but don't pollute it back.
           - v2-godeps-{{ .Branch }}-{{ .Revision }}
           - v2-godeps-{{ .Branch }}-
-          - v2-godeps-master-
+          #- v2-godeps-master-
     - run: &enter_venv
         name: add virtualenv to bashrc
         command: echo "source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ templates:
           # use master's cache but don't pollute it back.
           - v2-godeps-{{ .Branch }}-{{ .Revision }}
           - v2-godeps-{{ .Branch }}-
-          #- v2-godeps-master-
+          - v2-godeps-master-
     - run: &enter_venv
         name: add virtualenv to bashrc
         command: echo "source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate" >> $BASH_ENV

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,7 +21,7 @@
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
-  digest = "1:7900eeaa09c57a4a83d7b61ccc9c5e48418826211154e17fcecdbf2c14ba2a7b"
+  digest = "1:15ae950195c3095bd0c4df4f54df83ae09de31f86f11330f1bc24e6ede86d7bc"
   name = "github.com/CharlyF/custom-metrics-apiserver"
   packages = [
     "pkg/apiserver",
@@ -34,7 +34,7 @@
     "pkg/registry/external_metrics",
   ]
   pruneopts = ""
-  revision = "8cee0380c23166fe328fedd088446df3c8254223"
+  revision = "3e7ca2be638146c574ff3be0a506a08d23ce6a46"
 
 [[projects]]
   digest = "1:b5c465c820ef1df848ddc2da97e7ebfc1e152fcc2bef8262f047522692e9fc6f"
@@ -897,7 +897,6 @@
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "log",
     "model",
   ]
   pruneopts = ""
@@ -1250,6 +1249,7 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
@@ -1305,6 +1305,7 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
+    "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/rand",
     "pkg/util/runtime",
@@ -1446,6 +1447,8 @@
     "informers/batch/v2alpha1",
     "informers/certificates",
     "informers/certificates/v1beta1",
+    "informers/coordination",
+    "informers/coordination/v1beta1",
     "informers/core",
     "informers/core/v1",
     "informers/events",
@@ -1503,6 +1506,8 @@
     "kubernetes/typed/batch/v2alpha1/fake",
     "kubernetes/typed/certificates/v1beta1",
     "kubernetes/typed/certificates/v1beta1/fake",
+    "kubernetes/typed/coordination/v1beta1",
+    "kubernetes/typed/coordination/v1beta1/fake",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/core/v1/fake",
     "kubernetes/typed/events/v1beta1",
@@ -1542,6 +1547,7 @@
     "listers/batch/v1beta1",
     "listers/batch/v2alpha1",
     "listers/certificates/v1beta1",
+    "listers/coordination/v1beta1",
     "listers/core/v1",
     "listers/events/v1beta1",
     "listers/extensions/v1beta1",
@@ -1611,6 +1617,7 @@
     "pkg/apis/custom_metrics",
     "pkg/apis/custom_metrics/install",
     "pkg/apis/custom_metrics/v1beta1",
+    "pkg/apis/custom_metrics/v1beta2",
     "pkg/apis/external_metrics",
     "pkg/apis/external_metrics/install",
     "pkg/apis/external_metrics/v1beta1",
@@ -1622,6 +1629,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/CharlyF/custom-metrics-apiserver/pkg/apiserver",
     "github.com/CharlyF/custom-metrics-apiserver/pkg/cmd",
     "github.com/CharlyF/custom-metrics-apiserver/pkg/provider",
     "github.com/DataDog/agent-payload/gogen",
@@ -1658,7 +1666,6 @@
     "github.com/go-ini/ini",
     "github.com/go-ole/go-ole",
     "github.com/gogo/protobuf/proto",
-    "github.com/golang/glog",
     "github.com/gorilla/mux",
     "github.com/hashicorp/consul/api",
     "github.com/hectane/go-acl",
@@ -1671,7 +1678,6 @@
     "github.com/openshift/api/quota/v1",
     "github.com/patrickmn/go-cache",
     "github.com/pkg/errors",
-    "github.com/prometheus/common/log",
     "github.com/samuel/go-zookeeper/zk",
     "github.com/sbinet/go-python",
     "github.com/shirou/gopsutil/cpu",
@@ -1710,10 +1716,12 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/apiserver/pkg/server",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/autoscaling/v2beta1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,33 @@
   revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6978a38432a017763a148afbc7ce6491734b54292af7d3e969d84d2e9dd242e2"
+  name = "github.com/Azure/go-ansiterm"
+  packages = [
+    ".",
+    "winterm",
+  ]
+  pruneopts = ""
+  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
+
+[[projects]]
+  digest = "1:7900eeaa09c57a4a83d7b61ccc9c5e48418826211154e17fcecdbf2c14ba2a7b"
+  name = "github.com/CharlyF/custom-metrics-apiserver"
+  packages = [
+    "pkg/apiserver",
+    "pkg/apiserver/installer",
+    "pkg/cmd",
+    "pkg/cmd/server",
+    "pkg/dynamicmapper",
+    "pkg/provider",
+    "pkg/registry/custom_metrics",
+    "pkg/registry/external_metrics",
+  ]
+  pruneopts = ""
+  revision = "8cee0380c23166fe328fedd088446df3c8254223"
+
+[[projects]]
   digest = "1:b5c465c820ef1df848ddc2da97e7ebfc1e152fcc2bef8262f047522692e9fc6f"
   name = "github.com/DataDog/agent-payload"
   packages = ["gogen"]
@@ -80,6 +107,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
+  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
+  name = "github.com/Sirupsen/logrus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
   digest = "1:f82b8ac36058904227087141017bb82f4b0fc58272990a4cdae3e2d6d222644e"
@@ -248,6 +283,8 @@
     "api/types/versions",
     "api/types/volume",
     "client",
+    "pkg/term",
+    "pkg/term/windows",
     "pkg/tlsconfig",
   ]
   pruneopts = ""
@@ -468,6 +505,14 @@
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  branch = "master"
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
+  name = "github.com/google/btree"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
+
+[[projects]]
   digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -501,6 +546,25 @@
   pruneopts = ""
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:009a1928b8c096338b68b5822d838a72b4d8520715c1463614476359f3282ec8"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = ""
+  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
+
+[[projects]]
+  digest = "1:e24dc5ef44694848785de507f439a24e9e6d96d7b43b8cf3d6cfa857aa1e2186"
+  name = "github.com/grpc-ecosystem/go-grpc-prometheus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c225b8c3b01faf2899099b768856a9e916e5087b"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:92124c79d22ed5d033b38bd2f86be6dc0eae69658762d620db7c7ff6522329fc"
@@ -576,14 +640,6 @@
   revision = "7f56832555fc229dad908c67d65ed3ce6156b70c"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f81c8d7354cc0c6340f2f7a48724ee6c2b3db3e918ecd441c985b4d2d97dd3e7"
-  name = "github.com/howeyc/gopass"
-  packages = ["."]
-  pruneopts = ""
-  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
-
-[[projects]]
   digest = "1:302c6eb8e669c997bec516a138b8fc496018faa1ece4c13e445a2749fbe079bb"
   name = "github.com/imdario/mergo"
   packages = ["."]
@@ -628,21 +684,6 @@
   packages = ["."]
   pruneopts = ""
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
-
-[[projects]]
-  digest = "1:af03d69b06992d952e6f6fd7dc2dc87e1ec98fb2d45a1a91ad03d0b804399aae"
-  name = "github.com/kubernetes-incubator/custom-metrics-apiserver"
-  packages = [
-    "pkg/apiserver",
-    "pkg/apiserver/installer",
-    "pkg/cmd/server",
-    "pkg/dynamicmapper",
-    "pkg/provider",
-    "pkg/registry/custom_metrics",
-    "pkg/registry/external_metrics",
-  ]
-  pruneopts = ""
-  revision = "e61f72fec56ab519d74ebd396cd3fcf31b084558"
 
 [[projects]]
   branch = "master"
@@ -791,6 +832,22 @@
   version = "v1.2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:c24598ffeadd2762552269271b3b1510df2d83ee6696c1e543a0ff653af494bc"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  pruneopts = ""
+  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+
+[[projects]]
+  digest = "1:b46305723171710475f2dd37547edd57b67b9de9f2a6267cafdd98331fd6897f"
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
+  version = "v2.0.1"
+
+[[projects]]
   digest = "1:29e34e58f26655c4d73135cdfc0517ea2ff1483eff34e5d5ef4b6fddbb81e31b"
   name = "github.com/pierrec/lz4"
   packages = [
@@ -834,16 +891,17 @@
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bfbc121ef802d245ef67421cff206615357d9202337a3d492b8f668906b485a8"
+  branch = "addlog"
+  digest = "1:4151395b9f0f4ccec0e9cbe624c4b28faa8848f76ede4f07377ad12b6f046c04"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
+    "log",
     "model",
   ]
   pruneopts = ""
-  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
+  revision = "89d80287644767070914e30199b4d959e491bd3d"
 
 [[projects]]
   branch = "master"
@@ -1173,7 +1231,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:063b0970fabddacc03f0e07e1d0193460d050f2048d3244a3071cf2e0509a187"
+  digest = "1:b5b87220983c8ad79afb5bfff0a246ccdbbc6d65800b4cf83ad31034a7d115a2"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -1201,17 +1259,17 @@
     "rbac/v1alpha1",
     "rbac/v1beta1",
     "scheduling/v1alpha1",
+    "scheduling/v1beta1",
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "9e5ffd1f1320950b238cfce291b926411f0af722"
+  revision = "70491ec73e10be2989242c913738f049a37e72c7"
 
 [[projects]]
-  branch = "release-1.10"
-  digest = "1:33bcc98ed218289d68aeac0799649844075ee7a2fb1e686040b605b5b5a1523c"
+  digest = "1:83b4c4a296f4d2c9735073c36b4de76ad775d799bc5fe75004cbda1c2734ba48"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1220,9 +1278,6 @@
     "pkg/api/resource",
     "pkg/api/validation",
     "pkg/api/validation/path",
-    "pkg/apimachinery",
-    "pkg/apimachinery/announced",
-    "pkg/apimachinery/registered",
     "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
@@ -1267,10 +1322,10 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
+  revision = "d128f427fda3db9a4d1ebbf3d54b4949a3356662"
 
 [[projects]]
-  digest = "1:988f8eb584fb05903205e095e950cb3e51b5cdf2a511446a088f4c8a90bccb9e"
+  digest = "1:34421e7392d342a85ceff95081d4bac97ce61a5f4852327265a7972f6fd656ab"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/admission",
@@ -1283,17 +1338,18 @@
     "pkg/admission/plugin/webhook/config/apis/webhookadmission",
     "pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1",
     "pkg/admission/plugin/webhook/errors",
+    "pkg/admission/plugin/webhook/generic",
     "pkg/admission/plugin/webhook/mutating",
     "pkg/admission/plugin/webhook/namespace",
     "pkg/admission/plugin/webhook/request",
     "pkg/admission/plugin/webhook/rules",
     "pkg/admission/plugin/webhook/validating",
-    "pkg/admission/plugin/webhook/versioned",
     "pkg/apis/apiserver",
     "pkg/apis/apiserver/install",
     "pkg/apis/apiserver/v1alpha1",
     "pkg/apis/audit",
     "pkg/apis/audit/install",
+    "pkg/apis/audit/v1",
     "pkg/apis/audit/v1alpha1",
     "pkg/apis/audit/v1beta1",
     "pkg/apis/audit/validation",
@@ -1338,19 +1394,21 @@
     "pkg/server/routes/data/swagger",
     "pkg/server/storage",
     "pkg/storage",
+    "pkg/storage/cacher",
     "pkg/storage/errors",
     "pkg/storage/etcd",
     "pkg/storage/etcd/metrics",
     "pkg/storage/etcd/util",
     "pkg/storage/etcd3",
-    "pkg/storage/etcd3/preflight",
     "pkg/storage/names",
     "pkg/storage/storagebackend",
     "pkg/storage/storagebackend/factory",
     "pkg/storage/value",
+    "pkg/util/dryrun",
     "pkg/util/feature",
     "pkg/util/flag",
     "pkg/util/flushwriter",
+    "pkg/util/openapi",
     "pkg/util/trace",
     "pkg/util/webhook",
     "pkg/util/wsstream",
@@ -1362,11 +1420,10 @@
     "plugin/pkg/authorizer/webhook",
   ]
   pruneopts = ""
-  revision = "2cf66d2375dce045e1e02e1d7b74a0d1e34fedb3"
-  version = "kubernetes-1.10.3"
+  revision = "4e7be504bf8670b1b36388e3ce2d097c6347373a"
 
 [[projects]]
-  digest = "1:071cc2f032b701b9dba26568e040940f26931a49e3a3985f3375f17f7f6d9c5f"
+  digest = "1:859f27049a7a505bed463c990c6135b179f6ebeaacfde1bd6bd42b472c2e037e"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1406,6 +1463,7 @@
     "informers/rbac/v1beta1",
     "informers/scheduling",
     "informers/scheduling/v1alpha1",
+    "informers/scheduling/v1beta1",
     "informers/settings",
     "informers/settings/v1alpha1",
     "informers/storage",
@@ -1463,6 +1521,8 @@
     "kubernetes/typed/rbac/v1beta1/fake",
     "kubernetes/typed/scheduling/v1alpha1",
     "kubernetes/typed/scheduling/v1alpha1/fake",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/scheduling/v1beta1/fake",
     "kubernetes/typed/settings/v1alpha1",
     "kubernetes/typed/settings/v1alpha1/fake",
     "kubernetes/typed/storage/v1",
@@ -1491,16 +1551,19 @@
     "listers/rbac/v1alpha1",
     "listers/rbac/v1beta1",
     "listers/scheduling/v1alpha1",
+    "listers/scheduling/v1beta1",
     "listers/settings/v1alpha1",
     "listers/storage/v1",
     "listers/storage/v1alpha1",
     "listers/storage/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
     "rest",
     "rest/watch",
+    "restmapper",
     "testing",
     "tools/auth",
     "tools/cache",
@@ -1517,6 +1580,7 @@
     "transport",
     "util/buffer",
     "util/cert",
+    "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
@@ -1524,8 +1588,7 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "23781f4d6632d88e869066eaebb743857aa1ef9b"
-  version = "v7.0.0"
+  revision = "bdfc4cfc125f556bfe46fff68207767a605b64ed"
 
 [[projects]]
   branch = "master"
@@ -1542,7 +1605,7 @@
   revision = "b742be413d0a6f781c123bed504c8fb39264c57d"
 
 [[projects]]
-  digest = "1:f25f07a85862183de4ac853ef22fe8b7fd9fb08f7e26c21577e6e7133ecbd540"
+  digest = "1:5cda6735806fc01538c9529b2224a0f0ada454de8c2f168272c0be908d42feab"
   name = "k8s.io/metrics"
   packages = [
     "pkg/apis/custom_metrics",
@@ -1553,13 +1616,14 @@
     "pkg/apis/external_metrics/v1beta1",
   ]
   pruneopts = ""
-  revision = "0d9ea2ac660031c8f2726a735dda29441f396f99"
-  version = "kubernetes-1.10.3"
+  revision = "c368fb9b71245441cd3268fffdba58b28b9b4863"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/CharlyF/custom-metrics-apiserver/pkg/cmd",
+    "github.com/CharlyF/custom-metrics-apiserver/pkg/provider",
     "github.com/DataDog/agent-payload/gogen",
     "github.com/DataDog/gohai/cpu",
     "github.com/DataDog/gohai/filesystem",
@@ -1594,14 +1658,12 @@
     "github.com/go-ini/ini",
     "github.com/go-ole/go-ole",
     "github.com/gogo/protobuf/proto",
+    "github.com/golang/glog",
     "github.com/gorilla/mux",
     "github.com/hashicorp/consul/api",
     "github.com/hectane/go-acl",
     "github.com/k-sone/snmpgo",
     "github.com/kardianos/osext",
-    "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd/server",
-    "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/dynamicmapper",
-    "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider",
     "github.com/lxn/walk",
     "github.com/lxn/win",
     "github.com/mholt/archiver",
@@ -1609,6 +1671,7 @@
     "github.com/openshift/api/quota/v1",
     "github.com/patrickmn/go-cache",
     "github.com/pkg/errors",
+    "github.com/prometheus/common/log",
     "github.com/samuel/go-zookeeper/zk",
     "github.com/sbinet/go-python",
     "github.com/shirou/gopsutil/cpu",
@@ -1620,7 +1683,6 @@
     "github.com/shirou/w32",
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
-    "github.com/spf13/pflag",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
@@ -1648,12 +1710,10 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
-    "k8s.io/client-go/discovery",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/autoscaling/v2beta1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1200,8 +1200,8 @@
   version = "v2.12.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:b5b87220983c8ad79afb5bfff0a246ccdbbc6d65800b4cf83ad31034a7d115a2"
+  branch = "release-1.11"
+  digest = "1:77c0f2ebdb247964329c2495dea64be895fcc22de75f0fd719f092b6f869af53"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -1236,9 +1236,10 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "70491ec73e10be2989242c913738f049a37e72c7"
+  revision = "4e7be11eab3ffcfc1876898b8272df53785a9504"
 
 [[projects]]
+  branch = "release-1.11"
   digest = "1:36e48db24a383a02683a57b7a48d5c3e8937b1f5a71ccfb7e52ee5d77d796147"
   name = "k8s.io/apimachinery"
   packages = [
@@ -1392,6 +1393,7 @@
   revision = "d296c96c12b7d15d7fb5fea7a05fb165f8fd4014"
 
 [[projects]]
+  branch = "release-8.0"
   digest = "1:8dc30675df864683c2943f902446ea3df4042dcbb675cbebad499fe91a526e3f"
   name = "k8s.io/client-go"
   packages = [

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,18 +10,7 @@
   revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6978a38432a017763a148afbc7ce6491734b54292af7d3e969d84d2e9dd242e2"
-  name = "github.com/Azure/go-ansiterm"
-  packages = [
-    ".",
-    "winterm",
-  ]
-  pruneopts = ""
-  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
-
-[[projects]]
-  digest = "1:15ae950195c3095bd0c4df4f54df83ae09de31f86f11330f1bc24e6ede86d7bc"
+  digest = "1:457212d305ca8e8f68765cc6adb4e259a3aecc6513d79066736fbccbefc32485"
   name = "github.com/CharlyF/custom-metrics-apiserver"
   packages = [
     "pkg/apiserver",
@@ -34,7 +23,7 @@
     "pkg/registry/external_metrics",
   ]
   pruneopts = ""
-  revision = "3e7ca2be638146c574ff3be0a506a08d23ce6a46"
+  revision = "56ec6921a4cfec971e5a8c89d5f4629c17cbb21a"
 
 [[projects]]
   digest = "1:b5c465c820ef1df848ddc2da97e7ebfc1e152fcc2bef8262f047522692e9fc6f"
@@ -107,14 +96,6 @@
   packages = ["."]
   pruneopts = ""
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
-
-[[projects]]
-  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  pruneopts = ""
-  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
-  version = "v1.0.6"
 
 [[projects]]
   digest = "1:f82b8ac36058904227087141017bb82f4b0fc58272990a4cdae3e2d6d222644e"
@@ -283,8 +264,6 @@
     "api/types/versions",
     "api/types/volume",
     "client",
-    "pkg/term",
-    "pkg/term/windows",
     "pkg/tlsconfig",
   ]
   pruneopts = ""
@@ -557,14 +536,6 @@
   ]
   pruneopts = ""
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
-
-[[projects]]
-  digest = "1:e24dc5ef44694848785de507f439a24e9e6d96d7b43b8cf3d6cfa857aa1e2186"
-  name = "github.com/grpc-ecosystem/go-grpc-prometheus"
-  packages = ["."]
-  pruneopts = ""
-  revision = "c225b8c3b01faf2899099b768856a9e916e5087b"
-  version = "v1.2.0"
 
 [[projects]]
   digest = "1:92124c79d22ed5d033b38bd2f86be6dc0eae69658762d620db7c7ff6522329fc"
@@ -1249,7 +1220,6 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
-    "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
@@ -1269,7 +1239,7 @@
   revision = "70491ec73e10be2989242c913738f049a37e72c7"
 
 [[projects]]
-  digest = "1:83b4c4a296f4d2c9735073c36b4de76ad775d799bc5fe75004cbda1c2734ba48"
+  digest = "1:36e48db24a383a02683a57b7a48d5c3e8937b1f5a71ccfb7e52ee5d77d796147"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -1305,7 +1275,6 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
-    "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/rand",
     "pkg/util/runtime",
@@ -1323,10 +1292,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "d128f427fda3db9a4d1ebbf3d54b4949a3356662"
+  revision = "def12e63c512da17043b4f0293f52d1006603d9f"
 
 [[projects]]
-  digest = "1:34421e7392d342a85ceff95081d4bac97ce61a5f4852327265a7972f6fd656ab"
+  branch = "release-1.11"
+  digest = "1:6e561bc34c492c250fdf346e25e64acd1786b118b3beb997933be8383b1545be"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/admission",
@@ -1350,7 +1320,6 @@
     "pkg/apis/apiserver/v1alpha1",
     "pkg/apis/audit",
     "pkg/apis/audit/install",
-    "pkg/apis/audit/v1",
     "pkg/apis/audit/v1alpha1",
     "pkg/apis/audit/v1beta1",
     "pkg/apis/audit/validation",
@@ -1395,17 +1364,16 @@
     "pkg/server/routes/data/swagger",
     "pkg/server/storage",
     "pkg/storage",
-    "pkg/storage/cacher",
     "pkg/storage/errors",
     "pkg/storage/etcd",
     "pkg/storage/etcd/metrics",
     "pkg/storage/etcd/util",
     "pkg/storage/etcd3",
+    "pkg/storage/etcd3/preflight",
     "pkg/storage/names",
     "pkg/storage/storagebackend",
     "pkg/storage/storagebackend/factory",
     "pkg/storage/value",
-    "pkg/util/dryrun",
     "pkg/util/feature",
     "pkg/util/flag",
     "pkg/util/flushwriter",
@@ -1421,10 +1389,10 @@
     "plugin/pkg/authorizer/webhook",
   ]
   pruneopts = ""
-  revision = "4e7be504bf8670b1b36388e3ce2d097c6347373a"
+  revision = "d296c96c12b7d15d7fb5fea7a05fb165f8fd4014"
 
 [[projects]]
-  digest = "1:859f27049a7a505bed463c990c6135b179f6ebeaacfde1bd6bd42b472c2e037e"
+  digest = "1:8dc30675df864683c2943f902446ea3df4042dcbb675cbebad499fe91a526e3f"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1447,8 +1415,6 @@
     "informers/batch/v2alpha1",
     "informers/certificates",
     "informers/certificates/v1beta1",
-    "informers/coordination",
-    "informers/coordination/v1beta1",
     "informers/core",
     "informers/core/v1",
     "informers/events",
@@ -1506,8 +1472,6 @@
     "kubernetes/typed/batch/v2alpha1/fake",
     "kubernetes/typed/certificates/v1beta1",
     "kubernetes/typed/certificates/v1beta1/fake",
-    "kubernetes/typed/coordination/v1beta1",
-    "kubernetes/typed/coordination/v1beta1/fake",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/core/v1/fake",
     "kubernetes/typed/events/v1beta1",
@@ -1547,7 +1511,6 @@
     "listers/batch/v1beta1",
     "listers/batch/v2alpha1",
     "listers/certificates/v1beta1",
-    "listers/coordination/v1beta1",
     "listers/core/v1",
     "listers/events/v1beta1",
     "listers/extensions/v1beta1",
@@ -1594,7 +1557,7 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "bdfc4cfc125f556bfe46fff68207767a605b64ed"
+  revision = "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c"
 
 [[projects]]
   branch = "master"
@@ -1611,19 +1574,19 @@
   revision = "b742be413d0a6f781c123bed504c8fb39264c57d"
 
 [[projects]]
-  digest = "1:5cda6735806fc01538c9529b2224a0f0ada454de8c2f168272c0be908d42feab"
+  branch = "release-1.11"
+  digest = "1:c42d0ac160aebeae123cd081018be25fa4cbaa464d10cbdff2ce8c547d20b78b"
   name = "k8s.io/metrics"
   packages = [
     "pkg/apis/custom_metrics",
     "pkg/apis/custom_metrics/install",
     "pkg/apis/custom_metrics/v1beta1",
-    "pkg/apis/custom_metrics/v1beta2",
     "pkg/apis/external_metrics",
     "pkg/apis/external_metrics/install",
     "pkg/apis/external_metrics/v1beta1",
   ]
   pruneopts = ""
-  revision = "c368fb9b71245441cd3268fffdba58b28b9b4863"
+  revision = "972ef826b8401c180b89cefc7457daa2d116daa9"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,33 +40,27 @@
 
 [[override]]
   name = "github.com/kubernetes/apimachinery"
-  # branch = "release-1.11"
-  #        + pinning to commit in branch above
-  version = "kubernetes-1.10.3"
+  revision = "d128f427fda3db9a4d1ebbf3d54b4949a3356662"
 
 [[override]]
   name = "github.com/kubernetes/client-go"
-  version = "~v7.0.0"
+  revision = "bdfc4cfc125f556bfe46fff68207767a605b64ed"
 
 [[override]]
   name = "github.com/kubernetes/api"
-  # branch = "release-1.11"
-  #        + pinning to commit in branch above
-  version = "kubernetes-1.10.3"
+  revision = "70491ec73e10be2989242c913738f049a37e72c7"
 
 [[override]]
   name = "k8s.io/apiserver"
-  # branch = "release-1.11"
-  version = "kubernetes-1.10.3"
+  revision = "4e7be504bf8670b1b36388e3ce2d097c6347373a"
 
 [[override]]
   name = "k8s.io/metrics"
-  version = "kubernetes-1.10.3"
-  # branch = "release-1.11"
+  revision = "c368fb9b71245441cd3268fffdba58b28b9b4863"
 
 [[override]]
-  name = "github.com/kubernetes-incubator/custom-metrics-apiserver"
-  revision = "e61f72fec56ab519d74ebd396cd3fcf31b084558"
+  name = "github.com/CharlyF/custom-metrics-apiserver"
+  revision = "8cee0380c23166fe328fedd088446df3c8254223"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,27 +40,27 @@
 
 [[override]]
   name = "github.com/kubernetes/apimachinery"
-  revision = "d128f427fda3db9a4d1ebbf3d54b4949a3356662"
+  branch = "release-1.11"
 
 [[override]]
   name = "github.com/kubernetes/client-go"
-  revision = "bdfc4cfc125f556bfe46fff68207767a605b64ed"
+  branch = "release-8.0"
 
 [[override]]
   name = "github.com/kubernetes/api"
-  revision = "70491ec73e10be2989242c913738f049a37e72c7"
+  branch = "release-1.11"
 
 [[override]]
   name = "k8s.io/apiserver"
-  revision = "4e7be504bf8670b1b36388e3ce2d097c6347373a"
+  branch = "release-1.11"
 
 [[override]]
   name = "k8s.io/metrics"
-  revision = "c368fb9b71245441cd3268fffdba58b28b9b4863"
+  branch = "release-1.11"
 
 [[override]]
   name = "github.com/CharlyF/custom-metrics-apiserver"
-  revision = "3e7ca2be638146c574ff3be0a506a08d23ce6a46"
+  revision = "56ec6921a4cfec971e5a8c89d5f4629c17cbb21a"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@
 
 [[override]]
   name = "github.com/CharlyF/custom-metrics-apiserver"
-  revision = "8cee0380c23166fe328fedd088446df3c8254223"
+  revision = "3e7ca2be638146c574ff3be0a506a08d23ce6a46"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,15 +43,35 @@
   branch = "release-1.11"
 
 [[override]]
+  name = "k8s.io/apimachinery"
+  branch = "release-1.11"
+
+[[override]]
   name = "github.com/kubernetes/client-go"
   branch = "release-8.0"
+
+[[override]]
+    name = "k8s.io/client-go"
+    branch = "release-8.0"
 
 [[override]]
   name = "github.com/kubernetes/api"
   branch = "release-1.11"
 
 [[override]]
+  name = "k8s.io/api"
+  branch = "release-1.11"
+
+[[override]]
+  name = "github.com/kubernetes/apiserver"
+  branch = "release-1.11"
+
+[[override]]
   name = "k8s.io/apiserver"
+  branch = "release-1.11"
+
+[[override]]
+  name = "github.com/kubernetes/metrics"
   branch = "release-1.11"
 
 [[override]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,6 @@
 Component,Origin,License
 core,bitbucket.org/ww/goautoneg,BSD-3-Clause
+core,github.com/Azure/go-ansiterm,MIT
 core,github.com/DataDog/agent-payload,BSD-3-Clause
 core,github.com/DataDog/gohai,MIT
 core,github.com/DataDog/mmh3,MIT
@@ -48,10 +49,13 @@ core,github.com/golang/glog,Apache-2.0
 core,github.com/golang/groupcache,Apache-2.0
 core,github.com/golang/protobuf,BSD-3-Clause
 core,github.com/golang/snappy,BSD-3-Clause
+core,github.com/google/btree,Apache-2.0
 core,github.com/google/gofuzz,Apache-2.0
 core,github.com/googleapis/gnostic,Apache-2.0
 core,github.com/gorilla/context,BSD-3-Clause
 core,github.com/gorilla/mux,BSD-3-Clause
+core,github.com/gregjones/httpcache,MIT
+core,github.com/grpc-ecosystem/go-grpc-prometheus,Apache-2.0
 core,github.com/hashicorp/consul,MPL-2.0
 core,github.com/hashicorp/go-cleanhttp,MPL-2.0
 core,github.com/hashicorp/go-rootcerts,MPL-2.0
@@ -59,7 +63,6 @@ core,github.com/hashicorp/golang-lru,Mozilla-Public-License-2.0
 core,github.com/hashicorp/hcl,MPL-2.0
 core,github.com/hashicorp/serf,MPL-2.0
 core,github.com/hectane/go-acl,MIT
-core,github.com/howeyc/gopass,ISC
 core,github.com/imdario/mergo,BSD-3-Clause
 core,github.com/inconshreveable/mousetrap,Apache-2.0
 core,github.com/jmespath/go-jmespath,Apache-2.0
@@ -67,7 +70,7 @@ core,github.com/jquery/jquery,MIT
 core,github.com/json-iterator/go,MIT
 core,github.com/k-sone/snmpgo,MIT
 core,github.com/kardianos/osext,BSD-3-Clause
-core,github.com/kubernetes-incubator/custom-metrics-apiserver,Apache-2.0
+core,github.com/CharlyF/custom-metrics-apiserver,Apache-2.0
 core,github.com/lxn/walk,BSD-3-Clause
 core,github.com/lxn/win,BSD-3-Clause
 core,github.com/magiconair/properties,BSD-2-Clause
@@ -86,6 +89,8 @@ core,github.com/openshift/api,Apache-2.0
 core,github.com/patrickmn/go-cache,MIT
 core,github.com/pborman/uuid,BSD-3-Clause
 core,github.com/pelletier/go-toml,MIT
+core,github.com/petar/GoLLRB,BSD-3-Clause
+core,github.com/peterbourgon/diskv,MIT
 core,github.com/pierrec/lz4,BSD-3-Clause
 core,github.com/pkg/errors,BSD-2-Clause
 core,github.com/pmezard/go-difflib,BSD-3-Clause
@@ -97,6 +102,7 @@ core,github.com/samuel/go-zookeeper,BSD-3-Clause
 core,github.com/sbinet/go-python,Python-2.0
 core,github.com/shirou/gopsutil,BSD-3-Clause
 core,github.com/shirou/w32,BSD-3-Clause
+core,github.com/Sirupsen/logrus,MIT
 core,github.com/spf13/afero,Apache-2.0
 core,github.com/spf13/cast,MIT
 core,github.com/spf13/cobra,Apache-2.0

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,5 @@
 Component,Origin,License
 core,bitbucket.org/ww/goautoneg,BSD-3-Clause
-core,github.com/Azure/go-ansiterm,MIT
 core,github.com/DataDog/agent-payload,BSD-3-Clause
 core,github.com/DataDog/gohai,MIT
 core,github.com/DataDog/mmh3,MIT
@@ -55,7 +54,6 @@ core,github.com/googleapis/gnostic,Apache-2.0
 core,github.com/gorilla/context,BSD-3-Clause
 core,github.com/gorilla/mux,BSD-3-Clause
 core,github.com/gregjones/httpcache,MIT
-core,github.com/grpc-ecosystem/go-grpc-prometheus,Apache-2.0
 core,github.com/hashicorp/consul,MPL-2.0
 core,github.com/hashicorp/go-cleanhttp,MPL-2.0
 core,github.com/hashicorp/go-rootcerts,MPL-2.0
@@ -102,7 +100,6 @@ core,github.com/samuel/go-zookeeper,BSD-3-Clause
 core,github.com/sbinet/go-python,Python-2.0
 core,github.com/shirou/gopsutil,BSD-3-Clause
 core,github.com/shirou/w32,BSD-3-Clause
-core,github.com/Sirupsen/logrus,MIT
 core,github.com/spf13/afero,Apache-2.0
 core,github.com/spf13/cast,MIT
 core,github.com/spf13/cobra,Apache-2.0

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -90,7 +90,7 @@ func init() {
 
 	ClusterAgentCmd.PersistentFlags().StringVarP(&confPath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
 	ClusterAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
-	custommetrics.AddFlags(startCmd.Flags())
+	//custommetrics.AddFlags(startCmd.Flags())
 }
 
 func start(cmd *cobra.Command, args []string) error {
@@ -189,16 +189,10 @@ func start(cmd *cobra.Command, args []string) error {
 
 	// HPA Process
 	if config.Datadog.GetBool("external_metrics_provider.enabled") {
-		err = custommetrics.ValidateArgs(args)
+		// Start the k8s custom metrics server. This is a blocking call
+		err = custommetrics.StartServer()
 		if err != nil {
-			log.Error("Couldn't validate args for k8s custom metrics server, not starting it: ", err)
-
-		} else {
-			// Start the k8s custom metrics server. This is a blocking call
-			err = custommetrics.StartServer()
-			if err != nil {
-				log.Errorf("Could not start the custom metrics API server: %s", err.Error())
-			}
+			log.Errorf("Could not start the custom metrics API server: %s", err.Error())
 		}
 	}
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -90,7 +90,6 @@ func init() {
 
 	ClusterAgentCmd.PersistentFlags().StringVarP(&confPath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
 	ClusterAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
-	//custommetrics.AddFlags(startCmd.Flags())
 }
 
 func start(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -31,7 +31,6 @@ var stopCh chan struct{}
 
 type DatadogMetricsAdapter struct {
 	basecmd.AdapterBase
-	Message string
 }
 
 // StartServer creates and start a k8s custom metrics API server
@@ -44,7 +43,7 @@ func StartServer() error {
 		return err
 	}
 
-	// When we implement the custom metrics provider, add cmd.WithCustomMetrics(provider) here
+	// TODO when implementing the custom metrics provider, add cmd.WithCustomMetrics(provider) here
 	cmd.WithExternalMetrics(provider)
 	cmd.Name = "datadog-custom-metrics-adapter"
 
@@ -55,7 +54,7 @@ func StartServer() error {
 
 	server, err := conf.Complete(nil).New(cmd.Name, nil, provider)
 	if err != nil {
-		log.Infof("err server %#v", err)
+		return err
 	}
 
 	return server.GenericAPIServer.PrepareRun().Run(wait.NeverStop)
@@ -106,6 +105,7 @@ func (o DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 
+	// Get the certificates from the extension-apiserver-authentication ConfigMap
 	if err := o.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
 		log.Errorf("Could not create Authentication configuration: %v", err)
 		return nil, err

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -99,7 +99,7 @@ func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 	codecs := serializer.NewCodecFactory(scheme)
 	serverConfig := genericapiserver.NewConfig(codecs)
 
-	err := o.SecureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig)
+	err := o.SecureServing.ApplyTo(serverConfig)
 	if err != nil {
 		log.Errorf("Error while converting SecureServing type %v", err)
 		return nil, err

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -89,7 +89,7 @@ func (a *DatadogMetricsAdapter) makeProviderOrDie() (provider.ExternalMetricsPro
 }
 
 // Config creates the configuration containing the required parameters to communicate with the APIServer as an APIService
-func (o DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
+func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		log.Errorf("Failed to create self signed AuthN/Z configuration %#v", err)
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -9,87 +9,116 @@ package custommetrics
 
 import (
 	"fmt"
-	"os"
-	"time"
+	"net"
 
-	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd/server"
-	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/dynamicmapper"
-	"github.com/spf13/pflag"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
+	"github.com/CharlyF/custom-metrics-apiserver/pkg/apiserver"
+	basecmd "github.com/CharlyF/custom-metrics-apiserver/pkg/cmd"
+	"github.com/CharlyF/custom-metrics-apiserver/pkg/provider"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	genericapiserver "k8s.io/apiserver/pkg/server"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var options *server.CustomMetricsAdapterServerOptions
+var cmd *DatadogMetricsAdapter
+
 var stopCh chan struct{}
 
-func init() {
-	// FIXME: log to seelog
-	options = server.NewCustomMetricsAdapterServerOptions(os.Stdout, os.Stdout)
-}
-
-// AddFlags ensures the required flags exist
-func AddFlags(fs *pflag.FlagSet) {
-	options.SecureServing.AddFlags(fs)
-	options.Authentication.AddFlags(fs)
-	options.Authorization.AddFlags(fs)
-	options.Features.AddFlags(fs)
-}
-
-// ValidateArgs validates the custom metrics arguments passed
-func ValidateArgs(args []string) error {
-	return options.Validate(args)
+type DatadogMetricsAdapter struct {
+	basecmd.AdapterBase
+	Message string
 }
 
 // StartServer creates and start a k8s custom metrics API server
 func StartServer() error {
-	config, err := options.Config()
+	cmd = &DatadogMetricsAdapter{}
+	cmd.Flags()
+
+	provider, err := cmd.makeProviderOrDie()
 	if err != nil {
 		return err
 	}
-	var clientConfig *rest.Config
-	clientConfig, err = rest.InClusterConfig()
+
+	// When we implement the custom metrics provider, add cmd.WithCustomMetrics(provider) here
+	cmd.WithExternalMetrics(provider)
+	cmd.Name = "datadog-custom-metrics-adapter"
+
+	conf, err := cmd.Config()
 	if err != nil {
 		return err
 	}
 
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+	server, err := conf.Complete(nil).New(cmd.Name, nil, provider)
 	if err != nil {
-		return fmt.Errorf("unable to construct discovery client for dynamic client: %v", err)
+		log.Infof("err server %#v", err)
 	}
 
-	dynamicMapper, err := dynamicmapper.NewRESTMapper(discoveryClient, apimeta.InterfacesForUnstructured, time.Second*5)
+	return server.GenericAPIServer.PrepareRun().Run(wait.NeverStop)
+}
+
+func (a *DatadogMetricsAdapter) makeProviderOrDie() (provider.ExternalMetricsProvider, error) {
+	client, err := a.DynamicClient()
 	if err != nil {
-		return fmt.Errorf("unable to construct dynamic discovery mapper: %v", err)
+		log.Infof("Unable to construct dynamic client: %v", err)
+		return nil, err
+	}
+	apiCl, err := as.GetAPIClient()
+	if err != nil {
+		log.Errorf("Could not build API Client: %v", err)
+		return nil, err
 	}
 
-	clientPool := dynamic.NewClientPool(clientConfig, dynamicMapper, dynamic.LegacyAPIPathResolverFunc)
-	if err != nil {
-		return fmt.Errorf("unable to construct lister client to initialize provider: %v", err)
-	}
-
-	client, err := as.GetAPIClient()
-	if err != nil {
-		return err
-	}
 	datadogHPAConfigMap := custommetrics.GetConfigmapName()
-	store, err := custommetrics.NewConfigMapStore(client.Cl, common.GetResourcesNamespace(), datadogHPAConfigMap)
+	store, err := custommetrics.NewConfigMapStore(apiCl.Cl, common.GetResourcesNamespace(), datadogHPAConfigMap)
 	if err != nil {
-		return err
+		log.Errorf("Unable to create ConfigMap Store: %v", err)
+		return nil, err
 	}
-	emProvider := custommetrics.NewDatadogProvider(clientPool, dynamicMapper, store)
-	// As the Custom Metrics Provider is introduced, change the first emProvider to a cmProvider.
-	server, err := config.Complete().New("datadog-custom-metrics-adapter", emProvider, emProvider)
+
+	mapper, err := a.RESTMapper()
 	if err != nil {
-		return err
+		log.Errorf("Unable to construct discovery REST mapper: %v", err)
+		return nil, err
 	}
-	stopCh = make(chan struct{})
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+
+	return custommetrics.NewDatadogProvider(client, mapper, store), nil
+}
+
+// Config creates the configuration containing the required parameters to communicate with the APIServer as an APIService
+func (o DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
+	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+		log.Errorf("Failed to create self signed AuthN/Z configuration %#v", err)
+		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+	serverConfig := genericapiserver.NewConfig(codecs)
+
+	err := o.SecureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig)
+	if err != nil {
+		log.Errorf("Error while converting SecureServing type %v", err)
+		return nil, err
+	}
+
+	if err := o.Authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
+		log.Errorf("Could not create Authentication configuration: %v", err)
+		return nil, err
+	}
+
+	if err := o.Authorization.ApplyTo(&serverConfig.Authorization); err != nil {
+		log.Infof("Could not create Authorization configuration: %v", err)
+		return nil, err
+	}
+
+	return &apiserver.Config{
+		GenericConfig: serverConfig,
+	}, nil
 }
 
 // StopServer closes the connection and the server

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -15,13 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 type externalMetric struct {
@@ -50,14 +50,14 @@ func NewDatadogProvider(client dynamic.Interface, mapper apimeta.RESTMapper, sto
 	}
 }
 
-// GetRootScopedMetricByName - Not implemented
+// GetMetricByName - Not implemented
 func (p *datadogProvider) GetMetricByName(name types.NamespacedName, info provider.CustomMetricInfo) (*custom_metrics.MetricValue, error) {
-	return nil, fmt.Errorf("not Implemented - GetRootScopedMetricByName")
+	return nil, fmt.Errorf("not Implemented - GetMetricByName")
 }
 
-// GetRootScopedMetricBySelector - Not implemented
+// GetMetricBySelector - Not implemented
 func (p *datadogProvider) GetMetricBySelector(namespace string, selector labels.Selector, info provider.CustomMetricInfo) (*custom_metrics.MetricValueList, error) {
-	return nil, fmt.Errorf("not Implemented - GetRootScopedMetricBySelector")
+	return nil, fmt.Errorf("not Implemented - GetMetricBySelector")
 }
 
 // ListAllMetrics reads from a ConfigMap, similarly to ListExternalMetrics

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -95,7 +95,6 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 
 		externalMetricsInfoList = append(externalMetricsInfoList, provider.ExternalMetricInfo{
 			Metric: metric.MetricName,
-			//Labels: metric.Labels,
 		})
 	}
 	p.externalMetrics = externalMetricsList

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -120,7 +120,7 @@ func (c *APIClient) connect() error {
 		log.Infof("Could not get apiserver client: %v", err)
 		return err
 	}
-
+	//c.Cl.
 	// informer factory uses its own clientset with a larger timeout
 	c.InformerFactory, err = getInformerFactory()
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -120,7 +120,6 @@ func (c *APIClient) connect() error {
 		log.Infof("Could not get apiserver client: %v", err)
 		return err
 	}
-	//c.Cl.
 	// informer factory uses its own clientset with a larger timeout
 	c.InformerFactory, err = getInformerFactory()
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
+	"context"
 )
 
 const (
@@ -182,9 +183,11 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 }
 
 func (le *LeaderEngine) runLeaderElection() {
+	ctx := context.Background()
 	for {
 		log.Infof("Starting leader election process for %q...", le.HolderIdentity)
-		le.leaderElector.Run()
+
+		le.leaderElector.Run(ctx)
 		log.Info("Leader election lost")
 	}
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -8,6 +8,7 @@
 package leaderelection
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -26,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
-	"context"
 )
 
 const (

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -8,7 +8,6 @@
 package leaderelection
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -183,11 +182,10 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 }
 
 func (le *LeaderEngine) runLeaderElection() {
-	ctx := context.Background()
 	for {
 		log.Infof("Starting leader election process for %q...", le.HolderIdentity)
 
-		le.leaderElector.Run(ctx)
+		le.leaderElector.Run()
 		log.Info("Leader election lost")
 	}
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"context"
 )
 
 func (le *LeaderEngine) getCurrentLeader() (string, *v1.ConfigMap, error) {
@@ -69,7 +70,7 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 		return nil, err
 	}
 	log.Debugf("Current registered leader is %q, building leader elector %q as candidate", currentLeader, le.HolderIdentity)
-
+	//ctx := context.WithCancel()
 	callbacks := ld.LeaderCallbacks{
 		OnNewLeader: func(identity string) {
 			le.leaderIdentityMutex.Lock()
@@ -78,7 +79,7 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 
 			log.Infof("New leader %q", identity)
 		},
-		OnStartedLeading: func(stop <-chan struct{}) {
+		OnStartedLeading: func(context.Context) {
 			le.leaderIdentityMutex.Lock()
 			le.leaderIdentity = le.HolderIdentity
 			le.leaderIdentityMutex.Unlock()

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -8,6 +8,7 @@
 package leaderelection
 
 import (
+	"context"
 	"encoding/json"
 
 	"k8s.io/api/core/v1"
@@ -19,7 +20,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"context"
 )
 
 func (le *LeaderEngine) getCurrentLeader() (string, *v1.ConfigMap, error) {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -70,7 +70,6 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 		return nil, err
 	}
 	log.Debugf("Current registered leader is %q, building leader elector %q as candidate", currentLeader, le.HolderIdentity)
-	//ctx := context.WithCancel()
 	callbacks := ld.LeaderCallbacks{
 		OnNewLeader: func(identity string) {
 			le.leaderIdentityMutex.Lock()
@@ -79,7 +78,7 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 
 			log.Infof("New leader %q", identity)
 		},
-		OnStartedLeading: func(context.Context) {
+		OnStartedLeading: func(_ context.Context) {
 			le.leaderIdentityMutex.Lock()
 			le.leaderIdentity = le.HolderIdentity
 			le.leaderIdentityMutex.Unlock()

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -8,7 +8,6 @@
 package leaderelection
 
 import (
-	"context"
 	"encoding/json"
 
 	"k8s.io/api/core/v1"
@@ -78,7 +77,7 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 
 			log.Infof("New leader %q", identity)
 		},
-		OnStartedLeading: func(_ context.Context) {
+		OnStartedLeading: func(stop <-chan struct{}) {
 			le.leaderIdentityMutex.Lock()
 			le.leaderIdentity = le.HolderIdentity
 			le.leaderIdentityMutex.Unlock()

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 )
@@ -50,14 +49,10 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestStoppedLeading(t *testing.T) {
+func TestNewLeaseAcquiring(t *testing.T) {
 	const leaseName = "datadog-leader-election"
 
 	client := fake.NewSimpleClientset()
-
-	lock := newFakeLockObject("default", leaseName, "foo")
-	_, err := client.CoreV1().ConfigMaps("default").Create(lock)
-	require.NoError(t, err)
 
 	le := &LeaderEngine{
 		HolderIdentity:  "foo",
@@ -67,31 +62,21 @@ func TestStoppedLeading(t *testing.T) {
 
 		coreClient: client.CoreV1(),
 	}
+	_, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
+	require.Error(t, err)
 
 	le.leaderElector, err = le.newElection()
 	require.NoError(t, err)
 
-	le.EnsureLeaderElectionRuns()
+	newCm, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, newCm.Name, leaseName)
+	require.Nil(t, newCm.Annotations)
 
+	le.EnsureLeaderElectionRuns()
+	Cm, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, Cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
 	require.True(t, le.IsLeader())
 
-	lock = newFakeLockObject("default", leaseName, "bar")
-	_, err = client.CoreV1().ConfigMaps("default").Update(lock)
-	require.NoError(t, err)
-
-	// poll until election is lost
-	err = wait.Poll(1*time.Second, 10*time.Second, func() (done bool, err error) {
-		return le.IsLeader() == false, nil
-	})
-	require.NoError(t, err, "Should not be leader")
-
-	lock = newFakeLockObject("default", leaseName, "foo")
-	_, err = client.CoreV1().ConfigMaps("default").Update(lock)
-	require.NoError(t, err)
-
-	// poll until leader again
-	err = wait.Poll(1*time.Second, 10*time.Second, func() (done bool, err error) {
-		return le.IsLeader(), nil
-	})
-	require.NoError(t, err, "Should be leader")
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -49,6 +50,9 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+// TestNewLeaseAcquiring only test the proper creation of the lock,
+// the acquisition of the leadership and that the ConfigMap contains is properly updated.
+// The leadership transition is tested as part of an end to end test.
 func TestNewLeaseAcquiring(t *testing.T) {
 	const leaseName = "datadog-leader-election"
 
@@ -63,7 +67,7 @@ func TestNewLeaseAcquiring(t *testing.T) {
 		coreClient: client.CoreV1(),
 	}
 	_, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
-	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	le.leaderElector, err = le.newElection()
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

EKS released support for HPA as the aggregation layer was enabled.
To be successfully registered the APIService has to read the certificates from a ConfigMap called:
`extension-apiserver-authentication` (created by the APIServer).
In this ConfigMap are 2 crucial keys. `client-ca-file` and `requestheader-client-ca-file`.

The Cluster Agent implements the external metrics server as described in the [custom-metrics-apiserver](https://github.com/kubernetes-incubator/custom-metrics-apiserver) library.
It appears that the latest version (available as of today) pins the API Server at `15cbd7efdeb242a93307546b08843d55dcfddc33` which was promoted in [this PR](https://github.com/kubernetes/apiserver/commit/15cbd7efdeb242a93307546b08843d55dcfddc33).

However, there was [an issue](https://github.com/kubernetes/kubernetes/issues/65724) where basically if the  `client-ca-file` key was missing in the configmap, the APIService would not attempt to read the `requestheader-client-ca-file` and therefore would not start the  custom metrics server.
(either/both files can be configured in [the options](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) of the APIServer).

The fix was made in [this PR](https://github.com/kubernetes/kubernetes/pull/66394/files).

----

In this PR, we **temporarily** move away from the official library and point to the fork [here](https://github.com/CharlyF/custom-metrics-apiserver) which is just bumping the references to the upstream code and adapting the interfaces that changed to include the change in the apiserver code.
Made a PR against the official repo 
As per the description of the this PR
https://github.com/kubernetes-incubator/custom-metrics-apiserver/pull/32 which uses the same pins as the metrics server 0.3.0 (embedding the fix for this issue).

----

As soon as the upstream library pins the next version (proven that it embeds the fix), we will move back to it.

In the meantime, this PR allows for the DCA to serve custom metrics to Kubernetes on EKS out of the box.

### Motivation

Enable the HPA on EKS.