### PR TITLE
Sign docker images when pushing to Docker Hub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -792,6 +792,9 @@ testkitchen_cleanup_azure:
 #
 # image_build
 #
+# docker build must run with DOCKER_CONTENT_TRUST to
+# enable signature check of the base images
+#
 
 .docker_build_job_definition: &docker_build_job_definition
   stage: image_build
@@ -804,7 +807,7 @@ testkitchen_cleanup_azure:
     - aws s3 sync --only-show-errors "s3://dd-ci-artefacts-build-stable/datadog-agent/$CI_PIPELINE_ID" $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
-    - docker build $BUILD_ARG --pull --tag $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX $BUILD_CONTEXT
+    - DOCKER_CONTENT_TRUST=1 docker build $BUILD_ARG --pull --tag $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX $BUILD_CONTEXT
     - docker push $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX
 
 # build the agent6 image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -799,11 +799,10 @@ testkitchen_cleanup_azure:
 .docker_build_job_definition: &docker_build_job_definition
   stage: image_build
   tags: [ "runner:docker", "size:large" ]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   before_script: [ "# noop" ] # Override top level entry
   dependencies: [] # Don't download Gitlab artifacts
   script:
-    - apt-get update && apt-get install -y python-pip && pip install awscli
     - aws s3 sync --only-show-errors "s3://dd-ci-artefacts-build-stable/datadog-agent/$CI_PIPELINE_ID" $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
@@ -868,10 +867,9 @@ twistlock_scan:
 .docker_tag_job_definition: &docker_tag_job_definition
   stage: image_deploy
   tags: [ "runner:docker", "size:large" ]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   before_script:
     - export SRC_TAG=v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}
-    - apt-get update && apt-get install -y python-pip && pip install awscli
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - pip install -r requirements.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -873,11 +873,18 @@ twistlock_scan:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - pip install -r requirements.txt
+    - if [[ -z "$DELEGATION_PASS_SSM_KEY" ]]; then echo "No signing key set"; exit 0; fi
+    - echo "Importing delegation signing key"
+    - export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_PASS_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - mkdir -p ~/.docker/trust/private
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text > ~/.docker/trust/private/29dfad055b34905ad69404bfd8608c3cfa71110bdc50039e0c4c37dcda3f5d14.key
   dependencies: [] # Don't download Gitlab artefacts
 
 .docker_hub_variables: &docker_hub_variables
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
+  DELEGATION_KEY_SSM_KEY: docker_hub_signing_key
+  DELEGATION_PASS_SSM_KEY: docker_hub_signing_pass
   DOCKER_REGISTRY_URL: docker.io
   SRC_AGENT: *agent_ecr
   SRC_DSD: *dogstatsd_ecr

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -897,8 +897,8 @@ dev_branch_docker_hub:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:${CI_COMMIT_REF_SLUG}
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:${CI_COMMIT_REF_SLUG}
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
     - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
 dev_master_docker_hub:
@@ -908,8 +908,8 @@ dev_master_docker_hub:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:master
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:master-jmx
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:master
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:master-jmx
     - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:master
 
 dca_dev_branch_docker_hub:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1150,6 +1150,27 @@ latest_release:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent:latest-jmx
     - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:latest
 
+#
+# Use this step to revert the latest tag to a previous release
+# while maintaining content trust signatures
+# - remove the leading dot from the name
+# - set the RELEASE envvar
+# - in the gitlab pipeline view, trigger the step (in the first column)
+#
+.latest_revert_to_previous_release:
+  <<: *docker_tag_job_definition
+  stage: source_test
+  when: manual
+  variables:
+    <<: *docker_hub_variables
+    RELEASE: ""  # tag name of the non-jmx version, for example "6.9.0"
+  script:
+    - if [[ -z "$RELEASE" ]]; then echo "Need release version to revert to"; exit 1; fi
+    - inv -e docker.publish --signed-pull --signed-push datadog/agent:${RELEASE} datadog/agent:latest
+    - inv -e docker.publish --signed-pull --signed-push datadog/agent:${RELEASE}-jmx datadog/agent:latest-jmx
+    - inv -e docker.publish --signed-pull --signed-push datadog/dogstatsd:${RELEASE} datadog/dogstatsd:latest
+
+
 dca_tag_release:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_tag

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -877,7 +877,8 @@ twistlock_scan:
     - echo "Importing delegation signing key"
     - export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_PASS_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - mkdir -p ~/.docker/trust/private
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text > ~/.docker/trust/private/29dfad055b34905ad69404bfd8608c3cfa71110bdc50039e0c4c37dcda3f5d14.key
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text > /tmp/docker.key
+    - notary -d ~/.docker/trust key import /tmp/docker.key; rm /tmp/docker.key
   dependencies: [] # Don't download Gitlab artefacts
 
 .docker_hub_variables: &docker_hub_variables

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -907,7 +907,7 @@ dev_branch_docker_hub:
   script:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:${CI_COMMIT_REF_SLUG}
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:${CI_COMMIT_REF_SLUG}-jmx
-    - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:${CI_COMMIT_REF_SLUG}
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
 dev_master_docker_hub:
   <<: *docker_tag_job_definition
@@ -918,7 +918,7 @@ dev_master_docker_hub:
   script:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:master
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:master-jmx
-    - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:master
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:master
 
 dca_dev_branch_docker_hub:
   <<: *docker_tag_job_definition
@@ -928,7 +928,7 @@ dca_dev_branch_docker_hub:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG}
+    - inv -e docker.publish --signed-push ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG}
 
 dca_dev_master_docker_hub:
   <<: *docker_tag_job_definition
@@ -937,7 +937,7 @@ dca_dev_master_docker_hub:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent-dev:master
+    - inv -e docker.publish --signed-push ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent-dev:master
 
 # deploys to quay
 # docker images are mirrored on quay.io
@@ -1134,9 +1134,9 @@ tag_release:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG} datadog/agent:${CI_COMMIT_TAG}
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent:${CI_COMMIT_TAG}-jmx
-    - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:${CI_COMMIT_TAG}
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent:${CI_COMMIT_TAG}
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent:${CI_COMMIT_TAG}-jmx
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:${CI_COMMIT_TAG}
 
 latest_release:
   <<: *docker_tag_job_definition
@@ -1146,9 +1146,9 @@ latest_release:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG} datadog/agent:latest
-    - inv -e docker.publish ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent:latest-jmx
-    - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:latest
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent:latest
+    - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent:latest-jmx
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd:latest
 
 dca_tag_release:
   <<: *docker_tag_job_definition
@@ -1158,7 +1158,7 @@ dca_tag_release:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:${CI_COMMIT_TAG#$(echo "dca-")}
+    - inv -e docker.publish --signed-push ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:${CI_COMMIT_TAG#$(echo "dca-")}
 
 dca_latest_release:
   <<: *docker_tag_job_definition
@@ -1168,7 +1168,7 @@ dca_latest_release:
   variables:
     <<: *docker_hub_variables
   script:
-    - inv -e docker.publish ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:latest
+    - inv -e docker.publish --signed-push ${SRC_DCA}:${SRC_TAG} datadog/cluster-agent:latest
 
 # invalidate cloudfront cache
 deploy_cloudfront_invalidate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -876,7 +876,6 @@ twistlock_scan:
     - if [[ -z "$DELEGATION_PASS_SSM_KEY" ]]; then echo "No signing key set"; exit 0; fi
     - echo "Importing delegation signing key"
     - export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_PASS_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - mkdir -p ~/.docker/trust/private
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DELEGATION_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text > /tmp/docker.key
     - notary -d ~/.docker/trust key import /tmp/docker.key; rm /tmp/docker.key
   dependencies: [] # Don't download Gitlab artefacts

--- a/releasenotes/notes/docker-content-trust-a512f17d656813e6.yaml
+++ b/releasenotes/notes/docker-content-trust-a512f17d656813e6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Docker images are now signed with Content Trust to ensure their integrity when pulling

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -125,9 +125,14 @@ def mirror_image(ctx, src_image, dst_image="datadog/docker-library", dst_tag="au
 
 
 @task
-def publish(ctx, src, dst):
+def publish(ctx, src, dst, signed_push=False):
     print("Uploading {} to {}".format(src, dst))
-    ctx.run("docker pull {src} && docker tag {src} {dst} && docker push {dst}".format(
+    ctx.run("docker pull {src} && docker tag {src} {dst}".format(
         src=src,
         dst=dst)
     )
+
+    push_env = {}
+    if signed_push:
+        push_env["DOCKER_CONTENT_TRUST"] = "1"
+    ctx.run("docker push {dst}".format(dst=dst), env=push_env)

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -125,14 +125,21 @@ def mirror_image(ctx, src_image, dst_image="datadog/docker-library", dst_tag="au
 
 
 @task
-def publish(ctx, src, dst, signed_push=False):
+def publish(ctx, src, dst, signed_pull=False, signed_push=False):
     print("Uploading {} to {}".format(src, dst))
-    ctx.run("docker pull {src} && docker tag {src} {dst}".format(
-        src=src,
-        dst=dst)
+
+    pull_env = {}
+    if signed_pull:
+        pull_env["DOCKER_CONTENT_TRUST"] = "1"
+    ctx.run(
+        "docker pull {src} && docker tag {src} {dst}".format(src=src, dst=dst),
+        env=pull_env
     )
 
     push_env = {}
     if signed_push:
         push_env["DOCKER_CONTENT_TRUST"] = "1"
-    ctx.run("docker push {dst}".format(dst=dst), env=push_env)
+    ctx.run(
+        "docker push {dst}".format(dst=dst),
+        env=push_env
+    )


### PR DESCRIPTION
### What does this PR do?

- Enable Docker Content Trust when building our images, to ensure the base images are signed and secure
- Sign images we push to the Docker Hub with a valid delegation key
- Provide a manual `latest_revert_to_previous_release` gitlab step template to revert `latest` to a previous release while maintaining the content trust chain

### Motivation

Ensure our published container images can be safely pulled by users with Content Trust enabled.

### Additional Notes

`dca_latest_release` step modified for consistency, although it is not used anymore. Sister PR in `cluster-agent-release`: https://github.com/DataDog/cluster-agent-release/pull/5
