### PR TITLE
use json-iter for payload serialization

### DIFF
--- a/pkg/collector/metadata/agentchecks/payload.go
+++ b/pkg/collector/metadata/agentchecks/payload.go
@@ -6,8 +6,9 @@
 package agentchecks
 
 import (
-	"encoding/json"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -8,8 +8,9 @@
 package v5
 
 import (
-	"encoding/json"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"

--- a/pkg/metadata/v5/payload_common.go
+++ b/pkg/metadata/v5/payload_common.go
@@ -6,8 +6,9 @@
 package v5
 
 import (
-	"encoding/json"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"

--- a/pkg/metadata/v5/payload_test.go
+++ b/pkg/metadata/v5/payload_test.go
@@ -8,8 +8,9 @@
 package v5
 
 import (
-	"encoding/json"
 	"testing"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/gohai"
 	"github.com/stretchr/testify/require"

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -7,9 +7,10 @@ package metrics
 
 import (
 	"bytes"
-	"encoding/json"
 	"expvar"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gogo/protobuf/proto"
 

--- a/pkg/metrics/event_test.go
+++ b/pkg/metrics/event_test.go
@@ -71,7 +71,7 @@ func TestMarshalJSON(t *testing.T) {
 	payload, err := events.MarshalJSON()
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
-	assert.Equal(t, payload, []byte("{\"apiKey\":\"\",\"events\":{\"custom_source_type\":[{\"msg_title\":\"An event occurred\",\"msg_text\":\"event description\",\"timestamp\":12345,\"priority\":\"normal\",\"host\":\"my-hostname\",\"tags\":[\"tag1\",\"tag2:yes\"],\"alert_type\":\"error\",\"aggregation_key\":\"my_agg_key\",\"source_type_name\":\"custom_source_type\"}]},\"internalHostname\":\"test-hostname\"}\n"))
+	assert.JSONEq(t, string(payload), "{\"apiKey\":\"\",\"events\":{\"custom_source_type\":[{\"msg_title\":\"An event occurred\",\"msg_text\":\"event description\",\"timestamp\":12345,\"priority\":\"normal\",\"host\":\"my-hostname\",\"tags\":[\"tag1\",\"tag2:yes\"],\"alert_type\":\"error\",\"aggregation_key\":\"my_agg_key\",\"source_type_name\":\"custom_source_type\"}]},\"internalHostname\":\"test-hostname\"}\n")
 }
 
 func TestMarshalJSONOmittedFields(t *testing.T) {
@@ -91,7 +91,7 @@ func TestMarshalJSONOmittedFields(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
 	// These optional fields are not present in the serialized payload, and a default source type name is used
-	assert.Equal(t, payload, []byte("{\"apiKey\":\"\",\"events\":{\"api\":[{\"msg_title\":\"An event occurred\",\"msg_text\":\"event description\",\"timestamp\":12345,\"host\":\"my-hostname\"}]},\"internalHostname\":\"test-hostname\"}\n"))
+	assert.JSONEq(t, string(payload), "{\"apiKey\":\"\",\"events\":{\"api\":[{\"msg_title\":\"An event occurred\",\"msg_text\":\"event description\",\"timestamp\":12345,\"host\":\"my-hostname\"}]},\"internalHostname\":\"test-hostname\"}\n")
 }
 
 func TestSplitEvents(t *testing.T) {

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -7,10 +7,11 @@ package metrics
 
 import (
 	"bytes"
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gogo/protobuf/proto"
 

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -121,7 +121,7 @@ func TestMarshalJSONSeries(t *testing.T) {
 	payload, err := series.MarshalJSON()
 	assert.Nil(t, err)
 	assert.NotNil(t, payload)
-	assert.Equal(t, payload, []byte("{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device\":\"/dev/sda1\",\"type\":\"gauge\",\"interval\":0,\"source_type_name\":\"System\"}]}\n"))
+	assert.JSONEq(t, string(payload), "{\"series\":[{\"metric\":\"test.metrics\",\"points\":[[12345,21.21],[67890,12.12]],\"tags\":[\"tag1\",\"tag2:yes\"],\"host\":\"localHost\",\"device\":\"/dev/sda1\",\"type\":\"gauge\",\"interval\":0,\"source_type_name\":\"System\"}]}\n")
 }
 
 func TestSplitSerieasOneMetric(t *testing.T) {

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -7,9 +7,10 @@ package metrics
 
 import (
 	"bytes"
-	"encoding/json"
 	"expvar"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gogo/protobuf/proto"
 

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -6,10 +6,11 @@
 package serializer
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"

--- a/pkg/serializer/split/split.go
+++ b/pkg/serializer/split/split.go
@@ -92,9 +92,9 @@ func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarde
 			// This is the same function used in dd-agent
 			compressionRatio := float64(payloadSize) / float64(compressedSize)
 			numChunks := compressedSize/maxPayloadSize + 1 + int(compressionRatio/2)
-			log.Debugf("split the payload into into %f chunks", numChunks)
+			log.Debugf("split the payload into into %d chunks", numChunks)
 			chunks, err := toSplit.SplitPayload(numChunks)
-			log.Debugf("payload was split into %f chunks", len(chunks))
+			log.Debugf("payload was split into %d chunks", len(chunks))
 			if err != nil {
 				log.Warnf("Some payloads could not be split, dropping them")
 				splitterPayloadDrops.Add(1)

--- a/releasenotes/notes/use-jsoniter-payload-serialization-d8804813ba2b2b82.yaml
+++ b/releasenotes/notes/use-jsoniter-payload-serialization-d8804813ba2b2b82.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Use json-iterator, an optimized json library, for payload serialization.
+    Memory usage should be improved on agents handling a large number of metrics.


### PR DESCRIPTION
### What does this PR do

> It introduces jsoniter, a faster, leaner json encoder/decoder alternative (https://github.com/json-iterator/go). After exploring a few options decided to go with this alternative (as opposed to easyjson or ffjson) due to its simple drop-in replacement nature and great numbers compared to some of the other projects. It is still actively maintained. Most of our heavy-lifting is in encoding so the benefits are not going to be as massive as they'd be with a more heavily decoding application, that said the number of allocations should be reduced helping our footprint and garbage collection.

For now this library will only be used to serialize payloads. We made this choice following the discovery of some small compatibility issues with the stdlib (see https://github.com/DataDog/datadog-agent/pull/2231).

### Motivation

> Just trying to improve agent performance in general, starting with low hanging fruit like JSON encoding.

### Notes

See https://github.com/DataDog/datadog-agent/pull/1966 (reverted) for more details and graphs showing the impact.

`json-iterator` was already in the `Gopkg.toml`.