### PR TITLE
Fix build failure on 32bit armv7

### DIFF
--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -173,7 +173,12 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
 	length := int(argc)
 	subprocessArgs := make([]string, length-1)
+
+	// The maximum capacity of the following slice is limited to (2^29)-1 to remain compatible
+	// with 32-bit platforms. The size of a `*C.char` (a pointer) is 4 Byte on a 32-bit system
+	// and (2^29)*4 == math.MaxInt32 + 1. -- See issue golang/go#13656
 	cmdSlice := (*[1<<29 - 1]*C.char)(unsafe.Pointer(argv))[:length:length]
+
 	subprocessCmd := C.GoString(cmdSlice[0])
 	for i := 1; i < length; i++ {
 		subprocessArgs[i-1] = C.GoString(cmdSlice[i])
@@ -283,6 +288,10 @@ func SetExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int)
 	hname := C.GoString(hostname)
 	stype := C.GoString(sourceType)
 	tlen := int(tagsLen)
+
+	// The maximum capacity of the following slice is limited to (2^29)-1 to remain compatible
+	// with 32-bit platforms. The size of a `*C.char` (a pointer) is 4 Byte on a 32-bit system
+	// and (2^29)*4 == math.MaxInt32 + 1. -- See issue golang/go#13656
 	tagsSlice := (*[1<<29 - 1]*C.char)(unsafe.Pointer(tags))[:tlen:tlen]
 	tagsStrings := []string{}
 

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -173,7 +173,7 @@ func GetSubprocessOutput(argv **C.char, argc, raise int) *C.PyObject {
 
 	length := int(argc)
 	subprocessArgs := make([]string, length-1)
-	cmdSlice := (*[1 << 30]*C.char)(unsafe.Pointer(argv))[:length:length]
+	cmdSlice := (*[1<<29 - 1]*C.char)(unsafe.Pointer(argv))[:length:length]
 	subprocessCmd := C.GoString(cmdSlice[0])
 	for i := 1; i < length; i++ {
 		subprocessArgs[i-1] = C.GoString(cmdSlice[i])
@@ -283,7 +283,7 @@ func SetExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int)
 	hname := C.GoString(hostname)
 	stype := C.GoString(sourceType)
 	tlen := int(tagsLen)
-	tagsSlice := (*[1 << 30]*C.char)(unsafe.Pointer(tags))[:tlen:tlen]
+	tagsSlice := (*[1<<29 - 1]*C.char)(unsafe.Pointer(tags))[:tlen:tlen]
 	tagsStrings := []string{}
 
 	for i := 0; i < tlen; i++ {

--- a/releasenotes/notes/fix-build-failure-on-32bit-armv7-5b5b36c2d9f9ff00.yaml
+++ b/releasenotes/notes/fix-build-failure-on-32bit-armv7-5b5b36c2d9f9ff00.yaml
@@ -8,4 +8,4 @@
 ----
 fixes:
   - |
-    Support building on 32bit armv7
+    Fix build failure on 32bit armv7

--- a/releasenotes/notes/fix-build-failure-on-32bit-armv7-5b5b36c2d9f9ff00.yaml
+++ b/releasenotes/notes/fix-build-failure-on-32bit-armv7-5b5b36c2d9f9ff00.yaml
@@ -5,7 +5,7 @@
 # must be readable independently of the other.
 #
 # Each section note must be formatted as reStructuredText.
-----
+---
 fixes:
   - |
     Fix build failure on 32bit armv7

--- a/releasenotes/notes/support-32-bit-address-spaces-5b5b36c2d9f9ff00.yaml
+++ b/releasenotes/notes/support-32-bit-address-spaces-5b5b36c2d9f9ff00.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+----
+fixes:
+  - |
+    Support building on 32bit armv7


### PR DESCRIPTION
Building the agent on a 32 bits arm platform results in the following errors:

```
# github.com/DataDog/datadog-agent/pkg/collector/py
pkg/collector/py/datadog_agent.go:176:16: type [1073741824]*_Ctype_char larger than address space
pkg/collector/py/datadog_agent.go:176:16: type [1073741824]*_Ctype_char too large
pkg/collector/py/datadog_agent.go:286:17: type [1073741824]*_Ctype_char larger than address space
pkg/collector/py/datadog_agent.go:286:17: type [1073741824]*_Ctype_char too large
```

`1<<30` and `1<<29-1` are really close and I'm wondering if using the former was really intended?
In any case, this slice holds the arguments given to `get_subprocess_output`. I suppose that even on 64bits platform we'll be fine with this size: `1<<29-1 = 536870911`

I understand datadog does not officially support arm, but since the fix is pretty easy in this case, it seemed like a good candidate for a PR. With this I'm successfully embedding the python interpreter on my raspberry Pi:

```
Oct 16 01:38:04 unifi agent[3039]: 2018-10-16 01:38:04 UTC | INFO | (collector.go:55 in NewCollector) | Embedding Python 2.7.13 (default, Sep 26 2018, 18:42:22) [GCC 6.3.0 20170516]
```

Fixes:
- https://github.com/DataDog/datadog-agent/issues/1069
- https://github.com/DataDog/datadog-agent/issues/2389