### PR TITLE
Add ability to patch `match` string via invoke task to `git tags` so

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -300,7 +300,7 @@ def e2e_tests(ctx, target="gitlab", image=""):
 
 
 @task
-def version(ctx, url_safe=False, git_sha_length=7):
+def version(ctx, url_safe=False, git_sha_length=7, match=None):
     """
     Get the agent version.
     url_safe: get the version that is able to be addressed as a url
@@ -308,7 +308,7 @@ def version(ctx, url_safe=False, git_sha_length=7):
                     use this to explicitly set the version
                     (the windows builder and the default ubuntu version have such an incompatibility)
     """
-    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length))
+    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, match=match))
 
 
 class TestProfiler:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -148,10 +148,13 @@ def get_git_branch_name():
     return check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
 
 
-def query_version(ctx, git_sha_length=7):
+def query_version(ctx, git_sha_length=7, match=None):
     # The string that's passed in will look something like this: 6.0.0-beta.0-1-g4f19118
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
-    described_version = ctx.run("git describe --tags", hide=True).stdout.strip()
+    cmd = "git describe --tags"
+    if match:
+        cmd += " --match \"{}\"".format(match)
+    described_version = ctx.run(cmd, hide=True).stdout.strip()
     # For the tag 6.0.0-beta.0, this will match 6.0.0
     version_match = re.findall(r"^(?:dca-)?v?(\d+\.\d+\.\d+)", described_version)
 
@@ -192,10 +195,10 @@ def query_version(ctx, git_sha_length=7):
     return version, pre, commits_since_version, git_sha
 
 
-def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7):
+def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, match=None):
     # we only need the git info for the non omnibus builds, omnibus includes all this information by default
     version = ""
-    version, pre, commits_since_version, git_sha = query_version(ctx, git_sha_length)
+    version, pre, commits_since_version, git_sha = query_version(ctx, git_sha_length, match)
     if pre:
         version = "{0}-{1}".format(version, pre)
     if commits_since_version and include_git:

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -78,7 +78,7 @@ set -x
 # on linux it can just download the latest version from the package manager
 if [ -z ${AGENT_VERSION+x} ]; then
   pushd ../..
-    export AGENT_VERSION=`inv version --url-safe --git-sha-length=9`
+    export AGENT_VERSION=`inv version --url-safe --git-sha-length=9 --match=[0-9]*`
   popd
 fi
 


### PR DESCRIPTION
we can get specific agent version tags and avoid others

