### PR TITLE
[DCA] GC compares metrics, add unit tests

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hpa"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 )
@@ -309,6 +310,19 @@ func TestAutoscalerControllerGC(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 					UID:       "1111",
+				},
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "requests_per_s",
+								MetricSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"bar": "baz"},
+								},
+							},
+						},
+					},
 				},
 			},
 			expected: []custommetrics.ExternalMetricValue{ // skipped by gc

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -39,15 +39,15 @@ func Inspect(hpa *autoscalingv2.HorizontalPodAutoscaler) (emList []custommetrics
 
 // DiffExternalMetrics returns the list of external metrics that reference hpas that are not in the given list of hpas.
 func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, storedMetricsList []custommetrics.ExternalMetricValue) (toDelete []custommetrics.ExternalMetricValue) {
-	metricsList := map[string][]custommetrics.ExternalMetricValue{}
+	hpaMetrics := map[string][]custommetrics.ExternalMetricValue{}
 
 	for _, hpa := range informerList {
-		metricsList[string(hpa.UID)] = Inspect(hpa)
+		hpaMetrics[string(hpa.UID)] = Inspect(hpa)
 	}
 
 	for _, em := range storedMetricsList {
 		var found bool
-		emList := metricsList[em.HPA.UID]
+		emList := hpaMetrics[em.HPA.UID]
 		if emList == nil {
 			toDelete = append(toDelete, em)
 			continue

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -99,6 +99,21 @@ func TestInspect(t *testing.T) {
 	}
 }
 
+func makeSpec(metricName string, labels map[string]string) autoscalingv2.HorizontalPodAutoscalerSpec {
+	return autoscalingv2.HorizontalPodAutoscalerSpec{
+		Metrics: []autoscalingv2.MetricSpec{
+			{
+				Type: autoscalingv2.ExternalMetricSourceType,
+				External: &autoscalingv2.ExternalMetricSource{
+					MetricName: metricName,
+					MetricSelector: &metav1.LabelSelector{
+						MatchLabels: labels,
+					},
+				},
+			},
+		},
+	}
+}
 func TestDiffExternalMetrics(t *testing.T) {
 	testCases := map[string]struct {
 		lhs      []*autoscalingv2.HorizontalPodAutoscaler
@@ -110,13 +125,83 @@ func TestDiffExternalMetrics(t *testing.T) {
 			[]*autoscalingv2.HorizontalPodAutoscaler{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: types.UID(5),
+						UID:       types.UID(5),
+						Namespace: "nsbar",
+						Name:      "foo",
 					},
+					Spec: makeSpec("requests_per_s_one", map[string]string{"foo": "tagbar"}),
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: types.UID(7),
+						UID:       types.UID(7),
+						Namespace: "zanzi",
+						Name:      "bar",
 					},
+					Spec: makeSpec("requests_per_s_three", map[string]string{"foo": "tu"}),
+				},
+			},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "requests_per_s_one",
+					Labels:     map[string]string{"foo": "tagbar"},
+					Valid:      true,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(5),
+						Name:      "foo",
+						Namespace: "nsbar",
+					},
+				},
+				{
+					MetricName: "requests_per_s_two",
+					Labels:     map[string]string{"foo": "dre"},
+					Valid:      false,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(6),
+						Name:      "foo",
+						Namespace: "baz",
+					},
+				},
+				{
+					MetricName: "requests_per_s_three",
+					Labels:     map[string]string{"foo": "tu"},
+					Valid:      false,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(7),
+						Name:      "bar",
+						Namespace: "zanzi",
+					},
+				},
+			},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "requests_per_s_two",
+					Labels:     map[string]string{"foo": "dre"},
+					Valid:      false,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(6),
+						Name:      "foo",
+						Namespace: "baz",
+					},
+				},
+			},
+		},
+		"metric name changed": {
+			[]*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID(5),
+						Namespace: "bar",
+						Name:      "foo",
+					},
+					Spec: makeSpec("requests_per_s_one", map[string]string{"foo": "bar"}),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID(7),
+						Namespace: "baz",
+						Name:      "foo",
+					},
+					Spec: makeSpec("requests_per_s_new", map[string]string{"foo": "bar"}),
 				},
 			},
 			[]custommetrics.ExternalMetricValue{
@@ -125,33 +210,31 @@ func TestDiffExternalMetrics(t *testing.T) {
 					Labels:     map[string]string{"foo": "bar"},
 					Valid:      true,
 					HPA: custommetrics.ObjectReference{
-						UID: string(5),
+						UID:       string(5),
+						Namespace: "bar",
+						Name:      "foo",
 					},
 				},
 				{
-					MetricName: "requests_per_s_two",
+					MetricName: "requests_per_s_old",
 					Labels:     map[string]string{"foo": "bar"},
 					Valid:      false,
 					HPA: custommetrics.ObjectReference{
-						UID: string(6),
-					},
-				},
-				{
-					MetricName: "requests_per_s_three",
-					Labels:     map[string]string{"foo": "bar"},
-					Valid:      false,
-					HPA: custommetrics.ObjectReference{
-						UID: string(7),
+						UID:       string(7),
+						Namespace: "baz",
+						Name:      "foo",
 					},
 				},
 			},
 			[]custommetrics.ExternalMetricValue{
 				{
-					MetricName: "requests_per_s_two",
+					MetricName: "requests_per_s_old",
 					Labels:     map[string]string{"foo": "bar"},
 					Valid:      false,
 					HPA: custommetrics.ObjectReference{
-						UID: string(6),
+						UID:       string(7),
+						Name:      "foo",
+						Namespace: "baz",
 					},
 				},
 			},

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -239,6 +239,60 @@ func TestDiffExternalMetrics(t *testing.T) {
 				},
 			},
 		},
+		"metric labels changed": {
+			[]*autoscalingv2.HorizontalPodAutoscaler{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID(5),
+						Namespace: "bar",
+						Name:      "foo",
+					},
+					Spec: makeSpec("requests_per_s_one", map[string]string{"foo": "bar"}),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       types.UID(7),
+						Namespace: "baz",
+						Name:      "foo",
+					},
+					Spec: makeSpec("requests_per_s_two", map[string]string{"foo": "foobar"}),
+				},
+			},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "requests_per_s_one",
+					Labels:     map[string]string{"foo": "bar"},
+					Valid:      true,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(5),
+						Namespace: "bar",
+						Name:      "foo",
+					},
+				},
+				{
+					MetricName: "requests_per_s_two",
+					Labels:     map[string]string{"foo": "bar"},
+					Valid:      false,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(7),
+						Namespace: "baz",
+						Name:      "foo",
+					},
+				},
+			},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "requests_per_s_two",
+					Labels:     map[string]string{"foo": "bar"},
+					Valid:      false,
+					HPA: custommetrics.ObjectReference{
+						UID:       string(7),
+						Name:      "foo",
+						Namespace: "baz",
+					},
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
### What does this PR do?

There is an edge case where the Cluster agent might not properly delete entries from the global store.
If it has processed an HPA and stored the metrics in the global store, then becomes unresponsive to the informer's events (because it is down) it will miss any update event. So if the user were to update the metric name or the labels in the HPA, as the cluster agent comes back to life it will pick up this change as an Add event (not update). So the global store will keep one stale entry.

This makes sure that the cluster agent does a proper GC of the global store.

### Motivation

More robust support of the External Metrics provider process.
