### PR TITLE
Handles dd-agent-user on domain controllers

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -126,7 +126,7 @@ extern "C" UINT __stdcall AdjustDDRights(MSIHANDLE hInstall)
     // get the ddagent user name
     if(!loadDdAgentUserName(hInstall))
     {
-        
+        WcaLog(LOGMSG_STANDARD, "DDAGENT username not supplied, using default");
     }
     // if the log file or the auth token already exist, allow the dd-user to 
     // access them
@@ -204,7 +204,11 @@ extern "C" UINT __stdcall EnableServicesForDDUser(MSIHANDLE hInstall)
     ExitOnFailure(hr, "Failed to initialize");
     logProcCount();
     WcaLog(LOGMSG_STANDARD, "Initialized.");
-
+    // get the ddagent user name
+    if(!loadDdAgentUserName(hInstall, propertyCustomActionData.c_str() ))
+    {
+        WcaLog(LOGMSG_STANDARD, "DDAGENT username not supplied, using default");
+    }
     er = EnableServiceForUser(traceService, ddAgentUserName);
     if (0 != er) {
         hr = -1;
@@ -240,6 +244,11 @@ extern "C" UINT __stdcall VerifyDatadogRegistryPerms(MSIHANDLE hInstall) {
     ExitOnFailure(hr, "Failed to initialize");
     logProcCount();
     WcaLog(LOGMSG_STANDARD, "Initialized.");
+    // get the ddagent user name
+    if(!loadDdAgentUserName(hInstall))
+    {
+        WcaLog(LOGMSG_STANDARD, "DDAGENT username not supplied, using default");
+    }
     // make sure the key is there
     LSTATUS status = 0;
     HKEY hKey;

--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -87,11 +87,6 @@ extern "C" UINT __stdcall CreateOrUpdateDDUser(MSIHANDLE hInstall)
 {
     HRESULT hr = S_OK;
     UINT er = ERROR_SUCCESS;
-    LSA_HANDLE hLsa = NULL;
-    PSID sid = NULL;
-    DWORD nErr = 0;
-    LOCALGROUP_MEMBERS_INFO_0 lmi0;
-    memset(&lmi0, 0, sizeof(LOCALGROUP_MEMBERS_INFO_3));
 
     // that's helpful.  WcaInitialize Log header silently limited to 32 chars
     hr = WcaInitialize(hInstall, "CA: CreateOrUpdateDDUser");
@@ -104,6 +99,35 @@ extern "C" UINT __stdcall CreateOrUpdateDDUser(MSIHANDLE hInstall)
         hr = -1;
         goto LExit;
     } 
+LExit:
+
+    er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+
+}
+
+extern "C" UINT __stdcall AdjustDDRights(MSIHANDLE hInstall)
+{
+    HRESULT hr = S_OK;
+    UINT er = ERROR_SUCCESS;
+
+    LSA_HANDLE hLsa = NULL;
+    PSID sid = NULL;
+    DWORD nErr = 0;
+    LOCALGROUP_MEMBERS_INFO_0 lmi0;
+    memset(&lmi0, 0, sizeof(LOCALGROUP_MEMBERS_INFO_3));
+
+    
+    // that's helpful.  WcaInitialize Log header silently limited to 32 chars
+    hr = WcaInitialize(hInstall, "CA: AdjustDDRights");
+    ExitOnFailure(hr, "Failed to initialize");
+    logProcCount();
+    WcaLog(LOGMSG_STANDARD, "Initialized.");
+    // get the ddagent user name
+    if(!loadDdAgentUserName(hInstall))
+    {
+        
+    }
     // if the log file or the auth token already exist, allow the dd-user to 
     // access them
 
@@ -166,10 +190,8 @@ LExit:
     if (hLsa) {
         LsaClose(hLsa);
     }
-
     er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
     return WcaFinalize(er);
-
 }
 
 extern "C" UINT __stdcall EnableServicesForDDUser(MSIHANDLE hInstall) 

--- a/omnibus/resources/agent/msi/cal/CustomAction.def
+++ b/omnibus/resources/agent/msi/cal/CustomAction.def
@@ -8,3 +8,4 @@ EXPORTS
 	RemoveDDUser
 	RollbackInstallation
 	PreStopServices
+    AdjustDDRights

--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -18,7 +18,7 @@ DWORD changeRegistryAcls(const wchar_t* name);
 VOID  DoStopSvc(MSIHANDLE hInstall, std::wstring svcName);
 
 UINT doRemoveDDUser();
-
+bool isDomainController(MSIHANDLE hInstall);
 
 void MarkInstallStepComplete(std::wstring &step);
 bool WasInstallStepCompleted(std::wstring &step);

--- a/omnibus/resources/agent/msi/cal/stdafx.h
+++ b/omnibus/resources/agent/msi/cal/stdafx.h
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <strsafe.h>
 #include <msiquery.h>
+#include <lm.h>
 #include <lmaccess.h>
 #include <lmerr.h>
 

--- a/omnibus/resources/agent/msi/cal/stdafx.h
+++ b/omnibus/resources/agent/msi/cal/stdafx.h
@@ -21,6 +21,7 @@
 
 // std c++ lib
 #include <string>
+#include <sstream>
 #include <map>
 #include <sstream>
 

--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -6,8 +6,10 @@ std::wstring datadog_acl_key_datadog = L"MACHINE\\SOFTWARE\\" + datadog_path;
 std::wstring installStepsKey = datadog_key_root + L"\\installSteps";
 std::wstring datadog_service_name(L"DataDog Agent");
 
-std::wstring ddAgentUserName(L"ddagentuser");
-std::wstring ddAgentUserPasswordProperty(L"DDAGENTUSER_PASSWORD");
+std::wstring ddAgentUserName(L".\\ddagentuser");
+std::wstring ddAgentUserNameUnqualified;
+std::wstring ddAgentUserDomain;
+const wchar_t *ddAgentUserDomainPtr = NULL;
 std::wstring ddAgentUserDescription(L"User context under which the DataDog Agent service runs");
 
 std::wstring traceService(L"datadog-trace-agent");
@@ -16,7 +18,10 @@ std::wstring agentService(L"datadogagent");
 
 std::wstring propertyDDUserCreated(L"DDUSERCREATED");
 std::wstring propertyDDAgentUserName(L"DDAGENTUSER_NAME");
+std::wstring propertyDDAgentUserPassword(L"DDAGENTUSER_PASSWORD");
+std::wstring propertyEnableServicesDeferredKey(L"enableservices");
 std::wstring propertyRollbackState(L"CustomActionData");
+std::wstring propertyCustomActionData(L"CustomActionData");
 
 std::wstring programdataroot(L"c:\\ProgramData\\DataDog\\");
 std::wstring logfilename(L"c:\\ProgramData\\DataDog\\logs\\agent.log");
@@ -58,6 +63,10 @@ bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst,
 {
     TCHAR* szValueBuf = NULL;
     DWORD cchValueBuf = 0;
+    std::string propertyname;
+    std::string propval;
+    toMbcs(propertyname, propertyName);
+
     UINT uiStat =  MsiGetProperty(hInstall, propertyName, L"", &cchValueBuf);
     //cchValueBuf now contains the size of the property's string, without null termination
     if (ERROR_MORE_DATA == uiStat)
@@ -76,22 +85,47 @@ bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst,
         WcaLog(LOGMSG_STANDARD, "failed to get  property");
         return false;
     }
+    if (wcslen(szValueBuf) == 0){
+        WcaLog(LOGMSG_STANDARD, "Property %s is empty", propertyname.c_str());
+        delete [] szValueBuf;
+        return false;
+    }
     *dst=szValueBuf;
     *len = cchValueBuf;
-    std::string propertyname;
-    std::string propval;
-    toMbcs(propertyname, propertyName);
     toMbcs(propval, szValueBuf);
     WcaLog(LOGMSG_STANDARD, "loaded property %s = %s", propertyname.c_str(), propval.c_str());
 
     
-    return ERROR_SUCCESS;
+    return true;
 }
 
-bool loadDdAgentUserName(MSIHANDLE hInstall) {
-    return loadPropertyString(hInstall, propertyDDAgentUserName.c_str(), ddAgentUserName);
+bool loadDdAgentUserName(MSIHANDLE hInstall, LPCWSTR propertyName ) {
+    std::wstring tmpName;
+    if(loadPropertyString(hInstall, propertyName ? propertyName : propertyDDAgentUserName.c_str(), tmpName)){
+        if(std::wstring::npos == tmpName.find(L'\\')) {
+            WcaLog(LOGMSG_STANDARD, "loaded username doesn't have domain specifier, assuming local");
+            ddAgentUserName = L".\\" + tmpName;
+        } else {
+            ddAgentUserName = tmpName;
+        }
+        // now create the splits between the domain and user for all to use, too
+        std::wstring domain, user;
+        std::wistringstream asStream(tmpName);
+        // username is going to be of the form <domain>\<username>
+        // if the <domain> is ".", then just do local machine
+        getline(asStream, ddAgentUserDomain, L'\\');
+        getline(asStream, ddAgentUserNameUnqualified, L'\\');
+        if(domain == L"."){
+            ddAgentUserDomainPtr = NULL;
+        } else {
+            ddAgentUserDomainPtr = ddAgentUserDomain.c_str();
+        }
+
+        return true;
+    }
+    return false;
 }
 
 bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **pass, DWORD *len) {
-    return loadPropertyString(hInstall, ddAgentUserPasswordProperty.c_str(), pass, len);
+    return loadPropertyString(hInstall, propertyDDAgentUserPassword.c_str(), pass, len);
 }

--- a/omnibus/resources/agent/msi/cal/strings.h
+++ b/omnibus/resources/agent/msi/cal/strings.h
@@ -32,5 +32,9 @@ extern std::wstring strChangedRegistryPermissions;
 
 
 void toMbcs(std::string& target, LPCWSTR src);
+bool loadDdAgentUserName(MSIHANDLE hInstall);
+bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, std::wstring& dst);
+bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst, DWORD *len);
+bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **dst, DWORD *len);
 
 #define MAX_CUSTOM_PROPERTY_SIZE        128

--- a/omnibus/resources/agent/msi/cal/strings.h
+++ b/omnibus/resources/agent/msi/cal/strings.h
@@ -6,15 +6,22 @@ extern std::wstring installStepsKey;
 extern std::wstring datadog_service_name;
 
 extern std::wstring ddAgentUserName;
-extern std::wstring ddAgentUserPasswordProperty;
+extern std::wstring ddAgentUserNameUnqualified;
+extern std::wstring ddAgentUserDomain;
+extern const wchar_t *ddAgentUserDomainPtr;
+
 extern std::wstring ddAgentUserDescription;
 
 extern std::wstring traceService;
 extern std::wstring processService;
 extern std::wstring agentService;
 
+extern std::wstring propertyDDAgentUserName;
+extern std::wstring propertyDDAgentUserPassword;
 extern std::wstring propertyDDUserCreated;
+extern std::wstring propertyEnableServicesDeferredKey;
 extern std::wstring propertyRollbackState;
+extern std::wstring propertyCustomActionData;
 
 extern std::wstring programdataroot;
 extern std::wstring logfilename;
@@ -32,7 +39,7 @@ extern std::wstring strChangedRegistryPermissions;
 
 
 void toMbcs(std::string& target, LPCWSTR src);
-bool loadDdAgentUserName(MSIHANDLE hInstall);
+bool loadDdAgentUserName(MSIHANDLE hInstall, LPCWSTR propertyName = NULL);
 bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, std::wstring& dst);
 bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst, DWORD *len);
 bool loadDdAgentPassword(MSIHANDLE hInstall, wchar_t **dst, DWORD *len);

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -54,7 +54,7 @@
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
     <Property Id="DDAGENTUSER_NAME" />
-    <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
+    <Property Id="DDAGENTUSER_PASSWORD"  />
 
         <!-- This allows downgrades, and same-version reinstalls.  Otherwise,
       same version gets installed "side by side" -->
@@ -66,8 +66,6 @@
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_USERS" />
     <Media Id="1" Cabinet="agent.cab" EmbedCab="yes" />
-
-    <Property Id="DDUSER" Value="ddagentuser"/>
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder">
@@ -81,7 +79,7 @@
             <CreateFolder>
                 <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" ChangePermission="yes"/>
                 <Permission User="[WIX_ACCOUNT_LOCALSYSTEM]" GenericAll="yes" ChangePermission="yes"/>
-                <Permission User="[DDUSER]" GenericAll="yes"  ChangePermission="yes"/>
+                <Permission User="[DDAGENTUSER_NAME]" GenericAll="yes"  ChangePermission="yes"/>
                 <Permission User="[WIX_ACCOUNT_USERS]" GenericAll="no" ChangePermission="yes"/>
             </CreateFolder>
           </Component>
@@ -379,7 +377,7 @@
               <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" ChangePermission="yes"/>
               <Permission User="[WIX_ACCOUNT_LOCALSYSTEM]" GenericAll="yes" ChangePermission="yes"/>
               <Permission User="[WIX_ACCOUNT_USERS]" GenericAll="no" ChangePermission="yes"/>
-              <Permission User="[DDUSER]" GenericAll="yes"  ChangePermission="yes"/>
+              <Permission User="[DDAGENTUSER_NAME]" GenericAll="yes"  ChangePermission="yes"/>
           </CreateFolder>
         </Component>
       </Directory>
@@ -394,7 +392,7 @@
                 <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" ChangePermission="yes"/>
                 <Permission User="[WIX_ACCOUNT_LOCALSYSTEM]" GenericAll="yes" ChangePermission="yes"/>
                 <Permission User="[WIX_ACCOUNT_USERS]" GenericAll="no" ChangePermission="yes"/>
-                <Permission User="[DDUSER]" GenericAll="yes"  ChangePermission="yes"/>
+                <Permission User="[DDAGENTUSER_NAME]" GenericAll="yes"  ChangePermission="yes"/>
             </CreateFolder>
      
         </Component>

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -53,6 +53,7 @@
     <!-- No need to restart Windows after the installation -->
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
+    <Property Id="DDAGENTUSER_NAME" />
     <Property Id="DDAGENTUSER_PASSWORD" Hidden="yes" />
 
         <!-- This allows downgrades, and same-version reinstalls.  Otherwise,
@@ -202,7 +203,7 @@
                           Type="ownProcess"
                           Vital="yes"
                           Interactive="no"
-                          Account=".\ddagentuser"
+                          Account="[DDAGENTUSER_NAME]"
                           Password="[DDAGENTUSER_PASSWORD]">
             <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
             <util:ServiceConfig
@@ -250,7 +251,7 @@
                             Type="ownProcess"
                             Vital="yes"
                             Interactive="no"
-                          Account=".\ddagentuser"
+                          Account="[DDAGENTUSER_NAME]"
                           Password="[DDAGENTUSER_PASSWORD]"
                             Arguments="--config=c:\programdata\datadog\datadog.yaml" >
               <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
@@ -449,6 +450,7 @@
 
     <InstallExecuteSequence>
       <Custom Action='adddduser' Before='CreateFolders'> NOT (REMOVE = "ALL") </Custom>
+      <Custom Action='adjustrights' After='adddduser'> NOT (REMOVE = "ALL") </Custom>
       <Custom Action='deldduser' After='DeleteServices'> (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
       <Custom Action='verifyregperms' After='adddduser'> NOT (REMOVE = "ALL") </Custom>
       <Custom Action='enableservices' Before='InstallFinalize'> NOT (REMOVE = "ALL") </Custom>
@@ -585,6 +587,7 @@
 
     <CustomAction Id='enableservices' BinaryKey='wixcadll' DllEntry='EnableServicesForDDUser' Execute='deferred' Return='check'/>
     <CustomAction Id='adddduser' BinaryKey='wixcadll' DllEntry='CreateOrUpdateDDUser' Execute='immediate' Return='check'/>
+    <CustomAction Id='adjustrights' BinaryKey='wixcadll' DllEntry='AdjustDDRights' Execute='immediate' Return='check'/>
     <CustomAction Id='deldduser' BinaryKey='wixcadll' DllEntry='RemoveDDUser' Execute='immediate' Return='check'/>
     <CustomAction Id='verifyregperms' BinaryKey='wixcadll' DllEntry='VerifyDatadogRegistryPerms' Execute='immediate' Return='check'/>
     <CustomAction Id='InstallationRollback' BinaryKey='wixcadll' DllEntry='RollbackInstallation' Execute='rollback' />


### PR DESCRIPTION
### What does this PR do?
Changes how we handle creating dd-agent-user

- On all machines, allows users to specify on command line the ddagent user name and/or password
- On domain controller machines, _requires_ user to specify ddagent user name and password


### Motivation
Previously known limitations on how we handle creating user in domain environment