### PR TITLE
[jmx] fix configuration name typo for `jmx_restart_interval`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,7 +278,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)
 	config.BindEnvAndSetDefault("jmx_max_restarts", int64(3))
-	config.BindEnvAndSetDefault("jmx_max_restart_interval", int64(5))
+	config.BindEnvAndSetDefault("jmx_restart_interval", int64(5))
 
 	// Go_expvar server port
 	config.BindEnvAndSetDefault("expvar_port", "5000")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -321,8 +321,8 @@ api_key:
 # Number of JMX restarts allowed in the restart-interval before giving up
 # jmx_max_restarts: 3
 #
-# Duration of the restart interval in secons
-# jmx_max_restart_interval: 5
+# Duration of the restart interval in seconds
+# jmx_restart_interval: 5
 #
 #
 {{ end -}}

--- a/pkg/jmxfetch/jmxfetch_nix.go
+++ b/pkg/jmxfetch/jmxfetch_nix.go
@@ -43,7 +43,7 @@ func (j *JMXFetch) Monitor() {
 		// stopTimes here will only start yielding values potentially <= ival _after_ the first
 		// maxRestarts attempts, which is fine and consistent.
 		if stopTimes[idx].Sub(stopTimes[oldestIdx]).Seconds() <= ival {
-			log.Errorf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up")
+			log.Errorf("Too many JMXFetch restarts (%v) in time interval (%vs) - giving up", maxRestarts, ival)
 			return
 		}
 

--- a/releasenotes/notes/jmxfetch-process-managemenet-d0815996c58bef6e.yaml
+++ b/releasenotes/notes/jmxfetch-process-managemenet-d0815996c58bef6e.yaml
@@ -6,9 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-enhancements:
-  - |
-    Adding process reaping for children in docker environments.
 fixes:
   - |
-    Reintroducing JMXFetch process management and healthcheck.
+    Reintroducing JMXFetch process lifecycle management on Linux.
+    Adding JMXFetch healthcheck for docker environments.


### PR DESCRIPTION
### What does this PR do?

Fixes a typo by which we were using the wrong config name for `jmx_restart_interval`, breaking the throttling feature.

### Motivation

Throttling behavior not working as expected.

### Additional Notes

Anything else we should know when reviewing?
