### PR TITLE
[flare] add a permissions.log file into the flare archive

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -106,15 +106,18 @@ func GenerateRootCert(hosts []string, bits int) (
 	return
 }
 
+// GetAuthTokenFilepath returns the path to the auth_token file.
+func GetAuthTokenFilepath() string {
+	if config.Datadog.GetString("auth_token_file_path") != "" {
+		return config.Datadog.GetString("auth_token_file_path")
+	}
+	return filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
+}
+
 // FetchAuthToken gets the authentication token from the auth token file & creates one if it doesn't exist
 // Requires that the config has been set up before calling
 func FetchAuthToken() (string, error) {
-	var authTokenFile string
-	if config.Datadog.GetString("auth_token_file_path") != "" {
-		authTokenFile = config.Datadog.GetString("auth_token_file_path")
-	} else {
-		authTokenFile = filepath.Join(filepath.Dir(config.Datadog.ConfigFileUsed()), authTokenName)
-	}
+	authTokenFile := GetAuthTokenFilepath()
 
 	// Create a new token if it doesn't exist
 	if _, e := os.Stat(authTokenFile); os.IsNotExist(e) {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -133,7 +133,7 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 
 	// auth token permissions info (only if existing)
 	if _, err = os.Stat(security.GetAuthTokenFilepath()); err == nil && !os.IsNotExist(err) {
-		permsInfos.Add(security.GetAuthTokenFilepath())
+		permsInfos.add(security.GetAuthTokenFilepath())
 	}
 
 	err = zipConfigFiles(tempDir, hostname, confSearchPaths, permsInfos)
@@ -190,7 +190,7 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 	}
 
 	// gets files infos and write the permissions.log file
-	if err := permsInfos.Commit(); err != nil {
+	if err := permsInfos.commit(); err != nil {
 		log.Errorf("Could not write permissions.log file: %s", err)
 	}
 
@@ -239,7 +239,7 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos *PermsInfos) 
 			dst := filepath.Join(tempDir, hostname, "logs", f.Name())
 
 			if permsInfos != nil {
-				permsInfos.Add(dst)
+				permsInfos.add(dst)
 			}
 
 			return util.CopyFileAll(src, dst)
@@ -341,7 +341,7 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 			}
 
 			if permsInfos != nil {
-				permsInfos.Add(filePath)
+				permsInfos.add(filePath)
 			}
 		}
 	}
@@ -455,7 +455,7 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 				}
 
 				if permsInfos != nil {
-					permsInfos.Add(src)
+					permsInfos.add(src)
 				}
 			}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -455,7 +455,7 @@ func walkConfigFilePaths(tempDir, hostname string, confSearchPaths SearchPaths, 
 				}
 
 				if permsInfos != nil {
-					permsInfos.Add(f)
+					permsInfos.Add(src)
 				}
 			}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -102,6 +103,12 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		if err != nil {
 			log.Errorf("Could not zip config check: %s", err)
 		}
+	}
+
+	// auth token permissions info
+	err = addPermsInfo(tempDir, hostname, os.ModePerm, security.GetAuthTokenFilepath())
+	if err != nil {
+		log.Errorf("Could not get permissions of the auth token: %s", err)
 	}
 
 	err = zipConfigFiles(tempDir, hostname, confSearchPaths)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -239,7 +239,7 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos *PermsInfos) 
 			dst := filepath.Join(tempDir, hostname, "logs", f.Name())
 
 			if permsInfos != nil {
-				permsInfos.add(dst)
+				permsInfos.add(src)
 			}
 
 			return util.CopyFileAll(src, dst)

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -78,12 +78,12 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		}
 	}
 
-	err = zipLogFiles(tempDir, hostname, logFilePath)
+	err = zipLogFiles(tempDir, hostname, logFilePath, nil)
 	if err != nil {
 		return "", err
 	}
 
-	err = zipConfigFiles(tempDir, hostname, confSearchPaths)
+	err = zipConfigFiles(tempDir, hostname, confSearchPaths, nil)
 
 	if err != nil {
 		return "", err

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -78,12 +78,14 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		}
 	}
 
-	err = zipLogFiles(tempDir, hostname, logFilePath, nil)
+	permsInfos := make(permissionsInfos)
+
+	err = zipLogFiles(tempDir, hostname, logFilePath, permsInfos)
 	if err != nil {
 		return "", err
 	}
 
-	err = zipConfigFiles(tempDir, hostname, confSearchPaths, nil)
+	err = zipConfigFiles(tempDir, hostname, confSearchPaths, permsInfos)
 
 	if err != nil {
 		return "", err
@@ -109,6 +111,11 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 		if err != nil {
 			return "", err
 		}
+	}
+
+	err = permsInfos.commit(tempDir, hostname, os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("while creating permissions infos file: %s", err)
 	}
 
 	err = archiver.Zip.Make(zipFilePath, []string{filepath.Join(tempDir, hostname)})

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -115,7 +115,7 @@ func createDCAArchive(zipFilePath string, local bool, confSearchPaths SearchPath
 
 	err = permsInfos.commit(tempDir, hostname, os.ModePerm)
 	if err != nil {
-		return "", fmt.Errorf("while creating permissions infos file: %s", err)
+		log.Infof("Error while creating permissions.log infos file: %s", err)
 	}
 
 	err = archiver.Zip.Make(zipFilePath, []string{filepath.Join(tempDir, hostname)})

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -7,10 +7,83 @@
 
 package flare
 
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
 func zipCounterStrings(tempDir, hostname string) error {
 	return nil
 }
 
 func zipTypeperfData(tempDir, hostname string) error {
 	return nil
+}
+
+// initPermsInfo creates the permissions.log file and write the headers.
+func initPermsInfo(tempDir, hostname string, p os.FileMode) error {
+	t := filepath.Join(tempDir, hostname, "permissions.log")
+
+	if err := ensureParentDirsExist(t); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE|os.O_APPEND, p)
+	if err != nil {
+		return fmt.Errorf("while opening: %s", err)
+	}
+
+	defer f.Close()
+
+	s := fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", "File path", "mode", "owner", "group")
+	if _, err = f.Write([]byte(s)); err != nil {
+		return err
+	}
+
+	_, err = f.Write([]byte(strings.Repeat("-", len(s)) + "\n"))
+	return err
+}
+
+// addPermsInfo appends permissions info of the given file using its filePath
+// into the permissions.log file which is shipped in the flare archive.
+func addPermsInfo(tempDir, hostname string, p os.FileMode, filePath string) error {
+	t := filepath.Join(tempDir, hostname, "permissions.log")
+	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE|os.O_APPEND, p)
+	if err != nil {
+		return fmt.Errorf("while opening %s: %s", t, err)
+	}
+
+	defer f.Close()
+
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("while getting info of %s: %s", filePath, err)
+	}
+
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		// not enough information to append for this file
+		// might happen on system not supporting this feature, but as
+		// we're building with !windows tag, shouldn't happen except for
+		// very exotic system.
+		_, err = f.WriteString(fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", filePath, fi.Mode().String(), "???", "???"))
+		return err
+	}
+
+	u, err := user.LookupId(strconv.Itoa(int(sys.Uid)))
+	if err != nil {
+		return fmt.Errorf("can't lookup for uid info: %v", err)
+	}
+	g, err := user.LookupGroupId(strconv.Itoa(int(sys.Gid)))
+	if err != nil {
+		return fmt.Errorf("can't lookup for gid info: %v", err)
+	}
+
+	_, err = f.WriteString(fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", filePath, fi.Mode().String(), u.Name, g.Name))
+	return err
 }

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -98,7 +98,9 @@ func (p *PermsInfos) write() error {
 	if _, err = f.Write([]byte(s)); err != nil {
 		return err
 	}
-	_, err = f.Write([]byte(strings.Repeat("-", len(s)) + "\n"))
+	if _, err = f.Write([]byte(strings.Repeat("-", len(s)) + "\n")); err != nil {
+		return err
+	}
 
 	// write each file permissions infos
 	for filePath, perms := range p.infos {

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -9,6 +9,7 @@ package flare
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -25,65 +26,87 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
-// initPermsInfo creates the permissions.log file and write the headers.
-func initPermsInfo(tempDir, hostname string, p os.FileMode) error {
-	t := filepath.Join(tempDir, hostname, "permissions.log")
+// Add puts the given filepath in the map
+// of files to process later during the commit phase.
+func (p *PermsInfos) Add(filePath string) {
+	p.infos[filePath] = permsInfo{}
+}
+
+// Commit resolves the infos of every stacked files in the map
+// and then writes the permissions.log file on the filesystem.
+func (p *PermsInfos) Commit() error {
+	if err := p.statFiles(); err != nil {
+		return err
+	}
+	if err := p.write(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *PermsInfos) statFiles() error {
+	for filePath := range p.infos {
+		fi, err := os.Stat(filePath)
+		if err != nil {
+			log.Println(err)
+			return fmt.Errorf("while getting info of %s: %s", filePath, err)
+		}
+
+		sys, ok := fi.Sys().(*syscall.Stat_t)
+		if !ok {
+			// not enough information to append for this file
+			// might rarely happen on system not supporting this feature, but as
+			// we're building with !windows tag, shouldn't happen except for plan9
+			return fmt.Errorf("can't retrieve file uid/gid infos")
+		}
+
+		u, err := user.LookupId(strconv.Itoa(int(sys.Uid)))
+		if err != nil {
+			return fmt.Errorf("can't lookup for uid info: %v", err)
+		}
+		g, err := user.LookupGroupId(strconv.Itoa(int(sys.Gid)))
+		if err != nil {
+			return fmt.Errorf("can't lookup for gid info: %v", err)
+		}
+
+		p.infos[filePath] = permsInfo{
+			mode:  fi.Mode(),
+			owner: u.Name,
+			group: g.Name,
+		}
+	}
+	return nil
+}
+
+func (p *PermsInfos) write() error {
+	// init the file
+	t := filepath.Join(p.tempDir, p.hostname, "permissions.log")
 
 	if err := ensureParentDirsExist(t); err != nil {
 		return err
 	}
 
-	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE|os.O_APPEND, p)
+	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE|os.O_APPEND, p.filemode)
 	if err != nil {
 		return fmt.Errorf("while opening: %s", err)
 	}
 
 	defer f.Close()
 
+	// write headers
 	s := fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", "File path", "mode", "owner", "group")
 	if _, err = f.Write([]byte(s)); err != nil {
 		return err
 	}
-
 	_, err = f.Write([]byte(strings.Repeat("-", len(s)) + "\n"))
-	return err
-}
 
-// addPermsInfo appends permissions info of the given file using its filePath
-// into the permissions.log file which is shipped in the flare archive.
-func addPermsInfo(tempDir, hostname string, p os.FileMode, filePath string) error {
-	t := filepath.Join(tempDir, hostname, "permissions.log")
-	f, err := os.OpenFile(t, os.O_RDWR|os.O_CREATE|os.O_APPEND, p)
-	if err != nil {
-		return fmt.Errorf("while opening %s: %s", t, err)
+	// write each file permissions infos
+	for filePath, perms := range p.infos {
+		_, err = f.WriteString(fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", filePath, perms.mode.String(), perms.owner, perms.group))
+		if err != nil {
+			return err
+		}
 	}
 
-	defer f.Close()
-
-	fi, err := os.Stat(filePath)
-	if err != nil {
-		return fmt.Errorf("while getting info of %s: %s", filePath, err)
-	}
-
-	sys, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		// not enough information to append for this file
-		// might happen on system not supporting this feature, but as
-		// we're building with !windows tag, shouldn't happen except for
-		// very exotic system.
-		_, err = f.WriteString(fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", filePath, fi.Mode().String(), "???", "???"))
-		return err
-	}
-
-	u, err := user.LookupId(strconv.Itoa(int(sys.Uid)))
-	if err != nil {
-		return fmt.Errorf("can't lookup for uid info: %v", err)
-	}
-	g, err := user.LookupGroupId(strconv.Itoa(int(sys.Gid)))
-	if err != nil {
-		return fmt.Errorf("can't lookup for gid info: %v", err)
-	}
-
-	_, err = f.WriteString(fmt.Sprintf("%-50s | %-5s | %-10s | %-10s\n", filePath, fi.Mode().String(), u.Name, g.Name))
-	return err
+	return nil
 }

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -28,13 +28,13 @@ func zipTypeperfData(tempDir, hostname string) error {
 
 // Add puts the given filepath in the map
 // of files to process later during the commit phase.
-func (p *PermsInfos) Add(filePath string) {
+func (p *PermsInfos) add(filePath string) {
 	p.infos[filePath] = permsInfo{}
 }
 
 // Commit resolves the infos of every stacked files in the map
 // and then writes the permissions.log file on the filesystem.
-func (p *PermsInfos) Commit() error {
+func (p *PermsInfos) commit() error {
 	if err := p.statFiles(); err != nil {
 		return err
 	}

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -50,8 +50,7 @@ func TestPermsFile(t *testing.T) {
 func TestAddPermsInfo(t *testing.T) {
 	assert := assert.New(t)
 
-	err := initPermsInfo(os.TempDir(), "", os.ModePerm)
-	assert.NoError(err, "creating the permissions.log info file shouldn't failed")
+	permsInfos := NewPermsInfos(os.TempDir(), "", os.ModePerm)
 
 	// create two files for which we'll add infos into the permissions.log
 	f1, err := ioutil.TempFile("", "ddtests*")
@@ -61,13 +60,13 @@ func TestAddPermsInfo(t *testing.T) {
 	assert.NoError(err, "creating a temporary file should not fail")
 	assert.NotNil(f2, "temporary file should not be nil")
 
-	err = addPermsInfo(os.TempDir(), "", os.ModePerm, f1.Name())
-	assert.NoError(err, "addPermsInfos should correctly add the f1 permission to a permissions.log file")
-	err = addPermsInfo(os.TempDir(), "", os.ModePerm, f2.Name())
-
-	assert.NoError(err, "addPermsInfos should correctly add the f2 permission to a permissions.log file")
+	permsInfos.Add(f1.Name())
+	permsInfos.Add(f2.Name())
 
 	permsFilePath := filepath.Join(os.TempDir(), "permissions.log")
+
+	err = permsInfos.Commit()
+	assert.NoError(err, "stating files + writing permissions.log should not fail")
 
 	// should have created a permissions.log in the tmp dir
 	// + added headers and info of the previously created files

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build !windows
+
+package flare
+
+import (
+	"archive/zip"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure the permissions.log is being created
+func TestPermsFile(t *testing.T) {
+	assert := assert.New(t)
+
+	common.SetupConfig("./test")
+	config.Datadog.Set("confd_path", "./test/confd")
+	config.Datadog.Set("log_file", "./test/logs/agent.log")
+	zipFilePath := getArchivePath()
+	filePath, err := createArchive(zipFilePath, true, SearchPaths{}, "")
+	defer os.Remove(zipFilePath)
+
+	assert.Nil(err)
+	assert.Equal(zipFilePath, filePath)
+
+	// asserts that it as indeed created a permissions.log file
+	z, err := zip.OpenReader(zipFilePath)
+	assert.NoError(err, "opening the zip shouldn't pop an error")
+
+	ok := false
+	for _, f := range z.File {
+		if strings.HasSuffix(f.Name, "permissions.log") {
+			ok = true
+		}
+	}
+	assert.True(ok, "a permissions.log should have been appended to the zip")
+}
+
+func TestAddPermsInfo(t *testing.T) {
+	assert := assert.New(t)
+
+	err := initPermsInfo(os.TempDir(), "", os.ModePerm)
+	assert.NoError(err, "creating the permissions.log info file shouldn't failed")
+
+	// create two files for which we'll add infos into the permissions.log
+	f1, err := ioutil.TempFile("", "ddtests*")
+	assert.NoError(err, "creating a temporary file should not fail")
+	assert.NotNil(f1, "temporary file should not be nil")
+	f2, err := ioutil.TempFile("", "ddtests*")
+	assert.NoError(err, "creating a temporary file should not fail")
+	assert.NotNil(f2, "temporary file should not be nil")
+
+	err = addPermsInfo(os.TempDir(), "", os.ModePerm, f1.Name())
+	assert.NoError(err, "addPermsInfos should correctly add the f1 permission to a permissions.log file")
+	err = addPermsInfo(os.TempDir(), "", os.ModePerm, f2.Name())
+
+	assert.NoError(err, "addPermsInfos should correctly add the f2 permission to a permissions.log file")
+
+	permsFilePath := filepath.Join(os.TempDir(), "permissions.log")
+
+	// should have created a permissions.log in the tmp dir
+	// + added headers and info of the previously created files
+	data, err := ioutil.ReadFile(permsFilePath)
+	assert.NoError(err, "should be able to read the temporary permissions file")
+	assert.Equal(4, strings.Count(string(data), "\n"), "the permissions file should contain 2 lines of headers, 2 lines of entries")
+
+	os.Remove(filepath.Join(os.TempDir(), "permissions.log"))
+	os.Remove(f1.Name())
+	os.Remove(f2.Name())
+}

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -60,12 +60,12 @@ func TestAddPermsInfo(t *testing.T) {
 	assert.NoError(err, "creating a temporary file should not fail")
 	assert.NotNil(f2, "temporary file should not be nil")
 
-	permsInfos.Add(f1.Name())
-	permsInfos.Add(f2.Name())
+	permsInfos.add(f1.Name())
+	permsInfos.add(f2.Name())
 
 	permsFilePath := filepath.Join(os.TempDir(), "permissions.log")
 
-	err = permsInfos.Commit()
+	err = permsInfos.commit()
 	assert.NoError(err, "stating files + writing permissions.log should not fail")
 
 	// should have created a permissions.log in the tmp dir

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -50,7 +50,7 @@ func TestPermsFile(t *testing.T) {
 func TestAddPermsInfo(t *testing.T) {
 	assert := assert.New(t)
 
-	permsInfos := NewPermsInfos(os.TempDir(), "", os.ModePerm)
+	permsInfos := make(permissionsInfos)
 
 	// create two files for which we'll add infos into the permissions.log
 	f1, err := ioutil.TempFile("", "ddtests*")
@@ -65,7 +65,7 @@ func TestAddPermsInfo(t *testing.T) {
 
 	permsFilePath := filepath.Join(os.TempDir(), "permissions.log")
 
-	err = permsInfos.commit()
+	err = permsInfos.commit(os.TempDir(), "", os.ModePerm)
 	assert.NoError(err, "stating files + writing permissions.log should not fail")
 
 	// should have created a permissions.log in the tmp dir

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -83,7 +83,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
-func (p *permissionsInfos) add(filePath string) {}
-func (p *permissionsInfos) commit(tempDir, hostname string, mode os.FileMode) error {
+func (p permissionsInfos) add(filePath string) {}
+func (p permissionsInfos) commit(tempDir, hostname string, mode os.FileMode) error {
 	return nil
 }

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -83,7 +83,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
-func (p *PermsInfos) Add(filePath string) {}
-func (p *PermsInfos) Commit() error {
+func (p *PermsInfos) add(filePath string) {}
+func (p *PermsInfos) commit() error {
 	return nil
 }

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -83,10 +83,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
-func initPermsInfo(tempDir, hostname string, p os.FileMode) error {
-	return nil
-}
-
-func addPermsInfo(tempDir, hostname string, p os.FileMode, filepath string) error {
+func (p *PermsInfos) Add(filePath string) {}
+func (p *PermsInfos) Commit() error {
 	return nil
 }

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -83,10 +83,10 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
-func initPermsInfo(tempDir, hostname, p os.FileMode) error {
+func initPermsInfo(tempDir, hostname string, p os.FileMode) error {
 	return nil
 }
 
-func addPermsInfo(tempDir, hostname, p os.FileMode, filepath string) error {
+func addPermsInfo(tempDir, hostname string, p os.FileMode, filepath string) error {
 	return nil
 }

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -82,3 +82,11 @@ func zipTypeperfData(tempDir, hostname string) error {
 	}
 	return nil
 }
+
+func initPermsInfo(tempDir, hostname, p os.FileMode) error {
+	return nil
+}
+
+func addPermsInfo(tempDir, hostname, p os.FileMode, filepath string) error {
+	return nil
+}

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -83,7 +83,7 @@ func zipTypeperfData(tempDir, hostname string) error {
 	return nil
 }
 
-func (p *PermsInfos) add(filePath string) {}
-func (p *PermsInfos) commit() error {
+func (p *permissionsInfos) add(filePath string) {}
+func (p *permissionsInfos) commit(tempDir, hostname string, mode os.FileMode) error {
 	return nil
 }

--- a/releasenotes/notes/flare-add-permissions-file-8d3258c068998a48.yaml
+++ b/releasenotes/notes/flare-add-permissions-file-8d3258c068998a48.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``permissions.log`` file to the flare archive.


### PR DESCRIPTION
### What does this PR do?

This PR adds a `permissions.log` file to the flare archive. As the files shipped in the flare archive are contained in a zip archive, we lost their permissions info of the original system. This file provide them.

### Motivation

The `permissions.log` file was available in the agent v5 flare archive but not in the v6.
It could be used to diagnose permissions errors of the agent setup.

### Additional Notes

There is a slight difference in the file format, the mode info were displayed as an octal number (e.g. `0644`) while this version displays them like a `ls -l` output: `-rw-r--r--`
The complexity to display them as `0644` _with the file type_ was ridiculous compared to calling the method for the latter display. Or maybe I've missed an obvious solution (see https://golang.org/src/os/types.go?#L65 for reference).

Note that this PR doesn't cover the Windows build.
