### PR TITLE
cmd/trace-agent: move logic to pkg/trace/agent

### DIFF
--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -1,28 +1,13 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"math/rand"
 	"os"
 	"os/signal"
-	"runtime"
-	"runtime/pprof"
-	"strings"
 	"syscall"
-	"time"
 
 	_ "net/http/pprof"
 
 	log "github.com/cihub/seelog"
-
-	"github.com/DataDog/datadog-agent/pkg/pidfile"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/trace/flags"
-	"github.com/DataDog/datadog-agent/pkg/trace/info"
-	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
-	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
-	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
 
 // handleSignal closes a channel to exit cleanly from routines
@@ -42,138 +27,5 @@ func handleSignal(onSignal func()) {
 		default:
 			log.Warnf("unhandled signal %d (%v)", signo, signo)
 		}
-	}
-}
-
-const agentDisabledMessage = `trace-agent not enabled.
-Set env var DD_APM_ENABLED=true or add
-apm_enabled: true
-to your datadog.conf file.
-Exiting.`
-
-// runAgent is the entrypoint of our code
-func runAgent(ctx context.Context) {
-	// configure a default logger before anything so we can observe initialization
-	if flags.Info || flags.Version {
-		log.UseLogger(log.Disabled)
-	} else {
-		SetupDefaultLogger()
-		defer log.Flush()
-	}
-
-	defer watchdog.LogOnPanic()
-
-	// start CPU profiling
-	if flags.CPUProfile != "" {
-		f, err := os.Create(flags.CPUProfile)
-		if err != nil {
-			log.Critical(err)
-		}
-		pprof.StartCPUProfile(f)
-		log.Info("CPU profiling started...")
-		defer pprof.StopCPUProfile()
-	}
-
-	if flags.Version {
-		fmt.Print(info.VersionString())
-		return
-	}
-
-	if !flags.Info && flags.PIDFilePath != "" {
-		err := pidfile.WritePID(flags.PIDFilePath)
-		if err != nil {
-			log.Errorf("Error while writing PID file, exiting: %v", err)
-			os.Exit(1)
-		}
-
-		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), flags.PIDFilePath)
-		defer func() {
-			// remove pidfile if set
-			os.Remove(flags.PIDFilePath)
-		}()
-	}
-
-	cfg, err := config.Load(flags.ConfigPath)
-	if err != nil {
-		osutil.Exitf("%v", err)
-	}
-	err = info.InitInfo(cfg) // for expvar & -info option
-	if err != nil {
-		panic(err)
-	}
-
-	if flags.Info {
-		if err := info.Info(os.Stdout, cfg); err != nil {
-			os.Stdout.WriteString(fmt.Sprintf("failed to print info: %s\n", err))
-			os.Exit(1)
-		}
-		return
-	}
-
-	// Exit if tracing is not enabled
-	if !cfg.Enabled {
-		log.Info(agentDisabledMessage)
-
-		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
-		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
-		// http://supervisord.org/subprocess.html#process-states
-		time.Sleep(5 * time.Second)
-		return
-	}
-
-	// Initialize logging (replacing the default logger). No need
-	// to defer log.Flush, it was already done when calling
-	// "SetupDefaultLogger" earlier.
-	cfgLogLevel := strings.ToLower(cfg.LogLevel)
-	if cfgLogLevel == "warning" {
-		// to match core agent:
-		// https://github.com/DataDog/datadog-agent/blob/6f2d901aeb19f0c0a4e09f149c7cc5a084d2f708/pkg/config/log.go#L74-L76
-		cfgLogLevel = "warn"
-	}
-	logLevel, ok := log.LogLevelFromString(cfgLogLevel)
-	if !ok {
-		logLevel = log.InfoLvl
-	}
-	duration := 10 * time.Second
-	if !cfg.LogThrottlingEnabled {
-		duration = 0
-	}
-	err = SetupLogger(logLevel, cfg.LogFilePath, duration, 10)
-	if err != nil {
-		osutil.Exitf("cannot create logger: %v", err)
-	}
-
-	// Initialize dogstatsd client
-	err = metrics.Configure(cfg, []string{"version:" + info.Version})
-	if err != nil {
-		osutil.Exitf("cannot configure dogstatsd: %v", err)
-	}
-
-	// count the number of times the agent started
-	metrics.Count("datadog.trace_agent.started", 1, nil, 1)
-
-	// Seed rand
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	agent := NewAgent(ctx, cfg)
-
-	log.Infof("trace-agent running on host %s", cfg.Hostname)
-	agent.Run()
-
-	// collect memory profile
-	if flags.MemProfile != "" {
-		f, err := os.Create(flags.MemProfile)
-		if err != nil {
-			log.Critical("could not create memory profile: ", err)
-		}
-
-		// get up-to-date statistics
-		runtime.GC()
-		// Not using WriteHeapProfile but instead calling WriteTo to
-		// make sure we pass debug=1 and resolve pointers to names.
-		if err := pprof.Lookup("heap").WriteTo(f, 1); err != nil {
-			log.Critical("could not write memory profile: ", err)
-		}
-		f.Close()
 	}
 }

--- a/cmd/trace-agent/main_nix.go
+++ b/cmd/trace-agent/main_nix.go
@@ -4,8 +4,8 @@ package main
 
 import (
 	"context"
-	_ "net/http/pprof"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
 
@@ -19,5 +19,5 @@ func main() {
 		handleSignal(cancelFunc)
 	}()
 
-	runAgent(ctx)
+	agent.Run(ctx)
 }

--- a/cmd/trace-agent/main_windows.go
+++ b/cmd/trace-agent/main_windows.go
@@ -9,8 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	_ "net/http/pprof"
-
+	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/flags"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 
@@ -57,7 +56,7 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 		}
 	}()
 	elog.Info(0x40000003, ServiceName)
-	runAgent(ctx)
+	agent.Run(ctx)
 
 	changes <- svc.Status{State: svc.Stopped}
 	return
@@ -154,7 +153,7 @@ func main() {
 	}()
 
 	// Invoke the Agent
-	runAgent(ctx)
+	agent.Run(ctx)
 }
 
 func startService() error {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/event"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
@@ -357,7 +356,7 @@ func TestSampling(t *testing.T) {
 			if tt.hasErrors {
 				root.Error = 1
 			}
-			pt := agent.ProcessedTrace{Trace: pb.Trace{root}, Root: root}
+			pt := ProcessedTrace{Trace: pb.Trace{root}, Root: root}
 			if tt.hasPriority {
 				sampler.SetSamplingPriority(pt.Root, 1)
 			}
@@ -550,13 +549,13 @@ func BenchmarkAgentTraceProcessingWithWorstCaseFiltering(b *testing.B) {
 func runTraceProcessingBenchmark(b *testing.B, c *config.AgentConfig) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	agent := NewAgent(ctx, c)
+	ta := NewAgent(ctx, c)
 	log.UseLogger(log.Disabled)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		agent.Process(testutil.RandomTrace(10, 8))
+		ta.Process(testutil.RandomTrace(10, 8))
 	}
 }
 
@@ -565,12 +564,12 @@ func BenchmarkWatchdog(b *testing.B) {
 	conf.Endpoints[0].APIKey = "apikey_2"
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
-	agent := NewAgent(ctx, conf)
+	ta := NewAgent(ctx, conf)
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		agent.watchdog()
+		ta.watchdog()
 	}
 }
 
@@ -578,7 +577,7 @@ func BenchmarkWatchdog(b *testing.B) {
 func formatTrace(t pb.Trace) pb.Trace {
 	for _, span := range t {
 		obfuscate.NewObfuscator(nil).Obfuscate(span)
-		agent.Truncate(span)
+		Truncate(span)
 	}
 	return t
 }

--- a/pkg/trace/agent/log.go
+++ b/pkg/trace/agent/log.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"fmt"

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/pidfile"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/flags"
+	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
+)
+
+const agentDisabledMessage = `trace-agent not enabled.
+Set env var DD_APM_ENABLED=true or add
+apm_enabled: true
+to your datadog.conf file.
+Exiting.`
+
+// Run is the entrypoint of our code, which starts the agent.
+func Run(ctx context.Context) {
+	// configure a default logger before anything so we can observe initialization
+	if flags.Info || flags.Version {
+		log.UseLogger(log.Disabled)
+	} else {
+		SetupDefaultLogger()
+		defer log.Flush()
+	}
+
+	defer watchdog.LogOnPanic()
+
+	// start CPU profiling
+	if flags.CPUProfile != "" {
+		f, err := os.Create(flags.CPUProfile)
+		if err != nil {
+			log.Critical(err)
+		}
+		pprof.StartCPUProfile(f)
+		log.Info("CPU profiling started...")
+		defer pprof.StopCPUProfile()
+	}
+
+	if flags.Version {
+		fmt.Print(info.VersionString())
+		return
+	}
+
+	if !flags.Info && flags.PIDFilePath != "" {
+		err := pidfile.WritePID(flags.PIDFilePath)
+		if err != nil {
+			log.Errorf("Error while writing PID file, exiting: %v", err)
+			os.Exit(1)
+		}
+
+		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), flags.PIDFilePath)
+		defer func() {
+			// remove pidfile if set
+			os.Remove(flags.PIDFilePath)
+		}()
+	}
+
+	cfg, err := config.Load(flags.ConfigPath)
+	if err != nil {
+		osutil.Exitf("%v", err)
+	}
+	err = info.InitInfo(cfg) // for expvar & -info option
+	if err != nil {
+		panic(err)
+	}
+
+	if flags.Info {
+		if err := info.Info(os.Stdout, cfg); err != nil {
+			os.Stdout.WriteString(fmt.Sprintf("failed to print info: %s\n", err))
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Exit if tracing is not enabled
+	if !cfg.Enabled {
+		log.Info(agentDisabledMessage)
+
+		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
+		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
+		// http://supervisord.org/subprocess.html#process-states
+		time.Sleep(5 * time.Second)
+		return
+	}
+
+	// Initialize logging (replacing the default logger). No need
+	// to defer log.Flush, it was already done when calling
+	// "SetupDefaultLogger" earlier.
+	cfgLogLevel := strings.ToLower(cfg.LogLevel)
+	if cfgLogLevel == "warning" {
+		// to match core agent:
+		// https://github.com/DataDog/datadog-agent/blob/6f2d901aeb19f0c0a4e09f149c7cc5a084d2f708/pkg/config/log.go#L74-L76
+		cfgLogLevel = "warn"
+	}
+	logLevel, ok := log.LogLevelFromString(cfgLogLevel)
+	if !ok {
+		logLevel = log.InfoLvl
+	}
+	duration := 10 * time.Second
+	if !cfg.LogThrottlingEnabled {
+		duration = 0
+	}
+	err = SetupLogger(logLevel, cfg.LogFilePath, duration, 10)
+	if err != nil {
+		osutil.Exitf("cannot create logger: %v", err)
+	}
+
+	// Initialize dogstatsd client
+	err = metrics.Configure(cfg, []string{"version:" + info.Version})
+	if err != nil {
+		osutil.Exitf("cannot configure dogstatsd: %v", err)
+	}
+
+	// count the number of times the agent started
+	metrics.Count("datadog.trace_agent.started", 1, nil, 1)
+
+	// Seed rand
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	ta := NewAgent(ctx, cfg)
+
+	log.Infof("trace-agent running on host %s", cfg.Hostname)
+	ta.Run()
+
+	// collect memory profile
+	if flags.MemProfile != "" {
+		f, err := os.Create(flags.MemProfile)
+		if err != nil {
+			log.Critical("could not create memory profile: ", err)
+		}
+
+		// get up-to-date statistics
+		runtime.GC()
+		// Not using WriteHeapProfile but instead calling WriteTo to
+		// make sure we pass debug=1 and resolve pointers to names.
+		if err := pprof.Lookup("heap").WriteTo(f, 1); err != nil {
+			log.Critical("could not write memory profile: ", err)
+		}
+		f.Close()
+	}
+}

--- a/pkg/trace/agent/sampler.go
+++ b/pkg/trace/agent/sampler.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"fmt"
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/cihub/seelog"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
@@ -64,7 +63,7 @@ func (s *Sampler) Run() {
 }
 
 // Add samples a trace and returns true if trace was sampled (should be kept), false otherwise
-func (s *Sampler) Add(t agent.ProcessedTrace) (sampled bool, rate float64) {
+func (s *Sampler) Add(t ProcessedTrace) (sampled bool, rate float64) {
 	atomic.AddUint64(&s.totalTraceCount, 1)
 	sampled, rate = s.engine.Sample(t.Trace, t.Root, t.Env)
 	if sampled {

--- a/pkg/trace/agent/service.go
+++ b/pkg/trace/agent/service.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"sync"

--- a/pkg/trace/agent/service_test.go
+++ b/pkg/trace/agent/service_test.go
@@ -1,4 +1,4 @@
-package main
+package agent
 
 import (
 	"testing"


### PR DESCRIPTION
This change moves the agent initialization logic into the
`pkg/trace/agent` package, making the `cmd/trace-agent` package slim
with program-starting logic only.