### PR TITLE
Add image contents sanity checks to agent.docker-build task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -809,6 +809,7 @@ testkitchen_cleanup_azure:
     - aws s3 sync --only-show-errors "s3://dd-ci-artefacts-build-stable/datadog-agent/$CI_PIPELINE_ID" $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
+    - test "$TESTING_ARG" && docker build $TESTING_ARG --pull $BUILD_CONTEXT
     - DOCKER_CONTENT_TRUST=1 docker build $BUILD_ARG --pull --tag $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX $BUILD_CONTEXT
     - docker push $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX
 
@@ -818,6 +819,8 @@ build_agent6:
   variables:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
+    BUILD_ARG: --target release
+    TESTING_ARG:  --target testing
 
 # build the agent6 jmx image
 build_agent6_jmx:
@@ -826,7 +829,8 @@ build_agent6_jmx:
     IMAGE: &agent_ecr 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -jmx
-    BUILD_ARG: --build-arg WITH_JMX=true
+    BUILD_ARG: --target release --build-arg WITH_JMX=true
+    TESTING_ARG:  --target testing --build-arg WITH_JMX=true
 
 # build the cluster-agent image
 build_cluster_agent:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -795,9 +795,6 @@ testkitchen_cleanup_azure:
 #
 # image_build
 #
-# docker build must run with DOCKER_CONTENT_TRUST to
-# enable signature check of the base images
-#
 
 .docker_build_job_definition: &docker_build_job_definition
   stage: image_build
@@ -809,9 +806,15 @@ testkitchen_cleanup_azure:
     - aws s3 sync --only-show-errors "s3://dd-ci-artefacts-build-stable/datadog-agent/$CI_PIPELINE_ID" $BUILD_CONTEXT
     - TAG_SUFFIX=${TAG_SUFFIX:-}
     - BUILD_ARG=${BUILD_ARG:-}
-    - test "$TESTING_ARG" && docker build $TESTING_ARG --pull $BUILD_CONTEXT
-    - DOCKER_CONTENT_TRUST=1 docker build $BUILD_ARG --pull --tag $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX $BUILD_CONTEXT
-    - docker push $IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX
+    - TARGET_TAG=$IMAGE:v$CI_PIPELINE_ID-${CI_COMMIT_SHA:0:7}$TAG_SUFFIX
+    # Pull base image(s) with content trust enabled
+    - pip install -r requirements.txt
+    - inv -e docker.pull-base-images --signed-pull $BUILD_CONTEXT/Dockerfile
+    # Build testing stage if provided
+    - test "$TESTING_ARG" &&  docker build $TESTING_ARG $BUILD_CONTEXT
+    # Build release stage and push to ECR
+    - docker build $BUILD_ARG --pull --tag $TARGET_TAG $BUILD_CONTEXT
+    - docker push $TARGET_TAG
 
 # build the agent6 image
 build_agent6:

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -1,8 +1,8 @@
-##########################################
-# Preparation stage: extract and cleanup #
-##########################################
+############################################
+#  Preparation stage: extract and cleanup  #
+############################################
 
-FROM debian:buster-slim as extract
+FROM debian:buster-slim AS extract
 ARG WITH_JMX
 COPY datadog-agent*_amd64.deb /
 WORKDIR /output
@@ -43,11 +43,11 @@ RUN dpkg -x /datadog-agent*_amd64.deb . \
 COPY datadog*.yaml etc/datadog-agent/
 
 
-####################################
-# Actual docker image construction #
-####################################
+######################################
+#  Actual docker image construction  #
+######################################
 
-FROM debian:buster-slim
+FROM debian:buster-slim AS release
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ENV DOCKER_DD_AGENT=true \
@@ -120,3 +120,15 @@ HEALTHCHECK --interval=2m --timeout=5s --retries=2 \
 VOLUME ["/var/run/s6", "/etc/datadog-agent", "/var/log/datadog", "/tmp"]
 
 CMD ["/init"]
+
+
+################################################################
+#  Sanity checks on the image contents                         #
+#  Build the release artifact with "--target release" to skip  #
+################################################################
+
+FROM release AS testing
+ARG WITH_JMX
+
+COPY test_*.py /
+RUN python /test_image_contents.py -v

--- a/Dockerfiles/agent/test_image_contents.py
+++ b/Dockerfiles/agent/test_image_contents.py
@@ -1,0 +1,46 @@
+#!/opt/datadog-agent/embedded/bin/python
+
+import os
+import os.path
+import unittest
+from hashlib import sha256
+
+EXPECTED_PRESENT = [
+    "/etc/datadog-agent/datadog-docker.yaml",
+    "/etc/datadog-agent/datadog-kubernetes.yaml",
+    "/etc/datadog-agent/datadog-k8s-docker.yaml",
+    "/etc/datadog-agent/datadog-ecs.yaml",
+]
+
+EXPECTED_ABSENT = [
+    # This will be symlinked by an entrypoint script if no set by user
+    "/etc/datadog-agent/datadog.yaml",
+]
+
+EXPECTED_CHECKSUMS = {
+    # See https://github.com/DataDog/datadog-agent/pull/1337
+    "/etc/s6/init/init-stage3": "710c5b63d7bf1d23897991cba43b8de68aef163e570a2a676db2d897bb09baf7",
+}
+
+
+class TestFiles(unittest.TestCase):
+
+    def test_files_present(self):
+        for file in EXPECTED_PRESENT:
+            self.assertTrue(os.path.isfile(file), file + " should be present")
+
+    def test_files_absent(self):
+        for file in EXPECTED_ABSENT:
+            self.assertFalse(os.path.isfile(file), file + " should NOT be present")
+
+    def test_files_checksums(self):
+        for file, digest in EXPECTED_CHECKSUMS.iteritems():
+            sha = sha256()
+            with open(file, 'rb') as f:
+                for chunk in iter(lambda: f.read(4096), b''):
+                    sha.update(chunk)
+            self.assertEqual(sha.hexdigest(), digest, file + " checksum mismatch")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -218,7 +218,7 @@ def system_tests(ctx):
 
 
 @task
-def image_build(ctx, base_dir="omnibus"):
+def image_build(ctx, base_dir="omnibus", skip_tests=False):
     """
     Build the docker image
     """
@@ -232,7 +232,13 @@ def image_build(ctx, base_dir="omnibus"):
         raise Exit(code=1)
     latest_file = max(list_of_files, key=os.path.getctime)
     shutil.copy2(latest_file, "Dockerfiles/agent/")
-    ctx.run("docker build -t {} Dockerfiles/agent".format(AGENT_TAG))
+
+    # Build with the testing target
+    if not skip_tests:
+        ctx.run("docker build -t {} --target testing Dockerfiles/agent".format(AGENT_TAG))
+
+    # Build with the release target
+    ctx.run("docker build -t {} --target release Dockerfiles/agent".format(AGENT_TAG))
     ctx.run("rm Dockerfiles/agent/datadog-agent*_amd64.deb")
 
 

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -143,3 +143,38 @@ def publish(ctx, src, dst, signed_pull=False, signed_push=False):
         "docker push {dst}".format(dst=dst),
         env=push_env
     )
+
+@task
+def pull_base_images(ctx, dockerfile, signed_pull=True):
+    """
+    Pulls the base images for a given Dockerfile, with
+    content trust enabled by default, to ensure the base
+    images are signed
+    """
+    images = set()
+    stages = set()
+
+    with open(dockerfile, "r") as f:
+        for line in f:
+            words = line.split()
+            # Get source images
+            if len(words) < 2 or words[0].lower() != "from":
+                continue
+            images.add(words[1])
+            # Get stage names to remove them from pull
+            if len(words) < 4 or words[2].lower() != "as":
+                continue
+            stages.add(words[3])
+
+    if stages:
+        print("Ignoring intermediate stage names: {}".format(", ".join(stages)))
+        images -= stages
+
+    print("Pulling following base images: {}".format(", ".join(images)))
+
+    pull_env = {}
+    if signed_pull:
+        pull_env["DOCKER_CONTENT_TRUST"] = "1"
+
+    for i in images:
+        ctx.run("docker pull {}".format(i), env=pull_env)


### PR DESCRIPTION
### What does this PR do?

To avoid regressions like https://github.com/DataDog/datadog-agent/pull/2093, we need some sanity checks on the image contents, that are overkill for e2e, but non trivial to run.

This PR takes advantage of [multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to introduce them in the build step. The image now has three steps:
  - extract
  - release (previously the last one)
  - testing

The `agent.image-build` invoke task and gitlab `image_build` steps will build the image twice:
  - first, targeting explicitly the `testing` target, failing if the tests fail
  - second, targeting the `release` target, and reusing the build cache from the first build

Tests are expressed in python for readability and avoiding false negatives on bash syntax issues.