### PR TITLE
Allow installing an integration from local wheel

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -29,6 +29,7 @@ import (
 const (
 	tufConfigFile       = "public-tuf-config.json"
 	reqAgentReleaseFile = "requirements-agent-release.txt"
+	constraintsFile     = "final_constraints.txt"
 	tufPkgPattern       = "datadog(-|_).*"
 	tufIndex            = "https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/"
 	reqLinePattern      = "%s==(\\d+\\.\\d+\\.\\d+)"
@@ -357,8 +358,15 @@ func install(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	here, err := executable.Folder()
+	if err != nil {
+		return err
+	}
+	constraintsPath := filepath.Join(here, relConstraintsPath)
+
 	pipArgs := []string{
 		"install",
+		"--constraint", constraintsPath,
 		"--cache-dir", cachePath,
 		// We replace the PyPI index with our own by default, in order to prevent
 		// accidental installation of Datadog or even third-party packages from

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -123,7 +123,7 @@ func init() {
 
 	showCmd.Flags().BoolVarP(&versionOnly, "show-version-only", "q", false, "only display version information")
 	installCmd.Flags().BoolVarP(
-		&localWheel, "local-wheel", "w", false, "install from locally available wheel file, without security verifications",
+		&localWheel, "local-wheel", "w", false, "install an agent check from a locally available wheel file. No security validation is performed, so use at your own risk.",
 	)
 }
 
@@ -373,6 +373,8 @@ func install(cmd *cobra.Command, args []string) error {
 		// Specific case when installing from locally available wheel
 		// No compatibility verifications are performed, just install the wheel (with --no-deps still)
 		// Verify that the wheel depends on `datadog_checks_base` to decide if it's an agent check or not
+		fmt.Println("Trying to install a package from a local file is at your own risk. No security verifications will be performed.")
+		fmt.Println("You should only use this to install an agent check, and not arbitrary wheels.")
 		if ok, err := validateBaseDependency(args[0]); err != nil {
 			return fmt.Errorf("error while reading the wheel %s: %v", args[0], err)
 		} else if !ok {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -34,6 +34,8 @@ const (
 	tufIndex            = "https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/"
 	reqLinePattern      = "%s==(\\d+\\.\\d+\\.\\d+)"
 	yamlFilePattern     = "[\\w_]+\\.yaml.*"
+	disclaimer          = "For your security, only use this to install wheels containing an Agent integration " +
+		"and coming from a known source. The Agent cannot perform any verification on local wheels."
 )
 
 var (
@@ -124,7 +126,7 @@ func init() {
 
 	showCmd.Flags().BoolVarP(&versionOnly, "show-version-only", "q", false, "only display version information")
 	installCmd.Flags().BoolVarP(
-		&localWheel, "local-wheel", "w", false, "install an agent check from a locally available wheel file. No security validation is performed, so use at your own risk.",
+		&localWheel, "local-wheel", "w", false, fmt.Sprintf("install an agent check from a locally available wheel file. %s", disclaimer),
 	)
 }
 
@@ -381,8 +383,7 @@ func install(cmd *cobra.Command, args []string) error {
 		// Specific case when installing from locally available wheel
 		// No compatibility verifications are performed, just install the wheel (with --no-deps still)
 		// Verify that the wheel depends on `datadog_checks_base` to decide if it's an agent check or not
-		fmt.Println("Trying to install a package from a local file is at your own risk. No security verifications will be performed.")
-		fmt.Println("You should only use this to install an agent check, and not arbitrary wheels.")
+		fmt.Println(disclaimer)
 		if ok, err := validateBaseDependency(args[0]); err != nil {
 			return fmt.Errorf("error while reading the wheel %s: %v", args[0], err)
 		} else if !ok {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -356,18 +356,21 @@ func install(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	pipArgs := []string{
+		"install",
+		"--cache-dir", cachePath,
+		// We replace the PyPI index with our own by default, in order to prevent
+		// accidental installation of Datadog or even third-party packages from
+		// PyPI.
+		"--index-url", tufIndex,
+		// Do *not* install dependencies by default. This is partly to prevent
+		// accidental installation / updates of third-party dependencies from PyPI.
+		"--no-deps",
+	}
+
 	if localWheel {
 		// Specific case when installing from locally available wheel
 		// No compatibility verifications are performed, just install the wheel (with --no-deps still)
-		pipArgs := []string{
-			"install",
-			"--cache-dir", cachePath,
-			// Do *not* install dependencies by default. This is partly to prevent
-			// accidental installation / updates of third-party dependencies from PyPI.
-			"--no-deps",
-		}
-
-		// Install the wheel
 		return pip(append(pipArgs, args[0]), true)
 	}
 
@@ -412,18 +415,6 @@ func install(cmd *cobra.Command, args []string) error {
 			"error when validating the agent's python environment, won't install %s: %v",
 			integration, err,
 		)
-	}
-
-	pipArgs := []string{
-		"install",
-		"--cache-dir", cachePath,
-		// We replace the PyPI index with our own by default, in order to prevent
-		// accidental installation of Datadog or even third-party packages from
-		// PyPI.
-		"--index-url", tufIndex,
-		// Do *not* install dependencies by default. This is partly to prevent
-		// accidental installation / updates of third-party dependencies from PyPI.
-		"--no-deps",
 	}
 
 	// Install the wheel

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -359,7 +359,7 @@ func install(cmd *cobra.Command, args []string) error {
 	if localWheel {
 		// Specific case when installing from locally available wheel
 		// No compatibility verifications are performed, just install the wheel (with --no-deps still)
-		tufArgs := []string{
+		pipArgs := []string{
 			"install",
 			"--cache-dir", cachePath,
 			// Do *not* install dependencies by default. This is partly to prevent
@@ -368,7 +368,7 @@ func install(cmd *cobra.Command, args []string) error {
 		}
 
 		// Install the wheel
-		return tuf(append(tufArgs, args[0]), true)
+		return pip(append(pipArgs, args[0]), true)
 	}
 
 	// Additional verification for installation

--- a/cmd/agent/app/integrations_nix.go
+++ b/cmd/agent/app/integrations_nix.go
@@ -24,6 +24,7 @@ var (
 	relTufConfigFilePath   = filepath.Join("..", "..", tufConfigFile)
 	relChecksPath          = filepath.Join("..", "..", "embedded", "lib", "python2.7", "site-packages", "datadog_checks")
 	relReqAgentReleasePath = filepath.Join("..", "..", reqAgentReleaseFile)
+	relConstraintsPath     = filepath.Join("..", "..", constraintsFile)
 	relTufPipCache         = filepath.Join("..", "..", "repositories", "cache")
 )
 

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -118,3 +118,23 @@ func TestGetVersionFromReqLine(t *testing.T) {
 	assert.Nil(t, version)
 	assert.NotNil(t, err)
 }
+
+func TestValidateTufArgs(t *testing.T) {
+	// No args
+	args := []string{}
+	err := validateTufArgs(args, false)
+	assert.NotNil(t, err)
+
+	// Too many args
+	args = []string{"arg1", "arg2"}
+	err = validateTufArgs(args, true)
+	assert.NotNil(t, err)
+
+	// Not local => name starts with datadog
+	args = []string{"foo"}
+	err = validateTufArgs(args, false)
+	assert.NotNil(t, err)
+	args = []string{"datadog-foo"}
+	err = validateTufArgs(args, false)
+	assert.Nil(t, err)
+}

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -119,22 +119,22 @@ func TestGetVersionFromReqLine(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestValidateTufArgs(t *testing.T) {
+func TestValidateArgs(t *testing.T) {
 	// No args
 	args := []string{}
-	err := validateTufArgs(args, false)
+	err := validateArgs(args, false)
 	assert.NotNil(t, err)
 
 	// Too many args
 	args = []string{"arg1", "arg2"}
-	err = validateTufArgs(args, true)
+	err = validateArgs(args, true)
 	assert.NotNil(t, err)
 
 	// Not local => name starts with datadog
 	args = []string{"foo"}
-	err = validateTufArgs(args, false)
+	err = validateArgs(args, false)
 	assert.NotNil(t, err)
 	args = []string{"datadog-foo"}
-	err = validateTufArgs(args, false)
+	err = validateArgs(args, false)
 	assert.Nil(t, err)
 }

--- a/cmd/agent/app/integrations_windows.go
+++ b/cmd/agent/app/integrations_windows.go
@@ -25,6 +25,7 @@ var (
 	relTufConfigFilePath   = filepath.Join("..", tufConfigFile)
 	relChecksPath          = filepath.Join("Lib", "site-packages", "datadog_checks")
 	relReqAgentReleasePath = filepath.Join("..", reqAgentReleaseFile)
+	relConstraintsPath     = filepath.Join("..", constraintsFile)
 	tufPipCachePath        = filepath.Join("c:\\", "ProgramData", "Datadog", "repositories", "cache")
 )
 

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -50,6 +50,7 @@ blacklist = [
 ]
 
 core_constraints_file = 'core_constraints.txt'
+final_constraints_file = 'final_constraints.txt'
 agent_requirements_file = 'agent_requirements.txt'
 
 build do
@@ -169,6 +170,9 @@ build do
     else
       pip "install -c #{project_dir}/#{core_constraints_file} --require-hashes --no-deps -r #{install_dir}/#{agent_requirements_file}", :env => nix_build_env
     end
+    # Create a constraint file after installing all the core dependencies and before any integration
+    # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
+    pip "freeze > #{install_dir}/#{final_constraints_file}"
 
     # Ship requirements-agent-release.txt file containing the versions of every check shipped with the agent
     # Used by the `datadog-agent integration` command to prevent downgrading a check to a version

--- a/releasenotes/notes/integration_local-66c0a1e1b1bb572b.yaml
+++ b/releasenotes/notes/integration_local-66c0a1e1b1bb572b.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    ``datadog-agent integration install`` command allows to install a check from a locally available wheel (.whl file)
+    with the added parameter ``--local-wheel``.


### PR DESCRIPTION
### What does this PR do?

The integration command now accepts a new flag `--local-wheel` to allow one to install a python package from a locally available wheel.

### Motivation

Useful for workshops along with the `ddev` tooling to create new integrations. That will allow users to build their wheel and install it in an agent to test it right away.

### Additional Notes

Anything else we should know when reviewing?