### PR TITLE
[agent] remove go-reaper

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1056,13 +1056,6 @@
   revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
 
 [[projects]]
-  digest = "1:3b5435ace50a6acfa3fd9c32b08b886e7a3ad81833eac37c5126492e472423e8"
-  name = "github.com/ramr/go-reaper"
-  packages = ["."]
-  pruneopts = ""
-  revision = "35f6a64e44ff062abfcec2d27cef674212d445c0"
-
-[[projects]]
   branch = "master"
   digest = "1:7fc2f428767a2521abc63f1a663d981f61610524275d6c0ea645defadd4e916f"
   name = "github.com/samuel/go-zookeeper"
@@ -1955,7 +1948,6 @@
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
-    "github.com/ramr/go-reaper",
     "github.com/samuel/go-zookeeper/zk",
     "github.com/sbinet/go-python",
     "github.com/shirou/gopsutil/cpu",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,10 +38,6 @@
   name = "github.com/gogo/protobuf"
   version = "~v1.0.0"
 
-[[constraint]]
-  name = "github.com/ramr/go-reaper"
-  revision = "35f6a64e44ff062abfcec2d27cef674212d445c0"
-
 [[override]]
   name = "github.com/kubernetes/apimachinery"
   branch = "release-1.11"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -109,7 +109,6 @@ core,github.com/prometheus/client_golang,Apache-2.0
 core,github.com/prometheus/client_model,Apache-2.0
 core,github.com/prometheus/common,Apache-2.0
 core,github.com/prometheus/procfs,Apache-2.0
-core,github.com/ramr/go-reaper,MIT
 core,github.com/samuel/go-zookeeper,BSD-3-Clause
 core,github.com/sbinet/go-python,Python-2.0
 core,github.com/shirou/gopsutil,BSD-3-Clause

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -14,21 +14,9 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	reaper "github.com/ramr/go-reaper"
 )
 
 func main() {
-	if common.IsDockerRunning() {
-		// Reap orphaned child processes
-		reaperCfg := reaper.Config{
-			Pid:              0, //wait for child'd process group ID is equal to that of the calling process.
-			Options:          0,
-			DisablePid1Check: true, // we will not be pid 1 with s6
-		}
-		go reaper.Start(reaperCfg)
-	}
-
 	// Invoke the Agent
 	if err := app.AgentCmd.Execute(); err != nil {
 		os.Exit(-1)


### PR DESCRIPTION
### What does this PR do?

We remove the go-reaper, it's unnecessary as long as the agent takes care of it's own (immediate) children, which we do - every launched process is accounted for with the corresponding `Wait()`

### Motivation

Unnecessary reaper. Not only was it unnecessary it also polluted stdout.

### Additional Notes

Tested for healthy reaping:
```
root@datadog-agent-b92fg:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 23:31 ?        00:00:00 s6-svscan -t0 /var/run/s6/services
root          30       1  0 23:31 ?        00:00:00 s6-supervise s6-fdholderd
root         358       1  0 23:31 ?        00:00:00 s6-supervise network/log
root         359       1  0 23:31 ?        00:00:00 s6-supervise network
root         360       1  0 23:31 ?        00:00:00 s6-supervise process/log
root         361       1  0 23:31 ?        00:00:00 s6-supervise process
root         362       1  0 23:31 ?        00:00:00 s6-supervise trace/log
root         363       1  0 23:31 ?        00:00:00 s6-supervise trace
root         365       1  0 23:31 ?        00:00:00 s6-supervise agent/log
root         366       1  0 23:31 ?        00:00:00 s6-supervise agent
root         369     365  0 23:31 ?        00:00:00 s6-format-filter [ AGENT ] %s
root         370     360  0 23:31 ?        00:00:00 s6-format-filter [PROCESS] %s
root         371     366  2 23:31 ?        00:00:11 agent run
root         372     361  0 23:31 ?        00:00:01 process-agent --config=/etc/datadog-agent/datadog.yaml
root        3472       0  0 23:38 ?        00:00:00 /bin/bash
root        3820     371 15 23:38 ?        00:00:04 java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -classpath /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.24.0-jar-with-dependencies.jar org.datadog.jmxfetch.App --ipc_host localhost --ipc_port 5001 --check_period 15000 --log_level INFO --r
root        4092       0  0 23:39 ?        00:00:00 /bin/sh ./probe.sh
root        4098    4092  0 23:39 ?        00:00:00 /opt/datadog-agent/bin/agent/agent health
root        4107    3472  0 23:39 ?        00:00:00 ps -ef
root@datadog-agent-b92fg:/# kill -9 3820
root@datadog-agent-b92fg:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 23:31 ?        00:00:00 s6-svscan -t0 /var/run/s6/services
root          30       1  0 23:31 ?        00:00:00 s6-supervise s6-fdholderd
root         358       1  0 23:31 ?        00:00:00 s6-supervise network/log
root         359       1  0 23:31 ?        00:00:00 s6-supervise network
root         360       1  0 23:31 ?        00:00:00 s6-supervise process/log
root         361       1  0 23:31 ?        00:00:00 s6-supervise process
root         362       1  0 23:31 ?        00:00:00 s6-supervise trace/log
root         363       1  0 23:31 ?        00:00:00 s6-supervise trace
root         365       1  0 23:31 ?        00:00:00 s6-supervise agent/log
root         366       1  0 23:31 ?        00:00:00 s6-supervise agent
root         369     365  0 23:31 ?        00:00:00 s6-format-filter [ AGENT ] %s
root         370     360  0 23:31 ?        00:00:00 s6-format-filter [PROCESS] %s
root         371     366  2 23:31 ?        00:00:11 agent run
root         372     361  0 23:31 ?        00:00:01 process-agent --config=/etc/datadog-agent/datadog.yaml
root        3472       0  0 23:38 ?        00:00:00 /bin/bash
root        4209     371 28 23:39 ?        00:00:02 java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -classpath /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.24.0-jar-with-dependencies.jar org.datadog.jmxfetch.App --ipc_host localhost --ipc_port 5001 --check_period 15000 --log_level INFO --r
root        4272    3472  0 23:39 ?        00:00:00 ps -ef
root@datadog-agent-b92fg:/# kill -2 4209
root@datadog-agent-b92fg:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 23:31 ?        00:00:00 s6-svscan -t0 /var/run/s6/services
root          30       1  0 23:31 ?        00:00:00 s6-supervise s6-fdholderd
root         358       1  0 23:31 ?        00:00:00 s6-supervise network/log
root         359       1  0 23:31 ?        00:00:00 s6-supervise network
root         360       1  0 23:31 ?        00:00:00 s6-supervise process/log
root         361       1  0 23:31 ?        00:00:00 s6-supervise process
root         362       1  0 23:31 ?        00:00:00 s6-supervise trace/log
root         363       1  0 23:31 ?        00:00:00 s6-supervise trace
root         365       1  0 23:31 ?        00:00:00 s6-supervise agent/log
root         366       1  0 23:31 ?        00:00:00 s6-supervise agent
root         369     365  0 23:31 ?        00:00:00 s6-format-filter [ AGENT ] %s
root         370     360  0 23:31 ?        00:00:00 s6-format-filter [PROCESS] %s
root         371     366  2 23:31 ?        00:00:16 agent run
root         372     361  0 23:31 ?        00:00:02 process-agent --config=/etc/datadog-agent/datadog.yaml
root        3472       0  0 23:38 ?        00:00:00 /bin/bash
root        6218     371 30 23:43 ?        00:00:00 java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -classpath /opt/datadog-agent/bin/agent/dist/jmx/jmxfetch-0.24.0-jar-with-dependencies.jar org.datadog.jmxfetch.App --ipc_host localhost --ipc_port 5001 --check_period 15000 --log_level INFO --r
root        6231       0  0 23:43 ?        00:00:00 /bin/sh ./probe.sh
root        6239    6231  0 23:43 ?        00:00:00 /opt/datadog-agent/bin/agent/agent health
root        6247    3472  0 23:43 ?        00:00:00 ps -ef
``` 

