### PR TITLE
Add postgresql dependency on ARM and pass environment to pip commands

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -12,6 +12,17 @@ dependency 'datadog-agent'
 dependency 'pip2'
 dependency 'pip3'
 
+if arm?
+  # psycopg2 doesn't come with pre-built wheel on the arm architecture.
+  # to compile from source, it requires the `pg_config` executable present on the $PATH
+  dependency 'postgresql'
+  # same with libffi to build the cffi wheel
+  dependency 'libffi'
+  # same with libxml2 and libxslt to build the lxml wheel
+  dependency 'libxml2'
+  dependency 'libxslt'
+end
+
 if linux?
   # add nfsiostat script
   dependency 'unixodbc'
@@ -140,8 +151,8 @@ build do
       command "#{python2} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{static_reqs_out_file}"
     else
       command "#{pip2} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      command "#{pip2} install --no-deps .", :cwd => "#{project_dir}/datadog_checks_downloader"
-      command "#{python2} -m piptools compile --generate-hashes --output-file #{install_dir}/#{agent_requirements_file} #{static_reqs_out_file}"
+      command "#{pip2} install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_downloader"
+      command "#{python2} -m piptools compile --generate-hashes --output-file #{install_dir}/#{agent_requirements_file} #{static_reqs_out_file}", :env => nix_build_env
     end
 
     # From now on we don't need piptools anymore, uninstall its deps so we don't include them in the final artifact

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -25,6 +25,10 @@ def windows?()
     return ohai['platform_family'] == 'windows'
 end
 
+def arm?()
+    return ohai["kernel"]["machine"].start_with?("aarch") || ohai["kernel"]["machine"].start_with?("arm")
+end
+
 def os
     case RUBY_PLATFORM
     when /linux/


### PR DESCRIPTION
To install psycopg2 on ARM, there is no pre-built wheel/binary and it needs to be compiled from source. Doing so requires the `pg_config` executable on the path.

This PR adds postgresql as a dependency to datadog-agent-integrations on arm platforms and passes down the environment variables to a couple pip commands, which didn't have it yet.

```
[Builder: datadog-agent-integrations] I | 2018-10-18T14:21:26+00:00 | Build datadog-agent-integrations: 182.1557s
The following shell command exited with status 1:

    $ /opt/datadog-agent/embedded/bin/python -m piptools compile --generate-hashes --output-file /opt/datadog-agent/agent_requirements.txt /root/.omnibus/src/datadog-agent-integrations/integrations-core/datadog_checks_base/datadog_checks/base/data/agent_requirements.in

Output:

    (nothing)

Error:

    No handlers could be found for logger "pip._vendor.cachecontrol.controller"
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/datadog-agent/embedded/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/__main__.py", line 16, in <module>
    cli()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/scripts/compile.py", line 187, in cli
    results = resolver.resolve(max_rounds=max_rounds)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/resolver.py", line 102, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/resolver.py", line 199, in _resolve_one_round
    for dep in self._iter_dependencies(best_match):
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/resolver.py", line 285, in _iter_dependencies
    dependencies = self.repository.get_dependencies(ireq)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/repositories/pypi.py", line 146, in get_dependencies
    self._dependencies_cache[ireq] = reqset._prepare_file(self.finder, ireq)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/_vendored/pip/req/req_set.py", line 634, in _prepare_file
    abstract_dist.prep_for_dist()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/_vendored/pip/req/req_set.py", line 129, in prep_for_dist
    self.req_to_install.run_egg_info()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/_vendored/pip/req/req_install.py", line 439, in run_egg_info
    command_desc='python setup.py egg_info')
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/_vendored/pip/utils/__init__.py", line 707, in call_subprocess
    % (command_desc, proc.returncode, cwd))
pip.exceptions.InstallationError: Command "python setup.py egg_info" failed with error code 1 in /tmp/tmpJc0yFlbuild/psycopg2-binary/
```

and 

```
    Error: pg_config executable not found.

    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:
```