### PR TITLE
Add no-deps, in-toto and verbose flags to integration command

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -47,7 +47,7 @@ func init() {
 	tufCmd.AddCommand(freezeCmd)
 	tufCmd.PersistentFlags().BoolVarP(&withoutTuf, "no-tuf", "t", false, "don't use TUF repo")
 	tufCmd.PersistentFlags().BoolVarP(&inToto, "in-toto", "i", false, "enable in-toto")
-	tufCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable TUF logging")
+	tufCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging on pip and TUF")
 	tufCmd.PersistentFlags().BoolVarP(&allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
 	tufCmd.PersistentFlags().BoolVarP(&useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
 	tufCmd.PersistentFlags().StringVar(&tufConfig, "tuf-cfg", getTufConfigPath(), "path to TUF config file")
@@ -189,7 +189,6 @@ func tuf(args []string) error {
 	implicitFlags = append(implicitFlags, "--disable-pip-version-check")
 	args = append([]string{"-mpip"}, cmd)
 
-	// Increase verbosity of pip if tuf logging enabled
 	if verbose {
 		args = append(args, "-vvv")
 	}

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -44,6 +44,7 @@ func init() {
 	tufCmd.AddCommand(searchCmd)
 	tufCmd.AddCommand(freezeCmd)
 	tufCmd.PersistentFlags().BoolVarP(&withoutTuf, "no-tuf", "t", false, "don't use TUF repo")
+	tufCmd.PersistentFlags().BoolVarP(&inToto, "phase-1", "1", false, "enable in-toto")
 	tufCmd.PersistentFlags().BoolVarP(&allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
 	tufCmd.PersistentFlags().BoolVarP(&useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
 	tufCmd.PersistentFlags().StringVar(&tufConfig, "tuf-cfg", getTufConfigPath(), "path to TUF config file")
@@ -216,6 +217,12 @@ func tuf(args []string) error {
 		tufCmd.Env = append(tufCmd.Env,
 			fmt.Sprintf("TUF_CONFIG_FILE=%s", tufPath),
 		)
+		// Enable phase 1, aka in-toto
+		if inToto {
+			tufCmd.Env = append(tufCmd.Env,
+				fmt.Sprintf("TUF_DOWNLOAD_IN_TOTO_METADATA=1")
+			)
+		}
 	}
 
 	// forward the standard output to the Agent logger
@@ -270,6 +277,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 		"install",
 		"--cache-dir", cachePath,
 		"-c", constraintsPath,
+		"--no-deps",
 	}
 
 	tufArgs = append(tufArgs, args...)

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -220,7 +220,7 @@ func tuf(args []string) error {
 		// Enable phase 1, aka in-toto
 		if inToto {
 			tufCmd.Env = append(tufCmd.Env,
-				fmt.Sprintf("TUF_DOWNLOAD_IN_TOTO_METADATA=1"),
+				"TUF_DOWNLOAD_IN_TOTO_METADATA=1",
 			)
 		}
 	}

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -220,7 +220,7 @@ func tuf(args []string) error {
 		// Enable phase 1, aka in-toto
 		if inToto {
 			tufCmd.Env = append(tufCmd.Env,
-				fmt.Sprintf("TUF_DOWNLOAD_IN_TOTO_METADATA=1")
+				fmt.Sprintf("TUF_DOWNLOAD_IN_TOTO_METADATA=1"),
 			)
 		}
 	}

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -34,7 +34,7 @@ var (
 	allowRoot    bool
 	withoutTuf   bool
 	inToto       bool
-	tufLog       bool
+	verbose      bool
 	useSysPython bool
 	tufConfig    string
 )
@@ -47,7 +47,7 @@ func init() {
 	tufCmd.AddCommand(freezeCmd)
 	tufCmd.PersistentFlags().BoolVarP(&withoutTuf, "no-tuf", "t", false, "don't use TUF repo")
 	tufCmd.PersistentFlags().BoolVarP(&inToto, "in-toto", "i", false, "enable in-toto")
-	tufCmd.PersistentFlags().BoolVarP(&tufLog, "tuf-log", "l", false, "enable TUF logging")
+	tufCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable TUF logging")
 	tufCmd.PersistentFlags().BoolVarP(&allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
 	tufCmd.PersistentFlags().BoolVarP(&useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
 	tufCmd.PersistentFlags().StringVar(&tufConfig, "tuf-cfg", getTufConfigPath(), "path to TUF config file")
@@ -190,7 +190,7 @@ func tuf(args []string) error {
 	args = append([]string{"-mpip"}, cmd)
 
 	// Increase verbosity of pip if tuf logging enabled
-	if tufLog {
+	if verbose {
 		args = append(args, "-vvv")
 	}
 
@@ -227,7 +227,7 @@ func tuf(args []string) error {
 		)
 
 		// Enable tuf logging
-		if tufLog {
+		if verbose {
 			tufCmd.Env = append(tufCmd.Env,
 				"TUF_ENABLE_LOGGING=1",
 			)
@@ -241,7 +241,7 @@ func tuf(args []string) error {
 		}
 	} else {
 		if inToto {
-			return errors.New("--in-toto conflicts with --no-tuf!")
+			return errors.New("--in-toto conflicts with --no-tuf")
 		}
 	}
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -33,7 +33,7 @@ const (
 var (
 	allowRoot    bool
 	withoutTuf   bool
-	inToto   bool
+	inToto       bool
 	useSysPython bool
 	tufConfig    string
 )

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -33,6 +33,7 @@ const (
 var (
 	allowRoot    bool
 	withoutTuf   bool
+	inToto   bool
 	useSysPython bool
 	tufConfig    string
 )

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -45,7 +45,7 @@ func init() {
 	tufCmd.AddCommand(searchCmd)
 	tufCmd.AddCommand(freezeCmd)
 	tufCmd.PersistentFlags().BoolVarP(&withoutTuf, "no-tuf", "t", false, "don't use TUF repo")
-	tufCmd.PersistentFlags().BoolVarP(&inToto, "phase-1", "1", false, "enable in-toto")
+	tufCmd.PersistentFlags().BoolVarP(&inToto, "in-toto", "i", false, "enable in-toto")
 	tufCmd.PersistentFlags().BoolVarP(&allowRoot, "allow-root", "r", false, "flag to enable root to install packages")
 	tufCmd.PersistentFlags().BoolVarP(&useSysPython, "use-sys-python", "p", false, "use system python instead [dev flag]")
 	tufCmd.PersistentFlags().StringVar(&tufConfig, "tuf-cfg", getTufConfigPath(), "path to TUF config file")
@@ -264,11 +264,6 @@ func installTuf(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	constraintsPath, err := getConstraintsFilePath()
-	if err != nil {
-		return err
-	}
-
 	cachePath, err := getTUFPipCachePath()
 	if err != nil {
 		return err
@@ -277,7 +272,6 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	tufArgs := []string{
 		"install",
 		"--cache-dir", cachePath,
-		"-c", constraintsPath,
 		"--no-deps",
 	}
 

--- a/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
+++ b/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
@@ -8,7 +8,8 @@
 ---
 features:
   - |
-    Add ``--phase-1`` flag to ``datadog-agent integration`` command to enable in-toto
+    Add ``--in-toto`` flag to ``datadog-agent integration`` command to enable in-toto
+  - Add ``--tuf-log`` flag to ``datadog-agent integration`` command to enable TUF logging
 enhancements:
   - |
     Install integration wheels with ``--no-deps`` to prevent installation of unwanted dependencies

--- a/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
+++ b/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
@@ -9,7 +9,7 @@
 features:
   - |
     Add ``--in-toto`` flag to ``datadog-agent integration`` command to enable in-toto
-  - Add ``--verbose`` flag to ``datadog-agent integration`` command to enable TUF logging
+  - Add ``--verbose`` flag to ``datadog-agent integration`` command to enable verbose logging on pip and TUF
 enhancements:
   - |
     ``datadog-agent integration`` command will not pull any of the integration's dependencies

--- a/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
+++ b/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
@@ -9,7 +9,7 @@
 features:
   - |
     Add ``--in-toto`` flag to ``datadog-agent integration`` command to enable in-toto
-  - Add ``--tuf-log`` flag to ``datadog-agent integration`` command to enable TUF logging
+  - Add ``--verbose`` flag to ``datadog-agent integration`` command to enable TUF logging
 enhancements:
   - |
-    Install integration wheels with ``--no-deps`` to prevent installation of unwanted dependencies
+    ``datadog-agent integration`` command will not pull any of the integration's dependencies

--- a/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
+++ b/releasenotes/notes/nodeps_intoto-208171c6e23123a0.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add ``--phase-1`` flag to ``datadog-agent integration`` command to enable in-toto
+enhancements:
+  - |
+    Install integration wheels with ``--no-deps`` to prevent installation of unwanted dependencies


### PR DESCRIPTION
### What does this PR do?

- Add --no-deps flag to pip to prevent installing unwanted dependencies
- Add --in-toto flag to `integration` command to enable phase 1
- Add --verbose flag to enable tuf logging

### Motivation

Adding this for beta testing in 6.6
