### PR TITLE
remove quotes from systemd template Description values

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.network.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.network.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Network Tracer"
+Description=Datadog Network Tracer
 After=network.target
 StartLimitIntervalSec=10
 StartLimitBurst=5

--- a/omnibus/config/templates/datadog-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.process.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Process Agent"
+Description=Datadog Process Agent
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
 StartLimitIntervalSec=10

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Agent"
+Description=Datadog Agent
 After=network.target
 Wants=datadog-agent-trace.service datadog-agent-process.service
 StartLimitIntervalSec=10

--- a/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Trace Agent (APM)"
+Description=Datadog Trace Agent (APM)
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
 StartLimitIntervalSec=10

--- a/omnibus/config/templates/datadog-dogstatsd/systemd.service.erb
+++ b/omnibus/config/templates/datadog-dogstatsd/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog statsd server"
+Description=Datadog statsd server
 After=network.target
 
 [Service]

--- a/omnibus/config/templates/datadog-puppy/systemd.service.erb
+++ b/omnibus/config/templates/datadog-puppy/systemd.service.erb
@@ -1,5 +1,5 @@
 [Unit]
-Description="Datadog Agent"
+Description=Datadog Agent
 After=network.target
 
 [Service]


### PR DESCRIPTION
### What does this PR do?

Closes #2772 by removing quotation marks from the `Description=` field in each systemd template

### Motivation

Writing my own systemd scripts and looking at Datadog for inspiration, noticed the use of quotes and did research to figure out if they were needed. They are not :)

### Additional Notes

I suspect this has zero impact other than cosmetic, but I defer to y'all for best judgment.
