### PR TITLE
Avoid panicking for missing fields in HPA

### DIFF
--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -21,6 +21,11 @@ func Inspect(hpa *autoscalingv2.HorizontalPodAutoscaler) (emList []custommetrics
 	for _, metricSpec := range hpa.Spec.Metrics {
 		switch metricSpec.Type {
 		case autoscalingv2.ExternalMetricSourceType:
+			// The metricSelector and the external fields are optional. We do not support *.
+			if metricSpec.External == nil || metricSpec.External.MetricSelector == nil {
+				log.Errorf("Unexpected type for the HPA %#v, skipping processing", hpa)
+				continue
+			}
 			emList = append(emList, custommetrics.ExternalMetricValue{
 				MetricName: metricSpec.External.MetricName,
 				HPA: custommetrics.ObjectReference{

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -23,7 +23,7 @@ func Inspect(hpa *autoscalingv2.HorizontalPodAutoscaler) (emList []custommetrics
 		case autoscalingv2.ExternalMetricSourceType:
 			// The metricSelector and the external fields are optional. We do not support *.
 			if metricSpec.External == nil || metricSpec.External.MetricSelector == nil {
-				log.Errorf("Unexpected type for the HPA %#v, skipping processing", hpa)
+				log.Errorf("Missing required fields for the External Metrics template of the HPA %s/%s, skipping processing", hpa.Namespace, hpa.Name)
 				continue
 			}
 			emList = append(emList, custommetrics.ExternalMetricValue{

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -259,6 +259,34 @@ func TestInspect(t *testing.T) {
 			},
 			[]custommetrics.ExternalMetricValue{},
 		},
+		"incomplete, missing labels": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: "foo",
+							},
+						},
+					},
+				},
+			},
+			[]custommetrics.ExternalMetricValue{},
+		},
+		"incomplete, missing external metrics": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type:     autoscalingv2.ExternalMetricSourceType,
+							External: nil,
+						},
+					},
+				},
+			},
+			[]custommetrics.ExternalMetricValue{},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
### What does this PR do?

Bug reported by a user to the support team.
Because the metricsSelector field and the External metrics field are actually optionnal, this is a legit manifest:

```
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: redis-autoscaling
spec:
  minReplicas: 1
  maxReplicas: 3
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: redis
  metrics:
  - type: External
    external:
      metricName: aws.ses.max_24_hour_send
      metricSelector:
      targetAverageValue: 500
```
The external field is also optional according to the code, but the manifest does not seem to be parsed if we remove it.
Regardless, let's make sure we do not try to access nil pointers.

### Motivation

Fix.

### Additional Notes

The issue arises if one does not specify labels in the metricsSelector, this field is required for the query to be processed.
example:
```
  - type: External
    external:
      metricName: aws.ses.max_24_hour_send
      metricSelector:
        matchLabels:
            region: eu-west-1
      targetAverageValue: 500
```

