### PR TITLE
check if the deb is in the pool in the job that releases the deb

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,7 +922,9 @@ deploy_deb:
     # We first check that the current version hasn't already been deployed
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
+    - pushd $OMNIBUS_PACKAGE_DIR
     - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
+    - popd
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:
-  - deploy
   - source_test
   - binary_build
   - integration_test
@@ -10,6 +9,7 @@ stages:
   - testkitchen_cleanup
   - image_build
   - image_deploy
+  - deploy
   - deploy_invalidate
   - e2e
 
@@ -912,17 +912,17 @@ check_already_deployed_version:
 
 # deploy debian packages to apt staging repo
 deploy_deb:
+  <<: *run_when_triggered
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
-    - mkdir -p $OMNIBUS_PACKAGE_DIR
+    - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
     # We first check that the current version hasn't already been deployed
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
-    - touch datadog-agent_6.5.2-1_amd64.deb
     - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
     - popd
     - source /usr/local/rvm/scripts/rvm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -919,6 +919,10 @@ deploy_deb:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
+    # We first check that the current version hasn't already been deployed
+    # (same as the check_already_deployed_version). We do this twice to mitigate
+    # races and issues with retries while failing early if there is an issue.
+    - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
     - source /usr/local/rvm/scripts/rvm
     - rvm use 2.4
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
+  - deploy
   - source_test
   - binary_build
   - integration_test
@@ -9,7 +10,6 @@ stages:
   - testkitchen_cleanup
   - image_build
   - image_deploy
-  - deploy
   - deploy_invalidate
   - e2e
 
@@ -912,17 +912,17 @@ check_already_deployed_version:
 
 # deploy debian packages to apt staging repo
 deploy_deb:
-  <<: *run_when_triggered
   stage: deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
-    - ls $OMNIBUS_PACKAGE_DIR
+    - mkdir -p $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
     # We first check that the current version hasn't already been deployed
     # (same as the check_already_deployed_version). We do this twice to mitigate
     # races and issues with retries while failing early if there is an issue.
     - pushd $OMNIBUS_PACKAGE_DIR
+    - touch datadog-agent_6.5.2-1_amd64.deb
     - /deploy_scripts/fail_deb_is_pkg_already_exists.sh
     - popd
     - source /usr/local/rvm/scripts/rvm


### PR DESCRIPTION
### What does this PR do?

Checks if the deb is in the pool in the job that releases the deb.

### Motivation

> We currently have a step early in the gitlab pipeline that checks if the deb pkg is already in the pool, and fails if it's already in the pool (avoids hash sum mismatch errors).
> When there's a flake later in the pipeline though, pipelines that started later can push their deb package, and when the original is retried it won't check again for this case, and we'll hit the mismatch errors again.