### PR TITLE
Switch to user email to avoid non ascii ec2 tags

### DIFF
--- a/test/e2e/scripts/setup-instance/02-ec2.sh
+++ b/test/e2e/scripts/setup-instance/02-ec2.sh
@@ -8,7 +8,7 @@ cd "$(dirname $0)"
 
 export COMMIT_ID=$(git rev-parse --verify HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-COMMIT_USER=$(git log -1 --pretty=format:'%an' | tr -d [:space:])
+COMMIT_USER=$(git log -1 --pretty=format:'%ae' | tr -d [:space:])
 
 # If not using the default value, remember to change the following settings:
 # - AMI


### PR DESCRIPTION
### What does this PR do?

Non ascii chars in commit username are breaking the e2e instance setup

### Motivation

Fix e2e