### PR TITLE
Add the ability to run a check n times

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -137,7 +137,7 @@ var checkCmd = &cobra.Command{
 			fmt.Println(string(checkStatus))
 		}
 
-		if checkRate == false {
+		if checkRate == false && checkTimes < 2 {
 			color.Yellow("Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.")
 		}
 
@@ -150,6 +150,9 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 	i := 0
 	times := checkTimes
 	if checkRate {
+		if checkTimes > 2 {
+			color.Yellow("The check-rate option is overriding check-times to 2")
+		}
 		times = 2
 	}
 	for i < times {

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	checkRate  bool
+	checkTimes int
 	checkName  string
 	checkDelay int
 	logLevel   string
@@ -38,6 +39,7 @@ func init() {
 	AgentCmd.AddCommand(checkCmd)
 
 	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice")
+	checkCmd.Flags().IntVarP(&checkTimes, "check-times", "t", 1, "number of times to run the check")
 	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")
 	checkCmd.SetArgs([]string{"checkName"})
@@ -146,7 +148,7 @@ var checkCmd = &cobra.Command{
 func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 	s := check.NewStats(c)
 	i := 0
-	times := 1
+	times := checkTimes
 	if checkRate {
 		times = 2
 	}

--- a/releasenotes/notes/check-n-times-3bdb7eb6f43051b1.yaml
+++ b/releasenotes/notes/check-n-times-3bdb7eb6f43051b1.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add an option to the `agent check` command to run the check n times


### PR DESCRIPTION
### What does this PR do?

Add a `-t` option to `agent check` to run a check `n` times

### Motivation

Benchmarking + using rates/counter in prometheus with some label joining requires at least 3 runs to have the metrics

