### PR TITLE
[Logs]: Fix an issue that would lead the logs-agent to retain files on the system

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -54,7 +54,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, endpoints 
 
 	// setup the inputs
 	inputs := []restart.Restartable{
-		file.NewScanner(sources, config.LogsAgent.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.DefaultSleepDuration),
+		file.NewScanner(sources, config.LogsAgent.GetInt("logs_config.open_files_limit"), pipelineProvider, auditor, file.MinWaitDuration),
 		container.NewLauncher(sources, services, pipelineProvider, auditor),
 		listener.NewLauncher(sources, config.LogsAgent.GetInt("logs_config.frame_size"), pipelineProvider),
 		journald.NewLauncher(sources, pipelineProvider, auditor),

--- a/pkg/logs/input/file/tailer_test.go
+++ b/pkg/logs/input/file/tailer_test.go
@@ -51,8 +51,8 @@ func (suite *TailerTestSuite) SetupTest() {
 		Type: config.FileType,
 		Path: suite.testPath,
 	})
-	sleepDuration := 10 * time.Millisecond
-	suite.tl = NewTailer(suite.outputChan, suite.source, suite.testPath, sleepDuration)
+	minWaitDuration := 10 * time.Millisecond
+	suite.tl = NewTailer(suite.outputChan, suite.source, suite.testPath, minWaitDuration)
 }
 
 func (suite *TailerTestSuite) TearDownTest() {


### PR DESCRIPTION
### What does this PR do?

Change the logic to stop reading content from files.
Before we would stop reading a file when we encounter an error which is different from `EOF`
Now we stop reading a file after an encountering an error which is different from `EOF` or after a delay of no new data.

### Motivation

Fix a bug that would prevent files from being removed from disk because the logs-agent would retain a reference.

### Additional Notes

This is a proposal and this logic is likely to change
TODO:
* [ ] Add unit-tests
* [ ] Add a release note