### PR TITLE
Ship file containing versions of checks included in agent

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -167,6 +167,11 @@ build do
       pip "install -c #{project_dir}/#{core_constraints_file} --require-hashes --no-deps -r #{install_dir}/#{agent_requirements_file}"
     end
 
+    # Ship requirements-agent-release.txt file containing the versions of every check shipped with the agent
+    # Used by the `datadog-agent integration` command to prevent downgrading a check to a version
+    # older than the one shipped in the agent
+    copy "#{project_dir}/requirements-agent-release.txt", "#{install_dir}/"
+
     # install integrations
     Dir.glob("#{project_dir}/*").each do |check_dir|
       check = check_dir.split('/').last


### PR DESCRIPTION
### What does this PR do?

Ship https://github.com/DataDog/integrations-core/blob/master/requirements-agent-release.txt so we are able to prevent users from installing a check with an older version than the one shipped with the agent.
This will allow the following scenario: 
- user has agent 6.6 that ship integration `foo` version 2.2.0
- user upgrades integration `foo` to version 2.3.0 to try new feature
- user will be able to downgrade back to `foo` version 2.2.0 if not satisfied, but they won't be able to downgrade to a version older that 2.2.0

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?