### PR TITLE
[install scripts] Add support of DD_SITE

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -25,6 +25,10 @@ if [ -n "$DD_API_KEY" ]; then
     apikey=$DD_API_KEY
 fi
 
+if [ -n "$DD_SITE" ]; then
+    site=$DD_SITE
+fi
+
 if [ $dd_upgrade ]; then
     if [ ! -f /opt/datadog-agent/etc/datadog.conf ]; then
         printf "\033[31mDD_UPGRADE set but no config was found at /opt/datadog-agent/etc/datadog.conf.\033[0m\n"
@@ -72,6 +76,7 @@ function new_config() {
     i_cmd="-i ''"
     if [ $(sed --version 2>/dev/null | grep -c "GNU") -ne 0 ]; then i_cmd="-i"; fi
     $sudo_cmd sh -c "sed $i_cmd 's/api_key:.*/api_key: $apikey/' \"/opt/datadog-agent/etc/datadog.yaml\""
+    $sudo_cmd sh -c "sed $i_cmd 's/# site:.*/site: $site/' \"/opt/datadog-agent/etc/datadog.yaml\""
     $sudo_cmd chown $real_user:admin "/opt/datadog-agent/etc/datadog.yaml"
     $sudo_cmd chmod 640 /opt/datadog-agent/etc/datadog.yaml
 }

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -76,7 +76,9 @@ function new_config() {
     i_cmd="-i ''"
     if [ $(sed --version 2>/dev/null | grep -c "GNU") -ne 0 ]; then i_cmd="-i"; fi
     $sudo_cmd sh -c "sed $i_cmd 's/api_key:.*/api_key: $apikey/' \"/opt/datadog-agent/etc/datadog.yaml\""
-    $sudo_cmd sh -c "sed $i_cmd 's/# site:.*/site: $site/' \"/opt/datadog-agent/etc/datadog.yaml\""
+    if [ $site ]; then
+        $sudo_cmd sh -c "sed $i_cmd 's/# site:.*/site: $site/' \"/opt/datadog-agent/etc/datadog.yaml\""
+    fi
     $sudo_cmd chown $real_user:admin "/opt/datadog-agent/etc/datadog.yaml"
     $sudo_cmd chmod 640 /opt/datadog-agent/etc/datadog.yaml
 }

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -50,6 +50,10 @@ if [ -n "$DD_HOSTNAME" ]; then
     dd_hostname=$DD_HOSTNAME
 fi
 
+if [ -n "$DD_SITE" ]; then
+    site="$DD_SITE"
+fi
+
 if [ -n "$DD_API_KEY" ]; then
     apikey=$DD_API_KEY
 fi
@@ -223,6 +227,10 @@ else
       printf "\033[31mThe Agent won't start automatically at the end of the script because the Api key is missing, please add one in datadog.yaml and start the agent manually.\n\033[0m\n"
       no_start=true
     fi
+  fi
+  if [ $site ]; then
+    printf "\033[34m\n* Setting SITE in the Agent configuration: $CONF\n\033[0m\n"
+    $sudo_cmd sh -c "sed -i 's/# site:.*/site: $site/' $CONF"
   fi
   if [ -n "$DD_URL" ]; then
     $sudo_cmd sh -c "sed -i 's/# dd_url:.*/dd_url: $DD_URL/' $CONF"


### PR DESCRIPTION
### What does this PR do?

Adds support of `DD_SITE` env var in install scripts. Follow-up to https://github.com/DataDog/datadog-agent/pull/2412, see details there

### Additional Notes

Should be merged once 6.6.0 is out
