### PR TITLE
Fix potential race in the autoscalers controller

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -194,6 +194,11 @@ func (h *AutoscalersController) updateExternalMetrics() {
 		return
 	}
 
+	// prevent some update to get into the store between ListAllExternalMetricValues
+	// and SetExternalMetricValues otherwise it would get erased
+	h.toStore.m.Lock()
+	defer h.toStore.m.Unlock()
+
 	emList, err := h.store.ListAllExternalMetricValues()
 	if err != nil {
 		log.Errorf("Error while retrieving external metrics from the store: %s", err)

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -174,7 +174,10 @@ func (h *AutoscalersController) pushToGlobalStore() error {
 	localStore := h.toStore.data
 	h.toStore.data = nil
 	h.toStore.m.Unlock()
-
+	if localStore == nil {
+		log.Trace("No batched metrics to push to the Global Store")
+		return nil
+	}
 	if !h.le.IsLeader() {
 		return nil
 	}
@@ -184,9 +187,16 @@ func (h *AutoscalersController) pushToGlobalStore() error {
 }
 
 func (h *AutoscalersController) updateExternalMetrics() {
+	// We force a flush of the most up to date metrics that might remain in the batch
+	err := h.pushToGlobalStore()
+	if err != nil {
+		log.Errorf("Error while pushing external metrics to the store: %s", err)
+		return
+	}
+
 	emList, err := h.store.ListAllExternalMetricValues()
 	if err != nil {
-		log.Infof("Error while retrieving external metrics from the store: %s", err)
+		log.Errorf("Error while retrieving external metrics from the store: %s", err)
 		return
 	}
 
@@ -196,9 +206,10 @@ func (h *AutoscalersController) updateExternalMetrics() {
 	}
 
 	updated := h.hpaProc.UpdateExternalMetrics(emList)
-	h.toStore.m.Lock()
-	h.toStore.data = append(h.toStore.data, updated...)
-	h.toStore.m.Unlock()
+	err = h.store.SetExternalMetricValues(updated)
+	if err != nil {
+		log.Errorf("Not able to store the updated metrics in the Global Store: %v", err)
+	}
 }
 
 // gc checks if any hpas have been deleted (possibly while the Datadog Cluster Agent was


### PR DESCRIPTION
What does this PR do?
If a user changed a HPA at the same time as the cluster agent was updating it, it would result in the Store keeping the stale entry which would get removed in the next GC.

Details:
pushToGlobalStore is called in a ticker, its role it to flush the accumulated entries from the informer (to avoid hitting the global store at every event, and especially at start, when it lists all the HPAs).
https://github.com/DataDog/datadog-agent/blob/master/pkg/util/kubernetes/apiserver/hpa_controller.go#L174-L182

updateExternalMetrics on the other hand, lists the entries in the global store, updates them and pushes them in the batch (which was supposed to be then processed at the next pushToGlobalStore)
https://github.com/DataDog/datadog-agent/blob/master/pkg/util/kubernetes/apiserver/hpa_controller.go#L187-L201

Hence, a modified entry not yet pushed, if updated would be pushed as it was in the global store.

Because receiving an update is now guaranteed to be a relevant update, it makes sense to push to the store right away #2454

Also added a check not to check for the leader and SetExternalMetricValues if there is nothing to push.

From https://github.com/DataDog/datadog-agent/pull/2473 (master frozen at the time being)