### PR TITLE
Sort file by reverse lexicographical order before tailing them

### DIFF
--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -130,6 +131,20 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 		return nil, fmt.Errorf("could not find any file matching pattern %s, check that all its subdirectories are executable", pattern)
 	}
 	var files []*File
+
+	// Files are sorted because of a heuristic on the filename: often the filename and/or the folder name
+	// contains information in the file datetime. Most of the time we want the most recent files.
+	// Here, we reverse paths to have stable sort keep reverse lexicographical order w.r.t dir names. Example:
+	// [/tmp/1/2017.log, /tmp/1/2018.log, /tmp/2/2018.log] becomes [/tmp/2/2018.log, /tmp/1/2018.log, /tmp/1/2017.log]
+	// then kept as is by the sort below.
+	for i := len(paths)/2 - 1; i >= 0; i-- {
+		opp := len(paths) - 1 - i
+		paths[i], paths[opp] = paths[opp], paths[i]
+	}
+	// sort paths by descending filenames
+	sort.SliceStable(paths, func(i, j int) bool {
+		return filepath.Base(paths[i]) > filepath.Base(paths[j])
+	})
 	for _, path := range paths {
 		files = append(files, NewFile(path, source))
 	}

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -52,7 +52,7 @@ func NewProvider(filesLimit int) *Provider {
 // FilesToTail returns all the Files matching paths in sources,
 // it cannot return more than filesLimit Files.
 // For now, there is no way to prioritize specific Files over others,
-// they are just returned in alphabetical order
+// they are just returned in reverse lexicographical order, see `searchFiles`
 func (p *Provider) FilesToTail(sources []*config.LogSource) []*File {
 	var filesToTail []*File
 	shouldLogErrors := p.shouldLogErrors
@@ -137,6 +137,7 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 	// Here, we reverse paths to have stable sort keep reverse lexicographical order w.r.t dir names. Example:
 	// [/tmp/1/2017.log, /tmp/1/2018.log, /tmp/2/2018.log] becomes [/tmp/2/2018.log, /tmp/1/2018.log, /tmp/1/2017.log]
 	// then kept as is by the sort below.
+	// https://github.com/golang/go/wiki/SliceTricks#reversing
 	for i := len(paths)/2 - 1; i >= 0; i-- {
 		opp := len(paths) - 1 - i
 		paths[i], paths[opp] = paths[opp], paths[i]

--- a/pkg/logs/input/file/file_provider_test.go
+++ b/pkg/logs/input/file/file_provider_test.go
@@ -90,9 +90,9 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromDirectory() {
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(3, len(files))
-	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/1/3.log", suite.testDir), files[0].Path)
 	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[1].Path)
-	suite.Equal(fmt.Sprintf("%s/1/3.log", suite.testDir), files[2].Path)
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[2].Path)
 	suite.Equal([]string{"3 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
 		[]string{
@@ -109,8 +109,8 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsAllFilesFromAnyDirectoryWi
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(2, len(files))
-	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
-	suite.Equal(fmt.Sprintf("%s/2/1.log", suite.testDir), files[1].Path)
+	suite.Equal(fmt.Sprintf("%s/2/1.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[1].Path)
 	suite.Equal([]string{"2 files tailed out of 2 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(make([]string, 0), logSources[0].Messages.GetWarnings())
 }
@@ -122,9 +122,9 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 	files := fileProvider.FilesToTail(logSources)
 
 	suite.Equal(3, len(files))
-	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/1/3.log", suite.testDir), files[0].Path)
 	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[1].Path)
-	suite.Equal(fmt.Sprintf("%s/1/3.log", suite.testDir), files[2].Path)
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[2].Path)
 	suite.Equal([]string{"3 files tailed out of 3 files matching"}, logSources[0].Messages.GetMessages())
 	suite.Equal(
 		[]string{
@@ -132,6 +132,20 @@ func (suite *ProviderTestSuite) TestFilesToTailReturnsSpecificFileWithWildcard()
 		},
 		logSources[0].Messages.GetWarnings(),
 	)
+}
+
+func (suite *ProviderTestSuite) TestWildcardPathsAreSorted() {
+	filesLimit := 6
+	path := fmt.Sprintf("%s/*/*.log", suite.testDir)
+	fileProvider := NewProvider(filesLimit)
+	logSources := suite.newLogSources(path)
+	files := fileProvider.FilesToTail(logSources)
+	suite.Equal(5, len(files))
+	suite.Equal(fmt.Sprintf("%s/1/3.log", suite.testDir), files[0].Path)
+	suite.Equal(fmt.Sprintf("%s/2/2.log", suite.testDir), files[1].Path)
+	suite.Equal(fmt.Sprintf("%s/1/2.log", suite.testDir), files[2].Path)
+	suite.Equal(fmt.Sprintf("%s/2/1.log", suite.testDir), files[3].Path)
+	suite.Equal(fmt.Sprintf("%s/1/1.log", suite.testDir), files[4].Path)
 }
 
 func (suite *ProviderTestSuite) TestNumberOfFilesToTailDoesNotExceedLimit() {

--- a/releasenotes/notes/tail-files-reverse-lex-order-d4fe0fa158fa8441.yaml
+++ b/releasenotes/notes/tail-files-reverse-lex-order-d4fe0fa158fa8441.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Files are not tailed in reverse lexicographical order w.r.t their file names then dir name. If you have files
+    `/1/2017.log`, `/1/2018.log`, `/2/2018.log` and `logs_config.open_files_limit == 2`, then you will tail
+    `/2/2018.log` and `/1/2018.log`.


### PR DESCRIPTION
### What does this PR do?

Sort file by reverse lexicographiccal order before tailing them. The heuristic is that filenames often contain a datetime information

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
