### PR TITLE
Add original spf13/viper license info

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1723,7 +1723,7 @@
     "github.com/DataDog/gohai/processes",
     "github.com/DataDog/mmh3",
     "github.com/DataDog/zstd",
-    "github.com/Datadog/viper",
+    "github.com/DataDog/viper",
     "github.com/Microsoft/go-winio",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -107,6 +107,7 @@ core,github.com/spf13/cast,MIT
 core,github.com/spf13/cobra,Apache-2.0
 core,github.com/spf13/jwalterweatherman,MIT
 core,github.com/spf13/pflag,BSD-3-Clause
+core,github.com/spf13/viper,MIT
 core,github.com/stretchr/objx,MIT
 core,github.com/stretchr/testify,MIT
 core,github.com/ugorji/go,MIT


### PR DESCRIPTION
### What does this PR do?

The original Viper is still used by our dependency Cobra, this PR re-introduce the license info of `spf13/viper`.

### Motivation

master builds fail if license info are missing for our dependencies.

