### PR TITLE
Fix status command JSON output by removing text header

### DIFF
--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -54,7 +54,9 @@ var statusCmd = &cobra.Command{
 }
 
 func requestStatus() error {
-	fmt.Printf("Getting the status from the agent.\n\n")
+	if !prettyPrintJSON && !jsonStatus {
+		fmt.Printf("Getting the status from the agent.\n\n")
+	}
 	var e error
 	var s string
 	c := util.GetClient(false) // FIX: get certificates right then make this true

--- a/pkg/config/config_android.go
+++ b/pkg/config/config_android.go
@@ -25,7 +25,7 @@ const (
 	defaultAdditionalChecksPath = ""
 	defaultRunPath              = ""
 	defaultSyslogURI            = ""
-	defaultGuiPort              = "5002"
+	defaultGuiPort              = 5002
 )
 
 func setAssetFs(config Config) {

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -10,7 +10,7 @@ const (
 	defaultAdditionalChecksPath = "/opt/datadog-agent/etc/checks.d"
 	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///var/run/syslog"
-	defaultGuiPort              = "5002"
+	defaultGuiPort              = 5002
 )
 
 // called by init in config.go, to ensure any os-specific config is done

--- a/pkg/config/config_nix.go
+++ b/pkg/config/config_nix.go
@@ -13,7 +13,7 @@ const (
 	defaultAdditionalChecksPath = "/etc/datadog-agent/checks.d"
 	defaultRunPath              = "/opt/datadog-agent/run"
 	defaultSyslogURI            = "unixgram:///dev/log"
-	defaultGuiPort              = "-1"
+	defaultGuiPort              = -1
 )
 
 // called by init in config.go, to ensure any os-specific config is done

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -16,7 +16,7 @@ var (
 	defaultAdditionalChecksPath = "c:\\programdata\\datadog\\checks.d"
 	defaultRunPath              = "c:\\programdata\\datadog\\run"
 	defaultSyslogURI            = ""
-	defaultGuiPort              = "5002"
+	defaultGuiPort              = 5002
 )
 
 // ServiceName is the name that'll be used to register the Agent

--- a/releasenotes/notes/fix-status-command-json-output-530b5e252a2a8799.yaml
+++ b/releasenotes/notes/fix-status-command-json-output-530b5e252a2a8799.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix "status" command JSON output to exclude non JSON header. The output of
+    the command is now a valid JSON payload.


### PR DESCRIPTION
### What does this PR do?

Also fix the default type of "GUI_port" option from string to int to
avoid Viper printing a warning about type change in the configuration.
