### PR TITLE
Fix dogstatsd image failing healthcheck

### DIFF
--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -16,4 +16,4 @@ HEALTHCHECK --interval=1m --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/dogstatsd", "-c", "/etc/datadog-agent/" "start"]
+CMD ["/dogstatsd", "-c", "/etc/datadog-agent/", "start"]

--- a/Dockerfiles/dogstatsd/alpine/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/Dockerfile
@@ -16,4 +16,4 @@ HEALTHCHECK --interval=1m --timeout=5s --retries=2 \
   CMD ["/probe.sh"]
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/dogstatsd", "start"]
+CMD ["/dogstatsd", "-c", "/etc/datadog-agent/" "start"]


### PR DESCRIPTION
### What does this PR do?
Passes the dogstatsd.yaml path as a param into the dogstatsd command. 

### Motivation
The healthcheck was failing due to the removal of the `DD_HEALTH_PORT=5555` env var and the relocation of the dogstatsd.yaml config file. 