### PR TITLE
build puppy deb on arm and arm64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -297,7 +297,7 @@ agent_deb-x64:
     paths:
       - $OMNIBUS_PACKAGE_DIR
 
-# build Agent package for deb-x64
+# build Puppy package for deb-x64
 puppy_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
@@ -313,12 +313,48 @@ puppy_deb-x64:
     - inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-puppy*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-puppy*_amd64.deb $S3_ARTEFACTS_URI/datadog-puppy_amd64.deb
-  # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
-  # cache:
-  #   # cache per branch
-  #   key: $CI_COMMIT_REF_NAME
-  #   paths:
-  #     - $OMNIBUS_BASE_DIR
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+
+# build Puppy package for deb-x64
+puppy_deb-arm:
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:2xlarge" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    # Artifacts and cache must live within project directory but we run omnibus
+    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+    # pointing to a gitlab-friendly location.
+    - GOOS=linux GOARM=7 GOARCH=arm inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
+    - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-puppy*_amd64.deb
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-puppy*_amd64.deb $S3_ARTEFACTS_URI/datadog-puppy_amd64.deb
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+
+# build Puppy package for deb-x64
+puppy_deb-arm64:
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deb_x64:latest
+  tags: [ "runner:main", "size:2xlarge" ]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    # Artifacts and cache must live within project directory but we run omnibus
+    # from the GOPATH (see above). We then call `invoke` passing --base-dir,
+    # pointing to a gitlab-friendly location.
+    - GOOS=linux GOARM=8 GOARCH=arm64 inv -e agent.omnibus-build --puppy --log-level debug --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR
+    - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-puppy*_amd64.deb
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-puppy*_amd64.deb $S3_ARTEFACTS_URI/datadog-puppy_amd64.deb
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
### What does this PR do?

Builds the puppy deb package for ARM7 (ARM) and ARM8 (ARM64).

https://github.com/golang/go/wiki/GoArm