### PR TITLE
Fix a bug where docker source would not be properly removed

### DIFF
--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -17,33 +17,33 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// NewLauncher returns a new container scanner,
+// NewLauncher returns a new container launcher,
 // by default returns a docker launcher that uses the docker socket to collect logs.
 // The docker launcher can be used both on a non kubernetes and kubernetes environment.
 // When a docker launcher can not be initialized properly and when the log collection is enabled for all containers,
-// the scanner will attempt to initialize a kubernetes scanner which will detect and tail all the logs files localized
+// the launcher will attempt to initialize a kubernetes launcher which will detect and tail all the logs files localized
 // in '/var/log/pods' of all the containers running on the kubernetes cluster.
 func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
 	switch {
 	case config.LogsAgent.GetBool("logs_config.container_collect_all"):
-		// attempt to initialize a docker scanner
+		// attempt to initialize a docker launcher
 		launcher, err := docker.NewLauncher(sources, services, pipelineProvider, registry)
 		if err == nil {
 			return launcher
 		}
-		// attempt to initialize a kubernetes scanner
-		log.Warnf("Could not setup the docker scanner, falling back to the kubernetes one: %v", err)
-		scanner, err := kubernetes.NewLauncher(sources, services)
+		// attempt to initialize a kubernetes launcher
+		log.Warnf("Could not setup the docker launcher, falling back to the kubernetes one: %v", err)
+		kubernetesLauncher, err := kubernetes.NewLauncher(sources, services)
 		if err == nil {
-			return scanner
+			return kubernetesLauncher
 		}
-		log.Warnf("Could not setup the kubernetes scanner: %v", err)
+		log.Warnf("Could not setup the kubernetes launcher: %v", err)
 	default:
 		launcher, err := docker.NewLauncher(sources, services, pipelineProvider, registry)
 		if err == nil {
 			return launcher
 		}
-		log.Warnf("Could not setup the docker scanner: %v", err)
+		log.Warnf("Could not setup the docker launcher: %v", err)
 	}
 	return NewNoopLauncher()
 }

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -147,8 +147,8 @@ func (l *Launcher) run() {
 		case source := <-l.removedSources:
 			for i, src := range l.activeSources {
 				if src == source {
-					// Stopping the tailer is the responsibility of the service
-					// Can we receive a source to remove without receiving a service to remove ?
+					// no need to stop any tailer here, it will be stopped after receiving a
+					// "remove service" event.
 					l.activeSources = append(l.activeSources[:i], l.activeSources[i+1:]...)
 					break
 				}

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -30,7 +30,8 @@ const (
 // A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
 type Launcher struct {
 	pipelineProvider   pipeline.Provider
-	sources            chan *config.LogSource
+	addedSources       chan *config.LogSource
+	removedSources     chan *config.LogSource
 	addedServices      chan *service.Service
 	removedServices    chan *service.Service
 	activeSources      []*config.LogSource
@@ -62,7 +63,8 @@ func NewLauncher(sources *config.LogSources, services *service.Services, pipelin
 	// a channel that will lock the scheduler in case of setup failure
 	// FIXME(achntrl): Find a better way of choosing the right launcher
 	// between Docker and Kubernetes
-	launcher.sources = sources.GetAddedForType(config.DockerType)
+	launcher.addedSources = sources.GetAddedForType(config.DockerType)
+	launcher.removedSources = sources.GetRemovedForType(config.DockerType)
 	launcher.addedServices = services.GetAddedServices(service.Docker)
 	launcher.removedServices = services.GetRemovedServices(service.Docker)
 	return launcher, nil
@@ -126,7 +128,7 @@ func (l *Launcher) run() {
 				// so it's put in a cache until a matching source is found.
 				l.pendingContainers[service.Identifier] = container
 			}
-		case source := <-l.sources:
+		case source := <-l.addedSources:
 			// detected a new source that has been created either from a configuration file,
 			// a docker label or a pod annotation.
 			l.activeSources = append(l.activeSources, source)
@@ -142,6 +144,15 @@ func (l *Launcher) run() {
 			}
 			// keep the containers that have not found any source yet for next iterations
 			l.pendingContainers = pendingContainers
+		case source := <-l.removedSources:
+			for i, src := range l.activeSources {
+				if src == source {
+					// Stopping the tailer is the responsibility of the service
+					// Can we receive a source to remove without receiving a service to remove ?
+					l.activeSources = append(l.activeSources[:i], l.activeSources[i+1:]...)
+					break
+				}
+			}
 		case service := <-l.removedServices:
 			// detected that a container has been stopped.
 			containerID := service.Identifier

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -58,7 +58,6 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 			for _, source := range sources {
 				s.sources.AddSource(source)
 			}
-			break
 		case s.newService(config):
 			log.Infof("Received a new service: %v", config.Entity)
 			service, err := s.toService(config)
@@ -69,7 +68,7 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 			s.services.AddService(service)
 		default:
 			// invalid integration config
-			break
+			continue
 		}
 	}
 }

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -86,11 +86,11 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 			_, identifier, err := s.parseEntity(config.Entity)
 			if err != nil {
 				log.Warnf("Invalid configuration: %v", err)
+				continue
 			}
 
 			for _, source := range s.sources.GetSources() {
 				if identifier == source.Config.Identifier {
-					log.Info("Id: ", identifier)
 					s.sources.RemoveSource(source)
 				}
 			}

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -84,27 +84,17 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 		case s.newSources(config):
 			log.Infof("New source to remove: entity: %v", config.Entity)
 
-			// These are copy of the source we want to delete
-			// They will be GCed after the end of the block
-			sourcesToFind, err := s.toSources(config)
+			_, identifier, err := s.parseEntity(config.Entity)
 			if err != nil {
 				log.Warnf("Invalid configuration: %v", err)
-				continue
 			}
 
-			var sourcesToDelete []*logsConfig.LogSource
-			for _, sourceToFind := range sourcesToFind {
-				for _, source := range s.sources.GetSources() {
-					if source.Config.Identifier == sourceToFind.Config.Identifier {
-						sourcesToDelete = append(sourcesToDelete, source)
-					}
+			for _, source := range s.sources.GetSources() {
+				if identifier == source.Config.Identifier {
+					log.Info("Id: ", identifier)
+					s.sources.RemoveSource(source)
 				}
 			}
-
-			for _, sourceToDelete := range sourcesToDelete {
-				s.sources.RemoveSource(sourceToDelete)
-			}
-			continue
 		case s.newService(config):
 			// new service to remove
 			log.Infof("New service to remove: entity: %v", config.Entity)

--- a/pkg/logs/scheduler/scheduler_test.go
+++ b/pkg/logs/scheduler/scheduler_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchedule(t *testing.T) {
+	logSources := config.NewLogSources()
+	services := service.NewServices()
+	scheduler := NewScheduler(logSources, services)
+
+	logSourcesStream := logSources.GetAddedForType(config.DockerType)
+	servicesStream := services.GetAddedServices(service.Docker)
+
+	configService := integration.Config{
+		LogsConfig:   []byte(""),
+		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
+
+	configSource := integration.Config{
+		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
+		Provider:      providers.Kubernetes,
+		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck:  false,
+		CreationTime:  0,
+	}
+
+	go scheduler.Schedule([]integration.Config{configService})
+	svc := <-servicesStream
+	assert.Equal(t, configService.Entity, svc.GetEntityID())
+
+	go scheduler.Schedule([]integration.Config{configSource})
+	logSource := <-logSourcesStream
+	assert.Equal(t, config.DockerType, logSource.Name)
+	// We use the docker socket, not sourceType here
+	assert.Equal(t, "", logSource.GetSourceType())
+	assert.Equal(t, "foo", logSource.Config.Service)
+	assert.Equal(t, "bar", logSource.Config.Source)
+	assert.Equal(t, config.DockerType, logSource.Config.Type)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
+}
+
+func TestUnschedule(t *testing.T) {
+	logSources := config.NewLogSources()
+	services := service.NewServices()
+	scheduler := NewScheduler(logSources, services)
+	logSourcesStream := logSources.GetRemovedForType(config.DockerType)
+	servicesStream := services.GetRemovedServices(service.Docker)
+
+	configService := integration.Config{
+		LogsConfig:   []byte(""),
+		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
+
+	configSource := integration.Config{
+		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
+		Provider:      providers.Kubernetes,
+		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck:  false,
+		CreationTime:  0,
+	}
+
+	// We need to have a source to remove
+	sources, _ := scheduler.toSources(configSource)
+	logSources.AddSource(sources[0])
+
+	go scheduler.Unschedule([]integration.Config{configService})
+	svc := <-servicesStream
+	assert.Equal(t, configService.Entity, svc.GetEntityID())
+
+	go scheduler.Unschedule([]integration.Config{configSource})
+	logSource := <-logSourcesStream
+	assert.Equal(t, config.DockerType, logSource.Name)
+	// We use the docker socket, not sourceType here
+	assert.Equal(t, "", logSource.GetSourceType())
+	assert.Equal(t, "foo", logSource.Config.Service)
+	assert.Equal(t, "bar", logSource.Config.Source)
+	assert.Equal(t, config.DockerType, logSource.Config.Type)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
+}


### PR DESCRIPTION

### Motivation

We discovered a leak of file sources and docker sources. The file sources leak has been addressed here https://github.com/DataDog/datadog-agent/pull/2418.

### What does this PR do?

This PR addresses the docker source leak

### Additional Notes

**Can we receive a source to remove without receiving a service to remove ?**
