### PR TITLE
Remove command arguments from flare's container list

### DIFF
--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -21,6 +22,8 @@ import (
 
 	"github.com/docker/docker/api/types"
 )
+
+const DOCKER_PS_COMMAND_MAX_LENGTH = 18
 
 func zipDockerSelfInspect(tempDir, hostname string) error {
 	du, err := docker.GetDockerUtil()
@@ -91,14 +94,8 @@ func zipDockerPs(tempDir, hostname string) error {
 
 	fmt.Fprintln(w, "CONTAINER ID\tIMAGE\tCOMMAND\tSTATUS\tPORTS\tNAMES\t")
 	for _, c := range containerList {
-		// Trimming command if too large
-		var command_limit = 18
-		command := c.Command
-		if len(c.Command) >= command_limit {
-			command = c.Command[:command_limit] + "…"
-		}
 		fmt.Fprintf(w, "%s\t%s\t%q\t%s\t%v\t%v\t\n",
-			c.ID[:12], c.Image, command, c.Status, c.Ports, c.Names)
+			c.ID[:12], c.Image, trimCommand(c.Command), c.Status, c.Ports, c.Names)
 	}
 	err = w.Flush()
 	if err != nil {
@@ -118,4 +115,25 @@ func zipDockerPs(tempDir, hostname string) error {
 	}
 
 	return nil
+}
+
+// trimCommand removes arguments from command string
+// and trims it to 18 character max.
+func trimCommand(command string) string {
+	cutoff := strings.Index(command, " ")
+	if cutoff > 0 {
+		// Add a trailing space between cmd and … to
+		// differentiate removed args vs max length
+		cutoff += 1
+	} else {
+		cutoff = len(command)
+	}
+	if cutoff > DOCKER_PS_COMMAND_MAX_LENGTH {
+		cutoff = DOCKER_PS_COMMAND_MAX_LENGTH
+	}
+
+	if cutoff == len(command) {
+		return command
+	}
+	return command[:cutoff] + "…"
 }

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-const DOCKER_PS_COMMAND_MAX_LENGTH = 18
+const DOCKER_PS_COMMAND_MAX_LENGTH = 29
 
 func zipDockerSelfInspect(tempDir, hostname string) error {
 	du, err := docker.GetDockerUtil()

--- a/pkg/flare/archive_docker.go
+++ b/pkg/flare/archive_docker.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-const DOCKER_PS_COMMAND_MAX_LENGTH = 29
+const dockerCommandMaxLength = 29
 
 func zipDockerSelfInspect(tempDir, hostname string) error {
 	du, err := docker.GetDockerUtil()
@@ -118,7 +118,7 @@ func zipDockerPs(tempDir, hostname string) error {
 }
 
 // trimCommand removes arguments from command string
-// and trims it to 18 character max.
+// and trims it to 29 characters max.
 func trimCommand(command string) string {
 	cutoff := strings.Index(command, " ")
 	if cutoff > 0 {
@@ -128,8 +128,8 @@ func trimCommand(command string) string {
 	} else {
 		cutoff = len(command)
 	}
-	if cutoff > DOCKER_PS_COMMAND_MAX_LENGTH {
-		cutoff = DOCKER_PS_COMMAND_MAX_LENGTH
+	if cutoff > dockerCommandMaxLength {
+		cutoff = dockerCommandMaxLength
 	}
 
 	if cutoff == len(command) {

--- a/pkg/flare/archive_docker_test.go
+++ b/pkg/flare/archive_docker_test.go
@@ -20,7 +20,8 @@ func TestTrimCommand(t *testing.T) {
 		"nginx -g 'daemon off;'":                     "nginx …",
 		"/entrypoint.sh datadog-cluster-agent start": "/entrypoint.sh …",
 		"/coredns -conf /etc/coredns/Corefile":       "/coredns …",
-		"/my/very/long/command":                      "/my/very/long/comm…",
+		"/my/very/long/command":                      "/my/very/long/command",
+		"/my/very/very/very/very/very/long/command":  "/my/very/very/very/very/very/…",
 	} {
 		t.Run(fmt.Sprintf(in), func(t *testing.T) {
 			assert.Equal(t, out, trimCommand(in))

--- a/pkg/flare/archive_docker_test.go
+++ b/pkg/flare/archive_docker_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package flare
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimCommand(t *testing.T) {
+	for in, out := range map[string]string{
+		"/pause":                                     "/pause",
+		"nginx -g 'daemon off;'":                     "nginx …",
+		"/entrypoint.sh datadog-cluster-agent start": "/entrypoint.sh …",
+		"/coredns -conf /etc/coredns/Corefile":       "/coredns …",
+		"/my/very/long/command":                      "/my/very/long/comm…",
+	} {
+		t.Run(fmt.Sprintf(in), func(t *testing.T) {
+			assert.Equal(t, out, trimCommand(in))
+		})
+	}
+}

--- a/releasenotes/notes/flare-docker-ps-arguments-8eaf9e69375e6ff8.yaml
+++ b/releasenotes/notes/flare-docker-ps-arguments-8eaf9e69375e6ff8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Removed the command arguments from the flare's container list
+    to avoid collecting sensitive information


### PR DESCRIPTION
### What does this PR do?

Removed the command arguments from the flare's container list to avoid collecting sensitive information.

Results visible in test cases:

```
"/pause":                                     "/pause",
"nginx -g 'daemon off;'":                     "nginx …",
"/entrypoint.sh datadog-cluster-agent start": "/entrypoint.sh …",
"/coredns -conf /etc/coredns/Corefile":       "/coredns …",
"/my/very/long/command":                      "/my/very/long/comm…",
```