### PR TITLE
[codeowners] Update logs team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/burrito
 /pkg/util/retry/                        @DataDog/container-integrations
 
-/pkg/logs/                              @DataDog/ramen-intake
+/pkg/logs/                              @DataDog/logs-intake
 
 /pkg/metadata/ecs/                      @DataDog/burrito
 /pkg/metadata/kubernetes/               @DataDog/burrito


### PR DESCRIPTION
Changed from `ramen-intake` to `logs-intake` recently