### PR TITLE
Adding IsLeader check to syncAutoscalers

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -267,6 +267,10 @@ func (h *AutoscalersController) handleErr(err error, key interface{}) {
 }
 
 func (h *AutoscalersController) syncAutoscalers(key interface{}) error {
+	if !h.le.IsLeader() {
+		log.Trace("Only the leader needs to sync the Autoscalers")
+		return nil
+	}
 	ns, name, err := cache.SplitMetaNamespaceKey(key.(string))
 	if err != nil {
 		log.Errorf("Could not split the key: %v", err)

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -262,9 +262,8 @@ func TestAutoscalerController(t *testing.T) {
 
 func TestAutoscalerSync(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	i := &fakeLeaderElector{}
 	d := &fakeDatadogClient{}
-	hctrl, inf := newFakeAutoscalerController(client, i, d)
+	hctrl, inf := newFakeAutoscalerController(client, alwaysLeader, d)
 	obj := newFakeHorizontalPodAutoscaler(
 		"hpa_1",
 		"default",

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -469,8 +469,8 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 		informerFactory.Core().V1().Nodes(),
 		informerFactory.Core().V1().Endpoints(),
 	)
-	metaController.nodeListerSynced = informerFactory.Core().V1().Nodes().Informer().HasSynced
-	metaController.endpointsListerSynced = informerFactory.Core().V1().Endpoints().Informer().HasSynced
+	metaController.nodeListerSynced = func() bool { return true }
+	metaController.endpointsListerSynced = func() bool { return true }
 	metaController.endpoints = make(chan struct{}, 1)
 	metaController.nodes = make(chan struct{}, 1)
 
@@ -480,7 +480,7 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 func requireReceive(t *testing.T, ch chan struct{}, msgAndArgs ...interface{}) {
 	select {
 	case <-ch:
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 		require.FailNow(t, "Timeout waiting to receive from channel", msgAndArgs...)
 	}
 }

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -469,8 +469,8 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 		informerFactory.Core().V1().Nodes(),
 		informerFactory.Core().V1().Endpoints(),
 	)
-	metaController.nodeListerSynced = func() bool { return true }
-	metaController.endpointsListerSynced = func() bool { return true }
+	metaController.nodeListerSynced = informerFactory.Core().V1().Nodes().Informer().HasSynced
+	metaController.endpointsListerSynced = informerFactory.Core().V1().Endpoints().Informer().HasSynced
 	metaController.endpoints = make(chan struct{}, 1)
 	metaController.nodes = make(chan struct{}, 1)
 
@@ -480,7 +480,7 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 func requireReceive(t *testing.T, ch chan struct{}, msgAndArgs ...interface{}) {
 	select {
 	case <-ch:
-	case <-time.After(5 * time.Second):
+	case <-time.After(3 * time.Second):
 		require.FailNow(t, "Timeout waiting to receive from channel", msgAndArgs...)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Only the leader should be querying Datadog. This happens when a HPA is added or when the scope/metric name is changed in an existing HPA.

Updated test to support the leader case. No test for Non leader.

Also added real HasSync method to (attempt to) fix the flakyness of the metadataController test.