### PR TITLE
Remove the unused error return from tagger.Init

### DIFF
--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -23,10 +23,7 @@ import (
 //   2. add the check loaders
 func SetupAutoConfig(confdPath string) {
 	// start tagging system
-	err := tagger.Init()
-	if err != nil {
-		log.Errorf("Unable to start tagging system: %s", err)
-	}
+	tagger.Init()
 
 	// create the Collector instance and start all the components
 	// NOTICE: this will also setup the Python environment, if available
@@ -57,7 +54,7 @@ func SetupAutoConfig(confdPath string) {
 
 	// Register additional configuration providers
 	var CP []config.ConfigurationProviders
-	err = config.Datadog.UnmarshalKey("config_providers", &CP)
+	err := config.Datadog.UnmarshalKey("config_providers", &CP)
 
 	if err == nil {
 		// Add extra config providers

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -180,10 +180,7 @@ func start(cmd *cobra.Command, args []string) error {
 
 	// container tagging initialisation if origin detection is on
 	if config.Datadog.GetBool("dogstatsd_origin_detection") {
-		err = tagger.Init()
-		if err != nil {
-			log.Criticalf("Unable to start tagging system: %s", err)
-		}
+		tagger.Init()
 	}
 
 	aggregatorInstance := aggregator.InitAggregator(s, hname, "agent")

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/docker/docker/client"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -20,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -81,10 +81,7 @@ func (l *Launcher) setup() error {
 		return err
 	}
 	// initialize the tagger
-	err = tagger.Init()
-	if err != nil {
-		return err
-	}
+	tagger.Init()
 	return nil
 }
 

--- a/pkg/logs/input/journald/docker.go
+++ b/pkg/logs/input/journald/docker.go
@@ -42,8 +42,5 @@ func (t *Tailer) getContainerTags(containerID string) []string {
 
 // initializeTagger initializes the tag collector.
 func (t *Tailer) initializeTagger() {
-	err := tagger.Init()
-	if err != nil {
-		log.Warn(err)
-	}
+	tagger.Init()
 }

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -81,12 +81,8 @@ func isIntegrationAvailable() bool {
 
 // setup initializes the pod watcher and the tagger.
 func (l *Launcher) setup() error {
-	var err error
 	// initialize the tagger to collect container tags
-	err = tagger.Init()
-	if err != nil {
-		return err
-	}
+	tagger.Init()
 	return nil
 }
 

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -29,8 +29,7 @@ var ChecksCardinality collectors.TagCardinality
 var DogstatsdCardinality collectors.TagCardinality
 
 // Init must be called once config is available, call it in your cmd
-// defaultTagger.Init cannot fail for now, keeping the `error` for API stability
-func Init() error {
+func Init() {
 	initOnce.Do(func() {
 		var err error
 		checkCard := config.Datadog.GetString("checks_tag_cardinality")
@@ -49,7 +48,6 @@ func Init() error {
 
 		defaultTagger.Init(collectors.DefaultCatalog)
 	})
-	return nil
 }
 
 // Tag queries the defaultTagger to get entity tags from cache or sources.

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -99,10 +99,7 @@ func setup() error {
 	}
 
 	// Setup tagger
-	err = tagger.Init()
-	if err != nil {
-		return err
-	}
+	tagger.Init()
 
 	// Start compose recipes
 	for projectName, file := range defaultCatalog.composeFilesByProjects {


### PR DESCRIPTION
### What does this PR do?

The package-global `tagger.Init` was modified to never fail, but kept it's `error` return type for API compatibility.
As this led to confusion on what could fail, this PR removes it from the method signature and cleans out the error handling in methods that called Init.

Tagging @sunhay as process-agent will require a change on dependency upgrade.
