### PR TITLE
Add additional installation tests via kitchen

### DIFF
--- a/test/kitchen/.gitignore
+++ b/test/kitchen/.gitignore
@@ -10,3 +10,4 @@ cookbooks/
 ssh-key
 ssh-key.pub
 azureid.sh
+*.bat

--- a/test/kitchen/.kitchen-azure-winstall.yml
+++ b/test/kitchen/.kitchen-azure-winstall.yml
@@ -14,6 +14,31 @@
   end
 %>
 
+provisioner:
+  name: chef_solo
+  require_chef_omnibus: true
+  product_version: 13.6.4
+  require_chef_omnibus: 13.6.4
+
+<% if ENV['KITCHEN_DRIVER'] && ENV['KITCHEN_DRIVER'] == "hyperv" %>
+driver:
+  name: hyperv
+  vm_switch: <%= ENV['KITCHEN_HYPERV_SWITCH'] %>
+  dynamic_memory: true
+  <% if ENV['KITCHEN_HYPERV_MEM_MIN'] %>
+  dynamic_memory_min_bytes: <%= ENV['KITCHEN_HYPERV_MEM_MIN'] %>
+  memory_startup_bytes: <%= ENV['KITCHEN_HYPERV_MEM_MIN'] %>
+  <% else %>
+  dynamic_memory_min_bytes: 2GB
+  memory_startup_bytes: 2GB
+  <% end %>
+  <% if ENV['KITCHEN_HYPERV_MEM_MAX'] %>
+  dynamic_memory_max_bytes: <%= ENV['KITCHEN_HYPERV_MEM_MAX'] %>
+  <% else %>
+  dynamic_memory_max_bytes: 8GB
+  <% end %>
+<% else %>
+
 driver:
   name: azurerm
 
@@ -25,12 +50,7 @@ driver_config:
   <% else %>
   azure_resource_group_suffix: plnone
   <% end %>
-
-provisioner:
-  name: chef_solo
-  require_chef_omnibus: true
-  product_version: 13.6.4
-  require_chef_omnibus: 13.6.4
+<% end %>
 
 platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions,
@@ -39,6 +59,7 @@ platforms:
 
 <%
     # TEST_PLATFORMS syntax is `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1`
+    # TEST_PLATFORMS syntax is `short_name1,parent vhd folder,parent_vhd_name|...`
     azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').map { |p| p.split(',') }
 
     chef_versions = %w(
@@ -75,7 +96,11 @@ platforms:
     idx += 1
     location = locations[idx % locations.length]
 
-    platform_name = platform[0] + "-azure"
+    host = "azure"
+    if ENV['KITCHEN_DRIVER'] && ENV['KITCHEN_DRIVER'] == "hyperv"
+      host = "hyperv"
+    end
+    platform_name = platform[0] + "-#{host}"
     windows = platform_name.include?("win")
     if windows
       windows_platforms << platform_name
@@ -84,17 +109,26 @@ platforms:
     else
       size = sizes[idx % sizes.length]
     end
+    
+    vm_username = ENV['VM_USERNAME'] ? ENV['VM_USERNAME'] : "datadog"
+    vm_password = ENV['SERVER_PASSWORD']
+    vm_hyperv_switch = ENV['KITCHEN_HYPERV_SWITCH'] ? ENV['KITCHEN_HYPERV_SWITCH'] : "public_eth"
 
 %>
 - name: <%= platform_name %>
+  <% if host == "hyperv" %>
+  driver:
+    name: hyperv
+    parent_vhd_folder: <%= platform[1] %>
+    parent_vhd_name: <%= platform[2] %>
+    vm_switch: <%= vm_hyperv_switch %>
+  <% else %>
   driver_config:
     machine_size: <%= size %>
     image_urn: <%= platform[1] %>
     location: <%= location %>
     <% if windows %>
     vm_name: ddat<%= platform[0] %>
-    username: datadog
-    password: <%= ENV['SERVER_PASSWORD'] %>
     <% else %>
     vm_name: dd-agent-testing-<%= platform[0] %>-azure
     <% end %>
@@ -102,15 +136,20 @@ platforms:
       <% vm_tags.each do |key,value| %>
       <%= key %>: <%= value %>
       <% end %>
+  <% end %>
+    username: <%= vm_username %>
+    password: <%= vm_password %>
+
   transport:
     <% if windows %>
     name: winrm
+    username: <%= vm_username %>
+    password: <%= vm_password %>
     <% else %>
     ssh_key: <%= ENV['AZURE_SSH_KEY_PATH'] %>
     <% end %>
 
 <% end %>
-
 suites:
 
 <%
@@ -118,7 +157,7 @@ suites:
   api_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   yumrepo = "http://yumtesting.datad0g.com/pipeline-#{ENV['CI_PIPELINE_ID']}/x86_64/"
   yumrepo_suse = "http://yumtesting.datad0g.com/suse/pipeline-#{ENV['CI_PIPELINE_ID']}/x86_64/"
-  windows_agent_url = "https://s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}/"
+  windows_agent_url = ENV['WINDOWS_AGENT_URL'] ? ENV['WINDOWS_AGENT_URL'] : "https://s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}/"
   dd_agent_config = {
     'agent6': true,
     'api_key': api_key,

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -14,6 +14,31 @@
   end
 %>
 
+provisioner:
+  name: chef_solo
+  require_chef_omnibus: true
+  product_version: 13.6.4
+  require_chef_omnibus: 13.6.4
+
+<% if ENV['KITCHEN_DRIVER'] && ENV['KITCHEN_DRIVER'] == "hyperv" %>
+driver:
+  name: hyperv
+  vm_switch: <%= ENV['KITCHEN_HYPERV_SWITCH'] %>
+  dynamic_memory: true
+  <% if ENV['KITCHEN_HYPERV_MEM_MIN'] %>
+  dynamic_memory_min_bytes: <%= ENV['KITCHEN_HYPERV_MEM_MIN'] %>
+  memory_startup_bytes: <%= ENV['KITCHEN_HYPERV_MEM_MIN'] %>
+  <% else %>
+  dynamic_memory_min_bytes: 2GB
+  memory_startup_bytes: 2GB
+  <% end %>
+  <% if ENV['KITCHEN_HYPERV_MEM_MAX'] %>
+  dynamic_memory_max_bytes: <%= ENV['KITCHEN_HYPERV_MEM_MAX'] %>
+  <% else %>
+  dynamic_memory_max_bytes: 8GB
+  <% end %>
+<% else %>
+
 driver:
   name: azurerm
 
@@ -25,12 +50,7 @@ driver_config:
   <% else %>
   azure_resource_group_suffix: plnone
   <% end %>
-
-provisioner:
-  name: chef_solo
-  require_chef_omnibus: true
-  product_version: 13.6.4
-  require_chef_omnibus: 13.6.4
+<% end %>
 
 platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions,
@@ -39,6 +59,7 @@ platforms:
 
 <%
     # TEST_PLATFORMS syntax is `short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1`
+    # TEST_PLATFORMS syntax is `short_name1,parent vhd folder,parent_vhd_name|...`
     azure_test_platforms = ENV['TEST_PLATFORMS'].split('|').map { |p| p.split(',') }
 
     chef_versions = %w(
@@ -75,7 +96,11 @@ platforms:
     idx += 1
     location = locations[idx % locations.length]
 
-    platform_name = platform[0] + "-azure"
+    host = "azure"
+    if ENV['KITCHEN_DRIVER'] && ENV['KITCHEN_DRIVER'] == "hyperv"
+      host = "hyperv"
+    end
+    platform_name = platform[0] + "-#{host}"
     windows = platform_name.include?("win")
     if windows
       windows_platforms << platform_name
@@ -84,17 +109,26 @@ platforms:
     else
       size = sizes[idx % sizes.length]
     end
+    
+    vm_username = ENV['VM_USERNAME'] ? ENV['VM_USERNAME'] : "datadog"
+    vm_password = ENV['SERVER_PASSWORD']
+    vm_hyperv_switch = ENV['KITCHEN_HYPERV_SWITCH'] ? ENV['KITCHEN_HYPERV_SWITCH'] : "public_eth"
 
 %>
 - name: <%= platform_name %>
+  <% if host == "hyperv" %>
+  driver:
+    name: hyperv
+    parent_vhd_folder: <%= platform[1] %>
+    parent_vhd_name: <%= platform[2] %>
+    vm_switch: <%= vm_hyperv_switch %>
+  <% else %>
   driver_config:
     machine_size: <%= size %>
     image_urn: <%= platform[1] %>
     location: <%= location %>
     <% if windows %>
     vm_name: ddat<%= platform[0] %>
-    username: datadog
-    password: <%= ENV['SERVER_PASSWORD'] %>
     <% else %>
     vm_name: dd-agent-testing-<%= platform[0] %>-azure
     <% end %>
@@ -102,15 +136,20 @@ platforms:
       <% vm_tags.each do |key,value| %>
       <%= key %>: <%= value %>
       <% end %>
+  <% end %>
+    username: <%= vm_username %>
+    password: <%= vm_password %>
+
   transport:
     <% if windows %>
     name: winrm
+    username: <%= vm_username %>
+    password: <%= vm_password %>
     <% else %>
     ssh_key: <%= ENV['AZURE_SSH_KEY_PATH'] %>
     <% end %>
 
 <% end %>
-
 suites:
 
 <%
@@ -118,7 +157,7 @@ suites:
   api_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   yumrepo = "http://yumtesting.datad0g.com/pipeline-#{ENV['CI_PIPELINE_ID']}/x86_64/"
   yumrepo_suse = "http://yumtesting.datad0g.com/suse/pipeline-#{ENV['CI_PIPELINE_ID']}/x86_64/"
-  windows_agent_url = "https://s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}/"
+  windows_agent_url = ENV['WINDOWS_AGENT_URL'] ? ENV['WINDOWS_AGENT_URL'] : "https://s3.amazonaws.com/#{ENV['WINDOWS_TESTING_S3_BUCKET']}/"
   dd_agent_config = {
     'agent6': true,
     'api_key': api_key,
@@ -154,7 +193,9 @@ suites:
       windows_version: "<%= ENV['AGENT_VERSION'] %>"
       <% end %>
       windows_agent_url: <%= windows_agent_url %>
-
+      <% if ENV['WINDOWS_AGENT_FILE'] %>
+      windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
+      <% end %>
 
 # Installs the latest release Agent 6, then updates it to the latest release
 # candidate
@@ -192,6 +233,7 @@ suites:
       agent6_yumrepo: http://yum.datadoghq.com/beta/x86_64/
       agent6_yumrepo_suse: http://yum.datadoghq.com/suse/beta/x86_64/
       windows_agent_url: https://s3.amazonaws.com/ddagent-windows-stable/
+      windows_agent_filename: datadog-agent-6-latest.amd64
     dd-agent-upgrade:
       add_new_repo: true
       aptrepo: <%= aptrepo %>
@@ -202,6 +244,10 @@ suites:
       <% if ENV['AGENT_VERSION'] %>
       windows_version: "<%= ENV['AGENT_VERSION'] %>"
       <% end %>
+      <% if ENV['WINDOWS_AGENT_FILE'] %>
+      windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
+      <% end %>
+
     dd-agent-upgrade-rspec:
       # Used by the rspec test to know the version to which the agent should be upgraded
       agent_expected_version: &agent_expected_version <%= ENV['DD_AGENT_EXPECTED_VERSION'] || "5.99.0" %>
@@ -213,6 +259,10 @@ suites:
   run_list:
     - "recipe[datadog::dd-agent]"
     - "recipe[dd-agent-upgrade]"
+  excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
+    <% windows_platforms.each do |p| %>
+    - <%= p %>
+    <% end %>
   attributes:
     apt:
       unattended_upgrades:
@@ -238,6 +288,9 @@ suites:
       windows_agent_url: <%= windows_agent_url %>
       <% if ENV['AGENT_VERSION'] %>
       windows_version: "<%= ENV['AGENT_VERSION'] %>"
+      <% end %>
+      <% if ENV['WINDOWS_AGENT_FILE'] %>
+      windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
       <% end %>
     dd-agent-upgrade-rspec:
       # Used by the rspec test to know the version to which the agent should be upgraded

--- a/test/kitchen/.kitchen-azure.yml
+++ b/test/kitchen/.kitchen-azure.yml
@@ -259,10 +259,6 @@ suites:
   run_list:
     - "recipe[datadog::dd-agent]"
     - "recipe[dd-agent-upgrade]"
-  excludes: <% if windows_platforms.nil? || windows_platforms.empty? %>[]<% end %>
-    <% windows_platforms.each do |p| %>
-    - <%= p %>
-    <% end %>
   attributes:
     apt:
       unattended_upgrades:

--- a/test/kitchen/docs/README.md
+++ b/test/kitchen/docs/README.md
@@ -1,0 +1,75 @@
+## Test Kitchen Overview
+
+### Build pipeline testing
+
+#### Configuration (.gitlab-ci.yml)
+
+The gitlab pipelines which require kitchen testing have 3 independent steps for provisioning kitchen testing, running kitchen testing, and cleaning up (removing the artifacts).  The _deploy\_<platform>\_testing_ stages copy the build artifacts to an S3 bucket.  The _kitchen\_<platform> stages execute the kitchen tests.  The _testkitchen\_cleanup tasks clean up the s3 buckets and the azure virtual machines.
+
+##### Test execution
+
+Each individual test environment is controlled from _.gitlab\_ci.yml_.  The tests are set up using an environment variable, which is a list of test platforms which are turned into test kitchen platforms.  In _.gitlab\_ci.yml_, the platform list has the following syntax:
+        short_name1,azure_full_qualified_name1|short_name2,azure_full_qualified_name1|
+
+This configuration is fed to the script _tasks/run-test-kitchen.sh_. That script in turn sets up additional variables for Azure (authentication/environment variables), and then executes the actual kitchen command.  Using the ruby _erb_ syntax, a full matrix of platforms and tests is generated and executed.
+
+There are currently two input files.
+1. .kitchen-azure.yml contains a set of installation and upgrade tests that are executed on all of the available platforms
+2. .kitchen-azure-winstall.yml contains a set of  Windows specific tests for command-line installation options. These tests are currently (as configured in .gitlab-ci.yml) only run on one Windows OS for brevity.
+
+### Test Implementation
+
+#### Directory structure
+
+Test kitchen imposes a very specific directory structure.  For more information, see the test kitchen documentation.  However, a brief overview:
+
+The _site\_cookbooks_ tree contains the chef cookbooks that are run during the _kitchen converge_ stage.  
+```
+.
+├── site-cookbooks
+│   ├── dd-agent-install
+│   │   ├── attributes
+│   │   │   └── default.rb
+│   │   ├── recipes
+│   │   │   ├── _agent6_windows_config.rb
+│   │   │   ├── default.rb
+│   │   │   ├── _install_windows_base.rb
+│   │   │   └── _install_windows.rb
+│   ├── dd-agent-install-script
+│   │   ├── attributes
+│   │   │   └── default.rb
+│   │   ├── recipes
+│   │   │   └── default.rb
+```
+etc.
+
+The cookbooks are run prior to an individual test.  Each listed cookbook is run before any verification stage, so multi-stage tests can't do verification in between stages (like the upgrade test).
+
+The _test/integration_ tree contains the _rspec_ verification tests that are run during the _verify_ stage.
+
+```
+└── test
+    └── integration
+        ├── common
+        │   └── rspec
+        │       └── spec_helper.rb
+        ├── dd-agent
+        │   └── rspec
+        │       ├── dd-agent_spec.rb
+        │       └── spec_helper.rb -> ../../common/rspec/spec_helper.rb
+        ├── dd-agent-all-subservices
+        │   └── rspec
+        │       ├── dd-agent-all-subservices_spec.rb
+        │       └── spec_helper.rb -> ../../common/rspec/spec_helper.rb
+        ├── dd-agent-installopts
+        │   └── rspec
+        │       ├── dd-agent-installopts_spec.rb
+        │       └── spec_helper.rb -> ../../common/rspec/spec_helper.rb
+```
+Note that each directory contains a symbolic link for spec_helper.rb to the common directory.  The symbolic link is necessary because chef/kitchen will copy the test files from the test directory only to the target machine.  To prevent copy/paste, and make maintenance manageable, therefore there's a group of common test definitions in _spec\_helper.rb_ that is shared via the symbolic links.
+
+**On Windows** symbolic links must be explicitly enabled in git prior to fetching the tree.  This can be done at install time, or after the fact with `git config --global core.symlinks=true`
+
+#### Test definition
+
+The test suites are defined in the various .kitchen-*.yml files.  Each test suite runs one or more chef recipes (usually to install the agent in various ways), and then its verifier.  The verifier is assumed (by kitchen) to be in the directory that has the name of the suite.  So, the `dd-agent-installopts` suite runs the verifier script in `dd-agent-installopts/rspec/dd-agent-installopts_spec.rb`.

--- a/test/kitchen/docs/dd-agent-all-subservices.md
+++ b/test/kitchen/docs/dd-agent-all-subservices.md
@@ -1,0 +1,27 @@
+## dd-agent-all-subservices.md
+
+### Objective
+
+Test the Windows command line installer options for explicitly enabling the various datadog subservices (processes, trace, and logs)
+
+### Installation Recipe
+
+Uses the \_install_windows_base recipe to do a fresh install of the agent.
+1. Uses a fresh install because install options are ignored on upgrades
+2. Uses the \_base recipe which allows setting of additional options
+
+### Test definition
+
+The test is successful if:
+1. APM 
+    1. APM is enabled in the configuration file
+    2. Something is listening on port 8126
+    3. there is a process in the process table called `trace-agent.exe`
+    4. There is a service registered called `datadog-trace-agent` which can be queried via `sc qc`
+2. Logs
+    1. Logs is enabled in the configuration file
+3. Process
+    1. Process is enabled in the configuration file
+    2. There is a process in the process table called `process-agent.exe`
+    3. There is a service registered called `datadog-process-agent` which can be queried via `sc qc`
+   

--- a/test/kitchen/docs/dd-agent-installopts.md
+++ b/test/kitchen/docs/dd-agent-installopts.md
@@ -1,0 +1,15 @@
+## dd-agent-installopts
+
+### Objective
+
+Test the Windows command line installer options for tags, hostname, command port, all proxy settings, and datadog site-specific settings
+
+### Installation Recipe
+
+Uses the \_install_windows_base recipe to do a fresh install of the agent.
+1. Uses a fresh install because install options are ignored on upgrades
+2. Uses the \_base recipe which allows setting of additional options
+
+### Test definition
+
+Test is successful if the options are correctly written to `datadog.yaml`.  The verifier reads and parses the resulting configuration file to verify the test options are correctly written. 

--- a/test/kitchen/docs/dd-agent-no-subservices.md
+++ b/test/kitchen/docs/dd-agent-no-subservices.md
@@ -1,0 +1,27 @@
+## dd-agent-no-subservices.md
+
+### Objective
+
+Test the Windows command line installer options for explicitly disabling the various datadog subservices (processes, trace, and logs)
+
+### Installation Recipe
+
+Uses the \_install_windows_base recipe to do a fresh install of the agent.
+1. Uses a fresh install because install options are ignored on upgrades
+2. Uses the \_base recipe which allows setting of additional options
+
+### Test definition
+
+The test is successful if:
+1. APM 
+    1. APM is disabled in the configuration file
+    2. Nothing is listening on port 8126
+    3. there is no process in the process table called `trace-agent.exe`
+    4. There is not a service registered called `datadog-trace-agent` which can be queried via `sc qc`
+2. Logs
+    1. Logs is not enabled in the configuration file
+3. Process
+    1. Process is disabled in the configuration file
+    2. There is no process in the process table called `process-agent.exe`
+    3. There is not a service registered called `datadog-process-agent` which can be queried via `sc qc`
+   

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/Gemfile
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '1.17.3'
 gem 'berkshelf'

--- a/test/kitchen/site-cookbooks/dd-agent-install/Gemfile
+++ b/test/kitchen/site-cookbooks/dd-agent-install/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '1.17.3'
 gem 'berkshelf'

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -55,6 +55,6 @@ remote_file temp_file do
 end
 
 execute "install-agent" do
-  command "start /wait msiexec /q /i #{temp_file} #{install_options}"
+  command "start /wait msiexec /log install.log /q /i #{temp_file} #{install_options}"
   action :run
 end

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -10,14 +10,19 @@
 package_retries = node['dd-agent-install']['agent_package_retries']
 package_retry_delay = node['dd-agent-install']['agent_package_retry_delay']
 dd_agent_version = node['dd-agent-install']['windows_version']
+dd_agent_filename = node['dd-agent-install']['windows_agent_filename']
 
-if dd_agent_version
-  dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
+if dd_agent_filename
+  dd_agent_installer_basename = dd_agent_filename
 else
-  dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
+  if dd_agent_version
+    dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
+  else
+    dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
+  end
 end
 
-temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli')
+temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
 
 dd_agent_installer = "#{dd_agent_installer_basename}.msi"
 temp_file = "#{temp_file_basename}.msi"
@@ -50,6 +55,6 @@ remote_file temp_file do
 end
 
 execute "install-agent" do
-  command "start /wait #{temp_file} #{install_options}"
+  command "start /wait msiexec /q /i #{temp_file} #{install_options}"
   action :run
 end

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/Gemfile
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '1.17.3'
 gem 'berkshelf'

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/Gemfile
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '1.17.3'
 gem 'berkshelf'

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -87,7 +87,7 @@ if node['platform_family'] == 'windows'
     end
   end
   
-  temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli')
+  temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-up').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
 
   dd_agent_installer = "#{dd_agent_installer_basename}.msi"
   temp_file = "#{temp_file_basename}.msi"
@@ -111,7 +111,7 @@ if node['platform_family'] == 'windows'
   end
 
   execute "install-agent" do
-    command "start /wait msiexec /q /i #{temp_file} #{install_options}"
+    command "start /wait msiexec /log upgrade.log /q /i #{temp_file} #{install_options}"
     action :run
     notifies :restart, 'service[datadog-agent]'
   end

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -75,13 +75,18 @@ if node['platform_family'] == 'windows'
   package_retries = node['dd-agent-upgrade']['agent_package_retries']
   package_retry_delay = node['dd-agent-upgrade']['agent_package_retry_delay']
   dd_agent_version = node['dd-agent-upgrade']['windows_version']
+  dd_agent_filename = node['dd-agent-upgrade']['windows_agent_filename']
 
-  if dd_agent_version
-    dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
+  if dd_agent_filename
+    dd_agent_installer_basename = dd_agent_filename
   else
-    dd_agent_installer_basename = "datadog-agent-latest-x86_64"
+    if dd_agent_version
+      dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
+    else
+      dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
+    end
   end
-
+  
   temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli')
 
   dd_agent_installer = "#{dd_agent_installer_basename}.msi"
@@ -106,7 +111,7 @@ if node['platform_family'] == 'windows'
   end
 
   execute "install-agent" do
-    command "start /wait #{temp_file} #{install_options}"
+    command "start /wait msiexec /q /i #{temp_file} #{install_options}"
     action :run
     notifies :restart, 'service[datadog-agent]'
   end

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -87,7 +87,7 @@ if [ -z ${SERVER_PASSWORD+x} ]; then
   export SERVER_PASSWORD=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)
 fi
 
-chef gem install net-ssh berkshelf rake psych:2.2.2 kitchen-azurerm:0.13.0 test-kitchen
+chef gem install bundler:1.17.3 net-ssh berkshelf rake psych:2.2.2 kitchen-azurerm:0.13.0 test-kitchen
 cp .kitchen-azure.yml .kitchen.yml
 
 ## check to see if we want the windows-installer tester instead

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -99,7 +99,9 @@ end
 
 def status
   if os == :windows
-    `sc interrogate datadogagent 2>&1`.include?('RUNNING')
+    status_out = `sc interrogate datadogagent 2>&1`
+    puts status_out
+    status_out.include?('RUNNING')
   else
     if has_systemctl
       system('sudo systemctl status --no-pager datadog-agent.service')

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -99,9 +99,7 @@ end
 
 def status
   if os == :windows
-    status_out = `sc interrogate datadogagent 2>&1`
-    puts status_out
-    status_out.include?('RUNNING')
+    `sc interrogate datadogagent 2>&1`.include?('RUNNING')
   else
     if has_systemctl
       system('sudo systemctl status --no-pager datadog-agent.service')

--- a/test/kitchen/test/integration/dd-agent-upgrade-agent5
+++ b/test/kitchen/test/integration/dd-agent-upgrade-agent5
@@ -1,1 +1,1 @@
-test/integration/dd-agent-upgrade
+dd-agent-upgrade

--- a/test/kitchen/test/integration/dd-agent-upgrade-agent6
+++ b/test/kitchen/test/integration/dd-agent-upgrade-agent6
@@ -1,1 +1,1 @@
-test/integration/dd-agent-upgrade
+dd-agent-upgrade

--- a/test/kitchen/test/integration/dd-agent-upgrade/rspec/dd-agent-upgrade_spec.rb
+++ b/test/kitchen/test/integration/dd-agent-upgrade/rspec/dd-agent-upgrade_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 describe 'the upgraded agent' do
-  include_examples 'Agent'
+  it_behaves_like 'an installed Agent'
+  it_behaves_like 'a running Agent with no errors'
 
   # We retrieve the value defined in .kitchen.yml because there is no simple way
   # to set env variables on the target machine or via parameters in Kitchen/Busser
   # See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
   let(:agent_expected_version) {
     if os == :windows
-      dna_json_path = 'C:\\Users\\azure\\AppData\\Local\\Temp\\kitchen\\dna.json'
+      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
     else
       dna_json_path = "/tmp/kitchen/dna.json"
     end
@@ -17,17 +18,17 @@ describe 'the upgraded agent' do
 
   it 'runs with the expected version (based on the `info` command output)' do
     agent_short_version = /(\.?\d)+/.match(agent_expected_version)[0]
-    expect(info).to include "v #{agent_short_version}"
+    expect(info).to include "v#{agent_short_version}"
   end
 
   it 'runs with the expected version (based on the version manifest file)' do
     if os == :windows
-      version_manifest_file = "C:\\Program Files\\Datadog\\Datadog Agent\\version-manifest.txt"
+      version_manifest_file = "C:/Program Files/Datadog/Datadog Agent/version-manifest.txt"
     else
       version_manifest_file = '/opt/datadog-agent/version-manifest.txt'
     end
     expect(File).to exist(version_manifest_file)
     # Match the first line of the manifest file
-    expect(File.open(version_manifest_file) {|f| f.readline.strip}).to match "datadog-agent #{agent_expected_version}"
+    expect(File.open(version_manifest_file) {|f| f.readline.strip}).to match "agent #{agent_expected_version}"
   end
 end


### PR DESCRIPTION
Add support for hyper-v driver

Fix upgrade template

Add docs

**Disables agent5->agent6 on windows (isn't really testing anything)**
Add hyper-v setup to basic tests.
add ability to set agent filename in environment (helpful for local
testing)
