### PR TITLE
Temporarily blacklist Aerospike

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -42,6 +42,7 @@ blacklist = [
   'datadog_checks_base',           # namespacing package for wheels (NOT AN INTEGRATION)
   'datadog_checks_dev',            # Development package, (NOT AN INTEGRATION)
   'datadog_checks_tests_helper',   # Testing and Development package, (NOT AN INTEGRATION)
+  'aerospike',                     # Temporarily blacklist Aerospike until builder supports new dependency
   'agent_metrics',
   'docker_daemon',
   'kubernetes',

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -42,13 +42,16 @@ blacklist = [
   'datadog_checks_base',           # namespacing package for wheels (NOT AN INTEGRATION)
   'datadog_checks_dev',            # Development package, (NOT AN INTEGRATION)
   'datadog_checks_tests_helper',   # Testing and Development package, (NOT AN INTEGRATION)
-  'aerospike',                     # Temporarily blacklist Aerospike until builder supports new dependency
   'agent_metrics',
   'docker_daemon',
   'kubernetes',
   'ntp',                           # provided as a go check by the core agent
   'openstack_controller',          # Check currently under active development and in beta
 ]
+
+if suse?
+  blacklist.push('aerospike')  # Temporarily blacklist Aerospike until builder supports new dependency
+end
 
 core_constraints_file = 'core_constraints.txt'
 agent_requirements_file = 'agent_requirements.txt'


### PR DESCRIPTION
until builder supports new dependency