### PR TITLE
Keep the cluster-agent auth token in cache

### DIFF
--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -9,16 +9,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
-	token        string
-	dcaToken     string
-	dcaTokenOnce sync.Once
+	token    string
+	dcaToken string
 )
 
 // SetAuthToken sets the session token
@@ -43,10 +40,15 @@ func GetAuthToken() string {
 // SetDCAAuthToken sets the session token for the Cluster Agent
 // Requires that the config has been set up before calling
 func SetDCAAuthToken() error {
-	dcaTokenOnce.Do(func() {
-		dcaToken = config.Datadog.GetString("cluster_agent.auth_token")
-	})
-	return nil
+	// Noop if dcaToken is already set
+	if dcaToken != "" {
+		return nil
+	}
+
+	// dcaToken is only set once, no need to mutex protect
+	var err error
+	dcaToken, err = security.GetClusterAgentAuthToken()
+	return err
 }
 
 // GetDCAAuthToken gets the session token


### PR DESCRIPTION
### What does this PR do?

`ValidateDCARequest` used to query the auto_token from viper for every request. This PR makes the token cached in the `util.dcaToken` package variable.

This can provide a significant speedup on heavy workloads.
