### PR TITLE
Increase timeout in isLocked test to reduce flakyness

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -54,7 +54,7 @@ func isLocked(l lockable) bool {
 	select {
 	case <-ok:
 		return false
-	case <-time.After(1 * time.Millisecond):
+	case <-time.After(10 * time.Millisecond):
 		return true
 	}
 }


### PR DESCRIPTION
### What does this PR do?

A 1ms timeout made `requireNotLocked` flaky no heavily-loaded nodes. Increase it to reduce the risk for false-positives.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
