### PR TITLE
Add container_cgroup_prefix option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -216,6 +216,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("container_cgroup_prefix", "")
 
 	// CRI
 	config.BindEnvAndSetDefault("cri_socket_path", "")              // empty is disabled

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -514,6 +514,14 @@ api_key:
 #
 {{ end -}}
 {{- if .DockerTagging }}
+# Container detection
+#
+# On hosts with mixed workloads, non-containernized processes can
+# mistakenly be detected as containerized. This option can be used to
+# tune the detection logic to your system and avoid false-positives.
+#
+# container_cgroup_prefix: "/docker/"
+#
 # Docker tag extraction
 #
 # We can extract container label or environment variables

--- a/pkg/util/containers/metrics/cgroup_detect.go
+++ b/pkg/util/containers/metrics/cgroup_detect.go
@@ -150,13 +150,15 @@ func ScrapeAllCgroups() (map[string]*ContainerCgroup, error) {
 		return cgs, err
 	}
 
+	prefix := config.Datadog.GetString("container_cgroup_prefix")
+
 	for _, dirName := range dirNames {
 		pid, err := strconv.ParseInt(dirName, 10, 32)
 		if err != nil {
 			continue
 		}
 		cgPath := hostProc(dirName, "cgroup")
-		containerID, paths, err := ReadCgroupsForPath(cgPath)
+		containerID, paths, err := ReadCgroupsForPath(cgPath, prefix)
 		if containerID == "" {
 			continue
 		}
@@ -186,13 +188,15 @@ func ScrapeAllCgroups() (map[string]*ContainerCgroup, error) {
 // containerd / cri-o default Kubernetes cgroups
 func ContainerIDForPID(pid int) (string, error) {
 	cgPath := hostProc(strconv.Itoa(pid), "cgroup")
-	containerID, _, err := ReadCgroupsForPath(cgPath)
+	prefix := config.Datadog.GetString("container_cgroup_prefix")
+
+	containerID, _, err := ReadCgroupsForPath(cgPath, prefix)
 
 	return containerID, err
 }
 
 // ReadCgroupsForPath reads the cgroups from a /proc/$pid/cgroup path.
-func ReadCgroupsForPath(pidCgroupPath string) (string, map[string]string, error) {
+func ReadCgroupsForPath(pidCgroupPath, prefix string) (string, map[string]string, error) {
 	f, err := os.Open(pidCgroupPath)
 	if os.IsNotExist(err) {
 		log.Debugf("cgroup path '%s' could not be read: %s", pidCgroupPath, err)
@@ -202,7 +206,7 @@ func ReadCgroupsForPath(pidCgroupPath string) (string, map[string]string, error)
 		return "", nil, err
 	}
 	defer f.Close()
-	return parseCgroupPaths(f)
+	return parseCgroupPaths(f, prefix)
 }
 
 // parseCgroupPaths parses out the cgroup paths from a /proc/$pid/cgroup file.
@@ -216,13 +220,13 @@ func ReadCgroupsForPath(pidCgroupPath string) (string, map[string]string, error)
 //
 // Returns the common containerID and a mapping of target => path
 // If the first line doesn't have a valid container ID we will return an empty string
-func parseCgroupPaths(r io.Reader) (string, map[string]string, error) {
+func parseCgroupPaths(r io.Reader, prefix string) (string, map[string]string, error) {
 	var containerID string
 	paths := make(map[string]string)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		l := scanner.Text()
-		cID, ok := containerIDFromCgroup(l)
+		cID, ok := containerIDFromCgroup(l, prefix)
 		if !ok {
 			log.Tracef("could not parse container id from path '%s'", l)
 			continue
@@ -255,9 +259,12 @@ func parseCgroupPaths(r io.Reader) (string, map[string]string, error) {
 	return containerID, paths, nil
 }
 
-func containerIDFromCgroup(cgroup string) (string, bool) {
+func containerIDFromCgroup(cgroup, prefix string) (string, bool) {
 	sp := strings.SplitN(cgroup, ":", 3)
 	if len(sp) < 3 {
+		return "", false
+	}
+	if prefix != "" && !strings.HasPrefix(sp[2], prefix) {
 		return "", false
 	}
 	matches := containerRe.FindAllString(sp[2], -1)

--- a/pkg/util/containers/metrics/cgroup_detect_test.go
+++ b/pkg/util/containers/metrics/cgroup_detect_test.go
@@ -257,7 +257,7 @@ func TestParseCgroupPaths(t *testing.T) {
 		},
 	} {
 		contents := strings.NewReader(strings.Join(tc.contents, "\n"))
-		c, p, err := parseCgroupPaths(contents)
+		c, p, err := parseCgroupPaths(contents, "")
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expectedContainer, c)
 		assert.Equal(t, tc.expectedPaths, p)
@@ -279,10 +279,28 @@ func TestContainerIDFromCgroup(t *testing.T) {
 		// Legacy systems
 		"6:legacy:a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope",
 	} {
-		c, err := containerIDFromCgroup(tc)
+		c, err := containerIDFromCgroup(tc, "")
 		assert.True(t, err)
 		assert.Equal(t, c, "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419")
 	}
+}
+
+func TestCgroupPrefixFiltering(t *testing.T) {
+	c, ok := containerIDFromCgroup("2:classic:/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419", "")
+	assert.True(t, ok)
+	assert.Equal(t, "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419", c)
+
+	c, ok = containerIDFromCgroup("2:classic:/docker/a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419", "/docker/")
+	assert.True(t, ok)
+	assert.Equal(t, "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419", c)
+
+	c, ok = containerIDFromCgroup("5:coreos_7xx:/system.slice/docker-a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope", "")
+	assert.True(t, ok)
+	assert.Equal(t, "a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419", c)
+
+	c, ok = containerIDFromCgroup("5:coreos_7xx:/system.slice/docker-a27f1331f6ddf72629811aac65207949fc858ea90100c438768b531a4c540419.scope", "/docker/")
+	assert.False(t, ok)
+	assert.Equal(t, "", c)
 }
 
 // TestDindContainer is to test if our agent can handle dind container correctly

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -240,7 +240,8 @@ func (d *DockerUtil) Inspect(id string, withSize bool) (types.ContainerJSON, err
 
 // Inspect detect the container ID we are running in and returns the inspect contents.
 func (d *DockerUtil) InspectSelf() (types.ContainerJSON, error) {
-	cID, _, err := metrics.ReadCgroupsForPath("/proc/self/cgroup")
+	prefix := config.Datadog.GetString("container_cgroup_prefix")
+	cID, _, err := metrics.ReadCgroupsForPath("/proc/self/cgroup", prefix)
 	if err != nil {
 		return types.ContainerJSON{}, err
 	}

--- a/releasenotes/notes/container-cgroup-prefix-5d288c3f33f96607.yaml
+++ b/releasenotes/notes/container-cgroup-prefix-5d288c3f33f96607.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added a new ``container_cgroup_prefix`` option to fix some cases where system slices
+    were detected as containers.


### PR DESCRIPTION
### What does this PR do?

On hosts with mixed workloads, non-containernized processes can mistakenly be detected as containerized, because our detection logic needs to be broad in order to support legacy systems.

This PR adds and option to restrict the cgroup->container matching logic to a given cgroup prefix, to avoid false-positives.

### Motivation

A user had system slices with 64 characters in their name detected as containers, and making the live container view show bad data.

### Additional Notes

Anything else we should know when reviewing?
