### PR TITLE
[py] fix the list of integrations returned by blacklisting non-integrations

### DIFF
--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -285,7 +285,7 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 	integrations = append(integrations, goIntegrations...)
 
 	// Get jmx-checks
-	for integration, _ := range check.JMXChecks {
+	for integration := range check.JMXChecks {
 		integrations = append(integrations, integration)
 	}
 

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -297,29 +297,51 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(res))
 }
 
+// collects the configs in the specified path
+func getConfigsInPath(path string) ([]string, error) {
+	filenames := []string{}
+
+	files, e := readConfDir(path)
+	if e != nil {
+		return []string{}, nil
+	}
+
+	// If a default config is found but a non-default version exists, ignore default
+	sort.Strings(files)
+	lookup := make(map[string]bool)
+	for _, file := range files {
+		checkName := file[:strings.Index(file, ".")]
+		fileName := filepath.Base(file)
+
+		// metrics yaml does not contain the actual check config - skip
+		match, _ := filepath.Match(fileName, "metrics.yaml")
+		if checkName != "metrics" && match {
+			continue
+		}
+
+		if ext := filepath.Ext(fileName); ext == ".default" {
+			if _, exists := lookup[checkName]; exists {
+				continue
+			}
+		}
+
+		filenames = append(filenames, file)
+		lookup[checkName] = true
+	}
+	return filenames, nil
+}
+
 // Sends a list containing the names of all the config files
 func listConfigs(w http.ResponseWriter, r *http.Request) {
 	filenames := []string{}
 	for _, path := range configPaths {
-		files, e := readConfDir(path)
 
-		if e == nil {
-			// If a default config is found but a non-default version exists, ignore default
-			sort.Strings(files)
-			lookup := make(map[string]bool)
-			for _, file := range files {
-				checkName := file[:strings.Index(file, ".")]
-
-				if ext := filepath.Ext(file); ext == ".default" {
-					if _, exists := lookup[checkName]; exists {
-						continue
-					}
-				}
-
-				filenames = append(filenames, file)
-				lookup[checkName] = true
-			}
+		configs, e := getConfigsInPath(path)
+		if e != nil {
+			log.Errorf("Unable to list configurations from %s: %v", path, e)
+			continue
 		}
+		filenames = append(filenames, configs...)
 	}
 
 	if len(filenames) == 0 {

--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -270,7 +270,6 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Get wheels
 	pyIntegrations, err := getPythonChecks()
 	if err != nil {
 		log.Errorf("Unable to compile list of installed integrations: %v", err)
@@ -278,6 +277,7 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Get python wheels
 	integrations = append(integrations, pyIntegrations...)
 
 	// Get go-checks
@@ -285,7 +285,9 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 	integrations = append(integrations, goIntegrations...)
 
 	// Get jmx-checks
-	integrations = append(integrations, check.JMXChecks...)
+	for integration, _ := range check.JMXChecks {
+		integrations = append(integrations, integration)
+	}
 
 	if len(integrations) == 0 {
 		w.Write([]byte("No check (.py) files found."))

--- a/cmd/agent/gui/checks_py.go
+++ b/cmd/agent/gui/checks_py.go
@@ -8,9 +8,25 @@
 package gui
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 )
 
 func getPythonChecks() ([]string, error) {
-	return py.GetPythonIntegrationList()
+	pyChecks := []string{}
+
+	// The integration list includes JMX integrations, they ship as wheels too.
+	// JMX wheels just contain sample configs, but they do ship.
+	integrations, err := py.GetPythonIntegrationList()
+	if err != nil {
+		return []string{}, err
+	}
+
+	for _, integration := range integrations {
+		if _, ok := check.JMXChecks[integration]; !ok {
+			pyChecks = append(pyChecks, integration)
+		}
+	}
+
+	return pyChecks, nil
 }

--- a/cmd/agent/gui/checks_test.go
+++ b/cmd/agent/gui/checks_test.go
@@ -24,3 +24,18 @@ func TestReadConfDir(t *testing.T) {
 
 	assert.Equal(t, expected, files)
 }
+
+func TestConfigsInPath(t *testing.T) {
+	files, err := getConfigsInPath("testdata")
+	assert.Nil(t, err)
+
+	sort.Strings(files)
+	expected := []string{
+		"check.yaml",
+		"check.yaml.example",
+		"foo.d/conf.yaml",
+		"foo.d/conf.yaml.example",
+	}
+
+	assert.Equal(t, expected, files)
+}

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -13,13 +13,13 @@ import (
 
 // JMXChecks list of JMXFetch checks supported: implemented as set with an empty struct map
 var JMXChecks = map[string]struct{}{
-	"activemq":    struct{}{},
-	"activemq_58": struct{}{},
-	"cassandra":   struct{}{},
-	"jmx":         struct{}{},
-	"solr":        struct{}{},
-	"tomcat":      struct{}{},
-	"kafka":       struct{}{},
+	"activemq":    {},
+	"activemq_58": {},
+	"cassandra":   {},
+	"jmx":         {},
+	"solr":        {},
+	"tomcat":      {},
+	"kafka":       {},
 }
 
 // IsJMXConfig checks if a certain YAML config is a JMX config

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -11,24 +11,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
-// JMXChecks list of JMXFetch checks supported
-var JMXChecks = []string{
-	"activemq",
-	"activemq_58",
-	"cassandra",
-	"jmx",
-	"solr",
-	"tomcat",
-	"kafka",
+// JMXChecks list of JMXFetch checks supported: implemented as set with an empty struct map
+var JMXChecks = map[string]struct{}{
+	"activemq":    struct{}{},
+	"activemq_58": struct{}{},
+	"cassandra":   struct{}{},
+	"jmx":         struct{}{},
+	"solr":        struct{}{},
+	"tomcat":      struct{}{},
+	"kafka":       struct{}{},
 }
 
 // IsJMXConfig checks if a certain YAML config is a JMX config
 func IsJMXConfig(name string, initConf integration.Data) bool {
 
-	for _, check := range JMXChecks {
-		if check == name {
-			return true
-		}
+	if _, ok := JMXChecks[name]; ok {
+		return true
 	}
 
 	rawInitConfig := integration.RawMap{}

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -54,10 +54,10 @@ const (
 var (
 	// implements a string set of non-intergrations with an empty stuct map
 	nonIntegrationsWheelSet = map[string]struct{}{
-		"checks_base":        struct{}{},
-		"checks_dev":         struct{}{},
-		"checks_test_helper": struct{}{},
-		"a7":                 struct{}{},
+		"checks_base":        {},
+		"checks_dev":         {},
+		"checks_test_helper": {},
+		"a7":                 {},
 	}
 )
 

--- a/pkg/collector/py/utils.go
+++ b/pkg/collector/py/utils.go
@@ -51,6 +51,16 @@ const (
 	pyIntegrationListFunc = "get_datadog_wheels"
 )
 
+var (
+	// implements a string set of non-intergrations with an empty stuct map
+	nonIntegrationsWheelSet = map[string]struct{}{
+		"checks_base":        struct{}{},
+		"checks_dev":         struct{}{},
+		"checks_test_helper": struct{}{},
+		"a7":                 struct{}{},
+	}
+)
+
 // newStickyLock register the current thread with the interpreter and locks
 // the GIL. It also sticks the goroutine to the current thread so that a
 // subsequent call to `Unlock` will unregister the very same thread.
@@ -448,7 +458,7 @@ func GetPythonIntegrationList() ([]string, error) {
 	ddPythonPackages := []string{}
 	for i := 0; i < python.PyList_Size(packages); i++ {
 		pkgName := python.PyString_AsString(python.PyList_GetItem(packages, i))
-		if pkgName == "checks_base" {
+		if _, ok := nonIntegrationsWheelSet[pkgName]; ok {
 			continue
 		}
 		ddPythonPackages = append(ddPythonPackages, pkgName)


### PR DESCRIPTION
### What does this PR do?

We now have a bunch of wheels that are not integrations which may be bundled with the agent.

### Motivation

The GUI was showing A7 as an integration, it's not, it's a linter. There are other wheels in `integrations-core` which may be potentially installed that would also show up, so blacklist those as well.

