### PR TITLE
push datadog/cluster-agent-dev:master for every build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -870,7 +870,6 @@ dca_dev_branch_docker_hub:
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
-  <<: *run_when_triggered_on_nightly
   variables:
     <<: *docker_hub_variables
   script:


### PR DESCRIPTION
### What does this PR do?

Push the `datadog/cluster-agent-dev:master` image to docker hub for every pipeline, instead of only nightlies, as it is done with the other images.

### Motivation

Fresher images for testing
