### PR TITLE
Fix a regression in parsing ignore.resources for traces

### DIFF
--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -6,6 +6,7 @@
 package legacy
 
 import (
+	"encoding/csv"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -229,15 +230,12 @@ func extractTraceAgentConfig(agentConfig Config, configConverter *config.LegacyC
 
 	// ignored resources
 	if v, ok := agentConfig["trace.ignore.resource"]; ok {
-		var err error
-		r := strings.Split(v, ",")
-		for i := range r {
-			r[i], err = strconv.Unquote(r[i])
-			if err != nil {
-				return err
-			}
+		r, err := splitString(v, ',')
+		if err == nil {
+			configConverter.Set("apm_config.ignore_resources", r)
+		} else {
+			fmt.Println("Ignoring value provided trace.ignore.resource because of parsing error")
 		}
-		configConverter.Set("apm_config.ignore_resources", r)
 	}
 
 	return nil
@@ -436,4 +434,19 @@ func buildHistogramPercentiles(agentConfig Config) []string {
 	}
 
 	return histogramPercentile
+}
+
+func splitString(s string, sep rune) ([]string, error) {
+	r := csv.NewReader(strings.NewReader(s))
+	r.TrimLeadingSpace = true
+	r.LazyQuotes = true
+	r.Comma = sep
+
+	record, err := r.Read()
+
+	if err != nil {
+		return []string{}, err
+	}
+
+	return record, nil
 }

--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -441,12 +441,5 @@ func splitString(s string, sep rune) ([]string, error) {
 	r.TrimLeadingSpace = true
 	r.LazyQuotes = true
 	r.Comma = sep
-
-	record, err := r.Read()
-
-	if err != nil {
-		return []string{}, err
-	}
-
-	return record, nil
+	return r.Read()
 }

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -205,6 +205,29 @@ func TestDefaultValues(t *testing.T) {
 	assert.Equal(t, true, config.Datadog.GetBool("hostname_fqdn"))
 }
 
+func TestTraceIgnoreResources(t *testing.T) {
+	require := require.New(t)
+
+	cases := []struct {
+		config   string
+		expected []string
+	}{
+		{"r1", []string{"r1"}},
+		{"\"r1\",\"r2,\"", []string{"r1", "r2,"}},
+		{"\"r1\"", []string{"r1"}},
+		{"r1,r2", []string{"r1", "r2"}},
+	}
+
+	for _, c := range cases {
+		cfg := make(Config)
+		cfg["trace.ignore.resource"] = c.config
+		err := FromAgentConfig(cfg)
+		require.NoError(err)
+		require.Equal(c.expected, config.Datadog.GetStringSlice("apm_config.ignore_resources"))
+
+	}
+}
+
 func TestConverter(t *testing.T) {
 	require := require.New(t)
 	cfg, err := GetAgentConfig("./tests/datadog.conf")

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -213,8 +213,8 @@ func TestTraceIgnoreResources(t *testing.T) {
 		expected []string
 	}{
 		{"r1", []string{"r1"}},
-		{"\"r1\",\"r2,\"", []string{"r1", "r2,"}},
-		{"\"r1\"", []string{"r1"}},
+		{`"r1","r2,"`, []string{"r1", "r2,"}},
+		{`"r1"`, []string{"r1"}},
 		{"r1,r2", []string{"r1", "r2"}},
 	}
 

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -212,10 +212,10 @@ func TestTraceIgnoreResources(t *testing.T) {
 		config   string
 		expected []string
 	}{
-		{"r1", []string{"r1"}},
+		{`r1`, []string{"r1"}},
 		{`"r1","r2,"`, []string{"r1", "r2,"}},
 		{`"r1"`, []string{"r1"}},
-		{"r1,r2", []string{"r1", "r2"}},
+		{`r1,r2`, []string{"r1", "r2"}},
 	}
 
 	for _, c := range cases {

--- a/releasenotes/notes/fix-trace-ignore-933ede7647b4f7fa.yaml
+++ b/releasenotes/notes/fix-trace-ignore-933ede7647b4f7fa.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug with parsing of ``trace.ignore`` in the ``import`` command.


### PR DESCRIPTION
### What does this PR do?

This PR addresses a regression in the parsing of the ini configuration for the trace agent introduced in https://github.com/DataDog/datadog-agent/pull/2698. 

It used to accept strings normal strings, but now requires them to be escaped with quotes. Meaning that:

```
[trace.ignore]
resource: config.get_config
```
used to work but is now broken. And given the ini parser strips quotes, the only way I've found to parse a single resource is to do:

```
[trace.ignore]
resource: '"/health"'
```

It currently works for multiple resources with the format:
```
[trace.ignore]
resource: "/health","/500"
```

But this is not backward compatible with the previous version that was:

```
[trace.ignore]
resource: "/health,/500"
```



### Motivation

This PR reverts the original behavior to avoid having a non backward compatible change.

### Additional Notes


