### PR TITLE
Isolate tag freshness check

### DIFF
--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -96,5 +96,6 @@ func SetupAutoConfig(confdPath string) {
 //   3. run all the Checks for each configuration found
 func StartAutoConfig() {
 	AC.StartConfigPolling()
+	AC.StartTagFreshnessChecker()
 	AC.LoadAndRun()
 }

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -72,6 +72,8 @@ type AutoConfig struct {
 	healthPolling      *health.Handle
 	listenerStop       chan struct{}
 	healthListening    *health.Handle
+	tagFreshnessTicker *time.Ticker
+	healthTagFreshness *health.Handle
 	newService         chan listeners.Service
 	delService         chan listeners.Service
 	store              *store
@@ -81,13 +83,14 @@ type AutoConfig struct {
 // NewAutoConfig creates an AutoConfig instance.
 func NewAutoConfig(scheduler *scheduler.MetaScheduler) *AutoConfig {
 	ac := &AutoConfig{
-		providers:          make([]*providerDescriptor, 0, 5),
+		providers:          make([]*providerDescriptor, 0, 8),
 		listenerCandidates: make(map[string]listeners.ServiceListenerFactory),
 		listenerRetryStop:  nil, // We'll open it if needed
 		pollerStop:         make(chan struct{}),
 		healthPolling:      health.Register("ad-configpolling"),
 		listenerStop:       make(chan struct{}),
 		healthListening:    health.Register("ad-servicelistening"),
+		healthTagFreshness: health.Register("ad-tagfreshnesschecker"),
 		newService:         make(chan listeners.Service),
 		delService:         make(chan listeners.Service),
 		store:              newStore(),
@@ -107,6 +110,38 @@ func (ac *AutoConfig) StartConfigPolling() {
 	ac.configsPollTicker = time.NewTicker(configsPollIntl)
 	ac.pollConfigs()
 	ac.pollerActive = true
+}
+
+// StartTagFreshnessChecker checks periodically if tags associated to a service
+// are up-to-date, act as the service was restarted to reschedule potential checks
+func (ac *AutoConfig) StartTagFreshnessChecker() {
+	ac.tagFreshnessTicker = time.NewTicker(15 * time.Second) // we can miss tags for one run
+	go func() {
+		for {
+			select {
+			case <-ac.healthTagFreshness.C:
+			case <-ac.tagFreshnessTicker.C:
+				// check if services tags are up to date
+				var servicesToRefresh []listeners.Service
+				for _, service := range ac.store.getServices() {
+					previousHash := ac.store.getTagsHashForService(service.GetEntity())
+					currentHash := tagger.GetEntityHash(service.GetEntity())
+					if currentHash != previousHash {
+						ac.store.setTagsHashForService(service.GetEntity(), currentHash)
+						if previousHash != "" {
+							// only refresh service if we already had a hash to avoid resetting it
+							servicesToRefresh = append(servicesToRefresh, service)
+						}
+					}
+				}
+				for _, service := range servicesToRefresh {
+					log.Debugf("Tags changed for service %s, rescheduling associated checks if any", service.GetEntity())
+					ac.processDelService(service)
+					ac.processNewService(service)
+				}
+			}
+		}
+	}()
 }
 
 // startServiceListening waits on services and templates and process them as they come.
@@ -137,6 +172,12 @@ func (ac *AutoConfig) startServiceListening() {
 func (ac *AutoConfig) Stop() {
 	ac.m.Lock()
 	defer ac.m.Unlock()
+
+	// stop the tag freshness ticker if running
+	if ac.tagFreshnessTicker != nil {
+		ac.healthTagFreshness.Deregister()
+		ac.tagFreshnessTicker.Stop()
+	}
 
 	// stop the config poller if running
 	if ac.pollerActive {
@@ -464,24 +505,6 @@ func (ac *AutoConfig) pollConfigs() {
 				return
 			case <-ac.healthPolling.C:
 			case <-ac.configsPollTicker.C:
-				// check if services tags are up to date
-				var servicesToRefresh []listeners.Service
-				for _, service := range ac.store.getServices() {
-					previousHash := ac.store.getTagsHashForService(service.GetEntity())
-					currentHash := tagger.GetEntityHash(service.GetEntity())
-					if currentHash != previousHash {
-						ac.store.setTagsHashForService(service.GetEntity(), currentHash)
-						if previousHash != "" {
-							// only refresh service if we already had a hash to avoid resetting it
-							servicesToRefresh = append(servicesToRefresh, service)
-						}
-					}
-				}
-				for _, service := range servicesToRefresh {
-					log.Debugf("Tags changed for service %s, rescheduling associated checks if any", service.GetEntity())
-					ac.processDelService(service)
-					ac.processNewService(service)
-				}
 				// invoke Collect on the known providers
 				for _, pd := range ac.providers {
 					// skip providers that don't want to be polled


### PR DESCRIPTION
### What does this PR do?

Isolate the routine to check if service tags are fresh away from the config polling.

### Motivation

It should not be tied to config polling interval.
