### PR TITLE
Add a kubelet_wait_on_missing_container option to handle slow kubelet updates

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -231,6 +231,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("kubelet_client_crt", "")
 	config.BindEnvAndSetDefault("kubelet_client_key", "")
 
+	config.BindEnvAndSetDefault("kubelet_wait_on_missing_container", 0)
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -555,6 +555,11 @@ api_key:
 # kubelet_client_crt: /path/to/key
 # kubelet_client_key: /path/to/key
 #
+# On some kubelet versions, containers can take up to a second to
+# register in the podlist. This option allows to wait for a given
+# number of seconds when a container does not exist in the podlist.
+# kubelet_wait_on_missing_container: 0
+#
 {{ end -}}
 {{- if .KubeApiServer }}
 # Kubernetes apiserver integration

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -556,8 +556,8 @@ api_key:
 # kubelet_client_key: /path/to/key
 #
 # On some kubelet versions, containers can take up to a second to
-# register in the podlist. This option allows to wait for a given
-# number of seconds when a container does not exist in the podlist.
+# register in the podlist. This option allows to wait for up to a given
+# number of seconds (in 250ms chunks) when a container does not exist in the podlist.
 # kubelet_wait_on_missing_container: 0
 #
 {{ end -}}

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_empty.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_empty.json
@@ -1,0 +1,6 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": []
+}

--- a/releasenotes/notes/kubelet_wait_for_container-bc4b78630674e75a.yaml
+++ b/releasenotes/notes/kubelet_wait_for_container-bc4b78630674e75a.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    Added a ``kubelet_wait_on_missing_container`` option to handle hosts where
+    the kubelet's podlist is slow to update, leading to missing tags
+    or failing Autodiscovery. Set it to 1 for a 1 second maximum wait


### PR DESCRIPTION
### What does this PR do?

On some hosts, containers can take up to a second to register in the kubelet podlist. This can lead to race conditions where the container is running but not available in the podlist, with the following possible consequences:

- Autodiscovery failures because the agent cannot retrieve the pod IP from the kubelet
- Missing kubernetes tags on logs and custom metrics, if the application starts sending logs / metrics before the podlist is updated

This PR adds a `kubelet_wait_on_missing_container` option that makes the agent take this delay into account. It is implemented by making the `KubeUtil.GetPodForContainerID` retry every 250ms until the configured delay is expired.

### Rationale

- This logic adds less complexity than retrying the container search in both the Autodiscovery and Tagger subsystems
- On the recommended `1 second` setting for affected hosts, worst case impact would be similar to increasing the kubelet query timeout to 2 seconds, but stays bound
- Host where some containers are not handled by kubernetes (direct docker runs) would incur the 1 second cost for these containers (which is why the option is disabled by default), but on full-kube hosts, container IDs should all be in the podlist.

### Motivation

Be more resilient to lag in the kubelet podlist updates 
