### PR TITLE
Cluster-checks: patch configurations on schedule

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -208,6 +208,25 @@ func (c *Data) MergeAdditionalTags(tags []string) error {
 	return nil
 }
 
+// SetField allows to set an arbitrary field to a given value,
+// overriding the existing value if present
+func (c *Data) SetField(key string, value interface{}) error {
+	rawConfig := RawMap{}
+	err := yaml.Unmarshal(*c, &rawConfig)
+	if err != nil {
+		return err
+	}
+
+	rawConfig[key] = value
+	out, err := yaml.Marshal(&rawConfig)
+	if err != nil {
+		return err
+	}
+	*c = Data(out)
+
+	return nil
+}
+
 // Digest returns an hash value representing the data stored in this configuration.
 // The ClusterCheck field is intentionally left out to keep a stable digest
 // between the cluster-agent and the node-agents

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -103,6 +103,30 @@ func TestMergeAdditionalTags(t *testing.T) {
 	assert.Contains(t, rawConfig["tags"], "bar")
 }
 
+func TestSetField(t *testing.T) {
+	instance := Data("onefield: true\ntags: [\"foo\", \"foo:bar\"]")
+
+	// Add new field
+	instance.SetField("otherfield", 50)
+	rawConfig := RawMap{}
+	err := yaml.Unmarshal(instance, &rawConfig)
+	assert.Nil(t, err)
+	assert.Contains(t, rawConfig["tags"], "foo")
+	assert.Contains(t, rawConfig["tags"], "foo:bar")
+	assert.Equal(t, true, rawConfig["onefield"])
+	assert.Equal(t, 50, rawConfig["otherfield"])
+
+	// Override existing field
+	instance.SetField("onefield", "testing")
+	rawConfig = RawMap{}
+	err = yaml.Unmarshal(instance, &rawConfig)
+	assert.Nil(t, err)
+	assert.Contains(t, rawConfig["tags"], "foo")
+	assert.Contains(t, rawConfig["tags"], "foo:bar")
+	assert.Equal(t, "testing", rawConfig["onefield"])
+	assert.Equal(t, 50, rawConfig["otherfield"])
+}
+
 func TestDigest(t *testing.T) {
 	emptyConfig := &Config{}
 	assert.Equal(t, "cbf29ce484222325", emptyConfig.Digest())

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -9,11 +9,13 @@ package clusterchecks
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -21,6 +23,7 @@ import (
 type dispatcher struct {
 	store                 *clusterStore
 	nodeExpirationSeconds int64
+	extraTags             []string
 }
 
 func newDispatcher() *dispatcher {
@@ -28,6 +31,13 @@ func newDispatcher() *dispatcher {
 		store: newClusterStore(),
 	}
 	d.nodeExpirationSeconds = config.Datadog.GetInt64("cluster_checks.node_expiration_timeout")
+
+	clusterTagValue := clustername.GetClusterName()
+	clusterTagName := config.Datadog.GetString("cluster_checks.cluster_tag_name")
+	if clusterTagName != "" && clusterTagValue != "" {
+		d.extraTags = append(d.extraTags, fmt.Sprintf("%s:%s", clusterTagName, clusterTagValue))
+	}
+
 	return d
 }
 
@@ -39,23 +49,35 @@ func (d *dispatcher) Stop() {
 // Schedule implements the scheduler.Scheduler interface
 func (d *dispatcher) Schedule(configs []integration.Config) {
 	for _, c := range configs {
-		d.add(c)
+		if !c.ClusterCheck {
+			continue // Ignore non cluster-check configs
+		}
+		patched, err := d.patchConfiguration(c)
+		if err != nil {
+			log.Warnf("Cannot patch configuration %s: %s", c.Digest(), err)
+			continue
+		}
+		d.add(patched)
 	}
 }
 
 // Unschedule implements the scheduler.Scheduler interface
 func (d *dispatcher) Unschedule(configs []integration.Config) {
 	for _, c := range configs {
-		d.remove(c)
+		if !c.ClusterCheck {
+			continue // Ignore non cluster-check configs
+		}
+		patched, err := d.patchConfiguration(c)
+		if err != nil {
+			log.Warnf("Cannot patch configuration %s: %s", c.Digest(), err)
+			continue
+		}
+		d.remove(patched)
 	}
 }
 
 // add stores and delegates a given configuration
 func (d *dispatcher) add(config integration.Config) {
-	if !config.ClusterCheck {
-		return // Ignore non cluster-check configs
-	}
-
 	target := d.getLeastBusyNode()
 	if target == "" {
 		// If no node is found, store it in the danglingConfigs map for retrying later.
@@ -69,9 +91,6 @@ func (d *dispatcher) add(config integration.Config) {
 
 // remove deletes a given configuration
 func (d *dispatcher) remove(config integration.Config) {
-	if !config.ClusterCheck {
-		return // Ignore non cluster-check configs
-	}
 	digest := config.Digest()
 	log.Debugf("Removing configuration %s:%s", config.Name, digest)
 	d.removeConfig(digest)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -348,6 +348,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
 	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)         // value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 
 	setAssetFs(config)
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -535,6 +535,11 @@ api_key:
 #   dispatching configurations. This delay is configurable here.
 #   warmup_duration: 30
 #
+#   If a cluster_name value is set or autodetected, a "cluster_name" tag is added
+#   to all cluster-check configurations sent to the node-agents.
+#   You can use another tag name, or disable it by setting an empty name.
+#   cluster_tag_name: cluster_name
+#
 {{ end -}}
 {{- if .DockerTagging }}
 # Container detection


### PR DESCRIPTION
### What does this PR do?

When configurations enter the clusterchecks dispatcher from the AD, make the following changes:

   - empty the ADIdentifiers array, to avoid node-agents detecting them as templates
   - clear the ClusterCheck boolean
   - add the `empty_default_hostname` option to all instances, so metrics are submitted with no hostname
   - optionaly inject the `cluster_name` tag in all instances

Doing the modifications here make digests different between the DCA's AD and the clusterchecks logic, but ensure they will be identical between the DCA and the node-agnets, which will be more useful for debugging.

This step of the pipeline has been chosen because this is the earliest point in the pipeline all necessary information is available to batch all required changes in one operation. 