### PR TITLE
Add kube_apiserver hostname provider for the cluster-agent

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -26,7 +26,8 @@ FROM debian:buster-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/:$PATH"
+ENV DOCKER_DD_AGENT=true \
+    PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/:$PATH"
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y ca-certificates curl \

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -26,8 +26,7 @@ FROM debian:buster-slim
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV DOCKER_DD_AGENT=true \
-    PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/:$PATH"
+ENV PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/:$PATH"
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y ca-certificates curl \

--- a/pkg/util/hostname/kube_apiserver.go
+++ b/pkg/util/hostname/kube_apiserver.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+// +build !kubelet
+
+// This provider is only useful for the cluser-agent, that does
+// not have kubelet compiled it. Disable it for the node-agent
+// that already has the kubelet provider available.
+
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+
+func init() {
+	RegisterHostnameProvider("kube_apiserver", apiserver.HostnameProvider)
+}

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -10,10 +10,9 @@
 package util
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func getContainerHostname() (bool, string) {
@@ -35,10 +34,18 @@ func getContainerHostname() (bool, string) {
 	if config.IsKubernetes() == false {
 		return false, name
 	}
-	// Kubernetes
-	log.Debug("GetHostname trying Kubernetes trough kubelet API...")
+	// Kubelet
 	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
+		log.Debug("GetHostname trying Kubernetes trough kubelet API...")
 		name, err := getKubeletHostname(name)
+		if err == nil && ValidHostname(name) == nil {
+			return true, name
+		}
+	}
+	// Kube apiserver
+	if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
+		log.Debug("GetHostname trying Kubernetes trough API server...")
+		name, err := getKubeHostname(name)
 		if err == nil && ValidHostname(name) == nil {
 			return true, name
 		}

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -18,9 +18,20 @@ import (
 func getContainerHostname() (bool, string) {
 	var name string
 
+	// Cluster-agent logic: Kube apiserver
+	if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
+		log.Debug("GetHostname trying Kubernetes trough API server...")
+		name, err := getKubeHostname(name)
+		if err == nil && ValidHostname(name) == nil {
+			return true, name
+		}
+	}
+
 	if config.IsContainerized() == false {
 		return false, name
 	}
+
+	// Node-agent logic: docker or kubelet
 
 	// Docker
 	log.Debug("GetHostname trying Docker API...")
@@ -38,14 +49,6 @@ func getContainerHostname() (bool, string) {
 	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
 		log.Debug("GetHostname trying Kubernetes trough kubelet API...")
 		name, err := getKubeletHostname(name)
-		if err == nil && ValidHostname(name) == nil {
-			return true, name
-		}
-	}
-	// Kube apiserver
-	if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
-		log.Debug("GetHostname trying Kubernetes trough API server...")
-		name, err := getKubeHostname(name)
 		if err == nil && ValidHostname(name) == nil {
 			return true, name
 		}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -350,6 +350,15 @@ func (c *APIClient) NodeLabels(nodeName string) (map[string]string, error) {
 	return node.Labels, nil
 }
 
+// GetNodeForPod retrieves a pod and returns the name of the node it is scheduled on
+func (c *APIClient) GetNodeForPod(namespace, pod_name string) (string, error) {
+	pod, err := c.Cl.CoreV1().Pods(namespace).Get(pod_name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return pod.Spec.NodeName, nil
+}
+
 // GetMetadataMapBundleOnAllNodes is used for the CLI svcmap command to run fetch the metadata map of all nodes.
 func GetMetadataMapBundleOnAllNodes(cl *APIClient) (map[string]interface{}, error) {
 	nodePodMetadataMap := make(map[string]*MetadataMapperBundle)

--- a/pkg/util/kubernetes/apiserver/common/common.go
+++ b/pkg/util/kubernetes/apiserver/common/common.go
@@ -21,6 +21,11 @@ func GetResourcesNamespace() string {
 		return namespace
 	}
 	log.Debugf("No configured namespace for the resource, fetching from the current context")
+	return GetMyNamespace()
+}
+
+// GetMyNamespace returns the namespace our pod is running in
+func GetMyNamespace() string {
 	namespacePath := "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	val, e := ioutil.ReadFile(namespacePath)
 	if e == nil && val != nil {

--- a/pkg/util/kubernetes/apiserver/hostname.go
+++ b/pkg/util/kubernetes/apiserver/hostname.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// HostnameProvider retrieves the hostname from the apiserver, assuming our hostname
+// is the pod name. It connects to the apiserver, and returns the node name where
+// our pod is scheduled.
+// Tested in the TestHostnameProvider integration test
+func HostnameProvider(_ string) (string, error) {
+	c, err := GetAPIClient()
+	if err != nil {
+		return "", fmt.Errorf("could not connect to the apiserver: %s", err)
+	}
+	podName, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("could not fetch our hostname: %s", err)
+	}
+
+	nodeName, err := c.GetNodeForPod(common.GetMyNamespace(), podName)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch the host nodename from the apiserver: %s", err)
+	}
+	clusterName := clustername.GetClusterName()
+	if clusterName == "" {
+		log.Debugf("Now using plain kubernetes nodename as an alias: no cluster name was set and none could be autodiscovered")
+		return nodeName, nil
+	} else {
+		return (nodeName + "-" + clusterName), nil
+	}
+}

--- a/test/integration/util/kube_apiserver/common.go
+++ b/test/integration/util/kube_apiserver/common.go
@@ -44,3 +44,21 @@ func createEvent(namespace, name, reason string, involvedObject apiv1.ObjectRefe
 		Reason:         reason,
 	}
 }
+
+func createPodOnNode(namespace, name, nodeName string) *apiv1.Pod {
+	return &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: apiv1.PodSpec{
+			NodeName: nodeName,
+			Containers: []apiv1.Container{
+				{
+					Name:  "dummy",
+					Image: "dummy",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
### What does this PR do?

As the cluster agent does not have access to the kubelet or the container runtime, it currently fails to retrieve a valid hostname, except on GCE thanks to https://github.com/DataDog/datadog-agent/pull/2420

This PR adds a new `kube_apiserver` hostname provider, that is only compiled in the cluster-agent (build tag `!kubelet`) and allows the cluster-agent to inspect its own pod to retrive the node it is scheduled on, mirroring the `kubelet` logic.

It supports the `cluster_name` configuration for consistency with the node-agent

On EKS, it does play nice with the `EC2` config provider, and returns the instance name:

> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:127 in GetHostname) | Unable to get the hostname from the config file: hostname is empty
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:128 in GetHostname) | Trying to determine a reliable host name automatically...
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:137 in GetHostname) | GetHostname trying GCE metadata...
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:148 in GetHostname) | Unable to get hostname from GCE:  unable to retrieve hostname from GCE: status code 404 trying to GET http://169.254.169.254/computeMetadata/v1/instance/hostname
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:152 in GetHostname) | GetHostname trying FQDN/`hostname -f`...
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:163 in GetHostname) | Unable to get FQDN from system:  <nil>
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname_docker.go:27 in getContainerHostname) | GetHostname trying Docker API...
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname_docker.go:48 in getContainerHostname) | GetHostname trying Kubernetes trough API server...
> 2018-10-09 09:12:33 UTC | DEBUG | (apiserver.go:138 in connect) | Connected to kubernetes apiserver, version v1
> 2018-10-09 09:12:33 UTC | DEBUG | (apiserver.go:144 in connect) | Could successfully collect Pods, Nodes, Services and Events
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:39 in HostnameProvider) | Now using plain kubernetes nodename as an alias: no cluster name was set and none could be autodiscovered
> 2018-10-09 09:12:33 UTC | DEBUG | (hostname.go:198 in GetHostname) | GetHostname trying EC2 metadata...
> 2018-10-09 09:12:33 UTC | DEBUG | (ec2.go:88 in HostnameProvider) | GetHostname trying EC2 metadata...
> 2018-10-09 09:12:33 UTC | INFO | (app.go:136 in start) | Hostname is: i-09a80cf2ab3f958b5

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
