### PR TITLE
clusterchecks: simple dispatching logic

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -221,7 +221,7 @@ func setupClusterCheck(ctx context.Context) *clusterchecks.Handler {
 		return nil
 	}
 
-	handler, err := clusterchecks.SetupHandler(common.AC)
+	handler, err := clusterchecks.NewHandler(common.AC)
 	if err != nil {
 		log.Errorf("Could not setup the cluster-checks Autodiscovery: %s", err.Error())
 		return nil

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -8,6 +8,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -108,6 +109,9 @@ func start(cmd *cobra.Command, args []string) error {
 		logFile = ""
 	}
 
+	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
+	defer mainCtxCancel() // Calling cancel twice is safe
+
 	err = config.SetupLogger(
 		config.Datadog.GetString("log_level"),
 		logFile,
@@ -176,7 +180,7 @@ func start(cmd *cobra.Command, args []string) error {
 	common.StartAutoConfig()
 
 	// Start the cluster-check discovery if configured
-	clusterCheckHandler := setupClusterCheck()
+	clusterCheckHandler := setupClusterCheck(mainCtx)
 	// start the cmd HTTPS server
 	sc := clusteragent.ServerContext{
 		ClusterCheckHandler: clusterCheckHandler,
@@ -196,9 +200,10 @@ func start(cmd *cobra.Command, args []string) error {
 
 	// Block here until we receive the interrupt signal
 	<-signalCh
-	if clusterCheckHandler != nil {
-		clusterCheckHandler.StopDiscovery()
-	}
+
+	// Cancel the main context to stop components
+	mainCtxCancel()
+
 	if config.Datadog.GetBool("external_metrics_provider.enabled") {
 		custommetrics.StopServer()
 	}
@@ -210,23 +215,19 @@ func start(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func setupClusterCheck() *clusterchecks.Handler {
+func setupClusterCheck(ctx context.Context) *clusterchecks.Handler {
 	if !config.Datadog.GetBool("cluster_checks.enabled") {
 		log.Debug("Cluster check Autodiscovery disabled")
 		return nil
 	}
 
-	clusterCheckHandler, err := clusterchecks.SetupHandler(common.AC)
+	handler, err := clusterchecks.SetupHandler(common.AC)
 	if err != nil {
 		log.Errorf("Could not setup the cluster-checks Autodiscovery: %s", err.Error())
 		return nil
 	}
-	err = clusterCheckHandler.StartDiscovery()
-	if err != nil {
-		log.Errorf("Could not start the cluster-checks Autodiscovery: %s", err.Error())
-		return nil
-	}
+	go handler.Run(ctx)
 
 	log.Info("Started cluster check Autodiscovery")
-	return clusterCheckHandler
+	return handler
 }

--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -23,7 +23,7 @@ const defaultGraceDuration = 60 * time.Second
 type ClusterChecksConfigProvider struct {
 	dcaClient      *clusteragent.DCAClient
 	graceDuration  time.Duration
-	lastPing       time.Time
+	heartbeat      time.Time
 	lastChange     int64
 	nodeName       string
 	flushedConfigs bool
@@ -62,7 +62,7 @@ func (c *ClusterChecksConfigProvider) String() string {
 }
 
 func (c *ClusterChecksConfigProvider) withinGracePeriod() bool {
-	return c.lastPing.Add(c.graceDuration).After(time.Now())
+	return c.heartbeat.Add(c.graceDuration).After(time.Now())
 }
 
 // IsUpToDate queries the cluster-agent to update its status and
@@ -90,7 +90,7 @@ func (c *ClusterChecksConfigProvider) IsUpToDate() (bool, error) {
 		return false, err
 	}
 
-	c.lastPing = time.Now()
+	c.heartbeat = time.Now()
 	if reply.IsUpToDate {
 		log.Tracef("Up to date with change %d", c.lastChange)
 	} else {

--- a/pkg/clusteragent/clusterchecks/README.md
+++ b/pkg/clusteragent/clusterchecks/README.md
@@ -64,3 +64,10 @@ atomic, the stores are designed with an external locking, held by the `dispatche
 ## Node-agent communication
 
 The node-agent queries the cluster-agent through the autodiscovery `ClusterChecksConfigProvider`.
+As nodes can be removed without notice, the cluster-agent has to detect when a node is not
+connected anymore and re-dispatch the configurations to other, active, nodes.
+
+This is handled by the `node_expiration_timeout` option (30 seconds by default) and the
+`dispatcher.expireNodes` method. The node-agents heartbeat is updated when they POST on the
+`status` url (10 seconds in the default configuration). When that heartbeat timestamp is too
+old, the node is deleted and its configurations put back in the dangling map.

--- a/pkg/clusteragent/clusterchecks/api_nocompile.go
+++ b/pkg/clusteragent/clusterchecks/api_nocompile.go
@@ -8,6 +8,7 @@
 package clusterchecks
 
 import (
+	"context"
 	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
@@ -29,16 +30,11 @@ func (h *Handler) GetAllConfigs() ([]integration.Config, error) {
 }
 
 // SetupHandler not implemented
-func SetupHandler(ac *autodiscovery.AutoConfig) (*Handler, error) {
+func SetupHandler(_ *autodiscovery.AutoConfig) (*Handler, error) {
 	return nil, ErrNotCompiled
 }
 
-// StartDiscovery not implemented
-func (h *Handler) StartDiscovery() error {
-	return ErrNotCompiled
-}
-
-// StopDiscovery not implemented
-func (h *Handler) StopDiscovery() error {
+// Run not implemented
+func (h *Handler) Run(_ context.Context) error {
 	return ErrNotCompiled
 }

--- a/pkg/clusteragent/clusterchecks/api_nocompile.go
+++ b/pkg/clusteragent/clusterchecks/api_nocompile.go
@@ -29,8 +29,8 @@ func (h *Handler) GetAllConfigs() ([]integration.Config, error) {
 	return nil, ErrNotCompiled
 }
 
-// SetupHandler not implemented
-func SetupHandler(_ *autodiscovery.AutoConfig) (*Handler, error) {
+// NewHandler not implemented
+func NewHandler(_ *autodiscovery.AutoConfig) (*Handler, error) {
 	return nil, ErrNotCompiled
 }
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -27,9 +27,6 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 	digest := config.Digest()
 	d.store.digestToConfig[digest] = config
 
-	if targetNodeName == "" {
-		return
-	}
 	currentNode, foundCurrent := d.store.getNodeStore(d.store.digestToNode[digest])
 	targetNode := d.store.getOrCreateNodeStore(targetNodeName)
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -87,9 +87,9 @@ func (d *dispatcher) cleanupLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-cleanupTicker.C:
-			// Expire old configs
-			orphanedConfigs := d.expireNodes()
-			d.Schedule(orphanedConfigs)
+			// Expire old nodes, orphaned configs are moved to dangling
+			d.expireNodes()
+
 			// Re-dispatch dangling configs
 			if d.shouldDispatchDanling() {
 				d.Schedule(d.retrieveAndClearDangling())

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -88,8 +88,8 @@ func (d *dispatcher) cleanupLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-expireTicker.C:
-			expired := d.expireNodes()
-			d.Schedule(expired)
+			orphanedConfigs := d.expireNodes()
+			d.Schedule(orphanedConfigs)
 		}
 	}
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -58,7 +58,7 @@ func (d *dispatcher) add(config integration.Config) {
 	target := d.getLeastBusyNode()
 	if target == "" {
 		// If no node is found, store it in the danglingConfigs map for retrying later.
-		log.Infof("No available node to dispatch %s:%s on, will retry later", config.Name, config.Digest())
+		log.Warnf("No available node to dispatch %s:%s on, will retry later", config.Name, config.Digest())
 	} else {
 		log.Infof("Dispatching configuration %s:%s to node %s", config.Name, config.Digest(), target)
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -40,7 +40,7 @@ func (d *dispatcher) processNodeStatus(nodeName string, status types.NodeStatus)
 	node.Lock()
 	defer node.Unlock()
 	node.lastStatus = status
-	node.lastPing = timestampNow()
+	node.heartbeat = timestampNow()
 
 	return (node.lastConfigChange == status.LastChange), nil
 }
@@ -78,10 +78,10 @@ func (d *dispatcher) expireNodes() {
 
 	for name, node := range d.store.nodes {
 		node.RLock()
-		if node.lastPing < cutoffTimestamp {
+		if node.heartbeat < cutoffTimestamp {
 			if name != "" {
 				// Don't report on the dummy "" host for unscheduled configs
-				log.Infof("Expiring out node %s, last status report %d seconds ago", name, timestampNow()-node.lastPing)
+				log.Infof("Expiring out node %s, last status report %d seconds ago", name, timestampNow()-node.heartbeat)
 			}
 			for digest, config := range node.digestToConfig {
 				d.store.danglingConfigs[digest] = config

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -49,8 +49,8 @@ func (d *dispatcher) processNodeStatus(nodeName string, status types.NodeStatus)
 // the lowest number of checks. In case of equality, one is chosen
 // randomly, based on map iterations being randomized.
 func (d *dispatcher) getLeastBusyNode() string {
-	var lowestName string
-	lowestNumber := int(-1)
+	var leastBusyNode string
+	minCheckCount := int(-1)
 
 	d.store.RLock()
 	defer d.store.RUnlock()
@@ -59,15 +59,15 @@ func (d *dispatcher) getLeastBusyNode() string {
 		if name == "" {
 			continue
 		}
-		if lowestNumber == -1 || len(store.digestToConfig) < lowestNumber {
-			lowestName = name
-			lowestNumber = len(store.digestToConfig)
+		if minCheckCount == -1 || len(store.digestToConfig) < minCheckCount {
+			leastBusyNode = name
+			minCheckCount = len(store.digestToConfig)
 		}
 	}
-	return lowestName
+	return leastBusyNode
 }
 
-// ExpireNodes iterates over nodes and removes the ones that have not
+// expireNodes iterates over nodes and removes the ones that have not
 // reported for more than the expiration duration. It returns configs
 // that were dispatched to these nodes, to re-dispatch them.
 func (d *dispatcher) expireNodes() []integration.Config {

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -108,18 +108,18 @@ func TestProcessNodeStatus(t *testing.T) {
 	node1, found := dispatcher.store.getNodeStore("node1")
 	assert.True(t, found)
 	assert.Equal(t, status1, node1.lastStatus)
-	assert.True(t, timestampNow() >= node1.lastPing)
-	assert.True(t, timestampNow() <= node1.lastPing+1)
+	assert.True(t, timestampNow() >= node1.heartbeat)
+	assert.True(t, timestampNow() <= node1.heartbeat+1)
 
 	// Give changes
 	node1.lastConfigChange = timestampNow()
-	node1.lastPing = node1.lastPing - 50
+	node1.heartbeat = node1.heartbeat - 50
 	status2 := types.NodeStatus{LastChange: node1.lastConfigChange - 2}
 	upToDate, err = dispatcher.processNodeStatus("node1", status2)
 	assert.NoError(t, err)
 	assert.False(t, upToDate)
-	assert.True(t, timestampNow() >= node1.lastPing)
-	assert.True(t, timestampNow() <= node1.lastPing+1)
+	assert.True(t, timestampNow() >= node1.heartbeat)
+	assert.True(t, timestampNow() <= node1.heartbeat+1)
 
 	// No change
 	status3 := types.NodeStatus{LastChange: node1.lastConfigChange}
@@ -174,8 +174,8 @@ func TestExpireNodes(t *testing.T) {
 	assert.Equal(t, 2, len(dispatcher.store.nodes))
 
 	// Fake the status report timestamps, nodeB should expire
-	dispatcher.store.nodes["nodeA"].lastPing = timestampNow() - 25
-	dispatcher.store.nodes["nodeB"].lastPing = timestampNow() - 35
+	dispatcher.store.nodes["nodeA"].heartbeat = timestampNow() - 25
+	dispatcher.store.nodes["nodeB"].heartbeat = timestampNow() - 35
 
 	assert.Equal(t, 0, len(dispatcher.store.danglingConfigs))
 	dispatcher.expireNodes()

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -8,6 +8,7 @@
 package clusterchecks
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -23,49 +24,48 @@ type Handler struct {
 	m          sync.Mutex
 	autoconfig *autodiscovery.AutoConfig
 	dispatcher *dispatcher
-	running    bool
 }
 
 // SetupHandler returns a populated Handler
 // If will hook on the specified AutoConfig instance at Start
 func SetupHandler(ac *autodiscovery.AutoConfig) (*Handler, error) {
+	if ac == nil {
+		return nil, errors.New("empty autoconfig object")
+	}
 	h := &Handler{
 		autoconfig: ac,
 	}
 	return h, nil
 }
 
-// StartDiscovery hooks to Autodiscovery and starts managing checks
-func (h *Handler) StartDiscovery() error {
+// Run is the main goroutine for the handler. It has to
+// be called in a goroutine with a cancellable context.
+func (h *Handler) Run(ctx context.Context) {
+	h.startDiscovery(ctx)
+	<-ctx.Done()
+	h.stopDiscovery()
+}
+
+// startDiscovery hooks to Autodiscovery and starts managing checks
+func (h *Handler) startDiscovery(ctx context.Context) {
 	h.m.Lock()
 	defer h.m.Unlock()
-	if h.running {
-		return errors.New("already running")
-	}
-
 	// Clean initial state
 	h.dispatcher = newDispatcher()
-	h.running = true
+	go h.dispatcher.cleanupLoop(ctx)
 
 	// Register our scheduler and ask for a config replay
 	h.autoconfig.AddScheduler(schedulerName, h.dispatcher, true)
-
-	return nil
 }
 
-// StopDiscovery stops the management logic and un-hooks from Autodiscovery
-func (h *Handler) StopDiscovery() error {
+// stopDiscovery stops the management logic and un-hooks from Autodiscovery
+func (h *Handler) stopDiscovery() {
 	h.m.Lock()
 	defer h.m.Unlock()
-	if !h.running {
-		return errors.New("not running")
-	}
 
 	// AD will call dispatcher.Stop for us
 	h.autoconfig.RemoveScheduler(schedulerName)
 
 	// Release memory
 	h.dispatcher = nil
-
-	return nil
 }

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -26,9 +26,9 @@ type Handler struct {
 	dispatcher *dispatcher
 }
 
-// SetupHandler returns a populated Handler
-// If will hook on the specified AutoConfig instance at Start
-func SetupHandler(ac *autodiscovery.AutoConfig) (*Handler, error) {
+// NewHandler returns a populated Handler
+// It will hook on the specified AutoConfig instance at Start
+func NewHandler(ac *autodiscovery.AutoConfig) (*Handler, error) {
 	if ac == nil {
 		return nil, errors.New("empty autoconfig object")
 	}

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -24,7 +24,7 @@ func makeConfigArray(configMap map[string]integration.Config) []integration.Conf
 	return configSlice
 }
 
-// timestampNow provides a consistent way to keep a timestamp
+// timestampNow provides a consistent way to keep a seconds timestamp
 func timestampNow() int64 {
 	return time.Now().Unix()
 }

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -23,7 +23,7 @@ type clusterStore struct {
 	digestToConfig  map[string]integration.Config // All configurations to dispatch
 	digestToNode    map[string]string             // Node running a config
 	nodes           map[string]*nodeStore         // All nodes known to the cluster-agent
-	danglingConfigs map[string]integration.Config // Configs we count not dispatch to any node
+	danglingConfigs map[string]integration.Config // Configs we could not dispatch to any node
 }
 
 func newClusterStore() *clusterStore {
@@ -62,7 +62,7 @@ func (s *clusterStore) clearDangling() {
 // Lock is to be held by the user (dispatcher)
 type nodeStore struct {
 	sync.RWMutex
-	lastPing         int64
+	heartbeat        int64
 	lastStatus       types.NodeStatus
 	lastConfigChange int64
 	digestToConfig   map[string]integration.Config

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -20,16 +20,18 @@ import (
 // operations involving several calls.
 type clusterStore struct {
 	sync.RWMutex
-	digestToConfig map[string]integration.Config // All configurations to dispatch
-	digestToNode   map[string]string             // Node running a config
-	nodes          map[string]*nodeStore         // All nodes known to the cluster-agent
+	digestToConfig  map[string]integration.Config // All configurations to dispatch
+	digestToNode    map[string]string             // Node running a config
+	nodes           map[string]*nodeStore         // All nodes known to the cluster-agent
+	danglingConfigs map[string]integration.Config // Configs we count not dispatch to any node
 }
 
 func newClusterStore() *clusterStore {
 	return &clusterStore{
-		digestToConfig: make(map[string]integration.Config),
-		digestToNode:   make(map[string]string),
-		nodes:          make(map[string]*nodeStore),
+		digestToConfig:  make(map[string]integration.Config),
+		digestToNode:    make(map[string]string),
+		nodes:           make(map[string]*nodeStore),
+		danglingConfigs: make(map[string]integration.Config),
 	}
 }
 
@@ -49,6 +51,11 @@ func (s *clusterStore) getOrCreateNodeStore(nodeName string) *nodeStore {
 	node = newNodeStore()
 	s.nodes[nodeName] = node
 	return node
+}
+
+// clearDangling resets the danglingConfigs map to a new empty one
+func (s *clusterStore) clearDangling() {
+	s.danglingConfigs = make(map[string]integration.Config)
 }
 
 // nodeStore holds the state store for one node.

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -46,8 +46,6 @@ func (s *clusterStore) getOrCreateNodeStore(nodeName string) *nodeStore {
 	if ok {
 		return node
 	}
-
-	log.Debugf("unknown node %s, registering", nodeName)
 	node = newNodeStore()
 	s.nodes[nodeName] = node
 	return node

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -330,6 +330,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30) // value in seconds
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
+	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
 
 	setAssetFs(config)
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -475,6 +475,20 @@ api_key:
 # ad_config_poll_interval: 10
 #
 {{ end -}}
+{{- if .ClusterChecks }}
+# Cluster check dispatching
+#
+# The cluster-agent is able to autodiscover cluster resources and dispatch checks on
+# the node-agents (provided the clustercheck config provider is enabled on them).
+#
+# cluster_checks:
+#   Set to true to enable the dispatching logic on the leader cluster-agent.
+#   enabled: "true"
+#   Node-agents that have not queried the cluster-agent for 30 seconds will be deleted,
+#   and their checks re-dispatched to other nodes. This delay is configurable here.
+#   node_expiration_timeout: 30
+#
+{{ end -}}
 {{- if .DockerTagging }}
 # Docker tag extraction
 #
@@ -641,7 +655,7 @@ api_key:
 #   dd_agent_bin:
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
-{{ end -}} 
+{{ end -}}
 
 {{- if .NetworkTracer }}
 # Network tracer specific settings

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -35,6 +35,7 @@ type context struct {
 	NetworkTracer     bool
 	KubeApiServer     bool
 	TraceAgent        bool
+	ClusterChecks     bool
 }
 
 func mkContext(buildType string) context {
@@ -81,6 +82,7 @@ func mkContext(buildType string) context {
 			Common:        true,
 			Logging:       true,
 			KubeApiServer: true,
+			ClusterChecks: true,
 		}
 	}
 

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -20,6 +20,7 @@ BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
+    "clusterchecks",
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Add a simple dispatching logic for cluster-checks to account for node-agent churn:

- configs are assigned to the node that has the less configs assigned to it
- nodes are removed from the store if they don't report for 30 seconds (configurable)
- configs dispatched to expired nodes are re-dispatched on other available nodes
- if no nodes are available, configs are dispatched to a dummy node with an empty hostname. It will expire in 15 seconds and we will try re-dispatching the configurations

As the lifecycle of the package will become more complex when adding the leader election handling, I'm experimenting with the use of contexts to handle the sub-routines. If that does not prove better, I'll move back to stop channels.

### Testing

Logs of a test session with three clients:

- Start the cluster-agent with no node-agent: config is in standby
- Start `node1` and `node2`, config gets delegated to `node1`
- Stop `node1`, it expires and config is delegated to `node2`
- Stop `node2`, no more available nodes, config is in standby
- Start `node3`, config gets delegated to it

> 2018-10-01 16:24:37 UTC | INFO | (dispatcher_main.go:62 in add) | No available node to dispatch http_check:22f5b2455bae3d2d on, will retry later
> 2018-10-01 16:24:52 UTC | INFO | (dispatcher_main.go:64 in add) | Dispatching configuration http_check:22f5b2455bae3d2d to node node1
> 2018-10-01 16:25:52 UTC | INFO | (dispatcher_nodes.go:84 in expireNodes) | expiring out node node1, last status report 35 seconds ago
> 2018-10-01 16:25:52 UTC | INFO | (dispatcher_main.go:64 in add) | Dispatching configuration http_check:22f5b2455bae3d2d to node node2
> 2018-10-01 16:27:07 UTC | INFO | (dispatcher_nodes.go:84 in expireNodes) | Expiring out node node2, last status report 37 seconds ago
> 2018-10-01 16:27:07 UTC | INFO | (dispatcher_main.go:62 in add) | No available node to dispatch http_check:22f5b2455bae3d2d on, will retry later
> 2018-10-01 16:27:22 UTC | INFO | (dispatcher_main.go:62 in add) | No available node to dispatch http_check:22f5b2455bae3d2d on, will retry later
> 2018-10-01 16:27:37 UTC | INFO | (dispatcher_main.go:62 in add) | No available node to dispatch http_check:22f5b2455bae3d2d on, will retry later
> 2018-10-01 16:27:52 UTC | INFO | (dispatcher_main.go:62 in add) | No available node to dispatch http_check:22f5b2455bae3d2d on, will retry later
> 2018-10-01 16:28:07 UTC | INFO | (dispatcher_main.go:64 in add) | Dispatching configuration http_check:22f5b2455bae3d2d to node node3
