### PR TITLE
Have independent pollers for config providers

### DIFF
--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -66,14 +66,7 @@ func SetupAutoConfig(confdPath string) {
 			if found {
 				configProvider, err := factory(cp)
 				if err == nil {
-					pollInterval := defaultPollingInterval
-					if cp.PollInterval != "" {
-						customInterval, err := time.ParseDuration(cp.PollInterval)
-						if err == nil {
-							pollInterval = customInterval
-						}
-					}
-
+					pollInterval := providers.GetPollInterval(cp)
 					if cp.Polling {
 						log.Infof("Registering %s config provider polled every %s", cp.Name, pollInterval.String())
 					} else {

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -7,7 +7,6 @@ package common
 
 import (
 	"path/filepath"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
@@ -59,7 +58,6 @@ func SetupAutoConfig(confdPath string) {
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders
 	err = config.Datadog.UnmarshalKey("config_providers", &CP)
-	defaultPollingInterval := config.Datadog.GetDuration("ad_config_poll_interval") * time.Second
 	if err == nil {
 		for _, cp := range CP {
 			factory, found := providers.ProviderCatalog[cp.Name]

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -74,12 +74,12 @@ func SetupAutoConfig(confdPath string) {
 						}
 					}
 
-					AC.AddConfigProvider(configProvider, cp.Polling, pollInterval)
 					if cp.Polling {
 						log.Infof("Registering %s config provider polled every %s", cp.Name, pollInterval.String())
 					} else {
 						log.Infof("Registering %s config provider", cp.Name)
 					}
+					AC.AddConfigProvider(configProvider, cp.Polling, pollInterval)
 				} else {
 					log.Errorf("Error while adding config provider %v: %v", cp.Name, err)
 				}

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -144,8 +144,8 @@ func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 	ac.LoadAndRun()
 	require.Len(suite.T(), ac.providers, 2)
 	assert.Equal(suite.T(), 1, mp.collectCounter)
-	assert.False(suite.T(), ac.providers[0].poll)
-	assert.True(suite.T(), ac.providers[1].poll)
+	assert.False(suite.T(), ac.providers[0].canPoll)
+	assert.True(suite.T(), ac.providers[1].canPoll)
 }
 
 func (suite *AutoConfigTestSuite) TestAddListener() {

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -134,14 +134,13 @@ func (suite *AutoConfigTestSuite) SetupTest() {
 	listeners.ServiceListenerFactories = make(map[string]listeners.ServiceListenerFactory)
 }
 
-func (suite *AutoConfigTestSuite) TestAddProvider() {
+func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 	ac := NewAutoConfig(scheduler.NewMetaScheduler())
-	ac.StartConfigPolling()
 	assert.Len(suite.T(), ac.providers, 0)
 	mp := &MockProvider{}
-	ac.AddProvider(mp, false)
-	ac.AddProvider(mp, false) // this should be a noop
-	ac.AddProvider(&MockProvider2{}, true)
+	ac.AddConfigProvider(mp, false, 0)
+	ac.AddConfigProvider(mp, false, 0) // this should be a noop
+	ac.AddConfigProvider(&MockProvider2{}, true, 1*time.Second)
 	ac.LoadAndRun()
 	require.Len(suite.T(), ac.providers, 2)
 	assert.Equal(suite.T(), 1, mp.collectCounter)
@@ -177,7 +176,6 @@ func (suite *AutoConfigTestSuite) TestContains() {
 
 func (suite *AutoConfigTestSuite) TestStop() {
 	ac := NewAutoConfig(scheduler.NewMetaScheduler())
-	ac.StartConfigPolling() // otherwise Stop would block
 
 	ml := &MockListener{}
 	listeners.Register("mock", ml.fakeFactory)

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -168,7 +168,7 @@ func (suite *AutoConfigTestSuite) TestAddListener() {
 func (suite *AutoConfigTestSuite) TestContains() {
 	c1 := integration.Config{Name: "bar"}
 	c2 := integration.Config{Name: "foo"}
-	pd := providerDescriptor{}
+	pd := configPoller{}
 	pd.configs = append(pd.configs, c1)
 	assert.True(suite.T(), pd.contains(&c1))
 	assert.False(suite.T(), pd.contains(&c2))

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -15,21 +15,29 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// providerDescriptor keeps track of the configurations loaded by a certain
+// configPoller keeps track of the configurations loaded by a certain
 // `ConfigProvider` and whether it should be polled or not.
-type providerDescriptor struct {
+type configPoller struct {
 	provider     providers.ConfigProvider
 	configs      []integration.Config
 	canPoll      bool
 	isPolling    bool
 	pollInterval time.Duration
-	ticker       *time.Ticker
 	stopChan     chan struct{}
 	healthHandle *health.Handle
 }
 
+func newConfigPoller(provider providers.ConfigProvider, canPoll bool, interval time.Duration) *configPoller {
+	return &configPoller{
+		provider:     provider,
+		configs:      []integration.Config{},
+		canPoll:      canPoll,
+		pollInterval: interval,
+	}
+}
+
 // contains checks if the providerDescriptor contains the Config passed
-func (pd *providerDescriptor) contains(c *integration.Config) bool {
+func (pd *configPoller) contains(c *integration.Config) bool {
 	for _, config := range pd.configs {
 		if config.Equal(c) {
 			return true
@@ -39,33 +47,36 @@ func (pd *providerDescriptor) contains(c *integration.Config) bool {
 }
 
 // stop stops the provider descriptor if it's polling
-func (pd *providerDescriptor) stop() {
+func (pd *configPoller) stop() {
+	if !pd.canPoll || pd.isPolling {
+		return
+	}
 	pd.stopChan <- struct{}{}
 	pd.isPolling = false
 }
 
 // start starts polling the provider descriptor
-func (pd *providerDescriptor) start(ac *AutoConfig) {
+func (pd *configPoller) start(ac *AutoConfig) {
+	if !pd.canPoll {
+		return
+	}
+	pd.stopChan = make(chan struct{})
+	pd.healthHandle = health.Register(fmt.Sprintf("ad-config-provider-%s", pd.provider.String()))
 	pd.isPolling = true
 	go pd.poll(ac)
 }
 
 // poll polls config of the corresponding config provider
-func (pd *providerDescriptor) poll(ac *AutoConfig) {
-	if !pd.canPoll {
-		return
-	}
-	pd.ticker = time.NewTicker(pd.pollInterval)
-	pd.stopChan = make(chan struct{})
-	pd.healthHandle = health.Register(fmt.Sprintf("ad-config-provider-%s", pd.provider.String()))
+func (pd *configPoller) poll(ac *AutoConfig) {
+	ticker := time.NewTicker(pd.pollInterval)
 	for {
 		select {
 		case <-pd.healthHandle.C:
 		case <-pd.stopChan:
 			pd.healthHandle.Deregister()
-			pd.ticker.Stop()
+			ticker.Stop()
 			return
-		case <-pd.ticker.C:
+		case <-ticker.C:
 			log.Tracef("Polling %s config provider", pd.provider.String())
 			// Check if the CPupdate cache is up to date. Fill it and trigger a Collect() if outdated.
 			upToDate, err := pd.provider.IsUpToDate()
@@ -80,6 +91,11 @@ func (pd *providerDescriptor) poll(ac *AutoConfig) {
 			// retrieve the list of newly added configurations as well
 			// as removed configurations
 			newConfigs, removedConfigs := pd.collect()
+			if len(newConfigs) > 0 || len(removedConfigs) > 0 {
+				log.Infof("%v provider: collected %d new configurations, removed %d", pd.provider, len(newConfigs), len(removedConfigs))
+			} else {
+				log.Debugf("%v provider: no configuration change", pd.provider)
+			}
 			// Process removed configs first to handle the case where a
 			// container churn would result in the same configuration hash.
 			ac.processRemovedConfigs(removedConfigs)
@@ -95,7 +111,7 @@ func (pd *providerDescriptor) poll(ac *AutoConfig) {
 
 // collect is just a convenient wrapper to fetch configurations from a provider and
 // see what changed from the last time we called Collect().
-func (pd *providerDescriptor) collect() ([]integration.Config, []integration.Config) {
+func (pd *configPoller) collect() ([]integration.Config, []integration.Config) {
 	var newConf []integration.Config
 	var removedConf []integration.Config
 	old := pd.configs
@@ -117,11 +133,6 @@ func (pd *providerDescriptor) collect() ([]integration.Config, []integration.Con
 		if !pd.contains(&c) {
 			removedConf = append(removedConf, c)
 		}
-	}
-	if len(newConf) > 0 || len(removedConf) > 0 {
-		log.Infof("%v provider: collected %d new configurations, removed %d", pd.provider, len(newConf), len(removedConf))
-	} else {
-		log.Debugf("%v provider: no configuration change", pd.provider)
 	}
 	return newConf, removedConf
 }

--- a/pkg/autodiscovery/provider_descriptor.go
+++ b/pkg/autodiscovery/provider_descriptor.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package autodiscovery
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// providerDescriptor keeps track of the configurations loaded by a certain
+// `ConfigProvider` and whether it should be polled or not.
+type providerDescriptor struct {
+	provider     providers.ConfigProvider
+	configs      []integration.Config
+	canPoll      bool
+	isPolling    bool
+	pollInterval time.Duration
+	ticker       *time.Ticker
+	stopChan     chan struct{}
+	healthHandle *health.Handle
+}
+
+// contains checks if the providerDescriptor contains the Config passed
+func (pd *providerDescriptor) contains(c *integration.Config) bool {
+	for _, config := range pd.configs {
+		if config.Equal(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// stop stops the provider descriptor if it's polling
+func (pd *providerDescriptor) stop() {
+	pd.stopChan <- struct{}{}
+	pd.isPolling = false
+}
+
+// start starts polling the provider descriptor
+func (pd *providerDescriptor) start(ac *AutoConfig) {
+	pd.isPolling = true
+	go pd.poll(ac)
+}
+
+// poll polls config of the corresponding config provider
+func (pd *providerDescriptor) poll(ac *AutoConfig) {
+	if !pd.canPoll {
+		return
+	}
+	pd.ticker = time.NewTicker(pd.pollInterval)
+	pd.stopChan = make(chan struct{})
+	pd.healthHandle = health.Register(fmt.Sprintf("ad-config-provider-%s", pd.provider.String()))
+	for {
+		select {
+		case <-pd.healthHandle.C:
+		case <-pd.stopChan:
+			pd.healthHandle.Deregister()
+			pd.ticker.Stop()
+			return
+		case <-pd.ticker.C:
+			log.Tracef("Polling %s config provider", pd.provider.String())
+			// Check if the CPupdate cache is up to date. Fill it and trigger a Collect() if outdated.
+			upToDate, err := pd.provider.IsUpToDate()
+			if err != nil {
+				log.Errorf("Cache processing of %v configuration provider failed: %v", pd.provider, err)
+			}
+			if upToDate == true {
+				log.Debugf("No modifications in the templates stored in %v configuration provider", pd.provider)
+				break
+			}
+
+			// retrieve the list of newly added configurations as well
+			// as removed configurations
+			newConfigs, removedConfigs := pd.collect()
+			// Process removed configs first to handle the case where a
+			// container churn would result in the same configuration hash.
+			ac.processRemovedConfigs(removedConfigs)
+
+			for _, config := range newConfigs {
+				config.Provider = pd.provider.String()
+				resolvedConfigs := ac.processNewConfig(config)
+				ac.schedule(resolvedConfigs)
+			}
+		}
+	}
+}
+
+// collect is just a convenient wrapper to fetch configurations from a provider and
+// see what changed from the last time we called Collect().
+func (pd *providerDescriptor) collect() ([]integration.Config, []integration.Config) {
+	var newConf []integration.Config
+	var removedConf []integration.Config
+	old := pd.configs
+
+	fetched, err := pd.provider.Collect()
+	if err != nil {
+		log.Errorf("Unable to collect configurations from provider %s: %s", pd.provider, err)
+		return nil, nil
+	}
+
+	for _, c := range fetched {
+		if !pd.contains(&c) {
+			newConf = append(newConf, c)
+		}
+	}
+
+	pd.configs = fetched
+	for _, c := range old {
+		if !pd.contains(&c) {
+			removedConf = append(removedConf, c)
+		}
+	}
+	if len(newConf) > 0 || len(removedConf) > 0 {
+		log.Infof("%v provider: collected %d new configurations, removed %d", pd.provider, len(newConf), len(removedConf))
+	} else {
+		log.Debugf("%v provider: no configuration change", pd.provider)
+	}
+	return newConf, removedConf
+}

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -12,21 +12,21 @@ import (
 
 const (
 	// Consul represents the name of the Consul config provider
-	Consul = "Consul"
+	Consul = "consul"
 	// ClusterChecks represents the name of the Cluster checks config provider
-	ClusterChecks = "Cluster checks"
+	ClusterChecks = "cluster-checks"
 	// Docker represents the name of the docker config provider
-	Docker = "Docker"
+	Docker = "docker"
 	// ECS represents the name of the ecs config provider
-	ECS = "ECS"
+	ECS = "ecs"
 	// Etcd represents the name of the etcd config provider
 	Etcd = "etcd"
 	// File represents the name of the file config provider
-	File = "File"
+	File = "file"
 	// Kubernetes represents the name of the kubernetes config provider
-	Kubernetes = "Kubernetes"
+	Kubernetes = "kubernetes"
 	// Zookeeper represents the name of the zookeeper config provider
-	Zookeeper = "Zookeeper"
+	Zookeeper = "zookeeper"
 )
 
 // ProviderCatalog keeps track of config providers by name

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -170,4 +171,15 @@ func extractLogsTemplatesFromMap(key string, input map[string]string, prefix str
 	default:
 		return []integration.Config{}, fmt.Errorf("invalid format, expected an array, got: '%v'", data)
 	}
+}
+
+// GetPollInterval computes the poll interval from the config
+func GetPollInterval(cp config.ConfigurationProviders) time.Duration {
+	if cp.PollInterval != "" {
+		customInterval, err := time.ParseDuration(cp.PollInterval)
+		if err == nil {
+			return customInterval
+		}
+	}
+	return config.Datadog.GetDuration("ad_config_poll_interval") * time.Second
 }

--- a/pkg/autodiscovery/providers/utils_test.go
+++ b/pkg/autodiscovery/providers/utils_test.go
@@ -9,11 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestParseJSONValue(t *testing.T) {
@@ -297,4 +299,17 @@ func TestExtractTemplatesFromMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPollInterval(t *testing.T) {
+	cp := config.ConfigurationProviders{}
+	assert.Equal(t, GetPollInterval(cp), 10*time.Second)
+	cp = config.ConfigurationProviders{
+		PollInterval: "foo",
+	}
+	assert.Equal(t, GetPollInterval(cp), 10*time.Second)
+	cp = config.ConfigurationProviders{
+		PollInterval: "1s",
+	}
+	assert.Equal(t, GetPollInterval(cp), 1*time.Second)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ type MetadataProviders struct {
 type ConfigurationProviders struct {
 	Name             string `mapstructure:"name"`
 	Polling          bool   `mapstructure:"polling"`
+	PollInterval     string `mapstructure:"poll_interval"`
 	TemplateURL      string `mapstructure:"template_url"`
 	TemplateDir      string `mapstructure:"template_dir"`
 	Username         string `mapstructure:"username"`

--- a/releasenotes/notes/independent-config-polling-4041382ffdb98cb4.yaml
+++ b/releasenotes/notes/independent-config-polling-4041382ffdb98cb4.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    It's possible now to have different poll intervals for
+    each autodiscovery configuration providers


### PR DESCRIPTION
### What does this PR do?

* Have independant poller for config providers to scrap config at different intervals (by default 10sec if not specified)
* Configuration providers will start polling immediatly after being added
* Each configuration provider now has its own health check

### Motivation

Better polling control over each individual configuration provider
