### PR TITLE
Add a configuration flag to disable yaml unsafe methods monkey patching in custom checks.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,9 @@ func initConfig(config Config) {
 	// Use to force client side TLS version to 1.2
 	config.BindEnvAndSetDefault("force_tls_12", false)
 
+	// Defaults to safe YAML methods in base and custom checks.
+	config.BindEnvAndSetDefault("disable_unsafe_yaml", true)
+
 	// Agent GUI access port
 	config.BindEnvAndSetDefault("GUI_port", defaultGuiPort)
 	if IsContainerized() {

--- a/releasenotes/notes/pyyaml-methods-4c2b28f6e3c69f73.yaml
+++ b/releasenotes/notes/pyyaml-methods-4c2b28f6e3c69f73.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Custom checks default on safe pyyaml methods.


### PR DESCRIPTION
### What does this PR do?

Adds a configuration flag to disable yaml unsafe methods monkey patching in custom checks.

### Motivation

Due to [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342), we prefer the custom checks to use the safe methods of pyyaml by default.

Please note that we are *not* affected by the vulnerability, this is for added safety in custom check scenarios.

### Additional Notes

This PR is linked to this one in integrations-core: https://github.com/DataDog/integrations-core/pull/3089