### PR TITLE
Use Codecov for code coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,10 @@ jobs:
       - run:
           name: run unit tests
           command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 4
+      - run:
+          name: upload code coverage results
+          # Never fail on coverage upload
+          command: bash <(curl -s https://codecov.io/bash) -f profile.cov || true
 
   integration_tests:
     <<: *job_template

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  branches: null
+
+
+coverage:
+  range: 50..100
+  round: down
+  precision: 2
+
+  status:
+    patch:
+      default:
+        target: '30'

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ comment:
 
 
 coverage:
-  range: 50..100
+  range: 20..100
   round: down
   precision: 2
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/master.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/master)
 [![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/master?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/master)
+[![Coverage status](https://codecov.io/github/DataDog/datadog-agent/coverage.svg?branch=master)](https://codecov.io/github/DataDog/datadog-agent?branch=master)
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)
 [![Go Report Card](https://goreportcard.com/badge/github.com/DataDog/datadog-agent)](https://goreportcard.com/report/github.com/DataDog/datadog-agent)
 
@@ -28,7 +29,7 @@ To build the Agent you need:
 
 **Note:** You may have previously installed `invoke` via brew on MacOS, or `pip` in
       any other platform. We recommend you use the version pinned in the requirements
-      file for a smooth development/build experience. 
+      file for a smooth development/build experience.
 
 Builds and tests are orchestrated with `invoke`, type `invoke --list` on a shell
 to see the available tasks.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ install:
   - 7z x *.zip > NUL
   - set PATH=C:\deps\bin;%GOPATH%\bin;%GOROOT%\bin;%RUBY_PATH%\bin;%RI_DEVKIT%bin;%RI_DEVKIT%mingw\bin;c:\python27-x64;c:\python27-x64\scripts;%PATH%
   - go version
+  - pip install codecov
   - pip install -r %GOPATH%\src\github.com\DataDog\datadog-agent\requirements.txt
 
 cache:
@@ -38,4 +39,5 @@ build: off
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - inv -e deps
-  - inv -e test --race --profile --fail-on-fmt
+  - inv -e test --coverage --race --profile --fail-on-fmt
+  - codecov -f profile.cov


### PR DESCRIPTION
### What does this PR do?

This service provides a rich UI for displaying code coverage at various resolutions: project-wide, per-directory/package, user-defined flags (e.g. unit, integration, docker), line-by-line, etc. You can also control CI & PR pass/fail based on coverage percentage. There is also the ability to use a pull request comment bot and dictate its contents. And there is a Chrome extension that overlays stats on GitHub's UI.

Also, AppVeyor now reports coverage too so you get a fuller picture. Codecov automatically merges reports.

### Motivation

Gain better insight into health of repo & encourage mentality of testing. Here is what `integrations-core` looks like: https://codecov.io/github/DataDog/integrations-core?branch=master

### Note

I got the idea that this will benefit the Agent while reading about how Elastic does coverage for all of their Golang stuff https://www.elastic.co/blog/code-coverage-for-your-golang-system-tests