### PR TITLE
[docs] bump macOS minimal version from 10.10 to 10.12

### DIFF
--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -42,7 +42,7 @@ Agent 6 is currently available on these platforms:
 | Ubuntu x86_64 | version 12.04 and above |
 | RedHat/CentOS x86_64 | version 6 and above |
 | SUSE Enterprise Linux x86_64 | version 11 SP4 and above (we do not support SysVinit)|
-| MacOS | 10.10 and above |
+| MacOS | 10.12 and above |
 | Windows Server 64-bit |  2008 R2 and above |
 | Docker | Version 1.12 and higher|
 |Kubernetes | Version 1.3 and higher |


### PR DESCRIPTION
### What does this PR do?

Bump macOS minimal version from 10.10 to 10.12

### Motivation

The Agent v6 is not compatible with macOS < 10.12 due to a system library having changed.
