### PR TITLE
[Logs]: Fixed a leak in file scanner that could occur when the k8s integration is enabled

### DIFF
--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -11,15 +11,17 @@ import (
 
 // LogSources stores a list of log sources.
 type LogSources struct {
-	mu           sync.Mutex
-	sources      []*LogSource
-	streamByType map[string]chan *LogSource
+	mu            sync.Mutex
+	sources       []*LogSource
+	addedByType   map[string]chan *LogSource
+	removedByType map[string]chan *LogSource
 }
 
 // NewLogSources creates a new log sources.
 func NewLogSources() *LogSources {
 	return &LogSources{
-		streamByType: make(map[string]chan *LogSource),
+		addedByType:   make(map[string]chan *LogSource),
+		removedByType: make(map[string]chan *LogSource),
 	}
 }
 
@@ -30,7 +32,7 @@ func (s *LogSources) AddSource(source *LogSource) {
 	if source.Config == nil || source.Config.Validate() != nil {
 		return
 	}
-	stream, exists := s.streamByType[source.Config.Type]
+	stream, exists := s.addedByType[source.Config.Type]
 	s.mu.Unlock()
 
 	if exists {
@@ -41,25 +43,44 @@ func (s *LogSources) AddSource(source *LogSource) {
 // RemoveSource removes a source.
 func (s *LogSources) RemoveSource(source *LogSource) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
+	var sourceFound bool
 	for i, src := range s.sources {
 		if src == source {
 			s.sources = append(s.sources[:i], s.sources[i+1:]...)
+			sourceFound = true
 			break
 		}
 	}
+	stream, streamExists := s.removedByType[source.Config.Type]
+	s.mu.Unlock()
+
+	if sourceFound && streamExists {
+		stream <- source
+	}
 }
 
-// GetSourceStreamForType returns the stream of valid sources matching the provided type.
-func (s *LogSources) GetSourceStreamForType(sourceType string) chan *LogSource {
+// GetAddedForType returns the new added sources matching the provided type.
+func (s *LogSources) GetAddedForType(sourceType string) chan *LogSource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	stream, exists := s.streamByType[sourceType]
+	stream, exists := s.addedByType[sourceType]
 	if !exists {
 		stream = make(chan *LogSource)
-		s.streamByType[sourceType] = stream
+		s.addedByType[sourceType] = stream
+	}
+	return stream
+}
+
+// GetRemovedForType returns the new removed sources matching the provided type.
+func (s *LogSources) GetRemovedForType(sourceType string) chan *LogSource {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stream, exists := s.removedByType[sourceType]
+	if !exists {
+		stream = make(chan *LogSource)
+		s.removedByType[sourceType] = stream
 	}
 	return stream
 }

--- a/pkg/logs/config/sources_test.go
+++ b/pkg/logs/config/sources_test.go
@@ -47,17 +47,36 @@ func TestGetSources(t *testing.T) {
 	assert.Equal(t, 1, len(sources.GetSources()))
 }
 
-func TestGetSourceStreamForType(t *testing.T) {
+func TestGetAddedForType(t *testing.T) {
 	sources := NewLogSources()
 	source := NewLogSource("foo", &LogsConfig{Type: "foo"})
 
 	sources.AddSource(source)
 
-	stream := sources.GetSourceStreamForType("foo")
+	stream := sources.GetAddedForType("foo")
 	assert.NotNil(t, stream)
 	assert.Equal(t, 0, len(stream))
 
 	go func() { sources.AddSource(source) }()
+	s := <-stream
+	assert.Equal(t, s, source)
+}
+
+func TestGetRemovedForType(t *testing.T) {
+	sources := NewLogSources()
+	source := NewLogSource("foo", &LogsConfig{Type: "foo"})
+
+	sources.RemoveSource(source)
+
+	stream := sources.GetRemovedForType("foo")
+	assert.NotNil(t, stream)
+	assert.Equal(t, 0, len(stream))
+
+	sources.RemoveSource(source)
+	assert.Equal(t, 0, len(stream))
+
+	sources.AddSource(source)
+	go func() { sources.RemoveSource(source) }()
 	s := <-stream
 	assert.Equal(t, s, source)
 }

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -62,7 +62,7 @@ func NewLauncher(sources *config.LogSources, services *service.Services, pipelin
 	// a channel that will lock the scheduler in case of setup failure
 	// FIXME(achntrl): Find a better way of choosing the right launcher
 	// between Docker and Kubernetes
-	launcher.sources = sources.GetSourceStreamForType(config.DockerType)
+	launcher.sources = sources.GetAddedForType(config.DockerType)
 	launcher.addedServices = services.GetAddedServices(service.Docker)
 	launcher.removedServices = services.GetRemovedServices(service.Docker)
 	return launcher, nil

--- a/pkg/logs/input/journald/launcher.go
+++ b/pkg/logs/input/journald/launcher.go
@@ -27,7 +27,7 @@ type Launcher struct {
 // New returns a new Launcher.
 func NewLauncher(sources *config.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry) *Launcher {
 	return &Launcher{
-		sources:          sources.GetSourceStreamForType(config.JournaldType),
+		sources:          sources.GetAddedForType(config.JournaldType),
 		pipelineProvider: pipelineProvider,
 		registry:         registry,
 		tailers:          make(map[string]*Tailer),

--- a/pkg/logs/input/listener/launcher.go
+++ b/pkg/logs/input/listener/launcher.go
@@ -26,8 +26,8 @@ func NewLauncher(sources *config.LogSources, frameSize int, pipelineProvider pip
 	return &Launcher{
 		pipelineProvider: pipelineProvider,
 		frameSize:        frameSize,
-		tcpSources:       sources.GetSourceStreamForType(config.TCPType),
-		udpSources:       sources.GetSourceStreamForType(config.UDPType),
+		tcpSources:       sources.GetAddedForType(config.TCPType),
+		udpSources:       sources.GetAddedForType(config.UDPType),
 		stop:             make(chan struct{}),
 	}
 }

--- a/pkg/logs/input/windowsevent/launcher.go
+++ b/pkg/logs/input/windowsevent/launcher.go
@@ -24,7 +24,7 @@ type Launcher struct {
 // NewLauncher returns a new Launcher.
 func NewLauncher(sources *config.LogSources, pipelineProvider pipeline.Provider) *Launcher {
 	return &Launcher{
-		sources:          sources.GetSourceStreamForType(config.WindowsEventType),
+		sources:          sources.GetAddedForType(config.WindowsEventType),
 		pipelineProvider: pipelineProvider,
 		tailers:          make(map[string]*Tailer),
 		stop:             make(chan struct{}),

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -16,7 +16,7 @@ import (
 func TestSourceAreGroupedByIntegrations(t *testing.T) {
 	sources := config.NewLogSources()
 	go func() {
-		sources := sources.GetSourceStreamForType("foo")
+		sources := sources.GetAddedForType("foo")
 		for range sources {
 			// ensure that another component is consuming the channel to prevent
 			// the producer to get stuck.
@@ -47,7 +47,7 @@ func TestSourceAreGroupedByIntegrations(t *testing.T) {
 func TestStatusDeduplicateWarnings(t *testing.T) {
 	sources := config.NewLogSources()
 	go func() {
-		sources := sources.GetSourceStreamForType("foo")
+		sources := sources.GetAddedForType("foo")
 		for range sources {
 			// ensure that another component is consuming the channel to prevent
 			// the producer to get stuck.


### PR DESCRIPTION
### What does this PR do?

Sources created from new containers are retained by the file scanner and never released when containers get deleted.
Added a new stream for removed sources so that the file scanner can register and release its sources and stop / clear its cache after on.

### Motivation

Fix the leak and ensure we can keep on collecting logs on k8s when the agent has been running for a while (i.e it already opened over 100 files).

### Additional Notes

Internal use only.
