### PR TITLE
Message file should have positional parameter (%1) instead of printf

### DIFF
--- a/cmd/agent/agentmsg.mc
+++ b/cmd/agent/agentmsg.mc
@@ -116,5 +116,5 @@ MessageId=15
 SymbolicName=MSG_WARNING_PROGRAMDATA_ERROR
 Severity=Warning
 Language=English
-Unable to determine the location of Program Data using the default value %s.
+Unable to determine the location of Program Data using the default value %1.
 .


### PR DESCRIPTION
format string (%s)

Tested by creating custom agent executable that forced failure of winutil.GetProgramDataDir()
Discovered that overall logging worked as planned; however, there was the typo in the message file.