### PR TITLE
[logs sources] Fix deadlock when a logs config is invalid

### DIFF
--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -30,6 +30,7 @@ func (s *LogSources) AddSource(source *LogSource) {
 	s.mu.Lock()
 	s.sources = append(s.sources, source)
 	if source.Config == nil || source.Config.Validate() != nil {
+		s.mu.Unlock()
 		return
 	}
 	stream, exists := s.addedByType[source.Config.Type]

--- a/pkg/logs/config/sources_test.go
+++ b/pkg/logs/config/sources_test.go
@@ -20,6 +20,9 @@ func TestAddSource(t *testing.T) {
 
 	sources.AddSource(NewLogSource("bar", &LogsConfig{Type: "boo"}))
 	assert.Equal(t, 2, len(sources.GetSources()))
+
+	sources.AddSource(NewLogSource("baz", &LogsConfig{})) // invalid config
+	assert.Equal(t, 3, len(sources.GetSources()))
 }
 
 func TestRemoveSource(t *testing.T) {

--- a/releasenotes/notes/fix-deadlock-logs-sources-efb2317f259167b5.yaml
+++ b/releasenotes/notes/fix-deadlock-logs-sources-efb2317f259167b5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix deadlock when an config item under ``logs`` is invalid


### PR DESCRIPTION
### What does this PR do?

Properly unlock mutex when a logs config is invalid.

### Motivation

I ran into this while testing something unrelated. The bug is present since https://github.com/DataDog/datadog-agent/pull/2306 / `6.5.0`.

Would lock the whole `LogSources` struct if one configured log config is invalid (e.g. if a `logs` instance in the yaml doesn't have a `type`), which incidentally also makes the `status` page and expvar output hang.

### Additional notes

Added a test that deadlocks without the fix.