### PR TITLE
Disable gohai in dogstatsd alpine image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# dogstatsd image temporary file
-Dockerfiles/dogstatsd/alpine/dogstatsd
+# dogstatsd image temporary binaries
+Dockerfiles/dogstatsd/alpine/static/
 
 # folders
 vendor/

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -2,12 +2,11 @@ FROM alpine:3.8
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV DOCKER_DD_AGENT=true \
-    DD_HEALTH_PORT=5555
+ENV DOCKER_DD_AGENT=true
 
 RUN apk add --no-cache ca-certificates
 
-COPY entrypoint.sh probe.sh /
+COPY entrypoint.sh probe.sh dogstatsd.yaml /
 COPY static/dogstatsd /dogstatsd
 
 EXPOSE 8125/udp
@@ -16,4 +15,4 @@ HEALTHCHECK --interval=1m --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/dogstatsd", "start"]
+CMD ["/dogstatsd", "-c", "/", "start"]

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -6,7 +6,8 @@ ENV DOCKER_DD_AGENT=true
 
 RUN apk add --no-cache ca-certificates
 
-COPY entrypoint.sh probe.sh dogstatsd.yaml /
+COPY entrypoint.sh probe.sh /
+COPY dogstatsd.yaml /etc/datadog-agent/dogstatsd.yaml
 COPY static/dogstatsd /dogstatsd
 
 EXPOSE 8125/udp
@@ -15,4 +16,4 @@ HEALTHCHECK --interval=1m --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/dogstatsd", "-c", "/", "start"]
+CMD ["/dogstatsd", "start"]

--- a/Dockerfiles/dogstatsd/alpine/dogstatsd.yaml
+++ b/Dockerfiles/dogstatsd/alpine/dogstatsd.yaml
@@ -1,0 +1,7 @@
+## Provides sane defaults, to be overriden by environment variables
+
+# Required for probe.sh
+health_port: 5555
+
+# Gohai does not support alpine
+enable_gohai: false

--- a/releasenotes/notes/dsd-image-no-gohai-88b8b32fe4001738.yaml
+++ b/releasenotes/notes/dsd-image-no-gohai-88b8b32fe4001738.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    datadog/dogstatsd image: gohai metadata collection is now disabled by default


### PR DESCRIPTION
### What does this PR do?

Following-up with https://github.com/helm/charts/pull/9421#issuecomment-446982510

Busybox's `df` command does not recognise the `-l` argument passed by gohai. This makes the host metadata collection throw an error. This PR disables gohai by default in this image.

Following the same direction as the agent's image, this option (and the health port) are moved to a default config file, so they can easily be overriden.

