### PR TITLE
[LOGS]: Made pipeline configurable and added new metrics to the logs-agent

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -305,6 +305,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
 	config.BindEnvAndSetDefault("logs_config.dd_url_443", "agent-443-intake.logs.datadoghq.com")
 	config.BindEnvAndSetDefault("logs_config.stop_grace_period", 30)
+	config.BindEnvAndSetDefault("logs_config.pipeline.count", 4)
+	config.BindEnvAndSetDefault("logs_config.pipeline.buffer_size", 100)
 
 	// Tagger full cardinality mode
 	// Undocumented opt-in feature for now

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -61,9 +61,10 @@ func (suite *AgentTestSuite) TearDownTest() {
 	os.Remove(suite.testDir)
 
 	// Resets the metrics we check.
-	metrics.LogsDecoded.Set(0)
+	metrics.LogsCollected.Set(0)
 	metrics.LogsProcessed.Set(0)
 	metrics.LogsSent.Set(0)
+	metrics.LogsCommitted.Set(0)
 	metrics.DestinationErrors.Set(0)
 }
 
@@ -87,9 +88,10 @@ func (suite *AgentTestSuite) TestAgent() {
 	agent, sources, _ := createAgent(endpoints)
 
 	zero := int64(0)
-	assert.Equal(suite.T(), zero, metrics.LogsDecoded.Value())
+	assert.Equal(suite.T(), zero, metrics.LogsCollected.Value())
 	assert.Equal(suite.T(), zero, metrics.LogsProcessed.Value())
 	assert.Equal(suite.T(), zero, metrics.LogsSent.Value())
+	assert.Equal(suite.T(), zero, metrics.LogsCommitted.Value())
 	assert.Equal(suite.T(), zero, metrics.DestinationErrors.Value())
 
 	agent.Start()
@@ -98,9 +100,10 @@ func (suite *AgentTestSuite) TestAgent() {
 	time.Sleep(10 * time.Millisecond)
 	agent.Stop()
 
-	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
+	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsCollected.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsProcessed.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsSent.Value())
+	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsCommitted.Value())
 	assert.Equal(suite.T(), zero, metrics.DestinationErrors.Value())
 
 	// Validate that we can restart it without obvious breakages.
@@ -120,9 +123,11 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {
 	time.Sleep(10 * time.Millisecond)
 	agent.Stop()
 
-	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsDecoded.Value())
+	zero := int64(0)
+	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsCollected.Value())
 	assert.Equal(suite.T(), suite.fakeLogs, metrics.LogsProcessed.Value())
-	assert.Equal(suite.T(), int64(0), metrics.LogsSent.Value())
+	assert.Equal(suite.T(), zero, metrics.LogsSent.Value())
+	assert.Equal(suite.T(), zero, metrics.LogsCommitted.Value())
 	assert.True(suite.T(), metrics.DestinationErrors.Value() > 0)
 }
 

--- a/pkg/logs/auditor/auditor_test.go
+++ b/pkg/logs/auditor/auditor_test.go
@@ -43,7 +43,7 @@ func (suite *AuditorTestSuite) SetupTest() {
 	_, err = os.Create(suite.testPath)
 	suite.Nil(err)
 
-	suite.a = New("", health.Register("fake"))
+	suite.a = New("", 100, health.Register("fake"))
 	suite.a.registryPath = suite.testPath
 	suite.source = config.NewLogSource("", &config.LogsConfig{Path: testpath})
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -30,6 +30,8 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.logs_dd_url"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_config.logs_no_ssl"))
 	assert.Equal(t, 30, LogsAgent.GetInt("logs_config.stop_grace_period"))
+	assert.Equal(t, 4, LogsAgent.GetInt("logs_config.pipeline.count"))
+	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.pipeline.buffer_size"))
 }
 
 func TestDefaultSources(t *testing.T) {

--- a/pkg/logs/config/constants.go
+++ b/pkg/logs/config/constants.go
@@ -5,12 +5,6 @@
 
 package config
 
-// Pipeline constraints
-const (
-	ChanSize          = 100
-	NumberOfPipelines = 4
-)
-
 const (
 	// DateFormat is the default date format.
 	DateFormat = "2006-01-02T15:04:05.000000000Z"

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // DefaultSleepDuration represents the amount of time the tailer waits before reading new data when no data is received
@@ -192,6 +193,7 @@ func (t *Tailer) forwardMessages() {
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {
+		metrics.LogsCollected.Add(1)
 		offset := t.decodedOffset + int64(output.RawDataLen)
 		identifier := t.Identifier()
 		if !t.shouldTrackOffset() {

--- a/pkg/logs/input/journald/tailer.go
+++ b/pkg/logs/input/journald/tailer.go
@@ -13,11 +13,12 @@ import (
 	"io"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/coreos/go-systemd/sdjournal"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // defaultWaitDuration represents the delay before which we try to collect a new log from the journal
@@ -152,6 +153,7 @@ func (t *Tailer) tail() {
 			if t.shouldDrop(entry) {
 				continue
 			}
+			metrics.LogsCollected.Add(1)
 			t.outputChan <- t.toMessage(entry)
 		}
 	}

--- a/pkg/logs/input/journald/tailer.go
+++ b/pkg/logs/input/journald/tailer.go
@@ -13,8 +13,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/coreos/go-systemd/sdjournal"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"

--- a/pkg/logs/input/listener/tailer.go
+++ b/pkg/logs/input/listener/tailer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/parser"
 )
 
@@ -62,6 +63,7 @@ func (t *Tailer) forwardMessages() {
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {
+		metrics.LogsCollected.Add(1)
 		output.Origin = message.NewOrigin(t.source)
 		output.SetStatus(message.StatusInfo)
 		t.outputChan <- output

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -18,6 +18,8 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // Start starts tailing the event log.
@@ -91,6 +93,7 @@ func goNotificationCallback(handle C.ULONGLONG, ctx C.PVOID) {
 		return
 	}
 
+	metrics.LogsCollected.Add(1)
 	t.outputChan <- msg
 }
 

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -12,21 +12,23 @@ import (
 var (
 	// LogsExpvars contains metrics for the logs agent.
 	LogsExpvars *expvar.Map
-	// LogsDecoded is the total number of decoded logs
-	LogsDecoded = expvar.Int{}
+	// LogsCollected is the total number of collected logs.
+	LogsCollected = expvar.Int{}
 	// LogsProcessed is the total number of processed logs.
 	LogsProcessed = expvar.Int{}
 	// LogsSent is the total number of sent logs.
 	LogsSent = expvar.Int{}
+	// LogsCommitted is the total number of committed logs.
+	LogsCommitted = expvar.Int{}
 	// DestinationErrors is the total number of network errors.
 	DestinationErrors = expvar.Int{}
-	// TODO: Add LogsCollected for the total number of collected logs.
 )
 
 func init() {
 	LogsExpvars = expvar.NewMap("logs-agent")
-	LogsExpvars.Set("LogsDecoded", &LogsDecoded)
+	LogsExpvars.Set("LogsCollected", &LogsCollected)
 	LogsExpvars.Set("LogsProcessed", &LogsProcessed)
 	LogsExpvars.Set("LogsSent", &LogsSent)
+	LogsExpvars.Set("LogsCommitted", &LogsCommitted)
 	LogsExpvars.Set("DestinationErrors", &DestinationErrors)
 }

--- a/pkg/logs/metrics/metrics_test.go
+++ b/pkg/logs/metrics/metrics_test.go
@@ -12,5 +12,5 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	assert.Equal(t, LogsExpvars.String(), `{"DestinationErrors": 0, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0}`)
+	assert.Equal(t, LogsExpvars.String(), `{"DestinationErrors": 0, "LogsCollected": 0, "LogsCommitted": 0, "LogsProcessed": 0, "LogsSent": 0}`)
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -7,7 +7,6 @@ package pipeline
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/processor"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
@@ -21,7 +20,7 @@ type Pipeline struct {
 }
 
 // NewPipeline returns a new Pipeline
-func NewPipeline(outputChan chan *message.Message, endpoints *client.Endpoints, destinationsContext *client.DestinationsContext) *Pipeline {
+func NewPipeline(outputChan chan *message.Message, bufferSize int, endpoints *client.Endpoints, destinationsContext *client.DestinationsContext) *Pipeline {
 	// initialize the main destination
 	main := client.NewDestination(endpoints.Main, destinationsContext)
 
@@ -33,11 +32,11 @@ func NewPipeline(outputChan chan *message.Message, endpoints *client.Endpoints, 
 
 	// initialize the sender
 	destinations := client.NewDestinations(main, additionals)
-	senderChan := make(chan *message.Message, config.ChanSize)
+	senderChan := make(chan *message.Message, bufferSize)
 	sender := sender.NewSender(senderChan, outputChan, destinations)
 
 	// initialize the input chan
-	inputChan := make(chan *message.Message, config.ChanSize)
+	inputChan := make(chan *message.Message, bufferSize)
 
 	// initialize the processor
 	encoder := processor.NewEncoder(endpoints.Main.UseProto)

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -24,6 +24,7 @@ type Provider interface {
 // provider implements providing logic
 type provider struct {
 	numberOfPipelines int
+	bufferSize        int
 	auditor           *auditor.Auditor
 	outputChan        chan *message.Message
 	endpoints         *client.Endpoints
@@ -34,9 +35,10 @@ type provider struct {
 }
 
 // NewProvider returns a new Provider
-func NewProvider(numberOfPipelines int, auditor *auditor.Auditor, endpoints *client.Endpoints, destinationsContext *client.DestinationsContext) Provider {
+func NewProvider(numberOfPipelines int, bufferSize int, auditor *auditor.Auditor, endpoints *client.Endpoints, destinationsContext *client.DestinationsContext) Provider {
 	return &provider{
 		numberOfPipelines:   numberOfPipelines,
+		bufferSize:          bufferSize,
 		auditor:             auditor,
 		endpoints:           endpoints,
 		pipelines:           []*Pipeline{},
@@ -50,7 +52,7 @@ func (p *provider) Start() {
 	p.outputChan = p.auditor.Channel()
 
 	for i := 0; i < p.numberOfPipelines; i++ {
-		pipeline := NewPipeline(p.outputChan, p.endpoints, p.destinationsContext)
+		pipeline := NewPipeline(p.outputChan, p.bufferSize, p.endpoints, p.destinationsContext)
 		pipeline.Start()
 		p.pipelines = append(p.pipelines, pipeline)
 	}

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -23,9 +23,11 @@ type ProviderTestSuite struct {
 }
 
 func (suite *ProviderTestSuite) SetupTest() {
-	suite.a = auditor.New("", health.Register("fake"))
+	bufferSize := 100
+	suite.a = auditor.New("", bufferSize, health.Register("fake"))
 	suite.p = &provider{
 		numberOfPipelines: 3,
+		bufferSize:        bufferSize,
 		auditor:           suite.a,
 		pipelines:         []*Pipeline{},
 		endpoints:         client.NewEndpoints(client.Endpoint{}, nil),

--- a/pkg/logs/pipeline/registry.json
+++ b/pkg/logs/pipeline/registry.json
@@ -1,0 +1,1 @@
+{"Version":2,"Registry":{}}

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -50,11 +50,10 @@ func (p *Processor) run() {
 		p.done <- struct{}{}
 	}()
 	for msg := range p.inputChan {
-		metrics.LogsDecoded.Add(1)
 		if shouldProcess, redactedMsg := applyRedactingRules(msg); shouldProcess {
 			metrics.LogsProcessed.Add(1)
 
-			// Encode the message to its final format
+			// encode the message to its final format
 			content, err := p.encoder.encode(msg, redactedMsg)
 			if err != nil {
 				log.Error("unable to encode msg ", err)

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -74,10 +74,10 @@ func TestStatusDeduplicateWarnings(t *testing.T) {
 func TestMetrics(t *testing.T) {
 	defer Clear()
 	Clear()
-	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": false, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`)
+	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": false, "LogsCollected": 0, "LogsCommitted": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": ""}`)
 
 	sources := createSources()
 	logSources := sources.GetSources()
 	logSources[0].Messages.AddWarning("bar", "Unique Warning")
-	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`)
+	assert.Equal(t, metrics.LogsExpvars.String(), `{"DestinationErrors": 0, "IsRunning": true, "LogsCollected": 0, "LogsCommitted": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`)
 }


### PR DESCRIPTION
### What does this PR do?

* Moved pipeline parameters out of `constants.go` and made them configurable
* Added metrics for logs collected and logs commited
* Removed metric for logs decoded as it seems to be redundant with logs collected
* Added a bunch of comments to explain how the logs-agent backoff work
* Fixed a bug in the sender when stoping the agent, one log would be committed while it should not

### Motivation

* Make clear how the logs-agent work when having to backoff
* Make parameters configurable from `datadog.yaml`
* Have more metrics

### Additional Notes

Would be nice to refactor the code to have only one "abstract" tailer that could be reused for any kind of input implementation.

Changed few logic that @iksaif worked on several days ago, I'd be happy to discuss to share the same vision.

### Open Questions

For now several stage of the pipeline can buffer messages, I think we should limit this behaviour only to senders as they are the only blocking stage of the pipeline, this would enable us to reduce the number of inflight data when having networking issues from:
```
pipeline.count * ( 2 * pipeline.buffer_size ) + pipeline.buffer_size
```
to:
```
pipeline.count * pipeline.buffer_size
```


