### PR TITLE
[flare] scrub api keys from other services.

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -48,7 +48,7 @@ var (
 	// It is a best effort to match the api key field without matching our
 	// own already redacted (we don't want to match: **************************abcde)
 	// Basically we allow many special chars while forbidding *
-	otherAPIKeysRx       = regexp.MustCompile(`api_key: [a-zA-Z0-9/\]\[\(\)\{\}><#@$+=]+`)
+	otherAPIKeysRx       = regexp.MustCompile(`api_key:\s*[a-zA-Z0-9\/\]\[\(\)\{\}><#@$+=]+`)
 	otherAPIKeysReplacer = log.Replacer{
 		Regex: otherAPIKeysRx,
 		ReplFunc: func(b []byte) []byte {

--- a/pkg/flare/writer_test.go
+++ b/pkg/flare/writer_test.go
@@ -47,6 +47,37 @@ log_level: info`
 
 }
 
+func TestRedactingOtherServicesApiKey(t *testing.T) {
+	clear := `init_config:
+instances:
+- host: 127.0.0.1
+  api_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  port: 8082
+  api_key: dGhpc2++lzM+XBhc3N3b3JkW113aXRo/c29tZWN]oYXJzMTIzCg==
+  version: 4 # omit this line if you're running pdns_recursor version 3.x`
+	redacted := `init_config:
+instances:
+- host: 127.0.0.1
+  api_key: ***************************aaaaa
+  port: 8082
+  api_key: ********
+  version: 4 # omit this line if you're running pdns_recursor version 3.x`
+
+	buf := bytes.NewBuffer([]byte{})
+
+	w := RedactingWriter{
+		targetBuf: bufio.NewWriter(buf),
+	}
+	w.RegisterReplacer(otherAPIKeysReplacer)
+
+	n, err := w.Write([]byte(clear))
+	assert.Nil(t, err)
+	err = w.Flush()
+	assert.Nil(t, err)
+	assert.Equal(t, len(redacted), n)
+	assert.Equal(t, redacted, buf.String())
+}
+
 func TestRedactingWriterReplacers(t *testing.T) {
 	redacted := `dd_url: https://app.datadoghq.com
 api_key: ***************************aaaaa

--- a/releasenotes/notes/redact-non-dd-apikeys-fda787625ce110fe.yaml
+++ b/releasenotes/notes/redact-non-dd-apikeys-fda787625ce110fe.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    In the flare, try to redact api keys from other services.


### PR DESCRIPTION
### What does this PR do?

Redacts API key which are not Datadog API keys.

### Motivation

Some `.yaml` files ship API keys which are not the Datadog one and not using the same format, we want to redact them in the flare too.

### Additional Notes

To use the RedactingWriter instead of re-reading the data to scrub, it is a best effort using a quite basic regexp, which does not match our own redacted API key.