### PR TITLE
Support running in awsvpc mode on classic ECS

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -305,7 +305,7 @@ func (l *DockerListener) getHostsFromPs(co types.Container) map[string]string {
 	}
 
 	if len(ips) == 0 {
-		// More cases require a container inspect, delay it until
+		// Other edge cases require a container inspect, delay it until
 		// template resolution, when GetHosts will be called.
 		return nil
 	}

--- a/pkg/util/ecs/ecs_test.go
+++ b/pkg/util/ecs/ecs_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -172,6 +173,9 @@ func TestGetAgentContainerURLS(t *testing.T) {
 	nets["foo"] = &network.EndpointSettings{IPAddress: "172.17.0.3"}
 
 	co := types.ContainerJSON{
+		Config: &container.Config{
+			Hostname: "ip-172-29-167-5",
+		},
 		ContainerJSONBase: &types.ContainerJSONBase{},
 		NetworkSettings: &types.NetworkSettings{
 			Networks: nets,
@@ -183,7 +187,8 @@ func TestGetAgentContainerURLS(t *testing.T) {
 
 	agentURLS, err := getAgentContainerURLS()
 	assert.NoError(t, err)
-	assert.Len(t, agentURLS, 2)
+	require.Len(t, agentURLS, 3)
 	assert.Contains(t, agentURLS, "http://172.17.0.2:51678/")
 	assert.Contains(t, agentURLS, "http://172.17.0.3:51678/")
+	assert.Equal(t, "http://ip-172-29-167-5:51678/", agentURLS[2])
 }

--- a/releasenotes/notes/ecs-awsvpc-fc19d0bf007aec66.yaml
+++ b/releasenotes/notes/ecs-awsvpc-fc19d0bf007aec66.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    ECS: running the agent in awsvpc mode is now supported, provided it runs in a
+    security group that can reach both the containers to monitor and the host via
+    its private IP on port 51678


### PR DESCRIPTION
### What does this PR do?

Several small changes to work OOTB when running on classic ECS_EC2 in `awsvpc` networking mode:

#### Fargate detection: remove false positive

All containers in awsvpc mode can access `http://169.254.170.2/v2/metadata`, which means the current Fargate detection logic fires up a false positive. In this PR, I add two more conditions, we probably only want to keep one:

1. Check that the `AWS_EXECUTION_ENV` envvar is set to `AWS_ECS_FARGATE`. On EC2 instances, it is set to  `AWS_ECS_EC2`
2. Ensure the EC2 host metadata is not reachable. If it is reachable, we are sure to be in ECS_EC2 mode.

First is the most accurate, the second is the most conservative.

#### ECS-Agent: reach by instance private hostname

The default configuration of the ecs-agent container is to run in host network mode. When the agent runs in bridge mode, we manage to reach it via the default gateway. Add code to also try reaching the ecs-agent via the host's private hostname.

This works on the default setup, and requires an inbound rule on port 51678 from the agent's security group.

An alternative would be to query `http://169.254.169.254/latest/meta-data/private-ipv4` to get the private ipv4.

#### Autodiscovery: reach containers via their ENI hostname

Tasks in awsvpc are assigned one Elastic Network Interface in the given VPC. It it handled by the CNI plugin directly and not available through the docker inspect. The `%%hostname%%` variable introduced in https://github.com/DataDog/datadog-agent/pull/1894 for a similar CNI behaviour does work with awsvpc tasks. Example value: `ip-172-29-182-30.ec2.internal`

To work OOTB, we retrieve the hostname's value as a last resort of no other IP is found.

The alternative would be to override `GetHost` on ECS docker containers to retrieve the IP from the task metadata. It would yield the same result, with more code.

### Documentation updates to do

We'll need to update the ECS documentation by stating that running that versions 6.10+ of the agent are compatible with awsvpc mode, both for applicative containers and the agent container. Two use cases:

1. Apps in awsvpc, agent in awsvpc: security groups must be set to allow:
   - the agent's sg to reach the applicative containers on relevant ports
    - the agent's sg to reach the host instances on TCP port 51678. The ecs-agent container must either run in host network mode (default) or have a port binding on the host
1. Apps in awsvpc, agent in bridge mode: security groups must be set to allow the host instances sg to reach the applicative containers on relevant ports