### PR TITLE
Change docker inspect error to debug

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -114,7 +114,7 @@ func (c *DockerCollector) fetchForDockerID(cID string) ([]string, []string, erro
 	co, err := c.dockerUtil.Inspect(cID, false)
 	if err != nil {
 		// TODO separate "not found" and inspect error
-		log.Errorf("Failed to inspect container %s - %s", cID, err)
+		log.Debugf("Failed to inspect container %s - %s", cID, err)
 		return nil, nil, err
 	}
 	return c.extractFromInspect(co)

--- a/releasenotes/notes/change-docker-inspect-error-to-debug-831a153cc318b73f.yaml
+++ b/releasenotes/notes/change-docker-inspect-error-to-debug-831a153cc318b73f.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Configure error log when failing to run docker inspect to read as debug instead, as this log is duplicated by the tagger.

--- a/releasenotes/notes/change-docker-inspect-error-to-debug-831a153cc318b73f.yaml
+++ b/releasenotes/notes/change-docker-inspect-error-to-debug-831a153cc318b73f.yaml
@@ -1,3 +1,4 @@
-features:
+---
+fixes:
   - |
     Configure error log when failing to run docker inspect to read as debug instead, as this log is duplicated by the tagger.


### PR DESCRIPTION
### What does this PR do?

Alter the docker collector failure to inspect log from error to debug.

### Motivation

The tagger already logs the message in Warn, so the duplicated error log can be changed to debug. Raised here: #https://github.com/DataDog/datadog-agent/issues/1522

### Testing
Line will only display in debug: https://cl.ly/9c39d5a8622b