### PR TITLE
Implement check metadata payloads

### DIFF
--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner"
+	"github.com/DataDog/datadog-agent/pkg/metadata/checkmetadata"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
@@ -62,11 +63,13 @@ func GetPayload() *Payload {
 	metaPayload := host.GetMeta()
 	metaPayload.Hostname = hostname
 	cp := common.GetPayload(hostname)
+	cmp := checkmetadata.GetPayload()
 	ehp := externalhost.GetPayload()
 	payload := &Payload{
 		CommonPayload{*cp},
 		MetaPayload{*metaPayload},
 		agentChecksPayload,
+		CheckMetadataPayload{*cmp},
 		ExternalHostPayload{*ehp},
 	}
 

--- a/pkg/collector/metadata/agentchecks/agentchecks_test.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks_test.go
@@ -8,9 +8,24 @@ package agentchecks
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/metadata/checkmetadata"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCheckMetadata(t *testing.T) {
+	checkID1 := "mysql:12345"
+	checkID2 := "mysql:56789"
+	name := "version.mysql"
+	value := "5"
+
+	checkmetadata.SetCheckMetadata(checkID1, name, value)
+	checkmetadata.SetCheckMetadata(checkID2, name, value)
+
+	pl := GetPayload()
+	cmpl := pl.CheckMetadataPayload.Payload
+	assert.Len(t, cmpl, 2)
+}
 
 func TestExternalHostTags(t *testing.T) {
 	host1 := "localhost"

--- a/pkg/collector/metadata/agentchecks/payload.go
+++ b/pkg/collector/metadata/agentchecks/payload.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/metadata/checkmetadata"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
@@ -20,6 +21,7 @@ type Payload struct {
 	CommonPayload
 	MetaPayload
 	ACPayload
+	CheckMetadataPayload
 	ExternalHostPayload
 }
 
@@ -36,6 +38,11 @@ type CommonPayload struct {
 // ACPayload wraps the Agent Checks payload
 type ACPayload struct {
 	AgentChecks []interface{} `json:"agent_checks"`
+}
+
+// CheckMetadataPayload wraps Payload from the `checkmetadata` package
+type CheckMetadataPayload struct {
+	checkmetadata.Payload `json:"check_metadata"`
 }
 
 // ExternalHostPayload wraps Payload from the `externalhost` package

--- a/pkg/collector/py/datadog_agent.c
+++ b/pkg/collector/py/datadog_agent.c
@@ -23,6 +23,7 @@ PyObject* GetClusterName(PyObject *self, PyObject *args);
 PyObject* LogMessage(char *message, int logLevel);
 PyObject* GetConfig(char *key);
 PyObject* GetSubprocessOutput(char **args, int argc, int raise);
+PyObject* SetCheckMetadata(const char *checkID, const char *name, const char *value);
 PyObject* SetExternalTags(const char *hostname, const char *source_type, char **tags, int tags_s);
 
 // Exceptions
@@ -114,6 +115,22 @@ static PyObject *get_subprocess_output(PyObject *self, PyObject *args) {
     free(subprocess_args);
 
     return py_result;
+}
+
+static PyObject *set_check_metadata(PyObject *self, PyObject *args) {
+    char *check_id, *name, *value;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    // datadog_agent.set_check_metadata(check_id, name, value)
+    if (!PyArg_ParseTuple(args, "sss", &check_id, &name, &value)) {
+      PyGILState_Release(gstate);
+      return NULL;
+    }
+
+    PyGILState_Release(gstate);
+    return SetCheckMetadata(check_id, name, value);
 }
 
 static PyObject *set_external_tags(PyObject *self, PyObject *args) {
@@ -237,6 +254,7 @@ static PyMethodDef datadogAgentMethods[] = {
   {"get_hostname", GetHostname, METH_VARARGS, "Get the agent hostname."},
   {"get_clustername", GetClusterName, METH_VARARGS, "Get the agent cluster name."},
   {"log", log_message, METH_VARARGS, "Log a message through the agent logger."},
+  {"set_check_metadata", set_check_metadata, METH_VARARGS, "Send check metadata."},
   {"set_external_tags", set_external_tags, METH_VARARGS, "Send external host tags."},
   {NULL, NULL}
 };

--- a/pkg/collector/py/datadog_agent.go
+++ b/pkg/collector/py/datadog_agent.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/pkg/metadata/checkmetadata"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -292,6 +293,18 @@ func SetExternalTags(hostname, sourceType *C.char, tags **C.char, tagsLen C.int)
 	}
 
 	externalhost.SetExternalTags(hname, stype, tagsStrings)
+	return C._none()
+}
+
+// SetCheckMetadata updates a metadata value for one check instance in the cache.
+// Indirectly used by the C function `set_check_metadata` that's mapped to `datadog_agent.set_check_metadata`.
+//export SetCheckMetadata
+func SetCheckMetadata(checkID, name, value *C.char) *C.PyObject {
+	cid := C.GoString(checkID)
+	key := C.GoString(name)
+	val := C.GoString(value)
+
+	checkmetadata.SetCheckMetadata(cid, key, val)
 	return C._none()
 }
 

--- a/pkg/collector/py/tests/check_metadata.py
+++ b/pkg/collector/py/tests/check_metadata.py
@@ -1,0 +1,12 @@
+import datadog_agent
+
+METADATA_PAYLOADS = (
+    ('http_check:12345', 'config.http_check.exists.check_certificate_expiration', 'true'),
+    ('redis:12345', 'version.redis', '4.0.0'),
+    ('redis:12345', 'version.redis', '5.0.0'),
+)
+
+
+def test():
+    for check_id, name, value in METADATA_PAYLOADS:
+        datadog_agent.set_check_metadata(check_id, name, value)

--- a/pkg/metadata/checkmetadata/check_metadata.go
+++ b/pkg/metadata/checkmetadata/check_metadata.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package checkmetadata
+
+import "sync"
+
+// metadata name -> value
+type instanceMetadataCache map[string]string
+
+var (
+	// checkMetadataCache maps checkID -> instanceMetadataCache
+	// The checkID is necessary since different instances may
+	// report the same metadata name with different values.
+	checkMetadataCache = make(map[string]instanceMetadataCache)
+	cacheMutex         = &sync.Mutex{}
+)
+
+// SetCheckMetadata updates a metadata value for one check instance in the cache.
+func SetCheckMetadata(checkID, name, value string) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
+	_, found := checkMetadataCache[checkID]
+	if !found {
+		checkMetadataCache[checkID] = make(instanceMetadataCache)
+	}
+
+	checkMetadataCache[checkID][name] = value
+}
+
+// GetPayload fills and returns the check metadata payload
+func GetPayload() *Payload {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
+	payload := Payload{}
+	for _, instanceCache := range checkMetadataCache {
+		for name, value := range instanceCache {
+			payload = append(payload, [2]string{name, value})
+		}
+	}
+
+	// clear the cache
+	checkMetadataCache = make(map[string]instanceMetadataCache)
+	return &payload
+}

--- a/pkg/metadata/checkmetadata/check_metadata_test.go
+++ b/pkg/metadata/checkmetadata/check_metadata_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package checkmetadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPayload(t *testing.T) {
+	// empty cache, empty payload
+	p := *GetPayload()
+	assert.Len(t, p, 0)
+
+	checkID := "postgres:12345"
+	name := "version.postgresql"
+	value1 := "5.0.0"
+	value2 := "7.0.0"
+
+	// add a few payloads to the cache
+	SetCheckMetadata(checkID, name, value1)
+	SetCheckMetadata(checkID, name, value2)
+
+	p = *GetPayload()
+	assert.Len(t, p, 1)
+	assert.Equal(t, value2, p[0][1])
+
+	// GetPayload is supposed to empty the cache
+	assert.Len(t, checkMetadataCache, 0)
+}

--- a/pkg/metadata/checkmetadata/doc.go
+++ b/pkg/metadata/checkmetadata/doc.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+/*
+Package checkmetadata implements the Check Metadata provider.
+
+This sends info such as versions of applications monitored, configuration options used, etc.
+
+The collector keeps a cache of check metadata `checkMetadataCache` and exports the function
+`SetCheckMetadata` so that entries can be added from other packages. This metadata provider
+is unlike most others in that it doesn't actually collect any info, but rather it simply
+sends whatever it finds stored in the cache. The cache is cleared at every collection.
+*/
+package checkmetadata

--- a/pkg/metadata/checkmetadata/payload.go
+++ b/pkg/metadata/checkmetadata/payload.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package checkmetadata
+
+/*
+The payload is a sequence of name-value pairs.
+*/
+
+// Payload handles the JSON unmarshalling of the check metadata payload
+type Payload [][2]string

--- a/releasenotes/notes/Implement-check-metadata-payloads-f8f74962b4b2a382.yaml
+++ b/releasenotes/notes/Implement-check-metadata-payloads-f8f74962b4b2a382.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Implements a way for checks to send their own metadata.


### PR DESCRIPTION
### What does this PR do?

Implements a way for checks to send their own metadata. The backend will learn to work with this in upcoming PRs to respective repos.

### Motivation

So we can track things like versions of applications monitored (MySQL, Redis, ...), configuration options used, etc.