### PR TITLE
Set PYTHONHOME at compile time when using a virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ To build the Agent you need:
    This will also pull in [Invoke](http://www.pyinvoke.org) if not yet installed.
 
 **Note:** you may want to use a python virtual environment to avoid polluting your
-      system-wide python environment with the agent build/dev dependencies.
+      system-wide python environment with the agent build/dev dependencies. By default, this environment is only used for dev dependencies listed in `requirements.txt`, if you want the agent to use the virtual environment's interpreter and libraries instead of the system python's ones,
+      add `--use-venv` to the build command.
 
 **Note:** You may have previously installed `invoke` via brew on MacOS, or `pip` in
       any other platform. We recommend you use the version pinned in the requirements
@@ -40,7 +41,7 @@ To start working on the Agent, you can build the `master` branch:
 2. cd into the project folder: `cd $GOPATH/src/github.com/DataDog/datadog-agent`.
 3. install project's dependencies: `invoke deps`.
    Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
-4. build the whole project with `invoke agent.build --build-exclude=snmp,systemd`
+4. build the whole project with `invoke agent.build --build-exclude=snmp,systemd` (with `--use-venv` to use a python virtualenv)
 
 Please refer to the [Agent Developer Guide](docs/dev/README.md) for more details.
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -71,7 +71,7 @@ PUPPY_CORECHECKS = [
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
           puppy=False, use_embedded_libs=False, development=True, precompile_only=False,
-          skip_assets=False):
+          skip_assets=False, use_venv=False):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -83,7 +83,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
-    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs, use_venv=use_venv)
 
     if not sys.platform.startswith('linux'):
         for ex in LINUX_ONLY_TAGS:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -49,7 +49,7 @@ def pkg_config_path(use_embedded_libs):
     return retval
 
 
-def get_build_flags(ctx, static=False, use_embedded_libs=False):
+def get_build_flags(ctx, static=False, use_embedded_libs=False, use_venv=False):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 
@@ -76,7 +76,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
                                   env=env, hide=True).stdout.strip()
         ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, embedded_prefix)
         ldflags += "-r {} ".format(embedded_lib_path)
-    elif os.getenv('VIRTUAL_ENV'):
+    elif use_venv and os.getenv('VIRTUAL_ENV'):
         venv_prefix = os.getenv('VIRTUAL_ENV')
         ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, venv_prefix)
 

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -76,6 +76,9 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False):
                                   env=env, hide=True).stdout.strip()
         ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, embedded_prefix)
         ldflags += "-r {} ".format(embedded_lib_path)
+    elif os.getenv('VIRTUAL_ENV'):
+        venv_prefix = os.getenv('VIRTUAL_ENV')
+        ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, venv_prefix)
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"


### PR DESCRIPTION
### Motivation

To be able to use a virtualenv to develop on the agent. At the moment if the embedded environment is not used, the agent use the system python.

With this patch, we can install all the check-related modules like `datadog_check_base` in a venv. If the venv is activated at compile time. It will be used by the agent
