### PR TITLE
Add relative file path in logs

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -107,10 +107,10 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 
 	configTemplate += fmt.Sprintf(`</outputs>
 	<formats>
-		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%File&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
-		<format id="common" format="%%Date(%s) | %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n"/>
+		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
+		<format id="common" format="%%Date(%s) | %%LEVEL | (%%RelFile:%%Line in %%FuncShort) | %%Msg%%n"/>
 		<format id="syslog-json" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%RelFile&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
-		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%File:%%Line in %%FuncShort) | %%Msg%%n" />
+		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%RelFile:%%Line in %%FuncShort) | %%Msg%%n" />
 	</formats>
 </seelog>`, logDateFormat, logDateFormat)
 

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractShortPathFromFullPath(t *testing.T) {
+	// omnibus path
+	assert.Equal(t, "pkg/collector/scheduler.go", extractShortPathFromFullPath("/go/src/github.com/DataDog/datadog-agent/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/scheduler.go"))
+	// dev env path
+	assert.Equal(t, "cmd/agent/app/start.go", extractShortPathFromFullPath("/home/vagrant/go/src/github.com/DataDog/datadog-agent/cmd/agent/app/start.go"))
+	// relative path
+	assert.Equal(t, "pkg/collector/scheduler.go", extractShortPathFromFullPath("pkg/collector/scheduler.go"))
+	// no path
+	assert.Equal(t, "main.go", extractShortPathFromFullPath("main.go"))
+}

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -6,8 +6,11 @@
 package config
 
 import (
+	"bufio"
+	"bytes"
 	"testing"
 
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,4 +23,23 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 	assert.Equal(t, "pkg/collector/scheduler.go", extractShortPathFromFullPath("pkg/collector/scheduler.go"))
 	// no path
 	assert.Equal(t, "main.go", extractShortPathFromFullPath("main.go"))
+}
+
+func benchmarkLogFormat(logFormat string, b *testing.B) {
+	var buff bytes.Buffer
+	w := bufio.NewWriter(&buff)
+
+	l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, logFormat)
+
+	for n := 0; n < b.N; n++ {
+		l.Infof("Hello I am a log")
+	}
+}
+
+func BenchmarkLogFormatFilename(b *testing.B) {
+	benchmarkLogFormat("%Date(%s) | %LEVEL | (%File:%Line in %FuncShort) | %Msg", b)
+}
+
+func BenchmarkLogFormatShortFilePath(b *testing.B) {
+	benchmarkLogFormat("%Date(%s) | %LEVEL | (%ShortFilePath:%Line in %FuncShort) | %Msg", b)
 }

--- a/releasenotes/notes/agent-log-relative-file-fd9022ec8b80ec0d.yaml
+++ b/releasenotes/notes/agent-log-relative-file-fd9022ec8b80ec0d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The logs now contains the relative file path (including the package) instead of only the filename

--- a/releasenotes/notes/agent-log-relative-file-fd9022ec8b80ec0d.yaml
+++ b/releasenotes/notes/agent-log-relative-file-fd9022ec8b80ec0d.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    The logs now contains the relative file path (including the package) instead of only the filename
+    The Agent logs now contains the relative file path (including the package) instead of only the filename.


### PR DESCRIPTION
### What does this PR do?

Parses a short file path (from the `datadog-agent` root) from the full path to include the pkg

before:
```
2019-01-02 15:12:03 UTC | INFO | (scheduler.go:63 in Schedule) | Scheduling check cpu
```
after:
```
2019-01-02 16:11:41 UTC | INFO | (pkg/collector/scheduler.go:63 in Schedule) | Scheduling check cpu
```

### Motivation

Improve logs/flare as we have several files with the same name in different packages