### PR TITLE
Cluster-checks: handle leader election and follower->leader redirection

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -123,8 +123,8 @@ func writeJSONResponse(w http.ResponseWriter, data interface{}) {
 	w.WriteHeader(http.StatusNotFound)
 }
 
-// redirectToLeader handles the logic for followers to transparently
-// redirect the requests to the leader cluster-agent
+// shouldHandle is common code to handle redirection and errors
+// due to the handler state
 func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handler) bool {
 	code, reason := h.ShouldHandle()
 
@@ -132,11 +132,13 @@ func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handl
 	case http.StatusOK:
 		return true
 	case http.StatusFound:
+		// Redirection to leader
 		url := r.URL
 		url.Host = reason
 		http.Redirect(w, r, url.String(), http.StatusFound)
 		return false
 	default:
+		// Unexpected error
 		http.Error(w, reason, code)
 		return false
 	}

--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -34,7 +34,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !shouldHandle(w, r, sc.ClusterCheckHandler) {
+		if !shouldHandle(w, r, sc.ClusterCheckHandler, "postCheckStatus") {
 			return
 		}
 
@@ -46,16 +46,18 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 		err := decoder.Decode(&status)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			incrementRequestMetric("postCheckStatus", http.StatusInternalServerError)
 			return
 		}
 
 		response, err := sc.ClusterCheckHandler.PostStatus(nodeName, status)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			incrementRequestMetric("postCheckStatus", http.StatusInternalServerError)
 			return
 		}
 
-		writeJSONResponse(w, response)
+		writeJSONResponse(w, response, "postCheckStatus")
 	}
 }
 
@@ -68,7 +70,7 @@ func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !shouldHandle(w, r, sc.ClusterCheckHandler) {
+		if !shouldHandle(w, r, sc.ClusterCheckHandler, "getCheckConfigs") {
 			return
 		}
 
@@ -77,10 +79,11 @@ func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 		response, err := sc.ClusterCheckHandler.GetConfigs(nodeName)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			incrementRequestMetric("getCheckConfigs", http.StatusInternalServerError)
 			return
 		}
 
-		writeJSONResponse(w, response)
+		writeJSONResponse(w, response, "getCheckConfigs")
 	}
 }
 
@@ -93,39 +96,43 @@ func getAllCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWrite
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !shouldHandle(w, r, sc.ClusterCheckHandler) {
+		if !shouldHandle(w, r, sc.ClusterCheckHandler, "getAllCheckConfigs") {
 			return
 		}
 
 		response, err := sc.ClusterCheckHandler.GetAllConfigs()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			incrementRequestMetric("getAllCheckConfigs", http.StatusInternalServerError)
 			return
 		}
 
-		writeJSONResponse(w, response)
+		writeJSONResponse(w, response, "getAllCheckConfigs")
 	}
 }
 
 // writeJSONResponse serialises and writes data to the response
-func writeJSONResponse(w http.ResponseWriter, data interface{}) {
+func writeJSONResponse(w http.ResponseWriter, data interface{}, handler string) {
 	slcB, err := json.Marshal(data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		incrementRequestMetric(handler, http.StatusInternalServerError)
 		return
 	}
 
 	if len(slcB) != 0 {
 		w.WriteHeader(http.StatusOK)
 		w.Write(slcB)
+		incrementRequestMetric(handler, http.StatusOK)
 		return
 	}
 	w.WriteHeader(http.StatusNotFound)
+	incrementRequestMetric(handler, http.StatusNotFound)
 }
 
 // shouldHandle is common code to handle redirection and errors
 // due to the handler state
-func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handler) bool {
+func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handler, handler string) bool {
 	code, reason := h.ShouldHandle()
 
 	switch code {
@@ -136,10 +143,12 @@ func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handl
 		url := r.URL
 		url.Host = reason
 		http.Redirect(w, r, url.String(), http.StatusFound)
+		incrementRequestMetric(handler, http.StatusFound)
 		return false
 	default:
 		// Unexpected error
 		http.Error(w, reason, code)
+		incrementRequestMetric(handler, code)
 		return false
 	}
 }

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -33,6 +33,10 @@ func init() {
 	prometheus.MustRegister(apiRequests)
 }
 
+func incrementRequestMetric(handler string, status int) {
+	apiRequests.WithLabelValues(handler, strconv.Itoa(status)).Inc()
+}
+
 // Install registers v1 API endpoints
 func Install(r *mux.Router, sc clusteragent.ServerContext) {
 	r.HandleFunc("/tags/pod/{nodeName}/{ns}/{podName}", getPodMetadata).Methods("GET")

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -8,20 +8,37 @@
 package clusterchecks
 
 import (
+	"net/http"
+
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 )
 
-// TODO: handle non-leader / warmup phases, handler methods will
-// become more complex at that stage
+const notReadyReason = "Startup in progress"
 
-// ShouldRedirect returns the leader's hostname if the cluster-agent
-// is currently a follower, or an empty string if we should handle the query
-func (h *Handler) ShouldRedirect() string {
-	return ""
+// ShouldHandle indicates whether the cluster-agent should serve cluster-check
+// requests. Current known responses:
+//   - 302, string: follower, leader IP in string
+//   - 503, string: not ready, error string returned
+//   - 200, "": leader and ready for serving requests
+func (h *Handler) ShouldHandle() (int, string) {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
+	switch h.state {
+	case leader:
+		return http.StatusOK, ""
+	case follower:
+		return http.StatusFound, h.leaderIP
+	default:
+		return http.StatusServiceUnavailable, notReadyReason
+	}
 }
 
 // GetAllConfigs returns all configurations known to the store, for reporting
 func (h *Handler) GetAllConfigs() (types.ConfigResponse, error) {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
 	configs, err := h.dispatcher.getAllConfigs()
 	response := types.ConfigResponse{
 		Configs: configs,
@@ -31,6 +48,9 @@ func (h *Handler) GetAllConfigs() (types.ConfigResponse, error) {
 
 // GetConfigs returns configurations dispatched to a given node
 func (h *Handler) GetConfigs(nodeName string) (types.ConfigResponse, error) {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
 	configs, lastChange, err := h.dispatcher.getNodeConfigs(nodeName)
 	response := types.ConfigResponse{
 		Configs:    configs,
@@ -41,10 +61,19 @@ func (h *Handler) GetConfigs(nodeName string) (types.ConfigResponse, error) {
 
 // PostStatus handles status reports from the node agents
 func (h *Handler) PostStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
+	select {
+	case h.nodeStatusChan <- struct{}{}:
+	default:
+	}
+
 	upToDate, err := h.dispatcher.processNodeStatus(nodeName, status)
 
 	response := types.StatusResponse{
 		IsUpToDate: upToDate,
 	}
+
 	return response, err
 }

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -59,6 +59,5 @@ func (h *Handler) PostStatus(nodeName string, status types.NodeStatus) (types.St
 	response := types.StatusResponse{
 		IsUpToDate: upToDate,
 	}
-
 	return response, err
 }

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -36,9 +36,6 @@ func (h *Handler) ShouldHandle() (int, string) {
 
 // GetAllConfigs returns all configurations known to the store, for reporting
 func (h *Handler) GetAllConfigs() (types.ConfigResponse, error) {
-	h.m.RLock()
-	defer h.m.RUnlock()
-
 	configs, err := h.dispatcher.getAllConfigs()
 	response := types.ConfigResponse{
 		Configs: configs,
@@ -48,9 +45,6 @@ func (h *Handler) GetAllConfigs() (types.ConfigResponse, error) {
 
 // GetConfigs returns configurations dispatched to a given node
 func (h *Handler) GetConfigs(nodeName string) (types.ConfigResponse, error) {
-	h.m.RLock()
-	defer h.m.RUnlock()
-
 	configs, lastChange, err := h.dispatcher.getNodeConfigs(nodeName)
 	response := types.ConfigResponse{
 		Configs:    configs,
@@ -61,9 +55,6 @@ func (h *Handler) GetConfigs(nodeName string) (types.ConfigResponse, error) {
 
 // PostStatus handles status reports from the node agents
 func (h *Handler) PostStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
-	h.m.RLock()
-	defer h.m.RUnlock()
-
 	upToDate, err := h.dispatcher.processNodeStatus(nodeName, status)
 	response := types.StatusResponse{
 		IsUpToDate: upToDate,

--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -64,13 +64,7 @@ func (h *Handler) PostStatus(nodeName string, status types.NodeStatus) (types.St
 	h.m.RLock()
 	defer h.m.RUnlock()
 
-	select {
-	case h.nodeStatusChan <- struct{}{}:
-	default:
-	}
-
 	upToDate, err := h.dispatcher.processNodeStatus(nodeName, status)
-
 	response := types.StatusResponse{
 		IsUpToDate: upToDate,
 	}

--- a/pkg/clusteragent/clusterchecks/api_test.go
+++ b/pkg/clusteragent/clusterchecks/api_test.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build clusterchecks
+
+package clusterchecks
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+func TestShouldHandle(t *testing.T) {
+	h := &Handler{}
+
+	// Initial state
+	code, reason := h.ShouldHandle()
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, notReadyReason, reason)
+
+	// Leader and ready
+	h.state = leader
+	h.dispatcher = newDispatcher()
+	code, reason = h.ShouldHandle()
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "", reason)
+
+	// Follower with an active dispatcher (ongoing stop)
+	h.state = follower
+	h.leaderIP = "1.2.3.4"
+	h.dispatcher = newDispatcher()
+	code, reason = h.ShouldHandle()
+	assert.Equal(t, http.StatusFound, code)
+	assert.Equal(t, "1.2.3.4", reason)
+
+	// Follower
+	h.leaderIP = "1.2.3.4"
+	h.dispatcher = nil
+	code, reason = h.ShouldHandle()
+	assert.Equal(t, http.StatusFound, code)
+	assert.Equal(t, "1.2.3.4", reason)
+}
+
+func TestPostStatusNonBlocking(t *testing.T) {
+	h := &Handler{
+		dispatcher:     newDispatcher(),
+		nodeStatusChan: make(chan struct{}, 1),
+	}
+
+	nodes := []string{"a", "b", "c", "d"}
+
+	for _, n := range nodes {
+		// Run the health status in a goroutine
+		ch := make(chan struct{}, 1)
+		go func() {
+			h.PostStatus(n, types.NodeStatus{})
+			ch <- struct{}{}
+		}()
+
+		select {
+		case <-ch:
+			break
+		case <-time.After(50 * time.Millisecond):
+			assert.Fail(t, fmt.Sprintf("Status for node %q was blocking", n))
+		}
+	}
+
+	select {
+	case <-h.nodeStatusChan:
+		break
+	case <-time.After(50 * time.Millisecond):
+		assert.Fail(t, "Timeout while waiting for channel message")
+	}
+}

--- a/pkg/clusteragent/clusterchecks/api_test.go
+++ b/pkg/clusteragent/clusterchecks/api_test.go
@@ -24,22 +24,13 @@ func TestShouldHandle(t *testing.T) {
 
 	// Leader and ready
 	h.state = leader
-	h.dispatcher = newDispatcher()
 	code, reason = h.ShouldHandle()
 	assert.Equal(t, http.StatusOK, code)
 	assert.Equal(t, "", reason)
 
-	// Follower with an active dispatcher (ongoing stop)
+	// Follower
 	h.state = follower
 	h.leaderIP = "1.2.3.4"
-	h.dispatcher = newDispatcher()
-	code, reason = h.ShouldHandle()
-	assert.Equal(t, http.StatusFound, code)
-	assert.Equal(t, "1.2.3.4", reason)
-
-	// Follower
-	h.leaderIP = "1.2.3.4"
-	h.dispatcher = nil
 	code, reason = h.ShouldHandle()
 	assert.Equal(t, http.StatusFound, code)
 	assert.Equal(t, "1.2.3.4", reason)

--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -8,11 +8,15 @@
 package clusterchecks
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 )
 
 type lockable interface {
@@ -70,4 +74,66 @@ func TestLocked(t *testing.T) {
 func TestStoreNotLocked(t *testing.T) {
 	s := newClusterStore()
 	requireNotLocked(t, s)
+}
+
+type mockedPluggableAutoConfig struct {
+	mock.Mock
+}
+
+func (m *mockedPluggableAutoConfig) AddScheduler(name string, s scheduler.Scheduler, replay bool) {
+	m.Called(name, s, replay)
+	return
+}
+
+func (m *mockedPluggableAutoConfig) RemoveScheduler(name string) {
+	m.Called(name)
+	return
+}
+
+// assertTrueBeforeTimeout regularly checks whether a condition is met. It
+// does so until a timeout is reached, in which case it makes the test fail.
+// Condition is evaluated in a goroutine to avoid tests hanging if a system
+// is deadlocked.
+func assertTrueBeforeTimeout(t *testing.T, frequency, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ok := make(chan struct{}, 1)
+	var ranOnce bool
+
+	go func() {
+		// Try once immediately
+		if condition() {
+			ok <- struct{}{}
+			return
+		}
+
+		// Retry until timeout
+		checkTicker := time.NewTicker(frequency)
+		defer checkTicker.Stop()
+		for {
+			select {
+			case <-checkTicker.C:
+				if condition() {
+					ok <- struct{}{}
+					return
+				}
+				ranOnce = true
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ok:
+		return
+	case <-ctx.Done():
+		if ranOnce {
+			assert.Fail(t, "Timeout waiting for condition to happen, function returned false")
+		} else {
+			assert.Fail(t, "Timeout waiting for condition to happen, function never returned")
+		}
+		return
+	}
 }

--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -139,3 +139,22 @@ func assertTrueBeforeTimeout(t *testing.T, frequency, timeout time.Duration, con
 		}
 	}
 }
+
+type fakeLeaderEngine struct {
+	sync.Mutex
+	ip  string
+	err error
+}
+
+func (e *fakeLeaderEngine) get() (string, error) {
+	e.Lock()
+	defer e.Unlock()
+	return e.ip, e.err
+}
+
+func (e *fakeLeaderEngine) set(ip string, err error) {
+	e.Lock()
+	defer e.Unlock()
+	e.ip = ip
+	e.err = err
+}

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -77,6 +77,13 @@ func (d *dispatcher) remove(config integration.Config) {
 	d.removeConfig(digest)
 }
 
+// reset empties the store and resets all states
+func (d *dispatcher) reset() {
+	d.store.Lock()
+	defer d.store.Unlock()
+	d.store.reset()
+}
+
 // run is the main management goroutine for the dispatcher
 func (d *dispatcher) run(ctx context.Context) {
 	d.store.Lock()

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -77,9 +77,12 @@ func (d *dispatcher) remove(config integration.Config) {
 	d.removeConfig(digest)
 }
 
-// cleanupLoop is the cleanup goroutine for the dispatcher.
-// It has to be called in a goroutine with a cancellable context.
-func (d *dispatcher) cleanupLoop(ctx context.Context) {
+// run is the main management goroutine for the dispatcher
+func (d *dispatcher) run(ctx context.Context) {
+	d.store.Lock()
+	d.store.active = true
+	d.store.Unlock()
+
 	healthProbe := health.Register("clusterchecks-dispatch")
 	defer health.Deregister(healthProbe)
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -36,11 +36,12 @@ func (d *dispatcher) processNodeStatus(nodeName string, status types.NodeStatus)
 	var upToDate bool
 
 	d.store.Lock()
-	node := d.store.getOrCreateNodeStore(nodeName)
 	if !d.store.active {
-		// Keep node-agent caches up during warmup phase
+		// Keep node-agent caches up during warmup phase,
+		// but continue processing the node status.
 		upToDate = true
 	}
+	node := d.store.getOrCreateNodeStore(nodeName)
 	d.store.Unlock()
 
 	node.Lock()

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -270,7 +270,7 @@ func TestReset(t *testing.T) {
 	stored, err := dispatcher.getAllConfigs()
 	assert.NoError(t, err)
 	assert.Len(t, stored, 0)
-	configs1, _, err = dispatcher.getNodeConfigs("node1")
+	_, _, err = dispatcher.getNodeConfigs("node1")
 	assert.EqualError(t, err, "node node1 is unknown")
 
 	requireNotLocked(t, dispatcher.store)

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -252,5 +252,26 @@ func TestDanglingConfig(t *testing.T) {
 	configs := dispatcher.retrieveAndClearDangling()
 	assert.Equal(t, []integration.Config{config}, configs)
 	assert.Equal(t, 0, len(dispatcher.store.danglingConfigs))
+}
 
+func TestReset(t *testing.T) {
+	dispatcher := newDispatcher()
+	config := generateIntegration("cluster-check")
+
+	// Register to node1
+	dispatcher.addConfig(config, "node1")
+	configs1, _, err := dispatcher.getNodeConfigs("node1")
+	assert.NoError(t, err)
+	assert.Len(t, configs1, 1)
+	assert.Contains(t, configs1, config)
+
+	// Reset
+	dispatcher.reset()
+	stored, err := dispatcher.getAllConfigs()
+	assert.NoError(t, err)
+	assert.Len(t, stored, 0)
+	configs1, _, err = dispatcher.getNodeConfigs("node1")
+	assert.EqualError(t, err, "node node1 is unknown")
+
+	requireNotLocked(t, dispatcher.store)
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -98,10 +98,9 @@ func TestScheduleReschedule(t *testing.T) {
 
 func TestProcessNodeStatus(t *testing.T) {
 	dispatcher := newDispatcher()
+	status1 := types.NodeStatus{LastChange: 10}
 
-	status1 := types.NodeStatus{LastChange: 0}
-
-	// Initial node register
+	// Warmup phase, upToDate is unconditionally true
 	upToDate, err := dispatcher.processNodeStatus("node1", status1)
 	assert.NoError(t, err)
 	assert.True(t, upToDate)
@@ -110,6 +109,12 @@ func TestProcessNodeStatus(t *testing.T) {
 	assert.Equal(t, status1, node1.lastStatus)
 	assert.True(t, timestampNow() >= node1.heartbeat)
 	assert.True(t, timestampNow() <= node1.heartbeat+1)
+
+	// Warmup is finished, timestamps differ
+	dispatcher.store.active = true
+	upToDate, err = dispatcher.processNodeStatus("node1", status1)
+	assert.NoError(t, err)
+	assert.False(t, upToDate)
 
 	// Give changes
 	node1.lastConfigChange = timestampNow()

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -187,13 +187,14 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 //   - true: becoming leader
 //   - false: lost leadership
 func (h *Handler) updateLeaderIP(firstRun bool) error {
-	h.m.Lock()
-	defer h.m.Unlock()
-
 	newIP, err := h.leaderStatusCallback()
 	if err != nil {
 		return err
 	}
+
+	// Lock after the kubernetes call returns, leaderStatusCallback is constant
+	h.m.Lock()
+	defer h.m.Unlock()
 
 	// Fast exit if no change
 	if !firstRun && (newIP == h.leaderIP) {

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -11,61 +11,230 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
 	schedulerName = "clusterchecks"
 )
 
+type state int
+
+const (
+	unknown state = iota
+	leader
+	follower
+)
+
+// leaderIPCallback describes the leader-election method we
+// need and allows to inject a custom one for tests
+type leaderIPCallback func() (string, error)
+
+// pluggableAutoConfig describes the AC methods we use and allows
+// to mock it for tests (see mockedPluggableAutoConfig)
+type pluggableAutoConfig interface {
+	AddScheduler(string, scheduler.Scheduler, bool)
+	RemoveScheduler(string)
+}
+
 // The handler is the glue holding all components for cluster-checks management
 type Handler struct {
-	m          sync.Mutex
-	autoconfig *autodiscovery.AutoConfig
-	dispatcher *dispatcher
+	m                    sync.RWMutex
+	autoconfig           pluggableAutoConfig
+	dispatcher           *dispatcher
+	dispatcherCancel     context.CancelFunc
+	state                state
+	leaderIP             string
+	warmupDuration       time.Duration
+	leaderStatusFreq     time.Duration
+	leaderStatusCallback leaderIPCallback
+	leadershipChan       chan state
+	nodeStatusChan       chan struct{}
 }
 
 // NewHandler returns a populated Handler
 // It will hook on the specified AutoConfig instance at Start
-func NewHandler(ac *autodiscovery.AutoConfig) (*Handler, error) {
+func NewHandler(ac pluggableAutoConfig) (*Handler, error) {
 	if ac == nil {
 		return nil, errors.New("empty autoconfig object")
 	}
 	h := &Handler{
-		autoconfig: ac,
+		autoconfig:       ac,
+		leaderStatusFreq: 5 * time.Second,
+		warmupDuration:   config.Datadog.GetDuration("cluster_checks.warmup_duration") * time.Second,
+		leadershipChan:   make(chan state, 1),
+		nodeStatusChan:   make(chan struct{}, 1),
+		dispatcher:       newDispatcher(),
 	}
+
+	if config.Datadog.GetBool("leader_election") {
+		callback, err := getLeaderIPCallback()
+		if err != nil {
+			return nil, err
+		}
+		h.leaderStatusCallback = callback
+	}
+
 	return h, nil
 }
 
 // Run is the main goroutine for the handler. It has to
 // be called in a goroutine with a cancellable context.
 func (h *Handler) Run(ctx context.Context) {
-	h.startDiscovery(ctx)
-	<-ctx.Done()
-	h.stopDiscovery()
+	h.m.Lock()
+	if h.leaderStatusCallback != nil {
+		go h.leaderWatch(ctx)
+	} else {
+		// With no leader election enabled, we assume only one DCA is running
+		h.state = leader
+		h.leadershipChan <- leader
+	}
+	h.m.Unlock()
+
+	for {
+		// Follower / unknown
+		select {
+		case <-ctx.Done():
+			return
+		case newState := <-h.leadershipChan:
+			if newState != leader {
+				// Still follower, go back to select
+				continue
+			}
+		}
+
+		// Leading, first empty nodeStatusChan
+		select {
+		case <-h.nodeStatusChan:
+		default:
+		}
+
+		// Wait until first node status to start warmup
+		log.Info("Gained leadership, waiting for first agent to connect")
+		select {
+		case <-ctx.Done():
+			return
+		case newState := <-h.leadershipChan:
+			if newState == leader {
+				continue
+			}
+		case <-h.nodeStatusChan:
+			break
+		}
+
+		// Got first node status, sleep for warmup duration
+		log.Infof("Got a node-agent status, waiting %s for other agents", h.warmupDuration)
+		select {
+		case <-ctx.Done():
+			return
+		case newState := <-h.leadershipChan:
+			if newState != leader {
+				continue
+			}
+		case <-time.After(h.warmupDuration):
+			break
+		}
+
+		// Run discovery and dispatching
+		log.Info("Warmup phase finished, starting to serve configurations")
+		dispatchCtx, dispatchCancel := context.WithCancel(ctx)
+		go h.runDispatch(dispatchCtx)
+
+		// Wait until we lose leadership or exit
+		for {
+			var newState state
+
+			select {
+			case <-ctx.Done():
+				dispatchCancel()
+				return
+			case newState = <-h.leadershipChan:
+				// Store leadership status
+			}
+
+			if newState != leader {
+				log.Info("Lost leadership, reverting to follower")
+				dispatchCancel()
+				break // Return back to main loop start
+			}
+		}
+	}
 }
 
-// startDiscovery hooks to Autodiscovery and starts managing checks
-func (h *Handler) startDiscovery(ctx context.Context) {
-	h.m.Lock()
-	defer h.m.Unlock()
-	// Clean initial state
-	h.dispatcher = newDispatcher()
-	go h.dispatcher.cleanupLoop(ctx)
-
+// startDispatch hooks to Autodiscovery and manages checks
+func (h *Handler) runDispatch(ctx context.Context) {
 	// Register our scheduler and ask for a config replay
 	h.autoconfig.AddScheduler(schedulerName, h.dispatcher, true)
+
+	// Run dispatcher cleanup loop - blocking until context is cancelled
+	h.dispatcher.run(ctx)
+
+	h.m.Lock()
+	defer h.m.Unlock()
+	// Churn the dispatcher and restart fresh
+	h.dispatcher = newDispatcher()
+	h.autoconfig.RemoveScheduler(schedulerName)
 }
 
-// stopDiscovery stops the management logic and un-hooks from Autodiscovery
-func (h *Handler) stopDiscovery() {
+func (h *Handler) leaderWatch(ctx context.Context) {
+	err := h.updateLeaderIP(true)
+	if err != nil {
+		log.Warnf("Could not refresh leadership status: %s", err)
+	}
+
+	watchTicker := time.NewTicker(h.leaderStatusFreq)
+	defer watchTicker.Stop()
+
+	for {
+		select {
+		case <-watchTicker.C:
+			err := h.updateLeaderIP(false)
+			if err != nil {
+				log.Warnf("Could not refresh leadership status: %s", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// updateLeaderIP queries the leader election engine and updates
+// the leader IP accordlingly. In case of leadership statuschange,
+// a boolean is sent on leadershipChan:
+//   - true: becoming leader
+//   - false: lost leadership
+func (h *Handler) updateLeaderIP(firstRun bool) error {
 	h.m.Lock()
 	defer h.m.Unlock()
 
-	// AD will call dispatcher.Stop for us
-	h.autoconfig.RemoveScheduler(schedulerName)
+	newIP, err := h.leaderStatusCallback()
+	if err != nil {
+		return err
+	}
 
-	// Release memory
-	h.dispatcher = nil
+	// Fast exit if no change
+	if !firstRun && (newIP == h.leaderIP) {
+		return nil
+	}
+
+	// Test if the leader/follower status changed
+	newState := follower
+	if newIP == "" {
+		newState = leader
+	}
+	statusChange := h.state != newState
+
+	// Store new state
+	h.leaderIP = newIP
+	h.state = newState
+
+	// Notify leadership status change
+	if firstRun || statusChange {
+		h.leadershipChan <- newState
+	}
+	return nil
 }

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -144,12 +144,12 @@ func (h *Handler) Run(ctx context.Context) {
 	}
 }
 
-// startDispatch hooks to Autodiscovery and manages checks
+// runDispatch hooks in the Autodiscovery and runs the dispatch's run method
 func (h *Handler) runDispatch(ctx context.Context) {
 	// Register our scheduler and ask for a config replay
 	h.autoconfig.AddScheduler(schedulerName, h.dispatcher, true)
 
-	// Run dispatcher cleanup loop - blocking until context is cancelled
+	// Run dispatcher loop - blocking until context is cancelled
 	h.dispatcher.run(ctx)
 
 	// Reset the dispatcher

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -1,0 +1,276 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build clusterchecks
+
+package clusterchecks
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+)
+
+func (h *Handler) setCallback(ip string, err error) {
+	h.m.Lock()
+	defer h.m.Unlock()
+	h.leaderStatusCallback = func() (string, error) { return ip, err }
+}
+
+func (h *Handler) assertLeadershipMessage(t *testing.T, expected state) {
+	t.Helper()
+	select {
+	case value := <-h.leadershipChan:
+		assert.Equal(t, expected, value)
+	case <-time.After(50 * time.Millisecond):
+		assert.Fail(t, "Timeout while waiting for channel message")
+	}
+}
+
+func (h *Handler) assertNoLeadershipMessage(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.leadershipChan:
+		assert.Fail(t, "Unexpected channel message")
+	case <-time.After(50 * time.Millisecond):
+		return
+	}
+}
+
+func TestUpdateLeaderIP(t *testing.T) {
+	h := &Handler{
+		leadershipChan: make(chan state, 1),
+	}
+
+	// First run, become leader
+	h.setCallback("", nil)
+	err := h.updateLeaderIP(true)
+	assert.NoError(t, err)
+	assert.Equal(t, "", h.leaderIP)
+	h.assertLeadershipMessage(t, leader)
+
+	// Second run, still leader, no update
+	err = h.updateLeaderIP(false)
+	assert.NoError(t, err)
+	assert.Equal(t, "", h.leaderIP)
+	h.assertNoLeadershipMessage(t)
+
+	// Query error
+	queryError := errors.New("test query error")
+	h.setCallback("1.2.3.4", queryError)
+	err = h.updateLeaderIP(false)
+	assert.Equal(t, queryError, err)
+	assert.Equal(t, "", h.leaderIP)
+	h.assertNoLeadershipMessage(t)
+
+	// Lose leadership
+	h.setCallback("1.2.3.4", nil)
+	err = h.updateLeaderIP(false)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4", h.leaderIP)
+	h.assertLeadershipMessage(t, follower)
+
+	// New leader, still following
+	h.setCallback("1.2.3.40", nil)
+	err = h.updateLeaderIP(false)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.40", h.leaderIP)
+	h.assertNoLeadershipMessage(t)
+
+	// Back to leader
+	h.setCallback("", nil)
+	err = h.updateLeaderIP(false)
+	assert.NoError(t, err)
+	assert.Equal(t, "", h.leaderIP)
+	h.assertLeadershipMessage(t, leader)
+
+	// Start fresh, test unknown -> follower
+	h = &Handler{
+		leadershipChan: make(chan state, 1),
+	}
+	h.setCallback("1.2.3.4", nil)
+	err = h.updateLeaderIP(true)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4", h.leaderIP)
+	h.assertLeadershipMessage(t, follower)
+}
+
+// TestHandlerRun tests the full lifecycle of the handling/dispatching
+// lifecycle: unknown -> follower -> leader -> follower -> leader -> stop
+func TestHandlerRun(t *testing.T) {
+	dummyT := &testing.T{}
+	ac := &mockedPluggableAutoConfig{}
+	ac.Test(t)
+
+	h := &Handler{
+		autoconfig:       ac,
+		leaderStatusFreq: 100 * time.Millisecond,
+		warmupDuration:   250 * time.Millisecond,
+		leadershipChan:   make(chan state, 1),
+		nodeStatusChan:   make(chan struct{}, 1),
+		dispatcher:       newDispatcher(),
+	}
+	h.setCallback("", errors.New("failing"))
+
+	//
+	// Initialisation and unknown state
+	//
+
+	ctx, cancelRun := context.WithCancel(context.Background())
+	runReturned := make(chan struct{}, 1)
+	go func() {
+		h.Run(ctx)
+		runReturned <- struct{}{}
+	}()
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// State is unknown
+		h.m.RLock()
+		defer h.m.RUnlock()
+		return h.state == unknown
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// API replys not ready
+		code, reason := h.ShouldHandle()
+		return code == http.StatusServiceUnavailable && reason == notReadyReason
+	})
+
+	//
+	// Unknown -> follower
+	//
+
+	h.setCallback("1.2.3.4", nil)
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Internal state change
+		h.m.RLock()
+		defer h.m.RUnlock()
+		return h.state == follower && h.leaderIP == "1.2.3.4"
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// API redirects to leader
+		code, reason := h.ShouldHandle()
+		return code == http.StatusFound && reason == "1.2.3.4"
+	})
+
+	//
+	// Follower -> leader
+	//
+
+	h.setCallback("", nil)
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Internal state change
+		h.m.RLock()
+		defer h.m.RUnlock()
+		return h.state == leader && h.leaderIP == ""
+	})
+	// We should not hook up to the AD yet
+	assert.Len(t, ac.Calls, 0)
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// API serves requests
+		code, reason := h.ShouldHandle()
+		return code == http.StatusOK && reason == ""
+	})
+
+	// Trigger warmup and AC connection
+	ac.On("AddScheduler", schedulerName, mock.AnythingOfType("*clusterchecks.dispatcher"), true).Return()
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Keep node-agent caches even when timestamp is off (warmup)
+		response, err := h.PostStatus("dummy", types.NodeStatus{LastChange: -50})
+		return err == nil && response.IsUpToDate == true
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+		// Test whether we're connected to the AD
+		return ac.AssertNumberOfCalls(dummyT, "AddScheduler", 1)
+
+	})
+	ac.AssertExpectations(t)
+
+	// Schedule a check and make sure it is assigned to the node "dummy"
+	testConfig := integration.Config{
+		Name:         "unit_test",
+		ClusterCheck: true,
+	}
+	h.dispatcher.Schedule([]integration.Config{testConfig})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Found one configuration for node dummy
+		configs, err := h.GetConfigs("dummy")
+		return err == nil && len(configs.Configs) == 1
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Flush node-agent caches when timestamp is off
+		response, err := h.PostStatus("dummy", types.NodeStatus{LastChange: -50})
+		return err == nil && response.IsUpToDate == false
+	})
+
+	//
+	// Leader -> follower
+	//
+
+	ac.On("RemoveScheduler", schedulerName).Return()
+	h.setCallback("1.2.3.6", nil)
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Internal state change
+		h.m.RLock()
+		defer h.m.RUnlock()
+		return h.state == follower && h.leaderIP == "1.2.3.6"
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// Dispatcher is flushed, no config remain
+		allconfigs, err := h.GetAllConfigs()
+		return err == nil && len(allconfigs.Configs) == 0
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// API redirects to leader again
+		code, reason := h.ShouldHandle()
+		return code == http.StatusFound && reason == "1.2.3.6"
+	})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+		// RemoveScheduler is called
+		return ac.AssertNumberOfCalls(dummyT, "RemoveScheduler", 1)
+	})
+	ac.AssertExpectations(t)
+
+	//
+	// Follower -> leader again
+	//
+
+	h.setCallback("", nil)
+	h.PostStatus("dummy", types.NodeStatus{})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
+		// API serves requests
+		code, reason := h.ShouldHandle()
+		return code == http.StatusOK && reason == ""
+	})
+	h.PostStatus("dummy", types.NodeStatus{})
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+		// Test whether we're connected to the AD
+		return ac.AssertNumberOfCalls(dummyT, "AddScheduler", 2)
+	})
+
+	//
+	// Leader -> stop
+	//
+
+	ac.On("RemoveScheduler", schedulerName).Return()
+	cancelRun()
+	select {
+	case <-runReturned:
+		// All good
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Timeout while waiting for Run method to end")
+	}
+
+	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
+		// RemoveScheduler is called
+		return ac.AssertNumberOfCalls(dummyT, "RemoveScheduler", 2)
+	})
+}

--- a/pkg/clusteragent/clusterchecks/leadership_kube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_kube.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build clusterchecks
+// +build kubeapiserver
+
+package clusterchecks
+
+import "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
+
+func getLeaderIPCallback() (leaderIPCallback, error) {
+	engine, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		return nil, err
+	}
+
+	return engine.GetLeaderIP, engine.EnsureLeaderElectionRuns()
+}

--- a/pkg/clusteragent/clusterchecks/leadership_nokube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_nokube.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build clusterchecks
+// +build !kubeapiserver
+
+package clusterchecks
+
+import "errors"
+
+func getLeaderIPCallback() (leaderIPCallback, error) {
+	return nil, errors.New("No leader election engine compiled in")
+}

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -20,6 +20,7 @@ import (
 // operations involving several calls.
 type clusterStore struct {
 	sync.RWMutex
+	active          bool
 	digestToConfig  map[string]integration.Config // All configurations to dispatch
 	digestToNode    map[string]string             // Node running a config
 	nodes           map[string]*nodeStore         // All nodes known to the cluster-agent

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -28,12 +28,18 @@ type clusterStore struct {
 }
 
 func newClusterStore() *clusterStore {
-	return &clusterStore{
-		digestToConfig:  make(map[string]integration.Config),
-		digestToNode:    make(map[string]string),
-		nodes:           make(map[string]*nodeStore),
-		danglingConfigs: make(map[string]integration.Config),
-	}
+	s := &clusterStore{}
+	s.reset()
+	return s
+}
+
+// reset empties the store and resets all states
+func (s *clusterStore) reset() {
+	s.active = false
+	s.digestToConfig = make(map[string]integration.Config)
+	s.digestToNode = make(map[string]string)
+	s.nodes = make(map[string]*nodeStore)
+	s.danglingConfigs = make(map[string]integration.Config)
 }
 
 // getNodeStore retrieves the store struct for a given node name, if it exists

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -336,7 +336,7 @@ func initConfig(config Config) {
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
 	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
-	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 15)         // value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)         // value in seconds
 
 	setAssetFs(config)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -336,6 +336,7 @@ func initConfig(config Config) {
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
 	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 15)         // value in seconds
 
 	setAssetFs(config)
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -508,9 +508,14 @@ api_key:
 # cluster_checks:
 #   Set to true to enable the dispatching logic on the leader cluster-agent.
 #   enabled: "true"
+#
 #   Node-agents that have not queried the cluster-agent for 30 seconds will be deleted,
 #   and their checks re-dispatched to other nodes. This delay is configurable here.
 #   node_expiration_timeout: 30
+#
+#   The cluster-agent needs to wait for all node-agents to report to it before
+#   dispatching configurations. This delay is configurable here.
+#   warmup_duration: 30
 #
 {{ end -}}
 {{- if .DockerTagging }}


### PR DESCRIPTION
### What does this PR do?

Make the cluster-check handler aware of the leader election status to be able to:
  - plug into discovery when leading
  - unplug and redirect to leader IP when following

Accordingly to the RFC: in order to spread checks on all available nodes, the logic introduces a "warmup period" between becoming leader and starting to dispatch configuration. It is set to 30 seconds after becoming leader.

Leader election is not required: if it is disabled, the DCA assumes it is alone and starts serving as a leader.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
