### PR TITLE
[flare] the display name may be empty, use the login name.

### DIFF
--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -66,9 +66,15 @@ func (p permissionsInfos) statFiles() error {
 			return fmt.Errorf("can't lookup for gid info: %v", err)
 		}
 
+		uname := u.Name
+		if len(uname) == 0 {
+			// full name could be empty, use the login name instead
+			uname = u.Username
+		}
+
 		p[filePath] = filePermsInfo{
 			mode:  fi.Mode(),
-			owner: u.Name,
+			owner: uname,
 			group: g.Name,
 		}
 	}


### PR DESCRIPTION
While fetching file permissions infos, we have to ensure that we're not
using an empty display name. Use the login name if the display name is
empty.

### What does this PR do?

Fixes the `owner` field in the `permissions.log` file  integrated in the flare. This field is empty if the display name of the user is not set on the system.
