### PR TITLE
Move datadog-cluster-agent binary and add agent symlink

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -6,17 +6,16 @@ FROM debian:buster-slim as builder
 
 WORKDIR /output
 
-RUN mkdir -p opt/datadog-agent/bin/datadog-cluster-agent/
-
-COPY datadog-cluster-agent opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+COPY datadog-cluster-agent opt/datadog-agent/bin/datadog-cluster-agent
 COPY ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
-COPY ./dist opt/datadog-agent/bin/datadog-cluster-agent/dist
+COPY ./dist opt/datadog-agent/bin/dist
 COPY entrypoint.sh .
 
 RUN chmod 755 entrypoint.sh \
     && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
-    && chmod +x opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent
+    && chmod +x opt/datadog-agent/bin/datadog-cluster-agent \
+    && ln -s /opt/datadog-agent/bin/datadog-cluster-agent opt/datadog-agent/bin/agent
 
 ####################################
 # Actual docker image construction #
@@ -26,7 +25,7 @@ FROM debian:buster-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/:$PATH"
+ENV PATH="/opt/datadog-agent/bin/:$PATH"
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y ca-certificates curl \


### PR DESCRIPTION
### What does this PR do?

- Remove one nesting level: move `/opt/datadog-agent/bin/datadog-cluster-agent/datadog-cluster-agent` to `/opt/datadog-agent/bin/datadog-cluster-agent`
- Add an `agent` symlink so `kubectl exec .... agent status` work OOTB
- Remove the non-existent `/opt/datadog-agent/embedded/bin/` from the PATH
- Keep the full binary name in the `CMD` so that process lists show it's the DCA


### New layout:

/opt/
/opt/datadog-agent
/opt/datadog-agent/bin
/opt/datadog-agent/bin/dist
/opt/datadog-agent/bin/dist/templates
/opt/datadog-agent/bin/dist/templates/collector.tmpl
/opt/datadog-agent/bin/dist/templates/header.tmpl
/opt/datadog-agent/bin/dist/templates/metadatamapper.tmpl
/opt/datadog-agent/bin/dist/templates/custommetricsprovider.tmpl
/opt/datadog-agent/bin/dist/templates/forwarder.tmpl
/opt/datadog-agent/bin/agent
/opt/datadog-agent/bin/datadog-cluster-agent

/etc/datadog-agent/
/etc/datadog-agent/datadog-cluster.yaml
/etc/datadog-agent/conf.d
/etc/datadog-agent/conf.d/kubernetes_apiserver.d
/etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default

### Result is a symlink

root@810b77662867:/opt/datadog-agent/bin# ls -lh
total 65M
lrwxrwxrwx 1 root root   44 Oct  5 15:30 agent -> /opt/datadog-agent/bin/datadog-cluster-agent
-rwxrwxr-x 1 root root  64M Oct  5 15:27 datadog-cluster-agent
drwxr-xr-x 3 root root 4.0K Oct  5 15:30 dist