### PR TITLE
Fix configcheck verbose output

### DIFF
--- a/cmd/agent/api/response/types.go
+++ b/cmd/agent/api/response/types.go
@@ -11,10 +11,10 @@ import (
 
 // ConfigCheckResponse holds the config check response
 type ConfigCheckResponse struct {
-	Configs         []integration.Config          `json:"configs"`
-	ResolveWarnings map[string][]string           `json:"resolve_warnings"`
-	ConfigErrors    map[string]string             `json:"config_errors"`
-	Unresolved      map[string]integration.Config `json:"unresolved"`
+	Configs         []integration.Config            `json:"configs"`
+	ResolveWarnings map[string][]string             `json:"resolve_warnings"`
+	ConfigErrors    map[string]string               `json:"config_errors"`
+	Unresolved      map[string][]integration.Config `json:"unresolved"`
 }
 
 // TaggerListResponse holds the tagger list response

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -559,7 +559,7 @@ func (ac *AutoConfig) GetLoadedConfigs() map[string]integration.Config {
 }
 
 // GetUnresolvedTemplates returns templates in cache yet to be resolved
-func (ac *AutoConfig) GetUnresolvedTemplates() map[string]integration.Config {
+func (ac *AutoConfig) GetUnresolvedTemplates() map[string][]integration.Config {
 	return ac.store.templateCache.GetUnresolvedTemplates()
 }
 

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -73,6 +73,7 @@ func (c *Config) String() string {
 	rawConfig := make(map[interface{}]interface{})
 	var initConfig interface{}
 	var instances []interface{}
+	var logsConfig interface{}
 
 	yaml.Unmarshal(c.InitConfig, &initConfig)
 	rawConfig["init_config"] = initConfig
@@ -83,6 +84,9 @@ func (c *Config) String() string {
 		instances = append(instances, instance)
 	}
 	rawConfig["instances"] = instances
+
+	yaml.Unmarshal(c.LogsConfig, &logsConfig)
+	rawConfig["logs_config"] = logsConfig
 
 	buffer, err := yaml.Marshal(&rawConfig)
 	if err != nil {

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -69,6 +69,7 @@ func TestString(t *testing.T) {
   fooBarBaz: test
 instances:
 - justFoo
+logs_config: null
 `
 	assert.Equal(t, config.String(), expected)
 }

--- a/pkg/autodiscovery/templatecache.go
+++ b/pkg/autodiscovery/templatecache.go
@@ -76,11 +76,11 @@ func (cache *TemplateCache) Get(adID string) ([]integration.Config, error) {
 }
 
 // GetUnresolvedTemplates returns templates yet to be resolved
-func (cache *TemplateCache) GetUnresolvedTemplates() map[string]integration.Config {
-	tpls := make(map[string]integration.Config)
+func (cache *TemplateCache) GetUnresolvedTemplates() map[string][]integration.Config {
+	tpls := make(map[string][]integration.Config)
 	for d, config := range cache.digestToTemplate {
 		ids := strings.Join(cache.digestToADId[d][:], ",")
-		tpls[ids] = config
+		tpls[ids] = append(tpls[ids], config)
 	}
 	return tpls
 }

--- a/pkg/autodiscovery/templatecache_test.go
+++ b/pkg/autodiscovery/templatecache_test.go
@@ -93,8 +93,8 @@ func TestGetUnresolvedTemplates(t *testing.T) {
 	cache := NewTemplateCache()
 	tpl := integration.Config{ADIdentifiers: []string{"foo", "bar"}}
 	cache.Set(tpl)
-	expected := map[string]integration.Config{
-		"foo,bar": tpl,
+	expected := map[string][]integration.Config{
+		"foo,bar": {tpl},
 	}
 
 	assert.Equal(t, cache.GetUnresolvedTemplates(), expected)

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -76,10 +76,12 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 		}
 		if len(cr.Unresolved) > 0 {
 			fmt.Fprintln(w, fmt.Sprintf("\n=== %s Configs ===", color.YellowString("Unresolved")))
-			for ids, config := range cr.Unresolved {
+			for ids, configs := range cr.Unresolved {
 				fmt.Fprintln(w, fmt.Sprintf("\n%s: %s", color.BlueString("Auto-discovery IDs"), color.YellowString(ids)))
-				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Template")))
-				fmt.Fprintln(w, config.String())
+				fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Templates")))
+				for _, config := range configs {
+					fmt.Fprintln(w, config.String())
+				}
 			}
 		}
 	}

--- a/releasenotes/notes/configcheck-verbose-7c579b5c0ebe8063.yaml
+++ b/releasenotes/notes/configcheck-verbose-7c579b5c0ebe8063.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the display of unresolved configs in the verbose output of the ``configcheck`` command


### PR DESCRIPTION
### What does this PR do?

One autodiscovery identifier can have multiple configs attached to it, especially since https://github.com/DataDog/datadog-agent/pull/2432 which made the `unresolved config` section of the `configcheck` unreliable because of its datastructure. 

Also adding the logs config section to the output

Before
```
Auto-discovery IDs: docker://37d4064fff81545c3efe8fd83628c79e91a5b899f9f122b08c98b670bba0cd66
Template:
init_config: null
instances: []


Auto-discovery IDs: docker://dd68015898c1cac315a0685876fce62b2571d3ae12a698e002237fbc2139c3d6
Template:
init_config: {}
instances:
- host: '%%host%%'
  port: '%%port%%'
```

After
```
Auto-discovery IDs: docker://37d4064fff81545c3efe8fd83628c79e91a5b899f9f122b08c98b670bba0cd66
Templates:
init_config: {}
instances:
- host: '%%host%%'
  port: '%%port%%'
logs_config: null

init_config: null
instances: []
logs_config:
- service: redis
  source: redis


Auto-discovery IDs: docker://dd68015898c1cac315a0685876fce62b2571d3ae12a698e002237fbc2139c3d6
Templates:
init_config: {}
instances:
- host: '%%host%%'
  port: '%%port%%'
logs_config: null

init_config: null
instances: []
logs_config:
- service: redis
  source: redis
```

### Motivation

Have a more accurate `configcheck -v` output

### Additional Notes

Anything else we should know when reviewing?
