### PR TITLE
Send *_PROXY env var to pip if proxies configured in the agent

### DIFF
--- a/releasenotes/notes/pip_proxy_env-8bf23f475b80a058.yaml
+++ b/releasenotes/notes/pip_proxy_env-8bf23f475b80a058.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Correctly pass the agent's proxy settings to pip when using the ``datadog-agent integration`` command with TUF enabled.


### PR DESCRIPTION
### What does this PR do?

If proxies have been configured in the agent, set and pass *PROXY env vars to pip when invoking `integration` command

### Motivation

Proxies weren't correctly set when using pip+tuf, so `integration` invocation would fail

### Additional Notes

Anything else we should know when reviewing?