### PR TITLE
[docs] Update hostname resolution doc

### DIFF
--- a/docs/agent/hostname-resolution.md
+++ b/docs/agent/hostname-resolution.md
@@ -1,24 +1,24 @@
 _Edit 2018-09-18 : Highlight the differences between Windows and other OSes._
 
-_Edit 2018-10-16 : The default value of the new `hostname_fqdn` flag is planned to change in 6.7.0 instead of 6.4.0 to give users more time to take it into account._
+_Edit 2018-11-21 : The default value of the new `hostname_fqdn` flag is planned to change in 6.9.0 instead of 6.4.0 to give users more time to take it into account and evaluate impact_
 
-# Difference in hostname resolution between Agent v5 and Agent v6 (<v6.7)
+# Difference in hostname resolution between Agent v5 and Agent v6 (<v6.9)
 
 ## Linux/MacOS
 
-In some cases, it is possible to see a difference in the hostname that’s reported by your Agent when upgrading from Agent v5 to Agent v6 (for versions < 6.7).
+In some cases, it is possible to see a difference in the hostname that’s reported by your Agent when upgrading from Agent v5 to Agent v6 (for versions < 6.9).
 
-To resolve the system hostname the Agent 5 uses the `hostname -f` command while the Agent v6 (for versions < 6.7) uses the Golang API `os.Hostname()`.
+To resolve the system hostname the Agent 5 uses the `hostname -f` command while the Agent v6 (for versions < 6.9) uses the Golang API `os.Hostname()`.
 
-On upgrades from Agent v5 to Agent v6 (<6.7.0), this may make the Agent hostname change from a Fully-Qualified Domain Name (FQDN, ex. sub.domain.tld) to a short hostname (ex. sub).
+On upgrades from Agent v5 to Agent v6 (<6.9.0), this may make the Agent hostname change from a Fully-Qualified Domain Name (FQDN, ex. sub.domain.tld) to a short hostname (ex. sub).
 
-Starting from the Agent v6.3 a configuration flag called `hostname_fqdn` has been introduced that allows the Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3 and enabled by default in version 6.7.
+Starting from the Agent v6.3 a configuration flag called `hostname_fqdn` has been introduced that allows the Agent v6 to have the same behavior as Agent v5. This flag is disabled by default on version 6.3 and will be enabled by default in version 6.9.
 
 ### Determine if you're affected
 
-Starting with v6.3.0, the Agent will log a warning (`DEPRECATION NOTICE: The agent resolved your hostname as <hostname>. However starting from version 6.7, it will be resolved as <fqdn> by default. To enable the behavior of 6.7+, please enable the `hostname_fqdn` flag in the configuration.`) if you’re affected by this change.
+Starting with v6.3.0, the Agent will log a warning (`DEPRECATION NOTICE: The agent resolved your hostname as <hostname>. However starting from version 6.9, it will be resolved as <fqdn> by default. To enable the behavior of 6.9+, please enable the `hostname_fqdn` flag in the configuration.`) if you’re affected by this change.
 
-You are not affected if any of the following is true :
+You are not affected if any of the following is true:
 - You are running the Agent in GCE
 - You are setting the Agent hostname in datadog.conf, datadog.yaml or through the DD_HOSTNAME environment variable
 - You are running the Agent in a container with access to the Docker or Kubernetes API
@@ -32,9 +32,9 @@ If you're affected by this change, we recommend that you take the following acti
 
 - Upgrading from Agent v5 to Agent >= v6.3: enable the `hostname_fqdn` option in the Agent v6 configuration to ensure that you will keep the same hostname.
 
-- Upgrading from Agent v5 to Agent v >= 6.7 (future): you don’t need to take any action.
+- Upgrading from Agent v5 to Agent v >= 6.9 (future): you don’t need to take any action.
 
-- Upgrading from Agent v6 < 6.7 to Agent >= v6.7: If you wish to keep the behavior of Agent v6 (<6.7) for now, set hostname_fqdn to false. We recommend you switch hostname_fqdn to true whenever possible.
+- Upgrading from Agent v6 < 6.9 to Agent >= v6.9: If you wish to keep the behavior of Agent v6 (<6.9) for now, set hostname_fqdn to false. We recommend you switch hostname_fqdn to true whenever possible.
 
 ## Windows
 


### PR DESCRIPTION
### What does this PR do?

Update hostname resolution doc with new expected release of the change of defaults.

### Motivation

The change will not happen until 6.9 at least. We've scheduled work on this right after
the 6.8.0 freeze so that we can actually make a final decision on whether to switch the default
in 6.9 or wait until 7.0