### PR TITLE
Fix pdh-based go checks, when variable instances are added & removed

### DIFF
--- a/pkg/collector/corechecks/system/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/file_handles_windows.go
@@ -20,7 +20,7 @@ const fileHandlesCheckName = "file_handle"
 
 type fhCheck struct {
 	core.CheckBase
-	counter *pdhutil.PdhCounterSet
+	counter *pdhutil.PdhMultiInstanceCounterSet
 }
 
 // Run executes the check
@@ -30,11 +30,12 @@ func (c *fhCheck) Run() error {
 	if err != nil {
 		return err
 	}
-	val, err := c.counter.GetSingleValue()
+	vals, err := c.counter.GetAllValues()
 	if err != nil {
 		log.Warnf("Error getting handle value %v", err)
 		return err
 	}
+	val := vals["_Total"]
 	log.Debugf("Submitting system.fs.file_handles_in_use %v", val)
 	sender.Gauge("system.fs.file_handles.in_use", float64(val), "", nil)
 	sender.Commit()
@@ -44,7 +45,7 @@ func (c *fhCheck) Run() error {
 
 // The check doesn't need configuration
 func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
-	c.counter, err = pdhutil.GetCounterSet("Process", "Handle Count", "_Total", nil)
+	c.counter, err = pdhutil.GetMultiInstanceCounter("Process", "Handle Count", &[]string{"_Total"}, nil)
 	return err
 }
 

--- a/pkg/collector/corechecks/system/file_handles_windows_test.go
+++ b/pkg/collector/corechecks/system/file_handles_windows_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+// +build windows
+
+package system
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
+)
+
+func TestFhCheckWindows(t *testing.T) {
+
+	pdhtest.SetupTesting("testfiles\\counter_indexes_en-us.txt", "testfiles\\allcounters_en-us.txt")
+	pdhtest.SetQueryReturnValue("\\\\.\\Process(_Total)\\Handle Count", 0.006848775103963421)
+
+	fileHandleCheck := new(fhCheck)
+	fileHandleCheck.Configure(nil, nil)
+
+	mock := mocksender.NewMockSender(fileHandleCheck.ID())
+
+	mock.On("Gauge", "system.fs.file_handles.in_use", 0.006848775103963421, "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+	fileHandleCheck.Run()
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 1)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+
+}

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -40,7 +40,7 @@ const (
 type IOCheck struct {
 	core.CheckBase
 	blacklist    *regexp.Regexp
-	counters     map[string]*pdhutil.PdhCounterSet
+	counters     map[string]*pdhutil.PdhMultiInstanceCounterSet
 	counternames map[string]string
 }
 
@@ -73,10 +73,10 @@ func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data) 
 		"Disk Reads/sec":            "system.io.r_s",
 		"Current Disk Queue Length": "system.io.avg_q_sz"}
 
-	c.counters = make(map[string]*pdhutil.PdhCounterSet)
+	c.counters = make(map[string]*pdhutil.PdhMultiInstanceCounterSet)
 
 	for name := range c.counternames {
-		c.counters[name], err = pdhutil.GetCounterSet("LogicalDisk", name, "", isDrive)
+		c.counters[name], err = pdhutil.GetMultiInstanceCounter("LogicalDisk", name, nil, isDrive)
 		if err != nil {
 			return err
 		}

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -44,6 +44,12 @@ type IOCheck struct {
 	counternames map[string]string
 }
 
+var pfnGetDriveType = getDriveType
+
+func getDriveType(drive string) uintptr {
+	r, _, _ := procGetDriveType.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(drive))))
+	return r
+}
 func isDrive(instance string) bool {
 	if unmountedDrivePattern.MatchString(instance) {
 		return true
@@ -52,7 +58,8 @@ func isDrive(instance string) bool {
 		return false
 	}
 	instance += "\\"
-	r, _, _ := procGetDriveType.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(instance))))
+
+	r := pfnGetDriveType(instance)
 	if r != DRIVE_FIXED {
 		return false
 	}

--- a/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+// +build windows
+
+package system
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
+)
+
+func TestIoCheckWindows(t *testing.T) {
+
+	pdhtest.SetupTesting("testfiles\\counter_indexes_en-us.txt", "testfiles\\allcounters_en-us.txt")
+
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(_Total)\\Disk Write Bytes/sec", 1.111)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(C:)\\Disk Write Bytes/sec", 1.222)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume1)\\Disk Write Bytes/sec", 1.333)
+
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(_Total)\\Disk Writes/sec", 2.111)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(C:)\\Disk Writes/sec", 2.222)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume1)\\Disk Writes/sec", 2.333)
+
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(_Total)\\Disk Read Bytes/sec", 3.111)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(C:)\\Disk Read Bytes/sec", 3.222)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume1)\\Disk Read Bytes/sec", 3.333)
+
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(_Total)\\Disk Reads/sec", 4.111)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(C:)\\Disk Reads/sec", 4.222)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume1)\\Disk Reads/sec", 4.333)
+
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(_Total)\\Current Disk Queue Length", 5.111)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(C:)\\Current Disk Queue Length", 5.222)
+	pdhtest.SetQueryReturnValue("\\\\.\\LogicalDisk(HarddiskVolume1)\\Current Disk Queue Length", 5.333)
+
+	ioCheck := new(IOCheck)
+	ioCheck.Configure(nil, nil)
+
+	mock := mocksender.NewMockSender(ioCheck.ID())
+
+	mock.On("Gauge", "system.io.wkb_s", 1.222/1024, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.wkb_s", 1.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.w_s", 2.222, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.w_s", 2.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.rkb_s", 3.222/1024, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.rkb_s", 3.333/1024, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.r_s", 4.222, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.r_s", 4.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+
+	mock.On("Gauge", "system.io.avg_q_sz", 5.222, "", []string{"device:C:"}).Return().Times(1)
+	mock.On("Gauge", "system.io.avg_q_sz", 5.333, "", []string{"device:HarddiskVolume1"}).Return().Times(1)
+
+	mock.On("Commit").Return().Times(1)
+	ioCheck.Run()
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 10)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+
+}

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -28,23 +28,23 @@ var runtimeOS = runtime.GOOS
 // MemoryCheck doesn't need additional fields
 type MemoryCheck struct {
 	core.CheckBase
-	cacheBytes     *pdhutil.PdhCounterSet
-	committedBytes *pdhutil.PdhCounterSet
-	pagedBytes     *pdhutil.PdhCounterSet
-	nonpagedBytes  *pdhutil.PdhCounterSet
+	cacheBytes     *pdhutil.PdhSingleInstanceCounterSet
+	committedBytes *pdhutil.PdhSingleInstanceCounterSet
+	pagedBytes     *pdhutil.PdhSingleInstanceCounterSet
+	nonpagedBytes  *pdhutil.PdhSingleInstanceCounterSet
 }
 
 const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
 func (c *MemoryCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
-	c.cacheBytes, err = pdhutil.GetCounterSet("Memory", "Cache Bytes", "", nil)
+	c.cacheBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Cache Bytes")
 	if err == nil {
-		c.committedBytes, err = pdhutil.GetCounterSet("Memory", "Committed Bytes", "", nil)
+		c.committedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Committed Bytes")
 		if err == nil {
-			c.pagedBytes, err = pdhutil.GetCounterSet("Memory", "Pool Paged Bytes", "", nil)
+			c.pagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Paged Bytes")
 			if err == nil {
-				c.nonpagedBytes, err = pdhutil.GetCounterSet("Memory", "Pool Nonpaged Bytes", "", nil)
+				c.nonpagedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Pool Nonpaged Bytes")
 			}
 		}
 	}
@@ -60,7 +60,7 @@ func (c *MemoryCheck) Run() error {
 
 	var val float64
 	if c.cacheBytes != nil {
-		val, err = c.cacheBytes.GetSingleValue()
+		val, err = c.cacheBytes.GetValue()
 		if err == nil {
 			sender.Gauge("system.mem.cached", float64(val)/mbSize, "", nil)
 		} else {
@@ -69,7 +69,7 @@ func (c *MemoryCheck) Run() error {
 	}
 
 	if c.committedBytes != nil {
-		val, err = c.committedBytes.GetSingleValue()
+		val, err = c.committedBytes.GetValue()
 		if err == nil {
 			sender.Gauge("system.mem.committed", float64(val)/mbSize, "", nil)
 		} else {
@@ -78,7 +78,7 @@ func (c *MemoryCheck) Run() error {
 	}
 
 	if c.pagedBytes != nil {
-		val, err = c.pagedBytes.GetSingleValue()
+		val, err = c.pagedBytes.GetValue()
 		if err == nil {
 			sender.Gauge("system.mem.paged", float64(val)/mbSize, "", nil)
 		} else {
@@ -87,7 +87,7 @@ func (c *MemoryCheck) Run() error {
 	}
 
 	if c.nonpagedBytes != nil {
-		val, err = c.nonpagedBytes.GetSingleValue()
+		val, err = c.nonpagedBytes.GetValue()
 		if err == nil {
 			sender.Gauge("system.mem.nonpaged", float64(val)/mbSize, "", nil)
 		} else {

--- a/pkg/collector/corechecks/system/testfiles/counter_indexes_en-us.txt
+++ b/pkg/collector/corechecks/system/testfiles/counter_indexes_en-us.txt
@@ -1,0 +1,20255 @@
+1
+1847
+2
+System
+4
+Memory
+6
+% Processor Time
+10
+File Read Operations/sec
+12
+File Write Operations/sec
+14
+File Control Operations/sec
+16
+File Read Bytes/sec
+18
+File Write Bytes/sec
+20
+File Control Bytes/sec
+24
+Available Bytes
+26
+Committed Bytes
+28
+Page Faults/sec
+30
+Commit Limit
+32
+Write Copies/sec
+34
+Transition Faults/sec
+36
+Cache Faults/sec
+38
+Demand Zero Faults/sec
+40
+Pages/sec
+42
+Page Reads/sec
+44
+Processor Queue Length
+46
+Thread State
+48
+Pages Output/sec
+50
+Page Writes/sec
+52
+Browser
+54
+Announcements Server/sec
+56
+Pool Paged Bytes
+58
+Pool Nonpaged Bytes
+60
+Pool Paged Allocs
+64
+Pool Nonpaged Allocs
+66
+Pool Paged Resident Bytes
+68
+System Code Total Bytes
+70
+System Code Resident Bytes
+72
+System Driver Total Bytes
+74
+System Driver Resident Bytes
+76
+System Cache Resident Bytes
+78
+Announcements Domain/sec
+80
+Election Packets/sec
+82
+Mailslot Writes/sec
+84
+Server List Requests/sec
+86
+Cache
+88
+Data Maps/sec
+90
+Sync Data Maps/sec
+92
+Async Data Maps/sec
+94
+Data Map Hits %
+96
+Data Map Pins/sec
+98
+Pin Reads/sec
+100
+Sync Pin Reads/sec
+102
+Async Pin Reads/sec
+104
+Pin Read Hits %
+106
+Copy Reads/sec
+108
+Sync Copy Reads/sec
+110
+Async Copy Reads/sec
+112
+Copy Read Hits %
+114
+MDL Reads/sec
+116
+Sync MDL Reads/sec
+118
+Async MDL Reads/sec
+120
+MDL Read Hits %
+122
+Read Aheads/sec
+124
+Fast Reads/sec
+126
+Sync Fast Reads/sec
+128
+Async Fast Reads/sec
+130
+Fast Read Resource Misses/sec
+132
+Fast Read Not Possibles/sec
+134
+Lazy Write Flushes/sec
+136
+Lazy Write Pages/sec
+138
+Data Flushes/sec
+140
+Data Flush Pages/sec
+142
+% User Time
+144
+% Privileged Time
+146
+Context Switches/sec
+148
+Interrupts/sec
+150
+System Calls/sec
+152
+Level 1 TLB Fills/sec
+154
+Level 2 TLB Fills/sec
+156
+Enumerations Server/sec
+158
+Enumerations Domain/sec
+160
+Enumerations Other/sec
+162
+Missed Server Announcements
+164
+Missed Mailslot Datagrams
+166
+Missed Server List Requests
+168
+Server Announce Allocations Failed/sec
+170
+Mailslot Allocations Failed
+172
+Virtual Bytes Peak
+174
+Virtual Bytes
+178
+Working Set Peak
+180
+Working Set
+182
+Page File Bytes Peak
+184
+Page File Bytes
+186
+Private Bytes
+188
+Announcements Total/sec
+190
+Enumerations Total/sec
+198
+Current Disk Queue Length
+200
+% Disk Time
+202
+% Disk Read Time
+204
+% Disk Write Time
+206
+Avg. Disk sec/Transfer
+208
+Avg. Disk sec/Read
+210
+Avg. Disk sec/Write
+212
+Disk Transfers/sec
+214
+Disk Reads/sec
+216
+Disk Writes/sec
+218
+Disk Bytes/sec
+220
+Disk Read Bytes/sec
+222
+Disk Write Bytes/sec
+224
+Avg. Disk Bytes/Transfer
+226
+Avg. Disk Bytes/Read
+228
+Avg. Disk Bytes/Write
+230
+Process
+232
+Thread
+234
+PhysicalDisk
+236
+LogicalDisk
+238
+Processor
+240
+% Total Processor Time
+242
+% Total User Time
+244
+% Total Privileged Time
+246
+Total Interrupts/sec
+248
+Processes
+250
+Threads
+252
+Events
+254
+Semaphores
+256
+Mutexes
+258
+Sections
+260
+Objects
+262
+Redirector
+264
+Bytes Received/sec
+266
+Packets Received/sec
+268
+Read Bytes Paging/sec
+270
+Read Bytes Non-Paging/sec
+272
+Read Bytes Cache/sec
+274
+Read Bytes Network/sec
+276
+Bytes Transmitted/sec
+278
+Packets Transmitted/sec
+280
+Write Bytes Paging/sec
+282
+Write Bytes Non-Paging/sec
+284
+Write Bytes Cache/sec
+286
+Write Bytes Network/sec
+288
+Read Operations/sec
+290
+Read Operations Random/sec
+292
+Read Packets/sec
+294
+Reads Large/sec
+296
+Read Packets Small/sec
+298
+Write Operations/sec
+300
+Write Operations Random/sec
+302
+Write Packets/sec
+304
+Writes Large/sec
+306
+Write Packets Small/sec
+308
+Reads Denied/sec
+310
+Writes Denied/sec
+312
+Network Errors/sec
+314
+Server Sessions
+316
+Server Reconnects
+318
+Connects Core
+320
+Connects Lan Manager 2.0
+322
+Connects Lan Manager 2.1
+324
+Connects Windows NT
+326
+Server Disconnects
+328
+Server Sessions Hung
+330
+Server
+336
+Thread Wait Reason
+340
+Sessions Timed Out
+342
+Sessions Errored Out
+344
+Sessions Logged Off
+346
+Sessions Forced Off
+348
+Errors Logon
+350
+Errors Access Permissions
+352
+Errors Granted Access
+354
+Errors System
+356
+Blocking Requests Rejected
+358
+Work Item Shortages
+360
+Files Opened Total
+362
+Files Open
+366
+File Directory Searches
+370
+Pool Nonpaged Failures
+372
+Pool Nonpaged Peak
+376
+Pool Paged Failures
+378
+Pool Paged Peak
+388
+Bytes Total/sec
+392
+Current Commands
+398
+NWLink NetBIOS
+400
+Packets/sec
+404
+Context Blocks Queued/sec
+406
+File Data Operations/sec
+408
+% Free Space
+410
+Free Megabytes
+412
+Connections Open
+414
+Connections No Retries
+416
+Connections With Retries
+418
+Disconnects Local
+420
+Disconnects Remote
+422
+Failures Link
+424
+Failures Adapter
+426
+Connection Session Timeouts
+428
+Connections Canceled
+430
+Failures Resource Remote
+432
+Failures Resource Local
+434
+Failures Not Found
+436
+Failures No Listen
+438
+Datagrams/sec
+440
+Datagram Bytes/sec
+442
+Datagrams Sent/sec
+444
+Datagram Bytes Sent/sec
+446
+Datagrams Received/sec
+448
+Datagram Bytes Received/sec
+452
+Packets Sent/sec
+456
+Frames/sec
+458
+Frame Bytes/sec
+460
+Frames Sent/sec
+462
+Frame Bytes Sent/sec
+464
+Frames Received/sec
+466
+Frame Bytes Received/sec
+468
+Frames Re-Sent/sec
+470
+Frame Bytes Re-Sent/sec
+472
+Frames Rejected/sec
+474
+Frame Bytes Rejected/sec
+476
+Expirations Response
+478
+Expirations Ack
+480
+Window Send Maximum
+482
+Window Send Average
+484
+Piggyback Ack Queued/sec
+486
+Piggyback Ack Timeouts
+488
+NWLink IPX
+490
+NWLink SPX
+492
+NetBEUI
+494
+NetBEUI Resource
+496
+Used Maximum
+498
+Used Average
+500
+Times Exhausted
+502
+NBT Connection
+506
+Bytes Sent/sec
+508
+Total Bytes/sec
+510
+Network Interface
+512
+Bytes/sec
+520
+Current Bandwidth
+524
+Packets Received Unicast/sec
+526
+Packets Received Non-Unicast/sec
+528
+Packets Received Discarded
+530
+Packets Received Errors
+532
+Packets Received Unknown
+536
+Packets Sent Unicast/sec
+538
+Packets Sent Non-Unicast/sec
+540
+Packets Outbound Discarded
+542
+Packets Outbound Errors
+544
+Output Queue Length
+546
+IPv4
+548
+IPv6
+552
+Datagrams Received Header Errors
+554
+Datagrams Received Address Errors
+556
+Datagrams Forwarded/sec
+558
+Datagrams Received Unknown Protocol
+560
+Datagrams Received Discarded
+562
+Datagrams Received Delivered/sec
+566
+Datagrams Outbound Discarded
+568
+Datagrams Outbound No Route
+570
+Fragments Received/sec
+572
+Fragments Re-assembled/sec
+574
+Fragment Re-assembly Failures
+576
+Fragmented Datagrams/sec
+578
+Fragmentation Failures
+580
+Fragments Created/sec
+582
+ICMP
+584
+Messages/sec
+586
+Messages Received/sec
+588
+Messages Received Errors
+590
+Received Dest. Unreachable
+592
+Received Time Exceeded
+594
+Received Parameter Problem
+596
+Received Source Quench
+598
+Received Redirect/sec
+600
+Received Echo/sec
+602
+Received Echo Reply/sec
+604
+Received Timestamp/sec
+606
+Received Timestamp Reply/sec
+608
+Received Address Mask
+610
+Received Address Mask Reply
+612
+Messages Sent/sec
+614
+Messages Outbound Errors
+616
+Sent Destination Unreachable
+618
+Sent Time Exceeded
+620
+Sent Parameter Problem
+622
+Sent Source Quench
+624
+Sent Redirect/sec
+626
+Sent Echo/sec
+628
+Sent Echo Reply/sec
+630
+Sent Timestamp/sec
+632
+Sent Timestamp Reply/sec
+634
+Sent Address Mask
+636
+Sent Address Mask Reply
+638
+TCPv4
+640
+Segments/sec
+642
+Connections Established
+644
+Connections Active
+646
+Connections Passive
+648
+Connection Failures
+650
+Connections Reset
+652
+Segments Received/sec
+654
+Segments Sent/sec
+656
+Segments Retransmitted/sec
+658
+UDPv4
+660
+% Total DPC Time
+662
+% Total Interrupt Time
+664
+Datagrams No Port/sec
+666
+Datagrams Received Errors
+670
+Disk Storage Unit
+672
+Allocation Failures
+674
+System Up Time
+676
+System Handle Count
+678
+Free System Page Table Entries
+680
+Thread Count
+682
+Priority Base
+684
+Elapsed Time
+686
+Alignment Fixups/sec
+688
+Exception Dispatches/sec
+690
+Floating Emulations/sec
+692
+Logon/sec
+694
+Priority Current
+696
+% DPC Time
+698
+% Interrupt Time
+700
+Paging File
+702
+% Usage
+704
+% Usage Peak
+706
+Start Address
+708
+User PC
+710
+Mapped Space No Access
+712
+Mapped Space Read Only
+714
+Mapped Space Read/Write
+716
+Mapped Space Write Copy
+718
+Mapped Space Executable
+720
+Mapped Space Exec Read Only
+722
+Mapped Space Exec Read/Write
+724
+Mapped Space Exec Write Copy
+726
+Reserved Space No Access
+728
+Reserved Space Read Only
+730
+Reserved Space Read/Write
+732
+Reserved Space Write Copy
+734
+Reserved Space Executable
+736
+Reserved Space Exec Read Only
+738
+Reserved Space Exec Read/Write
+740
+Image
+742
+Reserved Space Exec Write Copy
+744
+Unassigned Space No Access
+746
+Unassigned Space Read Only
+748
+Unassigned Space Read/Write
+750
+Unassigned Space Write Copy
+752
+Unassigned Space Executable
+754
+Unassigned Space Exec Read Only
+756
+Unassigned Space Exec Read/Write
+758
+Unassigned Space Exec Write Copy
+760
+Image Space No Access
+762
+Image Space Read Only
+764
+Image Space Read/Write
+766
+Image Space Write Copy
+768
+Image Space Executable
+770
+Image Space Exec Read Only
+772
+Image Space Exec Read/Write
+774
+Image Space Exec Write Copy
+776
+Bytes Image Reserved
+778
+Bytes Image Free
+780
+Bytes Reserved
+782
+Bytes Free
+784
+ID Process
+786
+Process Address Space
+788
+No Access
+790
+Read Only
+792
+Read/Write
+794
+Write Copy
+796
+Executable
+798
+Exec Read Only
+800
+Exec Read/Write
+802
+Exec Write Copy
+804
+ID Thread
+806
+Mailslot Receives Failed
+808
+Mailslot Writes Failed
+810
+Mailslot Opens Failed/sec
+812
+Duplicate Master Announcements
+814
+Illegal Datagrams/sec
+816
+Thread Details
+818
+Cache Bytes
+820
+Cache Bytes Peak
+822
+Pages Input/sec
+824
+Transition Pages RePurposed/sec
+872
+Bytes Transmitted
+874
+Bytes Received
+876
+Frames Transmitted
+878
+Frames Received.
+880
+Percent Compression Out
+882
+Percent Compression In
+884
+CRC Errors
+886
+Timeout Errors
+888
+Serial Overrun Errors
+890
+Alignment Errors
+892
+Buffer Overrun Errors
+894
+Total Errors
+896
+Bytes Transmitted/Sec
+898
+Bytes Received/Sec
+900
+Frames Transmitted/Sec
+902
+Frames Received/Sec
+904
+Total Errors/Sec
+908
+Total Connections
+920
+WINS Server
+922
+Unique Registrations/sec
+924
+Group Registrations/sec
+926
+Total Number of Registrations/sec
+928
+Unique Renewals/sec
+930
+Group Renewals/sec
+932
+Total Number of Renewals/sec
+934
+Releases/sec
+936
+Queries/sec
+938
+Unique Conflicts/sec
+940
+Group Conflicts/sec
+942
+Total Number of Conflicts/sec
+944
+Successful Releases/sec
+946
+Failed Releases/sec
+948
+Successful Queries/sec
+950
+Failed Queries/sec
+952
+Handle Count
+1000
+MacFile Server
+1002
+Max Paged Memory
+1004
+Current Paged Memory
+1006
+Max NonPaged Memory
+1008
+Current NonPaged memory
+1010
+Current Sessions
+1012
+Maximum Sessions
+1014
+Current Files Open
+1016
+Maximum Files Open
+1018
+Failed Logons
+1020
+Data Read/sec
+1022
+Data Written/sec
+1024
+Data Received/sec
+1026
+Data Transmitted/sec
+1028
+Current Queue Length
+1030
+Maximum Queue Length
+1032
+Current Threads
+1034
+Maximum Threads
+1050
+AppleTalk
+1052
+Packets In/sec
+1054
+Packets Out/sec
+1056
+Bytes In/sec
+1058
+Bytes Out/sec
+1060
+Average Time/DDP Packet
+1062
+DDP Packets/sec
+1064
+Average Time/AARP Packet
+1066
+AARP Packets/sec
+1068
+Average Time/ATP Packet
+1070
+ATP Packets/sec
+1072
+Average Time/NBP Packet
+1074
+NBP Packets/sec
+1076
+Average Time/ZIP Packet
+1078
+ZIP Packets/sec
+1080
+Average Time/RTMP Packet
+1082
+RTMP Packets/sec
+1084
+ATP Retries Local
+1086
+ATP Response Timouts
+1088
+ATP XO Response/Sec
+1090
+ATP ALO Response/Sec
+1092
+ATP Recvd Release/Sec
+1094
+Current NonPaged Pool
+1096
+Packets Routed In/Sec
+1098
+Packets dropped
+1100
+ATP Retries Remote
+1102
+Packets Routed Out/Sec
+1110
+Network Segment
+1112
+Total frames received/second
+1114
+Total bytes received/second
+1116
+Broadcast frames received/second
+1118
+Multicast frames received/second
+1120
+% Network utilization
+1124
+% Broadcast Frames
+1126
+% Multicast Frames
+1150
+Telephony
+1152
+Lines
+1154
+Telephone Devices
+1156
+Active Lines
+1158
+Active Telephones
+1160
+Outgoing Calls/sec
+1162
+Incoming Calls/sec
+1164
+Client Apps
+1166
+Current Outgoing Calls
+1168
+Current Incoming Calls
+1232
+Packet Burst Read NCP Count/sec
+1234
+Packet Burst Read Timeouts/sec
+1236
+Packet Burst Write NCP Count/sec
+1238
+Packet Burst Write Timeouts/sec
+1240
+Packet Burst IO/sec
+1260
+Logon Total
+1262
+Total Durable Handles
+1264
+Reconnected Durable Handles
+1266
+SMB BranchCache Hash Header Requests
+1268
+SMB BranchCache Hash Generation Requests
+1270
+SMB BranchCache Hash Requests Received
+1272
+SMB BranchCache Hash Responses Sent
+1274
+SMB BranchCache Hash Bytes Sent
+1276
+Total Resilient Handles
+1278
+Reconnected Resilient Handles
+1300
+Server Work Queues
+1302
+Queue Length
+1304
+Active Threads
+1306
+Available Threads
+1308
+Available Work Items
+1310
+Borrowed Work Items
+1312
+Work Item Shortages
+1314
+Current Clients
+1320
+Bytes Transferred/sec
+1324
+Read Bytes/sec
+1328
+Write Bytes/sec
+1332
+Total Operations/sec
+1334
+DPCs Queued/sec
+1336
+DPC Rate
+1342
+Total DPCs Queued/sec
+1344
+Total DPC Rate
+1350
+% Registry Quota In Use
+1360
+VL Memory
+1362
+VLM % Virtual Size In Use
+1364
+VLM Virtual Size
+1366
+VLM Virtual Size Peak
+1368
+VLM Virtual Size Available
+1370
+VLM Commit Charge
+1372
+VLM Commit Charge Peak
+1374
+System VLM Commit Charge
+1376
+System VLM Commit Charge Peak
+1378
+System VLM Shared Commit Charge
+1380
+Available KBytes
+1382
+Available MBytes
+1400
+Avg. Disk Queue Length
+1402
+Avg. Disk Read Queue Length
+1404
+Avg. Disk Write Queue Length
+1406
+% Committed Bytes In Use
+1408
+Full Image
+1410
+Creating Process ID
+1412
+IO Read Operations/sec
+1414
+IO Write Operations/sec
+1416
+IO Data Operations/sec
+1418
+IO Other Operations/sec
+1420
+IO Read Bytes/sec
+1422
+IO Write Bytes/sec
+1424
+IO Data Bytes/sec
+1426
+IO Other Bytes/sec
+1450
+Print Queue
+1452
+Total Jobs Printed
+1454
+Bytes Printed/sec
+1456
+Total Pages Printed
+1458
+Jobs
+1460
+References
+1462
+Max References
+1464
+Jobs Spooling
+1466
+Max Jobs Spooling
+1468
+Out of Paper Errors
+1470
+Not Ready Errors
+1472
+Job Errors
+1474
+Enumerate Network Printer Calls
+1476
+Add Network Printer Calls
+1478
+Working Set - Private
+1480
+Working Set - Shared
+1482
+% Idle Time
+1484
+Split IO/Sec
+1500
+Job Object
+1502
+Current % Processor Time
+1504
+Current % User Mode Time
+1506
+Current % Kernel Mode Time
+1508
+This Period mSec - Processor
+1510
+This Period mSec - User Mode
+1512
+This Period mSec - Kernel Mode
+1514
+Pages/Sec
+1516
+Process Count - Total
+1518
+Process Count - Active
+1520
+Process Count - Terminated
+1522
+Total mSec - Processor
+1524
+Total mSec - User Mode
+1526
+Total mSec - Kernel Mode
+1530
+TCPv6
+1532
+UDPv6
+1534
+ICMPv6
+1536
+Received Packet Too Big
+1538
+Received Membership Query
+1540
+Received Membership Report
+1542
+Received Membership Reduction
+1544
+Received Router Solicit
+1546
+Received Router Advert
+1548
+Job Object Details
+1550
+Received Neighbor Solicit
+1552
+Received Neighbor Advert
+1554
+Sent Packet Too Big
+1556
+Sent Membership Query
+1558
+Sent Membership Report
+1560
+Sent Membership Reduction
+1562
+Sent Router Solicit
+1564
+Sent Router Advert
+1566
+Sent Neighbor Solicit
+1568
+Sent Neighbor Advert
+1570
+Security System-Wide Statistics
+1572
+NTLM Authentications
+1574
+Kerberos Authentications
+1576
+KDC AS Requests
+1578
+KDC TGS Requests
+1580
+Schannel Session Cache Entries
+1582
+Active Schannel Session Cache Entries
+1584
+SSL Client-Side Full Handshakes
+1586
+SSL Client-Side Reconnect Handshakes
+1588
+SSL Server-Side Full Handshakes
+1590
+SSL Server-Side Reconnect Handshakes
+1592
+Digest Authentications
+1594
+Forwarded Kerberos Requests
+1596
+Offloaded Connections
+1598
+TCP Active RSC Connections
+1600
+TCP RSC Coalesced Packets/sec
+1602
+TCP RSC Exceptions/sec
+1604
+TCP RSC Average Packet Size
+1620
+KDC armored AS Requests
+1622
+KDC armored TGS Requests
+1624
+KDC claims-aware AS Requests
+1626
+KDC claims-aware service asserted identity TGS requests
+1628
+KDC classic type constrained delegation TGS Requests
+1630
+KDC resource type constrained delegation TGS Requests
+1632
+KDC claims-aware TGS Requests
+1670
+Security Per-Process Statistics
+1672
+Credential Handles
+1674
+Context Handles
+1676
+Free & Zero Page List Bytes
+1678
+Modified Page List Bytes
+1680
+Standby Cache Reserve Bytes
+1682
+Standby Cache Normal Priority Bytes
+1684
+Standby Cache Core Bytes
+1686
+Long-Term Average Standby Cache Lifetime (s)
+1746
+% Idle Time
+1748
+% C1 Time
+1750
+% C2 Time
+1752
+% C3 Time
+1754
+C1 Transitions/sec
+1756
+C2 Transitions/sec
+1758
+C3 Transitions/sec
+1760
+Heap
+1762
+Committed Bytes
+1764
+Reserved Bytes
+1766
+Virtual Bytes
+1768
+Free Bytes
+1770
+Free List Length
+1772
+Avg. alloc rate
+1774
+Avg. free rate
+1776
+Uncommitted Ranges Length
+1778
+Allocs - Frees
+1780
+Cached Allocs/sec
+1782
+Cached Frees/sec
+1784
+Allocs <1K/sec
+1786
+Frees <1K/sec
+1788
+Allocs 1-8K/sec
+1790
+Frees 1-8K/sec
+1792
+Allocs over 8K/sec
+1794
+Frees over 8K/sec
+1796
+Total Allocs/sec
+1798
+Total Frees/sec
+1800
+Blocks in Heap Cache
+1802
+Largest Cache Depth
+1804
+% Fragmentation
+1806
+% VAFragmentation
+1808
+Heap Lock contention
+1810
+Dirty Pages
+1812
+Dirty Page Threshold
+1814
+NUMA Node Memory
+1816
+Total MBytes
+1818
+Free & Zero Page List MBytes
+1820
+Network Adapter
+1822
+Standby List MBytes
+1824
+Available MBytes
+1826
+SMB BranchCache Hash V2 Header Requests
+1828
+SMB BranchCache Hash V2 Generation Requests
+1830
+SMB BranchCache Hash V2 Requests Received
+1832
+SMB BranchCache Hash V2 Responses Sent
+1834
+SMB BranchCache Hash V2 Bytes Sent
+1836
+SMB BranchCache Hash V2 Requests Served From Dedup
+1846
+End Marker
+1848
+WMI Objects
+1850
+HiPerf Classes
+1852
+HiPerf Validity
+1854
+iSCSI Connections
+1856
+Bytes Received
+1858
+Bytes Sent
+1860
+PDUs Sent
+1862
+PDUs Received
+1864
+iSCSI Initiator Instance
+1866
+Session Cxn Timeout Errors
+1868
+Session Digest Errors
+1870
+Sessions Failed
+1872
+Session Format Errors
+1874
+iSCSI Initiator Login statistics
+1876
+Login Accept Responses
+1878
+Logins  Failed
+1880
+Login Authentication Failed Responses
+1882
+Failed Logins
+1884
+Login Negotiation Failed
+1886
+Login Other Failed Responses
+1888
+Login Redirect Responses
+1890
+Logout Normal
+1892
+Logout Other Codes
+1894
+iSCSI HBA Main Mode IPSEC Statistics
+1896
+AcquireFailures
+1898
+AcquireHeapSize
+1900
+ActiveAcquire
+1902
+ActiveReceive
+1904
+AuthenticationFailures
+1906
+ConnectionListSize
+1908
+GetSPIFailures
+1910
+InvalidCookiesReceived
+1912
+InvalidPackets
+1914
+KeyAdditionFailures
+1916
+KeyAdditions
+1918
+KeyUpdateFailures
+1920
+KeyUpdates
+1922
+NegotiationFailures
+1924
+OakleyMainMode
+1926
+OakleyQuickMode
+1928
+ReceiveFailures
+1930
+ReceiveHeapSize
+1932
+SendFailures
+1934
+SoftAssociations
+1936
+TotalGetSPI
+1938
+MSiSCSI_NICPerformance
+1940
+BytesReceived
+1942
+BytesTransmitted
+1944
+PDUReceived
+1946
+PDUTransmitted
+1948
+iSCSI HBA Quick Mode IPSEC Statistics
+1950
+ActiveSA
+1952
+ActiveTunnels
+1954
+AuthenticatedBytesReceived
+1956
+AuthenticatedBytesSent
+1958
+BadSPIPackets
+1960
+ConfidentialBytesReceived
+1962
+ConfidentialBytesSent
+1964
+KeyAdditions
+1966
+KeyDeletions
+1968
+PacketsNotAuthenticated
+1970
+PacketsNotDecrypted
+1972
+PacketsWithReplayDetection
+1974
+PendingKeyOperations
+1976
+ReKeys
+1978
+TransportBytesReceived
+1980
+TransportBytesSent
+1982
+TunnelBytesReceived
+1984
+TunnelBytesSent
+1986
+iSCSI Request Processing Time
+1988
+Average Request Processing Time
+1990
+Max Request Processing Time
+1992
+iSCSI Sessions
+1994
+Bytes Received
+1996
+Bytes Sent
+1998
+ConnectionTimeout Errors
+2000
+Digest Errors
+2002
+Format Errors
+2004
+PDUs Sent
+2006
+PDUs Received
+2008
+Processor Performance
+2010
+Processor Frequency
+2012
+% of Maximum Frequency
+2014
+Processor State Flags
+2016
+WF (System.Workflow) 4.0.0.0
+2018
+Workflows Created
+2020
+Workflows Created/sec
+2022
+Workflows Unloaded
+2024
+Workflows Unloaded/sec
+2026
+Workflows Loaded
+2028
+Workflows Loaded/sec
+2030
+Workflows Completed
+2032
+Workflows Completed/sec
+2034
+Workflows Suspended
+2036
+Workflows Suspended/sec
+2038
+Workflows Terminated
+2040
+Workflows Terminated/sec
+2042
+Workflows In Memory
+2044
+Workflows Aborted
+2046
+Workflows Aborted/sec
+2048
+Workflows Persisted
+2050
+Workflows Persisted/sec
+2052
+Workflows Executing
+2054
+Workflows Idle/sec
+2056
+Workflows Runnable
+2058
+Workflows Pending
+2060
+Web Service
+2062
+Total Bytes Sent
+2064
+Bytes Sent/sec
+2066
+Total Bytes Received
+2068
+Bytes Received/sec
+2070
+Total Bytes Transferred
+2072
+Bytes Total/sec
+2074
+Total Files Sent
+2076
+Files Sent/sec
+2078
+Total Files Received
+2080
+Files Received/sec
+2082
+Total Files Transferred
+2084
+Files/sec
+2086
+Current Anonymous Users
+2088
+Current NonAnonymous Users
+2090
+Total Anonymous Users
+2092
+Anonymous Users/sec
+2094
+Total NonAnonymous Users
+2096
+NonAnonymous Users/sec
+2098
+Maximum Anonymous Users
+2100
+Maximum NonAnonymous Users
+2102
+Current Connections
+2104
+Maximum Connections
+2106
+Total Connection Attempts (all instances)
+2108
+Connection Attempts/sec
+2110
+Total Logon Attempts
+2112
+Logon Attempts/sec
+2114
+Total Options Requests
+2116
+Options Requests/sec
+2118
+Total Get Requests
+2120
+Get Requests/sec
+2122
+Total Post Requests
+2124
+Post Requests/sec
+2126
+Total Head Requests
+2128
+Head Requests/sec
+2130
+Total Put Requests
+2132
+Put Requests/sec
+2134
+Total Delete Requests
+2136
+Delete Requests/sec
+2138
+Total Trace Requests
+2140
+Trace Requests/sec
+2142
+Total Move Requests
+2144
+Move Requests/sec
+2146
+Total Copy Requests
+2148
+Copy Requests/sec
+2150
+Total Mkcol Requests
+2152
+Mkcol Requests/sec
+2154
+Total Propfind Requests
+2156
+Propfind Requests/sec
+2158
+Total Proppatch Requests
+2160
+Proppatch Requests/sec
+2162
+Total Search Requests
+2164
+Search Requests/sec
+2166
+Total Lock Requests
+2168
+Lock Requests/sec
+2170
+Total Unlock Requests
+2172
+Unlock Requests/sec
+2174
+Total Other Request Methods
+2176
+Other Request Methods/sec
+2178
+Total Method Requests
+2180
+Total Method Requests/sec
+2182
+Total CGI Requests
+2184
+CGI Requests/sec
+2186
+Total ISAPI Extension Requests
+2188
+ISAPI Extension Requests/sec
+2190
+Total Not Found Errors
+2192
+Not Found Errors/sec
+2194
+Total Locked Errors
+2196
+Locked Errors/sec
+2198
+Current CGI Requests
+2200
+Current ISAPI Extension Requests
+2202
+Maximum CGI Requests
+2204
+Maximum ISAPI Extension Requests
+2206
+Current CAL count for authenticated users
+2208
+Maximum CAL count for authenticated users
+2210
+Total count of failed CAL requests for authenticated users
+2212
+Current CAL count for SSL connections
+2214
+Maximum CAL count for SSL connections
+2216
+Total Blocked Async I/O Requests
+2218
+Total Allowed Async I/O Requests
+2220
+Total Rejected Async I/O Requests
+2222
+Current Blocked Async I/O Requests
+2224
+Total count of failed CAL requests for SSL connections
+2226
+Measured Async I/O Bandwidth Usage
+2228
+Total blocked bandwidth bytes.
+2230
+Current blocked bandwidth bytes.
+2232
+Service Uptime
+2234
+Web Service Cache
+2236
+Current Files Cached
+2238
+Total Files Cached
+2240
+File Cache Hits
+2242
+File Cache Misses
+2244
+File Cache Hits %
+2248
+File Cache Flushes
+2250
+Current File Cache Memory Usage
+2252
+Maximum File Cache Memory Usage
+2254
+Active Flushed Entries
+2256
+Total Flushed Files
+2258
+Current URIs Cached
+2260
+Total URIs Cached
+2262
+URI Cache Hits
+2264
+URI Cache Misses
+2266
+URI Cache Hits %
+2270
+URI Cache Flushes
+2272
+Total Flushed URIs
+2274
+Current Metadata Cached
+2276
+Total Metadata Cached
+2278
+Metadata Cache Hits
+2280
+Metadata Cache Misses
+2282
+Metadata Cache Hits %
+2286
+Metadata Cache Flushes
+2288
+Total Flushed Metadata
+2290
+Kernel: Current URIs Cached
+2292
+Kernel: Total URIs Cached
+2294
+Kernel: URI Cache Hits
+2296
+Kernel: Uri Cache Hits/sec
+2298
+Kernel: URI Cache Misses
+2300
+Kernel: URI Cache Hits %
+2304
+Kernel: URI Cache Flushes
+2306
+Kernel: Total Flushed URIs
+2308
+Output Cache Current Memory Usage
+2310
+Output Cache Current Items
+2312
+Output Cache Total Hits
+2314
+Output Cache Total Misses
+2316
+Output Cache Total Flushes
+2318
+Output Cache Current Flushed Items
+2320
+Output Cache Total Flushed Items
+2322
+Output Cache Current Hits %
+2324
+Bulk Bytes/Sec
+2326
+Isochronous Bytes/Sec
+2328
+Interrupt Bytes/Sec
+2330
+Control Data Bytes/Sec
+2332
+Controller PCI Interrupts/Sec
+2334
+Controller WorkSignals/Sec
+2336
+% Total Bandwidth Used for Interrupt
+2338
+% Total Bandwidth Used for Iso
+2340
+USB
+2342
+Avg. Bytes/Transfer
+2344
+Iso Packet Errors/Sec
+2346
+Avg ms latency for ISO transfers
+2348
+Transfer Errors/Sec
+2350
+Host Controller Idle
+2352
+Host Controller Async Idle
+2354
+Host Controller Async Cache Flush Count
+2356
+Host Controller Periodic Idle
+2358
+Host Controller Periodic Cache Flush Count
+2360
+Terminal Services Session
+2362
+Telephony
+2364
+Number of Lines
+2366
+Number of Telephone devices
+2368
+Number of Active Lines
+2370
+Number of Active Telephones
+2372
+Outgoing calls/sec
+2374
+Incoming calls/sec
+2376
+Number of Client Apps
+2378
+Current Outgoing Calls
+2380
+Current Incoming Calls
+2382
+SMSvcHost 4.0.0.0
+2384
+Protocol Failures over net.tcp
+2386
+Protocol Failures over net.pipe
+2388
+Dispatch Failures over net.tcp
+2390
+Dispatch Failures over net.pipe
+2392
+Connections Dispatched over net.tcp
+2394
+Connections Dispatched over net.pipe
+2396
+Connections Accepted over net.tcp
+2398
+Connections Accepted over net.pipe
+2400
+Registrations Active for net.tcp
+2402
+Registrations Active for net.pipe
+2404
+Uris Registered for net.tcp
+2406
+Uris Registered for net.pipe
+2408
+Uris Unregistered for net.tcp
+2410
+Uris Unregistered for net.pipe
+2412
+LS:SipEps - Sip Dialogs
+2414
+SipEps - Active Dialogs
+2416
+SipEps - Dialogs Created
+2418
+SipEps - Dialogs Created /sec
+2420
+SipEps - CoreManagerQueueLength
+2422
+SipEps - CoreManagerMaximumQueueExecutionTime
+2424
+SipEps - CoreManagerTotalWorkitemsExecuted
+2426
+SipEps - NumberOfBrokenDialogs
+2428
+SipEps - NumberOfBrokenDialogsPerSecond
+2430
+SipEps - NumberOfHealedDialogs
+2432
+SipEps - NumberOfHealedDialogsPerSecond
+2434
+SipEps - NumberOfAttemptsToHealDialog
+2436
+SipEps - NumberOfAttemptsToHealDialogPerSecond
+2438
+SipEps - NumberOfFailedAttemptsToHealDialog
+2440
+SipEps - NumberOfFailedAttemptsToHealDialogPerSecond
+2442
+LS:SipEps - SipEps Transactions
+2444
+SipEps - Outgoing Transactions Processed
+2446
+SipEps - Outgoing Transactions Processed/sec
+2448
+SipEps - Incoming Transactions Processed
+2450
+SipEps - Incoming Transactions Processed/sec
+2452
+SipEps - Active Transactions
+2454
+SipEps - Transactions Processed
+2456
+SipEps - Transactions Processed/sec
+2458
+SipEps - Transactions Timed Out
+2460
+SipEps - Transactions Timed Out/sec
+2462
+LS:SipEps - SipEps Connections
+2464
+SipEps - Bytes Received
+2466
+SipEps - Bytes Received/sec
+2468
+SipEps - Bytes Sent
+2470
+SipEps - Bytes Sent/sec
+2472
+SipEps - Disconnections
+2474
+SipEps - Disconnections/sec
+2476
+SipEps - Incoming Connections
+2478
+SipEps - Incoming Connections/sec
+2480
+SipEps - Outgoing Connections
+2482
+SipEps - Outgoing Connections/sec
+2484
+SipEps - NumberOfDNSResolutionFailures
+2486
+SipEps - NumberOfDNSResolutionFailuresPerSecond
+2488
+LS:SipEps - SipEps Incoming Messages
+2490
+SipEps - Incoming Messages
+2492
+SipEps - Incoming Messages/sec
+2494
+SipEps - Failed Incoming Messages
+2496
+SipEps - Failed Incoming Messages/sec
+2498
+SipEps - Incoming ACK messages
+2500
+SipEps - Incoming ACK messages/sec
+2502
+SipEps - Incoming BYE messages
+2504
+SipEps - Incoming BYE messages/sec
+2506
+SipEps - Incoming CANCEL messages
+2508
+SipEps - Incoming CANCEL messages/sec
+2510
+SipEps - Incoming INFO messages
+2512
+SipEps - Incoming INFO messages/sec
+2514
+SipEps - Incoming INVITE messages
+2516
+SipEps - Incoming INVITE messages/sec
+2518
+SipEps - Incoming MESSAGE messages
+2520
+SipEps - Incoming MESSAGE messages/sec
+2522
+SipEps - Incoming NEGOTIATE messages
+2524
+SipEps - Incoming NEGOTIATE messages/sec
+2526
+SipEps - Incoming NOTIFY messages
+2528
+SipEps - Incoming NOTIFY messages/sec
+2530
+SipEps - Incoming OPTIONS messages
+2532
+SipEps - Incoming OPTIONS messages/sec
+2534
+SipEps - Incoming REFER messages
+2536
+SipEps - Incoming REFER messages/sec
+2538
+SipEps - Incoming REGISTER messages
+2540
+SipEps - Incoming REGISTER messages/sec
+2542
+SipEps - Incoming SERVICE messages
+2544
+SipEps - Incoming SERVICE messages/sec
+2546
+SipEps - Incoming SUBSCRIBE messages
+2548
+SipEps - Incoming SUBSCRIBE messages/sec
+2550
+SipEps - Incoming Generic Messages
+2552
+SipEps - Incoming Generic Messages/sec
+2554
+SipEps - Incoming 3xx Responses
+2556
+SipEps - Incoming 3xx Responses/sec
+2558
+SipEps - Incoming 4xx Responses
+2560
+SipEps - Incoming 4xx Responses/sec
+2562
+SipEps - Incoming 5xx Responses
+2564
+SipEps - Incoming 5xx Responses/sec
+2566
+SipEps - Incoming 6xx Responses
+2568
+SipEps - Incoming 6xx Responses/sec
+2570
+SipEps - Incoming 180(Ringing) Responses
+2572
+SipEps - Incoming 180(Ringing) Responses/sec
+2574
+SipEps - Incoming 200 Responses
+2576
+SipEps - Incoming 200 Responses/sec
+2578
+SipEps - Incoming 301(Moved Permanently) Responses
+2580
+SipEps - Incoming 301(Moved Permanently) Responses/sec
+2582
+SipEps - Incoming 302(Moved Temporarily) Responses
+2584
+SipEps - Incoming 302(Moved Temporarily) Responses/sec
+2586
+SipEps - Incoming 400(Bad Request) Responses
+2588
+SipEps - Incoming 400(Bad Request) Responses/sec
+2590
+SipEps - Incoming 401(Unauthorized) Responses
+2592
+SipEps - Incoming 401(Unauthorized) Responses/sec
+2594
+SipEps - Incoming 403(Forbidden) Responses
+2596
+SipEps - Incoming 403(Forbidden) Responses/sec
+2598
+SipEps - Incoming 404(Not Found) Responses
+2600
+SipEps - Incoming 404(Not Found) Responses/sec
+2602
+SipEps - Incoming 407(Proxy Authentication Required) Responses
+2604
+SipEps - Incoming 407(Proxy Authentication Required) Responses/sec
+2606
+SipEps - Incoming 409 Responses
+2608
+SipEps - Incoming 409 Responses/sec
+2610
+SipEps - Incoming 413(Request Entity Too Large) Responses
+2612
+SipEps - Incoming 413(Request Entity Too Large) Responses/sec
+2614
+SipEps - Incoming 421(Extension Required) Responses
+2616
+SipEps - Incoming 421(Extension Required) Responses/sec
+2618
+SipEps - Incoming 430(Flow Failed) Responses
+2620
+SipEps - Incoming 430(Flow Failed) Responses/sec
+2622
+SipEps - Incoming 480(Temporarily Unavailable) Responses
+2624
+SipEps - Incoming 480(Temporarily Unavailable) Responses/sec
+2626
+SipEps - Incoming 481(Call/Transaction Does Not Exist) Responses
+2628
+SipEps - Incoming 481(Call/Transaction Does Not Exist) Responses/sec
+2630
+SipEps - Incoming 486(Busy Here) Responses
+2632
+SipEps - Incoming 486(Busy Here) Responses/sec
+2634
+SipEps - Incoming 487(Request Terminated) Responses
+2636
+SipEps - Incoming 487(Request Terminated) Responses/sec
+2638
+SipEps - Incoming 488(Not Acceptable Here) Responses
+2640
+SipEps - Incoming 488(Not Acceptable Here) Responses/sec
+2642
+SipEps - Incoming 499 Responses
+2644
+SipEps - Incoming 499 Responses/sec
+2646
+SipEps - Incoming 500(Internal Server Error) Responses
+2648
+SipEps - Incoming 500(Internal Server Error) Responses/sec
+2650
+SipEps - Incoming 501(Not Implemented) Responses
+2652
+SipEps - Incoming 501(Not Implemented) Responses/sec
+2654
+SipEps - Incoming 503(Service Unavailable) Responses
+2656
+SipEps - Incoming 503(Service Unavailable) Responses/sec
+2658
+SipEps - Incoming 504(Server Time-out) Responses
+2660
+SipEps - Incoming 504(Server Time-out) Responses/sec
+2662
+SipEps - Incoming 599 Responses
+2664
+SipEps - Incoming 599 Responses/sec
+2666
+SipEps - Incoming 600(Busy Everywhere) Responses
+2668
+SipEps - Incoming 600(Busy Everywhere) Responses/sec
+2670
+SipEps - Incoming 603(Decline) Responses
+2672
+SipEps - Incoming 603(Decline) Responses/sec
+2674
+SipEps - Incoming 699 Responses
+2676
+SipEps - Incoming 699 Responses/sec
+2678
+SipEps - Incoming out of sequence Notifies
+2680
+SipEps - Incoming out of sequence Notifies/sec
+2682
+LS:SipEps - SipEps Outgoing Messages
+2684
+SipEps - Outgoing Messages
+2686
+SipEps - Outgoing Messages/sec
+2688
+SipEps - Failed Outgoing Messages
+2690
+SipEps - Failed Outgoing Messages/sec
+2692
+SipEps - Outgoing ACK messages
+2694
+SipEps - Outgoing ACK messages/sec
+2696
+SipEps - Outgoing BYE messages
+2698
+SipEps - Outgoing BYE messages/sec
+2700
+SipEps - Outgoing CANCEL messages
+2702
+SipEps - Outgoing CANCEL messages/sec
+2704
+SipEps - Outgoing INFO messages
+2706
+SipEps - Outgoing INFO messages/sec
+2708
+SipEps - Outgoing INVITE messages
+2710
+SipEps - Outgoing INVITE messages/sec
+2712
+SipEps - Outgoing MESSAGE messages
+2714
+SipEps - Outgoing MESSAGE messages/sec
+2716
+SipEps - Outgoing NEGOTIATE messages
+2718
+SipEps - Outgoing NEGOTIATE messages/sec
+2720
+SipEps - Outgoing NOTIFY messages
+2722
+SipEps - Outgoing NOTIFY messages/sec
+2724
+SipEps - Outgoing OPTIONS messages
+2726
+SipEps - Outgoing OPTIONS messages/sec
+2728
+SipEps - Outgoing REFER messages
+2730
+SipEps - Outgoing REFER messages/sec
+2732
+SipEps - Outgoing REGISTER messages
+2734
+SipEps - Outgoing REGISTER messages/sec
+2736
+SipEps - Outgoing SERVICE messages
+2738
+SipEps - Outgoing SERVICE messages/sec
+2740
+SipEps - Outgoing SUBSCRIBE messages
+2742
+SipEps - Outgoing SUBSCRIBE messages/sec
+2744
+SipEps - Outgoing Generic Messages
+2746
+SipEps - Outgoing Generic Messages/sec
+2748
+SipEps - Outgoing 3xx Responses
+2750
+SipEps - Outgoing 3xx Responses/sec
+2752
+SipEps - Outgoing 4xx Responses
+2754
+SipEps - Outgoing 4xx Responses/sec
+2756
+SipEps - Outgoing 5xx Responses
+2758
+SipEps - Outgoing 5xx Responses/sec
+2760
+SipEps - Outgoing 6xx Responses
+2762
+SipEps - Outgoing 6xx Responses/sec
+2764
+SipEps - Outgoing 180(Ringing) Responses
+2766
+SipEps - Outgoing 180(Ringing) Responses/sec
+2768
+SipEps - Outgoing 200 Responses
+2770
+SipEps - Outgoing 200 Responses/sec
+2772
+SipEps - Outgoing 301(Moved Permanently) Responses
+2774
+SipEps - Outgoing 301(Moved Permanently) Responses/sec
+2776
+SipEps - Outgoing 302(Moved Temporarily) Responses
+2778
+SipEps - Outgoing 302(Moved Temporarily) Responses/sec
+2780
+SipEps - Outgoing 400(Bad Request) Responses
+2782
+SipEps - Outgoing 400(Bad Request) Responses/sec
+2784
+SipEps - Outgoing 401(Unauthorized) Responses
+2786
+SipEps - Outgoing 401(Unauthorized) Responses/sec
+2788
+SipEps - Outgoing 403(Forbidden) Responses
+2790
+SipEps - Outgoing 403(Forbidden) Responses/sec
+2792
+SipEps - Outgoing 404(Not Found) Responses
+2794
+SipEps - Outgoing 404(Not Found) Responses/sec
+2796
+SipEps - Outgoing 407(Proxy Authentication Required) Responses
+2798
+SipEps - Outgoing 407(Proxy Authentication Required) Responses/sec
+2800
+SipEps - Outgoing 409 Responses
+2802
+SipEps - Outgoing 409 Responses/sec
+2804
+SipEps - Outgoing 413(Request Entity Too Large) Responses
+2806
+SipEps - Outgoing 413(Request Entity Too Large) Responses/sec
+2808
+SipEps - Outgoing 421(Extension Required) Responses
+2810
+SipEps - Outgoing 421(Extension Required) Responses/sec
+2812
+SipEps - Outgoing 480(Temporarily Unavailable) Responses
+2814
+SipEps - Outgoing 480(Temporarily Unavailable) Responses/sec
+2816
+SipEps - Outgoing 481(Call/Transaction Does Not Exist) Responses
+2818
+SipEps - Outgoing 481(Call/Transaction Does Not Exist) Responses/sec
+2820
+SipEps - Outgoing 486(Busy Here) Responses
+2822
+SipEps - Outgoing 486(Busy Here) Responses/sec
+2824
+SipEps - Outgoing 487(Request Terminated) Responses
+2826
+SipEps - Outgoing 487(Request Terminated) Responses/sec
+2828
+SipEps - Outgoing 488(Not Acceptable Here) Responses
+2830
+SipEps - Outgoing 488(Not Acceptable Here) Responses/sec
+2832
+SipEps - Outgoing 499 Responses
+2834
+SipEps - Outgoing 499 Responses/sec
+2836
+SipEps - Outgoing 500(Internal Server Error) Responses
+2838
+SipEps - Outgoing 500(Internal Server Error) Responses/sec
+2840
+SipEps - Outgoing 501(Not Implemented) Responses
+2842
+SipEps - Outgoing 501(Not Implemented) Responses/sec
+2844
+SipEps - Outgoing 503(Service Unavailable) Responses
+2846
+SipEps - Outgoing 503(Service Unavailable) Responses/sec
+2848
+SipEps - Outgoing 504(Server Time-out) Responses
+2850
+SipEps - Outgoing 504(Server Time-out) Responses/sec
+2852
+SipEps - Outgoing 599 Responses
+2854
+SipEps - Outgoing 599 Responses/sec
+2856
+SipEps - Outgoing 600(Busy Everywhere) Responses
+2858
+SipEps - Outgoing 600(Busy Everywhere) Responses/sec
+2860
+SipEps - Outgoing 603(Decline) Responses
+2862
+SipEps - Outgoing 603(Decline) Responses/sec
+2864
+SipEps - Outgoing 699 Responses
+2866
+SipEps - Outgoing 699 Responses/sec
+2868
+RAS Port
+2870
+Bytes Transmitted
+2872
+Bytes Received
+2874
+Frames Transmitted
+2876
+Frames Received
+2878
+Percent Compression Out
+2880
+Percent Compression In
+2882
+CRC Errors
+2884
+Timeout Errors
+2886
+Serial Overrun Errors
+2888
+Alignment Errors
+2890
+Buffer Overrun Errors
+2892
+Total Errors
+2894
+Bytes Transmitted/Sec
+2896
+Bytes Received/Sec
+2898
+Frames Transmitted/Sec
+2900
+Frames Received/Sec
+2902
+Total Errors/Sec
+2904
+RAS Total
+2906
+Total Connections
+2908
+NTDS
+2910
+MSExchangeWS
+2912
+GetItem Requests
+2914
+GetItem Requests/sec
+2916
+GetItem Average Response Time
+2918
+ConvertId Requests
+2920
+ConvertId Requests/sec
+2922
+ConvertId Average Response Time
+2924
+Total Number of Ids converted
+2926
+Ids Converted/sec
+2928
+CreateItem Requests
+2930
+CreateItem Requests/sec
+2932
+CreateItem Average Response Time
+2934
+UploadItems Requests
+2936
+UploadItems Requests/sec
+2938
+UploadItems Average Response Time
+2940
+UploadLargeItem Requests
+2942
+UploadLargeItem Requests/sec
+2944
+UploadLargeItem Average Response Time
+2946
+ChunkUpload Requests
+2948
+ChunkUpload Requests/sec
+2950
+ChunkUpload Average Response Time
+2952
+CompleteLargeItemUpload Requests
+2954
+CompleteLargeItemUpload Requests/sec
+2956
+CompleteLargeItemUpload Average Response Time
+2958
+ExportItems Requests
+2960
+ExportItems Requests/sec
+2962
+ExportItems Average Response Time
+2964
+DeleteItem Requests
+2966
+DeleteItem Requests/sec
+2968
+DeleteItem Average Response Time
+2970
+UpdateItem Requests
+2972
+UpdateItem Requests/sec
+2974
+UpdateItem Average Response Time
+2976
+UpdateItemInRecoverableItems Requests
+2978
+UpdateItemInRecoverableItems Requests/sec
+2980
+UpdateItemInRecoverableItems Average Response Time
+2982
+MarkAllItemsAsRead Requests
+2984
+MarkAllItemsAsRead Requests/sec
+2986
+MarkAllItemsAsRead Average Response Time
+2988
+MarkAsJunk Requests
+2990
+MarkAsJunk Requests/sec
+2992
+MarkAsJunk Average Response Time
+2994
+MarkAsJunk Successful Requests
+2996
+GetClientExtension Requests
+2998
+GetClientExtension Requests/sec
+3000
+GetClientExtension Average Response Time
+3002
+SetClientExtension Requests
+3004
+SetClientExtension Requests/sec
+3006
+SetClientExtension Average Response Time
+3008
+GetAppManifests Requests
+3010
+GetAppManifests Requests/sec
+3012
+GetAppManifests Average Response Time
+3014
+GetClientExtensionToken Requests
+3016
+GetClientExtensionToken Requests/sec
+3018
+GetClientExtensionToken Average Response Time
+3020
+InstallApp Requests
+3022
+InstallApp Requests/sec
+3024
+InstallApp Average Response Time
+3026
+UninstallApp Requests
+3028
+UninstallApp Requests/sec
+3030
+UninstallApp Average Response Time
+3032
+DisableApp Requests
+3034
+DisableApp Requests/sec
+3036
+DisableApp Average Response Time
+3038
+GetAppMarketplaceUrl Requests
+3040
+GetAppMarketplaceUrl Requests/sec
+3042
+GetAppMarketplaceUrl Average Response Time
+3044
+AddImContactToGroup Requests
+3046
+AddImContactToGroup Requests/sec
+3048
+AddImContactToGroup Average Response Time
+3050
+AddImContactToGroup Successful Requests
+3052
+RemoveImContactFromGroup Requests
+3054
+RemoveImContactFromGroup Requests/sec
+3056
+RemoveImContactFromGroup Average Response Time
+3058
+RemoveImContactFromGroup Successful Requests
+3060
+AddNewImContactToGroup Requests
+3062
+AddNewImContactToGroup Requests/sec
+3064
+AddNewImContactToGroup Average Response Time
+3066
+AddNewImContactToGroup Successful Requests
+3068
+AddNewTelUriContactToGroup Requests
+3070
+AddNewTelUriContactToGroup Requests/sec
+3072
+AddNewTelUriContactToGroup Average Response Time
+3074
+AddNewTelUriContactToGroup Successful Requests
+3076
+AddDistributionGroupToImList Requests
+3078
+AddDistributionGroupToImList Requests/sec
+3080
+AddDistributionGroupToImList Average Response Time
+3082
+AddDistributionGroupToImList Successful Requests
+3084
+AddImGroup Requests
+3086
+AddImGroup Requests/sec
+3088
+AddImGroup Average Response Time
+3090
+AddImGroup Successful Requests
+3092
+GetImItemList Requests
+3094
+GetImItemList Requests/sec
+3096
+GetImItemList Average Response Time
+3098
+GetImItemList Successful Requests
+3100
+GetImItems Requests
+3102
+GetImItems Requests/sec
+3104
+GetImItems Average Response Time
+3106
+GetImItems Successful Requests
+3108
+RemoveContactFromImList Requests
+3110
+RemoveContactFromImList Requests/sec
+3112
+RemoveContactFromImList Average Response Time
+3114
+RemoveContactFromImList Successful Requests
+3116
+RemoveDistributionGroupFromImList Requests
+3118
+RemoveDistributionGroupFromImList Requests/sec
+3120
+RemoveDistributionGroupFromImList Average Response Time
+3122
+RemoveDistributionGroupFromImList Successful Requests
+3124
+RemoveImGroup Requests
+3126
+RemoveImGroup Requests/sec
+3128
+RemoveImGroup Average Response Time
+3130
+RemoveImGroup Successful Requests
+3132
+SetImGroup Requests
+3134
+SetImGroup Requests/sec
+3136
+SetImGroup Average Response Time
+3138
+SetImGroup Successful Requests
+3140
+SetImListMigrationCompleted Requests
+3142
+SetImListMigrationCompleted Requests/sec
+3144
+SetImListMigrationCompleted Average Response Time
+3146
+SetImListMigrationCompleted Successful Requests
+3148
+GetConversationItems Requests
+3150
+GetConversationItems Requests/sec
+3152
+GetConversationItems Average Response Time
+3154
+SendItem Requests
+3156
+SendItem Requests/sec
+3158
+SendItem Average Response Time
+3160
+ArchiveItem Requests
+3162
+ArchiveItem Requests/sec
+3164
+ArchiveItem Average Response Time
+3166
+MoveItem Requests
+3168
+MoveItem Requests/sec
+3170
+MoveItem Average Response Time
+3172
+CopyItem Requests
+3174
+CopyItem Requests/sec
+3176
+CopyItem Average Response Time
+3178
+GetFolder Requests
+3180
+GetFolder Requests/sec
+3182
+GetFolder Average Response Time
+3184
+CreateFolder Requests
+3186
+CreateFolder Requests/sec
+3188
+CreateFolder Average Response Time
+3190
+CreateFolderPath Requests
+3192
+CreateFolderPath Requests/sec
+3194
+CreateFolderPath Average Response Time
+3196
+CreateManagedFolder Requests
+3198
+CreateManagedFolder Requests/sec
+3200
+CreateManagedFolder Average Response Time
+3202
+DeleteFolder Requests
+3204
+DeleteFolder Requests/sec
+3206
+DeleteFolder Average Response Time
+3208
+EmptyFolder Requests
+3210
+EmptyFolder Requests/sec
+3212
+EmptyFolder Average Response Time
+3214
+UpdateFolder Requests
+3216
+UpdateFolder Requests/sec
+3218
+UpdateFolder Average Response Time
+3220
+MoveFolder Requests
+3222
+MoveFolder Requests/sec
+3224
+MoveFolder Average Response Time
+3226
+CopyFolder Requests
+3228
+CopyFolder Requests/sec
+3230
+CopyFolder Average Response Time
+3232
+FindItem Requests
+3234
+FindItem Requests/sec
+3236
+FindItem Average Response Time
+3238
+FindFolder Requests
+3240
+FindFolder Requests/sec
+3242
+FindFolder Average Response Time
+3244
+ResolveNames Requests
+3246
+ResolveNames Requests/sec
+3248
+ResolveNames Average Response Time
+3250
+ExpandDL Requests
+3252
+ExpandDL Requests/sec
+3254
+ExpandDL Average Response Time
+3256
+GetPasswordExpirationDate Requests
+3258
+GetPasswordExpirationDate Requests/sec
+3260
+GetPasswordExpirationDate Average Response Time
+3262
+GetPasswordExpirationDate Successful Requests
+3264
+CreateAttachment Requests
+3266
+CreateAttachment Requests/sec
+3268
+CreateAttachment Average Response Time
+3270
+DeleteAttachment Requests
+3272
+DeleteAttachment Requests/sec
+3274
+DeleteAttachment Average Response Time
+3276
+GetAttachment Requests
+3278
+GetAttachment Requests/sec
+3280
+GetAttachment Average Response Time
+3282
+GetClientAccessToken Requests
+3284
+GetClientAccessToken Requests/sec
+3286
+GetClientAccessToken Average Response Time
+3288
+Subscribe Requests
+3290
+Subscribe Requests/sec
+3292
+Subscribe Average Response Time
+3294
+Unsubscribe Requests
+3296
+Unsubscribe Requests/sec
+3298
+Unsubscribe Average Response Time
+3300
+GetStreamingEvents Requests
+3302
+GetStreamingEvents Requests/sec
+3304
+GetStreamingEvents Average Response Time
+3306
+GetEvents Requests
+3308
+GetEvents Requests/sec
+3310
+GetEvents Average Response Time
+3312
+GetServiceConfiguration Requests
+3314
+GetServiceConfiguration Requests/sec
+3316
+GetServiceConfiguration Average Response Time
+3318
+GetMailTips Requests
+3320
+GetMailTips Requests/sec
+3322
+GetMailTips Average Response Time
+3324
+SyncFolderHierarchy Requests
+3326
+SyncFolderHierarchy Requests/sec
+3328
+SyncFolderHierarchy Average Response Time
+3330
+SyncFolderItems Requests
+3332
+SyncFolderItems Requests/sec
+3334
+SyncFolderItems Average Response Time
+3336
+GetDelegate Requests
+3338
+GetDelegate Requests/sec
+3340
+GetDelegate Average Response Time
+3342
+AddDelegate Requests
+3344
+AddDelegate Requests/sec
+3346
+AddDelegate Average Response Time
+3348
+RemoveDelegate Requests
+3350
+RemoveDelegate Requests/sec
+3352
+RemoveDelegate Average Response Time
+3354
+UpdateDelegate Requests
+3356
+UpdateDelegate Requests/sec
+3358
+UpdateDelegate Average Response Time
+3360
+CreateUserConfiguration Requests
+3362
+CreateUserConfiguration Requests/sec
+3364
+CreateUserConfiguration Average Response Time
+3366
+GetUserConfiguration Requests
+3368
+GetUserConfiguration Requests/sec
+3370
+GetUserConfiguration Average Response Time
+3372
+UpdateUserConfiguration Requests
+3374
+UpdateUserConfiguration Requests/sec
+3376
+UpdateUserConfiguration Average Response Time
+3378
+DeleteUserConfiguration Requests
+3380
+DeleteUserConfiguration Requests/sec
+3382
+DeleteUserConfiguration Average Response Time
+3384
+GetUserAvailability Requests
+3386
+GetUserAvailability Requests/sec
+3388
+GetUserAvailability Average Response Time
+3390
+GetUserOofSettings Requests
+3392
+GetUserOofSettings Requests/sec
+3394
+GetUserOofSettings Average Response Time
+3396
+SetUserOofSettings Requests
+3398
+SetUserOofSettings Requests/sec
+3400
+SetUserOofSettings Average Response Time
+3402
+GetSharingMetadata Requests
+3404
+GetSharingMetadata Requests/sec
+3406
+GetSharingMetadata Average Response Time
+3408
+RefreshSharingFolder Requests
+3410
+RefreshSharingFolder Requests/sec
+3412
+RefreshSharingFolder Average Response Time
+3414
+GetSharingFolder Requests
+3416
+GetSharingFolder Requests/sec
+3418
+GetSharingFolder Average Response Time
+3420
+SetTeamMailbox Requests
+3422
+SetTeamMailbox Requests/sec
+3424
+SetTeamMailbox Average Response Time
+3426
+SetTeamMailbox Successful Requests
+3428
+UnpinTeamMailbox Requests
+3430
+UnpinTeamMailbox Requests/sec
+3432
+UnpinTeamMailbox Average Response Time
+3434
+UnpinTeamMailbox Successful Requests
+3436
+GetRoomLists Requests
+3438
+GetRoomLists Requests/sec
+3440
+GetRoomLists Average Response Time
+3442
+SubscribeToPushNotification Requests
+3444
+SubscribeToPushNotification Requests/sec
+3446
+SubscribeToPushNotification Average Response Time
+3448
+GetRooms Requests
+3450
+GetRooms Requests/sec
+3452
+GetRooms Average Response Time
+3454
+PerformReminderAction Requests
+3456
+PerformReminderAction Requests/sec
+3458
+PerformReminderAction Average Response Time
+3460
+GetReminders Requests
+3462
+GetReminders Requests/sec
+3464
+GetReminders Average Response Time
+3466
+Provision Requests
+3468
+Provision Requests/sec
+3470
+Provision Average Response Time
+3472
+Deprovision Requests
+3474
+Deprovision Requests/sec
+3476
+Deprovision Average Response Time
+3478
+FindConversation Requests
+3480
+FindConversation Requests/sec
+3482
+FindConversation Average Response Time
+3484
+FindPeople Requests
+3486
+FindPeople Requests/sec
+3488
+FindPeople Average Response Time
+3490
+SyncPeople Requests
+3492
+SyncPeople Requests/sec
+3494
+SyncPeople Average Response Time
+3496
+GetPersona Requests
+3498
+GetPersona Requests/sec
+3500
+GetPersona Average Response Time
+3502
+SyncConversation Requests
+3504
+SyncConversation Requests/sec
+3506
+SyncConversation Average Response Time
+3508
+GetTimeZoneOffsets Requests
+3510
+GetTimeZoneOffsets Requests/sec
+3512
+GetTimeZoneOffsets Average Response Time
+3514
+TimeZoneOffsets Tables Built
+3516
+FindMailboxStatisticsByKeywords Requests
+3518
+FindMailboxStatisticsByKeywords Requests/sec
+3520
+FindMailboxStatisticsByKeywords Average Response Time
+3522
+GetSearchableMailboxes Requests
+3524
+GetSearchableMailboxes Requests/sec
+3526
+GetSearchableMailboxes Average Response Time
+3528
+SearchMailboxes Requests
+3530
+SearchMailboxes Requests/sec
+3532
+SearchMailboxes Average Response Time
+3534
+GetDiscoverySearchConfiguration Requests
+3536
+GetDiscoverySearchConfiguration Requests/sec
+3538
+GetDiscoverySearchConfiguration Average Response Time
+3540
+GetHoldOnMailboxes Requests
+3542
+GetHoldOnMailboxes Requests/sec
+3544
+GetHoldOnMailboxes Average Response Time
+3546
+SetHoldOnMailboxes Requests
+3548
+SetHoldOnMailboxes Requests/sec
+3550
+SetHoldOnMailboxes Average Response Time
+3552
+GetNonIndexableItemStatistics Requests
+3554
+GetNonIndexableItemStatistics Requests/sec
+3556
+GetNonIndexableItemStatistics Average Response Time
+3558
+GetNonIndexableItemDetails Requests
+3560
+GetNonIndexableItemDetails Requests/sec
+3562
+GetNonIndexableItemDetails Average Response Time
+3564
+GetUserRetentionPolicyTags Requests
+3566
+GetUserRetentionPolicyTags Requests/sec
+3568
+GetUserRetentionPolicyTags Average Response Time
+3570
+PlayOnPhone Requests
+3572
+PlayOnPhone Requests/sec
+3574
+PlayOnPhone Average Response Time
+3576
+GetPhoneCallInformation Requests
+3578
+GetPhoneCallInformation Requests/sec
+3580
+GetPhoneCallInformation Average Response Time
+3582
+DisconnectPhoneCall Requests
+3584
+DisconnectPhoneCall Requests/sec
+3586
+DisconnectPhoneCall Average Response Time
+3588
+CreateUMPrompt Requests
+3590
+CreateUMPrompt Requests/sec
+3592
+CreateUMPrompt Average Response Time
+3594
+GetUMPrompt Requests
+3596
+GetUMPrompt Requests/sec
+3598
+GetUMPrompt Average Response Time
+3600
+GetUMPromptNames Requests
+3602
+GetUMPromptNames Requests/sec
+3604
+GetUMPromptNames Average Response Time
+3606
+DeleteUMPrompts Requests
+3608
+DeleteUMPrompts Requests/sec
+3610
+DeleteUMPrompts Average Response Time
+3612
+GetServerTimeZones Requests
+3614
+GetServerTimeZones Requests/sec
+3616
+GetServerTimeZones Average Response Time
+3618
+SendNotification Requests
+3620
+SendNotification Requests/sec
+3622
+SendNotification Average Response Time
+3624
+FindMessageTrackingReport Requests
+3626
+FindMessageTrackingReport Requests/sec
+3628
+FindMessageTrackingReport Average Response Time
+3630
+GetMessageTrackingReport Requests
+3632
+GetMessageTrackingReport Requests/sec
+3634
+GetMessageTrackingReport Average Response Time
+3636
+ApplyConversationAction Requests
+3638
+ApplyConversationAction Requests/sec
+3640
+ApplyConversationAction Average Response Time
+3642
+ExecuteDiagnosticMethod Requests
+3644
+ExecuteDiagnosticMethod Requests/sec
+3646
+ExecuteDiagnosticMethod Average Response Time
+3648
+GetInboxRules Requests
+3650
+GetInboxRules Requests/sec
+3652
+GetInboxRules Average Response Time
+3654
+GetInboxRules Successful Requests
+3656
+UpdateInboxRules Requests
+3658
+UpdateInboxRules Requests/sec
+3660
+UpdateInboxRules Average Response Time
+3662
+UpdateInboxRules Successful Requests
+3664
+IsUMEnabled Requests
+3666
+IsUMEnabled Requests/sec
+3668
+IsUMEnabled Average Response Time
+3670
+IsUMEnabled Successful Requests
+3672
+GetUMProperties Requests
+3674
+GetUMProperties Requests/sec
+3676
+GetUMProperties Average Response Time
+3678
+GetUMProperties Successful Requests
+3680
+SetOofStatus Requests
+3682
+SetOofStatus Requests/sec
+3684
+SetOofStatus Average Response Time
+3686
+SetOofStatus Successful Requests
+3688
+SetPlayOnPhoneDialString Requests
+3690
+SetPlayOnPhoneDialString Requests/sec
+3692
+SetPlayOnPhoneDialString Average Response Time
+3694
+SetPlayOnPhoneDialString Successful Requests
+3696
+SetTelephoneAccessFolderEmail Requests
+3698
+SetTelephoneAccessFolderEmail Requests/sec
+3700
+SetTelephoneAccessFolderEmail Average Response Time
+3702
+SetTelephoneAccessFolderEmail Successful Requests
+3704
+SetMissedCallNotificationEnabled Requests
+3706
+SetMissedCallNotificationEnabled Requests/sec
+3708
+SetMissedCallNotificationEnabled Average Response Time
+3710
+SetMissedCallNotificationEnabled Successful Requests
+3712
+ResetPIN Requests
+3714
+ResetPIN Requests/sec
+3716
+ResetPIN Average Response Time
+3718
+ResetPIN Successful Requests
+3720
+GetCallInfo Requests
+3722
+GetCallInfo Requests/sec
+3724
+GetCallInfo Average Response Time
+3726
+GetCallInfo Successful Requests
+3728
+Disconnect Requests
+3730
+Disconnect Requests/sec
+3732
+Disconnect Average Response Time
+3734
+Disconnect Successful Requests
+3736
+PlayOnPhoneGreeting Requests
+3738
+PlayOnPhoneGreeting Requests/sec
+3740
+PlayOnPhoneGreeting Average Response Time
+3742
+PlayOnPhoneGreeting Successful Requests
+3744
+Total StreamedEvents
+3746
+StreamedEvents/sec
+3748
+Total Requests
+3750
+Requests/sec
+3752
+Average Response Time
+3754
+Items Created
+3756
+Items Created/sec
+3758
+Items Deleted
+3760
+Items Deleted/sec
+3762
+Items Sent
+3764
+Items Sent/sec
+3766
+Items Read
+3768
+Items Read/sec
+3770
+Items Updated
+3772
+Items Updated/sec
+3774
+Items Copied
+3776
+Items Copied/sec
+3778
+Items Moved
+3780
+Items Moved/sec
+3782
+Folders Created
+3784
+Folders Created/sec
+3786
+Folders Deleted
+3788
+Folders Deleted/sec
+3790
+Folders Read
+3792
+Folders Sent/sec
+3794
+Folders Updated
+3796
+Folders Updated/sec
+3798
+Folders Copied
+3800
+Folders Copied/sec
+3802
+Folders Moved
+3804
+Folders Moved/sec
+3806
+Folders Synchronized
+3808
+Folders Synced/sec
+3810
+Items Synchronized
+3812
+Items Synced/sec
+3814
+Push Notifications Succeeded
+3816
+Push Notifications Failed
+3818
+Active Streaming Connections
+3820
+Active Subscriptions
+3822
+Total Failed Subscriptions
+3824
+Failed Subscriptions/sec
+3826
+TotalClientDisconnects
+3828
+Process ID
+3830
+Completed Requests
+3832
+Completed requests/sec
+3834
+Request rejections
+3836
+Request rejections/sec
+3838
+Number of current proxy calls
+3840
+Total number of proxied requests
+3842
+Number of Proxied Requests per Second
+3844
+Total number of bytes proxied
+3846
+Total number of proxy response bytes
+3848
+Total number of proxy failover
+3850
+Number of Proxy Failovers per Second
+3852
+Proxy Average Response Time
+3854
+GetUserPhoto Requests
+3856
+GetUserPhoto Requests/sec
+3858
+GetUserPhoto Average Response Time
+3860
+CopyFolder Successful Requests
+3862
+ArchiveItem Successful Requests
+3864
+CopyItem Successful Requests
+3866
+CreateFolder Successful Requests
+3868
+CreateFolderPath Successful Requests
+3870
+CreateItem Successful Requests
+3872
+CreateManagedFolder Successful Requests
+3874
+DeleteFolder Successful Requests
+3876
+DeleteItem Successful Requests
+3878
+ExpandDL Successful Requests
+3880
+FindFolder Successful Requests
+3882
+FindItem Successful Requests
+3884
+FindConversation Successful Requests
+3886
+FindPeople Successful Requests
+3888
+SyncPeople Successful Requests
+3890
+GetPersona Successful Requests
+3892
+SyncConversation Successful Requests
+3894
+GetTimeZoneOffsets Successful Requests
+3896
+GetEvents Successful Requests
+3898
+GetStreamingEvents Successful Requests
+3900
+GetFolder Successful Requests
+3902
+GetMailTips Successful Requests
+3904
+PlayOnPhone Successful Requests
+3906
+GetPhoneCallInformation Successful Requests
+3908
+DisconnectPhoneCall Successful Requests
+3910
+CreateUMPrompt Successful Requests
+3912
+GetUMPrompt Successful Requests
+3914
+GetUMPromptNames Successful Requests
+3916
+DeleteUMPrompts Successful Requests
+3918
+GetServiceConfiguration Successful Requests
+3920
+GetItem Successful Requests
+3922
+GetServerTimeZones Successful Requests
+3924
+MoveFolder Successful Requests
+3926
+MoveItem Successful Requests
+3928
+ResolveNames Successful Requests
+3930
+SendItem Successful Requests
+3932
+Subscribe Successful Requests
+3934
+Unsubscribe Successful Requests
+3936
+UpdateFolder Successful Requests
+3938
+UpdateItem Successful Requests
+3940
+UpdateItemInRecoverableItems Successful Requests
+3942
+CreateAttachment Successful Requests
+3944
+DeleteAttachment Successful Requests
+3946
+GetAttachment Successful Requests
+3948
+GetClientAccessToken Successful Requests
+3950
+SendNotification Successful Requests
+3952
+SyncFolderItems Successful Requests
+3954
+SyncFolderHierarchy Successful Requests
+3956
+ConvertId Successful Requests
+3958
+GetDelegate Successful Requests
+3960
+AddDelegate Successful Requests
+3962
+RemoveDelegate Successful Requests
+3964
+UpdateDelegate Successful Requests
+3966
+CreateUserConfiguration Successful Requests
+3968
+DeleteUserConfiguration Successful Requests
+3970
+GetUserConfiguration Successful Requests
+3972
+UpdateUserConfiguration Successful Requests
+3974
+GetUserAvailability Successful Requests
+3976
+GetUserOofSettings Successful Requests
+3978
+SetUserOofSettings Successful Requests
+3980
+GetSharingMetadata Successful Requests
+3982
+RefreshSharingFolder Successful Requests
+3984
+GetSharingFolder Successful Requests
+3986
+GetRoomLists Successful Requests
+3988
+GetRooms Successful Requests
+3990
+PerformReminderAction Successful Requests
+3992
+GetReminders Successful Requests
+3994
+Provision Successful Requests
+3996
+Deprovision Successful Requests
+3998
+FindMessageTrackingReport Successful Requests
+4000
+GetMessageTrackingReport Successful Requests
+4002
+ApplyConversationAction Successful Requests
+4004
+EmptyFolder Successful Requests
+4006
+UploadItems Successful Requests
+4008
+ExportItems Successful Requests
+4010
+ExecuteDiagnosticMethod Successful Requests
+4012
+FindMailboxStatisticsByKeywords Successful Requests
+4014
+GetSearchableMailboxes Successful Requests
+4016
+SearchMailboxes Successful Requests
+4018
+GetDiscoverySearchConfiguration Successful Requests
+4020
+GetHoldOnMailboxes Successful Requests
+4022
+SetHoldOnMailboxes Successful Requests
+4024
+GetNonIndexableItemStatistics Successful Requests
+4026
+GetNonIndexableItemDetails Successful Requests
+4028
+MarkAllItemsAsRead Successful Requests
+4030
+GetClientExtension Successful Requests
+4032
+SetClientExtension Successful Requests
+4034
+SubscribeToPushNotification Successful Requests
+4036
+GetAppManifests Successful Requests
+4038
+InstallApp Successful Requests
+4040
+UninstallApp Successful Requests
+4042
+DisableApp Successful Requests
+4044
+GetAppMarketplaceUrl Successful Requests
+4046
+GetClientExtensionToken Successful Requests
+4048
+GetConversationItems Successful Requests
+4050
+GetUserRetentionPolicyTags Successful Requests
+4052
+GetUserPhoto Successful Requests
+4054
+StartFindInGALSpeechRecognition Requests
+4056
+StartFindInGALSpeechRecognition Requests/sec
+4058
+StartFindInGALSpeechRecognition Average Response Time
+4060
+StartFindInGALSpeechRecognition Successful Requests
+4062
+CompleteFindInGALSpeechRecognition Requests
+4064
+CompleteFindInGALSpeechRecognition Requests/sec
+4066
+CompleteFindInGALSpeechRecognition Average Response Time
+4068
+CompleteFindInGALSpeechRecognition Successful Requests
+4070
+CreateUMCallDataRecord Requests
+4072
+CreateUMCallDataRecord Requests/sec
+4074
+CreateUMCallDataRecord Average Response Time
+4076
+CreateUMCallDataRecord Successful Requests
+4078
+GetUMCallDataRecords Requests
+4080
+GetUMCallDataRecords Requests/sec
+4082
+GetUMCallDataRecords Average Response Time
+4084
+GetUMCallDataRecords Successful Requests
+4086
+GetUMCallSummary Requests
+4088
+GetUMCallSummary Requests/sec
+4090
+GetUMCallSummary Average Response Time
+4092
+GetUMCallSummary Successful Requests
+4094
+GetUserPhotoData Requests
+4096
+GetUserPhotoData Requests/sec
+4098
+GetUserPhotoData Average Response Time
+4100
+GetUserPhotoData Successful Requests
+4102
+InitUMMailbox Requests
+4104
+InitUMMailbox Requests/sec
+4106
+InitUMMailbox Average Response Time
+4108
+InitUMMailbox Successful Requests
+4110
+ResetUMMailbox Requests
+4112
+ResetUMMailbox Requests/sec
+4114
+ResetUMMailbox Average Response Time
+4116
+ResetUMMailbox Successful Requests
+4118
+ValidateUMPin Requests
+4120
+ValidateUMPin Requests/sec
+4122
+ValidateUMPin Average Response Time
+4124
+ValidateUMPin Successful Requests
+4126
+SaveUMPin Requests
+4128
+SaveUMPin Requests/sec
+4130
+SaveUMPin Average Response Time
+4132
+SaveUMPin Successful Requests
+4134
+GetUMPin Requests
+4136
+GetUMPin Requests/sec
+4138
+GetUMPin Average Response Time
+4140
+GetUMPin Successful Requests
+4142
+GetClientIntent Requests
+4144
+GetClientIntent Requests/sec
+4146
+GetClientIntent Average Response Time
+4148
+GetClientIntent Successful Requests
+4150
+GetUMSubscriberCallAnsweringData Requests
+4152
+GetUMSubscriberCallAnsweringData Requests/sec
+4154
+GetUMSubscriberCallAnsweringData Average Response Time
+4156
+GetUMSubscriberCallAnsweringData Successful Requests
+4158
+MSExchangeWorkerTaskFrameworkLocalDataAccess
+4160
+Last Probe Result ID
+4162
+Last Monitor Result ID
+4164
+Last Responder Result ID
+4166
+Last Maintenance Result ID
+4168
+MSExchangeWorkerTaskFramework
+4170
+Workitem Execution Rate
+4172
+Active Workitem Count
+4174
+Timed Out Workitem Count
+4176
+Workitem Retrieval Rate
+4178
+Throttle Rate
+4180
+Query Rate
+4182
+Scheduling Latency
+4184
+MSExchangeUMVoiceMailSpeechRecognition
+4186
+Current Sessions
+4188
+Voice Messages Processed
+4190
+Voice Messages Processed with Low Confidence
+4192
+Voice Messages Not Processed Because of Low Availability of Resources
+4194
+Voice Messages Partially Processed Because of Low Availability of Resources
+4196
+Average Confidence %
+4198
+MSExchangeUMSubscriberAccess
+4200
+Subscriber Logons
+4202
+Subscriber Authentication Failures
+4204
+Subscriber Logon Failures
+4206
+Average Subscriber Call Duration
+4208
+Average Recent Subscriber Call Duration
+4210
+Voice Message Queue Accessed
+4212
+Voice Messages Heard
+4214
+Protected Voice Messages Heard
+4216
+Voice Messages Sent
+4218
+Protected Voice Messages Sent
+4220
+Voice Message Protection Failures
+4222
+Voice Message Decryption Failures
+4224
+Average Sent Voice Message Size
+4226
+Average Recent Sent Voice Message Size
+4228
+Voice Messages Deleted
+4230
+Reply Messages Sent
+4232
+Forward Messages Sent
+4234
+Email Message Queue Accessed
+4236
+Email Messages Heard
+4238
+Email Messages Deleted
+4240
+Calendar Accessed
+4242
+Calendar Items Heard
+4244
+Calendar Late Attendance
+4246
+Calendar Items Details Requested
+4248
+Meetings Declined
+4250
+Meetings Accepted
+4252
+Called Meeting Organizer
+4254
+Replied to Organizer
+4256
+Contacts Accessed
+4258
+Contact Items Heard
+4260
+Calls Disconnected by Callers During UM Audio Hourglass
+4262
+Launched Calls
+4264
+Directory Accessed
+4266
+Directory Accessed by Extension
+4268
+Directory Accessed by Dial by Name
+4270
+Directory Accessed Successfully by Dial by Name
+4272
+Directory Accessed by Spoken Name
+4274
+Directory Accessed Successfully by Spoken Name
+4276
+Calls Disconnected by UM on Irrecoverable External Error
+4278
+MSExchangeUMPerformance
+4280
+Operations under Two Seconds
+4282
+Operations Between Two and Three Seconds
+4284
+Operations Between Three and Four Seconds
+4286
+Operations Between Four and Five Seconds
+4288
+Operations Between Five and Six Seconds
+4290
+Operations over Six Seconds
+4292
+MSExchangeUMMessageWaitingIndicator
+4294
+Total MWI Messages
+4296
+Total Failed MWI Messages
+4298
+Average MWI Processing Time
+4300
+MSExchangeUMGeneral
+4302
+Total Calls
+4304
+Total Calls per Second
+4306
+Calls Disconnected by User Failure
+4308
+Current Calls
+4310
+Current Voice Mail Calls
+4312
+Current Fax Calls
+4314
+Current Subscriber Access Calls
+4316
+Current Auto Attendant Calls
+4318
+Current Play on Phone Calls
+4320
+Current Unauthenticated Pilot Number Calls
+4322
+Current Prompt Editing Calls
+4324
+Total Play on Phone Calls
+4326
+Average Call Duration
+4328
+Average Recent Call Duration
+4330
+User Response Latency
+4332
+Delayed Calls
+4334
+Call Duration Exceeded
+4336
+OCS User Event Notifications
+4338
+Average MWI Latency
+4340
+Caller ID Resolutions Attempted
+4342
+Caller ID Resolutions Succeeded
+4344
+% Successful Caller ID Resolutions
+4346
+Base counter for % Successful CallerID resolutions
+4348
+Extension Caller ID Resolutions Attempted
+4350
+Extension Caller ID Resolutions Succeeded
+4352
+% Successful Extension Caller ID Resolutions
+4354
+Base counter for % Successful Extension CallerID resolutions
+4356
+MSExchangeUMFax
+4358
+Total Invalid Fax Calls
+4360
+Total Valid Fax Calls
+4362
+Total Succesful Valid Fax Calls
+4364
+Percentage of Successful Valid Fax Calls
+4366
+Base for Percentage Successful Valid Fax Calls
+4368
+MSExchangeUMClientAccess
+4370
+Total Number of Play on Phone Requests
+4372
+Total Number of Failed Play on Phone Requests
+4374
+Total Number of PIN Reset Requests
+4376
+Total Number of Failed PIN Reset Requests
+4378
+PID
+4380
+MSExchangeUMCallRouterAvailability
+4382
+% of Missed Call Notification Proxy Failed at UM Call Router Over the Last Hour
+4384
+Total Inbound Calls Rejected by the UM Call Router
+4386
+Total Inbound Calls Received by the UM Call Router
+4388
+% of Inbound Calls Rejected by the UM Call Router Over the Last Hour
+4390
+MSExchangeUMCallAnswer
+4392
+Call Answering Calls
+4394
+Call Answering Voice Messages
+4396
+Call Answering Protected Voice Messages
+4398
+Call Answering Voice Message Protection Failures
+4400
+Call Answering Missed Calls
+4402
+Call Answering Escapes
+4404
+Average Voice Message Size
+4406
+Average Recent Voice Message Size
+4408
+Average Greeting Size
+4410
+Calls Without Personal Greetings
+4412
+Fetch Greeting Timed Out
+4414
+Calls Disconnected by Callers During UM Audio Hourglass
+4416
+Diverted Extension Not Provisioned
+4418
+Calls Disconnected by UM on Irrecoverable External Error
+4420
+Pipeline Not Healthy
+4422
+Total Calls to Subscribers with One or More Call Answering Rules Configured
+4424
+Total Number of Timed-out Call Answering Rule Evaluations
+4426
+Average Time Taken for Call Answering Rule Evaluations
+4428
+Total Number of Call Answering Rules Calls
+4430
+MSExchangeUMAvailability
+4432
+Directory Access Failures
+4434
+Worker Process Recycled
+4436
+Total Inbound Calls Rejected by the UM Service
+4438
+% of Inbound Calls Rejected by the UM Service Over the Last Hour
+4440
+Total Inbound Calls Rejected by the UM Worker Process
+4442
+% of Inbound Calls Rejected by the UM Worker Process Over the Last Hour
+4444
+Total Worker Process Call Count
+4446
+Calls Disconnected on Irrecoverable Internal Error
+4448
+Incomplete Signaling Information
+4450
+Calls Disconnected by UM on Irrecoverable External Error
+4452
+Total Queued Messages
+4454
+Spoken Name Accessed
+4456
+Name TTSed
+4458
+% of Messages Successfully Processed Over the Last Hour
+4460
+Average Processing Time in seconds per Message (Over the Last 50 Messages)
+4462
+Failed Mailbox Connection Attempts %
+4464
+Base counter for Failed Mailbox connection attempts %
+4466
+% of Failed Mailbox Connection Attempts Over the Last Hour
+4468
+Custom Prompt Download Failures %
+4470
+Custom Prompt Download Failures % Base
+4472
+Call Answering Rules Download Failures %
+4474
+Call Answering Rules Download Failures % Base
+4476
+Average Voice Message Transcription Failures %
+4478
+Base Counter for Average Voice Message Transcription Failures %
+4480
+Average Hub Transport Access Failures %
+4482
+Base Counter for Average Hub Transport Access Failures %
+4484
+% of Partner Voice Message Transcription Failures Over the Last Hour
+4486
+Average Partner Voice Message Transcription Failures %
+4488
+Base counter for Average Partner Voice Message Transcription Failures %
+4490
+MSExchangeUMAutoAttendant
+4492
+Total Calls
+4494
+Business Hours Calls
+4496
+Out of Hours Calls
+4498
+Disconnected Without Input
+4500
+Transferred Count
+4502
+Directory Accessed
+4504
+Directory Accessed by Extension
+4506
+Directory Accessed by Dial by Name
+4508
+Directory Accessed Successfully by Dial by Name
+4510
+Directory Accessed by Spoken Name
+4512
+Directory Accessed Successfully by Spoken Name
+4514
+Operator Transfers
+4516
+Custom Menu Options
+4518
+Menu Option 1 Used
+4520
+Menu Option 2 Used
+4522
+Menu Option 3 Used
+4524
+Menu Option 4 Used
+4526
+Menu Option 5 Used
+4528
+Menu Option 6 Used
+4530
+Menu Option 7 Used
+4532
+Menu Option 8 Used
+4534
+Menu Option 9 Used
+4536
+Menu Option Timed Out
+4538
+Average Call Time
+4540
+Average Recent Call Time
+4542
+Calls Disconnected by UM on Irrecoverable External Error
+4544
+Calls with Speech Input
+4546
+Ambiguous Name Transfers
+4548
+Disallowed Transfers
+4550
+Calls with Spoken Name
+4552
+Calls with Sent Message
+4554
+Calls with DTMF fallback
+4556
+Sent to Auto Attendant
+4558
+Operator Transfers Requested by User
+4560
+% Successful Calls
+4562
+Base counter for % Successful Calls
+4564
+Operator Transfers Requested by User from Opening Menu
+4566
+MSExchangeTransport SmtpSend
+4568
+Connections Current
+4570
+Connections Created/sec
+4572
+Connections Total
+4574
+Messages Sent/sec
+4576
+Messages Sent Total
+4578
+Message Bytes Sent Total
+4580
+Message Bytes Sent/sec
+4582
+Messages Suppressed Due to Bare Linefeeds
+4584
+Bytes Sent Total
+4586
+Bytes Sent/sec
+4588
+Recipients sent
+4590
+Average recipients/message
+4592
+Average recipients (message base)
+4594
+Average message bytes/message
+4596
+Average message bytes/message Base
+4598
+Average messages/connection
+4600
+Average messages (connection Base)
+4602
+Average bytes/connection
+4604
+Average bytes (connection Base)
+4606
+DNS Errors
+4608
+Connection Failures
+4610
+Socket Errors
+4612
+Protocol Errors
+4614
+MSExchangeTransport SMTPReceive
+4616
+Connections Current
+4618
+Connections Created/sec
+4620
+Connections Total
+4622
+Disconnections by Agents/second
+4624
+Disconnections By Agents
+4626
+Messages Received/sec
+4628
+Messages Received Total
+4630
+Message Bytes Received/sec
+4632
+Message Bytes Received Total
+4634
+Messages Refused for Size
+4636
+Messages Received Containing Bare Linefeeds in the SMTP DATA Stream
+4638
+Messages Rejected During SMTP DATA Due to Bare Linefeeds
+4640
+Recipients accepted Total
+4642
+Average bytes/message
+4644
+Average bytes/message Base
+4646
+Average recipients/message
+4648
+Average recipients/message base
+4650
+Average bytes/connection
+4652
+Average bytes/connection base
+4654
+Average messages/connection
+4656
+Average messages/connection base
+4658
+Bytes Received/sec
+4660
+Bytes Received Total
+4662
+Tarpitting Delays Authenticated
+4664
+Tarpitting Delays Anonymous
+4666
+Tarpitting Delays Authenticated/sec
+4668
+Tarpitting Delays Anonymous/sec
+4670
+MSExchangeTransport SMTPAvailability
+4672
+Total Connections
+4674
+% Availability
+4676
+% Activity
+4678
+% Failures Due To MaxInboundConnectionLimit
+4680
+% Failures Due To WLID Down
+4682
+% Failures Due To Active Directory Down
+4684
+% Failures Due To Back Pressure
+4686
+% Failures Due To IO Exceptions
+4688
+% Failures Due To TLS Errors
+4690
+Failures Due to Maximum Local Loop Count
+4692
+MSExchangeTransport Shadow Redundancy Host Info
+4694
+Shadow Queue Length
+4696
+Shadow Heartbeat Latency Average Time
+4698
+Shadow Heartbeat Latency Average Time Base
+4700
+Shadow Failure Count
+4702
+Resubmitted Message Count
+4704
+Shadow Heartbeat Failure Count
+4706
+Shadowed Message Count
+4708
+MSExchangeTransport Shadow Redundancy
+4710
+Redundant Message Discard Events
+4712
+Redundant Message Discard Events Expired
+4714
+Current Messages Acknowledged before Relay Completed
+4716
+Shadow Host Selection Average Time
+4718
+Shadow Host Selection Average Time Base
+4720
+Shadow Host Negotiation Average Time
+4722
+Shadow Host Negotiation Average Time Base
+4724
+Shadow Host Successful Negotiation Average Time
+4726
+Shadow Host Successful Negotiation Average Time Base
+4728
+Percentage of Messages Shadowed to Local Site
+4730
+Messages Failed to be made Redundant
+4732
+Percentage of Messages Failed to be made Redundant
+4734
+Total SMTP Timeouts
+4736
+Client ACK Failure Count
+4738
+MSExchangeTransport ServerAlive
+4740
+Server Alive
+4742
+MSExchangeTransport Safety Net
+4744
+Safety Net Resubmission Count
+4746
+Shadow Safety Net Resubmission Count
+4748
+Resubmit Latency Average Time
+4750
+Resubmit Latency Average Time Base
+4752
+Resubmit Request Count
+4754
+Safety Net Resubmit Request Count
+4756
+Shadow Safety Net Resubmit Request Count
+4758
+Average Safety Net Resubmit Request Time Span
+4760
+MSExchangeTransport Routing
+4762
+Routing NDRs Total
+4764
+Routing Tables Calculated Total
+4766
+Routing Tables Changed Total
+4768
+MSExchangeTransport Resolver
+4770
+Messages Retried
+4772
+Messages Created
+4774
+Messages Chipped
+4776
+Failed Recipients
+4778
+Unresolved Org Recipients
+4780
+Ambiguous Recipients
+4782
+Loop Recipients
+4784
+Unresolved Org Senders
+4786
+Ambiguous Senders
+4788
+Message directed to catch-all recipient.
+4790
+MSExchangeTransport Queues
+4792
+External Active Remote Delivery Queue Length
+4794
+Internal Active Remote Delivery Queue Length
+4796
+External Retry Remote Delivery Queue Length
+4798
+Internal Retry Remote Delivery Queue Length
+4800
+Active Mailbox Delivery Queue Length
+4802
+Retry Mailbox Delivery Queue Length
+4804
+Active Non-Smtp Delivery Queue Length
+4806
+Retry Non-Smtp Delivery Queue Length
+4808
+Internal Aggregate Delivery Queue Length (All Internal Queues)
+4810
+External Aggregate Delivery Queue Length (All External Queues)
+4812
+Internal Largest Delivery Queue Length
+4814
+External Largest Delivery Queue Length
+4816
+Items Queued For Delivery Total
+4818
+Items Queued for Delivery Per Second
+4820
+Items Completed Delivery Total
+4822
+Items Completed Delivery Per Second
+4824
+Items Queued For Delivery Expired Total
+4826
+Locks Expired In Delivery Total
+4828
+Items Deleted By Admin Total
+4830
+Items Resubmitted Total
+4832
+Messages Deferred Due To Local Loop
+4834
+Messages Queued For Delivery
+4836
+Messages Queued For Delivery Total
+4838
+Messages Queued for Delivery Per Second
+4840
+Messages Completed Delivery Total
+4842
+Messages Completed Delivery Per Second
+4844
+Unreachable Queue Length
+4846
+Poison Queue Length
+4848
+Submission Queue Length
+4850
+Messages Submitted Total
+4852
+Messages Submitted Per Second
+4854
+Submission Queue Items Expired Total
+4856
+Submission Queue Locks Expired Total
+4858
+Aggregate Shadow Queue Length
+4860
+Shadow Queue Auto Discards Total
+4862
+Messages Completing Categorization
+4864
+Messages Deferred during Categorization
+4866
+Categorizer Job Availability
+4868
+MSExchangeTransport Pickup
+4870
+Messages Submitted
+4872
+Messages NDRed
+4874
+Messages Badmailed
+4876
+MSExchangeTransport Extensibility Agents
+4878
+Average Agent Processing Time (sec)
+4880
+Average Agent Processing Time Base (sec)
+4882
+Average CPU usage of synchronous invocations of agent (milliseconds)
+4884
+Base counter of AverageAgentProcessorUsageSynchronousInvocations
+4886
+Average CPU usage of asynchronous invocations of agent (milliseconds)
+4888
+Base counter of AverageAgentProcessorUsageAsynchronousInvocations
+4890
+Total synchronous invocations of agent
+4892
+Total asynchronous invocations of agent
+4894
+Total Agent Invocations
+4896
+MSExchangeTransport End To End Latency
+4898
+Percentile50
+4900
+Percentile80
+4902
+Percentile90
+4904
+Percentile95
+4906
+Percentile99
+4908
+MSExchangeTransport DSN
+4910
+Failure DSNs Total
+4912
+Delay DSNs
+4914
+Relay DSNs
+4916
+Delivered DSNs
+4918
+Expanded DSNs
+4920
+Failure DSNs within the last hour
+4922
+Alertable failure DSNs within the last hour
+4924
+Delayed DSNs within the last hour
+4926
+NDRs generated for catch-all recipients.
+4928
+MSExchangeTransport DeliveryAgent
+4930
+Messages Delivered Total
+4932
+Messages Delivered Per Second
+4934
+Connections Completed Total
+4936
+Connections Completed Per Second
+4938
+Connections Failed Total
+4940
+Connections Failed Per Second
+4942
+Current Connection Count
+4944
+Messages Deferred Total
+4946
+Messages Deferred Per Second
+4948
+Messages Failed Total
+4950
+Messages Failed Per Second
+4952
+Recipient Deliveries Completed Total
+4954
+Recipient Deliveries Completed Per Second
+4956
+Average Recipients Per Message
+4958
+Average Recipients per Message (base)
+4960
+Message bytes sent total
+4962
+Message Bytes Sent Per Second
+4964
+Average Messages Per Connection
+4966
+Average Messages Per Connection (base)
+4968
+Average Bytes Per Message
+4970
+Average Bytes Per Message (base)
+4972
+Invocation Total
+4974
+Invocation Duration Total
+4976
+Average Invocation Duration
+4978
+Average Invocation Duration (base)
+4980
+MSExchangeTransport Delivery Failures
+4982
+Routing: Percentage of 5.4.4 Failures
+4984
+Routing: Total Delivery Failures
+4986
+Resolver: Percentage of 5.1.4 Failures
+4988
+Resolver: Percentage of 5.2.0 Failures
+4990
+Resolver: Percentage of 5.2.4 Failures
+4992
+Resolver: Percentage of 5.4.6 Failures
+4994
+Resolver: Total Delivery Failures
+4996
+SMTP: Percentage of 5.6.0 Failures
+4998
+SMTP: Total Delivery Failures
+5000
+Store Driver: Percentage of 5.2.0 Failures
+5002
+Store Driver: Percentage of 5.6.0 Failures
+5004
+Store Driver: Total Delivery Failures
+5006
+Delivery Agent: Total Delivery Failures
+5008
+Foreign Connector: Total Delivery Failures
+5010
+MSExchangeTransport Database
+5012
+DataRow seeks total
+5014
+DataRow seeks prefix total
+5016
+DataRow loads total
+5018
+DataRow updates total
+5020
+DataRow new inserts total
+5022
+DataRow clones total
+5024
+DataRow moves total
+5026
+DataRow deletes total
+5028
+DataRow minimize memory total
+5030
+Stream read total
+5032
+Stream bytes read total
+5034
+Stream writes total
+5036
+Stream bytes written total
+5038
+Stream set length count
+5040
+Lazy bytes load requested total
+5042
+Lazy bytes load performed total
+5044
+Column cache load total
+5046
+Column cache loaded columns total
+5048
+Column cache loaded bytes total
+5050
+Column cache save total
+5052
+Column cache saved columns total
+5054
+Column cache saved bytes total
+5056
+Extended property writes total
+5058
+Extended property bytes written total
+5060
+Extended property reads total
+5062
+Extended property bytes read total
+5064
+Transaction Pending Count
+5066
+Transaction Count
+5068
+Transactions/sec
+5070
+Transaction Pending 99 Percentile Duration
+5072
+Transaction Pending Average Duration
+5074
+Transaction Pending Average Duration Base
+5076
+Transaction Commit Soft Pending
+5078
+Transaction Commit Soft Count
+5080
+Transaction Commit Soft/sec
+5082
+Transaction Commit Soft Average Pending Duration
+5084
+Transaction Commit Soft Average Pending Duration Base
+5086
+Transaction Commit Hard Pending
+5088
+Transaction Commit Hard Count
+5090
+Transaction Commit Hard/sec
+5092
+Transaction Abort Count
+5094
+Transaction Aborts/sec
+5096
+Transaction Commit Hard Pending Average Duration
+5098
+Transaction Commit Hard Pending Average Duration Base
+5100
+Transaction Commit Async Pending
+5102
+Transaction Commit Async Count
+5104
+Transaction Commit Async/sec
+5106
+Transaction Commit Async Average Pending Duration
+5108
+Transaction Commit Async Pending Average Duration Base
+5110
+Transaction Durable Callback Count
+5112
+Transaction Durable Callback Count/sec
+5114
+MailItem new total
+5116
+MailItem clone create total
+5118
+MailItem dehydrate total
+5120
+MailItem load total
+5122
+MailItem commit immediate total
+5124
+MailItem materialize
+5126
+MailItem begin commit total
+5128
+MailItem commit lazy total
+5130
+MailItem delete lazy total
+5132
+MailItem writeMimeTo total
+5134
+MailItem Count
+5136
+MailRecipient Count
+5138
+MailRecipient Active Count
+5140
+MailRecipient SafetyNet Count
+5142
+MailRecipient SafetyNet Mdb Count
+5144
+MailRecipient Shadow SafetyNet Count
+5146
+Generation Count
+5148
+Generation Expired Count
+5150
+Generation Last Cleanup Latency
+5152
+Bootloader Outstanding Items
+5154
+Bootloaded Item Count
+5156
+Bootloaded Items/sec
+5158
+Bootloaded Item Average Latency
+5160
+Bootloaded Item Average Latency Base
+5162
+Replayed Item Count
+5164
+Replayed Items/sec
+5166
+Replayed Item Average Latency
+5168
+Average Replayed Item Average Latency Base
+5170
+Replay Bookmark Average Latency
+5172
+Replay Bookmark Average Latency Base
+5174
+DataRow seeks/sec
+5176
+DataRow seeks prefix/sec
+5178
+DataRow loads/sec
+5180
+DataRow updates/sec
+5182
+DataRow new inserts/sec
+5184
+DataRow clones/sec
+5186
+DataRow moves/sec
+5188
+DataRow deletes/sec
+5190
+DataRow minimize memory/sec
+5192
+Stream read/sec
+5194
+Stream bytes read/sec
+5196
+Stream writes/sec
+5198
+Stream bytes written/sec
+5200
+Stream set length/sec
+5202
+Lazy bytes load requested/sec
+5204
+Lazy bytes load performed/sec
+5206
+Column cache load/sec
+5208
+Column cache loaded columns/sec
+5210
+Column cache loaded bytes/sec
+5212
+Column cache save/sec
+5214
+Column cache saved columns/sec
+5216
+Column cache saved bytes/sec
+5218
+Extended property writes/sec
+5220
+Extended property bytes written/sec
+5222
+Extended property reads/sec
+5224
+Extended property bytes read/sec
+5226
+MailItem new/sec
+5228
+MailItem clone create/sec
+5230
+MailItem dehydrate/sec
+5232
+MailItem load/sec
+5234
+MailItem commit immediate/sec
+5236
+MailItem materialize/sec
+5238
+MailItem begin commit/sec
+5240
+MailItem commit lazy/sec
+5242
+MailItem delete lazy/sec
+5244
+MailItem writeMimeTo/sec
+5246
+Database connections current
+5248
+Database connections rejected total
+5250
+Cursors opened total
+5252
+Cursors closed total
+5254
+MSExchangeTransport Configuration Cache
+5256
+Configuration Cache Total requests
+5258
+Configuration Cache requests per sec
+5260
+Configuration Cache hit ratio
+5262
+Configuration Cache hit ratio base counter
+5264
+Configuration Cache size
+5266
+Configuration Cache size in MB
+5268
+MSExchangeTransport Component Latency
+5270
+Percentile50
+5272
+Percentile80
+5274
+Percentile90
+5276
+Percentile95
+5278
+Percentile99
+5280
+MSExchangeTransport Certificate Validation Cache
+5282
+Total Requests
+5284
+Requests per Second
+5286
+Hit Ratio
+5288
+Certificate Validation Result Cache hit ratio base counter
+5290
+Cache Size
+5292
+MSExchangeTenantMonitoring
+5294
+Datacenter and Site Location Attempts per Period
+5296
+Datacenter and Site Location Successes per Period
+5298
+Partner Datacenter and Site Location Attempts per Period
+5300
+Partner Datacenter and Site Location Successes per Period
+5302
+Remote PowerShell Tenant User Authorization Attempts per Period
+5304
+Remote PoweSshell Tenant User Authorization Successes per Period
+5306
+Remote PowerShell Tenant Session Creation Attempts per Period
+5308
+Remote PowerShell Tenant Session Creation Successes per Period
+5310
+Remote PowerShell Partner Authorization Attempts per Period
+5312
+Remote Powershell Partner Authorization Successes per Period
+5314
+Remote PowerShell Partner Session Creation Attempts per Period
+5316
+Remote PowerShell partner session creation successes per period.
+5318
+Exchange Control Panel Session Creation Attempts per Period
+5320
+Exchange Control Panel Session Creation Successes per Period
+5322
+ECP session redirection successes per period
+5324
+NewMailbox Attempts per Period
+5326
+NewMailbox Successes per Period
+5328
+NewMailbox Iteration Attempts per Period
+5330
+NewMailbox Iteration Successes per Period
+5332
+NewOrganization Attempts per Period
+5334
+NewOrganization Successes per Period
+5336
+NewOrganization Iteration Attempts per Period
+5338
+NewOrganization Iteration Successes per Period
+5340
+RemoveOrganization Attempts per Period
+5342
+RemoveOrganization successes per period
+5344
+RemoveOrganization Iteration Attempts per Period
+5346
+RemoveOrganization Iteration Successes per Period
+5348
+AddSecondaryDomain Attempts Per Period
+5350
+AddSecondaryDomain Successes per Period
+5352
+AddSecondaryDomainIteration Attempts per Period
+5354
+AddSecondaryDomain Iteration Successes per Period
+5356
+RemoveSecondaryDomain Attempts per Period
+5358
+RemoveSecondaryDomain Successes per Period
+5360
+RemoveSecondaryDomain Iteration Attempts per Period
+5362
+RemoveSecondaryDomain Iteration Successes per Period
+5364
+StartOrganizationPilot Attempts per Period
+5366
+StartOrganizationPilot Successes per Period
+5368
+StartOrganizationPilot Iteration Attempts per Period
+5370
+StartOrganizationPilot Iteration Successes per Period
+5372
+StartOrganizationUpgrade Attempts per Period
+5374
+StartOrganizationUpgrade Successes per Period
+5376
+StartOrganizationUpgrade Iteration Attempts per Period
+5378
+StartOrganizationUpgrade Iteration Successes per Period
+5380
+CompleteOrganizationUpgrade Attempts per Period
+5382
+CompleteOrganizationUpgrade Successes per Period
+5384
+CompleteOrganizationUpgrade Iteration Attempts per Period
+5386
+CompleteOrganizationUpgrade Iteration Successes per Period
+5388
+GetManagementEndpoint Attempts per Period
+5390
+GetManagementEndpoint Successes per Period
+5392
+GetManagementEndpoint Iteration Attempts per Period
+5394
+GetManagementEndpoint Iteration Successes per Period
+5396
+Cmdlet attempts per period. This is only for cmdlets which are to be monitored.
+5398
+Cmdlet Successes per Period. This is only for cmdlets which are to be monitored.
+5400
+Cmdlet Iteration Attempts per Period
+5402
+Cmdlet Iteration Successes per Period
+5404
+MSExchangeSearch MailboxSession Cache
+5406
+Cache Requests
+5408
+Cache Hits
+5410
+Cache Misses
+5412
+Cache Hit Ratio
+5414
+Cache Hit Ratio Base
+5416
+Cache Miss Ratio
+5418
+Cache Miss Ratio Base
+5420
+MSExchangeSearch Mailbox Operators
+5422
+Retriever: Items processed 0-50 ms
+5424
+Retriever: Items processed 50-100 ms
+5426
+Retriever: Items processed 100-2000 ms
+5428
+Retriever: Items processed in greater than 2000 ms
+5430
+Retriever: Items with valid annotation token
+5432
+Retriever: Items without annotation token
+5434
+Retriever: Items with Rights Management attempted for processing.
+5436
+Retriever: Items with Rights Management partially processed.
+5438
+Retriever: Items with Rights Management skipped.
+5440
+MSExchangeSearch IndexAgent
+5442
+Document Processing Rate Per Second
+5444
+Number Of Processed Documents
+5446
+Document Failure Rate Per Second
+5448
+Number Of Failed Documents
+5450
+Document Skip Rate Per Second
+5452
+Number Of Skipped Documents
+5454
+Average Document Processing Time In Milliseconds
+5456
+Average Document Processing Time Base
+5458
+Documents processed under 250ms
+5460
+Documents processed under 500ms
+5462
+Documents processed under 1000ms
+5464
+Documents processed under 2000ms
+5466
+Documents processed under 5000ms
+5468
+Documents processed over 5000ms
+5470
+MSExchangeRepl Source Database
+5472
+Total Bytes Sent
+5474
+Avg. Network sec/Write
+5476
+AverageWriteTimeBase
+5478
+Avg. Disk sec/Read
+5480
+AverageReadTimeBase
+5482
+Network Write Bytes/sec
+5484
+MSExchangeRemotePowershell
+5486
+Process ID
+5488
+Current Connected Sessions
+5490
+Current Connected Unique Users
+5492
+FailFast User Cache Size
+5494
+Connected User Cache Size
+5496
+Authenticated User Cache Size
+5498
+Per-User Budgets Dictionary Size
+5500
+Per-Tenant Budgets Dictionary Size
+5502
+Per-User KeyToRemoveBudgets Cache Size
+5504
+Per-Tenant KeyToRemoveBudgets Cache Size
+5506
+Failure Throttling User Cache Size
+5508
+Requests be Fail-fasted
+5510
+Connection Leak
+5512
+MSExchangePop3
+5514
+Connections Current
+5516
+Connections Failed
+5518
+Connections Rejected
+5520
+Connections Total
+5522
+Current Unauthenticated Connections
+5524
+Unauthenticated Connections/sec
+5526
+Proxy Current Connections
+5528
+Proxy Connections Failed
+5530
+Proxy Total Connections
+5532
+Active SSL Connections
+5534
+SSL Connections
+5536
+Invalid Commands
+5538
+Invalid Commands Rate
+5540
+AUTH Failures
+5542
+AUTH Rate
+5544
+AUTH Total
+5546
+CAPA Failures
+5548
+CAPA Rate
+5550
+CAPA Total
+5552
+DELE Failures
+5554
+DELE Rate
+5556
+DELE Total
+5558
+LIST Failures
+5560
+LIST Rate
+5562
+LIST Total
+5564
+NOOP Failures
+5566
+NOOP Rate
+5568
+NOOP Total
+5570
+PASS Failures
+5572
+PASS Rate
+5574
+PASS Total
+5576
+QUIT Failures
+5578
+QUIT Rate
+5580
+QUIT Total
+5582
+Request Failures
+5584
+Request Rate
+5586
+Request Total
+5588
+RETR Failures
+5590
+RETR Rate
+5592
+RETR Total
+5594
+RSET Failures
+5596
+RSET Rate
+5598
+RSET Total
+5600
+STAT Failures
+5602
+STAT Rate
+5604
+STAT Total
+5606
+STLS Failures
+5608
+STLS Rate
+5610
+STLS Total
+5612
+TOP Failures
+5614
+TOP Rate
+5616
+TOP Total
+5618
+UIDL Failures
+5620
+UIDL Rate
+5622
+UIDL Total
+5624
+USER Failures
+5626
+USER Rate
+5628
+USER Total
+5630
+XPRX Failures
+5632
+XPRX Rate
+5634
+XPRX Total
+5636
+Average Command Processing Time (milliseconds)
+5638
+Connections Rate
+5640
+Transient Mailbox Connection Failures/minute
+5642
+Mailbox Offline Errors/minute
+5644
+Transient Storage Errors/minute
+5646
+Permanent Storage Errors/minute
+5648
+Transient Active Directory Errors/minute
+5650
+Permanent Active Directory Errors/minute
+5652
+Transient Errors/minute
+5654
+Average RPC Latency
+5656
+Average LDAP Latency
+5658
+MSExchangeOABRequestHandler
+5660
+Request Handling Average Time
+5662
+Request Handling Average Time Base
+5664
+Access Denied Failures
+5666
+Access Denied Failures/Sec
+5668
+Invalid Request Failures
+5670
+Invalid Request Failures/Sec
+5672
+File Not Available Failures
+5674
+File Not Available Failures/Sec
+5676
+Current Number Requests In Cache
+5678
+MSExchangeIS Store
+5680
+Total searches
+5682
+Total searches in progress
+5684
+Search/sec
+5686
+Total search queries completed in 0-0.5 sec
+5688
+Total search queries completed in 0.5-2 sec
+5690
+Total search queries completed in 2-10 sec
+5692
+Total search queries completed in 10-60 sec
+5694
+Total search queries completed in > 60 sec
+5696
+Total number of successful search queries
+5698
+Successful search/sec
+5700
+Search results/sec
+5702
+Average search results per query
+5704
+Base for AverageSearchQueryResultSize
+5706
+MultiMailbox Preview Search/sec
+5708
+MultiMailbox Keyword Stats Search/sec
+5710
+MultiMailbox Search Full Text Index Query/sec
+5712
+Average MultiMailbox Search time spent in FullTextIndex
+5714
+Base for AverageMultiMailboxSearchTimeSpentInFTIndex
+5716
+Average MultiMailbox Search time spent in Store calls
+5718
+Average Execution Time Spent in Store Base
+5720
+Average Search Execution Time
+5722
+Average MultiMailbox Preview Search Execution Base
+5724
+Average Keyword Stats Search Execution Time
+5726
+Average Keyword Stats Execution Base
+5728
+Average MultiMailbox Search Failed
+5730
+Average MultiMailbox Search Failed Base
+5732
+Average MultiMailbox Search Query Length
+5734
+Average MultiMailbox Search Query Length Base
+5736
+Average number of Keywords in MultiMailbox Search
+5738
+Average MultiMailbox Search Keyword Count Base
+5740
+Total MultiMailbox preview searches
+5742
+Total MultiMailbox keyword statistics searches
+5744
+Total multi mailbox preview searches timed out
+5746
+Total multi mailbox searches Full Text Index Query Execution
+5748
+Total multi mailbox keyword statistics searches timed out
+5750
+Total failed multi mailbox Preview Searches
+5752
+Total failed multi mailbox keyword statistics Searches
+5754
+Total Multi Mailbox searches failed due to FullText failure
+5756
+Lazy indexes created/sec
+5758
+Lazy indexes deleted/sec
+5760
+Lazy index full refresh/sec
+5762
+Lazy index incremental refresh/sec
+5764
+Lazy index invalidation/sec
+5766
+Lazy index invalidation due to locale version change/sec
+5768
+Folders opened/sec
+5770
+Folders created/sec
+5772
+Folders deleted/sec
+5774
+Messages opened/sec
+5776
+Messages created/sec
+5778
+Messages updated/sec
+5780
+Messages deleted/sec
+5782
+Subobjects opened/sec
+5784
+Subobjects created/sec
+5786
+Subobjects deleted/sec
+5788
+Subobjects cleaned/sec
+5790
+Property promotions/sec
+5792
+Property Promotion Tasks
+5794
+Property promotion messages/sec
+5796
+Active mailboxes
+5798
+Non recursive folder hierarchy reloads/sec
+5800
+Recursive folder hierarchy reloads/sec
+5802
+Messages Delivered/sec
+5804
+Messages Submitted/sec
+5806
+MAPI Messages Created/sec
+5808
+MAPI Messages Opened/sec
+5810
+MAPI Messages Modified/sec
+5812
+RPC Requests
+5814
+% RPC Requests
+5816
+% RPC Requests Base
+5818
+RPC Packets/sec
+5820
+RPC Operations/sec
+5822
+RPC Average Latency
+5824
+Average Time spent in an RPC Base
+5826
+RPC Pool: Pools
+5828
+RPC Pool: Context Handles
+5830
+RPC Pool: Parked Async Notification Calls
+5832
+Mailbox Level Maintenance Items
+5834
+Mailboxes With Maintenance Items
+5836
+Mailbox Level Maintenances/sec
+5838
+Database Level Maintenances/sec
+5840
+Process ID
+5842
+Lost Diagnostic Entries
+5844
+Quarantined Mailbox Count
+5846
+Number of active background tasks
+5848
+Size of Address Info cache
+5850
+Cache lookups in the AddressInfo cache/sec
+5852
+Cache misses in the AddressInfo cache/sec
+5854
+Cache hits in the AddressInfo cache/sec
+5856
+Cache inserts in the AddressInfo cache/sec
+5858
+Cache deletes in the AddressInfo cache/sec
+5860
+Size of the expiration queue for the AddressInfo cache
+5862
+Size of Mailbox Info cache
+5864
+Cache lookups in the MailboxInfo cache/sec
+5866
+Cache misses in the MailboxInfo cache/sec
+5868
+Cache hits in the MailboxInfo cache/sec
+5870
+Cache inserts in the MailboxInfo cache/sec
+5872
+Cache deletes in the MailboxInfo cache/sec
+5874
+Size of the expiration queue for the MailboxInfo cache
+5876
+Size of Database Info cache
+5878
+Cache lookups in the DatabaseInfo cache/sec
+5880
+Cache misses in the DatabaseInfo cache/sec
+5882
+Cache hits in the DatabaseInfo cache/sec
+5884
+Cache inserts in the DatabaseInfo cache/sec
+5886
+Cache deletes in the DatabaseInfo cache/sec
+5888
+Size of the expiration queue for the DatabaseInfo cache
+5890
+Size of Organization Container cache
+5892
+Cache lookups in the Organization Container cache/sec
+5894
+Cache misses in the Organization Container cache/sec
+5896
+Cache hits in the Organization Container cache/sec
+5898
+Cache inserts in the Organization Container cache/sec
+5900
+Cache deletes in the Organization Container cache/sec
+5902
+Size of the expiration queue for the Organization Container cache
+5904
+Size of DistributionListMembership cache
+5906
+Cache lookups in the DistributionListMembership cache/sec
+5908
+Cache misses in the DistributionListMembership cache/sec
+5910
+Cache hits in the DistributionListMembership cache/sec
+5912
+Cache inserts in the DistributionListMembership cache/sec
+5914
+Cache deletes in the DistributionListMembership cache/sec
+5916
+Size of the expiration queue for the DistributionListMembership cache
+5918
+Size of LogicalIndex cache
+5920
+Cache lookups in the LogicalIndex cache/sec
+5922
+Cache misses in the LogicalIndex cache/sec
+5924
+Cache hits in the LogicalIndex cache/sec
+5926
+Cache inserts in the LogicalIndex cache/sec
+5928
+Cache deletes in the LogicalIndex cache/sec
+5930
+Size of the expiration queue for the LogicalIndex cache
+5932
+Number of scheduled LogicalIndex maintenance tasks
+5934
+Number of processing LogicalIndex maintenance tasks
+5936
+Number of mailboxes marked for WLM LogicalIndex maintenance table maintenance
+5938
+Number of active WLM LogicalIndex maintenance table maintenances
+5940
+MSExchangeIS Physical Access
+5942
+Number of Queries per second
+5944
+Number of Inserts per second
+5946
+Number of Updates per second
+5948
+Number of Deletes per second
+5950
+Number of Others per second
+5952
+Other - Rows read per second
+5954
+Other - Seeks per second
+5956
+Other - Rows accepted per second
+5958
+Other - Rows written per second
+5960
+Other - Bytes read per second
+5962
+Other - Bytes written per second
+5964
+TableFunction - Rows read per second
+5966
+TableFunction - Rows accepted per second
+5968
+TableFunction - Bytes read per second
+5970
+Temp - Rows read per second
+5972
+Temp - Seeks per second
+5974
+Temp - Rows accepted per second
+5976
+Temp - Rows written per second
+5978
+Temp - Bytes read per second
+5980
+Temp - Bytes written per second
+5982
+LazyIndex - Rows read per second
+5984
+LazyIndex - Seeks per second
+5986
+LazyIndex - Rows accepted per second
+5988
+LazyIndex - Rows written per second
+5990
+LazyIndex - Bytes read per second
+5992
+LazyIndex - Bytes written per second
+5994
+Folder - Rows read per second
+5996
+Folder - Seeks per second
+5998
+Folder - Rows accepted per second
+6000
+Folder - Rows written per second
+6002
+Folder - Bytes read per second
+6004
+Folder - Bytes written per second
+6006
+Message - Rows read per second
+6008
+Message - Seeks per second
+6010
+Message - Rows accepted per second
+6012
+Message - Rows written per second
+6014
+Message - Bytes read per second
+6016
+Message - Bytes written per second
+6018
+Attachment - Rows read per second
+6020
+Attachment - Seeks per second
+6022
+Attachment - Rows accepted per second
+6024
+Attachment - Rows written per second
+6026
+Attachment - Bytes read per second
+6028
+Attachment - Bytes written per second
+6030
+PseudoIndexMaintenance - Rows read per second
+6032
+PseudoIndexMaintenance - Seeks per second
+6034
+PseudoIndexMaintenance - Rows accepted per second
+6036
+PseudoIndexMaintenance - Rows written per second
+6038
+PseudoIndexMaintenance - Bytes read per second
+6040
+PseudoIndexMaintenance - Bytes written per second
+6042
+Events - Rows read per second
+6044
+Events - Seeks per second
+6046
+Events - Rows accepted per second
+6048
+Events - Rows written per second
+6050
+Events - Bytes read per second
+6052
+Events - Bytes written per second
+6054
+Total - Rows read per second
+6056
+Total - Seeks per second
+6058
+Total - Rows accepted per second
+6060
+Total - Rows written per second
+6062
+Total - Bytes read per second
+6064
+Total - Bytes written per second
+6066
+MSExchangeIS HA Active Database Sender
+6068
+Total Bytes Sent
+6070
+Total Network Writes
+6072
+Network Writes/sec
+6074
+Avg. Network sec/Write
+6076
+AverageWriteTimeBase
+6078
+Avg. Network Bytes/Write
+6080
+AverageWriteSizeBase
+6082
+Network Write Bytes/sec
+6084
+Avg. mSec/Write Ack
+6086
+AverageWriteAckLatencyBase
+6088
+Acknowledged Generation Number
+6090
+MSExchangeIS HA Active Database
+6092
+Total Log Bytes Generated
+6094
+Log Generation Rate (Bytes/sec)
+6096
+Total Emit Calls
+6098
+Emit Calls/sec
+6100
+Average Emit Latency
+6102
+AverageEmitTimeBase
+6104
+Average Emit And Send Latency
+6106
+AverageEmitAndSendTimeBase
+6108
+Current Log Generation Number
+6110
+Block Mode Replication Overflows
+6112
+CompressionEnabled
+6114
+Total Bytes Input To Compression
+6116
+Total Bytes Output From Compression
+6118
+MSExchangeIS Client Type
+6120
+Admin RPC Requests
+6122
+Administrative RPC requests/sec
+6124
+Directory Access: LDAP Searches/sec
+6126
+RPC Requests
+6128
+RPC Bytes Received/sec
+6130
+RPC Bytes Sent/sec
+6132
+RPC Packets/sec
+6134
+RPC Operations/sec
+6136
+RPC Average Latency
+6138
+Average Time spent in an RPC Base
+6140
+Lazy indexes created/sec
+6142
+Lazy indexes deleted/sec
+6144
+Lazy index full refresh/sec
+6146
+Lazy index incremental refresh/sec
+6148
+Messages opened/sec
+6150
+Messages created/sec
+6152
+Messages updated/sec
+6154
+Messages deleted/sec
+6156
+Property promotions/sec
+6158
+Jet Pages Referenced/sec
+6160
+Jet Pages Read/sec
+6162
+Jet Pages Preread/sec
+6164
+Jet Pages Modified/sec
+6166
+Jet Pages Remodified/sec
+6168
+Jet Log Records/sec
+6170
+Jet Log Record Bytes/sec
+6172
+MSExchangeInference StatefulComponent
+6174
+Average Signal Dispatching Latency (msec)
+6176
+Average Signal Dispatching Latency Base
+6178
+MSExchangeInference Pipeline
+6180
+Number of Outstanding Documents
+6182
+Document Incoming Rate Per Second
+6184
+Number Of Incoming Documents
+6186
+Document Reject Rate Per Second
+6188
+Number Of Rejected Documents
+6190
+Document Processing Rate Per Second
+6192
+Number Of Processed Documents
+6194
+Document Success Rate Per Second
+6196
+Number Of Succeeded Documents
+6198
+Document Failure Rate Per Second
+6200
+Number Of Failed Documents
+6202
+Average Document Processing Time In Seconds
+6204
+Average Document Processing Time Base
+6206
+Number Of Components Poisoned
+6208
+MSExchangeInference Model
+6210
+Number of times model got reset
+6212
+MSExchangeInference Classification Latency
+6214
+Items processed 0-100 ms
+6216
+Items processed 100-200 ms
+6218
+Items processed 200-500 ms
+6220
+Items processed 500-750 ms
+6222
+Items processed 750-1000 ms
+6224
+Items processed 1000-5000 ms
+6226
+Items processed in greater than 5000 ms
+6228
+MSExchangeImap4
+6230
+Current Connections
+6232
+Connections Failed
+6234
+Connections Rejected
+6236
+Connections Total
+6238
+Current Unauthenticated Connections
+6240
+Unauthenticated Connections/sec
+6242
+Proxy Current Connections
+6244
+Proxy Connections Failed
+6246
+Proxy Total Connections
+6248
+Active SSL Connections
+6250
+SSL Connections
+6252
+Invalid Commands
+6254
+Invalid Commands Rate
+6256
+Append Failures
+6258
+Append Rate
+6260
+Append Total
+6262
+Authenticate Failures
+6264
+Authenticate Rate
+6266
+Authenticate Total
+6268
+Capability Failures
+6270
+Capability Rate
+6272
+Capability Total
+6274
+Check Failures
+6276
+Check Rate
+6278
+Check Total
+6280
+Close Failures
+6282
+Close Rate
+6284
+Close Total
+6286
+Copy Failures
+6288
+Copy Rate
+6290
+Copy Total
+6292
+Create Failures
+6294
+Create Rate
+6296
+Create Total
+6298
+Delete Failures
+6300
+Delete Rate
+6302
+Delete Total
+6304
+Examine Failures
+6306
+Examine Rate
+6308
+Examine Total
+6310
+Expunge Failures
+6312
+Expunge Rate
+6314
+Expunge Total
+6316
+Fetch Failures
+6318
+Fetch Rate
+6320
+Fetch Total
+6322
+Idle Failures
+6324
+Idle Rate
+6326
+Idle Total
+6328
+List Failures
+6330
+List Rate
+6332
+List Total
+6334
+Login Failures
+6336
+Login Rate
+6338
+Login Total
+6340
+Logout Failures
+6342
+Logout Rate
+6344
+Logout Total
+6346
+LSUB Failures
+6348
+LSUB Rate
+6350
+LSUB Total
+6352
+Namespace Failures
+6354
+Namespace Rate
+6356
+Namespace Total
+6358
+NOOP Failures
+6360
+NOOP Rate
+6362
+NOOP Total
+6364
+Rename Failures
+6366
+Rename Rate
+6368
+Rename Total
+6370
+Request Failures
+6372
+Request Rate
+6374
+Request Total
+6376
+Search Failures
+6378
+Search Rate
+6380
+Search Total
+6382
+Select Failures
+6384
+Select Rate
+6386
+Select Total
+6388
+STARTTLS Failures
+6390
+STARTTLS Rate
+6392
+STARTTLS Total
+6394
+Status Failures
+6396
+Status Rate
+6398
+Status Total
+6400
+Store Failures
+6402
+Store Rate
+6404
+Store Total
+6406
+Subscribe Failures
+6408
+Subscribe Rate
+6410
+Subscribe Total
+6412
+Unsubscribe Failures
+6414
+Unsubscribe Rate
+6416
+Unsubscribe Total
+6418
+XPROXY Failures
+6420
+XPROXY Rate
+6422
+XPROXY Total
+6424
+Average Command Processing Time (milliseconds)
+6426
+Connections Rate
+6428
+SearchFolder Creation Rate
+6430
+SearchFolder Creation Total
+6432
+Folder View Reload Rate
+6434
+Folder View Reload Total
+6436
+Transient Mailbox Connection Failures/minute
+6438
+Mailbox Offline Errors/minute
+6440
+Transient Storage Errors/minute
+6442
+Permanent Storage Errors/minute
+6444
+Transient Active Directory Errors/minute
+6446
+Permanent Active Directory Errors/minute
+6448
+Transient Errors/minute
+6450
+Average RPC Latency
+6452
+Average LDAP Latency
+6454
+Total IMAP UID Fixes
+6456
+Current IMAP UID Fixes
+6458
+Total IMAP UID Items Fixed
+6460
+MSExchangeFrontEndTransport SmtpSend
+6462
+Connections Current
+6464
+Connections Created/sec
+6466
+Connections Total
+6468
+Messages Sent/sec
+6470
+Messages Sent Total
+6472
+Message Bytes Sent Total
+6474
+Message Bytes Sent/sec
+6476
+Messages Suppressed Due to Bare Linefeeds
+6478
+Bytes Sent Total
+6480
+Bytes Sent/sec
+6482
+Recipients sent
+6484
+Average recipients/message
+6486
+Average recipients (message base)
+6488
+Average message bytes/message
+6490
+Average message bytes/message Base
+6492
+Average messages/connection
+6494
+Average messages (connection Base)
+6496
+Average bytes/connection
+6498
+Average bytes (connection Base)
+6500
+DNS Errors
+6502
+Connection Failures
+6504
+Socket Errors
+6506
+Protocol Errors
+6508
+MSExchangeFrontEndTransport SmtpReceive
+6510
+Connections Current
+6512
+Connections Created/sec
+6514
+Connections Total
+6516
+Inbound Message Connections Current
+6518
+Connections Created/sec for inbound proxy messages
+6520
+Inbound Message Connections Total
+6522
+Disconnections by Agents/second
+6524
+Disconnections By Agents
+6526
+Inbound Messages Received/sec
+6528
+Inbound Messages Received Total
+6530
+Inbound Message Bytes Received/sec
+6532
+Inbound Message Bytes Received Total
+6534
+InboundMessages Refused for Size
+6536
+InboundRecipients accepted Total
+6538
+Average bytes/inbound message
+6540
+Average bytes/inbound message Base
+6542
+Average recipients/inbound message
+6544
+Average Recipients/Inbound Message Base
+6546
+Average bytes/connection
+6548
+Average bytes/connection base
+6550
+Average inbound messages/connection
+6552
+Average inbound messages/connection base
+6554
+Bytes Received/sec
+6556
+Bytes Received Total
+6558
+Tarpitting Delays Authenticated
+6560
+Tarpitting Delays Anonymous
+6562
+Tarpitting Delays Authenticated/sec
+6564
+Tarpitting Delays Anonymous/sec
+6566
+MSExchangeFrontEndTransport SmtpAvailability
+6568
+Total Connections
+6570
+% Availability
+6572
+% Activity
+6574
+% Failures Due To MaxInboundConnectionLimit
+6576
+% Failures Due To WLID Down
+6578
+% Failures Due To Active Directory Down
+6580
+% Failures Due To Back Pressure
+6582
+% Failures Due To IO Exceptions
+6584
+% Failures Due To TLS Errors
+6586
+Failures Due to Maximum Local Loop Count
+6588
+MSExchangeFrontEndTransport Smtp Blind Proxy
+6590
+Total Proxy Attempts
+6592
+Total Successful Proxy Sessions
+6594
+Percentage Proxy Setup Failures
+6596
+Total Proxy User Lookup Failures
+6598
+Total Proxy Dns Lookup Failures
+6600
+Total Proxy Connection Failures
+6602
+Total Proxy Protocol Errors
+6604
+Total Proxy Socket Errors
+6606
+Total Bytes Proxied
+6608
+MSExchangeFrontEndTransport Routing
+6610
+Routing NDRs Total
+6612
+Routing Tables Calculated Total
+6614
+Routing Tables Changed Total
+6616
+MSExchangeFrontEndTransport ProxyHubSelector
+6618
+Hub Selection Requests Total
+6620
+Hub Selection Resolver Failures
+6622
+Hub Selection Organization Mailbox Failures
+6624
+Hub Selection Messages Without Mailbox Recipients
+6626
+Hub Selection Messages Without Organization Mailboxes
+6628
+Hub Selection Fallback Routing Requests
+6630
+Hub Selection Routing Failures
+6632
+MSExchangeFrontendTransport Proxy Routing Agent
+6634
+MessagesSuccessfullyRouted
+6636
+MessagesFailedToRoute
+6638
+MSExchangeFrontEndTransport Extensibility Agents
+6640
+Average Agent Processing Time (sec)
+6642
+Average Agent Processing Time Base (sec)
+6644
+Average CPU usage of synchronous invocations of agent (milliseconds)
+6646
+Base counter of AverageAgentProcessorUsageSynchronousInvocations
+6648
+Average CPU usage of asynchronous invocations of agent (milliseconds)
+6650
+Base counter of AverageAgentProcessorUsageAsynchronousInvocations
+6652
+Total synchronous invocations of agent
+6654
+Total asynchronous invocations of agent
+6656
+Total Agent Invocations
+6658
+MSExchangeFrontEndTransport Configuration Cache
+6660
+Configuration Cache Total requests
+6662
+Configuration Cache requests per sec
+6664
+Configuration Cache hit ratio
+6666
+Configuration Cache hit ratio base counter
+6668
+Configuration Cache size
+6670
+Configuration Cache size in MB
+6672
+MSExchangeFrontEndTransport Component Latency
+6674
+Percentile50
+6676
+Percentile80
+6678
+Percentile90
+6680
+Percentile95
+6682
+Percentile99
+6684
+MSExchangeFrontEndTransport Certificate Validation Cache
+6686
+Total Requests
+6688
+Requests per Second
+6690
+Hit Ratio
+6692
+Certificate Validation Result Cache hit ratio base counter
+6694
+Cache Size
+6696
+MSExchangeEdgeSync Topology
+6698
+Total topology updates
+6700
+Exchange Servers total
+6702
+Edge Servers total
+6704
+Hub Transport Servers total
+6706
+Edge Servers leased total
+6708
+SyncNow started total
+6710
+SyncNow Edges not completed total
+6712
+MSExchangeEdgeSync Synchronizer
+6714
+Total Objects Added
+6716
+Total objects updated
+6718
+Total objects deleted
+6720
+Objects Added per Synchronization Cycle
+6722
+Objects updated per synchronization cycle
+6724
+Objects deleted per synchronization cycle
+6726
+Number of full synchronizations
+6728
+MSExchangeAutodiscover
+6730
+Total Requests
+6732
+Requests/sec
+6734
+Error Responses
+6736
+Error Responses/sec
+6738
+Process ID
+6740
+MSExchangeAB
+6742
+PID
+6744
+NSPI Connections Current
+6746
+NSPI Connections Total
+6748
+NSPI Connections/sec
+6750
+NSPI RPC Requests
+6752
+NSPI RPC Requests Total
+6754
+NSPI RPC Requests Average Latency
+6756
+NSPI RPC Requests/sec
+6758
+NSPI RPC Browse Requests
+6760
+NSPI RPC Browse Requests Total
+6762
+NSPI RPC Browse Requests Average Latency
+6764
+NSPI RPC Browse Requests/sec
+6766
+Referral RPC Requests
+6768
+Referral RPC Requests Total
+6770
+Referral RPC Requests/sec
+6772
+Referral RPC Requests Average Latency
+6774
+ThumbnailPhoto Average Time
+6776
+ThumbnailPhoto Average Time Base
+6778
+ThumbnailPhoto From Mailbox Count
+6780
+ThumbnailPhoto From Directory Count
+6782
+ThumbnailPhoto Not Present Count
+6784
+MSExchange WorkloadManagement Workloads
+6786
+ActiveTasks
+6788
+QueuedTasks
+6790
+BlockedTasks
+6792
+CompletedTasks
+6794
+YieldedTasks
+6796
+Tasks Per Minute
+6798
+Average Step Execution Length
+6800
+Active
+6802
+MSExchange WorkloadManagement Classification
+6804
+Workload Count
+6806
+Active Thread Count
+6808
+Fairness Factor
+6810
+MSExchange WorkloadManagement
+6812
+Workload Count
+6814
+Active Classifications
+6816
+MSExchange UserPhotos
+6818
+UserPhotos Current Requests
+6820
+MSExchange User WorkloadManager
+6822
+Average Task Wait Time
+6824
+Max Task Queue Length
+6826
+Max Worker Thread Count
+6828
+Task Queue Length
+6830
+New Task Rejections
+6832
+New Task Rejections/sec
+6834
+Total New Tasks
+6836
+New Tasks Submitted/sec
+6838
+Total Task Failures
+6840
+Task Failures/sec
+6842
+Current Delayed Tasks
+6844
+Max Delay Per Minute
+6846
+Users Delayed X Milliseconds
+6848
+Delay Time Threshold
+6850
+Task Timeouts Per Minute
+6852
+Max Delayed Tasks
+6854
+MSExchange User Throttling
+6856
+Unique Budgets OverBudget
+6858
+Total Unique Budgets
+6860
+Delayed Threads
+6862
+Users Locked Out
+6864
+Percentage Users Micro Delayed
+6866
+Percentage Users At Maximum Delay
+6868
+Number Of Users At Maximum Delay
+6870
+Number Of Users Micro Delayed
+6872
+Budget Usage Five Minute Window 99.9%
+6874
+Budget Usage Five Minute Window 99%
+6876
+Budget Usage Five Minute Window 75%
+6878
+Average Budget Usage Five Minute Window
+6880
+Budget Usage One Hour Window 99.9%
+6882
+Budget Usage One Hour Window 99%
+6884
+Budget Usage One Hour Window 75%
+6886
+Average Budget Usage One Hour Window
+6888
+MSExchange Update Agent
+6890
+Total Updates
+6892
+Total SRL Parameter Updates
+6894
+MSExchange UnJournaling Agent
+6896
+Messages Processed by Unjournaling
+6898
+Messages Unjournaled successfully by Unjournaling
+6900
+Messages marked as defective journals by Unjournaling
+6902
+UnJournaling Processing Time
+6904
+UnJournaling Processing Time per Message
+6906
+Average unjournaling processing time/message base
+6908
+MSExchange Transport Sync Worker Framework
+6910
+Sync Framework - Average Processing Time (sec) to sync a subscription
+6912
+Sync Framework - Average Processing Time Base (sec)
+6914
+Sync Framework - Last Processing Time (msec) to sync a subscription
+6916
+Sync Framework - Subscriptions Syncing
+6918
+Sync Result - Total Canceled
+6920
+Sync Result - Total Failed
+6922
+Sync Result - Total Successful
+6924
+Sync Result - Total Successful Per Second
+6926
+Sync Result - Total Failed Transiently
+6928
+Sync Result - Total Recovery Syncs Needed
+6930
+MSExchange Transport Sync Worker Core
+6932
+Download Speed (Bytes/sec)
+6934
+Messages Submitted to Pipeline - Total Count
+6936
+Sync Scheduler - Total On Server
+6938
+Sync Scheduler - Total In Retry Queue
+6940
+Messages Submitted to Pipeline - Rate (per second)
+6942
+Total bytes downloaded
+6944
+Total subscriptions aggregated
+6946
+Total bytes uploaded
+6948
+Upload speed (bytes/sec)
+6950
+MSExchange Transport Sync Manager By SLA
+6952
+95 percentile subscription polling frequency (seconds)
+6954
+MSExchange Transport Sync Manager By Protocol
+6956
+Average Time to Complete Dispatch (sec)
+6958
+Average Time to Complete Dispatch Base (sec)
+6960
+Time to Complete Last Dispatch (msec)
+6962
+Last Subscription Dispatch to Completion Time
+6964
+95 Percentile Processing Time to Sync a Subscription (secs)
+6966
+Subscriptions Completing Sync
+6968
+Dispatch Queue - Total Subscriptions
+6970
+Dispatch Queue - Total Sync Now Subscriptions
+6972
+Subscription Dispatch - Total Attempts
+6974
+Subscription Dispatch - Total Attempts per second
+6976
+Subscription Dispatch - Total Successful
+6978
+Subscription Dispatch - Total Successful Per Second
+6980
+Subscription Dispatch - Total Duplicate Attempts
+6982
+Subscription Dispatch - Total Duplicate Attempts Per Second
+6984
+Subscription Dispatch - Total Transient Failures
+6986
+MSExchange Transport Sync Manager By Database
+6988
+Database Queue Manager - Total subscriptions queued
+6990
+Database Queue Manager - Total subscription instances queued
+6992
+MSExchange Transport Sync Manager
+6994
+Subscription queue dispatching lag (seconds)
+6996
+Total number of user mailboxes in the Subscription Caches for all databases
+6998
+Total number of mailboxes in the Subscription Caches to be rebuilt.
+7000
+Total number of mailboxes in the Subscription Caches rebuilt
+7002
+Total number of mailboxes in the Subscription Caches that rebuild repaired
+7004
+Last wait (msec) to get a token
+7006
+MSExchange Transport Sync - Pop
+7008
+Message Bytes Received Total
+7010
+Message Bytes Received/sec
+7012
+Messages Received Total
+7014
+Messages Received/sec
+7016
+MSExchange Transport Sync - IMAP
+7018
+Total bytes downloaded
+7020
+Bytes Downloaded/sec
+7022
+Total bytes uploaded
+7024
+Bytes Uploaded/sec
+7026
+Total Messages Downloaded
+7028
+Messages Downloaded/sec
+7030
+Total Messages Uploaded
+7032
+Messages Uploaded/sec
+7034
+MSExchange Transport Sync - Hotmail
+7036
+Total bytes downloaded
+7038
+Bytes Downloaded/sec
+7040
+Total bytes uploaded
+7042
+Bytes Uploaded/sec
+7044
+Total Messages Downloaded
+7046
+Messages Downloaded/sec
+7048
+Total Messages Uploaded
+7050
+Messages Uploaded/sec
+7052
+MSExchange Transport Sync - Contacts
+7054
+Total bytes downloaded
+7056
+Bytes Downloaded/sec
+7058
+Total bytes uploaded
+7060
+Bytes Uploaded/sec
+7062
+Total Contacts Downloaded
+7064
+Contacts Downloaded/sec
+7066
+Total Requests
+7068
+Total Requests with No Changes
+7070
+MSExchange Transport Rules
+7072
+Messages Evaluated
+7074
+Messages Evaluated/sec
+7076
+Messages Processed
+7078
+Messages Processed/sec
+7080
+Messages Skipped
+7082
+Messages Skipped/sec
+7084
+Messages Deferred Due to Errors
+7086
+Messages Deferred/sec
+7088
+MSExchange Topology
+7090
+Latest Exchange Topology Discovery Time in Seconds
+7092
+Number of Exchange Topology Discoveries
+7094
+Number of Siteless Servers
+7096
+MSExchange TopN Words Assistant
+7098
+Time to Process Last Mailbox in Milliseconds
+7100
+Number of Mailboxes Processed
+7102
+MSExchange Throttling Service Client
+7104
+Percentage of Successful Submission Requests.
+7106
+Percentage of Denied Submission Request.
+7108
+Percentage of Bypassed Submission Requests.
+7110
+Average request processing time.
+7112
+MSExchange Throttling
+7114
+Average Thread Sleep Time
+7116
+Active PowerShell Runspaces
+7118
+Active PowerShell Runspaces/Sec
+7120
+Exchange Executing Cmdlets
+7122
+Exchange Executing Cmdlets/Sec
+7124
+Organization Throttling Policy Cache Hit Count
+7126
+Organization Throttling Policy Cache Miss Count
+7128
+Organization Throttling Policy Cache Length
+7130
+Organization Throttling Policy Cache Length Percentage
+7132
+Throttling Policy Cache Hit Count
+7134
+Throttling Policy Cache Miss Count
+7136
+Throttling Policy Cache Length
+7138
+Throttling Policy Cache Length Percentage
+7140
+MSExchange Text Messaging
+7142
+Total Text Messages Sent
+7144
+Text Messages Sent/sec
+7146
+Total Text Messages Sent via Exchange ActiveSync
+7148
+Text Messages Sent via Exchange ActiveSync/sec
+7150
+Total Messages Sent via SMTP
+7152
+Text messages Sent via SMTP/sec
+7154
+Average Text Message Delivery Latency (milliseconds)
+7156
+Text Messages Pending Delivery
+7158
+MSExchange Submission Store Driver Database
+7160
+Submission attempts per minute over the last 5 minutes
+7162
+Submission failures per minute over the last 5 minutes
+7164
+MSExchange Submission Store Driver Agents
+7166
+StoreDriverSubmission Agent Failure
+7168
+MSExchange Submission Store Driver
+7170
+Outbound: Submitted Mail Items
+7172
+Outbound: Submitted Mail Items Per Second
+7174
+Outbound: TotalRecipients
+7176
+MSExchange Submission SmtpSend
+7178
+Connections Current
+7180
+Connections Created/sec
+7182
+Connections Total
+7184
+Messages Sent/sec
+7186
+Messages Sent Total
+7188
+Message Bytes Sent Total
+7190
+Message Bytes Sent/sec
+7192
+Messages Suppressed Due to Bare Linefeeds
+7194
+Bytes Sent Total
+7196
+Bytes Sent/sec
+7198
+Recipients sent
+7200
+Average recipients/message
+7202
+Average recipients (message base)
+7204
+Average message bytes/message
+7206
+Average message bytes/message Base
+7208
+Average messages/connection
+7210
+Average messages (connection Base)
+7212
+Average bytes/connection
+7214
+Average bytes (connection Base)
+7216
+DNS Errors
+7218
+Connection Failures
+7220
+Socket Errors
+7222
+Protocol Errors
+7224
+MSExchange Submission Routing
+7226
+Routing NDRs Total
+7228
+Routing Tables Calculated Total
+7230
+Routing Tables Changed Total
+7232
+MSExchange Submission ProxyHubSelector
+7234
+Hub Selection Requests Total
+7236
+Hub Selection Resolver Failures
+7238
+Hub Selection Organization Mailbox Failures
+7240
+Hub Selection Messages Without Mailbox Recipients
+7242
+Hub Selection Messages Without Organization Mailboxes
+7244
+Hub Selection Fallback Routing Requests
+7246
+Hub Selection Routing Failures
+7248
+MSExchange Submission Extensibility Agents
+7250
+Average Agent Processing Time (sec)
+7252
+Average Agent Processing Time Base (sec)
+7254
+Average CPU usage of synchronous invocations of agent (milliseconds)
+7256
+Base counter of AverageAgentProcessorUsageSynchronousInvocations
+7258
+Average CPU usage of asynchronous invocations of agent (milliseconds)
+7260
+Base counter of AverageAgentProcessorUsageAsynchronousInvocations
+7262
+Total synchronous invocations of agent
+7264
+Total asynchronous invocations of agent
+7266
+Total Agent Invocations
+7268
+MSExchange Submission DSN
+7270
+Failure DSNs Total
+7272
+Delay DSNs
+7274
+Relay DSNs
+7276
+Delivered DSNs
+7278
+Expanded DSNs
+7280
+Failure DSNs within the last hour
+7282
+Alertable failure DSNs within the last hour
+7284
+Delayed DSNs within the last hour
+7286
+NDRs generated for catch-all recipients.
+7288
+MSExchange Submission Configuration Cache
+7290
+Configuration Cache Total requests
+7292
+Configuration Cache requests per sec
+7294
+Configuration Cache hit ratio
+7296
+Configuration Cache hit ratio base counter
+7298
+Configuration Cache size
+7300
+Configuration Cache size in MB
+7302
+MSExchange Submission Component Latency
+7304
+Percentile50
+7306
+Percentile80
+7308
+Percentile90
+7310
+Percentile95
+7312
+Percentile99
+7314
+MSExchange Submission Certificate Validation Cache
+7316
+Total Requests
+7318
+Requests per Second
+7320
+Hit Ratio
+7322
+Certificate Validation Result Cache hit ratio base counter
+7324
+Cache Size
+7326
+MSExchange Submission
+7328
+Successful Submissions
+7330
+Successful Submissions Per Second
+7332
+Failed Submissions
+7334
+Failed Submissions Per Second
+7336
+Percent of Permanent Failed Submissions within the last 5 minutes
+7338
+Temporary Submission Failures
+7340
+Temporary Submission Failures/sec
+7342
+Pending Submissions
+7344
+MSExchange Store Interface
+7346
+ConnectionCache num caches
+7348
+ConnectionCache total capacity
+7350
+ConnectionCache active connections
+7352
+ConnectionCache idle connections
+7354
+ConnectionCache out of limit creations
+7356
+ExRpcConnection creation events
+7358
+ExRpcConnection disposal events
+7360
+ExRpcConnection outstanding
+7362
+UNK Objects total
+7364
+UNK Logons
+7366
+UNK Folders
+7368
+UNK Messages
+7370
+RPC Requests sent
+7372
+RPC Requests succeeded
+7374
+RPC Requests failed
+7376
+RPC Requests failed with exception
+7378
+RPC Requests failed (%)
+7380
+RPC Requests outstanding
+7382
+RPC Requests sent/sec
+7384
+RPC Latency total (msec)
+7386
+RPC Latency average (msec)
+7388
+RPC Slow requests
+7390
+RPC Slow requests (%)
+7392
+RPC Slow requests latency total (msec)
+7394
+RPC Slow requests latency average (msec)
+7396
+RPC Bytes sent
+7398
+RPC Bytes sent average
+7400
+RPC Bytes received
+7402
+RPC Bytes received average
+7404
+ROP Requests sent
+7406
+ROP Requests complete
+7408
+ROP Requests outstanding
+7410
+RPC Pool: Pools
+7412
+RPC Pool: RPC Context Handles
+7414
+RPC Pool: Sessions
+7416
+RPC Pool: Active Threads Ratio
+7418
+RPC Pool: Average Latency
+7420
+RPC Pool: Session Notifications Received/sec
+7422
+RPC Pool: Async Notifications Received/sec
+7424
+RPC Pool: Parked Async Notification Calls
+7426
+MSExchange Sharing Engine
+7428
+Calendar Items Synchronized
+7430
+Contact Items Synchronized
+7432
+Folder Synchronization Failures
+7434
+Folders Processed Synchronously
+7436
+Folders Synchronization Timeouts
+7438
+Last Folder Synchronization Time (in seconds)
+7440
+Average Folder Synchronization Time (in seconds)
+7442
+Base for Average Time to Synchronize a Folder
+7444
+Average Time to Request a Token for an External Authentication
+7446
+Base for Average Time to Request a Token for an External Authentication
+7448
+Number of Successful Token Requests for External Authentication
+7450
+Number of Failed Token Requests for External Authentication
+7452
+MSExchange Sender Id Agent
+7454
+Messages Validated
+7456
+Messages Validated/sec
+7458
+Messages That Bypassed Validation
+7460
+Messages That Bypassed Validation/sec
+7462
+Messages Validated with a Pass Result
+7464
+Messages Validated/sec with a Pass Result
+7466
+Messages Validated with a Neutral Result
+7468
+Messages Validated/sec with a Neutral Result
+7470
+Messages Validated with a SoftFail Result
+7472
+Messages Validated/sec with a SoftFail Result
+7474
+Messages Validated with a Fail - Not Permitted Result
+7476
+Messages Validated/sec with a Fail Not - Permitted Result
+7478
+Messages Validated with a Fail - Malformed Domain Result
+7480
+Messages Validated/sec with a Fail - Malformed Domain Result
+7482
+Messages Validated with a Fail - Non-Existent Domain Result
+7484
+Messages Validated/sec with a Fail - Non-Existent Domain Result
+7486
+Messages Validated with a None Result
+7488
+Messages Validated/sec with a None Result
+7490
+Messages Validated with a TempError Result
+7492
+Messages Validated/sec with a TempError Result
+7494
+Messages Validated with a PermError Result
+7496
+Messages Validated/sec with a PermError Result
+7498
+DNS Queries
+7500
+DNS Queries/sec
+7502
+Messages with No PRA
+7504
+Messages With No PRA/sec
+7506
+Messages Missing Originating IP
+7508
+Messages Missing Originating IP/sec
+7510
+MSExchange Sender Filter Agent
+7512
+Messages Evaluated by Sender Filter
+7514
+Messages Evaluated by Sender Filter/sec
+7516
+Messages Filtered by Sender Filter
+7518
+Messages Filtered by Sender Filter/sec
+7520
+Senders Blocked Due to Per-Recipient Blocked Senders
+7522
+MSExchange Secure Mail Transport
+7524
+Domain Secure Messages Received
+7526
+Domain Secure Messages Sent
+7528
+Domain Secure Outbound Session Failures
+7530
+MSExchange Search Indexes
+7532
+Notifications: Processed
+7534
+Notifications: Processed/sec
+7536
+Notifications: Updates Processed
+7538
+Notifications: Updates Processed/sec
+7540
+Notifications: Creates Processed
+7542
+Notifications: Creates Processed/sec
+7544
+Notifications: Deletes Processed
+7546
+Notifications: Deletes Processed/sec
+7548
+Notifications: Moves Processed
+7550
+Notifications: Moves Processed/sec
+7552
+Notifications: Queue Length
+7554
+Notifications: Delayed Items
+7556
+Notifications: Age of Last Notification Processed
+7558
+Notifications: Awaiting Processing
+7560
+Notifications: Items Sent for Processing
+7562
+Notifications: Items Processed
+7564
+Notifications: Last Successful Poll Timestamp
+7566
+Notifications: Stall Time
+7568
+Crawler: Mailboxes Remaining
+7570
+Crawler: Items Sent for Processing
+7572
+Crawler: Items Processed
+7574
+Crawler: Submission Delays
+7576
+Crawler: Submission Delay Time
+7578
+Failed Items
+7580
+Retry: Retriable Items
+7582
+Retry: Items Sent for Processing
+7584
+Retry: Items Processed
+7586
+Retry: Submission Delays
+7588
+Retry: Submission Delay Time
+7590
+Retry: Deleted Mailboxes Remaining
+7592
+Retry: Items Sent for Deletion
+7594
+Retry: Items Deleted
+7596
+Feeding Sessions
+7598
+Items Processed
+7600
+Items Processed/sec
+7602
+MSExchange RpcClientAccess Per Server
+7604
+RPC Average Latency (End To End)
+7606
+RPC Average Latency (End To End) - Online Mode
+7608
+RPC Average Latency (End To End) - Cached Mode
+7610
+RPC Average Latency (Backend)
+7612
+RPC Failed Backend Connections
+7614
+RPC Active Backend Connections (% of Limit)
+7616
+MSExchange RpcClientAccess
+7618
+RPC Requests
+7620
+RPC Packets/sec
+7622
+RPC Operations/sec
+7624
+RPC Averaged Latency
+7626
+RPC Clients Bytes Read
+7628
+RPC Clients Bytes Written
+7630
+RPC Clients Uncompressed Bytes Read
+7632
+RPC Clients Uncompressed Bytes Written
+7634
+Connection Count
+7636
+Active User Count
+7638
+User Count
+7640
+Client: RPCs attempted
+7642
+Client: RPCs succeeded
+7644
+Client: Background RPCs succeeded
+7646
+Client: Foreground RPCs succeeded
+7648
+Client: RPCs Failed
+7650
+Client: Background RPCs Failed
+7652
+Client: Foreground RPCs Failed
+7654
+Client: Latency > 2 sec RPCs
+7656
+Client: Latency > 5 sec RPCs
+7658
+Client: Latency > 10 sec RPCs
+7660
+RPC dispatch task queue length
+7662
+RPC dispatch task threads
+7664
+RPC dispatch task active threads
+7666
+RPC dispatch task operations/sec
+7668
+XTC dispatch task queue length
+7670
+XTC dispatch task threads
+7672
+XTC dispatch task active threads
+7674
+XTC dispatch task operations/sec
+7676
+RpcHttpConnectionRegistration dispatch task queue length
+7678
+RpcHttpConnectionRegistration dispatch task threads
+7680
+RpcHttpConnectionRegistration dispatch task active threads
+7682
+RpcHttpConnectionRegistration dispatch task operations/sec
+7684
+MSExchange RMS Decryption Agent
+7686
+Message successfully decrypted by RMS Decryption Agent
+7688
+Message failed to be decrypted by RMS Decryption Agent
+7690
+Over 5% of messages failed to decrypt in the last 30 minutes
+7692
+MSExchange RMS Agents
+7694
+Active RMS Licensing Agents
+7696
+Total active RMS Licensing Agents
+7698
+Active RMS Licensing Agents/sec
+7700
+Total RMS Licensing Agents Failed to Process
+7702
+RMS Licensing Agents Failed to Process/sec
+7704
+MSExchange Rights Management
+7706
+Total successful Certify()
+7708
+Successful Certify()/sec
+7710
+Total time for successful Certify()
+7712
+Average time for successful Certify()
+7714
+Base of Average time for successful Certify()
+7716
+Total failed Certify()
+7718
+Failed Certify()/sec
+7720
+Total successful GetClientLicensorCert()
+7722
+Successful GetClientLicensorCert()/sec
+7724
+Total time for successful GetClientLicensorCert()
+7726
+Average time for successful GetClientLicensorCert()
+7728
+Base of Average time for successful GetClientLicensorCert()
+7730
+Total failed GetClientLicensorCert()
+7732
+Failed GetClientLicensorCert()/sec
+7734
+Total successful AcquireLicense()
+7736
+Successful AcquireLicense()/sec
+7738
+Total time for successful AcquireLicense()
+7740
+Average time for successful AcquireLicense()
+7742
+Base of Average time for successful AcquireLicense()
+7744
+Total failed AcquireLicense()
+7746
+Failed AcquireLicense()/sec
+7748
+Total successful AcquirePreLicense()
+7750
+Successful AcquirePreLicense()/sec
+7752
+Total time for successful AcquirePreLicense()
+7754
+Average time for successful AcquirePreLicense()
+7756
+Base of Average time for successful AcquirePreLicense()
+7758
+Total failed AcquirePreLicense()
+7760
+Failed AcquirePreLicense()/sec
+7762
+Total successful FindServiceLocations()
+7764
+Successful FindServiceLocations()/sec
+7766
+Total time for successful FindServiceLocations()
+7768
+Average time for successful FindServiceLocations()
+7770
+Base of Average time for successful FindServiceLocations()
+7772
+Total failed FindServiceLocations()
+7774
+Failed FindServiceLocations()/sec
+7776
+Total successful AcquireTemplates()
+7778
+Successful AcquireTemplates()/sec
+7780
+Total time for successful AcquireTemplates()
+7782
+Average time for successful AcquireTemplates()
+7784
+Base of Average time for successful AcquireTemplates()
+7786
+Total failed AcquireTemplates()
+7788
+Failed AcquireTemplates()/sec
+7790
+Total cache-hit of RMS Server Info
+7792
+Cache-hit of RMS Server Info/sec
+7794
+Total cache-miss of RMS Server Info
+7796
+Cache-miss of RMS Server Info/sec
+7798
+Total entries added into RMS Server Info cache.
+7800
+Entries added into RMS Server Info cache/sec
+7802
+Total entries removed from RMS Server Info cache
+7804
+Entries removed from RMS Server Info cache/sec
+7806
+Total L1 Cache-Hit of Rms License Store
+7808
+L1 Cache-Hit of RMS License Store/sec
+7810
+Total L1 Cache-Miss of RMS License Store
+7812
+L1 Cache-Miss of RMS License Store/sec
+7814
+Total L2 Cache-Hit of RMS License Store
+7816
+L2 Cache-Hit of RMS License Store/sec
+7818
+Total L2 Cache-Miss of RMS License Store
+7820
+L2 Cache-Miss of RMS License Store/sec
+7822
+Total entries added into RMS License Store
+7824
+Entries added into RMS License Store/sec
+7826
+Total entries removed from RMS License Store
+7828
+Entries removed from RMS License Store/sec
+7830
+Total files read by RMS License Store from Disk
+7832
+Files read by RMS License Store/sec
+7834
+Total files written by RMS License Store to Disk
+7836
+Files written by RMS License Store/sec
+7838
+Total external successful certification requests
+7840
+Successful External Certification Requests/sec
+7842
+Total external failed certification requests
+7844
+Failed External Certification Requests/sec
+7846
+Total external successful AcquireLicense requests
+7848
+Successful External AcquireLicense Requests/sec
+7850
+Total external failed AcquireLicense requests
+7852
+Failed External AcquireLicense Requests/sec
+7854
+MSExchange Resource Load
+7856
+Resource Metric
+7858
+Resource Load
+7860
+MSExchange Resource Booking
+7862
+Events
+7864
+Requests Submitted
+7866
+Requests Processed
+7868
+Requests Failed
+7870
+Accepted
+7872
+Declined
+7874
+Cancelled
+7876
+Average Resource Booking Processing Time
+7878
+Average Processing Time Base
+7880
+MSExchange ReportingWebService
+7882
+PID
+7884
+RBAC Principals
+7886
+RBAC Principals - Total
+7888
+RBAC Principals/sec
+7890
+RBAC Principals - Peak
+7892
+RBAC Principals - Average Creation Time
+7894
+RBAC Principals - Average Creation Time Base
+7896
+PowerShell Runspaces
+7898
+PowerShell Runspaces - Total
+7900
+PowerShell Runspaces/sec
+7902
+PowerShell Runspaces - Peak
+7904
+PowerShell Runspaces - Average Creation Time
+7906
+PowerShell Runspaces - Average Creation Time Base
+7908
+PowerShell Runspaces - Active
+7910
+PowerShell Runspaces - Activations Total
+7912
+PowerShell Runspaces - Activations/sec
+7914
+PowerShell Runspaces - Peak Active
+7916
+PowerShell Runspaces - Average Active Time
+7918
+PowerShell Runspaces - Average Active Time Base
+7920
+Request Failures
+7922
+Request Failures/sec
+7924
+Report Cmdlet Failures
+7926
+Report Cmdlet Failures/sec
+7928
+Watson Reports
+7930
+Requests - Active
+7932
+Requests - Activations Total
+7934
+Requests - Activations/sec
+7936
+Requests - Peak Active
+7938
+Requests - Average Response Time
+7940
+Requests - Average Response Time Base
+7942
+Report Cmdlet - Average Response Time
+7944
+Report Cmdlet - Average Response Time Base
+7946
+Average Report Row
+7948
+Average Report Row Base
+7950
+MSExchange Replication Server
+7952
+GetCopyStatus Server-Side Calls
+7954
+GetCopyStatus Server-Side Calls/sec
+7956
+MSExchange Replication
+7958
+CopyNotificationGenerationNumber
+7960
+CopyGenerationNumber
+7962
+Log Copy KB/Sec
+7964
+Avg. Network sec/Read
+7966
+Base for LogCopyNetReadLatency
+7968
+InspectorGenerationNumber
+7970
+ReplayNotificationGenerationNumber
+7972
+ReplayGenerationNumber
+7974
+ReplayQueueLength
+7976
+CopyQueueLength
+7978
+CopyQueueLength excluding inspection
+7980
+Failed
+7982
+Initializing
+7984
+FailedSuspended
+7986
+Resynchronizing
+7988
+Disconnected
+7990
+SinglePageRestore
+7992
+ActivationSuspended
+7994
+Suspended
+7996
+Suspended and not Seeding
+7998
+Seeding
+8000
+ReplayLagDisabled
+8002
+ReplayLag Percent of Configured Lag
+8004
+CompressionEnabled
+8006
+EncryptionEnabled
+8008
+TruncatedGenerationNumber
+8010
+IncReseedDBPagesReadNumber
+8012
+IncReseedLogCopiedNumber
+8014
+Log Generation Rate on Source (generations/sec)
+8016
+Log Inspection Rate (generations/sec)
+8018
+Log Copying is Not Keeping Up
+8020
+Log Replay Rate (generations/sec)
+8022
+Log Replay is Not Keeping Up
+8024
+Continuous replication - block mode Active
+8026
+Total Bytes Received Block Mode
+8028
+Average Bytes Per Log Generation - Block Mode
+8030
+Avg. Block Mode Disk sec/Write
+8032
+AvgBlockModeConsumerWriteTimeBase
+8034
+Avg. File Mode Disk sec/Log Generation
+8036
+AvgFileModeWriteTimeBase
+8038
+SeedingSource
+8040
+GetCopyStatus Server-Side Calls
+8042
+GetCopyStatus Server-Side Calls/sec
+8044
+MSExchange Replica Seeder
+8046
+Database Seeding Progress %
+8048
+Database Seeding Bytes Read (KB)
+8050
+Database Seeding Bytes Read (KB/sec)
+8052
+Database Seeding Bytes Written (KB)
+8054
+Database Seeding Bytes Written (KB/sec)
+8056
+Catalog Seeding In Progress
+8058
+Catalog Seeding Progress %
+8060
+Catalog Seeding Successes
+8062
+Catalog Seeding Failures
+8064
+MSExchange Recipient Filter Agent
+8066
+Recipients Rejected by Recipient Validation
+8068
+Recipients Rejected by Recipient Validation/sec
+8070
+Recipients Rejected by Block List
+8072
+Recipients Rejected by Block List/sec
+8074
+MSExchange Recipient Cache
+8076
+Individual Address Lookups
+8078
+Batched Address Lookups
+8080
+Expand Group Requests
+8082
+Address Lookups Pending
+8084
+Active Directory recipient cache aggregate total lookups
+8086
+Active Directory recipient cache aggregate hits
+8088
+Active Directory recipient cache aggregate hits base counter.
+8090
+Active Directory recipient cache aggregate misses
+8092
+Active Directory recipient cache aggregate misses base counter.
+8094
+Average Active Directory recipient cache lookup query latecy
+8096
+Average Active Directory recipient cache lookup query latency base counter.
+8098
+Total repeated queries for the same recipient
+8100
+Number of queries per recipient cache, 50th percentile
+8102
+Number of queries per recipient cache, 80th percentile
+8104
+Number of queries per recipient cache, 95th percentile
+8106
+Number of queries per recipient cache, 99th percentile
+8108
+MSExchange Push Notifications Publishers
+8110
+Publisher Queue Size - Count
+8112
+Publisher Queue Size - Peak
+8114
+Publisher Queue Size - Total
+8116
+Publisher Enqueue Error - Counter
+8118
+Preprocess Error - Counter
+8120
+Total Notifications Sent - Counter
+8122
+Total Notifications Discarded - Counter
+8124
+Publisher Send - Average Time
+8126
+Publisher Send - Average Time Base
+8128
+Preprocess - Average Time
+8130
+Preprocess - Average Time Base
+8132
+Preprocess Error - Average Time
+8134
+Preprocess Error - Average Time Base
+8136
+Queue Item - Average Time
+8138
+Queue Item - Average Time Base
+8140
+MSExchange Push Notifications Publisher Manager
+8142
+Total Notification Requests - Count
+8144
+Total Invalid Notifications - Count
+8146
+Total Discarded Notifications - Count
+8148
+MSExchange Push Notifications Pending Get
+8150
+Try get Connection - Average Time
+8152
+Try get Connection - Average Time Base
+8154
+Connection Cached - Average Time
+8156
+Connection Cached - Average Time Base
+8158
+Add New Connection - Average Time
+8160
+Add New Connection - Average Time Base
+8162
+Pending Get Connection Cache - Count
+8164
+Pending Get Connection Cache - Peak
+8166
+Pending Get Connection Cache - Total
+8168
+MSExchange Push Notifications Assistant
+8170
+Subscription - Expired cleanup Count
+8172
+Subscription - Created Count
+8174
+Subscription - Created Count/sec
+8176
+Email Notification - Average Processing Time
+8178
+Email Notification - Average Processing Time Base
+8180
+Publishing EsoRequest - Average processing Time
+8182
+Publishing EsoRequest - Average processing Time Base
+8184
+Publishing EsoRequest - Error Count
+8186
+Publishing EsoRequest - Error Count/sec
+8188
+Notification Batch - Average Count
+8190
+Notification Batch - Count Base
+8192
+Notification Batch Discarded - Average Count
+8194
+Notification Batch Discarded - Count Base
+8196
+MSExchange Push Notifications Apns Channel
+8198
+Apns Connection Failed - Counter
+8200
+Apns Auth Retry - Counter
+8202
+Apns Read Task Ended - Counter
+8204
+Apns Reset - Counter
+8206
+Apns Connection - Average Time
+8208
+Apns Connection - Average Time Base
+8210
+Apns Auth - Average Time
+8212
+Apns Auth - Average Time Base
+8214
+Apns Channel Send - Average Time
+8216
+Apns Channel Send - Average Time Base
+8218
+Apns Response Read - Average Time
+8220
+Apns Response Read - Average Time Base
+8222
+Unconfirmed Notifications - Count
+8224
+Unconfirmed Notifications - Peak
+8226
+Unconfirmed Notifications - Total
+8228
+MSExchange Provisioning Cache
+8230
+Provisioning Cache global data aggregate hits.
+8232
+Provisioning Cache global data aggregate misses.
+8234
+Provisioning Cache organization data aggregate hits.
+8236
+Provisioning Cache organization data aggregate misses.
+8238
+Provisioning Cache Received Invalidation Msg Counter.
+8240
+Provisioning Cache Total Cached Object Counter.
+8242
+MSExchange Provisioning
+8244
+Number of New-Mailbox Calls
+8246
+Number of New-MailUser Calls
+8248
+Number of New-RemoteMailbox Calls
+8250
+Number of New-SyncMailbox Calls
+8252
+Number of New-SyncMailUser Calls
+8254
+Number of Undo-SoftDeletedMailbox Calls
+8256
+Number of Undo-SyncSoftDeletedMailbox Calls
+8258
+Number of Undo-SyncSoftDeletedMailuser Calls
+8260
+Number of Successful New-Mailbox Calls
+8262
+Number of Successful New-MailUser Calls
+8264
+Number of Successful New-RemoteMailbox Calls
+8266
+Number of Successful New-SyncMailbox Calls
+8268
+Number of successful New-SyncMailUser Calls
+8270
+Number of successful Undo-SoftDeletedMailbox Calls
+8272
+Number of successful Undo-SyncSoftDeletedMailbox Calls
+8274
+Number of successful Undo-SyncSoftDeletedMailuser Calls
+8276
+Average New-Mailbox Response Time
+8278
+Average New-Mailbox Response TimeBase
+8280
+Average New-Mailbox Response Time with Active Provisioning Cache
+8282
+Average New-Mailbox Response TimeBase with Active Provisioning Cache
+8284
+Average New-Mailbox Response Time Without Active Provisioning Cache
+8286
+Average New-Mailbox Response TimeBase Without Active Provisioning Cache
+8288
+Average New-MailUser Response Time
+8290
+Average New-MailUser Response TimeBase
+8292
+Average New-MailUser Response Time with Active Provisioning Cache
+8294
+Average New-MailUser Response TimeBase with Active Provisioning Cache
+8296
+Average New-MailUser Response Time Without Active Provisioning Cache
+8298
+Average New-MailUser Response TimeBase Without Active Provisioning Cache
+8300
+Average New-RemoteMailbox Response Time
+8302
+Average New-RemoteMailbox Response TimeBase
+8304
+Average New-RemoteMailbox Response Time with Active Provisioning Cache
+8306
+Average New-RemoteMailbox Response TimeBase with Active Provisioning Cache
+8308
+Average New-RemoteMailbox Response Time Without Active Provisioning Cache
+8310
+Average New-RemoteMailbox Response TimeBase Without Active Provisioning Cache
+8312
+Average New-SyncMailbox Response Time
+8314
+Average New-SyncMailbox Response TimeBase
+8316
+Average New-SyncMailbox Response Time with Active Provisioning Cache
+8318
+Average New-SyncMailbox Response TimeBase with Active Provisioning Cache
+8320
+Average New-SyncMailbox Response Time Without Active Provisioning Cache
+8322
+Average New-SyncMailbox Response TimeBase Without Active Provisioning Cache
+8324
+Average New-SyncMailUser Response Time
+8326
+Average New-SyncMailUser Response TimeBase
+8328
+Average New-SyncMailUser Response Time with Active Provisioning Cache
+8330
+Average New-SyncMailUser Response TimeBase with Active Provisioning Cache
+8332
+Average New-SyncMailUser Response Time Without Active Provisioning Cache
+8334
+Average New-SyncMailUser Response TimeBase Without Active Provisioning Cache
+8336
+Average Undo-SoftDeletedMailbox Response Time
+8338
+Average Undo-SoftDeletedMailbox Response TimeBase
+8340
+Average Undo-SoftDeletedMailbox Response Time with Active Provisioning Cache
+8342
+Average Undo-SoftDeletedMailbox Response TimeBase with Active Provisioning Cache
+8344
+Average Undo-SoftDeletedMailbox Response Time Without Active Provisioning Cache
+8346
+Average Undo-SoftDeletedMailbox Response TimeBase Without Active Cache
+8348
+Average Undo-SyncSoftDeletedMailbox Response Time
+8350
+Average Undo-SyncSoftDeletedMailbox Response TimeBase
+8352
+Average Undo-SyncSoftDeletedMailbox Response Time with Active Provisioning Cache
+8354
+Average Undo-SyncSoftDeletedMailbox Response TimeBase with Provisioning Cache
+8356
+Average Undo-SyncSoftDeletedMailbox Response Time Without Provisioning Cache
+8358
+Average Undo-SyncSoftDeletedMailbox Response TimeBase Without Active Cache
+8360
+Average Undo-SyncSoftDeletedMailuser Response Time
+8362
+Average Undo-SyncSoftDeletedMailuser Response TimeBase
+8364
+Average Undo-SyncSoftDeletedMailuser Response Time with Provisioning Cache
+8366
+Average Undo-SyncSoftDeletedMailuser Response TimeBase with Provisioning Cache
+8368
+Average Undo-SyncSoftDeletedMailuser Response Time Without Provisioning Cache
+8370
+Average Undo-SyncSoftDeletedMailuser Response TimeBase Without Active Cache
+8372
+Total New-Mailbox Response Time
+8374
+Total New-MailUser Response Time
+8376
+Total New-RemoteMailbox Response Time
+8378
+Total New-SyncMailbox Response Time
+8380
+Total New-SyncMailUser Response Time
+8382
+Total Undo-SoftDeletedMailbox Response Time
+8384
+Total Undo-SyncSoftDeletedMailbox Response Time
+8386
+Total Undo-SyncSoftDeletedMailuser Response Time
+8388
+Percentage of New-Mailbox Calls with Active Provisioning Cache
+8390
+Percentage Base of New-Mailbox Calls with Active Provisioning Cache
+8392
+Percentage of New-MailUser Calls with Active Provisioning Cache
+8394
+Percentage Base of New-MailUser Calls with Active Provisioning Cache
+8396
+Percentage of New-RemoteMailbox Calls with Active Provisioning Cache
+8398
+Percentage Base of New-RemoteMailbox Calls with Active Provisioning Cache
+8400
+Percentage of New-SyncMailbox calls with Active Provisioning Cache
+8402
+Percentage Base of New-SyncMailbox Calls with Active Provisioning Cache
+8404
+Percentage of New-SyncMailUser Calls with Active Provisioning Cache
+8406
+Percentage Base of New-SyncMailUser Calls with Active Provisioning Cache
+8408
+Percentage of Undo-SoftDeletedMailbox Calls with Active Provisioning Cache
+8410
+Percentage Base of Undo-SoftDeletedMailbox Calls with Active Provisioning Cache
+8412
+Percentage of Undo-SyncSoftDeletedMailbox Calls with Active Provisioning Cache
+8414
+Percentage Base of Undo-SyncSoftDeletedMailbox Calls with Provisioning Cache
+8416
+Percentage of Undo-SyncSoftDeletedMailuser Calls with Active Provisioning Cache
+8418
+Percentage Base of Undo-SyncSoftDeletedMailuser Calls with Provisioning Cache
+8420
+MSExchange Protocol Analysis Background Agent
+8422
+Socks4 Proxy Found
+8424
+Socks5 Proxy Found
+8426
+HttpConnect Proxy Found
+8428
+HttpPost Proxy Found
+8430
+Telnet Proxy Found
+8432
+Cisco Proxy Found
+8434
+Wingate Proxy Found
+8436
+Negative Open Proxy
+8438
+Unknown Open Proxy
+8440
+Open Proxy Tests
+8442
+Reverse DNS Sucess
+8444
+Reverse DNS Failure
+8446
+Block Senders
+8448
+MSExchange Protocol Analysis Agent
+8450
+Calculations at SRL 0
+8452
+Calculations at SRL 1
+8454
+Calculations at SRL 2
+8456
+Calculations at SRL 3
+8458
+Calculations at SRL 4
+8460
+Calculations at SRL 5
+8462
+Calculations at SRL 6
+8464
+Calculations at SRL 7
+8466
+Calculations at SRL 8
+8468
+Calculations at SRL 9
+8470
+Senders Blocked Because of Local SRL
+8472
+Senders Blocked Because of Remote SRL
+8474
+Senders Blocked Because of Local Open Proxy
+8476
+Senders Blocked Because of Remote Open Proxy
+8478
+Senders Bypass Local SRL Calculation
+8480
+Senders Processed
+8482
+MSExchange Prelicensing Agent
+8484
+Total Messages Prelicensed
+8486
+Messages Prelicensed/sec
+8488
+Total Messages Failed To Prelicense
+8490
+Messages Failed To Prelicense/sec
+8492
+Total Number of Deferrals when Prelicensing Messages
+8494
+Rate of Deferrals to Prelicense/sec
+8496
+Total Recipients Prelicensed
+8498
+Recipients Prelicensed/sec
+8500
+Total Recipients Failed To Prelicense
+8502
+Recipients Failed To Prelicense/sec
+8504
+Over 5% of messages failed prelicensing or server licensing in last 30 minutes
+8506
+Total Messages Licensed
+8508
+Messages Licensed/sec
+8510
+Total Messages Failed to License
+8512
+Messages Failed To License/sec
+8514
+Total Deferrals Of Messages To License
+8516
+Deferrals Of Messages To License/sec
+8518
+Total External Messages prelicensed
+8520
+External IRM-Protected Messages Prelicensed/sec
+8522
+Total External Messages Failed To Prelicense
+8524
+External Messages Failed To Prelicense/sec
+8526
+Total Deferrals To Prelicense For External Messages
+8528
+Rate of Deferrals to Prelicense External Messages/sec
+8530
+Total Recipients Prelicensed for Messages Protected by External AD RMS Server
+8532
+Recipients Prelicensed For External Messages/sec
+8534
+Total Recipients Failed To Prelicense For External Messages
+8536
+Total Recipients Failed To Prelicense/sec For External Messages
+8538
+MSExchange OWA
+8540
+Current Users
+8542
+Current Unique Users
+8544
+Total Users
+8546
+Logons/sec
+8548
+Total Unique Users
+8550
+Peak User Count
+8552
+Current Users Light
+8554
+Current Unique Users Light
+8556
+Total Users Light
+8558
+Logons/sec Light
+8560
+Total Unique Users Light
+8562
+Peak User Count Light
+8564
+Current Users Premium
+8566
+Current Unique Users Premium
+8568
+Total Users Premium
+8570
+Logons/sec Premium
+8572
+Total Unique Users Premium
+8574
+Peak User Count Premium
+8576
+Average Response Time
+8578
+Sessions Ended by Logoff
+8580
+Sessions Ended by Time-out
+8582
+Calendar Views Loaded
+8584
+Calendar View Refreshed
+8586
+Items Created Since OWA Start
+8588
+Items Updated Since OWA Start
+8590
+Items Deleted Since OWA Start
+8592
+Attachments Uploaded Since OWA Start
+8594
+Mail Views Loaded
+8596
+Mail View Refreshes
+8598
+Messages Sent
+8600
+IRM-protected Messages Sent
+8602
+Average Search Time
+8604
+Searches
+8606
+Searches Timed Out
+8608
+Requests
+8610
+Requests/sec
+8612
+Requests Failed
+8614
+Failed Requests/sec
+8616
+PID
+8618
+Average Check Spelling Time
+8620
+Spelling Checks
+8622
+Conversions
+8624
+Active Conversions
+8626
+Rejected Conversions
+8628
+Queued Conversion Requests
+8630
+Conversions Ended by Time-out
+8632
+Conversions Ended with Errors
+8634
+Conversion Requests KB/sec
+8636
+Successful Conversion Requests KB/sec
+8638
+Conversion Responses KB/sec
+8640
+Average Conversion Time
+8642
+Average Conversion Queuing Time
+8644
+Invalid Canary Requests
+8646
+Names Checked
+8648
+Password Changes
+8650
+Current Proxy Users
+8652
+Proxy User Requests
+8654
+Proxy User Requests/sec
+8656
+Proxy Response Time Average
+8658
+Proxy Request Bytes
+8660
+Proxy Response Bytes
+8662
+WSS Response Bytes
+8664
+WSS Response Bytes/sec
+8666
+UNC Response Bytes
+8668
+UNC Response Bytes/sec
+8670
+WSS Requests
+8672
+UNC Requests
+8674
+AS Queries
+8676
+AS Queries Failure %
+8678
+Store Logon Failure %
+8680
+CAS Intra-Site Redirection Later to Earlier Version
+8682
+CAS Intra-Site Redirection Earlier to Later Version
+8684
+CAS Cross-Site Redirection Later to Earlier Version
+8686
+CAS Cross-Site Redirection Earlier to Later Version
+8688
+Active Mailbox Subscriptions
+8690
+Total Mailbox Notifications
+8692
+Mailbox Notifications/sec
+8694
+Total Usercontext ReInitialization requests
+8696
+Mailbox Offline Exception Failure %
+8698
+Connection Failed Transient Exception %
+8700
+Storage Transient Exception Failure %
+8702
+Storage Permanent Exception Failure %
+8704
+IM - Total Messages Sent
+8706
+IM - Messages Sent/sec
+8708
+IM - Total Messages Received
+8710
+IM - Messages Received/sec
+8712
+IM - Total Presence Queries
+8714
+IM - Presence Queries/sec
+8716
+IM - Total Message Delivery Failures
+8718
+IM - Message Delivery Failures/sec
+8720
+IM - Sign-In Failures
+8722
+IM - Sign-In Failures/sec
+8724
+IM - Users Currently Signed In
+8726
+IM - Total Users
+8728
+IM - Average Sign-In Time
+8730
+IM - Sign-In Failure %
+8732
+IM - Sent Message Delivery Failure %
+8734
+Failure rate of requests from OWA to EWS.
+8736
+Request Time-Outs
+8738
+Sender Photos - Total LDAP calls
+8740
+Sender Photos - Total LDAP calls returned non-empty image data
+8742
+Sender Photos - LDAP calls/sec
+8744
+Sender Photos - Total entries in Recipients Negative Cache
+8746
+Sender Photos - Total number of avoided LDAP calls due to cache
+8748
+MSExchange OAuth
+8750
+Total Auth Requests
+8752
+Auth Requests/sec
+8754
+Failed Auth Requests Total
+8756
+Failed Auth Requests/sec
+8758
+Average Auth Response Time
+8760
+Base for Average Auth Response Time
+8762
+Average AuthServer Response Time
+8764
+Base for Average AuthServer Response Time
+8766
+Total Token Requests to AuthServer
+8768
+Token Requests to AuthServer/sec
+8770
+Number of Pending AuthServer Requests
+8772
+AuthServer Token Cache Size
+8774
+MSExchange OAB Generator Assistant
+8776
+Total number of OAB records
+8778
+MSExchange NSPI RPC Client Connections
+8780
+Number of Open NSPI RPC Client Connections
+8782
+MSExchange Network Manager
+8784
+Log Copy KB Received/Sec
+8786
+Log Copy KB Sent/Sec
+8788
+Seeder KB Received/Sec
+8790
+Seeder KB Sent/Sec
+8792
+Total Compressed Log Bytes Received
+8794
+Total Log Bytes Decompressed
+8796
+Total Compressed Seeding Bytes Received
+8798
+Total Seeding Bytes Decompressed
+8800
+MSExchange Middle-Tier Storage
+8802
+Named Property cache entries.
+8804
+Named Property cache misses.
+8806
+Base counter for Named Property cache misses.
+8808
+Dumpster Active Sessions
+8810
+Dumpster Active Delegate Sessions
+8812
+Dumpster Active Directory Settings Cache Entries
+8814
+Dumpster Active Directory Settings Refresh/sec
+8816
+Items Moved to Dumpster/sec.
+8818
+Items Copied to Dumpster/sec.
+8820
+Dumpster Calendar Log Entries/sec
+8822
+Items Dumpster Deletions/sec
+8824
+Items Dumpster Purges/sec
+8826
+Items Dumpster Versions/sec
+8828
+Folder Enumerations for Dumpster/sec
+8830
+Items Forced Copied into Dumpster/sec
+8832
+Items Moved in Dumpster not Kept/sec
+8834
+Items Copy in Dumpster not Kept/sec
+8836
+Audit records for folder bind/sec
+8838
+Audit records for group change/sec
+8840
+Audit records for item change/sec
+8842
+Total audits saved
+8844
+Audits saved/sec
+8846
+Total time for saving audits
+8848
+Average time for saving audits
+8850
+Base of average time for saving audits
+8852
+Items copied to discovery mailbox/sec.
+8854
+Number of mailbox searches that are queued
+8856
+Number of mailbox searches that are active
+8858
+Number of mailboxes being searched
+8860
+Dumpster versions reverted on failure.
+8862
+Dumpster Active Directory Settings cache misses.
+8864
+Base counter for Dumpster Active Directory Settings cache misses.
+8866
+MSExchange Message Tracking
+8868
+Search-MessageTrackingReport task executed
+8870
+Search-MessageTrackingReport task executed/sec
+8872
+Search-MessageTrackingReport Processing Time
+8874
+Average Search-MessageTrackingReport Processing Time
+8876
+Average Search-MessageTrackingReport Processing Time base
+8878
+Total Queries by Search-MessageTrackingReport
+8880
+Average Queries by Search-MessageTrackingReport
+8882
+Average Queries by Search-MessageTrackingReport base
+8884
+Get-MessageTrackingReport Task Executed
+8886
+Get-MessageTrackingReport Task Executed/Sec
+8888
+Get-MessageTrackingReport Processing Time
+8890
+Average Get-MessageTrackingReport Processing Time
+8892
+Average Get-MessageTrackingReport Processing Time Base
+8894
+Total Queries by Get-MessageTrackingReport
+8896
+Average Queries by Get-MessageTrackingReport
+8898
+Average Queries by Get-MessageTrackingReport base
+8900
+MessageTracking current request dispatcher requests
+8902
+Percentage of MessageTrackingReport operations (via task) completed with errors
+8904
+Percentage of MessageTrackingReport operations (via EWS) completed with errors
+8906
+MSExchange Managed Folder Assistant
+8908
+Items Moved
+8910
+Items Deleted but Recoverable
+8912
+Items Permanently Deleted
+8914
+Items Moved to Discovery Holds
+8916
+Items Marked as Past Retention Date
+8918
+Items Subject to Retention Policy
+8920
+Items Journaled
+8922
+Mailbox Dumpsters Skipped
+8924
+Mailbox Dumpsters Expired Items
+8926
+System Data Expired Items
+8928
+Total Over Quota Dumpsters
+8930
+Total Over Quota Dumpster Items
+8932
+Total Over Quota Dumpster Items Deleted
+8934
+Size of Items subject to Retention Policy (In Bytes)
+8936
+Size of Items Deleted but Recoverable (In Bytes)
+8938
+Size of Items Permanently Deleted (In Bytes)
+8940
+Size of Items Moved to Discovery Holds (In Bytes)
+8942
+Size of Items Moved due to an Archive policy tag (In Bytes)
+8944
+Items stamped with Personal Tag
+8946
+Items stamped with Default Tag
+8948
+Items stamped with Cleanup System Tag
+8950
+Items expired by a Default Policy Tag
+8952
+Total items expired by a Personal Tag
+8954
+Total items moved by a default Archive tag
+8956
+Items Moved due to an Archive Tag
+8958
+Mailbox Dumpsters Moved Items
+8960
+Health Monitor Average Delay (In Milliseconds)
+8962
+Health Monitor Delays/sec
+8964
+Health Monitor Count of Unhealthy Database Hits
+8966
+MSExchange MailTips
+8968
+GetMailTipsConfiguration Average Response Time
+8970
+GetServiceConfiguration average response time
+8972
+GetMailTips Average Response Time
+8974
+In-Forest GetMailTips Response Time, 99th Percentile
+8976
+In-Forest GetMailTips Response Time, 95th Percentile
+8978
+In-Forest GetMailTips Response Time, 90th Percentile
+8980
+In-Forest GetMailTips Response Time, 80th Percentile
+8982
+In-Forest GetMailTips Response Time, 50th Percentile
+8984
+Cross-Forest GetMailTips Response Time, 99th Percentile
+8986
+Cross-Forest GetMailTips Response Time, 95th Percentile
+8988
+Cross-Forest GetMailTips Response Time, 90th Percentile
+8990
+Cross-Forest GetMailTips Response Time, 80th Percentile
+8992
+Cross-Forest GetMailTips Response Time, 50th Percentile
+8994
+GetMailTips Average Recipient Number
+8996
+Average Active Directory Response Time
+8998
+MailboxFull Answered Within One Second
+9000
+Base Counter for MailboxFull Answered Within One Second
+9002
+MailboxFull Answered Within Three Seconds
+9004
+Base Counter for MailboxFull Answered Within Three Seconds
+9006
+MailboxFull Answered Within Ten Seconds
+9008
+Base Counter for MailboxFull Answered Within Ten Seconds
+9010
+MailboxFull with Positive Responses
+9012
+Automatic Replies (1 sec)
+9014
+Base counter for Automatic Replies (1 sec)
+9016
+Automatic Replies (3 sec)
+9018
+Base counter for Automatic Replies (3 sec)
+9020
+Automatic Replies (10 sec)
+9022
+Base counter for Automatic Replies (10 sec)
+9024
+Automatic Replies Turned On
+9026
+MailTips Queries Answered Within One Second
+9028
+Base Counter for MailTips Queries Answered Within One Second
+9030
+MailTips Queries Answered Within Three Seconds
+9032
+Base Counter for MailTips Queries Answered Within Three Seconds
+9034
+MailTips Queries Answered Within Ten Seconds
+9036
+Base Counter for MailTips Queries Answered Within Ten Seconds
+9038
+Intra-Site MailTips Failures (sec)
+9040
+Count of GroupMetrics Queries (sec)
+9042
+MailTips Current Requests
+9044
+MailTips Accumulated Recipients
+9046
+MailTips Accumulated Mailbox Sourced Recipients
+9048
+MailTips Accumulated Exception Recipients
+9050
+MailTips Accumulated Requests
+9052
+MSExchange Mailbox Replication Service Per Mdb
+9054
+Active Moves: Total Moves
+9056
+Active Moves: Moves in Initial Seeding State
+9058
+Active Moves: Moves in Completion State
+9060
+Active Moves: Stalled Moves Total
+9062
+Active Moves: Stalled Moves (Database Replication)
+9064
+Active Moves: Stalled Moves (Content Indexing)
+9066
+Active Moves: Transient Failure (Total)
+9068
+Active Moves: Transient Failure (Network)
+9070
+Active Moves: Transient Failure (MDB Offline)
+9072
+Active Moves: Transfer Rate (KB/sec)
+9074
+Active Moves: Transfer Rate (KB/sec) (base)
+9076
+Active Moves: Bytes Transferred
+9078
+Move Requests: Completed
+9080
+Move Requests: Completed/hour
+9082
+Move Requests: Completed/hour (base)
+9084
+Move Requests: Completed with Warnings
+9086
+Move Requests: Completed with Warnings/hour
+9088
+Move Requests: Completed with Warnings/hour (base)
+9090
+Move Requests: Canceled
+9092
+Move Requests: Canceled/hour
+9094
+Move Requests: Canceled/hour (base)
+9096
+Move Requests: Transient Failures
+9098
+Move Requests: Transient Failures/hour
+9100
+Move Requests: Transient Failures/hour (base)
+9102
+Move Requests: Transient Failures (Network)
+9104
+Move Requests: Transient Failures (Network)/hour
+9106
+Move Requests: Transient Failures (Network)/hour (base)
+9108
+Move Requests: Transient Failures (Proxy Backoff)
+9110
+Move Requests: Transient Failures (Proxy Backoff)/hour
+9112
+Move Requests: Transient Failures (Proxy Backoff)/hour (base)
+9114
+Move Requests: Failed
+9116
+Move Requests: Failed/hour
+9118
+Move Requests: Failed/hour (base)
+9120
+Move Requests: Failed (Bad Item Limit)
+9122
+Move Requests: Failed (Bad Item Limit)/hour
+9124
+Move Requests: Failed (Bad Item Limit)/hour (base)
+9126
+Move Requests: Failed (Network)
+9128
+Move Requests: Failed (Network)/hour
+9130
+Move Requests: Failed (Network)/hour (base)
+9132
+Move Requests: Failed (Stall Content Indexing)
+9134
+Move Requests: Failed (Stall Content Indexing)/hour
+9136
+Move Requests: Failed (Stall Content Indexing)/hour (base)
+9138
+Move Requests: Failed (Stall Database Replication)
+9140
+Move Requests: Failed (Stall Database Replication)/hour
+9142
+Move Requests: Failed (Stall Database Replication)/hour (base)
+9144
+Move Requests: Failed (MAPI)
+9146
+Move Requests: Failed (MAPI)/hour
+9148
+Move Requests: Failed (MAPI)/hour (base)
+9150
+Move Requests: Failed (Other)
+9152
+Move Requests: Failed (Other)/hour
+9154
+Move Requests: Failed (Other)/hour (base)
+9156
+Move Requests: Stalls
+9158
+Move Requests: Move Stalls/hour
+9160
+Move Requests: Move Stalls/hour (base)
+9162
+Move Requests: Stalls (Database Replication)
+9164
+Move Requests: Move Stalls (Database Replication)/hour
+9166
+Move Requests: Move Stalls (Database Replication)/hour (base)
+9168
+Move Requests: Stalls (Content Indexing)
+9170
+Move Requests: Move Stalls (Content Indexing)/hour
+9172
+Move Requests: Move Stalls (Content Indexing)/hour (base)
+9174
+Last Scan: Timestamp (UTC)
+9176
+Last Scan: Duration (msec)
+9178
+MDB Health: Scan Failure
+9180
+MDB Health: Content Indexing Lagging
+9182
+MDB Health: Database Replication Lagging
+9184
+MDB Throttle: Raw write throttle due to Mdb resource
+9186
+MDB Throttle: Raw read throttle due to Mdb resource
+9188
+MDB Throttle: Raw write throttle due to HA resource
+9190
+MDB Throttle: Raw write throttle due to CI resource
+9192
+MDB Health: Write Capacity
+9194
+MDB Health: Read Capacity
+9196
+MDB Health: Active Write Jobs
+9198
+MDB Health: Active Read Jobs
+9200
+MSExchange Mailbox Replication Service
+9202
+Unreachable Databases
+9204
+Last Scan Timestamp (UTC)
+9206
+Last Scan Duration (msec)
+9208
+Total jobs currently being processed by this server
+9210
+CPU Throttle: Raw write throttle due to Cpu resource
+9212
+CPU Throttle: Raw read throttle due to Cpu resource
+9214
+PST Read Bytes/sec
+9216
+PST Write Bytes/sec
+9218
+PST Read Operations/sec
+9220
+PST Write Operations/sec
+9222
+PST Read Messages/sec
+9224
+PST Write Messages/sec
+9226
+PST Heap Cache Bytes
+9228
+PST Block BTree Cache Bytes
+9230
+PST Node BTree Cache Bytes
+9232
+PST AMap Cache Bytes
+9234
+Named Property Cache Entries.
+9236
+MSExchange Log Search Service
+9238
+Search requests processed
+9240
+Search requests processed/sec
+9242
+Average search processing time
+9244
+Base to compute average processing time
+9246
+Search requests rejected
+9248
+Search requests timed out
+9250
+MSExchange Junk E-mail Options Assistant
+9252
+Recipients updated
+9254
+Recipients updated per second
+9256
+Partial updates due to oversized safe or block lists
+9258
+MSExchange Journaling Agent
+9260
+Users Journaled
+9262
+Users Journaled/sec
+9264
+Journal Reports created Total
+9266
+Journal Reports with RMS protected messages created
+9268
+Journal Reports Created/sec
+9270
+Messages Processed by Journaling
+9272
+Journaling Processing Time
+9274
+Journaling Processing Time per Message
+9276
+Average journaling processing time/message base
+9278
+MSExchange Journal Report Decryption Agent
+9280
+Total Journal Reports decrypted
+9282
+Journal Reports decrypted/sec
+9284
+Total Journal Reports failed to decrypt
+9286
+Journal Reports failed to decrypt/sec
+9288
+Total deferrals of Journal Reports
+9290
+Deferrals of Journal Reports/sec
+9292
+MSExchange Inbound SMS Delivery Agent
+9294
+Number of SMS messages received
+9296
+Maximum message processing time
+9298
+Average message processing time
+9300
+MSExchange HttpProxy Cache
+9302
+AnchorMailbox to Database Cache Size
+9304
+AnchorMailbox to Database Cache Hit Rate
+9306
+AnchorMailbox to Database Cache Hit Rate Base
+9308
+DatabaseGuid to MailboxServer Cache Size
+9310
+DatabaseGuid to MailboxServer Cache Hit Rate
+9312
+DatabaseGuid to MailboxServer Cache Hit Rate Base
+9314
+DatabaseGuid to MailboxServer Cache Refreshing Queue Length
+9316
+DatabaseGuid to MailboxServer Cache Refreshing Status
+9318
+FBAModule Key Cache Size
+9320
+FBAModule Key Cache Hits Rate
+9322
+FBAModule Key Cache Hits Rate Base
+9324
+AnchorMailbox to MailboxServer Cookie Hit Rate
+9326
+AnchorMailbox to MailboxServer Cookie Hit Rate Base
+9328
+Overall Cache Effectiveness (% of requests)
+9330
+Overall Cache Effectiveness (% of requests) Base
+9332
+DatabaseGuid to MailboxServer Cache Hit Rate (Moving Average)
+9334
+AnchorMailbox to MailboxServer Cookie Hit Rate (Moving Average)
+9336
+MSExchange HttpProxy
+9338
+Outstanding Proxy Requests
+9340
+Total Requests
+9342
+Requests/Sec
+9344
+Total Bytes Out
+9346
+Bytes Out/Sec
+9348
+Total Bytes In
+9350
+Bytes In/Sec
+9352
+Total Proxy Requests
+9354
+Proxy Requests/Sec
+9356
+MailboxServerLocator Calls
+9358
+MailboxServerLocator Calls/Sec
+9360
+MailboxServerLocator Failed Calls
+9362
+MailboxServerLocator Retried Calls
+9364
+MailboxServerLocator Last Call Latency
+9366
+MailboxServerLocator Average Latency
+9368
+MailboxServerLocator Average Latency Base
+9370
+ClientAccess 2010 Total Servers
+9372
+ClientAccess 2010 Healthy Servers
+9374
+ClientAccess 2010 Servers Last Ping
+9376
+Load Balancer Health Checks
+9378
+Average ClientAccess Server Processing Latency
+9380
+Average Mailbox Server Proxying Latency
+9382
+Average Active Directory Latency
+9384
+Average Tenant Lookup Latency
+9386
+Average Authentication Latency
+9388
+MailboxServerLocator Average Latency (Moving Average)
+9390
+Mailbox Server Proxy Failure Rate
+9392
+MailboxServerLocator Retried Rate
+9394
+MailboxServerLocator Failure Rate
+9396
+MSExchange Encryption Agent
+9398
+Total messages encrypted for policy
+9400
+Messages encrypted for policy/sec
+9402
+Total messages failed to encrypt for policy
+9404
+Messages failed to encrypt for policy/sec
+9406
+Total deferrals of messages for policy
+9408
+Deferrals of messages for policy/sec
+9410
+Over 5% of messages failing Transport Policy Encryption in the last 30 minutes
+9412
+Total messages reencrypted
+9414
+Messages reencrypted/sec
+9416
+Total messages failed to reencrypt
+9418
+Messages failed to reencrypt/sec
+9420
+MSExchange Diagnostics Service
+9422
+Bytes left to be processed on disk
+9424
+Number of batches uploaded for the last hour
+9426
+Number of batches uploaded since service started
+9428
+Successful uploads in last hundred batches
+9430
+Failed uploads in last hundred batches
+9432
+Retry count since last successful upload
+9434
+Average connection open latency for last hundred batches
+9436
+Connection open latency for last batch
+9438
+Average upload latency for last hundred batches
+9440
+Upload latency for last batch
+9442
+Average upload size for last hundred batches
+9444
+Upload size for last batch
+9446
+MSExchange Delivery Store Driver Database
+9448
+Delivery attempts per minute over the last 5 minutes
+9450
+Delivery failures per minute over the last 5 minutes
+9452
+MSExchange Delivery Store Driver Agents
+9454
+StoreDriverDelivery Agent Failure
+9456
+MSExchange Delivery Store Driver
+9458
+Inbound: LocalDeliveryCalls
+9460
+Inbound: LocalDeliveryCallsPerSecond
+9462
+Inbound: MessageDeliveryAttempts
+9464
+Inbound: MessageDeliveryAttemptsPerSecond
+9466
+Inbound: Recipients Delivered
+9468
+Inbound: Recipients Delivered Per Second
+9470
+Percent of Permanent Failed Deliveries within the last 5 minutes
+9472
+Percent of Temporary Failed Deliveries within the last 5 minutes
+9474
+Inbound: Bytes Delivered
+9476
+Inbound: Number of Delivering Threads
+9478
+Inbound: Retried Recipients
+9480
+Inbound: Rerouted Recipients
+9482
+Inbound: Duplicate Deliveries
+9484
+Mailbox Rules: Active Directory queries
+9486
+Mailbox Rules: Active Directory queries per second
+9488
+Mailbox Rules: MAPI operations
+9490
+Mailbox Rules: MAPI operations per second
+9492
+Mailbox Rules: Average milliseconds spent processing rules.
+9494
+Mailbox Rules: 90th percentile of milliseconds spent processing rules.
+9496
+Inbound: TotalMeetingMessages
+9498
+Inbound: TotalMeetingFailures
+9500
+Pending Deliveries
+9502
+Delivery attempts per minute over the last 5 minutes
+9504
+Delivery failures per minute over the last 5 minutes
+9506
+SuccessfulDeliveries
+9508
+SuccessfulDeliveriesPerSecond
+9510
+FailedDeliveries
+9512
+FailedDeliveriesPerSecond
+9514
+MSExchange Delivery SmtpSend
+9516
+Connections Current
+9518
+Connections Created/sec
+9520
+Connections Total
+9522
+Messages Sent/sec
+9524
+Messages Sent Total
+9526
+Message Bytes Sent Total
+9528
+Message Bytes Sent/sec
+9530
+Messages Suppressed Due to Bare Linefeeds
+9532
+Bytes Sent Total
+9534
+Bytes Sent/sec
+9536
+Recipients sent
+9538
+Average recipients/message
+9540
+Average recipients (message base)
+9542
+Average message bytes/message
+9544
+Average message bytes/message Base
+9546
+Average messages/connection
+9548
+Average messages (connection Base)
+9550
+Average bytes/connection
+9552
+Average bytes (connection Base)
+9554
+DNS Errors
+9556
+Connection Failures
+9558
+Socket Errors
+9560
+Protocol Errors
+9562
+MSExchange Delivery SmtpReceive
+9564
+Connections Current
+9566
+Connections Created/sec
+9568
+Connections Total
+9570
+Disconnections by Agents/second
+9572
+Disconnections By Agents
+9574
+Messages Received/sec
+9576
+Messages Received Total
+9578
+Message Bytes Received/sec
+9580
+Message Bytes Received Total
+9582
+Messages Refused for Size
+9584
+Messages Received Containing Bare Linefeeds in the SMTP DATA Stream
+9586
+Messages Rejected During SMTP DATA Due to Bare Linefeeds
+9588
+Recipients accepted Total
+9590
+Average bytes/message
+9592
+Average bytes/message Base
+9594
+Average recipients/message
+9596
+Average recipients/message base
+9598
+Average bytes/connection
+9600
+Average bytes/connection base
+9602
+Average messages/connection
+9604
+Average messages/connection base
+9606
+Bytes Received/sec
+9608
+Bytes Received Total
+9610
+Tarpitting Delays Authenticated
+9612
+Tarpitting Delays Anonymous
+9614
+Tarpitting Delays Authenticated/sec
+9616
+Tarpitting Delays Anonymous/sec
+9618
+MSExchange Delivery SmtpAvailability
+9620
+Total Connections
+9622
+% Availability
+9624
+% Activity
+9626
+% Failures Due To MaxInboundConnectionLimit
+9628
+% Failures Due To WLID Down
+9630
+% Failures Due To Active Directory Down
+9632
+% Failures Due To Back Pressure
+9634
+% Failures Due To IO Exceptions
+9636
+% Failures Due To TLS Errors
+9638
+Failures Due to Maximum Local Loop Count
+9640
+MSExchange Delivery Routing
+9642
+Routing NDRs Total
+9644
+Routing Tables Calculated Total
+9646
+Routing Tables Changed Total
+9648
+MSExchange Delivery ProxyHubSelector
+9650
+Hub Selection Requests Total
+9652
+Hub Selection Resolver Failures
+9654
+Hub Selection Organization Mailbox Failures
+9656
+Hub Selection Messages Without Mailbox Recipients
+9658
+Hub Selection Messages Without Organization Mailboxes
+9660
+Hub Selection Fallback Routing Requests
+9662
+Hub Selection Routing Failures
+9664
+MSExchange Delivery Extensibility Agents
+9666
+Average Agent Processing Time (sec)
+9668
+Average Agent Processing Time Base (sec)
+9670
+Average CPU usage of synchronous invocations of agent (milliseconds)
+9672
+Base counter of AverageAgentProcessorUsageSynchronousInvocations
+9674
+Average CPU usage of asynchronous invocations of agent (milliseconds)
+9676
+Base counter of AverageAgentProcessorUsageAsynchronousInvocations
+9678
+Total synchronous invocations of agent
+9680
+Total asynchronous invocations of agent
+9682
+Total Agent Invocations
+9684
+MSExchange Delivery End To End Latency
+9686
+Percentile50
+9688
+Percentile80
+9690
+Percentile90
+9692
+Percentile95
+9694
+Percentile99
+9696
+MSExchange Delivery DSN
+9698
+Failure DSNs Total
+9700
+Delay DSNs
+9702
+Relay DSNs
+9704
+Delivered DSNs
+9706
+Expanded DSNs
+9708
+Failure DSNs within the last hour
+9710
+Alertable failure DSNs within the last hour
+9712
+Delayed DSNs within the last hour
+9714
+NDRs generated for catch-all recipients.
+9716
+MSExchange Delivery Configuration Cache
+9718
+Configuration Cache Total requests
+9720
+Configuration Cache requests per sec
+9722
+Configuration Cache hit ratio
+9724
+Configuration Cache hit ratio base counter
+9726
+Configuration Cache size
+9728
+Configuration Cache size in MB
+9730
+MSExchange Delivery Component Latency
+9732
+Percentile50
+9734
+Percentile80
+9736
+Percentile90
+9738
+Percentile95
+9740
+Percentile99
+9742
+MSExchange Delivery Certificate Validation Cache
+9744
+Total Requests
+9746
+Requests per Second
+9748
+Hit Ratio
+9750
+Certificate Validation Result Cache hit ratio base counter
+9752
+Cache Size
+9754
+MSExchange Database Pinger
+9756
+Pings Per Minute
+9758
+Failed Pings
+9760
+Number of Ping Timeouts
+9762
+Cache Size
+9764
+Databases Quarantined
+9766
+Database Concurrency Limit
+9768
+MSExchange Conversations Transport Agent
+9770
+Average message processing time
+9772
+Last message processing time
+9774
+MSExchange Control Panel
+9776
+PID
+9778
+RBAC Sessions
+9780
+RBAC Sessions - Total
+9782
+RBAC Sessions/sec
+9784
+RBAC Sessions - Peak
+9786
+RBAC Sessions - Average Creation Time
+9788
+RBAC Sessions - Average Creation Time Base
+9790
+PowerShell Runspaces
+9792
+PowerShell Runspaces - Total
+9794
+PowerShell Runspaces/sec
+9796
+PowerShell Runspaces - Peak
+9798
+PowerShell Runspaces - Average Creation Time
+9800
+PowerShell Runspaces - Average Creation Time Base
+9802
+PowerShell Runspaces - Active
+9804
+PowerShell Runspaces - Activations Total
+9806
+PowerShell Runspaces - Activations/sec
+9808
+PowerShell Runspaces - Peak Active
+9810
+PowerShell Runspaces - Average Active Time
+9812
+PowerShell Runspaces - Average Active Time Base
+9814
+ASP.Net Request Failures
+9816
+ASP.Net Request Failures/sec
+9818
+Web Service Request Failures
+9820
+Web Service Request Failures/sec
+9822
+Watson Reports
+9824
+Requests Redirected To Error Page
+9826
+Requests Redirected To Error Page/sec
+9828
+Web Service - GetList Calls
+9830
+Web Service - GetList Calls/sec
+9832
+Web Service - GetObject Calls
+9834
+Web Service - GetObject Calls/sec
+9836
+Web Service - NewObject Calls
+9838
+Web Service - NewObject Calls/sec
+9840
+Web Service - SetObject Calls
+9842
+Web Service - SetObject Calls/sec
+9844
+Web Service - RemoveObject Calls
+9846
+Web Service - RemoveObject Calls/sec
+9848
+Requests - Active
+9850
+Requests - Activations Total
+9852
+Requests - Activations/sec
+9854
+Requests - Peak Active
+9856
+Requests - Average Response Time
+9858
+Requests - Average Response Time Base
+9860
+Outbound Proxy Sessions
+9862
+Outbound Proxy Sessions - Total
+9864
+Outbound Proxy Sessions/sec
+9866
+Outbound Proxy Sessions - Peak
+9868
+Outbound Proxy Requests
+9870
+Outbound Proxy Requests - Total
+9872
+Outbound Proxy Requests/sec
+9874
+Outbound Proxy Requests - Peak
+9876
+Outbound Proxy Requests - Average Response Time
+9878
+Outbound Proxy Requests - Average Response Time Base
+9880
+Outbound Proxy Request Bytes
+9882
+Outbound Proxy Response Bytes
+9884
+Explicit Sign-On Outbound Proxy Sessions
+9886
+Explicit Sign-On Outbound Proxy Sessions - Total
+9888
+Explicit Sign-On Outbound Proxy Sessions/sec
+9890
+Explicit Sign-On Outbound Proxy Sessions - Peak
+9892
+Explicit Sign-On Outbound Proxy Requests
+9894
+Explicit Sign-On Outbound Proxy Requests - Total
+9896
+Explicit Sign-On Outbound Proxy Requests/sec
+9898
+Explicit Sign-On Outbound Proxy Requests - Peak
+9900
+Explicit Sign-On Outbound Proxy Requests - Average Response Time
+9902
+Explicit Sign-On Outbound Proxy Requests - Average Response Time Base
+9904
+Explicit Sign-On Outbound Proxy Request Bytes
+9906
+Explicit Sign-On Outbound Proxy Response Bytes
+9908
+Inbound Proxy Sessions
+9910
+Inbound Proxy Sessions - Total
+9912
+Inbound Proxy Sessions/sec
+9914
+Inbound Proxy Sessions - Peak
+9916
+Inbound Proxy Requests
+9918
+Inbound Proxy Requests - Total
+9920
+Inbound Proxy Requests/sec
+9922
+Inbound Proxy Requests - Peak
+9924
+Explicit Sign-On Inbound Proxy Sessions
+9926
+Explicit Sign-On Inbound Proxy Sessions - Total
+9928
+Explicit Sign-On Inbound Proxy Sessions/sec
+9930
+Explicit Sign-On Inbound Proxy Sessions - Peak
+9932
+Explicit Sign-On Inbound Proxy Requests
+9934
+Explicit Sign-On Inbound Proxy Requests - Total
+9936
+Explicit Sign-On Inbound Proxy Requests/sec
+9938
+Explicit Sign-On Inbound Proxy Requests - Peak
+9940
+Standard RBAC Sessions
+9942
+Standard RBAC Sessions - Total
+9944
+Standard RBAC Sessions/sec
+9946
+Standard RBAC Sessions - Peak
+9948
+Standard RBAC Requests
+9950
+Standard RBAC Requests - Total
+9952
+Standard RBAC Requests/sec
+9954
+Standard RBAC Requests - Peak
+9956
+Explicit Sign-On Standard RBAC Sessions
+9958
+Explicit Sign-On Standard RBAC Sessions - Total
+9960
+Explicit Sign-On Standard RBAC Sessions/sec
+9962
+Explicit Sign-On Standard RBAC Sessions - Peak
+9964
+Explicit Sign-On Standard RBAC Requests
+9966
+Explicit Sign-On Standard RBAC Requests - Total
+9968
+Explicit Sign-On Standard RBAC Requests/sec
+9970
+Explicit Sign-On Standard RBAC Requests - Peak
+9972
+MSExchange Content Filter Agent
+9974
+Messages that Bypassed Scanning
+9976
+Messages with a Preexisting SCL
+9978
+Messages Scanned
+9980
+Messages with SCL Unknown
+9982
+Messages Scanned Per Second
+9984
+Messages with SCL 0
+9986
+Messages with SCL 1
+9988
+Messages with SCL 2
+9990
+Messages with SCL 3
+9992
+Messages with SCL 4
+9994
+Messages with SCL 5
+9996
+Messages with SCL 6
+9998
+Messages with SCL 7
+10000
+Messages with SCL 8
+10002
+Messages with SCL 9
+10004
+Messages Deleted
+10006
+Messages Rejected
+10008
+Messages Quarantined
+10010
+Messages that Bypassed Scanning due to an organization-wide Safe Sender
+10012
+Bypassed recipients due to per-recipient Safe Senders
+10014
+Bypassed recipients due to per-recipient Safe Recipients
+10016
+Messages that include an Outlook E-mail Postmark that validated successfully
+10018
+Messages that include an Outlook E-mail Postmark that did not validate
+10020
+MSExchange Connection Filtering Agent
+10022
+Connections on IP Allow List
+10024
+Connections on IP Allow List/sec
+10026
+Connections on IP Block List
+10028
+Connections on IP Block List/sec
+10030
+Connections on IP Allow List Providers
+10032
+Connections on IP Allow List Providers/sec
+10034
+Connections on IP Block List Providers
+10036
+Connections on IP Block List Providers /sec
+10038
+Messages with Originating IP on IP Allow List
+10040
+Messages with Originating IP on IP Allow List/sec
+10042
+Messages with Originating IP on IP Block List
+10044
+Messages with Originating IP on IP Block List/sec
+10046
+Messages with Originating IP on IP Allow List Providers
+10048
+Messages with Originating IP on IP Allow List Providers/sec
+10050
+Messages with Originating IP on IP Block List Providers
+10052
+Messages with Originating IP on IP Block List Providers/sec
+10054
+MSExchange Calendar Sync Assistant
+10056
+On demand requests
+10058
+Average Number of Subscriptions per Mailbox
+10060
+Average Number of Subscriptions per Mailbox Base
+10062
+Average Time Between Syncs
+10064
+Average Time Between Syncs Base
+10066
+Average Download Time
+10068
+Average Download Time Base
+10070
+Average Subscription Processing Time
+10072
+Average Subscription Processing Time Base
+10074
+Average Subscription Import Time
+10076
+Average Subscription Import Time Base
+10078
+MSExchange Calendar Repair Assistant
+10080
+Items Inspected
+10082
+Items Repaired
+10084
+MSExchange Calendar Attendant
+10086
+Meeting Messages Processed
+10088
+Meeting Messages Deleted
+10090
+Requests Failed
+10092
+Invitations
+10094
+Meeting Responses
+10096
+Meeting Cancellations
+10098
+Lost Races
+10100
+Last Calendar Attendant Processing Time
+10102
+Average Calendar Attendant Processing Time
+10104
+Average Calendar Attendant Processing Time Base
+10106
+MSExchange Bulk User Provisioning
+10108
+Total Recipients Attempted
+10110
+Recipients Attempted Per Second
+10112
+Total Recipients Created
+10114
+Recipients Created Per Second
+10116
+Total Recipients Failed
+10118
+Total Mailboxes Attempted
+10120
+Mailboxes Attempted Per Second
+10122
+Total Mailboxes Created
+10124
+Mailboxes Created Per Second
+10126
+Total Mailboxes Failed
+10128
+Total Contacts Attempted
+10130
+Contacts Attempted Per Second
+10132
+Total Contacts Created
+10134
+Contacts Created Per Second
+10136
+Total Contacts Failed
+10138
+Total Groups Attempted
+10140
+Groups Attempted Per Second
+10142
+Total Groups Created
+10144
+Groups Created Per Second
+10146
+Total Groups Failed
+10148
+Total Members Attempted
+10150
+Members Attempted Per Second
+10152
+Total Members Created
+10154
+Members Created Per Second
+10156
+Total Members Failed
+10158
+Total UpdateContacts Attempted
+10160
+UpdateContacts Attempted Per Second
+10162
+Total UpdateContacts Created
+10164
+UpdateContacts Created Per Second
+10166
+Total UpdateContacts Failed
+10168
+Total UpdateUser Attempted
+10170
+UpdateUser Attempted Per Second
+10172
+Total UpdateUser Created
+10174
+UpdateUser Created Per Second
+10176
+Total UpdateUser Failed
+10178
+Requests Loaded For Processing
+10180
+Requests Completed
+10182
+Total Requests With Transient Error
+10184
+Requests Without Progress
+10186
+Requests With Progress
+10188
+Rounds With Requests Without Progress
+10190
+Rounds Without Progress
+10192
+Last Attempted Recipient Timestamp
+10194
+MSExchange Availability Service
+10196
+Average Time to Process a Free Busy Request
+10198
+Base for Average Time to Process a Free Busy Request
+10200
+Average Time to Process a Meeting Suggestions Request
+10202
+Base for Average Time to Process a Meeting Suggestions Request
+10204
+Average Number of Mailboxes Processed per Request
+10206
+Base for Average Number of Mailboxes Processed per Request
+10208
+Average Time to Process a Cross-Site Free Busy Request
+10210
+Base forAverage Time to Process a Cross-Site Free Busy Request
+10212
+Average Time to Process a Cross-Forest Free Busy Request
+10214
+Base for Average Time to Process a Cross-Forest Free Busy Request
+10216
+Availability Requests (sec)
+10218
+Suggestions Requests (sec)
+10220
+Intra-Site Calendar Queries (sec)
+10222
+Cross-Site Calendar Queries (sec)
+10224
+Cross-Forest Calendar Queries (sec)
+10226
+Public Folder Queries (sec)
+10228
+Foreign Connector Queries (sec)
+10230
+Intra-Site Calendar Failures (sec)
+10232
+Cross-Site Calendar Failures (sec)
+10234
+Cross-Forest Calendar Failures (sec)
+10236
+Public Folder Request Failures (sec)
+10238
+Foreign Connector Request Failure Rate
+10240
+Average Time to Map External Caller to Internal Identity
+10242
+Base for Average Time for External Caller to Internal Identity
+10244
+Federated Free Busy Calendar Queries (sec)
+10246
+Federated Free Busy Failures (sec)
+10248
+Average Time to Process a Federated Free Busy Request
+10250
+Base for Average Time to Process a Federated Free Busy Request
+10252
+Current Requests
+10254
+Intra-Site Proxy Free Busy Calendar Queries (sec)
+10256
+Intra-Site Proxy Free Busy Failures (sec)
+10258
+Average Time to Process an Intra-Site Free Busy Request
+10260
+Base for Average Time to Process an Intra-Site Free/Busy Request
+10262
+Client-Reported Failures - Total
+10264
+Client-Reported Failures - Autodiscover Failures
+10266
+Client-Reported Failures - Timeout Failures
+10268
+Client-Reported Failures - Connection Failures
+10270
+Client-Reported Failures - Partial or Other Failures
+10272
+Successful Client-Reported Requests - Total
+10274
+Successful Client-Reported Requests - Less than 5 seconds
+10276
+Successful Client-Reported Requests - Less than 10 seconds
+10278
+Successful Client-Reported Requests - Less than 20 seconds
+10280
+Successful Client-Reported Requests - Over 20 seconds
+10282
+MSExchange Authentication
+10284
+Outstanding Authentication Requests
+10286
+Total Authentication Requests
+10288
+Rejected Authentication Requests
+10290
+Authentication Latency
+10292
+MSExchange Attachment Filtering
+10294
+Messages Attachment Filtered
+10296
+Messages Filtered/sec
+10298
+MSExchange Assistants - Per Database
+10300
+Events in queue
+10302
+Average Event Processing Time In seconds
+10304
+Average Event Processing Time Base
+10306
+Events Polled
+10308
+Events Polled/sec
+10310
+Polling Delay
+10312
+Highest Event Counter Polled
+10314
+Elapsed Time Since Last Event Polled
+10316
+Elapsed Time Since Last Event Polling Attempt
+10318
+Elapsed Time Since Last Database Status Update Attempt
+10320
+Percentage of Interesting Events
+10322
+Base Counter for Percentage of Interesting Events
+10324
+Events Interesting to Multiple Asssitants
+10326
+Base Counter for Events Interesting to Multiple Asssitants
+10328
+Mailbox Dispatchers
+10330
+Mailbox Sessions In Use By Dispatchers
+10332
+Average Mailbox Processing Time In seconds
+10334
+Average Mailbox Processing Time In seconds Base
+10336
+Mailboxes Processed
+10338
+Mailboxes processed/sec
+10340
+Number of Threads Used
+10342
+Health Measure
+10344
+MSExchange Assistants - Per Assistant
+10346
+Events in Queue
+10348
+Events Processed
+10350
+Events Processed/sec
+10352
+Average Event Queue Time In Seconds
+10354
+Average Event Queue Time Base
+10356
+Average Event Processing Time In Seconds
+10358
+Average Event Processing Time Base
+10360
+Percentage of Interesting Events
+10362
+Base counter for Percentage of Interesting Events
+10364
+Percentage of Events Discarded by Mailbox Filter
+10366
+Base Counter for Percentage of Events Discarded by Mailbox Filter
+10368
+Percentage of Queued Events Discarded by Mailbox Filter
+10370
+Base Counter for Percentage of Queued Events Discarded by Mailbox Filter
+10372
+Elapsed Time Since Last Event Queued
+10374
+Event Dispatchers
+10376
+Failed Event Dispatchers
+10378
+Percentage of Failed Event Dispatchers
+10380
+Base Counter for Percentage of Failed Event Dispatchers
+10382
+Handled Exceptions
+10384
+MSExchange Approval Framework
+10386
+Number of Initiation Messages
+10388
+Number of Initiation Messages/sec
+10390
+Number of Decision Messages
+10392
+Number of Decision Messages/sec
+10394
+Decision Messages Processed
+10396
+Decision Messages Processed/sec
+10398
+Total Time to Find Initiation Message in Milliseconds
+10400
+Total time to find initiation message to corelate NDRs or OOFs in milliseconds
+10402
+Number of searches based on NDR and OOF
+10404
+Number of NDRs and OOFs processed
+10406
+Number of NDR and OOF that result in updates
+10408
+MSExchange Approval Assistant
+10410
+Approval Requests Processed
+10412
+Approval Requests Approved
+10414
+Approval Requests Rejected
+10416
+Approval Requests Expired
+10418
+Last Approval Assistant Processing Time
+10420
+Average Approval Assistant Processing Time
+10422
+Average Approval Assistant Processing Time Base
+10424
+MSExchange Anti-Malware Agent
+10426
+Messages Scanned
+10428
+Messages Scanned per Second
+10430
+Scan Time per Message - 90th Percentile
+10432
+Scan Time per Message - 99th Percentile
+10434
+MB Scanned per Second
+10436
+MB Scanned per Second (Base Counter)
+10438
+Scan Time per MB - 90th Percentile
+10440
+Scan Time per MB - 99th Percentile
+10442
+Messages Containing Malware
+10444
+Messages Containing Malware Percentage
+10446
+Messages Deferred
+10448
+Messages Deferred Percentage
+10450
+Messages with Scan Error
+10452
+Messages with Scan Error Percentage
+10454
+Messages Blocked
+10456
+Messages Blocked Percentage
+10458
+Messages Containing Malware - Replaced
+10460
+Messages Containing Malware - Replaced (%)
+10462
+Messages Bypassed
+10464
+Messages Bypassing Malware Scanning Percentage
+10466
+Messages that Timed Out
+10468
+Messages that Timed Out Percentage
+10470
+Recovery Store Percentage Full
+10472
+MB Used by Recovery Store
+10474
+Messages Written to Recovery Store
+10476
+Messages with Fewer Engine Scans than Expected
+10478
+Messages with Fewer Engine Scans than Expected Percentage
+10480
+Messages with Fewer Engine Scans than Minimum Threshold
+10482
+Messages with Fewer Engine Scans than Minimum Threshold Percentage
+10484
+MSExchange Admin Audit Log
+10486
+Total Admin Audit Log records saved.
+10488
+Admin Audit Log records saved/sec.
+10490
+Total time for saving Admin Audit Log records.
+10492
+Average time for saving Admin Audit Log records.
+10494
+Base of Average time for saving Admin Audit Log records.
+10496
+MSExchange ADAccess Topology Service
+10498
+PID
+10500
+Active Work Item Count
+10502
+Work Items Executed
+10504
+Work Items Cancelled
+10506
+Work Items Failures
+10508
+Work Items Average Run Time
+10510
+Work Items Average Run Time Base
+10512
+MSExchange ADAccess Forest Discovery
+10514
+In-site Domain Controllers
+10516
+In-site Global Catalogs
+10518
+Out-of-site Domain Controllers
+10520
+Out-of-site Global Catalogs
+10522
+Discovery Failures
+10524
+Topology Version
+10526
+Average Discovery Time
+10528
+Average Discovery Time Base
+10530
+Max Discovery Time
+10532
+Last Topology Discovery Duration Time
+10534
+Web Service - Get Servers For Role Average Call Duration
+10536
+Web Service - Get Servers For Role Average Call Duration Base
+10538
+Web Service - Get Servers For Role Max Call Duration
+10540
+MSExchange Activity Context Resources
+10542
+Time in Resource per second
+10544
+MSExchange ActiveSync
+10546
+Requests Total
+10548
+Current Requests
+10550
+Incoming Proxy Requests Total
+10552
+Outgoing Proxy Requests Total
+10554
+Wrong CAS Proxy Requests Total
+10556
+PID
+10558
+Average Request Time
+10560
+Average Hang Time
+10562
+Requests/sec
+10564
+Get Hierarchy Total
+10566
+Get Hierarchy Commands/sec
+10568
+Move Items Total
+10570
+Move Items Commands/sec
+10572
+Meeting Response Total
+10574
+Meeting Response Commands/sec
+10576
+Folder Sync Total
+10578
+Folder Sync Commands/sec
+10580
+Folder Update Total
+10582
+Folder Update Commands/sec
+10584
+Folder Create Total
+10586
+Folder Create Commands/sec
+10588
+Folder Delete Total
+10590
+Folder Delete Commands/sec
+10592
+Options Total
+10594
+Options Commands/sec
+10596
+Sync Total
+10598
+Sync Commands/sec
+10600
+Recovery Sync Total
+10602
+Recovery Sync Commands/sec
+10604
+Get Item Estimate Total
+10606
+Get Item Estimate Commands/sec
+10608
+Create Collection Total
+10610
+Create Collection Commands/sec
+10612
+Move Collection Total
+10614
+Move Collection Commands/sec
+10616
+Delete Collection Total
+10618
+Delete Collection Commands/sec
+10620
+Get Attachment Total
+10622
+Get Attachment Commands/sec
+10624
+IRM-protected Message Downloads - Total
+10626
+IRM-protected Message Downloads/sec
+10628
+Send IRM-protected Messages - Total
+10630
+Send IRM-protected Messages/sec
+10632
+Send Mail Total
+10634
+Send Mail Commands/sec
+10636
+Smart Reply Total
+10638
+Smart Reply Commands/sec
+10640
+Smart Forward Total
+10642
+Smart Forward Commands/sec
+10644
+Search Total
+10646
+Search Commands/sec
+10648
+GAL Search Total
+10650
+GAL Searches/sec
+10652
+Mailbox Search Total
+10654
+Mailbox Searches/sec
+10656
+Document Library Search Total
+10658
+Document Library Searches/sec
+10660
+Item Operations Total
+10662
+Item Operations Commands/sec
+10664
+Document Library Fetch Total
+10666
+Document Library Fetch Commands/sec
+10668
+Mailbox Item Fetch Total
+10670
+Mailbox Item Fetch Commands/sec
+10672
+Empty Folder Contents Total
+10674
+Empty Folder Contents/sec
+10676
+Mailbox Attachment Fetch Total
+10678
+Mailbox Attachment Fetch Commands/sec
+10680
+Settings Total
+10682
+Settings Commands/sec
+10684
+Ping Total
+10686
+Ping Commands/sec
+10688
+Ping Commands Pending
+10690
+Ping Dropped Total
+10692
+Ping Commands Dropped/sec
+10694
+Heartbeat Interval
+10696
+Provision Total
+10698
+Provision Commands/sec
+10700
+Failed Item Conversion Total
+10702
+Bad Item Reports Generated Total
+10704
+Proxy Logon Commands Sent Total
+10706
+Proxy Logon Received Total
+10708
+Sync State KBytes Left Compressed
+10710
+Sync State KBytes Total
+10712
+Sync Commands Pending
+10714
+Sync Dropped Total
+10716
+Sync Commands Dropped/sec
+10718
+Conflicting Concurrent Sync Total
+10720
+Conflicting Concurrent Sync/sec
+10722
+Number of AD Policy Queries on Reconnect
+10724
+Number of Notification Manager Objects in Memory
+10726
+Availability Requests Total
+10728
+Availability Requests/sec
+10730
+Transient Mailbox Connection Failures/minute
+10732
+Mailbox Offline Errors/minute
+10734
+Transient Storage Errors/minute
+10736
+Permanent Storage Errors/minute
+10738
+Transient Active Directory Errors/minute
+10740
+Permanent Active Directory Errors/minute
+10742
+Transient Errors/minute
+10744
+Average RPC Latency
+10746
+Average LDAP Latency
+10748
+Number of auto-blocked devices
+10750
+MSExchange Active Manager Server
+10752
+GetServerForDatabase Server-Side Calls
+10754
+Server-Side Calls/sec
+10756
+Active Manager Database State writes to Persistent storage
+10758
+Active Manager Database State writes to Persistent storage/sec
+10760
+Total Number of Databases
+10762
+Active Manager Role
+10764
+MSExchange Active Manager Dag Name Instance
+10766
+Active Manager Role In Dag
+10768
+MSExchange Active Manager Client
+10770
+Client-side Calls
+10772
+Client-side Calls/Sec
+10774
+Client-side Cache Hits
+10776
+Client-side Cache Misses
+10778
+Client-side Calls ReadThrough
+10780
+Client-side RPC Calls
+10782
+Unique databases queried
+10784
+Unique servers queried
+10786
+Location cache entries
+10788
+Location cache update time
+10790
+Server-Information Cache Hits
+10792
+Server-Information Cache Misses
+10794
+Server-Information Cache Entries
+10796
+CalculatePreferredHomeServer Calls
+10798
+CalculatePreferredHomeServer Calls/Sec
+10800
+CalculatePreferredHomeServer Redirects
+10802
+CalculatePreferredHomeServer Redirects/Sec
+10804
+MSExchange Active Manager
+10806
+Database Mounted
+10808
+Database Copy Role Active
+10810
+MSDTC Bridge 4.0.0.0
+10812
+Message send failures/sec
+10814
+Prepare retry count/sec
+10816
+Commit retry count/sec
+10818
+Prepared retry count/sec
+10820
+Replay retry count/sec
+10822
+Faults received count/sec
+10824
+Faults sent count/sec
+10826
+Average participant prepare response time
+10828
+Average participant prepare response time Base
+10830
+Average participant commit response time
+10832
+Average participant commit response time Base
+10834
+Distributed Transaction Coordinator
+10836
+Active Transactions
+10838
+Committed Transactions
+10840
+Aborted Transactions
+10842
+In Doubt Transactions
+10844
+Active Transactions Maximum
+10846
+Force Committed Transactions
+10848
+Force Aborted Transactions
+10850
+Response Time -- Minimum
+10852
+Response Time -- Average
+10854
+Response Time -- Maximum
+10856
+Transactions/sec
+10858
+Committed Transactions/sec
+10860
+Aborted Transactions/sec
+10862
+LS:MEDIA - Operations
+10864
+MEDIA - Global health
+10866
+MEDIA - TCP disconnects because remote out of sync
+10868
+MEDIA - Relay allocation failures
+10870
+MEDIA - Number of packets dropped by Secure RTP/sec
+10872
+LS:MEDIA - Planning
+10874
+MEDIA - Number of conferences started
+10876
+MEDIA - Number of audio channels started
+10878
+MEDIA - Number of video channels started
+10880
+MEDIA - Number of data channels started
+10882
+MEDIA - Number of conferences with NORMAL health
+10884
+MEDIA - Number of conferences with OVERLOADED health
+10886
+MEDIA - Number of packets dropped in flow control
+10888
+MEDIA - Number of failed end to end connectivity checks
+10890
+MEDIA - Number of packet loss events raised on data channels
+10892
+MEDIA - Number of occasions conference processing is delayed significantly
+10894
+LS:MEDIA - Informational
+10896
+MEDIA - Number of send-only audio channels started
+10898
+MEDIA - Number of receive-only audio channels started
+10900
+MEDIA - Number of send-receive audio channels started
+10902
+MEDIA - Number of send-only video channels started
+10904
+MEDIA - Number of receive-only video channels started
+10906
+MEDIA - Number of send-receive video channels started
+10908
+MEDIA - Average time spent in processing audio packets
+10910
+ 
+10912
+MEDIA - Timer ticks/sec
+10914
+MEDIA - Conference process rate
+10916
+MEDIA - Average ICE Address Binding Time
+10918
+ 
+10920
+MEDIA - Average ICE Connectivity Check Time
+10922
+ 
+10924
+MEDIA - Audio packets received from transport provider/sec
+10926
+MEDIA - Audio packets received from RTP layer/sec
+10928
+MEDIA - Audio packets received from audio engine/sec
+10930
+MEDIA - Audio packets sent into audio engine/sec
+10932
+MEDIA - Audio router input buffers/sec
+10934
+MEDIA - Audio router output buffers/sec
+10936
+MEDIA - Audio packets sent to RTP/sec
+10938
+MEDIA - Audio packets sent to transport provider/sec
+10940
+MEDIA - Audio FEC packets sent/sec
+10942
+MEDIA - Video packets received from transport provider/sec
+10944
+MEDIA - Video packets received from RTP/sec
+10946
+MEDIA - Video frame received from users/sec
+10948
+MEDIA - Video packets sent to video engine/sec
+10950
+MEDIA - Video packets sent to RTP/sec
+10952
+MEDIA - Video packets sent to transport provider/sec
+10954
+MEDIA - Video switcher input frames/sec
+10956
+MEDIA - Video switcher output frames/sec
+10958
+MEDIA - Data packets received from transport provider/sec
+10960
+MEDIA - Data packets sent to transport provider/sec
+10962
+MEDIA - The number of times data channel is stalled
+10964
+MEDIA - The number of times data channel transport is stalled
+10966
+MEDIA - Packets produced by the TCP packetizer/sec
+10968
+MEDIA - Number of successful receive IO/sec
+10970
+MEDIA - Number of successful send IO/sec
+10972
+MEDIA - Number of failed receive IO/sec
+10974
+MEDIA - Number of failed send IO/sec
+10976
+MEDIA - RTCP packets received/sec
+10978
+MEDIA - RTCP packets sent/sec
+10980
+MEDIA - Heap allocation
+10982
+MEDIA - Heap free
+10984
+MEDIA - Total number of network buffers
+10986
+MEDIA - Total number of streaming buffers
+10988
+MEDIA - Total number of port collisions
+10990
+MEDIA - Total number of media timeouts
+10992
+MEDIA - Video switcher rate matched frames/sec
+10994
+MEDIA - Number of incoming QVGA video streams
+10996
+MEDIA - Number of incoming VGA video streams
+10998
+MEDIA - Number of incoming HD video streams
+11000
+MEDIA - Number of incoming PANO video streams
+11002
+MEDIA - Number of outgoing QVGA video streams
+11004
+MEDIA - Number of outgoing VGA video streams
+11006
+MEDIA - Number of outgoing HD video streams
+11008
+MEDIA - Number of outgoing PANO video streams
+11010
+MEDIA - Number of incoming VC1 video streams
+11012
+MEDIA - Number of outgoing VC1 video streams
+11014
+MEDIA - Total bandwidth of incoming audio streams in bytes per second
+11016
+MEDIA - Total bandwidth of outgoing audio streams in bytes per second
+11018
+MEDIA - Total bandwidth of incoming video streams in bytes per second
+11020
+MEDIA - Total bandwidth of outgoing video streams in bytes per second
+11022
+MEDIA - Total bandwidth of incoming data streams in bytes per second
+11024
+MEDIA - Total bandwidth of outgoing data streams in bytes per second
+11026
+MEDIA - Siren audio encode/sec
+11028
+MEDIA - Siren audio decode/sec
+11030
+MEDIA - RTVoice audio encode/sec
+11032
+MEDIA - RTVoice audio decode/sec
+11034
+MEDIA - Other audio encode/sec
+11036
+MEDIA - Other audio decode/sec
+11038
+MEDIA - G722 audio encode/sec
+11040
+MEDIA - G722 audio decode/sec
+11042
+LS:MEDIA - Private
+11044
+MEDIA - Audio buffer hits/sec
+11046
+MEDIA - Audio router timeslice/sec
+11048
+MEDIA - Total conference processed/sec
+11050
+MEDIA - Average Conference Processing Time
+11052
+ 
+11054
+MEDIA - Average Transport Processing Time
+11056
+ 
+11058
+MEDIA - Number of audio channels with 20ms send ptime
+11060
+MEDIA - Number of audio channels with 40ms send ptime
+11062
+MEDIA - Number of audio channels with 60ms send ptime
+11064
+MEDIA - Number of audio channels with 100ms send ptime
+11066
+MEDIA - Number of audio channels with 200ms send ptime
+11068
+MEDIA - Number of audio channels with 20ms receive ptime
+11070
+MEDIA - Number of audio channels with 40ms receive ptime
+11072
+MEDIA - Number of audio channels with 60ms receive ptime
+11074
+MEDIA - Number of audio channels with 100ms receive ptime
+11076
+MEDIA - Number of audio channels with 200ms receive ptime
+11078
+MEDIA - Average Siren Encode Time(100ns)
+11080
+ 
+11082
+MEDIA - Average Siren Decode Time(100ns)
+11084
+ 
+11086
+MEDIA - Average Scale SRTP encrypt large packet Time(100ns)
+11088
+ 
+11090
+MEDIA - Average Scale SRTP encrypt small packet Time(100ns)
+11092
+ 
+11094
+MEDIA - Average Scale SRTP inc auth large packet Time(100ns)
+11096
+ 
+11098
+MEDIA - Average Scale SRTP inc auth small packet Time(100ns)
+11100
+ 
+11102
+MEDIA - Average Scale SRTP final auth large packet Time(100ns)
+11104
+ 
+11106
+MEDIA - Average Scale SRTP final auth small packet Time(100ns)
+11108
+ 
+11110
+MEDIA - Average Scale SRTP decrypt large packet Time(100ns)
+11112
+ 
+11114
+MEDIA - Average Scale SRTP decrypt small packet Time(100ns)
+11116
+ 
+11118
+MEDIA - Average SRTP auth check large packet Time(100ns)
+11120
+ 
+11122
+MEDIA - Average SRTP auth check small packet Time(100ns)
+11124
+ 
+11126
+MEDIA - Number of packets dropped in transport
+11128
+MEDIA - Average time(100ns) to send a packet
+11130
+ 
+11132
+MEDIA - Average time(us) process audio router
+11134
+ 
+11136
+MEDIA - Average time(us) process video router
+11138
+ 
+11140
+MEDIA - Average time(us) process channel router
+11142
+ 
+11144
+MEDIA - Counter1
+11146
+MEDIA - Counter2
+11148
+MEDIA - Counter3
+11150
+MEDIA - Counter4
+11152
+MEDIA - Value1
+11154
+MEDIA - Value2
+11156
+MEDIA - Value3
+11158
+MEDIA - Value4
+11160
+MEDIA - Average value1
+11162
+ 
+11164
+MEDIA - Average value2
+11166
+ 
+11168
+MEDIA - Average value3
+11170
+ 
+11172
+MEDIA - Average value4
+11174
+ 
+11176
+MEDIA - Number of audio mixes/sec
+11178
+MEDIA - Number of bytes sent using RMA
+11180
+MEDIA - Number of bytes received using RMA
+11182
+MEDIA - Number of RMA sent event
+11184
+MEDIA - Number of RMA receive event
+11186
+MEDIA - Maximum number of streams being audio-mixed in one mixer
+11188
+MEDIA - Outstanding heap allocations from MEMPOOL_STREAM
+11190
+MEDIA - Outstanding heap allocations from MEMPOOL_AUDIO_SOURCE
+11192
+MEDIA - Outstanding heap allocations from MEMPOOL_AUDIO_ENCODE
+11194
+MEDIA - Outstanding heap allocations from MEMPOOL_AUDIO_METADATA
+11196
+MEDIA - Outstanding heap allocations from MEMPOOL_RTCP
+11198
+MEDIA - Outstanding heap allocations from MEMPOOL_RTPEXTHEADER
+11200
+MEDIA - Outstanding heap allocations from MEMPOOL_RTPHEADER
+11202
+MEDIA - Outstanding heap allocations from MEMPOOL_TRANSPORTIOCONTEXT
+11204
+MEDIA - Total number of CBufferTransportIOContext objects posted
+11206
+MEDIA - Number of conference across core moves/sec
+11208
+ 
+11210
+MEDIA - Number of conferences across core moves
+11212
+MEDIA - No conferences Core 1
+11214
+MEDIA - Conference duration on Core 1
+11216
+MEDIA - Conference workitem duration on Core 1
+11218
+MEDIA - Transport offload duration on Core 1
+11220
+MEDIA - No conferences Core 2
+11222
+MEDIA - Conference duration on Core 2
+11224
+MEDIA - Conference workitem duration on Core 2
+11226
+MEDIA - Transport offload duration on Core 2
+11228
+MEDIA - No conferences Core 3
+11230
+MEDIA - Conference duration on Core 3
+11232
+MEDIA - Conference workitem duration on Core 3
+11234
+MEDIA - Transport offload duration on Core 3
+11236
+MEDIA - No conferences Core 4
+11238
+MEDIA - Conference duration on Core 4
+11240
+MEDIA - Conference workitem duration on Core 4
+11242
+MEDIA - Transport offload duration on Core 4
+11244
+MEDIA - No conferences Core 5
+11246
+MEDIA - Conference duration on Core 5
+11248
+MEDIA - Conference workitem duration on Core 5
+11250
+MEDIA - Transport offload duration on Core 5
+11252
+MEDIA - No conferences Core 6
+11254
+MEDIA - Conference duration on Core 6
+11256
+MEDIA - Conference workitem duration on Core 6
+11258
+MEDIA - Transport offload duration on Core 6
+11260
+MEDIA - No conferences Core 7
+11262
+MEDIA - Conference duration on Core 7
+11264
+MEDIA - Conference workitem duration on Core 7
+11266
+MEDIA - Transport offload duration on Core
+11268
+MEDIA - No conferences Core 8
+11270
+MEDIA - Conference duration on Core 8
+11272
+MEDIA - Conference workitem duration on Core 8
+11274
+MEDIA - Transport offload duration on Core 8
+11276
+Internet Information Services Global
+11278
+Total Allowed Async I/O Requests
+11280
+Total Blocked Async I/O Requests
+11282
+Total Rejected Async I/O Requests
+11284
+Current Blocked Async I/O Requests
+11286
+Measured Async I/O Bandwidth Usage
+11288
+Current Files Cached
+11290
+Total Files Cached
+11292
+File Cache Hits
+11294
+File Cache Misses
+11296
+File Cache Hits %
+11300
+File Cache Flushes
+11302
+Current File Cache Memory Usage
+11304
+Maximum File Cache Memory Usage
+11306
+Active Flushed Entries
+11308
+Total Flushed Files
+11310
+Current URIs Cached
+11312
+Total URIs Cached
+11314
+URI Cache Hits
+11316
+URI Cache Misses
+11318
+URI Cache Hits %
+11322
+URI Cache Flushes
+11324
+Total Flushed URIs
+11326
+Current BLOBs Cached
+11328
+Total BLOBs Cached
+11330
+BLOB Cache Hits
+11332
+BLOB Cache Misses
+11334
+BLOB Cache Hits %
+11338
+BLOB Cache Flushes
+11340
+Total Flushed BLOBs
+11342
+GALSync
+11344
+Number of mailboxes created
+11346
+Client reported number of mailboxes created
+11348
+Client reported number of mailboxes to create
+11350
+Client reported total time used for Mailbox creation in milliseconds
+11352
+Number of export sync runs
+11354
+Number of import sync runs
+11356
+Number of sucessful export sync runs
+11358
+Number of sucessful import sync runs
+11360
+Number of connection errors
+11362
+Number of permission errors
+11364
+Number of LiveId errors
+11366
+Number of ILM logic errors
+11368
+Number of ILM other errors
+11370
+Expanded Groups Cache
+11372
+Resolved Groups Cache Hit Count
+11374
+Resolved Groups Cache Miss Count
+11376
+Resolved Groups Cache Size
+11378
+Resolved Groups Cache Size Percentage
+11380
+Expanded Groups Cache Hit Count
+11382
+Expanded Groups Cache Miss Count
+11384
+Expanded Groups Cache Size
+11386
+Expanded Groups Cache Size Percentage
+11388
+LDAP Queries Issued by Expanded Groups.
+11390
+Database
+11392
+Pages Converted/sec
+11394
+Pages Converted
+11396
+Records Converted/sec
+11398
+Records Converted
+11400
+Defragmentation Tasks
+11402
+Defragmentation Tasks Pending
+11404
+Defragmentation Tasks Discarded
+11406
+Defragmentation Tasks Scheduled/sec
+11408
+Defragmentation Tasks Completed/sec
+11410
+Heap Allocs/sec
+11412
+Heap Frees/sec
+11414
+Heap Allocations
+11416
+Heap Bytes Allocated
+11418
+Page Bytes Reserved
+11420
+Page Bytes Committed
+11422
+FCB Async Scan/sec
+11424
+FCB Async Purge/sec
+11426
+FCB Async Threshold-Scan/sec
+11428
+FCB Async Threshold-Purge/sec
+11430
+FCB Async Threshold Purge Failures (Conflicts)/sec
+11432
+FCB Async Threshold Purge Failures (In Use)/sec
+11434
+FCB Async Threshold Purge Failures (Sentinel)/sec
+11436
+FCB Async Threshold Purge Failures (Delete Pending)/sec
+11438
+FCB Async Threshold Purge Failures (Outstanding Versions)/sec
+11440
+FCB Async Threshold Purge Failures (LV Outstanding)/sec
+11442
+FCB Async Threshold Purge Failures (Index Outstanding)/sec
+11444
+FCB Async Threshold Purge Failures (Active Tasks)/sec
+11446
+FCB Async Threshold Purge Failures (Callbacks)/sec
+11448
+FCB Async Threshold Purge Failures (Other)/sec
+11450
+FCB Async Purge Failures (Conflicts)/sec
+11452
+FCB Async Purge Failures (In Use)/sec
+11454
+FCB Async Purge Failures (Sentinel)/sec
+11456
+FCB Async Purge Failures (Delete Pending)/sec
+11458
+FCB Async Purge Failures (Outstanding Versions)/sec
+11460
+FCB Async Purge Failures (LV Outstanding)/sec
+11462
+FCB Async Purge Failures (Index Outstanding)/sec
+11464
+FCB Async Purge Failures (Active Tasks)/sec
+11466
+FCB Async Purge Failures (Callbacks)/sec
+11468
+FCB Async Purge Failures (Other)/sec
+11470
+FCB Sync Purge/sec
+11472
+FCB Sync Purge Stalls/sec
+11474
+FCB Allocations Wait For Version Cleanup/sec
+11476
+FCB Purge On Cursor Close/sec
+11478
+FCB Cache % Hit
+11480
+No name
+11482
+FCB Cache Stalls/sec
+11484
+FCB Cache Maximum
+11486
+FCB Cache Preferred
+11488
+FCB Cache Allocated
+11490
+FCB Cache Allocated/sec
+11492
+FCB Cache Available
+11494
+FCB Attached RCEs
+11496
+Sessions In Use
+11498
+Sessions % Used
+11500
+No name
+11502
+Resource Manager FCB Allocated
+11504
+Resource Manager FCB Allocated Used
+11506
+Resource Manager FCB Quota
+11508
+Resource Manager FUCB Allocated
+11510
+Resource Manager FUCB Allocated Used
+11512
+Resource Manager FUCB Quota
+11514
+Resource Manager TDB Allocated
+11516
+Resource Manager TDB Allocated Used
+11518
+Resource Manager TDB Quota
+11520
+Resource Manager IDB Allocated
+11522
+Resource Manager IDB Allocated Used
+11524
+Resource Manager IDB Quota
+11526
+Table Open Cache % Hit
+11528
+No name
+11530
+Table Open Cache Hits/sec
+11532
+Table Open Cache Misses/sec
+11534
+Table Open Pages Read/sec
+11536
+Table Open Pages Preread/sec
+11538
+Table Opens/sec
+11540
+Table Closes/sec
+11542
+Tables Open
+11544
+Log Bytes Write/sec
+11546
+Log Bytes Generated/sec
+11548
+Log Buffer Bytes Used
+11550
+Log Buffer Bytes Free
+11552
+Log Buffer Bytes Committed
+11554
+Log Threads Waiting
+11556
+Log Checkpoint Depth
+11558
+Log Generation Checkpoint Depth
+11560
+Log Checkpoint Maintenance Outstanding IO Max
+11562
+User Read Only Transaction Commits to Level 0/sec
+11564
+User Read/Write Transaction Commits to Level 0 (Durable)/sec
+11566
+User Read/Write Transaction Commits to Level 0 (Lazy)/sec
+11568
+User Wait All Transaction Commits/sec
+11570
+User Wait Last Transaction Commits/sec
+11572
+User Transaction Commits to Level 0/sec
+11574
+User Read Only Transaction Rollbacks to Level 0/sec
+11576
+User Read/Write Transaction Rollbacks to Level 0/sec
+11578
+User Transaction Rollbacks to Level 0/sec
+11580
+System Read Only Transaction Commits to Level 0/sec
+11582
+System Read/Write Transaction Commits to Level 0 (Durable)/sec
+11584
+System Read/Write Transaction Commits to Level 0 (Lazy)/sec
+11586
+System Transaction Commits to Level 0/sec
+11588
+System Read Only Transaction Rollbacks to Level 0/sec
+11590
+System Read/Write Transaction Rollbacks to Level 0/sec
+11592
+System Transaction Rollbacks to Level 0/sec
+11594
+Database Page Allocation File Extension Async Consumed/sec
+11596
+Database Page Allocation File Extension Stalls/sec
+11598
+Database Page Allocation File Shrink Stalls/sec
+11600
+Log Records/sec
+11602
+Log Buffer Capacity Flushes/sec
+11604
+Log Buffer Commit Flushes/sec
+11606
+Log Buffer Flushes Skipped/sec
+11608
+Log Buffer Flushes Blocked/sec
+11610
+Log Buffer Flushes/sec
+11612
+Log Writes/sec
+11614
+Log Full Segment Writes/sec
+11616
+Log Partial Segment Writes/sec
+11618
+Log Bytes Wasted/sec
+11620
+Log Record Stalls/sec
+11622
+Version Buckets Allocated
+11624
+Version Buckets Allocated for Deletes
+11626
+VER Bucket Allocations Wait For Version Cleanup/sec
+11628
+Version Store Average RCE Bookmark Length
+11630
+Version Store Unnecessary Calls/sec
+11632
+Version Store Cleanup Tasks Asynchronously Dispatched/sec
+11634
+Version Store Cleanup Tasks Synchronously Dispatched/sec
+11636
+Version Store Cleanup Tasks Discarded/sec
+11638
+Version Store Cleanup Tasks Failures/sec
+11640
+Record Inserts/sec
+11642
+Record Deletes/sec
+11644
+Record Replaces/sec
+11646
+Record Unnecessary Replaces/sec
+11648
+Record Redundant Replaces/sec
+11650
+Record Escrow-Updates/sec
+11652
+Secondary Index Inserts/sec
+11654
+Secondary Index Deletes/sec
+11656
+False Index Column Updates/sec
+11658
+False Tuple Index Column Updates/sec
+11660
+Record Intrinsic Long-Values Updated/sec
+11662
+Record Separated Long-Values Added/sec
+11664
+Record Separated Long-Values Forced/sec
+11666
+Record Separated Long-Values All Forced/sec
+11668
+Record Separated Long-Values Reference All/sec
+11670
+Record Separated Long-Values Dereference All/sec
+11672
+Separated Long-Value Seeks/sec
+11674
+Separated Long-Value Retrieves/sec
+11676
+Separated Long-Value Creates/sec
+11678
+Long-Value Maximum LID
+11680
+Separated Long-Value Updates/sec
+11682
+Separated Long-Value Deletes/sec
+11684
+Separated Long-Value Copies/sec
+11686
+Separated Long-Value Chunk Seeks/sec
+11688
+Separated Long-Value Chunk Retrieves/sec
+11690
+Separated Long-Value Chunk Appends/sec
+11692
+Separated Long-Value Chunk Replaces/sec
+11694
+Separated Long-Value Chunk Deletes/sec
+11696
+Separated Long-Value Chunk Copies/sec
+11698
+B+ Tree Append Splits/sec
+11700
+B+ Tree Right Splits/sec
+11702
+B+ Tree Right Hotpoint Splits/sec
+11704
+B+ Tree Vertical Splits/sec
+11706
+B+ Tree Splits/sec
+11708
+B+ Tree Empty Page Merges/sec
+11710
+B+ Tree Right Merges/sec
+11712
+B+ Tree Partial Merges/sec
+11714
+B+ Tree Left Merges/sec
+11716
+B+ Tree Partial Left Merges/sec
+11718
+B+ Tree Page Moves/sec
+11720
+B+ Tree Merges/sec
+11722
+B+ Tree Failed Simple Page Cleanup Attempts/sec
+11724
+B+ Tree Seek Short Circuits/sec
+11726
+B+ Tree Opportune Prereads/sec
+11728
+B+ Tree Unnecessary Sibling Latches/sec
+11730
+B+ Tree Move Nexts/sec
+11732
+B+ Tree Move Nexts (Non-Visible Nodes Skipped)/sec
+11734
+B+ Tree Move Nexts (Nodes Filtered)/sec
+11736
+B+ Tree Move Prevs/sec
+11738
+B+ Tree Move Prevs (Non-Visible Nodes Skipped)/sec
+11740
+B+ Tree Move Prevs (Nodes Filtered)/sec
+11742
+B+ Tree Seeks/sec
+11744
+B+ Tree Inserts/sec
+11746
+B+ Tree Replaces/sec
+11748
+B+ Tree Flag Deletes/sec
+11750
+B+ Tree Deletes/sec
+11752
+B+ Tree Appends/sec
+11754
+B+ Tree Creates/sec
+11756
+B+ Tree Creates (Total)
+11758
+B+ Tree Destroys/sec
+11760
+B+ Tree Destroys (Total)
+11762
+Pages Trimmed/sec
+11764
+Pages Trimmed (Total)
+11766
+Pages Not Trimmed Unaligned/sec
+11768
+Pages Not Trimmed Unaligned (Total)
+11770
+Pages Trimmed Dirty/sec
+11772
+Pages Trimmed Dirty (Total)
+11774
+Database Cache Misses/sec
+11776
+Database Cache % Hit
+11778
+No name
+11780
+Database Cache % Hit (Uncorrelated)
+11782
+No name
+11784
+Database Cache Requests/sec
+11786
+Database Cache % Pinned
+11788
+No name
+11790
+Database Cache % Clean
+11792
+No name
+11794
+Database Pages Read Async/sec
+11796
+Database Pages Read Sync/sec
+11798
+Database Pages Dirtied/sec
+11800
+Database Pages Dirtied (Repeatedly)/sec
+11802
+Database Pages Written/sec
+11804
+Database Opportune Write Issued (Total)
+11806
+Database Pages Transferred/sec
+11808
+OS Memory Pages Trimmed/sec
+11810
+Database Pages Trimmed/sec
+11812
+Database Pages Non-Resident Reclaimed (Soft Faulted)/sec
+11814
+Database Pages Non-Resident Reclaimed (Failed)/sec
+11816
+Database Pages Non-Resident Re-read/sec
+11818
+Database Pages Non-Resident Evicted (Normally)/sec
+11820
+Database Pages Non-Resident Faulted In Average Latency
+11822
+No name
+11824
+Database Page Latches/sec
+11826
+Database Page Fast Latches/sec
+11828
+Database Page Bad Latch Hints/sec
+11830
+Database Cache % Fast Latch
+11832
+No name
+11834
+Database Page Touches (Non-Touch)/sec
+11836
+Database Page Touches (k=1)/sec
+11838
+Database Page Touches (k=2)/sec
+11840
+Database Page Touches (Correlated)/sec
+11842
+Database Pages Colded (Ext)/sec
+11844
+Database Pages Colded (Int)/sec
+11846
+Database Page Latch Conflicts/sec
+11848
+Database Page Latch Stalls/sec
+11850
+Database Cache % Available
+11852
+No name
+11854
+Database Page Faults/sec
+11856
+Database Page Evictions/sec
+11858
+Database Page Evictions (Preread Untouched)/sec
+11860
+Database Page Evictions (k=1)/sec
+11862
+Database Page Evictions (k=2)/sec
+11864
+Database Page Evictions (Scavenging)/sec
+11866
+Database Page Evictions (Scavenging.SuperCold.Int)/sec
+11868
+Database Page Evictions (Scavenging.SuperCold.Ext)/sec
+11870
+Database Page Evictions (Shrink)/sec
+11872
+Database Page Evictions (Purge)/sec
+11874
+Database Page Evictions (Patch)/sec
+11876
+Database Page Fault Stalls/sec
+11878
+Database Cache Size (MB)
+11880
+Database Cache Size
+11882
+Database Cache Size Effective (MB)
+11884
+Database Cache Size Effective
+11886
+Database Cache Memory Committed (MB)
+11888
+Database Cache Memory Committed
+11890
+Database Cache Memory Reserved (MB)
+11892
+Database Cache Memory Reserved
+11894
+Database Cache Size Target (MB)
+11896
+Database Cache Size Target
+11898
+Database Cache Size Min
+11900
+Database Cache Size Max
+11902
+Database Cache Size Resident
+11904
+Database Cache Size Resident (MB)
+11906
+Database Cache Size Unattached (MB)
+11908
+Database Cache Sizing Duration
+11910
+Database Cache % Available Min
+11912
+No name
+11914
+Database Cache % Available Max
+11916
+No name
+11918
+Database Pages Preread/sec
+11920
+Database Page Preread Stalls/sec
+11922
+Database Pages Preread (Unnecessary)/sec
+11924
+Database Pages Dehydrated/sec
+11926
+Database Pages Rehydrated/sec
+11928
+Database Pages Versioned/sec
+11930
+Database Pages Version Copied/sec
+11932
+Database Cache % Versioned
+11934
+No name
+11936
+Database Pages Repeatedly Written/sec
+11938
+Database Pages Flushed (Cache Shrink)/sec
+11940
+Database Pages Flushed (Checkpoint)/sec
+11942
+Database Pages Flushed (Checkpoint Foreground)/sec
+11944
+Database Pages Flushed (Context Flush)/sec
+11946
+Database Pages Flushed (Idle)/sec
+11948
+Database Pages Flushed (Filthy Foreground)/sec
+11950
+Database Pages Flushed (Scavenge)/sec
+11952
+Database Pages Flushed (Scavenge.SuperCold.Int)/sec
+11954
+Database Pages Flushed (Scavenge.SuperCold.Ext)/sec
+11956
+Database Pages Flushed Opportunely/sec
+11958
+Database Pages Flushed Opportunely Clean/sec
+11960
+Database Pages Coalesced Written/sec
+11962
+Database Pages Coalesced Read/sec
+11964
+Database cache lifetime
+11966
+Database Cache Lifetime (Supercold)
+11968
+Database Cache Lifetime (Longest)
+11970
+Database Cache Lifetime (Normal)
+11972
+Database Cache Lifetime (Low)
+11974
+Database Cache Lifetime Agg Var
+11976
+Database Cache Lifetime (K1)
+11978
+Database Cache Lifetime (K2)
+11980
+Database Cache Scan Pages Evaluated/sec
+11982
+Database Cache Scan Pages Moved/sec
+11984
+Database Cache Scan Page Evaluated Out-of-Order/sec
+11986
+No name
+11988
+Database Cache Scan Entries/scan
+11990
+Database Cache Scan Buckets Scanned/scan
+11992
+Database Cache Scan Empty Buckets Scanned/scan
+11994
+Database Cache Scan ID Range/scan
+11996
+Database Cache Scan Time (ms)/scan
+11998
+Database Cache Scan Found-to-Evict Range
+12000
+Database Cache Super Colded Resources
+12002
+Database Cache Super Cold Attempts/sec
+12004
+Database Cache Super Cold Successes/sec
+12006
+Database Page History Records
+12008
+Database Page History % Hit
+12010
+No name
+12012
+Database Cache % Resident
+12014
+No name
+12016
+Database Cache % Dehydrated
+12018
+No name
+12020
+Database Pages Repeatedly Read/sec
+12022
+Streaming Backup Pages Read/sec
+12024
+Online Defrag Pages Referenced/sec
+12026
+Online Defrag Pages Read/sec
+12028
+Online Defrag Pages Preread/sec
+12030
+Online Defrag Pages Dirtied/sec
+12032
+Online Defrag Pages Re-Dirtied/sec
+12034
+Online Defrag Pages Freed/sec
+12036
+Online Defrag Data Moves/sec
+12038
+Online Defrag Page Moves/sec
+12040
+Online Defrag Log Records/sec
+12042
+Online Defrag Average Log Bytes
+12044
+No name
+12046
+Database Maintenance Duration
+12048
+Database Maintenance Pages Read
+12050
+Database Maintenance Pages Read/sec
+12052
+Database Maintenance Pages Zeroed
+12054
+Database Maintenance Pages Zeroed/sec
+12056
+Database Maintenance Pages Bad Checksums
+12058
+Database Maintenance IO Reads/sec
+12060
+Database Maintenance IO Reads Average Bytes
+12062
+No name
+12064
+Database Maintenance Throttle Setting
+12066
+Database Maintenance IO Re-Reads/sec
+12068
+Database Maintenance IO Re-Reads Average Bytes
+12070
+No name
+12072
+Database Maintenance IO Re-Reads Average Latency
+12074
+No name
+12076
+Database Tasks Pages Referenced/sec
+12078
+Database Tasks Pages Read/sec
+12080
+Database Tasks Pages Preread/sec
+12082
+Database Tasks Pages Dirtied/sec
+12084
+Database Tasks Pages Re-Dirtied/sec
+12086
+Database Tasks Log Records/sec
+12088
+Database Tasks Average Log Bytes
+12090
+No name
+12092
+I/O Database Reads (Attached)/sec
+12094
+I/O Database Reads (Attached) Average Latency
+12096
+No name
+12098
+I/O Database Reads (Attached) Average Bytes
+12100
+No name
+12102
+I/O Database Reads (Attached) In Heap
+12104
+I/O Database Reads (Attached) Async Pending
+12106
+I/O Database Reads (Attached) Abnormal Latency/sec
+12108
+I/O Database Reads (Recovery)/sec
+12110
+I/O Database Reads (Recovery) Average Latency
+12112
+No name
+12114
+I/O Database Reads (Recovery) Average Bytes
+12116
+No name
+12118
+I/O Database Reads (Recovery) In Heap
+12120
+I/O Database Reads (Recovery) Async Pending
+12122
+I/O Database Reads (Recovery) Abnormal Latency/sec
+12124
+I/O Database Reads/sec
+12126
+I/O Database Reads Average Latency
+12128
+No name
+12130
+I/O Database Reads Average Bytes
+12132
+No name
+12134
+I/O Database Reads In Heap
+12136
+I/O Database Reads Async Pending
+12138
+I/O Database Reads Abnormal Latency/sec
+12140
+I/O Log Reads/sec
+12142
+I/O Log Reads Average Latency
+12144
+No name
+12146
+I/O Log Reads Average Bytes
+12148
+No name
+12150
+I/O Log Reads In Heap
+12152
+I/O Log Reads Async Pending
+12154
+I/O Log Reads Abnormal Latency/sec
+12156
+I/O Database Writes (Attached)/sec
+12158
+I/O Database Writes (Attached) Average Latency
+12160
+No name
+12162
+I/O Database Writes (Attached) Average Bytes
+12164
+No name
+12166
+I/O Database Writes (Attached) In Heap
+12168
+I/O Database Writes (Attached) Async Pending
+12170
+I/O Database Writes (Attached) Abnormal Latency/sec
+12172
+I/O Database Writes (Recovery)/sec
+12174
+I/O Database Writes (Recovery) Average Latency
+12176
+No name
+12178
+I/O Database Writes (Recovery) Average Bytes
+12180
+No name
+12182
+I/O Database Writes (Recovery) In Heap
+12184
+I/O Database Writes (Recovery) Async Pending
+12186
+I/O Database Writes (Recovery) Abnormal Latency/sec
+12188
+I/O Database Writes/sec
+12190
+I/O Database Writes Average Latency
+12192
+No name
+12194
+I/O Database Writes Average Bytes
+12196
+No name
+12198
+I/O Database Writes In Heap
+12200
+I/O Database Writes Async Pending
+12202
+I/O Database Writes Abnormal Latency/sec
+12204
+I/O Log Writes/sec
+12206
+I/O Log Writes Average Latency
+12208
+No name
+12210
+I/O Log Writes Average Bytes
+12212
+No name
+12214
+I/O Log Writes In Heap
+12216
+I/O Log Writes Async Pending
+12218
+I/O Log Writes Abnormal Latency/sec
+12220
+Threads Blocked/sec
+12222
+Threads Blocked
+12224
+Record Failed Compression Bytes/sec
+12226
+Pages Reorganized (Other)/sec
+12228
+Pages Reorganized (Free Space Request)/sec
+12230
+Pages Reorganized (Page Move Logging)/sec
+12232
+Pages Reorganized (Dehydrate Buffer)/sec
+12234
+Program Marker
+12236
+Database ==> TableClasses
+12238
+Record Inserts/sec
+12240
+Record Deletes/sec
+12242
+Record Replaces/sec
+12244
+Record Unnecessary Replaces/sec
+12246
+Record Redundant Replaces/sec
+12248
+Record Escrow-Updates/sec
+12250
+Secondary Index Inserts/sec
+12252
+Secondary Index Deletes/sec
+12254
+False Index Column Updates/sec
+12256
+False Tuple Index Column Updates/sec
+12258
+Record Intrinsic Long-Values Updated/sec
+12260
+Record Separated Long-Values Added/sec
+12262
+Record Separated Long-Values Forced/sec
+12264
+Record Separated Long-Values All Forced/sec
+12266
+Record Separated Long-Values Reference All/sec
+12268
+Record Separated Long-Values Dereference All/sec
+12270
+Separated Long-Value Seeks/sec
+12272
+Separated Long-Value Retrieves/sec
+12274
+Separated Long-Value Creates/sec
+12276
+Long-Value Maximum LID
+12278
+Separated Long-Value Updates/sec
+12280
+Separated Long-Value Deletes/sec
+12282
+Separated Long-Value Copies/sec
+12284
+Separated Long-Value Chunk Seeks/sec
+12286
+Separated Long-Value Chunk Retrieves/sec
+12288
+Separated Long-Value Chunk Appends/sec
+12290
+Separated Long-Value Chunk Replaces/sec
+12292
+Separated Long-Value Chunk Deletes/sec
+12294
+Separated Long-Value Chunk Copies/sec
+12296
+B+ Tree Append Splits/sec
+12298
+B+ Tree Right Splits/sec
+12300
+B+ Tree Right Hotpoint Splits/sec
+12302
+B+ Tree Vertical Splits/sec
+12304
+B+ Tree Splits/sec
+12306
+B+ Tree Empty Page Merges/sec
+12308
+B+ Tree Right Merges/sec
+12310
+B+ Tree Partial Merges/sec
+12312
+B+ Tree Left Merges/sec
+12314
+B+ Tree Partial Left Merges/sec
+12316
+B+ Tree Page Moves/sec
+12318
+B+ Tree Merges/sec
+12320
+B+ Tree Failed Simple Page Cleanup Attempts/sec
+12322
+B+ Tree Seek Short Circuits/sec
+12324
+B+ Tree Opportune Prereads/sec
+12326
+B+ Tree Unnecessary Sibling Latches/sec
+12328
+B+ Tree Move Nexts/sec
+12330
+B+ Tree Move Nexts (Non-Visible Nodes Skipped)/sec
+12332
+B+ Tree Move Nexts (Nodes Filtered)/sec
+12334
+B+ Tree Move Prevs/sec
+12336
+B+ Tree Move Prevs (Non-Visible Nodes Skipped)/sec
+12338
+B+ Tree Move Prevs (Nodes Filtered)/sec
+12340
+B+ Tree Seeks/sec
+12342
+B+ Tree Inserts/sec
+12344
+B+ Tree Replaces/sec
+12346
+B+ Tree Flag Deletes/sec
+12348
+B+ Tree Deletes/sec
+12350
+B+ Tree Appends/sec
+12352
+B+ Tree Creates/sec
+12354
+B+ Tree Creates (Total)
+12356
+B+ Tree Destroys/sec
+12358
+B+ Tree Destroys (Total)
+12360
+Database Pages Preread Untouched/sec
+12362
+Database Page Evictions (k=1)/sec
+12364
+Database Page Evictions (k=2)/sec
+12366
+Database Page Evictions (Scavenging)/sec
+12368
+Database Page Evictions (Shrink)/sec
+12370
+Database Page Evictions (Purge)/sec
+12372
+Database Page Evictions (Patch)/sec
+12374
+Database Cache Size (MB)
+12376
+Database Cache Size
+12378
+Database Cache Misses/sec
+12380
+Database Cache % Hit
+12382
+No name
+12384
+Database Cache % Hit (Uncorrelated)
+12386
+No name
+12388
+Database Cache Requests/sec
+12390
+Database Pages Read Async/sec
+12392
+Database Pages Read Sync/sec
+12394
+Database Pages Dirtied/sec
+12396
+Database Pages Dirtied (Repeatedly)/sec
+12398
+Database Pages Written/sec
+12400
+Database Pages Transferred/sec
+12402
+Database Pages Non-Resident Reclaimed (Soft Faulted)/sec
+12404
+Database Pages Non-Resident Reclaimed (Failed)/sec
+12406
+Database Pages Non-Resident Re-read/sec
+12408
+Database Pages Non-Resident Evicted (Normally)/sec
+12410
+Database Page Touches (Non-Touch)/sec
+12412
+Database Page Touches (k=1)/sec
+12414
+Database Page Touches (k=2)/sec
+12416
+Database Page Touches (Correlated)/sec
+12418
+Database Pages Colded (Ext)/sec
+12420
+Database Pages Colded (Int)/sec
+12422
+Database Pages Preread/sec
+12424
+Database Page Preread Stalls/sec
+12426
+Database Pages Preread (Unnecessary)/sec
+12428
+Database Pages Dehydrated/sec
+12430
+Database Pages Rehydrated/sec
+12432
+Database Pages Versioned/sec
+12434
+Database Pages Version Copied/sec
+12436
+Database Pages Repeatedly Written/sec
+12438
+Database Pages Flushed (Cache Shrink)/sec
+12440
+Database Pages Flushed (Checkpoint)/sec
+12442
+Database Pages Flushed (Checkpoint Foreground)/sec
+12444
+Database Pages Flushed (Context Flush)/sec
+12446
+Database Pages Flushed (Idle)/sec
+12448
+Database Pages Flushed (Filthy Foreground)/sec
+12450
+Database Pages Flushed (Scavenge)/sec
+12452
+Database Pages Flushed Opportunely/sec
+12454
+Database Pages Flushed Opportunely Clean/sec
+12456
+Database Pages Coalesced Written/sec
+12458
+Database Pages Coalesced Read/sec
+12460
+Database Pages Repeatedly Read/sec
+12462
+FCB Async Scan/sec
+12464
+FCB Async Purge/sec
+12466
+FCB Async Threshold-Scan/sec
+12468
+FCB Async Threshold-Purge/sec
+12470
+FCB Async Threshold Purge Failures (Conflicts)/sec
+12472
+FCB Async Threshold Purge Failures (In Use)/sec
+12474
+FCB Async Threshold Purge Failures (Sentinel)/sec
+12476
+FCB Async Threshold Purge Failures (Delete Pending)/sec
+12478
+FCB Async Threshold Purge Failures (Outstanding Versions)/sec
+12480
+FCB Async Threshold Purge Failures (LV Outstanding)/sec
+12482
+FCB Async Threshold Purge Failures (Index Outstanding)/sec
+12484
+FCB Async Threshold Purge Failures (Active Tasks)/sec
+12486
+FCB Async Threshold Purge Failures (Callbacks)/sec
+12488
+FCB Async Threshold Purge Failures (Other)/sec
+12490
+FCB Async Purge Failures (Conflicts)/sec
+12492
+FCB Async Purge Failures (In Use)/sec
+12494
+FCB Async Purge Failures (Sentinel)/sec
+12496
+FCB Async Purge Failures (Delete Pending)/sec
+12498
+FCB Async Purge Failures (Outstanding Versions)/sec
+12500
+FCB Async Purge Failures (LV Outstanding)/sec
+12502
+FCB Async Purge Failures (Index Outstanding)/sec
+12504
+FCB Async Purge Failures (Active Tasks)/sec
+12506
+FCB Async Purge Failures (Callbacks)/sec
+12508
+FCB Async Purge Failures (Other)/sec
+12510
+FCB Sync Purge/sec
+12512
+Table Open Pages Read/sec
+12514
+Table Open Pages Preread/sec
+12516
+Database ==> Instances
+12518
+Pages Converted/sec
+12520
+Pages Converted
+12522
+Records Converted/sec
+12524
+Records Converted
+12526
+Defragmentation Tasks
+12528
+Defragmentation Tasks Pending
+12530
+Defragmentation Tasks Discarded
+12532
+Defragmentation Tasks Scheduled/sec
+12534
+Defragmentation Tasks Completed/sec
+12536
+FCB Async Scan/sec
+12538
+FCB Async Purge/sec
+12540
+FCB Async Threshold-Scan/sec
+12542
+FCB Async Threshold-Purge/sec
+12544
+FCB Async Threshold Purge Failures (Conflicts)/sec
+12546
+FCB Async Threshold Purge Failures (In Use)/sec
+12548
+FCB Async Threshold Purge Failures (Sentinel)/sec
+12550
+FCB Async Threshold Purge Failures (Delete Pending)/sec
+12552
+FCB Async Threshold Purge Failures (Outstanding Versions)/sec
+12554
+FCB Async Threshold Purge Failures (LV Outstanding)/sec
+12556
+FCB Async Threshold Purge Failures (Index Outstanding)/sec
+12558
+FCB Async Threshold Purge Failures (Active Tasks)/sec
+12560
+FCB Async Threshold Purge Failures (Callbacks)/sec
+12562
+FCB Async Threshold Purge Failures (Other)/sec
+12564
+FCB Async Purge Failures (Conflicts)/sec
+12566
+FCB Async Purge Failures (In Use)/sec
+12568
+FCB Async Purge Failures (Sentinel)/sec
+12570
+FCB Async Purge Failures (Delete Pending)/sec
+12572
+FCB Async Purge Failures (Outstanding Versions)/sec
+12574
+FCB Async Purge Failures (LV Outstanding)/sec
+12576
+FCB Async Purge Failures (Index Outstanding)/sec
+12578
+FCB Async Purge Failures (Active Tasks)/sec
+12580
+FCB Async Purge Failures (Callbacks)/sec
+12582
+FCB Async Purge Failures (Other)/sec
+12584
+FCB Sync Purge/sec
+12586
+FCB Sync Purge Stalls/sec
+12588
+FCB Allocations Wait For Version Cleanup/sec
+12590
+FCB Purge On Cursor Close/sec
+12592
+FCB Cache % Hit
+12594
+No name
+12596
+FCB Cache Stalls/sec
+12598
+FCB Cache Maximum
+12600
+FCB Cache Preferred
+12602
+FCB Cache Allocated
+12604
+FCB Cache Allocated/sec
+12606
+FCB Cache Available
+12608
+FCB Cache Allocations Failed
+12610
+FCB Cache Allocation Average Latency (ms)
+12612
+No name
+12614
+FCB Attached RCEs
+12616
+Sessions In Use
+12618
+Sessions % Used
+12620
+No name
+12622
+Table Open Cache % Hit
+12624
+No name
+12626
+Table Open Cache Hits/sec
+12628
+Table Open Cache Misses/sec
+12630
+Table Open Pages Read/sec
+12632
+Table Open Pages Preread/sec
+12634
+Table Opens/sec
+12636
+Table Closes/sec
+12638
+Tables Open
+12640
+Log Bytes Write/sec
+12642
+Log Bytes Generated/sec
+12644
+Log Buffer Size
+12646
+Log Buffer Bytes Used
+12648
+Log Buffer Bytes Free
+12650
+Log Buffer Bytes Committed
+12652
+Log Threads Waiting
+12654
+Log File Size
+12656
+Log Checkpoint Depth
+12658
+Log Generation Checkpoint Depth
+12660
+Log Checkpoint Maintenance Outstanding IO Max
+12662
+Log Generation Checkpoint Depth Target
+12664
+Log Checkpoint Depth as a % of Target
+12666
+No name
+12668
+Log Generation Checkpoint Depth Max
+12670
+Log Generation Loss Resiliency Depth
+12672
+Log Files Generated
+12674
+Log Files Generated Prematurely
+12676
+Log File Current Generation
+12678
+User Read Only Transaction Commits to Level 0/sec
+12680
+User Read/Write Transaction Commits to Level 0 (Durable)/sec
+12682
+User Read/Write Transaction Commits to Level 0 (Lazy)/sec
+12684
+User Wait All Transaction Commits/sec
+12686
+User Wait Last Transaction Commits/sec
+12688
+User Transaction Commits to Level 0/sec
+12690
+User Read Only Transaction Rollbacks to Level 0/sec
+12692
+User Read/Write Transaction Rollbacks to Level 0/sec
+12694
+User Transaction Rollbacks to Level 0/sec
+12696
+System Read Only Transaction Commits to Level 0/sec
+12698
+System Read/Write Transaction Commits to Level 0 (Durable)/sec
+12700
+System Read/Write Transaction Commits to Level 0 (Lazy)/sec
+12702
+System Transaction Commits to Level 0/sec
+12704
+System Read Only Transaction Rollbacks to Level 0/sec
+12706
+System Read/Write Transaction Rollbacks to Level 0/sec
+12708
+System Transaction Rollbacks to Level 0/sec
+12710
+Database Page Allocation File Extension Async Consumed/sec
+12712
+Database Page Allocation File Extension Stalls/sec
+12714
+Database Page Allocation File Shrink Stalls/sec
+12716
+Log Records/sec
+12718
+Log Buffer Capacity Flushes/sec
+12720
+Log Buffer Commit Flushes/sec
+12722
+Log Buffer Flushes Skipped/sec
+12724
+Log Buffer Flushes Blocked/sec
+12726
+Log Buffer Flushes/sec
+12728
+Log Writes/sec
+12730
+Log Full Segment Writes/sec
+12732
+Log Partial Segment Writes/sec
+12734
+Log Bytes Wasted/sec
+12736
+Log Record Stalls/sec
+12738
+Version buckets allocated
+12740
+Version buckets allocated for deletes
+12742
+VER Bucket Allocations Wait For Version Cleanup/sec
+12744
+Version store average RCE bookmark length
+12746
+Version store unnecessary calls/sec
+12748
+Version store cleanup tasks asynchronously dispatched/sec
+12750
+Version store cleanup tasks synchronously dispatched/sec
+12752
+Version store cleanup tasks discarded/sec
+12754
+Version store cleanup tasks failures/sec
+12756
+Record Inserts/sec
+12758
+Record Deletes/sec
+12760
+Record Replaces/sec
+12762
+Record Unnecessary Replaces/sec
+12764
+Record Redundant Replaces/sec
+12766
+Record Escrow-Updates/sec
+12768
+Secondary Index Inserts/sec
+12770
+Secondary Index Deletes/sec
+12772
+False Index Column Updates/sec
+12774
+False Tuple Index Column Updates/sec
+12776
+Record Intrinsic Long-Values Updated/sec
+12778
+Record Separated Long-Values Added/sec
+12780
+Record Separated Long-Values Forced/sec
+12782
+Record Separated Long-Values All Forced/sec
+12784
+Record Separated Long-Values Reference All/sec
+12786
+Record Separated Long-Values Dereference All/sec
+12788
+Separated Long-Value Seeks/sec
+12790
+Separated Long-Value Retrieves/sec
+12792
+Separated Long-Value Creates/sec
+12794
+Long-Value Maximum LID
+12796
+Separated Long-Value Updates/sec
+12798
+Separated Long-Value Deletes/sec
+12800
+Separated Long-Value Copies/sec
+12802
+Separated Long-Value Chunk Seeks/sec
+12804
+Separated Long-Value Chunk Retrieves/sec
+12806
+Separated Long-Value Chunk Appends/sec
+12808
+Separated Long-Value Chunk Replaces/sec
+12810
+Separated Long-Value Chunk Deletes/sec
+12812
+Separated Long-Value Chunk Copies/sec
+12814
+B+ Tree Append Splits/sec
+12816
+B+ Tree Right Splits/sec
+12818
+B+ Tree Right Hotpoint Splits/sec
+12820
+B+ Tree Vertical Splits/sec
+12822
+B+ Tree Splits/sec
+12824
+B+ Tree Empty Page Merges/sec
+12826
+B+ Tree Right Merges/sec
+12828
+B+ Tree Partial Merges/sec
+12830
+B+ Tree Left Merges/sec
+12832
+B+ Tree Partial Left Merges/sec
+12834
+B+ Tree Page Moves/sec
+12836
+B+ Tree Merges/sec
+12838
+B+ Tree Failed Simple Page Cleanup Attempts/sec
+12840
+B+ Tree Seek Short Circuits/sec
+12842
+B+ Tree Opportune Prereads/sec
+12844
+B+ Tree Unnecessary Sibling Latches/sec
+12846
+B+ Tree Move Nexts/sec
+12848
+B+ Tree Move Nexts (Non-Visible Nodes Skipped)/sec
+12850
+B+ Tree Move Nexts (Nodes Filtered)/sec
+12852
+B+ Tree Move Prevs/sec
+12854
+B+ Tree Move Prevs (Non-Visible Nodes Skipped)/sec
+12856
+B+ Tree Move Prevs (Nodes Filtered)/sec
+12858
+B+ Tree Seeks/sec
+12860
+B+ Tree Inserts/sec
+12862
+B+ Tree Replaces/sec
+12864
+B+ Tree Flag Deletes/sec
+12866
+B+ Tree Deletes/sec
+12868
+B+ Tree Appends/sec
+12870
+B+ Tree Creates/sec
+12872
+B+ Tree Creates (Total)
+12874
+B+ Tree Destroys/sec
+12876
+B+ Tree Destroys (Total)
+12878
+Pages Trimmed/sec
+12880
+Pages Trimmed (Total)
+12882
+Pages Not Trimmed Unaligned/sec
+12884
+Pages Not Trimmed Unaligned (Total)
+12886
+Pages Trimmed Dirty/sec
+12888
+Pages Trimmed Dirty (Total)
+12890
+Database Pages Preread Untouched/sec
+12892
+Database Page Evictions (k=1)/sec
+12894
+Database Page Evictions (k=2)/sec
+12896
+Database Page Evictions (Scavenging)/sec
+12898
+Database Page Evictions (Shrink)/sec
+12900
+Database Page Evictions (Purge)/sec
+12902
+Database Page Evictions (Patch)/sec
+12904
+Database Cache Size (MB)
+12906
+Database Cache Misses/sec
+12908
+Database Cache % Hit
+12910
+No name
+12912
+Database Cache % Hit (Uncorrelated)
+12914
+No name
+12916
+Database Cache Requests/sec
+12918
+Instance Status
+12920
+Database Pages Read Async/sec
+12922
+Database Pages Read Sync/sec
+12924
+Database Pages Dirtied/sec
+12926
+Database Pages Dirtied (Repeatedly)/sec
+12928
+Database Pages Written/sec
+12930
+Database Pages Transferred/sec
+12932
+Database Pages Non-Resident Reclaimed (Soft Faulted)/sec
+12934
+Database Pages Non-Resident Reclaimed (Failed)/sec
+12936
+Database Pages Non-Resident Re-read/sec
+12938
+Database Pages Non-Resident Evicted (Normally)/sec
+12940
+Database Page Touches (Non-Touch)/sec
+12942
+Database Page Touches (k=1)/sec
+12944
+Database Page Touches (k=2)/sec
+12946
+Database Page Touches (Correlated)/sec
+12948
+Database Pages Colded (Ext)/sec
+12950
+Database Pages Colded (Int)/sec
+12952
+Database Pages Preread/sec
+12954
+Database Page Preread Stalls/sec
+12956
+Database Pages Preread (Unnecessary)/sec
+12958
+Database Pages Dehydrated/sec
+12960
+Database Pages Rehydrated/sec
+12962
+Database Pages Versioned/sec
+12964
+Database Pages Version Copied/sec
+12966
+Database Pages Repeatedly Written/sec
+12968
+Database Pages Flushed (Cache Shrink)/sec
+12970
+Database Pages Flushed (Checkpoint)/sec
+12972
+Database Pages Flushed (Checkpoint Foreground)/sec
+12974
+Database Pages Flushed (Context Flush)/sec
+12976
+Database Pages Flushed (Idle)/sec
+12978
+Database Pages Flushed (Filthy Foreground)/sec
+12980
+Database Pages Flushed (Scavenge)/sec
+12982
+Database Pages Flushed Opportunely/sec
+12984
+Database Pages Flushed Opportunely Clean/sec
+12986
+Database Pages Coalesced Written/sec
+12988
+Database Pages Coalesced Read/sec
+12990
+Database Pages Repeatedly Read/sec
+12992
+Streaming Backup Pages Read/sec
+12994
+Online Defrag Pages Referenced/sec
+12996
+Online Defrag Pages Read/sec
+12998
+Online Defrag Pages Preread/sec
+13000
+Online Defrag Pages Dirtied/sec
+13002
+Online Defrag Pages Re-Dirtied/sec
+13004
+Online Defrag Pages Freed/sec
+13006
+Online Defrag Data Moves/sec
+13008
+Online Defrag Page Moves/sec
+13010
+Online Defrag Log Records/sec
+13012
+Online Defrag Average Log Bytes
+13014
+No name
+13016
+Database Maintenance Duration
+13018
+Database Maintenance Pages Read
+13020
+Database Maintenance Pages Read/sec
+13022
+Database Maintenance Pages Zeroed
+13024
+Database Maintenance Pages Zeroed/sec
+13026
+Database Maintenance Pages Bad Checksums
+13028
+Database Maintenance IO Reads/sec
+13030
+Database Maintenance IO Reads Average Bytes
+13032
+No name
+13034
+Database Maintenance Throttle Setting
+13036
+Database Maintenance IO Re-Reads/sec
+13038
+Database Maintenance IO Re-Reads Average Bytes
+13040
+No name
+13042
+Database Maintenance IO Re-Reads Average Latency
+13044
+No name
+13046
+Database Tasks Pages Referenced/sec
+13048
+Database Tasks Pages Read/sec
+13050
+Database Tasks Pages Preread/sec
+13052
+Database Tasks Pages Dirtied/sec
+13054
+Database Tasks Pages Re-Dirtied/sec
+13056
+Database Tasks Log Records/sec
+13058
+Database Tasks Average Log Bytes
+13060
+No name
+13062
+I/O Database Reads (Attached)/sec
+13064
+I/O Database Reads (Attached) Average Latency
+13066
+No name
+13068
+I/O Database Reads (Attached) Average Bytes
+13070
+No name
+13072
+I/O Database Reads (Attached) In Heap
+13074
+I/O Database Reads (Attached) Async Pending
+13076
+I/O Database Reads (Attached) Abnormal Latency/sec
+13078
+I/O Database Reads (Recovery)/sec
+13080
+I/O Database Reads (Recovery) Average Latency
+13082
+No name
+13084
+I/O Database Reads (Recovery) Average Bytes
+13086
+No name
+13088
+I/O Database Reads (Recovery) In Heap
+13090
+I/O Database Reads (Recovery) Async Pending
+13092
+I/O Database Reads (Recovery) Abnormal Latency/sec
+13094
+I/O Database Reads/sec
+13096
+I/O Database Reads Average Latency
+13098
+No name
+13100
+I/O Database Reads Average Bytes
+13102
+No name
+13104
+I/O Database Reads In Heap
+13106
+I/O Database Reads Async Pending
+13108
+I/O Database Reads Abnormal Latency/sec
+13110
+I/O Log Reads/sec
+13112
+I/O Log Reads Average Latency
+13114
+No name
+13116
+I/O Log Reads Average Bytes
+13118
+No name
+13120
+I/O Log Reads In Heap
+13122
+I/O Log Reads Async Pending
+13124
+I/O Log Reads Abnormal Latency/sec
+13126
+I/O Database Writes (Attached)/sec
+13128
+I/O Database Writes (Attached) Average Latency
+13130
+No name
+13132
+I/O Database Writes (Attached) Average Bytes
+13134
+No name
+13136
+I/O Database Writes (Attached) In Heap
+13138
+I/O Database Writes (Attached) Async Pending
+13140
+I/O Database Writes (Attached) Abnormal Latency/sec
+13142
+I/O Database Writes (Recovery)/sec
+13144
+I/O Database Writes (Recovery) Average Latency
+13146
+No name
+13148
+I/O Database Writes (Recovery) Average Bytes
+13150
+No name
+13152
+I/O Database Writes (Recovery) In Heap
+13154
+I/O Database Writes (Recovery) Async Pending
+13156
+I/O Database Writes (Recovery) Abnormal Latency/sec
+13158
+I/O Database Writes/sec
+13160
+I/O Database Writes Average Latency
+13162
+No name
+13164
+I/O Database Writes Average Bytes
+13166
+No name
+13168
+I/O Database Writes In Heap
+13170
+I/O Database Writes Async Pending
+13172
+I/O Database Writes Abnormal Latency/sec
+13174
+I/O Log Writes/sec
+13176
+I/O Log Writes Average Latency
+13178
+No name
+13180
+I/O Log Writes Average Bytes
+13182
+No name
+13184
+I/O Log Writes In Heap
+13186
+I/O Log Writes Async Pending
+13188
+I/O Log Writes Abnormal Latency/sec
+13190
+Record Failed Compression Bytes/sec
+13192
+Pages Reorganized (Other)/sec
+13194
+Pages Reorganized (Free Space Request)/sec
+13196
+Pages Reorganized (Page Move Logging)/sec
+13198
+Pages Reorganized (Dehydrate Buffer)/sec
+13200
+MSExchange Database
+13202
+Pages Converted/sec
+13204
+Pages Converted
+13206
+Records Converted/sec
+13208
+Records Converted
+13210
+Defragmentation Tasks
+13212
+Defragmentation Tasks Pending
+13214
+Defragmentation Tasks Discarded
+13216
+Defragmentation Tasks Scheduled/sec
+13218
+Defragmentation Tasks Completed/sec
+13220
+Heap Allocs/sec
+13222
+Heap Frees/sec
+13224
+Heap Allocations
+13226
+Heap Bytes Allocated
+13228
+Page Bytes Reserved
+13230
+Page Bytes Committed
+13232
+FCB Async Scan/sec
+13234
+FCB Async Purge/sec
+13236
+FCB Async Threshold-Scan/sec
+13238
+FCB Async Threshold-Purge/sec
+13240
+FCB Async Threshold Purge Failures (Conflicts)/sec
+13242
+FCB Async Threshold Purge Failures (In Use)/sec
+13244
+FCB Async Threshold Purge Failures (Sentinel)/sec
+13246
+FCB Async Threshold Purge Failures (Delete Pending)/sec
+13248
+FCB Async Threshold Purge Failures (Outstanding Versions)/sec
+13250
+FCB Async Threshold Purge Failures (LV Outstanding)/sec
+13252
+FCB Async Threshold Purge Failures (Index Outstanding)/sec
+13254
+FCB Async Threshold Purge Failures (Active Tasks)/sec
+13256
+FCB Async Threshold Purge Failures (Callbacks)/sec
+13258
+FCB Async Threshold Purge Failures (Other)/sec
+13260
+FCB Async Purge Failures (Conflicts)/sec
+13262
+FCB Async Purge Failures (In Use)/sec
+13264
+FCB Async Purge Failures (Sentinel)/sec
+13266
+FCB Async Purge Failures (Delete Pending)/sec
+13268
+FCB Async Purge Failures (Outstanding Versions)/sec
+13270
+FCB Async Purge Failures (LV Outstanding)/sec
+13272
+FCB Async Purge Failures (Index Outstanding)/sec
+13274
+FCB Async Purge Failures (Active Tasks)/sec
+13276
+FCB Async Purge Failures (Callbacks)/sec
+13278
+FCB Async Purge Failures (Other)/sec
+13280
+FCB Sync Purge/sec
+13282
+FCB Sync Purge Stalls/sec
+13284
+FCB Allocations Wait For Version Cleanup/sec
+13286
+FCB Purge On Cursor Close/sec
+13288
+FCB Cache % Hit
+13290
+No name
+13292
+FCB Cache Stalls/sec
+13294
+FCB Cache Maximum
+13296
+FCB Cache Preferred
+13298
+FCB Cache Allocated
+13300
+FCB Cache Allocated/sec
+13302
+FCB Cache Available
+13304
+FCB Attached RCEs
+13306
+Sessions In Use
+13308
+Sessions % Used
+13310
+No name
+13312
+Resource Manager FCB Allocated
+13314
+Resource Manager FCB Allocated Used
+13316
+Resource Manager FCB Quota
+13318
+Resource Manager FUCB Allocated
+13320
+Resource Manager FUCB Allocated Used
+13322
+Resource Manager FUCB Quota
+13324
+Resource Manager TDB Allocated
+13326
+Resource Manager TDB Allocated Used
+13328
+Resource Manager TDB Quota
+13330
+Resource Manager IDB Allocated
+13332
+Resource Manager IDB Allocated Used
+13334
+Resource Manager IDB Quota
+13336
+Table Open Cache % Hit
+13338
+No name
+13340
+Table Open Cache Hits/sec
+13342
+Table Open Cache Misses/sec
+13344
+Table Open Pages Read/sec
+13346
+Table Open Pages Preread/sec
+13348
+Table Opens/sec
+13350
+Table Closes/sec
+13352
+Tables Open
+13354
+Log Bytes Write/sec
+13356
+Log Bytes Generated/sec
+13358
+Log Buffer Bytes Used
+13360
+Log Buffer Bytes Free
+13362
+Log Threads Waiting
+13364
+Log Checkpoint Depth
+13366
+Log Generation Checkpoint Depth
+13368
+Log Checkpoint Maintenance Outstanding IO Max
+13370
+User Read Only Transaction Commits to Level 0/sec
+13372
+User Read/Write Transaction Commits to Level 0 (Durable)/sec
+13374
+User Read/Write Transaction Commits to Level 0 (Lazy)/sec
+13376
+User Wait All Transaction Commits/sec
+13378
+User Wait Last Transaction Commits/sec
+13380
+User Transaction Commits to Level 0/sec
+13382
+User Read Only Transaction Rollbacks to Level 0/sec
+13384
+User Read/Write Transaction Rollbacks to Level 0/sec
+13386
+User Transaction Rollbacks to Level 0/sec
+13388
+System Read Only Transaction Commits to Level 0/sec
+13390
+System Read/Write Transaction Commits to Level 0 (Durable)/sec
+13392
+System Read/Write Transaction Commits to Level 0 (Lazy)/sec
+13394
+System Transaction Commits to Level 0/sec
+13396
+System Read Only Transaction Rollbacks to Level 0/sec
+13398
+System Read/Write Transaction Rollbacks to Level 0/sec
+13400
+System Transaction Rollbacks to Level 0/sec
+13402
+Database Page Allocation File Extension Async Consumed/sec
+13404
+Database Page Allocation File Extension Stalls/sec
+13406
+Database Page Allocation File Shrink Stalls/sec
+13408
+Log Records/sec
+13410
+Log Buffer Capacity Flushes/sec
+13412
+Log Buffer Commit Flushes/sec
+13414
+Log Buffer Flushes Skipped/sec
+13416
+Log Buffer Flushes Blocked/sec
+13418
+Log Buffer Flushes/sec
+13420
+Log Writes/sec
+13422
+Log Full Segment Writes/sec
+13424
+Log Partial Segment Writes/sec
+13426
+Log Record Stalls/sec
+13428
+Version Buckets Allocated
+13430
+Version Buckets Allocated for Deletes
+13432
+VER Bucket Allocations Wait For Version Cleanup/sec
+13434
+Version Store Average RCE Bookmark Length
+13436
+Version Store Unnecessary Calls/sec
+13438
+Version Store Cleanup Tasks Asynchronously Dispatched/sec
+13440
+Version Store Cleanup Tasks Synchronously Dispatched/sec
+13442
+Version Store Cleanup Tasks Discarded/sec
+13444
+Version Store Cleanup Tasks Failures/sec
+13446
+Record Inserts/sec
+13448
+Record Deletes/sec
+13450
+Record Replaces/sec
+13452
+Record Unnecessary Replaces/sec
+13454
+Record Redundant Replaces/sec
+13456
+Record Escrow-Updates/sec
+13458
+Secondary Index Inserts/sec
+13460
+Secondary Index Deletes/sec
+13462
+False Index Column Updates/sec
+13464
+False Tuple Index Column Updates/sec
+13466
+Record Intrinsic Long-Values Updated/sec
+13468
+Record Separated Long-Values Added/sec
+13470
+Record Separated Long-Values Forced/sec
+13472
+Record Separated Long-Values All Forced/sec
+13474
+Record Separated Long-Values Reference All/sec
+13476
+Record Separated Long-Values Dereference All/sec
+13478
+Separated Long-Value Seeks/sec
+13480
+Separated Long-Value Retrieves/sec
+13482
+Separated Long-Value Creates/sec
+13484
+Long-Value Maximum LID
+13486
+Separated Long-Value Updates/sec
+13488
+Separated Long-Value Deletes/sec
+13490
+Separated Long-Value Copies/sec
+13492
+Separated Long-Value Chunk Seeks/sec
+13494
+Separated Long-Value Chunk Retrieves/sec
+13496
+Separated Long-Value Chunk Appends/sec
+13498
+Separated Long-Value Chunk Replaces/sec
+13500
+Separated Long-Value Chunk Deletes/sec
+13502
+Separated Long-Value Chunk Copies/sec
+13504
+B+ Tree Append Splits/sec
+13506
+B+ Tree Right Splits/sec
+13508
+B+ Tree Right Hotpoint Splits/sec
+13510
+B+ Tree Vertical Splits/sec
+13512
+B+ Tree Splits/sec
+13514
+B+ Tree Empty Page Merges/sec
+13516
+B+ Tree Right Merges/sec
+13518
+B+ Tree Partial Merges/sec
+13520
+B+ Tree Left Merges/sec
+13522
+B+ Tree Partial Left Merges/sec
+13524
+B+ Tree Page Moves/sec
+13526
+B+ Tree Merges/sec
+13528
+B+ Tree Failed Simple Page Cleanup Attempts/sec
+13530
+B+ Tree Seek Short Circuits/sec
+13532
+B+ Tree Opportune Prereads/sec
+13534
+B+ Tree Unnecessary Sibling Latches/sec
+13536
+B+ Tree Move Nexts/sec
+13538
+B+ Tree Move Nexts (Non-Visible Nodes Skipped)/sec
+13540
+B+ Tree Move Nexts (Nodes Filtered)/sec
+13542
+B+ Tree Move Prevs/sec
+13544
+B+ Tree Move Prevs (Non-Visible Nodes Skipped)/sec
+13546
+B+ Tree Move Prevs (Nodes Filtered)/sec
+13548
+B+ Tree Seeks/sec
+13550
+B+ Tree Inserts/sec
+13552
+B+ Tree Replaces/sec
+13554
+B+ Tree Flag Deletes/sec
+13556
+B+ Tree Deletes/sec
+13558
+B+ Tree Appends/sec
+13560
+B+ Tree Creates/sec
+13562
+B+ Tree Creates (Total)
+13564
+B+ Tree Destroys/sec
+13566
+B+ Tree Destroys (Total)
+13568
+Database Cache Misses/sec
+13570
+Database Cache % Hit
+13572
+No name
+13574
+Database Cache % Hit (Uncorrelated)
+13576
+No name
+13578
+Database Cache Requests/sec
+13580
+Database Cache % Pinned
+13582
+No name
+13584
+Database Cache % Clean
+13586
+No name
+13588
+Database Pages Read Async/sec
+13590
+Database Pages Read Sync/sec
+13592
+Database Pages Dirtied/sec
+13594
+Database Pages Dirtied (Repeatedly)/sec
+13596
+Database Pages Written/sec
+13598
+Database Opportune Write Issued (Total)
+13600
+Database Pages Transferred/sec
+13602
+OS Memory Pages Trimmed/sec
+13604
+Database Pages Trimmed/sec
+13606
+Database Pages Non-Resident Reclaimed (Soft Faulted)/sec
+13608
+Database Pages Non-Resident Reclaimed (Failed)/sec
+13610
+Database Pages Non-Resident Re-read/sec
+13612
+Database Pages Non-Resident Evicted (Normally)/sec
+13614
+Database Pages Non-Resident Faulted In Average Latency
+13616
+No name
+13618
+Database Page Latches/sec
+13620
+Database Page Fast Latches/sec
+13622
+Database Page Bad Latch Hints/sec
+13624
+Database Cache % Fast Latch
+13626
+No name
+13628
+Database Page Touches (Non-Touch)/sec
+13630
+Database Page Touches (k=1)/sec
+13632
+Database Page Touches (k=2)/sec
+13634
+Database Page Touches (Correlated)/sec
+13636
+Database Pages Colded (Ext)/sec
+13638
+Database Pages Colded (Int)/sec
+13640
+Database Page Latch Conflicts/sec
+13642
+Database Page Latch Stalls/sec
+13644
+Database Cache % Available
+13646
+No name
+13648
+Database Page Faults/sec
+13650
+Database Page Evictions/sec
+13652
+Database Page Evictions (Preread Untouched)/sec
+13654
+Database Page Evictions (k=1)/sec
+13656
+Database Page Evictions (k=2)/sec
+13658
+Database Page Evictions (Scavenging)/sec
+13660
+Database Page Evictions (Shrink)/sec
+13662
+Database Page Evictions (Purge)/sec
+13664
+Database Page Evictions (Patch)/sec
+13666
+Database Page Fault Stalls/sec
+13668
+Database Cache Size (MB)
+13670
+Database Cache Size
+13672
+Database Cache Size Effective (MB)
+13674
+Database Cache Size Effective
+13676
+Database Cache Memory Committed (MB)
+13678
+Database Cache Memory Committed
+13680
+Database Cache Memory Reserved (MB)
+13682
+Database Cache Memory Reserved
+13684
+Database Cache Size Target (MB)
+13686
+Database Cache Size Target
+13688
+Database Cache Size Min
+13690
+Database Cache Size Max
+13692
+Database Cache Size Resident
+13694
+Database Cache Size Resident (MB)
+13696
+Database Cache Size Unattached (MB)
+13698
+Database Cache Sizing Duration
+13700
+Database Cache % Available Min
+13702
+No name
+13704
+Database Cache % Available Max
+13706
+No name
+13708
+Database Pages Preread/sec
+13710
+Database Page Preread Stalls/sec
+13712
+Database Pages Preread (Unnecessary)/sec
+13714
+Database Pages Dehydrated/sec
+13716
+Database Pages Rehydrated/sec
+13718
+Database Pages Versioned/sec
+13720
+Database Pages Version Copied/sec
+13722
+Database Cache % Versioned
+13724
+No name
+13726
+Database Pages Repeatedly Written/sec
+13728
+Database Pages Flushed (Cache Shrink)/sec
+13730
+Database Pages Flushed (Checkpoint)/sec
+13732
+Database Pages Flushed (Checkpoint Foreground)/sec
+13734
+Database Pages Flushed (Context Flush)/sec
+13736
+Database Pages Flushed (Idle)/sec
+13738
+Database Pages Flushed (Filthy Foreground)/sec
+13740
+Database Pages Flushed (Scavenge)/sec
+13742
+Database Pages Flushed Opportunely/sec
+13744
+Database Pages Flushed Opportunely Clean/sec
+13746
+Database Pages Coalesced Written/sec
+13748
+Database Pages Coalesced Read/sec
+13750
+Database cache lifetime
+13752
+Database Page History Records
+13754
+Database Page History % Hit
+13756
+No name
+13758
+Database Page Scans/sec
+13760
+Database Page Scans Out-of-Order/sec
+13762
+No name
+13764
+Database Cache % Resident
+13766
+No name
+13768
+Database Cache % Dehydrated
+13770
+No name
+13772
+Database Pages Repeatedly Read/sec
+13774
+Streaming Backup Pages Read/sec
+13776
+Online Defrag Pages Referenced/sec
+13778
+Online Defrag Pages Read/sec
+13780
+Online Defrag Pages Preread/sec
+13782
+Online Defrag Pages Dirtied/sec
+13784
+Online Defrag Pages Re-Dirtied/sec
+13786
+Online Defrag Pages Freed/sec
+13788
+Online Defrag Data Moves/sec
+13790
+Online Defrag Page Moves/sec
+13792
+Online Defrag Log Records/sec
+13794
+Online Defrag Average Log Bytes
+13796
+No name
+13798
+Database Maintenance Duration
+13800
+Database Maintenance Pages Read
+13802
+Database Maintenance Pages Read/sec
+13804
+Database Maintenance Pages Zeroed
+13806
+Database Maintenance Pages Zeroed/sec
+13808
+Database Maintenance Pages Bad Checksums
+13810
+Database Maintenance IO Reads/sec
+13812
+Database Maintenance IO Reads Average Bytes
+13814
+No name
+13816
+Database Maintenance Throttle Setting
+13818
+Database Maintenance IO Re-Reads/sec
+13820
+Database Maintenance IO Re-Reads Average Bytes
+13822
+No name
+13824
+Database Maintenance IO Re-Reads Average Latency
+13826
+No name
+13828
+Database Tasks Pages Referenced/sec
+13830
+Database Tasks Pages Read/sec
+13832
+Database Tasks Pages Preread/sec
+13834
+Database Tasks Pages Dirtied/sec
+13836
+Database Tasks Pages Re-Dirtied/sec
+13838
+Database Tasks Log Records/sec
+13840
+Database Tasks Average Log Bytes
+13842
+No name
+13844
+I/O Database Reads (Attached)/sec
+13846
+I/O Database Reads (Attached) Average Latency
+13848
+No name
+13850
+I/O Database Reads (Attached) Average Bytes
+13852
+No name
+13854
+I/O Database Reads (Attached) In Heap
+13856
+I/O Database Reads (Attached) Async Pending
+13858
+I/O Database Reads (Attached) Abnormal Latency/sec
+13860
+I/O Database Reads (Recovery)/sec
+13862
+I/O Database Reads (Recovery) Average Latency
+13864
+No name
+13866
+I/O Database Reads (Recovery) Average Bytes
+13868
+No name
+13870
+I/O Database Reads (Recovery) In Heap
+13872
+I/O Database Reads (Recovery) Async Pending
+13874
+I/O Database Reads (Recovery) Abnormal Latency/sec
+13876
+I/O Database Reads/sec
+13878
+I/O Database Reads Average Latency
+13880
+No name
+13882
+I/O Database Reads Average Bytes
+13884
+No name
+13886
+I/O Database Reads In Heap
+13888
+I/O Database Reads Async Pending
+13890
+I/O Database Reads Abnormal Latency/sec
+13892
+I/O Log Reads/sec
+13894
+I/O Log Reads Average Latency
+13896
+No name
+13898
+I/O Log Reads Average Bytes
+13900
+No name
+13902
+I/O Log Reads In Heap
+13904
+I/O Log Reads Async Pending
+13906
+I/O Log Reads Abnormal Latency/sec
+13908
+I/O Database Writes (Attached)/sec
+13910
+I/O Database Writes (Attached) Average Latency
+13912
+No name
+13914
+I/O Database Writes (Attached) Average Bytes
+13916
+No name
+13918
+I/O Database Writes (Attached) In Heap
+13920
+I/O Database Writes (Attached) Async Pending
+13922
+I/O Database Writes (Attached) Abnormal Latency/sec
+13924
+I/O Database Writes (Recovery)/sec
+13926
+I/O Database Writes (Recovery) Average Latency
+13928
+No name
+13930
+I/O Database Writes (Recovery) Average Bytes
+13932
+No name
+13934
+I/O Database Writes (Recovery) In Heap
+13936
+I/O Database Writes (Recovery) Async Pending
+13938
+I/O Database Writes (Recovery) Abnormal Latency/sec
+13940
+I/O Database Writes/sec
+13942
+I/O Database Writes Average Latency
+13944
+No name
+13946
+I/O Database Writes Average Bytes
+13948
+No name
+13950
+I/O Database Writes In Heap
+13952
+I/O Database Writes Async Pending
+13954
+I/O Database Writes Abnormal Latency/sec
+13956
+I/O Log Writes/sec
+13958
+I/O Log Writes Average Latency
+13960
+No name
+13962
+I/O Log Writes Average Bytes
+13964
+No name
+13966
+I/O Log Writes In Heap
+13968
+I/O Log Writes Async Pending
+13970
+I/O Log Writes Abnormal Latency/sec
+13972
+Threads Blocked/sec
+13974
+Threads Blocked
+13976
+Record Failed Compression Bytes/sec
+13978
+Pages Reorganized (Other)/sec
+13980
+Pages Reorganized (Free Space Request)/sec
+13982
+Pages Reorganized (Page Move Logging)/sec
+13984
+Pages Reorganized (Dehydrate Buffer)/sec
+13986
+Program Marker
+13988
+MSExchange Database ==> TableClasses
+13990
+Record Inserts/sec
+13992
+Record Deletes/sec
+13994
+Record Replaces/sec
+13996
+Record Unnecessary Replaces/sec
+13998
+Record Redundant Replaces/sec
+14000
+Record Escrow-Updates/sec
+14002
+Secondary Index Inserts/sec
+14004
+Secondary Index Deletes/sec
+14006
+False Index Column Updates/sec
+14008
+False Tuple Index Column Updates/sec
+14010
+Record Intrinsic Long-Values Updated/sec
+14012
+Record Separated Long-Values Added/sec
+14014
+Record Separated Long-Values Forced/sec
+14016
+Record Separated Long-Values All Forced/sec
+14018
+Record Separated Long-Values Reference All/sec
+14020
+Record Separated Long-Values Dereference All/sec
+14022
+Separated Long-Value Seeks/sec
+14024
+Separated Long-Value Retrieves/sec
+14026
+Separated Long-Value Creates/sec
+14028
+Long-Value Maximum LID
+14030
+Separated Long-Value Updates/sec
+14032
+Separated Long-Value Deletes/sec
+14034
+Separated Long-Value Copies/sec
+14036
+Separated Long-Value Chunk Seeks/sec
+14038
+Separated Long-Value Chunk Retrieves/sec
+14040
+Separated Long-Value Chunk Appends/sec
+14042
+Separated Long-Value Chunk Replaces/sec
+14044
+Separated Long-Value Chunk Deletes/sec
+14046
+Separated Long-Value Chunk Copies/sec
+14048
+B+ Tree Append Splits/sec
+14050
+B+ Tree Right Splits/sec
+14052
+B+ Tree Right Hotpoint Splits/sec
+14054
+B+ Tree Vertical Splits/sec
+14056
+B+ Tree Splits/sec
+14058
+B+ Tree Empty Page Merges/sec
+14060
+B+ Tree Right Merges/sec
+14062
+B+ Tree Partial Merges/sec
+14064
+B+ Tree Left Merges/sec
+14066
+B+ Tree Partial Left Merges/sec
+14068
+B+ Tree Page Moves/sec
+14070
+B+ Tree Merges/sec
+14072
+B+ Tree Failed Simple Page Cleanup Attempts/sec
+14074
+B+ Tree Seek Short Circuits/sec
+14076
+B+ Tree Opportune Prereads/sec
+14078
+B+ Tree Unnecessary Sibling Latches/sec
+14080
+B+ Tree Move Nexts/sec
+14082
+B+ Tree Move Nexts (Non-Visible Nodes Skipped)/sec
+14084
+B+ Tree Move Nexts (Nodes Filtered)/sec
+14086
+B+ Tree Move Prevs/sec
+14088
+B+ Tree Move Prevs (Non-Visible Nodes Skipped)/sec
+14090
+B+ Tree Move Prevs (Nodes Filtered)/sec
+14092
+B+ Tree Seeks/sec
+14094
+B+ Tree Inserts/sec
+14096
+B+ Tree Replaces/sec
+14098
+B+ Tree Flag Deletes/sec
+14100
+B+ Tree Deletes/sec
+14102
+B+ Tree Appends/sec
+14104
+B+ Tree Creates/sec
+14106
+B+ Tree Creates (Total)
+14108
+B+ Tree Destroys/sec
+14110
+B+ Tree Destroys (Total)
+14112
+Database Pages Preread Untouched/sec
+14114
+Database Page Evictions (k=1)/sec
+14116
+Database Page Evictions (k=2)/sec
+14118
+Database Page Evictions (Scavenging)/sec
+14120
+Database Page Evictions (Shrink)/sec
+14122
+Database Page Evictions (Purge)/sec
+14124
+Database Page Evictions (Patch)/sec
+14126
+Database Cache Size (MB)
+14128
+Database Cache Size
+14130
+Database Cache Misses/sec
+14132
+Database Cache % Hit
+14134
+No name
+14136
+Database Cache % Hit (Uncorrelated)
+14138
+No name
+14140
+Database Cache Requests/sec
+14142
+Database Pages Read Async/sec
+14144
+Database Pages Read Sync/sec
+14146
+Database Pages Dirtied/sec
+14148
+Database Pages Dirtied (Repeatedly)/sec
+14150
+Database Pages Written/sec
+14152
+Database Pages Transferred/sec
+14154
+Database Pages Non-Resident Reclaimed (Soft Faulted)/sec
+14156
+Database Pages Non-Resident Reclaimed (Failed)/sec
+14158
+Database Pages Non-Resident Re-read/sec
+14160
+Database Pages Non-Resident Evicted (Normally)/sec
+14162
+Database Page Touches (Non-Touch)/sec
+14164
+Database Page Touches (k=1)/sec
+14166
+Database Page Touches (k=2)/sec
+14168
+Database Page Touches (Correlated)/sec
+14170
+Database Pages Colded (Ext)/sec
+14172
+Database Pages Colded (Int)/sec
+14174
+Database Pages Preread/sec
+14176
+Database Page Preread Stalls/sec
+14178
+Database Pages Preread (Unnecessary)/sec
+14180
+Database Pages Dehydrated/sec
+14182
+Database Pages Rehydrated/sec
+14184
+Database Pages Versioned/sec
+14186
+Database Pages Version Copied/sec
+14188
+Database Pages Repeatedly Written/sec
+14190
+Database Pages Flushed (Cache Shrink)/sec
+14192
+Database Pages Flushed (Checkpoint)/sec
+14194
+Database Pages Flushed (Checkpoint Foreground)/sec
+14196
+Database Pages Flushed (Context Flush)/sec
+14198
+Database Pages Flushed (Idle)/sec
+14200
+Database Pages Flushed (Filthy Foreground)/sec
+14202
+Database Pages Flushed (Scavenge)/sec
+14204
+Database Pages Flushed Opportunely/sec
+14206
+Database Pages Flushed Opportunely Clean/sec
+14208
+Database Pages Coalesced Written/sec
+14210
+Database Pages Coalesced Read/sec
+14212
+Database Pages Repeatedly Read/sec
+14214
+FCB Async Scan/sec
+14216
+FCB Async Purge/sec
+14218
+FCB Async Threshold-Scan/sec
+14220
+FCB Async Threshold-Purge/sec
+14222
+FCB Async Threshold Purge Failures (Conflicts)/sec
+14224
+FCB Async Threshold Purge Failures (In Use)/sec
+14226
+FCB Async Threshold Purge Failures (Sentinel)/sec
+14228
+FCB Async Threshold Purge Failures (Delete Pending)/sec
+14230
+FCB Async Threshold Purge Failures (Outstanding Versions)/sec
+14232
+FCB Async Threshold Purge Failures (LV Outstanding)/sec
+14234
+FCB Async Threshold Purge Failures (Index Outstanding)/sec
+14236
+FCB Async Threshold Purge Failures (Active Tasks)/sec
+14238
+FCB Async Threshold Purge Failures (Callbacks)/sec
+14240
+FCB Async Threshold Purge Failures (Other)/sec
+14242
+FCB Async Purge Failures (Conflicts)/sec
+14244
+FCB Async Purge Failures (In Use)/sec
+14246
+FCB Async Purge Failures (Sentinel)/sec
+14248
+FCB Async Purge Failures (Delete Pending)/sec
+14250
+FCB Async Purge Failures (Outstanding Versions)/sec
+14252
+FCB Async Purge Failures (LV Outstanding)/sec
+14254
+FCB Async Purge Failures (Index Outstanding)/sec
+14256
+FCB Async Purge Failures (Active Tasks)/sec
+14258
+FCB Async Purge Failures (Callbacks)/sec
+14260
+FCB Async Purge Failures (Other)/sec
+14262
+FCB Sync Purge/sec
+14264
+Table Open Pages Read/sec
+14266
+Table Open Pages Preread/sec
+14268
+MSExchange Database ==> Instances
+14270
+Pages Converted/sec
+14272
+Pages Converted
+14274
+Records Converted/sec
+14276
+Records Converted
+14278
+Defragmentation Tasks
+14280
+Defragmentation Tasks Pending
+14282
+Defragmentation Tasks Discarded
+14284
+Defragmentation Tasks Scheduled/sec
+14286
+Defragmentation Tasks Completed/sec
+14288
+FCB Async Scan/sec
+14290
+FCB Async Purge/sec
+14292
+FCB Async Threshold-Scan/sec
+14294
+FCB Async Threshold-Purge/sec
+14296
+FCB Async Threshold Purge Failures (Conflicts)/sec
+14298
+FCB Async Threshold Purge Failures (In Use)/sec
+14300
+FCB Async Threshold Purge Failures (Sentinel)/sec
+14302
+FCB Async Threshold Purge Failures (Delete Pending)/sec
+14304
+FCB Async Threshold Purge Failures (Outstanding Versions)/sec
+14306
+FCB Async Threshold Purge Failures (LV Outstanding)/sec
+14308
+FCB Async Threshold Purge Failures (Index Outstanding)/sec
+14310
+FCB Async Threshold Purge Failures (Active Tasks)/sec
+14312
+FCB Async Threshold Purge Failures (Callbacks)/sec
+14314
+FCB Async Threshold Purge Failures (Other)/sec
+14316
+FCB Async Purge Failures (Conflicts)/sec
+14318
+FCB Async Purge Failures (In Use)/sec
+14320
+FCB Async Purge Failures (Sentinel)/sec
+14322
+FCB Async Purge Failures (Delete Pending)/sec
+14324
+FCB Async Purge Failures (Outstanding Versions)/sec
+14326
+FCB Async Purge Failures (LV Outstanding)/sec
+14328
+FCB Async Purge Failures (Index Outstanding)/sec
+14330
+FCB Async Purge Failures (Active Tasks)/sec
+14332
+FCB Async Purge Failures (Callbacks)/sec
+14334
+FCB Async Purge Failures (Other)/sec
+14336
+FCB Sync Purge/sec
+14338
+FCB Sync Purge Stalls/sec
+14340
+FCB Allocations Wait For Version Cleanup/sec
+14342
+FCB Purge On Cursor Close/sec
+14344
+FCB Cache % Hit
+14346
+No name
+14348
+FCB Cache Stalls/sec
+14350
+FCB Cache Maximum
+14352
+FCB Cache Preferred
+14354
+FCB Cache Allocated
+14356
+FCB Cache Allocated/sec
+14358
+FCB Cache Available
+14360
+FCB Cache Allocations Failed
+14362
+FCB Cache Allocation Average Latency (ms)
+14364
+No name
+14366
+FCB Attached RCEs
+14368
+Sessions In Use
+14370
+Sessions % Used
+14372
+No name
+14374
+Table Open Cache % Hit
+14376
+No name
+14378
+Table Open Cache Hits/sec
+14380
+Table Open Cache Misses/sec
+14382
+Table Open Pages Read/sec
+14384
+Table Open Pages Preread/sec
+14386
+Table Opens/sec
+14388
+Table Closes/sec
+14390
+Tables Open
+14392
+Log Bytes Write/sec
+14394
+Log Bytes Generated/sec
+14396
+Log Buffer Size
+14398
+Log Buffer Bytes Used
+14400
+Log Buffer Bytes Free
+14402
+Log Threads Waiting
+14404
+Log File Size
+14406
+Log Checkpoint Depth
+14408
+Log Generation Checkpoint Depth
+14410
+Log Checkpoint Maintenance Outstanding IO Max
+14412
+Log Generation Checkpoint Depth Target
+14414
+Log Checkpoint Depth as a % of Target
+14416
+No name
+14418
+Log Generation Checkpoint Depth Max
+14420
+Log Generation Loss Resiliency Depth
+14422
+Log Files Generated
+14424
+Log Files Generated Prematurely
+14426
+Log File Current Generation
+14428
+User Read Only Transaction Commits to Level 0/sec
+14430
+User Read/Write Transaction Commits to Level 0 (Durable)/sec
+14432
+User Read/Write Transaction Commits to Level 0 (Lazy)/sec
+14434
+User Wait All Transaction Commits/sec
+14436
+User Wait Last Transaction Commits/sec
+14438
+User Transaction Commits to Level 0/sec
+14440
+User Read Only Transaction Rollbacks to Level 0/sec
+14442
+User Read/Write Transaction Rollbacks to Level 0/sec
+14444
+User Transaction Rollbacks to Level 0/sec
+14446
+System Read Only Transaction Commits to Level 0/sec
+14448
+System Read/Write Transaction Commits to Level 0 (Durable)/sec
+14450
+System Read/Write Transaction Commits to Level 0 (Lazy)/sec
+14452
+System Transaction Commits to Level 0/sec
+14454
+System Read Only Transaction Rollbacks to Level 0/sec
+14456
+System Read/Write Transaction Rollbacks to Level 0/sec
+14458
+System Transaction Rollbacks to Level 0/sec
+14460
+Database Page Allocation File Extension Async Consumed/sec
+14462
+Database Page Allocation File Extension Stalls/sec
+14464
+Database Page Allocation File Shrink Stalls/sec
+14466
+Log Records/sec
+14468
+Log Buffer Capacity Flushes/sec
+14470
+Log Buffer Commit Flushes/sec
+14472
+Log Buffer Flushes Skipped/sec
+14474
+Log Buffer Flushes Blocked/sec
+14476
+Log Buffer Flushes/sec
+14478
+Log Writes/sec
+14480
+Log Full Segment Writes/sec
+14482
+Log Partial Segment Writes/sec
+14484
+Log Record Stalls/sec
+14486
+Version buckets allocated
+14488
+Version buckets allocated for deletes
+14490
+VER Bucket Allocations Wait For Version Cleanup/sec
+14492
+Version store average RCE bookmark length
+14494
+Version store unnecessary calls/sec
+14496
+Version store cleanup tasks asynchronously dispatched/sec
+14498
+Version store cleanup tasks synchronously dispatched/sec
+14500
+Version store cleanup tasks discarded/sec
+14502
+Version store cleanup tasks failures/sec
+14504
+Record Inserts/sec
+14506
+Record Deletes/sec
+14508
+Record Replaces/sec
+14510
+Record Unnecessary Replaces/sec
+14512
+Record Redundant Replaces/sec
+14514
+Record Escrow-Updates/sec
+14516
+Secondary Index Inserts/sec
+14518
+Secondary Index Deletes/sec
+14520
+False Index Column Updates/sec
+14522
+False Tuple Index Column Updates/sec
+14524
+Record Intrinsic Long-Values Updated/sec
+14526
+Record Separated Long-Values Added/sec
+14528
+Record Separated Long-Values Forced/sec
+14530
+Record Separated Long-Values All Forced/sec
+14532
+Record Separated Long-Values Reference All/sec
+14534
+Record Separated Long-Values Dereference All/sec
+14536
+Separated Long-Value Seeks/sec
+14538
+Separated Long-Value Retrieves/sec
+14540
+Separated Long-Value Creates/sec
+14542
+Long-Value Maximum LID
+14544
+Separated Long-Value Updates/sec
+14546
+Separated Long-Value Deletes/sec
+14548
+Separated Long-Value Copies/sec
+14550
+Separated Long-Value Chunk Seeks/sec
+14552
+Separated Long-Value Chunk Retrieves/sec
+14554
+Separated Long-Value Chunk Appends/sec
+14556
+Separated Long-Value Chunk Replaces/sec
+14558
+Separated Long-Value Chunk Deletes/sec
+14560
+Separated Long-Value Chunk Copies/sec
+14562
+B+ Tree Append Splits/sec
+14564
+B+ Tree Right Splits/sec
+14566
+B+ Tree Right Hotpoint Splits/sec
+14568
+B+ Tree Vertical Splits/sec
+14570
+B+ Tree Splits/sec
+14572
+B+ Tree Empty Page Merges/sec
+14574
+B+ Tree Right Merges/sec
+14576
+B+ Tree Partial Merges/sec
+14578
+B+ Tree Left Merges/sec
+14580
+B+ Tree Partial Left Merges/sec
+14582
+B+ Tree Page Moves/sec
+14584
+B+ Tree Merges/sec
+14586
+B+ Tree Failed Simple Page Cleanup Attempts/sec
+14588
+B+ Tree Seek Short Circuits/sec
+14590
+B+ Tree Opportune Prereads/sec
+14592
+B+ Tree Unnecessary Sibling Latches/sec
+14594
+B+ Tree Move Nexts/sec
+14596
+B+ Tree Move Nexts (Non-Visible Nodes Skipped)/sec
+14598
+B+ Tree Move Nexts (Nodes Filtered)/sec
+14600
+B+ Tree Move Prevs/sec
+14602
+B+ Tree Move Prevs (Non-Visible Nodes Skipped)/sec
+14604
+B+ Tree Move Prevs (Nodes Filtered)/sec
+14606
+B+ Tree Seeks/sec
+14608
+B+ Tree Inserts/sec
+14610
+B+ Tree Replaces/sec
+14612
+B+ Tree Flag Deletes/sec
+14614
+B+ Tree Deletes/sec
+14616
+B+ Tree Appends/sec
+14618
+B+ Tree Creates/sec
+14620
+B+ Tree Creates (Total)
+14622
+B+ Tree Destroys/sec
+14624
+B+ Tree Destroys (Total)
+14626
+Database Pages Preread Untouched/sec
+14628
+Database Page Evictions (k=1)/sec
+14630
+Database Page Evictions (k=2)/sec
+14632
+Database Page Evictions (Scavenging)/sec
+14634
+Database Page Evictions (Shrink)/sec
+14636
+Database Page Evictions (Purge)/sec
+14638
+Database Page Evictions (Patch)/sec
+14640
+Database Cache Size (MB)
+14642
+Database Cache Misses/sec
+14644
+Database Cache % Hit
+14646
+No name
+14648
+Database Cache % Hit (Uncorrelated)
+14650
+No name
+14652
+Database Cache Requests/sec
+14654
+Instance Status
+14656
+Database Pages Read Async/sec
+14658
+Database Pages Read Sync/sec
+14660
+Database Pages Dirtied/sec
+14662
+Database Pages Dirtied (Repeatedly)/sec
+14664
+Database Pages Written/sec
+14666
+Database Pages Transferred/sec
+14668
+Database Pages Non-Resident Reclaimed (Soft Faulted)/sec
+14670
+Database Pages Non-Resident Reclaimed (Failed)/sec
+14672
+Database Pages Non-Resident Re-read/sec
+14674
+Database Pages Non-Resident Evicted (Normally)/sec
+14676
+Database Page Touches (Non-Touch)/sec
+14678
+Database Page Touches (k=1)/sec
+14680
+Database Page Touches (k=2)/sec
+14682
+Database Page Touches (Correlated)/sec
+14684
+Database Pages Colded (Ext)/sec
+14686
+Database Pages Colded (Int)/sec
+14688
+Database Pages Preread/sec
+14690
+Database Page Preread Stalls/sec
+14692
+Database Pages Preread (Unnecessary)/sec
+14694
+Database Pages Dehydrated/sec
+14696
+Database Pages Rehydrated/sec
+14698
+Database Pages Versioned/sec
+14700
+Database Pages Version Copied/sec
+14702
+Database Pages Repeatedly Written/sec
+14704
+Database Pages Flushed (Cache Shrink)/sec
+14706
+Database Pages Flushed (Checkpoint)/sec
+14708
+Database Pages Flushed (Checkpoint Foreground)/sec
+14710
+Database Pages Flushed (Context Flush)/sec
+14712
+Database Pages Flushed (Idle)/sec
+14714
+Database Pages Flushed (Filthy Foreground)/sec
+14716
+Database Pages Flushed (Scavenge)/sec
+14718
+Database Pages Flushed Opportunely/sec
+14720
+Database Pages Flushed Opportunely Clean/sec
+14722
+Database Pages Coalesced Written/sec
+14724
+Database Pages Coalesced Read/sec
+14726
+Database Pages Repeatedly Read/sec
+14728
+Streaming Backup Pages Read/sec
+14730
+Online Defrag Pages Referenced/sec
+14732
+Online Defrag Pages Read/sec
+14734
+Online Defrag Pages Preread/sec
+14736
+Online Defrag Pages Dirtied/sec
+14738
+Online Defrag Pages Re-Dirtied/sec
+14740
+Online Defrag Pages Freed/sec
+14742
+Online Defrag Data Moves/sec
+14744
+Online Defrag Page Moves/sec
+14746
+Online Defrag Log Records/sec
+14748
+Online Defrag Average Log Bytes
+14750
+No name
+14752
+Database Maintenance Duration
+14754
+Database Maintenance Pages Read
+14756
+Database Maintenance Pages Read/sec
+14758
+Database Maintenance Pages Zeroed
+14760
+Database Maintenance Pages Zeroed/sec
+14762
+Database Maintenance Pages Bad Checksums
+14764
+Database Maintenance IO Reads/sec
+14766
+Database Maintenance IO Reads Average Bytes
+14768
+No name
+14770
+Database Maintenance Throttle Setting
+14772
+Database Maintenance IO Re-Reads/sec
+14774
+Database Maintenance IO Re-Reads Average Bytes
+14776
+No name
+14778
+Database Maintenance IO Re-Reads Average Latency
+14780
+No name
+14782
+Database Tasks Pages Referenced/sec
+14784
+Database Tasks Pages Read/sec
+14786
+Database Tasks Pages Preread/sec
+14788
+Database Tasks Pages Dirtied/sec
+14790
+Database Tasks Pages Re-Dirtied/sec
+14792
+Database Tasks Log Records/sec
+14794
+Database Tasks Average Log Bytes
+14796
+No name
+14798
+I/O Database Reads (Attached)/sec
+14800
+I/O Database Reads (Attached) Average Latency
+14802
+No name
+14804
+I/O Database Reads (Attached) Average Bytes
+14806
+No name
+14808
+I/O Database Reads (Attached) In Heap
+14810
+I/O Database Reads (Attached) Async Pending
+14812
+I/O Database Reads (Attached) Abnormal Latency/sec
+14814
+I/O Database Reads (Recovery)/sec
+14816
+I/O Database Reads (Recovery) Average Latency
+14818
+No name
+14820
+I/O Database Reads (Recovery) Average Bytes
+14822
+No name
+14824
+I/O Database Reads (Recovery) In Heap
+14826
+I/O Database Reads (Recovery) Async Pending
+14828
+I/O Database Reads (Recovery) Abnormal Latency/sec
+14830
+I/O Database Reads/sec
+14832
+I/O Database Reads Average Latency
+14834
+No name
+14836
+I/O Database Reads Average Bytes
+14838
+No name
+14840
+I/O Database Reads In Heap
+14842
+I/O Database Reads Async Pending
+14844
+I/O Database Reads Abnormal Latency/sec
+14846
+I/O Log Reads/sec
+14848
+I/O Log Reads Average Latency
+14850
+No name
+14852
+I/O Log Reads Average Bytes
+14854
+No name
+14856
+I/O Log Reads In Heap
+14858
+I/O Log Reads Async Pending
+14860
+I/O Log Reads Abnormal Latency/sec
+14862
+I/O Database Writes (Attached)/sec
+14864
+I/O Database Writes (Attached) Average Latency
+14866
+No name
+14868
+I/O Database Writes (Attached) Average Bytes
+14870
+No name
+14872
+I/O Database Writes (Attached) In Heap
+14874
+I/O Database Writes (Attached) Async Pending
+14876
+I/O Database Writes (Attached) Abnormal Latency/sec
+14878
+I/O Database Writes (Recovery)/sec
+14880
+I/O Database Writes (Recovery) Average Latency
+14882
+No name
+14884
+I/O Database Writes (Recovery) Average Bytes
+14886
+No name
+14888
+I/O Database Writes (Recovery) In Heap
+14890
+I/O Database Writes (Recovery) Async Pending
+14892
+I/O Database Writes (Recovery) Abnormal Latency/sec
+14894
+I/O Database Writes/sec
+14896
+I/O Database Writes Average Latency
+14898
+No name
+14900
+I/O Database Writes Average Bytes
+14902
+No name
+14904
+I/O Database Writes In Heap
+14906
+I/O Database Writes Async Pending
+14908
+I/O Database Writes Abnormal Latency/sec
+14910
+I/O Log Writes/sec
+14912
+I/O Log Writes Average Latency
+14914
+No name
+14916
+I/O Log Writes Average Bytes
+14918
+No name
+14920
+I/O Log Writes In Heap
+14922
+I/O Log Writes Async Pending
+14924
+I/O Log Writes Abnormal Latency/sec
+14926
+Record Failed Compression Bytes/sec
+14928
+Pages Reorganized (Other)/sec
+14930
+Pages Reorganized (Free Space Request)/sec
+14932
+Pages Reorganized (Page Move Logging)/sec
+14934
+Pages Reorganized (Dehydrate Buffer)/sec
+14936
+DNS
+14938
+Total Query Received
+14940
+Total Query Received/sec
+14942
+UDP Query Received
+14944
+UDP Query Received/sec
+14946
+TCP Query Received
+14948
+TCP Query Received/sec
+14950
+Total Response Sent
+14952
+Total Response Sent/sec
+14954
+UDP Response Sent
+14956
+UDP Response Sent/sec
+14958
+TCP Response Sent
+14960
+TCP Response Sent/sec
+14962
+Recursive Queries
+14964
+Recursive Queries/sec
+14966
+Recursive Send TimeOuts
+14968
+Recursive TimeOut/sec
+14970
+Recursive Query Failure
+14972
+Recursive Query Failure/sec
+14974
+Notify Sent
+14976
+Zone Transfer Request Received
+14978
+Zone Transfer Success
+14980
+Zone Transfer Failure
+14982
+AXFR Request Received
+14984
+AXFR Success Sent
+14986
+IXFR Request Received
+14988
+IXFR Success Sent
+14990
+Notify Received
+14992
+Zone Transfer SOA Request Sent
+14994
+AXFR Request Sent
+14996
+AXFR Response Received
+14998
+AXFR Success Received
+15000
+IXFR Request Sent
+15002
+IXFR Response Received
+15004
+IXFR Success Received
+15006
+IXFR UDP Success Received
+15008
+IXFR TCP Success Received
+15010
+WINS Lookup Received
+15012
+WINS Lookup Received/sec
+15014
+WINS Response Sent
+15016
+WINS Response Sent/sec
+15018
+WINS Reverse Lookup Received
+15020
+WINS Reverse Lookup Received/sec
+15022
+WINS Reverse Response Sent
+15024
+WINS Reverse Response Sent/sec
+15026
+Dynamic Update Received
+15028
+Dynamic Update Received/sec
+15030
+Dynamic Update NoOperation
+15032
+Dynamic Update NoOperation/sec
+15034
+Dynamic Update Written to Database
+15036
+Dynamic Update Written to Database/sec
+15038
+Dynamic Update Rejected
+15040
+Dynamic Update TimeOuts
+15042
+Dynamic Update Queued
+15044
+Secure Update Received
+15046
+Secure Update Received/sec
+15048
+Secure Update Failure
+15050
+Database Node Memory
+15052
+Record Flow Memory
+15054
+Caching Memory
+15056
+UDP Message Memory
+15058
+TCP Message Memory
+15060
+Nbstat Memory
+15062
+Unmatched Responses Received
+15064
+DirectoryServices
+15066
+DRA Inbound Properties Total/sec
+15068
+AB Browses/sec
+15070
+DRA Inbound Objects Applied/sec
+15072
+DS Threads in Use
+15074
+AB Client Sessions
+15076
+DRA Pending Replication Synchronizations
+15078
+DRA Inbound Object Updates Remaining in Packet
+15080
+DS Security Descriptor sub-operations/sec
+15082
+DS Security Descriptor Propagations Events
+15084
+LDAP Client Sessions
+15086
+LDAP Active Threads
+15088
+LDAP Writes/sec
+15090
+LDAP Searches/sec
+15092
+DRA Outbound Objects/sec
+15094
+DRA Outbound Properties/sec
+15096
+DRA Inbound Values Total/sec
+15098
+DRA Sync Requests Made
+15100
+DRA Sync Requests Successful
+15102
+DRA Sync Failures on Schema Mismatch
+15104
+DRA Inbound Objects/sec
+15106
+DRA Inbound Properties Applied/sec
+15108
+DRA Inbound Properties Filtered/sec
+15110
+DS Monitor List Size
+15112
+DS Notify Queue Size
+15114
+LDAP UDP operations/sec
+15116
+DS Search sub-operations/sec
+15118
+DS Name Cache hit rate
+15120
+DS Name Cache reads
+15122
+DRA Highest USN Issued (Low part)
+15124
+DRA Highest USN Issued (High part)
+15126
+DRA Highest USN Committed (Low part)
+15128
+DRA Highest USN Committed (High part)
+15130
+DS % Writes from SAM
+15132
+Total Writes 1
+15134
+DS % Writes from DRA
+15136
+Total Writes 2
+15138
+DS % Writes from LDAP
+15140
+Total Writes 3
+15142
+DS % Writes from LSA
+15144
+Total Writes 4
+15146
+DS % Writes from KCC
+15148
+Total Writes 6
+15150
+DS % Writes from NSPI
+15152
+Total Writes 7
+15154
+DS % Writes Other
+15156
+Total Writes 8
+15158
+DS Directory Writes/sec
+15160
+DS % Searches from SAM
+15162
+Total Searches 1
+15164
+DS % Searches from DRA
+15166
+Total Searches 2
+15168
+DS % Searches from LDAP
+15170
+Total Searches 3
+15172
+DS % Searches from LSA
+15174
+Total Searches 4
+15176
+DS % Searches from KCC
+15178
+Total Searches 6
+15180
+DS % Searches from NSPI
+15182
+Total Searches 7
+15184
+DS % Searches Other
+15186
+Total Searches 8
+15188
+DS Directory Searches/sec
+15190
+DS % Reads from SAM
+15192
+Total Reads 1
+15194
+DS % Reads from DRA
+15196
+Total Reads 2
+15198
+DRA Inbound Values (DNs only)/sec
+15200
+DRA Inbound Objects Filtered/sec
+15202
+DS % Reads from LSA
+15204
+Total Reads 4
+15206
+DS % Reads from KCC
+15208
+Total Reads 6
+15210
+DS % Reads from NSPI
+15212
+Total Reads 7
+15214
+DS % Reads Other
+15216
+Total Reads 8
+15218
+DS Directory Reads/sec
+15220
+LDAP Successful Binds/sec
+15222
+LDAP Bind Time
+15224
+SAM Successful Computer Creations/sec: Includes all requests
+15226
+SAM Machine Creation Attempts/sec
+15228
+SAM Successful User Creations/sec
+15230
+SAM User Creation Attempts/sec
+15232
+SAM Password Changes/sec
+15234
+SAM Membership Changes/sec
+15236
+SAM Display Information Queries/sec
+15238
+SAM Enumerations/sec
+15240
+SAM Transitive Membership Evaluations/sec
+15242
+SAM Non-Transitive Membership Evaluations/sec
+15244
+SAM Domain Local Group Membership Evaluations/sec
+15246
+SAM Universal Group Membership Evaluations/sec
+15248
+SAM Global Group Membership Evaluations/sec
+15250
+SAM GC Evaluations/sec
+15252
+DRA Inbound Full Sync Objects Remaining
+15254
+DRA Inbound Bytes Total/sec
+15256
+DRA Inbound Bytes Not Compressed (Within Site)/sec
+15258
+DRA Inbound Bytes Compressed (Between Sites, Before Compression)/sec
+15260
+DRA Inbound Bytes Compressed (Between Sites, After Compression)/sec
+15262
+DRA Outbound Bytes Total/sec
+15264
+DRA Outbound Bytes Not Compressed (Within Site)/sec
+15266
+DRA Outbound Bytes Compressed (Between Sites, Before Compression)/sec
+15268
+DRA Outbound Bytes Compressed (Between Sites, After Compression)/sec
+15270
+DS Client Binds/sec
+15272
+DS Server Binds/sec
+15274
+DS Client Name Translations/sec
+15276
+DS Server Name Translations/sec
+15278
+DS Security Descriptor Propagator Runtime Queue
+15280
+DS Security Descriptor Propagator Average Exclusion Time
+15282
+DRA Outbound Objects Filtered/sec
+15284
+DRA Outbound Values Total/sec
+15286
+DRA Outbound Values (DNs only)/sec
+15288
+AB ANR/sec
+15290
+AB Property Reads/sec
+15292
+AB Searches/sec
+15294
+AB Matches/sec
+15296
+AB Proxy Lookups/sec
+15298
+ATQ Threads Total
+15300
+ATQ Threads LDAP
+15302
+ATQ Threads Other
+15304
+DRA Inbound Bytes Total Since Boot
+15306
+DRA Inbound Bytes Not Compressed (Within Site) Since Boot
+15308
+DRA Inbound Bytes Compressed (Between Sites, Before Compression) Since Boot
+15310
+DRA Inbound Bytes Compressed (Between Sites, After Compression) Since Boot
+15312
+DRA Outbound Bytes Total Since Boot
+15314
+DRA Outbound Bytes Not Compressed (Within Site) Since Boot
+15316
+DRA Outbound Bytes Compressed (Between Sites, Before Compression) Since Boot
+15318
+DRA Outbound Bytes Compressed (Between Sites, After Compression) Since Boot
+15320
+LDAP New Connections/sec
+15322
+LDAP Closed Connections/sec
+15324
+LDAP New SSL Connections/sec
+15326
+DRA Pending Replication Operations
+15328
+DRA Threads Getting NC Changes
+15330
+DRA Threads Getting NC Changes Holding Semaphore
+15332
+DRA Inbound Link Value Updates Remaining in Packet
+15334
+DRA Inbound Total Updates Remaining in Packet
+15336
+DS % Writes from NTDSAPI
+15338
+Total Writes 9
+15340
+DS % Searches from NTDSAPI
+15342
+Total Searches 9
+15344
+DS % Reads from NTDSAPI
+15346
+Total Reads 9
+15348
+SAM Account Group Evaluation Latency
+15350
+SAM Resource Group Evaluation Latency
+15352
+ATQ Outstanding Queued Requests
+15354
+ATQ Request Latency
+15356
+ATQ Estimated Queue Delay
+15358
+Tombstones Garbage Collected/sec
+15360
+Phantoms Cleaned/sec
+15362
+Link Values Cleaned/sec
+15364
+Tombstones Visited/sec
+15366
+Phantoms Visited/sec
+15368
+NTLM Binds/sec
+15370
+Negotiated Binds/sec
+15372
+Digest Binds/sec
+15374
+Simple Binds/sec
+15376
+External Binds/sec
+15378
+Fast Binds/sec
+15380
+Base searches/sec
+15382
+Subtree searches/sec
+15384
+Onelevel searches/sec
+15386
+Database adds/sec
+15388
+Database modifys/sec
+15390
+Database deletes/sec
+15392
+Database recycles/sec
+15394
+Approximate highest DNT
+15396
+Transitive operations/sec
+15398
+Transitive suboperations/sec
+15400
+Transitive operations milliseconds run
+15402
+DirSync sessions in progress
+15404
+DirSync session throttling rate
+15406
+DRA Inbound Sync Link Deletion/sec
+15408
+Calendar Notifications Assistant
+15410
+Number of notifications sent
+15412
+Notifications sent/sec
+15414
+Number of agenda notifications sent
+15416
+Agenda notifications sent/sec
+15418
+Number of calendar text reminder notifications sent
+15420
+Text Reminder notifications sent/sec
+15422
+Number of calendar voice reminder notifications sent
+15424
+Voice Reminder notifications sent/sec
+15426
+Number of calendar update notifications sent
+15428
+Update notifications sent/sec
+15430
+Number of interesting mailbox events
+15432
+Interesting mailbox events/sec
+15434
+Average update processing latency (milliseconds)
+15436
+BITS Net Utilization
+15438
+Remote Server Speed (Bits/Sec)
+15440
+Netcard Speed (Bits/Sec)
+15442
+Percent Netcard Free
+15444
+IGD Speed (Bits/Sec)
+15446
+Percent IGD Free
+15448
+BITS Download BlockSize (Bytes)
+15450
+BITS Download Response Interval (msec)
+15452
+Estimated bandwidth available to the remote system (Bits/sec)
+15454
+ASP.NET State Service
+15680
+State Server Sessions Active
+15682
+State Server Sessions Abandoned
+15684
+State Server Sessions Timed Out
+15686
+State Server Sessions Total
+15688
+ASP.NET v4.0.30319
+15690
+ASP.NET Apps v4.0.30319
+15692
+Application Restarts
+15694
+Applications Running
+15696
+Requests Disconnected
+15698
+Request Execution Time
+15700
+Requests Rejected
+15702
+Requests Queued
+15704
+Worker Processes Running
+15706
+Worker Process Restarts
+15708
+Request Wait Time
+15710
+State Server Sessions Active
+15712
+State Server Sessions Abandoned
+15714
+State Server Sessions Timed Out
+15716
+State Server Sessions Total
+15718
+Requests Current
+15720
+Audit Success Events Raised
+15722
+Audit Failure Events Raised
+15724
+Error Events Raised
+15726
+Request Error Events Raised
+15728
+Infrastructure Error Events Raised
+15730
+Requests In Native Queue
+15732
+Anonymous Requests
+15734
+Anonymous Requests/Sec
+15736
+Cache Total Entries
+15738
+Cache Total Turnover Rate
+15740
+Cache Total Hits
+15742
+Cache Total Misses
+15744
+Cache Total Hit Ratio
+15746
+Cache Total Hit Ratio Base
+15748
+Cache API Entries
+15750
+Cache API Turnover Rate
+15752
+Cache API Hits
+15754
+Cache API Misses
+15756
+Cache API Hit Ratio
+15758
+Cache API Hit Ratio Base
+15760
+Output Cache Entries
+15762
+Output Cache Turnover Rate
+15764
+Output Cache Hits
+15766
+Output Cache Misses
+15768
+Output Cache Hit Ratio
+15770
+Output Cache Hit Ratio Base
+15772
+Compilations Total
+15774
+Debugging Requests
+15776
+Errors During Preprocessing
+15778
+Errors During Compilation
+15780
+Errors During Execution
+15782
+Errors Unhandled During Execution
+15784
+Errors Unhandled During Execution/Sec
+15786
+Errors Total
+15788
+Errors Total/Sec
+15790
+Pipeline Instance Count
+15792
+Request Bytes In Total
+15794
+Request Bytes Out Total
+15796
+Requests Executing
+15798
+Requests Failed
+15800
+Requests Not Found
+15802
+Requests Not Authorized
+15804
+Requests In Application Queue
+15806
+Requests Timed Out
+15808
+Requests Succeeded
+15810
+Requests Total
+15812
+Requests/Sec
+15814
+Sessions Active
+15816
+Sessions Abandoned
+15818
+Sessions Timed Out
+15820
+Sessions Total
+15822
+Transactions Aborted
+15824
+Transactions Committed
+15826
+Transactions Pending
+15828
+Transactions Total
+15830
+Transactions/Sec
+15832
+Session State Server connections total
+15834
+Session SQL Server connections total
+15836
+Events Raised
+15838
+Events Raised/Sec
+15840
+Application Lifetime Events
+15842
+Application Lifetime Events/Sec
+15844
+Error Events Raised
+15846
+Error Events Raised/Sec
+15848
+Request Error Events Raised
+15850
+Request Error Events Raised/Sec
+15852
+Infrastructure Error Events Raised
+15854
+Infrastructure Error Events Raised/Sec
+15856
+Request Events Raised
+15858
+Request Events Raised/Sec
+15860
+Audit Success Events Raised
+15862
+Audit Failure Events Raised
+15864
+Membership Authentication Success
+15866
+Membership Authentication Failure
+15868
+Forms Authentication Success
+15870
+Forms Authentication Failure
+15872
+Viewstate MAC Validation Failure
+15874
+Request Execution Time
+15876
+Requests Disconnected
+15878
+Requests Rejected
+15880
+Request Wait Time
+15882
+Cache % Machine Memory Limit Used
+15884
+Cache % Machine Memory Limit Used Base
+15886
+Cache % Process Memory Limit Used
+15888
+Cache % Process Memory Limit Used Base
+15890
+Cache Total Trims
+15892
+Cache API Trims
+15894
+Output Cache Trims
+15896
+% Managed Processor Time (estimated)
+15898
+% Managed Processor Time Base (estimated)
+15900
+Managed Memory Used (estimated)
+15902
+Request Bytes In Total (WebSockets)
+15904
+Request Bytes Out Total (WebSockets)
+15906
+Requests Executing (WebSockets)
+15908
+Requests Failed (WebSockets)
+15910
+Requests Succeeded (WebSockets)
+15912
+Requests Total (WebSockets)
+15914
+ASP.NET
+15916
+ASP.NET Applications
+15918
+Application Restarts
+15920
+Applications Running
+15922
+Requests Disconnected
+15924
+Request Execution Time
+15926
+Requests Rejected
+15928
+Requests Queued
+15930
+Worker Processes Running
+15932
+Worker Process Restarts
+15934
+Request Wait Time
+15936
+State Server Sessions Active
+15938
+State Server Sessions Abandoned
+15940
+State Server Sessions Timed Out
+15942
+State Server Sessions Total
+15944
+Requests Current
+15946
+Audit Success Events Raised
+15948
+Audit Failure Events Raised
+15950
+Error Events Raised
+15952
+Request Error Events Raised
+15954
+Infrastructure Error Events Raised
+15956
+Requests In Native Queue
+15958
+Anonymous Requests
+15960
+Anonymous Requests/Sec
+15962
+Cache Total Entries
+15964
+Cache Total Turnover Rate
+15966
+Cache Total Hits
+15968
+Cache Total Misses
+15970
+Cache Total Hit Ratio
+15972
+Cache Total Hit Ratio Base
+15974
+Cache API Entries
+15976
+Cache API Turnover Rate
+15978
+Cache API Hits
+15980
+Cache API Misses
+15982
+Cache API Hit Ratio
+15984
+Cache API Hit Ratio Base
+15986
+Output Cache Entries
+15988
+Output Cache Turnover Rate
+15990
+Output Cache Hits
+15992
+Output Cache Misses
+15994
+Output Cache Hit Ratio
+15996
+Output Cache Hit Ratio Base
+15998
+Compilations Total
+16000
+Debugging Requests
+16002
+Errors During Preprocessing
+16004
+Errors During Compilation
+16006
+Errors During Execution
+16008
+Errors Unhandled During Execution
+16010
+Errors Unhandled During Execution/Sec
+16012
+Errors Total
+16014
+Errors Total/Sec
+16016
+Pipeline Instance Count
+16018
+Request Bytes In Total
+16020
+Request Bytes Out Total
+16022
+Requests Executing
+16024
+Requests Failed
+16026
+Requests Not Found
+16028
+Requests Not Authorized
+16030
+Requests In Application Queue
+16032
+Requests Timed Out
+16034
+Requests Succeeded
+16036
+Requests Total
+16038
+Requests/Sec
+16040
+Sessions Active
+16042
+Sessions Abandoned
+16044
+Sessions Timed Out
+16046
+Sessions Total
+16048
+Transactions Aborted
+16050
+Transactions Committed
+16052
+Transactions Pending
+16054
+Transactions Total
+16056
+Transactions/Sec
+16058
+Session State Server connections total
+16060
+Session SQL Server connections total
+16062
+Events Raised
+16064
+Events Raised/Sec
+16066
+Application Lifetime Events
+16068
+Application Lifetime Events/Sec
+16070
+Error Events Raised
+16072
+Error Events Raised/Sec
+16074
+Request Error Events Raised
+16076
+Request Error Events Raised/Sec
+16078
+Infrastructure Error Events Raised
+16080
+Infrastructure Error Events Raised/Sec
+16082
+Request Events Raised
+16084
+Request Events Raised/Sec
+16086
+Audit Success Events Raised
+16088
+Audit Failure Events Raised
+16090
+Membership Authentication Success
+16092
+Membership Authentication Failure
+16094
+Forms Authentication Success
+16096
+Forms Authentication Failure
+16098
+Viewstate MAC Validation Failure
+16100
+Request Execution Time
+16102
+Requests Disconnected
+16104
+Requests Rejected
+16106
+Request Wait Time
+16108
+Cache % Machine Memory Limit Used
+16110
+Cache % Machine Memory Limit Used Base
+16112
+Cache % Process Memory Limit Used
+16114
+Cache % Process Memory Limit Used Base
+16116
+Cache Total Trims
+16118
+Cache API Trims
+16120
+Output Cache Trims
+16122
+% Managed Processor Time (estimated)
+16124
+% Managed Processor Time Base (estimated)
+16126
+Managed Memory Used (estimated)
+16128
+Request Bytes In Total (WebSockets)
+16130
+Request Bytes Out Total (WebSockets)
+16132
+Requests Executing (WebSockets)
+16134
+Requests Failed (WebSockets)
+16136
+Requests Succeeded (WebSockets)
+16138
+Requests Total (WebSockets)
+16140
+ADWS
+16142
+Create Operations Per Second
+16144
+Delete Operations Per Second
+16146
+Get Operations Per Second
+16148
+Put Operations Per Second
+16150
+Enumerate Operations Per Second
+16152
+Pull Operations Per Second
+16154
+Open Enumeration Contexts
+16156
+GetADGroupMember Operations Per Second
+16158
+GetADPrincipalGroupMembership Operations Per Second
+16160
+SetPassword Operations Per Second
+16162
+ChangePassword Operations Per Second
+16164
+GetADPrincipalAuthorizationGroup Operations Per Second
+16166
+TranslateName Operations Per Second
+16168
+GetADDomainController Operations Per Second
+16170
+GetADDomain Operations Per Second
+16172
+MoveADOperationMasterRole Operations Per Second
+16174
+GetADForest Operations Per Second
+16176
+ChangeOptionalFeature Operations Per Second
+16178
+GetVersion Operations Per Second
+16180
+Number of Directory Instances
+16182
+Possible Connections
+16184
+Allocated Connections
+16186
+Reserved Connections
+16188
+Non-reserved Connections In Use
+16190
+Reserved Connections In Use
+16192
+Open Web Service Sessions
+16194
+Active Web Service Sessions
+16196
+Web Service Sessions Created Per Second
+16198
+Custom Action LDAP Cache Maximum Possible Size
+16200
+Custom Action LDAP Cache Connection Creation Rate
+16202
+Custom Action LDAP Cache Connection Reuse Rate
+16204
+Custom Action DS RPC Cache Maximum Possible Size
+16206
+Custom Action DS RPC Cache Connection Creation Rate
+16208
+Custom Action DS RPC Cache Connection Reuse Rate
+16210
+Custom Action Cache Size
+16212
+.NET CLR Memory
+16214
+# Gen 0 Collections
+16216
+# Gen 1 Collections
+16218
+# Gen 2 Collections
+16220
+Promoted Memory from Gen 0
+16222
+Promoted Memory from Gen 1
+16224
+Gen 0 Promoted Bytes/Sec
+16226
+Gen 1 Promoted Bytes/Sec
+16228
+Promoted Finalization-Memory from Gen 0
+16230
+Process ID
+16232
+Gen 0 heap size
+16234
+Gen 1 heap size
+16236
+Gen 2 heap size
+16238
+Large Object Heap size
+16240
+Finalization Survivors
+16242
+# GC Handles
+16244
+Allocated Bytes/sec
+16246
+# Induced GC
+16248
+% Time in GC
+16250
+Not Displayed
+16252
+# Bytes in all Heaps
+16254
+# Total committed Bytes
+16256
+# Total reserved Bytes
+16258
+# of Pinned Objects
+16260
+# of Sink Blocks in use
+16262
+.NET CLR Loading
+16264
+Total Classes Loaded
+16266
+% Time Loading
+16268
+Assembly Search Length
+16270
+Total # of Load Failures
+16272
+Rate of Load Failures
+16274
+Bytes in Loader Heap
+16276
+Total appdomains unloaded
+16278
+Rate of appdomains unloaded
+16280
+Current Classes Loaded
+16282
+Rate of Classes Loaded
+16284
+Current appdomains
+16286
+Total Appdomains
+16288
+Rate of appdomains
+16290
+Current Assemblies
+16292
+Total Assemblies
+16294
+Rate of Assemblies
+16296
+.NET CLR Jit
+16298
+# of Methods Jitted
+16300
+# of IL Bytes Jitted
+16302
+Total # of IL Bytes Jitted
+16304
+IL Bytes Jitted / sec
+16306
+Standard Jit Failures
+16308
+% Time in Jit
+16310
+Not Displayed
+16312
+.NET CLR Interop
+16314
+# of CCWs
+16316
+# of Stubs
+16318
+# of marshalling
+16320
+# of TLB imports / sec
+16322
+# of TLB exports / sec
+16324
+.NET CLR LocksAndThreads
+16326
+Total # of Contentions
+16328
+Contention Rate / sec
+16330
+Current Queue Length
+16332
+Queue Length Peak
+16334
+Queue Length / sec
+16336
+# of current logical Threads
+16338
+# of current physical Threads
+16340
+# of current recognized threads
+16342
+# of total recognized threads
+16344
+rate of recognized threads / sec
+16346
+.NET CLR Security
+16348
+Total Runtime Checks
+16350
+% Time Sig. Authenticating
+16352
+# Link Time Checks
+16354
+% Time in RT checks
+16356
+Not Displayed
+16358
+Stack Walk Depth
+16360
+.NET CLR Remoting
+16362
+Remote Calls/sec
+16364
+Channels
+16366
+Context Proxies
+16368
+Context-Bound Classes Loaded
+16370
+Context-Bound Objects Alloc / sec
+16372
+Contexts
+16374
+Total Remote Calls
+16376
+.NET CLR Exceptions
+16378
+# of Exceps Thrown
+16380
+# of Exceps Thrown / sec
+16382
+# of Filters / sec
+16384
+# of Finallys / sec
+16386
+Throw To Catch Depth / sec
+16388
+.NET Memory Cache 4.0
+16390
+Cache Hits
+16392
+Cache Misses
+16394
+Cache Hit Ratio
+16396
+Cache Hit Ratio Base
+16398
+Cache Trims
+16400
+Cache Entries
+16402
+Cache Turnover Rate
+16404
+.NET Data Provider for SqlServer
+16406
+HardConnectsPerSecond
+16408
+HardDisconnectsPerSecond
+16410
+SoftConnectsPerSecond
+16412
+SoftDisconnectsPerSecond
+16414
+NumberOfNonPooledConnections
+16416
+NumberOfPooledConnections
+16418
+NumberOfActiveConnectionPoolGroups
+16420
+NumberOfInactiveConnectionPoolGroups
+16422
+NumberOfActiveConnectionPools
+16424
+NumberOfInactiveConnectionPools
+16426
+NumberOfActiveConnections
+16428
+NumberOfFreeConnections
+16430
+NumberOfStasisConnections
+16432
+NumberOfReclaimedConnections
+16434
+.NET Data Provider for Oracle
+16436
+HardConnectsPerSecond
+16438
+HardDisconnectsPerSecond
+16440
+SoftConnectsPerSecond
+16442
+SoftDisconnectsPerSecond
+16444
+NumberOfNonPooledConnections
+16446
+NumberOfPooledConnections
+16448
+NumberOfActiveConnectionPoolGroups
+16450
+NumberOfInactiveConnectionPoolGroups
+16452
+NumberOfActiveConnectionPools
+16454
+NumberOfInactiveConnectionPools
+16456
+NumberOfActiveConnections
+16458
+NumberOfFreeConnections
+16460
+NumberOfStasisConnections
+16462
+NumberOfReclaimedConnections
+16464
+.NET CLR Networking 4.0.0.0
+16466
+Connections Established
+16468
+Bytes Received
+16470
+Bytes Sent
+16472
+Datagrams Received
+16474
+Datagrams Sent
+16476
+HttpWebRequests Created/Sec
+16478
+HttpWebRequests Average Lifetime
+16480
+HttpWebRequests Average Lifetime Base
+16482
+HttpWebRequests Queued/Sec
+16484
+HttpWebRequests Average Queue Time
+16486
+HttpWebRequests Average Queue Time Base
+16488
+HttpWebRequests Aborted/Sec
+16490
+HttpWebRequests Failed/Sec
+16492
+.NET CLR Networking
+16494
+Connections Established
+16496
+Bytes Received
+16498
+Bytes Sent
+16500
+Datagrams Received
+16502
+Datagrams Sent
+16504
+.NET CLR Data
+16506
+SqlClient: Current # pooled and nonpooled connections
+16508
+SqlClient: Current # pooled connections
+16510
+SqlClient: Current # connection pools
+16512
+SqlClient: Peak # pooled connections
+16514
+SqlClient: Total # failed connects
+16516
+SqlClient: Total # failed commands
+20648
+MSExchange ADAccess Caches
+20650
+Cache Hits/sec
+20652
+Cache Misses/sec
+20654
+Cache Expiries/sec (User Data)
+20656
+Cache Expiries/sec (Configuration Data)
+20658
+Cache Inserts/sec (User Data)
+20660
+Cache Inserts/sec (Configuration Data)
+20662
+LDAP Searches/sec
+20664
+Outstanding Async Notifies
+20666
+Outstanding Async Reads
+20668
+Outstanding Async Searches
+20670
+Total Entries (User Data)
+20672
+Total Entries (Configuration Data)
+20674
+DN Entries (User Data)
+20676
+DN Entries (Configuration Data)
+20678
+Search Entries (User Data)
+20680
+Search Entries (Configuration Data)
+20682
+Not Found DN Entries (User Data)
+20684
+Not Found DN Entries (Configuration Data)
+20686
+Not Found GUID Entries (User Data)
+20688
+Not Found GUID Entries (Configuration Data)
+20690
+Total Entries Memory (User Data)
+20692
+Total Entries Memory (Configuration Data)
+20694
+DN Entries Memory (User Data)
+20696
+DN Entries Memory (Configuration Data)
+20698
+Search Entries Memory (User Data)
+20700
+Search Entries Memory (Configuration Data)
+20702
+Not Found DN Entries Memory (User Data)
+20704
+Not Found DN Entries Memory (Configuration Data)
+20706
+Not Found GUID Entries Memory (User Data)
+20708
+Not Found GUID Entries Memory (Configuration Data)
+20710
+Cache Hits Total
+20712
+Cache Misses Total
+20714
+Cache Expiries Total (User Data)
+20716
+Cache Expiries Total (Configuration Data)
+20718
+Cache Inserts Total (User Data)
+20720
+Cache Inserts Total (Configuration Data)
+20722
+LDAP Searches Total
+20724
+MSExchange ADAccess Processes
+20726
+Process ID
+20728
+LDAP Read Calls/sec
+20730
+LDAP Search Calls/sec
+20732
+LDAP Write Calls/sec
+20734
+LDAP Pages/sec
+20736
+LDAP VLV Requests/sec
+20738
+LDAP Not Found Configuration Read Calls/sec
+20740
+Long Running LDAP Operations/min
+20742
+LDAP Timeout Errors/sec
+20744
+LDAP Notifications received/sec
+20746
+LDAP Notifications Reported/sec
+20748
+Critical Validation Failures/min
+20750
+Non-critical Validation Failures/min
+20752
+Ignored Validation Failures/min
+20754
+Open Connections to Domain Controllers
+20756
+Open Connections to Global Catalogs
+20758
+Number of Outstanding Requests
+20760
+Topology Version
+20762
+LDAP Read Time
+20764
+LDAP Read Time Base
+20766
+LDAP Search Time
+20768
+LDAP Search Time Base
+20770
+LDAP Search Time 90th Percentile
+20772
+LDAP Search Time 90th Percentile Base
+20774
+LDAP Search Time 95th Percentile
+20776
+LDAP Search Time 95th Percentile Base
+20778
+LDAP Search Time 99th Percentile
+20780
+LDAP Search Time 99th Percentile Base
+20782
+LDAP Search Time Server Side
+20784
+LDAP Search Time Server Side Base
+20786
+Search Cost
+20788
+Search Cost Base
+20790
+LDAP Write Time
+20792
+LDAP Write Time Base
+20794
+MSExchange ADAccess Domain Controllers
+20796
+LDAP Read Calls/sec
+20798
+LDAP Search Calls/sec
+20800
+LDAP Searches Timed Out per Minute
+20802
+LDAP Searches Time Limit Exceeded per Minute
+20804
+LDAP Fatal Errors per Minute
+20806
+LDAP Disconnects per Minute
+20808
+User Searches Failed per Minute
+20810
+LDAP Modification Error per Minute
+20812
+Bind Failures per Minute
+20814
+Long Running LDAP Operations/min
+20816
+LDAP Pages/sec
+20818
+LDAP VLV Requests/sec
+20820
+Number of Outstanding Requests
+20822
+DsGetDcName Elapsed Time
+20824
+GetHostByName Elapsed Time
+20826
+Kerberos Ticket Lifetime
+20828
+LDAP Connection Lifetime
+20830
+Local Site Flag
+20832
+Reachability Bitmask
+20834
+IsSynchronized Flag
+20836
+GC Capable Flag
+20838
+PDC Flag
+20840
+SACL Right Flag
+20842
+Critical Data Flag
+20844
+Netlogon Flag
+20846
+OS Version Flag
+20848
+LDAP Read Time
+20850
+LDAP Read Time Base
+20852
+LDAP Search Time
+20854
+LDAP Search Time Base
+20856
+MSExchange ADAccess Local Site Domain Controllers
+20858
+LDAP Read Calls/sec
+20860
+LDAP Search Calls/sec
+20862
+LDAP Searches Timed Out per Minute
+20864
+LDAP Searches Time Limit Exceeded per Minute
+20866
+LDAP Fatal Errors per Minute
+20868
+LDAP Disconnects per Minute
+20870
+User Searches Failed per Minute
+20872
+LDAP Modification Error per Minute
+20874
+Bind Failures per Minute
+20876
+Long Running LDAP Operations/min
+20878
+LDAP Pages/sec
+20880
+LDAP VLV Requests/sec
+20882
+Number of Outstanding Requests
+20884
+DsGetDcName Elapsed Time
+20886
+GetHostByName Elapsed Time
+20888
+Kerberos Ticket Lifetime
+20890
+LDAP Connection Lifetime
+20892
+Reachability Bitmask
+20894
+IsSynchronized Flag
+20896
+GC Capable Flag
+20898
+PDC flag
+20900
+SACL Right Flag
+20902
+Critical Data Flag
+20904
+Netlogon Flag
+20906
+OS Version Flag
+20908
+LDAP Read Time
+20910
+LDAP Read Time Base
+20912
+LDAP Search Time
+20914
+LDAP Search Time Base
+20916
+MSExchange ADAccess Global Counters
+20918
+Topology Discovery Duration Time
+20920
+DNS Query Duration Time
+20922
+In-site Domain Controllers
+20924
+In-site Global Catalogs
+20926
+Out-of-site Domain Controllers
+20928
+Out-of-site Global Catalogs
+20930
+WMI Objects
+20932
+HiPerf Classes
+20934
+HiPerf Validity
+20936
+iSCSI Connections
+20938
+Bytes Received
+20940
+Bytes Sent
+20942
+PDUs Sent
+20944
+PDUs Received
+20946
+iSCSI Initiator Instance
+20948
+Session Cxn Timeout Errors
+20950
+Session Digest Errors
+20952
+Sessions Failed
+20954
+Session Format Errors
+20956
+iSCSI Initiator Login statistics
+20958
+Login Accept Responses
+20960
+Logins  Failed
+20962
+Login Authentication Failed Responses
+20964
+Failed Logins
+20966
+Login Negotiation Failed
+20968
+Login Other Failed Responses
+20970
+Login Redirect Responses
+20972
+Logout Normal
+20974
+Logout Other Codes
+20976
+iSCSI HBA Main Mode IPSEC Statistics
+20978
+AcquireFailures
+20980
+AcquireHeapSize
+20982
+ActiveAcquire
+20984
+ActiveReceive
+20986
+AuthenticationFailures
+20988
+ConnectionListSize
+20990
+GetSPIFailures
+20992
+InvalidCookiesReceived
+20994
+InvalidPackets
+20996
+KeyAdditionFailures
+20998
+KeyAdditions
+21000
+KeyUpdateFailures
+21002
+KeyUpdates
+21004
+NegotiationFailures
+21006
+OakleyMainMode
+21008
+OakleyQuickMode
+21010
+ReceiveFailures
+21012
+ReceiveHeapSize
+21014
+SendFailures
+21016
+SoftAssociations
+21018
+TotalGetSPI
+21020
+MSiSCSI_NICPerformance
+21022
+BytesReceived
+21024
+BytesTransmitted
+21026
+PDUReceived
+21028
+PDUTransmitted
+21030
+iSCSI HBA Quick Mode IPSEC Statistics
+21032
+ActiveSA
+21034
+ActiveTunnels
+21036
+AuthenticatedBytesReceived
+21038
+AuthenticatedBytesSent
+21040
+BadSPIPackets
+21042
+ConfidentialBytesReceived
+21044
+ConfidentialBytesSent
+21046
+KeyAdditions
+21048
+KeyDeletions
+21050
+PacketsNotAuthenticated
+21052
+PacketsNotDecrypted
+21054
+PacketsWithReplayDetection
+21056
+PendingKeyOperations
+21058
+ReKeys
+21060
+TransportBytesReceived
+21062
+TransportBytesSent
+21064
+TunnelBytesReceived
+21066
+TunnelBytesSent
+21068
+iSCSI Request Processing Time
+21070
+Average Request Processing Time
+21072
+Max Request Processing Time
+21074
+iSCSI Sessions
+21076
+Bytes Received
+21078
+Bytes Sent
+21080
+ConnectionTimeout Errors
+21082
+Digest Errors
+21084
+Format Errors
+21086
+PDUs Sent
+21088
+PDUs Received
+21090
+Processor Performance
+21092
+Processor Frequency
+21094
+% of Maximum Frequency
+21096
+Processor State Flags
+20544
+W3SVC_W3WP
+20546
+Total HTTP Requests Served
+20548
+Requests / Sec
+20550
+Active Requests
+20552
+Total Threads
+20554
+Active Threads Count
+20556
+Maximum Threads Count
+20558
+Current File Cache Memory Usage
+20560
+Maximum File Cache Memory Usage
+20562
+Output Cache Current Memory Usage
+20564
+Current Files Cached
+20566
+Total Files Cached
+20568
+File Cache Hits
+20570
+File Cache Misses
+20572
+File Cache Flushes
+20574
+Active Flushed Entries
+20576
+Total Flushed Files
+20578
+Current URIs Cached
+20580
+Total URIs Cached
+20582
+URI Cache Hits
+20584
+URI Cache Misses
+20586
+URI Cache Flushes
+20588
+Total Flushed URIs
+20590
+Current Metadata Cached
+20592
+Total Metadata Cached
+20594
+Metadata Cache Hits
+20596
+Metadata Cache Misses
+20598
+Metadata Cache Flushes
+20600
+Total Flushed Metadata
+20602
+Output Cache Current Items
+20604
+Output Cache Total Hits
+20606
+Output Cache Total Misses
+20608
+Output Cache Total Flushes
+20610
+Output Cache Current Flushed Items
+20612
+Output Cache Total Flushed Items
+20614
+File Cache Hits / sec
+20616
+Metadata Cache Hits / sec
+20618
+Output Cache Hits / sec
+20620
+Uri Cache Hits / sec
+20622
+File Cache Misses / sec
+20624
+Metadata Cache Misses / sec
+20626
+Output Cache Misses / sec
+20628
+Uri Cache Misses / sec
+20630
+% 401 HTTP Response Sent
+20632
+% 403 HTTP Response Sent
+20634
+% 404 HTTP Response Sent
+20636
+% 500 HTTP Response Sent
+20640
+WebSocket Active Requests
+20642
+WebSocket Connection Attempts / Sec
+20644
+WebSocket Connections Rejected / Sec
+20646
+WebSocket Connections Accepted / Sec
+20496
+WorkflowServiceHost 4.0.0.0
+20498
+Workflows Created
+20500
+Workflows Created Per Second
+20502
+Workflows Executing
+20504
+Workflows Completed
+20506
+Workflows Completed Per Second
+20508
+Workflows Aborted
+20510
+Workflows Aborted Per Second
+20512
+Workflows In Memory
+20514
+Workflows Persisted
+20516
+Workflows Persisted Per Second
+20518
+Workflows Terminated
+20520
+Workflows Terminated Per Second
+20522
+Workflows Loaded
+20524
+Workflows Loaded Per Second
+20526
+Workflows Unloaded
+20528
+Workflows Unloaded Per Second
+20530
+Workflows Suspended
+20532
+Workflows Suspended Per Second
+20534
+Workflows Idle Per Second
+20536
+Average Workflow Load Time
+20538
+Average Workflow Load Time Base
+20540
+Average Workflow Persist Time
+20542
+Average Workflow Persist Time Base
+20488
+Terminal Services
+20490
+Active Sessions
+20492
+Inactive Sessions
+20494
+Total Sessions
+20446
+Pacer Flow
+20448
+Packets dropped
+20450
+Packets scheduled
+20452
+Packets transmitted
+20454
+Bytes scheduled
+20456
+Bytes transmitted
+20458
+Bytes transmitted/sec
+20460
+Bytes scheduled/sec
+20462
+Packets transmitted/sec
+20464
+Packets scheduled/sec
+20466
+Packets dropped/sec
+20468
+Nonconforming packets scheduled
+20470
+Nonconforming packets scheduled/sec
+20472
+Average packets in shaper
+20474
+Max packets in shaper
+20476
+Average packets in sequencer
+20478
+Max packets in sequencer
+20480
+Maximum packets in netcard
+20482
+Average packets in netcard
+20484
+Nonconforming packets transmitted
+20486
+Nonconforming packets transmitted/sec
+20410
+Pacer Pipe
+20412
+Out of packets
+20414
+Flows opened
+20416
+Flows closed
+20418
+Flows rejected
+20420
+Flows modified
+20422
+Flow mods rejected
+20424
+Max simultaneous flows
+20426
+Nonconforming packets scheduled
+20428
+Nonconforming packets scheduled/sec
+20430
+Average packets in shaper
+20432
+Max packets in shaper
+20434
+Average packets in sequencer
+20436
+Max packets in sequencer
+20438
+Max packets in netcard
+20440
+Average packets in netcard
+20442
+Nonconforming packets transmitted
+20444
+Nonconforming packets transmitted/sec
+20382
+Generic IKEv1, AuthIP, and IKEv2
+20384
+IKEv1 Main Mode Negotiation Time
+20386
+AuthIP Main Mode Negotiation Time
+20388
+IKEv1 Quick Mode Negotiation Time
+20390
+AuthIP Quick Mode Negotiation Time
+20392
+Extended Mode Negotiation Time
+20394
+Packets Received/sec
+20396
+Invalid Packets Received/sec
+20398
+Successful Negotiations
+20400
+Successful Negotiations/sec
+20402
+Failed Negotiations
+20404
+Failed Negotiations/sec
+20406
+IKEv2 Main Mode Negotiation Time
+20408
+IKEv2 Quick Mode Negotiation Time
+20344
+IPsec IKEv2 IPv4
+20346
+Active Main Mode SAs
+20348
+Pending Main Mode Negotiations
+20350
+Main Mode Negotiations
+20352
+Main Mode Negotiations/sec
+20354
+Successful Main Mode Negotiations
+20356
+Successful Main Mode Negotiations/sec
+20358
+Failed Main Mode Negotiations
+20360
+Failed Main Mode Negotiations/sec
+20362
+Main Mode Negotiation Requests Received
+20364
+Main Mode Negotiation Requests Received/sec
+20366
+Active Quick Mode SAs
+20368
+Pending Quick Mode Negotiations
+20370
+Quick Mode Negotiations
+20372
+Quick Mode Negotiations/sec
+20374
+Successful Quick Mode Negotiations
+20376
+Successful Quick Mode Negotiations/sec
+20378
+Failed Quick Mode Negotiations
+20380
+Failed Quick Mode Negotiations/sec
+20284
+IPsec AuthIP IPv4
+20286
+Active Main Mode SAs
+20288
+Pending Main Mode Negotiations
+20290
+Main Mode Negotiations
+20292
+Main Mode Negotiations/sec
+20294
+Successful Main Mode Negotiations
+20296
+Successful Main Mode Negotiations/sec
+20298
+Failed Main Mode Negotiations
+20300
+Failed Main Mode Negotiations/sec
+20302
+Main Mode Negotiation Requests Received
+20304
+Main Mode Negotiation Requests Received/sec
+20306
+Main Mode SAs That Used Impersonation
+20308
+Main Mode SAs That Used Impersonation/sec
+20310
+Active Quick Mode SAs
+20312
+Pending Quick Mode Negotiations
+20314
+Quick Mode Negotiations
+20316
+Quick Mode Negotiations/sec
+20318
+Successful Quick Mode Negotiations
+20320
+Successful Quick Mode Negotiations/sec
+20322
+Failed Quick Mode Negotiations
+20324
+Failed Quick Mode Negotiations/sec
+20326
+Active Extended Mode SAs
+20328
+Pending Extended Mode Negotiations
+20330
+Extended Mode Negotiations
+20332
+Extended Mode Negotiations/sec
+20334
+Successful Extended Mode Negotiations
+20336
+Successful Extended Mode Negotiations/sec
+20338
+Failed Extended Mode Negotiations
+20340
+Failed Extended Mode Negotiations/sec
+20342
+Extended Mode SAs That Used Impersonation
+20270
+IPsec Connections
+20272
+Total Number current Connections
+20274
+Total number of cumulative connections since boot
+20276
+Max number of connections since boot
+20278
+Total Bytes In since start
+20280
+Total Bytes Out since start
+20282
+Number of failed authentications
+20210
+IPsec AuthIP IPv6
+20212
+Active Main Mode SAs
+20214
+Pending Main Mode Negotiations
+20216
+Main Mode Negotiations
+20218
+Main Mode Negotiations/sec
+20220
+Successful Main Mode Negotiations
+20222
+Successful Main Mode Negotiations/sec
+20224
+Failed Main Mode Negotiations
+20226
+Failed Main Mode Negotiations/sec
+20228
+Main Mode Negotiation Requests Received
+20230
+Main Mode Negotiation Requests Received/sec
+20232
+Main Mode SAs That Used Impersonation
+20234
+Main Mode SAs That Used Impersonation/sec
+20236
+Active Quick Mode SAs
+20238
+Pending Quick Mode Negotiations
+20240
+Quick Mode Negotiations
+20242
+Quick Mode Negotiations/sec
+20244
+Successful Quick Mode Negotiations
+20246
+Successful Quick Mode Negotiations/sec
+20248
+Failed Quick Mode Negotiations
+20250
+Failed Quick Mode Negotiations/sec
+20252
+Active Extended Mode SAs
+20254
+Pending Extended Mode Negotiations
+20256
+Extended Mode Negotiations
+20258
+Extended Mode Negotiations/sec
+20260
+Successful Extended Mode Negotiations
+20262
+Successful Extended Mode Negotiations/sec
+20264
+Failed Extended Mode Negotiations
+20266
+Failed Extended Mode Negotiations/sec
+20268
+Extended Mode SAs That Used Impersonation
+20172
+IPsec IKEv2 IPv6
+20174
+Active Main Mode SAs
+20176
+Pending Main Mode Negotiations
+20178
+Main Mode Negotiations
+20180
+Main Mode Negotiations/sec
+20182
+Successful Main Mode Negotiations
+20184
+Successful Main Mode Negotiations/sec
+20186
+Failed Main Mode Negotiations
+20188
+Failed Main Mode Negotiations/sec
+20190
+Main Mode Negotiation Requests Received
+20192
+Main Mode Negotiation Requests Received/sec
+20194
+Active Quick Mode SAs
+20196
+Pending Quick Mode Negotiations
+20198
+Quick Mode Negotiations
+20200
+Quick Mode Negotiations/sec
+20202
+Successful Quick Mode Negotiations
+20204
+Successful Quick Mode Negotiations/sec
+20206
+Failed Quick Mode Negotiations
+20208
+Failed Quick Mode Negotiations/sec
+20144
+WFPv4
+20146
+Inbound Packets Discarded/sec
+20148
+Outbound Packets Discarded/sec
+20150
+Packets Discarded/sec
+20152
+Blocked Binds
+20154
+Inbound Connections Blocked/sec
+20156
+Outbound Connections Blocked/sec
+20158
+Inbound Connections Allowed/sec
+20160
+Outbound Connections Allowed/sec
+20162
+Inbound Connections
+20164
+Outbound Connections
+20166
+Active Inbound Connections
+20168
+Active Outbound Connections
+20170
+Allowed Classifies/sec
+20106
+IPsec IKEv1 IPv4
+20108
+Active Main Mode SAs
+20110
+Pending Main Mode Negotiations
+20112
+Main Mode Negotiations
+20114
+Main Mode Negotiations/sec
+20116
+Successful Main Mode Negotiations
+20118
+Successful Main Mode Negotiations/sec
+20120
+Failed Main Mode Negotiations
+20122
+Failed Main Mode Negotiations/sec
+20124
+Main Mode Negotiation Requests Received
+20126
+Main Mode Negotiation Requests Received/sec
+20128
+Active Quick Mode SAs
+20130
+Pending Quick Mode Negotiations
+20132
+Quick Mode Negotiations
+20134
+Quick Mode Negotiations/sec
+20136
+Successful Quick Mode Negotiations
+20138
+Successful Quick Mode Negotiations/sec
+20140
+Failed Quick Mode Negotiations
+20142
+Failed Quick Mode Negotiations/sec
+20068
+IPsec IKEv1 IPv6
+20070
+Active Main Mode SAs
+20072
+Pending Main Mode Negotiations
+20074
+Main Mode Negotiations
+20076
+Main Mode Negotiations/sec
+20078
+Successful Main Mode Negotiations
+20080
+Successful Main Mode Negotiations/sec
+20082
+Failed Main Mode Negotiations
+20084
+Failed Main Mode Negotiations/sec
+20086
+Main Mode Negotiation Requests Received
+20088
+Main Mode Negotiation Requests Received/sec
+20090
+Active Quick Mode SAs
+20092
+Pending Quick Mode Negotiations
+20094
+Quick Mode Negotiations
+20096
+Quick Mode Negotiations/sec
+20098
+Successful Quick Mode Negotiations
+20100
+Successful Quick Mode Negotiations/sec
+20102
+Failed Quick Mode Negotiations
+20104
+Failed Quick Mode Negotiations/sec
+20004
+IPsec Driver
+20006
+Active Security Associations
+20008
+Pending Security Associations
+20010
+Incorrect SPI Packets
+20012
+Incorrect SPI Packets/sec
+20014
+Bytes Received in Tunnel Mode/sec
+20016
+Bytes Sent in Tunnel Mode/sec
+20018
+Bytes Received in Transport Mode/sec
+20020
+Bytes Sent in Transport Mode/sec
+20022
+Offloaded Security Associations
+20024
+Offloaded Bytes Received/sec
+20026
+Offloaded Bytes Sent/sec
+20028
+Packets That Failed Replay Detection
+20030
+Packets That Failed Replay Detection/sec
+20032
+Packets Not Authenticated
+20034
+Packets Not Authenticated/sec
+20036
+Packets Not Decrypted
+20038
+Packets Not Decrypted/sec
+20040
+SA Rekeys
+20042
+Security Associations Added
+20044
+Packets That Failed ESP Validation
+20046
+Packets That Failed ESP Validation/sec
+20048
+Packets That Failed UDP-ESP Validation
+20050
+Packets That Failed UDP-ESP Validation/sec
+20052
+Packets Received Over Wrong SA
+20054
+Packets Received Over Wrong SA/sec
+20056
+Plaintext Packets Received
+20058
+Plaintext Packets Received/sec
+20060
+Total Inbound Packets Received
+20062
+Inbound Packets Received/sec
+20064
+Total Inbound Packets Dropped
+20066
+Inbound Packets Dropped/sec
+20000
+WFP
+20002
+Provider Count
+19972
+WFPv6
+19974
+Inbound Packets Discarded/sec
+19976
+Outbound Packets Discarded/sec
+19978
+Packets Discarded/sec
+19980
+Blocked Binds
+19982
+Inbound Connections Blocked/sec
+19984
+Outbound Connections Blocked/sec
+19986
+Inbound Connections Allowed/sec
+19988
+Outbound Connections Allowed/sec
+19990
+Inbound Connections
+19992
+Outbound Connections
+19994
+Active Inbound Connections
+19996
+Active Outbound Connections
+19998
+Allowed Classifies/sec
+19966
+Authorization Manager Applications
+19968
+Total number of scopes
+19970
+Number of Scopes loaded in memory
+19910
+DFS Replicated Folders
+19912
+Staging Files Generated
+19914
+Staging Bytes Generated
+19916
+Staging Files Cleaned up
+19918
+Staging Bytes Cleaned up
+19920
+Staging Space In Use
+19922
+Conflict Files Generated
+19924
+Conflict Bytes Generated
+19926
+Conflict Files Cleaned up
+19928
+Conflict Bytes Cleaned up
+19930
+Conflict Space In Use
+19932
+Conflict Folder Cleanups Completed
+19934
+File Installs Succeeded
+19936
+File Installs Retried
+19938
+Updates Dropped
+19940
+Deleted Files Generated
+19942
+Deleted Bytes Generated
+19944
+Deleted Files Cleaned up
+19946
+Deleted Bytes Cleaned up
+19948
+Deleted Space In Use
+19950
+Total Files Received
+19952
+Size of Files Received
+19954
+Compressed Size of Files Received
+19956
+RDC Number of Files Received
+19958
+RDC Size of Files Received
+19960
+RDC Compressed Size of Files Received
+19962
+RDC Bytes Received
+19964
+Bandwidth Savings Using DFS Replication
+19888
+DFS Replication Connections
+19890
+Total Bytes Received
+19892
+Total Files Received
+19894
+Size of Files Received
+19896
+Compressed Size of Files Received
+19898
+Bytes Received Per Second
+19900
+RDC Number of Files Received
+19902
+RDC Size of Files Received
+19904
+RDC Compressed Size of Files Received
+19906
+RDC Bytes Received
+19908
+Bandwidth Savings Using DFS Replication
+19876
+DFS Replication Service Volumes
+19878
+USN Journal Records Read
+19880
+USN Journal Records Accepted
+19882
+USN Journal Unread Percentage
+19884
+Database Commits
+19886
+Database Lookups
+19862
+Search Platform Services
+19864
+Message queue length
+19866
+Message queue avg blocked time
+19868
+Message queue avg blocked time base
+19870
+Message queue avg message age
+19872
+Message queue avg message age base
+19874
+Message queue currently blocked
+19684
+Search Fs
+19686
+LookupNumOps
+19688
+LookupRecall
+19690
+LookupRankStage1
+19692
+LookupRankStage2
+19694
+LookupAggregators
+19696
+LookupFinalSort
+19698
+LookupTotal
+19700
+DocSumNumOps
+19702
+DocSumTotal
+19704
+IndexDocNumOps
+19706
+IndexDocTotal
+19708
+IndexDocBegin
+19710
+IndexDocFreeText
+19712
+IndexDocString
+19714
+IndexDocSummary
+19716
+IndexDocRemove
+19718
+IndexDocCommit
+19720
+IndexDocOperation
+19722
+IndexDocNumOcc
+19724
+IndexDocSumSize
+19726
+IndexDocNumUpdateGroups
+19728
+IndexDocSPId
+19730
+IndexCommitNumOps
+19732
+IndexCommitTotal
+19734
+IndexCommitCommit
+19736
+IndexCommitAddPart
+19738
+IndexDocCommitNumDocs
+19740
+IndexCommitGenId
+19742
+MergeNumOps
+19744
+MergeTotal
+19746
+MergeLock
+19748
+MergeIdMap
+19750
+MergeInit
+19752
+MergeRenumberWords
+19754
+MergeDocAttributes
+19756
+MergeMergeOcc
+19758
+MergeAttributeVector
+19760
+MergeDocSum
+19762
+MergeFinalize
+19764
+MergeNumDocs
+19766
+MergeNumPartitionsFrom
+19768
+MergeNumPartitionsTo
+19770
+BitVectorCacheLookupHits
+19772
+BitVectorCacheLookupTotal
+19774
+IntRangeBitVectorCacheLookupHits
+19776
+IntRangeBitVectorCacheLookupTotal
+19778
+BoolOccurrenceCacheLookupHits
+19780
+BoolOccurrenceCacheLookupTotal
+19782
+PosOccurrenceCacheLookupHits
+19784
+PosOccurrenceCacheLookupTotal
+19786
+IntOccurrenceCacheLookupHits
+19788
+IntOccurrenceCacheLookupTotal
+19790
+DocInfoCacheLookupHits
+19792
+DocInfoCacheLookupTotal
+19794
+DictionaryCacheLookupHits
+19796
+DictionaryCacheLookupTotal
+19798
+SubQueryCacheLookupHits
+19800
+SubQueryCacheLookupTotal
+19802
+WorkingGenerationPartitions
+19804
+IndexInMemoryKBytes
+19806
+MergeLevel
+19808
+LookupQueue
+19810
+DocSumQueue
+19812
+MemoryUsedByCachesCurrent
+19814
+MemoryUsedByCachesMax
+19816
+NumInMemoryParts
+19818
+NumDiskParts
+19820
+IndexIdMapKBytes
+19822
+IndexAttributeVectorKBytes
+19824
+IndexIntegerIndexKBytes
+19826
+IndexDocInfoKBytes
+19828
+TotalNumDocs
+19830
+AggregatorCacheLookupHits
+19832
+AggregatorCacheLookupTotal
+19834
+PreCalcCacheLookupHits
+19836
+PreCalcCacheLookupTotal
+19838
+ResultCacheLookupHits
+19840
+ResultCacheLookupTotal
+19842
+SkiplistBoolOccCacheLookupHits
+19844
+SkiplistBoolOccCacheLookupTotal
+19846
+SkiplistPosOccCacheLookupHits
+19848
+SkiplistPosOccCacheLookupTotal
+19850
+RefineAggregatorNumOps
+19852
+RefineAggregatorTotal
+19854
+OnDiskKBytes
+19856
+NumMasterMergeStarted
+19858
+NumMasterMergeSuccessful
+19860
+NumMasterMergeFailed
+19680
+Search JournalShipper
+19682
+JournalReplicationLag
+19648
+Search Content Processing
+19650
+# Callbacks Available
+19652
+# Callbacks Total
+19654
+# Callbacks Per Second
+19656
+# Completed Callbacks Total
+19658
+# Completed Callbacks Per Second
+19660
+# Failed Callbacks Total
+19662
+# Failed Callbacks Per Second
+19664
+# Flow Instances Active
+19666
+# Flow Instances Completed
+19668
+# Flow Instances Failed
+19670
+# Flow Instances Aborted
+19672
+# Flow Instances That Cannot Be Stopped
+19674
+# Flow Instances Aborted Due To Full Queues
+19676
+# Operators Aborted Due To Timeouts
+19678
+# Flow instances with empty queues
+19640
+Search Analysis Engine Analytics Processing Components
+19642
+Running Tasks
+19644
+Long Running Tasks
+19646
+Failed Tasks
+19626
+Search Index
+19628
+CheckpointTime
+19630
+CheckpointNumDocs
+19632
+BadContentMessages
+19634
+BadQueryMessages
+19636
+DocsPerIndexCell
+19638
+DiskUsePerIndexCell
+19612
+Search Generation Controller
+19614
+GenerationsCreatedTotalContentGroups
+19616
+GenerationsCreated
+19618
+GenerationContentGroupCount
+19620
+NumberOfIndexPartitions
+19622
+ActiveCellInPartitions
+19624
+IndexCellsInPartitions
+19600
+Search IndexRouter
+19602
+PendingDocuments
+19604
+DocumentsDrained
+19606
+IndexingBlocked
+19608
+DocumentsDropped
+19610
+DocumentQueueFillPercentage
+19580
+Search Analysis Engine
+19582
+Event Queue Length
+19584
+Running Tasks
+19586
+Task Fill Factor
+19588
+Running Analyses
+19590
+Active Analytics Processing Components
+19592
+Uptime In Seconds
+19594
+Failed Tasks
+19596
+File Deletes
+19598
+Uptime In Days
+19562
+Search SPLookupService
+19564
+QueryLookupTime
+19566
+DocSumLookupTime
+19568
+NumQueryLookupOps
+19570
+NumDocSumLookupOps
+19572
+AvgQueryLookupTimeBase
+19574
+AvgQueryLookupTime
+19576
+AvgDocSumLookupTimeBase
+19578
+AvgDocSumLookupTime
+19550
+Search Flow Statistics
+19552
+# Threads Active
+19554
+# Items Queued For Processing
+19556
+Input Queue Full Time
+19558
+Input Queue Empty Time
+19560
+# Inbound Items Total
+19536
+Search Journal
+19538
+GenerationIndexed
+19540
+GenerationIndexing
+19542
+GenerationCheckpointed
+19544
+GenerationCheckpointing
+19546
+JournalEntries
+19548
+JournalPercent
+19532
+Search ULS Diagnostics Counter Set
+19534
+ULS Diagnostics Counter
+19518
+Search Content Router
+19520
+IndexTime
+19522
+IndexTimeBase
+19524
+NumSuccessIndex
+19526
+NumFailedIndex
+19528
+PendingContentGroups
+19530
+TimeBlockedOnFullQueue
+19190
+Search Query Processing
+19192
+Flow Instances Created
+19194
+Flow Instances In Use
+19196
+Flow Instances In Cache
+19198
+Flow Executors In Cache
+19200
+Flow Executors Running
+19202
+Flow Executors Existing
+19204
+Flow Executors Created
+19206
+Flow Executors Destroyed
+19208
+Operator Executors In Cache
+19210
+Operator Executors Running
+19212
+Operator Executors Existing
+19214
+Operator Executors Created
+19216
+Operator Executors Destroyed
+19218
+ProductivitySearchFlowExecutors In Cache
+19220
+ProductivitySearchFlowExecutors Running
+19222
+ProductivitySearchFlowExecutors Existing
+19224
+ProductivitySearchFlowExecutors Created
+19226
+ProductivitySearchFlowExecutors Destroyed
+19228
+Flow Instances Destroyed
+19230
+Number Of Successful Queries
+19232
+Number Of Failed Queries
+19234
+Number Of Queries Failed With Common Evaluation Failure
+19236
+Number Of Queries Failed With Other Evaluation Failure
+19238
+Number Of Timed Out Queries
+19240
+Average Flow Latency
+19242
+Average Flow Latency Base
+19244
+Successful Queries Per Second
+19246
+Failed Queries Per Second
+19248
+Flow Group 1: Flow Instances Created
+19250
+Flow Group 1: Flow Instances In Use
+19252
+Flow Group 1: Flow Instances In Cache
+19254
+Flow Group 1: Flow Instances Destroyed
+19256
+Flow Group 1: Number Of Successful Queries
+19258
+Flow Group 1: Number Of Failed Queries
+19260
+Flow Group 1: Number Of Queries Failed With Common Evaluation Failure
+19262
+Flow Group 1: Number Of Queries Failed With Other Evaluation Failure
+19264
+Flow Group 1: Number Of Timed Out Queries
+19266
+Flow Group 1: Average Flow Latency
+19268
+Flow Group 1: Average Flow Latency Base
+19270
+Flow Group 1: Successful Queries Per Second
+19272
+Flow Group 1: Failed Queries Per Second
+19274
+Flow Group 2: Flow Instances Created
+19276
+Flow Group 2: Flow Instances In Use
+19278
+Flow Group 2: Flow Instances In Cache
+19280
+Flow Group 2: Flow Instances Destroyed
+19282
+Flow Group 2: Number Of Successful Queries
+19284
+Flow Group 2: Number Of Failed Queries
+19286
+Flow Group 2: Number Of Queries Failed With Common Evaluation Failure
+19288
+Flow Group 2: Number Of Queries Failed With Other Evaluation Failure
+19290
+Flow Group 2: Number Of Timed Out Queries
+19292
+Flow Group 2: Average Flow Latency
+19294
+Flow Group 2: Average Flow Latency Base
+19296
+Flow Group 2: Successful Queries Per Second
+19298
+Flow Group 2: Failed Queries Per Second
+19300
+Flow Group 3: Flow Instances Created
+19302
+Flow Group 3: Flow Instances In Use
+19304
+Flow Group 3: Flow Instances In Cache
+19306
+Flow Group 3: Flow Instances Destroyed
+19308
+Flow Group 3: Number Of Successful Queries
+19310
+Flow Group 3: Number Of Failed Queries
+19312
+Flow Group 3: Number Of Queries Failed With Common Evaluation Failure
+19314
+Flow Group 3: Number Of Queries Failed With Other Evaluation Failure
+19316
+Flow Group 3: Number Of Timed Out Queries
+19318
+Flow Group 3: Average Flow Latency
+19320
+Flow Group 3: Average Flow Latency Base
+19322
+Flow Group 3: Successful Queries Per Second
+19324
+Flow Group 3: Failed Queries Per Second
+19326
+Flow Group 4: Flow Instances Created
+19328
+Flow Group 4: Flow Instances In Use
+19330
+Flow Group 4: Flow Instances In Cache
+19332
+Flow Group 4: Flow Instances Destroyed
+19334
+Flow Group 4: Number Of Successful Queries
+19336
+Flow Group 4: Number Of Failed Queries
+19338
+Flow Group 4: Number Of Queries Failed With Common Evaluation Failure
+19340
+Flow Group 4: Number Of Queries Failed With Other Evaluation Failure
+19342
+Flow Group 4: Number Of Timed Out Queries
+19344
+Flow Group 4: Average Flow Latency
+19346
+Flow Group 4: Average Flow Latency Base
+19348
+Flow Group 4: Successful Queries Per Second
+19350
+Flow Group 4: Failed Queries Per Second
+19352
+Flow Group 5: Flow Instances Created
+19354
+Flow Group 5: Flow Instances In Use
+19356
+Flow Group 5: Flow Instances In Cache
+19358
+Flow Group 5: Flow Instances Destroyed
+19360
+Flow Group 5: Number Of Successful Queries
+19362
+Flow Group 5: Number Of Failed Queries
+19364
+Flow Group 5: Number Of Queries Failed With Common Evaluation Failure
+19366
+Flow Group 5: Number Of Queries Failed With Other Evaluation Failure
+19368
+Flow Group 5: Number Of Timed Out Queries
+19370
+Flow Group 5: Average Flow Latency
+19372
+Flow Group 5: Average Flow Latency Base
+19374
+Flow Group 5: Successful Queries Per Second
+19376
+Flow Group 5: Failed Queries Per Second
+19378
+Flow Group 6: Flow Instances Created
+19380
+Flow Group 6: Flow Instances In Use
+19382
+Flow Group 6: Flow Instances In Cache
+19384
+Flow Group 6: Flow Instances Destroyed
+19386
+Flow Group 6: Number Of Successful Queries
+19388
+Flow Group 6: Number Of Failed Queries
+19390
+Flow Group 6: Number Of Queries Failed With Common Evaluation Failure
+19392
+Flow Group 6: Number Of Queries Failed With Other Evaluation Failure
+19394
+Flow Group 6: Number Of Timed Out Queries
+19396
+Flow Group 6: Average Flow Latency
+19398
+Flow Group 6: Average Flow Latency Base
+19400
+Flow Group 6: Successful Queries Per Second
+19402
+Flow Group 6: Failed Queries Per Second
+19404
+Flow Group 7: Flow Instances Created
+19406
+Flow Group 7: Flow Instances In Use
+19408
+Flow Group 7: Flow Instances In Cache
+19410
+Flow Group 7: Flow Instances Destroyed
+19412
+Flow Group 7: Number Of Successful Queries
+19414
+Flow Group 7: Number Of Failed Queries
+19416
+Flow Group 7: Number Of Queries Failed With Common Evaluation Failure
+19418
+Flow Group 7: Number Of Queries Failed With Other Evaluation Failure
+19420
+Flow Group 7: Number Of Timed Out Queries
+19422
+Flow Group 7: Average Flow Latency
+19424
+Flow Group 7: Average Flow Latency Base
+19426
+Flow Group 7: Successful Queries Per Second
+19428
+Flow Group 7: Failed Queries Per Second
+19430
+Flow Group 8: Flow Instances Created
+19432
+Flow Group 8: Flow Instances In Use
+19434
+Flow Group 8: Flow Instances In Cache
+19436
+Flow Group 8: Flow Instances Destroyed
+19438
+Flow Group 8: Number Of Successful Queries
+19440
+Flow Group 8: Number Of Failed Queries
+19442
+Flow Group 8: Number Of Queries Failed With Common Evaluation Failure
+19444
+Flow Group 8: Number Of Queries Failed With Other Evaluation Failure
+19446
+Flow Group 8: Number Of Timed Out Queries
+19448
+Flow Group 8: Average Flow Latency
+19450
+Flow Group 8: Average Flow Latency Base
+19452
+Flow Group 8: Successful Queries Per Second
+19454
+Flow Group 8: Failed Queries Per Second
+19456
+Flow Group 9: Flow Instances Created
+19458
+Flow Group 9: Flow Instances In Use
+19460
+Flow Group 9: Flow Instances In Cache
+19462
+Flow Group 9: Flow Instances Destroyed
+19464
+Flow Group 9: Number Of Successful Queries
+19466
+Flow Group 9: Number Of Failed Queries
+19468
+Flow Group 9: Number Of Queries Failed With Common Evaluation Failure
+19470
+Flow Group 9: Number Of Queries Failed With Other Evaluation Failure
+19472
+Flow Group 9: Number Of Timed Out Queries
+19474
+Flow Group 9: Average Flow Latency
+19476
+Flow Group 9: Average Flow Latency Base
+19478
+Flow Group 9: Successful Queries Per Second
+19480
+Flow Group 9: Failed Queries Per Second
+19482
+Flow Group 10: Flow Instances Created
+19484
+Flow Group 10: Flow Instances In Use
+19486
+Flow Group 10: Flow Instances In Cache
+19488
+Flow Group 10: Flow Instances Destroyed
+19490
+Flow Group 10: Number Of Successful Queries
+19492
+Flow Group 10: Number Of Failed Queries
+19494
+Flow Group 10: Number Of Queries Failed With Common Evaluation Failure
+19496
+Flow Group 10: Number Of Queries Failed With Other Evaluation Failure
+19498
+Flow Group 10: Number Of Timed Out Queries
+19500
+Flow Group 10: Average Flow Latency
+19502
+Flow Group 10: Average Flow Latency Base
+19504
+Flow Group 10: Successful Queries Per Second
+19506
+Flow Group 10: Failed Queries Per Second
+19508
+Queries Throttled
+19510
+Query Successes
+19512
+Query Errors
+19514
+Queries Executing
+19516
+Query Duration
+19082
+Search Linguistics
+19084
+QueryClassificationDictionarySize
+19086
+SpellingDictionarySize
+19088
+DictionaryDeploymentRuns
+19090
+ExtractedCustomEntities
+19092
+LangIdFallBack
+19094
+WordBreakerDocumentsProcessed
+19096
+WordBreakerDocumentsTimedOut
+19098
+WordBreakerDocumentsExceededThreshold
+19100
+QueryCount
+19102
+QuerySpellingSuggestions
+19104
+QuerySpellingSuggestionsFromInclusions
+19106
+QuerySpellingSuggestionsBlockedExclusions
+19108
+QuerySpellingSecurityTrimmingQueries
+19110
+QuerySpellingSecurityTrimmingNoEffect
+19112
+QuerySpellingSecurityTrimmingTimeouts
+19114
+QueryStemmingExpandedTokens
+19116
+QueryStemmingExpansions
+19118
+QueryStemmingLimitHits
+19120
+QuerySynonymExpansions
+19122
+QueryTokenCount
+19124
+QueryWordBreakerExpansions
+19126
+QuerySpellingDictionaryUpdates
+19128
+QuerySpellingDictionaryUpdateDuration
+19130
+QuerySpellingIndexTerms
+19132
+QuerySpellingDictionaryTerms
+19134
+WordBreakerFieldsProcessed
+19136
+WordBreakerFieldsTimeOut
+19138
+WordBreakerFieldsThreshold
+19140
+WordBreakerFieldsByFallback
+19142
+CompanyInclusionsDictionarySize
+19144
+CompanyExclusionsDictionarySize
+19146
+QueryClassificationDictionaryEntries
+19148
+SpellingInclusionDictionaryEntries
+19150
+SpellingDontSuggestDictionaryEntries
+19152
+SpellingDictionaryEntries
+19154
+CompanyInclusionDictionaryEntries
+19156
+CompanyExclusionDictionaryEntries
+19158
+ExtractedCompaniesBuiltinDictionary
+19160
+ExtractedCompaniesInclusionDictionary
+19162
+ExcludedCompanies
+19164
+QuerySpellingInclusionDictionaryTerms
+19166
+QuerySpellingExclusionDictionaryTerms
+19168
+CompanyInclusionDictionaryTerms
+19170
+CompanyExclusionDictionaryTerms
+19172
+SpellingInclusionsDictionarySize
+19174
+SpellingDontSuggestDictionarySize
+19176
+CustomDictionaryUpdates
+19178
+QueryClassificationDictionaryUpdates
+19180
+ReservedCounter1
+19182
+ReservedCounter2
+19184
+ReservedCounter3
+19186
+ReservedCounter4
+19188
+ReservedCounter5
+19000
+Search Additional Counters
+19002
+Placeholder 1
+19004
+Placeholder 2
+19006
+Placeholder 3
+19008
+Placeholder 4
+19010
+Placeholder 5
+19012
+Placeholder 6
+19014
+Placeholder 7
+19016
+Placeholder 8
+19018
+Placeholder 9
+19020
+Placeholder 10
+19022
+Placeholder 11
+19024
+Placeholder 12
+19026
+Placeholder 13
+19028
+Placeholder 14
+19030
+Placeholder 15
+19032
+Placeholder 16
+19034
+Placeholder 17
+19036
+Placeholder 18
+19038
+Placeholder 19
+19040
+Placeholder 20
+19042
+Placeholder 21
+19044
+Placeholder 22
+19046
+Placeholder 23
+19048
+Placeholder 24
+19050
+Placeholder 25
+19052
+Placeholder 26
+19054
+Placeholder 27
+19056
+Placeholder 28
+19058
+Placeholder 29
+19060
+Placeholder 30
+19062
+Placeholder 31
+19064
+Placeholder 32
+19066
+Placeholder 33
+19068
+Placeholder 34
+19070
+Placeholder 35
+19072
+Placeholder 36
+19074
+Placeholder 37
+19076
+Placeholder 38
+19078
+Placeholder 39
+19080
+Placeholder 40
+18992
+Seeding/Backup performance counter set
+18994
+Completed volume in percentage
+18996
+Completed volume in MB
+18998
+Average speed so far in MB/s
+18974
+Search Analysis Engine Analyses
+18976
+Active Files
+18978
+Disk Usage
+18980
+Running Tasks
+18982
+Failed Tasks Since Startup
+18984
+Failed Tasks In Current Run
+18986
+Restarts
+18988
+Clear Analysis Count
+18990
+File Deletes
+18960
+Search Host Controller
+18962
+Component Restarts
+18964
+Component Uptime
+18966
+Placeholder 1
+18968
+Placeholder 2
+18970
+Placeholder 3
+18972
+Placeholder 4
+18862
+Search Document Feeder
+18864
+ItemsTotalAccepted
+18866
+ItemsTotalAcceptedInsert
+18868
+ItemsTotalAcceptedUpdate
+18870
+ItemsTotalAcceptedDelete
+18872
+ItemsTotalAcceptedPartialupdate
+18874
+ItemsTotalFinished
+18876
+ItemsTotalFinishedRate
+18878
+AvgItemSizeBase
+18880
+AvgItemSize
+18882
+AvgEndToEndLatency
+18884
+AvgEndToEndLatencyBase
+18886
+ItemsTotalSubmitted
+18888
+ItemsCompleted
+18890
+ItemsCompletedRate
+18892
+ItemsFailed
+18894
+ItemsFailedRate
+18896
+ItemsFailedTransient
+18898
+ItemsReceived
+18900
+ItemsReceivedRate
+18902
+ItemsWarnings
+18904
+ItemsRetried
+18906
+ItemsRetriedRate
+18908
+ItemsWaiting
+18910
+ItemsSubmittedNoCallback
+18912
+ItemsDepending
+18914
+AvgCallbackLatencyBase
+18916
+AvgCallbackLatency
+18918
+AvgWaitLatencyBase
+18920
+AvgWaitLatency
+18922
+ActiveItemsSize
+18924
+AvgBatchSizeBase
+18926
+AvgBatchSize
+18928
+AvgBatchSizeBytesBase
+18930
+AvgBatchSizeBytes
+18932
+AvgBatchSubmitLatencyBase
+18934
+AvgBatchSubmitLatency
+18936
+Recoveries
+18938
+DocumentTimeouts
+18940
+CTSTimeouts
+18942
+CTSFailover
+18944
+CallbackQueueSize
+18946
+ItemSize
+18948
+EndToEndLatency
+18950
+CallbackLatency
+18952
+WaitLatency
+18954
+BatchSize
+18956
+BatchSizeBytes
+18958
+BatchSubmitLatency
+18840
+Search Submission Service
+18842
+# Active Sessions
+18844
+# Aborted Sessions
+18846
+# Callbacks Available
+18848
+# Callbacks Total
+18850
+# Client Polls
+18852
+# Client Submits
+18854
+# Documents Skipped
+18856
+# Documents Timed Out
+18858
+# Flows Used For Feeding
+18860
+# Pending Items
+18616
+Search Document Parsing
+18618
+Active parsing sessions
+18620
+Parser server worker restart failures
+18622
+Format handler start failures
+18624
+Parsing failures
+18626
+Parsing failures on supported formats
+18628
+Parsing failures on unsupported format
+18630
+Parsing timeout failures
+18632
+Maximum parsing output size failures
+18634
+Empty parsing output
+18636
+Parsing requests per second
+18638
+Parsed documents per second
+18640
+Partially parsed documents
+18642
+Merged content operations
+18644
+Parsing conversion rate
+18646
+Parsing conversion ratio base
+18648
+Average parsing time
+18650
+Parsed documents to compute the average parsing time
+18652
+Word Metro Handler - average parsing time
+18654
+Word Metro Handler - average parsing time base
+18656
+Word Metro Handler - parsed documents
+18658
+Word Metro Handler - parsed documents per second
+18660
+Word Metro Handler - partially parsed documents
+18662
+IFilter Handler - average parsing time
+18664
+IFilter Handler - average parsing time base
+18666
+IFilter Handler - parsed documents
+18668
+IFilter Handler - parsed documents per second
+18670
+IFilter Handler - partially parsed documents
+18672
+Word and PowerPoint Legacy IFilter Handler - average parsing time
+18674
+Word and PowerPoint Legacy IFilter Handler - average parsing time base
+18676
+Word and PowerPoint Legacy IFilter Handler - parsed documents
+18678
+Word and PowerPoint Legacy IFilter Handler - parsed documents per second
+18680
+Word and PowerPoint Legacy IFilter Handler - partially parsed documents
+18682
+Excel Metro IFilter Handler - average parsing time
+18684
+Excel Metro IFilter Handler - average parsing time base
+18686
+Excel Metro IFilter Handler - parsed documents
+18688
+Excel Metro IFilter Handler - parsed documents per second
+18690
+Excel Metro IFilter Handler - partially parsed documents
+18692
+GIF Handler - average parsing time
+18694
+GIF Handler - average parsing time base
+18696
+GIF Handler - parsed documents
+18698
+GIF Handler - parsed documents per second
+18700
+GIF Handler - partially parsed documents
+18702
+HTML Handler - average parsing time
+18704
+HTML Handler - average parsing time base
+18706
+HTML Handler - parsed documents
+18708
+HTML Handler - parsed documents per second
+18710
+HTML Handler - partially parsed documents
+18712
+JPEG Handler - average parsing time
+18714
+JPEG Handler - average parsing time base
+18716
+JPEG Handler - parsed documents
+18718
+JPEG Handler - parsed documents per second
+18720
+JPEG Handler - partially parsed documents
+18722
+PDF Handler - average parsing time
+18724
+PDF Handler - average parsing time base
+18726
+PDF Handler - parsed documents
+18728
+PDF Handler - parsed documents per second
+18730
+PDF Handler - partially parsed documents
+18732
+PlainText Handler - average parsing time
+18734
+PlainText Handler - average parsing time base
+18736
+PlainText Handler - parsed documents
+18738
+PlainText Handler - parsed documents per second
+18740
+PlainText Handler - partially parsed documents
+18742
+PowerPoint Metro Handler - average parsing time
+18744
+PowerPoint Metro Handler - average parsing time base
+18746
+PowerPoint Metro Handler - parsed documents
+18748
+PowerPoint Metro Handler - parsed documents per second
+18750
+PowerPoint Metro Handler - partially parsed documents
+18752
+XML Handler - average parsing time
+18754
+XML Handler - average parsing time base
+18756
+XML Handler - parsed documents
+18758
+XML Handler - parsed documents per second
+18760
+XML Handler - partially parsed documents
+18762
+Sandbox average parsing time
+18764
+Number of documents parsed in a sandbox
+18766
+Active sandbox workers
+18768
+Sandbox queue length
+18770
+Average sandbox waiting time
+18772
+Number of sandbox worker requests
+18774
+Parsed documents
+18776
+Word Metro Handler - total parsing time
+18778
+Word Metro Handler - parsing failures
+18780
+PowerPoint Metro Handler - total parsing time
+18782
+PowerPoint Metro Handler - parsing failures
+18784
+PDF Handler - total parsing time
+18786
+PDF Handler - parsing failures
+18788
+Parsing requests
+18790
+XML Handler - total parsing time
+18792
+XML Handler - parsing failures
+18794
+PlainText Handler - total parsing time
+18796
+PlainText Handler - parsing failures
+18798
+Excel Metro IFilter Handler - total parsing time
+18800
+Excel Metro IFilter Handler - parsing failures
+18802
+GIF Handler - total parsing time
+18804
+GIF Handler - parsing failures
+18806
+HTML Handler - total parsing time
+18808
+HTML Handler - parsing failures
+18810
+JPEG Handler - total parsing time
+18812
+JPEG Handler - parsing failures
+18814
+IFilter Handler - total parsing time
+18816
+IFilter Handler - parsing failures
+18818
+Word and PowerPoint Legacy IFilter Handler - total parsing time
+18820
+Word and PowerPoint Legacy IFilter Handler - parsing failures
+18822
+Excel Legacy Handler - total parsing time
+18824
+Excel Legacy Handler - parsing failures
+18826
+Excel Legacy Handler - partially parsed documents
+18828
+Excel Legacy Handler - parsed documents per second
+18830
+Excel Legacy Handler - parsed documents
+18832
+Parsing failures on undetected format
+18834
+Excel Legacy Handler - average parsing time base
+18836
+Sandbox total parsing time
+18838
+Orphan parsing operations
+18606
+Microsoft Winsock BSP
+18608
+Dropped Datagrams/sec
+18610
+Dropped Datagrams
+18612
+Rejected Connections/sec
+18614
+Rejected Connections
+18532
+Storage Spaces Write Cache
+18534
+Cache Writes/sec
+18536
+Cache Write Bytes/sec
+18538
+Avg. Cache Bytes/Write
+18540
+Cache Overwrites/sec
+18542
+Cache Overwrite Bytes/sec
+18544
+Avg. Cache Bytes/Overwrite
+18546
+Cache Evicts/sec
+18548
+Cache Evict Bytes/sec
+18550
+Avg. Cache Bytes/Evict
+18552
+Current Destage Queue Length
+18554
+Destage Operations/sec
+18556
+Avg. Destage sec/Operation
+18558
+Avg. Destage Queue Length
+18560
+Destage Optimized Operations/sec
+18562
+Destage Evicts/sec
+18564
+Avg. Destage Evicts/Operation
+18566
+Destage Evict Bytes/sec
+18568
+Avg. Destage Bytes/Evict
+18570
+Avg. Destage Evict Bytes/Operation
+18572
+Destage Transfers/sec
+18574
+Avg. Destage Transfers/Operation
+18576
+Avg. Destage Transfers/Evict
+18578
+Destage Transfer Bytes/sec
+18580
+Avg. Destage Bytes/Transfer
+18582
+Avg. Destage Transfer Bytes/Operation
+18584
+Bytes Cached
+18586
+Bytes Reserved
+18588
+Bytes Reclaimable
+18590
+Bytes Used
+18592
+Cache Size
+18594
+Cache Writes
+18596
+Cache Overwrites
+18598
+Cache Evicts
+18600
+Destage Operations
+18602
+Destage Evicts
+18604
+Destage Transfers
+18492
+Storage Spaces Tier
+18494
+Tier Reads/sec
+18496
+Avg. Tier sec/Read
+18498
+Avg. Tier Read Queue Length
+18500
+Tier Read Bytes/sec
+18502
+Avg. Tier Bytes/Read
+18504
+Tier Writes/sec
+18506
+Avg. Tier sec/Write
+18508
+Avg. Tier Write Queue Length
+18510
+Tier Write Bytes/sec
+18512
+Avg. Tier Bytes/Write
+18514
+Current Tier Queue Length
+18516
+Tier Transfers/sec
+18518
+Avg. Tier sec/Transfer
+18520
+Avg. Tier Queue Length
+18522
+Tier Transfer Bytes/sec
+18524
+Avg. Tier Bytes/Transfer
+18526
+Tier Reads
+18528
+Tier Writes
+18530
+Tier Transfers
+18474
+WAS_W3WP
+18476
+Total Requests Served
+18478
+Total Health Pings.
+18480
+Total Runtime Status Queries
+18482
+Active Listener Channels
+18484
+Active Protocol Handlers
+18486
+Total WAS Messages Received
+18488
+Total Messages Sent to WAS
+18490
+Health Ping Reply Latency
+18450
+RPC/HTTP Proxy
+18452
+Current Number of Unique Users
+18454
+Number of Back-End Connection Attempts per Second
+18456
+Number of Failed Back-End Connection Attempts per Second
+18458
+RPC/HTTP Requests per Second
+18460
+Current Number of Incoming RPC over HTTP Connections
+18462
+Total Incoming Bandwidth from Back-End Servers
+18464
+Total Outgoing Bandwidth to Back-End Servers
+18466
+Attempted RPC Load Balancing Decisions per Second
+18468
+Failed RPC Load Balancing Decisions per Second
+18470
+Attempted RPC Load Balancing Broker Requests per Second
+18472
+Failed RPC Load Balancing Broker Requests per Second
+18446
+RPC/HTTP Proxy Per Server
+18448
+Current Number of Backend Connections
+18416
+SMB Direct Connection
+18418
+Stalls (Send Credit)/sec
+18420
+Stalls (Send Queue)/sec
+18422
+Stalls (RDMA Registrations)/sec
+18424
+Sends/sec
+18426
+Remote Invalidations/sec
+18428
+Bytes Received/sec
+18430
+Bytes Sent/sec
+18432
+Bytes RDMA Read/sec
+18434
+Bytes RDMA Written/sec
+18436
+Stalls (RDMA Read)/sec
+18438
+Receives/sec
+18440
+RDMA Registrations/sec
+18442
+SCQ Notification Events/sec
+18444
+RCQ Notification Events/sec
+18402
+Offline Files
+18404
+Bytes Received
+18406
+Bytes Transmitted
+18408
+Bytes Transmitted/sec
+18412
+Bytes Received/sec
+18374
+Client Side Caching
+18376
+SMB BranchCache Bytes Requested
+18378
+SMB BranchCache Bytes Received
+18380
+SMB BranchCache Bytes Published
+18382
+SMB BranchCache Bytes Requested From Server
+18384
+SMB BranchCache Hashes Requested
+18386
+SMB BranchCache Hashes Received
+18388
+SMB BranchCache Hash Bytes Received
+18390
+Prefetch Operations Queued
+18392
+Prefetch Bytes Read From Cache
+18394
+Prefetch Bytes Read From Server
+18396
+Application Bytes Read From Cache
+18398
+Application Bytes Read From Server
+18400
+Application Bytes Read From Server (Not Cached)
+18364
+KPSSVC
+18366
+Incoming Requests
+18368
+Incoming Armored Requests
+18370
+Incoming Password Change Requests
+18372
+Failed Requests
+18290
+IPsec DoS Protection
+18292
+State Entries
+18294
+State Entries/sec
+18296
+Current State Entries
+18298
+Inbound Allowed IPv6 IPsec Unauthenticated Packets
+18300
+Inbound Allowed IPv6 IPsec Unauthenticated Packets/sec
+18302
+Inbound Allowed IPv6 IPsec Authenticated Packets
+18304
+Inbound Allowed IPv6 IPsec Authenticated Packets/sec
+18306
+Inbound Allowed ICMPv6 Packets
+18308
+Inbound Allowed ICMPv6 Packets/sec
+18310
+Inbound Allowed Filter Exempt IPv6 Packets
+18312
+Inbound Allowed Filter Exempt IPv6 Packets/sec
+18314
+Inbound Allowed Default Block Exempt Packets
+18316
+Inbound Allowed Default Block Exempt Packets/sec
+18318
+Inbound Rate Limit Discarded IPv6 IPsec Unauthenticated Packets
+18320
+Inbound Rate Limit Discarded IPv6 IPsec Unauthenticated Packets/sec
+18322
+Inbound Per IP Rate Limit Discarded IPv6 IPsec Unauthenticated Packets
+18324
+Inbound Per IP Rate Limit Discarded IPv6 IPsec Unauthenticated Packets/sec
+18326
+Inbound Other Discarded IPv6 IPsec Unauthenticated Packets
+18328
+Inbound Other Discarded IPv6 IPsec Unauthenticated Packets/sec
+18330
+Inbound Rate Limit Discarded IPv6 IPsec Authenticated Packets
+18332
+Inbound Rate Limit Discarded IPv6 IPsec Authenticated Packets/sec
+18334
+Inbound Other Discarded IPv6 IPsec Authenticated Packets
+18336
+Inbound Other Discarded IPv6 IPsec Authenticated Packets/sec
+18338
+Inbound Rate Limit Discarded ICMPv6 Packets
+18340
+Inbound Rate Limit Discarded ICMPv6 Packets/sec
+18342
+Inbound Rate Limit Discarded Filter Exempt IPv6 Packets
+18344
+Inbound Rate Limit Discarded Filter Exempt IPv6 Packets/sec
+18346
+Inbound Discarded Filter Block IPv6 Packets
+18348
+Inbound Discarded Filter Block IPv6 Packets/sec
+18350
+Inbound Rate Limit Discarded Default Block Exempt Packets
+18352
+Inbound Rate Limit Discarded Default Block Exempt Packets/sec
+18354
+Inbound Discarded Default Block Packets
+18356
+Inbound Discarded Default Block Packets/sec
+18358
+Inbound Discarded Packets
+18360
+Inbound Discarded Packets/sec
+18362
+Per IP Rate Limit Queues
+18244
+Teredo Relay
+18246
+In - Teredo Relay Total Packets: Success + Error
+18248
+In - Teredo Relay Success Packets: Total
+18250
+In - Teredo Relay Success Packets: Bubbles
+18252
+In - Teredo Relay Success Packets: Data Packets
+18254
+In - Teredo Relay Error Packets: Total
+18256
+In - Teredo Relay Error Packets: Header Error
+18258
+In - Teredo Relay Error Packets: Source Error
+18260
+In - Teredo Relay Error Packets: Destination Error
+18262
+Out - Teredo Relay Total Packets: Success + Error
+18264
+Out - Teredo Relay Success Packets
+18266
+Out - Teredo Relay Success Packets: Bubbles
+18268
+Out - Teredo Relay Success Packets: Data Packets
+18270
+Out - Teredo Relay Error Packets
+18272
+Out - Teredo Relay Error Packets: Header Error
+18274
+Out - Teredo Relay Error Packets: Source Error
+18276
+Out - Teredo Relay Error Packets: Destination Error
+18278
+In - Teredo Relay Total Packets: Success + Error / sec
+18280
+Out - Teredo Relay Total Packets: Success + Error / sec
+18282
+In - Teredo Relay Success Packets: Data Packets User Mode
+18284
+In - Teredo Relay Success Packets: Data Packets Kernel Mode
+18286
+Out - Teredo Relay Success Packets: Data Packets User Mode
+18288
+Out - Teredo Relay Success Packets: Data Packets Kernel Mode
+18228
+IPHTTPS Session
+18230
+Packets received on this session
+18232
+Packets sent on this session
+18234
+Bytes received on this session
+18236
+Bytes sent on this session
+18238
+Errors - Transmit errors on this session
+18240
+Errors - Receive errors on this session
+18242
+Duration - Duration of the session (Seconds)
+18214
+DNS64 Global
+18216
+AAAA queries - Successful
+18218
+AAAA queries - Failed
+18220
+IP6.ARPA queries - Matched
+18222
+Other queries - Successful
+18224
+Other queries - Failed
+18226
+AAAA - Synthesized records
+18192
+IPHTTPS Global
+18194
+In - Total bytes received
+18196
+Out - Total bytes sent
+18198
+Drops - Neighbor resolution timeouts
+18200
+Errors - Authentication Errors
+18202
+Out - Total bytes forwarded
+18204
+Errors - Transmit errors on the server
+18206
+Errors - Receive errors on the server
+18208
+In - Total packets received
+18210
+Out - Total packets sent
+18212
+Sessions - Total sessions
+18162
+Teredo Server
+18164
+In - Teredo Server Total Packets: Success + Error
+18166
+In - Teredo Server Success Packets: Total
+18168
+In - Teredo Server Success Packets: Bubbles
+18170
+In - Teredo Server Success Packets: Echo
+18172
+In - Teredo Server Success Packets: RS-Primary
+18174
+In - Teredo Server Success Packets: RS-Secondary
+18176
+In - Teredo Server Error Packets: Total
+18178
+In - Teredo Server Error Packets: Header Error
+18180
+In - Teredo Server Error Packets: Source Error
+18182
+In - Teredo Server Error Packets: Destination Error
+18184
+In - Teredo Server Error Packets: Authentication Error
+18186
+Out - Teredo Server: RA-Primary
+18188
+Out - Teredo Server: RA-Secondary 
+18190
+In - Teredo Server Total Packets: Success + Error / sec
+18138
+Teredo Client
+18140
+In - Teredo Router Advertisement
+18142
+In - Teredo Bubble
+18144
+In - Teredo Data
+18146
+In - Teredo Invalid
+18148
+Out - Teredo Router Solicitation
+18150
+Out - Teredo Bubble
+18152
+Out - Teredo Data
+18154
+In - Teredo Data User Mode
+18156
+In - Teredo Data Kernel Mode
+18158
+Out - Teredo Data User Mode
+18160
+Out - Teredo Data Kernel Mode
+18134
+Hyper-V Dynamic Memory Integration Service
+18136
+Maximum Memory, Mbytes
+18112
+Classification Engine: Rule Package Cache
+18114
+Successful Cache Hits
+18116
+Recoverable Cache Misses
+18118
+Unrecoverable Cache Misses
+18120
+Forced Rule Package Retrievals
+18122
+Average Time to Retrieve Rules
+18126
+Average Time to Load Rules
+18130
+Rule Package Count Evictions
+18132
+Rule Package Memory Evictions
+18098
+Classification Engine: Content Analysis Session
+18100
+Average Time to Retrieve Data
+18104
+Average Time to Classify All Rules
+18108
+Average Time to Classify OOB Rules
+18018
+ServiceModelService 4.0.0.0
+18020
+Calls
+18022
+Calls Per Second
+18024
+Calls Outstanding
+18026
+Calls Failed
+18028
+Calls Failed Per Second
+18030
+Calls Faulted
+18032
+Calls Faulted Per Second
+18034
+Calls Duration
+18036
+Security Validation and Authentication Failures
+18038
+Security Validation and Authentication Failures Per Second
+18040
+Security Calls Not Authorized
+18042
+Security Calls Not Authorized Per Second
+18044
+Instances
+18046
+Instances Created Per Second
+18048
+Reliable Messaging Sessions Faulted
+18050
+Reliable Messaging Sessions Faulted Per Second
+18052
+Reliable Messaging Messages Dropped
+18054
+Reliable Messaging Messages Dropped Per Second
+18056
+Transactions Flowed
+18058
+Transactions Flowed Per Second
+18060
+Transacted Operations Committed
+18062
+Transacted Operations Committed Per Second
+18064
+Transacted Operations Aborted
+18066
+Transacted Operations Aborted Per Second
+18068
+Transacted Operations In Doubt
+18070
+Transacted Operations In Doubt Per Second
+18072
+Queued Poison Messages
+18074
+Queued Poison Messages Per Second
+18076
+Queued Messages Rejected
+18078
+Queued Messages Rejected Per Second
+18080
+Queued Messages Dropped
+18082
+Queued Messages Dropped Per Second
+18084
+Percent Of Max Concurrent Calls
+18086
+Percent Of Max Concurrent Instances
+18088
+Percent Of Max Concurrent Sessions
+18090
+CallDurationBase
+18092
+CallsPercentMaxConcurrentCallsBase
+18094
+InstancesPercentMaxConcurrentInstancesBase
+18096
+SessionsPercentMaxConcurrentSessionsBase
+17986
+ServiceModelOperation 4.0.0.0
+17988
+Calls
+17990
+Calls Per Second
+17992
+Calls Outstanding
+17994
+Calls Failed
+17996
+Call Failed Per Second
+17998
+Calls Faulted
+18000
+Calls Faulted Per Second
+18002
+Calls Duration
+18004
+Security Validation and Authentication Failures
+18006
+Security Validation and Authentication Failures Per Second
+18008
+Security Calls Not Authorized
+18010
+Security Calls Not Authorized Per Second
+18012
+Transactions Flowed
+18014
+Transactions Flowed Per Second
+18016
+CallsDurationBase
+17946
+ServiceModelEndpoint 4.0.0.0
+17948
+Calls
+17950
+Calls Per Second
+17952
+Calls Outstanding
+17954
+Calls Failed
+17956
+Calls Failed Per Second
+17958
+Calls Faulted
+17960
+Calls Faulted Per Second
+17962
+Calls Duration
+17964
+Security Validation and Authentication Failures
+17966
+Security Validation and Authentication Failures Per Second
+17968
+Security Calls Not Authorized
+17970
+Security Calls Not Authorized Per Second
+17972
+Reliable Messaging Sessions Faulted
+17974
+Reliable Messaging Sessions Faulted Per Second
+17976
+Reliable Messaging Messages Dropped
+17978
+Reliable Messaging Messages Dropped Per Second
+17980
+Transactions Flowed
+17982
+Transactions Flowed Per Second
+17984
+CallDurationBase
+17932
+MSExchange Hygiene Cache
+17934
+Requests/sec
+17936
+Hits/sec
+17938
+Misses/sec
+17940
+Evictions/sec
+17942
+Hits/Requests Base
+17944
+Hit Rate (Hits/Requests)
+17906
+MSExchange Hygiene Classification
+17908
+Items Processed
+17910
+Scan Time Base
+17912
+Scan Time/item
+17914
+Engine Errors
+17916
+Items with Classification Detections
+17918
+Items Processed/sec
+17920
+Engine Load Time Base
+17922
+Engine Load Time/load
+17924
+Successful Scans
+17926
+Failed Scans
+17928
+Bytes Classified Base
+17930
+Bytes Classified/ms
+17880
+MSExchange Hygiene Antimalware
+17882
+Items Processed
+17884
+Scan Time Base
+17886
+Scan Time/item
+17888
+Engine Errors
+17890
+Items with Malware Detections
+17892
+Items Processed/sec
+17894
+Successful Scans
+17896
+Failed Scans
+17898
+Engine Load Time Base
+17900
+Engine Load Time/load
+17902
+Bytes Scanned Base
+17904
+Bytes Scanned/ms
+17788
+MSExchange Hygiene
+17790
+Scan Requests Submitted
+17792
+Scan Requests Submitted/sec
+17794
+Scan Requests Queued
+17796
+Scan Processes Below Configured Minimum
+17798
+Scan Request Wait Time Base
+17800
+Scan Request Wait Time/req
+17802
+Total Scan Requests Processed
+17804
+Scan Requests Processed/sec
+17806
+Scan Time Base
+17808
+Scan Time/req
+17810
+Scan Time in 99th Percentile
+17812
+Scan Time in 95th Percentile
+17814
+Scan Time in 90th Percentile
+17816
+Scan Processes Running
+17818
+Scan Process Crashes
+17820
+Scan Requests Retried
+17822
+Scan Request Timeouts
+17824
+Scan Requests Fatal Errors
+17826
+Unhealthy Antimalware engines
+17828
+Antimalware Processing Time Base
+17830
+Antimalware Processing Time/req
+17832
+Classification Processing Time Base
+17834
+Classification Processing Time/req
+17836
+Scan Requests Processing Time Base
+17838
+Scan Requests Processing Time/req
+17840
+Scan Processes Restarted
+17842
+Scan Requests Being Scanned
+17844
+Scan Requests Outstanding
+17846
+Scan Requests Bytes Scanned/sec
+17848
+Scan Requests Bytes Base
+17850
+Scan Requests Bytes/req
+17852
+Scan Requests Rejected
+17854
+Scan Requests Rejected/sec
+17856
+Scan Time Median
+17858
+Average Scan Time
+17860
+Scan Requests Processed
+17862
+Scan Detection
+17864
+Scan Detection Rate Base
+17866
+Scan Detection Rate
+17868
+Scan Errors
+17870
+Scan Error Rate Base
+17872
+Scan Error Rate
+17874
+Scan Request Errors
+17876
+Scan Request Error Ratio Base
+17878
+Scan Request Error Ratio
+17752
+APP_POOL_WAS
+17754
+Current Worker Processes
+17756
+Maximum Worker Processes
+17758
+Total Application Pool Recycles
+17760
+Current Application Pool Uptime
+17762
+Total Application Pool Uptime
+17764
+Recent Worker Process Failures
+17766
+Total Worker Process Failures
+17768
+Current Application Pool State
+17776
+Total Worker Process Startup Failures
+17778
+Total Worker Process Shutdown Failures
+17780
+Total Worker Process Ping Failures
+17782
+Time Since Last Worker Process Failure
+17786
+Total Worker Processes Created
+17746
+Power Meter
+17748
+Power
+17750
+Power Budget
+17702
+TCPIP Performance Diagnostics
+17704
+IPv4 NBLs indicated with low-resource flag
+17706
+IPv4 NBLs/sec indicated with low-resource flag
+17708
+IPv6 NBLs indicated with low-resource flag
+17710
+IPv6 NBLs/sec indicated with low-resource flag
+17712
+IPv4 NBLs indicated without prevalidation
+17714
+IPv4 NBLs/sec indicated without prevalidation
+17716
+IPv6 NBLs indicated without prevalidation
+17718
+IPv6 NBLs/sec indicated without prevalidation
+17720
+IPv4 NBLs treated as non-prevalidated
+17722
+IPv4 NBLs/sec treated as non-prevalidated
+17724
+IPv6 NBLs treated as non-prevalidated
+17726
+IPv6 NBLs/sec treated as non-prevalidated
+17728
+IPv4 outbound NBLs not processed via fast path
+17730
+IPv4 outbound NBLs/sec not processed via fast path
+17732
+IPv6 outbound NBLs not processed via fast path
+17734
+IPv6 outbound NBLs/sec not processed via fast path
+17736
+TCP inbound segments not processed via fast path
+17738
+TCP inbound segments/sec not processed via fast path
+17740
+TCP connect requests fallen off loopback fast path
+17742
+TCP connect requests/sec fallen off loopback fast path
+17744
+Denied connect or send requests in low-power mode
+17692
+Remote Desktop Connection Broker Redirector Counterset
+17694
+RPC Context
+17696
+Threads waiting for RPC Context
+17698
+Context acquisition wait time
+17700
+Connection time
+17678
+WinNAT UDP
+17680
+NumberOfSessions
+17682
+NumberOfBindings
+17684
+NumIntToExtTranslations
+17686
+NumExtToIntTranslations
+17688
+NumPacketsDropped
+17690
+NumSessionsTimedOut
+17668
+WinNAT Instance
+17670
+TCP Ports In Use
+17672
+TCP Ports Available
+17674
+UDP Ports In Use
+17676
+UDP Ports Available
+17654
+WinNAT TCP
+17656
+NumberOfSessions
+17658
+NumberOfBindings
+17660
+NumIntToExtTranslations
+17662
+NumExtToIntTranslations
+17664
+NumPacketsDropped
+17666
+NumSessionsTimedOut
+17624
+WinNAT
+17626
+Sessions/sec
+17628
+Current Session Count
+17630
+Packets/sec Internal to External
+17632
+Packets Internal to External
+17634
+Packets/sec External to Internal
+17636
+Packets External to Internal
+17638
+Dropped Packets/sec
+17640
+Dropped Packets
+17642
+Dropped ICMP error packets/sec
+17644
+Dropped ICMP error packets
+17646
+Inter-RoutingDomain Hairpinned Packets/sec
+17648
+Inter-RoutingDomain Hairpinned Packets
+17650
+Intra-RoutingDomain Hairpinned Packets/sec
+17652
+Intra-RoutingDomain Hairpinned Packets
+17610
+WinNAT ICMP
+17612
+NumberOfSessions
+17614
+NumberOfBindings
+17616
+NumIntToExtTranslations
+17618
+NumExtToIntTranslations
+17620
+NumPacketsDropped
+17622
+NumSessionsTimedOut
+17592
+HTTP Service Request Queues
+17594
+CurrentQueueSize
+17596
+MaxQueueItemAge
+17598
+ArrivalRate
+17600
+RejectionRate
+17602
+RejectedRequests
+17604
+CacheHitRate
+17572
+HTTP Service Url Groups
+17574
+BytesSentRate
+17576
+BytesReceivedRate
+17578
+BytesTransferredRate
+17580
+CurrentConnections
+17582
+MaxConnections
+17584
+ConnectionAttempts
+17586
+GetRequests
+17588
+HeadRequests
+17590
+AllRequests
+17558
+HTTP Service
+17560
+CurrentUrisCached
+17562
+TotalUrisCached
+17564
+UriCacheHits
+17566
+UriCacheMisses
+17568
+UriCacheFlushes
+17570
+TotalFlushedUris
+17498
+PowerShell Workflow
+17500
+# of failed workflow jobs
+17502
+# of failed workflow jobs/sec
+17504
+# of resumed workflow jobs
+17506
+# of resumed workflow jobs/sec
+17508
+# of running workflow jobs
+17510
+# of running workflow jobs / sec
+17512
+# of stopped workflow jobs
+17514
+# of stopped workflow jobs / sec
+17516
+# of succeeded workflow jobs
+17518
+# of succeeded workflow jobs/sec
+17520
+# of suspended workflow jobs
+17522
+# of suspended workflow jobs/sec
+17524
+# of terminated workflow jobs
+17526
+# of terminated workflow jobs / sec
+17528
+# of waiting workflow jobs
+17530
+Activity Host Manager: # of busy host processes
+17532
+Activity Host Manager: # of failed requests/sec
+17534
+Activity Host Manager: # of failed requests in queue
+17536
+Activity Host Manager: # of incoming requests/sec
+17538
+Activity Host Manager: # of pending requests in queue
+17540
+Activity Host Manager: # of created host processes
+17542
+Activity Host Manager: # of disposed host processes
+17544
+Activity Host Manager: host processes pool size
+17546
+PowerShell Remoting: # of pending requests in queue
+17548
+PowerShell Remoting: # of requests being serviced
+17550
+PowerShell Remoting: # of forced to wait requests in queue
+17552
+PowerShell Remoting: # of created connections
+17554
+PowerShell Remoting: # of disposed connections
+17556
+PowerShell Remoting: # of connections closed-reopened
+17452
+Windows Media Player Metadata
+17454
+Files Scanned/Minute
+17458
+Monitored Folder Updates/Second
+17462
+Groveler Service Routine Executions/Second
+17466
+Library Description Updates/Second
+17470
+Library Description Change Notifications/Second
+17474
+File Scanning Thread Prioirty
+17476
+Directory Change Queue Length
+17478
+Scanning State
+17480
+Dirty Directory Hit Count
+17482
+Timestamp Directory Hit Count
+17484
+AFTS Execution Time (ms)
+17486
+URL Classification Time (ms)
+17488
+Property Extraction Time (ms)
+17490
+Art Extraction Time (ms)
+17492
+Reorganize Time (ms)
+17494
+Commit Time (ms)
+17496
+Normalization Time (ms)
+17432
+RemoteFX Graphics
+17434
+Input Frames/Second
+17436
+Graphics Compression ratio
+17438
+Output Frames/Second
+17440
+Frames Skipped/Second - Insufficient Client Resources
+17442
+Frames Skipped/Second - Insufficient Network Resources
+17444
+Frames Skipped/Second - Insufficient Server Resources
+17446
+Frame Quality
+17448
+Average Encoding Time
+17450
+Source Frames/Second
+17382
+RemoteFX Network
+17384
+Base TCP RTT
+17386
+Current TCP RTT
+17388
+Current TCP Bandwidth
+17390
+Total Received Rate
+17392
+TCP Received Rate
+17394
+UDP Received Rate
+17396
+UDP Packets Received/sec
+17398
+Total Sent Rate
+17400
+TCP Sent Rate
+17402
+UDP Sent Rate
+17404
+UDP Packets Sent/sec
+17406
+Sent Rate P0
+17408
+Sent Rate P1
+17410
+Sent Rate P2
+17412
+Sent Rate P3
+17414
+Loss Rate
+17416
+Retransmission Rate
+17418
+FEC Rate
+17422
+Base UDP RTT
+17424
+Current UDP RTT
+17426
+Current UDP Bandwidth
+17428
+Total Sent Bytes
+17430
+Total Received Bytes
+17378
+MSExchange Hygiene Updates Connectivity
+17380
+Update Path Connection Failure
+17372
+MSExchange Hygiene Updates Pipeline
+17374
+Pending Operations
+17376
+Timeout
+17360
+MSExchange Hygiene Updates Engine
+17362
+Updates Attempted
+17364
+Updates Successful
+17366
+No Updates Available
+17368
+Total Failed Updates
+17370
+Consecutive Failed Updates
+17268
+SMB Server Shares
+17270
+Received Bytes/sec
+17272
+Requests/sec
+17274
+Tree Connect Count
+17276
+Current Open File Count
+17278
+Sent Bytes/sec
+17280
+Transferred Bytes/sec
+17282
+Current Pending Requests
+17284
+Avg. sec/Request
+17288
+Write Requests/sec
+17290
+Avg. sec/Write
+17294
+Write Bytes/sec
+17296
+Read Requests/sec
+17298
+Avg. sec/Read
+17302
+Read Bytes/sec
+17304
+Total File Open Count
+17306
+Files Opened/sec
+17308
+Current Durable Open File Count
+17310
+Total Durable Handle Reopen Count
+17312
+Total Failed Durable Handle Reopen Count
+17314
+% Resilient Handles
+17318
+Total Resilient Handle Reopen Count
+17320
+Total Failed Resilient Handle Reopen Count
+17322
+% Persistent Handles
+17326
+Total Persistent Handle Reopen Count
+17328
+Total Failed Persistent Handle Reopen Count
+17330
+Metadata Requests/sec
+17332
+Avg. sec/Data Request
+17336
+Avg. Data Bytes/Request
+17340
+Avg. Bytes/Read
+17344
+Avg. Bytes/Write
+17348
+Avg. Read Queue Length
+17350
+Avg. Write Queue Length
+17352
+Avg. Data Queue Length
+17354
+Data Bytes/sec
+17356
+Data Requests/sec
+17358
+Current Data Queue Length
+17176
+SMB Server Sessions
+17178
+Received Bytes/sec
+17180
+Requests/sec
+17182
+Tree Connect Count
+17184
+Current Open File Count
+17186
+Sent Bytes/sec
+17188
+Transferred Bytes/sec
+17190
+Current Pending Requests
+17192
+Avg. sec/Request
+17196
+Write Requests/sec
+17198
+Avg. sec/Write
+17202
+Write Bytes/sec
+17204
+Read Requests/sec
+17206
+Avg. sec/Read
+17210
+Read Bytes/sec
+17212
+Total File Open Count
+17214
+Files Opened/sec
+17216
+Current Durable Open File Count
+17218
+Total Durable Handle Reopen Count
+17220
+Total Failed Durable Handle Reopen Count
+17222
+% Resilient Handles
+17226
+Total Resilient Handle Reopen Count
+17228
+Total Failed Resilient Handle Reopen Count
+17230
+% Persistent Handles
+17234
+Total Persistent Handle Reopen Count
+17236
+Total Failed Persistent Handle Reopen Count
+17238
+Metadata Requests/sec
+17240
+Avg. sec/Data Request
+17244
+Avg. Data Bytes/Request
+17248
+Avg. Bytes/Read
+17252
+Avg. Bytes/Write
+17256
+Avg. Read Queue Length
+17258
+Avg. Write Queue Length
+17260
+Avg. Data Queue Length
+17262
+Data Bytes/sec
+17264
+Data Requests/sec
+17266
+Current Data Queue Length
+17162
+Netlogon
+17164
+Semaphore Waiters
+17166
+Semaphore Holders
+17168
+Semaphore Acquires
+17170
+Semaphore Timeouts
+17172
+Average Semaphore Hold Time
+17174
+Semaphore Hold Time Base
+17148
+XHCI Interrupter
+17150
+Interrupts/sec
+17152
+DPCs/sec
+17154
+Events processed/DPC
+17156
+DPC count
+17158
+EventRingFullCount
+17160
+DpcRequeueCount
+17132
+XHCI TransferRing
+17134
+Transfers/sec
+17136
+Failed Transfer Count
+17138
+Bytes/Sec
+17140
+Isoch TD/sec
+17142
+Isoch TD Failures/sec
+17144
+Missed Service Error Count
+17146
+Underrun Overrun count
+17122
+XHCI CommonBuffer
+17124
+PagesTotal
+17126
+PagesInUse
+17128
+AllocationCount
+17130
+FreeCount
+17110
+Physical Network Interface Card Activity
+17112
+Device Power State
+17114
+% Time Suspended (Instantaneous)
+17116
+% Time Suspended (Lifetime)
+17118
+Low Power Transitions (Lifetime)
+17058
+Per Processor Network Interface Card Activity
+17060
+DPCs Queued/sec
+17062
+Interrupts/sec
+17064
+Receive Indications/sec
+17066
+Return Packet Calls/sec
+17068
+Passive Return Packet Calls/sec
+17070
+Received Packets/sec
+17072
+Returned Packets/sec
+17074
+Passive Returned Packets/sec
+17076
+DPCs Queued on Other CPUs/sec
+17078
+Send Request Calls/sec
+17080
+Passive Send Request Calls/sec
+17082
+Send Complete Calls/sec
+17084
+Sent Packets/sec
+17086
+Passive Sent Packets/sec
+17088
+Sent Complete Packets/sec
+17090
+Build Scatter Gather List Calls/sec
+17092
+RSS Indirection Table Change Calls/sec
+17094
+Low Resource Receive Indications/sec
+17096
+Low Resource Received Packets/sec
+17098
+Tcp Offload Receive Indications/sec
+17100
+Tcp Offload Send Request Calls/sec
+17102
+Tcp Offload Receive bytes/sec
+17104
+Tcp Offload Send bytes/sec
+17106
+DPCs Deferred/sec
+17108
+Packets Coalesced/sec
+17030
+Per Processor Network Activity Cycles
+17032
+Interrupt DPC Cycles/sec
+17034
+Interrupt Cycles/sec
+17036
+NDIS Receive Indication Cycles/sec
+17038
+Stack Receive Indication Cycles/sec
+17040
+NDIS Return Packet Cycles/sec
+17042
+Miniport Return Packet Cycles/sec
+17044
+NDIS Send Cycles/sec
+17046
+Miniport Send Cycles/sec
+17048
+NDIS Send Complete Cycles/sec
+17050
+Build Scatter Gather Cycles/sec
+17052
+Miniport RSS Indirection Table Change Cycles
+17054
+Stack Send Complete Cycles/sec
+17056
+Interrupt DPC Latency Cycles/sec
+17008
+RDMA Activity
+17010
+RDMA Initiated Connections
+17012
+RDMA Accepted Connections
+17014
+RDMA Failed Connection Attempts
+17016
+RDMA Connection Errors
+17018
+RDMA Active Connections
+17020
+RDMA Completion Queue Errors
+17022
+RDMA Inbound Bytes/sec
+17024
+RDMA Outbound Bytes/sec
+17026
+RDMA Inbound Frames/sec
+17028
+RDMA Outbound Frames/sec
+17002
+FileSystem Disk Activity
+17004
+FileSystem Bytes Read
+17006
+FileSystem Bytes Written
+16990
+Event Tracing for Windows Session
+16992
+Buffer Memory Usage -- Paged Pool
+16994
+Buffer Memory Usage -- Non-Paged Pool
+16996
+Events Logged per sec
+16998
+Events Lost
+17000
+Number of Real-Time Consumers
+16924
+Processor Information
+16926
+% Processor Time
+16928
+% User Time
+16930
+% Privileged Time
+16932
+Interrupts/sec
+16934
+% DPC Time
+16936
+% Interrupt Time
+16938
+DPCs Queued/sec
+16940
+DPC Rate
+16942
+% Idle Time
+16944
+% C1 Time
+16946
+% C2 Time
+16948
+% C3 Time
+16950
+C1 Transitions/sec
+16952
+C2 Transitions/sec
+16954
+C3 Transitions/sec
+16956
+% Priority Time
+16958
+Parking Status
+16960
+Processor Frequency
+16962
+% of Maximum Frequency
+16964
+Processor State Flags
+16966
+Clock Interrupts/sec
+16968
+Average Idle Time
+16972
+Idle Break Events/sec
+16974
+% Processor Performance
+16978
+% Processor Utility
+16982
+% Privileged Utility
+16986
+% Performance Limit
+16988
+Performance Limit Flags
+16916
+Thermal Zone Information
+16918
+Temperature
+16920
+% Passive Limit
+16922
+Throttle Reasons
+16902
+Event Tracing for Windows
+16904
+Total Number of Distinct Enabled Providers
+16906
+Total Number of Distinct Pre-Enabled Providers
+16908
+Total Number of Distinct Disabled Providers
+16910
+Total Number of Active Sessions
+16912
+Total Memory Usage --- Paged Pool
+16914
+Total Memory Usage --- Non-Paged Pool
+16816
+Synchronization
+16818
+Spinlock Acquires/sec
+16820
+Spinlock Contentions/sec
+16822
+Spinlock Spins/sec
+16824
+IPI Send Broadcast Requests/sec
+16826
+IPI Send Routine Requests/sec
+16828
+IPI Send Software Interrupts/sec
+16830
+Exec. Resource Total Initialize/sec
+16832
+Exec. Resource Total Re-Initialize/sec
+16834
+Exec. Resource Total Delete/sec
+16836
+Exec. Resource Total Acquires/sec
+16838
+Exec. Resource Total Contentions/sec
+16840
+Exec. Resource Total Exclusive Releases/sec
+16842
+Exec. Resource Total Shared Releases/sec
+16844
+Exec. Resource Total Conv. Exclusive To Shared/sec
+16846
+Exec. Resource Attempts AcqExclLite/sec
+16848
+Exec. Resource Acquires AcqExclLite/sec
+16850
+Exec. Resource Recursive Excl. Acquires AcqExclLite/sec
+16852
+Exec. Resource Contention AcqExclLite/sec
+16854
+Exec. Resource no-Waits AcqExclLite/sec
+16856
+Exec. Resource Attempts AcqShrdLite/sec
+16858
+Exec. Resource Recursive Excl. Acquires AcqShrdLite/sec
+16860
+Exec. Resource Acquires AcqShrdLite/sec
+16862
+Exec. Resource Recursive Sh. Acquires AcqShrdLite/sec
+16864
+Exec. Resource Contention AcqShrdLite/sec
+16866
+Exec. Resource no-Waits AcqShrdLite/sec
+16868
+Exec. Resource Attempts AcqShrdStarveExcl/sec
+16870
+Exec. Resource Recursive Excl. Acquires AcqShrdStarveExcl/sec
+16872
+Exec. Resource Acquires AcqShrdStarveExcl/sec
+16874
+Exec. Resource Recursive Sh. Acquires AcqShrdStarveExcl/sec
+16876
+Exec. Resource Contention AcqShrdStarveExcl/sec
+16878
+Exec. Resource no-Waits AcqShrdStarveExcl/sec
+16880
+Exec. Resource Attempts AcqShrdWaitForExcl/sec
+16882
+Exec. Resource Recursive Excl. Acquires AcqShrdWaitForExcl/sec
+16884
+Exec. Resource Acquires AcqShrdWaitForExcl/sec
+16886
+Exec. Resource Recursive Sh. Acquires AcqShrdWaitForExcl/sec
+16888
+Exec. Resource Contention AcqShrdWaitForExcl/sec
+16890
+Exec. Resource no-Waits AcqShrdWaitForExcl/sec
+16892
+Exec. Resource Set Owner Pointer Exclusive/sec
+16894
+Exec. Resource Set Owner Pointer Shared (New Owner)/sec
+16896
+Exec. Resource Set Owner Pointer Shared (Existing Owner)/sec
+16898
+Exec. Resource Boost Excl. Owner/sec
+16900
+Exec. Resource Boost Shared Owners/sec
+16730
+SynchronizationNuma
+16732
+Spinlock Acquires/sec
+16734
+Spinlock Contentions/sec
+16736
+Spinlock Spins/sec
+16738
+IPI Send Broadcast Requests/sec
+16740
+IPI Send Routine Requests/sec
+16742
+IPI Send Software Interrupts/sec
+16744
+Exec. Resource Total Initialize/sec
+16746
+Exec. Resource Total Re-Initialize/sec
+16748
+Exec. Resource Total Delete/sec
+16750
+Exec. Resource Total Acquires/sec
+16752
+Exec. Resource Total Contentions/sec
+16754
+Exec. Resource Total Exclusive Releases/sec
+16756
+Exec. Resource Total Shared Releases/sec
+16758
+Exec. Resource Total Conv. Exclusive To Shared/sec
+16760
+Exec. Resource Attempts AcqExclLite/sec
+16762
+Exec. Resource Acquires AcqExclLite/sec
+16764
+Exec. Resource Recursive Excl. Acquires AcqExclLite/sec
+16766
+Exec. Resource Contention AcqExclLite/sec
+16768
+Exec. Resource no-Waits AcqExclLite/sec
+16770
+Exec. Resource Attempts AcqShrdLite/sec
+16772
+Exec. Resource Recursive Excl. Acquires AcqShrdLite/sec
+16774
+Exec. Resource Acquires AcqShrdLite/sec
+16776
+Exec. Resource Recursive Sh. Acquires AcqShrdLite/sec
+16778
+Exec. Resource Contention AcqShrdLite/sec
+16780
+Exec. Resource no-Waits AcqShrdLite/sec
+16782
+Exec. Resource Attempts AcqShrdStarveExcl/sec
+16784
+Exec. Resource Recursive Excl. Acquires AcqShrdStarveExcl/sec
+16786
+Exec. Resource Acquires AcqShrdStarveExcl/sec
+16788
+Exec. Resource Recursive Sh. Acquires AcqShrdStarveExcl/sec
+16790
+Exec. Resource Contention AcqShrdStarveExcl/sec
+16792
+Exec. Resource no-Waits AcqShrdStarveExcl/sec
+16794
+Exec. Resource Attempts AcqShrdWaitForExcl/sec
+16796
+Exec. Resource Recursive Excl. Acquires AcqShrdWaitForExcl/sec
+16798
+Exec. Resource Acquires AcqShrdWaitForExcl/sec
+16800
+Exec. Resource Recursive Sh. Acquires AcqShrdWaitForExcl/sec
+16802
+Exec. Resource Contention AcqShrdWaitForExcl/sec
+16804
+Exec. Resource no-Waits AcqShrdWaitForExcl/sec
+16806
+Exec. Resource Set Owner Pointer Exclusive/sec
+16808
+Exec. Resource Set Owner Pointer Shared (New Owner)/sec
+16810
+Exec. Resource Set Owner Pointer Shared (Existing Owner)/sec
+16812
+Exec. Resource Boost Excl. Owner/sec
+16814
+Exec. Resource Boost Shared Owners/sec
+16680
+SMB Client Shares
+16682
+Read Bytes/sec
+16684
+Write Bytes/sec
+16686
+Read Requests/sec
+16688
+Write Requests/sec
+16690
+Avg. Bytes/Read
+16694
+Avg. Bytes/Write
+16698
+Avg. sec/Read
+16702
+Avg. sec/Write
+16706
+Data Bytes/sec
+16708
+Data Requests/sec
+16710
+Avg. Data Bytes/Request
+16714
+Avg. sec/Data Request
+16718
+Current Data Queue Length
+16720
+Avg. Read Queue Length
+16722
+Avg. Write Queue Length
+16724
+Avg. Data Queue Length
+16726
+Metadata Requests/sec
+16728
+Credit Stalls/sec
+16666
+Network QoS Policy
+16668
+Packets transmitted
+16670
+Packets transmitted/sec
+16672
+Bytes transmitted
+16674
+Bytes transmitted/sec
+16676
+Packets dropped
+16678
+Packets dropped/sec
+16654
+DFS Namespace Service API Requests
+16656
+Requests Processed
+16658
+Avg. Response Time
+16660
+Avg. Response Time Base
+16662
+Requests Failed
+16664
+Requests Processed /sec
+16642
+DFS Namespace Service Referrals
+16644
+Requests Processed
+16646
+Avg. Response Time
+16648
+Avg. Response Time Base
+16650
+Requests Failed
+16652
+Requests Processed /sec
+16638
+DFS Namespace
+16640
+Folder Count
+16622
+WSMan Quota Statistics
+16624
+Total Requests/Second
+16626
+User Quota Violations/Second
+16628
+System Quota Violations/Second
+16630
+Active Shells
+16632
+Active Operations
+16634
+Active Users
+16636
+Process ID
+16610
+RAS
+16612
+Total Clients
+16614
+Max Clients
+16616
+Failed Authentications
+16618
+Bytes Received By Disconnected Clients
+16620
+Bytes Transmitted By Disconnected Clients
+16592
+MSMQ Session
+16594
+Incoming Messages/sec
+16596
+Outgoing Messages/sec
+16598
+Incoming Bytes/sec
+16600
+Outgoing Bytes/sec
+16602
+Incoming Messages
+16604
+Outgoing Messages
+16606
+Incoming Bytes
+16608
+Outgoing Bytes
+16582
+MSMQ Queue
+16584
+Bytes in Journal Queue
+16586
+Bytes in Queue
+16588
+Messages in Journal Queue
+16590
+Messages in Queue
+16572
+MSMQ Outgoing Multicast Session
+16574
+Outgoing Multicast Messages/sec
+16576
+Outgoing Multicast Bytes/sec
+16578
+Outgoing Multicast Messages
+16580
+Outgoing Multicast Bytes
+16548
+MSMQ Service
+16550
+Incoming Messages/sec
+16552
+Incoming Multicast Sessions
+16554
+IP Sessions
+16556
+MSMQ Incoming Messages
+16558
+MSMQ Outgoing Messages
+16560
+Outgoing HTTP Sessions
+16562
+Outgoing Messages/sec
+16564
+Outgoing Multicast Sessions
+16566
+Sessions
+16568
+Total bytes in all queues
+16570
+Total messages in all queues
+16538
+MSMQ Incoming HTTP Traffic
+16540
+Incoming HTTP Messages/sec
+16542
+Incoming HTTP Bytes/sec
+16544
+Incoming HTTP Messages
+16546
+Incoming HTTP Bytes
+16528
+MSMQ Incoming Multicast Session
+16530
+Incoming Multicast Messages/sec
+16532
+Incoming Multicast Bytes/sec
+16534
+Incoming Multicast Messages
+16536
+Incoming Multicast Bytes
+16518
+MSMQ Outgoing HTTP Session
+16520
+Outgoing HTTP Messages/sec
+16522
+Outgoing HTTP Bytes/sec
+16524
+Outgoing HTTP Messages
+16526
+Outgoing HTTP Bytes
+

--- a/pkg/collector/corechecks/system/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc_windows.go
@@ -18,8 +18,8 @@ const winprocCheckName = "winproc"
 
 type processChk struct {
 	core.CheckBase
-	numprocs *pdhutil.PdhCounterSet
-	pql      *pdhutil.PdhCounterSet
+	numprocs *pdhutil.PdhSingleInstanceCounterSet
+	pql      *pdhutil.PdhSingleInstanceCounterSet
 }
 
 // Run executes the check
@@ -29,8 +29,8 @@ func (c *processChk) Run() error {
 		return err
 	}
 
-	procQueueLength, _ := c.pql.GetSingleValue()
-	procCount, _ := c.numprocs.GetSingleValue()
+	procQueueLength, _ := c.pql.GetValue()
+	procCount, _ := c.numprocs.GetValue()
 
 	sender.Gauge("system.proc.queue_length", procQueueLength, "", nil)
 	sender.Gauge("system.proc.count", procCount, "", nil)
@@ -45,11 +45,11 @@ func (c *processChk) Configure(data integration.Data, initConfig integration.Dat
 		return err
 	}
 
-	c.numprocs, err = pdhutil.GetCounterSet("System", "Processes", "", nil)
+	c.numprocs, err = pdhutil.GetSingleInstanceCounter("System", "Processes")
 	if err != nil {
 		return err
 	}
-	c.pql, err = pdhutil.GetCounterSet("System", "Processor Queue Length", "", nil)
+	c.pql, err = pdhutil.GetSingleInstanceCounter("System", "Processor Queue Length")
 
 	return err
 }

--- a/pkg/collector/corechecks/system/winproc_windows_test.go
+++ b/pkg/collector/corechecks/system/winproc_windows_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+// +build windows
+
+package system
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
+)
+
+func TestWinprocCheckWindows(t *testing.T) {
+
+	pdhtest.SetupTesting("testfiles\\counter_indexes_en-us.txt", "testfiles\\allcounters_en-us.txt")
+	pdhtest.SetQueryReturnValue("\\\\.\\System\\Processor Queue Length", 2.0)
+	pdhtest.SetQueryReturnValue("\\\\.\\System\\Processes", 32.0)
+
+	winprocCheck := new(processChk)
+	winprocCheck.Configure(nil, nil)
+
+	mock := mocksender.NewMockSender(winprocCheck.ID())
+
+	mock.On("Gauge", "system.proc.queue_length", 2.0, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.proc.count", 32.0, "", []string(nil)).Return().Times(1)
+	mock.On("Commit").Return().Times(1)
+	winprocCheck.Run()
+
+	mock.AssertExpectations(t)
+	mock.AssertNumberOfCalls(t, "Gauge", 2)
+	mock.AssertNumberOfCalls(t, "Commit", 1)
+
+}

--- a/pkg/logs/pipeline/registry.json
+++ b/pkg/logs/pipeline/registry.json
@@ -1,0 +1,1 @@
+{"Version":2,"Registry":{}}

--- a/pkg/logs/pipeline/registry.json
+++ b/pkg/logs/pipeline/registry.json
@@ -1,1 +1,0 @@
-{"Version":2,"Registry":{}}

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -215,3 +215,9 @@ func PdhCloseQuery(hQuery PDH_HQUERY) uint32 {
 
 	return uint32(ret)
 }
+
+// PdhRemoveCounter removes a counter from a query
+func PdhRemoveCounter(hCounter PDH_HCOUNTER) uint32 {
+	ret, _, _ := procPdhRemoveCounter.Call(uintptr(hCounter))
+	return uint32(ret)
+}

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -13,16 +13,18 @@ import (
 )
 
 // For testing
-var pfnMakeCounterSetInstances = makeCounterSetIndexes
-var pfnPdhOpenQuery = PdhOpenQuery
-var pfnPdhAddCounter = PdhAddCounter
-var pfnPdhCollectQueryData = PdhCollectQueryData
-var pfnPdhEnumObjectItems = pdhEnumObjectItems
-var pfnPdhRemoveCounter = PdhRemoveCounter
-var pfnPdhLookupPerfNameByIndex = pdhLookupPerfNameByIndex
-var pfnPdhGetFormattedCounterValueFloat = pdhGetFormattedCounterValueFloat
-var pfnPdhCloseQuery = PdhCloseQuery
-var pfnPdhMakeCounterPath = pdhMakeCounterPath
+var (
+	pfnMakeCounterSetInstances          = makeCounterSetIndexes
+	pfnPdhOpenQuery                     = PdhOpenQuery
+	pfnPdhAddCounter                    = PdhAddCounter
+	pfnPdhCollectQueryData              = PdhCollectQueryData
+	pfnPdhEnumObjectItems               = pdhEnumObjectItems
+	pfnPdhRemoveCounter                 = PdhRemoveCounter
+	pfnPdhLookupPerfNameByIndex         = pdhLookupPerfNameByIndex
+	pfnPdhGetFormattedCounterValueFloat = pdhGetFormattedCounterValueFloat
+	pfnPdhCloseQuery                    = PdhCloseQuery
+	pfnPdhMakeCounterPath               = pdhMakeCounterPath
+)
 
 // CounterInstanceVerify is a callback function called by GetCounterSet for each
 // instance of the counter.  Implementation should return true if that instance
@@ -53,13 +55,13 @@ type PdhMultiInstanceCounterSet struct {
 }
 
 // Initialize initializes a counter set object
-func (p *PdhCounterSet) Initialize(className string) (err error) {
+func (p *PdhCounterSet) Initialize(className string) error {
 
 	// the counter index list may be > 1, but for class name, only take the first
 	// one.  If not present at all, try the english counter name
 	ndxlist, err := getCounterIndexList(className)
 	if err != nil {
-		return
+		return err
 	}
 	if ndxlist == nil || len(ndxlist) == 0 {
 		log.Warnf("Didn't find counter index for class %s, attempting english counter", className)
@@ -184,7 +186,7 @@ func (p *PdhMultiInstanceCounterSet) MakeInstanceList() error {
 		var hc PDH_HCOUNTER
 		winerror := pfnPdhAddCounter(p.query, path, uintptr(0), &hc)
 		if ERROR_SUCCESS != winerror {
-			log.Debugf("Failed to add counter path%s", path)
+			log.Debugf("Failed to add counter path %s", path)
 			continue
 		}
 		log.Debugf("Adding missing counter instance %s", inst)

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -203,7 +203,7 @@ func (p *PdhMultiInstanceCounterSet) RemoveInvalidInstance(badInstance string) {
 	hc := p.countermap[badInstance]
 	if hc != PDH_HCOUNTER(0) {
 		log.Debugf("Removing non-existent counter instance %s", badInstance)
-		PdhRemoveCounter(hc)
+		pfnPdhRemoveCounter(hc)
 		delete(p.countermap, badInstance)
 	} else {
 		log.Debugf("Instance handle not found")
@@ -262,7 +262,8 @@ func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, 
 	var removeList []string
 	pfnPdhCollectQueryData(p.query)
 	for inst, hcounter := range p.countermap {
-		values[inst], err = pfnPdhGetFormattedCounterValueFloat(hcounter)
+		var retval float64
+		retval, err = pfnPdhGetFormattedCounterValueFloat(hcounter)
 		if err != nil {
 			switch err.(type) {
 			case *ErrPdhInvalidInstance:
@@ -275,6 +276,7 @@ func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, 
 				return
 			}
 		}
+		values[inst] = retval
 	}
 	for _, inst := range removeList {
 		p.RemoveInvalidInstance(inst)
@@ -290,7 +292,7 @@ func (p *PdhSingleInstanceCounterSet) GetValue() (val float64, err error) {
 		return 0, fmt.Errorf("Not a single-value counter")
 	}
 	pfnPdhCollectQueryData(p.query)
-	return pdhGetFormattedCounterValueFloat(p.singleCounter)
+	return pfnPdhGetFormattedCounterValueFloat(p.singleCounter)
 
 }
 

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -8,17 +8,8 @@ package pdhutil
 
 import (
 	"fmt"
-	"strconv"
-	"syscall"
-	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/winutil"
-	"golang.org/x/sys/windows"
-)
-
-var (
-	counterToIndex map[string][]int
 )
 
 // CounterInstanceVerify is a callback function called by GetCounterSet for each
@@ -28,60 +19,32 @@ type CounterInstanceVerify func(string) bool
 
 // PdhCounterSet is the object which represents a pdh counter set.
 type PdhCounterSet struct {
-	className     string
-	counterName   string
-	query         PDH_HQUERY
-	countermap    map[string]PDH_HCOUNTER // map instance name to counter handle
+	className string
+	query     PDH_HQUERY
+
+	counterName string
+}
+
+type PdhSingleInstanceCounterSet struct {
+	PdhCounterSet
 	singleCounter PDH_HCOUNTER
 }
 
-const singleInstanceKey = "_singleInstance_"
-
-func makeCounterSetIndexes() error {
-	counterToIndex = make(map[string][]int)
-
-	bufferIncrement := uint32(1024)
-	bufferSize := bufferIncrement
-	var counterlist []uint16
-	for {
-		var regtype uint32
-		counterlist = make([]uint16, bufferSize)
-		var sz uint32
-		sz = bufferSize
-		regerr := windows.RegQueryValueEx(syscall.HKEY_PERFORMANCE_DATA,
-			syscall.StringToUTF16Ptr("Counter 009"),
-			nil, // reserved
-			&regtype,
-			(*byte)(unsafe.Pointer(&counterlist[0])),
-			&sz)
-		if regerr == error(syscall.ERROR_MORE_DATA) {
-			// buffer's not big enough
-			bufferSize += bufferIncrement
-			continue
-		} else if regerr != nil {
-			return regerr
-		}
-		break
-	}
-	clist := winutil.ConvertWindowsStringList(counterlist)
-	for i := 0; (i + 1) < len(clist); i += 2 {
-		ndx, _ := strconv.Atoi(clist[i])
-		counterToIndex[clist[i+1]] = append(counterToIndex[clist[i+1]], ndx)
-	}
-	return nil
+type PdhMultiInstanceCounterSet struct {
+	PdhCounterSet
+	requestedCounterName string
+	requestedInstances   map[string]bool
+	countermap           map[string]PDH_HCOUNTER // map instance name to counter handle
+	verifyfn             CounterInstanceVerify
 }
 
-// GetCounterSet returns an initialized PDH counter set.
-func GetCounterSet(className string, counterName string, instanceName string, verifyfn CounterInstanceVerify) (*PdhCounterSet, error) {
-	var p PdhCounterSet
-	p.countermap = make(map[string]PDH_HCOUNTER)
-	var err error
+func (p *PdhCounterSet) Initialize(className string) (err error) {
 
 	// the counter index list may be > 1, but for class name, only take the first
 	// one.  If not present at all, try the english counter name
 	ndxlist, err := getCounterIndexList(className)
 	if err != nil {
-		return nil, err
+		return
 	}
 	if ndxlist == nil || len(ndxlist) == 0 {
 		log.Warnf("Didn't find counter index for class %s, attempting english counter", className)
@@ -93,7 +56,7 @@ func GetCounterSet(className string, counterName string, instanceName string, ve
 		ndx := ndxlist[0]
 		p.className, err = pdhLookupPerfNameByIndex(ndx)
 		if err != nil {
-			return nil, fmt.Errorf("Class name not found: %s", counterName)
+			return fmt.Errorf("Class name not found: %s", className)
 		}
 		log.Debugf("Found class name for %s %s", className, p.className)
 	}
@@ -101,61 +64,129 @@ func GetCounterSet(className string, counterName string, instanceName string, ve
 	winerror := PdhOpenQuery(uintptr(0), uintptr(0), &p.query)
 	if ERROR_SUCCESS != winerror {
 		err = fmt.Errorf("Failed to open PDH query handle %d", winerror)
+		return err
+	}
+	return nil
+}
+func GetSingleInstanceCounter(className, counterName string) (*PdhSingleInstanceCounterSet, error) {
+	var p PdhSingleInstanceCounterSet
+	if err := p.Initialize(className); err != nil {
 		return nil, err
 	}
+	// check to make sure this is really a single instance counter
 	allcounters, instances, err := pdhEnumObjectItems(p.className)
+	if len(instances) > 0 {
+		return nil, fmt.Errorf("Requested counter is not single-instance: %s", p.className)
+	}
+	path, err := p.MakeCounterPath("", counterName, "", allcounters)
 	if err != nil {
 		return nil, err
 	}
-	if instanceName == "" && len(instances) > 0 {
-		// asked for all instances of this class
-		for _, inst := range instances {
-			if verifyfn != nil {
-				if verifyfn(inst) == false {
-					// verify function said not interested in this instance, move on
-					continue
-				}
-			}
-			path, err := p.MakeCounterPath("", counterName, inst, allcounters)
-			if err != nil {
-				continue
-			}
-			var hc PDH_HCOUNTER
-			winerror = PdhAddCounter(p.query, path, uintptr(0), &hc)
-			if ERROR_SUCCESS != winerror {
-				continue
-			}
-			p.countermap[inst] = hc
-		}
-	} else {
-		if instanceName != "" {
-			// they asked for specific instance
-			if len(instances) <= 0 {
-				return nil, fmt.Errorf("Requested instance of sigle instance counter")
-			}
-			found := false
-			for _, inst := range instances {
-				if inst == instanceName {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return nil, fmt.Errorf("Didn't find instance name %s", instanceName)
-			}
-		}
-		path, err := p.MakeCounterPath("", counterName, instanceName, allcounters)
-		if err != nil {
-			return nil, err
-		}
-		winerror = PdhAddCounter(p.query, path, uintptr(0), &p.singleCounter)
-		if ERROR_SUCCESS != winerror {
-			return nil, fmt.Errorf("Failed to add single counter %d", winerror)
-		}
+	winerror := PdhAddCounter(p.query, path, uintptr(0), &p.singleCounter)
+	if ERROR_SUCCESS != winerror {
+		return nil, fmt.Errorf("Failed to add single counter %d", winerror)
 	}
+
 	// do the initial collect now
 	PdhCollectQueryData(p.query)
 	return &p, nil
+}
+
+func GetMultiInstanceCounter(className, counterName string, requestedInstances *[]string, verifyfn CounterInstanceVerify) (*PdhMultiInstanceCounterSet, error) {
+	var p PdhMultiInstanceCounterSet
+	if err := p.Initialize(className); err != nil {
+		return nil, err
+	}
+	p.countermap = make(map[string]PDH_HCOUNTER)
+	p.verifyfn = verifyfn
+	p.requestedCounterName = counterName
+
+	// check to make sure this is really a single instance counter
+	_, instances, err := pdhEnumObjectItems(p.className)
+	if len(instances) <= 0 {
+		return nil, fmt.Errorf("Requested counter is a single-instance: %s", p.className)
+	}
+	// save the requested instances
+	if requestedInstances != nil && len(*requestedInstances) > 0 {
+		p.requestedInstances = make(map[string]bool)
+		for _, inst := range *requestedInstances {
+			p.requestedInstances[inst] = true
+		}
+	}
+	if err = p.MakeInstanceList(); err != nil {
+		return nil, err
+	}
+	return &p, nil
+
+}
+
+func (p *PdhMultiInstanceCounterSet) MakeInstanceList() error {
+	allcounters, instances, err := pdhEnumObjectItems(p.className)
+	if err != nil {
+		return err
+	}
+	var instToMake []string
+	for _, actualInstance := range instances {
+		// if we have a list of requested instances, walk it, and make sure
+		// they're here.  If not, add them to the list of instances to make
+		if p.requestedInstances != nil {
+			// if it's not in the requestedInstances, don't bother
+			if !p.requestedInstances[actualInstance] {
+				continue
+			}
+			// ok.  it was requested.  If it's not in our map
+			// of counters, we have to add it
+			if p.countermap[actualInstance] != PDH_HCOUNTER(0) {
+				log.Debugf("Adding requested instance %s", actualInstance)
+				instToMake = append(instToMake, actualInstance)
+			}
+		} else {
+			// wanted all the instances.  Make sure all of the instances
+			// are present
+			if p.countermap[actualInstance] == PDH_HCOUNTER(0) {
+				instToMake = append(instToMake, actualInstance)
+			}
+		}
+	}
+	added := false
+	for _, inst := range instToMake {
+		if p.verifyfn != nil {
+			if p.verifyfn(inst) == false {
+				// not interested, moving on
+				continue
+			}
+		}
+		path, err := p.MakeCounterPath("", p.requestedCounterName, inst, allcounters)
+		if err != nil {
+			log.Debugf("Failed tomake counter path %s %s", p.counterName, inst)
+			continue
+		}
+		var hc PDH_HCOUNTER
+		winerror := PdhAddCounter(p.query, path, uintptr(0), &hc)
+		if ERROR_SUCCESS != winerror {
+			log.Debugf("Failed to add counter path%s", path)
+			continue
+		}
+		log.Debugf("Adding missing counter instance %s", inst)
+		p.countermap[inst] = hc
+		added = true
+	}
+	if added {
+		// do the initial collect now
+		PdhCollectQueryData(p.query)
+	}
+	return nil
+}
+
+func (p *PdhMultiInstanceCounterSet) RemoveInvalidInstance(badInstance string) {
+	hc := p.countermap[badInstance]
+	if hc != PDH_HCOUNTER(0) {
+		log.Debugf("Removing non-existent counter instance %s", badInstance)
+		PdhRemoveCounter(hc)
+		delete(p.countermap, badInstance)
+	} else {
+		log.Debugf("Instance handle not found")
+	}
 }
 
 // MakeCounterPath creates a counter path from the counter instance and
@@ -204,33 +235,42 @@ func (p *PdhCounterSet) MakeCounterPath(machine, counterName, instanceName strin
 }
 
 // GetAllValues returns the data associated with each instance in a query.
-func (p *PdhCounterSet) GetAllValues() (values map[string]float64, err error) {
+func (p *PdhMultiInstanceCounterSet) GetAllValues() (values map[string]float64, err error) {
 	values = make(map[string]float64)
 	err = nil
+	var removeList []string
 	PdhCollectQueryData(p.query)
-	if p.singleCounter != PDH_HCOUNTER(0) {
-		values[singleInstanceKey], _ = pdhGetFormattedCounterValueFloat(p.singleCounter)
-		return
-	}
 	for inst, hcounter := range p.countermap {
 		values[inst], err = pdhGetFormattedCounterValueFloat(hcounter)
 		if err != nil {
-			return
+			switch err.(type) {
+			case *ErrPdhInvalidInstance:
+				removeList = append(removeList, inst)
+				log.Debugf("Got invalid instance for %s %s", p.requestedCounterName, inst)
+				err = nil
+				continue
+			default:
+				log.Debugf("Other Error getting all values %s %s %v", p.requestedCounterName, inst, err)
+				return
+			}
 		}
 	}
+	for _, inst := range removeList {
+		p.RemoveInvalidInstance(inst)
+	}
+	// check for newly found instances
+	p.MakeInstanceList()
 	return
 }
 
 // GetSingleValue returns the data associated with a single-value counter
-func (p *PdhCounterSet) GetSingleValue() (val float64, err error) {
+func (p *PdhSingleInstanceCounterSet) GetValue() (val float64, err error) {
 	if p.singleCounter == PDH_HCOUNTER(0) {
 		return 0, fmt.Errorf("Not a single-value counter")
 	}
-	vals, err := p.GetAllValues()
-	if err != nil {
-		return 0, err
-	}
-	return vals[singleInstanceKey], nil
+	PdhCollectQueryData(p.query)
+	return pdhGetFormattedCounterValueFloat(p.singleCounter)
+
 }
 
 // Close closes the query handle, freeing the underlying windows resources.

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -8,11 +8,13 @@ package pdhutil
 
 import (
 	"fmt"
+	"strconv"
 	"syscall"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -26,6 +28,11 @@ var (
 	procPdhCollectQueryData         = modPdhDll.NewProc("PdhCollectQueryData")
 	procPdhCloseQuery               = modPdhDll.NewProc("PdhCloseQuery")
 	procPdhOpenQuery                = modPdhDll.NewProc("PdhOpenQuery")
+	procPdhRemoveCounter            = modPdhDll.NewProc("PdhRemoveCounter")
+)
+
+var (
+	counterToIndex map[string][]int
 )
 
 const (
@@ -76,7 +83,7 @@ func pdhEnumObjectItems(className string) (counters []string, instances []string
 		uintptr(PERF_DETAIL_WIZARD),
 		uintptr(0))
 	if r != PDH_MORE_DATA {
-		log.Errorf("Failed to enumerage windows performance counters (class %s)", className)
+		log.Errorf("Failed to enumerate windows performance counters (class %s)", className)
 		log.Errorf("This error indicates that the Windows performance counter database may need to be rebuilt")
 		return nil, nil, fmt.Errorf("Failed to get buffer size %v", r)
 	}
@@ -118,6 +125,19 @@ type pdh_counter_path_elements struct {
 	countername       uintptr
 }
 
+type ErrPdhInvalidInstance struct {
+	message string
+}
+
+func NewErrPdhInvalidInstance(message string) *ErrPdhInvalidInstance {
+	return &ErrPdhInvalidInstance{
+		message: message,
+	}
+}
+
+func (e *ErrPdhInvalidInstance) Error() string {
+	return e.message
+}
 func pdhMakeCounterPath(machine string, object string, instance string, counter string) (path string, err error) {
 	var elems pdh_counter_path_elements
 
@@ -170,6 +190,9 @@ func pdhGetFormattedCounterValueLarge(hCounter PDH_HCOUNTER) (val int64, err err
 		uintptr(unsafe.Pointer(&lpdwType)),
 		uintptr(unsafe.Pointer(&pValue)))
 	if ERROR_SUCCESS != ret {
+		if ret == PDH_INVALID_DATA && pValue.CStatus == PDH_CSTATUS_NO_INSTANCE {
+			return 0, NewErrPdhInvalidInstance("Invalid counter instance")
+		}
 		return 0, fmt.Errorf("Error retrieving large value 0x%x 0x%x", ret, pValue.CStatus)
 	}
 
@@ -186,8 +209,45 @@ func pdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, err e
 		uintptr(unsafe.Pointer(&lpdwType)),
 		uintptr(unsafe.Pointer(&pValue)))
 	if ERROR_SUCCESS != ret {
+		if ret == PDH_INVALID_DATA && pValue.CStatus == PDH_CSTATUS_NO_INSTANCE {
+			return 0, NewErrPdhInvalidInstance("Invalid counter instance")
+		}
 		return 0, fmt.Errorf("Error retrieving float value 0x%x 0x%x", ret, pValue.CStatus)
 	}
 
 	return pValue.DoubleValue, nil
+}
+
+func makeCounterSetIndexes() error {
+	counterToIndex = make(map[string][]int)
+
+	bufferIncrement := uint32(1024)
+	bufferSize := bufferIncrement
+	var counterlist []uint16
+	for {
+		var regtype uint32
+		counterlist = make([]uint16, bufferSize)
+		var sz uint32
+		sz = bufferSize
+		regerr := windows.RegQueryValueEx(syscall.HKEY_PERFORMANCE_DATA,
+			syscall.StringToUTF16Ptr("Counter 009"),
+			nil, // reserved
+			&regtype,
+			(*byte)(unsafe.Pointer(&counterlist[0])),
+			&sz)
+		if regerr == error(syscall.ERROR_MORE_DATA) {
+			// buffer's not big enough
+			bufferSize += bufferIncrement
+			continue
+		} else if regerr != nil {
+			return regerr
+		}
+		break
+	}
+	clist := winutil.ConvertWindowsStringList(counterlist)
+	for i := 0; (i + 1) < len(clist); i += 2 {
+		ndx, _ := strconv.Atoi(clist[i])
+		counterToIndex[clist[i+1]] = append(counterToIndex[clist[i+1]], ndx)
+	}
+	return nil
 }

--- a/pkg/util/winutil/pdhutil/pdhmocks_windows.go
+++ b/pkg/util/winutil/pdhutil/pdhmocks_windows.go
@@ -4,6 +4,7 @@ package pdhutil
 
 import (
 	"fmt"
+	"strings"
 )
 
 var activeCounterStrings CounterStrings
@@ -109,8 +110,10 @@ func mockpdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, e
 		return 0, fmt.Errorf("Invalid handle")
 	}
 	if _, ok = countervalues[ctr.name]; ok {
-		val, countervalues[ctr.name] = countervalues[ctr.name][0], countervalues[ctr.name][1:]
-		return val, nil
+		if len(countervalues[ctr.name]) > 0 {
+			val, countervalues[ctr.name] = countervalues[ctr.name][0], countervalues[ctr.name][1:]
+			return val, nil
+		}
 	}
 	return 0, NewErrPdhInvalidInstance("Invalid counter instance")
 }
@@ -155,4 +158,23 @@ func SetupTesting(counterstringsfile, countersfile string) {
 func SetQueryReturnValue(counter string, val float64) {
 	countervalues[counter] = append(countervalues[counter], val)
 
+}
+
+// RemoveCounterInstance removes a specific instance from the table of available instances
+func RemoveCounterInstance(clss, inst string) {
+	for idx, val := range activeAvailableCounters.instancesByClass[clss] {
+		if strings.EqualFold(inst, val) {
+			activeAvailableCounters.instancesByClass[clss] =
+				append(activeAvailableCounters.instancesByClass[clss][:idx],
+					activeAvailableCounters.instancesByClass[clss][idx+1:]...)
+			return
+		}
+	}
+}
+
+// AddCounterInstance adds a specific instance to the table of available instances
+func AddCounterInstance(clss, inst string) {
+	activeAvailableCounters.instancesByClass[clss] =
+		append(activeAvailableCounters.instancesByClass[clss], inst)
+	return
 }

--- a/pkg/util/winutil/pdhutil/pdhmocks_windows.go
+++ b/pkg/util/winutil/pdhutil/pdhmocks_windows.go
@@ -1,0 +1,158 @@
+// +build windows
+
+package pdhutil
+
+import (
+	"fmt"
+)
+
+var activeCounterStrings CounterStrings
+var activeAvailableCounters AvailableCounters
+
+func mockmakeCounterSetIndexes() error {
+	if !activeCounterStrings.initialized {
+		return fmt.Errorf("Counter strings not initialized")
+	}
+	counterToIndex = make(map[string][]int)
+	for k, v := range activeCounterStrings.counterIndex {
+		counterToIndex[v] = append(counterToIndex[v], k)
+	}
+	return nil
+}
+
+type mockCounter struct {
+	name string
+}
+
+type mockQuery struct {
+	counters map[int]mockCounter
+}
+
+var openQueries = make(map[int]mockQuery)
+var openQueriesIndex = 0
+var counterIndex = 0 // index of counter into the query must be global, because
+// RemoveCounter can be called on just a counter index
+
+var countervalues = make(map[string][]float64)
+
+func mockPdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQUERY) uint32 {
+	var mq mockQuery
+	mq.counters = make(map[int]mockCounter)
+	openQueriesIndex++
+
+	openQueries[openQueriesIndex] = mq
+	*phQuery = PDH_HQUERY(uintptr(openQueriesIndex))
+	return 0
+}
+
+func mockPdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
+	ndx := int(hQuery)
+	var thisQuery mockQuery
+	var ok bool
+	if thisQuery, ok = openQueries[ndx]; ok == false {
+		return uint32(PDH_INVALID_PATH)
+	}
+	counterIndex++
+
+	thisQuery.counters[counterIndex] = mockCounter{name: szFullCounterPath}
+	*phCounter = PDH_HCOUNTER(uintptr(counterIndex))
+
+	return 0
+}
+
+func mockPdhCollectQueryData(hQuery PDH_HQUERY) uint32 {
+	return 0
+}
+
+func mockPdhCloseQuery(hQuery PDH_HQUERY) uint32 {
+	iQuery := int(hQuery)
+	if _, ok := openQueries[iQuery]; !ok {
+		return PDH_INVALID_HANDLE
+	}
+	delete(openQueries, iQuery)
+	return 0
+}
+
+func mockPdhRemoveCounter(hCounter PDH_HCOUNTER) uint32 {
+	counterIndex := int(hCounter)
+
+	for _, query := range openQueries {
+		if _, ok := query.counters[counterIndex]; ok {
+			delete(query.counters, counterIndex)
+			return 0
+		}
+	}
+	return PDH_INVALID_HANDLE
+}
+
+func mockpdhLookupPerfNameByIndex(ndx int) (string, error) {
+	if !activeCounterStrings.initialized {
+		return "", fmt.Errorf("Counter strings not initialized")
+	}
+	if name, ok := activeCounterStrings.counterIndex[ndx]; ok {
+		return name, nil
+	}
+	return "", fmt.Errorf("Index not found")
+}
+
+func mockpdhGetFormattedCounterValueFloat(hCounter PDH_HCOUNTER) (val float64, err error) {
+	// check to see that it's a valid counter
+	ndx := int(hCounter)
+	var ctr mockCounter
+	var ok bool
+	for _, query := range openQueries {
+		if ctr, ok = query.counters[ndx]; ok {
+			break
+		}
+	}
+	if !ok {
+		return 0, fmt.Errorf("Invalid handle")
+	}
+	if _, ok = countervalues[ctr.name]; ok {
+		val, countervalues[ctr.name] = countervalues[ctr.name][0], countervalues[ctr.name][1:]
+		return val, nil
+	}
+	return 0, NewErrPdhInvalidInstance("Invalid counter instance")
+}
+func mockpdhMakeCounterPath(machine string, object string, instance string, counter string) (path string, err error) {
+	var inst string
+	if len(instance) != 0 {
+		inst = fmt.Sprintf("(%s)", instance)
+	}
+	if len(machine) == 0 {
+		machine = "."
+	}
+	path = fmt.Sprintf("\\\\%s\\%s%s\\%s", machine, object, inst, counter)
+	return
+}
+
+func mockpdhEnumObjectItems(className string) (counters []string, instances []string, err error) {
+	counters = activeAvailableCounters.countersByClass[className]
+	instances = activeAvailableCounters.instancesByClass[className]
+	return
+}
+
+// SetupTesting initializes the PDH libarary with the mock functions rather than the real thing
+func SetupTesting(counterstringsfile, countersfile string) {
+	activeCounterStrings, _ = ReadCounterStrings(counterstringsfile)
+	activeAvailableCounters, _ = ReadCounters(countersfile)
+	// For testing
+	pfnMakeCounterSetInstances = mockmakeCounterSetIndexes
+	pfnPdhOpenQuery = mockPdhOpenQuery
+	pfnPdhAddCounter = mockPdhAddCounter
+	pfnPdhCollectQueryData = mockPdhCollectQueryData
+	pfnPdhEnumObjectItems = mockpdhEnumObjectItems
+	pfnPdhRemoveCounter = mockPdhRemoveCounter
+	pfnPdhLookupPerfNameByIndex = mockpdhLookupPerfNameByIndex
+	pfnPdhGetFormattedCounterValueFloat = mockpdhGetFormattedCounterValueFloat
+	pfnPdhCloseQuery = mockPdhCloseQuery
+	pfnPdhMakeCounterPath = mockpdhMakeCounterPath
+
+}
+
+// SetQueryReturnValue provides an entry point for tests to set expected values for a
+// given counter
+func SetQueryReturnValue(counter string, val float64) {
+	countervalues[counter] = append(countervalues[counter], val)
+
+}

--- a/pkg/util/winutil/pdhutil/testdata_windows.go
+++ b/pkg/util/winutil/pdhutil/testdata_windows.go
@@ -1,0 +1,95 @@
+// +build windows
+
+package pdhutil
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// CounterStrings houses the mocked version of the registry-based counter strings database
+type CounterStrings struct {
+	initialized  bool
+	filename     string
+	data         []string
+	counterIndex map[int]string // maps the counter index to the string in the data array
+}
+
+// AvailableCounters houses the mocked version of the available counters & instances
+type AvailableCounters struct {
+	initialized      bool
+	filename         string
+	countersByClass  map[string][]string
+	instancesByClass map[string][]string
+}
+
+// ReadCounterStrings reads the counter strings from the provided file
+func ReadCounterStrings(fn string) (CounterStrings, error) {
+	var cs CounterStrings
+	cs.initialized = true
+	cs.counterIndex = make(map[int]string)
+	cs.filename = fn
+	inFile, _ := os.Open(fn)
+	defer inFile.Close()
+	scanner := bufio.NewScanner(inFile)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		cs.data = append(cs.data, scanner.Text())
+	}
+	for i := 0; i < len(cs.data)-2; i += 2 {
+		ci, _ := strconv.Atoi(cs.data[i])
+		cs.counterIndex[ci] = cs.data[i+1]
+	}
+
+	return cs, nil
+}
+
+// ReadCounters reads the available PDH counters from a static text file
+func ReadCounters(fn string) (AvailableCounters, error) {
+	var ac AvailableCounters
+	ac.initialized = true
+	ac.countersByClass = make(map[string][]string)
+	ac.instancesByClass = make(map[string][]string)
+	ac.filename = fn
+	inFile, _ := os.Open(fn)
+	defer inFile.Close()
+
+	scanner := bufio.NewScanner(inFile)
+	scanner.Split(bufio.ScanLines)
+
+	tmpInstancesByClass := make(map[string]map[string]bool)
+	tmpCountersByClass := make(map[string]map[string]bool)
+
+	for scanner.Scan() {
+		scannertext := scanner.Text()
+		parts := strings.Split(scannertext, "!")
+		clss := strings.TrimSpace(parts[0])
+		inst := strings.TrimSpace(parts[1])
+		counter := strings.TrimSpace(parts[2])
+		if _, ok := tmpCountersByClass[clss]; !ok {
+			tmpCountersByClass[clss] = make(map[string]bool)
+		}
+		tmpCountersByClass[clss][counter] = true
+
+		if len(inst) > 0 {
+			if _, ok := tmpInstancesByClass[clss]; !ok {
+				tmpInstancesByClass[clss] = make(map[string]bool)
+			}
+			tmpInstancesByClass[clss][inst] = true
+		}
+	}
+	for clss, instancemap := range tmpInstancesByClass {
+		for instance := range instancemap {
+			ac.instancesByClass[clss] = append(ac.instancesByClass[clss], instance)
+		}
+	}
+	for clss, countermap := range tmpCountersByClass {
+		for ctr := range countermap {
+			ac.countersByClass[clss] = append(ac.countersByClass[clss], ctr)
+		}
+	}
+	return ac, nil
+}

--- a/releasenotes/notes/fix_iostats_instances-3279da29103773b4.yaml
+++ b/releasenotes/notes/fix_iostats_instances-3279da29103773b4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes bug in windows core checks where adding/removing devices isn't
+    caught, so only devices present on startup are monitored.

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -29,6 +29,7 @@ WIN_MODULE_WHITELIST = [
 MISSPELL_IGNORED_TARGETS = [
     os.path.join("cmd", "agent", "dist", "checks", "prometheus_check"),
     os.path.join("cmd", "agent", "gui", "views", "private"),
+    os.path.join("pkg", "collector", "corechecks", "system", "testfiles"),
 ]
 
 @task


### PR DESCRIPTION
### What does this PR do?

Previously, available instances were only computed at `config` time; so if an instance was added (e.g. a drive plugged in), then it was missed by subsequent checks

### Motivation

customer issue

### Additional Notes

Also adds mocked version of PDH functions, and adds some unit tests.
