### PR TITLE
Fix datadog external metric query when no label is set

### DIFF
--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -21,20 +21,23 @@ func Inspect(hpa *autoscalingv2.HorizontalPodAutoscaler) (emList []custommetrics
 	for _, metricSpec := range hpa.Spec.Metrics {
 		switch metricSpec.Type {
 		case autoscalingv2.ExternalMetricSourceType:
-			// The metricSelector and the external fields are optional. We do not support *.
-			if metricSpec.External == nil || metricSpec.External.MetricSelector == nil {
-				log.Errorf("Missing required fields for the External Metrics template of the HPA %s/%s, skipping processing", hpa.Namespace, hpa.Name)
+			if metricSpec.External == nil {
+				log.Errorf("Missing required \"external\" section in the %s/%s HPA, skipping processing", hpa.Namespace, hpa.Name)
 				continue
 			}
-			emList = append(emList, custommetrics.ExternalMetricValue{
+
+			em := custommetrics.ExternalMetricValue{
 				MetricName: metricSpec.External.MetricName,
 				HPA: custommetrics.ObjectReference{
 					Name:      hpa.Name,
 					Namespace: hpa.Namespace,
 					UID:       string(hpa.UID),
 				},
-				Labels: metricSpec.External.MetricSelector.MatchLabels,
-			})
+			}
+			if metricSpec.External.MetricSelector != nil {
+				em.Labels = metricSpec.External.MetricSelector.MatchLabels
+			}
+			emList = append(emList, em)
 		default:
 			log.Debugf("Unsupported metric type %s", metricSpec.Type)
 		}

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -259,7 +259,7 @@ func TestInspect(t *testing.T) {
 			},
 			[]custommetrics.ExternalMetricValue{},
 		},
-		"incomplete, missing labels": {
+		"missing labels, still OK": {
 			&autoscalingv2.HorizontalPodAutoscaler{
 				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 					Metrics: []autoscalingv2.MetricSpec{
@@ -272,7 +272,15 @@ func TestInspect(t *testing.T) {
 					},
 				},
 			},
-			[]custommetrics.ExternalMetricValue{},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "foo",
+					Labels:     nil,
+					Timestamp:  0,
+					Value:      0,
+					Valid:      false,
+				},
+			},
 		},
 		"incomplete, missing external metrics": {
 			&autoscalingv2.HorizontalPodAutoscaler{

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	datadog "gopkg.in/zorkian/go-datadog-api.v2"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -128,11 +128,17 @@ func invalidate(emList []custommetrics.ExternalMetricValue) (invList []custommet
 }
 
 func getKey(name string, labels map[string]string) string {
+	// Support queries with no tags
+	if len(labels) == 0 {
+		return fmt.Sprintf("%s{*}", name)
+	}
+
 	datadogTags := []string{}
 	for key, val := range labels {
 		datadogTags = append(datadogTags, fmt.Sprintf("%s:%s", key, val))
 	}
 	sort.Strings(datadogTags)
 	tags := strings.Join(datadogTags, ",")
+
 	return fmt.Sprintf("%s{%s}", name, tags)
 }

--- a/pkg/util/kubernetes/hpa/processor_test.go
+++ b/pkg/util/kubernetes/hpa/processor_test.go
@@ -13,12 +13,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/zorkian/go-datadog-api.v2"
+	"github.com/stretchr/testify/require"
+	datadog "gopkg.in/zorkian/go-datadog-api.v2"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
-	"github.com/stretchr/testify/require"
 )
 
 type fakeDatadogClient struct {
@@ -488,6 +488,12 @@ func TestGetKey(t *testing.T) {
 				"ffoo": "bar",
 			},
 			"kubernetes.io{afoo:bar,ffoo:bar,zfoo:bar}",
+		},
+		{
+			"correct name, no labels",
+			"kubernetes.io",
+			nil,
+			"kubernetes.io{*}",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
### What does this PR do?

Following up on https://github.com/DataDog/datadog-agent/pull/2666 , the following configuration is accepted by the hpa controller:

```
    external:
      metricName: nginx.net.request_per_s
      metricSelector:
        matchLabels:
      targetAverageValue: 9
```

The current logic resulted in an invalid `nginx.net.request_per_s{}` datadog query, instead of `nginx.net.request_per_s{*}`, making the whole metric batch query fail. All metrics being batched together, that brings all other external metrics to age out and become invalid:

```
external_metric-default-nginxext-nginx.net.request_per_s: '{"metricName":"nginx.net.request_per_s","labels":null,"ts":1542795321,"hpa":{"name":"nginxext","namespace":"default","uid":"cd03c0f1-ecea-11e8-9341-42010a8400d9"},"value":0,"val
id":false}'
external_metric-default-nginxext2-docker.cpu.usage: '{"metricName":"docker.cpu.usage","labels":{"kube_container_name":"nginx","kube_deployment":"nginx2"},"ts":1542795321,"hpa":{"name":"nginxext2","namespace":"default","uid":"18c74728-ed
70-11e8-9341-42010a8400d9"},"value":0,"valid":false}'
```

This PR fixes `hpa.getKey` to handle the special case of `len(labels) == 0`, making the query layer resilient to empty tags.


Tested image: `xvellodatadog/agent-dev:hpa-notag`