### PR TITLE
force netcgo for real

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -34,6 +34,7 @@ DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
     "kubelet",
     "log",
+    "netcgo",
     "systemd",
     "process",
     "snmp",

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -20,6 +20,7 @@ ALL_TAGS = set([
     "kubeapiserver",
     "kubelet",
     "log",
+    "netcgo", # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "process",
     "snmp",
     "systemd",
@@ -37,8 +38,6 @@ LINUX_ONLY_TAGS = [
     "kubelet",
     "kubeapiserver",
     "cri",
-
-    # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "netcgo",
 ]
 


### PR DESCRIPTION
### What does this PR do?

Forgot to add the tag to `DEFAULT_BUILD_TAGS`  🤦‍♂️ 

Everything seems to work now:
```
root@ubuntu-xenial:/home/vagrant# GODEBUG=netdns=3 /opt/datadog-agent/bin/agent/agent run | grep -iv 2018
go package net: using cgo DNS resolver
go package net: hostLookupOrder(localhost) = cgo
go package net: hostLookupOrder(localhost) = cgo
go package net: hostLookupOrder(app.datadoghq.com) = cgo
go package net: hostLookupOrder(localhost) = cgo
go package net: hostLookupOrder(ubuntu-xenial) = cgo
go package net: hostLookupOrder() = cgo
go package net: hostLookupOrder(6-8-0-app.agent.datadoghq.com) = cgo
go package net: hostLookupOrder(0.datadog.pool.ntp.org) = cgo
go package net: hostLookupOrder(1.datadog.pool.ntp.org) = cgo
go package net: hostLookupOrder(2.datadog.pool.ntp.org) = cgo
go package net: hostLookupOrder(3.datadog.pool.ntp.org) = cgo
go package net: hostLookupOrder(localhost) = cgo
go package net: hostLookupOrder(localhost) = cgo
```