### PR TITLE
Disable cluster checks in cluster-agent 1.1.x

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -20,7 +20,7 @@ BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
-    "clusterchecks",
+    # "clusterchecks",
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Turn off the `clusterchecks` build tag for the `1.1.x` series. We will target 1.2.x for them.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
