### PR TITLE
Set a default value to the registry

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -40,10 +40,10 @@
     </Upgrade>
 
     <!-- Close application when uninstalling -->
-    <util:CloseApplication Id="CloseTrayApp" 
-                          CloseMessage="yes" 
+    <util:CloseApplication Id="CloseTrayApp"
+                          CloseMessage="yes"
                           EndSessionMessage="yes"
-                          Target="ddtray.exe" 
+                          Target="ddtray.exe"
                           ElevatedCloseMessage="yes"
                           TerminateProcess="1"
                           Timeout="1"
@@ -344,6 +344,16 @@
         </Component>
       </Directory>
 
+      <Directory Id="run" Name="run">
+        <Component Id="run"
+                   Guid="5acf7ec1-3bcf-40d7-8840-f8de8a472c3c"
+                   Permanent="yes"
+                   Location="either"
+                   NeverOverwrite="yes">
+          <CreateFolder/>
+        </Component>
+      </Directory>
+
       <Directory Id="EXAMPLECONFSLOCATION" Name= "conf.d">
         <Component Id="conf.d"
                    Guid="54fcfacb-726b-46e3-a699-ec19258a24be"
@@ -544,7 +554,7 @@
 
    <Binary Id="BannerBmp" SourceFile="Resources\assets\banner_background.bmp" />
     <Binary Id="BackgroundBmp" SourceFile="Resources\assets\dialog_background.bmp" />
-    
+
     <Property Id="ShortCompanyName" Value="!(loc.CompanyNameShort)" />
 
   </Product>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -344,8 +344,9 @@
         </Component>
       </Directory>
 
-      <Directory Id="run" Name="run">
-        <Component Id="run"
+      <!-- Directory to store the registry that keep track of tailed file offsets -->
+      <Directory Id="REGISTRYDIRECTORY" Name="run">
+        <Component Id="REGISTRYDIRECTORY"
                    Guid="5acf7ec1-3bcf-40d7-8840-f8de8a472c3c"
                    Permanent="yes"
                    Location="either"
@@ -437,6 +438,7 @@
       <ComponentRef Id="cache" />
       <ComponentRef Id="current_metadata" />
       <ComponentRef Id="previous_metadata" />
+      <ComponentRef Id="REGISTRYDIRECTORY" />
       <ComponentRef Id="root.json" />
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="DATADOGAGENTSERVICE" />

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -8,7 +8,7 @@ package config
 const (
 	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
-	defaultRunPath              = ""
+	defaultRunPath              = "c:\\programdata\\datadog"
 	defaultSyslogURI            = ""
 	defaultGuiPort              = "5002"
 )

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -8,7 +8,7 @@ package config
 const (
 	defaultConfdPath            = "c:\\programdata\\datadog\\conf.d"
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
-	defaultRunPath              = "c:\\programdata\\datadog"
+	defaultRunPath              = "c:\\programdata\\datadog\\run"
 	defaultSyslogURI            = ""
 	defaultGuiPort              = "5002"
 )

--- a/releasenotes/notes/add-default-value-to-registry-3a91e6b20f29f428.yaml
+++ b/releasenotes/notes/add-default-value-to-registry-3a91e6b20f29f428.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    "Add a default value to the registry on Windows: C:\ProgramData\datadog"
+    Adding a default location on Windows for the file storing pointers to make sure we never lose nor duplicate any logs

--- a/releasenotes/notes/add-default-value-to-registry-3a91e6b20f29f428.yaml
+++ b/releasenotes/notes/add-default-value-to-registry-3a91e6b20f29f428.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    "Add a default value to the registry on Windows: C:\ProgramData\datadog"


### PR DESCRIPTION
### What does this PR do?

Sets a default path to the registry

### Motivation

There is no default path for the registry. It is created in the folder from where the agent is started. The registry might not be accessible to the agent

### Additional Notes

How do we ensure that a client who upgrade the agent on windows migrate his current registry file ? If we don't, the client might end up with duplicated logs