### PR TITLE
[DCA] Forget keys to avoid borking hpa informer

### DIFF
--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -75,8 +75,8 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
 	copyAge := metav1.Now().Unix() - p.timestamp
-	if copyAge < p.maxAge { //&& p.externalMetrics != nil{
-		log.Tracef("Local copy is recent enough, not querying the GlobalStore. Remaining %d/%d seconds before next sync", copyAge, p.maxAge)
+	if copyAge < p.maxAge {
+		log.Tracef("Local copy is recent enough, not querying the GlobalStore. Remaining %d seconds before next sync", p.maxAge-copyAge)
 		for _, in := range p.externalMetrics {
 			externalMetricsInfoList = append(externalMetricsInfoList, in.info)
 		}

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -38,15 +38,18 @@ type datadogProvider struct {
 	resVersion      string
 	store           Store
 	timestamp       int64
+	maxAge          int64
 }
 
 // NewDatadogProvider creates a Custom Metrics and External Metrics Provider.
 func NewDatadogProvider(client dynamic.Interface, mapper apimeta.RESTMapper, store Store) provider.MetricsProvider {
+	maxAge := config.Datadog.GetInt64("external_metrics_provider.local_copy_refresh_rate")
 	return &datadogProvider{
 		client: client,
 		mapper: mapper,
 		values: make(map[provider.CustomMetricInfo]int64),
 		store:  store,
+		maxAge: maxAge,
 	}
 }
 
@@ -71,6 +74,16 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 	var externalMetricsInfoList []provider.ExternalMetricInfo
 	var externalMetricsList []externalMetric
 
+	copyAge := metav1.Now().Unix() - p.timestamp
+	if copyAge < p.maxAge { //&& p.externalMetrics != nil{
+		log.Tracef("Local copy is recent enough, not querying the GlobalStore. Remaining %d/%d seconds before next sync", copyAge, p.maxAge)
+		for _, in := range p.externalMetrics {
+			externalMetricsInfoList = append(externalMetricsInfoList, in.info)
+		}
+		return externalMetricsInfoList
+	}
+
+	log.Debugf("Local copy of external metrics from the global store is outdated by %d seconds, resyncing now", copyAge-p.maxAge)
 	rawMetrics, err := p.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Errorf("Could not list the external metrics in the store: %s", err.Error())
@@ -112,12 +125,7 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 func (p *datadogProvider) GetExternalMetric(namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
 	matchingMetrics := []external_metrics.ExternalMetricValue{}
 
-	copyAge := metav1.Now().Unix() - p.timestamp
-	maxAge := config.Datadog.GetInt64("external_metrics_provider.local_copy_refresh_rate")
-	if copyAge > maxAge {
-		log.Debugf("Local copy of external metrics from the global store is outdated: %d, resyncing now", copyAge)
-		p.ListAllExternalMetrics()
-	}
+	p.ListAllExternalMetrics() // get up to date values from the cache or the Global Store
 
 	for _, metric := range p.externalMetrics {
 		metricFromDatadog := external_metrics.ExternalMetricValue{

--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -159,7 +159,6 @@ func (c *configMapStore) DeleteExternalMetricValues(deleted []ExternalMetricValu
 func (c *configMapStore) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
 	if err := c.getConfigMap(); err != nil {
 		return nil, err
 	}

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -30,6 +30,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	// maxRetries is the maximum number of times we try to process an autoscaler before it is dropped out of the queue.
+	maxRetries = 10
+)
+
 type PollerConfig struct {
 	gcPeriodSeconds int
 	refreshPeriod   int
@@ -69,7 +74,7 @@ type AutoscalersController struct {
 func NewAutoscalersController(client kubernetes.Interface, le LeaderElectorInterface, dogCl hpa.DatadogClient, autoscalingInformer autoscalersinformer.HorizontalPodAutoscalerInformer) (*AutoscalersController, error) {
 	var err error
 	h := &AutoscalersController{
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "autoscalers"),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "autoscalers"),
 	}
 
 	gcPeriodSeconds := config.Datadog.GetInt("hpa_watcher_gc_period")
@@ -236,16 +241,30 @@ func (h *AutoscalersController) processNext() bool {
 	defer h.queue.Done(key)
 
 	err := h.syncAutoscalers(key)
-	if err != nil {
-		log.Errorf("Could not sync HPAs %s", err)
-	}
+	h.handleErr(err, key)
 
 	// Debug output for unit tests only
 	if h.autoscalers != nil {
 		h.autoscalers <- key
 	}
-
 	return true
+}
+
+func (h *AutoscalersController) handleErr(err error, key interface{}) {
+	if err == nil {
+		log.Tracef("Faithfully dropping key %v", key)
+		h.queue.Forget(key)
+		return
+	}
+
+	if h.queue.NumRequeues(key) < maxRetries {
+		log.Debugf("Error syncing the autoscaler %v, will rety for another %d/%d times: %v", key, h.queue.NumRequeues(key), maxRetries, err)
+		h.queue.AddRateLimited(key)
+		return
+	}
+	log.Errorf("Too many errors trying to sync the autoscaler %v, dropping out of the queue: %v", key, err)
+	h.queue.Forget(key)
+	return
 }
 
 func (h *AutoscalersController) syncAutoscalers(key interface{}) error {

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -258,13 +258,12 @@ func (h *AutoscalersController) handleErr(err error, key interface{}) {
 	}
 
 	if h.queue.NumRequeues(key) < maxRetries {
-		log.Debugf("Error syncing the autoscaler %v, will rety for another %d/%d times: %v", key, h.queue.NumRequeues(key), maxRetries, err)
+		log.Debugf("Error syncing the autoscaler %v, will rety for another %d times: %v", key, maxRetries-h.queue.NumRequeues(key), err)
 		h.queue.AddRateLimited(key)
 		return
 	}
 	log.Errorf("Too many errors trying to sync the autoscaler %v, dropping out of the queue: %v", key, err)
 	h.queue.Forget(key)
-	return
 }
 
 func (h *AutoscalersController) syncAutoscalers(key interface{}) error {


### PR DESCRIPTION
### What does this PR do?
This addresses 3 issues:

- If all metrics are invalid in the global store, this can result in unnecessary calls to the GlobalStore (that can be in high number).
- Leverage the DefaultItemBasedRateLimiter limiter and add the key forget an retry logic to avoid borking the informer with unfinished work.
- Move maxAge parameter to cache to avoid unnecessary calls to viper and also move the logic to the ListAllExternal metrics method to factorise calls.

### Motivation

QA fixes.