### PR TITLE
Fix signature to match change done in #2814

### DIFF
--- a/pkg/util/docker/global_nodocker.go
+++ b/pkg/util/docker/global_nodocker.go
@@ -8,7 +8,7 @@
 package docker
 
 // HostnameProvider docker implementation for the hostname provider
-func HostnameProvider(hostName string) (string, error) {
+func HostnameProvider() (string, error) {
 	return "", ErrDockerNotCompiled
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes `not enough arguments in call to docker.HostnameProvider have () want (string)`

### Additional Notes

Introduced in #2814 
