### PR TITLE
[flare] Stat the files permissions infos without type assertion

### DIFF
--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -52,12 +52,9 @@ func (p permissionsInfos) statFiles() error {
 			return fmt.Errorf("while getting info of %s: %s", filePath, err)
 		}
 
-		sys, ok := fi.Sys().(*syscall.Stat_t)
-		if !ok {
-			// not enough information to append for this file
-			// might rarely happen on system not supporting this feature, but as
-			// we're building with !windows tag, shouldn't happen except for plan9
-			return fmt.Errorf("can't retrieve file uid/gid infos")
+		var sys syscall.Stat_t
+		if err := syscall.Stat(filePath, &sys); err != nil {
+			return fmt.Errorf("can't retrieve file %s uid/gid infos: %s", filePath, err)
 		}
 
 		u, err := user.LookupId(strconv.Itoa(int(sys.Uid)))


### PR DESCRIPTION
### What does this PR do?

Stat the files permissions infos without type assertion.

### Motivation

Has exactly the same results but avoid a type assertion.

### Additional Notes

I was suprised to be forced to do a type assert to get the uid / gid. Well...