### PR TITLE
Add option to enable protobuf apiserver communications

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,6 +218,7 @@ func init() {
 	BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
+	BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 
 	// Kube ApiServer
 	BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,7 @@ func init() {
 	BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
-	BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
+	BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", true)
 
 	// Kube ApiServer
 	BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,7 @@ func init() {
 	BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
 	BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
-	BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", true)
+	BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 
 	// Kube ApiServer
 	BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -494,7 +494,7 @@ api_key:
 #
 {{ end -}}
 {{- if .ECS }}
-# ECS integration 
+# ECS integration
 #
 # The ECS agent container should be autodetected when running with the
 # default (ecs-agent) name. Else, you can change the container name the
@@ -536,6 +536,11 @@ api_key:
 # see https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
 #
 # kubernetes_kubeconfig_path: /path/to/file
+#
+# By default, communication with the apiserver is in json format. Setting the following
+# option to true will allow communication in the binary protobuf format, with a potential
+# performance improvement on both the agent and the apiserver.
+# kubernetes_apiserver_use_protobuf: false
 #
 # In order to collect Kubernetes service names, the agent needs certain rights (see RBAC documentation in
 # [docker readme](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#kubernetes)).

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -99,6 +99,10 @@ func getKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 		}
 	}
 	clientConfig.Timeout = timeout
+
+	if config.Datadog.GetBool("kubernetes_apiserver_use_protobuf") {
+		clientConfig.ContentType = "application/vnd.kubernetes.protobuf"
+	}
 	return kubernetes.NewForConfig(clientConfig)
 }
 

--- a/releasenotes/notes/kubernetes_apiserver_use_protobuf-8caae51d5372c5e3.yaml
+++ b/releasenotes/notes/kubernetes_apiserver_use_protobuf-8caae51d5372c5e3.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add an option to enable protobuf communication with the Kubernetes apiserver


### PR DESCRIPTION
### What does this PR do?

By default, communication with the apiserver is in json format. Adding the `kubernetes_apiserver_use_protobuf` option to allow communication in the binary protobuf format, with a potential performance improvement on both the agent and the apiserver.
We'll disable it by default for 6.6, to ensure stability.

Running the kube_apiserver integration test's performance is improved, we should measure it on a live system though:
- 8837.63kB heap allocations -> 4340.52kB
- 25.77s go cpu time -> 22.65s

I'm running a gitlab pipeline with the default set to `true` to ensure e2e passes with it.