### PR TITLE
Add option for JSON output to the check command

### DIFF
--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -45,7 +45,7 @@ func init() {
 	checkCmd.Flags().IntVar(&checkPause, "pause", 0, "pause between multiple runs of the check, in milliseconds")
 	checkCmd.Flags().StringVarP(&logLevel, "log-level", "l", "", "set the log level (default 'off')")
 	checkCmd.Flags().IntVarP(&checkDelay, "delay", "d", 100, "delay between running the check and grabbing the metrics in miliseconds")
-	checkCmd.Flags().BoolVarP(&formatJSON, "json", "", false, "format aggregator output as json")
+	checkCmd.Flags().BoolVarP(&formatJSON, "json", "", false, "format aggregator and check runner output as json")
 	checkCmd.SetArgs([]string{"checkName"})
 }
 
@@ -129,19 +129,47 @@ var checkCmd = &cobra.Command{
 			fmt.Println("Multiple check instances found, running each of them")
 		}
 
+		var instancesData []interface{}
+
 		for _, c := range cs {
 			s := runCheck(c, agg)
 
 			// Sleep for a while to allow the aggregator to finish ingesting all the metrics/events/sc
 			time.Sleep(time.Duration(checkDelay) * time.Millisecond)
 
-			printMetrics(agg)
+			if formatJSON {
+				aggregatorData := getMetricsData(agg)
+				var collectorData map[string]interface{}
 
-			checkStatus, _ := status.GetCheckStatus(c, s)
-			fmt.Println(string(checkStatus))
+				collectorJSON, _ := status.GetCheckStatusJSON(c, s)
+				json.Unmarshal(collectorJSON, &collectorData)
+
+				checkRuns := collectorData["runnerStats"].(map[string]interface{})["Checks"].(map[string]interface{})[checkName].(map[string]interface{})
+
+				// There is only one checkID per run so we'll just access that
+				var runnerData map[string]interface{}
+				for _, checkIDData := range checkRuns {
+					runnerData = checkIDData.(map[string]interface{})
+					break
+				}
+
+				instanceData := map[string]interface{}{
+					"aggregator": aggregatorData,
+					"runner":     runnerData,
+				}
+				instancesData = append(instancesData, instanceData)
+			} else {
+				printMetrics(agg)
+				checkStatus, _ := status.GetCheckStatus(c, s)
+				fmt.Println(string(checkStatus))
+			}
 		}
 
-		if checkRate == false && checkTimes < 2 && !formatJSON {
+		if formatJSON {
+			fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("JSON")))
+			instancesJSON, _ := json.MarshalIndent(instancesData, "", "  ")
+			fmt.Println(string(instancesJSON))
+		} else if checkRate == false && checkTimes < 2 {
 			color.Yellow("Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.")
 		}
 
@@ -178,55 +206,63 @@ func runCheck(c check.Check, agg *aggregator.BufferedAggregator) *check.Stats {
 }
 
 func printMetrics(agg *aggregator.BufferedAggregator) {
-	aggJSON := make(map[string]interface{})
-
 	series := agg.GetSeries()
 	if len(series) != 0 {
-		if formatJSON {
-			aggJSON["metrics"] = series
-		} else {
-			fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Series")))
-			j, _ := json.MarshalIndent(series, "", "  ")
-			fmt.Println(string(j))
-		}
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Series")))
+		j, _ := json.MarshalIndent(series, "", "  ")
+		fmt.Println(string(j))
 	}
 
 	sketches := agg.GetSketches()
 	if len(sketches) != 0 {
-		if formatJSON {
-			aggJSON["sketches"] = sketches
-		} else {
-			fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Sketches")))
-			j, _ := json.MarshalIndent(sketches, "", "  ")
-			fmt.Println(string(j))
-		}
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Sketches")))
+		j, _ := json.MarshalIndent(sketches, "", "  ")
+		fmt.Println(string(j))
 	}
 
 	serviceChecks := agg.GetServiceChecks()
 	if len(serviceChecks) != 0 {
-		if formatJSON {
-			aggJSON["service_checks"] = serviceChecks
-		} else {
-			fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Service Checks")))
-			j, _ := json.MarshalIndent(serviceChecks, "", "  ")
-			fmt.Println(string(j))
-		}
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Service Checks")))
+		j, _ := json.MarshalIndent(serviceChecks, "", "  ")
+		fmt.Println(string(j))
 	}
 
 	events := agg.GetEvents()
 	if len(events) != 0 {
-		if formatJSON {
-			aggJSON["events"] = events
-		} else {
-			fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Events")))
-			j, _ := json.MarshalIndent(events, "", "  ")
-			fmt.Println(string(j))
-		}
-	}
-
-	if formatJSON {
-		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("JSON")))
-		j, _ := json.MarshalIndent(aggJSON, "", "  ")
+		fmt.Fprintln(color.Output, fmt.Sprintf("=== %s ===", color.BlueString("Events")))
+		j, _ := json.MarshalIndent(events, "", "  ")
 		fmt.Println(string(j))
 	}
+}
+
+func getMetricsData(agg *aggregator.BufferedAggregator) map[string]interface{} {
+	aggData := make(map[string]interface{})
+
+	series := agg.GetSeries()
+	if len(series) != 0 {
+		// Workaround to get the raw sequence of metrics, see:
+		// https://github.com/DataDog/datadog-agent/blob/b2d9527ec0ec0eba1a7ae64585df443c5b761610/pkg/metrics/series.go#L109-L122
+		var data map[string]interface{}
+		sj, _ := json.Marshal(series)
+		json.Unmarshal(sj, &data)
+
+		aggData["metrics"] = data["series"]
+	}
+
+	sketches := agg.GetSketches()
+	if len(sketches) != 0 {
+		aggData["sketches"] = sketches
+	}
+
+	serviceChecks := agg.GetServiceChecks()
+	if len(serviceChecks) != 0 {
+		aggData["service_checks"] = serviceChecks
+	}
+
+	events := agg.GetEvents()
+	if len(events) != 0 {
+		aggData["events"] = events
+	}
+
+	return aggData
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -97,8 +97,8 @@ func GetAndFormatStatus() ([]byte, error) {
 	return []byte(st), nil
 }
 
-// GetCheckStatus gets the status of a single check
-func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
+// GetCheckStatusJSON gets the status of a single check as JSON
+func GetCheckStatusJSON(c check.Check, cs *check.Stats) ([]byte, error) {
 	s, err := GetStatus()
 	if err != nil {
 		return nil, err
@@ -108,6 +108,16 @@ func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
 	checks[c.String()].(map[check.ID]interface{})[c.ID()] = cs
 
 	statusJSON, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return statusJSON, nil
+}
+
+// GetCheckStatus gets the status of a single check as human-readable text
+func GetCheckStatus(c check.Check, cs *check.Stats) ([]byte, error) {
+	statusJSON, err := GetCheckStatusJSON(c, cs)
 	if err != nil {
 		return nil, err
 	}

--- a/releasenotes/notes/add-option-for-JSON-output-to-the-check-command-4731cb264afd546a.yaml
+++ b/releasenotes/notes/add-option-for-JSON-output-to-the-check-command-4731cb264afd546a.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a ``--json`` flag to the ``check`` command that will
+    output all aggregator data as JSON.


### PR DESCRIPTION
### What does this PR do?

Adds a `--json` flag to the `check` command that will output all aggregator and check runner data as JSON.

### Motivation

Easier parsing for external consumers, particularly new e2e features coming to `ddev` very soon (next week)

### Additional Notes

The output may contain logs first and I don't know how/if it's possible to serialize those, so I made a `=== JSON ===` header to indicate where the real output starts.

### Example

```
$ "C:\Program Files\Datadog\Datadog Agent\embedded\agent.exe" check --json vault
=== JSON ===
[
  {
    "aggregator": {
      "metrics": [
        {
          "host": "ozone",
          "interval": 0,
          "metric": "vault.is_leader",
          "points": [
            [
              1548557211,
              0
            ]
          ],
          "source_type_name": "System",
          "tags": [
            "instance:foobar",
            "is_leader:false"
          ],
          "type": "gauge"
        }
      ],
      "service_checks": [
        {
          "check": "vault.unsealed",
          "host_name": "ozone",
          "timestamp": 1548557211,
          "status": 0,
          "message": "",
          "tags": [
            "instance:foobar",
            "is_leader:false",
            "cluster_name:vault-cluster-00ca761a",
            "vault_version:1.0.2"
          ]
        },
        {
          "check": "vault.initialized",
          "host_name": "ozone",
          "timestamp": 1548557211,
          "status": 0,
          "message": "",
          "tags": [
            "instance:foobar",
            "is_leader:false",
            "cluster_name:vault-cluster-00ca761a",
            "vault_version:1.0.2"
          ]
        },
        {
          "check": "vault.can_connect",
          "host_name": "ozone",
          "timestamp": 1548557211,
          "status": 0,
          "message": "",
          "tags": [
            "instance:foobar",
            "is_leader:false",
            "cluster_name:vault-cluster-00ca761a",
            "vault_version:1.0.2"
          ]
        }
      ]
    },
    "runner": {
      "AverageExecutionTime": 14,
      "CheckID": "vault:918f116db5201c87",
      "CheckName": "vault",
      "CheckVersion": "1.3.1",
      "Events": 0,
      "ExecutionTimes": [
        14,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        0
      ],
      "LastError": "",
      "LastExecutionTime": 14,
      "LastWarnings": [],
      "MetricSamples": 1,
      "ServiceChecks": 3,
      "TotalErrors": 0,
      "TotalEvents": 0,
      "TotalMetricSamples": 1,
      "TotalRuns": 1,
      "TotalServiceChecks": 3,
      "TotalWarnings": 0,
      "UpdateTimestamp": 1548557211
    }
  }
]
```