### PR TITLE
[dev] Bump `requests` to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 invoke==1.0.0
 reno==2.9.2
 docker==3.0.1
-requests==2.19.1
+requests==2.20.0
 PyYAML==3.13
 toml==0.9.4


### PR DESCRIPTION
### What does this PR do?

Bumps `requests` dev dep to latest version (`2.20.0`)

### Motivation

2.19.1 is affected by a CVE (https://nvd.nist.gov/vuln/detail/CVE-2018-18074) that shouldn't affect the present repo, but let's update the dep anyway.

### Testing

I'll merge after double-checking circleCI and gitlab pipelines are successful