### PR TITLE
Monitor static pods

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -560,8 +560,9 @@ func IsPodReady(pod *Pod) bool {
 }
 
 // isPodStatic identifies whether a pod is static or not based on an annotation
+// Static pods can be sent to the kubelet from files or an http endpoint.
 func isPodStatic(pod *Pod) bool {
-	if source, ok := pod.Metadata.Annotations[configSourceAnnotation]; ok == true && source == "file" {
+	if source, ok := pod.Metadata.Annotations[configSourceAnnotation]; ok == true && source == "file" || source == "http" {
 		return len(pod.Status.Containers) == 0
 	}
 	return false

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -562,7 +562,7 @@ func IsPodReady(pod *Pod) bool {
 // isPodStatic identifies whether a pod is static or not based on an annotation
 // Static pods can be sent to the kubelet from files or an http endpoint.
 func isPodStatic(pod *Pod) bool {
-	if source, ok := pod.Metadata.Annotations[configSourceAnnotation]; ok == true && source == "file" || source == "http" {
+	if source, ok := pod.Metadata.Annotations[configSourceAnnotation]; ok == true && (source == "file" || source == "http") {
 		return len(pod.Status.Containers) == 0
 	}
 	return false

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -247,7 +247,7 @@ func (suite *KubeletTestSuite) TestGetLocalPodList() {
 	pods, err := kubeutil.GetLocalPodList()
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), pods)
-	require.Len(suite.T(), pods, 6)
+	require.Len(suite.T(), pods, 7)
 
 	select {
 	case r := <-kubelet.Requests:

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -64,12 +64,12 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 		}
 
 		podEntity := PodUIDToEntityName(pod.Metadata.UID)
-		newPod := false
+		newStaticPod := false
 		_, found := w.lastSeen[podEntity]
 		// static pods are included specifically because they won't have any container
 		// as they're not updated in the pod list after creation
 		if isPodStatic(pod) == true && found == false {
-			newPod = true
+			newStaticPod = true
 		}
 
 		// Refresh last pod seen time
@@ -83,7 +83,7 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 			}
 			w.lastSeen[container.ID] = now
 		}
-		if newPod || newContainer {
+		if newStaticPod || newContainer {
 			updatedPods = append(updatedPods, pod)
 		}
 	}

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -52,7 +52,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 
 	changes, err := watcher.computeChanges(threePods)
 	require.Nil(suite.T(), err)
-	// The second pod is a static pod but should be found
+	// The first pod is a static pod but should be found
 	require.Len(suite.T(), changes, 3)
 
 	// Same list should detect no change

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_1.8-2.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_1.8-2.json
@@ -785,6 +785,150 @@
         ],
         "qosClass": "BestEffort"
       }
+    },
+    {
+      "status": {
+          "phase": "Pending",
+          "conditions": [
+              {
+                  "status": "True",
+                  "lastProbeTime": null,
+                  "type": "PodScheduled",
+                  "lastTransitionTime": "2018-02-13T16:10:24Z"
+              }
+          ]
+      },
+      "spec": {
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": {},
+          "nodeName": "gke-haissam-default-pool-be5066f1-wnvn",
+          "schedulerName": "default-scheduler",
+          "hostNetwork": true,
+          "terminationGracePeriodSeconds": 30,
+          "restartPolicy": "Always",
+          "volumes": [
+              {
+                  "hostPath": {
+                      "path": "/usr/share/ca-certificates",
+                      "type": ""
+                  },
+                  "name": "usr-ca-certs"
+              },
+              {
+                  "hostPath": {
+                      "path": "/etc/ssl/certs",
+                      "type": ""
+                  },
+                  "name": "etc-ssl-certs"
+              },
+              {
+                  "hostPath": {
+                      "path": "/var/lib/kube-proxy/kubeconfig",
+                      "type": "FileOrCreate"
+                  },
+                  "name": "kubeconfig"
+              },
+              {
+                  "hostPath": {
+                      "path": "/var/log",
+                      "type": ""
+                  },
+                  "name": "varlog"
+              },
+              {
+                  "hostPath": {
+                      "path": "/run/xtables.lock",
+                      "type": "FileOrCreate"
+                  },
+                  "name": "iptableslock"
+              },
+              {
+                  "hostPath": {
+                      "path": "/lib/modules",
+                      "type": ""
+                  },
+                  "name": "lib-modules"
+              }
+          ],
+          "tolerations": [
+              {
+                  "operator": "Exists",
+                  "effect": "NoExecute"
+              },
+              {
+                  "operator": "Exists",
+                  "effect": "NoSchedule"
+              }
+          ],
+          "containers": [
+              {
+                  "terminationMessagePath": "/dev/termination-log",
+                  "name": "kube-proxy",
+                  "image": "gcr.io/google_containers/kube-proxy:v1.9.2-gke.1",
+                  "volumeMounts": [
+                      {
+                          "readOnly": true,
+                          "mountPath": "/etc/ssl/certs",
+                          "name": "etc-ssl-certs"
+                      },
+                      {
+                          "readOnly": true,
+                          "mountPath": "/usr/share/ca-certificates",
+                          "name": "usr-ca-certs"
+                      },
+                      {
+                          "mountPath": "/var/log",
+                          "name": "varlog"
+                      },
+                      {
+                          "mountPath": "/var/lib/kube-proxy/kubeconfig",
+                          "name": "kubeconfig"
+                      },
+                      {
+                          "mountPath": "/run/xtables.lock",
+                          "name": "iptableslock"
+                      },
+                      {
+                          "readOnly": true,
+                          "mountPath": "/lib/modules",
+                          "name": "lib-modules"
+                      }
+                  ],
+                  "terminationMessagePolicy": "File",
+                  "command": [
+                      "/bin/sh",
+                      "-c",
+                      "exec kube-proxy --master=https://35.189.248.80 --kubeconfig=/var/lib/kube-proxy/kubeconfig --cluster-cidr=10.8.0.0/14 --resource-container=\"\" --oom-score-adj=-998 --v=2 --feature-gates=ExperimentalCriticalPodAnnotation=true --iptables-sync-period=1m --iptables-min-sync-period=10s --ipvs-sync-period=1m --ipvs-min-sync-period=10s 1>>/var/log/kube-proxy.log 2>&1"
+                  ],
+                  "imagePullPolicy": "IfNotPresent",
+                  "securityContext": {
+                      "privileged": true
+                  },
+                  "resources": {
+                      "requests": {
+                          "cpu": "100m"
+                      }
+                  }
+              }
+          ]
+      },
+      "metadata": {
+          "name": "kube-proxy-gke-haissam-default-pool-be5066f1-wnvn",
+          "labels": {
+              "tier": "node",
+              "component": "kube-proxy"
+          },
+          "namespace": "kube-system",
+          "creationTimestamp": null,
+          "annotations": {
+              "scheduler.alpha.kubernetes.io/critical-pod": "",
+              "kubernetes.io/config.hash": "260c2b1d43b094af6d6b4ccba082c2db",
+              "kubernetes.io/config.source": "file",
+              "kubernetes.io/config.seen": "2018-02-13T16:10:19.507814572Z"
+          },
+          "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-gke-haissam-default-pool-be5066f1-wnvn",
+          "uid": "260c2b1d43b094af6d6b4ccba082c2db"
+      }
     }
   ]
 }

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_1.8-2.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_1.8-2.json
@@ -923,7 +923,7 @@
           "annotations": {
               "scheduler.alpha.kubernetes.io/critical-pod": "",
               "kubernetes.io/config.hash": "260c2b1d43b094af6d6b4ccba082c2db",
-              "kubernetes.io/config.source": "file",
+              "kubernetes.io/config.source": "http",
               "kubernetes.io/config.seen": "2018-02-13T16:10:19.507814572Z"
           },
           "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-gke-haissam-default-pool-be5066f1-wnvn",

--- a/releasenotes/notes/Monitor-static-pods-f4c6f64a6d8b8bb3.yaml
+++ b/releasenotes/notes/Monitor-static-pods-f4c6f64a6d8b8bb3.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Consider static pods as ready, even though their status is never updated in the pod list.
+    This creates the risk of running checks against pods that are not actually ready, but this
+    is necessary to make autodiscovery work on static pods (which are used in standard kops
+    deployments for example).


### PR DESCRIPTION
### What does this PR do?

Make the podwatch consider static pods.

### Motivation

Static pods are still bugged in Kubernetes (see https://github.com/kubernetes/kubernetes/pull/57106), the kubelet has the correct state in memory, and reports it correctly to the apiserver, but doesn't update the pod list it exposes on `/pods`. We need to workaround that to enable static pods monitoring.

Fixes https://github.com/DataDog/datadog-agent/issues/2803

### Additional Notes

Anything else we should know when reviewing?
