### PR TITLE
add region tag to fargate containers

### DIFF
--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -36,6 +36,12 @@ func (c *ECSFargateCollector) parseMetadata(meta ecs.TaskMetadata, parseAll bool
 			// cluster
 			tags.AddLow("cluster_name", parseECSClusterName(meta.ClusterName))
 
+			// aws region from cluster arn
+			region := parseFargateRegion(meta.ClusterName)
+			if region != "" {
+				tags.AddLow("region", region)
+			}
+
 			// task
 			tags.AddLow("task_family", meta.Family)
 			tags.AddLow("task_version", meta.Version)
@@ -88,4 +94,22 @@ func parseECSClusterName(value string) string {
 	} else {
 		return value
 	}
+}
+
+func parseFargateRegion(arn string) string {
+	arnParts := strings.Split(arn, ":")
+	if len(arnParts) < 4 {
+		return ""
+	}
+	if arnParts[0] != "arn" || arnParts[1] != "aws" {
+		return ""
+	}
+	region := arnParts[3]
+
+	// Sanity check
+	if strings.Count(region, "-") != 2 {
+		return ""
+	}
+
+	return region
 }

--- a/pkg/tagger/collectors/ecs_fargate_extract.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract.go
@@ -107,7 +107,7 @@ func parseFargateRegion(arn string) string {
 	region := arnParts[3]
 
 	// Sanity check
-	if strings.Count(region, "-") != 2 {
+	if strings.Count(region, "-") < 2 {
 		return ""
 	}
 

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -31,6 +31,17 @@ func TestParseECSClusterName(t *testing.T) {
 	}
 }
 
+func TestParseFargateRegion(t *testing.T) {
+	cases := map[string]string{
+		"old-cluster-name-09":                                          "",
+		"arn:aws:ecs:eu-central-1:601427279990:cluster/xvello-fargate": "eu-central-1",
+	}
+
+	for value, expected := range cases {
+		assert.Equal(t, expected, parseFargateRegion(value))
+	}
+}
+
 func TestParseMetadata(t *testing.T) {
 	raw, err := ioutil.ReadFile("./testdata/fargate_meta.json")
 	require.NoError(t, err)
@@ -64,6 +75,7 @@ func TestParseMetadata(t *testing.T) {
 				"task_family:redis-datadog",
 				"task_version:3",
 				"ecs_container_name:datadog-agent",
+				"region:eu-central-1",
 			},
 			HighCardTags: []string{
 				"container_id:1cd08ea0fc13ee643fa058a8e184861661eb29325c7df59ccc543597018ffcd4",
@@ -85,6 +97,7 @@ func TestParseMetadata(t *testing.T) {
 				"task_version:3",
 				"ecs_container_name:redis",
 				"lowtag:myvalue",
+				"region:eu-central-1",
 			},
 			HighCardTags: []string{
 				"container_name:ecs-redis-datadog-3-redis-f6eedfd8b18a8fbe1d00",

--- a/pkg/tagger/collectors/ecs_fargate_extract_test.go
+++ b/pkg/tagger/collectors/ecs_fargate_extract_test.go
@@ -33,8 +33,9 @@ func TestParseECSClusterName(t *testing.T) {
 
 func TestParseFargateRegion(t *testing.T) {
 	cases := map[string]string{
-		"old-cluster-name-09":                                          "",
-		"arn:aws:ecs:eu-central-1:601427279990:cluster/xvello-fargate": "eu-central-1",
+		"old-cluster-name-09":                                           "",
+		"arn:aws:ecs:eu-central-1:601427279990:cluster/xvello-fargate":  "eu-central-1",
+		"arn:aws:ecs:us-gov-east-1:601427279990:cluster/xvello-fargate": "us-gov-east-1",
 	}
 
 	for value, expected := range cases {

--- a/releasenotes/notes/fargate-region-tag-075a2072619dbba8.yaml
+++ b/releasenotes/notes/fargate-region-tag-075a2072619dbba8.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    Added a ``region`` tag to Fargate containers, indicating the AWS region
+    they run in


### PR DESCRIPTION
### What does this PR do?

Fargate API 1.1+ exposes the cluster name as a full ARN with region name. Parse it to add a new `region` tag to fargate containers. AZ is unfortunately not available.

Not adding it to ECS clusters, as this would be a duplicate of the host tag added by our AWS crawler.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
