### PR TITLE
allow ec2+gce hostname providers without build tag

### DIFF
--- a/pkg/util/hostname/ec2.go
+++ b/pkg/util/hostname/ec2.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build ec2
-
 package hostname
 
 import "github.com/DataDog/datadog-agent/pkg/util/ec2"

--- a/pkg/util/hostname/gce.go
+++ b/pkg/util/hostname/gce.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build gce
-
 package hostname
 
 import "github.com/DataDog/datadog-agent/pkg/util/gce"


### PR DESCRIPTION
### What does this PR do?

The DCA is compiled with minimal build tags to keep its size contained. This includes leaving out the `ec2` and `gce` flags, as we rely on the node-agents to retrieve the host tags. We still need a valid hostname though.

As both ec2 and gce hostname retrieval logics don't depend on the aforementioned build tags (they are used for host tag retrieval), this PR removes the build tag from the files registering the hostname providers. Build pass OK without the additional build tags.

Azure's host alias logic is already available with no build tag.

### Motivation

Avoid messy container-name-in-infrastructure-list situations.

This will also benefit the standalone dogstatsd in a sidecar scenario.