### PR TITLE
[DCA] Only process updates with relevant changes

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -343,6 +343,7 @@ func (h *AutoscalersController) updateAutoscaler(old, obj interface{}) {
 	oldAutoscaler, ok := old.(*autoscalingv2.HorizontalPodAutoscaler)
 	if !ok {
 		log.Errorf("Expected an HorizontalPodAutoscaler type, got: %v", old)
+		h.enqueue(newAutoscaler) // We still want to enqueue the newAutoscaler to get the new change
 		return
 	}
 

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -70,8 +70,5 @@ func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, 
 // AutoscalerMetricsUpdate will return true if the applied configuration of the Autoscaler has changed.
 // We only care about updates of the metrics or their scopes.
 func AutoscalerMetricsUpdate(new, old *autoscalingv2.HorizontalPodAutoscaler) bool {
-	if reflect.DeepEqual(new.Annotations, old.Annotations) {
-		return false
-	}
-	return true
+	return old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 }


### PR DESCRIPTION
What does this PR do?
Leverage diffing logic of Update callback to only query Datadog if there is a relevant change in the Autoscaler.

Motivation
Update events are submitted very often and this results in useless calls to Datadog.

(from https://github.com/DataDog/datadog-agent/pull/2454)