### PR TITLE
add datadog-agent config command to print runtime configuration

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -47,6 +47,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/{component}/configs", componentConfigHandler).Methods("GET")
 	r.HandleFunc("/gui/csrf-token", getCSRFToken).Methods("GET")
 	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
+	r.HandleFunc("/config", getRuntimeConfig).Methods("GET")
 	r.HandleFunc("/tagger-list", getTaggerList).Methods("GET")
 }
 
@@ -228,6 +229,17 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(jsonConfig)
+}
+
+func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
+	runtimeConfig, err := json.Marshal(config.Datadog.AllSettings())
+	if err != nil {
+		log.Errorf("Unable to marshal runtime config response: %s", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), 500)
+		return
+	}
+	w.Write(runtimeConfig)
 }
 
 func getTaggerList(w http.ResponseWriter, r *http.Request) {

--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var (
+	configJSON bool
+)
+
+func init() {
+	AgentCmd.AddCommand(configCommand)
+	configCommand.Flags().BoolVarP(&configJSON, "json", "j", false, "print out raw json")
+}
+
+var configCommand = &cobra.Command{
+	Use:   "config",
+	Short: "Print the runtime configuration of a running agent",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := common.SetupConfig(confFilePath)
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+		err = util.SetAuthToken()
+		if err != nil {
+			return err
+		}
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		runtimeConfig, err := requestConfig()
+		if err != nil {
+			return err
+		}
+
+		if configJSON {
+			jsonData, err := json.MarshalIndent(runtimeConfig, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(jsonData))
+		} else {
+			yamlData, err := yaml.Marshal(runtimeConfig)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(yamlData))
+		}
+
+		return nil
+	},
+}
+
+func requestConfig() (map[string]interface{}, error) {
+	var runtimeConfig map[string]interface{}
+
+	c := util.GetClient(false)
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/config", config.Datadog.GetInt("cmd_port"))
+
+	r, err := util.DoGet(c, apiConfigURL)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, errMap)
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			return runtimeConfig, fmt.Errorf(e)
+		}
+
+		return runtimeConfig, fmt.Errorf("Could not reach agent: %v \nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+	}
+
+	var rawConfig interface{}
+	if err = json.Unmarshal(r, &rawConfig); err != nil {
+		return runtimeConfig, fmt.Errorf("Error unmarshalling json: %s", err)
+	}
+	runtimeConfig = rawConfig.(map[string]interface{})
+
+	return runtimeConfig, nil
+}

--- a/releasenotes/notes/add-config-command-704a1a143ceca85e.yaml
+++ b/releasenotes/notes/add-config-command-704a1a143ceca85e.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The new command ``datadog-agent config`` prints the runtime config of the
+    agent.


### PR DESCRIPTION
### What does this PR do?

Adds a new command `datadog-agent config` that will print the running agent runtime configuration. 
By default the command will output the configuration formated in YAML but the `-j`/`--json` switch can be used to print JSON instead.

### Motivation

Useful to troubleshoot a running agent.

