### PR TITLE
Switch default TagCardinality for checks to Low + update containerd tagger call

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -342,6 +342,7 @@
     "api/types/versions",
     "api/types/volume",
     "client",
+    "pkg/testutil/assert",
     "pkg/tlsconfig",
   ]
   pruneopts = ""
@@ -1055,7 +1056,6 @@
   revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
 
 [[projects]]
-  branch = "master"
   digest = "1:3b5435ace50a6acfa3fd9c32b08b886e7a3ad81833eac37c5126492e472423e8"
   name = "github.com/ramr/go-reaper"
   packages = ["."]
@@ -1916,6 +1916,7 @@
     "github.com/containerd/containerd/api/types",
     "github.com/containerd/containerd/cio",
     "github.com/containerd/containerd/containers",
+    "github.com/containerd/containerd/events",
     "github.com/containerd/containerd/namespaces",
     "github.com/containerd/typeurl",
     "github.com/coreos/etcd/client",
@@ -1929,6 +1930,7 @@
     "github.com/docker/docker/api/types/swarm",
     "github.com/docker/docker/api/types/versions",
     "github.com/docker/docker/client",
+    "github.com/docker/docker/pkg/testutil/assert",
     "github.com/docker/go-connections/nat",
     "github.com/dustin/go-humanize",
     "github.com/fatih/color",

--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -27,6 +27,7 @@ import (
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -161,7 +162,7 @@ func computeEvents(events []containerdEvent, sender aggregator.Sender, userTags 
 		output.Title = fmt.Sprintf("Event on %s from Containerd", split[1])
 		if split[1] == "containers" || split[1] == "tasks" {
 			// For task events, we use the container ID in order to query the Tagger's API
-			tags, err := tagger.Tag(e.ID, true)
+			tags, err := tagger.Tag(e.ID, collectors.HighCardinality)
 			if err != nil {
 				// If there is an error retrieving tags from the Tagger, we can still submit the event as is.
 				log.Errorf("Could not retrieve tags for the container %s: %v", e.ID, err)
@@ -195,7 +196,7 @@ func computeMetrics(sender aggregator.Sender, nk context.Context, cu cutil.Conta
 		}
 		tags = append(tags, userTags...)
 		// Tagger tags
-		taggerTags, err := tagger.Tag(ctn.ID(), false)
+		taggerTags, err := tagger.Tag(ctn.ID(), collectors.HighCardinality)
 		if err != nil {
 			log.Errorf(err.Error())
 			continue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -318,9 +318,10 @@ func initConfig(config Config) {
 
 	// The cardinality of tags to send for checks and dogstatsd respectively.
 	// Choices are: low, orchestrator, high.
-	// WARNING: sending container tags for dogstatsd metrics may create more metrics
-	// (one per container instead of one per host). Changing this setting may have billing implications.
-	config.BindEnvAndSetDefault("checks_tag_cardinality", "orchestrator")
+	// WARNING: sending orchestrator, or high tags for dogstatsd metrics may create more metrics
+	// (one per container instead of one per host).
+	// Changing this setting may impact your custom metrics billing.
+	config.BindEnvAndSetDefault("checks_tag_cardinality", "low")
 	config.BindEnvAndSetDefault("dogstatsd_tag_cardinality", "low")
 
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution", false)


### PR DESCRIPTION
### What does this PR do?

Switch default TagCardinality for checks to Low + update containerd tagger call

### Motivation

Introducing OrchestratorCardinality as the default was reckless, better start with Low.
Also containerd and this option were merged roughly at the same time and that broke the tests. That fixes it. 

### Additional Notes

Updating https://github.com/DataDog/datadog-agent/compare/haissam/fix-tagger-containerd-call?expand=1#diff-7d170b282b8e9d0668a0aa386567dadeL198 to HighCard as per @CharlyF 's request
