### PR TITLE
document jmx new gc metric names option

### DIFF
--- a/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
@@ -29,7 +29,7 @@ instances:
   #   key_store_password: password
   #   rmi_registry_ssl: false # Optional, should be set to true if "com.sun.management.jmxremote.registry.ssl" is set to true on the target JVM.
   #
-  #   # Use better metric names for garbage collection metrics. The default value is false to ensure backward compatibility.
+  #   # Set to true to use better metric names for garbage collection metrics. The default value is false to ensure backward compatibility.
   #   # jvm.gc.cms.count   => jvm.gc.minor_collection_count
   #   #                       jvm.gc.major_collection_count
   #   # jvm.gc.parnew.time => jvm.gc.minor_collection_time

--- a/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jmx.d/conf.yaml.example
@@ -29,6 +29,13 @@ instances:
   #   key_store_password: password
   #   rmi_registry_ssl: false # Optional, should be set to true if "com.sun.management.jmxremote.registry.ssl" is set to true on the target JVM.
   #
+  #   # Use better metric names for garbage collection metrics. The default value is false to ensure backward compatibility.
+  #   # jvm.gc.cms.count   => jvm.gc.minor_collection_count
+  #   #                       jvm.gc.major_collection_count
+  #   # jvm.gc.parnew.time => jvm.gc.minor_collection_time
+  #   #                       jvm.gc.major_collection_time
+  #   new_gc_metrics: false
+  #
   #   # Optional (in seconds), default is 600 seconds. Sets refresh period for refreshing matching MBeans list.
   #   # Decreasing this value may result in increased CPU usage.
   #   refresh_beans: 600


### PR DESCRIPTION
### What does this PR do?

A new option to use better java garbage collection metric names has been added to jmxfetch.