### PR TITLE
Collect docker io metrics per device

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -345,19 +345,22 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.CgroupIOStat, tags []string, 
 	if io == nil {
 		return
 	}
-	// Read values, per device or fallback to sum
-	for dev, value := range io.DeviceReadBytes {
-		sender.Rate("docker.io.read_bytes", float64(value), "", append(tags, "device:"+dev))
-	}
-	if len(io.DeviceReadBytes) == 0 {
+
+	// Read values per device, or fallback to sum
+	if len(io.DeviceReadBytes) > 0 {
+		for dev, value := range io.DeviceReadBytes {
+			sender.Rate("docker.io.read_bytes", float64(value), "", append(tags, "device:"+dev))
+		}
+	} else {
 		sender.Rate("docker.io.read_bytes", float64(io.ReadBytes), "", tags)
 	}
 
-	// Write values, per device or fallback to sum
-	for dev, value := range io.DeviceWriteBytes {
-		sender.Rate("docker.io.write_bytes", float64(value), "", append(tags, "device:"+dev))
-	}
-	if len(io.DeviceWriteBytes) == 0 {
+	// Write values per device, or fallback to sum
+	if len(io.DeviceWriteBytes) > 0 {
+		for dev, value := range io.DeviceWriteBytes {
+			sender.Rate("docker.io.write_bytes", float64(value), "", append(tags, "device:"+dev))
+		}
+	} else {
 		sender.Rate("docker.io.write_bytes", float64(io.WriteBytes), "", tags)
 	}
 }

--- a/pkg/collector/corechecks/containers/docker_test.go
+++ b/pkg/collector/corechecks/containers/docker_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	cmetrics "github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+)
+
+func TestReportIOMetrics(t *testing.T) {
+	dockerCheck := &DockerCheck{
+		instance: &DockerConfig{},
+	}
+	mockSender := mocksender.NewMockSender(dockerCheck.ID())
+	mockSender.SetupAcceptAll()
+
+	tags := []string{"constant:tags", "container_name:dummy"}
+
+	// Test fallback to sums when per-device is not available
+	ioSum := &cmetrics.CgroupIOStat{
+		ReadBytes:  uint64(38989367),
+		WriteBytes: uint64(671846455),
+	}
+	dockerCheck.reportIOMetrics(ioSum, tags, mockSender)
+	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(38989367), "", tags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(671846455), "", tags)
+
+	// Test per-device when available
+	ioPerDevice := &cmetrics.CgroupIOStat{
+		ReadBytes:  uint64(38989367),
+		WriteBytes: uint64(671846455),
+		DeviceReadBytes: map[string]uint64{
+			"sda": 37858816,
+			"sdb": 1130496,
+		},
+		DeviceWriteBytes: map[string]uint64{
+			"sda": 671846400,
+			"sdb": 0,
+		},
+	}
+	sdaTags := append(tags, "device:sda")
+	sdbTags := append(tags, "device:sdb")
+	dockerCheck.reportIOMetrics(ioPerDevice, tags, mockSender)
+	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(37858816), "", sdaTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(671846400), "", sdaTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.read_bytes", float64(1130496), "", sdbTags)
+	mockSender.AssertMetric(t, "Rate", "docker.io.write_bytes", float64(0), "", sdbTags)
+}

--- a/pkg/util/containers/metrics/cgroup_metrics.go
+++ b/pkg/util/containers/metrics/cgroup_metrics.go
@@ -271,6 +271,7 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 }
 
 // IO returns the disk read and write bytes stats for this cgroup.
+// tested in DiskMappingTestSuite.TestContainerCgroupIO
 // Format:
 //
 // 8:0 Read 49225728
@@ -285,7 +286,12 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 // 252:0 Total 58945536
 //
 func (c ContainerCgroup) IO() (*CgroupIOStat, error) {
-	ret := &CgroupIOStat{ContainerID: c.ContainerID}
+	ret := &CgroupIOStat{
+		ContainerID:      c.ContainerID,
+		DeviceReadBytes:  make(map[string]uint64),
+		DeviceWriteBytes: make(map[string]uint64),
+	}
+
 	statfile := c.cgroupFilePath("blkio", "blkio.throttle.io_service_bytes")
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
@@ -296,18 +302,37 @@ func (c ContainerCgroup) IO() (*CgroupIOStat, error) {
 	}
 	defer f.Close()
 
+	// Get device id->name mapping
+	var devices map[string]string
+	mapping, err := getDiskDeviceMapping()
+	if err != nil {
+		log.Debugf("Cannot get per-device stats: %s", err)
+	} else {
+		devices = mapping.idToName
+	}
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		fields := strings.Split(scanner.Text(), " ")
+		if len(fields) < 3 {
+			continue
+		}
+		deviceName := devices[fields[0]]
 		if fields[1] == "Read" {
 			read, err := strconv.ParseUint(fields[2], 10, 64)
 			if err == nil {
-				ret.ReadBytes = read
+				ret.ReadBytes += read
+				if deviceName != "" {
+					ret.DeviceReadBytes[deviceName] = read
+				}
 			}
 		} else if fields[1] == "Write" {
 			write, err := strconv.ParseUint(fields[2], 10, 64)
 			if err == nil {
-				ret.WriteBytes = write
+				ret.WriteBytes += write
+				if deviceName != "" {
+					ret.DeviceWriteBytes[deviceName] = write
+				}
 			}
 		}
 	}

--- a/pkg/util/containers/metrics/cgroup_metrics.go
+++ b/pkg/util/containers/metrics/cgroup_metrics.go
@@ -307,6 +307,7 @@ func (c ContainerCgroup) IO() (*CgroupIOStat, error) {
 	mapping, err := getDiskDeviceMapping()
 	if err != nil {
 		log.Debugf("Cannot get per-device stats: %s", err)
+		// devices will stay nil, lookups are safe in nil maps
 	} else {
 		devices = mapping.idToName
 	}

--- a/pkg/util/containers/metrics/disk.go
+++ b/pkg/util/containers/metrics/disk.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build linux
+
+package metrics
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+)
+
+type diskDeviceMapping struct {
+	idToName map[string]string
+}
+
+var diskMappingCacheKey = cache.BuildAgentKey("containers", "disk_mapping")
+
+// getDiskDeviceMapping scrapes /proc/diskstats to build a mapping from
+// "major:minor" device numbers to device name.
+// It is cached for 1 minute
+// Format:
+// 7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
+// 7       1 loop1 0 0 0 0 0 0 0 0 0 0 0
+// 8       0 sda 24398 2788 1317975 40488 25201 46267 1584744 142336 0 22352 182660
+// 8       1 sda1 24232 2788 1312025 40376 25201 46267 1584744 142336 0 22320 182552
+// 8      16 sdb 189 0 4063 220 0 0 0 0 0 112 204
+func getDiskDeviceMapping() (*diskDeviceMapping, error) {
+	// Cache lookup
+	var mapping *diskDeviceMapping
+	var ok bool
+	if cached, hit := cache.Cache.Get(diskMappingCacheKey); hit {
+		if mapping, ok = cached.(*diskDeviceMapping); ok {
+			return mapping, nil
+		}
+	}
+
+	// Cache miss, parse file
+	statfile := hostProc("diskstats")
+	f, err := os.Open(statfile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	mapping = &diskDeviceMapping{
+		idToName: make(map[string]string),
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 14 {
+			// malformed line in /proc/diskstats, avoid panic by ignoring.
+			continue
+		}
+		mapping.idToName[fmt.Sprintf("%s:%s", fields[0], fields[1])] = fields[2]
+	}
+	if err := scanner.Err(); err != nil {
+		return mapping, fmt.Errorf("error reading %s: %s", statfile, err)
+	}
+
+	// Keep value in cache
+	cache.Cache.Set(diskMappingCacheKey, mapping, time.Minute)
+	return mapping, nil
+}

--- a/pkg/util/containers/metrics/disk_test.go
+++ b/pkg/util/containers/metrics/disk_test.go
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build linux
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+)
+
+type DiskMappingTestSuite struct {
+	suite.Suite
+	proc *tempFolder
+}
+
+func (s *DiskMappingTestSuite) SetupTest() {
+	var err error
+	s.proc, err = newTempFolder("test-disk-mapping")
+	assert.NoError(s.T(), err)
+	config.Datadog.SetDefault("container_proc_root", s.proc.RootPath)
+}
+
+func (s *DiskMappingTestSuite) TearDownTest() {
+	cache.Cache.Delete(diskMappingCacheKey)
+	config.Datadog.SetDefault("container_proc_root", "/proc")
+	s.proc.removeAll()
+	s.proc = nil
+}
+
+func (s *DiskMappingTestSuite) TestParsing() {
+	s.proc.add("diskstats", detab(`
+        7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
+        7       1 loop1 0 0 0 0 0 0 0 0 0 0 0
+        invalidline
+        8       0 sda 24398 2788 1317975 40488 25201 46267 1584744 142336 0 22352 182660
+        8       1 sda1 24232 2788 1312025 40376 25201 46267 1584744 142336 0 22320 182552
+        8      16 sdb 189 0 4063 220 0 0 0 0 0 112 204
+    `))
+
+	expectedMap := map[string]string{
+		"7:0":  "loop0",
+		"7:1":  "loop1",
+		"8:0":  "sda",
+		"8:1":  "sda1",
+		"8:16": "sdb",
+	}
+
+	mapping, err := getDiskDeviceMapping()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), expectedMap, mapping.idToName)
+
+	cached, ok := cache.Cache.Get(diskMappingCacheKey)
+	assert.True(s.T(), ok)
+	assert.EqualValues(s.T(), &diskDeviceMapping{expectedMap}, cached)
+}
+
+func (s *DiskMappingTestSuite) TestNotFound() {
+	mapping, err := getDiskDeviceMapping()
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "no such file or directory")
+	assert.Nil(s.T(), mapping)
+}
+
+func (s *DiskMappingTestSuite) TestCached() {
+	cachedMapping := &diskDeviceMapping{
+		idToName: map[string]string{
+			"1:2": "one",
+			"2:3": "two",
+		},
+	}
+	cache.Cache.Set(diskMappingCacheKey, cachedMapping, time.Minute)
+
+	mapping, err := getDiskDeviceMapping()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), cachedMapping, mapping)
+}
+
+func (s *DiskMappingTestSuite) TestContainerCgroupIO() {
+	s.proc.add("diskstats", detab(`
+        7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
+        7       1 loop1 0 0 0 0 0 0 0 0 0 0 0
+        8       0 sda 24398 2788 1317975 40488 25201 46267 1584744 142336 0 22352 182660
+        8       1 sda1 24232 2788 1312025 40376 25201 46267 1584744 142336 0 22320 182552
+        8      16 sdb 189 0 4063 220 0 0 0 0 0 112 204
+    `))
+
+	tempFolder, err := newTempFolder("io-stats")
+	assert.Nil(s.T(), err)
+	defer tempFolder.removeAll()
+
+	// 8:0  is sda
+	// 8:16 is sdb
+	// 55:0 is unknown, don't report per-device but keep in sum
+	tempFolder.add("blkio/blkio.throttle.io_service_bytes", detab(`
+		8:16 Read 1130496
+		8:16 Write 0
+		8:16 Sync 1130496
+		8:16 Async 0
+		8:16 Total 1130496
+		8:0 Read 37858816
+		8:0 Write 671846400
+		8:0 Sync 262450688
+		8:0 Async 447254528
+		8:0 Total 709705216
+		55:0 Read 55
+		55:0 Write 55
+		55:0 Sync 55
+		55:0 Async 55
+		55:0 Total 55
+	`))
+
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "blkio", "blkio")
+
+	expectedStats := &CgroupIOStat{
+		ContainerID: "dummy",
+		ReadBytes:   uint64(1130496 + 37858816 + 55),
+		WriteBytes:  uint64(0 + 671846400 + 55),
+		DeviceReadBytes: map[string]uint64{
+			"sda": 37858816,
+			"sdb": 1130496,
+		},
+		DeviceWriteBytes: map[string]uint64{
+			"sda": 671846400,
+			"sdb": 0,
+		},
+	}
+
+	ioStat, err := cgroup.IO()
+	assert.Nil(s.T(), err)
+	assert.EqualValues(s.T(), expectedStats, ioStat)
+}
+
+func (s *DiskMappingTestSuite) TestContainerCgroupIOFailedMapping() {
+	tempFolder, err := newTempFolder("io-stats")
+	assert.Nil(s.T(), err)
+	defer tempFolder.removeAll()
+
+	// 8:0  is sda
+	// 8:16 is sdb
+	// 55:0 is unknown, don't report per-device but keep in sum
+	tempFolder.add("blkio/blkio.throttle.io_service_bytes", detab(`
+		8:16 Read 1130496
+		8:16 Write 0
+		8:16 Sync 1130496
+		8:16 Async 0
+		8:16 Total 1130496
+		8:0 Read 37858816
+		8:0 Write 671846400
+		8:0 Sync 262450688
+		8:0 Async 447254528
+		8:0 Total 709705216
+		55:0 Read 55
+		55:0 Write 55
+		55:0 Sync 55
+		55:0 Async 55
+		55:0 Total 55
+	`))
+
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "blkio", "blkio")
+
+	expectedStats := &CgroupIOStat{
+		ContainerID:      "dummy",
+		ReadBytes:        uint64(1130496 + 37858816 + 55),
+		WriteBytes:       uint64(0 + 671846400 + 55),
+		DeviceReadBytes:  map[string]uint64{},
+		DeviceWriteBytes: map[string]uint64{},
+	}
+
+	ioStat, err := cgroup.IO()
+	assert.Nil(s.T(), err)
+	assert.EqualValues(s.T(), expectedStats, ioStat)
+}
+
+func TestDiskMappingTestSuite(t *testing.T) {
+	suite.Run(t, new(DiskMappingTestSuite))
+}

--- a/pkg/util/containers/metrics/network_test.go
+++ b/pkg/util/containers/metrics/network_test.go
@@ -22,6 +22,7 @@ func TestCollectNetworkStats(t *testing.T) {
 	assert.Nil(t, err)
 	defer dummyProcDir.removeAll() // clean up
 	config.Datadog.SetDefault("container_proc_root", dummyProcDir.RootPath)
+	defer config.Datadog.SetDefault("container_proc_root", "/proc")
 
 	for _, tc := range []struct {
 		pid        int

--- a/pkg/util/containers/metrics/types.go
+++ b/pkg/util/containers/metrics/types.go
@@ -66,10 +66,13 @@ type CgroupTimesStat struct {
 }
 
 // CgroupIOStat store I/O statistics about a cgroup.
+// Sums are stored in ReadBytes and WriteBytes
 type CgroupIOStat struct {
-	ContainerID string
-	ReadBytes   uint64
-	WriteBytes  uint64
+	ContainerID      string
+	ReadBytes        uint64
+	WriteBytes       uint64
+	DeviceReadBytes  map[string]uint64
+	DeviceWriteBytes map[string]uint64
 }
 
 // ContainerCgroup is a structure that stores paths and mounts for a cgroup.

--- a/releasenotes/notes/docker-io-per-device-92047e9e294be1a6.yaml
+++ b/releasenotes/notes/docker-io-per-device-92047e9e294be1a6.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Docker disk IO metrics are now tagged by ``device``


### PR DESCRIPTION
### What does this PR do?

Update the linux container metric collection backend and docker check to report IOs on all devices:
  - the live container view will display a sum taking all devices into account (for both docker and kubelet backends)
  - the `docker.io.*` metrics will now be tagged by `device`, consistent with the `io` check:

```
    {
      "metric": "docker.io.read_bytes",
      "points": [
        [
          1544456974,
          0
        ]
      ],
      "tags": [
        "container_id:47a23751f59bd0c1952c61a34f03d1e11507c6febfb1e34c78aa2a175f749809",
        "container_name:epic_wescoff",
        "docker_image:redis:latest",
        "image_name:redis",
        "image_tag:latest",
        "short_image:redis"
      ],
      "host": "ci-xaviervello",
      "device": "sdb",
      "type": "gauge",
      "interval": 0,
      "source_type_name": "System"
    },
    {
      "metric": "system.io.rkb_s",
      "points": [
        [
          1544456741,
          0
        ]
      ],
      "tags": null,
      "host": "ci-xaviervello",
      "device": "sdb",
      "type": "gauge",
      "interval": 0,
      "source_type_name": "System"
    },
```

The code gracefully degrades if we cannot map any device for some reason: the docker check will revert to one gauge per container, as the summed value.
