### PR TITLE
Deprecated logs_config.tcp_forward_port as it's no longer needed for other integrations.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -284,8 +284,6 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("log_enabled", false) // deprecated, use logs_enabled instead
 	// collect all logs from all containers:
 	config.BindEnvAndSetDefault("logs_config.container_collect_all", false)
-	// collect all logs forwarded by TCP on a specific port:
-	config.BindEnvAndSetDefault("logs_config.tcp_forward_port", -1)
 	// add a socks5 proxy:
 	config.BindEnvAndSetDefault("logs_config.socks5_proxy_address", "")
 	// send the logs to a proxy:

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -23,16 +23,6 @@ var LogsAgent = config.Datadog
 func DefaultSources() []*LogSource {
 	var sources []*LogSource
 
-	tcpForwardPort := LogsAgent.GetInt("logs_config.tcp_forward_port")
-	if tcpForwardPort > 0 {
-		// append source to collect all logs forwarded by TCP on a given port.
-		source := NewLogSource("tcp_forward", &LogsConfig{
-			Type: TCPType,
-			Port: tcpForwardPort,
-		})
-		sources = append(sources, source)
-	}
-
 	if LogsAgent.GetBool("logs_config.container_collect_all") {
 		// append a new source to collect all logs from all containers
 		source := NewLogSource("container_collect_all", &LogsConfig{

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -38,14 +38,9 @@ func TestDefaultSources(t *testing.T) {
 	LogsAgent.Set("logs_config.container_collect_all", true)
 
 	sources = DefaultSources()
-	assert.Equal(t, 2, len(sources))
+	assert.Equal(t, 1, len(sources))
 
 	source = sources[0]
-	assert.Equal(t, "tcp_forward", source.Name)
-	assert.Equal(t, TCPType, source.Config.Type)
-	assert.Equal(t, 1234, source.Config.Port)
-
-	source = sources[1]
 	assert.Equal(t, "container_collect_all", source.Name)
 	assert.Equal(t, DockerType, source.Config.Type)
 	assert.Equal(t, "docker", source.Config.Source)

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -25,7 +25,6 @@ func TestDefaultDatadogConfig(t *testing.T) {
 	assert.Equal(t, true, LogsAgent.GetBool("logs_config.dev_mode_use_proto"))
 	assert.Equal(t, 100, LogsAgent.GetInt("logs_config.open_files_limit"))
 	assert.Equal(t, 9000, LogsAgent.GetInt("logs_config.frame_size"))
-	assert.Equal(t, -1, LogsAgent.GetInt("logs_config.tcp_forward_port"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.socks5_proxy_address"))
 	assert.Equal(t, "", LogsAgent.GetString("logs_config.logs_dd_url"))
 	assert.Equal(t, false, LogsAgent.GetBool("logs_config.logs_no_ssl"))
@@ -36,7 +35,6 @@ func TestDefaultSources(t *testing.T) {
 	var sources []*LogSource
 	var source *LogSource
 
-	LogsAgent.Set("logs_config.tcp_forward_port", 1234)
 	LogsAgent.Set("logs_config.container_collect_all", true)
 
 	sources = DefaultSources()

--- a/releasenotes/notes/logs-deprecate-tcp-forward-all-26e3cbc7682d99be.yaml
+++ b/releasenotes/notes/logs-deprecate-tcp-forward-all-26e3cbc7682d99be.yaml
@@ -8,4 +8,4 @@
 ---
 deprecations:
   - |
-    Deprecated logs_config.tcp_forward_port as it's no longer needed for other integrations.
+    Removed support for logs_config.tcp_forward_port as it's no longer needed for other integrations.

--- a/releasenotes/notes/logs-deprecate-tcp-forward-all-26e3cbc7682d99be.yaml
+++ b/releasenotes/notes/logs-deprecate-tcp-forward-all-26e3cbc7682d99be.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Deprecated logs_config.tcp_forward_port as it's no longer needed for other integrations.


### PR DESCRIPTION
### What does this PR do?

Deprecate `logs_config.tcp_forward_port`

### Motivation

Clean config surface

### Additional Notes

This config should not be used.
