### PR TITLE
Fix access to collectAllSource

### DIFF
--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -228,7 +228,9 @@ func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
 func (l *Launcher) stopTailer(containerID string) {
 	if tailer, isTailed := l.tailers[containerID]; isTailed {
 		// No-op if the tailer source came from AD
-		l.collectAllSource.RemoveInput(containerID)
+		if l.collectAllSource != nil {
+			l.collectAllSource.RemoveInput(containerID)
+		}
 		go tailer.Stop()
 		l.removeTailer(containerID)
 	}
@@ -242,7 +244,9 @@ func (l *Launcher) restartTailer(containerID string) {
 	oldTailer, exists := l.tailers[containerID]
 	if exists {
 		source = oldTailer.source
-		l.collectAllSource.RemoveInput(containerID)
+		if l.collectAllSource != nil {
+			l.collectAllSource.RemoveInput(containerID)
+		}
 		oldTailer.Stop()
 		l.removeTailer(containerID)
 	}

--- a/releasenotes/notes/fix-npe-in-docker-launcher-531873788f6fe84c.yaml
+++ b/releasenotes/notes/fix-npe-in-docker-launcher-531873788f6fe84c.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a null pointer exception that would happen when the agent stopped tailing 
+    a container


### PR DESCRIPTION
### What does this PR do?

Fix a null pointer exception (reported in #2802)

### Motivation

The launcher holds a reference to the `containerCollectAll` source (to display containers in the agent status)
It is initialized only after seeing the first container catched by the `containerCollectAll` source but we try to remove inputs from it in all cases. This case would cause a NPE if `containerCollectAll` has not been initialized

### Additional Notes

Anything else we should know when reviewing?
