### PR TITLE
[syslog] unset syslog uri when syslog is disabled.

### DIFF
--- a/pkg/config/log_nix.go
+++ b/pkg/config/log_nix.go
@@ -7,19 +7,18 @@
 
 package config
 
-// GetSyslogURI returns the configured/default syslog uri
+// GetSyslogURI returns the configured/default syslog uri.
+// Returns an empty string when syslog is disabled.
 func GetSyslogURI() string {
 	enabled := Datadog.GetBool("log_to_syslog")
 	uri := Datadog.GetString("syslog_uri")
 
-	if enabled {
-		if uri == "" {
-			uri = defaultSyslogURI
-		}
-	} else {
-		// When syslog is disabled, don't try to connect to the
-		// configured uri (tcp, udp, ...).
-		uri = ""
+	if !enabled {
+		return ""
+	}
+
+	if uri == "" {
+		return defaultSyslogURI
 	}
 
 	return uri

--- a/pkg/config/log_nix.go
+++ b/pkg/config/log_nix.go
@@ -16,6 +16,10 @@ func GetSyslogURI() string {
 		if uri == "" {
 			uri = defaultSyslogURI
 		}
+	} else {
+		// When syslog is disabled, don't try to connect to the
+		// configured uri (tcp, udp, ...).
+		uri = ""
 	}
 
 	return uri

--- a/pkg/config/log_nix_test.go
+++ b/pkg/config/log_nix_test.go
@@ -1,0 +1,28 @@
+// +build linux freebsd netbsd openbsd solaris dragonfly darwin
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSyslogURI(t *testing.T) {
+	assert := assert.New(t)
+
+	mockConfig := Mock()
+	mockConfig.Set("log_to_syslog", true)
+	mockConfig.Set("syslog_uri", "")
+
+	assert.Equal(GetSyslogURI(), defaultSyslogURI)
+
+	mockConfig.Set("syslog_uri", "tcp://localhost:514")
+	assert.Equal(GetSyslogURI(), "tcp://localhost:514")
+
+	mockConfig.Set("log_to_syslog", false)
+	assert.Equal(GetSyslogURI(), "")
+
+	mockConfig.Set("syslog_uri", "")
+	assert.Equal(GetSyslogURI(), "")
+}


### PR DESCRIPTION
### What does this PR do?

This PR unsets the value of the syslog uri when syslog is disabled. 

On an Agent with a syslog uri configured, we're using the `syslog_uri` config entry to decide whether we should send to a syslog server, ignoring `log_to_syslog`.
If we don't unset it while syslog is disabled, the Agent is still trying to connect to the syslog server.

See https://github.com/DataDog/datadog-agent/blob/master/pkg/config/log.go#L56

### Motivation

The Agent was throwing an error for each log as I had a syslog uri configured to a stopped rsyslog daemon, even with `log_to_syslog` set to `false`.

### Additional Notes

Please feel free to reject this PR if I misunderstood or overlooked something.
