### PR TITLE
Periodically refresh tags on k8s

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -139,3 +139,20 @@ func (c *LogsConfig) Compile() error {
 	}
 	return nil
 }
+
+func (c *LogsConfig) updateTags(tags []string) {
+	tagSet := make(map[string]struct{})
+
+	for _, tag := range tags {
+		tagSet[tag] = struct{}{}
+	}
+	for _, tag := range c.Tags {
+		tagSet[tag] = struct{}{}
+	}
+
+	var updatedTags []string
+	for tag := range tagSet {
+		updatedTags = append(updatedTags, tag)
+	}
+	c.Tags = updatedTags
+}

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -70,3 +70,27 @@ func TestCompileShouldFailWithInvalidRules(t *testing.T) {
 		assert.Nil(t, rule.Reg)
 	}
 }
+
+func TestUpdateTags(t *testing.T) {
+	config := &LogsConfig{}
+	tags := []string{"foo:bar", "baz:qux"}
+	config.updateTags(tags)
+	assert.ElementsMatch(t, []string{"foo:bar", "baz:qux"}, config.Tags)
+
+	config = &LogsConfig{Tags: []string{"foobar:bazqux"}}
+	tags = []string{"foo:bar", "baz:qux"}
+	config.updateTags(tags)
+	assert.ElementsMatch(t, []string{"foobar:bazqux", "foo:bar", "baz:qux"}, config.Tags)
+	config.updateTags(tags)
+	assert.ElementsMatch(t, []string{"foobar:bazqux", "foo:bar", "baz:qux"}, config.Tags)
+
+	config = &LogsConfig{Tags: []string{"foo:bar", "baz:qux"}}
+	tags = []string{"foo:bar", "baz:qux"}
+	config.updateTags(tags)
+	assert.ElementsMatch(t, []string{"foo:bar", "baz:qux"}, config.Tags)
+
+	config = &LogsConfig{Tags: []string{"foo:bar", "baz:qux"}}
+	tags = []string(nil)
+	config.updateTags(tags)
+	assert.ElementsMatch(t, []string{"foo:bar", "baz:qux"}, config.Tags)
+}

--- a/pkg/logs/config/source.go
+++ b/pkg/logs/config/source.go
@@ -75,3 +75,12 @@ func (s *LogSource) GetSourceType() string {
 	defer s.lock.Unlock()
 	return s.sourceType
 }
+
+// UpdateTags update the tags of the its LogConfig
+func (s *LogSource) UpdateTags(tags []string) {
+	s.lock.Lock()
+	if s.Config != nil {
+		s.Config.updateTags(tags)
+	}
+	s.lock.Unlock()
+}

--- a/releasenotes/notes/periodicaly-refresh-tags-on-k8s-e5ec7e6a92c308ac.yaml
+++ b/releasenotes/notes/periodicaly-refresh-tags-on-k8s-e5ec7e6a92c308ac.yaml
@@ -1,0 +1,10 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+fixes:
+  - |
+    Fix a bug where kubernetes logs would have missing tags


### PR DESCRIPTION
### What does this PR do?

Add a goroutine that polls the tags on k8s periodically

### Motivation

Sometimes, the logs coming from the kubernetes integration wouldn'to have all their tags

### Additional Notes

I couldn't reproduce the bug locally 
