### PR TITLE
[check cmd] Add pause between 2 consecutive runs with `--check-rate`

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -149,7 +149,6 @@ var checkCmd = &cobra.Command{
 
 func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 	s := check.NewStats(c)
-	i := 0
 	times := checkTimes
 	pause := checkPause
 	if checkRate {
@@ -162,16 +161,15 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 		times = 2
 		pause = 1000
 	}
-	for i < times {
+	for i := 0; i < times; i++ {
 		t0 := time.Now()
 		err := c.Run()
 		warnings := c.GetWarnings()
 		mStats, _ := c.GetMetricStats()
 		s.Add(time.Since(t0), err, warnings, mStats)
-		if pause > 0 {
+		if pause > 0 && i < times-1 {
 			time.Sleep(time.Duration(pause) * time.Millisecond)
 		}
-		i++
 	}
 
 	return s

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -27,6 +27,7 @@ import (
 var (
 	checkRate  bool
 	checkTimes int
+	checkPause int
 	checkName  string
 	checkDelay int
 	logLevel   string
@@ -38,8 +39,9 @@ const checkCmdFlushInterval = time.Hour
 func init() {
 	AgentCmd.AddCommand(checkCmd)
 
-	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice")
+	checkCmd.Flags().BoolVarP(&checkRate, "check-rate", "r", false, "check rates by running the check twice with a 1sec-pause between the 2 runs")
 	checkCmd.Flags().IntVarP(&checkTimes, "check-times", "t", 1, "number of times to run the check")
+	checkCmd.Flags().IntVar(&checkPause, "pause", 0, "pause between multiple runs of the check, in milliseconds")
 	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")
 	checkCmd.SetArgs([]string{"checkName"})
@@ -149,11 +151,16 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 	s := check.NewStats(c)
 	i := 0
 	times := checkTimes
+	pause := checkPause
 	if checkRate {
 		if checkTimes > 2 {
 			color.Yellow("The check-rate option is overriding check-times to 2")
 		}
+		if pause > 0 {
+			color.Yellow("The check-rate option is overriding pause to 1000ms")
+		}
 		times = 2
+		pause = 1000
 	}
 	for i < times {
 		t0 := time.Now()
@@ -161,6 +168,9 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 		warnings := c.GetWarnings()
 		mStats, _ := c.GetMetricStats()
 		s.Add(time.Since(t0), err, warnings, mStats)
+		if pause > 0 {
+			time.Sleep(time.Duration(pause) * time.Millisecond)
+		}
 		i++
 	}
 

--- a/releasenotes/notes/cmd-check-pause-f786715982374ebf.yaml
+++ b/releasenotes/notes/cmd-check-pause-f786715982374ebf.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On the ``check`` command, add a pause of 1sec between the 2 check runs when
+    ``--check-rate`` is set. Allows some checks to gather more meaningful metric samples.


### PR DESCRIPTION
### What does this PR do?

On the `check` cmd, adds a pause of 1 second between 2 consecutive runs of a check when `--check-rate` is used.

### Motivation

`--check-rate` is meant to be used for the metrics that need the check to run twice to fully be reported. Some of these checks need some time to pass between their 2 runs, otherwise the runs are too close in time to provide meaningful samples, and the metrics are missing. This affects the go cpu check for example.

This sets a pause of 1 seconds between the 2 check runs when `--check-rate` is used. The option can be set separately with `--pause` if `--check-times` is used instead (default: no pause).

### Additional Notes

Didn't add a short flag on the new `--pause` option, because couldn't find one that really made sense.
