### PR TITLE
enable golang disk check on the puppy

### DIFF
--- a/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
@@ -43,6 +43,11 @@ instances:
     #  /dev/sda3: role:db,disk_size:large
     #  "c:": volume:boot
     #
+    # The (optional) tags parameter allows you to customize tags for the instance
+    # tags:
+    #   - optional_tag1
+    #   - optional_tag2
+    #
     # The (optional) service_check_rw parameter notifies when one of the partitions is in
     # read-only mode
     # service_check_rw: false

--- a/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
@@ -1,0 +1,48 @@
+init_config:
+
+instances:
+  # The use_mount parameter will instruct the check to collect disk
+  # and fs metrics using mount points instead of volumes
+  - use_mount: false
+    # The (optional) excluded_filesystems parameter will instruct the check to
+    # ignore disks using these filesystems. Note: On some linux distributions,
+    # rootfs will be found and tagged as a device, add rootfs here to exclude.
+    # excluded_filesystems:
+    #   - tmpfs
+
+    # The (optional) excluded_disks parameter will instruct the check to
+    # ignore this list of disks.
+    # Linux example:
+    # excluded_disks:
+    #   - /dev/sda1
+    #   - /dev/sda2
+    #
+    # The (optional) excluded_disk_re parameter will instruct the check to
+    # ignore all disks matching this regex.
+    # excluded_disk_re: /dev/sde.*
+    #
+    # The (optional) tag_by_filesystem parameter will instruct the check to
+    # tag all disks with their filesystem (for ex: filesystem:nfs).
+    # tag_by_filesystem: false
+    #
+    # The (optional) excluded_mountpoint_re parameter will instruct the check to
+    # ignore all mountpoints matching this regex.
+    # excluded_mountpoint_re: /mnt/somebody-elses-problem.*
+    #
+    # The (optional) all_partitions parameter will instruct the check to
+    # get metrics for all partitions. use_mount should be set to yes (to avoid
+    # collecting empty device names) when using this option.
+    # all_partitions: false
+    #
+    # The (optional) device_tag_re parameter will instruct the check to apply additional tags to
+    # volumes/mountpoints matching these regexes. Multiple comma-separated tags are supported.
+    # You must properly quote the string if the pattern contains special characters e.g. colons.
+    # Character casing is ignored on Windows.
+    # device_tag_re:
+    #  /san/.*: device_type:san
+    #  /dev/sda3: role:db,disk_size:large
+    #  "c:": volume:boot
+    #
+    # The (optional) service_check_rw parameter notifies when one of the partitions is in
+    # read-only mode
+    # service_check_rw: false

--- a/pkg/collector/corechecks/system/disk.go
+++ b/pkg/collector/corechecks/system/disk.go
@@ -32,7 +32,7 @@ type diskConfig struct {
 	excludedMountpointRe *regexp.Regexp
 	allPartitions        bool
 	deviceTagRe          map[*regexp.Regexp][]string
-	customeTags          []string
+	customTags           []string
 }
 
 func (c *DiskCheck) excludeDisk(mountpoint, device, fstype string) bool {
@@ -149,10 +149,10 @@ func (c *DiskCheck) instanceConfigure(data integration.Data) error {
 
 	tags, found := conf["tags"]
 	if tags, ok := tags.([]interface{}); found && ok {
-		c.cfg.customeTags = make([]string, 0, len(tags))
+		c.cfg.customTags = make([]string, 0, len(tags))
 		for _, tag := range tags {
 			if tag, ok := tag.(string); ok {
-				c.cfg.customeTags = append(c.cfg.customeTags, tag)
+				c.cfg.customTags = append(c.cfg.customTags, tag)
 			}
 		}
 	}

--- a/pkg/collector/corechecks/system/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk_nix.go
@@ -73,8 +73,8 @@ func (c *DiskCheck) collectPartitionMetrics(sender aggregator.Sender) error {
 			continue
 		}
 
-		tags := make([]string, len(c.cfg.customeTags), len(c.cfg.customeTags)+2)
-		copy(tags, c.cfg.customeTags)
+		tags := make([]string, len(c.cfg.customTags), len(c.cfg.customTags)+2)
+		copy(tags, c.cfg.customTags)
 
 		if c.cfg.tagByFilesystem {
 			tags = append(tags, fmt.Sprintf("filesystem:%s", partition.Fstype))
@@ -102,8 +102,8 @@ func (c *DiskCheck) collectDiskMetrics(sender aggregator.Sender) error {
 	}
 	for deviceName, ioCounter := range iomap {
 
-		tags := make([]string, len(c.cfg.customeTags), len(c.cfg.customeTags)+1)
-		copy(tags, c.cfg.customeTags)
+		tags := make([]string, len(c.cfg.customTags), len(c.cfg.customTags)+1)
+		copy(tags, c.cfg.customTags)
 		tags = append(tags, fmt.Sprintf("device:%s", deviceName))
 
 		tags = c.applyDeviceTags(deviceName, "", tags)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -59,6 +59,7 @@ AGENT_CORECHECKS = [
 
 PUPPY_CORECHECKS = [
     "cpu",
+    "disk",
     "io",
     "load",
     "memory",

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -26,6 +26,7 @@ from .agent import DEFAULT_BUILD_TAGS
 
 ANDROID_CORECHECKS = [
     "cpu",
+    "disk",
     "io",
     "load",
     "memory",


### PR DESCRIPTION
### What does this PR do?

Adds a default configuration for the disk check on the puppy agent.
