### PR TITLE
Fix DCA version in status

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -66,7 +66,7 @@ func stopAgent(w http.ResponseWriter, r *http.Request) {
 
 func getVersion(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	av, err := version.New(version.DCAVersion, version.Commit)
+	av, err := version.New(version.AgentVersion, version.Commit)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), 500)
 		return

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -62,7 +62,7 @@ metadata for their metrics.`,
 			if flagNoColor {
 				color.NoColor = true
 			}
-			av, _ := version.New(version.DCAVersion, version.Commit)
+			av, _ := version.New(version.AgentVersion, version.Commit)
 			meta := ""
 			if av.Meta != "" {
 				meta = fmt.Sprintf("- Meta: %s ", color.YellowString(av.Meta))
@@ -145,7 +145,7 @@ func start(cmd *cobra.Command, args []string) error {
 	s := serializer.NewSerializer(f)
 
 	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster_agent")
-	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.DCAVersion))
+	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.AgentVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -122,7 +122,7 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	}
 	stats["config"] = getDCAPartialConfig()
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
-	stats["version"] = version.DCAVersion
+	stats["version"] = version.AgentVersion
 	stats["pid"] = os.Getpid()
 	hostname, err := util.GetHostname()
 	if err != nil {

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -10,20 +10,13 @@ package version
 // AgentVersion contains the version of the Agent
 var AgentVersion string
 
-// DCAVersion contains the version of the Datatog Cluster Agent
-var DCAVersion string
-
 // Commit is populated with the short commit hash from which the Agent was built
 var Commit string
 
 var agentVersionDefault = "6.0.0"
-var clusterAgentVersionDefault = "1.0.0"
 
 func init() {
 	if AgentVersion == "" {
 		AgentVersion = agentVersionDefault
-	}
-	if DCAVersion == "" {
-		DCAVersion = clusterAgentVersionDefault
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Make `cluster-agent version` and `cluster-agent status` show a relevant version, instead of the hardcoded `1.0.0`.

I'm doing this by removing the hardcoded `version.DCAVersion` and using the same `version.AgentVersion` the agent is using. As the version is set at compile time, there is no need to keep duplicate logics.

### Motivation

Make flares show the correct version

### Additional Notes

Latest tag in the git history is parsed by invoke to get the version. `master` currently shows `v6.5.0+git.70.4ef73e5` as the latest tag on `master` is `6.5.0`.

One can test with a local tag: `git tag dca-1.2.3` before building. Status will show
```
==============================
Datadog Cluster Agent (v1.2.3)
==============================
```

[The current invoke logic](https://github.com/DataDog/datadog-agent/blob/846a2be09088c61f699a8851bb421e94c29b33a7/tasks/utils.py#L151-L156) strips `dca-` if present at the start of the tag. If we want tags to be `cluster-agent-x.y.z` we'll need to update it.