### PR TITLE
use `service` instead of `systemctl` by default

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -262,9 +262,9 @@ if command -v systemctl 2>&1; then
   start_instructions="$sudo_cmd systemctl start datadog-agent"
 elif /sbin/init --version 2>&1 | grep -q upstart; then
   # Try to detect Upstart, this works most of the times but still a best effort
-    restart_cmd="$sudo_cmd start datadog-agent"
-    stop_instructions="$sudo_cmd stop datadog-agent"
-    start_instructions="$sudo_cmd start datadog-agent"
+  restart_cmd="$sudo_cmd start datadog-agent"
+  stop_instructions="$sudo_cmd stop datadog-agent"
+  start_instructions="$sudo_cmd start datadog-agent"
 fi
 
 if [ $no_start ]; then

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -255,12 +255,12 @@ restart_cmd="$sudo_cmd service datadog-agent restart"
 stop_instructions="$sudo_cmd service datadog-agent stop"
 start_instructions="$sudo_cmd service datadog-agent start"
 
-if command -v systemctl 2>&1;
-then # Use systemd if systemctl binary exists
+if command -v systemctl 2>&1; then 
+  # Use systemd if systemctl binary exists
   restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"
   start_instructions="$sudo_cmd systemctl start datadog-agent"
-elif /sbin/init --version 2>&1 | grep -q upstart;
+elif /sbin/init --version 2>&1 | grep -q upstart; then
 then # Try to detect Upstart, this works most of the times but still a 
     restart_cmd="$sudo_cmd start datadog-agent"
     stop_instructions="$sudo_cmd stop datadog-agent"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -249,10 +249,18 @@ else
 fi
 
 
-# Use systemd by default
-restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
-stop_instructions="$sudo_cmd systemctl stop datadog-agent"
-start_instructions="$sudo_cmd systemctl start datadog-agent"
+# Use /usr/sbin/service by default. 
+# Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
+restart_cmd="$sudo_cmd service datadog-agent restart"
+stop_instructions="$sudo_cmd service datadog-agent stop"
+start_instructions="$sudo_cmd service datadog-agent start"
+
+if [ command -v systemctl >/dev/null ]
+then # Use systemd
+  restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
+  stop_instructions="$sudo_cmd systemctl stop datadog-agent"
+  start_instructions="$sudo_cmd systemctl start datadog-agent"
+fi
 
 # Try to detect Upstart, this works most of the times but still a best effort
 if /sbin/init --version 2>&1 | grep -q upstart; then

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -261,7 +261,7 @@ if command -v systemctl 2>&1; then
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"
   start_instructions="$sudo_cmd systemctl start datadog-agent"
 elif /sbin/init --version 2>&1 | grep -q upstart; then
-then # Try to detect Upstart, this works most of the times but still a 
+  # Try to detect Upstart, this works most of the times but still a best effort
     restart_cmd="$sudo_cmd start datadog-agent"
     stop_instructions="$sudo_cmd stop datadog-agent"
     start_instructions="$sudo_cmd start datadog-agent"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -255,15 +255,13 @@ restart_cmd="$sudo_cmd service datadog-agent restart"
 stop_instructions="$sudo_cmd service datadog-agent stop"
 start_instructions="$sudo_cmd service datadog-agent start"
 
-if [ "$(command -v systemctl >/dev/null)" ];
-then # Use systemd
+if command -v systemctl 2>&1;
+then # Use systemd if systemctl binary exists
   restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"
   start_instructions="$sudo_cmd systemctl start datadog-agent"
-fi
-
-# Try to detect Upstart, this works most of the times but still a best effort
-if /sbin/init --version 2>&1 | grep -q upstart; then
+elif /sbin/init --version 2>&1 | grep -q upstart;
+then # Try to detect Upstart, this works most of the times but still a 
     restart_cmd="$sudo_cmd start datadog-agent"
     stop_instructions="$sudo_cmd stop datadog-agent"
     start_instructions="$sudo_cmd start datadog-agent"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -255,7 +255,7 @@ restart_cmd="$sudo_cmd service datadog-agent restart"
 stop_instructions="$sudo_cmd service datadog-agent stop"
 start_instructions="$sudo_cmd service datadog-agent start"
 
-if [ command -v systemctl >/dev/null ]
+if [ "$(command -v systemctl >/dev/null)" ];
 then # Use systemd
   restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"


### PR DESCRIPTION
### What does this PR do?

use `service` to start/stop the agent by default; `systemctl` if it exists, then check for upstart.

### Motivation

customer issue. Failed to start the service on Debian7; the script ended up using systemctl which did not exist.

### Additional Notes

Tested on:
- Centos5  : used `service`
- Centos6  : used `upstart`
- Centos7  : used `systemctl`
- Debian7  : used `service`
- Debian8/9: used `systemctl`