### PR TITLE
Change test to remove flakiness

### DIFF
--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -44,9 +44,6 @@ type MetadataController struct {
 
 	// Endpoints that need to be added to services mapping.
 	queue workqueue.RateLimitingInterface
-
-	// used in unit tests to wait until objects are synced (tombstones will be ignored)
-	endpoints, nodes chan struct{}
 }
 
 func NewMetadataController(nodeInformer coreinformers.NodeInformer, endpointsInformer coreinformers.EndpointsInformer) *MetadataController {
@@ -105,10 +102,6 @@ func (m *MetadataController) processNextWorkItem() bool {
 		log.Debugf("Error syncing endpoints %v: %v", key, err)
 	}
 
-	if m.endpoints != nil {
-		m.endpoints <- struct{}{}
-	}
-
 	return true
 }
 
@@ -121,10 +114,6 @@ func (m *MetadataController) addNode(obj interface{}) {
 	_ = m.store.getOrCreate(node.Name)
 
 	log.Debugf("Detected node %s", node.Name)
-
-	if m.nodes != nil {
-		m.nodes <- struct{}{}
-	}
 }
 
 func (m *MetadataController) deleteNode(obj interface{}) {
@@ -145,10 +134,6 @@ func (m *MetadataController) deleteNode(obj interface{}) {
 	m.store.delete(node.Name)
 
 	log.Debugf("Forgot node %s", node.Name)
-
-	if m.nodes != nil {
-		m.nodes <- struct{}{}
-	}
 }
 
 func (m *MetadataController) addEndpoints(obj interface{}) {

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -288,13 +288,6 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 func TestMetadataController(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
-	metaController, informerFactory := newFakeMetadataController(client)
-
-	stop := make(chan struct{})
-	defer close(stop)
-	informerFactory.Start(stop)
-	go metaController.Run(stop)
-
 	c := client.CoreV1()
 	require.NotNil(t, c)
 
@@ -333,8 +326,6 @@ func TestMetadataController(t *testing.T) {
 	node.Name = "ip-172-31-119-125"
 	_, err := c.Nodes().Create(node)
 	require.NoError(t, err)
-
-	requireReceive(t, metaController.nodes, "nodes")
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -419,12 +410,6 @@ func TestMetadataController(t *testing.T) {
 	_, err = c.Endpoints("default").Create(ep)
 	require.NoError(t, err)
 
-	requireReceive(t, metaController.endpoints, "endpoints")
-	metadataNames, err := GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
-	require.NoError(t, err)
-	assert.Len(t, metadataNames, 1)
-	assert.Contains(t, metadataNames, "kube_service:nginx-1")
-
 	// Add a new service/endpoint on the nginx Pod
 	svc.Name = "nginx-2"
 	_, err = c.Services("default").Create(svc)
@@ -434,9 +419,18 @@ func TestMetadataController(t *testing.T) {
 	_, err = c.Endpoints("default").Create(ep)
 	require.NoError(t, err)
 
-	requireReceive(t, metaController.endpoints, "endpoints")
+	metaController, informerFactory := newFakeMetadataController(client)
 
-	metadataNames, err = GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
+	stop := make(chan struct{})
+	defer close(stop)
+	informerFactory.Start(stop)
+	go metaController.Run(stop)
+
+	for !metaController.endpointsListerSynced() && !metaController.nodeListerSynced() {
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	metadataNames, err := GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
 	require.NoError(t, err)
 	assert.Len(t, metadataNames, 2)
 	assert.Contains(t, metadataNames, "kube_service:nginx-1")
@@ -452,14 +446,6 @@ func TestMetadataController(t *testing.T) {
 	services, found := fullMap["ip-172-31-119-125"].ServicesForPod(metav1.NamespaceDefault, "nginx")
 	assert.True(t, found)
 	assert.Contains(t, services, "nginx-1")
-
-	err = c.Nodes().Delete(node.Name, &metav1.DeleteOptions{})
-	require.NoError(t, err)
-
-	requireReceive(t, metaController.nodes, "nodes")
-
-	_, err = GetMetadataMapBundleOnNode(node.Name)
-	require.Error(t, err)
 }
 
 func newFakeMetadataController(client kubernetes.Interface) (*MetadataController, informers.SharedInformerFactory) {
@@ -469,18 +455,6 @@ func newFakeMetadataController(client kubernetes.Interface) (*MetadataController
 		informerFactory.Core().V1().Nodes(),
 		informerFactory.Core().V1().Endpoints(),
 	)
-	metaController.nodeListerSynced = func() bool { return true }
-	metaController.endpointsListerSynced = func() bool { return true }
-	metaController.endpoints = make(chan struct{}, 1)
-	metaController.nodes = make(chan struct{}, 1)
 
 	return metaController, informerFactory
-}
-
-func requireReceive(t *testing.T, ch chan struct{}, msgAndArgs ...interface{}) {
-	select {
-	case <-ch:
-	case <-time.After(5 * time.Second):
-		require.FailNow(t, "Timeout waiting to receive from channel", msgAndArgs...)
-	}
 }

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -286,6 +286,8 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 }
 
 func TestMetadataController(t *testing.T) {
+	// FIXME: Updating to k8s.io/client-go v0.9+ should allow revert this PR https://github.com/DataDog/datadog-agent/pull/2524
+	// that allows a more fine-grain testing on the controller lifecycle (affected by bug https://github.com/kubernetes/kubernetes/pull/66078)
 	client := fake.NewSimpleClientset()
 
 	c := client.CoreV1()

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -429,7 +429,7 @@ func TestMetadataController(t *testing.T) {
 	go metaController.Run(stop)
 
 	for !metaController.endpointsListerSynced() && !metaController.nodeListerSynced() {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 	}
 
 	metadataNames, err := GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)


### PR DESCRIPTION
### What does this PR do?

It seems the fake client has a flaky behavior around the `watch` method and some events are never sent, changing the test logic to remove the flakiness.

### Motivation

Remove flaky test

### Additional Notes

We're losing a bit of details in testing with this, it can be reverted once we upgrade the `kubernetes/client-go` to v0.9+
