### PR TITLE
Add releases notes for PR #2684

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,11 @@ Other Notes
   the agent use glibc to resolve hostnames and should give more predictable
   results.
 
+- Starting with this Agent release, all the Datadog integrations that are installed
+  with the ``datadog-agent integration install`` command are reset to their
+  default versions when the Agent is upgraded.
+  This guarantees the integrity of the embedded python environment after the upgrade.
+
 
 .. _Release Notes_6.7.0:
 


### PR DESCRIPTION
Add a release note for https://github.com/DataDog/datadog-agent/pull/2684

### Motivation

This is a change in the behavior of the agent. There should be a release note about it
