### PR TITLE
reduce allocs in populateDeviceField

### DIFF
--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -89,6 +89,9 @@ func (series Series) Marshal() ([]byte, error) {
 //FIXME(olivier): remove this as soon as the v1 API can handle `device` as a regular tag
 func populateDeviceField(series Series) {
 	for _, serie := range series {
+		if !hasDeviceTag(serie) {
+			continue
+		}
 		// make a copy of the tags array. Otherwise the underlying array won't have
 		// the device tag for the Nth iteration (N>1), and the device field will
 		// be lost
@@ -103,6 +106,16 @@ func populateDeviceField(series Series) {
 		}
 		serie.Tags = filteredTags
 	}
+}
+
+// hasDeviceField check wehter or not a serie contains a device tag
+func hasDeviceTag(serie *Serie) bool {
+	for _, tag := range serie.Tags {
+		if strings.HasPrefix(tag, "device:") {
+			return true
+		}
+	}
+	return false
 }
 
 // MarshalJSON serializes timeseries to JSON so it can be sent to V1 endpoints

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -86,14 +86,13 @@ func (series Series) Marshal() ([]byte, error) {
 
 // populateDeviceField removes any `device:` tag in the series tags and uses the value to
 // populate the Serie.Device field
-// Mutates the `series` slice in place
 //FIXME(olivier): remove this as soon as the v1 API can handle `device` as a regular tag
 func populateDeviceField(series Series) {
 	for _, serie := range series {
 		// make a copy of the tags array. Otherwise the underlying array won't have
 		// the device tag for the Nth iteration (N>1), and the device field will
 		// be lost
-		var filteredTags []string
+		filteredTags := make([]string, 0, len(serie.Tags))
 
 		for _, tag := range serie.Tags {
 			if strings.HasPrefix(tag, "device:") {

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -108,7 +108,7 @@ func populateDeviceField(series Series) {
 	}
 }
 
-// hasDeviceField check wehter or not a serie contains a device tag
+// hasDeviceTag checks whether a series contains a device tag
 func hasDeviceTag(serie *Serie) bool {
 	for _, tag := range serie.Tags {
 		if strings.HasPrefix(tag, "device:") {

--- a/pkg/metrics/series_benchmark_test.go
+++ b/pkg/metrics/series_benchmark_test.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package metrics
+
+import "testing"
+
+func benchmarkPopulateDeviceField(numberOfTags int, b *testing.B) {
+	tags := make([]string, 0, numberOfTags+1)
+	for i := 0; i < numberOfTags; i++ {
+		tags = append(tags, "some:tag")
+	}
+	tags = append(tags, "device:test")
+
+	serie := &Serie{
+		Tags: tags,
+	}
+	series := []*Serie{serie}
+
+	for n := 0; n < b.N; n++ {
+		populateDeviceField(series)
+	}
+}
+
+func BenchmarkPopulateDeviceField1(b *testing.B)  { benchmarkPopulateDeviceField(1, b) }
+func BenchmarkPopulateDeviceField2(b *testing.B)  { benchmarkPopulateDeviceField(2, b) }
+func BenchmarkPopulateDeviceField3(b *testing.B)  { benchmarkPopulateDeviceField(3, b) }
+func BenchmarkPopulateDeviceField10(b *testing.B) { benchmarkPopulateDeviceField(10, b) }
+func BenchmarkPopulateDeviceField20(b *testing.B) { benchmarkPopulateDeviceField(20, b) }
+func BenchmarkPopulateDeviceField40(b *testing.B) { benchmarkPopulateDeviceField(40, b) }

--- a/pkg/metrics/series_benchmark_test.go
+++ b/pkg/metrics/series_benchmark_test.go
@@ -20,6 +20,7 @@ func benchmarkPopulateDeviceField(numberOfTags int, b *testing.B) {
 	series := []*Serie{serie}
 
 	for n := 0; n < b.N; n++ {
+		serie.Tags = tags
 		populateDeviceField(series)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Reduce the number of allocs in `populateDeviceField`. Implement what's described here https://github.com/DataDog/datadog-agent/pull/1284#discussion_r169061312

### Motivation

Low hanging fruit that should have a noticeable impact when metrics contains lots of tags.

![image](https://user-images.githubusercontent.com/9051073/52343380-2f244a80-2a18-11e9-991f-164ce48542a5.png)

### Notes

IMO this should be done in place but it seems that this was causing an issue in the past: https://github.com/DataDog/datadog-agent/pull/1284.
> To give some context on why we have to copy the `Tags` slice instead of modifying it in place: that's because the slice is the same one as the one that's stored upstream by the aggregator in its `context`-tracking related stores, so mutating the `Tags` in place will also mutate it in the aggregator, and later we'll lose the `device:` tag entirely.
https://github.com/DataDog/datadog-agent/pull/2997#pullrequestreview-202039309

I'm currently first iterating over the tags to find the device tag and then iterating a second time to remove the device tag if it was found. There is probably a better way to do both at once. Looking at the benchmark it does not seems to have a huge difference so I don't think there is a need to do everything in one iteration.

### Benchmarks (When there is a device tag. If there is none there will be no alloc)

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkPopulateDeviceField1-4      98.0          174           +77.55%
BenchmarkPopulateDeviceField2-4      217           125           -42.40%
BenchmarkPopulateDeviceField3-4      484           123           -74.59%
BenchmarkPopulateDeviceField10-4     630           432           -31.43%
BenchmarkPopulateDeviceField20-4     1417          668           -52.86%
BenchmarkPopulateDeviceField40-4     1539          1179          -23.39%

benchmark                            old allocs     new allocs     delta
BenchmarkPopulateDeviceField1-4      1              1              +0.00%
BenchmarkPopulateDeviceField2-4      2              1              -50.00%
BenchmarkPopulateDeviceField3-4      3              1              -66.67%
BenchmarkPopulateDeviceField10-4     5              1              -80.00%
BenchmarkPopulateDeviceField20-4     6              1              -83.33%
BenchmarkPopulateDeviceField40-4     7              1              -85.71%

benchmark                            old bytes     new bytes     delta
BenchmarkPopulateDeviceField1-4      16            32            +100.00%
BenchmarkPopulateDeviceField2-4      48            48            +0.00%
BenchmarkPopulateDeviceField3-4      112           64            -42.86%
BenchmarkPopulateDeviceField10-4     496           176           -64.52%
BenchmarkPopulateDeviceField20-4     1008          352           -65.08%
BenchmarkPopulateDeviceField40-4     2032          704           -65.35%
```


