### PR TITLE
fix(cluster-agent): Extend time for AWS Integration metrics

### DIFF
--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -61,7 +61,14 @@ func (p *Processor) UpdateExternalMetrics(emList []custommetrics.ExternalMetricV
 		metricIdentifier := getKey(em.MetricName, em.Labels)
 		metric := metrics[metricIdentifier]
 
-		if time.Now().Unix()-metric.timestamp > maxAge || !metric.valid {
+		now := time.Now().Unix()
+
+		// AWS Integration may be delayed
+		if strings.HasPrefix(em.MetricName, "aws.") {
+			now = now - 600
+		}
+
+		if now-metric.timestamp > maxAge || !metric.valid {
 			// invalidating sparse metrics that are outdated
 			em.Valid = false
 			em.Value = metric.value

--- a/releasenotes/notes/fix-max-age-aws-integration-metrics-cf99536953798689.yaml
+++ b/releasenotes/notes/fix-max-age-aws-integration-metrics-cf99536953798689.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Extend maxAge for AWS Integration metrics


### PR DESCRIPTION
### What does this PR do?

Extend maxAge for AWS Integration metrics.

### Motivation

In the case of AWS Integration metrics, it always exceeds maxAge.
Therefore, it can not be used as HPA metrics.

From the following document.
>If you receive 1-minute metrics with CloudWatch, then their availability delay is about 2 minutes—so total latency to view your metrics may be ~10-12 minutes.

https://docs.datadoghq.com/integrations/faq/are-my-aws-cloudwatch-metrics-delayed/

Since the default value of current `maxAge` is 120 sec, we need to extend time only for AWS Integration metrics.
I know that we can change `maxAge` using `DD_EXTERNAL_METRICS_PROVIDER_MAX_AGE`, but It does not seem to be good that AWS Integration metrics can not be used with default settings.

### Additional Notes

I think that we can change the default value of `DD_EXTERNAL_METRICS_PROVIDER_MAX_AGE`.
Please give me feedback if there is another way to fix it.
