### PR TITLE
implement integration install command workflow (install, check compatibility, rollback)

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -374,7 +374,6 @@ func installTuf(cmd *cobra.Command, args []string) error {
 			versionToInstall, integration, pipErr, tufErr,
 		)
 	}
-	return pipErr
 }
 
 func getIntegrationVersion(integration string) (string, error) {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -76,9 +76,10 @@ var tufCmd = &cobra.Command{
 var installCmd = &cobra.Command{
 	Use:   "install [package]",
 	Short: "Install Datadog integration core/extra packages",
-	Long: `You must specify a version of the package to install using the syntax: <package>==<version>, with
-- <package> of the form datadog-<integration-name>
-- <version> of the form x.y.z`,
+	Long: `Install Datadog integration core/extra packages
+You must specify a version of the package to install using the syntax: <package>==<version>, with
+ - <package> of the form datadog-<integration-name>
+ - <version> of the form x.y.z`,
 	RunE: installTuf,
 }
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -30,12 +30,6 @@ const (
 	pipFreezeOutputPattern = "%s==(\\d+\\.\\d+\\.\\d+)"
 )
 
-type DependencyError string
-
-func (s DependencyError) Error() string {
-	return string(s)
-}
-
 var (
 	allowRoot    bool
 	withoutTuf   bool

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -285,6 +285,9 @@ func installTuf(cmd *cobra.Command, args []string) error {
 
 	intVer := strings.Split(args[0], "==")
 	integration := strings.TrimSpace(intVer[0])
+	if integration == "datadog-checks-base" {
+		return fmt.Errorf("cannot upgrade datadog-checks-base")
+	}
 	versionToInstall := strings.TrimSpace(intVer[1])
 	currentVersion, err := getIntegrationVersion(integration)
 	if err != nil {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -25,7 +25,6 @@ import (
 )
 
 const (
-	constraintsFile       = "agent_requirements.txt"
 	tufConfigFile         = "public-tuf-config.json"
 	tufPkgPattern         = "datadog-.*"
 	pipCheckOutputPattern = "%s \\d+\\.\\d+\\.\\d+ has requirement " +
@@ -126,19 +125,6 @@ func getCommandPython() (string, error) {
 	}
 
 	return pyPath, nil
-}
-
-func getConstraintsFilePath() (string, error) {
-	here, _ := executable.Folder()
-	cPath := filepath.Join(here, relConstraintsPath)
-
-	if _, err := os.Stat(cPath); err != nil {
-		if os.IsNotExist(err) {
-			return cPath, err
-		}
-	}
-
-	return cPath, nil
 }
 
 func getTUFConfigFilePath() (string, error) {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -294,7 +294,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run pip check first to see if the python environment is clean
-	if err := pipCheck(); err != nil {
+	if err := pipCheck(cachePath); err != nil {
 		return fmt.Errorf(
 			"error when validating the agent's python environment, won't install %s: %v",
 			integration, err,

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -291,7 +291,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	// Run pip check first to see if the python environment is clean
 	if err := pipCheck(); err != nil {
 		return fmt.Errorf(
-			"error when validating the agen't python environment, won't install %s: %v",
+			"error when validating the agent's python environment, won't install %s: %v",
 			integration, err,
 		)
 	}

--- a/cmd/agent/app/integrations_nix.go
+++ b/cmd/agent/app/integrations_nix.go
@@ -21,7 +21,6 @@ const (
 
 var (
 	relPyPath            = filepath.Join("..", "..", "embedded", "bin", pythonBin)
-	relConstraintsPath   = filepath.Join("..", "..", constraintsFile)
 	relTufConfigFilePath = filepath.Join("..", "..", tufConfigFile)
 	relTufPipCache       = filepath.Join("..", "..", "repositories", "cache")
 )

--- a/cmd/agent/app/integrations_windows.go
+++ b/cmd/agent/app/integrations_windows.go
@@ -19,7 +19,6 @@ const (
 
 var (
 	relPyPath            = pythonBin
-	relConstraintsPath   = filepath.Join("..", constraintsFile)
 	relTufConfigFilePath = filepath.Join("..", tufConfigFile)
 	tufPipCachePath      = filepath.Join("c:\\", "ProgramData", "Datadog", "repositories", "cache")
 )

--- a/releasenotes/notes/install_workflow-f5a01445867a4a55.yaml
+++ b/releasenotes/notes/install_workflow-f5a01445867a4a55.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The ``datadog-agent integration install`` command will now check for compatibility with ``datadog-checks-base`` 
+    shipped with the agent. In case of mismatch, it will try to rollback to the previously installed integration 
+    version and exit with a failure.


### PR DESCRIPTION
### What does this PR do?

In order to prevent installation of incompatible integrations, we need to had more logic to the `install` command so that we check for compatibility issues with `pip check`, and then perform a rollback of the installation in case there are mismatches.

This is due to the behavior of pip to always install a wheel, even though some dependency constraints are not met.

### Motivation

What inspired you to submit this pull request?

### Additional Notes
To do next: 
 - prevent downgrading to an older version than the one shipped with the agent
 - copy data files (conf.yaml.example, ...) to proper destination
