### PR TITLE
Add flags to covecov reports to avoid coverage flakes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - run:
           name: upload code coverage results
           # Never fail on coverage upload
-          command: bash <(curl -s https://codecov.io/bash) -f profile.cov || true
+          command: bash <(curl -s https://codecov.io/bash) -f profile.cov -F linux || true
 
   integration_tests:
     <<: *job_template

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,4 +40,4 @@ test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - inv -e deps
   - inv -e test --coverage --race --profile --fail-on-fmt
-  - codecov -f profile.cov
+  - codecov -f profile.cov -F windows


### PR DESCRIPTION
### What does this PR do?

Codecov reports are flaky on this repo, always on platform specific (either linux-only or windows-only) files. My guess is that the circleci and appveyor reports collide and overwrite themselves.

This PR uses [the `flags` feature](https://docs.codecov.io/docs/flags) to keep both CIs in two separate report spaces. This hopefully should alleviate the flaky diff issue.

![](https://cl.ly/1e597542b12b/Image%202019-02-11%20at%203.35.46%20PM.png)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
