### PR TITLE
Fix kube metadata tag removal

### DIFF
--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -61,10 +61,6 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 				continue
 			}
 		}
-		if len(metadataNames) == 0 {
-			log.Tracef("No cluster metadata for the pod %s on node %s", po.Metadata.Name, po.Spec.NodeName)
-			continue
-		}
 		for _, tagDCA := range metadataNames {
 			log.Tracef("Tagging %s with %s", po.Metadata.Name, tagDCA)
 			tag = strings.Split(tagDCA, ":")

--- a/releasenotes/notes/tagger-service-removal-5609bce44b773f30.yaml
+++ b/releasenotes/notes/tagger-service-removal-5609bce44b773f30.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue where some kubernetes tags would not be removed properly.

--- a/releasenotes/notes/tagger-service-removal-5609bce44b773f30.yaml
+++ b/releasenotes/notes/tagger-service-removal-5609bce44b773f30.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix an issue where some kubernetes tags would not be removed properly.
+    Fix an issue where some kubernetes tags would not be properly removed.


### PR DESCRIPTION
### What does this PR do?

Remove an early return

### Motivation

Fix removal of the `kube_service` tags if the service is actually removed

### Additional Notes

Anything else we should know when reviewing?
