### PR TITLE
Enable docker config provider if docker.sock exists

### DIFF
--- a/Dockerfiles/agent/datadog-k8s-docker.yaml
+++ b/Dockerfiles/agent/datadog-k8s-docker.yaml
@@ -1,0 +1,21 @@
+## Provides autodetected defaults, for kubernetes environments
+## where configuration templates are set as docker labels
+## please see datadog.yaml.example for all supported options
+
+# Autodiscovery for Kubernetes
+listeners:
+  - name: kubelet
+config_providers:
+  - name: kubelet
+    polling: true
+  # needed to support legacy docker label config templates
+  - name: docker
+    polling: true
+
+# Enable APM by setting the DD_APM_ENABLED envvar to true, or override this configuration
+apm_config:
+  enabled: false
+  apm_non_local_traffic: true
+
+# Use java cgroup memory awareness
+jmx_use_cgroup_memory_limit: true

--- a/Dockerfiles/agent/entrypoint/50-kubernetes.sh
+++ b/Dockerfiles/agent/entrypoint/50-kubernetes.sh
@@ -7,8 +7,13 @@ fi
 # Set a default config for Kubernetes if found
 # Don't override /etc/datadog-agent/datadog.yaml if it exists
 if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
-    ln -s  /etc/datadog-agent/datadog-kubernetes.yaml \
+    if [[ -e /var/run/docker.sock ]]; then
+        ln -s /etc/datadog-agent/datadog-k8s-docker.yaml \
            /etc/datadog-agent/datadog.yaml
+    else
+        ln -s /etc/datadog-agent/datadog-kubernetes.yaml \
+           /etc/datadog-agent/datadog.yaml
+    fi
 fi
 
 # Enable kubernetes integrations (don't fail if integration absent)

--- a/releasenotes/notes/Enable-docker-config-provider-if-docker.sock-exists-816447ac92471e0d.yaml
+++ b/releasenotes/notes/Enable-docker-config-provider-if-docker.sock-exists-816447ac92471e0d.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable docker config provider if docker.sock exists


### PR DESCRIPTION
### What does this PR do?

enable both the docker and the kubelet config provider if the agent runs ok k8s and we can find the docker socket.

### Motivation

Some users still configure autodiscovery with docker labels directly in the image, so we need to support both annotations and labels in k8s.

### Additional Notes

I made it a new file after trying to optionally patch the existing one, which ended up being too brittle and would break at the next formatting change. Happy to change that if someone has an idea to make it robust.
