### PR TITLE
[flare] dump go routines as well

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -8,11 +8,14 @@ package flare
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"expvar"
+	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -29,6 +32,15 @@ import (
 
 	"github.com/mholt/archiver"
 	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	routineDumpFilename = "go-routine-dump.log"
+)
+
+var (
+	pprofURL = fmt.Sprintf("http://127.0.0.1:%s/debug/pprof/goroutine?debug=2",
+		config.Datadog.GetString("expvar_port"))
 )
 
 // SearchPaths is just an alias for a map of strings
@@ -149,6 +161,11 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 	err = zipHealth(tempDir, hostname)
 	if err != nil {
 		log.Errorf("Could not zip health check: %s", err)
+	}
+
+	err = zipStackTraces(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not collect go routine stack traces: %s", err)
 	}
 
 	if config.IsContainerized() {
@@ -415,6 +432,43 @@ func zipHealth(tempDir, hostname string) error {
 	defer w.Close()
 
 	_, err = w.Write(yamlValue)
+	return err
+}
+
+func zipStackTraces(tempDir, hostname string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	client := http.Client{}
+	req, err := http.NewRequest(http.MethodGet, pprofURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	f := filepath.Join(tempDir, hostname, routineDumpFilename)
+	err = ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
+	w, err := NewRedactingWriter(f, os.ModePerm, true)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	_, err = w.Write(body)
 	return err
 }
 

--- a/releasenotes/notes/flare-add-routine-dump-c1987d6824cb5aaa.yaml
+++ b/releasenotes/notes/flare-add-routine-dump-c1987d6824cb5aaa.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add an agent go-routine dump to the flare as reported
+    by the built-in pprof runtime profiling interface.


### PR DESCRIPTION
### What does this PR do?

Adds a goroutine stacktrace dump to the flare command. Should help us spot potential deadlocks, etc.

### Motivation

Desirable piece of information in debugging situations.

### Additional Notes

Note that we `GET` from `http://localhost:%s/debug/pprof/goroutine?debug=2`, and this provides what looks like relevant goroutines (blocked on IO, selects, semaphores, etc), not all goroutines, which could get out of hand quick. Also, I'm not sure how to list all goroutine even if we wanted to.
