### PR TITLE
Add a 'secret' command to the agent

### DIFF
--- a/cmd/agent/app/secret.go
+++ b/cmd/agent/app/secret.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/secrets"
+)
+
+func init() {
+	AgentCmd.AddCommand(secretInfoCommand)
+}
+
+var secretInfoCommand = &cobra.Command{
+	Use:   "secret",
+	Short: "Print information about decrypted secrets in configuration.",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := common.SetupConfig(confFilePath); err != nil {
+			fmt.Printf("unable to set up global agent configuration: %v", err)
+			return nil
+		}
+
+		if err := util.SetAuthToken(); err != nil {
+			fmt.Printf("%s", err)
+			return nil
+		}
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		if err := showSecretInfo(); err != nil {
+			fmt.Printf("%s", err)
+			return nil
+		}
+		return nil
+	},
+}
+
+func showSecretInfo() error {
+	c := util.GetClient(false)
+	apiConfigURL := fmt.Sprintf("https://localhost:%v/agent/secrets", config.Datadog.GetInt("cmd_port"))
+
+	r, err := util.DoGet(c, apiConfigURL)
+	if err != nil {
+		var errMap = make(map[string]string)
+		json.Unmarshal(r, errMap)
+		// If the error has been marshalled into a json object, check it and return it properly
+		if e, found := errMap["error"]; found {
+			return fmt.Errorf("%s", e)
+		}
+
+		return fmt.Errorf("Could not reach agent: %v\nMake sure the agent is running before requesting the runtime configuration and contact support if you continue having issues", err)
+	}
+
+	info := &secrets.SecretInfo{}
+	err = json.Unmarshal(r, info)
+	if err != nil {
+		return fmt.Errorf("Could not Unmarshal agent answer: %s", r)
+	}
+	info.Print(os.Stdout)
+	return nil
+}

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -446,27 +446,27 @@ func decryptConfig(conf integration.Config) (integration.Config, error) {
 	var err error
 
 	// init_config
-	conf.InitConfig, err = secrets.Decrypt(conf.InitConfig)
+	conf.InitConfig, err = secrets.Decrypt(conf.InitConfig, conf.Name)
 	if err != nil {
 		return conf, fmt.Errorf("error while decrypting secrets in 'init_config': %s", err)
 	}
 
 	// instances
 	for idx := range conf.Instances {
-		conf.Instances[idx], err = secrets.Decrypt(conf.Instances[idx])
+		conf.Instances[idx], err = secrets.Decrypt(conf.Instances[idx], conf.Name)
 		if err != nil {
 			return conf, fmt.Errorf("error while decrypting secrets in an instance: %s", err)
 		}
 	}
 
 	// metrics
-	conf.MetricConfig, err = secrets.Decrypt(conf.MetricConfig)
+	conf.MetricConfig, err = secrets.Decrypt(conf.MetricConfig, conf.Name)
 	if err != nil {
 		return conf, fmt.Errorf("error while decrypting secrets in 'metrics': %s", err)
 	}
 
 	// logs
-	conf.LogsConfig, err = secrets.Decrypt(conf.LogsConfig)
+	conf.LogsConfig, err = secrets.Decrypt(conf.LogsConfig, conf.Name)
 	if err != nil {
 		return conf, fmt.Errorf("error while decrypting secrets 'logs': %s", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -469,7 +469,7 @@ func Load() error {
 			return fmt.Errorf("unable to marshal configuration to YAML to decrypt secrets: %v", err)
 		}
 
-		finalConfig, err := secrets.Decrypt(conf)
+		finalConfig, err := secrets.Decrypt(conf, "datadog.yaml")
 		if err != nil {
 			return fmt.Errorf("unable to decrypt secret from datadog.yaml: %v", err)
 		}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -385,11 +385,16 @@ func zipSecrets(tempDir, hostname string) error {
 	var b bytes.Buffer
 
 	writer := bufio.NewWriter(&b)
-	secrets.GetDebugInfo(writer)
+	info, err := secrets.GetDebugInfo()
+	if err != nil {
+		fmt.Fprintf(writer, "%s", err)
+	} else {
+		info.Print(writer)
+	}
 	writer.Flush()
 
 	f := filepath.Join(tempDir, hostname, "secrets.log")
-	err := ensureParentDirsExist(f)
+	err = ensureParentDirsExist(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/secrets/check_right.go
+++ b/pkg/secrets/check_right.go
@@ -9,9 +9,7 @@ package secrets
 
 import (
 	"fmt"
-	"io"
 	"os/user"
-	"strconv"
 	"syscall"
 )
 
@@ -45,38 +43,4 @@ func checkRights(path string) error {
 	}
 
 	return nil
-}
-
-func listRights(path string, w io.Writer) {
-	fmt.Fprintf(w, "=== Checking executable rights ===\n")
-	fmt.Fprintf(w, "executable path: %s\n", path)
-
-	err := checkRights(path)
-	if err != nil {
-		fmt.Fprintf(w, "Check Rights: KO, %s\n", err)
-	} else {
-		fmt.Fprintf(w, "Check Rights: OK, the executable has the correct rights\n")
-	}
-
-	fmt.Fprintf(w, "\nRights Detail:\n")
-	var stat syscall.Stat_t
-	if err := syscall.Stat(path, &stat); err != nil {
-		fmt.Fprintf(w, "Could not stat %s: %s\n", path, err)
-		return
-	}
-	fmt.Fprintf(w, "file mode: %o\n", stat.Mode)
-
-	owner, err := user.LookupId(strconv.Itoa(int(stat.Uid)))
-	if err != nil {
-		fmt.Fprintf(w, "Owner username: could not fetch name for UID %d: %s\n", stat.Uid, err)
-	} else {
-		fmt.Fprintf(w, "Owner username: %s\n", owner.Username)
-	}
-
-	group, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
-	if err != nil {
-		fmt.Fprintf(w, "Group name: could not fetch name for GID %d: %s\n", stat.Gid, err)
-	} else {
-		fmt.Fprintf(w, "Group name: %s\n", group.Name)
-	}
 }

--- a/pkg/secrets/fetch_secret_test.go
+++ b/pkg/secrets/fetch_secret_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 )
 
 func TestLimitBuffer(t *testing.T) {
@@ -102,52 +104,82 @@ func TestExecCommandError(t *testing.T) {
 }
 
 func TestFetchSecretExecError(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
 	runCommand = func(string) ([]byte, error) { return nil, fmt.Errorf("some error") }
-	_, err := fetchSecret([]string{"handle1", "handle2"})
+	_, err := fetchSecret([]string{"handle1", "handle2"}, "test")
 	assert.NotNil(t, err)
 }
 
 func TestFetchSecretUnmarshalError(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
 	runCommand = func(string) ([]byte, error) { return []byte("{"), nil }
-	_, err := fetchSecret([]string{"handle1", "handle2"})
+	_, err := fetchSecret([]string{"handle1", "handle2"}, "test")
 	assert.NotNil(t, err)
 }
 
 func TestFetchSecretMissingSecret(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
 	secrets := []string{"handle1", "handle2"}
 
 	runCommand = func(string) ([]byte, error) { return []byte("{}"), nil }
-	_, err := fetchSecret(secrets)
+	_, err := fetchSecret(secrets, "test")
 	assert.NotNil(t, err)
 	assert.Equal(t, "secret handle 'handle1' was not decrypted by the secret_backend_command", err.Error())
 }
 
 func TestFetchSecretErrorForHandle(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
 	runCommand = func(string) ([]byte, error) {
 		return []byte("{\"handle1\":{\"value\": null, \"error\": \"some error\"}}"), nil
 	}
-	_, err := fetchSecret([]string{"handle1"})
+	_, err := fetchSecret([]string{"handle1"}, "test")
 	assert.NotNil(t, err)
 	assert.Equal(t, "an error occurred while decrypting 'handle1': some error", err.Error())
 }
 
 func TestFetchSecretEmptyValue(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
 	runCommand = func(string) ([]byte, error) {
 		return []byte("{\"handle1\":{\"value\": null}}"), nil
 	}
-	_, err := fetchSecret([]string{"handle1"})
+	_, err := fetchSecret([]string{"handle1"}, "test")
 	assert.NotNil(t, err)
 	assert.Equal(t, "decrypted secret for 'handle1' is empty", err.Error())
 
 	runCommand = func(string) ([]byte, error) {
 		return []byte("{\"handle1\":{\"value\": \"\"}}"), nil
 	}
-	_, err = fetchSecret([]string{"handle1"})
+	_, err = fetchSecret([]string{"handle1"}, "test")
 	assert.NotNil(t, err)
 	assert.Equal(t, "decrypted secret for 'handle1' is empty", err.Error())
 }
 
 func TestFetchSecret(t *testing.T) {
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+	}()
+
 	secrets := []string{"handle1", "handle2"}
 	// some dummy value to check the cache is not purge
 	secretCache["test"] = "yes"
@@ -158,7 +190,7 @@ func TestFetchSecret(t *testing.T) {
 		res = append(res, []byte("\"handle3\":{\"value\":\"p3\"}}")...)
 		return res, nil
 	}
-	resp, err := fetchSecret(secrets)
+	resp, err := fetchSecret(secrets, "test")
 	require.Nil(t, err)
 	assert.Equal(t, map[string]string{
 		"handle1": "p1",
@@ -169,4 +201,5 @@ func TestFetchSecret(t *testing.T) {
 		"handle1": "p1",
 		"handle2": "p2",
 	}, secretCache)
+	assert.Equal(t, map[string]common.StringSet{"handle1": common.NewStringSet("test"), "handle2": common.NewStringSet("test")}, secretOrigin)
 }

--- a/pkg/secrets/info.go
+++ b/pkg/secrets/info.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package secrets
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// SecretInfo export troubleshooting information about the decrypted secrets
+type SecretInfo struct {
+	ExecutablePath string
+	Rights         string
+	RightDetails   string
+	UnixOwner      string
+	UnixGroup      string
+	SecretsHandles map[string][]string
+}
+
+// Print output a SecretInfo to a io.Writer
+func (si *SecretInfo) Print(w io.Writer) {
+	fmt.Fprintf(w, "=== Checking executable rights ===\n")
+	fmt.Fprintf(w, "Executable path: %s\n", si.ExecutablePath)
+
+	fmt.Fprintf(w, "Check Rights: %s\n", si.Rights)
+
+	fmt.Fprintf(w, "\nRights Detail:\n")
+	fmt.Fprintf(w, "%s\n", si.RightDetails)
+
+	fmt.Fprintf(w, "Owner username: %s\n", si.UnixOwner)
+	fmt.Fprintf(w, "Group name: %s\n", si.UnixGroup)
+
+	fmt.Fprintf(w, "\n=== Secrets stats ===\n")
+	fmt.Fprintf(w, "Number of secrets decrypted: %d\n", len(si.SecretsHandles))
+	fmt.Fprintf(w, "Secrets handle decrypted:\n")
+	for handle, origins := range si.SecretsHandles {
+		fmt.Fprintf(w, "- %s: from %s\n", handle, strings.Join(origins, ", "))
+	}
+}

--- a/pkg/secrets/info_nix.go
+++ b/pkg/secrets/info_nix.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build !windows
+
+package secrets
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+func (info *SecretInfo) populateRights() {
+	err := checkRights(info.ExecutablePath)
+	if err != nil {
+		info.Rights = fmt.Sprintf("Error: %s", err)
+	} else {
+		info.Rights = fmt.Sprintf("OK, the executable has the correct rights")
+	}
+
+	var stat syscall.Stat_t
+	if err := syscall.Stat(secretBackendCommand, &stat); err != nil {
+		info.RightDetails = fmt.Sprintf("Could not stat %s: %s", secretBackendCommand, err)
+	} else {
+		info.RightDetails = fmt.Sprintf("file mode: %o", stat.Mode)
+	}
+
+	owner, err := user.LookupId(strconv.Itoa(int(stat.Uid)))
+	if err != nil {
+		info.UnixOwner = fmt.Sprintf("could not fetch name for UID %d: %s", stat.Uid, err)
+	} else {
+		info.UnixOwner = owner.Username
+	}
+
+	group, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
+	if err != nil {
+		info.UnixGroup = fmt.Sprintf("could not fetch name for GID %d: %s", stat.Gid, err)
+	} else {
+		info.UnixGroup = group.Name
+	}
+}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -9,16 +9,18 @@ package secrets
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
 	secretCache map[string]string
+	// list of handles and where they were found
+	secretOrigin map[string]common.StringSet
 
 	secretBackendCommand       string
 	secretBackendArguments     []string
@@ -28,6 +30,7 @@ var (
 
 func init() {
 	secretCache = make(map[string]string)
+	secretOrigin = make(map[string]common.StringSet)
 }
 
 // Init initializes the command and other options of the secrets package. Since
@@ -118,7 +121,7 @@ var secretFetcher = fetchSecret
 
 // Decrypt replaces all encrypted secrets in data by executing
 // "secret_backend_command" once if all secrets aren't present in the cache.
-func Decrypt(data []byte) ([]byte, error) {
+func Decrypt(data []byte, origin string) ([]byte, error) {
 	if data == nil || secretBackendCommand == "" {
 		log.Debugf("No data to decrypt or no secretBackendCommand set: skipping")
 		return data, nil
@@ -139,6 +142,8 @@ func Decrypt(data []byte) ([]byte, error) {
 			// Check if we already know this secret
 			if secret, ok := secretCache[handle]; ok {
 				log.Debugf("Secret '%s' was retrieved from cache", handle)
+				// keep track of place where a handle was found
+				secretOrigin[handle].Add(origin)
 				return secret, nil
 			}
 			newHandles = append(newHandles, handle)
@@ -156,7 +161,7 @@ func Decrypt(data []byte) ([]byte, error) {
 
 	// check if any new secrets need to be fetch
 	if len(newHandles) != 0 {
-		secrets, err := secretFetcher(newHandles)
+		secrets, err := secretFetcher(newHandles, origin)
 		if err != nil {
 			return nil, err
 		}
@@ -187,18 +192,17 @@ func Decrypt(data []byte) ([]byte, error) {
 }
 
 // GetDebugInfo exposes debug informations about secrets to be included in a flare
-func GetDebugInfo(w io.Writer) {
+func GetDebugInfo() (*SecretInfo, error) {
 	if secretBackendCommand == "" {
-		fmt.Fprintln(w, "No secret_backend_command set: secrets feature is not enabled")
-		return
+		return nil, fmt.Errorf("No secret_backend_command set: secrets feature is not enabled")
 	}
 
-	listRights(secretBackendCommand, w)
+	info := &SecretInfo{ExecutablePath: secretBackendCommand}
+	info.populateRights()
 
-	fmt.Fprintf(w, "=== Secrets stats ===\n")
-	fmt.Fprintf(w, "Number of secrets decrypted: %d\n", len(secretCache))
-	fmt.Fprintln(w, "secrets Handle decrypted:")
-	for handle := range secretCache {
-		fmt.Fprintf(w, "- %s\n", handle)
+	info.SecretsHandles = map[string][]string{}
+	for handle, originNames := range secretOrigin {
+		info.SecretsHandles[handle] = originNames.GetAll()
 	}
+	return info, nil
 }

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
@@ -52,6 +53,12 @@ instances:
   user: test
 - password: ENC[pass2]
   user: test2
+`)
+
+	testConf2 = []byte(`---
+instances:
+- password: ENC[pass3]
+- password: ENC[pass2]
 `)
 
 	testConfDecrypted = []byte(`instances:
@@ -149,32 +156,42 @@ func TestWalkerComplex(t *testing.T) {
 }
 
 func TestDecryptNoCommand(t *testing.T) {
-	secretFetcher = func(secrets []string) (map[string]string, error) {
+	defer func() { secretFetcher = fetchSecret }()
+	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
 		return nil, fmt.Errorf("some error")
 	}
 
 	// since we didn't set any command this should return without any error
-	_, err := Decrypt(testConf)
+	_, err := Decrypt(testConf, "test")
 	require.Nil(t, err)
 }
 
 func TestDecryptSecretError(t *testing.T) {
 	secretBackendCommand = "some_command"
-	defer func() { secretBackendCommand = "" }()
+	defer func() {
+		secretBackendCommand = ""
+		secretFetcher = fetchSecret
+	}()
 
-	secretFetcher = func(secrets []string) (map[string]string, error) {
+	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
 		return nil, fmt.Errorf("some error")
 	}
 
-	_, err := Decrypt(testConf)
+	_, err := Decrypt(testConf, "test")
 	require.NotNil(t, err)
 }
 
 func TestDecryptSecretNoCache(t *testing.T) {
 	secretBackendCommand = "some_command"
-	defer func() { secretBackendCommand = "" }()
 
-	secretFetcher = func(secrets []string) (map[string]string, error) {
+	defer func() {
+		secretBackendCommand = ""
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+		secretFetcher = fetchSecret
+	}()
+
+	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
 		sort.Strings(secrets)
 		assert.Equal(t, []string{
 			"pass1",
@@ -187,7 +204,7 @@ func TestDecryptSecretNoCache(t *testing.T) {
 		}, nil
 	}
 
-	newConf, err := Decrypt(testConf)
+	newConf, err := Decrypt(testConf, "test")
 	require.Nil(t, err)
 	assert.Equal(t, string(testConfDecrypted), string(newConf))
 }
@@ -197,9 +214,14 @@ func TestDecryptSecretPartialCache(t *testing.T) {
 	defer func() { secretBackendCommand = "" }()
 
 	secretCache["pass1"] = "password1"
-	defer func() { secretCache = map[string]string{} }()
+	secretOrigin["pass1"] = common.NewStringSet("test")
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+		secretFetcher = fetchSecret
+	}()
 
-	secretFetcher = func(secrets []string) (map[string]string, error) {
+	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
 		sort.Strings(secrets)
 		assert.Equal(t, []string{
 			"pass2",
@@ -210,7 +232,7 @@ func TestDecryptSecretPartialCache(t *testing.T) {
 		}, nil
 	}
 
-	newConf, err := Decrypt(testConf)
+	newConf, err := Decrypt(testConf, "test")
 	require.Nil(t, err)
 	assert.Equal(t, testConfDecrypted, newConf)
 }
@@ -221,14 +243,53 @@ func TestDecryptSecretFullCache(t *testing.T) {
 
 	secretCache["pass1"] = "password1"
 	secretCache["pass2"] = "password2"
-	defer func() { secretCache = map[string]string{} }()
+	secretOrigin["pass1"] = common.NewStringSet("previous_test")
+	secretOrigin["pass2"] = common.NewStringSet("previous_test")
+	defer func() {
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+		secretFetcher = fetchSecret
+	}()
 
-	secretFetcher = func(secrets []string) (map[string]string, error) {
+	secretFetcher = func(secrets []string, origin string) (map[string]string, error) {
 		require.Fail(t, "Secret Cache was not used properly")
 		return nil, nil
 	}
 
-	newConf, err := Decrypt(testConf)
+	newConf, err := Decrypt(testConf, "test")
 	require.Nil(t, err)
 	assert.Equal(t, testConfDecrypted, newConf)
+}
+
+func TestDebugInfo(t *testing.T) {
+	secretBackendCommand = "some_command"
+
+	defer func() {
+		secretBackendCommand = ""
+		secretCache = map[string]string{}
+		secretOrigin = map[string]common.StringSet{}
+		runCommand = execCommand
+	}()
+
+	runCommand = func(string) ([]byte, error) {
+		res := []byte("{\"pass1\":{\"value\":\"password1\"},")
+		res = append(res, []byte("\"pass2\":{\"value\":\"password2\"},")...)
+		res = append(res, []byte("\"pass3\":{\"value\":\"password3\"}}")...)
+		return res, nil
+	}
+
+	_, err := Decrypt(testConf, "test")
+	require.Nil(t, err)
+	_, err = Decrypt(testConf2, "test2")
+	require.Nil(t, err)
+
+	info, err := GetDebugInfo()
+	require.Nil(t, err)
+
+	assert.Equal(t, "some_command", info.ExecutablePath)
+	assert.Equal(t, map[string][]string{
+		"pass1": {"test"},
+		"pass2": {"test", "test2"},
+		"pass3": {"test2"},
+	}, info.SecretsHandles)
 }

--- a/pkg/secrets/secrets_win.go
+++ b/pkg/secrets/secrets_win.go
@@ -9,7 +9,6 @@ package secrets
 
 import (
 	"fmt"
-	"io"
 )
 
 // Init encrypted secrets are not available on windows
@@ -17,11 +16,11 @@ func Init(command string, arguments []string, timeout int, maxSize int) {
 }
 
 // Decrypt encrypted secrets are not available on windows
-func Decrypt(data []byte) ([]byte, error) {
+func Decrypt(data []byte, origin string) ([]byte, error) {
 	return data, nil
 }
 
 // GetDebugInfo exposes debug informations about secrets to be included in a flare
-func GetDebugInfo(w io.Writer) {
-	fmt.Fprintln(w, "Secret feature is not yet available on windows")
+func GetDebugInfo() (*SecretInfo, error) {
+	return nil, fmt.Errorf("Secret feature is not yet available on windows")
 }

--- a/pkg/util/common/common.go
+++ b/pkg/util/common/common.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package common
+
+// StringSet represents a list of uniq strings
+type StringSet map[string]struct{}
+
+// NewStringSet returns as new StringSet initialized with initItems
+func NewStringSet(initItems ...string) StringSet {
+	newSet := StringSet{}
+	for _, item := range initItems {
+		newSet.Add(item)
+	}
+	return newSet
+}
+
+// Add adds a item to the set
+func (s StringSet) Add(item string) {
+	s[item] = struct{}{}
+}
+
+// GetAll returns all the strings from the set
+func (s StringSet) GetAll() []string {
+	res := []string{}
+	for item := range s {
+		res = append(res, item)
+	}
+	return res
+}

--- a/pkg/util/common/common_test.go
+++ b/pkg/util/common/common_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package common
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStringSet(t *testing.T) {
+	s := NewStringSet()
+	assert.NotNil(t, s)
+	assert.Len(t, s, 0)
+
+	s = NewStringSet("a", "b", "b", "c")
+	assert.NotNil(t, s)
+	assert.Len(t, s, 3)
+}
+
+func TestStringSetAdd(t *testing.T) {
+	s := NewStringSet()
+	s.Add("a")
+	assert.Equal(t, []string{"a"}, s.GetAll())
+	s.Add("b")
+	res := sort.StringSlice(s.GetAll())
+	res.Sort()
+	assert.Equal(t, []string{"a", "b"}, []string(res))
+
+	s.Add("b")
+	res = sort.StringSlice(s.GetAll())
+	res.Sort()
+	assert.Equal(t, []string{"a", "b"}, []string(res))
+}
+
+func TestStringSetGetAll(t *testing.T) {
+	s := NewStringSet("a", "b", "b", "c", "c")
+	res := sort.StringSlice(s.GetAll())
+	res.Sort()
+	assert.Equal(t, []string{"a", "b", "c"}, []string(res))
+}

--- a/releasenotes/notes/secret-command-linux-48263d69619c9fce.yaml
+++ b/releasenotes/notes/secret-command-linux-48263d69619c9fce.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add of a "secrets" command to show information about decrypted secrets. We
+    now also track the configuration's name where each secrets was found.


### PR DESCRIPTION
### What does this PR do?

The new command show debug info about secrets. We now keep track of
where a secret handle was used to ease troubleshooting with external
secrets management service.

### Additional Notes

Command output looks like this:
```
=== Checking executable rights ===
Executable path: /home/dev/secret.py
Check Rights: OK, the executable has the correct rights

Rights Detail:
file mode: 100700
Owner username: dev-user
Group name: dev-user

=== Secrets stats ===
Number of secrets decrypted: 4
Secrets handle decrypted:
- agent_expvar: from go_expvar
- cpu_conf: from cpu
- expvar2: from go_expvar
- testtest: from datadog.yaml
```
