### PR TITLE
Updated timeout when connecting to containerd socket

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -179,7 +179,7 @@
   revision = "3024bc7cc0c88af4b32d38a14444f38e65ab169f"
 
 [[projects]]
-  digest = "1:d1b5539156e6a12334d99ffc59a40309b451c6f08b09583d917a8c4d0e5486fd"
+  digest = "1:7778290513552388cec9e9a7f70d9fd2e9b5b74eeeb5bf0d73a9a3ee71426e8b"
   name = "github.com/containerd/containerd"
   packages = [
     ".",
@@ -197,11 +197,13 @@
     "api/services/version/v1",
     "api/types",
     "api/types/task",
+    "archive",
+    "archive/compression",
     "cio",
     "containers",
     "content",
+    "content/proxy",
     "defaults",
-    "dialer",
     "diff",
     "errdefs",
     "events",
@@ -209,12 +211,14 @@
     "filters",
     "identifiers",
     "images",
+    "images/archive",
     "leases",
-    "linux/runctypes",
+    "leases/proxy",
     "log",
     "mount",
     "namespaces",
     "oci",
+    "pkg/dialer",
     "platforms",
     "plugin",
     "reference",
@@ -222,11 +226,14 @@
     "remotes/docker",
     "remotes/docker/schema1",
     "rootfs",
+    "runtime/linux/runctypes",
     "snapshots",
+    "snapshots/proxy",
+    "sys",
   ]
   pruneopts = ""
-  revision = "8f54c750c67e87a3b1c218208bbd5cc427c653e9"
-  version = "v1.1.3"
+  revision = "9754871865f7fe2f4e74d43e2fc7ccd237edcbce"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -239,6 +246,14 @@
   ]
   pruneopts = ""
   revision = "c7c5070e6f6e090ab93b0a61eb921f2196fc3383"
+
+[[projects]]
+  digest = "1:3bc276f1f7b8b1ec876ddaad0aba0671003c47feac2cdf6c74554c9d1631a4b1"
+  name = "github.com/containerd/cri"
+  packages = ["pkg/util"]
+  pruneopts = ""
+  revision = "f3687c59470b76ee57c90d4b3dd92888dec58c2b"
+  version = "v1.11.1"
 
 [[projects]]
   branch = "master"
@@ -342,6 +357,8 @@
     "api/types/versions",
     "api/types/volume",
     "client",
+    "pkg/random",
+    "pkg/stringid",
     "pkg/testutil/assert",
     "pkg/tlsconfig",
   ]
@@ -924,7 +941,10 @@
 [[projects]]
   digest = "1:fa19ddee0e5ee5951a6a450a4b6ec635a42957f86bfc87d9d778eeee04ad2036"
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user",
+  ]
   pruneopts = ""
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,6 +35,10 @@
   version = "~v1.13.1"
 
 [[constraint]]
+  name = "github.com/containerd/containerd"
+  version = "~v1.2.2"
+
+[[constraint]]
   name = "github.com/gogo/protobuf"
   version = "~v1.0.0"
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -19,6 +19,7 @@ core,github.com/cihub/seelog,BSD-3-Clause
 core,github.com/clbanning/mxj,MIT
 core,github.com/codemirror/CodeMirror,MIT
 core,github.com/containerd/containerd,Apache-2.0
+core,github.com/containerd/cri,Apache-2.0
 core,github.com/containerd/continuity,Apache-2.0
 core,github.com/containerd/cgroups,Apache-2.0
 core,github.com/containerd/fifo,Apache-2.0


### PR DESCRIPTION
### What does this PR do?

Timeout to connect to the containerd socket was the default from the grpc lib, which was 60s. This set it to be consistent with CRI.

### Motivation

Do not block flares etc, be consistent with docker and other socket based integrations.
