### PR TITLE
Make error in clusterchecks cmd clear when feature is disabled

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -28,9 +28,7 @@ func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) 
 // postCheckStatus is used by the node-agent's config provider
 func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
-		return func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}
+		return notEnabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -64,9 +62,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 // getCheckConfigs is used by the node-agent's config provider
 func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
-		return func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}
+		return notEnabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -90,9 +86,7 @@ func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 // getState is used by the clustercheck config
 func getState(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
-		return func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}
+		return notEnabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -148,4 +142,10 @@ func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handl
 		incrementRequestMetric(handler, code)
 		return false
 	}
+}
+
+// notEnabledHandler returns a 404 response when cluster-checks are disabled
+func notEnabledHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	w.Write([]byte("Cluster-checks are not enabled"))
 }

--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -28,7 +28,7 @@ func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) 
 // postCheckStatus is used by the node-agent's config provider
 func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
-		return notEnabledHandler
+		return clusterChecksDisabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +62,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 // getCheckConfigs is used by the node-agent's config provider
 func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
-		return notEnabledHandler
+		return clusterChecksDisabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -86,7 +86,7 @@ func getCheckConfigs(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 // getState is used by the clustercheck config
 func getState(sc clusteragent.ServerContext) func(w http.ResponseWriter, r *http.Request) {
 	if sc.ClusterCheckHandler == nil {
-		return notEnabledHandler
+		return clusterChecksDisabledHandler
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -144,8 +144,8 @@ func shouldHandle(w http.ResponseWriter, r *http.Request, h *clusterchecks.Handl
 	}
 }
 
-// notEnabledHandler returns a 404 response when cluster-checks are disabled
-func notEnabledHandler(w http.ResponseWriter, r *http.Request) {
+// clusterChecksDisabledHandler returns a 404 response when cluster-checks are disabled
+func clusterChecksDisabledHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 	w.Write([]byte("Cluster-checks are not enabled"))
 }

--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -27,6 +27,11 @@ func GetClusterChecks(w io.Writer) error {
 		color.NoColor = true
 	}
 
+	if !config.Datadog.GetBool("cluster_checks.enabled") {
+		fmt.Fprintln(w, "Cluster-checks are not enabled")
+		return nil
+	}
+
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
 	// Set session token
@@ -42,6 +47,7 @@ func GetClusterChecks(w io.Writer) error {
 		} else {
 			fmt.Fprintln(w, fmt.Sprintf("Failed to query the agent (running?): %s", err))
 		}
+		return err
 	}
 
 	var cr types.StateResponse


### PR DESCRIPTION
### What does this PR do?

When clusterchecks are disabled, the endpoints return a 404 error.
The error code does not bubble down from `utils.DoGet`, so `cluster-agent clusterchecks` returned a unhelpful error.

Two changes in this PR:
  - makes the endpoint send a "Cluster-checks are not enabled" body, that will bubble up the logs
  - when `cluster_checks.enabled` is false, do not even attempt to query the endpoint for the `clusterchecks` and `flare` commands, just print "Cluster-checks are not enabled" and exit

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
