### PR TITLE
Allow users to change the custom metric provider port, to run as non-root

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -48,6 +48,7 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/ /tmp/
 
 # Incompatible with the custom metrics API on port 443
+# Set DD_EXTERNAL_METRICS_PROVIDER_PORT to a higher value to run as non-root
 # USER dd-agent
 
 # Leave following directories RW to allow use of readonly rootfs

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -20,6 +20,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -91,6 +92,8 @@ func (a *DatadogMetricsAdapter) makeProviderOrDie() (provider.ExternalMetricsPro
 // Config creates the configuration containing the required parameters to communicate with the APIServer as an APIService
 func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 	o.SecureServing.ServerCert.CertDirectory = "/etc/datadog-agent/certificates"
+	o.SecureServing.BindPort = config.Datadog.GetInt("external_metrics_provider.port")
+
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		log.Errorf("Failed to create self signed AuthN/Z configuration %#v", err)
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -319,6 +319,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
+	config.BindEnvAndSetDefault("external_metrics_provider.port", int64(443))
 	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)          // value in seconds. Frequency of batch calls to the ConfigMap persistent store (GlobalStore) by the Leader.
 	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)            // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -319,7 +319,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
 	config.BindEnvAndSetDefault("external_metrics_provider.enabled", false)
-	config.BindEnvAndSetDefault("external_metrics_provider.port", int64(443))
+	config.BindEnvAndSetDefault("external_metrics_provider.port", 443)
 	config.BindEnvAndSetDefault("hpa_configmap_name", "datadog-custom-metrics")
 	config.BindEnvAndSetDefault("external_metrics_provider.refresh_period", 30)          // value in seconds. Frequency of batch calls to the ConfigMap persistent store (GlobalStore) by the Leader.
 	config.BindEnvAndSetDefault("external_metrics_provider.batch_window", 10)            // value in seconds. Batch the events from the Autoscalers informer to push updates to the ConfigMap (GlobalStore)


### PR DESCRIPTION
Only root can listen on ports < 1024, we cannot use port 443 when running as the dd-agent user (or with the random UID policy in OpenShift).

This PR adds the options to use a higher port, to enable non-root operations of the custom metrics provider. I'd love to change the default instead, but that might disrupt existing deployments.