### PR TITLE
[windows] repairs bug(s) when windows installation drive is not (c:)

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -242,7 +242,7 @@
                             Vital="yes"
                             Interactive="no"
                             Account="LocalSystem"
-                            Arguments="--config=c:\programdata\datadog\datadog.yaml" >
+                            Arguments="--config=[APPLICATIONDATADIRECTORY]datadog.yaml" >
               <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
               <util:ServiceConfig
                 FirstFailureActionType='restart'
@@ -283,7 +283,7 @@
                             Vital="yes"
                             Interactive="no"
                             Account="LocalSystem"
-                            Arguments="--config=c:\programdata\datadog\datadog.yaml" >
+                            Arguments="--config=[APPLICATIONDATADIRECTORY]datadog.yaml" >
               <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" />
               <util:ServiceConfig
                 FirstFailureActionType='restart'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,7 @@ type Proxy struct {
 }
 
 func init() {
+	osinit()
 	// Configure Datadog global configuration
 	Datadog = NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	// Configuration defaults

--- a/pkg/config/config_android.go
+++ b/pkg/config/config_android.go
@@ -15,6 +15,11 @@ import (
 	"golang.org/x/mobile/asset"
 )
 
+// called by init in config.go, to ensure any os-specific config is done
+// in time
+func osinit() {
+}
+
 const (
 	defaultConfdPath            = ""
 	defaultAdditionalChecksPath = ""

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -13,5 +13,10 @@ const (
 	defaultGuiPort              = "5002"
 )
 
+// called by init in config.go, to ensure any os-specific config is done
+// in time
+func osinit() {
+}
+
 // NewAssetFs  Should never be called on non-android
 func setAssetFs(config Config) {}

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -16,5 +16,10 @@ const (
 	defaultGuiPort              = "-1"
 )
 
+// called by init in config.go, to ensure any os-specific config is done
+// in time
+func osinit() {
+}
+
 // NewAssetFs  Should never be called on non-android
 func setAssetFs(config Config) {}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
@@ -22,7 +23,7 @@ var (
 // ServiceName is the name that'll be used to register the Agent
 const ServiceName = "DatadogAgent"
 
-func init() {
+func osinit() {
 	pd, err := winutil.GetProgramDataDir()
 	if err == nil {
 		defaultConfdPath = filepath.Join(pd, "Datadog", "conf.d")
@@ -31,6 +32,7 @@ func init() {
 	} else {
 		winutil.LogEventViewer(ServiceName, 0x8000000F, defaultConfdPath)
 	}
+	fmt.Printf("defaultRunPath is %s\n", defaultRunPath)
 }
 
 // NewAssetFs  Should never be called on non-android

--- a/releasenotes/notes/fixproblemswithaltwindir-afc7228d0f135400.yaml
+++ b/releasenotes/notes/fixproblemswithaltwindir-afc7228d0f135400.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, further fixes when installation drive isn't c:.  Fixes
+    problem where `logs` was effectively hardcoded to use `c:` for programdata
+    Fixes installation problem where process & trace service were using
+    `c:\programdata\...` to find datadog.yaml regardless of installation dir


### PR DESCRIPTION
- Fixes problem configuring programdata directory for logs
- Fixes problem that installer was still hard-writing (c:) for
  config files for trace & process

### Motivation

Customer request

### Additional Notes

Note that if upgrading *to* this build, prior releases will have written the wrong path (`c:`) to the config file; therefore, the config file must be updated.
