### PR TITLE
Make the agent systemd services compatible with systemd<=229

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.network.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.network.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description="Datadog Network Tracer"
 After=network.target
-StartLimitIntervalSec=10
+StartLimitInterval=10
 StartLimitBurst=5
 
 [Service]

--- a/omnibus/config/templates/datadog-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.process.service.erb
@@ -2,7 +2,7 @@
 Description="Datadog Process Agent"
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
-StartLimitIntervalSec=10
+StartLimitInterval=10
 StartLimitBurst=5
 
 [Service]

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -2,7 +2,7 @@
 Description="Datadog Agent"
 After=network.target
 Wants=datadog-agent-trace.service datadog-agent-process.service
-StartLimitIntervalSec=10
+StartLimitInterval=10
 StartLimitBurst=5
 
 [Service]

--- a/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
@@ -2,7 +2,7 @@
 Description="Datadog Trace Agent (APM)"
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
-StartLimitIntervalSec=10
+StartLimitInterval=10
 StartLimitBurst=5
 
 [Service]

--- a/releasenotes/notes/update-service-systemd-229-b8a764431ae3042e.yaml
+++ b/releasenotes/notes/update-service-systemd-229-b8a764431ae3042e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix warning about unknown setting "StartLimitIntervalSecs" in the agent
+    service file with systemd version <=229.


### PR DESCRIPTION
### What does this PR do?

`StartLimitInterval` was renamed `StartLimitIntervalSec` and move from
`[Service]` to `[Unit]` in systemd 230.  Since Ubuntu 16.04 ship systemd
229 we have to use the old variable name. `StartLimitInterval` is still
supported by systemd>=230 but no longer documented.

### Motivation

`StartLimitIntervalSec` will be ignored and generate warning in systemd logs with version <=229.