### PR TITLE
 Add integration version subcommand to get the installed version of a check

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -41,7 +41,7 @@ var (
 	verbose      bool
 	useSysPython bool
 	tufConfig    string
-	quietVersion bool
+	versionOnly  bool
 )
 
 type integrationVersion struct {
@@ -108,7 +108,7 @@ func init() {
 	tufCmd.AddCommand(removeCmd)
 	tufCmd.AddCommand(searchCmd)
 	tufCmd.AddCommand(freezeCmd)
-	tufCmd.AddCommand(integrationVersionCmd)
+	tufCmd.AddCommand(showCmd)
 	tufCmd.PersistentFlags().BoolVarP(&withoutTuf, "no-tuf", "t", false, "don't use TUF repo")
 	tufCmd.PersistentFlags().BoolVarP(&inToto, "in-toto", "i", false, "enable in-toto")
 	tufCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging on pip and TUF")
@@ -119,7 +119,7 @@ func init() {
 	// Power user flags - mark as hidden
 	tufCmd.PersistentFlags().MarkHidden("use-sys-python")
 
-	integrationVersionCmd.Flags().BoolVarP(&quietVersion, "quiet", "q", false, "only display version")
+	showCmd.Flags().BoolVarP(&versionOnly, "show-version-only", "q", false, "only display version information")
 }
 
 var tufCmd = &cobra.Command{
@@ -160,12 +160,12 @@ var freezeCmd = &cobra.Command{
 	RunE:  freeze,
 }
 
-var integrationVersionCmd = &cobra.Command{
-	Use:   "version [package]",
-	Short: "Print out the currently installed version of [package]",
+var showCmd = &cobra.Command{
+	Use:   "show [package]",
+	Short: "Print out information about [package]",
 	Args:  cobra.ExactArgs(1),
 	Long:  ``,
-	RunE:  integrationVersionCmdRun,
+	RunE:  show,
 }
 
 func getTufConfigPath() string {
@@ -621,7 +621,7 @@ func freeze(cmd *cobra.Command, args []string) error {
 	return tuf(tufArgs)
 }
 
-func integrationVersionCmdRun(cmd *cobra.Command, args []string) error {
+func show(cmd *cobra.Command, args []string) error {
 
 	cachePath, err := getTUFPipCachePath()
 	if err != nil {
@@ -640,11 +640,15 @@ func integrationVersionCmdRun(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if quietVersion {
+	if versionOnly {
 		// Print only the version for easier parsing
 		fmt.Println(version)
 	} else {
-		fmt.Printf("Installed version of %s: %s\n", packageName, version)
+		msg := `
+Package %s:
+Installed version: %s
+`
+		fmt.Printf(msg, packageName, version)
 	}
 
 	return nil

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -644,8 +644,7 @@ func integrationVersionCmdRun(cmd *cobra.Command, args []string) error {
 		// Print only the version for easier parsing
 		fmt.Println(version)
 	} else {
-		fmt.Printf("Installed version of %s: %s", packageName, version)
-		fmt.Println()
+		fmt.Printf("Installed version of %s: %s\n", packageName, version)
 	}
 
 	return nil

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -644,8 +644,7 @@ func show(cmd *cobra.Command, args []string) error {
 		// Print only the version for easier parsing
 		fmt.Println(version)
 	} else {
-		msg := `
-Package %s:
+		msg := `Package %s:
 Installed version: %s
 `
 		fmt.Printf(msg, packageName, version)

--- a/releasenotes/notes/integration_version-4471d5bef7bfca18.yaml
+++ b/releasenotes/notes/integration_version-4471d5bef7bfca18.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add ``datadog-agent integration version [package]`` command to show the currently installed version of an integration.

--- a/releasenotes/notes/integration_version-4471d5bef7bfca18.yaml
+++ b/releasenotes/notes/integration_version-4471d5bef7bfca18.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Add ``datadog-agent integration version [package]`` command to show the currently installed version of an integration.
+    Add ``datadog-agent integration show [package]`` command to show information about an installed integration.


### PR DESCRIPTION
### What does this PR do?

Print currently installed version of the specified package

```
$ datadog-agent integration show datadog-vsphere
Package datadog-vsphere:
Installed version: 3.6.0

$ datadog-agent integration show datadog-vsphere -q
3.6.0
```

Exit with 0 and prints nothing if the package is not installed 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?