### PR TITLE
Remove pywin32 dependency from omnibus

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -115,11 +115,6 @@ dependency 'cacerts'
 # creates required build directories
 dependency 'datadog-agent-prepare'
 
-# Windows-specific dependencies
-if windows?
-  dependency 'pywin32'
-end
-
 # Datadog agent
 dependency 'datadog-agent'
 


### PR DESCRIPTION
### Motivation

Move toward defining all requirements in `integrations-core` itself rather than the build system

### Additional Notes

https://github.com/DataDog/integrations-core/pull/2322