### PR TITLE
repair test kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,16 @@ before_script:
   only:
     - triggers
 
+
+# anchor to trigger test kitchen setup, run, and cleanup (so all stages
+# are run if one stage is run).  Triggers as defined:
+# - master
+# - tags (a tagged build)
+# - triggers (as above, when triggered by an external tool like jenkins)
+# - web (when the build is triggered by a specific build request through the
+#        web interface.  This way, if a kitchen run is desired on a specific branch,
+#        it can be triggered by requesting a specific build)
+#
 .run_when_testkitchen_triggered: &run_when_testkitchen_triggered
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,6 @@ before_script:
     - tags
     - triggers
     - web
-    - pushes
 
 # run job only when triggered by an external tool (ex: Jenkins) and when
 # RELEASE_VERSION is NOT "nightly". In this setting we are building either a

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -660,7 +660,7 @@ kitchen_suse:
     - cd $DD_AGENT_TESTING_DIR
     - mkdir $CI_PROJECT_DIR/kitchen_logs
     - ln -s $CI_PROJECT_DIR/kitchen_logs $DD_AGENT_TESTING_DIR/.kitchen
-    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP3:2017.12.11"
+    - export TEST_PLATFORMS="sles-12,SUSE:SLES:12-SP3:2018.09.04"
     - bash -l tasks/run-test-kitchen.sh
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,14 @@ before_script:
   only:
     - triggers
 
+.run_when_testkitchen_triggered: &run_when_testkitchen_triggered
+  only:
+    - master
+    - tags
+    - triggers
+    - web
+    - pushes
+
 # run job only when triggered by an external tool (ex: Jenkins) and when
 # RELEASE_VERSION is NOT "nightly". In this setting we are building either a
 # new tagged version of the agent (an RC for example). In both cases the
@@ -503,7 +511,7 @@ deploy_deb_testing:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
-  <<: *run_when_triggered
+  <<: *run_when_testkitchen_triggered
   tags: [ "runner:main", "size:large" ]
   script:
     - source /usr/local/rvm/scripts/rvm
@@ -525,7 +533,7 @@ deploy_deb_testing:
 
 # deploy rpm packages to yum staging repo
 deploy_rpm_testing:
-  <<: *run_when_triggered
+  <<: *run_when_testkitchen_triggered
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
@@ -542,7 +550,7 @@ deploy_rpm_testing:
 
 # deploy rpm packages to yum staging repo
 deploy_suse_rpm_testing:
-  <<: *run_when_triggered
+  <<: *run_when_testkitchen_triggered
   allow_failure: true
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
@@ -560,25 +568,22 @@ deploy_suse_rpm_testing:
 
 # deploy windows packages to our testing bucket
 deploy_windows_testing:
-  <<: *run_when_triggered
+  <<: *run_when_testkitchen_triggered
   allow_failure: true
   stage: testkitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:
-    - ls $OMNIBUS_PACKAGE_DIR_SUSE
+    - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_TESTING_S3_BUCKET/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD --recursive --exclude "*" --include "*.msi" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_TESTING_S3_BUCKET --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # run dd-agent-testing on windows
 kitchen_windows:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -602,10 +607,7 @@ kitchen_centos:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -627,10 +629,7 @@ kitchen_ubuntu:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -653,10 +652,7 @@ kitchen_suse:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -678,10 +674,7 @@ kitchen_debian:
   stage: testkitchen_testing
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
   tags: [ "runner:main", "size:large" ]
@@ -702,10 +695,7 @@ kitchen_debian:
 testkitchen_cleanup_s3:
   stage: testkitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   tags: [ "runner:main", "size:large" ]
   before_script:
     - ls
@@ -724,10 +714,7 @@ testkitchen_cleanup_s3:
 testkitchen_cleanup_azure:
   stage: testkitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
-  only:
-    - master
-    - tags
-    - triggers
+  <<: *run_when_testkitchen_triggered
   # even if this fails, it shouldn't block the pipeline.
   allow_failure: true
   when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -580,7 +580,7 @@ deploy_windows_testing:
 # run dd-agent-testing on windows
 kitchen_windows:
   stage: testkitchen_testing
-  allow_failure: true
+  allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:
@@ -604,7 +604,7 @@ kitchen_windows:
 # run dd-agent-testing on centos
 kitchen_centos:
   stage: testkitchen_testing
-  allow_failure: true
+  allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:
@@ -649,7 +649,7 @@ kitchen_ubuntu:
 # run dd-agent-testing on suse
 kitchen_suse:
   stage: testkitchen_testing
-  allow_failure: true
+  allow_failure: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -29,8 +29,8 @@ execute 'update Agent install script repository' do
   command <<-EOF
     sed -i 's/apt\\.datadoghq\\.com/#{node['dd-agent-install-script']['candidate_repo_domain_apt']}/' install-script
     sed -i 's/yum\\.datadoghq\\.com/#{node['dd-agent-install-script']['candidate_repo_domain_yum']}/' install-script
-    sed -i 's/apt.${dd_url}/#{node['dd-agent-install-script']['candidate_repo_domain_apt']}/' install-script
-    sed -i 's/yum.${dd_url}/#{node['dd-agent-install-script']['candidate_repo_domain_yum']}/' install-script
+    sed -i 's/apt.${repo_url}/#{node['dd-agent-install-script']['candidate_repo_domain_apt']}/' install-script
+    sed -i 's/yum.${repo_url}/#{node['dd-agent-install-script']['candidate_repo_domain_yum']}/' install-script
     sed -i 's~stable/x86_64~#{node['dd-agent-install-script']['candidate_repo_branch']}/x86_64~' install-script
     sed -i 's~rpm/x86_64~#{node['dd-agent-install-script']['candidate_repo_branch']}/x86_64~' install-script
     sed -i 's~beta/x86_64~#{node['dd-agent-install-script']['candidate_repo_branch']}/x86_64~' install-script

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -78,7 +78,7 @@ set -x
 # on linux it can just download the latest version from the package manager
 if [ -z ${AGENT_VERSION+x} ]; then
   pushd ../..
-    export AGENT_VERSION=`inv version --url-safe --git-sha-length=8`
+    export AGENT_VERSION=`inv version --url-safe --git-sha-length=9`
   popd
 fi
 


### PR DESCRIPTION
Make test kitchen runs function on all OSes.  Makes test kitchen required
for Windows, Centos.

Is currently not required for `apt` platforms, as there's a locking problem that causes 
tests to fail sometimes.

Creates a label for when kitchen runs so all kitchen-related stages are run based on
the same triggers (one of the problems fixed was that the kitchen tests were attempted 
when the kitchen-deploy stage hadn't run)

change git sha length to match what's pushed

