### PR TITLE
Add short image name in Source and Service fields

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 )
 
-// ContainerCollectAll is the name of the docker integration that catches all containers
+// ContainerCollectAll is the name of the docker integration that collect logs from all containers
 const ContainerCollectAll = "container_collect_all"
 
 // DefaultSources returns the default log sources that can be directly set from the datadog.yaml or through environment variables.

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -16,13 +16,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 )
 
+// ContainerCollectAll is the name of the docker integration that catches all containers
+const ContainerCollectAll = "container_collect_all"
+
 // DefaultSources returns the default log sources that can be directly set from the datadog.yaml or through environment variables.
 func DefaultSources() []*LogSource {
 	var sources []*LogSource
 
 	if coreConfig.Datadog.GetBool("logs_config.container_collect_all") {
 		// append a new source to collect all logs from all containers
-		source := NewLogSource("container_collect_all", &LogsConfig{
+		source := NewLogSource(ContainerCollectAll, &LogsConfig{
 			Type:    DockerType,
 			Service: "docker",
 			Source:  "docker",

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -29,31 +29,31 @@ const (
 
 // A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
 type Launcher struct {
-	pipelineProvider  pipeline.Provider
-	addedSources      chan *config.LogSource
-	removedSources    chan *config.LogSource
-	addedServices     chan *service.Service
-	removedServices   chan *service.Service
-	activeSources     []*config.LogSource
-	pendingContainers map[string]*Container
-	tailers           map[string]*Tailer
-	cli               *client.Client
-	registry          auditor.Registry
-	stop              chan struct{}
-	erroredContainer  chan *Container
-	lock              *sync.Mutex
+	pipelineProvider   pipeline.Provider
+	addedSources       chan *config.LogSource
+	removedSources     chan *config.LogSource
+	addedServices      chan *service.Service
+	removedServices    chan *service.Service
+	activeSources      []*config.LogSource
+	pendingContainers  map[string]*Container
+	tailers            map[string]*Tailer
+	cli                *client.Client
+	registry           auditor.Registry
+	stop               chan struct{}
+	erroredContainerID chan string
+	lock               *sync.Mutex
 }
 
 // NewLauncher returns a new launcher
 func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) (*Launcher, error) {
 	launcher := &Launcher{
-		pipelineProvider:  pipelineProvider,
-		tailers:           make(map[string]*Tailer),
-		pendingContainers: make(map[string]*Container),
-		registry:          registry,
-		stop:              make(chan struct{}),
-		erroredContainer:  make(chan *Container),
-		lock:              &sync.Mutex{},
+		pipelineProvider:   pipelineProvider,
+		tailers:            make(map[string]*Tailer),
+		pendingContainers:  make(map[string]*Container),
+		registry:           registry,
+		stop:               make(chan struct{}),
+		erroredContainerID: make(chan string),
+		lock:               &sync.Mutex{},
 	}
 	err := launcher.setup()
 	if err != nil {
@@ -158,13 +158,33 @@ func (l *Launcher) run() {
 			containerID := service.Identifier
 			l.stopTailer(containerID)
 			delete(l.pendingContainers, containerID)
-		case container := <-l.erroredContainer:
-			go l.restartTailer(container)
+		case containerID := <-l.erroredContainerID:
+			go l.restartTailer(containerID)
 		case <-l.stop:
 			// no docker container should be tailed anymore
 			return
 		}
 	}
+}
+
+// overrideSource create a new source with
+func (l *Launcher) overrideSource(container *Container, source *config.LogSource) *config.LogSource {
+	if source.Name != config.ContainerCollectAll {
+		return source
+	}
+
+	shortName, err := container.getShortImageName()
+	if err != nil {
+		containerID := container.service.Identifier
+		log.Warnf("Could not get short image name for container %v: %v", ShortContainerID(containerID), err)
+		return source
+	}
+
+	return config.NewLogSource(config.ContainerCollectAll, &config.LogsConfig{
+		Type:    config.DockerType,
+		Service: shortName,
+		Source:  shortName,
+	})
 }
 
 // startTailer starts a new tailer for the container matching with the source.
@@ -175,7 +195,8 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 		return
 	}
 
-	tailer := NewTailer(l.cli, container, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainer)
+	overridenSource := l.overrideSource(container, source)
+	tailer := NewTailer(l.cli, containerID, overridenSource, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), container.service.CreationTime)
@@ -202,8 +223,7 @@ func (l *Launcher) stopTailer(containerID string) {
 	}
 }
 
-func (l *Launcher) restartTailer(container *Container) {
-	containerID := container.service.Identifier
+func (l *Launcher) restartTailer(containerID string) {
 	backoffDuration := backoffInitialDuration
 	cumulatedBackoff := 0 * time.Second
 	var source *config.LogSource
@@ -215,7 +235,7 @@ func (l *Launcher) restartTailer(container *Container) {
 		l.removeTailer(containerID)
 	}
 
-	tailer := NewTailer(l.cli, container, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainer)
+	tailer := NewTailer(l.cli, containerID, source, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
 
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), service.Before)

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -99,7 +99,7 @@ func (l *Launcher) Stop() {
 	stopper := restart.NewParallelStopper()
 	for _, tailer := range l.tailers {
 		stopper.Add(tailer)
-		l.removeTailer(tailer.getContainerID())
+		l.removeTailer(tailer.ContainerID)
 	}
 	stopper.Stop()
 }

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -99,7 +99,7 @@ func (l *Launcher) Stop() {
 	stopper := restart.NewParallelStopper()
 	for _, tailer := range l.tailers {
 		stopper.Add(tailer)
-		l.removeTailer(tailer.ContainerID)
+		l.removeTailer(tailer.getContainerID())
 	}
 	stopper.Stop()
 }

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -168,7 +168,7 @@ func (l *Launcher) run() {
 	}
 }
 
-// overrideSource create a new source with
+// overrideSource create a new source with the image short name if the source is ContainerCollectAll
 func (l *Launcher) overrideSource(container *Container, source *config.LogSource) *config.LogSource {
 	if source.Name != config.ContainerCollectAll {
 		return source
@@ -202,6 +202,7 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 		return
 	}
 
+	// overridenSource == source if the containerCollectAll option is not activated or the container has AD labels
 	overridenSource := l.overrideSource(container, source)
 	tailer := NewTailer(l.cli, containerID, overridenSource, l.pipelineProvider.NextPipelineChan(), l.erroredContainerID)
 

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -82,6 +82,7 @@ func (t *Tailer) Stop() {
 	t.reader.Close()
 	// no-op if already closed because of a timeout
 	t.cancelFunc()
+	t.source.RemoveInput(t.ContainerID)
 	// wait for the decoder to be flushed
 	<-t.done
 }
@@ -131,8 +132,11 @@ func (t *Tailer) tail(since string) error {
 	err := t.setupReader()
 	if err != nil {
 		// could not start the tailer
+		t.source.Status.Error(err)
 		return err
 	}
+	t.source.Status.Success()
+	t.source.AddInput(t.ContainerID)
 
 	go t.keepDockerTagsUpdated()
 	go t.forwardMessages()

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -36,6 +36,7 @@ const tagsUpdatePeriod = 10 * time.Second
 // Logs from stdout and stderr are multiplexed into a single channel and needs to be demultiplexed later one.
 // To multiplex logs, docker adds a header to all logs with format '[SEV][TS] [MSG]'.
 type Tailer struct {
+	ContainerID   string
 	container     *Container
 	outputChan    chan *message.Message
 	decoder       *decoder.Decoder
@@ -58,6 +59,7 @@ type Tailer struct {
 // NewTailer returns a new Tailer
 func NewTailer(cli *client.Client, container *Container, source *config.LogSource, outputChan chan *message.Message, erroredContainer chan *Container) *Tailer {
 	return &Tailer{
+		ContainerID:      container.service.Identifier,
 		container:        container,
 		outputChan:       outputChan,
 		decoder:          decoder.InitializeDecoder(source, dockerParser),
@@ -73,18 +75,18 @@ func NewTailer(cli *client.Client, container *Container, source *config.LogSourc
 
 // Identifier returns a string that uniquely identifies a source
 func (t *Tailer) Identifier() string {
-	return fmt.Sprintf("docker:%s", t.getContainerID())
+	return fmt.Sprintf("docker:%s", t.ContainerID)
 }
 
 // Stop stops the tailer from reading new container logs,
 // this call blocks until the decoder is completely flushed
 func (t *Tailer) Stop() {
-	log.Infof("Stop tailing container: %v", ShortContainerID(t.getContainerID()))
+	log.Infof("Stop tailing container: %v", ShortContainerID(t.ContainerID))
 	t.stop <- struct{}{}
 	t.reader.Close()
 	// no-op if already closed because of a timeout
 	t.cancelFunc()
-	t.source.RemoveInput(t.getContainerID())
+	t.source.RemoveInput(t.ContainerID)
 	// wait for the decoder to be flushed
 	<-t.done
 }
@@ -94,7 +96,7 @@ func (t *Tailer) Stop() {
 // start from now if the container has been created before the agent started
 // start from oldest log otherwise
 func (t *Tailer) Start(since time.Time) error {
-	log.Infof("Start tailing container: %v", ShortContainerID(t.getContainerID()))
+	log.Infof("Start tailing container: %v", ShortContainerID(t.ContainerID))
 	return t.tail(since.Format(config.DateFormat))
 }
 
@@ -110,10 +112,6 @@ func (t *Tailer) setLastSince(since string) {
 	t.lastSince = since
 }
 
-func (t *Tailer) getContainerID() string {
-	return t.container.service.Identifier
-}
-
 // setupReader sets up the reader that reads the container's logs
 // with the proper configuration
 func (t *Tailer) setupReader() error {
@@ -126,7 +124,7 @@ func (t *Tailer) setupReader() error {
 		Since:      t.getLastSince(),
 	}
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	reader, err := t.cli.ContainerLogs(ctx, t.getContainerID(), options)
+	reader, err := t.cli.ContainerLogs(ctx, t.ContainerID, options)
 	t.reader = reader
 	t.cancelFunc = cancelFunc
 	return err
@@ -142,7 +140,7 @@ func (t *Tailer) tail(since string) error {
 		return err
 	}
 	t.source.Status.Success()
-	t.source.AddInput(t.getContainerID())
+	t.source.AddInput(t.ContainerID)
 
 	go t.keepDockerTagsUpdated()
 	go t.forwardMessages()
@@ -167,10 +165,10 @@ func (t *Tailer) readForever() {
 			if err != nil { // an error occurred, stop from reading new logs
 				switch {
 				case isContextCanceled(err):
-					log.Debugf("Restarting reader for container %v after a read timeout", ShortContainerID(t.getContainerID()))
+					log.Debugf("Restarting reader for container %v after a read timeout", ShortContainerID(t.ContainerID))
 					err := t.setupReader()
 					if err != nil {
-						log.Warnf("Could not restart the docker reader for container %v: %v:", ShortContainerID(t.getContainerID()), err)
+						log.Warnf("Could not restart the docker reader for container %v: %v:", ShortContainerID(t.ContainerID), err)
 						t.erroredContainer <- t.container
 						return
 					}
@@ -180,11 +178,11 @@ func (t *Tailer) readForever() {
 					return
 				case err == io.EOF:
 					// This error is raised when the container is stopping
-					t.source.RemoveInput(t.getContainerID())
+					t.source.RemoveInput(t.ContainerID)
 					return
 				default:
 					t.source.Status.Error(err)
-					log.Errorf("Could not tail logs for container %v: %v", ShortContainerID(t.getContainerID()), err)
+					log.Errorf("Could not tail logs for container %v: %v", ShortContainerID(t.ContainerID), err)
 					t.erroredContainer <- t.container
 					return
 				}
@@ -258,7 +256,7 @@ func (t *Tailer) keepDockerTagsUpdated() {
 }
 
 func (t *Tailer) checkForNewDockerTags() {
-	tags, err := tagger.Tag(dockerutil.ContainerIDToEntityName(t.getContainerID()), true)
+	tags, err := tagger.Tag(dockerutil.ContainerIDToEntityName(t.ContainerID), true)
 	if err != nil {
 		log.Warn(err)
 	} else {

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -82,7 +82,6 @@ func (t *Tailer) Stop() {
 	t.reader.Close()
 	// no-op if already closed because of a timeout
 	t.cancelFunc()
-	t.source.RemoveInput(t.ContainerID)
 	// wait for the decoder to be flushed
 	<-t.done
 }
@@ -132,11 +131,8 @@ func (t *Tailer) tail(since string) error {
 	err := t.setupReader()
 	if err != nil {
 		// could not start the tailer
-		t.source.Status.Error(err)
 		return err
 	}
-	t.source.Status.Success()
-	t.source.AddInput(t.ContainerID)
 
 	go t.keepDockerTagsUpdated()
 	go t.forwardMessages()

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -37,35 +37,39 @@ const tagsUpdatePeriod = 10 * time.Second
 // To multiplex logs, docker adds a header to all logs with format '[SEV][TS] [MSG]'.
 type Tailer struct {
 	ContainerID   string
+	container     *Container
 	outputChan    chan *message.Message
 	decoder       *decoder.Decoder
 	reader        io.ReadCloser
 	cli           *client.Client
 	source        *config.LogSource
+	originSource  *config.LogSource
 	containerTags []string
 
-	sleepDuration      time.Duration
-	shouldStop         bool
-	stop               chan struct{}
-	done               chan struct{}
-	erroredContainerID chan string
-	cancelFunc         context.CancelFunc
-	lastSince          string
-	mutex              sync.Mutex
+	sleepDuration    time.Duration
+	shouldStop       bool
+	stop             chan struct{}
+	done             chan struct{}
+	erroredContainer chan *Container
+	cancelFunc       context.CancelFunc
+	lastSince        string
+	mutex            sync.Mutex
 }
 
 // NewTailer returns a new Tailer
-func NewTailer(cli *client.Client, containerID string, source *config.LogSource, outputChan chan *message.Message, erroredContainerID chan string) *Tailer {
+func NewTailer(cli *client.Client, container *Container, source *config.LogSource, outputChan chan *message.Message, erroredContainer chan *Container) *Tailer {
 	return &Tailer{
-		ContainerID:        containerID,
-		outputChan:         outputChan,
-		decoder:            decoder.InitializeDecoder(source, dockerParser),
-		source:             source,
-		cli:                cli,
-		sleepDuration:      defaultSleepDuration,
-		stop:               make(chan struct{}, 1),
-		done:               make(chan struct{}, 1),
-		erroredContainerID: erroredContainerID,
+		ContainerID:      container.service.Identifier,
+		container:        container,
+		outputChan:       outputChan,
+		decoder:          decoder.InitializeDecoder(source, dockerParser),
+		source:           source,
+		originSource:     container.GetSourceShortImageName(source),
+		cli:              cli,
+		sleepDuration:    defaultSleepDuration,
+		stop:             make(chan struct{}, 1),
+		done:             make(chan struct{}, 1),
+		erroredContainer: erroredContainer,
 	}
 }
 
@@ -165,7 +169,7 @@ func (t *Tailer) readForever() {
 					err := t.setupReader()
 					if err != nil {
 						log.Warnf("Could not restart the docker reader for container %v: %v:", ShortContainerID(t.ContainerID), err)
-						t.erroredContainerID <- t.ContainerID
+						t.erroredContainer <- t.container
 						return
 					}
 					continue
@@ -179,7 +183,7 @@ func (t *Tailer) readForever() {
 				default:
 					t.source.Status.Error(err)
 					log.Errorf("Could not tail logs for container %v: %v", ShortContainerID(t.ContainerID), err)
-					t.erroredContainerID <- t.ContainerID
+					t.erroredContainer <- t.container
 					return
 				}
 			}
@@ -229,7 +233,7 @@ func (t *Tailer) forwardMessages() {
 	}()
 	for output := range t.decoder.OutputChan {
 		if len(output.Content) > 0 {
-			origin := message.NewOrigin(t.source)
+			origin := message.NewOrigin(t.originSource)
 			origin.Offset = output.Timestamp
 			t.setLastSince(output.Timestamp)
 			origin.Identifier = t.Identifier()

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -36,16 +36,14 @@ const tagsUpdatePeriod = 10 * time.Second
 // Logs from stdout and stderr are multiplexed into a single channel and needs to be demultiplexed later one.
 // To multiplex logs, docker adds a header to all logs with format '[SEV][TS] [MSG]'.
 type Tailer struct {
-	container  *Container
-	outputChan chan *message.Message
-	decoder    *decoder.Decoder
-	reader     io.ReadCloser
-	cli        *client.Client
-	source     *config.LogSource
-	// containersSource is the source that uses short image name as source and service
-	// tag if applicable (i.e. no k8s annotation nor docker label)
-	containerSource *config.LogSource
-	containerTags   []string
+	container     *Container
+	outputChan    chan *message.Message
+	decoder       *decoder.Decoder
+	reader        io.ReadCloser
+	cli           *client.Client
+	source        *config.LogSource
+	originSource  *config.LogSource
+	containerTags []string
 
 	sleepDuration    time.Duration
 	shouldStop       bool
@@ -64,7 +62,7 @@ func NewTailer(cli *client.Client, container *Container, source *config.LogSourc
 		outputChan:       outputChan,
 		decoder:          decoder.InitializeDecoder(source, dockerParser),
 		source:           source,
-		containerSource:  container.GetSourceShortImageName(source),
+		originSource:     container.GetSourceShortImageName(source),
 		cli:              cli,
 		sleepDuration:    defaultSleepDuration,
 		stop:             make(chan struct{}, 1),
@@ -237,7 +235,7 @@ func (t *Tailer) forwardMessages() {
 	}()
 	for output := range t.decoder.OutputChan {
 		if len(output.Content) > 0 {
-			origin := message.NewOrigin(t.containerSource)
+			origin := message.NewOrigin(t.originSource)
 			origin.Offset = output.Timestamp
 			t.setLastSince(output.Timestamp)
 			origin.Identifier = t.Identifier()

--- a/pkg/logs/input/docker/tailer_test.go
+++ b/pkg/logs/input/docker/tailer_test.go
@@ -63,17 +63,16 @@ func (m *mockReaderSleep) Close() error {
 
 func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer {
 	return &Tailer{
-		ContainerID:        "1234567890abcdef",
-		outputChan:         make(chan *message.Message, 100),
-		decoder:            nil,
-		source:             nil,
-		cli:                nil,
-		sleepDuration:      defaultSleepDuration,
-		stop:               make(chan struct{}, 1),
-		done:               make(chan struct{}, 1),
-		erroredContainerID: make(chan string, 100),
-		reader:             reader,
-		cancelFunc:         cancelFunc,
+		ContainerID:   "1234567890abcdef",
+		outputChan:    make(chan *message.Message, 100),
+		decoder:       nil,
+		source:        nil,
+		cli:           nil,
+		sleepDuration: defaultSleepDuration,
+		stop:          make(chan struct{}, 1),
+		done:          make(chan struct{}, 1),
+		reader:        reader,
+		cancelFunc:    cancelFunc,
 	}
 }
 

--- a/pkg/logs/input/docker/tailer_test.go
+++ b/pkg/logs/input/docker/tailer_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,7 +64,6 @@ func (m *mockReaderSleep) Close() error {
 
 func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer {
 	return &Tailer{
-		ContainerID:   "1234567890abcdef",
 		outputChan:    make(chan *message.Message, 100),
 		decoder:       nil,
 		source:        nil,
@@ -77,7 +77,8 @@ func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer 
 }
 
 func TestTailerIdentifier(t *testing.T) {
-	tailer := &Tailer{ContainerID: "test"}
+	container := &Container{service: &service.Service{Identifier: "test"}}
+	tailer := &Tailer{container: container}
 	assert.Equal(t, "docker:test", tailer.Identifier())
 }
 

--- a/pkg/logs/input/docker/tailer_test.go
+++ b/pkg/logs/input/docker/tailer_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
-	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,6 +63,7 @@ func (m *mockReaderSleep) Close() error {
 
 func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer {
 	return &Tailer{
+		ContainerID:   "1234567890abcdef",
 		outputChan:    make(chan *message.Message, 100),
 		decoder:       nil,
 		source:        nil,
@@ -77,8 +77,7 @@ func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer 
 }
 
 func TestTailerIdentifier(t *testing.T) {
-	container := &Container{service: &service.Service{Identifier: "test"}}
-	tailer := &Tailer{container: container}
+	tailer := &Tailer{ContainerID: "test"}
 	assert.Equal(t, "docker:test", tailer.Identifier())
 }
 

--- a/releasenotes/notes/default-to-short-image-name-container-collect-all-3885afb31b823541.yaml
+++ b/releasenotes/notes/default-to-short-image-name-container-collect-all-3885afb31b823541.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Set service and source to the docker short image name when container_collect_all flag
+    is enabled and no label or annotation is defined


### PR DESCRIPTION
### What does this PR do?

Set service and source to the docker short image name when container_collect_all flag is enabled and no label or annotation is defined

