### PR TITLE
Add s6 volume & squash daemonset

### DIFF
--- a/Dockerfiles/manifests/agent.yaml
+++ b/Dockerfiles/manifests/agent.yaml
@@ -16,17 +16,11 @@ spec:
         imagePullPolicy: Always
         name: datadog-agent
         ports:
-          - containerPort: 8125
-            name: dogstatsdport
-            protocol: UDP
-          - containerPort: 8126
-            name: traceport
-            protocol: TCP
+          - {containerPort: 8125, name: dogstatsdport, protocol: UDP}
+          - {containerPort: 8126, name: traceport, protocol: TCP}
         env:
-          - name: DD_API_KEY
-            value: <YOUR_API_KEY>
-          - name: KUBERNETES
-            value: "true"
+          - {name: DD_API_KEY, value: <YOUR_API_KEY>}
+          - {name: KUBERNETES, value: "true"}
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:
               fieldRef:
@@ -39,14 +33,10 @@ spec:
             memory: "256Mi"
             cpu: "200m"
         volumeMounts:
-          - name: dockersocket
-            mountPath: /var/run/docker.sock
-          - name: procdir
-            mountPath: /host/proc
-            readOnly: true
-          - name: cgroups
-            mountPath: /host/sys/fs/cgroup
-            readOnly: true
+          - {name: dockersocket, mountPath: /var/run/docker.sock}
+          - {name: procdir, mountPath: /host/proc, readOnly: true}
+          - {name: cgroups, mountPath: /host/sys/fs/cgroup, readOnly: true}
+          - {name: s6-run, mountPath: /var/run/s6}
         livenessProbe:
           exec:
             command:
@@ -55,12 +45,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 5
       volumes:
-        - hostPath:
-            path: /var/run/docker.sock
-          name: dockersocket
-        - hostPath:
-            path: /proc
-          name: procdir
-        - hostPath:
-            path: /sys/fs/cgroup
-          name: cgroups
+        - {name: dockersocket, hostPath: {path: /var/run/docker.sock}}
+        - {name: procdir, hostPath: {path: /proc}}
+        - {name: cgroups, hostPath: {path: /sys/fs/cgroup}}
+        - {name: s6-run, emptyDir: {}}


### PR DESCRIPTION
### What does this PR do?

* Add a volume for s6 run to avoid `noexec` issues on the volume
* Make some declarations oneliners for readability

### Motivation

Fix the daemonset latest cos containerd beta

### Additional Notes

Anything else we should know when reviewing?
