### PR TITLE
Use the appropriate port when redirecting node-agents to leader

### DIFF
--- a/pkg/clusteragent/clusterchecks/api.go
+++ b/pkg/clusteragent/clusterchecks/api.go
@@ -8,6 +8,7 @@
 package clusterchecks
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
@@ -28,7 +29,7 @@ func (h *Handler) ShouldHandle() (int, string) {
 	case leader:
 		return http.StatusOK, ""
 	case follower:
-		return http.StatusFound, h.leaderIP
+		return http.StatusFound, fmt.Sprintf("%s:%d", h.leaderIP, h.port)
 	default:
 		return http.StatusServiceUnavailable, notReadyReason
 	}

--- a/pkg/clusteragent/clusterchecks/api_test.go
+++ b/pkg/clusteragent/clusterchecks/api_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestShouldHandle(t *testing.T) {
-	h := &Handler{}
+	h := &Handler{
+		port: 5005,
+	}
 
 	// Initial state
 	code, reason := h.ShouldHandle()
@@ -33,5 +35,5 @@ func TestShouldHandle(t *testing.T) {
 	h.leaderIP = "1.2.3.4"
 	code, reason = h.ShouldHandle()
 	assert.Equal(t, http.StatusFound, code)
-	assert.Equal(t, "1.2.3.4", reason)
+	assert.Equal(t, "1.2.3.4:5005", reason)
 }

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -53,6 +53,7 @@ type Handler struct {
 	m                    sync.RWMutex // Below fields protected by the mutex
 	state                state
 	leaderIP             string
+	port                 int
 }
 
 // NewHandler returns a populated Handler
@@ -67,6 +68,7 @@ func NewHandler(ac pluggableAutoConfig) (*Handler, error) {
 		warmupDuration:   config.Datadog.GetDuration("cluster_checks.warmup_duration") * time.Second,
 		leadershipChan:   make(chan state, 1),
 		dispatcher:       newDispatcher(),
+		port:             config.Datadog.GetInt("cluster_agent.cmd_port"),
 	}
 
 	if config.Datadog.GetBool("leader_election") {

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -120,6 +120,7 @@ func TestHandlerRun(t *testing.T) {
 		leadershipChan:       make(chan state, 1),
 		dispatcher:           newDispatcher(),
 		leaderStatusCallback: le.get,
+		port:                 5005,
 	}
 
 	//
@@ -158,7 +159,7 @@ func TestHandlerRun(t *testing.T) {
 	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API redirects to leader
 		code, reason := h.ShouldHandle()
-		return code == http.StatusFound && reason == "1.2.3.4"
+		return code == http.StatusFound && reason == "1.2.3.4:5005"
 	})
 
 	//
@@ -225,7 +226,7 @@ func TestHandlerRun(t *testing.T) {
 	assertTrueBeforeTimeout(t, 10*time.Millisecond, 250*time.Millisecond, func() bool {
 		// API redirects to leader again
 		code, reason := h.ShouldHandle()
-		return code == http.StatusFound && reason == "1.2.3.6"
+		return code == http.StatusFound && reason == "1.2.3.6:5005"
 	})
 	assertTrueBeforeTimeout(t, 10*time.Millisecond, 500*time.Millisecond, func() bool {
 		// RemoveScheduler is called


### PR DESCRIPTION
### What does this PR do?

The query port is not available in the `request.URL` object, making the current redirection code send node-agents on the 443 port.

Assume all DCAs listen on the same port and use the `cluster_agent.cmd_port` option during redirection.
