### PR TITLE
Integration command prevents downgrading to version older than shipped

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -28,7 +28,7 @@ import (
 const (
 	tufConfigFile       = "public-tuf-config.json"
 	reqAgentReleaseFile = "requirements-agent-release.txt"
-	tufPkgPattern       = "datadog-.*"
+	tufPkgPattern       = "datadog(-|_).*"
 	tufIndex            = "https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/"
 	reqLinePattern      = "%s==(\\d+\\.\\d+\\.\\d+)"
 	yamlFilePattern     = "[\\w_]+\\.yaml.*"
@@ -271,7 +271,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	}
 
 	intVer := strings.Split(args[0], "==")
-	integration := strings.TrimSpace(intVer[0])
+	integration := strings.Replace(strings.TrimSpace(intVer[0]), "_", "-", -1)
 	if integration == "datadog-checks-base" {
 		return fmt.Errorf("cannot upgrade datadog-checks-base")
 	}

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -65,7 +65,7 @@ func (v *integrationVersion) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.fix)
 }
 
-func (v *integrationVersion) isAbove(otherVersion *integrationVersion) bool {
+func (v *integrationVersion) isAboveOrEqualTo(otherVersion *integrationVersion) bool {
 	if otherVersion == nil {
 		return true
 	}
@@ -331,7 +331,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to get minimal version of %s: %v", integration, err)
 	}
-	if !versionToInstall.isAbove(minVersion) {
+	if !versionToInstall.isAboveOrEqualTo(minVersion) {
 		return fmt.Errorf(
 			"this command does not allow installing version %s of %s older than version %s shipped with the agent",
 			versionToInstall, integration, minVersion,

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -342,6 +342,11 @@ func installTuf(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not get current version of %s: %v", integration, err)
 	}
 
+	if *versionToInstall == *currentVersion {
+		fmt.Printf("%s %s is already installed. Nothing to do.", integration, versionToInstall)
+		return nil
+	}
+
 	// Run pip check first to see if the python environment is clean
 	if err := pipCheck(cachePath); err != nil {
 		return fmt.Errorf(

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -465,12 +465,16 @@ func getVersionFromReqLine(integration string, lines string) (*integrationVersio
 		return nil, fmt.Errorf("internal error: %v", err)
 	}
 
-	groups := exp.FindStringSubmatch(lines)
+	groups := exp.FindAllStringSubmatch(lines, 2)
 	if groups == nil {
 		return nil, nil
 	}
 
-	version, err := parseVersion(groups[1])
+	if len(groups) > 1 {
+		return nil, fmt.Errorf("Found several matches for %s version in %s.\nAborting", integration, lines)
+	}
+
+	version, err := parseVersion(groups[0][1])
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -343,7 +343,7 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	}
 
 	if *versionToInstall == *currentVersion {
-		fmt.Printf("%s %s is already installed. Nothing to do.", integration, versionToInstall)
+		fmt.Printf("%s %s is already installed. Nothing to do.\n", integration, versionToInstall)
 		return nil
 	}
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -327,6 +327,16 @@ func installTuf(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unable to get version of %s to install: %v", integration, err)
 	}
+	currentVersion, err := installedVersion(integration, cachePath)
+	if err != nil {
+		return fmt.Errorf("could not get current version of %s: %v", integration, err)
+	}
+
+	if *versionToInstall == *currentVersion {
+		fmt.Printf("%s %s is already installed. Nothing to do.\n", integration, versionToInstall)
+		return nil
+	}
+
 	minVersion, err := minAllowedVersion(integration)
 	if err != nil {
 		return fmt.Errorf("unable to get minimal version of %s: %v", integration, err)
@@ -336,15 +346,6 @@ func installTuf(cmd *cobra.Command, args []string) error {
 			"this command does not allow installing version %s of %s older than version %s shipped with the agent",
 			versionToInstall, integration, minVersion,
 		)
-	}
-	currentVersion, err := installedVersion(integration, cachePath)
-	if err != nil {
-		return fmt.Errorf("could not get current version of %s: %v", integration, err)
-	}
-
-	if *versionToInstall == *currentVersion {
-		fmt.Printf("%s %s is already installed. Nothing to do.\n", integration, versionToInstall)
-		return nil
 	}
 
 	// Run pip check first to see if the python environment is clean
@@ -471,7 +472,7 @@ func getVersionFromReqLine(integration string, lines string) (*integrationVersio
 	}
 
 	if len(groups) > 1 {
-		return nil, fmt.Errorf("Found several matches for %s version in %s.\nAborting", integration, lines)
+		return nil, fmt.Errorf("Found several matches for %s version in %s\nAborting", integration, lines)
 	}
 
 	version, err := parseVersion(groups[0][1])

--- a/cmd/agent/app/integrations_nix.go
+++ b/cmd/agent/app/integrations_nix.go
@@ -20,10 +20,11 @@ const (
 )
 
 var (
-	relPyPath            = filepath.Join("..", "..", "embedded", "bin", pythonBin)
-	relTufConfigFilePath = filepath.Join("..", "..", tufConfigFile)
-	relChecksPath        = filepath.Join("..", "..", "embedded", "lib", "python2.7", "site-packages", "datadog_checks")
-	relTufPipCache       = filepath.Join("..", "..", "repositories", "cache")
+	relPyPath              = filepath.Join("..", "..", "embedded", "bin", pythonBin)
+	relTufConfigFilePath   = filepath.Join("..", "..", tufConfigFile)
+	relChecksPath          = filepath.Join("..", "..", "embedded", "lib", "python2.7", "site-packages", "datadog_checks")
+	relReqAgentReleasePath = filepath.Join("..", "..", reqAgentReleaseFile)
+	relTufPipCache         = filepath.Join("..", "..", "repositories", "cache")
 )
 
 func authorizedUser() bool {

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -99,4 +99,9 @@ func TestGetVersionFromReqLine(t *testing.T) {
 
 	version, _ = getVersionFromReqLine("package3", reqLines)
 	assert.Nil(t, version)
+
+	reqLines += "\npackage2==2.2.0"
+	version, err := getVersionFromReqLine("package2", reqLines)
+	assert.Nil(t, version)
+	assert.NotNil(t, err)
 }

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -84,6 +84,19 @@ func TestIsAboveOrEqualTo(t *testing.T) {
 
 	version, _ = parseVersion("1.2.2")
 	assert.False(t, version.isAboveOrEqualTo(baseVersion))
+
+	baseVersion = nil
+	assert.True(t, version.isAboveOrEqualTo(baseVersion))
+}
+
+func TestEquals(t *testing.T) {
+	v1, _ := parseVersion("1.2.3")
+	v2, _ := parseVersion("1.2.3")
+
+	assert.True(t, v1.equals(v2))
+
+	v2 = nil
+	assert.False(t, v1.equals(v2))
 }
 
 func TestGetVersionFromReqLine(t *testing.T) {

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -43,6 +43,7 @@ func TestMoveConfigurationsFiles(t *testing.T) {
 	filesNotMoved, _ := ioutil.ReadDir(srcFolder)
 	assert.Equal(t, 1, len(filesNotMoved))
 	assert.Equal(t, otherFile, filesNotMoved[0].Name())
+}
 
 func TestParseVersion(t *testing.T) {
 	version, err := parseVersion("1.2.3")

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -43,4 +43,59 @@ func TestMoveConfigurationsFiles(t *testing.T) {
 	filesNotMoved, _ := ioutil.ReadDir(srcFolder)
 	assert.Equal(t, 1, len(filesNotMoved))
 	assert.Equal(t, otherFile, filesNotMoved[0].Name())
+
+func TestParseVersion(t *testing.T) {
+	version, err := parseVersion("1.2.3")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, version.major)
+	assert.Equal(t, 2, version.minor)
+	assert.Equal(t, 3, version.fix)
+
+	version, err = parseVersion("1.2")
+	assert.Nil(t, version)
+	assert.NotNil(t, err)
+
+	version, err = parseVersion("")
+	assert.Nil(t, version)
+	assert.Nil(t, err)
+}
+
+func TestIsAboveOrEqualTo(t *testing.T) {
+	baseVersion, _ := parseVersion("1.2.3")
+
+	version, _ := parseVersion("1.2.3")
+	assert.True(t, version.isAboveOrEqualTo(baseVersion))
+
+	version, _ = parseVersion("1.2.4")
+	assert.True(t, version.isAboveOrEqualTo(baseVersion))
+
+	version, _ = parseVersion("1.3.0")
+	assert.True(t, version.isAboveOrEqualTo(baseVersion))
+
+	version, _ = parseVersion("2.0.0")
+	assert.True(t, version.isAboveOrEqualTo(baseVersion))
+
+	version, _ = parseVersion("1.1.9")
+	assert.False(t, version.isAboveOrEqualTo(baseVersion))
+
+	version, _ = parseVersion("0.0.1")
+	assert.False(t, version.isAboveOrEqualTo(baseVersion))
+
+	version, _ = parseVersion("1.2.2")
+	assert.False(t, version.isAboveOrEqualTo(baseVersion))
+}
+
+func TestGetVersionFromReqLine(t *testing.T) {
+	reqLines := "package1==3.2.1\npackage2==2.3.1"
+
+	version, _ := getVersionFromReqLine("package1", reqLines)
+	expectedVersion, _ := parseVersion("3.2.1")
+	assert.Equal(t, expectedVersion, version)
+
+	version, _ = getVersionFromReqLine("package2", reqLines)
+	expectedVersion, _ = parseVersion("2.3.1")
+	assert.Equal(t, expectedVersion, version)
+
+	version, _ = getVersionFromReqLine("package3", reqLines)
+	assert.Nil(t, version)
 }

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -113,6 +113,7 @@ func TestGetVersionFromReqLine(t *testing.T) {
 	version, _ = getVersionFromReqLine("package3", reqLines)
 	assert.Nil(t, version)
 
+	// Add package2 a second time, should error out
 	reqLines += "\npackage2==2.2.0"
 	version, err := getVersionFromReqLine("package2", reqLines)
 	assert.Nil(t, version)

--- a/cmd/agent/app/integrations_windows.go
+++ b/cmd/agent/app/integrations_windows.go
@@ -18,10 +18,11 @@ const (
 )
 
 var (
-	relPyPath            = pythonBin
-	relTufConfigFilePath = filepath.Join("..", tufConfigFile)
-	relChecksPath        = filepath.Join("Lib", "site-packages", "datadog_checks")
-	tufPipCachePath      = filepath.Join("c:\\", "ProgramData", "Datadog", "repositories", "cache")
+	relPyPath              = pythonBin
+	relTufConfigFilePath   = filepath.Join("..", tufConfigFile)
+	relChecksPath          = filepath.Join("Lib", "site-packages", "datadog_checks")
+	relReqAgentReleasePath = filepath.Join("..", reqAgentReleaseFile)
+	tufPipCachePath        = filepath.Join("c:\\", "ProgramData", "Datadog", "repositories", "cache")
 )
 
 func authorizedUser() bool {

--- a/releasenotes/notes/install_downgrade-0d94f87dd2601257.yaml
+++ b/releasenotes/notes/install_downgrade-0d94f87dd2601257.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    ``datadog-agent integration install`` command prevents a user to downgrade an integration
+    to a version older than the one shipped by default in the agent.


### PR DESCRIPTION
### What does this PR do?

Prevents a user from downgrading to a version older than the one shipped by default in the agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?