### PR TITLE
Run pip check during the omnibus build to ensure a clean env

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -121,6 +121,7 @@ dependency 'datadog-agent'
 # Additional software
 dependency 'datadog-pip'
 dependency 'datadog-agent-integrations'
+dependency 'datadog-agent-env-check'
 dependency 'jmxfetch'
 
 # External agents

--- a/omnibus/config/software/datadog-agent-env-check.rb
+++ b/omnibus/config/software/datadog-agent-env-check.rb
@@ -2,6 +2,7 @@ name 'datadog-agent-env-check'
 
 description "Execute pip check on the python environment of the agent to make sure everything is compatible"
 
+# Run the check after all the definitions touching the python environment of the agent.
 dependency "datadog-pip"
 dependency "datadog-agent"
 dependency "datadog-agent-integrations"

--- a/omnibus/config/software/datadog-agent-env-check.rb
+++ b/omnibus/config/software/datadog-agent-env-check.rb
@@ -1,0 +1,12 @@
+name 'datadog-agent-env-check'
+
+description "Execute pip check on the python environment of the agent to make sure everything is compatible"
+
+dependency "datadog-pip"
+dependency "datadog-agent"
+dependency "datadog-agent-integrations"
+
+build do
+    # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
+    pip "check"
+end


### PR DESCRIPTION
### What does this PR do?

Run pip check during the omnibus build to ensure a clean python environment. 
If there is a discrepancy in the installed dependencies (such as `urllib3` 1.25 and `requests` 2.20.1, which are incompatible), this step of the build will fail and will prevent shipping a broken environment, where, for one, the `datadog-agent integration` command cannot work.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?