### PR TITLE
Fix null pointer exception in docker tailer

### DIFF
--- a/pkg/logs/input/docker/reader.go
+++ b/pkg/logs/input/docker/reader.go
@@ -8,11 +8,11 @@
 package docker
 
 import (
-	"fmt"
+	"errors"
 	"io"
 )
 
-const readerNotInitialized = "reader not initialized"
+var readerNotInitializedError = errors.New("reader not initialized")
 
 type safeReader struct {
 	reader io.ReadCloser
@@ -28,7 +28,7 @@ func (s *safeReader) setUnsafeReader(reader io.ReadCloser) {
 
 func (s *safeReader) Read(p []byte) (int, error) {
 	if s.reader == nil {
-		err := fmt.Errorf(readerNotInitialized)
+		err := readerNotInitializedError
 		return 0, err
 	}
 
@@ -37,7 +37,7 @@ func (s *safeReader) Read(p []byte) (int, error) {
 
 func (s *safeReader) Close() error {
 	if s.reader == nil {
-		return fmt.Errorf(readerNotInitialized)
+		return readerNotInitializedError
 	}
 
 	return s.reader.Close()

--- a/pkg/logs/input/docker/reader.go
+++ b/pkg/logs/input/docker/reader.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"fmt"
+	"io"
+)
+
+const readerNotInitialized = "reader not initialized"
+
+type safeReader struct {
+	reader io.ReadCloser
+}
+
+func newSafeReader() *safeReader {
+	return &safeReader{}
+}
+
+func (s *safeReader) setUnsafeReader(reader io.ReadCloser) {
+	s.reader = reader
+}
+
+func (s *safeReader) Read(p []byte) (int, error) {
+	if s.reader == nil {
+		err := fmt.Errorf(readerNotInitialized)
+		return 0, err
+	}
+
+	return s.reader.Read(p)
+}
+
+func (s *safeReader) Close() error {
+	if s.reader == nil {
+		return fmt.Errorf(readerNotInitialized)
+	}
+
+	return s.reader.Close()
+}

--- a/pkg/logs/input/docker/reader_test.go
+++ b/pkg/logs/input/docker/reader_test.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build docker
+
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const fooError = "foo error"
+const barError = "bar error"
+
+type ReadCloserMock struct {
+	io.Reader
+	closer func() error
+}
+
+func (r *ReadCloserMock) Close() error {
+	return r.closer()
+}
+
+func NewReadCloserMock(r io.Reader, closer func() error) io.ReadCloser {
+	return &ReadCloserMock{
+		Reader: r,
+		closer: closer,
+	}
+}
+
+type ReadErrorMock struct {
+	io.Reader
+}
+
+func (r *ReadErrorMock) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf(fooError)
+}
+
+func TestSafeReaderRead(t *testing.T) {
+	reader := newSafeReader()
+	bytesArray := []byte("foo")
+	mockReadCloserNoError := NewReadCloserMock(bytes.NewReader(bytesArray), func() error {
+		return nil
+	})
+	mockReadCloserReadError := NewReadCloserMock(&ReadErrorMock{}, func() error {
+		return nil
+	})
+
+	n, err := reader.Read(bytesArray)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, fmt.Errorf(readerNotInitialized), err)
+
+	reader.setUnsafeReader(mockReadCloserNoError)
+	n, err = reader.Read(bytesArray)
+	assert.Equal(t, len(bytesArray), n)
+	assert.Nil(t, err)
+
+	reader.setUnsafeReader(mockReadCloserReadError)
+	n, err = reader.Read(bytesArray)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, fmt.Errorf(fooError), err)
+
+	reader.setUnsafeReader(nil)
+	n, err = reader.Read(bytesArray)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, fmt.Errorf(readerNotInitialized), err)
+}
+
+func TestSafeReaderClose(t *testing.T) {
+	reader := newSafeReader()
+	mockReadCloserNoError := NewReadCloserMock(&ReadErrorMock{}, func() error {
+		return nil
+	})
+	mockReadCloserCloseError := NewReadCloserMock(&ReadErrorMock{}, func() error {
+		return fmt.Errorf(barError)
+	})
+
+	err := reader.Close()
+	assert.Equal(t, fmt.Errorf(readerNotInitialized), err)
+
+	reader.setUnsafeReader(mockReadCloserNoError)
+	err = reader.Close()
+	assert.Nil(t, err)
+
+	reader.setUnsafeReader(mockReadCloserCloseError)
+	err = reader.Close()
+	assert.Equal(t, fmt.Errorf(barError), err)
+
+	reader.setUnsafeReader(nil)
+	err = reader.Close()
+	assert.Equal(t, fmt.Errorf(readerNotInitialized), err)
+}

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -79,7 +79,11 @@ func (t *Tailer) Identifier() string {
 func (t *Tailer) Stop() {
 	log.Infof("Stop tailing container: %v", ShortContainerID(t.ContainerID))
 	t.stop <- struct{}{}
-	t.reader.Close()
+
+	// t.reader can be nil when the t.setupReader() failed
+	if t.reader != nil {
+		t.reader.Close()
+	}
 	// no-op if already closed because of a timeout
 	t.cancelFunc()
 	t.source.RemoveInput(t.ContainerID)

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -212,6 +212,10 @@ func (t *Tailer) read(buffer []byte, timeout time.Duration) (int, error) {
 	var err error
 	doneReading := make(chan struct{})
 	go func() {
+		if t.reader == nil {
+			err = fmt.Errorf("reader not initialized")
+			return
+		}
 		n, err = t.reader.Read(buffer)
 		close(doneReading)
 	}()

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -54,35 +54,6 @@ type Tailer struct {
 	mutex              sync.Mutex
 }
 
-type safeReader struct {
-	reader io.ReadCloser
-}
-
-func newSafeReader() *safeReader {
-	return &safeReader{}
-}
-
-func (s *safeReader) setReader(reader io.ReadCloser) {
-	s.reader = reader
-}
-
-func (s *safeReader) Read(p []byte) (int, error) {
-	if s.reader == nil {
-		err := fmt.Errorf("reader not initialized")
-		return 0, err
-	}
-
-	return s.reader.Read(p)
-}
-
-func (s *safeReader) Close() error {
-	if s.reader == nil {
-		return fmt.Errorf("reader not initialized")
-	}
-
-	return s.reader.Close()
-}
-
 // NewTailer returns a new Tailer
 func NewTailer(cli *client.Client, containerID string, source *config.LogSource, outputChan chan *message.Message, erroredContainerID chan string) *Tailer {
 	return &Tailer{
@@ -160,7 +131,7 @@ func (t *Tailer) setupReader() error {
 	}
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	reader, err := t.cli.ContainerLogs(ctx, t.ContainerID, options)
-	t.reader.setReader(reader)
+	t.reader.setUnsafeReader(reader)
 	t.cancelFunc = cancelFunc
 	return err
 }

--- a/pkg/logs/input/docker/tailer_test.go
+++ b/pkg/logs/input/docker/tailer_test.go
@@ -75,7 +75,7 @@ func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer 
 		reader:        newSafeReader(),
 		cancelFunc:    cancelFunc,
 	}
-	tailer.reader.setReader(reader)
+	tailer.reader.setUnsafeReader(reader)
 
 	return tailer
 }

--- a/releasenotes/notes/fix-npe-docker-tailer-5d689aa527fce4de.yaml
+++ b/releasenotes/notes/fix-npe-docker-tailer-5d689aa527fce4de.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a panic that could occur if a container doesn't send logs for more than 30 sec and
+    the timestamp of the last received log is corrupted


### PR DESCRIPTION
### What does this PR do?

Fix a bug where the docker tailer would NPE if the docker timestamp format wasn't properly parsed.

### Motivation

A customer received a timestamp with `+2018-12-20T03:22:50.195175539Z` that sent to the docker cli as a reference for the `Since` parameter. It failed and we set up a `nil` `Reader` that we eventually tried to close

This PR fixes the bug by avoiding improper timestamp in the Docker CLI. And if the CLI call fails for any other reason, we now also check that the reader is not nil before using it as our last defensive option

### Additional Notes

Anything else we should know when reviewing?
