### PR TITLE
Add a mutext wrapping around viper

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package config
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Config represents an object that can load and store configuration parameters
+// coming from different kind of sources:
+// - defaults
+// - files
+// - environment variables
+// - flags
+type Config interface {
+	Set(key string, value interface{})
+	SetDefault(key string, value interface{})
+	IsSet(key string) bool
+
+	Get(key string) interface{}
+	GetString(key string) string
+	GetBool(key string) bool
+	GetInt(key string) int
+	GetInt64(key string) int64
+	GetFloat64(key string) float64
+	GetTime(key string) time.Time
+	GetDuration(key string) time.Duration
+	GetStringSlice(key string) []string
+	GetStringMap(key string) map[string]interface{}
+	GetStringMapString(key string) map[string]string
+	GetStringMapStringSlice(key string) map[string][]string
+	GetSizeInBytes(key string) uint
+
+	SetEnvPrefix(in string)
+	BindEnv(input ...string) error
+	SetEnvKeyReplacer(r *strings.Replacer)
+
+	UnmarshalKey(key string, rawVal interface{}) error
+	Unmarshal(rawVal interface{}) error
+	UnmarshalExact(rawVal interface{}) error
+
+	ReadInConfig() error
+	ReadConfig(in io.Reader) error
+	MergeConfig(in io.Reader) error
+
+	AllSettings() map[string]interface{}
+
+	AddConfigPath(in string)
+	SetConfigName(in string)
+	SetConfigFile(in string)
+	SetConfigType(in string)
+	ConfigFileUsed() string
+
+	BindPFlag(key string, flag *pflag.Flag) error
+}

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -24,15 +24,15 @@ type safeConfig struct {
 // Set is wrapped for concurrent access
 func (c *safeConfig) Set(key string, value interface{}) {
 	c.Lock()
+	defer c.Unlock()
 	c.Viper.Set(key, value)
-	c.Unlock()
 }
 
 // SetDefault is wrapped for concurrent access
 func (c *safeConfig) SetDefault(key string, value interface{}) {
 	c.Lock()
+	defer c.Unlock()
 	c.Viper.SetDefault(key, value)
-	c.Unlock()
 }
 
 // IsSet is wrapped for concurrent access
@@ -150,8 +150,8 @@ func (c *safeConfig) BindEnv(input ...string) error {
 // SetEnvKeyReplacer is wrapped for concurrent access
 func (c *safeConfig) SetEnvKeyReplacer(r *strings.Replacer) {
 	c.RLock()
+	defer c.RUnlock()
 	c.Viper.SetEnvKeyReplacer(r)
-	c.RUnlock()
 }
 
 // UnmarshalKey is wrapped for concurrent access
@@ -206,29 +206,29 @@ func (c *safeConfig) AllSettings() map[string]interface{} {
 // AddConfigPath is wrapped for concurrent access
 func (c *safeConfig) AddConfigPath(in string) {
 	c.Lock()
+	defer c.Unlock()
 	c.Viper.AddConfigPath(in)
-	c.Unlock()
 }
 
 // SetConfigName is wrapped for concurrent access
 func (c *safeConfig) SetConfigName(in string) {
 	c.Lock()
+	defer c.Unlock()
 	c.Viper.SetConfigName(in)
-	c.Unlock()
 }
 
 // SetConfigFile is wrapped for concurrent access
 func (c *safeConfig) SetConfigFile(in string) {
 	c.Lock()
+	defer c.Unlock()
 	c.Viper.SetConfigFile(in)
-	c.Unlock()
 }
 
 // SetConfigType is wrapped for concurrent access
 func (c *safeConfig) SetConfigType(in string) {
 	c.Lock()
+	defer c.Unlock()
 	c.Viper.SetConfigType(in)
-	c.Unlock()
 }
 
 // ConfigFileUsed is wrapped for concurrent access

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -37,8 +37,8 @@ func (c *safeConfig) SetDefault(key string, value interface{}) {
 
 // IsSet is wrapped for concurrent access
 func (c *safeConfig) IsSet(key string) bool {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.IsSet(key)
 }
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -23,9 +23,9 @@ type safeConfig struct {
 
 // Set is wrapped for concurrent access
 func (c *safeConfig) Set(key string, value interface{}) {
-	c.RLock()
+	c.Lock()
 	c.Viper.Set(key, value)
-	c.RUnlock()
+	c.Unlock()
 }
 
 // SetDefault is wrapped for concurrent access
@@ -44,92 +44,92 @@ func (c *safeConfig) IsSet(key string) bool {
 
 // Get is wrapped for concurrent access
 func (c *safeConfig) Get(key string) interface{} {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.Get(key)
 }
 
 // GetString is wrapped for concurrent access
 func (c *safeConfig) GetString(key string) string {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetString(key)
 }
 
 // GetBool is wrapped for concurrent access
 func (c *safeConfig) GetBool(key string) bool {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetBool(key)
 }
 
 // GetInt is wrapped for concurrent access
 func (c *safeConfig) GetInt(key string) int {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetInt(key)
 }
 
 // GetInt64 is wrapped for concurrent access
 func (c *safeConfig) GetInt64(key string) int64 {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetInt64(key)
 }
 
 // GetFloat64 is wrapped for concurrent access
 func (c *safeConfig) GetFloat64(key string) float64 {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetFloat64(key)
 }
 
 // GetTime is wrapped for concurrent access
 func (c *safeConfig) GetTime(key string) time.Time {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetTime(key)
 }
 
 // GetDuration is wrapped for concurrent access
 func (c *safeConfig) GetDuration(key string) time.Duration {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetDuration(key)
 }
 
 // GetStringSlice is wrapped for concurrent access
 func (c *safeConfig) GetStringSlice(key string) []string {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetStringSlice(key)
 }
 
 // GetStringMap is wrapped for concurrent access
 func (c *safeConfig) GetStringMap(key string) map[string]interface{} {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetStringMap(key)
 }
 
 // GetStringMapString is wrapped for concurrent access
 func (c *safeConfig) GetStringMapString(key string) map[string]string {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetStringMapString(key)
 }
 
 // GetStringMapStringSlice is wrapped for concurrent access
 func (c *safeConfig) GetStringMapStringSlice(key string) map[string][]string {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetStringMapStringSlice(key)
 }
 
 // GetSizeInBytes is wrapped for concurrent access
 func (c *safeConfig) GetSizeInBytes(key string) uint {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.GetSizeInBytes(key)
 }
 
@@ -142,16 +142,16 @@ func (c *safeConfig) SetEnvPrefix(in string) {
 
 // BindEnv is wrapped for concurrent access
 func (c *safeConfig) BindEnv(input ...string) error {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 	return c.Viper.BindEnv(input...)
 }
 
 // SetEnvKeyReplacer is wrapped for concurrent access
 func (c *safeConfig) SetEnvKeyReplacer(r *strings.Replacer) {
-	c.Lock()
+	c.RLock()
 	c.Viper.SetEnvKeyReplacer(r)
-	c.Unlock()
+	c.RUnlock()
 }
 
 // UnmarshalKey is wrapped for concurrent access

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -18,21 +18,21 @@ import (
 // safeConfig wraps viper with a safety lock
 type safeConfig struct {
 	*viper.Viper
-	sync.Mutex
+	sync.RWMutex
 }
 
 // Set is wrapped for concurrent access
 func (c *safeConfig) Set(key string, value interface{}) {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
 	c.Viper.Set(key, value)
+	c.RUnlock()
 }
 
 // SetDefault is wrapped for concurrent access
 func (c *safeConfig) SetDefault(key string, value interface{}) {
 	c.Lock()
-	defer c.Unlock()
 	c.Viper.SetDefault(key, value)
+	c.Unlock()
 }
 
 // IsSet is wrapped for concurrent access
@@ -150,8 +150,8 @@ func (c *safeConfig) BindEnv(input ...string) error {
 // SetEnvKeyReplacer is wrapped for concurrent access
 func (c *safeConfig) SetEnvKeyReplacer(r *strings.Replacer) {
 	c.Lock()
-	defer c.Unlock()
 	c.Viper.SetEnvKeyReplacer(r)
+	c.Unlock()
 }
 
 // UnmarshalKey is wrapped for concurrent access
@@ -206,29 +206,29 @@ func (c *safeConfig) AllSettings() map[string]interface{} {
 // AddConfigPath is wrapped for concurrent access
 func (c *safeConfig) AddConfigPath(in string) {
 	c.Lock()
-	defer c.Unlock()
 	c.Viper.AddConfigPath(in)
+	c.Unlock()
 }
 
 // SetConfigName is wrapped for concurrent access
 func (c *safeConfig) SetConfigName(in string) {
 	c.Lock()
-	defer c.Unlock()
 	c.Viper.SetConfigName(in)
+	c.Unlock()
 }
 
 // SetConfigFile is wrapped for concurrent access
 func (c *safeConfig) SetConfigFile(in string) {
 	c.Lock()
-	defer c.Unlock()
 	c.Viper.SetConfigFile(in)
+	c.Unlock()
 }
 
 // SetConfigType is wrapped for concurrent access
 func (c *safeConfig) SetConfigType(in string) {
 	c.Lock()
-	defer c.Unlock()
 	c.Viper.SetConfigType(in)
+	c.Unlock()
 }
 
 // ConfigFileUsed is wrapped for concurrent access

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -8,66 +8,251 @@ package config
 import (
 	"io"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-// Config represents an object that can load and store configuration parameters
-// coming from different kind of sources:
-// - defaults
-// - files
-// - environment variables
-// - flags
-type Config interface {
-	Set(key string, value interface{})
-	SetDefault(key string, value interface{})
-	IsSet(key string) bool
+// safeConfig wraps viper with a safety lock
+type safeConfig struct {
+	*viper.Viper
+	sync.Mutex
+}
 
-	Get(key string) interface{}
-	GetString(key string) string
-	GetBool(key string) bool
-	GetInt(key string) int
-	GetInt64(key string) int64
-	GetFloat64(key string) float64
-	GetTime(key string) time.Time
-	GetDuration(key string) time.Duration
-	GetStringSlice(key string) []string
-	GetStringMap(key string) map[string]interface{}
-	GetStringMapString(key string) map[string]string
-	GetStringMapStringSlice(key string) map[string][]string
-	GetSizeInBytes(key string) uint
+// Set is wrapped for concurrent access
+func (c *safeConfig) Set(key string, value interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.Set(key, value)
+}
 
-	SetEnvPrefix(in string)
-	BindEnv(input ...string) error
-	SetEnvKeyReplacer(r *strings.Replacer)
+// SetDefault is wrapped for concurrent access
+func (c *safeConfig) SetDefault(key string, value interface{}) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetDefault(key, value)
+}
 
-	UnmarshalKey(key string, rawVal interface{}) error
-	Unmarshal(rawVal interface{}) error
-	UnmarshalExact(rawVal interface{}) error
+// IsSet is wrapped for concurrent access
+func (c *safeConfig) IsSet(key string) bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.IsSet(key)
+}
 
-	ReadInConfig() error
-	ReadConfig(in io.Reader) error
-	MergeConfig(in io.Reader) error
+// Get is wrapped for concurrent access
+func (c *safeConfig) Get(key string) interface{} {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.Get(key)
+}
 
-	AllSettings() map[string]interface{}
+// GetString is wrapped for concurrent access
+func (c *safeConfig) GetString(key string) string {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetString(key)
+}
 
-	AddConfigPath(in string)
-	SetConfigName(in string)
-	SetConfigFile(in string)
-	SetConfigType(in string)
-	ConfigFileUsed() string
+// GetBool is wrapped for concurrent access
+func (c *safeConfig) GetBool(key string) bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetBool(key)
+}
 
-	BindPFlag(key string, flag *pflag.Flag) error
+// GetInt is wrapped for concurrent access
+func (c *safeConfig) GetInt(key string) int {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetInt(key)
+}
+
+// GetInt64 is wrapped for concurrent access
+func (c *safeConfig) GetInt64(key string) int64 {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetInt64(key)
+}
+
+// GetFloat64 is wrapped for concurrent access
+func (c *safeConfig) GetFloat64(key string) float64 {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetFloat64(key)
+}
+
+// GetTime is wrapped for concurrent access
+func (c *safeConfig) GetTime(key string) time.Time {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetTime(key)
+}
+
+// GetDuration is wrapped for concurrent access
+func (c *safeConfig) GetDuration(key string) time.Duration {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetDuration(key)
+}
+
+// GetStringSlice is wrapped for concurrent access
+func (c *safeConfig) GetStringSlice(key string) []string {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetStringSlice(key)
+}
+
+// GetStringMap is wrapped for concurrent access
+func (c *safeConfig) GetStringMap(key string) map[string]interface{} {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetStringMap(key)
+}
+
+// GetStringMapString is wrapped for concurrent access
+func (c *safeConfig) GetStringMapString(key string) map[string]string {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetStringMapString(key)
+}
+
+// GetStringMapStringSlice is wrapped for concurrent access
+func (c *safeConfig) GetStringMapStringSlice(key string) map[string][]string {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetStringMapStringSlice(key)
+}
+
+// GetSizeInBytes is wrapped for concurrent access
+func (c *safeConfig) GetSizeInBytes(key string) uint {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetSizeInBytes(key)
+}
+
+// SetEnvPrefix is wrapped for concurrent access
+func (c *safeConfig) SetEnvPrefix(in string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetEnvPrefix(in)
+}
+
+// BindEnv is wrapped for concurrent access
+func (c *safeConfig) BindEnv(input ...string) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.BindEnv(input...)
+}
+
+// SetEnvKeyReplacer is wrapped for concurrent access
+func (c *safeConfig) SetEnvKeyReplacer(r *strings.Replacer) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetEnvKeyReplacer(r)
+}
+
+// UnmarshalKey is wrapped for concurrent access
+func (c *safeConfig) UnmarshalKey(key string, rawVal interface{}) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.UnmarshalKey(key, rawVal)
+}
+
+// Unmarshal is wrapped for concurrent access
+func (c *safeConfig) Unmarshal(rawVal interface{}) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.Unmarshal(rawVal)
+}
+
+// UnmarshalExact is wrapped for concurrent access
+func (c *safeConfig) UnmarshalExact(rawVal interface{}) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.UnmarshalExact(rawVal)
+}
+
+// ReadInConfig is wrapped for concurrent access
+func (c *safeConfig) ReadInConfig() error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.ReadInConfig()
+}
+
+// ReadConfig is wrapped for concurrent access
+func (c *safeConfig) ReadConfig(in io.Reader) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.ReadConfig(in)
+}
+
+// MergeConfig is wrapped for concurrent access
+func (c *safeConfig) MergeConfig(in io.Reader) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.MergeConfig(in)
+}
+
+// AllSettings is wrapped for concurrent access
+func (c *safeConfig) AllSettings() map[string]interface{} {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.AllSettings()
+}
+
+// AddConfigPath is wrapped for concurrent access
+func (c *safeConfig) AddConfigPath(in string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.AddConfigPath(in)
+}
+
+// SetConfigName is wrapped for concurrent access
+func (c *safeConfig) SetConfigName(in string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetConfigName(in)
+}
+
+// SetConfigFile is wrapped for concurrent access
+func (c *safeConfig) SetConfigFile(in string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetConfigFile(in)
+}
+
+// SetConfigType is wrapped for concurrent access
+func (c *safeConfig) SetConfigType(in string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetConfigType(in)
+}
+
+// ConfigFileUsed is wrapped for concurrent access
+func (c *safeConfig) ConfigFileUsed() string {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.ConfigFileUsed()
+}
+
+// BindPFlag is wrapped for concurrent access
+func (c *safeConfig) BindPFlag(key string, flag *pflag.Flag) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.BindPFlag(key, flag)
 }
 
 // NewConfig returns a new Config object.
-func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) *viper.Viper {
-	viper := viper.New()
-	viper.SetConfigName(name)
-	viper.SetEnvPrefix(envPrefix)
-	viper.SetEnvKeyReplacer(envKeyReplacer)
-	viper.SetTypeByDefaultValue(true)
-	return viper
+func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) Config {
+	config := safeConfig{
+		Viper: viper.New(),
+	}
+	config.SetConfigName(name)
+	config.SetEnvPrefix(envPrefix)
+	config.SetEnvKeyReplacer(envKeyReplacer)
+	config.SetTypeByDefaultValue(true)
+	return &config
 }

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrency(t *testing.T) {
+	config := safeConfig{
+		Viper: viper.New(),
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for n := 0; n <= 1000; n++ {
+			config.GetString("foo")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for n := 0; n <= 1000; n++ {
+			config.Set("foo", "bar")
+		}
+	}()
+
+	wg.Wait()
+	assert.Equal(t, config.GetString("foo"), "bar")
+}


### PR DESCRIPTION
### What does this PR do?

Wraps viper with a mutext to avoid concurrent read/write operation on underlying viper's maps.

Using Viper object directly is not thread safe (spf13/viper#482) both added tests fail if `viper` is used directly instead of `safeConfig`

### Motivation

Avoid `fatal error: concurrent map read and map write`
