### PR TITLE
bump fqdn breaking version in deprecation warning

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -220,7 +220,7 @@ func GetHostname() (string, error) {
 	if err == nil && !config.Datadog.GetBool("hostname_fqdn") && fqdn != "" && hostName == h && h != fqdn {
 		if runtime.GOOS != "windows" {
 			// REMOVEME: This should be removed in 6.7
-			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as '%s'. However starting from version 6.7, it will be resolved as '%s' by default. To enable the behavior of 6.7+, please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
+			log.Warnf("DEPRECATION NOTICE: The agent resolved your hostname as '%s'. However starting from version 6.9, it will be resolved as '%s' by default. To enable the behavior of 6.9+, please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
 		} else { // OS is Windows
 			log.Warnf("The agent resolved your hostname as '%s', and will be reported this way to maintain compatibility with version 5. To enable reporting as '%s', please enable the `hostname_fqdn` flag in the configuration. For more information: https://dtdg.co/flag-hostname-fqdn", h, fqdn)
 		}


### PR DESCRIPTION
### What does this PR do?

We forgot this in https://github.com/DataDog/datadog-agent/pull/2703.