### PR TITLE
[windows] Fixes crash on malformed windows counter database.

### DIFF
--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -64,7 +64,7 @@ func makeCounterSetIndexes() error {
 		break
 	}
 	clist := winutil.ConvertWindowsStringList(counterlist)
-	for i := 0; i < len(clist); i += 2 {
+	for i := 0; (i + 1) < len(clist); i += 2 {
 		ndx, _ := strconv.Atoi(clist[i])
 		counterToIndex[clist[i+1]] = append(counterToIndex[clist[i+1]], ndx)
 	}

--- a/releasenotes/notes/fixpdhinitcrash-7515a73a7c9fcb39.yaml
+++ b/releasenotes/notes/fixpdhinitcrash-7515a73a7c9fcb39.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes crash on Windows when the agent encounters a malformed performance counter database


### PR DESCRIPTION
We sometimes encounter malformed windows performance counter databases.
We try to handle it gracefully.  However, we recently encountered a
database which was filled with empty strings.

Code change ensures we don't try to access off the end of the end of the
array of strings, which was possible in this particular case

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
