### PR TITLE
docs/trace-agent: fix mistake in max_cpu_percent default example

### DIFF
--- a/docs/trace-agent/datadog.example.yaml
+++ b/docs/trace-agent/datadog.example.yaml
@@ -103,7 +103,7 @@ apm_config:
 # 
 #   # Maximum CPU percentage allowed to be occupied by the trace agent
 #   # The agent will be killed if this number is surpassed.
-#   max_cpu_percent: 0.5
+#   max_cpu_percent: 50
 #
 #   # Defines obfuscation rules for sensitive data. Disabled by default.
 #   obfuscation:

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -267,7 +267,7 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.Equal(0.5, c.ExtraSampleRate)
 	assert.Equal(5.0, c.MaxTPS)
 	assert.Equal(50.0, c.MaxEPS)
-	assert.Equal(0.005, c.MaxCPU)
+	assert.Equal(0.5, c.MaxCPU)
 	assert.EqualValues(123.4, c.MaxMemory)
 	assert.Equal(12, c.MaxConnections)
 	assert.Equal("0.0.0.0", c.ReceiverHost)

--- a/pkg/trace/config/testdata/full.yaml
+++ b/pkg/trace/config/testdata/full.yaml
@@ -14,7 +14,7 @@ apm_config:
   enabled: false
   log_file: abc
   apm_dd_url: https://datadog.unittests
-  max_cpu_percent: 0.5
+  max_cpu_percent: 50
   max_memory: 123.4
   max_connections: 12
   additional_endpoints:


### PR DESCRIPTION
The default value for `max_cpu_percent` was wrong, this change corrects it.