### PR TITLE
[docs] Update hostname resolution doc, postpone to 6.7

### DIFF
--- a/docs/agent/hostname-resolution.md
+++ b/docs/agent/hostname-resolution.md
@@ -1,22 +1,22 @@
 _Edit 2018-09-18 : Highlight the differences between Windows and other OSes._
 
-_Edit 2018-08-31 : The default value of the new `hostname_fqdn` flag is planned to change in 6.6.0 instead of 6.4.0 to give users more time to take it into account._
+_Edit 2018-10-16 : The default value of the new `hostname_fqdn` flag is planned to change in 6.7.0 instead of 6.4.0 to give users more time to take it into account._
 
-# Difference in hostname resolution between Agent v5 and Agent v6 (<v6.6)
+# Difference in hostname resolution between Agent v5 and Agent v6 (<v6.7)
 
 ## Linux/MacOS
 
-In some cases, it is possible to see a difference in the hostname that’s reported by your Agent when upgrading from Agent v5 to Agent v6 (for versions < 6.6). 
+In some cases, it is possible to see a difference in the hostname that’s reported by your Agent when upgrading from Agent v5 to Agent v6 (for versions < 6.7).
 
-To resolve the system hostname the Agent 5 uses the `hostname -f` command while the Agent v6 (for versions < 6.6) uses the Golang API `os.Hostname()`. 
+To resolve the system hostname the Agent 5 uses the `hostname -f` command while the Agent v6 (for versions < 6.7) uses the Golang API `os.Hostname()`.
 
-On upgrades from Agent v5 to Agent v6 (<6.6.0), this may make the Agent hostname change from a Fully-Qualified Domain Name (FQDN, ex. sub.domain.tld) to a short hostname (ex. sub). 
+On upgrades from Agent v5 to Agent v6 (<6.7.0), this may make the Agent hostname change from a Fully-Qualified Domain Name (FQDN, ex. sub.domain.tld) to a short hostname (ex. sub).
 
-Starting from the Agent v6.3 a configuration flag called `hostname_fqdn` has been introduced that allows the Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3 and enabled by default in version 6.6.
+Starting from the Agent v6.3 a configuration flag called `hostname_fqdn` has been introduced that allows the Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3 and enabled by default in version 6.7.
 
 ### Determine if you're affected
 
-Starting with v6.3.0, the Agent will log a warning (`DEPRECATION NOTICE: The agent resolved your hostname as <hostname>. However starting from version 6.6, it will be resolved as <fqdn> by default. To enable the behavior of 6.6+, please enable the `hostname_fqdn` flag in the configuration.`) if you’re affected by this change.
+Starting with v6.3.0, the Agent will log a warning (`DEPRECATION NOTICE: The agent resolved your hostname as <hostname>. However starting from version 6.7, it will be resolved as <fqdn> by default. To enable the behavior of 6.7+, please enable the `hostname_fqdn` flag in the configuration.`) if you’re affected by this change.
 
 You are not affected if any of the following is true :
 - You are running the Agent in GCE
@@ -32,9 +32,9 @@ If you're affected by this change, we recommend that you take the following acti
 
 - Upgrading from Agent v5 to Agent >= v6.3: enable the `hostname_fqdn` option in the Agent v6 configuration to ensure that you will keep the same hostname.
 
-- Upgrading from Agent v5 to Agent v >= 6.6 (future): you don’t need to take any action.
+- Upgrading from Agent v5 to Agent v >= 6.7 (future): you don’t need to take any action.
 
-- Upgrading from Agent v6 < 6.6 to Agent >= v6.6: If you wish to keep the behavior of Agent v6 (<6.6) for now, set hostname_fqdn to false. We recommend you switch hostname_fqdn to true whenever possible.
+- Upgrading from Agent v6 < 6.7 to Agent >= v6.7: If you wish to keep the behavior of Agent v6 (<6.7) for now, set hostname_fqdn to false. We recommend you switch hostname_fqdn to true whenever possible.
 
 ## Windows
 
@@ -44,7 +44,7 @@ The Windows Agent will honor the configuration flag starting with version 6.5.  
 
 ### Recommended action
 
-By default, the recommended action is to do nothing. This will preserve the existing behavior, especially if upgrading from Agent v5.  
+By default, the recommended action is to do nothing. This will preserve the existing behavior, especially if upgrading from Agent v5.
 
 If you wish to have Windows hosts specifically report fully qualified host names, then add the `hostname_fqdn` flag to the configuration file.
 

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -219,8 +219,8 @@ func GetHostname() (string, error) {
 	h, err := os.Hostname()
 	if err == nil && !config.Datadog.GetBool("hostname_fqdn") && fqdn != "" && hostName == h && h != fqdn {
 		if runtime.GOOS != "windows" {
-			// REMOVEME: This should be removed in 6.6
-			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as '%s'. However starting from version 6.6, it will be resolved as '%s' by default. To enable the behavior of 6.6+, please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
+			// REMOVEME: This should be removed in 6.7
+			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as '%s'. However starting from version 6.7, it will be resolved as '%s' by default. To enable the behavior of 6.7+, please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
 		} else { // OS is Windows
 			log.Warnf("The agent resolved your hostname as '%s', and will be reported this way to maintain compatibility with version 5. To enable reporting as '%s', please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
 		}


### PR DESCRIPTION
### What does this PR do?

Still more data needed before switching the flag to `true` by default. 
If we can't get that data by 6.7, or the data is inconclusive, we'll probably postpone this change
to v7.0.