### PR TITLE
Only push cluster-agent-dev:master from master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -873,6 +873,8 @@ dca_dev_branch_docker_hub:
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
+  only:
+    - master
   variables:
     <<: *docker_hub_variables
   script:


### PR DESCRIPTION
Fix a bug in the cluster-agent-dev:master release steps: feature branches
also automatically pushed builds to this tag.