### PR TITLE
Set short image name as Source and Service tags in kubernetes integration

### DIFF
--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -41,8 +41,8 @@ func TestGetSource(t *testing.T) {
 	assert.Equal(t, "buu/fuz/foo", source.Name)
 	assert.Equal(t, "/var/log/pods/baz/foo/*.log", source.Config.Path)
 	assert.Equal(t, "boo", source.Config.Identifier)
-	assert.Equal(t, "kubernetes", source.Config.Source)
-	assert.Equal(t, "kubernetes", source.Config.Service)
+	assert.Equal(t, "bar", source.Config.Source)
+	assert.Equal(t, "bar", source.Config.Service)
 }
 
 func TestGetSourceShouldBeOverridenByAutoDiscoveryAnnotation(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Sets short image name as Source and Service tags in kubernetes integration

### Motivation

Forgot to do it in #2704

### Additional Notes

Reno is in #2704
