### PR TITLE
Fix flare if can't access APIServer

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/metadatamapper.tmpl
@@ -1,7 +1,8 @@
 ===============
 Metadata Mapper
 ===============
-{{- if .Errors -}}
+{{- if .Errors }}
+
 Could not run the service mapper: {{.Errors}}
 {{else}}
 {{ if .Warnings -}}

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -179,11 +179,7 @@ func zipMetadataMap(tempDir, hostname string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(f, sByte, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	return err
+	return ioutil.WriteFile(f, sByte, os.ModePerm)
 }
 
 func zipHPAStatus(tempDir, hostname string) error {


### PR DESCRIPTION
### What does this PR do?

If the Cluster Agent can't communicate with the API Server (RBAC, network ...) the flare would fail.
The logs would be explicit but it's better to still be able to generate the flare and send it to the support team.

### Motivation

Better error handlinng.
