### PR TITLE
logs: add more instrumentation to the log-agent

### DIFF
--- a/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/cmd/agent/dist/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -144,3 +144,15 @@ instances:
         type: rate
       - path: splitter/PayloadDrops
         type: rate
+
+      # datadog-agent logs-agent monitoring
+      - path: logs-agent/IsRunning
+        type: gauge
+      - path: logs-agent/DestinationErrors
+        type: rate
+      - path: logs-agent/LogsDecoded
+        type: rate
+      - path: logs-agent/LogsProcessed
+        type: rate
+      - path: logs-agent/LogsSent
+        type: rate

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -41,10 +41,12 @@ type Agent struct {
 
 // NewAgent returns a new Agent
 func NewAgent(sources *config.LogSources, services *service.Services, endpoints *config.Endpoints) *Agent {
-	h := health.Register("logs-agent")
+	health := health.Register("logs-agent")
 
 	// setup the auditor
-	auditor := auditor.New(config.LogsAgent.GetString("logs_config.run_path"), h)
+	// We pass the health handle to the auditor because it's the end of the pipeline and the most
+	// critical part. Arguably it could also be plugged to the destination.
+	auditor := auditor.New(config.LogsAgent.GetString("logs_config.run_path"), health)
 	destinationsCtx := sender.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender
@@ -64,7 +66,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, endpoints 
 		destinationsCtx:  destinationsCtx,
 		pipelineProvider: pipelineProvider,
 		inputs:           inputs,
-		health:           h,
+		health:           health,
 	}
 }
 

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
@@ -41,7 +43,7 @@ func (suite *AuditorTestSuite) SetupTest() {
 	_, err = os.Create(suite.testPath)
 	suite.Nil(err)
 
-	suite.a = New("")
+	suite.a = New("", health.Register("fake"))
 	suite.a.registryPath = suite.testPath
 	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})
 }

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -22,7 +22,6 @@ var (
 	LogsSent = expvar.Int{}
 	// DestinationErrors is the total number of network errors.
 	DestinationErrors = expvar.Int{}
-	// TODO: Would be nice to also have these per-destination.
 )
 
 func init() {

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -13,19 +13,21 @@ import (
 )
 
 var (
-	logsExpvars    *expvar.Map
-	agentWarnings  = expvar.String{}
-	agentIsRunning = expvar.Int{}
+	logsExpvars *expvar.Map
+	// LogsDecoded is the total number of decoded logs
+	LogsDecoded = expvar.Int{}
 	// LogsProcessed is the total number of processed logs.
 	LogsProcessed = expvar.Int{}
 	// LogsSent is the total number of sent logs.
 	LogsSent = expvar.Int{}
 	// DestinationErrors is the total number of network errors.
 	DestinationErrors = expvar.Int{}
+	// TODO: Add LogsCollected for the total number of collected logs.
 )
 
 func init() {
 	logsExpvars = expvar.NewMap("logs-agent")
+	logsExpvars.Set("LogsDecoded", &LogsDecoded)
 	logsExpvars.Set("LogsProcessed", &LogsProcessed)
 	logsExpvars.Set("LogsSent", &LogsSent)
 	logsExpvars.Set("DestinationErrors", &DestinationErrors)

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package metrics
+
+import (
+	"expvar"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/status"
+)
+
+var (
+	logsExpvars    *expvar.Map
+	agentWarnings  = expvar.String{}
+	agentIsRunning = expvar.Int{}
+	// LogsProcessed is the total number of processed logs.
+	LogsProcessed = expvar.Int{}
+	// LogsSent is the total number of sent logs.
+	LogsSent = expvar.Int{}
+	// DestinationErrors is the total number of network errors.
+	DestinationErrors = expvar.Int{}
+	// TODO: Would be nice to also have these per-destination.
+)
+
+func init() {
+	logsExpvars = expvar.NewMap("logs-agent")
+	logsExpvars.Set("LogsProcessed", &LogsProcessed)
+	logsExpvars.Set("LogsSent", &LogsSent)
+	logsExpvars.Set("DestinationErrors", &DestinationErrors)
+	logsExpvars.Set("Warnings", expvar.Func(func() interface{} {
+		return strings.Join(status.Get().Messages, ", ")
+	}))
+	logsExpvars.Set("IsRunning", expvar.Func(func() interface{} {
+		return status.Get().IsRunning
+	}))
+}

--- a/pkg/logs/metrics/metrics_test.go
+++ b/pkg/logs/metrics/metrics_test.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetrics(t *testing.T) {
+	assert.Equal(t, logsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`)
+}

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 )
@@ -21,7 +23,7 @@ type ProviderTestSuite struct {
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
-	suite.a = auditor.New("")
+	suite.a = auditor.New("", health.Register("fake"))
 	suite.p = &provider{
 		numberOfPipelines: 3,
 		auditor:           suite.a,

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -50,6 +50,7 @@ func (p *Processor) run() {
 		p.done <- struct{}{}
 	}()
 	for msg := range p.inputChan {
+		metrics.LogsDecoded.Add(1)
 		if shouldProcess, redactedMsg := applyRedactingRules(msg); shouldProcess {
 			metrics.LogsProcessed.Add(1)
 

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // A Processor updates messages from an inputChan and pushes
@@ -50,6 +51,8 @@ func (p *Processor) run() {
 	}()
 	for msg := range p.inputChan {
 		if shouldProcess, redactedMsg := applyRedactingRules(msg); shouldProcess {
+			metrics.LogsProcessed.Add(1)
+
 			// Encode the message to its final format
 			content, err := p.encoder.encode(msg, redactedMsg)
 			if err != nil {

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -7,7 +7,9 @@ package sender
 
 import (
 	"context"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // Sender is responsible for sending logs to different destinations.
@@ -68,6 +70,7 @@ func (s *Sender) send(payload *message.Message) {
 				// drop the message
 				break
 			default:
+				metrics.DestinationErrors.Add(1)
 				// retry as the error can be related to network issues
 				continue
 			}
@@ -80,6 +83,8 @@ func (s *Sender) send(payload *message.Message) {
 			// destinations.
 			destination.Send(payload)
 		}
+
+		metrics.LogsSent.Add(1)
 		break
 	}
 	s.outputChan <- payload

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -60,12 +60,14 @@ func (s *Sender) send(payload *message.Message) {
 		err := s.destinations.Main.Send(payload)
 		if err != nil {
 			if err == context.Canceled {
+				metrics.DestinationErrors.Add(1)
 				// the context was cancelled, agent is stopping non-gracefully.
 				// drop the message
 				break
 			}
 			switch err.(type) {
 			case *FramingError:
+				metrics.DestinationErrors.Add(1)
 				// the message can not be framed properly,
 				// drop the message
 				break

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -56,6 +56,11 @@ func Clear() {
 
 // Get returns the status of the logs-agent computed on the fly.
 func Get() Status {
+	if builder == nil {
+		return Status{
+			IsRunning: false,
+		}
+	}
 	// Sort sources by name (ie. by integration name ~= file name)
 	sources := make(map[string][]*config.LogSource)
 	for _, source := range builder.sources.GetSources() {


### PR DESCRIPTION
### What does this PR do?

> The shoemaker always wears the worst shoes

Currently we are mostly blind appart from logs when we want to observe and measure the behaviors of the log agent. This adds two things:
* very basic metrics with `expvar`, this is consistent with the other critical parts of the agent
* a simple health check plugged to the auditor

### Motivation

I want to be able to observe at least our fleet of agents.

### Additional Notes

`curl http://localhost:5000/debug/vars`
```
...
"logs-agent": {"DestinationErrors": 0, "IsRunning": true, "LogsProcessed": 246, "LogsSent": 246, "Status": ""},
...
```

`$ ./bin/agent/agent -c ./bin/agent/dist/datadog-dev.yaml health`
```
Agent health: PASS
=== 11 healthy components ===
ad-configpolling, ad-servicelistening, aggregator, collector-queue, dogstatsd-main, forwarder, healthcheck, logs-agent, metadata-agent_checks, metadata-host, tagger
```