### PR TITLE
Update docs mentioning Go version + trace Makefile.

### DIFF
--- a/Makefile.trace
+++ b/Makefile.trace
@@ -28,7 +28,7 @@ binaries:
 	mkdir -p ./bin
 	TRACE_AGENT_VERSION=$(V) go generate ./internal/info
 	go get -u github.com/karalabe/xgo
-	xgo -dest=bin -go=1.10 -out=trace-agent-$(V) -targets=windows-6.1/amd64,linux/amd64,darwin-10.11/amd64 ./cmd/trace-agent
+	xgo -dest=bin -go=1.11 -out=trace-agent-$(V) -targets=windows-6.1/amd64,linux/amd64,darwin-10.11/amd64 ./cmd/trace-agent
 	mv ./bin/trace-agent-$(V)-windows-6.1-amd64.exe ./bin/trace-agent-$(V)-windows-amd64.exe
 	mv ./bin/trace-agent-$(V)-darwin-10.11-amd64 ./bin/trace-agent-$(V)-darwin-amd64 
 	git reset --hard head && git checkout -

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and development, is located under [the docs directory](docs) of the present repo
 ## Getting started
 
 To build the Agent you need:
- * [Go](https://golang.org/doc/install) 1.10.2 or later.
+ * [Go](https://golang.org/doc/install) 1.11.5 or later.
  * Python 2.7 along with development libraries.
  * Python dependencies. You may install these with `pip install -r requirements.txt`
    This will also pull in [Invoke](http://www.pyinvoke.org) if not yet installed.

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -41,7 +41,7 @@ environment and ensure a clean system python.
 
 ## Golang
 
-You must install [go](https://golang.org/doc/install) version 1.10.2 or above. Make
+You must install [go](https://golang.org/doc/install) version 1.11.5 or above. Make
 sure that `$GOPATH/bin` is in your `$PATH` otherwise Invoke cannot use any
 additional tool it might need.
 

--- a/docs/trace-agent/README.md
+++ b/docs/trace-agent/README.md
@@ -69,7 +69,7 @@ And check that the status is "running".
 
 ## Development
 
-First, make sure Go 1.10+ is installed. You can do this by following the steps on the [official website](https://golang.org/dl/).
+First, make sure Go 1.11+ is installed. You can do this by following the steps on the [official website](https://golang.org/dl/).
 After cloning the repo, simply run the following command in the root of the `datadog-agent` repository:
 
 ```bash

--- a/pkg/logs/input/windowsevent/README.md
+++ b/pkg/logs/input/windowsevent/README.md
@@ -1,7 +1,7 @@
 # How to setup a windows eventlog dev environment
 
 Cross compilation from mac is not easy, an easier path is to use a linux vm for that (for instance `ubuntu/trusty64` vagrant vm).
-Requirements are to install go 1.10+, and to install `mingw-w64` with apt.
+Requirements are to install go 1.11+, and to install `mingw-w64` with apt.
 
 Once those requirements are met, to build, run:
 ```


### PR DESCRIPTION
### What does this PR do?

Updates docs mentioning the Go version needed to build the Agent.

Also updates the trace Agent Makefile.