### PR TITLE
Fix AD rescheduling issue when no template variables

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -478,9 +478,17 @@ func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 	ac.unschedule(configs)
 	for _, c := range configs {
 		ac.store.removeLoadedConfig(c)
+	}
+}
+
+func (ac *AutoConfig) removeConfigTemplates(configs []integration.Config) {
+	for _, c := range configs {
 		// if the config is a template, remove it from the cache
 		if c.IsTemplate() {
-			ac.store.templateCache.Del(c)
+			err := ac.store.templateCache.Del(c)
+			if err != nil {
+				log.Debugf("Could not delete template: %v", err)
+			}
 		}
 	}
 }

--- a/pkg/autodiscovery/config_poller.go
+++ b/pkg/autodiscovery/config_poller.go
@@ -99,6 +99,8 @@ func (pd *configPoller) poll(ac *AutoConfig) {
 			// Process removed configs first to handle the case where a
 			// container churn would result in the same configuration hash.
 			ac.processRemovedConfigs(removedConfigs)
+			// We can also remove any cached template
+			ac.removeConfigTemplates(removedConfigs)
 
 			for _, config := range newConfigs {
 				config.Provider = pd.provider.String()

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -75,6 +75,8 @@ func (c *Config) String() string {
 	var instances []interface{}
 	var logsConfig interface{}
 
+	rawConfig["check_name"] = c.Name
+
 	yaml.Unmarshal(c.InitConfig, &initConfig)
 	rawConfig["init_config"] = initConfig
 

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -65,7 +65,8 @@ func TestString(t *testing.T) {
 	config.InitConfig = Data("fooBarBaz: test")
 	config.Instances = []Data{Data("justFoo")}
 
-	expected := `init_config:
+	expected := `check_name: foo
+init_config:
   fooBarBaz: test
 instances:
 - justFoo

--- a/releasenotes/notes/ad-fix-static-templates-c93c6b539478b399.yaml
+++ b/releasenotes/notes/ad-fix-static-templates-c93c6b539478b399.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue where some auto-discovered integrations would not get rescheduled when the template was not containing variables


### PR DESCRIPTION
### What does this PR do?

Only remove templates when they are removed from the config providers, not the service.

### Motivation

This was causing issues when the resolved configuration was the same as the template (no template variables, which is the case for logs) preventing the template to trigger again when the service would come back.

### Additional Notes

Anything else we should know when reviewing?
