### PR TITLE
Integration install command moves configuration files

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -326,7 +326,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 		}
 
 		fmt.Printf("Installed %s %s", integration, versionToInstall)
-		return fmt.Errorf("Error while moving configuration files for %s: %v", integration, err)
+		return fmt.Errorf("Some errors prevented moving %s configuration files: %v", integration, err)
 	}
 
 	// We either detected a mismatch, or we failed to run pip check
@@ -434,6 +434,7 @@ func moveConfigurationFiles(integration string) error {
 	if err != nil {
 		return fmt.Errorf("internal error: %v", err)
 	}
+	errorMsg := ""
 	for _, file := range files {
 		filename := file.Name()
 		// Replace existing file
@@ -442,15 +443,18 @@ func moveConfigurationFiles(integration string) error {
 		}
 		src := filepath.Join(confFileSrc, filename)
 		dst := filepath.Join(confFileDest, filename)
-		err := os.Rename(src, dst)
+		err = os.Rename(src, dst)
 		if err != nil {
-			return err
+			errorMsg = fmt.Sprintf("%s\nError moving %s configuration file %s: %v", errorMsg, integration, filename, err)
+			continue
 		}
 		fmt.Println(color.GreenString(fmt.Sprintf(
 			"Successfully replaced %s configuration file %s", integration, filename,
 		)))
 	}
-
+	if errorMsg != "" {
+		return fmt.Errorf(errorMsg)
+	}
 	return nil
 }
 

--- a/cmd/agent/app/integrations_nix.go
+++ b/cmd/agent/app/integrations_nix.go
@@ -22,6 +22,7 @@ const (
 var (
 	relPyPath            = filepath.Join("..", "..", "embedded", "bin", pythonBin)
 	relTufConfigFilePath = filepath.Join("..", "..", tufConfigFile)
+	relChecksPath        = filepath.Join("..", "..", "embedded", "lib", "python2.7", "site-packages", "datadog_checks")
 	relTufPipCache       = filepath.Join("..", "..", "repositories", "cache")
 )
 

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython
+
+package app
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMoveConfigurationsFiles(t *testing.T) {
+	srcFolder, _ := ioutil.TempDir("", "srcFolder")
+	dstFolder, _ := ioutil.TempDir("", "dstFolder")
+	defer os.RemoveAll(srcFolder)
+	defer os.RemoveAll(dstFolder)
+	yamlFiles := []string{"conf.yaml.example", "conf.yaml.default", "metrics.yaml", "auto_conf.yaml"}
+	otherFile := "not_moved.txt"
+	for _, filename := range append(yamlFiles, otherFile) {
+		os.Create(filepath.Join(srcFolder, filename))
+	}
+
+	filesCreated, _ := ioutil.ReadDir(srcFolder)
+	assert.Equal(t, 5, len(filesCreated))
+	for _, file := range filesCreated {
+		assert.Contains(t, append(yamlFiles, otherFile), file.Name())
+	}
+
+	moveConfigurationFiles(srcFolder, dstFolder)
+
+	filesMoved, _ := ioutil.ReadDir(dstFolder)
+	assert.Equal(t, 4, len(filesMoved))
+	for _, file := range filesMoved {
+		assert.Contains(t, yamlFiles, file.Name())
+	}
+	filesNotMoved, _ := ioutil.ReadDir(srcFolder)
+	assert.Equal(t, 1, len(filesNotMoved))
+	assert.Equal(t, otherFile, filesNotMoved[0].Name())
+}

--- a/cmd/agent/app/integrations_windows.go
+++ b/cmd/agent/app/integrations_windows.go
@@ -20,6 +20,7 @@ const (
 var (
 	relPyPath            = pythonBin
 	relTufConfigFilePath = filepath.Join("..", tufConfigFile)
+	relChecksPath        = filepath.Join("Lib", "site-packages", "datadog_checks")
 	tufPipCachePath      = filepath.Join("c:\\", "ProgramData", "Datadog", "repositories", "cache")
 )
 

--- a/releasenotes/notes/move_conf_file-71b1addd871e26e4.yaml
+++ b/releasenotes/notes/move_conf_file-71b1addd871e26e4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    ``datadog-agent integration install`` command moves configuration file present in
+    the ``data`` directory of the wheel upon successful installation


### PR DESCRIPTION
### What does this PR do?

Make the `datadog-agent integration install` command move configuration files present in the `data` directory of the wheel.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?