### PR TITLE
[CI] Temporarily allow failures on kitchen windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -618,7 +618,8 @@ deploy_windows_testing:
 # run dd-agent-testing on windows
 kitchen_windows:
   stage: testkitchen_testing
-  allow_failure: false
+  # FIXME: do not allow failures once the DCA tags don't impact the Agent's nightly package versioning
+  allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:
@@ -641,7 +642,8 @@ kitchen_windows:
 
 kitchen_windows_installer:
   stage: testkitchen_testing
-  allow_failure: false
+  # FIXME: do not allow failures once the DCA tags don't impact the Agent's nightly package versioning
+  allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:


### PR DESCRIPTION
### What does this PR do?

Temporarily allow failures on kitchen windows until we fix the versioning issues

### Motivation

For some reason the DCA tags on master have broken the kitchen windows tests (the tests try to pull a version of the MSI that's different from what's actually built)

### Additional Notes

Might be related to https://github.com/DataDog/omnibus-ruby/pull/56, didn't have time to confirm

I'll investigate this a bit more on Monday to get to the bottom of the issue