### PR TITLE
[docs] Clarify log_to_syslog behavior

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -352,7 +352,9 @@ api_key:
 # disable_file_logging: false
 
 # Set to 'true' to enable logging to syslog.
-#
+# Note: Even if this option is set to 'false', the service launcher of your environment
+# may redirect the agent process' stdout/stderr to syslog. In that case, if you wish
+# to disable logging to syslog entirely, please set 'log_to_console' to 'false' as well.
 # log_to_syslog: false
 #
 # If 'syslog_uri' is left undefined/empty, a local domain socket connection will be attempted


### PR DESCRIPTION
### What does this PR do?

Add a note on Agent/OS behavior of logging to syslog.

### Motivation

More than one user was confused by the Agent logs ending up in syslog even though they set the `log_to_syslog` option to `false` (for example: https://github.com/DataDog/datadog-agent/issues/1606 + another occurrence in a support case). Probably means we need to clarify this.
