### PR TITLE
 Fix moving of configuration files

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -527,7 +527,7 @@ func moveConfigurationFilesOf(integration string) error {
 		check = strings.Replace(check, "-", "_", -1)
 	}
 	confFileDest := filepath.Join(confFolder, fmt.Sprintf("%s.d", check))
-	if err := os.MkdirAll(confFileDest, os.ModeDir); err != nil {
+	if err := os.MkdirAll(confFileDest, os.ModeDir|0755); err != nil {
 		return err
 	}
 
@@ -555,13 +555,18 @@ func moveConfigurationFiles(srcFolder string, dstFolder string) error {
 		}
 		src := filepath.Join(srcFolder, filename)
 		dst := filepath.Join(dstFolder, filename)
-		err = os.Rename(src, dst)
+		srcContent, err := ioutil.ReadFile(src)
 		if err != nil {
-			errorMsg = fmt.Sprintf("%s\nError moving configuration file %s: %v", errorMsg, filename, err)
+			errorMsg = fmt.Sprintf("%s\nError reading configuration file %s: %v", errorMsg, src, err)
+			continue
+		}
+		err = ioutil.WriteFile(dst, srcContent, 0644)
+		if err != nil {
+			errorMsg = fmt.Sprintf("%s\nError writing configuration file %s: %v", errorMsg, dst, err)
 			continue
 		}
 		fmt.Println(color.GreenString(fmt.Sprintf(
-			"Successfully moved configuration file %s", filename,
+			"Successfully copied configuration file %s", filename,
 		)))
 	}
 	if errorMsg != "" {

--- a/releasenotes/notes/fix_moving_conf_file-68579cce61154e9f.yaml
+++ b/releasenotes/notes/fix_moving_conf_file-68579cce61154e9f.yaml
@@ -9,7 +9,7 @@
 fixes:
   - |
     Fix bug of the ``datadog-agent integration install`` command that prevented
-    moving configuration files when the `conf.d` folder is a mounted directory.
+    moving configuration files when the ``conf.d`` folder is a mounted directory.
   - |
     The ``datadog-agent integration install`` command creates the configuration folder
-    for a integration with the correct permissions so that the configuration files can be copied.
+    for an integration with the correct permissions so that the configuration files can be copied.

--- a/releasenotes/notes/fix_moving_conf_file-68579cce61154e9f.yaml
+++ b/releasenotes/notes/fix_moving_conf_file-68579cce61154e9f.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix bug of the ``datadog-agent integration install`` command that prevented
+    moving configuration files when the `conf.d` folder is a mounted directory.
+  - |
+    The ``datadog-agent integration install`` command creates the configuration folder
+    for a integration with the correct permissions so that the configuration files can be copied.


### PR DESCRIPTION
### What does this PR do?

Fixes two bugs with the copy of configuration files in an integration wheel to the configuration folder of the agent 
 - when the `conf.d` folder is a mounted directory, it would fail with `invalid cross-link device`
 - when an integration didn't already have an existing `<check_name>.d` folder in `conf.d`, the folder would be created with `d---------` permissions

### Motivation

Fewer bugs

### Additional Notes

Anything else we should know when reviewing?