### PR TITLE
Ignore sysvinit scripts when systemd is used

### DIFF
--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -40,7 +40,7 @@ Agent 6 is currently available on these platforms:
 
 | System | Supported version |
 |--------|-------------------|
-| Debian x86_64 | version 7 (wheezy) and above (we do not support SysVinit)|
+| Debian x86_64 | version 7 (wheezy) and above (SysVinit support in agent >=6.6.0)|
 | Ubuntu x86_64 | version 12.04 and above |
 | RedHat/CentOS x86_64 | version 6 and above |
 | SUSE Enterprise Linux x86_64 | version 11 SP4 and above (we do not support SysVinit)|

--- a/docs/agent/changes.md
+++ b/docs/agent/changes.md
@@ -191,18 +191,18 @@ If the `service` wrapper command is not available on your system, use:
 
 If you're unsure which init system your distribution uses by default, please refer to the table below:
 
-| distribution \ init system | `upstart` | `systemd` | Notes |
-| -------------------------- |:---------:|:---------:| ----- |
-| Amazon Linux (<= 2017.09) | ✅ |  |  |
-| Amazon Linux 2 (>= 2017.12) |  | ✅ |  |
-| CentOS/RHEL 6 | ✅ |  |  |
-| CentOS/RHEL 7 |  | ✅ |  |
-| Debian 7 (wheezy) |  |  | _currently unsupported unless you install systemd_ |
-| Debian 8 (jessie) & 9 (stretch) |  | ✅ |  |
-| SUSE 11 |  |  | _currently unsupported unless you install systemd_ |
-| SUSE 12 |  | ✅ |  |
-| Ubuntu < 15.04 | ✅ | |  |
-| Ubuntu >= 15.04 |  | ✅ |  |
+| distribution \ init system | `upstart` | `systemd` | `sysvinit` | Notes |
+| -------------------------- |:---------:|:---------:|:----------:|----- |
+| Amazon Linux (<= 2017.09) | ✅ |  |  |  |
+| Amazon Linux 2 (>= 2017.12) |  | ✅ |  |  |
+| CentOS/RHEL 6 | ✅ |  |  |  |
+| CentOS/RHEL 7 |  | ✅ |  |  |
+| Debian 7 (wheezy) |  |  | ✅ (agent >= 6.6.0) | |
+| Debian 8 (jessie) & 9 (stretch) |  | ✅ |  |  |
+| SUSE 11 |  |  |  | _currently unsupported unless you install systemd_ |
+| SUSE 12 |  | ✅ |  |  |
+| Ubuntu < 15.04 | ✅ | |  |  |
+| Ubuntu >= 15.04 |  | ✅ |  |  |
 
 #### Agent commands
 

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -68,9 +68,9 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Only supports systemd and upstart
         echo "Enabling service $SERVICE_NAME"
         if command -v systemctl >/dev/null 2>&1; then
-            systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
-            systemctl enable $SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with systemctl"
-            systemctl enable $SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with systemctl"
+            SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
+            SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with systemctl"
+            SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with systemctl"
         elif command -v initctl >/dev/null 2>&1; then
             # Nothing to do, this is defined directly in the upstart job file
             :

--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -68,6 +68,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         # Only supports systemd and upstart
         echo "Enabling service $SERVICE_NAME"
         if command -v systemctl >/dev/null 2>&1; then
+            # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
             SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
             SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with systemctl"
             SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with systemctl"

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -45,9 +45,9 @@ deregister_agent()
     # Disable agent start on system boot
     # Only supports systemd and upstart
     if command -v systemctl >/dev/null 2>&1; then
-        systemctl disable $SERVICE_NAME-process || true
-        systemctl disable $SERVICE_NAME-trace || true
-        systemctl disable $SERVICE_NAME || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
+        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true
     elif command -v initctl >/dev/null 2>&1; then
         # Nothing to do, this is defined directly in the upstart job file
         :

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -45,6 +45,7 @@ deregister_agent()
     # Disable agent start on system boot
     # Only supports systemd and upstart
     if command -v systemctl >/dev/null 2>&1; then
+        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
         SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true

--- a/releasenotes/notes/debian-sysvinit-424c71c2b7e14a12.yaml
+++ b/releasenotes/notes/debian-sysvinit-424c71c2b7e14a12.yaml
@@ -9,3 +9,4 @@
 features:
   - |
     Support SysVinit on Debian
+    note: some warnings can appear if you enable/disable the agent manually on a systemd system. They can be safely ignored


### PR DESCRIPTION
### What does this PR do?
use `SYSTEMCTL_SKIP_SYSV` env var

### Motivation

Remove irrelevant warning on install

