### PR TITLE
pkg/config/legacy: enable API to support additional legacy keys from callers

### DIFF
--- a/pkg/config/legacy/tests/datadog.conf
+++ b/pkg/config/legacy/tests/datadog.conf
@@ -273,24 +273,30 @@ collect_instance_metadata: False
 # Tracing
 # ========================================================================== #
 
+[trace.config]
+env: my-env
+
 [trace.sampler]
 # Extra global sample rate to apply on all the traces
 # This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 # From 1 (no extra rate) to 0 (don't sample at all)
-# extra_sample_rate=1
+extra_sample_rate: 1.2
 
 # Maximum number of traces per second to sample.
 # The limit is applied over an average over a few minutes ; much bigger spikes are possible.
 # Set to 0 to disable the limit.
-# max_traces_per_second=10
+max_traces_per_second: 10
 
 [trace.receiver]
 # the port that the Receiver should listen on
-# receiver_port=8126
+receiver_port: 8126
 # how many unique client connections to allow during one 30 second lease period
-# connection_limit=2000
+connection_limit: 2000
 
 [trace.ignore]
 # a blacklist of regular expressions can be provided to disable certain traces based on their resource name
 # all entries must be surrounded by double quotes and separated by comas
-# resource="GET|POST /healthcheck","GET /V1"
+resource: "GET|POST /healthcheck","GET /V1"
+
+[trace.concentrator]
+bucket_size_seconds: 5


### PR DESCRIPTION
This change adds a new function (`Load`) to the `legacy` package allowing
callers to set further sections and keys from the Agent 5 configuration
onto the new configuration by means of a callback.

This is to enable agents (such as process and trace) to continue adding
new entries to the old configuration without needing to modify core
code.