### PR TITLE
[windows] fix downgrade handling.

### DIFF
--- a/omnibus/config/software/datadog-process-agent.rb
+++ b/omnibus/config/software/datadog-process-agent.rb
@@ -22,7 +22,7 @@ build do
     target_binary = "process-agent.exe"
     curl_cmd = "powershell -Command wget -OutFile #{binary} #{url}#{binary}"
     command curl_cmd
-    command "mv #{binary} #{install_dir}/bin/agent/#{target_binary}"
+    command "mv #{binary}  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/#{target_binary}"
   else
     binary = "process-agent-amd64-#{version}"
     target_binary = "process-agent"

--- a/omnibus/config/software/datadog-trace-agent.rb
+++ b/omnibus/config/software/datadog-trace-agent.rb
@@ -60,7 +60,8 @@ build do
 
     # copy binary
     if windows?
-      copy "#{gopath.to_path}/bin/#{trace_agent_binary}", "#{install_dir}/bin/agent"
+      #copy "#{gopath.to_path}/bin/#{trace_agent_binary}", "#{install_dir}/bin/agent"
+      copy "#{gopath.to_path}/bin/#{trace_agent_binary}", "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
     else
       copy "#{gopath.to_path}/bin/#{trace_agent_binary}", "#{install_dir}/embedded/bin"
     end

--- a/omnibus/resources/agent/msi/localbuild/.gitignore
+++ b/omnibus/resources/agent/msi/localbuild/.gitignore
@@ -1,0 +1,6 @@
+*.msi
+*.wixpdb
+*.wixobj
+*.wxs
+*.wxl
+resources

--- a/omnibus/resources/agent/msi/localbuild/README.md
+++ b/omnibus/resources/agent/msi/localbuild/README.md
@@ -1,0 +1,19 @@
+## LocalInstall
+
+The files here provide a means to more quickly test iterations of the Windows installer by creating an environment in which an installer can be recreated without an entire omnibus build.
+
+### Requirements
+
+Assumes that an omnibus build has been successfully completed; the script here will use the artifacts from that build.
+
+Assumes that the omnibus output directory is `c:\omnibus-ruby`, and the datadog installation directory is `c:\opt\datadog-agent`.  If your environment is different, you can modify the parameters to `heat` and `light` in `rebuild.bat`, and the file `parameters.wxi` in this directory.
+
+### rebuild.bat
+
+The batch file mimics the behavior of the omnibus build script, after all of the pieces have been put into
+place.  Executes `light` (which creates an XML representation of the directory structure) over `c:\opt\datadog-agent`
+and the configuration files directory, `c:\omnibus-ruby\src\etc\datadog-agent\extra_package_files`
+
+It includes `parameters.wxi`, where the variables such as the installation version can be changed (note that the included binaries will not be rebuilt, so the included binaries will not necessarily report the version specified in `parameters.wxi`.  However, the MSI itself will report itself as that version).
+
+

--- a/omnibus/resources/agent/msi/localbuild/parameters.wxi
+++ b/omnibus/resources/agent/msi/localbuild/parameters.wxi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+  <?define VersionNumber="6.4.1.1" ?>
+  <?define DisplayVersionNumber="6.4.1" ?>
+  <?define UpgradeCode="0c50421b-aefb-4f15-a809-7af256d608a5" ?>
+  <?define InstallDir="C:/opt/datadog-agent" ?>
+  <?define InstallFiles="C:/omnibus-ruby/src/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files" ?>
+  <?define BinFiles="c:\omnibus-ruby\src\datadog-agent\src\github.com\DataDog\datadog-agent\bin\agent" ?>
+  <?define EtcFiles="C:/omnibus-ruby/src\etc\datadog-agent" ?>
+  <?define ResourcesDir="c:\dev\go\src\github.com\datadog\datadog-agent\omnibus\resources\agent\msi"?>
+</Include>

--- a/omnibus/resources/agent/msi/localbuild/rebuild.bat
+++ b/omnibus/resources/agent/msi/localbuild/rebuild.bat
@@ -25,6 +25,8 @@ candle -arch x64 %wix_extension_switches% -dProjectSourceDir="c:\opt\datadog-age
 if not "%ERRORLEVEL%" == "0" goto :done
 light -ext WixUIExtension -ext WixBalExtension %wix_extension_switches% -cultures:en-us -loc localization-en-us.wxl project-files.wixobj source.wixobj %WIXOBJ_LIST% -out ddagent.msi
 
+@echo light returned code %ERRORLEVEL%
+
 
 :done
 cd %WD%

--- a/omnibus/resources/agent/msi/localbuild/rebuild.bat
+++ b/omnibus/resources/agent/msi/localbuild/rebuild.bat
@@ -1,0 +1,30 @@
+rem
+@setlocal
+@set WD=%CD%
+cd %~dp0
+
+copy ..\source.wxs.erb source.wxs
+xcopy /y/e/s/i ..\assets\*.* resources\assets
+REM run HEAT on c:\opt\datadog-agent
+REM
+heat.exe dir "c:\opt\datadog-agent" -nologo -srd -sreg -gg -cg ProjectDir -dr PROJECTLOCATION -var "var.ProjectSourceDir" -out "project-files.wxs"
+
+REM 
+REM run HEAT on the extras
+REM
+for /D %%D in (c:\omnibus-ruby\src\etc\datadog-agent\extra_package_files\*.*) do (
+    heat.exe dir %%D -nologo -srd -gg -cg Extra%%~nD -dr %%~nD -var "var.Extra%%~nD" -out "extra-%%~nD.wxs"
+    set CANDLE_VARS=%CANDLE_VARS% -dExtra%%~nD="%%D"
+    set WXS_LIST=%WX_LIST% extra-%%~nD.wxs
+    set WIXOBJ_LIST=%WIXOBJ_LIST% extra-%%~nD.wixobj
+)
+
+@set wix_extension_switches=-ext WixUtilExtension
+candle -arch x64 %wix_extension_switches% -dProjectSourceDir="c:\opt\datadog-agent" -dExtraEXAMPLECONFSLOCATION="C:\omnibus-ruby\src\etc\datadog-agent\extra_package_files\EXAMPLECONFSLOCATION" project-files.wxs %WXS_LIST% source.wxs
+
+if not "%ERRORLEVEL%" == "0" goto :done
+light -ext WixUIExtension -ext WixBalExtension %wix_extension_switches% -cultures:en-us -loc localization-en-us.wxl project-files.wixobj source.wixobj %WIXOBJ_LIST% -out ddagent.msi
+
+
+:done
+cd %WD%

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -38,6 +38,13 @@
                         Minimum='1.0.0' IncludeMinimum='yes'
                         Maximum="99.99.99.99" IncludeMaximum='no'/>
     </Upgrade>
+    
+    <!-- This allows downgrades, and same-version reinstalls.  Otherwise,
+    same version gets installed "side by side" -->
+    <MajorUpgrade
+      AllowDowngrades="yes"
+      Schedule="afterInstallInitialize" />
+
 
     <!-- Close application when uninstalling -->
     <util:CloseApplication Id="CloseTrayApp"
@@ -52,12 +59,6 @@
     <!-- No need to restart Windows after the installation -->
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
-        <!-- This allows downgrades, and same-version reinstalls.  Otherwise,
-      same version gets installed "side by side" -->
-
-    <MajorUpgrade
-      AllowDowngrades="yes"
-     />
      <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
      <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
      <PropertyRef Id="WIX_ACCOUNT_USERS" />
@@ -230,7 +231,7 @@
                 Vital="yes"
                 KeyPath="yes"
                 DiskId="1"
-                Source="$(var.InstallDir)/bin/agent/trace-agent.exe"/>
+                Source="$(var.BinFiles)/trace-agent.exe"/>
             <ServiceInstall Id="DatadogAPMServiceInstaller"
                             DisplayName="!(loc.ServiceApmDisplayName)"
                             Description="!(loc.ServiceApmDescription)"
@@ -271,7 +272,7 @@
                 Vital="yes"
                 KeyPath="yes"
                 DiskId="1"
-                Source="$(var.InstallDir)/bin/agent/process-agent.exe"/>
+                Source="$(var.BinFiles)/process-agent.exe"/>
             <ServiceInstall Id="DatadogProcessServiceInstaller"
                             DisplayName="!(loc.ServiceProcessDisplayName)"
                             Description="!(loc.ServiceProcessDescription)"
@@ -466,7 +467,8 @@
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>
     <Property Id="ARPPRODUCTICON" Value="project.ico" />
     <Property Id="ARPHELPLINK" Value="https://datadoghq.com/" />
-    <Property Id="WIXUI_INSTALLDIR" Value="<%= wix_install_dir %>" />
+    <!--
+    <Property Id="WIXUI_INSTALLDIR" Value="<%= wix_install_dir %>" /> -->
 
     <UIRef Id="ProjectUI_InstallDir"/>
     <UI Id="ProjectUI_InstallDir">
@@ -568,6 +570,7 @@
 
    <Binary Id="BannerBmp" SourceFile="Resources\assets\banner_background.bmp" />
     <Binary Id="BackgroundBmp" SourceFile="Resources\assets\dialog_background.bmp" />
+    <Binary Id="PrepBackgroundBmp" SourceFile="Resources\assets\dialog_background.bmp" />
 
     <Property Id="ShortCompanyName" Value="!(loc.CompanyNameShort)" />
 

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -211,7 +211,7 @@
                           Start="install"
                           Stop="both"
                           Remove="uninstall"
-                          Wait="no" />
+                          Wait="yes" />
           <RemoveFolder Id="APPLICATIONROOTDIRECTORY" On="uninstall" />
           <!-- The "Name" field must match the argument to eventlog.Open() -->
           <util:EventSource Log="Application" Name="DatadogAgent"
@@ -256,7 +256,7 @@
                             Start="install"
                             Stop="both"
                             Remove="uninstall"
-                            Wait="no" />
+                            Wait="yes" />
             <!-- The "Name" field must match the argument to eventlog.Open() -->
             <util:EventSource Log="Application" Name="datadog-trace-agent"
                     EventMessageFile="[AGENT]trace-agent.exe"
@@ -297,7 +297,7 @@
                             Start="install"
                             Stop="both"
                             Remove="uninstall"
-                            Wait="no" />
+                            Wait="yes" />
             <!-- The "Name" field must match the argument to eventlog.Open() -->
             <util:EventSource Log="Application" Name="datadog-process-agent"
                     EventMessageFile="[AGENT]process-agent.exe"

--- a/releasenotes/notes/fixdowngrades-af610fcaf8158ad1.yaml
+++ b/releasenotes/notes/fixdowngrades-af610fcaf8158ad1.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On windows, fixes downgrades.  Fix won't be apparent for an
+    additional release, since the core fix occurs on install.


### PR DESCRIPTION
### What does this PR do?

Root cause
appears to be that we were adding the subservices twice, and so
reference counting was thrown off.  This is made worse by the fact
that the omnibus processing explicitly ignores that error code.

### Motivation

downgrade wasn't working

### Additional Notes

Also added a subdirectory for recreating the MSI w/o an entire omnibus
build, which cuts a lot off the build/test cycle of installs.


Parallel A5 Fix: https://github.com/DataDog/dd-agent-omnibus/pull/343
Parallel Omnibus fix: https://github.com/DataDog/omnibus-ruby/pull/78


### Testing notes
Note that the root cause is in the installer.  Therefore, the bug will still manifest when upgrading from a previous build (i.e. `6.8`) to a build with the fix (i.e. `6.9`) (same relationship holds with A5).

To verify, therefore, a test will have to be done with, for example, RC2->RC1 or similar.