### PR TITLE
[Android] add default config so that network check is run by default.

### DIFF
--- a/cmd/agent/dist/conf.d/network.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/network.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+  - {}

--- a/cmd/agent/dist/conf.d/network.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/network.d/conf.yaml.default
@@ -1,2 +1,33 @@
+# This file is overwritten upon Agent upgrade.
+# To make modifications to the check configuration, please copy this file
+# to `network.yaml` and make your changes on that file.
+
+init_config:
+
 instances:
-  - {}
+  # Network check only supports one configured instance
+  - collect_connection_state: false
+    excluded_interfaces:
+      - lo
+      - lo0
+    # Optionally completely ignore any network interface
+    # matching the given regex:
+    # excluded_interface_re: my-network-interface.*
+
+    # Do not combine connection states
+    # By default we combine states like fin_wait_1 and fin_wait_2
+    # together into one state: 'closing'
+    # For some people, this is fine, but others need more granular data
+    # enable this option to get more granular data
+    # combine_connection_states: no
+
+    # By default, most metrics are submitted as rates.
+    # However, some metrics like tcp/udp retransmissions and errors are
+    # better handled as counts.
+    # You can choose to enable either or both types of metrics.
+    # Count metrics will have '.count' added to the metric name.
+    # collect_rate_metrics: true
+    # collect_count_metrics: false
+
+    # tags:
+    #   - optional:tag1

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -29,6 +29,7 @@ ANDROID_CORECHECKS = [
     "io",
     "load",
     "memory",
+    "network",
     "uptime",
 ]
 CORECHECK_CONFS_DIR = "cmd/agent/android/app/src/main/assets/conf.d"


### PR DESCRIPTION
### What does this PR do?

adds bits to make network check run by default

### Motivation

running network check on android/puppy

### Additional Notes

marked WIP because unsure whether this will have desired effect on other platforms
