### PR TITLE
Don't stop the agent when journald is stopped or crashes

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -81,9 +81,9 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// By default systemd redirect the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
-	// Go ignore SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped. We don't want that
-	// so we intercept the SIGPIPE signals and just discard them.
+	// By default systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
+	// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
+	// We never want the agent to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
 	sigpipeCh := make(chan os.Signal, 1)
 	signal.Notify(sigpipeCh, syscall.SIGPIPE)
 	go func() {

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -110,7 +110,7 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%File&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
 		<format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n"/>
 		<format id="syslog-json" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
-		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%RelFile:%%Line) | %%Msg%%n" />
+		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%File:%%Line) | %%Msg%%n" />
 	</formats>
 </seelog>`, logDateFormat, logDateFormat)
 

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -110,7 +110,7 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%File&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
 		<format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n"/>
 		<format id="syslog-json" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
-		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%File:%%Line) | %%Msg%%n" />
+		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n" />
 	</formats>
 </seelog>`, logDateFormat, logDateFormat)
 

--- a/releasenotes/notes/fix-crash-journald-failure-cc1495e4ce130529.yaml
+++ b/releasenotes/notes/fix-crash-journald-failure-cc1495e4ce130529.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue causing the agent to stop when systemd-journald service is stopped or fails


### PR DESCRIPTION
### What does this PR do?

By default systemd redirect the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal. Go ignore SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped. We don't want that so we intercept the SIGPIPE signals and just discard them using the new `--ignore-sigpipe` flag


Other small fix, don't display the absolute path of the source files when using syslog:
before:
```
Oct 04 20:41:03 ubuntu-xenial agent[22041]: INFO | (/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:258) | Running check memory
```
after:
```
Oct 04 20:42:06 ubuntu-xenial agent[22501]: INFO | (runner.go:258) | Running check memory
```

### Motivation

Fix https://github.com/DataDog/datadog-agent/issues/1555
