### PR TITLE
Revert "Use DataDog fork of Viper"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,14 +50,6 @@
   version = "v1.3.4"
 
 [[projects]]
-  digest = "1:b98ee2c3f1469ab3b494859d3a9c9e595ec2c63660dea130a5154cfcd427b608"
-  name = "github.com/DataDog/viper"
-  packages = ["."]
-  pruneopts = ""
-  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
-  version = "v1.3.1"
-
-[[projects]]
   digest = "1:a45cafbc9101cf1a3ce81f08296af380ece9c05b4acc92831eeeb0f61a5a7ef5"
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
@@ -1000,6 +992,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:3dab237cd3263a290d771d133fed777bb56c22e380b00ebe92e6531d5c8d3d0c"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = ""
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
   name = "github.com/stretchr/objx"
   packages = ["."]
@@ -1723,7 +1723,6 @@
     "github.com/DataDog/gohai/processes",
     "github.com/DataDog/mmh3",
     "github.com/DataDog/zstd",
-    "github.com/Datadog/viper",
     "github.com/Microsoft/go-winio",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials",
@@ -1779,6 +1778,7 @@
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
+    "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -123,8 +123,8 @@
   version = "~1.1.4"
 
 [[constraint]]
-  name = "github.com/DataDog/viper"
-  version = "=v1.3.1"
+  name = "github.com/spf13/viper"
+  version = "=v1.0.2"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -4,7 +4,6 @@ core,github.com/DataDog/agent-payload,BSD-3-Clause
 core,github.com/DataDog/gohai,MIT
 core,github.com/DataDog/mmh3,MIT
 core,github.com/DataDog/zstd,BSD-3-Clause
-core,github.com/DataDog/viper,MIT
 core,github.com/FortAwesome/Font-Awesome,MIT
 core,github.com/FortAwesome/Font-Awesome,SIL OFL 1.1
 core,github.com/Microsoft/go-winio,MIT
@@ -107,6 +106,7 @@ core,github.com/spf13/cast,MIT
 core,github.com/spf13/cobra,Apache-2.0
 core,github.com/spf13/jwalterweatherman,MIT
 core,github.com/spf13/pflag,BSD-3-Clause
+core,github.com/spf13/viper,MIT
 core,github.com/stretchr/objx,MIT
 core,github.com/stretchr/testify,MIT
 core,github.com/ugorji/go,MIT

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/viper"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 // safeConfig implements Config:

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/DataDog/viper"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/logs/config/parser.go
+++ b/pkg/logs/config/parser.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/DataDog/viper"
+	"github.com/spf13/viper"
 )
 
 // ParseJSON parses the data formatted in JSON


### PR DESCRIPTION
This reverts commit cb4564c69def1832eda12424620570a648bb8968.

### What does this PR do?

Using our Viper fork broke our license infos linter.

### Motivation

Fix the pipeline for now in order to look for a proper solution.
