### PR TITLE
Add chars to the "others api key" scrubbing regexp.

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -48,7 +48,7 @@ var (
 	// It is a best effort to match the api key field without matching our
 	// own already redacted (we don't want to match: **************************abcde)
 	// Basically we allow many special chars while forbidding *
-	otherAPIKeysRx       = regexp.MustCompile(`api_key:\s*[a-zA-Z0-9\/\]\[\(\)\{\}><#@$+=]+`)
+	otherAPIKeysRx       = regexp.MustCompile(`api_key\s*:\s*[a-zA-Z0-9\\\/\^\]\[\(\){}!|%:;"~><=#@$_\-\+]+`)
 	otherAPIKeysReplacer = log.Replacer{
 		Regex: otherAPIKeysRx,
 		ReplFunc: func(b []byte) []byte {


### PR DESCRIPTION
### What does this PR do?

Completed the regexp scrubbing api keys with every (not extended) ascii special chars except `*`.
Also permitted white spaces between the field name and the `:`
