### PR TITLE
cmd/trace-agent: fix trace-agent stop behaviour

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -67,6 +67,8 @@ type HTTPReceiver struct {
 
 	maxRequestBodyLength int64
 	debug                bool
+
+	exit chan struct{}
 }
 
 // NewHTTPReceiver returns a pointer to a new HTTPReceiver
@@ -85,6 +87,8 @@ func NewHTTPReceiver(
 
 		maxRequestBodyLength: maxRequestBodyLength,
 		debug:                strings.ToLower(conf.LogLevel) == "debug",
+
+		exit: make(chan struct{}),
 	}
 }
 
@@ -153,6 +157,11 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 
 // Stop stops the receiver and shuts down the HTTP server.
 func (r *HTTPReceiver) Stop() error {
+	r.exit <- struct{}{}
+	<-r.exit
+
+	r.PreSampler.Stop()
+
 	expiry := time.Now().Add(20 * time.Second) // give it 20 seconds
 	ctx, cancel := context.WithDeadline(context.Background(), expiry)
 	defer cancel()
@@ -300,36 +309,46 @@ func (r *HTTPReceiver) handleServices(v Version, w http.ResponseWriter, req *htt
 
 // logStats periodically submits stats about the receiver to statsd
 func (r *HTTPReceiver) logStats() {
+	defer close(r.exit)
+
 	var lastLog time.Time
 	accStats := info.NewReceiverStats()
 
-	for now := range time.Tick(10 * time.Second) {
-		metrics.Gauge("datadog.trace_agent.heartbeat", 1, nil, 1)
+	t := time.NewTicker(10 * time.Second)
+	defer t.Stop()
 
-		// We update accStats with the new stats we collected
-		accStats.Acc(r.Stats)
+	for {
+		select {
+		case <-r.exit:
+			return
+		case now := <-t.C:
+			metrics.Gauge("datadog.trace_agent.heartbeat", 1, nil, 1)
 
-		// Publish the stats accumulated during the last flush
-		r.Stats.Publish()
+			// We update accStats with the new stats we collected
+			accStats.Acc(r.Stats)
 
-		// We reset the stats accumulated during the last 10s.
-		r.Stats.Reset()
+			// Publish the stats accumulated during the last flush
+			r.Stats.Publish()
 
-		if now.Sub(lastLog) >= time.Minute {
-			// We expose the stats accumulated to expvar
-			info.UpdateReceiverStats(accStats)
+			// We reset the stats accumulated during the last 10s.
+			r.Stats.Reset()
 
-			for _, logStr := range accStats.Strings() {
-				log.Info(logStr)
+			if now.Sub(lastLog) >= time.Minute {
+				// We expose the stats accumulated to expvar
+				info.UpdateReceiverStats(accStats)
+
+				for _, logStr := range accStats.Strings() {
+					log.Info(logStr)
+				}
+
+				// We reset the stats accumulated during the last minute
+				accStats.Reset()
+				lastLog = now
+
+				// Also publish rates by service (they are updated by receiver)
+				rates := r.dynConf.RateByService.GetAll()
+				info.UpdateRateByService(rates)
 			}
-
-			// We reset the stats accumulated during the last minute
-			accStats.Reset()
-			lastLog = now
-
-			// Also publish rates by service (they are updated by receiver)
-			rates := r.dynConf.RateByService.GetAll()
-			info.UpdateRateByService(rates)
 		}
 	}
 }

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -256,7 +256,7 @@ func (w *StatsWriter) monitor() {
 		select {
 		case e, ok := <-monC:
 			if !ok {
-				break
+				return
 			}
 
 			switch e.typ {

--- a/releasenotes/notes/fix-trace-agent-goroutine-leak-c3be040113bbd6d2.yaml
+++ b/releasenotes/notes/fix-trace-agent-goroutine-leak-c3be040113bbd6d2.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a potential memory leak problem when the trace agent is stopped.


### PR DESCRIPTION
### What does this PR do?

When Stop() is called on trace-agent, this PR
1. fixes goroutine leaks
2. prevents 100% cpu usage due to infinite spin-loop in writer/stats.go
