### PR TITLE
Drop empty messages after parsing in the decoder

### DIFF
--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -93,6 +93,9 @@ func (h *SingleLineHandler) process(line []byte) {
 			log.Warn(err)
 			return
 		}
+		if len(output.Content) == 0 {
+			return
+		}
 		output.RawDataLen = lineLen + 1
 		h.outputChan <- output
 	} else {
@@ -101,6 +104,9 @@ func (h *SingleLineHandler) process(line []byte) {
 		output, err := h.parser.Parse(content)
 		if err != nil {
 			log.Warn(err)
+			return
+		}
+		if len(output.Content) == 0 {
 			return
 		}
 		output.RawDataLen = lineLen
@@ -217,6 +223,9 @@ func (h *MultiLineHandler) sendContent() {
 		output, err := h.parser.Parse(content)
 		if err != nil {
 			log.Warn(err)
+			return
+		}
+		if len(output.Content) == 0 {
 			return
 		}
 		output.RawDataLen = rawDataLen

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -93,11 +93,10 @@ func (h *SingleLineHandler) process(line []byte) {
 			log.Warn(err)
 			return
 		}
-		if len(output.Content) == 0 {
-			return
+		if len(output.Content) > 0 {
+			output.RawDataLen = lineLen + 1
+			h.outputChan <- output
 		}
-		output.RawDataLen = lineLen + 1
-		h.outputChan <- output
 	} else {
 		// add TRUNCATED at the end of content and send it
 		content := append(content, TRUNCATED...)
@@ -106,12 +105,11 @@ func (h *SingleLineHandler) process(line []byte) {
 			log.Warn(err)
 			return
 		}
-		if len(output.Content) == 0 {
-			return
+		if len(output.Content) > 0 {
+			output.RawDataLen = lineLen
+			h.outputChan <- output
+			h.shouldTruncate = true
 		}
-		output.RawDataLen = lineLen
-		h.outputChan <- output
-		h.shouldTruncate = true
 	}
 }
 
@@ -225,10 +223,9 @@ func (h *MultiLineHandler) sendContent() {
 			log.Warn(err)
 			return
 		}
-		if len(output.Content) == 0 {
-			return
+		if len(output.Content) > 0 {
+			output.RawDataLen = rawDataLen
+			h.outputChan <- output
 		}
-		output.RawDataLen = rawDataLen
-		h.outputChan <- output
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR drops logs that are empty after parsing

### Motivation

We don't check if messages are empty after parsing so we still ingest empty logs 

