### PR TITLE
Create node agent diagnose command

### DIFF
--- a/pkg/util/clusteragent/diagnose.go
+++ b/pkg/util/clusteragent/diagnose.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package clusteragent
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func init() {
+	diagnosis.Register("Cluster Agent availability", diagnose)
+}
+
+func diagnose() error {
+	_, err := getClusterAgentEndpoint()
+	if err != nil {
+		log.Error(err)
+	}
+	return err
+}

--- a/pkg/util/clusteragent/diagnosis.go
+++ b/pkg/util/clusteragent/diagnosis.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func diagnose() error {
-	_, err := getClusterAgentEndpoint()
+	_, err := GetClusterAgentClient()
 	if err != nil {
 		log.Error(err)
 	}

--- a/releasenotes/notes/dca-add-diagnosis-715155b4cd327dab.yaml
+++ b/releasenotes/notes/dca-add-diagnosis-715155b4cd327dab.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add diagnosis to the agent for connectvity to the cluster agent


### PR DESCRIPTION
### What does this PR do?

This adds a diagnosis for node agents to the DCA, by way of the agent `diagnose` command. 

### Motivation

In keeping with the congruency of being able to quickly monitor the connectivity of integrations reliant on an endpoint. The agent currently provides a diagnosis for the API server, and as the DCA will act as a proxy to the API server, we should be able to check connectivity.

### Testing
We expect a successful connection to the DCA to output `PASS` in the diagnosis: 
![image 2018-10-16 at 7 39 32 pm](https://user-images.githubusercontent.com/25290232/47078598-f0b61600-d203-11e8-94aa-f03aedf9eeb2.png) 

Otherwise it should result in a `FAIL` and log the connectivity issue: 
![image 2018-10-17 at 10 54 42 am](https://user-images.githubusercontent.com/25290232/47078744-4094dd00-d204-11e8-975f-1f4a42a34275.png)