### PR TITLE
Log sources from env var

### DIFF
--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -54,7 +54,7 @@ func SetupAutoConfig(confdPath string) {
 		"",
 	}
 	AC.AddProvider(providers.NewFileConfigProvider(confSearchPaths), false)
-	AC.AddProvider(providers.NewEnvProvider(), false)
+	AC.AddProvider(providers.NewEnvVarProvider(), false)
 
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -54,6 +54,7 @@ func SetupAutoConfig(confdPath string) {
 		"",
 	}
 	AC.AddProvider(providers.NewFileConfigProvider(confSearchPaths), false)
+	AC.AddProvider(providers.NewEnvProvider(), false)
 
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -256,7 +256,7 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 	for _, pd := range ac.providers {
 		cfgs, err := pd.provider.Collect()
 		if err != nil {
-			log.Debugf("Unexpected error returned when collecting configurations from provider %v: %v", pd.provider, err)
+			log.Errorf("Unexpected error returned when collecting configurations from provider %v: %v", pd.provider, err)
 		}
 
 		if fileConfPd, ok := pd.provider.(*providers.FileConfigProvider); ok {

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-const name = "dd_logs_config_custom_configs"
+const name = "dd_logs_config_custom_config"
 
 var collectors = []func(*EnvVarProvider) ([]integration.Config, error){
 	(*EnvVarProvider).collectLogsConfigs,
@@ -54,7 +54,7 @@ func (e *EnvVarProvider) Collect() ([]integration.Config, error) {
 }
 
 func (e *EnvVarProvider) collectLogsConfigs() ([]integration.Config, error) {
-	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_configs"))
+	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_config"))
 
 	if len(customConfigs) == 0 {
 		return []integration.Config{}, nil

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -6,6 +6,7 @@
 package providers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -14,19 +15,45 @@ import (
 
 const name = "dd_logs_config_custom_configs"
 
-// EnvProvider implements implements the ConfigProvider interface
-// It should be called once at the start of the agent.
-type EnvProvider struct{}
+var collectors = []func(*EnvVarProvider) ([]integration.Config, error){
+	(*EnvVarProvider).collectLogsConfigs,
+	(*EnvVarProvider).collectMetricsConfigs,
+}
 
-// NewEnvProvider creates a EnvProvider searching for
+// EnvVarProvider implements implements the ConfigProvider interface
+// It should be called once at the start of the agent.
+type EnvVarProvider struct{}
+
+// NewEnvVarProvider creates a EnvVarProvider searching for
 // configurations in env variables.
-func NewEnvProvider() *EnvProvider {
-	return &EnvProvider{}
+func NewEnvVarProvider() *EnvVarProvider {
+	return &EnvVarProvider{}
 }
 
 // Collect gets the value of env variables
 // and generate an integrationConfig out of it.
-func (e *EnvProvider) Collect() ([]integration.Config, error) {
+func (e *EnvVarProvider) Collect() ([]integration.Config, error) {
+	var integrationConfigs []integration.Config
+	var errors []string
+	var err error
+	for _, collector := range collectors {
+		collectorConfigs, err := collector(e)
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+		integrationConfigs = append(integrationConfigs, collectorConfigs...)
+	}
+
+	if len(errors) == 1 {
+		err = fmt.Errorf("%v", errors[0])
+	}
+	if len(errors) > 1 {
+		err = fmt.Errorf("Multiple errors: %s", strings.Join(errors, ","))
+	}
+	return integrationConfigs, err
+}
+
+func (e *EnvVarProvider) collectLogsConfigs() ([]integration.Config, error) {
 	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_configs"))
 
 	if len(customConfigs) == 0 {
@@ -37,13 +64,16 @@ func (e *EnvProvider) Collect() ([]integration.Config, error) {
 	integrationConfig.LogsConfig = []byte(customConfigs)
 	return []integration.Config{integrationConfig}, nil
 }
+func (e *EnvVarProvider) collectMetricsConfigs() ([]integration.Config, error) {
+	return []integration.Config{}, nil
+}
 
-// String returns a string representation of the EnvProvider
-func (e *EnvProvider) String() string {
+// String returns a string representation of the EnvVarProvider
+func (e *EnvVarProvider) String() string {
 	return EnvironmentVariable
 }
 
 // IsUpToDate is not implemented for the env Provider as the env are not meant to change.
-func (e *EnvProvider) IsUpToDate() (bool, error) {
+func (e *EnvVarProvider) IsUpToDate() (bool, error) {
 	return false, nil
 }

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package providers
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
+)
+
+// EnvProvider implements implements the ConfigProvider interface
+// It should be called once at the start of the agent.
+type EnvProvider struct{}
+
+// NewEnvProvider create a EnvProvider searching for
+// configurations in env variable DD_LOGS_CONFIG_CUSTOM_CONFIGS
+func NewEnvProvider() *EnvProvider {
+	return &EnvProvider{}
+}
+
+// Collect get the value of env variable DD_LOGS_CONFIG_CUSTOM_CONFIGS
+// and generate an integrationConfig out of it.
+func (e *EnvProvider) Collect() ([]integration.Config, error) {
+	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_configs"))
+	var confs []*logsConfig.LogsConfig
+	var integrationConfigs []integration.Config
+
+	if len(customConfigs) == 0 {
+		return integrationConfigs, nil
+	}
+
+	err := json.Unmarshal([]byte(customConfigs), &confs)
+	if err != nil {
+		return integrationConfigs, err
+	}
+
+	integrationConfig := integration.Config{Provider: Env}
+	integrationConfig.LogsConfig, err = json.Marshal(confs)
+	if err != nil {
+		return integrationConfigs, err
+	}
+	integrationConfigs = append(integrationConfigs, integrationConfig)
+	return integrationConfigs, nil
+}
+
+// String returns a string representation of the EnvProvider
+func (e *EnvProvider) String() string {
+	return Env
+}
+
+// IsUpToDate is not implemented for the env Provider as the env are not meant to change.
+func (e *EnvProvider) IsUpToDate() (bool, error) {
+	return false, nil
+}

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -15,9 +15,9 @@ import (
 
 const name = "dd_logs_config_custom_config"
 
-var collectors = []func(*EnvVarProvider) ([]integration.Config, error){
-	(*EnvVarProvider).collectLogsConfigs,
-	(*EnvVarProvider).collectMetricsConfigs,
+var collectors = []func() ([]integration.Config, error){
+	collectLogsConfigs,
+	collectMetricsConfigs,
 }
 
 // EnvVarProvider implements implements the ConfigProvider interface
@@ -37,7 +37,7 @@ func (e *EnvVarProvider) Collect() ([]integration.Config, error) {
 	var errors []string
 	var err error
 	for _, collector := range collectors {
-		collectorConfigs, err := collector(e)
+		collectorConfigs, err := collector()
 		if err != nil {
 			errors = append(errors, err.Error())
 		}
@@ -48,12 +48,12 @@ func (e *EnvVarProvider) Collect() ([]integration.Config, error) {
 		err = fmt.Errorf("%v", errors[0])
 	}
 	if len(errors) > 1 {
-		err = fmt.Errorf("Multiple errors: %s", strings.Join(errors, ","))
+		err = fmt.Errorf("Multiple errors: %s", strings.Join(errors, ", "))
 	}
 	return integrationConfigs, err
 }
 
-func (e *EnvVarProvider) collectLogsConfigs() ([]integration.Config, error) {
+func collectLogsConfigs() ([]integration.Config, error) {
 	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_config"))
 
 	if len(customConfigs) == 0 {
@@ -64,7 +64,7 @@ func (e *EnvVarProvider) collectLogsConfigs() ([]integration.Config, error) {
 	integrationConfig.LogsConfig = []byte(customConfigs)
 	return []integration.Config{integrationConfig}, nil
 }
-func (e *EnvVarProvider) collectMetricsConfigs() ([]integration.Config, error) {
+func collectMetricsConfigs() ([]integration.Config, error) {
 	return []integration.Config{}, nil
 }
 

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -18,13 +18,13 @@ const name = "dd_logs_config_custom_configs"
 // It should be called once at the start of the agent.
 type EnvProvider struct{}
 
-// NewEnvProvider create a EnvProvider searching for
-// configurations in env variable DD_LOGS_CONFIG_CUSTOM_CONFIGS
+// NewEnvProvider creates a EnvProvider searching for
+// configurations in env variables.
 func NewEnvProvider() *EnvProvider {
 	return &EnvProvider{}
 }
 
-// Collect get the value of env variable DD_LOGS_CONFIG_CUSTOM_CONFIGS
+// Collect gets the value of env variables
 // and generate an integrationConfig out of it.
 func (e *EnvProvider) Collect() ([]integration.Config, error) {
 	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_configs"))

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -6,12 +6,10 @@
 package providers
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
 const name = "dd_logs_config_custom_configs"
@@ -30,25 +28,14 @@ func NewEnvProvider() *EnvProvider {
 // and generate an integrationConfig out of it.
 func (e *EnvProvider) Collect() ([]integration.Config, error) {
 	customConfigs := strings.TrimSpace(config.Datadog.GetString("logs_config.custom_configs"))
-	var confs []*logsConfig.LogsConfig
-	var integrationConfigs []integration.Config
 
 	if len(customConfigs) == 0 {
-		return integrationConfigs, nil
-	}
-
-	err := json.Unmarshal([]byte(customConfigs), &confs)
-	if err != nil {
-		return integrationConfigs, err
+		return []integration.Config{}, nil
 	}
 
 	integrationConfig := integration.Config{Provider: EnvironmentVariable, Name: name}
-	integrationConfig.LogsConfig, err = json.Marshal(confs)
-	if err != nil {
-		return integrationConfigs, err
-	}
-	integrationConfigs = append(integrationConfigs, integrationConfig)
-	return integrationConfigs, nil
+	integrationConfig.LogsConfig = []byte(customConfigs)
+	return []integration.Config{integrationConfig}, nil
 }
 
 // String returns a string representation of the EnvProvider

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -14,6 +14,8 @@ import (
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 )
 
+const name = "dd_logs_config_custom_configs"
+
 // EnvProvider implements implements the ConfigProvider interface
 // It should be called once at the start of the agent.
 type EnvProvider struct{}
@@ -40,7 +42,7 @@ func (e *EnvProvider) Collect() ([]integration.Config, error) {
 		return integrationConfigs, err
 	}
 
-	integrationConfig := integration.Config{Provider: Env}
+	integrationConfig := integration.Config{Provider: Env, Name: name}
 	integrationConfig.LogsConfig, err = json.Marshal(confs)
 	if err != nil {
 		return integrationConfigs, err

--- a/pkg/autodiscovery/providers/env.go
+++ b/pkg/autodiscovery/providers/env.go
@@ -42,7 +42,7 @@ func (e *EnvProvider) Collect() ([]integration.Config, error) {
 		return integrationConfigs, err
 	}
 
-	integrationConfig := integration.Config{Provider: Env, Name: name}
+	integrationConfig := integration.Config{Provider: EnvironmentVariable, Name: name}
 	integrationConfig.LogsConfig, err = json.Marshal(confs)
 	if err != nil {
 		return integrationConfigs, err
@@ -53,7 +53,7 @@ func (e *EnvProvider) Collect() ([]integration.Config, error) {
 
 // String returns a string representation of the EnvProvider
 func (e *EnvProvider) String() string {
-	return Env
+	return EnvironmentVariable
 }
 
 // IsUpToDate is not implemented for the env Provider as the env are not meant to change.

--- a/pkg/autodiscovery/providers/env_test.go
+++ b/pkg/autodiscovery/providers/env_test.go
@@ -22,7 +22,7 @@ func TestEnvCollectEmpty(t *testing.T) {
 
 func TestEnvCollectValid(t *testing.T) {
 	envVar := `[{"type":"tcp","port":1234,"service":"fooService","source":"barSource","tags":["foo:bar","baz"]}]`
-	config.Datadog.Set("logs_config.custom_configs", envVar)
+	config.Datadog.Set("logs_config.custom_config", envVar)
 	envProvider := NewEnvVarProvider()
 
 	integrationConfigs, err := envProvider.Collect()
@@ -31,7 +31,7 @@ func TestEnvCollectValid(t *testing.T) {
 	assert.Equal(t, []byte(envVar), []byte(integrationConfigs[0].LogsConfig))
 
 	envVar = `[{"type":"tcp","port":1234,"service":"fooService","source":"barSource","tags":["foo:bar","baz"]}, {"type":"file","path":"/tmp/file.log","service":"fooService","source":"barSource","tags":["foo:bar","log"]}]`
-	config.Datadog.Set("logs_config.custom_configs", envVar)
+	config.Datadog.Set("logs_config.custom_config", envVar)
 	integrationConfigs, err = envProvider.Collect()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(integrationConfigs))

--- a/pkg/autodiscovery/providers/env_test.go
+++ b/pkg/autodiscovery/providers/env_test.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvCollectEmpty(t *testing.T) {
+	envProvider := NewEnvProvider()
+
+	integrationConfigs, err := envProvider.Collect()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(integrationConfigs))
+}
+
+func TestEnvCollectInvalid(t *testing.T) {
+	// Missing closing parenthesis at type key
+	config.Datadog.Set("logs_config.custom_configs", "[{\"type:\"tcp\",\"port\":1234,\"service\":\"fooService\",\"source\":\"barSource\",\"tags\":[\"foo:bar\",\"baz\"]}]")
+	envProvider := NewEnvProvider()
+
+	integrationConfigs, err := envProvider.Collect()
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(integrationConfigs))
+}
+
+func TestEnvCollectValid(t *testing.T) {
+	config.Datadog.Set("logs_config.custom_configs", "[{\"type\":\"tcp\",\"port\":1234,\"service\":\"fooService\",\"source\":\"barSource\",\"tags\":[\"foo:bar\",\"baz\"]}]")
+	envProvider := NewEnvProvider()
+
+	integrationConfigs, err := envProvider.Collect()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(integrationConfigs))
+
+	var logConfig []logsConfig.LogsConfig
+	err = json.Unmarshal(integrationConfigs[0].LogsConfig, &logConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(logConfig))
+
+	expectedConfig := logsConfig.LogsConfig{
+		Type:    "tcp",
+		Port:    1234,
+		Service: "fooService",
+		Source:  "barSource",
+		Tags:    []string{"foo:bar", "baz"},
+	}
+	assert.Equal(t, expectedConfig, logConfig[0])
+}
+
+func TestEnvCollectMultipleValid(t *testing.T) {
+	config.Datadog.Set("logs_config.custom_configs", "[{\"type\":\"tcp\",\"port\":1234,\"service\":\"fooService\",\"source\":\"barSource\",\"tags\":[\"foo:bar\",\"baz\"]}, {\"type\":\"file\",\"path\":\"/tmp/file.log\",\"service\":\"fooService\",\"source\":\"barSource\",\"tags\":[\"foo:bar\",\"log\"]}]")
+	envProvider := NewEnvProvider()
+
+	integrationConfigs, err := envProvider.Collect()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(integrationConfigs))
+
+	var logConfig []logsConfig.LogsConfig
+	err = json.Unmarshal(integrationConfigs[0].LogsConfig, &logConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(logConfig))
+
+	expectedConfig1 := logsConfig.LogsConfig{
+		Type:    "tcp",
+		Port:    1234,
+		Service: "fooService",
+		Source:  "barSource",
+		Tags:    []string{"foo:bar", "baz"},
+	}
+	expectedConfig2 := logsConfig.LogsConfig{
+		Type:    "file",
+		Path:    "/tmp/file.log",
+		Service: "fooService",
+		Source:  "barSource",
+		Tags:    []string{"foo:bar", "log"},
+	}
+	assert.Equal(t, expectedConfig1, logConfig[0])
+	assert.Equal(t, expectedConfig2, logConfig[1])
+}

--- a/pkg/autodiscovery/providers/env_test.go
+++ b/pkg/autodiscovery/providers/env_test.go
@@ -22,16 +22,6 @@ func TestEnvCollectEmpty(t *testing.T) {
 	assert.Equal(t, 0, len(integrationConfigs))
 }
 
-func TestEnvCollectInvalid(t *testing.T) {
-	// Missing closing parenthesis at type key
-	config.Datadog.Set("logs_config.custom_configs", "[{\"type:\"tcp\",\"port\":1234,\"service\":\"fooService\",\"source\":\"barSource\",\"tags\":[\"foo:bar\",\"baz\"]}]")
-	envProvider := NewEnvProvider()
-
-	integrationConfigs, err := envProvider.Collect()
-	assert.NotNil(t, err)
-	assert.Equal(t, 0, len(integrationConfigs))
-}
-
 func TestEnvCollectValid(t *testing.T) {
 	config.Datadog.Set("logs_config.custom_configs", "[{\"type\":\"tcp\",\"port\":1234,\"service\":\"fooService\",\"source\":\"barSource\",\"tags\":[\"foo:bar\",\"baz\"]}]")
 	envProvider := NewEnvProvider()

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -23,6 +23,8 @@ const (
 	Etcd = "etcd"
 	// File represents the name of the file config provider
 	File = "File"
+	// Env represents the name of the env config provider
+	Env = "Env"
 	// Kubernetes represents the name of the kubernetes config provider
 	Kubernetes = "Kubernetes"
 	// Zookeeper represents the name of the zookeeper config provider

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -23,8 +23,8 @@ const (
 	Etcd = "etcd"
 	// File represents the name of the file config provider
 	File = "File"
-	// Env represents the name of the env config provider
-	Env = "Env"
+	// EnvironmentVariable represents the name of the env config provider
+	EnvironmentVariable = "Environment variable"
 	// Kubernetes represents the name of the kubernetes config provider
 	Kubernetes = "Kubernetes"
 	// Zookeeper represents the name of the zookeeper config provider

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -285,7 +285,7 @@ func initConfig(config Config) {
 	// collect all logs from all containers:
 	config.BindEnvAndSetDefault("logs_config.container_collect_all", false)
 	// collect logs from the specified sources
-	config.BindEnvAndSetDefault("logs_config.custom_configs", "")
+	config.BindEnvAndSetDefault("logs_config.custom_config", "")
 	// collect all logs forwarded by TCP on a specific port:
 	config.BindEnvAndSetDefault("logs_config.tcp_forward_port", -1)
 	// add a socks5 proxy:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -284,6 +284,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("log_enabled", false) // deprecated, use logs_enabled instead
 	// collect all logs from all containers:
 	config.BindEnvAndSetDefault("logs_config.container_collect_all", false)
+	// collect logs from the specified sources
+	config.BindEnvAndSetDefault("logs_config.custom_configs", "")
 	// collect all logs forwarded by TCP on a specific port:
 	config.BindEnvAndSetDefault("logs_config.tcp_forward_port", -1)
 	// add a socks5 proxy:

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -25,7 +25,7 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, true, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
 	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.open_files_limit"))
 	assert.Equal(t, 9000, LogsAgent.GetInt("logs_config.frame_size"))
-	assert.Equal(t, "", LogsAgent.GetString("logs_config.custom_configs"))
+	assert.Equal(t, "", LogsAgent.GetString("logs_config.custom_config"))
 	assert.Equal(t, -1, LogsAgent.GetInt("logs_config.tcp_forward_port"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.socks5_proxy_address"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.logs_dd_url"))

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -25,6 +25,7 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, true, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
 	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.open_files_limit"))
 	assert.Equal(t, 9000, LogsAgent.GetInt("logs_config.frame_size"))
+	assert.Equal(t, "", LogsAgent.GetString("logs_config.custom_configs"))
 	assert.Equal(t, -1, LogsAgent.GetInt("logs_config.tcp_forward_port"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.socks5_proxy_address"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.logs_dd_url"))

--- a/pkg/logs/config/parser_test.go
+++ b/pkg/logs/config/parser_test.go
@@ -39,6 +39,17 @@ func TestParseJSONWithValidFormatShouldSucceed(t *testing.T) {
 	rule := config.ProcessingRules[0]
 	assert.Equal(t, "multi_line", rule.Type)
 	assert.Equal(t, "numbers", rule.Name)
+
+	configs, err = ParseJSON([]byte(`[{"type":"tcp","port":1234,"service":"fooService"}, {"type":"file","path":"/tmp/file.log","service":"fooService"}]`))
+	assert.Nil(t, err)
+	config0 := configs[0]
+	assert.Equal(t, "tcp", config0.Type)
+	assert.Equal(t, 1234, config0.Port)
+	assert.Equal(t, "fooService", config0.Service)
+	config1 := configs[1]
+	assert.Equal(t, "file", config1.Type)
+	assert.Equal(t, "/tmp/file.log", config1.Path)
+	assert.Equal(t, "fooService", config1.Service)
 }
 
 func TestParseJSONWithInvalidFormatShouldFail(t *testing.T) {

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -147,7 +147,7 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 	case providers.File:
 		// config defined in a file
 		configs, err = logsConfig.ParseYAML(config.LogsConfig)
-	case providers.Docker, providers.Kubernetes, providers.Env:
+	case providers.Docker, providers.Kubernetes, providers.EnvironmentVariable:
 		// config attached to a docker label or a pod annotation
 		// or coming from an env variable
 		configs, err = logsConfig.ParseJSON(config.LogsConfig)

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -147,8 +147,9 @@ func (s *Scheduler) toSources(config integration.Config) ([]*logsConfig.LogSourc
 	case providers.File:
 		// config defined in a file
 		configs, err = logsConfig.ParseYAML(config.LogsConfig)
-	case providers.Docker, providers.Kubernetes:
+	case providers.Docker, providers.Kubernetes, providers.Env:
 		// config attached to a docker label or a pod annotation
+		// or coming from an env variable
 		configs, err = logsConfig.ParseJSON(config.LogsConfig)
 	default:
 		// invalid provider

--- a/releasenotes/notes/add-env-variable-for-logs-config-82ebe18d0b30bd4d.yaml
+++ b/releasenotes/notes/add-env-variable-for-logs-config-82ebe18d0b30bd4d.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    DD_LOGS_CONFIG_CUSTOM_CONFIGS can now be used as to define log sources
+    using JSON format


### PR DESCRIPTION
### What does this PR do?

DD_LOGS_CONFIG_CUSTOM_CONFIG can now be used as to define log sources using JSON format

### Motivation

On some environement (PCF) it's not possible to have config files for the agent and everything must be done through env vars

