### PR TITLE
[omnibus] pin mixlib-cli to previous major to fix builds

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -6,3 +6,6 @@ gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: (ENV[
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.
 gem 'omnibus-software', git: 'https://github.com/DataDog/omnibus-software.git', branch: (ENV['OMNIBUS_SOFTWARE_VERSION'] || 'master')
+
+
+gem 'mixlib-cli', '~> 1.7.0'


### PR DESCRIPTION
### What does this PR do?

New `mixlib-cli` gem has been released breaking some builds. Let's pin to address the issue in the short term.

### Motivation

Broken build.
