### PR TITLE
Dogstatsd: inject tagger tags via special entity tag

### DIFF
--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -29,7 +29,6 @@ func init() {
 	udsExpvars.Set("OriginDetectionErrors", &udsOriginDetectionErrors)
 	udsExpvars.Set("PacketReadingErrors", &udsPacketReadingErrors)
 	udsExpvars.Set("Packets", &udsPackets)
-
 }
 
 // UDSListener implements the StatsdListener interface for Unix Domain

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -57,9 +57,9 @@ func nextField(slice, sep []byte) ([]byte, []byte) {
 	return slice[:sepIndex], slice[sepIndex+1:]
 }
 
-// parseTags parses `rawTags` and returns a slice of tags,
-// and, if extractHost is true, the extracted hostname
-func parseTags(rawTags []byte, extractHost bool, defaultHostname string) ([]string, string) {
+// parseTags parses `rawTags` and returns a slice of tags
+// and the extracted hostname
+func parseTags(rawTags []byte, defaultHostname string) ([]string, string) {
 	if len(rawTags) == 0 {
 		return nil, defaultHostname
 	}
@@ -71,7 +71,7 @@ func parseTags(rawTags []byte, extractHost bool, defaultHostname string) ([]stri
 	var tag []byte
 	for {
 		tag, remainder = nextField(remainder, tagSeparator)
-		if extractHost && bytes.HasPrefix(tag, []byte("host:")) {
+		if bytes.HasPrefix(tag, []byte("host:")) {
 			host = string(tag[5:])
 		} else {
 			tagsList = append(tagsList, string(tag))
@@ -133,7 +133,7 @@ func parseServiceCheckMessage(message []byte, defaultHostname string) (*metrics.
 		} else if bytes.HasPrefix(rawMetadataField, []byte("h:")) {
 			hostFromField = string(rawMetadataField[2:])
 		} else if bytes.HasPrefix(rawMetadataField, []byte("#")) {
-			service.Tags, hostFromTags = parseTags(rawMetadataField[1:], true, defaultHostname)
+			service.Tags, hostFromTags = parseTags(rawMetadataField[1:], defaultHostname)
 		} else if bytes.HasPrefix(rawMetadataField, []byte("m:")) {
 			service.Message = string(rawMetadataField[2:])
 		} else {
@@ -238,7 +238,7 @@ func parseEventMessage(message []byte, defaultHostname string) (*metrics.Event, 
 			} else if bytes.HasPrefix(rawMetadataFields[i], []byte("s:")) {
 				event.SourceTypeName = string(rawMetadataFields[i][2:])
 			} else if bytes.HasPrefix(rawMetadataFields[i], []byte("#")) {
-				event.Tags, hostFromTags = parseTags(rawMetadataFields[i][1:], true, defaultHostname)
+				event.Tags, hostFromTags = parseTags(rawMetadataFields[i][1:], defaultHostname)
 
 			} else {
 				log.Warnf("unknown metadata type: '%s'", rawMetadataFields[i])
@@ -285,7 +285,7 @@ func parseMetricMessage(message []byte, namespace string, defaultHostname string
 		rawMetadataField, remainder = nextField(remainder, fieldSeparator)
 
 		if bytes.HasPrefix(rawMetadataField, []byte("#")) {
-			metricTags, host = parseTags(rawMetadataField[1:], true, defaultHostname)
+			metricTags, host = parseTags(rawMetadataField[1:], defaultHostname)
 		} else if bytes.HasPrefix(rawMetadataField, []byte("@")) {
 			rawSampleRate := rawMetadataField[1:]
 			var err error

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -6,12 +6,9 @@
 package dogstatsd
 
 import (
-	// stdlib
-
-	"fmt"
+	"errors"
 	"testing"
 
-	// 3p
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -777,7 +774,7 @@ func TestEntityOriginDetectionTags(t *testing.T) {
 
 func TestEntityOriginDetectionTagsError(t *testing.T) {
 	getTags = func(entity string, cardinality collectors.TagCardinality) ([]string, error) {
-		return nil, fmt.Errorf("Cannot get tags")
+		return nil, errors.New("cannot get tags")
 	}
 
 	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,_dd.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -186,7 +186,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -200,7 +200,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithEmptyHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+",sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -383,7 +383,7 @@ func TestServiceCheckMetadataHostname(t *testing.T) {
 }
 
 func TestServiceCheckMetadataHostnameInTag(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#"+hostTagPrefix+"localhost"), "default-hostname")
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#host:localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -395,7 +395,7 @@ func TestServiceCheckMetadataHostnameInTag(t *testing.T) {
 }
 
 func TestServiceCheckMetadataEmptyHostTag(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#"+hostTagPrefix+",other:tag"), "default-hostname")
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#host:,other:tag"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -614,7 +614,7 @@ func TestEventMetadataHostname(t *testing.T) {
 }
 
 func TestEventMetadataHostnameInTag(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#"+hostTagPrefix+"localhost"), "default-hostname")
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#host:localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -630,7 +630,7 @@ func TestEventMetadataHostnameInTag(t *testing.T) {
 }
 
 func TestEventMetadataEmptyHostTag(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#"+hostTagPrefix+",other:tag"), "default-hostname")
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#host:,other:tag"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -739,7 +739,7 @@ func TestEntityOriginDetectionNoTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,"+entityIDTagPrefix+"foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd_entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -757,7 +757,7 @@ func TestEntityOriginDetectionTags(t *testing.T) {
 		return []string{"foo:bar", "bar:buz"}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,"+entityIDTagPrefix+"foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd_entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -777,7 +777,7 @@ func TestEntityOriginDetectionTagsError(t *testing.T) {
 		return nil, errors.New("cannot get tags")
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,"+entityIDTagPrefix+"foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd_entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -736,10 +736,13 @@ func TestNamespace(t *testing.T) {
 
 func TestEntityOriginDetectionNoTags(t *testing.T) {
 	getTags = func(entity string, cardinality collectors.TagCardinality) ([]string, error) {
+		if entity == "otherentity" {
+			return []string{"tag:ishouldnothave"}, nil
+		}
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd_entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -754,10 +757,13 @@ func TestEntityOriginDetectionNoTags(t *testing.T) {
 
 func TestEntityOriginDetectionTags(t *testing.T) {
 	getTags = func(entity string, cardinality collectors.TagCardinality) ([]string, error) {
-		return []string{"foo:bar", "bar:buz"}, nil
+		if entity == "kubernetes_pod://foo" {
+			return []string{"foo:bar", "bar:buz"}, nil
+		}
+		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd_entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -777,7 +783,7 @@ func TestEntityOriginDetectionTagsError(t *testing.T) {
 		return nil, errors.New("cannot get tags")
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd_entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -186,7 +186,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -200,7 +200,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithEmptyHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+",sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -383,7 +383,7 @@ func TestServiceCheckMetadataHostname(t *testing.T) {
 }
 
 func TestServiceCheckMetadataHostnameInTag(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#host:localhost"), "default-hostname")
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#"+hostTagPrefix+"localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -395,7 +395,7 @@ func TestServiceCheckMetadataHostnameInTag(t *testing.T) {
 }
 
 func TestServiceCheckMetadataEmptyHostTag(t *testing.T) {
-	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#host:,other:tag"), "default-hostname")
+	sc, err := parseServiceCheckMessage([]byte("_sc|agent.up|0|#"+hostTagPrefix+",other:tag"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "agent.up", sc.CheckName)
@@ -614,7 +614,7 @@ func TestEventMetadataHostname(t *testing.T) {
 }
 
 func TestEventMetadataHostnameInTag(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#host:localhost"), "default-hostname")
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#"+hostTagPrefix+"localhost"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -630,7 +630,7 @@ func TestEventMetadataHostnameInTag(t *testing.T) {
 }
 
 func TestEventMetadataEmptyHostTag(t *testing.T) {
-	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#host:,other:tag"), "default-hostname")
+	e, err := parseEventMessage([]byte("_e{10,9}:test title|test text|#"+hostTagPrefix+",other:tag"), "default-hostname")
 
 	require.Nil(t, err)
 	assert.Equal(t, "test title", e.Title)
@@ -739,7 +739,7 @@ func TestEntityOriginDetectionNoTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,_dd.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,"+entityIDTagPrefix+"foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -757,7 +757,7 @@ func TestEntityOriginDetectionTags(t *testing.T) {
 		return []string{"foo:bar", "bar:buz"}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,_dd.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,"+entityIDTagPrefix+"foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -777,7 +777,7 @@ func TestEntityOriginDetectionTagsError(t *testing.T) {
 		return nil, errors.New("cannot get tags")
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,_dd.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,"+hostTagPrefix+"my-hostname,"+entityIDTagPrefix+"foo,sometag2:somevalue2"), "", "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)

--- a/releasenotes/notes/entity-tag-origin-detection-05357abda2e211a9.yaml
+++ b/releasenotes/notes/entity-tag-origin-detection-05357abda2e211a9.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Dogstatsd can now inject extra tags on a metric when a special entity tag is provided


### PR DESCRIPTION
### What does this PR do?

Inject tagger entity tags if a special tag with the tagger entity name is supported

### Motivation

"magic" origin detection without UDS

### Additional Notes

Only supports `kubernetes_pod` entities for now
