### PR TITLE
Patch for CVE-2018-1002105

### DIFF
--- a/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml
+++ b/Dockerfiles/manifests/cluster-agent/rbac/rbac-cluster-agent.yaml
@@ -46,6 +46,12 @@ rules:
   - "/healthz"
   verbs:
   - get
+- apiGroups: # CVE-2018-1002105 https://github.com/kubernetes/kubernetes/issues/71411
+  - "authorization.k8s.io"
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
[CVE-2018-1002105](https://github.com/kubernetes/kubernetes/issues/71411) made the following change:
> remove all access to all aggregated APIs (including discovery permissions granted by the default discovery role bindings) from users that should not have full access to the aggregated APIs (note that this may disrupt users and controllers that make use of discovery information to map API types to URLs)

which appears to have removed the ability to `kubectl get --raw /apis/external.metrics.k8s.io/v1beta1/` with the following error:
```
Error from server (InternalError): an error on the server ("Internal Server Error: \"/apis/external.metrics.k8s.io/v1beta1/\": subjectaccessreviews.authorization.k8s.io is forbidden: User \"system:serviceaccount:monitoring:dca\" cannot create subjectaccessreviews.authorization.k8s.io at the cluster scope") has prevented the request from succeeding
```

Adding this permission allows the serviceaccount to verify whether or not the user performing the request has permissions to do so. I'm not sure if there are other permissions required.