### PR TITLE
[flare] include a status.log with a message if the agent is not running

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -84,9 +84,14 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		if err != nil {
 			return "", err
 		}
-	} else {
+
 		// Status informations will be unavailable unless the agent is running.
-		// Only zip them up if the agent is running
+		err = writeStatusFile(tempDir, hostname, []byte("agent is not running"))
+		if err != nil {
+			return "", err
+		}
+	} else {
+		// Status informations are available, zip them up as the agent is running.
 		err = zipStatusFile(tempDir, hostname)
 		if err != nil {
 			log.Errorf("Could not zip status: %s", err)
@@ -164,9 +169,12 @@ func zipStatusFile(tempDir, hostname string) error {
 	if err != nil {
 		return err
 	}
+	return writeStatusFile(tempDir, hostname, s)
+}
 
+func writeStatusFile(tempDir, hostname string, data []byte) error {
 	f := filepath.Join(tempDir, hostname, "status.log")
-	err = ensureParentDirsExist(f)
+	err := ensureParentDirsExist(f)
 	if err != nil {
 		return err
 	}
@@ -177,7 +185,7 @@ func zipStatusFile(tempDir, hostname string) error {
 	}
 	defer w.Close()
 
-	_, err = w.Write(s)
+	_, err = w.Write(data)
 	return err
 }
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -86,7 +86,7 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 		}
 
 		// Status informations will be unavailable unless the agent is running.
-		err = writeStatusFile(tempDir, hostname, []byte("agent is not running"))
+		err = writeStatusFile(tempDir, hostname, []byte("unable to get the status of the agent, is it running?"))
 		if err != nil {
 			return "", err
 		}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -85,8 +85,12 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 			return "", err
 		}
 
-		// Status informations will be unavailable unless the agent is running.
+		// Can't reach the agent, mention it in those two files
 		err = writeStatusFile(tempDir, hostname, []byte("unable to get the status of the agent, is it running?"))
+		if err != nil {
+			return "", err
+		}
+		err = writeConfigCheck(tempDir, hostname, []byte("unable to get loaded checks config, is the agent running?"))
 		if err != nil {
 			return "", err
 		}
@@ -334,6 +338,10 @@ func zipConfigCheck(tempDir, hostname string) error {
 	GetConfigCheck(writer, true)
 	writer.Flush()
 
+	return writeConfigCheck(tempDir, hostname, b.Bytes())
+}
+
+func writeConfigCheck(tempDir, hostname string, data []byte) error {
 	f := filepath.Join(tempDir, hostname, "config-check.log")
 	err := ensureParentDirsExist(f)
 	if err != nil {
@@ -346,7 +354,7 @@ func zipConfigCheck(tempDir, hostname string) error {
 	}
 	defer w.Close()
 
-	_, err = w.Write(b.Bytes())
+	_, err = w.Write(data)
 	return err
 }
 

--- a/releasenotes/notes/status-log-flare-bef2703f034a0f6f.yaml
+++ b/releasenotes/notes/status-log-flare-bef2703f034a0f6f.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add a ``status.log`` with a basic message in a flare if the
-    agent is not running
+    Add a ``status.log`` and a ``config-check.log`` with a basic message in the flare
+    if the agent is not running or is unreachable.

--- a/releasenotes/notes/status-log-flare-bef2703f034a0f6f.yaml
+++ b/releasenotes/notes/status-log-flare-bef2703f034a0f6f.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add a ``status.log`` with a basic message in a flare if the
+    agent is not running


### PR DESCRIPTION
### What does this PR do?

In case of the agent _not running_ or unreachable, this PR includes a `status.log` and a `config-check.log` file in the flare with a simple message about the agent state. The previous behavior was no `status.log`  and no `config-check.log` at all in the flare, which could be misleading for the person analyzing it.

(Note that a `status.log` and `config-check.log` with full infos are already included if the agent is running, this PR doesn't change anything about that)

### Motivation

Having the info that the agent is not reachable directly in the `status.log` and `config-check.log`avoid the person to miss `local` file info and directly notify the person about the agent state.

### Additional Notes

N/A