### PR TITLE
logs: allow logs-agent to be restarted

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/input/journald"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/listener"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/windowsevent"
-	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
@@ -40,12 +39,11 @@ type Agent struct {
 // NewAgent returns a new Agent
 func NewAgent(sources *config.LogSources, services *service.Services, endpoints *config.Endpoints) *Agent {
 	// setup the auditor
-	messageChan := make(chan *message.Message, config.ChanSize)
-	auditor := auditor.New(messageChan, config.LogsAgent.GetString("logs_config.run_path"))
+	auditor := auditor.New(config.LogsAgent.GetString("logs_config.run_path"))
 	destinationsCtx := sender.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, messageChan, endpoints, destinationsCtx)
+	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, endpoints, destinationsCtx)
 
 	// setup the inputs
 	inputs := []restart.Restartable{

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -81,6 +81,10 @@ func (suite *AgentTestSuite) TestAgent() {
 	// Give the tailer some time to start its job.
 	time.Sleep(10 * time.Millisecond)
 	agent.Stop()
+
+	// Validate that we can restart it without obvious breakages.
+	agent.Start()
+	agent.Stop()
 }
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -12,9 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
-	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
 var testpath = "testpath"
@@ -25,7 +26,6 @@ type AuditorTestSuite struct {
 	testPath string
 	testFile *os.File
 
-	inputChan chan *message.Message
 	a         *Auditor
 	source    *config.LogSource
 }
@@ -41,14 +41,21 @@ func (suite *AuditorTestSuite) SetupTest() {
 	_, err = os.Create(suite.testPath)
 	suite.Nil(err)
 
-	suite.inputChan = make(chan *message.Message)
-	suite.a = New(suite.inputChan, "")
+	suite.a = New("")
 	suite.a.registryPath = suite.testPath
 	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})
 }
 
 func (suite *AuditorTestSuite) TearDownTest() {
 	os.Remove(suite.testDir)
+}
+
+func (suite *AuditorTestSuite) TestAuditorStartStop() {
+	assert.Nil(suite.T(), suite.a.Channel())
+	suite.a.Start()
+	assert.NotNil(suite.T(), suite.a.Channel())
+	suite.a.Stop()
+	assert.Nil(suite.T(), suite.a.Channel())
 }
 
 func (suite *AuditorTestSuite) TestAuditorUpdatesRegistry() {

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -26,8 +26,8 @@ type AuditorTestSuite struct {
 	testPath string
 	testFile *os.File
 
-	a         *Auditor
-	source    *config.LogSource
+	a      *Auditor
+	source *config.LogSource
 }
 
 func (suite *AuditorTestSuite) SetupTest() {

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -38,7 +38,7 @@ type provider struct {
 func NewProvider(numberOfPipelines int, auditor *auditor.Auditor, endpoints *config.Endpoints, destinationsContext *sender.DestinationsContext) Provider {
 	return &provider{
 		numberOfPipelines:   numberOfPipelines,
-		auditor:          auditor,
+		auditor:             auditor,
 		endpoints:           endpoints,
 		pipelines:           []*Pipeline{},
 		destinationsContext: destinationsContext,

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -10,23 +10,28 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
 type ProviderTestSuite struct {
 	suite.Suite
 	p *provider
+	a *auditor.Auditor
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
+	suite.a = auditor.New("")
 	suite.p = &provider{
 		numberOfPipelines: 3,
+		auditor:           suite.a,
 		pipelines:         []*Pipeline{},
 		endpoints:         config.NewEndpoints(config.Endpoint{}, nil),
 	}
 }
 
 func (suite *ProviderTestSuite) TestProvider() {
+	suite.a.Start()
 	suite.p.Start()
 	suite.Equal(int32(0), suite.p.currentPipelineIndex)
 	suite.Equal(3, len(suite.p.pipelines))
@@ -43,6 +48,7 @@ func (suite *ProviderTestSuite) TestProvider() {
 	suite.Equal(int32(1), suite.p.currentPipelineIndex)
 
 	suite.p.Stop()
+	suite.a.Stop()
 	suite.Nil(suite.p.NextPipelineChan())
 }
 


### PR DESCRIPTION
Avoid a new leaks on Stop() and make sure that we can restart
the agent at least in the unit tests. It's likely to still be broken
for a few inputs but it's a good first step.
