### PR TITLE
Adding Changelog for the Datadog Cluster Agent 1.0.0

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -1,0 +1,75 @@
+=============
+Release Notes
+=============
+
+.. _Release Notes_1.0.0:
+
+1.0.0
+=====
+
+.. _Release Notes_1.0.0_Prelude:
+
+Prelude
+-------
+
+Released on: 2018-10-18
+
+The Datadog Cluster Agent is compatible with the Datadog Agent 6.5.0.
+
+- Please refer to the `6.5.0 tag on datadog-agent  <https://github.com/DataDog/datadog-agent/releases/tag/6.5.0>`_ for the list of changes on the Datadog Agent.
+
+It is only supported in containerized environments.
+
+- Please find the image on `our Docker Hub <https://hub.docker.com/r/datadog/cluster-agent/tags/>`_.
+
+1.0.0-rc.4
+==========
+2018-10-17
+
+Enhancement Notes
+------------------
+- Expose telemetry metrics with the Open Metrics format instead of goexpvar
+
+Bug Fixes
+---------
+- add mutex logic and safe guards to avoid race condition in the Autoscalers Controller.
+
+1.0.0-rc.3
+==========
+2018-10-15
+
+Enhancement Notes
+------------------
+- Leverage diff logic to only update the internal custom metrics store and Config Map with relevant changes.
+- Better logging on the Autoscalers Controller
+
+Bug Fixes
+---------
+- Make sure only the leader sync Autoscalers.
+- Forget keys from the informer's queue to avoid borking the Autoscalers Controller.
+
+1.0.0-rc.2
+==========
+2018-10-11
+
+Enhancement Notes
+------------------
+
+- Support `agent` and `datadog-cluster-agent` for the CLI of the Datadog Cluster Agent
+- Retrieve hostname in GCE
+
+1.0.0-rc.1
+==========
+2018-10-04
+
+New Features
+------------
+
+- Implement the External Metrics Interface to allow for the Horizontal Pod Autoscalers to be based off of Datadog metrics.
+- Use informers to be up to date with the Horizontal Pod Autoscalers object in the cluster.
+- Implement the metadata mapper.
+- Use informers to be up to date with the Endpoints and Nodes objects in the cluster.
+- Serve cluster level metadata on an external endpoint, `kube_service` tag is available.
+- Serve node labels as tags.
+- Run the kube_apiserver check to collect events and run a service check against each component of the Control Plane.
+- Implements the `flare`, `status` and `version` commands similar to the node agent.

--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -28,7 +28,7 @@ It is only supported in containerized environments.
 
 Enhancement Notes
 ------------------
-- Expose telemetry metrics with the Open Metrics format instead of goexpvar
+- Expose telemetry metrics with the Open Metrics format instead of expvar
 
 Bug Fixes
 ---------

--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -14,7 +14,7 @@ Prelude
 
 Released on: 2018-10-18
 
-The Datadog Cluster Agent is compatible with the Datadog Agent 6.5.0.
+The Datadog Cluster Agent is compatible with versions 6.5.1 and up of the Datadog Agent.
 
 - Please refer to the `6.5.0 tag on datadog-agent  <https://github.com/DataDog/datadog-agent/releases/tag/6.5.0>`_ for the list of changes on the Datadog Agent.
 

--- a/releasenotes-dca/config.yaml
+++ b/releasenotes-dca/config.yaml
@@ -1,0 +1,53 @@
+---
+collapse_pre_releases: true
+no_show_source: true
+release_tag_re: '^([\d.-]|rc)+$'
+pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
+template: |
+          # Each section from every releasenote are combined when the
+          # CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+          # it does not depend on any information only available in another
+          # section. This may mean repeating some details, but each section
+          # must be readable independently of the other.
+          #
+          # Each section note must be formatted as reStructuredText.
+          ---
+          features:
+            - |
+              List new features here, or remove this section.
+          enhancements:
+            - |
+              List enhancements (new behavior that is too small to be
+              considered a new feature), or remove this section.
+          issues:
+            - |
+              List known issues here, or remove this section.
+          upgrade:
+            - |
+              List upgrade notes here, or remove this section.
+              Only list known/potential breaking changes, or behavior changes
+              that users should absolutely know about before upgrading.
+          deprecations:
+            - |
+              List deprecations notes here, or remove this section.
+          security:
+            - |
+              Add security notes here, or remove this section.
+          fixes:
+            - |
+              Add normal bug fixes here, or remove this section.
+          other:
+            - |
+              Add here every other information you want in the CHANGELOG that
+              don't fit in any other section. This section should rarely be
+              used.
+sections:
+  # The prelude section is implicitly included.
+  - [features, New Features]
+  - [enhancements, Enhancement Notes]
+  - [issues, Known Issues]
+  - [upgrade, Upgrade Notes]
+  - [deprecations, Deprecation Notes]
+  - [security, Security Issues]
+  - [fixes, Bug Fixes]
+  - [other, Other Notes]


### PR DESCRIPTION
### What does this PR do?

Adding the Changelog for the 1.0.0 of the Datadog Cluster Agent.

