### PR TITLE
Add GetLeaderIP method to LeaderEngine

### DIFF
--- a/pkg/util/kubernetes/apiserver/endpoints.go
+++ b/pkg/util/kubernetes/apiserver/endpoints.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"errors"
+
+	"k8s.io/api/core/v1"
+
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
+)
+
+func SearchTargetPerName(endpoints *v1.Endpoints, targetName string) (v1.EndpointAddress, error) {
+	if endpoints == nil {
+		return v1.EndpointAddress{}, errors.New("nil endpoints object passed")
+	}
+	for _, subset := range endpoints.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.TargetRef == nil {
+				continue
+			}
+			if addr.TargetRef.Name == targetName {
+				return addr, nil
+			}
+		}
+	}
+	return v1.EndpointAddress{}, dderrors.NewNotFound("target named " + targetName)
+}

--- a/pkg/util/kubernetes/apiserver/endpoints.go
+++ b/pkg/util/kubernetes/apiserver/endpoints.go
@@ -15,6 +15,8 @@ import (
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 )
 
+// SearchTargetPerName returns the endpoint matching a given target name. It allows
+// to retrieve a given pod's endpoint address from a service.
 func SearchTargetPerName(endpoints *v1.Endpoints, targetName string) (v1.EndpointAddress, error) {
 	if endpoints == nil {
 		return v1.EndpointAddress{}, errors.New("nil endpoints object passed")

--- a/pkg/util/kubernetes/apiserver/endpoints_test.go
+++ b/pkg/util/kubernetes/apiserver/endpoints_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+)
+
+func TestSearchTargetPerName(t *testing.T) {
+	pod1 := newFakePod(
+		"foo",
+		"pod1_name",
+		"1111",
+		"1.1.1.1",
+	)
+
+	pod2 := newFakePod(
+		"foo",
+		"pod2_name",
+		"2222",
+		"2.2.2.2",
+	)
+
+	for nb, tc := range []struct {
+		targetName  string
+		endpoints   v1.Endpoints
+		expectedIP  string
+		expectedErr error
+	}{
+		{
+			"pod2_name",
+			v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							{}, // Empty addr with a nil targetRef
+						},
+					},
+					{
+						Addresses: []v1.EndpointAddress{
+							newFakeEndpointAddress("myNode", pod1),
+							newFakeEndpointAddress("myNode", pod2),
+						},
+					},
+				},
+			},
+			"2.2.2.2",
+			nil,
+		},
+		{
+			"pod_not_found",
+			v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses: []v1.EndpointAddress{
+							newFakeEndpointAddress("myNode", pod1),
+						},
+					},
+					{
+						Addresses: []v1.EndpointAddress{
+							newFakeEndpointAddress("myNode", pod2),
+						},
+					},
+				},
+			},
+			"",
+			errors.New("\"target named pod_not_found\" not found"),
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.targetName), func(t *testing.T) {
+			target, err := SearchTargetPerName(&tc.endpoints, tc.targetName)
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tc.expectedErr.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedIP, target.IP)
+			}
+		})
+	}
+}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -8,18 +8,44 @@
 package leaderelection
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 )
+
+func makeLeaderCM(name, namespace, leaderIdentity string, leaseDuration int) *corev1.ConfigMap {
+	record := rl.LeaderElectionRecord{
+		HolderIdentity:       leaderIdentity,
+		LeaseDurationSeconds: leaseDuration,
+		AcquireTime:          metav1.NewTime(time.Now()),
+		RenewTime:            metav1.NewTime(time.Now().Add(time.Duration(leaseDuration) * time.Second)),
+		LeaderTransitions:    1,
+	}
+	b, _ := json.Marshal(&record)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"control-plane.alpha.kubernetes.io/leader": string(b),
+			},
+		},
+	}
+}
 
 func newFakeLockObject(namespace, name, leaderIdentity string) *v1.ConfigMap {
 	return &v1.ConfigMap{
@@ -83,4 +109,80 @@ func TestNewLeaseAcquiring(t *testing.T) {
 	require.Contains(t, Cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
 	require.True(t, le.IsLeader())
 
+}
+
+func TestGetLeaderIPFollower(t *testing.T) {
+	const leaseName = "datadog-leader-election"
+	const endpointsName = "datadog-cluster-agent"
+
+	client := fake.NewSimpleClientset()
+
+	le := &LeaderEngine{
+		HolderIdentity:  "foo",
+		LeaseName:       leaseName,
+		LeaderNamespace: "default",
+		LeaseDuration:   120 * time.Second,
+		coreClient:      client.CoreV1(),
+	}
+
+	// Create leader-election configmap with current node as follower
+	electionCM := makeLeaderCM(leaseName, "default", "bar", 120)
+	_, err := client.CoreV1().ConfigMaps("default").Create(electionCM)
+	require.NoError(t, err)
+
+	// Create endpoints
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      endpointsName,
+			Namespace: "default",
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: "1.1.1.1",
+						TargetRef: &v1.ObjectReference{
+							Kind:      "pod",
+							Namespace: "default",
+							Name:      "foo",
+						},
+					},
+					{
+						IP: "1.1.1.2",
+						TargetRef: &v1.ObjectReference{
+							Kind:      "pod",
+							Namespace: "default",
+							Name:      "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	stored_endpoints, err := client.CoreV1().Endpoints("default").Create(endpoints)
+	require.NoError(t, err)
+
+	// Run leader election
+	le.leaderElector, err = le.newElection()
+	require.NoError(t, err)
+	le.EnsureLeaderElectionRuns()
+	Cm, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, Cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
+
+	// We should be follower, and GetLeaderIP should return bar's IP
+	require.False(t, le.IsLeader())
+	ip, err := le.GetLeaderIP()
+	assert.Equal(t, "1.1.1.2", ip)
+	assert.NoError(t, err)
+
+	// Remove bar from endpoints
+	stored_endpoints.Subsets[0].Addresses = stored_endpoints.Subsets[0].Addresses[0:1]
+	_, err = client.CoreV1().Endpoints("default").Update(stored_endpoints)
+	require.NoError(t, err)
+
+	// GetLeaderIP will "gracefully" error out
+	ip, err = le.GetLeaderIP()
+	assert.Equal(t, "", ip)
+	assert.True(t, dderrors.IsNotFound(err))
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -9,7 +9,6 @@ package leaderelection
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -42,21 +41,6 @@ func makeLeaderCM(name, namespace, leaderIdentity string, leaseDuration int) *co
 			Namespace: namespace,
 			Annotations: map[string]string{
 				"control-plane.alpha.kubernetes.io/leader": string(b),
-			},
-		},
-	}
-}
-
-func newFakeLockObject(namespace, name, leaderIdentity string) *v1.ConfigMap {
-	return &v1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-			Annotations: map[string]string{
-				rl.LeaderElectionRecordAnnotationKey: fmt.Sprintf(`{"holderIdentity":"%s"}`, leaderIdentity),
 			},
 		},
 	}
@@ -109,6 +93,10 @@ func TestNewLeaseAcquiring(t *testing.T) {
 	require.Contains(t, Cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
 	require.True(t, le.IsLeader())
 
+	// As a leader, GetLeaderIP should return an empty IP
+	ip, err := le.GetLeaderIP()
+	assert.Equal(t, "", ip)
+	assert.NoError(t, err)
 }
 
 func TestGetLeaderIPFollower(t *testing.T) {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/api/core/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -25,7 +24,7 @@ import (
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 )
 
-func makeLeaderCM(name, namespace, leaderIdentity string, leaseDuration int) *corev1.ConfigMap {
+func makeLeaderCM(name, namespace, leaderIdentity string, leaseDuration int) *v1.ConfigMap {
 	record := rl.LeaderElectionRecord{
 		HolderIdentity:       leaderIdentity,
 		LeaseDurationSeconds: leaseDuration,
@@ -35,7 +34,7 @@ func makeLeaderCM(name, namespace, leaderIdentity string, leaseDuration int) *co
 	}
 	b, _ := json.Marshal(&record)
 
-	return &corev1.ConfigMap{
+	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -119,7 +118,7 @@ func TestGetLeaderIPFollower(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create endpoints
-	endpoints := &corev1.Endpoints{
+	endpoints := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      endpointsName,
 			Namespace: "default",

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -153,9 +153,9 @@ func TestGetLeaderIPFollower(t *testing.T) {
 	le.leaderElector, err = le.newElection()
 	require.NoError(t, err)
 	le.EnsureLeaderElectionRuns()
-	Cm, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
+	cm, err := client.CoreV1().ConfigMaps("default").Get(leaseName, metav1.GetOptions{})
 	require.NoError(t, err)
-	require.Contains(t, Cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
+	require.Contains(t, cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
 
 	// We should be follower, and GetLeaderIP should return bar's IP
 	require.False(t, le.IsLeader())

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -130,7 +130,7 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False):
 
 
 @task
-def image_build(ctx):
+def image_build(ctx, tag=AGENT_TAG, push=False):
     """
     Build the docker image
     """
@@ -145,5 +145,7 @@ def image_build(ctx):
     ctx.run("chmod +x {}".format(latest_file))
 
     shutil.copy2(latest_file, "Dockerfiles/cluster-agent/")
-    ctx.run("docker build -t {} Dockerfiles/cluster-agent".format(AGENT_TAG))
+    ctx.run("docker build -t {} Dockerfiles/cluster-agent".format(tag))
     ctx.run("rm Dockerfiles/cluster-agent/datadog-cluster-agent")
+    if push:
+        ctx.run("docker push {}".format(tag))


### PR DESCRIPTION
### What does this PR do?

add GetLeaderIP method to LeaderEngine, allowing the leader election engine to inspect its kubernetes service endpoints and return the leader's IP if found.

### Motivation

Will be used by the cluster check followers to redirect requests to leader.

Split from https://github.com/DataDog/datadog-agent/pull/2696 to ease review.