### PR TITLE
Make sure all logs forwarded on UDP are separated with LF characters

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -46,7 +46,9 @@ type ProcessingRule struct {
 type LogsConfig struct {
 	Type string
 
-	Port int    // Network
+	Port             int  // Network
+	SplitPerDatagram bool `mapstructure:"split_per_datagram" json:"split_per_datagram"` // Network
+
 	Path string // File, Journald
 
 	IncludeUnits []string `mapstructure:"include_units" json:"include_units"` // Journald

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -46,9 +46,7 @@ type ProcessingRule struct {
 type LogsConfig struct {
 	Type string
 
-	Port             int  // Network
-	SplitPerDatagram bool `mapstructure:"split_per_datagram" json:"split_per_datagram"` // Network
-
+	Port int    // Network
 	Path string // File, Journald
 
 	IncludeUnits []string `mapstructure:"include_units" json:"include_units"` // Journald

--- a/pkg/logs/input/listener/udp.go
+++ b/pkg/logs/input/listener/udp.go
@@ -98,6 +98,13 @@ func (l *UDPListener) read(tailer *Tailer) ([]byte, error) {
 			// Adding '\n' ensures that the message will correctly be decoded later on and not mixed the following message.
 			frame[l.frameSize] = '\n'
 		}
+		if l.source.Config.SplitPerDatagram {
+			// make sure all logs are separated by line feeds, otherwise they don't get properly split downstream
+			if n > 0 && frame[n-1] != '\n' {
+				frame[n] = '\n'
+				n++
+			}
+		}
 		return frame[:n], nil
 	}
 }

--- a/pkg/logs/input/listener/udp.go
+++ b/pkg/logs/input/listener/udp.go
@@ -93,17 +93,14 @@ func (l *UDPListener) read(tailer *Tailer) ([]byte, error) {
 		go l.resetTailer()
 		return nil, err
 	default:
-		if n == l.frameSize+1 {
-			// The message is bigger than the length of the read buffer, the trailing part of the content will be dropped.
-			// Adding '\n' ensures that the message will correctly be decoded later on and not mixed the following message.
+		// make sure all logs are separated by line feeds, otherwise they don't get properly split downstream
+		if n > l.frameSize {
+			// the message is bigger than the length of the read buffer,
+			// the trailing part of the content will be dropped.
 			frame[l.frameSize] = '\n'
-		}
-		if l.source.Config.SplitPerDatagram {
-			// make sure all logs are separated by line feeds, otherwise they don't get properly split downstream
-			if n > 0 && frame[n-1] != '\n' {
-				frame[n] = '\n'
-				n++
-			}
+		} else if n > 0 && frame[n-1] != '\n' {
+			frame[n] = '\n'
+			n++
 		}
 		return frame[:n], nil
 	}

--- a/pkg/logs/input/listener/udp_nix_test.go
+++ b/pkg/logs/input/listener/udp_nix_test.go
@@ -20,6 +20,41 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline/mock"
 )
 
+func TestUDPShoulProperlyCollectLogSplitPerDatadgram(t *testing.T) {
+	pp := mock.NewMockProvider()
+	msgChan := pp.NextPipelineChan()
+	frameSize := 100
+	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
+	listener.Start()
+
+	conn, err := net.Dial("udp", fmt.Sprintf("%s", listener.tailer.conn.LocalAddr()))
+	assert.Nil(t, err)
+
+	var msg *message.Message
+
+	fmt.Fprintf(conn, strings.Repeat("a", 10))
+	msg = <-msgChan
+	assert.Equal(t, strings.Repeat("a", 10), string(msg.Content))
+
+	fmt.Fprintf(conn, strings.Repeat("a", 10)+"\n")
+	msg = <-msgChan
+	assert.Equal(t, strings.Repeat("a", 10), string(msg.Content))
+
+	fmt.Fprintf(conn, strings.Repeat("a", 10)+"\n"+strings.Repeat("a", 10))
+	msg = <-msgChan
+	assert.Equal(t, strings.Repeat("a", 10), string(msg.Content))
+	msg = <-msgChan
+	assert.Equal(t, strings.Repeat("a", 10), string(msg.Content))
+
+	fmt.Fprintf(conn, strings.Repeat("a", 10)+"\n"+strings.Repeat("a", 10)+"\n")
+	msg = <-msgChan
+	assert.Equal(t, strings.Repeat("a", 10), string(msg.Content))
+	msg = <-msgChan
+	assert.Equal(t, strings.Repeat("a", 10), string(msg.Content))
+
+	listener.Stop()
+}
+
 func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 	pp := mock.NewMockProvider()
 	msgChan := pp.NextPipelineChan()
@@ -32,15 +67,15 @@ func TestUDPShouldProperlyTruncateBigMessages(t *testing.T) {
 
 	var msg *message.Message
 
-	fmt.Fprintf(conn, strings.Repeat("a", frameSize-10)+"\n")
+	fmt.Fprintf(conn, strings.Repeat("a", frameSize-10))
 	msg = <-msgChan
 	assert.Equal(t, strings.Repeat("a", frameSize-10), string(msg.Content))
 
-	fmt.Fprintf(conn, strings.Repeat("a", frameSize)+"\n")
+	fmt.Fprintf(conn, strings.Repeat("a", frameSize))
 	msg = <-msgChan
 	assert.Equal(t, strings.Repeat("a", frameSize), string(msg.Content))
 
-	fmt.Fprintf(conn, strings.Repeat("a", frameSize+10)+"\n")
+	fmt.Fprintf(conn, strings.Repeat("a", frameSize+10))
 	msg = <-msgChan
 	assert.Equal(t, strings.Repeat("a", frameSize), string(msg.Content))
 
@@ -72,52 +107,6 @@ func TestUDPShoulDropTooBigMessages(t *testing.T) {
 	fmt.Fprintf(conn, strings.Repeat("a", maxUDPFrameLen-200)+"\n")
 	msg = <-msgChan
 	assert.Equal(t, strings.Repeat("a", maxUDPFrameLen-200), string(msg.Content))
-
-	listener.Stop()
-}
-
-func TestUDPShoulProperlyCollectLogSplitPerDatadgram(t *testing.T) {
-	pp := mock.NewMockProvider()
-	msgChan := pp.NextPipelineChan()
-	frameSize := 100
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort, SplitPerDatagram: true}), frameSize)
-	listener.Start()
-
-	conn, err := net.Dial("udp", fmt.Sprintf("%s", listener.tailer.conn.LocalAddr()))
-	assert.Nil(t, err)
-
-	var msg *message.Message
-
-	fmt.Fprintf(conn, strings.Repeat("a", frameSize-10))
-	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", frameSize-10), string(msg.Content))
-
-	fmt.Fprintf(conn, strings.Repeat("a", frameSize-10))
-	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", frameSize-10), string(msg.Content))
-
-	listener.Stop()
-}
-
-func TestUDPShoulProperlyCollectLogSplitPerLineFeed(t *testing.T) {
-	pp := mock.NewMockProvider()
-	msgChan := pp.NextPipelineChan()
-	frameSize := 100
-	listener := NewUDPListener(pp, config.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), frameSize)
-	listener.Start()
-
-	conn, err := net.Dial("udp", fmt.Sprintf("%s", listener.tailer.conn.LocalAddr()))
-	assert.Nil(t, err)
-
-	var msg *message.Message
-
-	fmt.Fprintf(conn, strings.Repeat("a", frameSize-10))
-	fmt.Fprintf(conn, "\n"+strings.Repeat("a", frameSize-10)+"\n")
-	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", frameSize-10), string(msg.Content))
-
-	msg = <-msgChan
-	assert.Equal(t, strings.Repeat("a", frameSize-10), string(msg.Content))
 
 	listener.Stop()
 }

--- a/releasenotes/notes/logs-fix-udp-forwarder-without-lf-788bd5b4d88d0ba5.yaml
+++ b/releasenotes/notes/logs-fix-udp-forwarder-without-lf-788bd5b4d88d0ba5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed bug where logs forwarded by UDP would not be splitted because of missing line feed character.

--- a/releasenotes/notes/logs-fix-udp-forwarder-without-lf-788bd5b4d88d0ba5.yaml
+++ b/releasenotes/notes/logs-fix-udp-forwarder-without-lf-788bd5b4d88d0ba5.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Fixed a bug where logs forwarded by UDP would not be split because of missing line feed character at the end of a datagram.
-    Now adding a line feed character at the end of each frame is deprecated because it is automacilly added by the agent on read operations.
+    Now adding a line feed character at the end of each frame is deprecated because it is automatically added by the agent on read operations.

--- a/releasenotes/notes/logs-fix-udp-forwarder-without-lf-788bd5b4d88d0ba5.yaml
+++ b/releasenotes/notes/logs-fix-udp-forwarder-without-lf-788bd5b4d88d0ba5.yaml
@@ -8,4 +8,5 @@
 ---
 fixes:
   - |
-    Fixed bug where logs forwarded by UDP would not be splitted because of missing line feed character.
+    Fixed a bug where logs forwarded by UDP would not be split because of missing line feed character at the end of a datagram.
+    Now adding a line feed character at the end of each frame is deprecated because it is automacilly added by the agent on read operations.


### PR DESCRIPTION
### What does this PR do?

Added a new option to logs-integration config to make sure that logs forwarded by UDP can be properly decoded when one diagram is equal to one log.

### Motivation

Collect logs from sent from cisco routers for example

### Additional Notes

Anything else we should know when reviewing?
