### PR TITLE
always run cloudfront invalidation regardless of the pipeline success

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1151,6 +1151,7 @@ deploy_cloudfront_invalidate:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   tags: [ "runner:main", "size:large" ]
+  when: always
   script:
     - cd /deploy_scripts/cloudfront-invalidation
     - "REPO=apt PATTERN_SUBSTRING=/$DEB_RPM_BUCKET_BRANCH/ ./invalidate.sh"


### PR DESCRIPTION
### What does this PR do?

This will make the job `deploy_cloudfront_invalidate` run at the end of all deployment pipelines, even if they fail. 

### Motivation

If a job failed during the deployment stage but `deb` and/or `rpm` jobs still succeeded we would miss the cloudfront invalidation.
