### PR TITLE
Match the number with what is specified in docs

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml
+++ b/Dockerfiles/manifests/cluster-agent/hpa-example/hpa-manifest.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginxext
 spec:
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 5
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
### What does this PR do?

Match the number with the number specified in docs.
https://github.com/DataDog/datadog-agent/blob/master/docs/cluster-agent/CUSTOM_METRICS_SERVER.md

### Motivation
It leads to a confusion when there are not as many replicas as docs was suggesting.
### Additional Notes

Anything else we should know when reviewing?
