### PR TITLE
Call Python3 linter on custom checks

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -121,6 +121,7 @@ dependency 'datadog-agent'
 # Additional software
 dependency 'datadog-pip'
 dependency 'datadog-agent-integrations'
+dependency 'datadog-a7'
 dependency 'datadog-agent-env-check'
 dependency 'jmxfetch'
 

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -11,11 +11,15 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	agentConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/sbinet/go-python"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -24,7 +28,18 @@ import (
 var (
 	pyLoaderStats   *expvar.Map
 	configureErrors map[string][]string
+	py3Warnings     map[string][]string
 	statsLock       sync.RWMutex
+)
+
+const (
+	wheelNamespace = "datadog_checks"
+	a7ReadyMetric  = "datadog.agent.check_ready"
+	a7Ready        = 1
+	a7NotReady     = 0
+	a7TagReady     = "ready"
+	a7TagNotReady  = "not_ready"
+	a7TagUnknown   = "unknown"
 )
 
 func init() {
@@ -34,6 +49,7 @@ func init() {
 	loaders.RegisterLoader(10, factory)
 
 	configureErrors = map[string][]string{}
+	py3Warnings = map[string][]string{}
 	pyLoaderStats = expvar.NewMap("pyLoader")
 	pyLoaderStats.Set("ConfigureErrors", expvar.Func(expvarConfigureErrors))
 }
@@ -45,6 +61,7 @@ const agentCheckModuleName = "checks"
 // PythonCheckLoader is a specific loader for checks living in Python modules
 type PythonCheckLoader struct {
 	agentCheckClass *python.PyObject
+	telemetry       aggregator.Sender
 }
 
 // NewPythonCheckLoader creates an instance of the Python checks loader
@@ -67,7 +84,13 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 		return nil, errors.New("unable to initialize AgentCheck class")
 	}
 
-	return &PythonCheckLoader{agentCheckClass}, nil
+	sender, err := aggregator.GetSender("collector_python")
+	if err != nil {
+		log.Errorf("Unable to get a new metrics sender: %s", err)
+		return nil, errors.New("unable to initialize collector telemetry")
+	}
+
+	return &PythonCheckLoader{agentCheckClass: agentCheckClass, telemetry: sender}, nil
 }
 
 // Load tries to import a Python module with the same name found in config.Name, searches for
@@ -75,7 +98,7 @@ func NewPythonCheckLoader() (*PythonCheckLoader, error) {
 func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, error) {
 	checks := []check.Check{}
 	moduleName := config.Name
-	whlModuleName := fmt.Sprintf("datadog_checks.%s", config.Name)
+	whlModuleName := fmt.Sprintf("%s.%s", wheelNamespace, config.Name)
 
 	// Looking for wheels first
 	modules := []string{whlModuleName, moduleName}
@@ -93,10 +116,15 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 
 	var pyErr string
 	var checkModule *python.PyObject
-	for _, name := range modules {
+	var name string
+	var loadedAsWheel bool
+	for _, name = range modules {
 		// import python module containing the check
 		checkModule = python.PyImport_ImportModule(name)
 		if checkModule != nil {
+			if strings.HasPrefix(name, fmt.Sprintf("%s.", wheelNamespace)) {
+				loadedAsWheel = true
+			}
 			break
 		}
 
@@ -160,7 +188,48 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 			} else {
 				log.Debugf("python check '%s' doesn't have a '__version__' attribute: %s", config.Name, errors.New(pyErr))
 			}
-			log.Infof("python check '%s' doesn't have a '__version__' attribute", config.Name)
+			log.Debugf("python check '%s' doesn't have a '__version__' attribute", config.Name)
+
+		}
+
+		if !agentConfig.Datadog.GetBool("disable_py3_validation") && !loadedAsWheel {
+			// Customers, though unlikely might version their custom checks.
+			// Let's use the module namespace to try to decide if this was a
+			// custom check, check for py3 compatibility
+			checkFilePath := checkModule.GetAttrString("__file__")
+
+			tags := []string{"check_name:" + name, "agent_version_major:6"}
+			if agentVersion, err := version.New(version.AgentVersion, version.Commit); err == nil {
+				tags = append(tags, fmt.Sprintf("agent_version_minor:%d", agentVersion.Minor))
+			}
+
+			if checkFilePath != nil {
+				defer checkFilePath.DecRef()
+				if python.PyString_Check(checkFilePath) {
+					filePath := python.PyString_AsString(checkFilePath)
+
+					// __file__ return the .pyc file path
+					if strings.HasSuffix(moduleName, ".pyc") {
+						filePath = filePath[:len(filePath)-1]
+					}
+					if warnings, err := validatePython3(name, filePath); err == nil {
+						val, status := addExpvarPy3Warnings(name, warnings)
+						tags = append(tags, fmt.Sprintf("status:%s", status))
+						cl.telemetry.Gauge(a7ReadyMetric, val, "", tags)
+					} else {
+						tags = append(tags, fmt.Sprintf("status:%s", a7TagUnknown))
+						cl.telemetry.Gauge(a7ReadyMetric, a7NotReady, "", tags)
+					}
+				} else {
+					tags = append(tags, fmt.Sprintf("status:%s", a7TagUnknown))
+					cl.telemetry.Gauge(a7ReadyMetric, a7NotReady, "", tags)
+					log.Debugf("Error: %s check attribute '__file__' is not a type string", name)
+				}
+			} else {
+				log.Debugf("Could not query the __file__ attribute for check %s", name)
+				python.PyErr_Clear()
+			}
+			cl.telemetry.Commit()
 		}
 	}
 
@@ -214,4 +283,22 @@ func addExpvarConfigureError(check string, errMsg string) {
 	} else {
 		configureErrors[check] = []string{errMsg}
 	}
+}
+
+func expvarPy3Warnings() interface{} {
+	statsLock.RLock()
+	defer statsLock.RUnlock()
+
+	return py3Warnings
+}
+
+func addExpvarPy3Warnings(checkName string, warnings []string) (float64, string) {
+	statsLock.Lock()
+	defer statsLock.Unlock()
+
+	if len(warnings) > 0 {
+		py3Warnings[checkName] = warnings
+		return a7NotReady, a7TagNotReady
+	}
+	return a7Ready, a7TagReady
 }

--- a/pkg/collector/py/py3_checker.go
+++ b/pkg/collector/py/py3_checker.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython
+
+package py
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	linterTimeout = 4 * time.Second
+)
+
+func init() {
+	here, _ := executable.Folder()
+	py3LinterPath = filepath.Join(here, py3LinterPath)
+	if _, err := os.Stat(py3LinterPath); err != nil {
+		log.Warnf("Could not find python linter '%s': disabling linter", py3LinterPath)
+		py3LinterPath = ""
+	}
+}
+
+type warning struct {
+	Message string
+}
+
+// verifyPython3 checks that a check can run on python 3
+func validatePython3(moduleName string, modulePath string) ([]string, error) {
+	if py3LinterPath == "" {
+		return nil, fmt.Errorf("no Python3 linter found")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), linterTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, py3LinterPath, modulePath)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("error running the linter on (%s): %s", err, stderr.String())
+	}
+
+	var warnings []warning
+	if err := json.Unmarshal(stdout.Bytes(), &warnings); err != nil {
+		return nil, fmt.Errorf("could not Unmarshal warnings from Python3 linter: %s", err)
+	}
+
+	res := []string{}
+	// no post processing needed for now, we just retrieve every messages
+	for _, warn := range warnings {
+		res = append(res, warn.Message)
+	}
+
+	return res, nil
+}

--- a/pkg/collector/py/py3_checker_nix.go
+++ b/pkg/collector/py/py3_checker_nix.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython,!windows
+
+package py
+
+import (
+	"path/filepath"
+)
+
+const (
+	py3LinterBin = "a7_validate"
+)
+
+var (
+	py3LinterPath = filepath.Join("..", "..", "embedded", "bin", py3LinterBin)
+)

--- a/pkg/collector/py/py3_checker_windows.go
+++ b/pkg/collector/py/py3_checker_windows.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+// +build cpython,windows
+
+package py
+
+import (
+	"path/filepath"
+)
+
+const (
+	py3LinterBin = "a7_validate.exe"
+)
+
+var (
+	py3LinterPath = filepath.Join("Scripts", py3LinterBin)
+)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,6 +117,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnvAndSetDefault("bind_host", "localhost")
 	config.BindEnvAndSetDefault("health_port", int64(0))
+	config.BindEnvAndSetDefault("disable_py3_validation", false)
 
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -185,6 +185,8 @@ api_key:
 # python package.
 # procfs_path: /proc
 
+# Disable Python3 validation of python checks
+# disable_py3_validation: false
 
 # BETA: Encrypted Secrets (Linux only)
 #


### PR DESCRIPTION
### What does this PR do?

In preparation to python2 being EOL we now ship a Python3 linter in preparation for Python3.