### PR TITLE
fix runtime config command

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // SetupHandlers adds the specific handlers for /agent endpoints
@@ -232,7 +233,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
-	runtimeConfig, err := json.Marshal(config.Datadog.AllSettings())
+	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
 	if err != nil {
 		log.Errorf("Unable to marshal runtime config response: %s", err)
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})


### PR DESCRIPTION
### What does this PR do?

It seems that for some config the following error was appearing:

```
2018-10-29 10:25:59 UTC | ERROR | (agent.go:237 in getRuntimeConfig) | Unable to marshal runtime config response: json: unsupported type: map[interface {}]interface {}
```

This suggests that some config contain maps with something else than a string as a key. As this is supported in YAML but not in JSON, I moved from JSON to YAML encoding in the API.

I also removed the `-j` options that was allowing the user to print the configuration as JSON (to ease automation with `jq`)