### PR TITLE
Fix go vet tests with Go 1.11

### DIFF
--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -89,7 +89,7 @@ func (c *CheckBase) CommonConfigure(instance integration.Data) error {
 
 // Warn sends an integration warning to logs + agent status.
 func (c *CheckBase) Warn(v ...interface{}) error {
-	w := log.Warn(v)
+	w := log.Warn(v...)
 	c.latestWarnings = append(c.latestWarnings, w)
 
 	return w
@@ -97,7 +97,7 @@ func (c *CheckBase) Warn(v ...interface{}) error {
 
 // Warnf sends an integration warning to logs + agent status.
 func (c *CheckBase) Warnf(format string, params ...interface{}) error {
-	w := log.Warnf(format, params)
+	w := log.Warnf(format, params...)
 	c.latestWarnings = append(c.latestWarnings, w)
 
 	return w

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -232,7 +232,7 @@ func (d *DockerCheck) Run() error {
 		if c.Network != nil {
 			for _, netStat := range c.Network {
 				if netStat.NetworkName == "" {
-					log.Debugf("Ignore network stat with empty name for container %s: %s", c.ID[:12], netStat)
+					log.Debugf("Ignore network stat with empty name for container %s", c.ID[:12])
 					continue
 				}
 				ifaceTags := append(tags, fmt.Sprintf("docker_network:%s", netStat.NetworkName))
@@ -307,7 +307,7 @@ func (d *DockerCheck) Run() error {
 		} else {
 			for _, stat := range stats {
 				if stat.Name != docker.DataStorageName && stat.Name != docker.MetadataStorageName {
-					log.Debugf("Ignoring unknown disk stats: %s", stat)
+					log.Debugf("Ignoring unknown disk stats: %s", stat.Name)
 					continue
 				}
 				if stat.Free != nil {

--- a/pkg/logs/input/docker/container.go
+++ b/pkg/logs/input/docker/container.go
@@ -77,7 +77,7 @@ func (c *Container) getShortImageName() (string, error) {
 	imageName := c.container.Image
 	imageName, err = du.ResolveImageName(imageName)
 	if err != nil {
-		log.Debugf("Could not resolve image name %d: %d", imageName, err)
+		log.Debugf("Could not resolve image name %s: %s", imageName, err)
 		return shortName, err
 	}
 	_, shortName, _, err = containers.SplitImageName(imageName)

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -209,13 +209,13 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 	// compute the offset to prevent from missing or duplicating logs
 	since, err := Since(l.registry, tailer.Identifier(), container.service.CreationTime)
 	if err != nil {
-		log.Warnf("Could not recover tailing from last committed offset: %v", ShortContainerID(containerID), err)
+		log.Warnf("Could not recover tailing from last committed offset %v: %v", ShortContainerID(containerID), err)
 	}
 
 	// start the tailer
 	err = tailer.Start(since)
 	if err != nil {
-		log.Warnf("Could not start tailer: %v", containerID, err)
+		log.Warnf("Could not start tailer %s: %v", containerID, err)
 		return
 	}
 	source.AddInput(containerID)

--- a/pkg/serializer/split/split.go
+++ b/pkg/serializer/split/split.go
@@ -92,9 +92,9 @@ func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarde
 			// This is the same function used in dd-agent
 			compressionRatio := float64(payloadSize) / float64(compressedSize)
 			numChunks := compressedSize/maxPayloadSize + 1 + int(compressionRatio/2)
-			log.Debugf("split the payload into into %f chunks", numChunks)
+			log.Debugf("split the payload into into %d chunks", numChunks)
 			chunks, err := toSplit.SplitPayload(numChunks)
-			log.Debugf("payload was split into %f chunks", len(chunks))
+			log.Debugf("payload was split into %d chunks", len(chunks))
 			if err != nil {
 				log.Warnf("Some payloads could not be split, dropping them")
 				splitterPayloadDrops.Add(1)

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -69,7 +69,7 @@ func (c *KubeMetadataCollector) Pull() error {
 	// Time constraints, get the delta in seconds to display it in the logs:
 	timeDelta := c.lastUpdate.Add(c.updateFreq).Unix() - time.Now().Unix()
 	if timeDelta > 0 {
-		log.Tracef("skipping, next effective Pull will be in %s seconds", timeDelta)
+		log.Tracef("skipping, next effective Pull will be in %d seconds", timeDelta)
 		return nil
 	}
 

--- a/pkg/util/containers/metrics/network.go
+++ b/pkg/util/containers/metrics/network.go
@@ -35,12 +35,12 @@ func CollectNetworkStats(pid int, networks map[string]string) (ContainerNetStats
 
 	procNetFile := hostProc(strconv.Itoa(int(pid)), "net", "dev")
 	if !pathExists(procNetFile) {
-		log.Debugf("Unable to read %s for pid %s", procNetFile, pid)
+		log.Debugf("Unable to read %s for pid %d", procNetFile, pid)
 		return netStats, nil
 	}
 	lines, err := readLines(procNetFile)
 	if err != nil {
-		log.Debugf("Unable to read %s for pid %s", procNetFile, pid)
+		log.Debugf("Unable to read %s for pid %d", procNetFile, pid)
 		return netStats, nil
 	}
 	if len(lines) < 2 {

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -194,14 +194,14 @@ func detectAgentURL() (string, error) {
 		// List all interfaces for the ecs-agent container
 		agentURLS, err := getAgentContainerURLS()
 		if err != nil {
-			log.Debugf("could inspect ecs-agent container: ", err)
+			log.Debugf("could inspect ecs-agent container: %s", err)
 		} else {
 			urls = append(urls, agentURLS...)
 		}
 		// Try the default gateway
 		gw, err := docker.DefaultGateway()
 		if err != nil {
-			log.Debugf("could not get docker default gateway: ", err)
+			log.Debugf("could not get docker default gateway: %s", err)
 		}
 		if gw != nil {
 			urls = append(urls, fmt.Sprintf("http://%s:%d/", gw.String(), DefaultAgentPort))

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// Go vet raise an error when test the "Warn" method: call has possible formatting directive %s
+// +build !novet
+
 package log
 
 import (


### PR DESCRIPTION
### What does this PR do?

Fix go vet tests with Go 1.11.
Go vet is more robust when format-checking printf wrappers: https://golang.org/doc/go1.11#vet