### PR TITLE
Always log host metadata payload, even when too large

### DIFF
--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -233,10 +233,10 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 		return fmt.Errorf("could not determine size of metadata payload: %s", err)
 	}
 
-	log.Tracef("Sending host metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
+	log.Debugf("Sending host metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
 
 	if !smallEnough {
-		return fmt.Errorf("metadata payload was too big to send, metadata payloads cannot be split")
+		return fmt.Errorf("metadata payload was too big to send (%d bytes), metadata payloads cannot be split", len(payload))
 	}
 
 	if err := s.Forwarder.SubmitV1Intake(forwarder.Payloads{&payload}, jsonExtraHeaders); err != nil {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -231,7 +231,11 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 	smallEnough, payload, err := split.CheckSizeAndSerialize(m, false, split.MarshalJSON)
 	if err != nil {
 		return fmt.Errorf("could not determine size of metadata payload: %s", err)
-	} else if !smallEnough {
+	}
+
+	log.Tracef("Sending host metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
+
+	if !smallEnough {
 		return fmt.Errorf("metadata payload was too big to send, metadata payloads cannot be split")
 	}
 
@@ -240,7 +244,6 @@ func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
 	}
 
 	log.Infof("Sent host metadata payload, size: %d bytes.", len(payload))
-	log.Debugf("Sent host metadata payload, content: %v", apiKeyRegExp.ReplaceAllString(string(payload), apiKeyReplacement))
 	return nil
 }
 

--- a/releasenotes/notes/log_host_meta-161ea1937da7bb2a.yaml
+++ b/releasenotes/notes/log_host_meta-161ea1937da7bb2a.yaml
@@ -1,0 +1,10 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - Log host metadata at debug level regardless of its size.


### PR DESCRIPTION
### What does this PR do?

Always log the host metadata payload at debug level, even when it is too large.

### Motivation

Helping with debugging in cases where the payload is too big to be sent.

### Additional Notes

Anything else we should know when reviewing?
