### PR TITLE
Remove mercurial dependency

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,7 +1,6 @@
 {
     "deps": {
         "order": [
-            "mercurial",
             "golang.org/x/lint/golint",
             "github.com/fzipp/gocyclo",
             "github.com/gordonklaus/ineffassign",
@@ -9,10 +8,6 @@
             "github.com/golang/dep/cmd/dep",
             "golang.org/x/mobile/cmd/gomobile"
         ],
-        "mercurial": {
-            "version": "4.6.2",
-            "type": "python"
-        },
         "github.com/golang/dep/cmd/dep": {
             "version": "v0.5.0",
             "type": "go"


### PR DESCRIPTION
### What does this PR do?

Remove mercurial from the bootstrap dependencies

### Motivation

Useless since we now get goautoneg from github: https://github.com/DataDog/datadog-agent/pull/2738


Note: we can also get rid of the python code which handles the dependency