### PR TITLE
Remove resolved configs when template are removed

### DIFF
--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -312,3 +312,34 @@ func TestResolveTemplate(t *testing.T) {
 	res = ac.resolveTemplate(tpl)
 	assert.Len(t, res, 1)
 }
+
+func TestRemoveTemplate(t *testing.T) {
+	ac := NewAutoConfig(scheduler.NewMetaScheduler())
+
+	// Add static config
+	c := integration.Config{
+		Name: "memory",
+	}
+	ac.processNewConfig(c)
+	assert.Len(t, ac.GetLoadedConfigs(), 1)
+
+	// Add new service
+	service := dummyService{
+		ID:            "a5901276aed16ae9ea11660a41fecd674da47e8f5d8d5bce0080a611feed2be9",
+		ADIdentifiers: []string{"redis"},
+	}
+	ac.processNewService(&service)
+
+	// Add matching template
+	tpl := integration.Config{
+		Name:          "cpu",
+		ADIdentifiers: []string{"redis"},
+	}
+	configs := ac.processNewConfig(tpl)
+	assert.Len(t, configs, 1)
+	assert.Len(t, ac.GetLoadedConfigs(), 2)
+
+	// Remove the template, config should be removed too
+	ac.removeConfigTemplates([]integration.Config{tpl})
+	assert.Len(t, ac.GetLoadedConfigs(), 1)
+}

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -16,6 +16,7 @@ import (
 type store struct {
 	serviceToConfigs  map[string][]integration.Config
 	serviceToTagsHash map[string]string
+	templateToConfigs map[string][]integration.Config
 	loadedConfigs     map[string]integration.Config
 	nameToJMXMetrics  map[string]integration.Data
 	adIDToServices    map[string]map[string]bool
@@ -29,6 +30,7 @@ func newStore() *store {
 	s := store{
 		serviceToConfigs:  make(map[string][]integration.Config),
 		serviceToTagsHash: make(map[string]string),
+		templateToConfigs: make(map[string][]integration.Config),
 		loadedConfigs:     make(map[string]integration.Config),
 		nameToJMXMetrics:  make(map[string]integration.Data),
 		adIDToServices:    make(map[string]map[string]bool),
@@ -63,6 +65,27 @@ func (s *store) addConfigForService(serviceEntity string, config integration.Con
 	} else {
 		s.serviceToConfigs[serviceEntity] = []integration.Config{config}
 	}
+}
+
+// getConfigsForTemplate gets config for a specified template
+func (s *store) getConfigsForTemplate(templateDigest string) []integration.Config {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.templateToConfigs[templateDigest]
+}
+
+// removeConfigsForTemplate removes a config for a specified template
+func (s *store) removeConfigsForTemplate(templateDigest string) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	delete(s.templateToConfigs, templateDigest)
+}
+
+// addConfigForTemplate adds a config for a specified template
+func (s *store) addConfigForTemplate(templateDigest string, config integration.Config) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.templateToConfigs[templateDigest] = append(s.templateToConfigs[templateDigest], config)
 }
 
 // getTagsHashForService return the tags hash for a specified service

--- a/pkg/autodiscovery/store_test.go
+++ b/pkg/autodiscovery/store_test.go
@@ -27,3 +27,21 @@ func TestServiceToConfig(t *testing.T) {
 	s.addConfigForService(service.GetEntity(), integration.Config{Name: "foo"})
 	assert.Equal(t, len(s.getConfigsForService(service.GetEntity())), 1)
 }
+
+func TestTemplateToConfig(t *testing.T) {
+	s := newStore()
+	s.addConfigForTemplate("digest1", integration.Config{Name: "foo"})
+	s.addConfigForTemplate("digest1", integration.Config{Name: "bar"})
+	s.addConfigForTemplate("digest2", integration.Config{Name: "foo"})
+
+	assert.Len(t, s.getConfigsForTemplate("digest1"), 2)
+	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
+
+	s.removeConfigsForTemplate("digest1")
+	assert.Len(t, s.getConfigsForTemplate("digest1"), 0)
+	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
+
+	s.addConfigForTemplate("digest1", integration.Config{Name: "foo"})
+	assert.Len(t, s.getConfigsForTemplate("digest1"), 1)
+	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
+}

--- a/releasenotes/notes/autodiscovery-remove-configs-from-template-858b60cc168edf3a.yaml
+++ b/releasenotes/notes/autodiscovery-remove-configs-from-template-858b60cc168edf3a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Autodiscovery now removes childen configurations when removing templates

--- a/releasenotes/notes/autodiscovery-remove-configs-from-template-858b60cc168edf3a.yaml
+++ b/releasenotes/notes/autodiscovery-remove-configs-from-template-858b60cc168edf3a.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Autodiscovery now removes childen configurations when removing templates
+    Autodiscovery now removes children configurations when removing templates


### PR DESCRIPTION
### What does this PR do?

When removing AD templates, we did not remove the associated check configurations.

This was not an issue for container annotations, as we removed configs via the service. But with support for `kube_service` annotations in clusterchecks, we want to support modifying/removing a template without churning the service itself.

Depends on https://github.com/DataDog/datadog-agent/pull/3001
