### PR TITLE
buffer packets at dogstatsd intake

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,8 +190,10 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
 	// Dogstatsd
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
-	config.BindEnvAndSetDefault("dogstatsd_port", 8125)          // Notice: 0 means UDP port closed
-	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
+	config.BindEnvAndSetDefault("dogstatsd_port", 8125)                                        // Notice: 0 means UDP port closed
+	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)                               // 8KB buffer
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 4096)                          // Number of packets to buffer at dogstatsd intake before flushing them to parsing/aggregation
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_flush_timeout", 100*time.Millisecond) // Timeout after which we force dogstatsd intake buffer to be flushed
 	config.BindEnvAndSetDefault("dogstatsd_non_local_traffic", false)
 	config.BindEnvAndSetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
 	config.BindEnvAndSetDefault("dogstatsd_stats_port", 5000)

--- a/pkg/dogstatsd/listeners/packet_buffer.go
+++ b/pkg/dogstatsd/listeners/packet_buffer.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package listeners
+
+import (
+	"sync"
+	"time"
+)
+
+type packetBuffer struct {
+	packets       Packets
+	flushTimer    *time.Ticker
+	bufferSize    uint
+	outputChannel chan Packets
+	closeChannel  chan struct{}
+	m             sync.Mutex
+}
+
+func newPacketBuffer(bufferSize uint, flushTimer time.Duration, outputChannel chan Packets) *packetBuffer {
+	pb := &packetBuffer{
+		bufferSize:    bufferSize,
+		flushTimer:    time.NewTicker(flushTimer),
+		outputChannel: outputChannel,
+		packets:       make(Packets, 0, bufferSize),
+		closeChannel:  make(chan struct{}),
+	}
+	go pb.flushLoop()
+	return pb
+}
+
+func (pb *packetBuffer) flushLoop() {
+	for {
+		select {
+		case <-pb.flushTimer.C:
+			pb.m.Lock()
+			pb.flush()
+			pb.m.Unlock()
+		case <-pb.closeChannel:
+			return
+		}
+	}
+}
+
+func (pb *packetBuffer) append(packet *Packet) {
+	pb.m.Lock()
+	defer pb.m.Unlock()
+	pb.packets = append(pb.packets, packet)
+	if uint(len(pb.packets)) == pb.bufferSize {
+		pb.flush()
+	}
+}
+
+func (pb *packetBuffer) flush() {
+	if len(pb.packets) > 0 {
+		pb.outputChannel <- pb.packets
+		pb.packets = make(Packets, 0, pb.bufferSize)
+	}
+}
+
+func (pb *packetBuffer) close() {
+	close(pb.closeChannel)
+}

--- a/pkg/dogstatsd/listeners/packet_buffer.go
+++ b/pkg/dogstatsd/listeners/packet_buffer.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+// packetBuffer is a buffer of packet that will automatically flush to configurable channel
+// when it is full or after a configurable duration
 type packetBuffer struct {
 	packets       Packets
 	flushTimer    *time.Ticker

--- a/pkg/dogstatsd/listeners/types.go
+++ b/pkg/dogstatsd/listeners/types.go
@@ -17,6 +17,9 @@ type Packet struct {
 	Origin   string // Origin container if identified
 }
 
+// Packets is a slice of packet pointers
+type Packets []*Packet
+
 // StatsdListener opens a communication channel to get statsd packets in.
 type StatsdListener interface {
 	Listen()

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -32,13 +32,14 @@ func init() {
 // processed.
 // Origin detection is not implemented for UDP.
 type UDPListener struct {
-	conn       net.PacketConn
-	packetPool *PacketPool
-	packetOut  chan *Packet
+	conn         net.PacketConn
+	packetPool   *PacketPool
+	packetOut    chan Packets
+	packetBuffer *packetBuffer
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
-func NewUDPListener(packetOut chan *Packet, packetPool *PacketPool) (*UDPListener, error) {
+func NewUDPListener(packetOut chan Packets, packetPool *PacketPool) (*UDPListener, error) {
 	var conn net.PacketConn
 	var err error
 	var url string
@@ -66,6 +67,8 @@ func NewUDPListener(packetOut chan *Packet, packetPool *PacketPool) (*UDPListene
 		packetOut:  packetOut,
 		packetPool: packetPool,
 		conn:       conn,
+		packetBuffer: newPacketBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),
+			config.Datadog.GetDuration("dogstatsd_packet_buffer_flush_timeout"), packetOut),
 	}
 	log.Debugf("dogstatsd-udp: %s successfully initialized", conn.LocalAddr())
 	return listener, nil
@@ -90,11 +93,12 @@ func (l *UDPListener) Listen() {
 		}
 
 		packet.Contents = packet.buffer[:n]
-		l.packetOut <- packet
+		l.packetBuffer.append(packet)
 	}
 }
 
 // Stop closes the UDP connection and stops listening
 func (l *UDPListener) Stop() {
+	l.packetBuffer.close()
 	l.conn.Close()
 }

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -34,7 +34,6 @@ func init() {
 type UDPListener struct {
 	conn         net.PacketConn
 	packetPool   *PacketPool
-	packetOut    chan Packets
 	packetBuffer *packetBuffer
 }
 
@@ -64,7 +63,6 @@ func NewUDPListener(packetOut chan Packets, packetPool *PacketPool) (*UDPListene
 	}
 
 	listener := &UDPListener{
-		packetOut:  packetOut,
 		packetPool: packetPool,
 		conn:       conn,
 		packetBuffer: newPacketBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -91,6 +91,8 @@ func (l *UDPListener) Listen() {
 		}
 
 		packet.Contents = packet.buffer[:n]
+
+		// packetBuffer handles the forwarding of the packets to the dogstatsd server intake channel
 		l.packetBuffer.append(packet)
 	}
 }

--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -117,7 +117,7 @@ func TestUDPReceive(t *testing.T) {
 	require.Nil(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	packetChannel := make(chan *Packet)
+	packetChannel := make(chan Packets)
 	s, err := NewUDPListener(packetChannel, packetPoolUDP)
 	require.NotNil(t, s)
 	assert.Nil(t, err)
@@ -131,8 +131,10 @@ func TestUDPReceive(t *testing.T) {
 	conn.Write(contents)
 
 	select {
-	case packet := <-packetChannel:
+	case packets := <-packetChannel:
+		packet := packets[0]
 		assert.NotNil(t, packet)
+		assert.Equal(t, 1, len(packets))
 		assert.Equal(t, contents, packet.Contents)
 		assert.Equal(t, "", packet.Origin)
 	case <-time.After(2 * time.Second):

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -38,7 +38,6 @@ func init() {
 // Origin detection will be implemented for UDS.
 type UDSListener struct {
 	conn            *net.UnixConn
-	packetOut       chan Packets
 	packetBuffer    *packetBuffer
 	packetPool      *PacketPool
 	oobPool         *sync.Pool // For origin detection ancilary data
@@ -95,7 +94,6 @@ func NewUDSListener(packetOut chan Packets, packetPool *PacketPool) (*UDSListene
 
 	listener := &UDSListener{
 		OriginDetection: originDetection,
-		packetOut:       packetOut,
 		packetPool:      packetPool,
 		conn:            conn,
 		packetBuffer: newPacketBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -153,6 +153,8 @@ func (l *UDSListener) Listen() {
 		}
 
 		packet.Contents = packet.buffer[:n]
+
+		// packetBuffer handles the forwarding of the packets to the dogstatsd server intake channel
 		l.packetBuffer.append(packet)
 	}
 }

--- a/pkg/dogstatsd/listeners/uds_common_test.go
+++ b/pkg/dogstatsd/listeners/uds_common_test.go
@@ -105,8 +105,8 @@ func TestUDSReceive(t *testing.T) {
 
 	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
-	packetChannel := make(chan *Packet)
-	s, err := NewUDSListener(packetChannel, packetPoolUDS)
+	packetsChannel := make(chan Packets)
+	s, err := NewUDSListener(packetsChannel, packetPoolUDS)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
@@ -118,8 +118,10 @@ func TestUDSReceive(t *testing.T) {
 	conn.Write(contents)
 
 	select {
-	case packet := <-packetChannel:
+	case packets := <-packetsChannel:
+		packet := packets[0]
 		assert.NotNil(t, packet)
+		assert.Equal(t, 1, len(packets))
 		assert.Equal(t, packet.Contents, contents)
 		assert.Equal(t, packet.Origin, "")
 	case <-time.After(2 * time.Second):

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -46,7 +46,7 @@ func init() {
 // Server represent a Dogstatsd server
 type Server struct {
 	listeners        []listeners.StatsdListener
-	packetIn         chan *listeners.Packet
+	packetsIn        chan listeners.Packets
 	Statistics       *util.Stats
 	Started          bool
 	packetPool       *listeners.PacketPool
@@ -72,13 +72,13 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 	}
 
-	packetChannel := make(chan *listeners.Packet, 100)
+	packetsChannel := make(chan listeners.Packets, 100)
 	packetPool := listeners.NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
 	tmpListeners := make([]listeners.StatsdListener, 0, 2)
 
 	socketPath := config.Datadog.GetString("dogstatsd_socket")
 	if len(socketPath) > 0 {
-		unixListener, err := listeners.NewUDSListener(packetChannel, packetPool)
+		unixListener, err := listeners.NewUDSListener(packetsChannel, packetPool)
 		if err != nil {
 			log.Errorf(err.Error())
 		} else {
@@ -86,7 +86,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		}
 	}
 	if config.Datadog.GetInt("dogstatsd_port") > 0 {
-		udpListener, err := listeners.NewUDPListener(packetChannel, packetPool)
+		udpListener, err := listeners.NewUDPListener(packetsChannel, packetPool)
 		if err != nil {
 			log.Errorf(err.Error())
 		} else {
@@ -117,7 +117,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 	s := &Server{
 		Started:          true,
 		Statistics:       stats,
-		packetIn:         packetChannel,
+		packetsIn:        packetsChannel,
 		listeners:        tmpListeners,
 		packetPool:       packetPool,
 		stopChan:         make(chan bool),
@@ -141,8 +141,8 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		if err != nil {
 			log.Warnf("Could not connect to statsd forward host : %s", err)
 		} else {
-			s.packetIn = make(chan *listeners.Packet, 100)
-			go s.forwarder(con, packetChannel)
+			s.packetsIn = make(chan listeners.Packets, 100)
+			go s.forwarder(con, packetsChannel)
 		}
 	}
 
@@ -173,19 +173,20 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 	}
 }
 
-func (s *Server) forwarder(fcon net.Conn, packetChannel chan *listeners.Packet) {
+func (s *Server) forwarder(fcon net.Conn, packetsChannel chan listeners.Packets) {
 	for {
 		select {
 		case <-s.stopChan:
 			return
-		case packet := <-packetChannel:
-			_, err := fcon.Write(packet.Contents)
+		case packets := <-packetsChannel:
+			for _, packet := range packets {
+				_, err := fcon.Write(packet.Contents)
 
-			if err != nil {
-				log.Warnf("Forwarding packet failed : %s", err)
+				if err != nil {
+					log.Warnf("Forwarding packet failed : %s", err)
+				}
 			}
-
-			s.packetIn <- packet
+			s.packetsIn <- packets
 		}
 	}
 }
@@ -196,8 +197,10 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 		case <-s.stopChan:
 			return
 		case <-s.health.C:
-		case packet := <-s.packetIn:
-			s.handlePacket(packet, metricOut, eventOut, serviceCheckOut)
+		case packets := <-s.packetsIn:
+			for _, packet := range packets {
+				s.handlePacket(packet, metricOut, eventOut, serviceCheckOut)
+			}
 		}
 	}
 }

--- a/releasenotes/notes/import-dogstatsd-perf-channels-3d0f06b26abe3403.yaml
+++ b/releasenotes/notes/import-dogstatsd-perf-channels-3d0f06b26abe3403.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The performance of the Agent under DogStatsD load has been improved.

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -56,9 +56,9 @@ func testUDSOriginDetection(t *testing.T) {
 	mockConfig.Set("dogstatsd_origin_detection", true)
 
 	// Start DSD
-	packetChannel := make(chan *listeners.Packet)
+	packetsChannel := make(chan listeners.Packets)
 	packetPool := listeners.NewPacketPool(mockConfig.GetInt("dogstatsd_buffer_size"))
-	s, err := listeners.NewUDSListener(packetChannel, packetPool)
+	s, err := listeners.NewUDSListener(packetsChannel, packetPool)
 	require.Nil(t, err)
 
 	go s.Listen()
@@ -85,7 +85,8 @@ func testUDSOriginDetection(t *testing.T) {
 	defer stopCmd.Run()
 
 	select {
-	case packet := <-packetChannel:
+	case packets := <-packetsChannel:
+		packet := packets[0]
 		require.NotNil(t, packet)
 		require.Equal(t, "custom_counter1:1|c", string(packet.Contents))
 		require.Equal(t, fmt.Sprintf("docker://%s", containerId), packet.Origin)


### PR DESCRIPTION
### What does this PR do?

Part 1/2 of getting https://github.com/DataDog/datadog-agent/pull/2161 merged.

Doing it in two PR to ease the review as it's dealing with sensitive components.

This PR adds some buffering at the dogstatsd intake to reduce contention issues around the channel between the dogstatsd UDP/UDS listener and the dogstatsd "server".

Part 2/2 will do the same but for the channel between the dogstatsd server and the aggregator.

TL;DR:

Now
```
UDP/UDS listener ---------> DogStatsD Parsers -----------------------------> Aggregator
                 (packet)                     (metric|service check|event)
```

Part 1/2
```
UDP/UDS listener ---------> DogStatsD Parsers -----------------------------> Aggregator
                 (packet[])                   (metric|service check|event)
```
Part 2/2 
```
UDP/UDS listener ---------> DogStatsD Parsers -----------------------------> Aggregator
                 (packet[])                 (metric[]|service check[]|event[])
```

### Additional Notes

I highly recommend reviewing one commit at a time. The first one only extracts a function but creates a huge diff mess.