### PR TITLE
Leader sync

### DIFF
--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -247,6 +247,10 @@ func (h *AutoscalersController) processNext() bool {
 }
 
 func (h *AutoscalersController) syncAutoscalers(key interface{}) error {
+	if !h.le.IsLeader() {
+		log.Trace("Only the leader needs to sync the Autoscalers")
+		return nil
+	}
 	ns, name, err := cache.SplitMetaNamespaceKey(key.(string))
 	if err != nil {
 		log.Errorf("Could not split the key: %v", err)

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -261,9 +261,8 @@ func TestAutoscalerController(t *testing.T) {
 
 func TestAutoscalerSync(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	i := &fakeLeaderElector{}
 	d := &fakeDatadogClient{}
-	hctrl, inf := newFakeAutoscalerController(client, i, d)
+	hctrl, inf := newFakeAutoscalerController(client, alwaysLeader, d)
 	obj := newFakeHorizontalPodAutoscaler(
 		"hpa_1",
 		"default",


### PR DESCRIPTION
What does this PR do?
Only the leader should be querying Datadog. This happens when a HPA is added or when the scope/metric name is changed in an existing HPA.

Updated test to support the leader case. No test for Non leader.

From https://github.com/DataDog/datadog-agent/pull/2455