### PR TITLE
pkg/trace/agent: improve NormalizeTag

### DIFF
--- a/pkg/trace/agent/tags.go
+++ b/pkg/trace/agent/tags.go
@@ -266,7 +266,7 @@ func NormalizeTag(tag string) string {
 			// we've reached the maximum
 			break
 		}
-		// all letters are ok
+		// fast path; all letters are ok
 		switch {
 		case c >= 'a' && c <= 'z':
 			chars++

--- a/releasenotes/notes/improve-performance-of-NormalizeTag-function-7eba70c13f0bdad7.yaml
+++ b/releasenotes/notes/improve-performance-of-NormalizeTag-function-7eba70c13f0bdad7.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    APM: improve performance of NormalizeTag function.


### PR DESCRIPTION
Improves performance of `NormalizeTag`

```
name                      old time/op    new time/op    delta
NormalizeTag/ok-4            129ns ± 0%      69ns ± 0%  -46.74%
NormalizeTag/trim-4          167ns ± 0%      92ns ± 0%  -44.97%
NormalizeTag/trim-both-4     197ns ± 0%     160ns ± 0%  -18.78%
NormalizeTag/plenty-4        193ns ± 0%     147ns ± 0%  -23.83%
NormalizeTag/more-4          261ns ± 0%     264ns ± 0%   +1.15%

name                      old alloc/op   new alloc/op   delta
NormalizeTag/ok-4             136B ± 0%       24B ± 0%  -82.35%
NormalizeTag/trim-4           160B ± 0%       32B ± 0%  -80.00%
NormalizeTag/trim-both-4      176B ± 0%       64B ± 0%  -63.64%
NormalizeTag/plenty-4         160B ± 0%       64B ± 0%  -60.00%
NormalizeTag/more-4           176B ± 0%      128B ± 0%  -27.27%

name                      old allocs/op  new allocs/op  delta
NormalizeTag/ok-4             3.00 ± 0%      2.00 ± 0%  -33.33%
NormalizeTag/trim-4           3.00 ± 0%      2.00 ± 0%  -33.33%
NormalizeTag/trim-both-4      3.00 ± 0%      3.00 ± 0%    0.00%
NormalizeTag/plenty-4         3.00 ± 0%      3.00 ± 0%    0.00%
NormalizeTag/more-4           3.00 ± 0%      4.00 ± 0%  +33.33%
```

Instead of creating a buffer, create a series of tuples representing cuts that need to happen inside the tag string, and apply them later. If no changes need to happen, the same string is returned without any extra allocations.

As can be seen in the benchmarks, the algorithm becomes slower the more cuts need to be made. For common scenarios with no changes or few changes, the improvement is around 400% for memory.