### PR TITLE
Adding fix for edge case in external metrics

### DIFF
--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -124,7 +124,9 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 // If the copy does not exist or is too old (>1 HPA controller default run cycle) we refresh it.
 func (p *datadogProvider) GetExternalMetric(namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
 	matchingMetrics := []external_metrics.ExternalMetricValue{}
+
 	p.ListAllExternalMetrics() // get up to date values from the cache or the Global Store
+
 	for _, metric := range p.externalMetrics {
 		metricFromDatadog := external_metrics.ExternalMetricValue{
 			MetricName:   metric.info.Metric,

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -124,16 +124,14 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 // If the copy does not exist or is too old (>1 HPA controller default run cycle) we refresh it.
 func (p *datadogProvider) GetExternalMetric(namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
 	matchingMetrics := []external_metrics.ExternalMetricValue{}
-
 	p.ListAllExternalMetrics() // get up to date values from the cache or the Global Store
-
 	for _, metric := range p.externalMetrics {
 		metricFromDatadog := external_metrics.ExternalMetricValue{
 			MetricName:   metric.info.Metric,
 			MetricLabels: metric.value.MetricLabels,
 			Value:        metric.value.Value,
 		}
-		if metric.info.Metric == metric.info.Metric &&
+		if info.Metric == metric.info.Metric &&
 			metricSelector.Matches(labels.Set(metric.value.MetricLabels)) {
 			metricValue := metricFromDatadog
 			metricValue.Timestamp = metav1.Now()

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	"fmt"
 	"github.com/CharlyF/custom-metrics-apiserver/pkg/provider"
 )
 
@@ -111,7 +112,7 @@ func TestGetExternalMetric(t *testing.T) {
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
 				ns,
-				badLabel,
+				goodLabel,
 			},
 			[]external_metrics.ExternalMetricValue{
 				{
@@ -154,11 +155,12 @@ func TestGetExternalMetric(t *testing.T) {
 			}
 			output, err := dp.GetExternalMetric(test.compared.namespace, test.compared.labels.AsSelector(), test.compared.name)
 			require.NoError(t, err)
-			require.Equal(t, len(output.Items), len(test.expected))
+			require.Equal(t, len(test.expected), len(output.Items))
 			// GetExternalMetric should only return one metric
 			if len(output.Items) == 1 {
-				require.Equal(t, output.Items[0].MetricName, test.expected[0].MetricName)
-				reflect.DeepEqual(output.Items[0].MetricLabels, test.expected[0].MetricLabels)
+				require.Equal(t, test.expected[0].MetricName, output.Items[0].MetricName)
+				fmt.Printf("test is %#v \n \n output is %#v \n \n", test.expected[0].MetricLabels, output.Items[0].MetricLabels)
+				require.True(t, reflect.DeepEqual(test.expected[0].MetricLabels, output.Items[0].MetricLabels))
 			}
 		})
 	}

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package custommetrics
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+
+	"github.com/CharlyF/custom-metrics-apiserver/pkg/provider"
+)
+
+type mockDatadogProvider struct {
+	mockListAllExternalMetricValues func() ([]ExternalMetricValue, error)
+	metrics                         []ExternalMetricValue
+}
+
+func (m *mockDatadogProvider) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
+	return m.mockListAllExternalMetricValues()
+}
+func (m *mockDatadogProvider) SetExternalMetricValues([]ExternalMetricValue) error    { return nil }
+func (m *mockDatadogProvider) DeleteExternalMetricValues([]ExternalMetricValue) error { return nil }
+func (m *mockDatadogProvider) GetMetrics() (*MetricsBundle, error)                    { return nil, nil }
+
+type metricCompare struct {
+	name      provider.ExternalMetricInfo
+	namespace string
+	labels    labels.Set
+}
+
+func TestGetExternalMetric(t *testing.T) {
+
+	metricName := "m1"
+	goodLabel := map[string]string{
+		"foo": "bar",
+	}
+	badLabel := map[string]string{
+		"oof": "bar",
+	}
+	ns := "default"
+	tests := []struct {
+		name          string
+		metricsStored []ExternalMetricValue
+		compared      metricCompare
+		expected      []external_metrics.ExternalMetricValue
+	}{
+		{
+			"nothing stored",
+			nil,
+			metricCompare{},
+			[]external_metrics.ExternalMetricValue{},
+		},
+		{
+			"one matching metric stored",
+			[]ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Labels:     goodLabel,
+					HPA:        ObjectReference{Namespace: ns},
+					Valid:      true,
+				}},
+			metricCompare{
+				provider.ExternalMetricInfo{Metric: metricName},
+				ns,
+				goodLabel,
+			},
+			[]external_metrics.ExternalMetricValue{
+				{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				}},
+		},
+		{
+			"one non matching metric stored",
+			[]ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Labels:     goodLabel,
+					HPA:        ObjectReference{Namespace: ns},
+					Valid:      true,
+				}},
+			metricCompare{
+				provider.ExternalMetricInfo{Metric: metricName},
+				ns,
+				badLabel,
+			},
+			[]external_metrics.ExternalMetricValue{},
+		},
+		{
+			"one matching name metrics stored",
+			[]ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Labels:     goodLabel,
+					HPA:        ObjectReference{Namespace: ns},
+					Valid:      true,
+				}, {
+					MetricName: metricName,
+					Labels:     badLabel,
+					HPA:        ObjectReference{Namespace: ns},
+					Valid:      true,
+				}},
+			metricCompare{
+				provider.ExternalMetricInfo{Metric: metricName},
+				ns,
+				badLabel,
+			},
+			[]external_metrics.ExternalMetricValue{
+				{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			},
+		},
+		{
+			"one non matching labels metrics stored",
+			[]ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Labels:     goodLabel,
+					HPA:        ObjectReference{Namespace: ns},
+					Valid:      true,
+				}, {
+					MetricName: metricName,
+					Labels:     goodLabel,
+					HPA:        ObjectReference{Namespace: ns},
+					Valid:      true,
+				}},
+			metricCompare{
+				provider.ExternalMetricInfo{Metric: metricName},
+				ns,
+				badLabel,
+			},
+			[]external_metrics.ExternalMetricValue{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &mockDatadogProvider{
+				mockListAllExternalMetricValues: func() ([]ExternalMetricValue, error) {
+					return test.metricsStored, nil
+				},
+			}
+			dp := datadogProvider{
+				store: Store(m),
+			}
+			output, err := dp.GetExternalMetric(test.compared.namespace, test.compared.labels.AsSelector(), test.compared.name)
+			require.NoError(t, err)
+			require.Equal(t, len(output.Items), len(test.expected))
+			// GetExternalMetric should only return one metric
+			if len(output.Items) == 1 {
+				require.Equal(t, output.Items[0].MetricName, test.expected[0].MetricName)
+				reflect.DeepEqual(output.Items[0].MetricLabels, test.expected[0].MetricLabels)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

As per the issue https://github.com/DataDog/datadog-agent/issues/2551:

If users configure a HPA with several metrics sharing the same scope this would result in seeing the value for both metrics as the sum of their values.

### Motivation
bugfix

### Additional Notes

Will work on a robust testing suite and will schedule a bugfix release asap.
