### PR TITLE
Make config polling interval configurable

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -26,7 +26,6 @@ import (
 )
 
 var (
-	configsPollIntl       = 10 * time.Second
 	listenerCandidateIntl = 30 * time.Second
 	acErrors              *expvar.Map
 	errorStats            = newAcErrorStats()
@@ -104,6 +103,7 @@ func (ac *AutoConfig) StartConfigPolling() {
 	ac.m.Lock()
 	defer ac.m.Unlock()
 
+	configsPollIntl := config.Datadog.GetDuration("ad_config_poll_interval") * time.Second
 	ac.configsPollTicker = time.NewTicker(configsPollIntl)
 	ac.pollConfigs()
 	ac.pollerActive = true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -193,6 +193,7 @@ func init() {
 	BindEnvAndSetDefault("exclude_pause_container", true)
 	BindEnvAndSetDefault("ac_include", []string{})
 	BindEnvAndSetDefault("ac_exclude", []string{})
+	BindEnvAndSetDefault("ad_config_poll_interval", int64(10)) // in seconds
 
 	// Docker
 	BindEnvAndSetDefault("docker_query_timeout", int64(5))

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -463,6 +463,10 @@ api_key:
 # is 5 seconds. It can be configured with this option.
 # docker_query_timeout: 5
 #
+# The default interval in second to check for new autodiscovery configurations
+# On all registered configuration providers
+# ad_config_poll_interval: 10
+#
 {{ end -}}
 {{- if .DockerTagging }}
 # Docker tag extraction

--- a/releasenotes/notes/ad-config-polling-dc20866864214e8c.yaml
+++ b/releasenotes/notes/ad-config-polling-dc20866864214e8c.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add a setting to configure the interval at which configs should be polled
+    for autodiscovery.


### PR DESCRIPTION
### What does this PR do?

Make config polling interval configurable

### Motivation

Make polling more aggressive on specific setups (like tailing short-lived containers on docker)
