### PR TITLE
Use `device_label` tag instead of `device-label`.

### DIFF
--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -77,7 +77,7 @@ func (c *IOCheck) nixIO() error {
 		tagbuff.WriteString(device)
 		tags := []string{tagbuff.String()}
 		if ioStats.Label != "" {
-			tags = append(tags, fmt.Sprintf("device-label:%s", ioStats.Label))
+			tags = append(tags, fmt.Sprintf("device_label:%s", ioStats.Label))
 		}
 
 		sender.Rate("system.io.r_s", float64(ioStats.ReadCount), "", tags)

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -98,10 +98,10 @@ func TestIOCheckDM(t *testing.T) {
 		mock.On("Rate", "system.io.r_s", 443071.0, "", []string{"device:C:"}).Return().Times(1)
 		mock.On("Rate", "system.io.w_s", 10412454.0, "", []string{"device:C:"}).Return().Times(1)
 	default: // Should cover Unices (Linux, OSX, FreeBSD,...)
-		mock.On("Rate", "system.io.r_s", 443071.0, "", []string{"device:dm0", "device-label:virtual-1"}).Return().Times(1)
-		mock.On("Rate", "system.io.w_s", 10412454.0, "", []string{"device:dm0", "device-label:virtual-1"}).Return().Times(1)
-		mock.On("Rate", "system.io.rrqm_s", 104744.0, "", []string{"device:dm0", "device-label:virtual-1"}).Return().Times(1)
-		mock.On("Rate", "system.io.wrqm_s", 310860.0, "", []string{"device:dm0", "device-label:virtual-1"}).Return().Times(1)
+		mock.On("Rate", "system.io.r_s", 443071.0, "", []string{"device:dm0", "device_label:virtual-1"}).Return().Times(1)
+		mock.On("Rate", "system.io.w_s", 10412454.0, "", []string{"device:dm0", "device_label:virtual-1"}).Return().Times(1)
+		mock.On("Rate", "system.io.rrqm_s", 104744.0, "", []string{"device:dm0", "device_label:virtual-1"}).Return().Times(1)
+		mock.On("Rate", "system.io.wrqm_s", 310860.0, "", []string{"device:dm0", "device_label:virtual-1"}).Return().Times(1)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

To be more consistent with other tags, use `device_label` for logical volumes instead of `device-label`.