### PR TITLE
Add kube_service config provider

### DIFF
--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build clusterchecks
+// +build kubeapiserver
+
+package providers
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// AD on the load-balanced service IPs
+	kubeServiceAnnotationPrefix = "ad.datadoghq.com/service."
+	kubeServiceIDPrefix         = "kube_service://"
+	// AD on the individual service endpoints (TODO)
+	kubeEndpointAnnotationPrefix = "ad.datadoghq.com/endpoints."
+	kubeEndpointIDPrefix         = "kube_endpoint://"
+)
+
+// KubeletConfigProvider implements the ConfigProvider interface for the kubelet.
+type KubeServiceConfigProvider struct {
+	sync.RWMutex
+	lister   listersv1.ServiceLister
+	upToDate bool
+}
+
+// KubeServiceConfigProvider returns a new ConfigProvider connected to kubelet.
+// Connectivity is not checked at this stage to allow for retries, Collect will do it.
+func NewKubeServiceConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	ac, err := apiserver.GetAPIClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)
+	}
+	servicesInformer := ac.InformerFactory.Core().V1().Services()
+	if servicesInformer == nil {
+		return nil, fmt.Errorf("cannot get service informer: %s", err)
+	}
+
+	p := &KubeServiceConfigProvider{
+		lister: servicesInformer.Lister(),
+	}
+
+	servicesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    p.invalidate,
+		UpdateFunc: p.invalidateIfChanged,
+		DeleteFunc: p.invalidate,
+	})
+
+	return p, nil
+}
+
+// String returns a string representation of the KubeServiceConfigProvider
+func (k *KubeServiceConfigProvider) String() string {
+	return KubeServices
+}
+
+// Collect retrieves services from the apiserver, builds Config objects and returns them
+func (k *KubeServiceConfigProvider) Collect() ([]integration.Config, error) {
+	services, err := k.lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	k.setUpToDate(true)
+
+	return parseServiceAnnotations(services)
+}
+
+// IsUpToDate allows to cache configs as long as no changes are detected in the apiserver
+func (k *KubeServiceConfigProvider) IsUpToDate() (bool, error) {
+	k.RLock()
+	defer k.RUnlock()
+	return k.upToDate, nil
+}
+
+func (k *KubeServiceConfigProvider) setUpToDate(value bool) {
+	k.Lock()
+	defer k.Unlock()
+	k.upToDate = value
+}
+
+func (k *KubeServiceConfigProvider) invalidate(obj interface{}) {
+	if obj != nil {
+		log.Trace("Invalidating configs on new/deleted service")
+		k.setUpToDate(false)
+	}
+}
+
+func (k *KubeServiceConfigProvider) invalidateIfChanged(old, obj interface{}) {
+	// Cast the updated object, don't invalidate on casting error.
+	// nil pointers are safely handled by the casting logic.
+	castedObj, ok := obj.(*v1.Service)
+	if !ok {
+		log.Errorf("Expected a Service type, got: %v", obj)
+		return
+	}
+	// Cast the old object, invalidate on casting error
+	castedOld, ok := old.(*v1.Service)
+	if !ok {
+		log.Errorf("Expected a Service type, got: %v", old)
+		k.setUpToDate(false)
+		return
+	}
+	// Quick exit if resversion did not change
+	if castedObj.ResourceVersion == castedOld.ResourceVersion {
+		return
+	}
+	// Compare annotations
+	if valuesDiffer(castedObj.Annotations, castedOld.Annotations, kubeServiceAnnotationPrefix) {
+		log.Trace("Invalidating configs on service change")
+		k.setUpToDate(false)
+		return
+	}
+}
+
+// valuesDiffer returns true if the annotations matching the
+// given prefix are different between map first and second.
+// It also counts the annotation count to catch deletions.
+func valuesDiffer(first, second map[string]string, prefix string) bool {
+	var matchingInFirst int
+	for name, value := range first {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		if second[name] != value {
+			return true
+		}
+		matchingInFirst++
+	}
+
+	var matchingInSecond int
+	for name := range second {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		matchingInSecond++
+	}
+
+	return matchingInFirst != matchingInSecond
+}
+
+func parseServiceAnnotations(services []*v1.Service) ([]integration.Config, error) {
+	var configs []integration.Config
+	for _, svc := range services {
+		if svc == nil || svc.ObjectMeta.UID == "" {
+			log.Debug("Ignoring a nil service")
+			continue
+		}
+		service_id := fmt.Sprintf("%s%s", kubeServiceIDPrefix, svc.ObjectMeta.UID)
+		c, errors := extractTemplatesFromMap(service_id, svc.Annotations, kubeServiceAnnotationPrefix)
+		for _, err := range errors {
+			log.Errorf("Cannot parse template for service %s/%s: %s", svc.Namespace, svc.Name, err)
+		}
+		configs = append(configs, c...)
+	}
+
+	// All configurations are cluster checks
+	for i := range configs {
+		configs[i].ClusterCheck = true
+	}
+	return configs, nil
+}
+
+func init() {
+	RegisterProvider("kube_services", NewKubeServiceConfigProvider)
+}

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -40,7 +40,7 @@ type KubeServiceConfigProvider struct {
 	upToDate bool
 }
 
-// KubeServiceConfigProvider returns a new ConfigProvider connected to kubelet.
+// NewKubeServiceConfigProvider returns a new ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
 func NewKubeServiceConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
 	ac, err := apiserver.GetAPIClient()

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -29,8 +29,8 @@ const (
 	kubeServiceAnnotationPrefix = "ad.datadoghq.com/service."
 	kubeServiceIDPrefix         = "kube_service://"
 	// AD on the individual service endpoints (TODO)
-	kubeEndpointAnnotationPrefix = "ad.datadoghq.com/endpoints."
-	kubeEndpointIDPrefix         = "kube_endpoint://"
+	// kubeEndpointAnnotationPrefix = "ad.datadoghq.com/endpoints."
+	// kubeEndpointIDPrefix         = "kube_endpoint://"
 )
 
 // KubeletConfigProvider implements the ConfigProvider interface for the kubelet.

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -156,13 +156,13 @@ func parseServiceAnnotations(services []*v1.Service) ([]integration.Config, erro
 		for _, err := range errors {
 			log.Errorf("Cannot parse template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 		}
+		// All configurations are cluster checks
+		for i := range c {
+			c[i].ClusterCheck = true
+		}
 		configs = append(configs, c...)
 	}
 
-	// All configurations are cluster checks
-	for i := range configs {
-		configs[i].ClusterCheck = true
-	}
 	return configs, nil
 }
 

--- a/pkg/autodiscovery/providers/kube_services_test.go
+++ b/pkg/autodiscovery/providers/kube_services_test.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build clusterchecks
+// +build kubeapiserver
+
+package providers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+)
+
+func TestParseKubeServiceAnnotations(t *testing.T) {
+	for _, tc := range []struct {
+		service     *v1.Service
+		expectedOut []integration.Config
+	}{
+		{
+			service:     nil,
+			expectedOut: nil,
+		},
+		{
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("test"),
+					Annotations: map[string]string{
+						"ad.datadoghq.com/service.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/service.init_configs": "[{}]",
+						"ad.datadoghq.com/service.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+					},
+				},
+			},
+			expectedOut: []integration.Config{
+				{
+					Name:          "http_check",
+					ADIdentifiers: []string{"kube_service://test"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					ClusterCheck:  true,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf(""), func(t *testing.T) {
+			cfgs, _ := parseServiceAnnotations([]*v1.Service{tc.service})
+			assert.EqualValues(t, tc.expectedOut, cfgs)
+		})
+	}
+}
+
+func TestInvalidateIfChanged(t *testing.T) {
+	s88 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "88",
+		},
+	}
+	s89 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "89",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/service.check_names":  "[\"http_check\"]",
+				"ad.datadoghq.com/service.init_configs": "[{}]",
+				"ad.datadoghq.com/service.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+			},
+		},
+	}
+	s90 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "90",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/service.check_names":  "[\"http_check\"]",
+				"ad.datadoghq.com/service.init_configs": "[{}]",
+				"ad.datadoghq.com/service.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+			},
+		},
+	}
+	s91 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "91",
+		},
+	}
+	invalid := &v1.Pod{}
+
+	for _, tc := range []struct {
+		old        interface{}
+		obj        interface{}
+		invalidate bool
+	}{
+		{
+			// Invalid input
+			old:        nil,
+			obj:        nil,
+			invalidate: false,
+		},
+		{
+			// Sync on missed create
+			old:        nil,
+			obj:        s88,
+			invalidate: true,
+		},
+		{
+			// Edit, annotations added
+			old:        s88,
+			obj:        s89,
+			invalidate: true,
+		},
+		{
+			// Informer resync, don't invalidate
+			old:        s89,
+			obj:        s89,
+			invalidate: false,
+		},
+		{
+			// Invalid input, don't invalidate
+			old:        s89,
+			obj:        invalid,
+			invalidate: false,
+		},
+		{
+			// Edit but same annotations
+			old:        s89,
+			obj:        s90,
+			invalidate: false,
+		},
+		{
+			// Edit, annotations removed
+			old:        s89,
+			obj:        s91,
+			invalidate: true,
+		},
+	} {
+		t.Run(fmt.Sprintf(""), func(t *testing.T) {
+			provider := &KubeServiceConfigProvider{upToDate: true}
+			provider.invalidateIfChanged(tc.old, tc.obj)
+
+			upToDate, err := provider.IsUpToDate()
+			assert.NoError(t, err)
+			assert.Equal(t, !tc.invalidate, upToDate)
+		})
+	}
+}

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -19,7 +19,7 @@ const (
 	Etcd          = "etcd"
 	File          = "file"
 	Kubernetes    = "kubernetes"
-	KubeServices  = "kubernetes services"
+	KubeServices  = "kubernetes-services"
 	Zookeeper     = "zookeeper"
 )
 

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -10,23 +10,17 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+// User-facing names for the config providers
 const (
-	// Consul represents the name of the Consul config provider
-	Consul = "consul"
-	// ClusterChecks represents the name of the Cluster checks config provider
+	Consul        = "consul"
 	ClusterChecks = "cluster-checks"
-	// Docker represents the name of the docker config provider
-	Docker = "docker"
-	// ECS represents the name of the ecs config provider
-	ECS = "ecs"
-	// Etcd represents the name of the etcd config provider
-	Etcd = "etcd"
-	// File represents the name of the file config provider
-	File = "file"
-	// Kubernetes represents the name of the kubernetes config provider
-	Kubernetes = "kubernetes"
-	// Zookeeper represents the name of the zookeeper config provider
-	Zookeeper = "zookeeper"
+	Docker        = "docker"
+	ECS           = "ecs"
+	Etcd          = "etcd"
+	File          = "file"
+	Kubernetes    = "kubernetes"
+	KubeServices  = "kubernetes services"
+	Zookeeper     = "zookeeper"
 )
 
 // ProviderCatalog keeps track of config providers by name

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -332,6 +332,12 @@ api_key:
 #   - name: clusterchecks
 #      grace_time_seconds: 60
 
+{{- if .ClusterChecks }}
+## The kube_services provider watches Kubernetes services for cluster-checks
+#   - name: kube_services
+#     polling: true
+{{ end -}}
+
 #   - name: etcd
 #     polling: true
 #     template_dir: /datadog/check_configs

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -30,6 +30,10 @@ var controllerCatalog = map[string]controllerFuncs{
 		func() bool { return config.Datadog.GetBool("external_metrics_provider.enabled") },
 		startAutoscalersController,
 	},
+	"services": {
+		func() bool { return config.Datadog.GetBool("cluster_checks.enabled") },
+		startServicesInformer,
+	},
 }
 
 type ControllerContext struct {
@@ -86,6 +90,14 @@ func startAutoscalersController(ctx ControllerContext) error {
 		return err
 	}
 	go autoscalersController.Run(ctx.StopCh)
+
+	return nil
+}
+
+func startServicesInformer(ctx ControllerContext) error {
+	// Just start the shared informer, the autodiscovery
+	// components will access it when needed.
+	go ctx.InformerFactory.Core().V1().Services().Informer().Run(ctx.StopCh)
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This AD config provider extracts cluster check templates from kube service annotations, to be later matched by services emitted by the associated listener (in a second PR).

It depends on a shared informer on services to be started. This is handled by `pkg/util/kubernetes/apiserver/controllers.go` when cluster-checks are enabled. A finer activation of the informer will be implemented later.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
