### PR TITLE
pkg/trace/event: remove dependency on 'agent' package.

### DIFF
--- a/cmd/trace-agent/agent.go
+++ b/cmd/trace-agent/agent.go
@@ -272,7 +272,7 @@ func (a *Agent) Process(t pb.Trace) {
 		}
 
 		// NOTE: Events can be processed on non-sampled traces.
-		events, numExtracted := a.EventProcessor.Process(pt)
+		events, numExtracted := a.EventProcessor.Process(pt.Root, pt.Trace)
 		tracePkg.Events = events
 
 		atomic.AddInt64(&ts.EventsExtracted, int64(numExtracted))

--- a/pkg/trace/event/extractor.go
+++ b/pkg/trace/event/extractor.go
@@ -1,8 +1,8 @@
 package event
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
 // Extractor extracts APM events from matching spans.
@@ -10,5 +10,5 @@ type Extractor interface {
 	// Extract decides whether to extract an APM event from the provided span with the specified priority and returns
 	// a suggested extraction sample rate and a bool value. If no event was extracted the bool value will be false and
 	// the rate should not be used.
-	Extract(span *stats.WeightedSpan, priority sampler.SamplingPriority) (rate float64, ok bool)
+	Extract(span *pb.Span, priority sampler.SamplingPriority) (rate float64, ok bool)
 }

--- a/pkg/trace/event/extractor_fixed_rate.go
+++ b/pkg/trace/event/extractor_fixed_rate.go
@@ -1,8 +1,8 @@
 package event
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
 // fixedRateExtractor is an event extractor that decides whether to extract APM events from spans based on
@@ -23,7 +23,7 @@ func NewFixedRateExtractor(rateByServiceAndName map[string]map[string]float64) E
 // on the rateByServiceAndName map passed in the constructor. The extracted event is returned along with the associated
 // extraction rate and a true value. If no extraction happened, false is returned as the third value and the others
 // are invalid.
-func (e *fixedRateExtractor) Extract(s *stats.WeightedSpan, priority sampler.SamplingPriority) (float64, bool) {
+func (e *fixedRateExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
 	operations, ok := e.rateByServiceAndName[s.Service]
 	if !ok {
 		return 0, false

--- a/pkg/trace/event/extractor_fixed_rate_test.go
+++ b/pkg/trace/event/extractor_fixed_rate_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
-func createTestSpans(serviceName string, operationName string) []*stats.WeightedSpan {
-	spans := make([]*stats.WeightedSpan, 1000)
+func createTestSpans(serviceName string, operationName string) []*pb.Span {
+	spans := make([]*pb.Span, 1000)
 	for i := range spans {
-		spans[i] = &stats.WeightedSpan{Span: &pb.Span{TraceID: rand.Uint64(), Service: serviceName, Name: operationName}}
+		spans[i] = &pb.Span{TraceID: rand.Uint64(), Service: serviceName, Name: operationName}
 	}
 	return spans
 }

--- a/pkg/trace/event/extractor_legacy.go
+++ b/pkg/trace/event/extractor_legacy.go
@@ -1,8 +1,9 @@
 package event
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 // legacyExtractor is an event extractor that decides whether to extract APM events from spans based on
@@ -23,8 +24,8 @@ func NewLegacyExtractor(rateByService map[string]float64) Extractor {
 // span's service. In this case the extracted event is returned along with the found extraction rate and a true value.
 // If this rate doesn't exist or the provided span is not a top level one, then no extraction is done and false is
 // returned as the third value, with the others being invalid.
-func (e *legacyExtractor) Extract(s *stats.WeightedSpan, priority sampler.SamplingPriority) (float64, bool) {
-	if !s.TopLevel {
+func (e *legacyExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
+	if !traceutil.HasTopLevel(s) {
 		return 0, false
 	}
 	extractionRate, ok := e.rateByService[s.Service]

--- a/pkg/trace/event/extractor_metric.go
+++ b/pkg/trace/event/extractor_metric.go
@@ -1,8 +1,8 @@
 package event
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
 // metricBasedExtractor is an event extractor that decides whether to extract APM events from spans based on
@@ -21,7 +21,7 @@ func NewMetricBasedExtractor() Extractor {
 //
 // NOTE: If priority is UserKeep (manually sampled) any extraction rate bigger than 0 is upscaled to 1 to ensure no
 // extraction sampling is done on this event.
-func (e *metricBasedExtractor) Extract(s *stats.WeightedSpan, priority sampler.SamplingPriority) (float64, bool) {
+func (e *metricBasedExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
 	if len(s.Metrics) == 0 {
 		// metric not set
 		return 0, false

--- a/pkg/trace/event/extractor_metric_test.go
+++ b/pkg/trace/event/extractor_metric_test.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
-func createTestSpansWithEventRate(eventRate float64) []*stats.WeightedSpan {
-	spans := make([]*stats.WeightedSpan, 1000)
+func createTestSpansWithEventRate(eventRate float64) []*pb.Span {
+	spans := make([]*pb.Span, 1000)
 	for i := range spans {
-		spans[i] = &stats.WeightedSpan{Span: &pb.Span{TraceID: rand.Uint64(), Service: "test", Name: "test", Metrics: map[string]float64{}}}
+		spans[i] = &pb.Span{TraceID: rand.Uint64(), Service: "test", Name: "test", Metrics: map[string]float64{}}
 		if eventRate >= 0 {
 			spans[i].Metrics[sampler.KeySamplingRateEventExtraction] = eventRate
 		}

--- a/pkg/trace/event/extractor_noop.go
+++ b/pkg/trace/event/extractor_noop.go
@@ -1,8 +1,8 @@
 package event
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
 // noopExtractor is a no-op APM event extractor used when APM event extraction is disabled.
@@ -13,6 +13,6 @@ func NewNoopExtractor() Extractor {
 	return &noopExtractor{}
 }
 
-func (e *noopExtractor) Extract(_ *stats.WeightedSpan, _ sampler.SamplingPriority) (float64, bool) {
+func (e *noopExtractor) Extract(_ *pb.Span, _ sampler.SamplingPriority) (float64, bool) {
 	return 0, false
 }

--- a/pkg/trace/event/extractor_test.go
+++ b/pkg/trace/event/extractor_test.go
@@ -3,14 +3,14 @@ package event
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 	"github.com/stretchr/testify/assert"
 )
 
 type extractorTestCase struct {
 	name                   string
-	spans                  []*stats.WeightedSpan
+	spans                  []*pb.Span
 	priority               sampler.SamplingPriority
 	expectedExtractionRate float64
 }

--- a/pkg/trace/event/processor.go
+++ b/pkg/trace/event/processor.go
@@ -1,10 +1,8 @@
 package event
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
 // Processor is responsible for all the logic surrounding extraction and sampling of APM events from processed traces.
@@ -47,64 +45,56 @@ func (p *Processor) Stop() {
 
 // Process takes a processed trace, extracts events from it and samples them, returning a collection of
 // sampled events along with the total count of extracted events.
-func (p *Processor) Process(t agent.ProcessedTrace) (events []*pb.Span, numExtracted int64) {
+func (p *Processor) Process(root *pb.Span, t pb.Trace) (events []*pb.Span, numExtracted int64) {
 	if len(p.extractors) == 0 {
 		return
 	}
 
-	priority, hasPriority := t.GetSamplingPriority()
+	priority, hasPriority := sampler.GetSamplingPriority(root)
 	if !hasPriority {
 		priority = sampler.PriorityNone
 	}
 
-	clientSampleRate := sampler.GetClientRate(t.Root)
-	preSampleRate := sampler.GetPreSampleRate(t.Root)
+	clientSampleRate := sampler.GetClientRate(root)
+	preSampleRate := sampler.GetPreSampleRate(root)
 
-	for _, wspan := range t.WeightedTrace {
-		extractionRate, ok := p.extract(wspan, priority)
+	for _, span := range t {
+		extractionRate, ok := p.extract(span, priority)
 		if !ok {
 			continue
 		}
-
-		event := wspan.Span
-		sampled := p.extractionSample(event, extractionRate)
-		if !sampled {
+		if !sampler.SampleByRate(span.TraceID, extractionRate) {
 			continue
 		}
+
 		numExtracted++
 
-		sampled, epsRate := p.maxEPSSample(event, priority)
+		sampled, epsRate := p.maxEPSSample(span, priority)
 		if !sampled {
 			continue
 		}
 
-		// This event got sampled, so add it to results
-		events = append(events, event)
-		// And set whatever rates had been set on the trace initially
-		sampler.SetClientRate(event, clientSampleRate)
-		sampler.SetPreSampleRate(event, preSampleRate)
-		// As well as the rates of sampling done during this processing
-		sampler.SetEventExtractionRate(event, extractionRate)
-		sampler.SetMaxEPSRate(event, epsRate)
+		sampler.SetMaxEPSRate(span, epsRate)
+		sampler.SetClientRate(span, clientSampleRate)
+		sampler.SetPreSampleRate(span, preSampleRate)
+		sampler.SetEventExtractionRate(span, extractionRate)
 		if hasPriority {
-			sampler.SetSamplingPriority(event, priority)
+			sampler.SetSamplingPriority(span, priority)
 		}
+
+		events = append(events, span)
 	}
 
-	return
+	return events, numExtracted
 }
 
-func (p *Processor) extract(span *stats.WeightedSpan, priority sampler.SamplingPriority) (float64, bool) {
+func (p *Processor) extract(span *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
 	for _, extractor := range p.extractors {
 		if rate, ok := extractor.Extract(span, priority); ok {
 			return rate, ok
 		}
 	}
 	return 0, false
-}
-
-func (p *Processor) extractionSample(event *pb.Span, extractionRate float64) bool {
-	return sampler.SampleByRate(event.TraceID, extractionRate)
 }
 
 func (p *Processor) maxEPSSample(event *pb.Span, priority sampler.SamplingPriority) (sampled bool, rate float64) {

--- a/pkg/trace/event/processor_test.go
+++ b/pkg/trace/event/processor_test.go
@@ -4,10 +4,8 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,19 +55,18 @@ func TestProcessor(t *testing.T) {
 			testSampler := &MockEventSampler{Rate: test.samplerRate}
 			p := newProcessor(extractors, testSampler)
 
-			testSpans := createTestSpans("test", "test")
-			testTrace := agent.ProcessedTrace{WeightedTrace: testSpans}
-			testTrace.Root = testSpans[0].Span
-			sampler.SetPreSampleRate(testTrace.Root, testPreSampleRate)
-			sampler.SetClientRate(testTrace.Root, testClientSampleRate)
+			testTrace := createTestSpans("test", "test")
+			root := testTrace[0]
+			sampler.SetPreSampleRate(root, testPreSampleRate)
+			sampler.SetClientRate(root, testClientSampleRate)
 			if test.priority != sampler.PriorityNone {
-				sampler.SetSamplingPriority(testTrace.Root, test.priority)
+				sampler.SetSamplingPriority(root, test.priority)
 			}
 
 			p.Start()
-			events, extracted := p.Process(testTrace)
+			events, extracted := p.Process(root, testTrace)
 			p.Stop()
-			total := len(testSpans)
+			total := len(testTrace)
 			returned := len(events)
 
 			expectedExtracted := float64(total) * test.expectedExtractedPct
@@ -107,7 +104,7 @@ type MockExtractor struct {
 	Rate float64
 }
 
-func (e *MockExtractor) Extract(s *stats.WeightedSpan, priority sampler.SamplingPriority) (float64, bool) {
+func (e *MockExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
 	if e.Rate < 0 {
 		return 0, false
 	}

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -22,8 +22,8 @@ func HasForceMetrics(s *pb.Span) bool {
 	return s.Meta[TraceMetricsKey] == "true"
 }
 
-// setTopLevel sets the top-level attribute of the span.
-func setTopLevel(s *pb.Span, topLevel bool) {
+// SetTopLevel sets the top-level attribute of the span.
+func SetTopLevel(s *pb.Span, topLevel bool) {
 	if !topLevel {
 		if s.Metrics == nil {
 			return

--- a/pkg/trace/traceutil/span_test.go
+++ b/pkg/trace/traceutil/span_test.go
@@ -117,17 +117,17 @@ func TestTopLevelGetSetBlackBox(t *testing.T) {
 	span := &pb.Span{}
 
 	assert.False(HasTopLevel(span), "by default, all spans are considered non top-level")
-	setTopLevel(span, true)
+	SetTopLevel(span, true)
 	assert.True(HasTopLevel(span), "marked as top-level")
-	setTopLevel(span, false)
+	SetTopLevel(span, false)
 	assert.False(HasTopLevel(span), "no more top-level")
 
 	span.Metrics = map[string]float64{"custom": 42}
 
 	assert.False(HasTopLevel(span), "by default, all spans are considered non top-level")
-	setTopLevel(span, true)
+	SetTopLevel(span, true)
 	assert.True(HasTopLevel(span), "marked as top-level")
-	setTopLevel(span, false)
+	SetTopLevel(span, false)
 	assert.False(HasTopLevel(span), "no more top-level")
 }
 
@@ -137,19 +137,19 @@ func TestTopLevelGetSetMetrics(t *testing.T) {
 	span := &pb.Span{}
 
 	assert.Nil(span.Metrics, "no meta at all")
-	setTopLevel(span, true)
+	SetTopLevel(span, true)
 	assert.Equal(float64(1), span.Metrics["_top_level"], "should have a _top_level:1 flag")
-	setTopLevel(span, false)
+	SetTopLevel(span, false)
 	assert.Equal(len(span.Metrics), 0, "no meta at all")
 
 	span.Metrics = map[string]float64{"custom": 42}
 
 	assert.False(HasTopLevel(span), "still non top-level")
-	setTopLevel(span, true)
+	SetTopLevel(span, true)
 	assert.Equal(float64(1), span.Metrics["_top_level"], "should have a _top_level:1 flag")
 	assert.Equal(float64(42), span.Metrics["custom"], "former metrics should still be here")
 	assert.True(HasTopLevel(span), "marked as top-level")
-	setTopLevel(span, false)
+	SetTopLevel(span, false)
 	assert.False(HasTopLevel(span), "non top-level any more")
 	assert.Equal(float64(0), span.Metrics["_top_level"], "should have no _top_level:1 flag")
 	assert.Equal(float64(42), span.Metrics["custom"], "former metrics should still be here")

--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -128,6 +128,6 @@ func ComputeTopLevel(t pb.Trace) {
 				continue
 			}
 		}
-		setTopLevel(span, true)
+		SetTopLevel(span, true)
 	}
 }


### PR DESCRIPTION
This change removes the dependency on the `agent` package from the
`event` package.

The `agent` package will import most of the other packages and will be
the "glue" that connects everything into the main program. Subsequent
PRs will make this happen primarily by moving ./cmd/trace-agent logic
into the `agent` package.