### PR TITLE
get goautoneg from github to unblock pipeline

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "default"
   digest = "1:db5c4e7a9516334fb1e9d5951fb9943d0f13e4f415a77c22b97e60f4d10a62a7"
   name = "bitbucket.org/ww/goautoneg"
   packages = ["."]
   pruneopts = ""
-  revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+  revision = "d788f35a0315672bc90f50a6145d1252a230ee0d"
+  source = "github.com/adjust/goautoneg"
 
 [[projects]]
   digest = "1:b5c465c820ef1df848ddc2da97e7ebfc1e152fcc2bef8262f047522692e9fc6f"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -174,3 +174,8 @@
 [[override]]
   name = "github.com/docker/distribution"
   revision = "83389a148052d74ac602f5f1d62f86ff2f3c4aa5"
+
+[[override]]
+  name = "bitbucket.org/ww/goautoneg"
+  source = "github.com/adjust/goautoneg"
+  revision = "d788f35a0315672bc90f50a6145d1252a230ee0d"


### PR DESCRIPTION
### What does this PR do?

One of k8s deps is pulled from bitbucket. There seems to be something preventing us from downloading it from there in our build pipeline. This force the use of a clone on github until the issue with bitbucket is fixed.

### Notes

Looks like digest did not change.