### PR TITLE
DCA: fix custom metrics server

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -50,9 +50,6 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
 # Incompatible with the custom metrics API on port 443
 # USER dd-agent
 
-# Custom metrics API server creates its certificate in the workdir
-WORKDIR /tmp
-
 # Leave following directories RW to allow use of readonly rootfs
 VOLUME ["/etc/datadog-agent", "/var/log/datadog", "/tmp"]
 

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -47,7 +47,11 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
  && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /tmp/ \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/ /tmp/
 
-USER dd-agent
+# Incompatible with the custom metrics API on port 443
+# USER dd-agent
+
+# Custom metrics API server creates its certificate in the workdir
+WORKDIR /tmp
 
 # Leave following directories RW to allow use of readonly rootfs
 VOLUME ["/etc/datadog-agent", "/var/log/datadog", "/tmp"]

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -90,6 +90,7 @@ func (a *DatadogMetricsAdapter) makeProviderOrDie() (provider.ExternalMetricsPro
 
 // Config creates the configuration containing the required parameters to communicate with the APIServer as an APIService
 func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
+	o.SecureServing.ServerCert.CertDirectory = "/etc/datadog-agent/certificates"
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		log.Errorf("Failed to create self signed AuthN/Z configuration %#v", err)
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)


### PR DESCRIPTION
- store certificates in /etc/datadog-agent, to run on read-only rootfs
- run as root by default, to use port 443
