### PR TITLE
Drop empty tags

### DIFF
--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -74,7 +74,9 @@ func parseTags(rawTags []byte, extractHost bool, defaultHostname string) ([]stri
 		if extractHost && bytes.HasPrefix(tag, []byte("host:")) {
 			host = string(tag[5:])
 		} else {
-			tagsList = append(tagsList, string(tag))
+			if len(tag) > 0 {
+				tagsList = append(tagsList, string(tag))
+			}
 		}
 
 		if remainder == nil {

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -733,3 +733,16 @@ func TestNamespace(t *testing.T) {
 	assert.Equal(t, "testNamespace.daemon", parsed.Name)
 	assert.Equal(t, "default-hostname", parsed.Host)
 }
+
+func TestParseGaugeWithEmptyTags(t *testing.T) {
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,,sometag2:somevalue2,"), "", "default-hostname")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "daemon", parsed.Name)
+	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
+	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
+	require.Equal(t, 2, len(parsed.Tags))
+	assert.Equal(t, "sometag1:somevalue1", parsed.Tags[0])
+	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
+	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
+}


### PR DESCRIPTION
### What does this PR do?

Drop empty tags when parsing dogstatsd package.

### Motivation

We had a bug in our application metrics code that caused empty tags to be inserted into the tag list.  When this happened, the metric would not be tagged with any of the tags after that empty value in the dogstatsd packet.

### Additional Notes

This break existing behavior, but I'm not sure  existing behavior on the datadog side is intended.
