### PR TITLE
[DCA] Only process updates with relevant changes

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -308,13 +308,23 @@ func (h *AutoscalersController) addAutoscaler(obj interface{}) {
 // Adding the new obj and dropping the previous one is sufficient.
 // FIXME if the metric name or scope is changed in the HPA manifest we should propagate the change
 // to the Global store here
-func (h *AutoscalersController) updateAutoscaler(_, obj interface{}) {
+func (h *AutoscalersController) updateAutoscaler(old, obj interface{}) {
 	newAutoscaler, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler)
 	if !ok {
 		log.Errorf("Expected an HorizontalPodAutoscaler type, got: %v", obj)
 		return
 	}
-	log.Tracef("Updating autoscaler %s/%s", newAutoscaler.Namespace, newAutoscaler.Name)
+	oldAutoscaler, ok := old.(*autoscalingv2.HorizontalPodAutoscaler)
+	if !ok {
+		log.Errorf("Expected an HorizontalPodAutoscaler type, got: %v", old)
+		return
+	}
+
+	if !hpa.AutoscalerMetricsUpdate(newAutoscaler, oldAutoscaler) {
+		log.Tracef("Update received for the %s/%s, without a relevant change to the configuration", newAutoscaler.Namespace, newAutoscaler.Name)
+		return
+	}
+	log.Debugf("Updating autoscaler %s/%s with configuration: %s", newAutoscaler.Namespace, newAutoscaler.Name, newAutoscaler.Annotations)
 	h.enqueue(newAutoscaler)
 }
 

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -317,6 +317,7 @@ func (h *AutoscalersController) updateAutoscaler(old, obj interface{}) {
 	oldAutoscaler, ok := old.(*autoscalingv2.HorizontalPodAutoscaler)
 	if !ok {
 		log.Errorf("Expected an HorizontalPodAutoscaler type, got: %v", old)
+		h.enqueue(newAutoscaler) // We still want to enqueue the newAutoscaler to get the new change
 		return
 	}
 

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -109,6 +109,27 @@ func makePtr(val string) *string {
 	return &val
 }
 
+func makeAnnotations(metricName string, labels map[string]string) map[string]string {
+	return map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": fmt.Sprintf(`
+			"kind":"HorizontalPodAutoscaler",
+			"spec":{
+				"metrics":[{
+					"external":{
+						"metricName":"%s",
+						"metricSelector":{
+							"matchLabels":{
+								%s
+							}
+						},
+					},
+					"type":"External"
+					}],
+				}
+			}"`, metricName, labels),
+	}
+}
+
 // TestAutoscalerController is an integration test of the AutoscalerController
 func TestAutoscalerController(t *testing.T) {
 	name := custommetrics.GetConfigmapName()
@@ -158,6 +179,7 @@ func TestAutoscalerController(t *testing.T) {
 		"foo",
 		map[string]string{"foo": "bar"},
 	)
+	mockedHPA.Annotations = makeAnnotations("foo", map[string]string{"foo": "bar"})
 
 	_, err := c.HorizontalPodAutoscalers("default").Create(mockedHPA)
 	require.NoError(t, err)
@@ -211,6 +233,7 @@ func TestAutoscalerController(t *testing.T) {
 			},
 		},
 	}
+	mockedHPA.Annotations = makeAnnotations("nginx.net.request_per_s", map[string]string{"dcos_version": "2.1.9"})
 	_, err = c.HorizontalPodAutoscalers(mockedHPA.Namespace).Update(mockedHPA)
 	require.NoError(t, err)
 	select {

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -66,3 +66,12 @@ func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, 
 	}
 	return
 }
+
+// AutoscalerMetricsUpdate will return true if the applied configuration of the Autoscaler has changed.
+// We only care about updates of the metrics or their scopes.
+func AutoscalerMetricsUpdate(new, old *autoscalingv2.HorizontalPodAutoscaler) bool {
+	if reflect.DeepEqual(new.Annotations, old.Annotations) {
+		return false
+	}
+	return true
+}

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -70,8 +70,5 @@ func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, 
 // AutoscalerMetricsUpdate will return true if the applied configuration of the Autoscaler has changed.
 // We only care about updates of the metrics or their scopes.
 func AutoscalerMetricsUpdate(new, old *autoscalingv2.HorizontalPodAutoscaler) bool {
-	if reflect.DeepEqual(new.Annotations, old.Annotations) {
-		return false
-	}
-	return true
+	return old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 }

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -20,6 +20,176 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 )
 
+func TestDiffAutoscalter(t *testing.T) {
+	testCases := map[string]struct {
+		hpaOld   *autoscalingv2.HorizontalPodAutoscaler
+		hpaNew   *autoscalingv2.HorizontalPodAutoscaler
+		expected bool
+	}{
+		"No-Op": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `
+						"apiVersion":"autoscaling/v2beta1",
+						"kind":"HorizontalPodAutoscaler",
+						"metadata":{
+							"annotations":{},
+							"name":"nginxext1",
+							"namespace":
+							"default"
+						},
+						"spec":{
+							"maxReplicas":5,
+							"metrics":[{
+								"external":{
+									"metricName":"nginx.net.request_per_s",
+									"metricSelector":{
+										"matchLabels":{
+											"cluster-name":"sic-kenafeh",
+											"kube_container_name":"nginx"
+										}
+								},
+								"targetValue":5},
+								"type":"External"
+							}],
+							"minReplicas":1,
+							"scaleTargetRef":{
+								"apiVersion":"apps/v1",
+								"kind":"Deployment",
+								"name":"nginx"
+							}
+						}"`,
+					},
+				},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					CurrentReplicas: 27,
+				},
+			},
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `
+						"apiVersion":"autoscaling/v2beta1",
+						"kind":"HorizontalPodAutoscaler",
+						"metadata":{
+							"annotations":{},
+							"name":"nginxext1",
+							"namespace":
+							"default"
+						},
+						"spec":{
+							"maxReplicas":5,
+							"metrics":[{
+								"external":{
+									"metricName":"nginx.net.request_per_s",
+									"metricSelector":{
+										"matchLabels":{
+											"cluster-name":"sic-kenafeh",
+											"kube_container_name":"nginx"
+										}
+								},
+								"targetValue":5},
+								"type":"External"
+							}],
+							"minReplicas":1,
+							"scaleTargetRef":{
+								"apiVersion":"apps/v1",
+								"kind":"Deployment",
+								"name":"nginx"
+							}
+						}"`,
+					},
+				},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					CurrentReplicas: 12,
+				},
+			},
+			false,
+		},
+		"Updated": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `
+						"apiVersion":"autoscaling/v2beta1",
+						"kind":"HorizontalPodAutoscaler",
+						"metadata":{
+							"annotations":{},
+							"name":"nginxext1",
+							"namespace":
+							"default"
+						},
+						"spec":{
+							"maxReplicas":5,
+							"metrics":[{
+								"external":{
+									"metricName":"nginx.net.request_per_s",
+									"metricSelector":{
+										"matchLabels":{
+											"cluster-name":"sic-kenafeh",
+											"kube_container_name":"nginx"
+										}
+								},
+								"targetValue":5},
+								"type":"External"
+							}],
+							"minReplicas":1,
+							"scaleTargetRef":{
+								"apiVersion":"apps/v1",
+								"kind":"Deployment",
+								"name":"nginx"
+							}
+						}"`,
+					},
+				},
+			},
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": `
+						"apiVersion":"autoscaling/v2beta1",
+						"kind":"HorizontalPodAutoscaler",
+						"metadata":{
+							"annotations":{},
+							"name":"nginxext1",
+							"namespace":
+							"default"
+						},
+						"spec":{
+							"maxReplicas":5,
+							"metrics":[{
+								"external":{
+									"metricName":"nginx.net.request_per_s",
+									"metricSelector":{
+										"matchLabels":{
+											"kube_container_name":"apache"
+										}
+								},
+								"targetValue":5},
+								"type":"External"
+							}],
+							"minReplicas":1,
+							"scaleTargetRef":{
+								"apiVersion":"apps/v1",
+								"kind":"Deployment",
+								"name":"nginx"
+							}
+						}"`,
+					},
+				},
+			},
+			true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			val := AutoscalerMetricsUpdate(testCase.hpaNew, testCase.hpaOld)
+			assert.Equal(t, testCase.expected, val)
+		})
+	}
+}
+
 func TestInspect(t *testing.T) {
 	metricName := "requests_per_s"
 

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -88,7 +88,7 @@ func (p *Processor) ProcessHPAs(hpa *autoscalingv2.HorizontalPodAutoscaler) []cu
 	metrics, err := p.validateExternalMetric(emList)
 	if err != nil && len(metrics) == 0 {
 		log.Errorf("Could not validate external metrics: %v", err)
-		return nil
+		return invalidate(emList)
 	}
 	for _, em := range emList {
 		maxAge := int64(p.externalMaxAge.Seconds())


### PR DESCRIPTION
### What does this PR do?

Leverage diffing logic of Update callback to only query Datadog if there is a relevant change in the Autoscaler.

### Motivation

Update events are submitted very often and this results in useless calls to Datadog.