### PR TITLE
Use newer versions of setuptools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ before_script:
   - echo running default before_script
   - rsync -azr --delete ./ $SRC_PATH
   - cd $SRC_PATH
-  - pip install -U pip
+  - pip install --upgrade --ignore-installed pip setuptools
   - pip install -r requirements.txt
   - inv -e deps
 


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/2322 introduced environment markers to dependencies of the `extras_require` of `datadog_checks_base` which older setuptools cannot handle