### PR TITLE
Set telemetry gauge for cluster-agent to datadog.cluster-agent.running

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -91,7 +91,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		s := serializer.NewSerializer(common.Forwarder)
-		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, checkCmdFlushInterval)
+		agg := aggregator.InitAggregatorWithFlushInterval(s, hostname, "agent", checkCmdFlushInterval)
 		common.SetupAutoConfig(config.Datadog.GetString("confd_path"))
 		cs := collector.GetChecksByNameForConfigs(checkName, common.AC.GetAllConfigs())
 		if len(cs) == 0 {

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -186,7 +186,7 @@ func StartAgent() error {
 
 	// setup the aggregator
 	s := serializer.NewSerializer(common.Forwarder)
-	agg := aggregator.InitAggregator(s, hostname)
+	agg := aggregator.InitAggregator(s, hostname, "agent")
 	agg.AddAgentStartupEvent(version.AgentVersion)
 
 	// start dogstatsd

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -143,7 +143,7 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := serializer.NewSerializer(f)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster-agent")
+	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster_agent")
 	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.DCAVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -143,7 +143,7 @@ func start(cmd *cobra.Command, args []string) error {
 	f.Start()
 	s := serializer.NewSerializer(f)
 
-	aggregatorInstance := aggregator.InitAggregator(s, hostname)
+	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster-agent")
 	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.DCAVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -17,7 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -28,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -169,7 +169,7 @@ func start(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	aggregatorInstance := aggregator.InitAggregator(s, hname)
+	aggregatorInstance := aggregator.InitAggregator(s, hname, "agent")
 	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
 	if err != nil {
 		log.Criticalf("Unable to start dogstatsd: %s", err)

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -23,7 +23,7 @@ var checkID2 check.ID = "2"
 func TestRegisterCheckSampler(t *testing.T) {
 	resetAggregator()
 
-	agg := InitAggregator(nil, "")
+	agg := InitAggregator(nil, "", "agent")
 	err := agg.registerSender(checkID1)
 	assert.Nil(t, err)
 	assert.Len(t, aggregatorInstance.checkSamplers, 1)
@@ -40,7 +40,7 @@ func TestRegisterCheckSampler(t *testing.T) {
 func TestDeregisterCheckSampler(t *testing.T) {
 	resetAggregator()
 
-	agg := InitAggregator(nil, "")
+	agg := InitAggregator(nil, "", "agent")
 	agg.registerSender(checkID1)
 	agg.registerSender(checkID2)
 	assert.Len(t, aggregatorInstance.checkSamplers, 2)
@@ -55,7 +55,7 @@ func TestDeregisterCheckSampler(t *testing.T) {
 
 func TestAddServiceCheckDefaultValues(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "resolved-hostname")
+	agg := InitAggregator(nil, "resolved-hostname", "agent")
 
 	agg.addServiceCheck(metrics.ServiceCheck{
 		// leave Host and Ts fields blank
@@ -84,7 +84,7 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 
 func TestAddEventDefaultValues(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "resolved-hostname")
+	agg := InitAggregator(nil, "resolved-hostname", "agent")
 
 	agg.addEvent(metrics.Event{
 		// only populate required fields
@@ -130,7 +130,7 @@ func TestAddEventDefaultValues(t *testing.T) {
 
 func TestSetHostname(t *testing.T) {
 	resetAggregator()
-	agg := InitAggregator(nil, "hostname")
+	agg := InitAggregator(nil, "hostname", "agent")
 	assert.Equal(t, "hostname", agg.hostname)
 	sender, err := GetSender(checkID1)
 	require.NoError(t, err)

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -19,7 +19,7 @@ import (
 func NewMockSender(id check.ID) *MockSender {
 	mockSender := new(MockSender)
 	// The MockSender will be injected in the corecheck via the aggregator
-	aggregator.InitAggregatorWithFlushInterval(nil, "", 1*time.Hour)
+	aggregator.InitAggregatorWithFlushInterval(nil, "", "", 1*time.Hour)
 	aggregator.SetSender(mockSender, id)
 
 	return mockSender

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -32,7 +32,7 @@ func resetAggregator() {
 
 func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "")
+	InitAggregator(nil, "", "")
 
 	s, err := GetDefaultSender()
 	assert.Nil(t, err)
@@ -48,7 +48,7 @@ func TestGetDefaultSenderReturnsSameSender(t *testing.T) {
 
 func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "")
+	InitAggregator(nil, "", "")
 
 	s, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -71,7 +71,7 @@ func TestGetSenderWithDifferentIDsReturnsDifferentCheckSamplers(t *testing.T) {
 
 func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "")
+	InitAggregator(nil, "", "")
 
 	sender1, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -88,7 +88,7 @@ func TestGetSenderWithSameIDsReturnsSameSender(t *testing.T) {
 
 func TestDestroySender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "")
+	InitAggregator(nil, "", "")
 
 	_, err := GetSender(checkID1)
 	assert.Nil(t, err)
@@ -104,7 +104,7 @@ func TestDestroySender(t *testing.T) {
 
 func TestGetAndSetSender(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "")
+	InitAggregator(nil, "", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
 	serviceCheckChan := make(chan metrics.ServiceCheck, 10)

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -121,7 +121,7 @@ func TestGetAndSetSender(t *testing.T) {
 
 func TestGetSenderDefaultHostname(t *testing.T) {
 	resetAggregator()
-	InitAggregator(nil, "testhostname")
+	InitAggregator(nil, "testhostname", "")
 
 	sender, err := GetSender(checkID1)
 	require.NoError(t, err)

--- a/pkg/collector/py/utils_test.go
+++ b/pkg/collector/py/utils_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 	// testing this package needs an inited aggregator
 	// to work properly.
-	aggregator.InitAggregatorWithFlushInterval(nil, "", time.Hour)
+	aggregator.InitAggregatorWithFlushInterval(nil, "", "", time.Hour)
 
 	ret := m.Run()
 


### PR DESCRIPTION
### What does this PR do?

Allow the cmd to customize the name of telemetry metrics sent by the aggregator. This is done by adding a new parameter to the `InitAggregator` function. There is no need to change it after init.

`noreno` as this has no customer-facing change

#### Agent
> 2018-09-26 12:26:12 UTC | DEBUG | (aggregator.go:347 in flushSeries) | {"metric":"datadog.agent.running","points":[[1537964772,1]],"tags":null,"host":"ci-xaviervello","type":"gauge","interval":0,"source_type_name":"System"}

#### Dogstatsd standalone: no change for now. We might want to move to a custom name too?
> 2018-09-26 12:29:54 UTC | DEBUG | (aggregator.go:389 in flushServiceChecks) | {"check":"datadog.agent.up","host_name":"ci-xaviervello","timestamp":1537964994,"status":0,"message":"","tags":null}

#### Cluster-agent:
> 2018-09-26 12:27:16 UTC | DEBUG | (aggregator.go:347 in flushSeries) | {"metric":"datadog.cluster-agent.running","points":[[1537964836,1]],"tags":null,"host":"ci-xaviervello","type":"gauge","interval":0,"source_type_name":"System"}

### Motivation

- Make it easier to locate what hosts are runnning a custer-agent
- Avoid collisions with the node-agent gauges 