### PR TITLE
Update outdated AgentCheck test

### DIFF
--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -22,7 +22,7 @@ class TestAggregatorCheck(AgentCheck):
         self.gauge("testmetric", 0, tags=None)
         self.gauge("testmetricnonevalue", None) # metrics with None values should be ignored by AgentCheck
         self.gauge("testmetricstringvalue", "2") # string values should be cast to floats
-        self.gauge("testmetricstringvalue", "notcastabletofloat") # values not castable to floats should raise an exception
+        self.gauge("testmetricstringvalue", "notcastabletofloat") # values not castable to floats shouldn't raise an exception, but won't be submitted
 
         self.increment("test.increment", tags=['foo', 'bar'])
         self.decrement("test.decrement", tags=['foo', 'bar', 'baz'])

--- a/pkg/collector/py/tests/testaggregator.py
+++ b/pkg/collector/py/tests/testaggregator.py
@@ -22,12 +22,7 @@ class TestAggregatorCheck(AgentCheck):
         self.gauge("testmetric", 0, tags=None)
         self.gauge("testmetricnonevalue", None) # metrics with None values should be ignored by AgentCheck
         self.gauge("testmetricstringvalue", "2") # string values should be cast to floats
-        try:
-            self.gauge("testmetricstringvalue", "notcastabletofloat") # values not castable to floats should raise an exception
-        except ValueError:
-            pass
-        else:
-            raise Exception("Expected gauge to raise ValueError")
+        self.gauge("testmetricstringvalue", "notcastabletofloat") # values not castable to floats should raise an exception
 
         self.increment("test.increment", tags=['foo', 'bar'])
         self.decrement("test.decrement", tags=['foo', 'bar', 'baz'])


### PR DESCRIPTION
### What does this PR do?

Updates the old tests that were created when AgentCheck was in the datadog-agent repo. 

### Motivation

Now AgentCheck is in datadog_checks_base and the import is redirected there. This PR https://github.com/DataDog/integrations-core/pull/2293 changed the behavior so we aren't throwing an exception on a single bad metric. Currently the CI is failing without this change as the old test expects an exception. 

The file wasn't removed because this is run as a check in another test that validates information about the CheckID. 

### Additional Notes

Anything else we should know when reviewing?
