### PR TITLE
Ship openstack_controller with next release

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -46,7 +46,6 @@ blacklist = [
   'docker_daemon',
   'kubernetes',
   'ntp',                           # provided as a go check by the core agent
-  'openstack_controller',          # Check currently under active development and in beta
 ]
 
 core_constraints_file = 'core_constraints.txt'


### PR DESCRIPTION
### What does this PR do?

The check was in beta for the past couple Agent releases, but agent-integrations is ready to ship this check with the next agent release (6.10.0) This removes the check from the blacklist so that its properly bundled. 