### PR TITLE
Validate the cluster agent client in init

### DIFF
--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -93,6 +93,13 @@ func (c *DCAClient) init() error {
 	c.clusterAgentAPIClient = util.GetClient(false)
 	c.clusterAgentAPIClient.Timeout = 2 * time.Second
 
+	// Validate the cluster-agent client by checking the version
+	ver, err := c.GetVersion()
+	if err != nil {
+		return err
+	}
+	log.Infof("Successfully connected to the Datadog Cluster Agent %v", ver)
+
 	// Clone the http client in a new client with built-in redirect handler
 	c.leaderClient = newLeaderClient(c.clusterAgentAPIClient, c.ClusterAgentAPIEndpoint)
 

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -43,6 +43,7 @@ type DCAClient struct {
 	initRetry retry.Retrier
 
 	ClusterAgentAPIEndpoint       string // ${SCHEME}://${clusterAgentHost}:${PORT}
+	ClusterAgentVersion           string // Version of the cluster-agent we're connected to
 	clusterAgentAPIClient         *http.Client
 	clusterAgentAPIRequestHeaders http.Header
 	leaderClient                  *leaderClient
@@ -94,11 +95,11 @@ func (c *DCAClient) init() error {
 	c.clusterAgentAPIClient.Timeout = 2 * time.Second
 
 	// Validate the cluster-agent client by checking the version
-	ver, err := c.GetVersion()
+	c.ClusterAgentVersion, err = c.GetVersion()
 	if err != nil {
 		return err
 	}
-	log.Infof("Successfully connected to the Datadog Cluster Agent %v", ver)
+	log.Infof("Successfully connected to the Datadog Cluster Agent %v", c.ClusterAgentVersion)
 
 	// Clone the http client in a new client with built-in redirect handler
 	c.leaderClient = newLeaderClient(c.clusterAgentAPIClient, c.ClusterAgentAPIEndpoint)

--- a/pkg/util/clusteragent/clusterchecks_test.go
+++ b/pkg/util/clusteragent/clusterchecks_test.go
@@ -84,13 +84,16 @@ func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	ca, err := GetClusterAgentClient()
 	require.NoError(suite.T(), err)
 
+	// checking version on init
+	assert.NotNil(suite.T(), follower.PopRequest(), "request did not go through follower")
+
 	// First request will be redirected
 	response, err := ca.PostClusterCheckStatus("mynode", types.NodeStatus{})
 	require.NoError(suite.T(), err)
 	assert.True(suite.T(), response.IsUpToDate)
 
-	assert.NotNil(suite.T(), follower.PopRequest(), "request did no go through follower")
-	assert.NotNil(suite.T(), leader.PopRequest(), "request did no reach leader")
+	assert.NotNil(suite.T(), follower.PopRequest(), "request did not go through follower")
+	assert.NotNil(suite.T(), leader.PopRequest(), "request did not reach leader")
 
 	// Subsequent requests will bypass the follower
 	configs, err := ca.GetClusterCheckConfigs("mynode")
@@ -101,7 +104,7 @@ func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	assert.Equal(suite.T(), "two", configs.Configs[1].Name)
 
 	assert.Nil(suite.T(), follower.PopRequest(), "request reached follower")
-	assert.NotNil(suite.T(), leader.PopRequest(), "request did no reach leader")
+	assert.NotNil(suite.T(), leader.PopRequest(), "request did not reach leader")
 
 	// Make leader fail, request will be retried on the main URL,
 	// and succeed on the new leader
@@ -115,6 +118,6 @@ func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	response, err = ca.PostClusterCheckStatus("mynode", types.NodeStatus{})
 	require.NoError(suite.T(), err, "request should not fail")
 	assert.False(suite.T(), response.IsUpToDate)
-	assert.NotNil(suite.T(), leader.PopRequest(), "request did no reach leader")
+	assert.NotNil(suite.T(), leader.PopRequest(), "request did not reach leader")
 	assert.NotNil(suite.T(), follower.PopRequest(), "request did not reach follower")
 }

--- a/releasenotes/notes/cluster-agent-init-f09b65c2920794be.yaml
+++ b/releasenotes/notes/cluster-agent-init-f09b65c2920794be.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    The cluster agent client init now fail as expected if the
+    The cluster agent client init now fails as expected if the
     cluster agent URL is not valid
 upgrade:
   - |

--- a/releasenotes/notes/cluster-agent-init-f09b65c2920794be.yaml
+++ b/releasenotes/notes/cluster-agent-init-f09b65c2920794be.yaml
@@ -3,3 +3,7 @@ fixes:
   - |
     The cluster agent client init now fail as expected if the
     cluster agent URL is not valid
+upgrade:
+  - |
+    The agent now requires a cluster agent version 1.0+ to establish
+    a valid connection

--- a/releasenotes/notes/cluster-agent-init-f09b65c2920794be.yaml
+++ b/releasenotes/notes/cluster-agent-init-f09b65c2920794be.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The cluster agent client init now fail as expected if the
+    cluster agent URL is not valid

--- a/releasenotes/notes/fix-dca-client-init-995558749ab988e1.yaml
+++ b/releasenotes/notes/fix-dca-client-init-995558749ab988e1.yaml
@@ -1,5 +1,0 @@
----
-upgrade:
-  - |
-    The agent now requires a cluster agent vesion 1.0+ to establish
-    a valid connection

--- a/releasenotes/notes/fix-dca-client-init-995558749ab988e1.yaml
+++ b/releasenotes/notes/fix-dca-client-init-995558749ab988e1.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The agent now requires a cluster agent vesion 1.0+ to establish
+    a valid connection


### PR DESCRIPTION
### What does this PR do?

Validate fully the cluster-agent client by checking the version

### Motivation

Avoid initializing cluster-agent client with an invalid URL

