### PR TITLE
Send message asynchronously to the additional destinations

### DIFF
--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -20,6 +20,8 @@ var (
 	LogsSent = expvar.Int{}
 	// DestinationErrors is the total number of network errors.
 	DestinationErrors = expvar.Int{}
+	// DestinationLogsDropped is the total number of logs dropped per Destination
+	DestinationLogsDropped = expvar.Map{}
 	// TODO: Add LogsCollected for the total number of collected logs.
 )
 
@@ -29,4 +31,5 @@ func init() {
 	LogsExpvars.Set("LogsProcessed", &LogsProcessed)
 	LogsExpvars.Set("LogsSent", &LogsSent)
 	LogsExpvars.Set("DestinationErrors", &DestinationErrors)
+	LogsExpvars.Set("DestinationLogsDropped", &DestinationLogsDropped)
 }

--- a/pkg/logs/metrics/metrics_test.go
+++ b/pkg/logs/metrics/metrics_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	assert.Equal(t, LogsExpvars.String(), `{"DestinationErrors": 0, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0}`)
+	assert.Equal(t, LogsExpvars.String(), `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0}`)
 }

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -48,6 +48,9 @@ func (s *Sender) run() {
 	defer func() {
 		s.done <- struct{}{}
 	}()
+	for _, destination := range s.destinations.Additionals {
+		go destination.ConsumeAsync()
+	}
 	for payload := range s.inputChan {
 		s.send(payload)
 	}
@@ -84,7 +87,7 @@ func (s *Sender) send(payload *message.Message) {
 			// FIXME: run all `Send` in parallel to avoid the effect on a slow
 			// destination on the others. Potentially add a buffer for secondary
 			// destinations.
-			destination.Send(payload.Content)
+			destination.SendAsync(payload.Content)
 		}
 
 		metrics.LogsSent.Add(1)

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -48,9 +48,6 @@ func (s *Sender) run() {
 	defer func() {
 		s.done <- struct{}{}
 	}()
-	for _, destination := range s.destinations.Additionals {
-		go destination.ConsumeAsync()
-	}
 	for payload := range s.inputChan {
 		s.send(payload)
 	}

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -79,11 +79,8 @@ func (s *Sender) send(payload *message.Message) {
 			}
 		}
 		for _, destination := range s.destinations.Additionals {
-			// try and forget strategy for additional endpoints
-			// this call is also blocking when the connection is not established yet
-			// FIXME: run all `Send` in parallel to avoid the effect on a slow
-			// destination on the others. Potentially add a buffer for secondary
-			// destinations.
+			// send to a queue then send asynchronously for additional endpoints,
+			// it will drop messages if the queue is full
 			destination.SendAsync(payload.Content)
 		}
 

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -74,10 +74,10 @@ func TestStatusDeduplicateWarnings(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	defer Clear()
 	Clear()
-	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`)
+	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`)
 
 	sources := createSources()
 	logSources := sources.GetSources()
 	logSources[0].Messages.AddWarning("bar", "Unique Warning")
-	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`)
+	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`)
 }


### PR DESCRIPTION
### What does this PR do?

Sends message asynchronously to the additional destinations

### Motivation

If the additional destinations are improperly configured, all the destinations are blocked and no messages are sent

### Additional Notes

I left 2 fixmes: 

- [ ] Which size for the inputChan is appropriate for the additional destination
- [ ] Is it ok to drop logs, if now how should we handle the case where the additional destination is slower than the main destination
