### PR TITLE
Allow to set additional Autodiscovery sources by envvars

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -109,6 +109,10 @@ DD_AC_INCLUDE = "image:cp-kafka image:k8szk"
 
 Please note that the `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings and always count all containers. This does not affect your per-container billing.
 
+### Additional Autodiscovery sources
+
+You can add extra listeners and config providers via the `DD_EXTRA_LISTENERS` and `DD_EXTRA_CONFIG_PROVIDERS` enviroment variables. They will be added on top of the ones defined in the `listeners` and `config_providers` section of the datadog.yaml configuration file.
+
 ### Datadog Cluster Agent
 
 The DCA is a **beta** feature, if you are facing any issues please reach out to our [support team](http://docs.datadoghq.com/help)
@@ -317,7 +321,7 @@ The source and service values can be overriden thanks to Autodiscovery as descri
 
 The second step is to use Autodiscovery to customize the `source` and `service` value. This allows Datadog to identify the log source for each container.
 
-Since version 6.2 of the Datadog Agent, you can [configure log collection directly in the container labels](https://docs.datadoghq.com/logs/log_collection/docker/?tab=dockerfile#activate-log-integrations). 
+Since version 6.2 of the Datadog Agent, you can [configure log collection directly in the container labels](https://docs.datadoghq.com/logs/log_collection/docker/?tab=dockerfile#activate-log-integrations).
 Pod annotations are also supported for Kubernetes environment, see the [Kubernetes Autodiscovery documentation][https://docs.datadoghq.com/agent/autodiscovery/#template-source-kubernetes-pod-annotations].
 
 ## How to build this image

--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -58,7 +58,12 @@ func SetupAutoConfig(confdPath string) {
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders
 	err = config.Datadog.UnmarshalKey("config_providers", &CP)
+
 	if err == nil {
+		// Add extra config providers
+		for _, name := range config.Datadog.GetStringSlice("extra_config_providers") {
+			CP = append(CP, config.ConfigurationProviders{Name: name, Polling: true})
+		}
 		for _, cp := range CP {
 			factory, found := providers.ProviderCatalog[cp.Name]
 			if found {
@@ -88,6 +93,10 @@ func SetupAutoConfig(confdPath string) {
 	var listeners []config.Listeners
 	err = config.Datadog.UnmarshalKey("listeners", &listeners)
 	if err == nil {
+		// Add extra listeners
+		for _, name := range config.Datadog.GetStringSlice("extra_listeners") {
+			listeners = append(listeners, config.Listeners{Name: name})
+		}
 		listeners = AutoAddListeners(listeners)
 		AC.AddListeners(listeners)
 	} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -206,6 +206,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})
 	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10)) // in seconds
+	config.BindEnvAndSetDefault("extra_listeners", []string{})
+	config.BindEnvAndSetDefault("extra_config_providers", []string{})
 
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -357,6 +357,13 @@ api_key:
 #     template_url: 127.0.0.1
 #     username:
 #     password:
+
+## You can also add additional config providers by name using their default settings,
+## and pooling enabled. This is list is available as an environment variable binding.
+#
+# extra_config_providers:
+#   - clusterchecks
+
 {{ end -}}
 {{- if .Logging }}
 # Logging
@@ -423,6 +430,12 @@ api_key:
 # listeners:
 #   - name: auto
 #   - name: docker
+#
+## You can also add additional listeners by name using their default settings.
+## This is list is available as an environment variable binding.
+#
+# extra_listeners:
+#   - kubelet
 #
 # Exclude containers from metrics and AD based on their name or image:
 # An excluded container will not get any individual container metric reported for it.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -359,7 +359,7 @@ api_key:
 #     password:
 
 ## You can also add additional config providers by name using their default settings,
-## and pooling enabled. This is list is available as an environment variable binding.
+## and pooling enabled. This list is available as an environment variable binding.
 #
 # extra_config_providers:
 #   - clusterchecks
@@ -432,7 +432,7 @@ api_key:
 #   - name: docker
 #
 ## You can also add additional listeners by name using their default settings.
-## This is list is available as an environment variable binding.
+## This list is available as an environment variable binding.
 #
 # extra_listeners:
 #   - kubelet

--- a/releasenotes/notes/ad-extra-sources-f7383a85d6d07a1d.yaml
+++ b/releasenotes/notes/ad-extra-sources-f7383a85d6d07a1d.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    You can add extra listeners and config providers via the ``DD_EXTRA_LISTENERS`` and
+    ``DD_EXTRA_CONFIG_PROVIDERS`` enviroment variables. They will be added on top of the
+    ones defined in the ``listeners`` and ``config_providers`` section of the datadog.yaml
+    configuration file.


### PR DESCRIPTION
### What does this PR do?

Allow to set additional Autodiscovery listeners and config providers by envvars

### Motivation

Current `listeners` and `config_providers` options are not available as envvar bindings, enabling cluster-checks would require users to mount their own `datadog.yaml` file, which is not supported by the chart.

### Additional Notes

Anything else we should know when reviewing?
