### PR TITLE
copy golang http.DefaultTransport configuration in our default transport

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -199,14 +199,19 @@ func CreateHTTPTransport() *http.Transport {
 		tlsConfig.MinVersion = tls.VersionTLS12
 	}
 
+	// Most of the following timeouts are a copy of Golang http.DefaultTransport
+	// They are mostly used to act as safeguards in case we forget to add a general
+	// timeout to our http clients.
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout: 30 * time.Second,
+			// Enables TCP keepalives to detect broken connections
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   5,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 5,
+		// This parameter is set to avoid connections sitting idle in the pool indefinitely
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -200,6 +200,7 @@ func CreateHTTPTransport() *http.Transport {
 
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		IdleConnTimeout: 90 * time.Second,
 	}
 
 	if proxies := config.GetProxies(); proxies != nil {

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -200,7 +201,15 @@ func CreateHTTPTransport() *http.Transport {
 
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
-		IdleConnTimeout: 90 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   5,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
 
 	if proxies := config.GetProxies(); proxies != nil {

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -208,6 +208,8 @@ func CreateHTTPTransport() *http.Transport {
 			Timeout: 30 * time.Second,
 			// Enables TCP keepalives to detect broken connections
 			KeepAlive: 30 * time.Second,
+			// Enables happy eyeballs
+			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 5,


### PR DESCRIPTION
### What does this PR do?

Copies values from https://github.com/golang/go/blob/go1.10.2/src/net/http/transport.go#L40-L51
in our default transport.

### Motivation

Here is a good visual explanation of the different http timeouts from this [article](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/).

![image](https://user-images.githubusercontent.com/9051073/46683485-9d830880-cbf0-11e8-854b-f080731a3120.png)

We never had an issue with timeouts in the agent but as this code is getting reused in multiple places let's be safe and use the same defaults as [Golang's default transport](https://github.com/golang/go/blob/go1.10.2/src/net/http/transport.go#L40-L51).

Apart from timeout two other options are getting enabled that are worth mentioning:
- `DualStack` which enables https://en.wikipedia.org/wiki/Happy_Eyeballs and might solve issues we had with golang ignoring ipv6 being disabled
- `KeepAlive` that enables keepalives for TCP

### QA

- We need to check that we don't get timeouted more often. This can be done by looking at the forwarder retry queue.

- We need to check if enabling `DualStack` / https://en.wikipedia.org/wiki/Happy_Eyeballs makes the agent use ipv6 to transport payloads to the intake more often. We should be able to do so by looking at the load balancer of staging. If so we also need to confirm this is ok with Bourbon.