### PR TITLE
[kerberos] adding support with libkrb5 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -464,7 +464,7 @@ dogstatsd_deb-x64:
     # Artifacts and cache must live within project directory but we run omnibus
     # from the GOPATH (see above). We then call `invoke` passing --base-dir,
     # pointing to a gitlab-friendly location.
-    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
     - dpkg -c $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb $S3_ARTEFACTS_URI/datadog-dogstatsd_amd64.deb
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
@@ -496,7 +496,7 @@ dogstatsd_rpm-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR --omnibus-s3-cache
     - rpm -i $OMNIBUS_PACKAGE_DIR/*.rpm
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
   # cache:
@@ -529,7 +529,7 @@ dogstatsd_suse-x64:
     - printf -- "$RPM_GPG_KEY" | gpg --import --batch
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.rpm_signing_key_passphrase --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - inv -e dogstatsd.omnibus-build --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION" --base-dir $OMNIBUS_BASE_DIR_SUSE --omnibus-s3-cache
     - rpm -i $OMNIBUS_PACKAGE_DIR_SUSE/*.rpm
   # TODO: enabling the cache cause builds to be slower and slower on `master`. Re-enable once this is investigated/fixed
   # cache:

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -17,6 +17,11 @@ if linux?
   dependency 'nfsiostat'
 end
 
+unless windows?
+  # need kerberos for hdfs
+  dependency 'libkrb5'
+end
+
 relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7"
 
@@ -92,18 +97,22 @@ build do
 
     all_reqs_file.close
 
+    nix_build_env = {
+      "CFLAGS" => "-I#{install_dir}/embedded/include",
+      "CXXFLAGS" => "-I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+      "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+    }
+
     # Install all the requirements
     # Install all the build requirements
-     if windows?
-       pip_args = "install --require-hashes -r #{project_dir}/check_requirements.txt"
-       command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
-     else
-       build_env = {
-         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
-       }
-       pip "install --require-hashes -r #{project_dir}/check_requirements.txt", :env => build_env
-     end
+    if windows?
+      pip_args = "install --require-hashes -r #{project_dir}/check_requirements.txt"
+      command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
+    else
+      pip "install --require-hashes -r #{project_dir}/check_requirements.txt", :env => nix_build_env
+    end
 
     # Set frozen requirements (save to var, and to file)
     # HACK: we need to do this like this due to the well known issues with omnibus
@@ -122,11 +131,7 @@ build do
       pip_args = "install pip-tools==#{PIPTOOLS_VERSION}"
       command "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe #{pip_args}"
     else
-      build_env = {
-        "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-        "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
-      }
-      pip "install pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
+      pip "install pip-tools==#{PIPTOOLS_VERSION}", :env => nix_build_env
     end
 
     # Windows pip workaround to support globs
@@ -140,11 +145,7 @@ build do
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(install_dir)}\\#{agent_requirements_file} #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\agent_requirements.in")
     else
-      build_env = {
-        "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-        "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
-      }
-      pip "install -c #{project_dir}/#{core_constraints_file} --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
+      pip "install -c #{project_dir}/#{core_constraints_file} --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/datadog_checks_base"
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{install_dir}/#{agent_requirements_file} #{project_dir}/datadog_checks_base/datadog_checks/base/data/agent_requirements.in")
     end
 
@@ -164,7 +165,7 @@ build do
     if windows?
       command("#{python_bin} -m #{python_pip_req} #{windows_safe_path(install_dir)}\\#{agent_requirements_file}")
     else
-      pip "install -c #{project_dir}/#{core_constraints_file} --require-hashes --no-deps -r #{install_dir}/#{agent_requirements_file}"
+      pip "install -c #{project_dir}/#{core_constraints_file} --require-hashes --no-deps -r #{install_dir}/#{agent_requirements_file}", :env => nix_build_env
     end
 
     # Ship requirements-agent-release.txt file containing the versions of every check shipped with the agent
@@ -228,11 +229,7 @@ build do
       if windows?
         command("#{python_bin} -m #{python_pip_no_deps}\\#{check}")
       else
-        build_env = {
-          "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-          "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
-        }
-        pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/#{check}"
+        pip "install --no-deps .", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
       end
     end
   end

--- a/releasenotes/notes/kerberos-support-with-libkrb5-dc8fd7b739047270.yaml
+++ b/releasenotes/notes/kerberos-support-with-libkrb5-dc8fd7b739047270.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adding kerberos support with libkrb5.
+enhancements:
+  - |
+    Consistent build environment for unix builds in omnibus.


### PR DESCRIPTION
### What does this PR do?

- Adds Kerberos.
- Fixes gitlab pipeline to use release.json for dogstatsd builds as well.
- Improves compilation of wheels with amended environment.

### Motivation

Requirement to ship kerberos imposed by new dependencies in integrations-core. 

### Additional Notes

`libkrb5` pulls in autoconf (maybe we can just update the builders), and the kerberos libs, adding quite a bit of weight to the RPM.

Related sister PR: https://github.com/DataDog/omnibus-software/pull/220
