### PR TITLE
Uninstall all datadog integrations on upgrade

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -45,9 +45,11 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         fi
     fi
 
-    echo "Resetting integrations..."
     PIP_PATH=$INSTALL_DIR/embedded/bin/pip
-    $PIP_PATH freeze | grep datadog | grep  -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q
+    if [ -x $PIP_PATH ]; then
+        echo "Resetting integrations..."
+        $PIP_PATH freeze | grep datadog | grep  -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir
+    fi
 
     if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
         # Nothing specific on Debian

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -45,6 +45,10 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         fi
     fi
 
+    echo "Resetting integrations..."
+    PIP_PATH=$INSTALL_DIR/embedded/bin/pip
+    $PIP_PATH freeze | grep datadog | grep  -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q
+
     if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
         # Nothing specific on Debian
         :

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -48,7 +48,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     PIP_PATH=$INSTALL_DIR/embedded/bin/pip
     if [ -x $PIP_PATH ]; then
         echo "Resetting integrations..."
-        $PIP_PATH freeze | grep datadog | grep  -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir
+        $PIP_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir || true
     fi
 
     if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then


### PR DESCRIPTION
### What does this PR do?

Uninstall all datadog integrations on upgrade

### Motivation

After an upgrade we want the installed integrations versions to be always the ones that ship with the agent package

### QA

- Install both previous and later integration versions with the `integration` command
- Upgrade the agent to a version with this change (the old version doesn't have to have it)
- Check that no leftover files are left (duplicate metadata folders for example)

It should support deb and rpm package formats