### PR TITLE
Add secrets info to the flare

### DIFF
--- a/pkg/secrets/check_right.go
+++ b/pkg/secrets/check_right.go
@@ -9,7 +9,9 @@ package secrets
 
 import (
 	"fmt"
+	"io"
 	"os/user"
+	"strconv"
 	"syscall"
 )
 
@@ -43,4 +45,38 @@ func checkRights(path string) error {
 	}
 
 	return nil
+}
+
+func listRights(path string, w io.Writer) {
+	fmt.Fprintf(w, "=== Checking executable rights ===\n")
+	fmt.Fprintf(w, "executable path: %s\n", path)
+
+	err := checkRights(path)
+	if err != nil {
+		fmt.Fprintf(w, "Check Rights: KO, %s\n", err)
+	} else {
+		fmt.Fprintf(w, "Check Rights: OK, the executable has the correct rights\n")
+	}
+
+	fmt.Fprintf(w, "\nRights Detail:\n")
+	var stat syscall.Stat_t
+	if err := syscall.Stat(path, &stat); err != nil {
+		fmt.Fprintf(w, "Could not stat %s: %s\n", path, err)
+		return
+	}
+	fmt.Fprintf(w, "file mode: %o\n", stat.Mode)
+
+	owner, err := user.LookupId(strconv.Itoa(int(stat.Uid)))
+	if err != nil {
+		fmt.Fprintf(w, "Owner username: could not fetch name for UID %d: %s\n", stat.Uid, err)
+	} else {
+		fmt.Fprintf(w, "Owner username: %s\n", owner.Username)
+	}
+
+	group, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
+	if err != nil {
+		fmt.Fprintf(w, "Group name: could not fetch name for GID %d: %s\n", stat.Gid, err)
+	} else {
+		fmt.Fprintf(w, "Group name: %s\n", group.Name)
+	}
 }

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -9,6 +9,7 @@ package secrets
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
@@ -183,4 +184,21 @@ func Decrypt(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("could not Marshal config after replacing encrypted secrets: %s", err)
 	}
 	return finalConfig, nil
+}
+
+// GetDebugInfo exposes debug informations about secrets to be included in a flare
+func GetDebugInfo(w io.Writer) {
+	if secretBackendCommand == "" {
+		fmt.Fprintln(w, "No secret_backend_command set: secrets feature is not enabled")
+		return
+	}
+
+	listRights(secretBackendCommand, w)
+
+	fmt.Fprintf(w, "=== Secrets stats ===\n")
+	fmt.Fprintf(w, "Number of secrets decrypted: %d\n", len(secretCache))
+	fmt.Fprintln(w, "secrets Handle decrypted:")
+	for handle := range secretCache {
+		fmt.Fprintf(w, "- %s\n", handle)
+	}
 }

--- a/pkg/secrets/secrets_win.go
+++ b/pkg/secrets/secrets_win.go
@@ -7,6 +7,11 @@
 
 package secrets
 
+import (
+	"fmt"
+	"io"
+)
+
 // Init encrypted secrets are not available on windows
 func Init(command string, arguments []string, timeout int, maxSize int) {
 }
@@ -14,4 +19,9 @@ func Init(command string, arguments []string, timeout int, maxSize int) {
 // Decrypt encrypted secrets are not available on windows
 func Decrypt(data []byte) ([]byte, error) {
 	return data, nil
+}
+
+// GetDebugInfo exposes debug informations about secrets to be included in a flare
+func GetDebugInfo(w io.Writer) {
+	fmt.Fprintln(w, "Secret feature is not yet available on windows")
 }

--- a/releasenotes/notes/add-secrets-to-flare-29cf71bedead1591.yaml
+++ b/releasenotes/notes/add-secrets-to-flare-29cf71bedead1591.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add debug information about the secrets feature to the flare.


### PR DESCRIPTION
### What does this PR do?

Add secrets info to the flare:
- We now list the rights of the executable
- list of handle detected by the agent