### PR TITLE
add cache generation mechanism to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,17 +18,23 @@ templates:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent
   step_templates:
-    - restore_cache: &restore_source
-        keys:
-          # Cache retrieval is faster than full git checkout
-          - v2-repo-{{ .Revision }}
     - restore_cache: &restore_deps
         keys:
           # The first match will be used. Doing that so new branches
           # use master's cache but don't pollute it back.
-          - v2-godeps-{{ .Branch }}-{{ .Revision }}
-          - v2-godeps-{{ .Branch }}-
-          - v2-godeps-master-
+          #
+          # If incremental dep fails, increase the cache gen number
+          # in restore_deps AND save_deps
+          - gen3-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen3-godeps-{{ .Branch }}-
+          - gen3-godeps-master-
+    - save_cache: &save_deps
+        key: gen3-godeps-{{ .Branch }}-{{ .Revision }}
+    - restore_cache: &restore_source
+        keys:
+          - v2-repo-{{ .Revision }}
+    - save_cache: &save_source
+        key: v2-repo-{{ .Revision }}
     - run: &enter_venv
         name: add virtualenv to bashrc
         command: echo "source /go/src/github.com/DataDog/datadog-agent/venv/bin/activate" >> $BASH_ENV
@@ -39,7 +45,7 @@ jobs:
     steps:
       - checkout
       - save_cache:
-          key: v2-repo-{{ .Revision }}
+          <<: *save_source
           paths:
             - /go/src/github.com/DataDog/datadog-agent
 
@@ -62,7 +68,7 @@ jobs:
           name: pre-compile go deps
           command: inv -e agent.build --race --precompile-only
       - save_cache:
-          key: v2-godeps-{{ .Branch }}-{{ .Revision }}
+          <<: *save_deps
           paths:
             - /go/src/github.com/DataDog/datadog-agent/vendor
             - /go/src/github.com/DataDog/datadog-agent/venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ templates:
           #
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
+          # See https://github.com/DataDog/datadog-agent/pull/2384
           - gen3-godeps-{{ .Branch }}-{{ .Revision }}
           - gen3-godeps-{{ .Branch }}-
           - gen3-godeps-master-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ templates:
         key: gen3-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
+          # Cache retrieval is faster than full git checkout
           - v2-repo-{{ .Revision }}
     - save_cache: &save_source
         key: v2-repo-{{ .Revision }}


### PR DESCRIPTION
### What does this PR do?

`dep ensure` sometimes fails on incremental builds with cache, and needs a reset of the `vendor` folder

As circleci v2 does to expose an API to clear the cache, we currently need to disable cache restoration in the `dependencies`, then revert the change. See https://github.com/DataDog/datadog-agent/commit/40b0a15275baf82da6a3dd89ab925c38ba3c31ee and https://github.com/DataDog/datadog-agent/commit/7564a8fe13666fe17c1321ad0d25589f1d123f14


This PR allows us to handle these issues at the branch level, by changing the cache key in the `step_templates` section, which will propagate to master on merge, and avoid manually clearing the cache.

Next time a dependency upgrade breaks dep, the developper will just need to `s/gen3/gen4/` in the yaml, which will restore tests on their branch, and avoid `master` breakage on merge.

### Motivation

Simpler and less error prone
