### PR TITLE
use netcgo resolver by default on linux

### DIFF
--- a/releasenotes/notes/use-netcgo-dns-68d9fbad3b7c01a9.yaml
+++ b/releasenotes/notes/use-netcgo-dns-68d9fbad3b7c01a9.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Use the cgo dns resolver instead of the golang one. The will make the agent
+    use glibc to resolve hostnames and should give more predicatable results.

--- a/releasenotes/notes/use-netcgo-dns-68d9fbad3b7c01a9.yaml
+++ b/releasenotes/notes/use-netcgo-dns-68d9fbad3b7c01a9.yaml
@@ -9,4 +9,4 @@
 other:
   - |
     Use the cgo dns resolver instead of the golang one. The will make the agent
-    use glibc to resolve hostnames and should give more predicatable results.
+    use glibc to resolve hostnames and should give more predictable results.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -37,6 +37,7 @@ LINUX_ONLY_TAGS = [
     "kubelet",
     "kubeapiserver",
     "cri",
+    "netcgo",
 ]
 
 REDHAT_AND_DEBIAN_ONLY_TAGS = [

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -37,6 +37,8 @@ LINUX_ONLY_TAGS = [
     "kubelet",
     "kubeapiserver",
     "cri",
+
+    # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "netcgo",
 ]
 


### PR DESCRIPTION
### What does this PR do?

Force the use of the `cgo` DNS resolver instead of the pure Golang one. 

This is done by enabling the `netcgo` build flag. This flag has the effect to enable this file at compilation:
https://github.com/golang/go/blob/master/src/net/conf_netcgo.go

This will force usage of `cgo`:
https://github.com/golang/go/blob/2e9f0817f070a3979afc580c740670690acab672/src/net/conf.go#L85

It seems that this behavior can be overwritten at runtime by setting the `GODEBUG` env var like so:
```
GODEBUG=netdns=go
```
https://github.com/golang/go/blob/2e9f0817f070a3979afc580c740670690acab672/src/net/conf.go#L129-L135

However, this might be impractical depending on how the agent is started.

### Motivation

The Golang resolver has some minor difference compared to `glibc` implementation leading to inconsistent behavior. More info can be found [here](https://engineering.grab.com/dns-resolution-in-go-and-cgo).

