### PR TITLE
Compile the process agent from source within omnibus

### DIFF
--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -3,9 +3,12 @@
 # This product includes software developed at Datadog (https:#www.datadoghq.com/).
 # Copyright 2018 Datadog, Inc.
 
-name "datadog-process-agent"
-always_build true
 require "./lib/ostools.rb"
+require 'pathname'
+
+name "datadog-process-agent"
+
+dependency "datadog-agent"
 
 process_agent_version = ENV['PROCESS_AGENT_VERSION']
 if process_agent_version.nil? || process_agent_version.empty?
@@ -13,21 +16,51 @@ if process_agent_version.nil? || process_agent_version.empty?
 end
 default_version process_agent_version
 
+source git: 'https://github.com/DataDog/datadog-process-agent.git'
+relative_path 'src/github.com/DataDog/datadog-process-agent'
+
+if windows?
+  process_agent_binary = "process-agent.exe"
+else
+  process_agent_binary = "process-agent"
+end
+
 build do
+  ship_license "https://raw.githubusercontent.com/DataDog/datadog-process-agent/#{version}/LICENSE"
+  # set GOPATH on the omnibus source dir for this software
+  gopath = Pathname.new(project_dir) + '../../../..'
   if windows?
-    binary = "process-agent-windows-#{version}.exe"
-    target_binary = "process-agent.exe"
-    url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
-    curl_cmd = "powershell -Command wget -OutFile #{binary} #{url}"
-    command curl_cmd
-    command "mv #{binary} #{install_dir}/bin/agent/#{target_binary}"
+    env = {
+      # Trace agent uses GNU make to build.  Some of the input to gnu make
+      # needs the path with `\` as separators, some needs `/`.  Provide both,
+      # and let the makefile sort it out (ugh)
+
+      # also on windows don't modify the path.  Modifying the path here mixes
+      # `/` with `\` in the PATH variable, which confuses the make (and sub-processes)
+      # below.  When properly configured the path on the windows box is sufficient.
+      'GOPATH' => "#{windows_safe_path(gopath.to_path)}",
+    }
   else
-    binary = "process-agent-amd64-#{version}"
-    target_binary = "process-agent"
-    url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
-    curl_cmd = "curl -f #{url} -o #{binary}"
-    command curl_cmd
-    command "chmod +x #{binary}"
-    command "mv #{binary} #{install_dir}/embedded/bin/#{target_binary}"
+    env = {
+      'GOPATH' => gopath.to_path,
+      'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
+    }
+  end
+
+  block do
+    # defer compilation step in a block to allow getting the project's build version, which is populated
+    # only once the software that the project takes its version from (i.e. `datadog-agent`) has finished building
+    env['PROCESS_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the process-agent, only keep digits and dots
+
+    # build process-agent
+    command "rake deps", :env => env
+    command "rake build", :env => env
+
+    # copy binary
+    if windows?
+      copy "#{project_dir}/#{process_agent_binary}", "#{install_dir}/bin/agent"
+    else
+      copy "#{project_dir}/#{process_agent_binary}", "#{install_dir}/embedded/bin"
+    end
   end
 end


### PR DESCRIPTION
Running the omnibus recipes on arm currently will package an amd64 version of the process agent, because it is downloaded from an s3 bucket.

I'm wondering if there is a reason for this that I am missing, that would require a download rather than a source build? Happy to hear more.

This PR basically copies the trace agent recipe, adapted for the process agent. Here is a diff between the two:
I might be missing windows-specific build instructions.

```diff
9c9
< name "datadog-trace-agent"
---
> name "datadog-process-agent"
13,15c13,15
< trace_agent_version = ENV['TRACE_AGENT_VERSION']
< if trace_agent_version.nil? || trace_agent_version.empty?
<   trace_agent_version = 'master'
---
> process_agent_version = ENV['PROCESS_AGENT_VERSION']
> if process_agent_version.nil? || process_agent_version.empty?
>   process_agent_version = 'master'
17c17
< default_version trace_agent_version
---
> default_version process_agent_version
19,20c19,20
< source git: 'https://github.com/DataDog/datadog-trace-agent.git'
< relative_path 'src/github.com/DataDog/datadog-trace-agent'
---
> source git: 'https://github.com/DataDog/datadog-process-agent.git'
> relative_path 'src/github.com/DataDog/datadog-process-agent'
23c23
<   trace_agent_binary = "trace-agent.exe"
---
>   process_agent_binary = "process-agent.exe"
25c25
<   trace_agent_binary = "trace-agent"
---
>   process_agent_binary = "process-agent"
29c29
<   ship_license "https://raw.githubusercontent.com/DataDog/datadog-trace-agent/#{version}/LICENSE"
---
>   ship_license "https://raw.githubusercontent.com/DataDog/datadog-process-agent/#{version}/LICENSE"
34c34
<       # Trace agent uses GNU make to build.  Some of the input to gnu make
---
>       # Trace agent uses GNU make to build.  Some of the input to gnu make
53c53
<     env['TRACE_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the trace-agent, only keep digits and dots
---
>     env['PROCESS_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the process-agent, only keep digits and dots
55,59c55,57
<     # build trace-agent
<     if windows?
<       command "make windows", :env => env
<     end
<     command "make install", :env => env
---
>     # build process-agent
>     command "rake deps", :env => env
>     command "rake build", :env => env
63c61
<       copy "#{gopath.to_path}/bin/#{trace_agent_binary}", "#{install_dir}/bin/agent"
---
>       copy "#{project_dir}/#{process_agent_binary}", "#{install_dir}/bin/agent"
65c63
<       copy "#{gopath.to_path}/bin/#{trace_agent_binary}", "#{install_dir}/embedded/bin"
---
>       copy "#{project_dir}/#{process_agent_binary}", "#{install_dir}/embedded/bin"
```