### PR TITLE
Explictly compile pprof in cluster-agent

### DIFF
--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -15,7 +15,8 @@ import (
 	"net/http"
 	"os"
 
-	_ "expvar"
+	_ "expvar"         // Blank import used because this isn't directly used in this file
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network"


### PR DESCRIPTION
### What does this PR do?

Make sure pprof is available on port 5000. It was already the case because of transitive imports, but not explicit.

### Motivation

Make it future-proof
