### PR TITLE
Fix cmd port on some commands

### DIFF
--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -25,8 +25,6 @@ func init() {
 	AgentCmd.AddCommand(taggerListCommand)
 }
 
-var taggerListURL = fmt.Sprintf("https://localhost:%v/agent/tagger-list", config.Datadog.GetInt("cmd_port"))
-
 var taggerListCommand = &cobra.Command{
 	Use:   "tagger-list",
 	Short: "Print the tagger content of a running agent",
@@ -47,7 +45,7 @@ var taggerListCommand = &cobra.Command{
 			return err
 		}
 
-		r, err := util.DoGet(c, taggerListURL)
+		r, err := util.DoGet(c, fmt.Sprintf("https://localhost:%v/agent/tagger-list", config.Datadog.GetInt("cmd_port")))
 		if err != nil {
 			if r != nil && string(r) != "" {
 				fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while getting tags list: %s", string(r)))

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -128,7 +128,7 @@ func TestZipConfigCheck(t *testing.T) {
 		w.Write(out)
 	}))
 	defer ts.Close()
-	ConfigCheckURL = ts.URL
+	configCheckURL = ts.URL
 
 	dir, err := ioutil.TempDir("", "TestZipConfigCheck")
 	if err != nil {

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -19,8 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// ConfigCheckURL contains the Agent API endpoint URL exposing the loaded checks
-var ConfigCheckURL = fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
+// configCheckURL contains the Agent API endpoint URL exposing the loaded checks
+var configCheckURL string
 
 // GetConfigCheck dump all loaded configurations to the writer
 func GetConfigCheck(w io.Writer, withDebug bool) error {
@@ -36,7 +36,10 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 		return err
 	}
 
-	r, err := util.DoGet(c, ConfigCheckURL)
+	if configCheckURL == "" {
+		configCheckURL = fmt.Sprintf("https://localhost:%v/agent/config-check", config.Datadog.GetInt("cmd_port"))
+	}
+	r, err := util.DoGet(c, configCheckURL)
 	if err != nil {
 		if r != nil && string(r) != "" {
 			return fmt.Errorf("the agent ran into an error while checking config: %s", string(r))
@@ -86,7 +89,7 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 
 // GetClusterAgentConfigCheck proxies GetConfigCheck overidding the URL
 func GetClusterAgentConfigCheck(w io.Writer, withDebug bool) error {
-	ConfigCheckURL = fmt.Sprintf("https://localhost:%v/config-check", config.Datadog.GetInt("cluster_agent.cmd_port"))
+	configCheckURL = fmt.Sprintf("https://localhost:%v/config-check", config.Datadog.GetInt("cluster_agent.cmd_port"))
 	return GetConfigCheck(w, withDebug)
 }
 

--- a/releasenotes/notes/fix-cmd-port-f5777b680f2e523e.yaml
+++ b/releasenotes/notes/fix-cmd-port-f5777b680f2e523e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix custom command line port configuration on `configcheck` and `tagger-list` CLI commands.


### PR DESCRIPTION
### What does this PR do?

Some command URLs were set before the configuration was parsed

### Motivation

Fix #2904 (which was introduced by https://github.com/DataDog/datadog-agent/pull/1479)

