### PR TITLE
Only expose cluster-check prometheus metrics when leading

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -112,6 +112,9 @@ func (d *dispatcher) run(ctx context.Context) {
 	healthProbe := health.Register("clusterchecks-dispatch")
 	defer health.Deregister(healthProbe)
 
+	registerMetrics()
+	defer unregisterMetrics()
+
 	cleanupTicker := time.NewTicker(time.Duration(d.nodeExpirationSeconds/2) * time.Second)
 	defer cleanupTicker.Stop()
 

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -34,10 +34,22 @@ var (
 		},
 		[]string{"node"},
 	)
+
+	allMetrics = []prometheus.Collector{
+		nodeAgents,
+		danglingConfigs,
+		dispatchedConfigs,
+	}
 )
 
-func init() {
-	prometheus.MustRegister(nodeAgents)
-	prometheus.MustRegister(danglingConfigs)
-	prometheus.MustRegister(dispatchedConfigs)
+func registerMetrics() {
+	for _, m := range allMetrics {
+		prometheus.Register(m)
+	}
+}
+
+func unregisterMetrics() {
+	for _, m := range allMetrics {
+		prometheus.Unregister(m)
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Only expose the ccheck metrics on the leader, to avoid zeros on followers breaking aggregation:

Displaying the avg of `nodes_reporting` on a 3 node cluster. Patched, master then patched again:
![](https://cl.ly/75a5035d320b/Image%202019-02-08%20at%201.08.40%20PM.png)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
