### PR TITLE
Support /conf.d in cluster-agent image

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -43,11 +43,11 @@ COPY --from=builder /output /
 # of an empty folder. Creating .placeholder files as a workaround.
 #
 RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agent \
- && mkdir -p /var/log/datadog/ \
+ && mkdir -p /var/log/datadog/ /conf.d \
  && touch /var/log/datadog/.placeholder \
  && touch /tmp/.placeholder \
- && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /tmp/ \
- && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/ /tmp/
+ && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/ \
+ && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/
 
 # Incompatible with the custom metrics API on port 443
 # Set DD_EXTERNAL_METRICS_PROVIDER_PORT to a higher value to run as non-root

--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -13,6 +13,9 @@ if [[ -z "$DD_API_KEY" ]]; then
     exit 1
 fi
 
+##### Copy the custom confs #####
+find /conf.d -name '*.yaml' -exec cp --parents -fv {} /etc/datadog-agent/ \;
+
 ##### Starting up #####
 export PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH
 


### PR DESCRIPTION
### What does this PR do?

As cluster-check configurations will be supported as yaml files for out-of-cluster resources, port the agent's support of the `/conf.d` folder to the cluster-agent image.
