### PR TITLE
fix hostname resolution logic on ec2/ecs when the hostname_fqdn flag is enabled

### DIFF
--- a/pkg/util/docker/diagnosis.go
+++ b/pkg/util/docker/diagnosis.go
@@ -25,7 +25,7 @@ func diagnose() error {
 		log.Info("successfully connected to docker")
 	}
 
-	hostname, err := HostnameProvider("")
+	hostname, err := HostnameProvider()
 	if err != nil {
 		log.Errorf("returned hostname %q with error: %s", hostname, err)
 	} else {

--- a/pkg/util/docker/global.go
+++ b/pkg/util/docker/global.go
@@ -52,7 +52,7 @@ func EnableTestingMode() {
 }
 
 // HostnameProvider docker implementation for the hostname provider
-func HostnameProvider(hostName string) (string, error) {
+func HostnameProvider() (string, error) {
 	du, err := GetDockerUtil()
 	if err != nil {
 		return "", err

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -82,12 +82,12 @@ func IsDefaultHostname(hostname string) bool {
 }
 
 // HostnameProvider gets the hostname
-func HostnameProvider(hostName string) (string, error) {
+func HostnameProvider() (string, error) {
 	_, err := ecs.GetUtil()
-	if err == nil || IsDefaultHostname(hostName) {
+	if err == nil {
 		log.Debug("GetHostname trying EC2 metadata...")
 		return GetInstanceID()
 	}
 
-	return "", fmt.Errorf("not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames")
+	return "", err
 }

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -83,11 +82,6 @@ func IsDefaultHostname(hostname string) bool {
 
 // HostnameProvider gets the hostname
 func HostnameProvider() (string, error) {
-	_, err := ecs.GetUtil()
-	if err == nil {
-		log.Debug("GetHostname trying EC2 metadata...")
-		return GetInstanceID()
-	}
-
-	return "", err
+	log.Debug("GetHostname trying EC2 metadata...")
+	return GetInstanceID()
 }

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -88,6 +88,11 @@ func GetUtil() (*Util, error) {
 	return globalUtil, nil
 }
 
+func IsECSInstance() bool {
+	_, err := GetUtil()
+	return err == nil
+}
+
 // init makes an empty Util bootstrap itself.
 func (u *Util) init() error {
 	url, err := detectAgentURL()

--- a/pkg/util/ecs/ecs.go
+++ b/pkg/util/ecs/ecs.go
@@ -88,6 +88,7 @@ func GetUtil() (*Util, error) {
 	return globalUtil, nil
 }
 
+// IsECSInstance returns whether the agent is running in ECS.
 func IsECSInstance() bool {
 	_, err := GetUtil()
 	return err == nil

--- a/pkg/util/ecs/ecs_nodocker.go
+++ b/pkg/util/ecs/ecs_nodocker.go
@@ -14,6 +14,11 @@ func GetUtil() (*Util, error) {
 	return nil, docker.ErrDockerNotCompiled
 }
 
+// IsECSInstance returns whether the agent is running in ECS.
+func IsECSInstance() bool {
+	return false
+}
+
 // IsFargateInstance returns whether the agent is in an ECS fargate task.
 // It detects it by getting and unmarshalling the metadata API response.
 func IsFargateInstance() bool {

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -97,6 +97,6 @@ func getResponse(url string) (string, error) {
 }
 
 // HostnameProvider GCE implementation of the HostnameProvider
-func HostnameProvider(hostName string) (string, error) {
+func HostnameProvider() (string, error) {
 	return GetHostname()
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -197,7 +197,7 @@ func GetHostname() (string, error) {
 	// and the hostname is one of the default ones
 	if getEC2Hostname, found := hostname.ProviderCatalog["ec2"]; found {
 		log.Debug("GetHostname trying EC2 metadata...")
-		if ec2.IsDefaultHostname(hostName) {
+		if ecs.IsECSInstance() || ec2.IsDefaultHostname(hostName) {
 			instanceID, err := getEC2Hostname()
 			if err == nil {
 				err = ValidHostname(instanceID)

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -217,7 +217,11 @@ func GetHostname() (string, error) {
 				log.Debug("Unable to determine hostname from EC2: ", err)
 			}
 		} else {
-			log.Debug("not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames")
+			err := fmt.Errorf("not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames")
+			log.Debug(err.Error())
+			expErr := new(expvar.String)
+			expErr.Set(err.Error())
+			hostnameErrors.Set("aws", expErr)
 		}
 	}
 

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -8,7 +8,6 @@ package util
 import (
 	"expvar"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"net"
 	"os"
 	"regexp"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -8,6 +8,7 @@ package util
 import (
 	"expvar"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"net"
 	"os"
 	"regexp"
@@ -112,12 +113,12 @@ func GetHostname() (string, error) {
 	var provider string
 
 	// try the name provided in the configuration file
-	name := config.Datadog.GetString("hostname")
-	err = ValidHostname(name)
+	configName := config.Datadog.GetString("hostname")
+	err = ValidHostname(configName)
 	if err == nil {
-		cache.Cache.Set(cacheHostnameKey, name, cache.NoExpiration)
+		cache.Cache.Set(cacheHostnameKey, configName, cache.NoExpiration)
 		hostnameProvider.Set("configuration")
-		return name, err
+		return configName, err
 	}
 
 	expErr := new(expvar.String)
@@ -136,11 +137,11 @@ func GetHostname() (string, error) {
 	// GCE metadata
 	log.Debug("GetHostname trying GCE metadata...")
 	if getGCEHostname, found := hostname.ProviderCatalog["gce"]; found {
-		name, err = getGCEHostname(name)
+		gceName, err := getGCEHostname()
 		if err == nil {
-			cache.Cache.Set(cacheHostnameKey, name, cache.NoExpiration)
+			cache.Cache.Set(cacheHostnameKey, gceName, cache.NoExpiration)
 			hostnameProvider.Set("gce")
-			return name, err
+			return gceName, err
 		}
 		expErr := new(expvar.String)
 		expErr.Set(err.Error())
@@ -163,10 +164,10 @@ func GetHostname() (string, error) {
 		log.Debug("Unable to get FQDN from system: ", err)
 	}
 
-	isContainerized, name := getContainerHostname()
+	isContainerized, containerName := getContainerHostname()
 	if isContainerized {
-		if name != "" {
-			hostName = name
+		if containerName != "" {
+			hostName = containerName
 			provider = "container"
 		} else {
 			expErr := new(expvar.String)
@@ -178,9 +179,9 @@ func GetHostname() (string, error) {
 	if hostName == "" {
 		// os
 		log.Debug("GetHostname trying os...")
-		name, err = os.Hostname()
+		systemName, err := os.Hostname()
 		if err == nil {
-			hostName = name
+			hostName = systemName
 			provider = "os"
 		} else {
 			expErr := new(expvar.String)
@@ -196,23 +197,27 @@ func GetHostname() (string, error) {
 	// and the hostname is one of the default ones
 	if getEC2Hostname, found := hostname.ProviderCatalog["ec2"]; found {
 		log.Debug("GetHostname trying EC2 metadata...")
-		instanceID, err := getEC2Hostname(name)
-		if err == nil {
-			err = ValidHostname(instanceID)
+		if ec2.IsDefaultHostname(hostName) {
+			instanceID, err := getEC2Hostname()
 			if err == nil {
-				hostName = instanceID
-				provider = "aws"
+				err = ValidHostname(instanceID)
+				if err == nil {
+					hostName = instanceID
+					provider = "aws"
+				} else {
+					expErr := new(expvar.String)
+					expErr.Set(err.Error())
+					hostnameErrors.Set("aws", expErr)
+					log.Debug("EC2 instance ID is not a valid hostname: ", err)
+				}
 			} else {
 				expErr := new(expvar.String)
 				expErr.Set(err.Error())
 				hostnameErrors.Set("aws", expErr)
-				log.Debug("EC2 instance ID is not a valid hostname: ", err)
+				log.Debug("Unable to determine hostname from EC2: ", err)
 			}
 		} else {
-			expErr := new(expvar.String)
-			expErr.Set(err.Error())
-			hostnameErrors.Set("aws", expErr)
-			log.Debug("Unable to determine hostname from EC2: ", err)
+			log.Debug("not retrieving hostname from AWS: the host is not an ECS instance, and other providers already retrieve non-default hostnames")
 		}
 	}
 

--- a/pkg/util/hostname/providers.go
+++ b/pkg/util/hostname/providers.go
@@ -6,7 +6,7 @@
 package hostname
 
 // Provider is a generic function to grab the hostname and return it
-type Provider func(string) (string, error)
+type Provider func() (string, error)
 
 // ProviderCatalog holds all the various kinds of hostname providers
 var ProviderCatalog = make(map[string]Provider)

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -21,7 +21,7 @@ func getContainerHostname() (bool, string) {
 	// Cluster-agent logic: Kube apiserver
 	if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
 		log.Debug("GetHostname trying Kubernetes trough API server...")
-		name, err := getKubeHostname(name)
+		name, err := getKubeHostname()
 		if err == nil && ValidHostname(name) == nil {
 			return true, name
 		}
@@ -36,7 +36,7 @@ func getContainerHostname() (bool, string) {
 	// Docker
 	log.Debug("GetHostname trying Docker API...")
 	if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
-		name, err := getDockerHostname(name)
+		name, err := getDockerHostname()
 		if err == nil && ValidHostname(name) == nil {
 			return true, name
 		}
@@ -48,7 +48,7 @@ func getContainerHostname() (bool, string) {
 	// Kubelet
 	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
 		log.Debug("GetHostname trying Kubernetes trough kubelet API...")
-		name, err := getKubeletHostname(name)
+		name, err := getKubeletHostname()
 		if err == nil && ValidHostname(name) == nil {
 			return true, name
 		}

--- a/pkg/util/kubernetes/apiserver/hostname.go
+++ b/pkg/util/kubernetes/apiserver/hostname.go
@@ -20,7 +20,7 @@ import (
 // is the pod name. It connects to the apiserver, and returns the node name where
 // our pod is scheduled.
 // Tested in the TestHostnameProvider integration test
-func HostnameProvider(_ string) (string, error) {
+func HostnameProvider() (string, error) {
 	c, err := GetAPIClient()
 	if err != nil {
 		return "", fmt.Errorf("could not connect to the apiserver: %s", err)

--- a/pkg/util/kubernetes/hostinfo/host_alias.go
+++ b/pkg/util/kubernetes/hostinfo/host_alias.go
@@ -16,7 +16,7 @@ import (
 
 // GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
 func GetHostAlias() (string, error) {
-	name, err := kubelet.HostnameProvider("")
+	name, err := kubelet.HostnameProvider()
 	if err == nil && util.ValidHostname(name) == nil {
 		return name, nil
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -501,7 +501,7 @@ func (ku *KubeUtil) init() error {
 	// setting the kubeletHost
 	ku.kubeletHost = config.Datadog.GetString("kubernetes_kubelet_host")
 	if ku.kubeletHost == "" {
-		ku.kubeletHost, err = docker.HostnameProvider("")
+		ku.kubeletHost, err = docker.HostnameProvider()
 		if err != nil {
 			return fmt.Errorf("unable to get hostname from docker, please set the kubernetes_kubelet_host option: %s", err)
 		}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -101,7 +101,7 @@ func GetKubeUtil() (*KubeUtil, error) {
 }
 
 // HostnameProvider kubelet implementation for the hostname provider
-func HostnameProvider(hostName string) (string, error) {
+func HostnameProvider() (string, error) {
 	ku, err := GetKubeUtil()
 	if err != nil {
 		return "", err

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -338,7 +338,7 @@ func (suite *KubeletTestSuite) TestHostnameProvider() {
 	config.Datadog.Set("kubelet_tls_verify", false)
 	config.Datadog.Set("kubelet_auth_token_path", "")
 
-	hostname, err := HostnameProvider("")
+	hostname, err := HostnameProvider()
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), "my-node-name", hostname)
 }

--- a/releasenotes/notes/fix-ec2-fqdn-f60585931c48412b.yaml
+++ b/releasenotes/notes/fix-ec2-fqdn-f60585931c48412b.yaml
@@ -8,10 +8,10 @@
 ---
 upgrade:
   - |
-    On ec2 hosts that were upgraded from Agent 5.x using the install script or that have the ``hostname_fqdn`` option enabled if your hostname currently begins by ``ip-`` or ``domU-`` (default ec2 hostnames) your hostname will change to the ec2 instance ID.
+    On EC2 hosts that were upgraded from Agent 5.x using the install script or that have the ``hostname_fqdn`` option enabled if your hostname currently begins by ``ip-`` or ``domU-`` (default EC2 hostnames) your hostname will change to the EC2 instance ID.
     Example: ``ip-10-1-1-1.ec2.internal`` => ``i-1234567890abcdef0``.
-    This is an effort to fix a bug in the hostname resolution that was intoduced in the version 6.3 of the agent.
+    This is an effort to fix a bug in the hostname resolution that was introduced in the version 6.3 of the Agent.
 
 fixes:
   - |
-    Fix a bug on ec2 hosts where the ``hostname_fqdn`` option is enabled making the hostname logic resolve the fully qualified domain name instead of the ec2 instance ID.
+    Fix a hostname resolution bug on EC2 hosts which could happen when the ``hostname_fqdn`` option was enabled, and which made the Agent use a non-unique FQDN instead of the EC2 instance ID.

--- a/releasenotes/notes/fix-ec2-fqdn-f60585931c48412b.yaml
+++ b/releasenotes/notes/fix-ec2-fqdn-f60585931c48412b.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    On ec2 hosts that were upgraded from Agent 5.x using the install script or that have the ``hostname_fqdn`` option enabled if your hostname currently begins by ``ip-`` or ``domU-`` (default ec2 hostnames) your hostname will change to the ec2 instance ID.
+    Example: ``ip-10-1-1-1.ec2.internal`` => ``i-1234567890abcdef0``.
+    This is an effort to fix a bug in the hostname resolution that was intoduced in the version 6.3 of the agent.
+
+fixes:
+  - |
+    Fix a bug on ec2 hosts where the ``hostname_fqdn`` option is enabled making the hostname logic resolve the fully qualified domain name instead of the ec2 instance ID.

--- a/releasenotes/notes/fix-ec2-fqdn-f60585931c48412b.yaml
+++ b/releasenotes/notes/fix-ec2-fqdn-f60585931c48412b.yaml
@@ -8,7 +8,7 @@
 ---
 upgrade:
   - |
-    On EC2 hosts that were upgraded from Agent 5.x using the install script or that have the ``hostname_fqdn`` option enabled if your hostname currently begins by ``ip-`` or ``domU-`` (default EC2 hostnames) your hostname will change to the EC2 instance ID.
+    On EC2 hosts that were upgraded from Agent 5.x using the install script or that have the ``hostname_fqdn`` option enabled if your hostname currently begins with ``ip-`` or ``domU-`` (default EC2 hostnames) your hostname will change to the EC2 instance ID.
     Example: ``ip-10-1-1-1.ec2.internal`` => ``i-1234567890abcdef0``.
     This is an effort to fix a bug in the hostname resolution that was introduced in the version 6.3 of the Agent.
 

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -183,7 +183,7 @@ func (suite *testSuite) TestHostnameProvider() {
 	defer core.Pods("default").Delete(myHostname, nil)
 
 	// Hostname provider should return the expected value
-	foundHost, err := apiserver.HostnameProvider("")
+	foundHost, err := apiserver.HostnameProvider()
 	assert.Equal(suite.T(), "target.host", foundHost)
 
 	// Testing hostname when a cluster name is set
@@ -193,6 +193,6 @@ func (suite *testSuite) TestHostnameProvider() {
 	defer config.Datadog.Set("cluster_name", "")
 	defer clustername.ResetClusterName()
 
-	foundHost, err = apiserver.HostnameProvider("")
+	foundHost, err = apiserver.HostnameProvider()
 	assert.Equal(suite.T(), "target.host-Laika", foundHost)
 }


### PR DESCRIPTION
### What does this PR do?

#### Fix an FQDN x EC2 bug in the hostname resolution

Some background first:

Currently, in the [hostname resolution logic](https://github.com/DataDog/datadog-agent/blob/fce7e5877371932df129ebf6d93cbb722b2f3ead/pkg/util/hostname.go#L104-L245) we have a variable called `hostName` that is used as a way to store the "best hostname we could find until now". This is the variable we return at the end of the logic.

The interface `Provider`, used to define hostname providers and implemented by the ec2 and gce hostname providers accepts a string as a parameter.
https://github.com/DataDog/datadog-agent/blob/fce7e5877371932df129ebf6d93cbb722b2f3ead/pkg/util/hostname/providers.go#L9
This string is used in and **only in** the ec2 provider logic. We use it to check if the given hostname matches the default ec2 hostname pattern. If it does we return the instance id and if it does not an error.
https://github.com/DataDog/datadog-agent/blob/fce7e5877371932df129ebf6d93cbb722b2f3ead/pkg/util/ec2/ec2.go#L85-L93

A second variable, called `name` is almost always used to store temporarily hostname values:
https://github.com/DataDog/datadog-agent/blob/595154c7e120cd8b3db072388adca7b3cb89741e/pkg/util/hostname.go#L166
https://github.com/DataDog/datadog-agent/blob/595154c7e120cd8b3db072388adca7b3cb89741e/pkg/util/hostname.go#L181

While it would probably have made sense to use the `hostName` variable to check that the current selected hostname is a default ec2 hostname, name was used instead:
https://github.com/DataDog/datadog-agent/blob/595154c7e120cd8b3db072388adca7b3cb89741e/pkg/util/hostname.go#L199

Unfortunately in https://github.com/DataDog/datadog-agent/pull/1822 I failed to identify this detail and used a variable called `fqdn` to temporarily store the FQDN:
https://github.com/DataDog/datadog-agent/blob/595154c7e120cd8b3db072388adca7b3cb89741e/pkg/util/hostname.go#L153

This led to a situation where on ec2 hosts with the `hostname_fqdn` flag enabled `hostName` was equal to the default ec2 FQDN (`ip-...`) and `name` to an empty string. Since empty string is not a default ec2 hostname, we were not replacing this default ec2 FQDN by the instance ID.

#### Modifications in this PR

- Remove the string parameter of the Provider interface (now `type Provider func() (string, error)`). It makes more sense to me to express the ec2 default hostname logic at the highest level. All other providers were just ignoring this param.
- Use a different variable to store each temporary hostname values to avoid side effects.
- Use `hostName` to check if the current selected hostname is a default ec2 hostname.

### Motivation

A few clients were hit by the issue.

### Additional Notes

- A potential edge case breaking change: `name` is always set by the providers, even if an error is returned. If for some reason the last provider that uses `name` before the ec2 logic returns both a valid ec2 hostname and an error the behavior will change after this PR.
- As written in the release note this will only affect ec2 agents with the `hostname_fqdn` option enabled.
- We lack testing on this logic

### Testing

[ ] ec2 x fqdn
[ ] ec2 x !fqdn
[ ] ecs x fqdn
[ ] ecs x !fqdn