### PR TITLE
Allow checks config to fail independently of logs config

### DIFF
--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -124,7 +124,7 @@ func parseDockerLabels(containers map[string]map[string]string) ([]integration.C
 		switch {
 		case err != nil:
 			log.Errorf("Can't parse template for container %s: %s", cID, err)
-			continue
+			configs = append(configs, c...)
 		case len(c) == 0:
 			continue
 		default:

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -120,16 +120,18 @@ func (d *DockerConfigProvider) IsUpToDate() (bool, error) {
 func parseDockerLabels(containers map[string]map[string]string) ([]integration.Config, error) {
 	var configs []integration.Config
 	for cID, labels := range containers {
-		c, err := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerADLabelPrefix)
-		switch {
-		case err != nil:
-			log.Errorf("Can't parse template for container %s: %s", cID, err)
-			configs = append(configs, c...)
-		case len(c) == 0:
+		c, errors := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerADLabelPrefix)
+
+		if len(c) == 0 {
 			continue
-		default:
-			configs = append(configs, c...)
 		}
+		if len(errors) > 0 {
+			for _, err := range errors {
+				log.Errorf("Can't parse template for container %s: %s", cID, err)
+			}
+		}
+
+		configs = append(configs, c...)
 	}
 	return configs, nil
 }

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -122,13 +122,8 @@ func parseDockerLabels(containers map[string]map[string]string) ([]integration.C
 	for cID, labels := range containers {
 		c, errors := extractTemplatesFromMap(docker.ContainerIDToEntityName(cID), labels, dockerADLabelPrefix)
 
-		if len(c) == 0 {
-			continue
-		}
-		if len(errors) > 0 {
-			for _, err := range errors {
-				log.Errorf("Can't parse template for container %s: %s", cID, err)
-			}
+		for _, err := range errors {
+			log.Errorf("Can't parse template for container %s: %s", cID, err)
 		}
 
 		configs = append(configs, c...)

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -85,13 +85,8 @@ func parseECSContainers(containers []ecs.Container) ([]integration.Config, error
 	for _, c := range containers {
 		configs, errors := extractTemplatesFromMap(docker.ContainerIDToEntityName(c.DockerID), c.Labels, ecsADLabelPrefix)
 
-		if len(configs) == 0 {
-			continue
-		}
-		if len(errors) > 0 {
-			for _, err := range errors {
-				log.Errorf("unable to extract templates for container %s - %s", c.DockerID, err)
-			}
+		for _, err := range errors {
+			log.Errorf("unable to extract templates for container %s - %s", c.DockerID, err)
 		}
 
 		templates = append(templates, configs...)

--- a/pkg/autodiscovery/providers/ecs.go
+++ b/pkg/autodiscovery/providers/ecs.go
@@ -87,7 +87,7 @@ func parseECSContainers(containers []ecs.Container) ([]integration.Config, error
 		switch {
 		case err != nil:
 			log.Errorf("unable to extract templates for container %s - %s", c.DockerID, err)
-			continue
+			templates = append(templates, configs...)
 		case len(configs) == 0:
 			continue
 		default:

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -95,7 +95,7 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 			switch {
 			case err != nil:
 				log.Errorf("Can't parse template for pod %s: %s", pod.Metadata.Name, err)
-				continue
+				configs = append(configs, c...)
 			case len(c) == 0:
 				continue
 			default:

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -90,18 +90,19 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 		}
 
 		for _, container := range pod.Status.Containers {
-			c, err := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
+			c, errors := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
 				fmt.Sprintf(adExtractFormat, container.Name))
-			switch {
-			case err != nil:
-				log.Errorf("Can't parse template for pod %s: %s", pod.Metadata.Name, err)
-				configs = append(configs, c...)
-			case len(c) == 0:
-				continue
-			default:
-				configs = append(configs, c...)
 
+			if len(c) == 0 {
+				continue
 			}
+			if len(errors) > 0 {
+				for _, err := range errors {
+					log.Errorf("Can't parse template for pod %s: %s", pod.Metadata.Name, err)
+				}
+			}
+
+			configs = append(configs, c...)
 		}
 	}
 	return configs, nil

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -93,13 +93,8 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 			c, errors := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
 				fmt.Sprintf(adExtractFormat, container.Name))
 
-			if len(c) == 0 {
-				continue
-			}
-			if len(errors) > 0 {
-				for _, err := range errors {
-					log.Errorf("Can't parse template for pod %s: %s", pod.Metadata.Name, err)
-				}
+			for _, err := range errors {
+				log.Errorf("Can't parse template for pod %s: %s", pod.Metadata.Name, err)
 			}
 
 			configs = append(configs, c...)

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -103,17 +103,26 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []in
 func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
 	configs := make([]integration.Config, 0)
 
-	checksConfigs, err := extractCheckTemplatesFromMap(key, input, prefix)
-	if err != nil {
-		return configs, err
+	checksConfigs, errCheck := extractCheckTemplatesFromMap(key, input, prefix)
+	if errCheck == nil {
+		configs = append(configs, checksConfigs...)
+	} else {
+		log.Warnf("could not extract checks config from template: %v", errCheck)
 	}
-	configs = append(configs, checksConfigs...)
 
-	logsConfigs, err := extractLogsTemplatesFromMap(key, input, prefix)
-	if err != nil {
-		return configs, err
+	logsConfigs, errLogs := extractLogsTemplatesFromMap(key, input, prefix)
+	if errLogs == nil {
+		configs = append(configs, logsConfigs...)
+	} else {
+		log.Warnf("could not extract logs config from template: %v", errLogs)
 	}
-	configs = append(configs, logsConfigs...)
+
+	if errCheck != nil {
+		return configs, errCheck
+	}
+	if errLogs != nil {
+		return configs, errLogs
+	}
 
 	return configs, nil
 }

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -101,8 +101,8 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []in
 // extractTemplatesFromMap looks for autodiscovery configurations in a given map
 // (either docker labels or kubernetes annotations) and returns them if found.
 func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, []error) {
-	configs := make([]integration.Config, 0)
-	errors := make([]error, 0)
+	var configs []integration.Config
+	var errors []error
 
 	checksConfigs, err := extractCheckTemplatesFromMap(key, input, prefix)
 	if err != nil {

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -100,31 +100,23 @@ func buildTemplates(key string, checkNames []string, initConfigs, instances []in
 
 // extractTemplatesFromMap looks for autodiscovery configurations in a given map
 // (either docker labels or kubernetes annotations) and returns them if found.
-func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, error) {
+func extractTemplatesFromMap(key string, input map[string]string, prefix string) ([]integration.Config, []error) {
 	configs := make([]integration.Config, 0)
+	errors := make([]error, 0)
 
-	checksConfigs, errCheck := extractCheckTemplatesFromMap(key, input, prefix)
-	if errCheck == nil {
-		configs = append(configs, checksConfigs...)
-	} else {
-		log.Warnf("could not extract checks config from template: %v", errCheck)
+	checksConfigs, err := extractCheckTemplatesFromMap(key, input, prefix)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("could not extract checks config: %v", err))
 	}
+	configs = append(configs, checksConfigs...)
 
-	logsConfigs, errLogs := extractLogsTemplatesFromMap(key, input, prefix)
-	if errLogs == nil {
-		configs = append(configs, logsConfigs...)
-	} else {
-		log.Warnf("could not extract logs config from template: %v", errLogs)
+	logsConfigs, err := extractLogsTemplatesFromMap(key, input, prefix)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("could not extract logs config: %v", err))
 	}
+	configs = append(configs, logsConfigs...)
 
-	if errCheck != nil {
-		return configs, errCheck
-	}
-	if errLogs != nil {
-		return configs, errLogs
-	}
-
-	return configs, nil
+	return configs, errors
 }
 
 // extractCheckTemplatesFromMap returns all the check configurations from a given map.

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -214,7 +214,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []integration.Config{},
+			output:       nil,
 		},
 		{
 			// Missing init_configs, error out
@@ -224,7 +224,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []integration.Config{},
+			output:       nil,
 			errs:         []error{errors.New("could not extract checks config: missing init_configs key")},
 		},
 		{
@@ -236,7 +236,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []integration.Config{},
+			output:       nil,
 			errs:         []error{errors.New("could not extract checks config: in instances: Failed to unmarshal JSON")},
 		},
 		{
@@ -246,7 +246,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			},
 			adIdentifier: "id",
 			prefix:       "prefix.",
-			output:       []integration.Config{},
+			output:       nil,
 			errs:         []error{errors.New("could not extract logs config: invalid format, expected an array, got: ")},
 		},
 		{
@@ -279,7 +279,7 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 				errors.New("could not extract checks config: missing init_configs key"),
 				errors.New("could not extract logs config: invalid format, expected an array, got: "),
 			},
-			output: []integration.Config{},
+			output: nil,
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -249,6 +249,23 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			output:       []integration.Config{},
 			err:          errors.New("invalid format, expected an array, got: "),
 		},
+		{
+			// Invalid checks but valid logs
+			source: map[string]string{
+				"prefix.check_names": "[\"apache\"]",
+				"prefix.instances":   "[{\"apache_status_url\":\"http://%%host%%/server-status?auto\"}]",
+				"prefix.logs":        "[{\"service\":\"any_service\",\"source\":\"any_source\"}]",
+			},
+			adIdentifier: "id",
+			prefix:       "prefix.",
+			err:          errors.New("missing init_configs key"),
+			output: []integration.Config{
+				{
+					LogsConfig:    integration.Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]"),
+					ADIdentifiers: []string{"id"},
+				},
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", nb, tc.source), func(t *testing.T) {
 			assert := assert.New(t)

--- a/releasenotes/notes/fix-bug-in-template-parsing-c2016519bcdd8cf4.yaml
+++ b/releasenotes/notes/fix-bug-in-template-parsing-c2016519bcdd8cf4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix bug that occurs when checks labels/annotation are misconfigured and would
+    prevent the logs of the container to be tailed


### PR DESCRIPTION
### What does this PR do?

Allows the logs config to be sent if the checks config parsing failed in AD. 
I refactor the `extractTemplatesFromMap` function to return an array of errors. I add the info whether checks or/and logs parsing failed.

I still handle the errors in the `providers` to give context on the errors (did it happen in a pod / docker container / ecs ?)

### Motivation

In Autodiscovery, when the parsing of checks config fails, the logs configs is not parsed and fails. We want to be able to send logs even if the checks config is broken

### Additional Notes

Ideally we would display something in the `agent status` (or `agent configcheck`?) when we fail to parse a config. I'm not sure there is a simple way of doing this for the logs.