### PR TITLE
Add health port to dogstatsd and cluster-agent

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -2,12 +2,18 @@ FROM alpine:3.8
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
+ENV DOCKER_DD_AGENT=true \
+    DD_HEALTH_PORT=5555
+
 RUN apk add --no-cache ca-certificates
 
-COPY entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh probe.sh /
 COPY static/dogstatsd /dogstatsd
 
 EXPOSE 8125/udp
+
+HEALTHCHECK --interval=1m --timeout=5s --retries=2 \
+  CMD ["/probe.sh"]
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/dogstatsd", "start"]

--- a/Dockerfiles/dogstatsd/alpine/probe.sh
+++ b/Dockerfiles/dogstatsd/alpine/probe.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+busybox wget -q -O /dev/null localhost:5555/

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -217,7 +217,7 @@ func start(cmd *cobra.Command, args []string) error {
 	// GetStatusNonBlocking has a 100ms timeout to avoid blocking
 	health, err := health.GetStatusNonBlocking()
 	if err != nil {
-		log.Warnf("Agent health unknown: %s", err)
+		log.Warnf("Cluster Agent health unknown: %s", err)
 	} else if len(health.Unhealthy) > 0 {
 		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
 	}

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -21,11 +21,13 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
@@ -130,6 +132,16 @@ func start(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Setup healthcheck port
+	var healthPort = config.Datadog.GetInt("health_port")
+	if healthPort > 0 {
+		err := healthprobe.Serve(mainCtx, healthPort)
+		if err != nil {
+			return log.Errorf("Error starting health port, exiting: %v", err)
+		}
+		log.Debugf("Health check listening on port %d", healthPort)
+	}
+
 	// get hostname
 	hostname, err := util.GetHostname()
 	if err != nil {
@@ -200,6 +212,15 @@ func start(cmd *cobra.Command, args []string) error {
 
 	// Block here until we receive the interrupt signal
 	<-signalCh
+
+	// retrieve the agent health before stopping the components
+	// GetStatusNonBlocking has a 100ms timeout to avoid blocking
+	health, err := health.GetStatusNonBlocking()
+	if err != nil {
+		log.Warnf("Agent health unknown: %s", err)
+	} else if len(health.Unhealthy) > 0 {
+		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
+	}
 
 	// Cancel the main context to stop components
 	mainCtxCancel()

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -85,6 +85,7 @@ func init() {
 func start(cmd *cobra.Command, args []string) error {
 	// Main context passed to components
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
+	defer mainCtxCancel() // Calling cancel twice is safe
 
 	configFound := false
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"context"
 	_ "expvar"
 	"fmt"
 	"net/http"
@@ -20,11 +21,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -80,6 +83,9 @@ func init() {
 }
 
 func start(cmd *cobra.Command, args []string) error {
+	// Main context passed to components
+	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
+
 	configFound := false
 
 	// a path to the folder containing the config file was passed
@@ -127,6 +133,16 @@ func start(cmd *cobra.Command, args []string) error {
 	if !config.Datadog.IsSet("api_key") {
 		log.Critical("no API key configured, exiting")
 		return nil
+	}
+
+	// Setup healthcheck port
+	var healthPort = config.Datadog.GetInt("health_port")
+	if healthPort > 0 {
+		err := healthprobe.Serve(mainCtx, healthPort)
+		if err != nil {
+			return log.Errorf("Error starting health port, exiting: %v", err)
+		}
+		log.Debugf("Health check listening on port %d", healthPort)
 	}
 
 	// setup the forwarder
@@ -182,6 +198,18 @@ func start(cmd *cobra.Command, args []string) error {
 
 	// Block here until we receive the interrupt signal
 	<-signalCh
+
+	// retrieve the agent health before stopping the components
+	// GetStatusNonBlocking has a 100ms timeout to avoid blocking
+	health, err := health.GetStatusNonBlocking()
+	if err != nil {
+		log.Warnf("Dogstatsd health unknown: %s", err)
+	} else if len(health.Unhealthy) > 0 {
+		log.Warnf("Some components were unhealthy: %v", health.Unhealthy)
+	}
+
+	// gracefully shut down any component
+	mainCtxCancel()
 
 	if metaScheduler != nil {
 		metaScheduler.Stop()

--- a/pkg/tagger/tagger.go
+++ b/pkg/tagger/tagger.go
@@ -60,7 +60,6 @@ func newTagger() *Tagger {
 		pruneTicker: time.NewTicker(5 * time.Minute),
 		retryTicker: time.NewTicker(30 * time.Second),
 		stop:        make(chan bool),
-		health:      health.Register("tagger"),
 	}
 }
 
@@ -69,6 +68,10 @@ func newTagger() *Tagger {
 // requests.
 func (t *Tagger) Init(catalog collectors.Catalog) {
 	t.Lock()
+
+	// Only register the health check when the tagger is started
+	t.health = health.Register("tagger")
+
 	// Populate collector candidate list from catalog
 	// as we'll remove entries we need to copy the map
 	for name, factory := range catalog {

--- a/releasenotes/notes/dogstatsd-health-check-ade16e325a855a37.yaml
+++ b/releasenotes/notes/dogstatsd-health-check-ade16e325a855a37.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Docker: the datadog/dogstatsd image now ships a healthcheck


### PR DESCRIPTION
### What does this PR do?

- Port the logic from https://github.com/DataDog/datadog-agent/pull/2359 in the dogstatsd and cluster-agent commands
- Add a `probe.sh` script in the dogstatsd docker image, to be compatible with the helm chart
- For both cmds, add the logic to print the health status on exit
- Fix tagger healthcheck lifecycle issue (register on Init, not constructor)

Test images:

- datadog/dogstatsd-dev:xvello-health-dsd-dca
- datadog/cluster-agent-dev:xvello-health-dsd-dca
