### PR TITLE
Bug fix for duplicate logs with docker

### DIFF
--- a/pkg/logs/input/docker/since.go
+++ b/pkg/logs/input/docker/since.go
@@ -26,8 +26,6 @@ func Since(registry auditor.Registry, identifier string, creationTime service.Cr
 		since, err = time.Parse(config.DateFormat, offset)
 		if err != nil {
 			since = time.Now().UTC()
-		} else {
-			since = since.Add(time.Nanosecond)
 		}
 	case creationTime == service.After:
 		// a new service has been discovered and was launched after the agent start, tail from the beginning

--- a/pkg/logs/input/docker/since_test.go
+++ b/pkg/logs/input/docker/since_test.go
@@ -36,7 +36,13 @@ func TestSince(t *testing.T) {
 	registry.SetOffset("2008-01-12T01:01:01.000000001Z")
 	since, err = Since(registry, "", service.Before)
 	assert.Nil(t, err)
-	assert.Equal(t, "2008-01-12T01:01:01.000000002Z", since.Format(config.DateFormat))
+	assert.Equal(t, "2008-01-12T01:01:01.000000001Z", since.Format(config.DateFormat))
+
+	// Not properly formated
+	registry.SetOffset("2008-01-12T01:01.000000001Z")
+	since, err = Since(registry, "", service.Before)
+	assert.NotNil(t, err)
+	assert.True(t, since.After(now))
 
 	registry.SetOffset("foo")
 	since, err = Since(registry, "", service.Before)

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -103,6 +103,8 @@ func (t *Tailer) getLastSince() string {
 	if err != nil {
 		since = time.Now().UTC()
 	} else {
+		// To avoid sending the last recorded log we add a nanosecond
+		// to the offset
 		since = since.Add(time.Nanosecond)
 	}
 	return since.Format(config.DateFormat)

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -99,7 +99,13 @@ func (t *Tailer) Start(since time.Time) error {
 func (t *Tailer) getLastSince() string {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	return t.lastSince
+	since, err := time.Parse(config.DateFormat, t.lastSince)
+	if err != nil {
+		since = time.Now().UTC()
+	} else {
+		since = since.Add(time.Nanosecond)
+	}
+	return since.Format(config.DateFormat)
 }
 
 func (t *Tailer) setLastSince(since string) {

--- a/pkg/logs/input/docker/tailer_test.go
+++ b/pkg/logs/input/docker/tailer_test.go
@@ -81,6 +81,11 @@ func TestTailerIdentifier(t *testing.T) {
 	assert.Equal(t, "docker:test", tailer.Identifier())
 }
 
+func TestGetLastSince(t *testing.T) {
+	tailer := &Tailer{lastSince: "2008-01-12T01:01:01.000000001Z"}
+	assert.Equal(t, "2008-01-12T01:01:01.000000002Z", tailer.getLastSince())
+}
+
 func TestRead(t *testing.T) {
 	tailer := NewTestTailer(&mockReaderNoSleep{}, func() {})
 	inBuf := make([]byte, 4096)

--- a/releasenotes/notes/fix-bug-duplicate-logs-4e26d6993874444c.yaml
+++ b/releasenotes/notes/fix-bug-duplicate-logs-4e26d6993874444c.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug that could send the last log multiple times when a container was not writing
+    new logs
+


### PR DESCRIPTION
### What does this PR do?
Fix a bug where the docker tailer would send the last line of log several time when a container wasn't writing much logs (less than 1 log / 30 sec)

### Motivation
What inspired you to submit this pull request?
