### PR TITLE
Check if the service is not nil, to fix potential race

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -556,7 +556,12 @@ func (ac *AutoConfig) resolveTemplate(tpl integration.Config) []integration.Conf
 		}
 
 		for serviceID := range serviceIds {
-			resolvedConfig, err := ac.resolveTemplateForService(tpl, ac.store.getServiceForEntity(serviceID))
+			svc := ac.store.getServiceForEntity(serviceID)
+			if svc == nil {
+				log.Warnf("Service %s was removed before we could resolve its config", serviceID)
+				continue
+			}
+			resolvedConfig, err := ac.resolveTemplateForService(tpl, svc)
 			if err != nil {
 				continue
 			}

--- a/releasenotes/notes/fix-race-ad-8336484e2cd1b6ce.yaml
+++ b/releasenotes/notes/fix-race-ad-8336484e2cd1b6ce.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a potential race in the autodiscovery where a service would be removed before
+    its config could be resolved (causing the agent to crash)


### PR DESCRIPTION
### What does this PR do?

Add a safety check to avoid sending `nil` service to the config resolver if it has been removed in between

### Motivation

Fix a `panic: runtime error: invalid memory address or nil pointer dereference` in the config resolver.
