### PR TITLE
Remove the unready redis on e2e step delete-redis

### DIFF
--- a/test/e2e/argo-workflows/agent.yaml
+++ b/test/e2e/argo-workflows/agent.yaml
@@ -714,6 +714,7 @@ spec:
             value: "{{item}}"
         withItems:
         - "{{inputs.parameters.redis-deployment}}"
+        - "{{inputs.parameters.redis-deployment-unready}}"
         - "{{inputs.parameters.redis-service}}"
 
     - - name: no-more-redis


### PR DESCRIPTION
### What does this PR do?

e2e are currently failing on master, on the `no-more-metrics-redis` step. https://github.com/DataDog/datadog-agent/pull/2771 added a new `redis-unready` deployment, without removing it in the `delete-redis` step.

This makes the check fail, as this AD instance will still be running.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
