### PR TITLE
[JMX] lifecycle management on linux/darwin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -909,6 +909,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:3b5435ace50a6acfa3fd9c32b08b886e7a3ad81833eac37c5126492e472423e8"
+  name = "github.com/ramr/go-reaper"
+  packages = ["."]
+  pruneopts = ""
+  revision = "35f6a64e44ff062abfcec2d27cef674212d445c0"
+
+[[projects]]
+  branch = "master"
   digest = "1:7fc2f428767a2521abc63f1a663d981f61610524275d6c0ea645defadd4e916f"
   name = "github.com/samuel/go-zookeeper"
   packages = ["zk"]
@@ -1765,6 +1773,7 @@
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/ramr/go-reaper",
     "github.com/samuel/go-zookeeper/zk",
     "github.com/sbinet/go-python",
     "github.com/shirou/gopsutil/cpu",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,7 @@
 
 [[constraint]]
   name = "github.com/ramr/go-reaper"
-  branch = "master"
+  revision = "35f6a64e44ff062abfcec2d27cef674212d445c0"
 
 [[override]]
   name = "github.com/kubernetes/apimachinery"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,6 +38,10 @@
   name = "github.com/gogo/protobuf"
   version = "~v1.0.0"
 
+[[constraint]]
+  name = "github.com/ramr/go-reaper"
+  branch = "master"
+
 [[override]]
   name = "github.com/kubernetes/apimachinery"
   branch = "release-1.11"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -97,6 +97,7 @@ core,github.com/prometheus/client_golang,Apache-2.0
 core,github.com/prometheus/client_model,Apache-2.0
 core,github.com/prometheus/common,Apache-2.0
 core,github.com/prometheus/procfs,Apache-2.0
+core,github.com/ramr/go-reaper,MIT
 core,github.com/samuel/go-zookeeper,BSD-3-Clause
 core,github.com/sbinet/go-python,Python-2.0
 core,github.com/shirou/gopsutil,BSD-3-Clause

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -161,7 +161,7 @@ func runJmxCommand(command string) error {
 
 	loadConfigs()
 
-	err = runner.Start()
+	err = runner.Start(false)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/common/auto_listener.go
+++ b/cmd/agent/common/auto_listener.go
@@ -32,7 +32,7 @@ func AutoAddListeners(listeners []config.Listeners) []config.Listeners {
 	// Remove the auto listener element from the listeners slice
 	listeners = remove(listeners, autoIdx)
 
-	if isDockerRunning() == false {
+	if IsDockerRunning() == false {
 		return listeners
 	}
 

--- a/cmd/agent/common/auto_listener_nodocker.go
+++ b/cmd/agent/common/auto_listener_nodocker.go
@@ -7,7 +7,7 @@
 
 package common
 
-// isDockerRunning check if docker is running
-func isDockerRunning() bool {
+// IsDockerRunning check if docker is running
+func IsDockerRunning() bool {
 	return false
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -14,9 +14,21 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	reaper "github.com/ramr/go-reaper"
 )
 
 func main() {
+	if common.IsDockerRunning() {
+		// Reap orphaned child processes
+		reaperCfg := reaper.Config{
+			Pid:              0, //wait for child'd process group ID is equal to that of the calling process.
+			Options:          0,
+			DisablePid1Check: true, // we will not be pid 1 with s6
+		}
+		go reaper.Start(reaperCfg)
+	}
+
 	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {
 		os.Exit(-1)

--- a/pkg/collector/corechecks/embed/jmx/runner.go
+++ b/pkg/collector/corechecks/embed/jmx/runner.go
@@ -50,7 +50,13 @@ func (r *runner) initRunner() {
 }
 
 func (r *runner) startRunner() error {
-	err := r.jmxfetch.Start()
+
+	lifecycleMgmt := true
+	if runtime.GOOS == "windows" {
+		lifecycleMgmt = false
+	}
+
+	err := r.jmxfetch.Start(lifecycleMgmt)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -270,6 +270,8 @@ func initConfig(config Config) {
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
+	config.BindEnvAndSetDefault("jmx_max_restarts", int64(3))
+	config.BindEnvAndSetDefault("jmx_max_restart_interval", int64(5))
 
 	// Go_expvar server port
 	config.BindEnvAndSetDefault("expvar_port", "5000")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -305,6 +305,13 @@ api_key:
 #
 # jmx_use_cgroup_memory_limit: true
 #
+# Number of JMX restarts allowed in the restart-interval before giving up
+# jmx_max_restarts: 3
+#
+# Duration of the restart interval in secons
+# jmx_max_restart_interval: 5
+#
+#
 {{ end -}}
 {{- if .Autoconfig }}
 # Autoconfig

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -232,7 +232,7 @@ func (j *JMXFetch) Start(manage bool) error {
 
 	// start syncrhonization channels
 	if err == nil && manage {
-		j.managed = manage
+		j.managed = true
 		j.shutdown = make(chan struct{})
 		j.stopped = make(chan struct{})
 
@@ -291,12 +291,12 @@ func (j *JMXFetch) Wait() error {
 
 func (j *JMXFetch) heartbeat(beat *time.Ticker) {
 	health := health.Register("jmxfetch")
+	defer health.Deregister()
 
 	for range beat.C {
 		select {
 		case <-health.C:
 		case <-j.shutdown:
-			health.Deregister()
 			return
 		}
 	}

--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build jmx
+// +build !windows
+
+package jmxfetch
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func (j *JMXFetch) Monitor() {
+	idx := 0
+	maxRestarts := config.Datadog.GetInt("jmx_max_restarts")
+	ival := float64(config.Datadog.GetInt("jmx_restart_interval"))
+	stopTimes := make([]time.Time, maxRestarts)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	go j.heartbeat(ticker)
+
+	for {
+		// TODO: what should we do with error codes
+		j.Wait()
+		stopTimes[idx] = time.Now()
+		oldestIdx := (idx + maxRestarts + 1) % maxRestarts
+
+		if stopTimes[idx].Sub(stopTimes[oldestIdx]).Seconds() <= ival {
+			log.Errorf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up")
+			close(j.stopped)
+			return
+		}
+
+		idx = (idx + 1) % maxRestarts
+
+		select {
+		case <-j.shutdown:
+			close(j.stopped)
+			return
+		default:
+			// restart
+			log.Warnf("JMXFetch process had to be restarted.")
+			j.Start(false)
+		}
+	}
+}

--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -37,6 +37,11 @@ func (j *JMXFetch) Monitor() {
 		stopTimes[idx] = time.Now()
 		oldestIdx := (idx + maxRestarts + 1) % maxRestarts
 
+		// Please note that the zero value for `time.Time` is `0001-01-01 00:00:00 +0000 UTC`
+		// therefore for the first iteration (the initial launch attempt), the interval will
+		// always be biger than ival (jmx_restart_interval). In fact, this sub operation with
+		// stopTimes here will only start yielding values potentially <= ival _after_ the first
+		// maxRestarts attempts, which is fine and consistent.
 		if stopTimes[idx].Sub(stopTimes[oldestIdx]).Seconds() <= ival {
 			log.Errorf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up")
 			return

--- a/pkg/jmxfetch/jmxfetch_windows.go
+++ b/pkg/jmxfetch/jmxfetch_windows.go
@@ -3,16 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
-// +build docker
+// +build jmx
 
-package common
+package jmxfetch
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
-)
-
-// IsDockerRunning check if docker is running
-func IsDockerRunning() bool {
-	_, err := docker.GetDockerUtil()
-	return err == nil
-}
+func (j *JMXFetch) Monitor() {}

--- a/releasenotes/notes/jmxfetch-process-managemenet-d0815996c58bef6e.yaml
+++ b/releasenotes/notes/jmxfetch-process-managemenet-d0815996c58bef6e.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adding process reaping for children in docker environments.
+fixes:
+  - |
+    Reintroducing JMXFetch process management and healthcheck.


### PR DESCRIPTION
### What does this PR do?

This PR adds some minor process management for JMXFetch. JMXFetch cannot currently be supervised from outside of the scope of the agent, we must therefore add some lifecycle management to ensure: 
- the process may be re-spawned in the event of crashes
- dead children reaped
- sanely give up if JMX continues to crash repeatedly or fails to come up. 

### Motivation

Regression after big JMX refactor left us without any process management for JMXFetch.

### Additional Notes

Anything else we should know when reviewing?
