### PR TITLE
disable happy eyeballs

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -208,8 +208,6 @@ func CreateHTTPTransport() *http.Transport {
 			Timeout: 30 * time.Second,
 			// Enables TCP keepalives to detect broken connections
 			KeepAlive: 30 * time.Second,
-			// Enables happy eyeballs
-			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 5,

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -208,6 +208,10 @@ func CreateHTTPTransport() *http.Transport {
 			Timeout: 30 * time.Second,
 			// Enables TCP keepalives to detect broken connections
 			KeepAlive: 30 * time.Second,
+			// Disable happy eyeballs. This option will be deprecated in go 1.12.
+			// At this point we will need to disable it by setting a new attribute to false.
+			// See https://github.com/DataDog/datadog-agent/pull/2464
+			DualStack: false,
 		}).DialContext,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 5,


### PR DESCRIPTION
### What does this PR do?

Disable happy eyeballs. It will be enabled by default in Go 1.12, but we have no way to disable it for now as the `DualStack` option [will be depreciated](https://github.com/golang/go/issues/22225#issuecomment-426746554). 
> Deprecate (ignore) DualStack, because we want it to default to true and can't distinguish "unset" from "set to false explicitly".

### Motivation

Some concerns have been raised about the effect this might have on the intake.


