### PR TITLE
[task] Allow missing bugfix note when generating minor changelog

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -40,7 +40,7 @@ def update_changelog(ctx, new_version):
         print("Error: invalid version: {}".format(new_version_int))
         raise Exit(1)
 
-    # let's avoid loosing uncommitted change with 'git reset --hard'
+    # let's avoid losing uncommitted change with 'git reset --hard'
     try:
         ctx.run("git diff --exit-code HEAD", hide="both")
     except Failure as e:
@@ -59,7 +59,7 @@ def update_changelog(ctx, new_version):
 
     # removing releasenotes from bugfix on the old minor.
     previous_minor = "%s.%s" % (new_version_int[0], new_version_int[1] - 1)
-    ctx.run("git rm `git log {}.0...remotes/origin/{}.x --name-only \
+    ctx.run("git rm --ignore-unmatch `git log {}.0...remotes/origin/{}.x --name-only \
             | grep releasenotes/notes/`".format(previous_minor, previous_minor))
 
     # generate the new changelog


### PR DESCRIPTION
### What does this PR do?

Allows missing bugfix note on master when generating minor changelog. Otherwise the task fails when a note is only on the previous bugfix's branch but not on master, typically with this error:

```
fatal: pathspec 'releasenotes/notes/prelude-release-6.5.2-9251d222d4969e43.yaml' did not match any files
```

### Motivation

Ran into this while generating the 6.6.0 changelog
