### PR TITLE
Adding rollup and fix to circumvent time aggregation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -320,12 +320,12 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
 	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
-	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)
-	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)            // value in seconds. Frequency of batch calls to the configmap persistent store (GlobalStore)
-	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 90)                 // value in seconds. 3 cycles from the HPA controller is enough to consider a metric stale
+	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)          // value in seconds. Frequency of batch calls to the ConfigMap persistent store (GlobalStore) by the Leader.
+	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)            // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)
+	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 120)                // value in seconds. 4 cycles from the HPA controller (up to Kubernetes 1.11) is enough to consider a metric stale
 	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                    // aggregator used for the external metrics. Choose from [avg,sum,max,min]
-	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)           // Window of the metric from Datadog
-	config.BindEnvAndSetDefault("external_metrics.query_rollup", 60)                     // Bucket size to circumvent time aggregation side effects.
+	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)           // Window to query to get the metric from Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                  // Bucket size to circumvent time aggregation side effects.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)              // value in seconds. Default to 5 minutes
 	config.BindEnvAndSetDefault("kubernetes_informers_restclient_timeout", 60)           // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30) // value in seconds

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -325,6 +325,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.max_age", 90)                 // value in seconds. 3 cycles from the HPA controller is enough to consider a metric stale
 	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                    // aggregator used for the external metrics. Choose from [avg,sum,max,min]
 	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)           // Window of the metric from Datadog
+	config.BindEnvAndSetDefault("external_metrics.query_rollup", 60)                     // Bucket size to circumvent time aggregation side effects.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)              // value in seconds. Default to 5 minutes
 	config.BindEnvAndSetDefault("kubernetes_informers_restclient_timeout", 60)           // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30) // value in seconds

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -132,7 +132,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 			precision := time.Now().Unix() - point.timestamp
 			metricsPrecision.WithLabelValues(m).Set(float64(precision))
 
-			log.Debugf("Validated %s | Value:%d at %d after %d/%d buckets", m, time.Now().Unix(), point.value, point.timestamp, i+1, len(serie.Points))
+			log.Debugf("Validated %s | Value:%d at %d after %d/%d buckets", m, point.value, point.timestamp, i+1, len(serie.Points))
 			break
 		}
 	}

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -66,6 +66,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 		log.Tracef("No processed external metrics to query")
 		return nil, nil
 	}
+	// TODO move viper parameters to the Processor struct
 	bucketSize := config.Datadog.GetInt64("external_metrics_provider.bucket_size")
 
 	aggregator := config.Datadog.GetString("external_metrics.aggregator")
@@ -104,7 +105,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 			continue
 		}
 
-		// Use on the penultimate bucket, since the very last bucket can be subject to variations due to the intake pipeline latency.
+		// Use on the penultimate bucket, since the very last bucket can be subject to variations due to late points.
 		fullBucketSeen := 0
 		var point Point
 		// Find the most recent value.

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -104,7 +104,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 			continue
 		}
 
-		// Because of the intake pipeline, the very last bucket can be subject to variations - Let's use the previous bucket.
+		// Use on the penultimate bucket, since the very last bucket can be subject to variations due to the intake pipeline latency.
 		fullBucketSeen := 0
 		var point Point
 		// Find the most recent value.
@@ -113,9 +113,9 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 				// We need this as if multiple metrics are queried, their points' timestamps align this can result in empty values.
 				continue
 			}
-			// If there is only one datapoint in the bucket, let's use it.
-			// This can happen with the batch of sparse and a regular metric.
-			if fullBucketSeen == 0 && len(serie.Points) > 2 {
+			// We need at least 2 points per window queried on batched metrics.
+			// If a single sparse metric is processed and only has 1 point in the window, use the value.
+			if fullBucketSeen == 0 && len(serie.Points) > 1 {
 				// Do not rely on the value stored in the last bucket
 				fullBucketSeen = fullBucketSeen + 1
 				continue

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -34,8 +34,8 @@ var (
 	},
 		[]string{"metric"},
 	)
-	metricsPrecision = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "external_metrics_delay",
+	metricsDelay = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "external_metrics_delay_seconds",
 		Help: "freshness of the metric evaluated from querying Datadog",
 	},
 		[]string{"metric"},
@@ -45,7 +45,7 @@ var (
 func init() {
 	prometheus.MustRegister(ddRequests)
 	prometheus.MustRegister(metricsEval)
-	prometheus.MustRegister(metricsPrecision)
+	prometheus.MustRegister(metricsDelay)
 }
 
 type Point struct {
@@ -131,7 +131,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 			// Prometheus submissions on the processed external metrics
 			metricsEval.WithLabelValues(m).Set(float64(point.value))
 			precision := time.Now().Unix() - point.timestamp
-			metricsPrecision.WithLabelValues(m).Set(float64(precision))
+			metricsDelay.WithLabelValues(m).Set(float64(precision))
 
 			log.Debugf("Validated %s | Value:%d at %d after %d/%d buckets", m, point.value, point.timestamp, i+1, len(serie.Points))
 			break

--- a/pkg/util/kubernetes/hpa/datadogexternal_test.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal_test.go
@@ -1,0 +1,134 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+// +build kubeapiserver
+
+package hpa
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+)
+
+// TestDatadogExternalQuery tests that the outputs gotten from Datadog are appropriately dealt with.
+// Worth noting: We check that the penultimate point is considered and also that even if buckets don't align, we can retrieve the last value.
+func TestDatadogExternalQuery(t *testing.T) {
+	tests := []struct {
+		name       string
+		queryfunc  func(from, to int64, query string) ([]datadog.Series, error)
+		metricName []string
+		points     map[string]Point
+		err        error
+	}{
+		{
+			"metricName is empty",
+			nil,
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"metricName yields empty response from Datadog",
+			func(from, to int64, query string) ([]datadog.Series, error) {
+				return nil, nil
+			},
+			[]string{"mymetric{foo:bar}"},
+			map[string]Point{"mymetric{foo:bar}": {value: 0, valid: false}},
+			fmt.Errorf("Returned series slice empty"),
+		},
+		{
+			"metricName yields rate limiting error response from Datadog",
+			func(int64, int64, string) ([]datadog.Series, error) {
+				return nil, fmt.Errorf("Rate limit of 300 requests in 3600 seconds.")
+			},
+			[]string{"mymetric{foo:bar}"},
+			nil,
+			fmt.Errorf("Error while executing metric query avg:mymetric{foo:bar}.rollup(30): Rate limit of 300 requests in 3600 seconds."),
+		},
+		{
+			"metrics with different granularities Datadog",
+			func(from, to int64, query string) ([]datadog.Series, error) {
+				return []datadog.Series{
+					{
+						// Note that points are ordered when we get them from Datadog.
+						Points: []datadog.DataPoint{
+							makePoints(100000, 40),
+							makePartialPoints(11000),
+							makePoints(200000, 23),
+							makePoints(300000, 42),
+							makePoints(400000, 911),
+						},
+						Scope:  makePtr("foo:bar,baz:ar"),
+						Metric: makePtr("mymetric"),
+					}, {
+						Points: []datadog.DataPoint{
+							makePartialPoints(10000),
+							makePoints(110000, 70),
+							makePartialPoints(20000),
+							makePoints(300000, 42),
+							makePartialPoints(40000),
+						},
+						Scope:  makePtr("foo:baz"),
+						Metric: makePtr("mymetric2"),
+					}, {
+						Points: []datadog.DataPoint{
+							makePartialPoints(10000),
+							makePoints(110000, 3),
+							makePartialPoints(20000),
+							makePartialPoints(30000),
+							makePartialPoints(40000),
+						},
+						Scope:  makePtr("ba:bar"),
+						Metric: makePtr("my.aws.metric"),
+					},
+				}, nil
+			},
+			[]string{"mymetric{foo:bar,baz:ar}", "mymetric2{foo:baz}", "my.aws.metric{ba:bar}"},
+			map[string]Point{
+				"mymetric{foo:bar,baz:ar}": {
+					value:     42,
+					valid:     true,
+					timestamp: 300,
+				},
+				"mymetric2{foo:baz}": {
+					value:     70,
+					valid:     true,
+					timestamp: 110,
+				},
+				"my.aws.metric{ba:bar}": {
+					value:     0,
+					valid:     false,
+					timestamp: time.Now().Unix(),
+				},
+			},
+			nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cl := &fakeDatadogClient{
+				queryMetricsFunc: test.queryfunc,
+			}
+			p := Processor{datadogClient: cl}
+			points, err := p.queryDatadogExternal(test.metricName)
+			if test.err != nil {
+				require.EqualError(t, test.err, err.Error())
+			}
+
+			require.Len(t, test.points, len(points))
+			for n, p := range test.points {
+				require.Equal(t, p.valid, points[n].valid)
+				require.Equal(t, p.value, points[n].value)
+				if !p.valid {
+					require.WithinDuration(t, time.Now(), time.Unix(points[n].timestamp, 0), 5*time.Second)
+				}
+			}
+		})
+	}
+}

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -9,6 +9,8 @@ package hpa
 
 import (
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,12 +18,9 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"math"
-
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"sort"
 )
 
 type DatadogClient interface {
@@ -38,7 +37,7 @@ type Processor struct {
 func NewProcessor(datadogCl DatadogClient) (*Processor, error) {
 	externalMaxAge := math.Max(config.Datadog.GetFloat64("external_metrics_provider.max_age"), 3*config.Datadog.GetFloat64("external_metrics_provider.rollup"))
 	return &Processor{
-		externalMaxAge: time.Duration(externalMaxAge) * time.Second, // Convert to int64 ?
+		externalMaxAge: time.Duration(externalMaxAge) * time.Second,
 		datadogClient:  datadogCl,
 	}, nil
 }

--- a/pkg/util/kubernetes/hpa/processor_test.go
+++ b/pkg/util/kubernetes/hpa/processor_test.go
@@ -43,6 +43,11 @@ func makePoints(ts, val int) datadog.DataPoint {
 	return datadog.DataPoint{&tsPtr, &valPtr}
 }
 
+func makePartialPoints(ts int) datadog.DataPoint {
+	tsPtr := float64(ts)
+	return datadog.DataPoint{&tsPtr, nil}
+}
+
 func makePtr(val string) *string {
 	return &val
 }


### PR DESCRIPTION
### Motivation

Relying on the very last value from the API response could lead to inconsistencies between the value collected by the cluster agent and the front end.

### What does this PR do?

In order to ensure consistency and better observability this PR introduces:
- New logic to use a rollup (configurable but not exposed in the docs)
- Adding metrics to surface the values collected and exposed to Kubernetes to autoscale.

### Details

The documentation will be improved in a follow up PR.
Users should not need to modify parameters, unless the granularity of their metrics is higher than the rollup or the query frequency. 
By default:
- A rollup of 30 seconds is used 
- The penultimate value is used. 
- Datadog is queried every 30 seconds.

Users should **not** expect sub-minute granularity. The cluster agent favours precision of a value to freshness.

New metrics are added in order to investigate:
- external_metrics_processed_value
- external_metrics_delay

These are scoped over the entire set of labels/metricname. The gist is to have a representation of what Kubernetes retrieves.
Both can be used to see how much delay the last data point has compared to the target metric's penultimate point. Also, the value can be used to compare with the upstream metric.
Nevertheless, those are not meant to be used as indicator of precision, but rather as indicator of health. 
Should you want to compare the metrics, make sure you compare apple to apple. 
A rollup of 30 seconds needs to be added to the upstream metric (the one used as a target to autoscale), the scopes should be the same and more importantly a timeshift, equivalent to the delay has to be applied. Comparing over a window that does not impact the size of the buckets.

<img width="1254" alt="image 2018-11-13 at 7 38 28 pm" src="https://user-images.githubusercontent.com/7433560/48452153-bd6f9400-e77b-11e8-9105-5aa0f7f013ff.png">

