### PR TITLE
Activate k8s on no logs_config.container_collect_all

### DIFF
--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -32,7 +32,7 @@ func NewLauncher(collectAll bool, sources *config.LogSources, services *service.
 	// attempt to initialize a kubernetes launcher
 	log.Warnf("Could not setup the docker launcher: %v", err)
 
-	kubernetesLauncher, err := kubernetes.NewLauncher(sources, services)
+	kubernetesLauncher, err := kubernetes.NewLauncher(sources, services, collectAll)
 	if err == nil {
 		return kubernetesLauncher
 	}

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -21,7 +21,7 @@ import (
 // By default, it returns a docker launcher that uses the docker socket to collect logs.
 // The docker launcher can be used both on a non kubernetes and kubernetes environment.
 // When a docker launcher cannot be initialized properly. The launcher will attempt to
-// initializea kubernetes launcher which will tail logs files (in '/var/log/pods') of all
+// initialize a kubernetes launcher which will tail logs files (in '/var/log/pods') of all
 // the containers running on the kubernetes cluster and matching the autodiscovery configuration.
 func NewLauncher(collectAll bool, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
 	// attempt to initialize a docker launcher

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -24,26 +24,18 @@ import (
 // the launcher will attempt to initialize a kubernetes launcher which will detect and tail all the logs files localized
 // in '/var/log/pods' of all the containers running on the kubernetes cluster.
 func NewLauncher(collectAll bool, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
-	switch {
-	case collectAll:
-		// attempt to initialize a docker launcher
-		launcher, err := docker.NewLauncher(sources, services, pipelineProvider, registry)
-		if err == nil {
-			return launcher
-		}
-		// attempt to initialize a kubernetes launcher
-		log.Warnf("Could not setup the docker launcher, falling back to the kubernetes one: %v", err)
-		kubernetesLauncher, err := kubernetes.NewLauncher(sources, services)
-		if err == nil {
-			return kubernetesLauncher
-		}
-		log.Warnf("Could not setup the kubernetes launcher: %v", err)
-	default:
-		launcher, err := docker.NewLauncher(sources, services, pipelineProvider, registry)
-		if err == nil {
-			return launcher
-		}
-		log.Warnf("Could not setup the docker launcher: %v", err)
+	// attempt to initialize a docker launcher
+	launcher, err := docker.NewLauncher(sources, services, pipelineProvider, registry)
+	if err == nil {
+		return launcher
 	}
+	// attempt to initialize a kubernetes launcher
+	log.Warnf("Could not setup the docker launcher: %v", err)
+
+	kubernetesLauncher, err := kubernetes.NewLauncher(sources, services)
+	if err == nil {
+		return kubernetesLauncher
+	}
+	log.Warnf("Could not setup the kubernetes launcher: %v", err)
 	return NewNoopLauncher()
 }

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -17,25 +17,30 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// NewLauncher returns a new container launcher,
-// by default returns a docker launcher that uses the docker socket to collect logs.
+// NewLauncher returns a new container launcher.
+// By default, it returns a docker launcher that uses the docker socket to collect logs.
 // The docker launcher can be used both on a non kubernetes and kubernetes environment.
-// When a docker launcher can not be initialized properly and when the log collection is enabled for all containers,
-// the launcher will attempt to initialize a kubernetes launcher which will detect and tail all the logs files localized
-// in '/var/log/pods' of all the containers running on the kubernetes cluster.
+// When a docker launcher cannot be initialized properly. The launcher will attempt to
+// initializea kubernetes launcher which will tail logs files (in '/var/log/pods') of all
+// the containers running on the kubernetes cluster and matching the autodiscovery configuration.
 func NewLauncher(collectAll bool, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {
 	// attempt to initialize a docker launcher
+	log.Info("Trying to initialize docker launcher")
 	launcher, err := docker.NewLauncher(sources, services, pipelineProvider, registry)
 	if err == nil {
+		log.Info("Docker launcher initialized")
 		return launcher
 	}
-	log.Warnf("Could not setup the docker launcher: %v", err)
+	log.Infof("Could not setup the docker launcher: %v", err)
 
 	// attempt to initialize a kubernetes launcher
+	log.Info("Trying to initialize kubernetes launcher")
 	kubernetesLauncher, err := kubernetes.NewLauncher(sources, services, collectAll)
 	if err == nil {
+		log.Info("Kubernetes launcher initialized")
 		return kubernetesLauncher
 	}
-	log.Warnf("Could not setup the kubernetes launcher: %v", err)
+	log.Infof("Could not setup the kubernetes launcher: %v", err)
+	log.Infof("Container logs won't be collected")
 	return NewNoopLauncher()
 }

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -29,9 +29,9 @@ func NewLauncher(collectAll bool, sources *config.LogSources, services *service.
 	if err == nil {
 		return launcher
 	}
-	// attempt to initialize a kubernetes launcher
 	log.Warnf("Could not setup the docker launcher: %v", err)
 
+	// attempt to initialize a kubernetes launcher
 	kubernetesLauncher, err := kubernetes.NewLauncher(sources, services, collectAll)
 	if err == nil {
 		return kubernetesLauncher

--- a/pkg/logs/input/container/launcher.go
+++ b/pkg/logs/input/container/launcher.go
@@ -20,7 +20,7 @@ import (
 // NewLauncher returns a new container launcher.
 // By default, it returns a docker launcher that uses the docker socket to collect logs.
 // The docker launcher can be used both on a non kubernetes and kubernetes environment.
-// When a docker launcher cannot be initialized properly. The launcher will attempt to
+// When a docker launcher cannot be initialized properly, the launcher will attempt to
 // initialize a kubernetes launcher which will tail logs files (in '/var/log/pods') of all
 // the containers running on the kubernetes cluster and matching the autodiscovery configuration.
 func NewLauncher(collectAll bool, sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) restart.Restartable {

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -8,8 +8,6 @@
 package docker
 
 import (
-	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -27,7 +25,6 @@ import (
 const (
 	backoffInitialDuration = 1 * time.Second
 	backoffMaxDuration     = 60 * time.Second
-	dockerSocketPath       = "/var/run/docker.sock"
 )
 
 // A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
@@ -50,10 +47,6 @@ type Launcher struct {
 
 // NewLauncher returns a new launcher
 func NewLauncher(sources *config.LogSources, services *service.Services, pipelineProvider pipeline.Provider, registry auditor.Registry) (*Launcher, error) {
-	if !isAvailable() {
-		return nil, fmt.Errorf("%s not found", dockerSocketPath)
-	}
-
 	launcher := &Launcher{
 		pipelineProvider:   pipelineProvider,
 		tailers:            make(map[string]*Tailer),
@@ -76,14 +69,6 @@ func NewLauncher(sources *config.LogSources, services *service.Services, pipelin
 	launcher.addedServices = services.GetAddedServices(service.Docker)
 	launcher.removedServices = services.GetRemovedServices(service.Docker)
 	return launcher, nil
-}
-
-func isAvailable() bool {
-	if _, err := os.Stat(dockerSocketPath); os.IsNotExist(err) {
-		return false
-	}
-
-	return true
 }
 
 // setup initializes the docker client and the tagger,

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -8,7 +8,6 @@
 package kubernetes
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -24,7 +23,7 @@ import (
 // The path to the pods log directory.
 const podsDirectoryPath = "/var/log/pods"
 
-var collectAllDisabledError = errors.New(fmt.Sprintf("%s disabled", config.ContainerCollectAll))
+var collectAllDisabledError = fmt.Errorf("%s disabled", config.ContainerCollectAll)
 
 // Launcher looks for new and deleted pods to create or delete one logs-source per container.
 type Launcher struct {

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -8,6 +8,7 @@
 package kubernetes
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,6 +24,8 @@ import (
 // The path to the pods log directory.
 const podsDirectoryPath = "/var/log/pods"
 
+var collectAllDisabledError = errors.New(fmt.Sprintf("%s disabled", config.ContainerCollectAll))
+
 // Launcher looks for new and deleted pods to create or delete one logs-source per container.
 type Launcher struct {
 	sources                   *config.LogSources
@@ -33,10 +36,11 @@ type Launcher struct {
 	dockerRemovedServices     chan *service.Service
 	containerdAddedServices   chan *service.Service
 	containerdRemovedServices chan *service.Service
+	collectAll                bool
 }
 
 // NewLauncher returns a new launcher.
-func NewLauncher(sources *config.LogSources, services *service.Services) (*Launcher, error) {
+func NewLauncher(sources *config.LogSources, services *service.Services, collectAll bool) (*Launcher, error) {
 	if !isAvailable() {
 		return nil, fmt.Errorf("%s not found", podsDirectoryPath)
 	}
@@ -50,6 +54,7 @@ func NewLauncher(sources *config.LogSources, services *service.Services) (*Launc
 		sourcesByContainer: make(map[string]*config.LogSource),
 		stopped:            make(chan struct{}),
 		kubeutil:           kubeutil,
+		collectAll:         collectAll,
 	}
 	err = launcher.setup()
 	if err != nil {
@@ -139,7 +144,9 @@ func (l *Launcher) addSource(svc *service.Service) {
 	}
 	source, err := l.getSource(pod, container)
 	if err != nil {
-		log.Warnf("Invalid configuration for pod %v, container %v: %v", pod.Metadata.Name, container.Name, err)
+		if err != collectAllDisabledError {
+			log.Warnf("Invalid configuration for pod %v, container %v: %v", pod.Metadata.Name, container.Name, err)
+		}
 		return
 	}
 
@@ -180,6 +187,9 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 		}
 		cfg = configs[0]
 	} else {
+		if !l.collectAll {
+			return nil, collectAllDisabledError
+		}
 		shortImageName, err := l.getShortImageName(container)
 		if err != nil {
 			cfg = &config.LogsConfig{

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -40,7 +40,7 @@ type Launcher struct {
 
 // NewLauncher returns a new launcher.
 func NewLauncher(sources *config.LogSources, services *service.Services, collectAll bool) (*Launcher, error) {
-	if !isAvailable() {
+	if !isIntegrationAvailable() {
 		return nil, fmt.Errorf("%s not found", podsDirectoryPath)
 	}
 
@@ -70,8 +70,8 @@ func NewLauncher(sources *config.LogSources, services *service.Services, collect
 	return launcher, nil
 }
 
-func isAvailable() bool {
-	if _, err := os.Stat(podsDirectoryPath); os.IsNotExist(err) {
+func isIntegrationAvailable() bool {
+	if _, err := os.Stat(podsDirectoryPath); err != nil {
 		return false
 	}
 

--- a/pkg/logs/input/kubernetes/launcher_nokubelet.go
+++ b/pkg/logs/input/kubernetes/launcher_nokubelet.go
@@ -16,7 +16,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new launcher
-func NewLauncher(sources *config.LogSources, services *service.Services) (*Launcher, error) {
+func NewLauncher(sources *config.LogSources, services *service.Services, collectAll bool) (*Launcher, error) {
 	return &Launcher{}, nil
 }
 

--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestGetSource(t *testing.T) {
-	launcher := &Launcher{}
+	launcher := &Launcher{collectAll: true}
 	container := kubelet.ContainerStatus{
 		Name:  "foo",
 		Image: "bar",
@@ -46,7 +46,7 @@ func TestGetSource(t *testing.T) {
 }
 
 func TestGetSourceShouldBeOverridenByAutoDiscoveryAnnotation(t *testing.T) {
-	launcher := &Launcher{}
+	launcher := &Launcher{collectAll: true}
 	container := kubelet.ContainerStatus{
 		Name:  "foo",
 		Image: "bar",
@@ -78,7 +78,7 @@ func TestGetSourceShouldBeOverridenByAutoDiscoveryAnnotation(t *testing.T) {
 }
 
 func TestGetSourceShouldFailWithInvalidAutoDiscoveryAnnotation(t *testing.T) {
-	launcher := &Launcher{}
+	launcher := &Launcher{collectAll: true}
 	container := kubelet.ContainerStatus{
 		Name:  "foo",
 		Image: "bar",
@@ -90,6 +90,7 @@ func TestGetSourceShouldFailWithInvalidAutoDiscoveryAnnotation(t *testing.T) {
 			Namespace: "buu",
 			UID:       "baz",
 			Annotations: map[string]string{
+				// missing [ ]
 				"ad.datadoghq.com/foo.logs": `{"source":"any_source","service":"any_service","tags":["tag1","tag2"]}`,
 			},
 		},
@@ -104,7 +105,7 @@ func TestGetSourceShouldFailWithInvalidAutoDiscoveryAnnotation(t *testing.T) {
 }
 
 func TestGetSourceAddContainerdParser(t *testing.T) {
-	launcher := &Launcher{}
+	launcher := &Launcher{collectAll: true}
 	container := kubelet.ContainerStatus{
 		Name:  "foo",
 		Image: "bar",
@@ -143,7 +144,7 @@ func TestSearchContainer(t *testing.T) {
 			Namespace: "podNamespace",
 			UID:       "podUID",
 			Annotations: map[string]string{
-				"ad.datadoghq.com/foo.logs": `{"source":"any_source","service":"any_service","tags":["tag1","tag2"]}`,
+				"ad.datadoghq.com/fooName.logs": `[{"source":"any_source","service":"any_service","tags":["tag1","tag2"]}]`,
 			},
 		},
 		Status: kubelet.Status{
@@ -165,6 +166,58 @@ func TestSearchContainer(t *testing.T) {
 
 	_, err := searchContainer(serviceBaz, pod)
 	assert.EqualError(t, err, "Container docker://bazID not found")
+}
+
+func TestContainerCollectAll(t *testing.T) {
+	launcherCollectAll := &Launcher{collectAll: true}
+	launcherCollectAllDisabled := &Launcher{collectAll: false}
+	containerFoo := kubelet.ContainerStatus{
+		Name:  "fooName",
+		Image: "fooImage",
+		ID:    "docker://fooID",
+	}
+	containerBar := kubelet.ContainerStatus{
+		Name:  "barName",
+		Image: "barImage",
+		ID:    "docker://barID",
+	}
+	podFoo := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "podName",
+			Namespace: "podNamespace",
+			UID:       "podUIDFoo",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/fooName.logs": `[{"source":"any_source","service":"any_service"}]`,
+			},
+		},
+		Status: kubelet.Status{
+			Containers: []kubelet.ContainerStatus{containerFoo, containerBar},
+		},
+	}
+	podBar := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "podName",
+			Namespace: "podNamespace",
+			UID:       "podUIDBarr",
+		},
+		Status: kubelet.Status{
+			Containers: []kubelet.ContainerStatus{containerFoo, containerBar},
+		},
+	}
+
+	source, err := launcherCollectAll.getSource(podFoo, containerFoo)
+	assert.Nil(t, err)
+	assert.Equal(t, "docker://fooID", source.Config.Identifier)
+	source, err = launcherCollectAll.getSource(podBar, containerBar)
+	assert.Nil(t, err)
+	assert.Equal(t, "docker://barID", source.Config.Identifier)
+
+	source, err = launcherCollectAllDisabled.getSource(podFoo, containerFoo)
+	assert.Nil(t, err)
+	assert.Equal(t, "docker://fooID", source.Config.Identifier)
+	source, err = launcherCollectAllDisabled.getSource(podBar, containerBar)
+	assert.Equal(t, collectAllDisabledError, err)
+	assert.Nil(t, source)
 }
 
 // contains returns true if the list contains all the items.

--- a/releasenotes/notes/logs-kubernetes-integration-without-collect-all-ef988eda34f14751.yaml
+++ b/releasenotes/notes/logs-kubernetes-integration-without-collect-all-ef988eda34f14751.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Kubernetes logs integration is now automatically enabled if it can find ``/var/log/pods``.
+    If ``logs_config.container_collect_all`` is not enabled, only pods with Datadog logs
+    annotation will be collected. If ``logs_config.container_collect_all`` is enabled, logs for
+    all pods (matching ``ac_exclude`` and ``ac_include`` filters if applicable) will be collected.
+


### PR DESCRIPTION
### What does this PR do?

This PR allow k8s logs integration even when `logs_config.container_collect_all` is not enabled. In that case, only pods with logs annotation are tailed

### Motivation

Coherence with the docker log integration behavior

### Additional Notes

Anything else we should know when reviewing?
