### PR TITLE
[windows] re add site config from install command line

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -246,20 +246,23 @@ func ImportRegistryConfig() error {
 	} else {
 		log.Debug("proxy key not found, not setting proxy config")
 	}
-
-	if val, _, err = k.GetStringValue("dd_url"); err == nil {
+	if val, _, err = k.GetStringValue("site"); err == nil && val != "" {
+		config.Datadog.Set("site", val)
+		log.Debugf("Setting site to %s", val)
+	}
+	if val, _, err = k.GetStringValue("dd_url"); err == nil && val != "" {
 		config.Datadog.Set("dd_url", val)
 		log.Debugf("Setting dd_url to %s", val)
 	}
-	if val, _, err = k.GetStringValue("logs_dd_url"); err == nil {
+	if val, _, err = k.GetStringValue("logs_dd_url"); err == nil && val != "" {
 		config.Datadog.Set("logs_config.dd_url", val)
 		log.Debugf("Setting logs_config.dd_url to %s", val)
 	}
-	if val, _, err = k.GetStringValue("process_dd_url"); err == nil {
+	if val, _, err = k.GetStringValue("process_dd_url"); err == nil && val != "" {
 		config.Datadog.Set("process_config.process_dd_url", val)
 		log.Debugf("Setting process_config.process_dd_url to %s", val)
 	}
-	if val, _, err = k.GetStringValue("trace_dd_url"); err == nil {
+	if val, _, err = k.GetStringValue("trace_dd_url"); err == nil && val != "" {
 		config.Datadog.Set("apm_config.apm_dd_url", val)
 		log.Debugf("Setting apm_config.apm_dd_url to %s", val)
 	}

--- a/omnibus/resources/agent/msi/README.md
+++ b/omnibus/resources/agent/msi/README.md
@@ -46,6 +46,8 @@ The following configuration command line options are available when installing t
 * PROXY_USER="_string_"
 * PROXY_PASSWORD="_string_"
   * Takes the combination of the provided PROXY_* options, and creates the HTTP proxy configuration which the agent will use to report metrics back to the Datadog service.
+* SITE="_string_"
+  * Sets the **site** variable in datadog.yaml to _string_.
 * DD_URL="_string_"
   * Sets the **dd_url** variable in datadog.yaml to _string_. 
 * LOGS_DD_URL="_string_"

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -155,6 +155,9 @@
           <RegistryValue Name="cmd_port"
                          Type="string"
                          Value="[CMD_PORT]" />
+          <RegistryValue Name="site"
+                         Type="string"
+                         Value="[SITE]" />
           <RegistryValue Name="dd_url"
                          Type="string"
                          Value="[DD_URL]" />


### PR DESCRIPTION
### What does this PR do?

adds the ability to set the `site` variable in the config from the command line

