### PR TITLE
improve logging when python checks send wrong object types as tags

### DIFF
--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -132,7 +132,7 @@ int _PyString_Check(PyObject *o) {
 
 PyObject* _PyObject_Repr(PyObject *o)
 {
-  return _PyObject_Repr(o);
+  return PyObject_Repr(o);
 }
 
 PyObject* PySequence_Fast_Get_Item(PyObject *o, Py_ssize_t i)

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -130,6 +130,11 @@ int _PyString_Check(PyObject *o) {
   return PyString_Check(o);
 }
 
+PyObject* _PyObject_Repr(PyObject *o)
+{
+  return _PyObject_Repr(o);
+}
+
 PyObject* PySequence_Fast_Get_Item(PyObject *o, Py_ssize_t i)
 {
   return PySequence_Fast_GET_ITEM(o, i);

--- a/pkg/collector/py/api.c
+++ b/pkg/collector/py/api.c
@@ -99,6 +99,10 @@ int _is_none(PyObject *o) {
   return o == Py_None;
 }
 
+const char* _object_type(PyObject *o) {
+  return Py_TYPE(o)->tp_name;
+}
+
 void initaggregator()
 {
   PyGILState_STATE gstate;

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -246,6 +246,7 @@ func isNone(o *C.PyObject) bool {
 func stringRepresentation(o *C.PyObject) string {
 	repr := C._PyObject_Repr(o)
 	if repr != nil {
+		defer C.Py_DecRef(repr)
 		return C.GoString(C.PyString_AsString(repr))
 	}
 	// error flag is set, not interesting to us so we can simply clear it

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -227,7 +227,8 @@ func extractTags(tags *C.PyObject, checkID string) (_tags []string, err error) {
 			item := C.PySequence_Fast_Get_Item(seq, i) // `item` is borrowed, no need to decref
 			if int(C._PyString_Check(item)) == 0 {
 				typeName := C.GoString(C._object_type(item))
-				log.Infof("One of the submitted tag for the check with ID %s is not a string but a %s, ignoring it", checkID, typeName)
+				stringRepr := stringRepresentation(item)
+				log.Infof("One of the submitted tag for the check with ID %s is not a string but a %s: %s, ignoring it", checkID, typeName, stringRepr)
 				continue
 			}
 			// at this point we're sure that `item` is a string, no further error checking needed
@@ -240,6 +241,14 @@ func extractTags(tags *C.PyObject, checkID string) (_tags []string, err error) {
 
 func isNone(o *C.PyObject) bool {
 	return int(C._is_none(o)) != 0
+}
+
+func stringRepresentation(o *C.PyObject) string {
+	repr := C._PyObject_Repr(o)
+	if repr != nil {
+		return C.GoString(C.PyString_AsString(repr))
+	}
+	return ""
 }
 
 func initAPI() {

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -228,7 +228,7 @@ func extractTags(tags *C.PyObject, checkID string) (_tags []string, err error) {
 			if int(C._PyString_Check(item)) == 0 {
 				typeName := C.GoString(C._object_type(item))
 				stringRepr := stringRepresentation(item)
-				log.Infof("One of the submitted tag for the check with ID %s is not a string but a %s: %s, ignoring it", checkID, typeName, stringRepr)
+				log.Infof("One of the submitted tags for the check with ID %s is not a string but a %s: %s, ignoring it", checkID, typeName, stringRepr)
 				continue
 			}
 			// at this point we're sure that `item` is a string, no further error checking needed
@@ -248,6 +248,8 @@ func stringRepresentation(o *C.PyObject) string {
 	if repr != nil {
 		return C.GoString(C.PyString_AsString(repr))
 	}
+	// error flag is set, not interesting to us so we can simply clear it
+	C.PyErr_Clear()
 	return ""
 }
 

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -227,7 +227,7 @@ func extractTags(tags *C.PyObject, checkID string) (_tags []string, err error) {
 			item := C.PySequence_Fast_Get_Item(seq, i) // `item` is borrowed, no need to decref
 			if int(C._PyString_Check(item)) == 0 {
 				typeName := C.GoString(C._object_type(item))
-				log.Errorf("One of the submitted tag for %s is not a string but a %s, ignoring it", checkID, typeName)
+				log.Debugf("One of the submitted tag for %s is not a string but a %s, ignoring it", checkID, typeName)
 				continue
 			}
 			// at this point we're sure that `item` is a string, no further error checking needed

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -41,7 +41,7 @@ func SubmitMetric(check *C.PyObject, checkID *C.char, mt C.MetricType, name *C.c
 
 	_name := C.GoString(name)
 	_value := float64(value)
-	_tags, err := extractTags(tags)
+	_tags, err := extractTags(tags, goCheckID)
 	if err != nil {
 		log.Error(err)
 		return nil
@@ -85,7 +85,7 @@ func SubmitServiceCheck(check *C.PyObject, checkID *C.char, name *C.char, status
 
 	_name := C.GoString(name)
 	_status := metrics.ServiceCheckStatus(status)
-	_tags, err := extractTags(tags)
+	_tags, err := extractTags(tags, goCheckID)
 	if err != nil {
 		log.Error(err)
 		return nil
@@ -118,7 +118,7 @@ func SubmitEvent(check *C.PyObject, checkID *C.char, event *C.PyObject) *C.PyObj
 		return C._none()
 	}
 
-	_event, err := extractEventFromDict(event)
+	_event, err := extractEventFromDict(event, goCheckID)
 	if err != nil {
 		log.Error(err)
 		return nil
@@ -132,7 +132,7 @@ func SubmitEvent(check *C.PyObject, checkID *C.char, event *C.PyObject) *C.PyObj
 // extractEventFromDict returns an `Event` populated with the fields of the passed event py object
 // The caller needs to check the returned `error`, any non-nil value indicates that the error flag is set
 // on the python interpreter.
-func extractEventFromDict(event *C.PyObject) (metrics.Event, error) {
+func extractEventFromDict(event *C.PyObject, checkID string) (metrics.Event, error) {
 	// Extract all string values
 	// Values that should be extracted from the python event dict as strings
 	eventStringValues := map[string]string{
@@ -191,7 +191,7 @@ func extractEventFromDict(event *C.PyObject) (metrics.Event, error) {
 
 	tags := C.PyDict_GetItemString(event, pyKey) // borrowed ref
 	if tags != nil {
-		_tags, err := extractTags(tags)
+		_tags, err := extractTags(tags, checkID)
 		if err != nil {
 			return _event, err
 		}
@@ -204,7 +204,7 @@ func extractEventFromDict(event *C.PyObject) (metrics.Event, error) {
 // extractTags returns a slice with the contents of the passed non-nil py object.
 // The caller needs to check the returned `error`, any non-nil value indicates that the error flag is set
 // on the python interpreter.
-func extractTags(tags *C.PyObject) (_tags []string, err error) {
+func extractTags(tags *C.PyObject, checkID string) (_tags []string, err error) {
 	if !isNone(tags) {
 		if int(C.PySequence_Check(tags)) == 0 {
 			log.Errorf("Submitted `tags` is not a sequence, ignoring tags")
@@ -226,7 +226,8 @@ func extractTags(tags *C.PyObject) (_tags []string, err error) {
 		for i = 0; i < C.PySequence_Fast_Get_Size(seq); i++ {
 			item := C.PySequence_Fast_Get_Item(seq, i) // `item` is borrowed, no need to decref
 			if int(C._PyString_Check(item)) == 0 {
-				log.Errorf("One of the submitted tag is not a string, ignoring it")
+				typeName := C.GoString(C._object_type(item))
+				log.Errorf("One of the submitted tag for %s is not a string but a %s, ignoring it", checkID, typeName)
 				continue
 			}
 			// at this point we're sure that `item` is a string, no further error checking needed

--- a/pkg/collector/py/api.go
+++ b/pkg/collector/py/api.go
@@ -227,7 +227,7 @@ func extractTags(tags *C.PyObject, checkID string) (_tags []string, err error) {
 			item := C.PySequence_Fast_Get_Item(seq, i) // `item` is borrowed, no need to decref
 			if int(C._PyString_Check(item)) == 0 {
 				typeName := C.GoString(C._object_type(item))
-				log.Debugf("One of the submitted tag for %s is not a string but a %s, ignoring it", checkID, typeName)
+				log.Infof("One of the submitted tag for the check with ID %s is not a string but a %s, ignoring it", checkID, typeName)
 				continue
 			}
 			// at this point we're sure that `item` is a string, no further error checking needed

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -29,6 +29,7 @@ const char* _object_type(PyObject *o);
 int _PyDict_Check(PyObject*);
 int _PyInt_Check(PyObject*);
 int _PyString_Check(PyObject*);
+PyObject* _PyObject_Repr(PyObject*);
 PyObject* PySequence_Fast_Get_Item(PyObject*, Py_ssize_t);
 Py_ssize_t PySequence_Fast_Get_Size(PyObject*);
 

--- a/pkg/collector/py/api.h
+++ b/pkg/collector/py/api.h
@@ -25,6 +25,7 @@ typedef enum {
 void initaggregator();
 PyObject* _none();
 int _is_none(PyObject*);
+const char* _object_type(PyObject *o);
 int _PyDict_Check(PyObject*);
 int _PyInt_Check(PyObject*);
 int _PyString_Check(PyObject*);

--- a/releasenotes/notes/empty-tag-better-log-f38836451a3a0ead.yaml
+++ b/releasenotes/notes/empty-tag-better-log-f38836451a3a0ead.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve logging when python checks report invalid tags

--- a/releasenotes/notes/empty-tag-better-log-f38836451a3a0ead.yaml
+++ b/releasenotes/notes/empty-tag-better-log-f38836451a3a0ead.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Improve logging when python checks report invalid tags
+    Improve logging when python checks use invalid types for tags


### PR DESCRIPTION
### What does this PR do?

When a an object that is not a string is passed as a tag from a python check to the agent, log from which check it came from and which was the type of the object.

### Motivation

We had saw this log line appear on a few occasions. It would help knowing which check it comes from and which type was given instead of strings.
