### PR TITLE
docs/trace-agent: clarify download locations

### DIFF
--- a/docs/trace-agent/README.md
+++ b/docs/trace-agent/README.md
@@ -17,8 +17,8 @@ The Trace Agent isn't part of the macOS Datadog Agent yet and it needs to be run
 on the side.
 
 - Have the [macOS Agent](https://app.datadoghq.com/account/settings#agent/mac) installed.
-- Download the [latest macOS Trace Agent release](https://github.com/DataDog/datadog-agent/releases/latest). For
-older releases (pre-6.9.0) use the [old repository](https://github.com/DataDog/datadog-trace-agent/releases/).
+- Download the latest macOS Trace Agent release from the [archive repository](https://github.com/DataDog/datadog-trace-agent/releases/).
+Once a newer release is out, it will be available on this repository's [releases section](https://github.com/DataDog/datadog-agent/releases).
 - Run the Trace Agent along the main agent:
 
     `./trace-agent-X.Y.Z-darwin-amd64 -config /opt/datadog-agent/etc/datadog.yaml`


### PR DESCRIPTION
Current text was a bit confusing because people were inclined to click on the link pointing to the latest release. This rephrasing clarifies where the location is. We can update it once the next release happens.