### PR TITLE
Get package version from invoke

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1097,8 +1097,8 @@ deploy_dsd:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
-    - export VERSION=$(inv agent.version --url-safe)
-    - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe)
+    - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy dsd binary to staging bucket
 deploy_puppy:
@@ -1110,8 +1110,8 @@ deploy_puppy:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/puppy/agent ./agent
-    - export VERSION=$(inv agent.version --url-safe)
-    - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/puppy/agent-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - export PACKAGE_VERSION=$(inv agent.version --url-safe)
+    - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/puppy/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 #
 # Docker releases

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1097,7 +1097,7 @@ deploy_dsd:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
-    - export VERSION=$(inv version --url-safe)
+    - export VERSION=$(inv agent.version --url-safe)
     - aws s3 cp --region us-east-1 ./dogstatsd $S3_DSD6_URI/dogstatsd-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 # deploy dsd binary to staging bucket
@@ -1110,7 +1110,7 @@ deploy_puppy:
   tags: [ "runner:main", "size:large" ]
   script:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/puppy/agent ./agent
-    - export VERSION=$(inv version --url-safe)
+    - export VERSION=$(inv agent.version --url-safe)
     - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/puppy/agent-$VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 #

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -21,6 +21,8 @@ else
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
+# build_version is computed by an invoke command/function.
+# We can't call it directly from there, we pass it through the environment instead.
 build_version ENV['PACKAGE_VERSION']
 
 build_iteration 1

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -21,10 +21,7 @@ else
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
-build_version do
-  source :git
-  output_format :dd_agent_format
-end
+build_version ENV['PACKAGE_VERSION']
 
 build_iteration 1
 

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -22,6 +22,8 @@ else
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
+# build_version is computed by an invoke command/function.
+# We can't call it directly from there, we pass it through the environment instead.
 build_version ENV['PACKAGE_VERSION']
 
 build_iteration 1

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -22,10 +22,7 @@ else
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
-build_version do
-  source :git
-  output_format :dd_agent_format
-end
+build_version ENV['PACKAGE_VERSION']
 
 build_iteration 1
 

--- a/omnibus/config/projects/puppy.rb
+++ b/omnibus/config/projects/puppy.rb
@@ -22,6 +22,8 @@ else
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
+# build_version is computed by an invoke command/function.
+# We can't call it directly from there, we pass it through the environment instead.
 build_version ENV['PACKAGE_VERSION']
 
 build_iteration 1

--- a/omnibus/config/projects/puppy.rb
+++ b/omnibus/config/projects/puppy.rb
@@ -22,10 +22,7 @@ else
   maintainer 'Datadog Packages <package@datadoghq.com>'
 end
 
-build_version do
-  source :git
-  output_format :dd_agent_format
-end
+build_version ENV['PACKAGE_VERSION']
 
 build_iteration 1
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -7,7 +7,7 @@ from invoke import Collection
 from . import agent, trace, android, benchmarks, customaction, docker, dogstatsd, pylauncher, cluster_agent, systray, release
 
 from .go import fmt, lint, vet, cyclo, ineffassign, misspell, deps, lint_licenses, reset
-from .test import test, integration_tests, version, lint_teamassignment, lint_releasenote, lint_milestone, lint_filenames, e2e_tests
+from .test import test, integration_tests, lint_teamassignment, lint_releasenote, lint_milestone, lint_filenames, e2e_tests
 from .build_tags import audit_tag_impact
 
 # the root namespace
@@ -25,7 +25,6 @@ ns.add_task(integration_tests)
 ns.add_task(deps)
 ns.add_task(lint_licenses)
 ns.add_task(reset)
-ns.add_task(version)
 ns.add_task(lint_teamassignment)
 ns.add_task(lint_releasenote)
 ns.add_task(lint_milestone)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -13,7 +13,7 @@ import invoke
 from invoke import task
 from invoke.exceptions import Exit
 
-from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions
+from .utils import bin_name, get_build_flags, get_version_numeric_only, load_release_versions, get_version
 from .utils import REPO_PATH
 from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS, REDHAT_AND_DEBIAN_ONLY_TAGS, REDHAT_AND_DEBIAN_DIST
 from .go import deps
@@ -307,6 +307,7 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
             args['populate_s3_cache'] = " --populate-s3-cache "
         if skip_sign:
             env['SKIP_SIGN_MAC'] = 'true'
+        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7, match=None)
         ctx.run(cmd.format(**args), env=env)
 
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -307,7 +307,7 @@ def omnibus_build(ctx, puppy=False, log_level="info", base_dir=None, gem_path=No
             args['populate_s3_cache'] = " --populate-s3-cache "
         if skip_sign:
             env['SKIP_SIGN_MAC'] = 'true'
-        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7, match=None)
+        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True)
         ctx.run(cmd.format(**args), env=env)
 
 
@@ -323,3 +323,15 @@ def clean(ctx):
     # remove the bin/agent folder
     print("Remove agent binary folder")
     ctx.run("rm -rf ./bin/agent")
+
+
+@task
+def version(ctx, url_safe=False, git_sha_length=7):
+    """
+    Get the agent version.
+    url_safe: get the version that is able to be addressed as a url
+    git_sha_length: different versions of git have a different short sha length,
+                    use this to explicitly set the version
+                    (the windows builder and the default ubuntu version have such an incompatibility)
+    """
+    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length))

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -94,7 +94,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         cmd = "./gradlew build"
     ctx.run(cmd)
     os.chdir(pwd)
-    ver = get_version(ctx, include_git=True, git_sha_length=7)
+    ver = get_version(ctx, include_git=True)
     outfile = "bin/agent/ddagent-{}-unsigned.apk".format(ver)
     shutil.copyfile("cmd/agent/android/app/build/outputs/apk/release/app-release-unsigned.apk", outfile)
 

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -94,7 +94,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
         cmd = "./gradlew build"
     ctx.run(cmd)
     os.chdir(pwd)
-    ver = get_version(ctx, include_git=True)
+    ver = get_version(ctx, include_git=True, git_sha_length=7)
     outfile = "bin/agent/ddagent-{}-unsigned.apk".format(ver)
     shutil.copyfile("cmd/agent/android/app/build/outputs/apk/release/app-release-unsigned.apk", outfile)
 

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -11,7 +11,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .build_tags import get_build_tags
-from .utils import get_build_flags, bin_name
+from .utils import get_build_flags, bin_name, get_version
 from .utils import REPO_PATH
 from .go import deps
 
@@ -153,3 +153,16 @@ def image_build(ctx, tag=AGENT_TAG, push=False):
     ctx.run("rm Dockerfiles/cluster-agent/datadog-cluster-agent")
     if push:
         ctx.run("docker push {}".format(tag))
+
+
+
+@task
+def version(ctx, url_safe=False, git_sha_length=7):
+    """
+    Get the agent version.
+    url_safe: get the version that is able to be addressed as a url
+    git_sha_length: different versions of git have a different short sha length,
+                    use this to explicitly set the version
+                    (the windows builder and the default ubuntu version have such an incompatibility)
+    """
+    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, dca=True))

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -38,7 +38,7 @@ def build(ctx, rebuild=False, build_include=None, build_exclude=None,
     build_tags = get_build_tags(build_include, build_exclude)
 
     # We rely on the go libs embedded in the debian stretch image to build dynamically
-    ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs, dca=True)
 
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent"

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -38,7 +38,7 @@ def build(ctx, rebuild=False, build_include=None, build_exclude=None,
     build_tags = get_build_tags(build_include, build_exclude)
 
     # We rely on the go libs embedded in the debian stretch image to build dynamically
-    ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs, dca=True)
+    ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs, prefix='dca')
 
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent"
@@ -165,4 +165,4 @@ def version(ctx, url_safe=False, git_sha_length=7):
                     use this to explicitly set the version
                     (the windows builder and the default ubuntu version have such an incompatibility)
     """
-    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, dca=True))
+    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, prefix='dca'))

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -192,7 +192,7 @@ def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
         }
         if omnibus_s3_cache:
             args['populate_s3_cache'] = " --populate-s3-cache "
-        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7, match=None)        
+        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7)
         ctx.run(cmd.format(**args), env=env)
 
 

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -13,7 +13,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .build_tags import get_build_tags, get_default_build_tags
-from .utils import get_build_flags, bin_name, get_root, load_release_versions
+from .utils import get_build_flags, bin_name, get_root, load_release_versions, get_version
 from .utils import REPO_PATH
 
 from .go import deps
@@ -192,6 +192,7 @@ def omnibus_build(ctx, log_level="info", base_dir=None, gem_path=None,
         }
         if omnibus_s3_cache:
             args['populate_s3_cache'] = " --populate-s3-cache "
+        env['PACKAGE_VERSION'] = get_version(ctx, include_git=True, url_safe=True, git_sha_length=7, match=None)        
         ctx.run(cmd.format(**args), env=env)
 
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -301,18 +301,6 @@ def e2e_tests(ctx, target="gitlab", image=""):
     ctx.run("./test/e2e/scripts/setup-instance/00-entrypoint-%s.sh" % target)
 
 
-@task
-def version(ctx, url_safe=False, git_sha_length=7, match=None):
-    """
-    Get the agent version.
-    url_safe: get the version that is able to be addressed as a url
-    git_sha_length: different versions of git have a different short sha length,
-                    use this to explicitly set the version
-                    (the windows builder and the default ubuntu version have such an incompatibility)
-    """
-    print(get_version(ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, match=match))
-
-
 class TestProfiler:
     times = []
     parser = re.compile("^ok\s+github.com\/DataDog\/datadog-agent\/(\S+)\s+([0-9\.]+)s", re.MULTILINE)

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -157,6 +157,8 @@ def query_version(ctx, git_sha_length=7, prefix=None):
     cmd = "git describe --tags --candidates=50"
     if prefix and type(prefix) == str:
         cmd += " --match \"{}-*\"".format(prefix)
+    else:
+        cmd += " --match \"[0-9]*\""
     if git_sha_length and type(git_sha_length) == int:
         cmd += " --abbrev={}".format(git_sha_length)
     described_version = ctx.run(cmd, hide=True).stdout.strip()

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -49,7 +49,7 @@ def pkg_config_path(use_embedded_libs):
     return retval
 
 
-def get_build_flags(ctx, static=False, use_embedded_libs=False, use_venv=False):
+def get_build_flags(ctx, static=False, use_embedded_libs=False, dca=False, use_venv=False):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 
@@ -57,7 +57,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, use_venv=False):
     Context object.
     """
     gcflags = ""
-    ldflags = get_version_ldflags(ctx)
+    ldflags = get_version_ldflags(ctx, dca)
     env = {
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs),
         "CGO_CFLAGS_ALLOW": "-static-libgcc",  # whitelist additional flags, here a flag used for net-snmp
@@ -124,7 +124,7 @@ def get_payload_version():
 
     return ""
 
-def get_version_ldflags(ctx):
+def get_version_ldflags(ctx, dca=False):
     """
     Compute the version from the git tags, and set the appropriate compiler
     flags
@@ -133,7 +133,7 @@ def get_version_ldflags(ctx):
     commit = ctx.run("git rev-parse --short HEAD", hide=True).stdout.strip()
 
     ldflags = "-X {}/pkg/version.Commit={} ".format(REPO_PATH, commit)
-    ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True))
+    ldflags += "-X {}/pkg/version.AgentVersion={} ".format(REPO_PATH, get_version(ctx, include_git=True, dca=True))
     ldflags += "-X {}/pkg/serializer.AgentPayloadVersion={} ".format(REPO_PATH, payload_v)
     return ldflags
 
@@ -151,57 +151,47 @@ def get_git_branch_name():
     return check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
 
 
-def query_version(ctx, git_sha_length=7, match=None):
+def query_version(ctx, git_sha_length=7, dca=False):
     # The string that's passed in will look something like this: 6.0.0-beta.0-1-g4f19118
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
     cmd = "git describe --tags"
-    if match:
-        cmd += " --match \"{}\"".format(match)
+    if dca:
+        cmd += " --match \"{}\"".format('dca-*')
+    if git_sha_length and type(git_sha_length) == int:
+        cmd += " --abbrev={}".format(git_sha_length)
     described_version = ctx.run(cmd, hide=True).stdout.strip()
-    # For the tag 6.0.0-beta.0, this will match 6.0.0
-    version_match = re.findall(r"^(?:dca-)?v?(\d+\.\d+\.\d+)", described_version)
-
-    if version_match and version_match[0]:
-        version = version_match[0]
-    else:
-        raise Exception("Could not query valid version from tags of local git repository")
 
     # for the example above, 6.0.0-beta.0-1-g4f19118, this will be 1
-    commits_since_version_match = re.findall(r"^.*-(\d+)\-g[0-9a-f]+$", described_version)
-    git_sha_match = re.findall(r"g([0-9a-f]+)$", described_version)
+    commit_number_match = re.match(r"^.*-(?P<commit_number>\d+)-g[0-9a-f]+$", described_version)
+    commit_number = 0
+    if commit_number_match:
+        commit_number = int(commit_number_match.group('commit_number'))
 
-    if commits_since_version_match and commits_since_version_match[0]:
-        commits_since_version = int(commits_since_version_match[0])
+    if commit_number == 0:
+        version_match = re.match(
+            r"^(?:dca-)?v?(?P<version>\d+\.\d+\.\d+)(?:(?:-|\.)(?P<pre>[0-9A-Za-z.-]+))?(?P<git_sha>)",
+            described_version)
     else:
-        commits_since_version = 0
+        version_match = re.match(
+            r"^(?:dca-)?v?(?P<version>\d+\.\d+\.\d+)(?:(?:-|\.)(?P<pre>[0-9A-Za-z.-]+))?-\d+-g(?P<git_sha>[0-9a-f]+)$",
+            described_version)
 
-    pre_regex = ""
-    # for the output, 6.0.0-beta.0-1-g4f19118, this will match beta.0
+    if not version_match:
+        raise Exception("Could not query valid version from tags of local git repository")
+
+    # version: for the tag 6.0.0-beta.0, this will match 6.0.0
+    # pre: for the output, 6.0.0-beta.0-1-g4f19118, this will match beta.0
     # if there have been no commits since, it will be just 6.0.0-beta.0,
     # and it will match beta.0
-    if commits_since_version == 0:
-        pre_regex = r"^(?:dca-)?v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)$"
-    else:
-        pre_regex = r"^(?:dca-)?v?\d+\.\d+\.\d+(?:-|\.)([0-9A-Za-z.-]+)-\d+-g[0-9a-f]+$"
-
-    pre_match = re.findall(pre_regex, described_version)
-    pre = ""
-    if pre_match and pre_match[0]:
-        pre = pre_match[0]
-
-    # for the output, 6.0.0-beta.0-1-g4f19118, this will match g4f19118
-    git_sha = ""
-    if git_sha_match and git_sha_match[0]:
-        git_sha_long = ctx.run("git rev-parse HEAD", hide=True).stdout.strip()
-        git_sha = git_sha_long[:git_sha_length]
-
-    return version, pre, commits_since_version, git_sha
+    # git_sha: for the output, 6.0.0-beta.0-1-g4f19118, this will match g4f19118
+    version, pre, git_sha = version_match.group('version', 'pre', 'git_sha')
+    return version, pre, commit_number, git_sha
 
 
-def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, match=None):
+def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, dca=False):
     # we only need the git info for the non omnibus builds, omnibus includes all this information by default
     version = ""
-    version, pre, commits_since_version, git_sha = query_version(ctx, git_sha_length, match)
+    version, pre, commits_since_version, git_sha = query_version(ctx, git_sha_length, dca)
     if pre:
         version = "{0}-{1}".format(version, pre)
     if commits_since_version and include_git:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -154,7 +154,7 @@ def get_git_branch_name():
 def query_version(ctx, git_sha_length=7, prefix=None):
     # The string that's passed in will look something like this: 6.0.0-beta.0-1-g4f19118
     # if the tag is 6.0.0-beta.0, it has been one commit since the tag and that commit hash is g4f19118
-    cmd = "git describe --tags"
+    cmd = "git describe --tags --candidates=50"
     if prefix and type(prefix) == str:
         cmd += " --match \"{}-*\"".format(prefix)
     if git_sha_length and type(git_sha_length) == int:

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -78,7 +78,7 @@ set -x
 # on linux it can just download the latest version from the package manager
 if [ -z ${AGENT_VERSION+x} ]; then
   pushd ../..
-    export AGENT_VERSION=`inv version --url-safe --git-sha-length=9 --match=[0-9]*`
+    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=9 --match=[0-9]*`
   popd
 fi
 


### PR DESCRIPTION
### Motivation

- Avoid duplicated logic in invoke and omnibus
- Split `inv version` command in two: `inv agent.version` and `inv cluster-agent.version`
- Development builds of the DCA will now use the latest dca tag instead of the latest regular agent tag

I've also refactored a bit the `query_version` function where all the logic is. I've tried to simplify more using a single a regexp but the case `commit_number == 0` is too painful to handle

I've tested the new logic in a few situations, like when the version should be a tag, a beta, or a git commit