### PR TITLE
Cache leader URL for clustercheck requests

### DIFF
--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -45,6 +45,7 @@ type DCAClient struct {
 	ClusterAgentAPIEndpoint       string // ${SCHEME}://${clusterAgentHost}:${PORT}
 	clusterAgentAPIClient         *http.Client
 	clusterAgentAPIRequestHeaders http.Header
+	leaderClient                  *leaderClient
 }
 
 // resetGlobalClusterAgentClient is a helper to remove the current DCAClient global
@@ -91,6 +92,9 @@ func (c *DCAClient) init() error {
 	// TODO remove insecure
 	c.clusterAgentAPIClient = util.GetClient(false)
 	c.clusterAgentAPIClient.Timeout = 2 * time.Second
+
+	// Clone the http client in a new client with built-in redirect handler
+	c.leaderClient = newLeaderClient(c.clusterAgentAPIClient, c.ClusterAgentAPIEndpoint)
 
 	return nil
 }

--- a/pkg/util/clusteragent/clusterchecks_test.go
+++ b/pkg/util/clusteragent/clusterchecks_test.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package clusteragent
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+var dummyStatusResponse = `{"isuptodate": true}`
+
+var dummyConfigs = `{
+"last_change": 42,
+"configs": [
+  {
+    "check_name": "one"
+  },
+  {
+    "check_name": "two"
+  }
+]
+}`
+
+func (suite *clusterAgentSuite) TestClusterChecksNominal() {
+	dca, err := newDummyClusterAgent()
+	require.NoError(suite.T(), err)
+
+	dca.rawResponses["/api/v1/clusterchecks/status/mynode"] = dummyStatusResponse
+	dca.rawResponses["/api/v1/clusterchecks/configs/mynode"] = dummyConfigs
+
+	ts, p, err := dca.StartTLS()
+	defer ts.Close()
+	require.NoError(suite.T(), err)
+	config.Datadog.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
+
+	ca, err := GetClusterAgentClient()
+	require.NoError(suite.T(), err)
+
+	response, err := ca.PostClusterCheckStatus("mynode", types.NodeStatus{})
+	require.NoError(suite.T(), err)
+	assert.True(suite.T(), response.IsUpToDate)
+
+	configs, err := ca.GetClusterCheckConfigs("mynode")
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), int64(42), configs.LastChange)
+	require.Len(suite.T(), configs.Configs, 2)
+	assert.Equal(suite.T(), "one", configs.Configs[0].Name)
+	assert.Equal(suite.T(), "two", configs.Configs[1].Name)
+}
+
+func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
+	// Leader starts first
+	leader, err := newDummyClusterAgent()
+	require.NoError(suite.T(), err)
+	leader.rawResponses["/api/v1/clusterchecks/status/mynode"] = `{"isuptodate": true}`
+	leader.rawResponses["/api/v1/clusterchecks/configs/mynode"] = dummyConfigs
+	ts, p, err := leader.StartTLS()
+	defer ts.Close()
+	require.NoError(suite.T(), err)
+
+	// Follower redirects to the leader
+	follower, err := newDummyClusterAgent()
+	require.NoError(suite.T(), err)
+	follower.redirectURL = fmt.Sprintf("https://127.0.0.1:%d", p)
+	follower.rawResponses["/api/v1/clusterchecks/status/mynode"] = `{"isuptodate": false}`
+	follower.rawResponses["/api/v1/clusterchecks/configs/mynode"] = dummyConfigs
+	ts, p, err = follower.StartTLS()
+	defer ts.Close()
+	require.NoError(suite.T(), err)
+
+	// Make sure both DCAs have the same token
+	assert.Equal(suite.T(), follower.token, leader.token)
+
+	// Client will start at the follower
+	config.Datadog.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
+	ca, err := GetClusterAgentClient()
+	require.NoError(suite.T(), err)
+
+	// First request will be redirected
+	response, err := ca.PostClusterCheckStatus("mynode", types.NodeStatus{})
+	require.NoError(suite.T(), err)
+	assert.True(suite.T(), response.IsUpToDate)
+
+	assert.NotNil(suite.T(), follower.PopRequest(), "request did no go through follower")
+	assert.NotNil(suite.T(), leader.PopRequest(), "request did no reach leader")
+
+	// Subsequent requests will bypass the follower
+	configs, err := ca.GetClusterCheckConfigs("mynode")
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), int64(42), configs.LastChange)
+	require.Len(suite.T(), configs.Configs, 2)
+	assert.Equal(suite.T(), "one", configs.Configs[0].Name)
+	assert.Equal(suite.T(), "two", configs.Configs[1].Name)
+
+	assert.Nil(suite.T(), follower.PopRequest(), "request reached follower")
+	assert.NotNil(suite.T(), leader.PopRequest(), "request did no reach leader")
+
+	// Make leader fail, request will be retried on the main URL,
+	// and succeed on the new leader
+	leader.Lock()
+	delete(leader.rawResponses, "/api/v1/clusterchecks/status/mynode")
+	leader.Unlock()
+	follower.Lock()
+	follower.redirectURL = ""
+	follower.Unlock()
+
+	response, err = ca.PostClusterCheckStatus("mynode", types.NodeStatus{})
+	require.NoError(suite.T(), err, "request should not fail")
+	assert.False(suite.T(), response.IsUpToDate)
+	assert.NotNil(suite.T(), leader.PopRequest(), "request did no reach leader")
+	assert.NotNil(suite.T(), follower.PopRequest(), "request did not reach follower")
+}

--- a/pkg/util/clusteragent/leader_client.go
+++ b/pkg/util/clusteragent/leader_client.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package clusteragent
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// leaderClient is used to keep track of the leading cluster-agent
+// to preferentially direct requests to it.
+// Test coverage is ensured by TestClusterChecksRedirect
+type leaderClient struct {
+	http.Client
+	m          sync.Mutex
+	serviceURL string // Common URL to fallback to
+	leaderURL  string // Current leader URL
+}
+
+func newLeaderClient(mainClient *http.Client, serviceURL string) *leaderClient {
+	l := &leaderClient{
+		Client:     *mainClient,
+		serviceURL: serviceURL,
+	}
+	l.CheckRedirect = l.redirected
+	return l
+}
+
+// getBaseURL returns the url to query: the last known url
+// of the leader, or the main url if not known
+func (l *leaderClient) getBaseURL() string {
+	l.m.Lock()
+	defer l.m.Unlock()
+
+	if l.leaderURL == "" {
+		return l.serviceURL
+	}
+	return l.leaderURL
+}
+
+// hasLeader returns true if a leader is in cache,
+// false if requests will go through the service
+func (l *leaderClient) hasLeader() bool {
+	l.m.Lock()
+	defer l.m.Unlock()
+	return l.leaderURL != ""
+}
+
+// buildURL is a convenience method to create a full url by
+// adding path parts to the base url
+func (l *leaderClient) buildURL(parts ...string) string {
+	urlParts := []string{l.getBaseURL()}
+	urlParts = append(urlParts, parts...)
+
+	return strings.Join(urlParts, "/")
+}
+
+// resetURL has to be called on errors to fallback
+// to the serviceURL when the leader churns away.
+func (l *leaderClient) resetURL() {
+	l.m.Lock()
+	defer l.m.Unlock()
+	l.leaderURL = ""
+}
+
+// redirected is passed to the http client to cache leader
+// redirections for future queries.
+func (l *leaderClient) redirected(req *http.Request, via []*http.Request) error {
+	// Copy of default behaviour to avoid infinite redirects
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+
+	// Continue passing the bearer token in headers
+	if len(via) == 0 {
+		return errors.New("cannot find previous request")
+	}
+	req.Header = via[0].Header
+
+	// Cache the target host for future requests
+	l.m.Lock()
+	defer l.m.Unlock()
+	newURL := &url.URL{
+		Scheme: req.URL.Scheme,
+		Host:   req.URL.Host,
+	}
+	l.leaderURL = newURL.String()
+
+	return nil
+}


### PR DESCRIPTION
Patch the node-agent's  clusteragent client class to support clustercheck requests being redirected from follower cluster-agents to the current leader.

The desired logic is, as described in the RFC:
  - agent requests the load-balanced service
  - if request reaches a follower, it will reply with a 302 redirect to the leader (to be implemented)
  - agent keeps this url in memory for future requests
  - if a request to the leader fails, the agent fall-backs to the service URL, to find the new leader 

Detecting requests is done via the `CheckRedirect` callback of a custom `http.Client`. We're calling it `leaderClient`.

Unit test coverage is achieved with two `dummyClusterAgent` instances.