### PR TITLE
Use multi-stage build for cluster-agent image

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -36,4 +36,7 @@ COPY --from=builder /output /
 
 ENTRYPOINT ["/entrypoint.sh"]
 
+# No docker healthcheck, use a HTTP check
+# on port 5005 and/or 443 on Kubernetes
+
 CMD ["datadog-cluster-agent", "start"]

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -1,28 +1,38 @@
+########################################
+# Preparation stage: layout and chmods #
+########################################
+
+FROM debian:buster-slim as builder
+
+WORKDIR /output
+
+RUN mkdir -p opt/datadog-agent/bin/datadog-cluster-agent/
+
+COPY datadog-cluster-agent opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+COPY ./conf.d etc/datadog-agent/conf.d
+COPY ./datadog-cluster.yaml etc/datadog-agent/datadog.yaml
+COPY ./dist opt/datadog-agent/bin/datadog-cluster-agent/dist
+COPY entrypoint.sh .
+
+RUN chmod 755 entrypoint.sh \
+    && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
+    && chmod +x opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+
+####################################
+# Actual docker image construction #
+####################################
+
 FROM debian:buster-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH
 
-# Install the Agent
-RUN mkdir -p /opt/datadog-agent/bin/datadog-cluster-agent/
-
-COPY datadog-cluster-agent /opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
-
-COPY ./conf.d /etc/datadog-agent/conf.d
-COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog.yaml
-COPY ./dist /opt/datadog-agent/bin/datadog-cluster-agent/dist
-
 RUN apt-get update \
- && apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl\
- && apt-get clean \
- && apt-get autoremove
+ && apt-get install --no-install-recommends -y ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY entrypoint.sh .
-
-RUN chmod 755 /entrypoint.sh \
-    && chmod g+r,g+w,g+X -R /etc/datadog-agent/ \
-    && chmod +x /opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+COPY --from=builder /output /
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
### What does this PR do?

Build the `datadog/cluster-agent` with a two-stage build to reduce image size and layer count.

Keep curl installed for support.

### Delta

master: 14 layers, 226MB uncompressed, 75 MB compressed
branch: 8 layers, 143MB uncompressed, 47 MB compressed