### PR TITLE
Fix folder permissions on containerd

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -36,10 +36,16 @@ COPY --from=builder /output /
 # Allow running as an unprivileged user:
 # - General case is the dd-agent user
 # - OpenShift uses a random UID in the root group
+#
+# Containerd does not preserve permissions when mounting a volume on top
+# of an empty folder. Creating .placeholder files as a workaround.
+#
 RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
  && mkdir -p /var/log/datadog/ \
- && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ \
- && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/
+ && touch /var/log/datadog/.placeholder \
+ && touch /tmp/.placeholder \
+ && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /tmp/ \
+ && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/ /tmp/
 
 USER dd-agent
 


### PR DESCRIPTION
### What does this PR do?

 Containerd does not preserve permissions when mounting a volume on top of an empty folder. Create .placeholder files in `/var/log/datadog/` and `/tmp` as a workaround.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
