### PR TITLE
Restart only the reader and not the whole tailer

### DIFF
--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -175,7 +175,7 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 		return
 	}
 
-	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID, l.registry)
+	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), container.service.CreationTime)
@@ -214,7 +214,7 @@ func (l *Launcher) restartTailer(containerID string) {
 		l.removeTailer(containerID)
 	}
 
-	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID, l.registry)
+	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), service.Before)

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -175,7 +175,7 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 		return
 	}
 
-	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
+	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID, l.registry)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), container.service.CreationTime)
@@ -214,7 +214,7 @@ func (l *Launcher) restartTailer(containerID string) {
 		l.removeTailer(containerID)
 	}
 
-	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
+	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID, l.registry)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), service.Before)


### PR DESCRIPTION
### What does this PR do?

Only restarts the reader and not the whole tailer when to docker socket timesout

### Motivation

Restarting the tailer was too spammy

### Additional Notes

The reno can be found here #2549