### PR TITLE
Cluster Agent HPA metrics case support

### DIFF
--- a/pkg/clusteragent/custommetrics/store.go
+++ b/pkg/clusteragent/custommetrics/store.go
@@ -223,9 +223,9 @@ func (c *configMapStore) updateConfigMap() error {
 func externalMetricValueKeyFunc(val ExternalMetricValue) string {
 	parts := []string{
 		"external_metric",
-		val.HPA.Namespace,
-		val.HPA.Name,
-		val.MetricName,
+		strings.ToLower(val.HPA.Namespace),
+		strings.ToLower(val.HPA.Name),
+		strings.ToLower(val.MetricName),
 	}
 	return strings.Join(parts, keyDelimeter)
 }

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -151,3 +151,41 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestExternalMetricValueKeyFunc(t *testing.T) {
+	test := []struct {
+		desc   string
+		emval  ExternalMetricValue
+		output string
+	}{
+		{
+			desc: "default case",
+			emval: ExternalMetricValue{
+				MetricName: "foo",
+				HPA: ObjectReference{
+					Name:      "bar",
+					Namespace: "default",
+				},
+			},
+			output: "external_metric-default-bar-foo",
+		},
+		{
+			desc: "custom case",
+			emval: ExternalMetricValue{
+				MetricName: "FoO",
+				HPA: ObjectReference{
+					Name:      "bar",
+					Namespace: "DefauLt",
+				},
+			},
+			output: "external_metric-default-bar-foo",
+		},
+	}
+
+	for i, tt := range test {
+		t.Run(fmt.Sprintf("#%d %s", i, tt.desc), func(t *testing.T) {
+			out := externalMetricValueKeyFunc(tt.emval)
+			assert.Equal(t, tt.output, out)
+		})
+	}
+}

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -28,6 +28,7 @@ func Inspect(hpa *autoscalingv2.HorizontalPodAutoscaler) (emList []custommetrics
 			}
 			em := custommetrics.ExternalMetricValue{
 				MetricName: strings.ToLower(metricSpec.External.MetricName),
+				Labels: make(map[string]string),
 				HPA: custommetrics.ObjectReference{
 					Name:      hpa.Name,
 					Namespace: hpa.Namespace,

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -12,9 +12,10 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"strings"
 )
 
 // Inspect returns the list of external metrics from the hpa to use for autoscaling.
@@ -28,7 +29,7 @@ func Inspect(hpa *autoscalingv2.HorizontalPodAutoscaler) (emList []custommetrics
 			}
 			em := custommetrics.ExternalMetricValue{
 				MetricName: strings.ToLower(metricSpec.External.MetricName),
-				Labels: make(map[string]string),
+				Labels:     make(map[string]string),
 				HPA: custommetrics.ObjectReference{
 					Name:      hpa.Name,
 					Namespace: hpa.Namespace,

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -275,7 +275,7 @@ func TestInspect(t *testing.T) {
 			[]custommetrics.ExternalMetricValue{
 				{
 					MetricName: "foo",
-					Labels:     nil,
+					Labels:     map[string]string{},
 					Timestamp:  0,
 					Value:      0,
 					Valid:      false,

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -192,7 +192,7 @@ func TestDiffAutoscalter(t *testing.T) {
 
 func TestInspect(t *testing.T) {
 	metricName := "requests_per_s"
-
+	metricNameUpper := "ReQuesTs_Per_S"
 	testCases := map[string]struct {
 		hpa      *autoscalingv2.HorizontalPodAutoscaler
 		expected []custommetrics.ExternalMetricValue
@@ -294,6 +294,34 @@ func TestInspect(t *testing.T) {
 				},
 			},
 			[]custommetrics.ExternalMetricValue{},
+		},
+		"upper cases handled": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					Metrics: []autoscalingv2.MetricSpec{
+						{
+							Type: autoscalingv2.ExternalMetricSourceType,
+							External: &autoscalingv2.ExternalMetricSource{
+								MetricName: metricNameUpper,
+								MetricSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"DcoS_vErsIoN": "1.9.4",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			[]custommetrics.ExternalMetricValue{
+				{
+					MetricName: "requests_per_s",
+					Labels:     map[string]string{"dcos_version": "1.9.4"},
+					Timestamp:  0,
+					Value:      0,
+					Valid:      false,
+				},
+			},
 		},
 	}
 

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -128,9 +128,10 @@ func invalidate(emList []custommetrics.ExternalMetricValue) (invList []custommet
 }
 
 func getKey(name string, labels map[string]string) string {
+	name = strings.ToLower(name)
 	// Support queries with no tags
 	if len(labels) == 0 {
-		return fmt.Sprintf("%s{*}", strings.ToLower(name))
+		return fmt.Sprintf("%s{*}", name)
 	}
 
 	datadogTags := []string{}

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -130,12 +130,12 @@ func invalidate(emList []custommetrics.ExternalMetricValue) (invList []custommet
 func getKey(name string, labels map[string]string) string {
 	// Support queries with no tags
 	if len(labels) == 0 {
-		return fmt.Sprintf("%s{*}", name)
+		return fmt.Sprintf("%s{*}", strings.ToLower(name))
 	}
 
 	datadogTags := []string{}
 	for key, val := range labels {
-		datadogTags = append(datadogTags, fmt.Sprintf("%s:%s", key, val))
+		datadogTags = append(datadogTags, fmt.Sprintf("%s:%s", strings.ToLower(key), strings.ToLower(val)))
 	}
 	sort.Strings(datadogTags)
 	tags := strings.Join(datadogTags, ",")


### PR DESCRIPTION
### What does this PR do?

It was [brought up](https://github.com/kubernetes/kubernetes/issues/72996) to our attention that the Cluster Agent does not support the upper case on metrics.
The issue being that Kubernetes converts the resources to lower case. This PR forces the lower case on metrics and labels.

### Motivation

Better support for the external metrics provider.
