### PR TITLE
[status] List of configured endpoints move visible in the status page

### DIFF
--- a/Dockerfiles/cluster-agent/dist/templates/endpoints.tmpl
+++ b/Dockerfiles/cluster-agent/dist/templates/endpoints.tmpl
@@ -8,7 +8,7 @@ Endpoints
 
 {{- with .}}
   {{- range $key, $value := .}}
-  {{$key}} - API Key{{ if gt (len $value) 1}}s{{end}} ending with: 
+  {{$key}} - API Key{{ if gt (len $value) 1}}s{{end}} ending with:
     {{- range $idx, $apikey := $value }}
       - {{$apikey}}
     {{- end}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -166,6 +166,23 @@
   </div>
 
   <div class="stat">
+    <span class="stat_title">Endpoints</span>
+    <span class="stat_data">
+    {{- with .endpoints}}
+      {{- range $key, $value := .}}
+        {{$key}}
+        {{- range $idx, $apikey := $value }}
+         - Api key ending with: {{$apikey}}
+        {{- end}}
+        <br>
+      {{- end}}
+    {{- else }}
+      No endpoints information. The agent may be misconfigured.
+    {{- end -}}
+    </span>
+  </div>
+
+  <div class="stat">
     <span class="stat_title">Logs Agent</span>
     <span class="stat_data">
     {{- with .logsStats -}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -168,17 +168,18 @@
   <div class="stat">
     <span class="stat_title">Endpoints</span>
     <span class="stat_data">
-    {{- with .endpoints}}
+    {{- with .endpointsInfos}}
       {{- range $key, $value := .}}
         {{$key}}
-        {{- range $idx, $apikey := $value }}
-         - Api key ending with: {{$apikey}}
-        {{- end}}
+          - API Key{{ if gt (len $value) 1}}s{{end}} ending with: <br>
+          {{- range $idx, $apikey := $value }}
+          &nbsp;&nbsp;- {{$apikey}} <br>
+          {{- end}}
         <br>
       {{- end}}
     {{- else }}
       No endpoints information. The agent may be misconfigured.
-    {{- end -}}
+    {{- end}}
     </span>
   </div>
 

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -114,7 +114,7 @@ func (fh *forwarderHealth) setAPIKeyStatus(apiKey string, domain string, status 
 	if len(apiKey) > 5 {
 		apiKey = apiKey[len(apiKey)-5:]
 	}
-	obfuscatedKey := fmt.Sprintf("API key ending with %s on endpoint %s", apiKey, domain)
+	obfuscatedKey := fmt.Sprintf("API key ending with %s", apiKey)
 	apiKeyStatus.Set(obfuscatedKey, status)
 }
 

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -33,9 +33,9 @@ func TestHasValidAPIKey(t *testing.T) {
 	fh.init()
 	assert.True(t, fh.hasValidAPIKey())
 
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with _key1 on endpoint "+ts1.URL))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with _key2 on endpoint "+ts1.URL))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3 on endpoint "+ts2.URL))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with _key1"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with _key2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
 }
 
 func TestHasValidAPIKeyErrors(t *testing.T) {
@@ -64,7 +64,7 @@ func TestHasValidAPIKeyErrors(t *testing.T) {
 	fh.init()
 	assert.True(t, fh.hasValidAPIKey())
 
-	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1 on endpoint "+ts1.URL))
-	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending with _key2 on endpoint "+ts1.URL))
-	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3 on endpoint "+ts2.URL))
+	assert.Equal(t, &apiKeyInvalid, apiKeyStatus.Get("API key ending with _key1"))
+	assert.Equal(t, &apiKeyStatusUnknown, apiKeyStatus.Get("API key ending with _key2"))
+	assert.Equal(t, &apiKeyValid, apiKeyStatus.Get("API key ending with key3"))
 }

--- a/pkg/status/dist/templates/endpoints.tmpl
+++ b/pkg/status/dist/templates/endpoints.tmpl
@@ -1,0 +1,16 @@
+==========
+Endpoints
+==========
+
+{{- with .}}
+  {{- range $key, $value := .}}
+  {{$key}} - API Key{{ if gt (len $value) 1}}s{{end}} ending with: 
+    {{- range $idx, $apikey := $value }}
+      - {{$apikey}}
+    {{- end}}
+  {{- end}}
+{{- else }}
+
+  No endpoints information. The agent may be misconfigured.
+{{- end }}
+

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -72,11 +72,13 @@ func FormatDCAStatus(data []byte) (string, error) {
 	runnerStats := stats["runnerStats"]
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
+	endpointsInfos := stats["endpointsInfos"]
 	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
 	renderChecksStats(b, runnerStats, nil, autoConfigStats, checkSchedulerStats, "")
 	renderForwarderStatus(b, forwarderStats)
+	renderEndpointsInfos(b, endpointsInfos)
 
 	return b.String(), nil
 }

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -44,12 +44,14 @@ func FormatStatus(data []byte) (string, error) {
 	jmxStats := stats["JMXStatus"]
 	logsStats := stats["logsStats"]
 	dcaStats := stats["clusterAgentStatus"]
+	endpointsInfos := stats["endpointsInfos"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
 	renderChecksStats(b, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
+	renderEndpointsInfos(b, endpointsInfos)
 	renderLogsStatus(b, logsStats)
 	renderAggregatorStatus(b, aggregatorStats)
 	renderDogstatsdStatus(b, dogstatsdStats)
@@ -129,6 +131,15 @@ func renderDogstatsdStatus(w io.Writer, dogstatsdStats interface{}) {
 func renderForwarderStatus(w io.Writer, forwarderStats interface{}) {
 	t := template.Must(template.New("forwarder.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "forwarder.tmpl")))
 	err := t.Execute(w, forwarderStats)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func renderEndpointsInfos(w io.Writer, endpointsInfos interface{}) {
+	t := template.Must(template.New("endpoints.tmpl").Funcs(fmap).ParseFiles(filepath.Join(templateFolder, "endpoints.tmpl")))
+
+	err := t.Execute(w, endpointsInfos)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -142,19 +142,19 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	stats["time"] = now.Format(timeFormat)
 	stats["leaderelection"] = getLeaderElectionDetails()
 
-	apiCl, err := apiserver.GetAPIClient()
-	if err != nil {
-		stats["custommetrics"] = map[string]string{"Error": err.Error()}
-		return stats, nil
-	}
-	stats["custommetrics"] = custommetrics.GetStatus(apiCl.Cl)
-
 	endpointsInfos, err := getEndpointsInfos()
 	if endpointsInfos != nil && err == nil {
 		stats["endpointsInfos"] = endpointsInfos
 	} else {
 		stats["endpointsInfos"] = nil
 	}
+
+	apiCl, err := apiserver.GetAPIClient()
+	if err != nil {
+		stats["custommetrics"] = map[string]string{"Error": err.Error()}
+		return stats, nil
+	}
+	stats["custommetrics"] = custommetrics.GetStatus(apiCl.Cl)
 
 	return stats, nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -149,6 +149,13 @@ func GetDCAStatus() (map[string]interface{}, error) {
 	}
 	stats["custommetrics"] = custommetrics.GetStatus(apiCl.Cl)
 
+	endpointsInfos, err := getEndpointsInfos()
+	if endpointsInfos != nil && err == nil {
+		stats["endpointsInfos"] = endpointsInfos
+	} else {
+		stats["endpointsInfos"] = nil
+	}
+
 	return stats, nil
 }
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -63,6 +63,13 @@ func GetStatus() (map[string]interface{}, error) {
 
 	stats["logsStats"] = logs.GetStatus()
 
+	endpointsInfos, err := getEndpointsInfos()
+	if endpointsInfos != nil && err == nil {
+		stats["endpointsInfos"] = endpointsInfos
+	} else {
+		stats["endpointsInfos"] = nil
+	}
+
 	if config.Datadog.GetBool("cluster_agent.enabled") {
 		stats["clusterAgentStatus"] = getDCAStatus()
 	}
@@ -190,7 +197,7 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	rv := make(map[string]interface{})
+	endpointsInfos := make(map[string]interface{})
 
 	// obfuscate the api keys
 	for endpoint, keys := range endpoints {
@@ -199,10 +206,10 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 				keys[i] = key[len(key)-5:]
 			}
 		}
-		rv[endpoint] = keys
+		endpointsInfos[endpoint] = keys
 	}
 
-	return rv, nil
+	return endpointsInfos, nil
 }
 
 func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
@@ -245,13 +252,6 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 		stats["pyLoaderStats"] = pyLoaderStats
 	} else {
 		stats["pyLoaderStats"] = nil
-	}
-
-	endpoints, err := getEndpointsInfos()
-	if endpoints != nil && err == nil {
-		stats["endpoints"] = endpoints
-	} else {
-		stats["endpoints"] = nil
 	}
 
 	hostnameStatsJSON := []byte(expvar.Get("hostname").String())

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -184,6 +184,27 @@ func getPartialConfig() map[string]string {
 	return conf
 }
 
+func getEndpointsInfos() (map[string]interface{}, error) {
+	endpoints, err := config.GetMultipleEndpoints()
+	if err != nil {
+		return nil, err
+	}
+
+	rv := make(map[string]interface{})
+
+	// obfuscate the api keys
+	for endpoint, keys := range endpoints {
+		for i, key := range keys {
+			if len(key) > 5 {
+				keys[i] = key[len(key)-5:]
+			}
+		}
+		rv[endpoint] = keys
+	}
+
+	return rv, nil
+}
+
 func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
@@ -224,6 +245,13 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 		stats["pyLoaderStats"] = pyLoaderStats
 	} else {
 		stats["pyLoaderStats"] = nil
+	}
+
+	endpoints, err := getEndpointsInfos()
+	if endpoints != nil && err == nil {
+		stats["endpoints"] = endpoints
+	} else {
+		stats["endpoints"] = nil
 	}
 
 	hostnameStatsJSON := []byte(expvar.Get("hostname").String())

--- a/releasenotes/notes/endpoints-infos-status-page-5cf49d91e4018737.yaml
+++ b/releasenotes/notes/endpoints-infos-status-page-5cf49d91e4018737.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add an Endpoints in the GUI Status page, listing
+    all endpoints used by the agent and their api keys.

--- a/releasenotes/notes/endpoints-infos-status-page-5cf49d91e4018737.yaml
+++ b/releasenotes/notes/endpoints-infos-status-page-5cf49d91e4018737.yaml
@@ -1,5 +1,6 @@
 ---
 enhancements:
   - |
-    Add an Endpoints section in the GUI Status page, listing
-    all endpoints used by the agent and their api keys.
+    Add an Endpoints section in the GUI status page and the
+    CLI status command, listing all endpoints used by the agent
+    and their api keys.

--- a/releasenotes/notes/endpoints-infos-status-page-5cf49d91e4018737.yaml
+++ b/releasenotes/notes/endpoints-infos-status-page-5cf49d91e4018737.yaml
@@ -1,5 +1,5 @@
 ---
 enhancements:
   - |
-    Add an Endpoints in the GUI Status page, listing
+    Add an Endpoints section in the GUI Status page, listing
     all endpoints used by the agent and their api keys.


### PR DESCRIPTION
### What does this PR do?

Adds an "Endpoints" section in the Agent GUI status page and in the CLI status command.

### Motivation

Endpoints information was deducible from the API key validity lines, however it was not clear, this is why we want a dedicated section.

### Additional Notes

Removed the endpoint info from the API key validity line.