### PR TITLE
Use Platform instead of PlatformFamily in host info

### DIFF
--- a/pkg/metadata/host/host_nix.go
+++ b/pkg/metadata/host/host_nix.go
@@ -18,5 +18,5 @@ type osVersion [3]string
 const osName = runtime.GOOS
 
 func fillOsVersion(stats *systemStats, info *host.InfoStat) {
-	stats.Nixver = osVersion{info.PlatformFamily, info.PlatformVersion, ""}
+	stats.Nixver = osVersion{info.Platform, info.PlatformVersion, ""}
 }

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -67,7 +67,7 @@ func InitHostMetadata() error {
 
 func fillOsVersion(stats *systemStats, info *InfoStat) {
 	// TODO
-	stats.Winver = osVersion{info.PlatformFamily, info.PlatformVersion}
+	stats.Winver = osVersion{info.Platform, info.PlatformVersion}
 }
 
 // GetStatusInformation just returns an InfoStat object, filled in with various


### PR DESCRIPTION
### Motivation

Currently:

- both debian and ubuntu are reported as "debian"
- RHEL, Centos, amazon linux, oracle linux are reported as "rhel"

It doesn't change anything for debian,windows and fedora

This is confusing since we end up with distributions like debian-16.04 and not consistent with agent 5 behavior.