### PR TITLE
Enable clusterchecks in DCA master

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -20,7 +20,7 @@ BIN_PATH = os.path.join(".", "bin", "datadog-cluster-agent")
 AGENT_TAG = "datadog/cluster_agent:master"
 DEFAULT_BUILD_TAGS = [
     "kubeapiserver",
-    # "clusterchecks",
+    "clusterchecks",
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Cluster-checks are almost ready for prime-time, let's re-enable them in the cluster-agent's `master` build to have an image for QA.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
