### PR TITLE
Fix race condition in connection_manager_test.go

### DIFF
--- a/pkg/logs/client/connection_manager_test.go
+++ b/pkg/logs/client/connection_manager_test.go
@@ -53,8 +53,8 @@ func TestNewConnectionReturnsWhenContextCancelled(t *testing.T) {
 	ctx := destinationsCtx.Context()
 
 	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		conn, err := connManager.NewConnection(ctx)
 		assert.Nil(t, conn)
 		assert.Error(t, err)


### PR DESCRIPTION
### What does this PR do?

Fix a race condition that would make a test flaky

### Motivation
https://circleci.com/gh/DataDog/datadog-agent/77565?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack

