### PR TITLE
Support adding/removing the AD annotation to an existing kube service

### DIFF
--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -137,6 +137,10 @@ func servicesDiffer(first, second *v1.Service) bool {
 	if first.ResourceVersion == second.ResourceVersion {
 		return false
 	}
+	// AD annotations
+	if isServiceAnnotated(first) != isServiceAnnotated(second) {
+		return true
+	}
 	// Cluster IP
 	if first.Spec.ClusterIP != second.Spec.ClusterIP {
 		return true
@@ -161,8 +165,7 @@ func (l *KubeServiceListener) createService(ksvc *v1.Service, firstRun bool) {
 	if ksvc == nil {
 		return
 	}
-	_, found := ksvc.Annotations[kubeServiceAnnotationFormat]
-	if !found {
+	if !isServiceAnnotated(ksvc) {
 		// Ignore services with no AD annotation
 		return
 	}
@@ -269,4 +272,9 @@ func (s *KubeServiceService) GetHostname() (string, error) {
 // GetCreationTime returns the creation time of the service compare to the agent start.
 func (s *KubeServiceService) GetCreationTime() integration.CreationTime {
 	return s.creationTime
+}
+
+func isServiceAnnotated(ksvc *v1.Service) bool {
+	_, found := ksvc.Annotations[kubeServiceAnnotationFormat]
+	return found
 }

--- a/pkg/autodiscovery/listeners/kube_services_test.go
+++ b/pkg/autodiscovery/listeners/kube_services_test.go
@@ -191,6 +191,66 @@ func TestServicesDiffer(t *testing.T) {
 			},
 			result: true,
 		},
+		"Add annotation": {
+			first: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []v1.ServicePort{
+						{Name: "test2", Port: 126},
+					},
+				},
+			},
+			second: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+					Annotations: map[string]string{
+						"ad.datadoghq.com/service.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/service.init_configs": "[{}]",
+						"ad.datadoghq.com/service.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []v1.ServicePort{
+						{Name: "test2", Port: 126},
+					},
+				},
+			},
+			result: true,
+		},
+		"Remove annotation": {
+			first: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123",
+					Annotations: map[string]string{
+						"ad.datadoghq.com/service.check_names":  "[\"http_check\"]",
+						"ad.datadoghq.com/service.init_configs": "[{}]",
+						"ad.datadoghq.com/service.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []v1.ServicePort{
+						{Name: "test2", Port: 126},
+					},
+				},
+			},
+			second: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "124",
+				},
+				Spec: v1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports: []v1.ServicePort{
+						{Name: "test2", Port: 126},
+					},
+				},
+			},
+			result: true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.result, servicesDiffer(tc.first, tc.second))


### PR DESCRIPTION
### What does this PR do?

The `kube_service` listener only sends (ad) services for (kube) services that have an annotation, in order to reduce the number of entities tracked in the store.

We did not look for the annotation status when comparing service updated with `servicesDiffer`. We do now :)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
