### PR TITLE
Enable add systemd flag to the centos build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,9 @@ run_test_rpm-x64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
   tags: [ "runner:main", "size:2xlarge" ]
   script:
-    - inv -e test --race --profile --cpus 4
+    # Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
+    #  https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46
+    - inv -e test --race --profile --cpus 4 --build-exclude=systemd
 
 # scan the dependencies for security vulnerabilities with snyk
 run_security_scan_test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,8 @@ run_test_rpm-x64:
   tags: [ "runner:main", "size:2xlarge" ]
   script:
     # Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
-    #  https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46
+    # https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46
+    # This is OK because the test on systemd still runs on the debian image above
     - inv -e test --race --profile --cpus 4 --build-exclude=systemd
 
 # scan the dependencies for security vulnerabilities with snyk

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -8,7 +8,7 @@ runs.
 
 Though you may install invoke in a variety of way we suggest you use
 the provided [requirements](https://github.com/DataDog/datadog-agent/blob/master/requirements.txt)
-file and `pip`: 
+file and `pip`:
 
 ```bash
 pip install -r requirements.txt
@@ -16,7 +16,7 @@ pip install -r requirements.txt
 
 This procedure ensures you not only get the correct version of invoke, but
 also any additional python dependencies our development workflow may require,
-at their expected versions. 
+at their expected versions.
 It will also pull other handy development tools/deps (reno, or docker).
 
 Tasks are usually parameterized and Invoke comes with some default values that
@@ -31,11 +31,11 @@ We don't want to pollute your system-wide python installation, so a python virtu
 environment is recommended (though optional). It will help keep an isolated development
 environment and ensure a clean system python.
 
-- Install the virtualenv module: 
+- Install the virtualenv module:
 ```pip install virtualenv```
-- Create the virtual environment: 
+- Create the virtual environment:
 ```virtualenv $GOPATH/src/github.com/DataDog/datadog-agent/venv```
-- Enable the virtual environment: 
+- Enable the virtual environment:
 ```source $GOPATH/src/github.com/DataDog/datadog-agent/venv/bin/activate```
 
 
@@ -151,9 +151,14 @@ setup efforts altogether.
 
 The agent is able to collect systemd journal logs using a wrapper on the systemd utility library.
 
-On Linux:
+On Ubuntu/Debian:
 ```
 sudo apt-get install libsystemd-dev
+```
+
+On Redhat/CentOS:
+```
+sudo yum install systemd-devel
 ```
 
 ## Docker

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, DEBIAN_ONLY_TAGS
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, CENTOS_AND_DEBIAN_ONLY_TAGS
 from .go import deps
 
 # constants
@@ -65,8 +65,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     # remove all tags that are only available on debian distributions
     distname = platform.linux_distribution()[0].lower()
-    if distname not in ['debian', 'ubuntu']:
-        for ex in DEBIAN_ONLY_TAGS:
+    if distname not in ['debian', 'ubuntu', 'centos']:
+        for ex in CENTOS_AND_DEBIAN_ONLY_TAGS:
             if ex not in build_exclude:
                 build_exclude.append(ex)
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, CENTOS_AND_DEBIAN_ONLY_TAGS
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, REDHAT_AND_DEBIAN_ONLY_TAGS, REDHAT_AND_DEBIAN_DIST
 from .go import deps
 
 # constants
@@ -65,8 +65,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     # remove all tags that are only available on debian distributions
     distname = platform.linux_distribution()[0].lower()
-    if distname not in ['debian', 'ubuntu', 'centos']:
-        for ex in CENTOS_AND_DEBIAN_ONLY_TAGS:
+    if distname not in REDHAT_AND_DEBIAN_DIST:
+        for ex in REDHAT_AND_DEBIAN_ONLY_TAGS:
             if ex not in build_exclude:
                 build_exclude.append(ex)
 

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -16,7 +16,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, DEBIAN_ONLY_TAGS
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, CENTOS_AND_DEBIAN_ONLY_TAGS
 from .go import deps
 
 # constants
@@ -41,7 +41,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     the values from `invoke.yaml` will be used.
 
     Example invokation:
-        inv android.build 
+        inv android.build
     """
     # ensure BIN_PATH exists
     if not os.path.exists(BIN_PATH):
@@ -62,8 +62,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     # remove all tags that are only available on debian distributions
     distname = platform.linux_distribution()[0].lower()
-    if distname not in ['debian', 'ubuntu']:
-        for ex in DEBIAN_ONLY_TAGS:
+    if distname not in ['debian', 'ubuntu', 'centos']:
+        for ex in CENTOS_AND_DEBIAN_ONLY_TAGS:
             if ex not in build_exclude:
                 build_exclude.append(ex)
 
@@ -163,11 +163,11 @@ def launchservice(ctx, api_key, hostname=None, tags=None):
     if api_key is None:
         print("must supply api key")
         return
-    
+
     if hostname is None:
         print("Setting hostname to android-tablet")
         hostname="android-tablet"
-    
+
     if tags is None:
         print("Setting tags to owner:db,env:local,role:windows")
         tags="owner:db,env:local,role:windows"
@@ -175,7 +175,7 @@ def launchservice(ctx, api_key, hostname=None, tags=None):
     cmd = "adb shell am startservice --es api_key {} --es hostname {} --es tags {} org.datadog.agent/.DDService".format(api_key, hostname, tags)
     ctx.run(cmd)
 
-@task   
+@task
 def stopservice(ctx):
     cmd = "adb shell am force-stop org.datadog.agent"
     ctx.run(cmd)

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -16,7 +16,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, CENTOS_AND_DEBIAN_ONLY_TAGS
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, REDHAT_AND_DEBIAN_ONLY_TAGS, REDHAT_AND_DEBIAN_DIST
 from .go import deps
 
 # constants
@@ -62,8 +62,8 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     # remove all tags that are only available on debian distributions
     distname = platform.linux_distribution()[0].lower()
-    if distname not in ['debian', 'ubuntu', 'centos']:
-        for ex in CENTOS_AND_DEBIAN_ONLY_TAGS:
+    if distname not in REDHAT_AND_DEBIAN_DIST:
+        for ex in REDHAT_AND_DEBIAN_ONLY_TAGS:
             if ex not in build_exclude:
                 build_exclude.append(ex)
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -37,9 +37,16 @@ LINUX_ONLY_TAGS = [
     "kubeapiserver",
 ]
 
-CENTOS_AND_DEBIAN_ONLY_TAGS = [
+REDHAT_AND_DEBIAN_ONLY_TAGS = [
     "systemd",
 ]
+
+REDHAT_AND_DEBIAN_DIST = [
+    'debian',
+    'ubuntu',
+    'centos',
+    'redhat'
+    ]
 
 
 def get_default_build_tags(puppy=False):
@@ -57,8 +64,8 @@ def get_default_build_tags(puppy=False):
 
     # remove all tags that are only available on debian distributions
     distname = platform.linux_distribution()[0].lower()
-    if distname not in ['debian', 'ubuntu', 'centos']:
-        exclude = exclude + CENTOS_AND_DEBIAN_ONLY_TAGS
+    if distname not in REDHAT_AND_DEBIAN_DIST:
+        exclude = exclude + REDHAT_AND_DEBIAN_ONLY_TAGS
 
     return get_build_tags(include, exclude)
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -37,7 +37,7 @@ LINUX_ONLY_TAGS = [
     "kubeapiserver",
 ]
 
-DEBIAN_ONLY_TAGS = [
+CENTOS_AND_DEBIAN_ONLY_TAGS = [
     "systemd",
 ]
 
@@ -57,8 +57,8 @@ def get_default_build_tags(puppy=False):
 
     # remove all tags that are only available on debian distributions
     distname = platform.linux_distribution()[0].lower()
-    if distname not in ['debian', 'ubuntu']:
-        exclude = exclude + DEBIAN_ONLY_TAGS
+    if distname not in ['debian', 'ubuntu', 'centos']:
+        exclude = exclude + CENTOS_AND_DEBIAN_ONLY_TAGS
 
     return get_build_tags(include, exclude)
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -46,7 +46,7 @@ REDHAT_AND_DEBIAN_DIST = [
     'ubuntu',
     'centos',
     'redhat'
-    ]
+]
 
 
 def get_default_build_tags(puppy=False):

--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, DEBIAN_ONLY_TAGS
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, CENTOS_AND_DEBIAN_ONLY_TAGS
 from .go import deps
 
 # constants

--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -15,7 +15,7 @@ from invoke.exceptions import Exit
 
 from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
 from .utils import REPO_PATH
-from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, CENTOS_AND_DEBIAN_ONLY_TAGS
+from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, REDHAT_AND_DEBIAN_ONLY_TAGS, REDHAT_AND_DEBIAN_DIST
 from .go import deps
 
 # constants


### PR DESCRIPTION
### What does this PR do?

This PR enables systemd build on the default source build of Centos

### Motivation

We want to enable the journald integration on Centos 7. For this, we need to enable the build flag systemd on Centos


### Note: 

The build succeeded https://gitlab.ddbuild.io/DataDog/datadog-agent/pipelines/715202
And the binary worked on 
- Centos 6
- Centos 7 (with systemd)
- Amazon Linux 
- Amazon Linux 2 (with systemd)


![image](https://user-images.githubusercontent.com/6985756/46364108-1aeccd00-c675-11e8-8485-b6fc49ec3131.png)
It worked on the image built by https://github.com/DataDog/datadog-agent-builders/pull/68