### PR TITLE
Dont block the agent if we can't send logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,7 +282,7 @@ func init() {
 	BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
-	BindEnvAndSetDefault("logs_config.stop_grace_period", "30s")
+	BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
 
 	// Tagger full cardinality mode
 	// Undocumented opt-in feature for now

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,6 +282,7 @@ func init() {
 	BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
+	BindEnvAndSetDefault("logs_config.stop_grace_period", "30s")
 
 	// Tagger full cardinality mode
 	// Undocumented opt-in feature for now

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -98,7 +98,7 @@ func (a *Agent) Stop() {
 		stopper.Stop()
 		close(c)
 	}()
-	timeout := config.LogsAgent.GetDuration("logs_config.stop_grace_period")
+	timeout := time.Duration(config.LogsAgent.GetInt("logs_config.stop_grace_period")) * time.Second
 	select {
 	case <-c:
 	case <-time.After(timeout):

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -6,6 +6,8 @@
 package logs
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/container"
@@ -16,7 +18,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Agent represents the data pipeline that collects, decodes,
@@ -28,6 +32,7 @@ import (
 // + ------------------------------------------------------ +
 type Agent struct {
 	auditor          *auditor.Auditor
+	destinationsCtx  *sender.DestinationsContext
 	pipelineProvider pipeline.Provider
 	inputs           []restart.Restartable
 }
@@ -37,9 +42,10 @@ func NewAgent(sources *config.LogSources, services *service.Services, endpoints 
 	// setup the auditor
 	messageChan := make(chan *message.Message, config.ChanSize)
 	auditor := auditor.New(messageChan, config.LogsAgent.GetString("logs_config.run_path"))
+	destinationsCtx := sender.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, messageChan, endpoints)
+	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, messageChan, endpoints, destinationsCtx)
 
 	// setup the inputs
 	inputs := []restart.Restartable{
@@ -52,6 +58,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, endpoints 
 
 	return &Agent{
 		auditor:          auditor,
+		destinationsCtx:  destinationsCtx,
 		pipelineProvider: pipelineProvider,
 		inputs:           inputs,
 	}
@@ -60,7 +67,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, endpoints 
 // Start starts all the elements of the data pipeline
 // in the right order to prevent data loss
 func (a *Agent) Start() {
-	starter := restart.NewStarter(a.auditor, a.pipelineProvider)
+	starter := restart.NewStarter(a.destinationsCtx, a.auditor, a.pipelineProvider)
 	for _, input := range a.inputs {
 		starter.Add(input)
 	}
@@ -78,6 +85,25 @@ func (a *Agent) Stop() {
 		inputs,
 		a.pipelineProvider,
 		a.auditor,
+		a.destinationsCtx,
 	)
-	stopper.Stop()
+
+	// This will try to stop everything in order, including the potentially blocking
+	// parts like the sender. After StopTimeout it will just stop the last part of the
+	// pipeline, disconnecting it from the auditor, to make sure that everything can
+	// stop.
+	// TODO: Add this feature in the stopper.
+	c := make(chan struct{})
+	go func() {
+		stopper.Stop()
+		close(c)
+	}()
+	timeout := config.LogsAgent.GetDuration("logs_config.stop_grace_period")
+	select {
+	case <-c:
+	case <-time.After(timeout):
+		log.Info("timed out when stopping agent, forcing is to stop now")
+		a.destinationsCtx.Stop()
+		<-c
+	}
 }

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -50,7 +50,7 @@ func (suite *AgentTestSuite) SetupTest() {
 
 	config.LogsAgent.Set("logs_config.run_path", suite.testDir)
 	// Shorter grace period for tests.
-	config.LogsAgent.Set("logs_config.stop_grace_period", 1*time.Millisecond)
+	config.LogsAgent.Set("logs_config.stop_grace_period", 1)
 }
 
 func (suite *AgentTestSuite) TearDownTest() {

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package logs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+)
+
+type AgentTestSuite struct {
+	suite.Suite
+	testDir     string
+	testLogFile string
+
+	source *config.LogSource
+}
+
+func (suite *AgentTestSuite) SetupTest() {
+	var err error
+
+	suite.testDir, err = ioutil.TempDir("", "tests")
+	suite.NoError(err)
+
+	suite.testLogFile = fmt.Sprintf("%s/test.log", suite.testDir)
+	fd, err := os.Create(suite.testLogFile)
+	suite.NoError(err)
+
+	fd.WriteString("test log1\n test log2\n")
+	fd.Close()
+
+	logConfig := config.LogsConfig{
+		Type:       config.FileType,
+		Path:       suite.testLogFile,
+		Identifier: "test", // As it was from service-discovery to force the tailer to read from the start.
+	}
+	suite.source = config.NewLogSource("", &logConfig)
+
+	config.LogsAgent.Set("logs_config.run_path", suite.testDir)
+	// Shorter grace period for tests.
+	config.LogsAgent.Set("logs_config.stop_grace_period", 1*time.Millisecond)
+}
+
+func (suite *AgentTestSuite) TearDownTest() {
+	os.Remove(suite.testDir)
+}
+
+func createAgent(endpoints *config.Endpoints) (*Agent, *config.LogSources, *service.Services) {
+	// setup the sources and the services
+	sources := config.NewLogSources()
+	services := service.NewServices()
+
+	// setup and start the agent
+	agent = NewAgent(sources, services, endpoints)
+	return agent, sources, services
+}
+
+func (suite *AgentTestSuite) TestAgent() {
+	l := mock.NewMockLogsIntake(suite.T())
+	defer l.Close()
+
+	endpoint := sender.AddrToEndPoint(l.Addr())
+	endpoints := config.NewEndpoints(endpoint, nil)
+
+	agent, sources, _ := createAgent(endpoints)
+
+	agent.Start()
+	sources.AddSource(suite.source)
+	// Give the tailer some time to start its job.
+	time.Sleep(10 * time.Millisecond)
+	agent.Stop()
+}
+
+func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {
+	endpoint := config.Endpoint{Host: "fake:", Port: 0}
+	endpoints := config.NewEndpoints(endpoint, nil)
+
+	agent, sources, _ := createAgent(endpoints)
+
+	agent.Start()
+	sources.AddSource(suite.source)
+	// Give the tailer some time to start its job.
+	time.Sleep(10 * time.Millisecond)
+	agent.Stop()
+}
+
+func TestAgentTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentTestSuite))
+}

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -31,12 +31,14 @@ type AuditorTestSuite struct {
 }
 
 func (suite *AuditorTestSuite) SetupTest() {
-	suite.testDir = "tests/"
-	os.Remove(suite.testDir)
-	os.MkdirAll(suite.testDir, os.ModeDir)
+	var err error
+
+	suite.testDir, err = ioutil.TempDir("", "tests")
+	suite.NoError(err)
+
 	suite.testPath = fmt.Sprintf("%s/auditor.json", suite.testDir)
 
-	_, err := os.Create(suite.testPath)
+	_, err = os.Create(suite.testPath)
 	suite.Nil(err)
 
 	suite.inputChan = make(chan *message.Message)

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -6,10 +6,8 @@
 package config
 
 import (
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestDefaultDatadogConfig(t *testing.T) {
@@ -28,7 +26,7 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.socks5_proxy_address"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.logs_dd_url"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_config.logs_no_ssl"))
-	assert.Equal(t, 30*time.Second, LogsAgent.GetDuration("logs_config.stop_grace_period"))
+	assert.Equal(t, 30, LogsAgent.GetInt("logs_config.stop_grace_period"))
 }
 
 func TestDefaultSources(t *testing.T) {

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,6 +28,7 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.socks5_proxy_address"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.logs_dd_url"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_config.logs_no_ssl"))
+	assert.Equal(t, 30*time.Second, LogsAgent.GetDuration("logs_config.stop_grace_period"))
 }
 
 func TestDefaultSources(t *testing.T) {

--- a/pkg/logs/input/file/scanner.go
+++ b/pkg/logs/input/file/scanner.go
@@ -6,6 +6,7 @@
 package file
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -103,7 +104,7 @@ func (s *Scanner) scan() {
 
 	for _, file := range files {
 		tailer, isTailed := s.tailers[file.Path]
-		if isTailed && tailer.shouldStop {
+		if isTailed && atomic.LoadInt32(&tailer.shouldStop) != 0 {
 			// skip this tailer as it must be stopped
 			continue
 		}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -26,6 +26,9 @@ var (
 
 // Start starts logs-agent
 func Start() error {
+	if IsAgentRunning() {
+		return nil
+	}
 	// setup the server config
 	endpoints, err := config.BuildEndpoints()
 	if err != nil {
@@ -44,9 +47,10 @@ func Start() error {
 
 	// setup and start the agent
 	agent = NewAgent(sources, services, endpoints)
-	log.Info("Starting logs-agent")
+	log.Info("Starting logs-agent...")
 	agent.Start()
 	isRunning = true
+	log.Info("logs-agent started")
 
 	// add the default sources
 	for _, source := range config.DefaultSources() {
@@ -59,10 +63,20 @@ func Start() error {
 // Stop stops properly the logs-agent to prevent data loss,
 // it only returns when the whole pipeline is flushed.
 func Stop() {
+	log.Info("Stopping logs-agent")
 	if isRunning {
-		log.Info("Stopping logs-agent")
-		agent.Stop()
+		if agent != nil {
+			agent.Stop()
+			agent = nil
+		}
+		if adScheduler != nil {
+			adScheduler.Stop()
+			adScheduler = nil
+		}
+		status.Clear()
+		isRunning = false
 	}
+	log.Info("logs-agent stopped")
 }
 
 // IsAgentRunning returns true if the logs-agent is running.
@@ -72,7 +86,7 @@ func IsAgentRunning() bool {
 
 // GetStatus returns logs-agent status
 func GetStatus() status.Status {
-	if !isRunning {
+	if !IsAgentRunning() {
 		return status.Status{IsRunning: false}
 	}
 	return status.Get()

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -20,14 +20,14 @@ type Pipeline struct {
 }
 
 // NewPipeline returns a new Pipeline
-func NewPipeline(outputChan chan *message.Message, endpoints *config.Endpoints, destinationContext *sender.DestinationsContext) *Pipeline {
+func NewPipeline(outputChan chan *message.Message, endpoints *config.Endpoints, destinationsContext *sender.DestinationsContext) *Pipeline {
 	// initialize the main destination
-	main := sender.NewDestination(endpoints.Main, destinationContext)
+	main := sender.NewDestination(endpoints.Main, destinationsContext)
 
 	// initialize the additional destinations
 	var additionals []*sender.Destination
 	for _, endpoint := range endpoints.Additionals {
-		additionals = append(additionals, sender.NewDestination(endpoint, destinationContext))
+		additionals = append(additionals, sender.NewDestination(endpoint, destinationsContext))
 	}
 
 	// initialize the sender

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -20,14 +20,14 @@ type Pipeline struct {
 }
 
 // NewPipeline returns a new Pipeline
-func NewPipeline(outputChan chan *message.Message, endpoints *config.Endpoints) *Pipeline {
+func NewPipeline(outputChan chan *message.Message, endpoints *config.Endpoints, destinationContext *sender.DestinationsContext) *Pipeline {
 	// initialize the main destination
-	main := sender.NewDestination(endpoints.Main)
+	main := sender.NewDestination(endpoints.Main, destinationContext)
 
 	// initialize the additional destinations
 	var additionals []*sender.Destination
 	for _, endpoint := range endpoints.Additionals {
-		additionals = append(additionals, sender.NewDestination(endpoint))
+		additionals = append(additionals, sender.NewDestination(endpoint, destinationContext))
 	}
 
 	// initialize the sender

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -6,6 +6,7 @@
 package pipeline
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -28,22 +29,24 @@ type provider struct {
 
 	pipelines            []*Pipeline
 	currentPipelineIndex int32
+	destinationContext   *sender.DestinationsContext
 }
 
 // NewProvider returns a new Provider
-func NewProvider(numberOfPipelines int, outputChan chan *message.Message, endpoints *config.Endpoints) Provider {
+func NewProvider(numberOfPipelines int, outputChan chan *message.Message, endpoints *config.Endpoints, destinationContext *sender.DestinationsContext) Provider {
 	return &provider{
-		numberOfPipelines: numberOfPipelines,
-		outputChan:        outputChan,
-		endpoints:         endpoints,
-		pipelines:         []*Pipeline{},
+		numberOfPipelines:  numberOfPipelines,
+		outputChan:         outputChan,
+		endpoints:          endpoints,
+		pipelines:          []*Pipeline{},
+		destinationContext: destinationContext,
 	}
 }
 
 // Start initializes the pipelines
 func (p *provider) Start() {
 	for i := 0; i < p.numberOfPipelines; i++ {
-		pipeline := NewPipeline(p.outputChan, p.endpoints)
+		pipeline := NewPipeline(p.outputChan, p.endpoints, p.destinationContext)
 		pipeline.Start()
 		p.pipelines = append(p.pipelines, pipeline)
 	}

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -29,24 +29,24 @@ type provider struct {
 
 	pipelines            []*Pipeline
 	currentPipelineIndex int32
-	destinationContext   *sender.DestinationsContext
+	destinationsContext   *sender.DestinationsContext
 }
 
 // NewProvider returns a new Provider
-func NewProvider(numberOfPipelines int, outputChan chan *message.Message, endpoints *config.Endpoints, destinationContext *sender.DestinationsContext) Provider {
+func NewProvider(numberOfPipelines int, outputChan chan *message.Message, endpoints *config.Endpoints, destinationsContext *sender.DestinationsContext) Provider {
 	return &provider{
 		numberOfPipelines:  numberOfPipelines,
 		outputChan:         outputChan,
 		endpoints:          endpoints,
 		pipelines:          []*Pipeline{},
-		destinationContext: destinationContext,
+		destinationsContext: destinationsContext,
 	}
 }
 
 // Start initializes the pipelines
 func (p *provider) Start() {
 	for i := 0; i < p.numberOfPipelines; i++ {
-		pipeline := NewPipeline(p.outputChan, p.endpoints, p.destinationContext)
+		pipeline := NewPipeline(p.outputChan, p.endpoints, p.destinationsContext)
 		pipeline.Start()
 		p.pipelines = append(p.pipelines, pipeline)
 	}

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -29,16 +29,16 @@ type provider struct {
 
 	pipelines            []*Pipeline
 	currentPipelineIndex int32
-	destinationsContext   *sender.DestinationsContext
+	destinationsContext  *sender.DestinationsContext
 }
 
 // NewProvider returns a new Provider
 func NewProvider(numberOfPipelines int, outputChan chan *message.Message, endpoints *config.Endpoints, destinationsContext *sender.DestinationsContext) Provider {
 	return &provider{
-		numberOfPipelines:  numberOfPipelines,
-		outputChan:         outputChan,
-		endpoints:          endpoints,
-		pipelines:          []*Pipeline{},
+		numberOfPipelines:   numberOfPipelines,
+		outputChan:          outputChan,
+		endpoints:           endpoints,
+		pipelines:           []*Pipeline{},
 		destinationsContext: destinationsContext,
 	}
 }

--- a/pkg/logs/sender/connection_manager_test.go
+++ b/pkg/logs/sender/connection_manager_test.go
@@ -6,14 +6,65 @@
 package sender
 
 import (
+	"net"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender/mock"
 )
 
+func newConnectionManagerForAddr(addr net.Addr) *ConnectionManager {
+	host, port := AddrToHostPort(addr)
+	return newConnectionManagerForHostPort(host, port)
+}
+
+func newConnectionManagerForHostPort(host string, port int) *ConnectionManager {
+	endpoint := config.Endpoint{Host: host, Port: port}
+	return NewConnectionManager(endpoint)
+}
+
 func TestAddress(t *testing.T) {
-	connManager := NewConnectionManager(config.Endpoint{Host: "foo", Port: 1234})
+	connManager := newConnectionManagerForHostPort("foo", 1234)
 	assert.Equal(t, "foo:1234", connManager.address())
+}
+
+func TestNewConnection(t *testing.T) {
+	l := mock.NewMockLogsIntake(t)
+	defer l.Close()
+
+	destinationsCtx := NewDestinationsContext()
+
+	connManager := newConnectionManagerForAddr(l.Addr())
+	destinationsCtx.Start()
+	defer destinationsCtx.Stop()
+
+	conn, err := connManager.NewConnection(destinationsCtx.Context())
+	assert.NotNil(t, conn)
+	assert.NoError(t, err)
+}
+
+func TestNewConnectionReturnsWhenContextCancelled(t *testing.T) {
+	destinationsCtx := NewDestinationsContext()
+	connManager := newConnectionManagerForHostPort("foo", 0)
+
+	destinationsCtx.Start()
+	ctx := destinationsCtx.Context()
+
+	wg := sync.WaitGroup{}
+	go func() {
+		wg.Add(1)
+		conn, err := connManager.NewConnection(ctx)
+		assert.Nil(t, conn)
+		assert.Error(t, err)
+		wg.Done()
+	}()
+
+	// This will cancel the context and should unblock new connection.
+	destinationsCtx.Stop()
+
+	// Make sure NewConnection really returns.
+	wg.Wait()
 }

--- a/pkg/logs/sender/destination.go
+++ b/pkg/logs/sender/destination.go
@@ -61,10 +61,6 @@ func (d *Destination) Send(payload *message.Message) error {
 		// If we have a context, use it, this will allow early cancellation.
 		if d.destinationsContext != nil {
 			ctx = d.destinationsContext.Context()
-			// FIXME: Beurk
-			if ctx == nil {
-				return context.Canceled
-			}
 		} else {
 			// Make the destinationsContext optional for easier tests.
 			ctx = context.Background()

--- a/pkg/logs/sender/destination.go
+++ b/pkg/logs/sender/destination.go
@@ -35,7 +35,6 @@ func (e *FramingError) Error() string {
 type Destination struct {
 	prefixer  Prefixer
 	delimiter Delimiter
-	/* TODO: Merge ConnectionManager into Destination (think about GRPC integration before) */
 	connManager         *ConnectionManager
 	destinationsContext *DestinationsContext
 	conn                net.Conn

--- a/pkg/logs/sender/destination.go
+++ b/pkg/logs/sender/destination.go
@@ -6,7 +6,6 @@
 package sender
 
 import (
-	"context"
 	"net"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -54,16 +53,10 @@ func NewDestination(endpoint config.Endpoint, destinationsContext *DestinationsC
 // returns an error if the operation failed.
 func (d *Destination) Send(payload *message.Message) error {
 	if d.conn == nil {
-		var ctx context.Context
 		var err error
 
-		// If we have a context, use it, this will allow early cancellation.
-		if d.destinationsContext != nil {
-			ctx = d.destinationsContext.Context()
-		} else {
-			// Make the destinationsContext optional for easier tests.
-			ctx = context.Background()
-		}
+		// We work only if we have a started destination context
+		ctx := d.destinationsContext.Context()
 		if d.conn, err = d.connManager.NewConnection(ctx); err != nil {
 			return err
 		}

--- a/pkg/logs/sender/destination.go
+++ b/pkg/logs/sender/destination.go
@@ -33,8 +33,8 @@ func (e *FramingError) Error() string {
 
 // Destination is responsible for shipping logs to a remote server over TCP.
 type Destination struct {
-	prefixer  Prefixer
-	delimiter Delimiter
+	prefixer            Prefixer
+	delimiter           Delimiter
 	connManager         *ConnectionManager
 	destinationsContext *DestinationsContext
 	conn                net.Conn

--- a/pkg/logs/sender/destinations_context.go
+++ b/pkg/logs/sender/destinations_context.go
@@ -42,8 +42,8 @@ func (dc *DestinationsContext) Stop() {
 }
 
 // Context allows one to access the current context of this DestinationsContext.
-func (sm *DestinationsContext) Context() context.Context {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-	return sm.context
+func (dc *DestinationsContext) Context() context.Context {
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+	return dc.context
 }

--- a/pkg/logs/sender/destinations_context.go
+++ b/pkg/logs/sender/destinations_context.go
@@ -38,9 +38,7 @@ func (sm *DestinationsContext) Stop() {
 		sm.cancel()
 		sm.cancel = nil
 	}
-	if sm.context != nil {
-		sm.context = nil
-	}
+	// Here we keep the cancelled context to make sure in-flight destination get it.
 }
 
 // Context allows one to access the current context of this DestinationsContext.

--- a/pkg/logs/sender/destinations_context.go
+++ b/pkg/logs/sender/destinations_context.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package sender
+
+import (
+	"context"
+	"sync"
+)
+
+// A DestinationsContext manages senders and allows us to "unclog" the pipeline
+// when trying to stop it and failing to send messages.
+type DestinationsContext struct {
+	context context.Context
+	cancel  context.CancelFunc
+	mutex   sync.Mutex
+}
+
+// NewDestinationsContext returns an initialized ConnectionManager
+func NewDestinationsContext() *DestinationsContext {
+	return &DestinationsContext{}
+}
+
+// Start creates a context that will be cancelled on Stop()
+func (sm *DestinationsContext) Start() {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	sm.context, sm.cancel = context.WithCancel(context.Background())
+}
+
+// Stop cancels the context that should be used by all senders.
+func (sm *DestinationsContext) Stop() {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if sm.cancel != nil {
+		sm.cancel()
+		sm.cancel = nil
+	}
+	if sm.context != nil {
+		sm.context = nil
+	}
+}
+
+// Context allows one to access the current context of this DestinationsContext.
+func (sm *DestinationsContext) Context() context.Context {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	return sm.context
+}

--- a/pkg/logs/sender/destinations_context.go
+++ b/pkg/logs/sender/destinations_context.go
@@ -24,19 +24,19 @@ func NewDestinationsContext() *DestinationsContext {
 }
 
 // Start creates a context that will be cancelled on Stop()
-func (sm *DestinationsContext) Start() {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-	sm.context, sm.cancel = context.WithCancel(context.Background())
+func (dc *DestinationsContext) Start() {
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+	dc.context, dc.cancel = context.WithCancel(context.Background())
 }
 
 // Stop cancels the context that should be used by all senders.
-func (sm *DestinationsContext) Stop() {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-	if sm.cancel != nil {
-		sm.cancel()
-		sm.cancel = nil
+func (dc *DestinationsContext) Stop() {
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+	if dc.cancel != nil {
+		dc.cancel()
+		dc.cancel = nil
 	}
 	// Here we keep the cancelled context to make sure in-flight destination get it.
 }

--- a/pkg/logs/sender/destinations_context_test.go
+++ b/pkg/logs/sender/destinations_context_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package sender
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewDestinationsContext(t *testing.T) {
+	destinationsCtx := NewDestinationsContext()
+	assert.Nil(t, destinationsCtx.Context())
+
+	destinationsCtx.Start()
+
+	context := destinationsCtx.Context()
+	assert.NotNil(t, context)
+
+	destinationsCtx.Stop()
+	assert.Nil(t, destinationsCtx.Context())
+
+	// We simply make sure that the DestinationsContext correctly cancels its context.
+	<-context.Done()
+}

--- a/pkg/logs/sender/destinations_context_test.go
+++ b/pkg/logs/sender/destinations_context_test.go
@@ -15,13 +15,16 @@ func TestNewDestinationsContext(t *testing.T) {
 	assert.Nil(t, destinationsCtx.Context())
 
 	destinationsCtx.Start()
-
 	context := destinationsCtx.Context()
 	assert.NotNil(t, context)
 
 	destinationsCtx.Stop()
-	assert.Nil(t, destinationsCtx.Context())
+	assert.NotNil(t, destinationsCtx.Context())
 
 	// We simply make sure that the DestinationsContext correctly cancels its context.
 	<-context.Done()
+
+	destinationsCtx.Start()
+	assert.NotNil(t, destinationsCtx.Context())
+	assert.NotEqual(t, context, destinationsCtx.Context())
 }

--- a/pkg/logs/sender/mock/mock.go
+++ b/pkg/logs/sender/mock/mock.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package mock
+
+import (
+	"io/ioutil"
+	"net"
+	"testing"
+)
+
+// NewMockLogsIntake creates a TCP server that mimics the logs backend and returns
+// a Listener. It's the caller's responsibility to close the listener.
+func NewMockLogsIntake(t *testing.T) net.Listener {
+	// This needs to be an IPv4 because most of the code doesn't handle IPv6 yet.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		defer l.Close()
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+
+			for {
+				_, err := ioutil.ReadAll(conn)
+				if err != nil {
+					break
+				}
+			}
+			return
+		}
+	}()
+	return l
+}

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -64,7 +64,7 @@ func (s *Sender) send(payload *message.Message) {
 			}
 			switch err.(type) {
 			case *FramingError:
-				// the message can not be framed properly,
+				// the message can notx be framed properly,
 				// drop the message
 				break
 			default:

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -64,7 +64,7 @@ func (s *Sender) send(payload *message.Message) {
 			}
 			switch err.(type) {
 			case *FramingError:
-				// the message can notx be framed properly,
+				// the message can not be framed properly,
 				// drop the message
 				break
 			default:

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -1,0 +1,52 @@
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package sender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender/mock"
+)
+
+func newMessage(content []byte, source *config.LogSource, status string) *message.Message {
+	origin := message.NewOrigin(source)
+	msg := message.NewMessage(content, origin, status)
+	return msg
+}
+
+func TestSender(t *testing.T) {
+	l := mock.NewMockLogsIntake(t)
+	defer l.Close()
+
+	source := config.NewLogSource("", &config.LogsConfig{})
+
+	input := make(chan *message.Message, 1)
+	output := make(chan *message.Message, 1)
+
+	destinationsCtx := NewDestinationsContext()
+	destinationsCtx.Start()
+
+	destination := AddrToDestination(l.Addr(), destinationsCtx)
+	destinations := NewDestinations(destination, nil)
+
+	sender := NewSender(input, output, destinations)
+	sender.Start()
+
+	expectedMessage := newMessage([]byte("fake line"), source, "")
+
+	// Write to the output should relay the message to the output (after sending it on the wire)
+	input <- expectedMessage
+	message, ok := <-output
+
+	assert.True(t, ok)
+	assert.Equal(t, message, expectedMessage)
+
+	sender.Stop()
+	destinationsCtx.Stop()
+}

--- a/pkg/logs/sender/testutil.go
+++ b/pkg/logs/sender/testutil.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package sender
+
+import (
+	"net"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+)
+
+// AddrToHostPort converts a net.Addr to a (string, int).
+func AddrToHostPort(remoteAddr net.Addr) (string, int) {
+	switch addr := remoteAddr.(type) {
+	case *net.UDPAddr:
+		return addr.IP.String(), int(addr.Port)
+	case *net.TCPAddr:
+		return addr.IP.String(), int(addr.Port)
+	}
+	return "", 0
+}
+
+// AddrToEndPoint creates an EndPoint from an Addr.
+func AddrToEndPoint(addr net.Addr) config.Endpoint {
+	host, port := AddrToHostPort(addr)
+	return config.Endpoint{Host: host, Port: port}
+}
+
+// AddrToDestination creates a Destination from an Addr
+func AddrToDestination(addr net.Addr, ctx *DestinationsContext) *Destination {
+	return NewDestination(AddrToEndPoint(addr), ctx)
+}

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -49,6 +49,11 @@ func Initialize(sources *config.LogSources) {
 	}
 }
 
+// Clear clears the status (which means it needs to be initialized again to be used).
+func Clear() {
+	builder = nil
+}
+
 // Get returns the status of the logs-agent computed on the fly.
 func Get() Status {
 	// Sort sources by name (ie. by integration name ~= file name)


### PR DESCRIPTION
### What does this PR do?

Currently if the Senders are not able to consume the messages of the
pipelines (for example, because they can't establish a connection) it
is impossible to stop the logging agent. Even worse, it is impossible
to stop the inputs too because the channels in-between components have
a fixed size.


### Additional Notes

This is based heavily on context.Context to allow us to have proper
composite timeouts / cancellations. This is the recommended way to do
that in go which is also already used in other parts of the agent.

This commit also changes the following things:
- Ads a DestinationContext that is restartable and allows to "unclog" the destinations when necessary
- Destination starts using context.Context in order to have proper cancelation timeouts.
- Add some cleanups in a few `Stop()` functions to make unit testing easier
- Add `agent_test.go`, `sender_test.go` and `connection_manager_test.go` with basic tests (with working and non-working backends)
- Add `logs_config.stop_grace_period`, both because this has an effect on the logs that could be lost on restart (for tcp/udp) and because it makes unit testing easier.