### PR TITLE
Promote integration command to Beta feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -169,6 +169,7 @@ Other Notes
   default versions when the Agent is upgraded.
   This guarantees the integrity of the embedded python environment after the upgrade.
 
+- The ``datadog-agent integration`` command is now in Beta.
 
 .. _Release Notes_6.7.0:
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -120,7 +120,7 @@ func init() {
 
 var tufCmd = &cobra.Command{
 	Use:   "integration [command]",
-	Short: "Datadog integration manager (ALPHA feature)",
+	Short: "Datadog integration manager (Beta feature)",
 	Long:  ``,
 }
 


### PR DESCRIPTION
### What does this PR do?

It changes the message printed on the CLI when using the `integration` command, the feature is almost ready for GA so it can be promoted to Beta.

### Motivation

Approaching GA in the next minor.
