### PR TITLE
Make getMainEndpoint public to be able to use it from other agents

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -472,7 +472,7 @@ func sanitizeAPIKey(config Config) {
 
 // GetMainInfraEndpoint returns the main DD Infra URL defined in the config, based on the value of `site` and `dd_url`
 func GetMainInfraEndpoint() string {
-	return getMainInfraEndpoint(Datadog)
+	return getMainInfraEndpointWithConfig(Datadog)
 }
 
 // GetMainEndpoint returns the main DD URL defined in the config, based on `site` and the prefix, or ddURLKey
@@ -482,7 +482,7 @@ func GetMainEndpoint(prefix string, ddURLKey string) string {
 
 // GetMultipleEndpoints returns the api keys per domain specified in the main agent config
 func GetMultipleEndpoints() (map[string][]string, error) {
-	return getMultipleEndpoints(Datadog)
+	return getMultipleEndpointsWithConfig(Datadog)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z
@@ -510,7 +510,7 @@ func AddAgentVersionToDomain(DDURL string, app string) (string, error) {
 	return u.String(), nil
 }
 
-func getMainInfraEndpoint(config Config) string {
+func getMainInfraEndpointWithConfig(config Config) string {
 	return GetMainEndpointWithConfig(config, infraURLPrefix, "dd_url")
 }
 
@@ -530,10 +530,10 @@ func GetMainEndpointWithConfig(config Config, prefix string, ddURLKey string) (r
 	return
 }
 
-// getMultipleEndpoints implements the logic to extract the api keys per domain from an agent config
-func getMultipleEndpoints(config Config) (map[string][]string, error) {
+// getMultipleEndpointsWithConfig implements the logic to extract the api keys per domain from an agent config
+func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) {
 	// Validating domain
-	ddURL := getMainInfraEndpoint(config)
+	ddURL := getMainInfraEndpointWithConfig(config)
 	_, err := url.Parse(ddURL)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse main endpoint: %s", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -477,7 +477,7 @@ func GetMainInfraEndpoint() string {
 
 // GetMainEndpoint returns the main DD URL defined in the config, based on `site` and the prefix, or ddURLKey
 func GetMainEndpoint(prefix string, ddURLKey string) string {
-	return getMainEndpoint(Datadog, prefix, ddURLKey)
+	return GetMainEndpointWithConfig(Datadog, prefix, ddURLKey)
 }
 
 // GetMultipleEndpoints returns the api keys per domain specified in the main agent config
@@ -511,11 +511,11 @@ func AddAgentVersionToDomain(DDURL string, app string) (string, error) {
 }
 
 func getMainInfraEndpoint(config Config) string {
-	return getMainEndpoint(config, infraURLPrefix, "dd_url")
+	return GetMainEndpointWithConfig(config, infraURLPrefix, "dd_url")
 }
 
-// getMainEndpoint implements the logic to extract the DD URL from a config, based on `site` and ddURLKey
-func getMainEndpoint(config Config, prefix string, ddURLKey string) (resolvedDDURL string) {
+// GetMainEndpointWithConfig implements the logic to extract the DD URL from a config, based on `site` and ddURLKey
+func GetMainEndpointWithConfig(config Config, prefix string, ddURLKey string) (resolvedDDURL string) {
 	if config.IsSet(ddURLKey) && config.GetString(ddURLKey) != "" {
 		// value under ddURLKey takes precedence over 'site'
 		resolvedDDURL = config.GetString(ddURLKey)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,7 +46,7 @@ api_key: fakeapikey
 	testConfig := setupConfFromYAML(datadogYaml)
 
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
-	externalAgentURL := getMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
+	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.com": {
@@ -67,7 +67,7 @@ api_key: fakeapikey
 	testConfig := setupConfFromYAML(datadogYaml)
 
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
-	externalAgentURL := getMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
+	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.eu": {
@@ -88,7 +88,7 @@ func TestSiteEnvVar(t *testing.T) {
 	testConfig := setupConfFromYAML("")
 
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
-	externalAgentURL := getMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
+	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.eu": {
@@ -112,7 +112,7 @@ func TestDDURLEnvVar(t *testing.T) {
 	testConfig.BindEnv("external_config.external_agent_dd_url")
 
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
-	externalAgentURL := getMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
+	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.eu": {
@@ -137,7 +137,7 @@ external_config:
 	testConfig := setupConfFromYAML(datadogYaml)
 
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
-	externalAgentURL := getMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
+	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.com": {
@@ -161,7 +161,7 @@ external_config:
 	testConfig := setupConfFromYAML(datadogYaml)
 
 	multipleEndpoints, err := getMultipleEndpoints(testConfig)
-	externalAgentURL := getMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
+	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.eu": {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,7 +45,7 @@ api_key: fakeapikey
 `
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
@@ -66,7 +66,7 @@ api_key: fakeapikey
 `
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
@@ -87,7 +87,7 @@ func TestSiteEnvVar(t *testing.T) {
 	defer os.Unsetenv("DD_SITE")
 	testConfig := setupConfFromYAML("")
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
@@ -111,7 +111,7 @@ func TestDDURLEnvVar(t *testing.T) {
 	testConfig := setupConfFromYAML("")
 	testConfig.BindEnv("external_config.external_agent_dd_url")
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
@@ -136,7 +136,7 @@ external_config:
 `
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
@@ -160,7 +160,7 @@ external_config:
 `
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 	externalAgentURL := GetMainEndpointWithConfig(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
 
 	expectedMultipleEndpoints := map[string][]string{
@@ -188,7 +188,7 @@ additional_endpoints:
 
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://foo.datadoghq.com": {
@@ -220,7 +220,7 @@ additional_endpoints:
 
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.eu": {
@@ -254,7 +254,7 @@ additional_endpoints:
 
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://foo.datadoghq.com": {
@@ -279,7 +279,7 @@ api_key: fakeapikey
 
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.com": {
@@ -307,7 +307,7 @@ additional_endpoints:
 
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.com": {
@@ -340,7 +340,7 @@ additional_endpoints:
 
 	testConfig := setupConfFromYAML(datadogYaml)
 
-	multipleEndpoints, err := getMultipleEndpoints(testConfig)
+	multipleEndpoints, err := getMultipleEndpointsWithConfig(testConfig)
 
 	expectedMultipleEndpoints := map[string][]string{
 		"https://app.datadoghq.com": {


### PR DESCRIPTION
### What does this PR do?

Make getMainEndpoint public to be able to use it from other agents

### Motivation

Currently migrating the process-agent to use the `datadog-agent/pkg/config` package and needed to tests configs (passing a custom Config)

### Additional Notes

Related changes on the process-agent: https://github.com/DataDog/datadog-process-agent/pull/210