### PR TITLE
Fix logrotate issues on windows

### DIFF
--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -97,6 +97,10 @@ func (t *Tailer) readForever() {
 	}
 }
 
+// openFileShareDeleteMode reimplement the os.Open function for Windows because the default
+// implementation opens files without the FILE_SHARE_DELETE flag.
+// cf: https://github.com/golang/go/blob/release-branch.go1.11/src/syscall/syscall_windows.go#L271
+// This prevents users from moving/removing files when the tailer is reading the file.
 func openFileShareDeleteMode(path string) (*os.File, error) {
 	pathp, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
@@ -104,6 +108,7 @@ func openFileShareDeleteMode(path string) (*os.File, error) {
 	}
 
 	access := uint32(syscall.GENERIC_READ)
+	// add FILE_SHARE_DELETE that is missing from os.Open implementation
 	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
 	createmode := uint32(syscall.OPEN_EXISTING)
 	var sa *syscall.SecurityAttributes

--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -101,6 +101,7 @@ func (t *Tailer) readForever() {
 // implementation opens files without the FILE_SHARE_DELETE flag.
 // cf: https://github.com/golang/go/blob/release-branch.go1.11/src/syscall/syscall_windows.go#L271
 // This prevents users from moving/removing files when the tailer is reading the file.
+// FIXME(achntrl): Should we stop opening/closing the file on every call to readAvailable ?
 func openFile(path string) (*os.File, error) {
 	pathp, err := syscall.UTF16PtrFromString(path)
 	if err != nil {

--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -35,7 +35,7 @@ func (t *Tailer) setup(offset int64, whence int) error {
 
 func (t *Tailer) readAvailable() (err error) {
 	err = nil
-	f, err := openFileShareDeleteMode(t.fullpath)
+	f, err := openFile(t.fullpath)
 	if err != nil {
 		return err
 	}
@@ -97,11 +97,11 @@ func (t *Tailer) readForever() {
 	}
 }
 
-// openFileShareDeleteMode reimplement the os.Open function for Windows because the default
+// openFile reimplement the os.Open function for Windows because the default
 // implementation opens files without the FILE_SHARE_DELETE flag.
 // cf: https://github.com/golang/go/blob/release-branch.go1.11/src/syscall/syscall_windows.go#L271
 // This prevents users from moving/removing files when the tailer is reading the file.
-func openFileShareDeleteMode(path string) (*os.File, error) {
+func openFile(path string) (*os.File, error) {
 	pathp, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, err

--- a/releasenotes/notes/open-files-in-share-delete-mode-windows-d8c5726ff0ed18d4.yaml
+++ b/releasenotes/notes/open-files-in-share-delete-mode-windows-d8c5726ff0ed18d4.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue where the log agent would prevent files from being log rotated on Windows


### PR DESCRIPTION
### What does this PR do?

Replace the `os.Open()` by the custom function that calls `syscall.CreateFile`

### Motivation

Bug on windows because the agent locks the files for move/remove when reading (because of https://github.com/golang/go/blob/master/src/syscall/syscall_windows.go#L272 cf [CreateFile doc](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-createfilea#parameters))

### Additional Notes

Not sure we want to do this, I'm a bit afraid of unexpected consequences of such a change

If we do, TODO: 

- [x] Add comments in the code to explain why we did this
