### PR TITLE
[gohai] Update to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen4-godeps-{{ .Branch }}-{{ .Revision }}
-          - gen4-godeps-{{ .Branch }}-
-          - gen4-godeps-master-
+          - gen5-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen5-godeps-{{ .Branch }}-
+          - gen5-godeps-master-
     - save_cache: &save_deps
-        key: gen4-godeps-{{ .Branch }}-{{ .Revision }}
+        key: gen5-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e629518d413e890d23a9cb7e1e4f3e559eb926f2442b3dfdc1c07915ce309162"
+  digest = "1:04fc5b6ce68df9a989cdaa226e7a179d64d5516619e02e038e74df982b3964e3"
   name = "github.com/DataDog/gohai"
   packages = [
     "cpu",
@@ -31,7 +31,7 @@
     "processes/gops",
   ]
   pruneopts = ""
-  revision = "508b4f7bfc834501c944ab00e99b6f0e760f5ea7"
+  revision = "0d4fd83b6a2de90467d4f7e7f0f881d92a5da130"
 
 [[projects]]
   branch = "master"

--- a/releasenotes/notes/gohai-nil-map-dereference-0e27e1c7d855f857.yaml
+++ b/releasenotes/notes/gohai-nil-map-dereference-0e27e1c7d855f857.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a rare crash caused by a nil map dereference in the ``gohai`` library


### PR DESCRIPTION
Fixes a nil map dereference (https://github.com/DataDog/gohai/pull/64).

The update also includes unrelated commits, but they're commits that affect the standalone build of the `gohai` binary only, I've double-check they won't have an impact on gohai when imported as a library.