### PR TITLE
Fix timezone mismatch in the status page

### DIFF
--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -25,10 +25,6 @@ func init() {
 	fmap["status"] = displayStatus
 }
 
-const (
-	timeFormat = "2006-01-02 15:04:05.000000 UTC"
-)
-
 // Data is a struct used for filling templates
 type Data struct {
 	Name       string

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -25,7 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-var timeFormat = "2006-01-02 15:04:05.000000 UTC"
+var timeFormat = "2006-01-02 15:04:05.000000 MST"
 
 // GetStatus grabs the status from expvar and puts it into a map
 func GetStatus() (map[string]interface{}, error) {

--- a/releasenotes/notes/fix-timezone-status-page-ac1b18bc0d34420d.yaml
+++ b/releasenotes/notes/fix-timezone-status-page-ac1b18bc0d34420d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Display the correct timezone name in the status page.


### PR DESCRIPTION
### What does this PR do?

Fix timezone mismatch in the status page. The correct placeholder for timezone is `MST`

