### PR TITLE
use pointers to pass events and service checks to the aggregator

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -188,7 +188,7 @@ func StartAgent() error {
 	// start dogstatsd
 	if config.Datadog.GetBool("use_dogstatsd") {
 		var err error
-		common.DSD, err = dogstatsd.NewServer(agg.GetChannels())
+		common.DSD, err = dogstatsd.NewServer(agg.GetBufferedChannels())
 		if err != nil {
 			log.Errorf("Could not start dogstatsd: %s", err)
 		}

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -184,7 +184,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	aggregatorInstance := aggregator.InitAggregator(s, hname, "agent")
-	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
+	statsd, err := dogstatsd.NewServer(aggregatorInstance.GetBufferedChannels())
 	if err != nil {
 		log.Criticalf("Unable to start dogstatsd: %s", err)
 		return nil

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -57,14 +57,14 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 	resetAggregator()
 	agg := InitAggregator(nil, "resolved-hostname", "agent")
 
-	agg.addServiceCheck(metrics.ServiceCheck{
+	agg.addServiceCheck(&metrics.ServiceCheck{
 		// leave Host and Ts fields blank
 		CheckName: "my_service.can_connect",
 		Status:    metrics.ServiceCheckOK,
 		Tags:      []string{"bar", "foo", "bar"},
 		Message:   "message",
 	})
-	agg.addServiceCheck(metrics.ServiceCheck{
+	agg.addServiceCheck(&metrics.ServiceCheck{
 		CheckName: "my_service.can_connect",
 		Status:    metrics.ServiceCheckOK,
 		Host:      "my-hostname",
@@ -86,12 +86,12 @@ func TestAddEventDefaultValues(t *testing.T) {
 	resetAggregator()
 	agg := InitAggregator(nil, "resolved-hostname", "agent")
 
-	agg.addEvent(metrics.Event{
+	agg.addEvent(&metrics.Event{
 		// only populate required fields
 		Title: "An event occurred",
 		Text:  "Event description",
 	})
-	agg.addEvent(metrics.Event{
+	agg.addEvent(&metrics.Event{
 		// populate all fields
 		Title:          "Another event occurred",
 		Text:           "Other event description",

--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -60,8 +60,8 @@ type checkSender struct {
 	metricStats             metricStats
 	priormetricStats        metricStats
 	smsOut                  chan<- senderMetricSample
-	serviceCheckOut         chan<- metrics.ServiceCheck
-	eventOut                chan<- metrics.Event
+	serviceCheckOut         chan<- *metrics.ServiceCheck
+	eventOut                chan<- *metrics.Event
 	checkTags               []string
 }
 
@@ -82,7 +82,7 @@ func init() {
 	}
 }
 
-func newCheckSender(id check.ID, defaultHostname string, smsOut chan<- senderMetricSample, serviceCheckOut chan<- metrics.ServiceCheck, eventOut chan<- metrics.Event) *checkSender {
+func newCheckSender(id check.ID, defaultHostname string, smsOut chan<- senderMetricSample, serviceCheckOut chan<- *metrics.ServiceCheck, eventOut chan<- *metrics.Event) *checkSender {
 	return &checkSender{
 		id:               id,
 		defaultHostname:  defaultHostname,
@@ -266,13 +266,13 @@ func (s *checkSender) Historate(metric string, value float64, hostname string, t
 // SendRawServiceCheck sends the raw service check
 // Useful for testing - submitting precomputed service check.
 func (s *checkSender) SendRawServiceCheck(sc *metrics.ServiceCheck) {
-	s.serviceCheckOut <- *sc
+	s.serviceCheckOut <- sc
 }
 
 // ServiceCheck submits a service check
 func (s *checkSender) ServiceCheck(checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string) {
 	log.Trace("Service check submitted: ", checkName, ": ", status.String(), " for hostname: ", hostname, " tags: ", tags)
-	serviceCheck := metrics.ServiceCheck{
+	serviceCheck := &metrics.ServiceCheck{
 		CheckName: checkName,
 		Status:    status,
 		Host:      hostname,
@@ -302,7 +302,7 @@ func (s *checkSender) Event(e metrics.Event) {
 		e.Host = s.defaultHostname
 	}
 
-	s.eventOut <- e
+	s.eventOut <- &e
 
 	s.metricStats.Lock.Lock()
 	s.metricStats.Events++

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -108,8 +108,8 @@ func TestGetAndSetSender(t *testing.T) {
 	InitAggregator(nil, "", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
-	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-	eventChan := make(chan metrics.Event, 10)
+	serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+	eventChan := make(chan *metrics.Event, 10)
 	testCheckSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
 
 	err := SetSender(testCheckSender, checkID1)
@@ -139,8 +139,8 @@ func TestGetSenderAddCheckCustomTagsMetrics(t *testing.T) {
 	InitAggregator(nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
-	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-	eventChan := make(chan metrics.Event, 10)
+	serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+	eventChan := make(chan *metrics.Event, 10)
 	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
 
 	// no custom tags
@@ -175,8 +175,8 @@ func TestGetSenderAddCheckCustomTagsService(t *testing.T) {
 	InitAggregator(nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
-	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-	eventChan := make(chan metrics.Event, 10)
+	serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+	eventChan := make(chan *metrics.Event, 10)
 	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
 
 	// no custom tags
@@ -211,8 +211,8 @@ func TestGetSenderAddCheckCustomTagsEvent(t *testing.T) {
 	InitAggregator(nil, "testhostname", "")
 
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
-	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-	eventChan := make(chan metrics.Event, 10)
+	serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+	eventChan := make(chan *metrics.Event, 10)
 	checkSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan)
 
 	event := metrics.Event{
@@ -255,8 +255,8 @@ func TestGetSenderAddCheckCustomTagsEvent(t *testing.T) {
 
 func TestCheckSenderInterface(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
-	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-	eventChan := make(chan metrics.Event, 10)
+	serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+	eventChan := make(chan *metrics.Event, 10)
 	checkSender := newCheckSender(checkID1, "default-hostname", senderMetricSampleChan, serviceCheckChan, eventChan)
 	checkSender.Gauge("my.metric", 1.0, "my-hostname", []string{"foo", "bar"})
 	checkSender.Rate("my.rate_metric", 2.0, "my-hostname", []string{"foo", "bar"})
@@ -322,7 +322,7 @@ func TestCheckSenderInterface(t *testing.T) {
 	assert.Equal(t, "message", serviceCheck.Message)
 
 	event := <-eventChan
-	assert.Equal(t, submittedEvent, event)
+	assert.Equal(t, submittedEvent, *event)
 }
 
 func TestCheckSenderHostname(t *testing.T) {
@@ -356,8 +356,8 @@ func TestCheckSenderHostname(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("case %d: %q -> %q", nb, tc.submittedHostname, tc.expectedHostname), func(t *testing.T) {
 			senderMetricSampleChan := make(chan senderMetricSample, 10)
-			serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-			eventChan := make(chan metrics.Event, 10)
+			serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+			eventChan := make(chan *metrics.Event, 10)
 			checkSender := newCheckSender(checkID1, defaultHostname, senderMetricSampleChan, serviceCheckChan, eventChan)
 			checkSender.DisableDefaultHostname(tc.defaultHostnameDisabled)
 
@@ -401,8 +401,8 @@ func TestCheckSenderHostname(t *testing.T) {
 
 func TestChangeAllSendersDefaultHostname(t *testing.T) {
 	senderMetricSampleChan := make(chan senderMetricSample, 10)
-	serviceCheckChan := make(chan metrics.ServiceCheck, 10)
-	eventChan := make(chan metrics.Event, 10)
+	serviceCheckChan := make(chan *metrics.ServiceCheck, 10)
+	eventChan := make(chan *metrics.Event, 10)
 	checkSender := newCheckSender(checkID1, "hostname1", senderMetricSampleChan, serviceCheckChan, eventChan)
 	SetSender(checkSender, checkID1)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,8 +190,10 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
 	// Dogstatsd
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
-	config.BindEnvAndSetDefault("dogstatsd_port", 8125)          // Notice: 0 means UDP port closed
-	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8) // 8KB buffer
+	config.BindEnvAndSetDefault("dogstatsd_port", 8125)                                        // Notice: 0 means UDP port closed
+	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)                               // 8KB buffer
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 4096)                          // Number of packets to buffer at dogstatsd intake before flushing them to parsing/aggregation
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_flush_timeout", 100*time.Millisecond) // Timeout after which we force dogstatsd intake buffer to be flushed
 	config.BindEnvAndSetDefault("dogstatsd_non_local_traffic", false)
 	config.BindEnvAndSetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
 	config.BindEnvAndSetDefault("dogstatsd_stats_port", 5000)

--- a/pkg/dogstatsd/README.md
+++ b/pkg/dogstatsd/README.md
@@ -13,7 +13,7 @@ Usage example:
 // you must first initialize the aggregator, see aggregator.InitAggregator
 
 // This will return an already running statd server ready to receive metrics
-statsd, err := dogstatsd.NewServer(aggregatorInstance.GetChannels())
+statsd, err := dogstatsd.NewServer(aggregatorInstance.GetBufferedChannels())
 
 // ...
 

--- a/pkg/dogstatsd/listeners/packet_buffer.go
+++ b/pkg/dogstatsd/listeners/packet_buffer.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package listeners
+
+import (
+	"sync"
+	"time"
+)
+
+type packetBuffer struct {
+	packets       Packets
+	flushTimer    *time.Ticker
+	bufferSize    uint
+	outputChannel chan Packets
+	closeChannel  chan struct{}
+	m             sync.Mutex
+}
+
+func newPacketBuffer(bufferSize uint, flushTimer time.Duration, outputChannel chan Packets) *packetBuffer {
+	pb := &packetBuffer{
+		bufferSize:    bufferSize,
+		flushTimer:    time.NewTicker(flushTimer),
+		outputChannel: outputChannel,
+		packets:       make(Packets, 0, bufferSize),
+		closeChannel:  make(chan struct{}),
+	}
+	go pb.flushLoop()
+	return pb
+}
+
+func (pb *packetBuffer) flushLoop() {
+	for {
+		select {
+		case <-pb.flushTimer.C:
+			pb.m.Lock()
+			pb.flush()
+			pb.m.Unlock()
+		case <-pb.closeChannel:
+			return
+		}
+	}
+}
+
+func (pb *packetBuffer) append(packet *Packet) {
+	pb.m.Lock()
+	defer pb.m.Unlock()
+	pb.packets = append(pb.packets, packet)
+	if uint(len(pb.packets)) == pb.bufferSize {
+		pb.flush()
+	}
+}
+
+func (pb *packetBuffer) flush() {
+	if len(pb.packets) > 0 {
+		pb.outputChannel <- pb.packets
+		pb.packets = make(Packets, 0, pb.bufferSize)
+	}
+}
+
+func (pb *packetBuffer) close() {
+	close(pb.closeChannel)
+}

--- a/pkg/dogstatsd/listeners/types.go
+++ b/pkg/dogstatsd/listeners/types.go
@@ -17,6 +17,9 @@ type Packet struct {
 	Origin   string // Origin container if identified
 }
 
+// Packets is a slice of packet pointers
+type Packets []*Packet
+
 // StatsdListener opens a communication channel to get statsd packets in.
 type StatsdListener interface {
 	Listen()

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -32,13 +32,14 @@ func init() {
 // processed.
 // Origin detection is not implemented for UDP.
 type UDPListener struct {
-	conn       net.PacketConn
-	packetPool *PacketPool
-	packetOut  chan *Packet
+	conn         net.PacketConn
+	packetPool   *PacketPool
+	packetOut    chan Packets
+	packetBuffer *packetBuffer
 }
 
 // NewUDPListener returns an idle UDP Statsd listener
-func NewUDPListener(packetOut chan *Packet, packetPool *PacketPool) (*UDPListener, error) {
+func NewUDPListener(packetOut chan Packets, packetPool *PacketPool) (*UDPListener, error) {
 	var conn net.PacketConn
 	var err error
 	var url string
@@ -66,6 +67,8 @@ func NewUDPListener(packetOut chan *Packet, packetPool *PacketPool) (*UDPListene
 		packetOut:  packetOut,
 		packetPool: packetPool,
 		conn:       conn,
+		packetBuffer: newPacketBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),
+			config.Datadog.GetDuration("dogstatsd_packet_buffer_flush_timeout"), packetOut),
 	}
 	log.Debugf("dogstatsd-udp: %s successfully initialized", conn.LocalAddr())
 	return listener, nil
@@ -90,11 +93,12 @@ func (l *UDPListener) Listen() {
 		}
 
 		packet.Contents = packet.buffer[:n]
-		l.packetOut <- packet
+		l.packetBuffer.append(packet)
 	}
 }
 
 // Stop closes the UDP connection and stops listening
 func (l *UDPListener) Stop() {
+	l.packetBuffer.close()
 	l.conn.Close()
 }

--- a/pkg/dogstatsd/listeners/udp.go
+++ b/pkg/dogstatsd/listeners/udp.go
@@ -34,7 +34,6 @@ func init() {
 type UDPListener struct {
 	conn         net.PacketConn
 	packetPool   *PacketPool
-	packetOut    chan Packets
 	packetBuffer *packetBuffer
 }
 
@@ -64,7 +63,6 @@ func NewUDPListener(packetOut chan Packets, packetPool *PacketPool) (*UDPListene
 	}
 
 	listener := &UDPListener{
-		packetOut:  packetOut,
 		packetPool: packetPool,
 		conn:       conn,
 		packetBuffer: newPacketBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),

--- a/pkg/dogstatsd/listeners/udp_test.go
+++ b/pkg/dogstatsd/listeners/udp_test.go
@@ -117,7 +117,7 @@ func TestUDPReceive(t *testing.T) {
 	require.Nil(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	packetChannel := make(chan *Packet)
+	packetChannel := make(chan Packets)
 	s, err := NewUDPListener(packetChannel, packetPoolUDP)
 	require.NotNil(t, s)
 	assert.Nil(t, err)
@@ -131,8 +131,10 @@ func TestUDPReceive(t *testing.T) {
 	conn.Write(contents)
 
 	select {
-	case packet := <-packetChannel:
+	case packets := <-packetChannel:
+		packet := packets[0]
 		assert.NotNil(t, packet)
+		assert.Equal(t, 1, len(packets))
 		assert.Equal(t, contents, packet.Contents)
 		assert.Equal(t, "", packet.Origin)
 	case <-time.After(2 * time.Second):

--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -38,7 +38,6 @@ func init() {
 // Origin detection will be implemented for UDS.
 type UDSListener struct {
 	conn            *net.UnixConn
-	packetOut       chan Packets
 	packetBuffer    *packetBuffer
 	packetPool      *PacketPool
 	oobPool         *sync.Pool // For origin detection ancilary data
@@ -95,7 +94,6 @@ func NewUDSListener(packetOut chan Packets, packetPool *PacketPool) (*UDSListene
 
 	listener := &UDSListener{
 		OriginDetection: originDetection,
-		packetOut:       packetOut,
 		packetPool:      packetPool,
 		conn:            conn,
 		packetBuffer: newPacketBuffer(uint(config.Datadog.GetInt("dogstatsd_packet_buffer_size")),

--- a/pkg/dogstatsd/listeners/uds_common_test.go
+++ b/pkg/dogstatsd/listeners/uds_common_test.go
@@ -105,8 +105,8 @@ func TestUDSReceive(t *testing.T) {
 
 	var contents = []byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2")
 
-	packetChannel := make(chan *Packet)
-	s, err := NewUDSListener(packetChannel, packetPoolUDS)
+	packetsChannel := make(chan Packets)
+	s, err := NewUDSListener(packetsChannel, packetPoolUDS)
 	assert.Nil(t, err)
 	assert.NotNil(t, s)
 
@@ -118,8 +118,10 @@ func TestUDSReceive(t *testing.T) {
 	conn.Write(contents)
 
 	select {
-	case packet := <-packetChannel:
+	case packets := <-packetsChannel:
+		packet := packets[0]
 		assert.NotNil(t, packet)
+		assert.Equal(t, 1, len(packets))
 		assert.Equal(t, packet.Contents, contents)
 		assert.Equal(t, packet.Origin, "")
 	case <-time.After(2 * time.Second):

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -46,7 +46,7 @@ func init() {
 // Server represent a Dogstatsd server
 type Server struct {
 	listeners        []listeners.StatsdListener
-	packetIn         chan *listeners.Packet
+	packetsIn        chan listeners.Packets
 	Statistics       *util.Stats
 	Started          bool
 	packetPool       *listeners.PacketPool
@@ -72,13 +72,13 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 	}
 
-	packetChannel := make(chan *listeners.Packet, 100)
+	packetsChannel := make(chan listeners.Packets, 100)
 	packetPool := listeners.NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
 	tmpListeners := make([]listeners.StatsdListener, 0, 2)
 
 	socketPath := config.Datadog.GetString("dogstatsd_socket")
 	if len(socketPath) > 0 {
-		unixListener, err := listeners.NewUDSListener(packetChannel, packetPool)
+		unixListener, err := listeners.NewUDSListener(packetsChannel, packetPool)
 		if err != nil {
 			log.Errorf(err.Error())
 		} else {
@@ -86,7 +86,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		}
 	}
 	if config.Datadog.GetInt("dogstatsd_port") > 0 {
-		udpListener, err := listeners.NewUDPListener(packetChannel, packetPool)
+		udpListener, err := listeners.NewUDPListener(packetsChannel, packetPool)
 		if err != nil {
 			log.Errorf(err.Error())
 		} else {
@@ -117,7 +117,7 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 	s := &Server{
 		Started:          true,
 		Statistics:       stats,
-		packetIn:         packetChannel,
+		packetsIn:        packetsChannel,
 		listeners:        tmpListeners,
 		packetPool:       packetPool,
 		stopChan:         make(chan bool),
@@ -141,8 +141,8 @@ func NewServer(metricOut chan<- *metrics.MetricSample, eventOut chan<- metrics.E
 		if err != nil {
 			log.Warnf("Could not connect to statsd forward host : %s", err)
 		} else {
-			s.packetIn = make(chan *listeners.Packet, 100)
-			go s.forwarder(con, packetChannel)
+			s.packetsIn = make(chan listeners.Packets, 100)
+			go s.forwarder(con, packetsChannel)
 		}
 	}
 
@@ -173,19 +173,20 @@ func (s *Server) handleMessages(metricOut chan<- *metrics.MetricSample, eventOut
 	}
 }
 
-func (s *Server) forwarder(fcon net.Conn, packetChannel chan *listeners.Packet) {
+func (s *Server) forwarder(fcon net.Conn, packetsChannel chan listeners.Packets) {
 	for {
 		select {
 		case <-s.stopChan:
 			return
-		case packet := <-packetChannel:
-			_, err := fcon.Write(packet.Contents)
+		case packets := <-packetsChannel:
+			for _, packet := range packets {
+				_, err := fcon.Write(packet.Contents)
 
-			if err != nil {
-				log.Warnf("Forwarding packet failed : %s", err)
+				if err != nil {
+					log.Warnf("Forwarding packet failed : %s", err)
+				}
 			}
-
-			s.packetIn <- packet
+			s.packetsIn <- packets
 		}
 	}
 }
@@ -196,8 +197,10 @@ func (s *Server) worker(metricOut chan<- *metrics.MetricSample, eventOut chan<- 
 		case <-s.stopChan:
 			return
 		case <-s.health.C:
-		case packet := <-s.packetIn:
-			s.handlePacket(packet, metricOut, eventOut, serviceCheckOut)
+		case packets := <-s.packetsIn:
+			for _, packet := range packets {
+				s.handlePacket(packet, metricOut, eventOut, serviceCheckOut)
+			}
 		}
 	}
 }

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -80,9 +80,9 @@ func TestUPDReceive(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	metricOut := make(chan *metrics.MetricSample)
-	eventOut := make(chan metrics.Event)
-	serviceOut := make(chan metrics.ServiceCheck)
+	metricOut := make(chan []*metrics.MetricSample)
+	eventOut := make(chan []*metrics.Event)
+	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
@@ -96,47 +96,55 @@ func TestUPDReceive(t *testing.T) {
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon")
-		assert.EqualValues(t, res.Value, 666.0)
-		assert.Equal(t, res.Mtype, metrics.GaugeType)
-		assert.ElementsMatch(t, res.Tags, []string{"sometag1:somevalue1", "sometag2:somevalue2"})
-	case <-time.After(2 * time.Second):
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon")
+		assert.EqualValues(t, sample.Value, 666.0)
+		assert.Equal(t, sample.Mtype, metrics.GaugeType)
+		assert.ElementsMatch(t, sample.Tags, []string{"sometag1:somevalue1", "sometag2:somevalue2"})
+	case <-time.After(100 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
 
 	conn.Write([]byte("daemon:666|c|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon")
-		assert.EqualValues(t, res.Value, 666.0)
-		assert.Equal(t, metrics.CounterType, res.Mtype)
-		assert.Equal(t, 0.5, res.SampleRate)
-	case <-time.After(2 * time.Second):
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon")
+		assert.EqualValues(t, sample.Value, 666.0)
+		assert.Equal(t, metrics.CounterType, sample.Mtype)
+		assert.Equal(t, 0.5, sample.SampleRate)
+	case <-time.After(100 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
 
 	conn.Write([]byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon")
-		assert.EqualValues(t, res.Value, 666.0)
-		assert.Equal(t, metrics.HistogramType, res.Mtype)
-		assert.Equal(t, 0.5, res.SampleRate)
-	case <-time.After(2 * time.Second):
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon")
+		assert.EqualValues(t, sample.Value, 666.0)
+		assert.Equal(t, metrics.HistogramType, sample.Mtype)
+		assert.Equal(t, 0.5, sample.SampleRate)
+	case <-time.After(100 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
 
 	conn.Write([]byte("daemon:666|ms|@0.5|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon")
-		assert.EqualValues(t, res.Value, 666.0)
-		assert.Equal(t, metrics.HistogramType, res.Mtype)
-		assert.Equal(t, 0.5, res.SampleRate)
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon")
+		assert.EqualValues(t, sample.Value, 666.0)
+		assert.Equal(t, metrics.HistogramType, sample.Mtype)
+		assert.Equal(t, 0.5, sample.SampleRate)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
@@ -144,10 +152,12 @@ func TestUPDReceive(t *testing.T) {
 	conn.Write([]byte("daemon_set:abc|s|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon_set")
-		assert.Equal(t, res.RawValue, "abc")
-		assert.Equal(t, res.Mtype, metrics.SetType)
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon_set")
+		assert.Equal(t, sample.RawValue, "abc")
+		assert.Equal(t, sample.Mtype, metrics.SetType)
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
@@ -156,8 +166,11 @@ func TestUPDReceive(t *testing.T) {
 	conn.Write([]byte("daemon1:666:777|g\ndaemon2:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon2")
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon2")
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
@@ -175,8 +188,10 @@ func TestUPDReceive(t *testing.T) {
 	conn.Write([]byte("_sc|agen.down\n_sc|agent.up|0|d:12345|h:localhost|m:this is fine|#sometag1:somevalyyue1,sometag2:somevalue2"))
 	select {
 	case res := <-serviceOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.CheckName, "agent.up")
+		assert.Equal(t, 1, len(res))
+		serviceCheck := res[0]
+		assert.NotNil(t, serviceCheck)
+		assert.Equal(t, serviceCheck.CheckName, "agent.up")
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
@@ -185,8 +200,9 @@ func TestUPDReceive(t *testing.T) {
 	conn.Write([]byte("_e{10,10}:test title|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
 	select {
 	case res := <-eventOut:
-		assert.NotNil(t, res)
-		assert.ElementsMatch(t, res.Tags, []string{"tag1", "tag2:test"})
+		event := res[0]
+		assert.NotNil(t, event)
+		assert.ElementsMatch(t, event.Tags, []string{"tag1", "tag2:test"})
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
@@ -195,8 +211,10 @@ func TestUPDReceive(t *testing.T) {
 	conn.Write([]byte("_e{10,0}:test title|\n_e{11,10}:test title2|test\\ntext|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
 	select {
 	case res := <-eventOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Title, "test title2")
+		assert.Equal(t, 1, len(res))
+		event := res[0]
+		assert.NotNil(t, event)
+		assert.Equal(t, event.Title, "test title2")
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}
@@ -221,9 +239,9 @@ func TestUDPForward(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	metricOut := make(chan *metrics.MetricSample)
-	eventOut := make(chan metrics.Event)
-	serviceOut := make(chan metrics.ServiceCheck)
+	metricOut := make(chan []*metrics.MetricSample)
+	eventOut := make(chan []*metrics.Event)
+	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
@@ -258,9 +276,9 @@ func TestHistToDist(t *testing.T) {
 	config.Datadog.SetDefault("histogram_copy_to_distribution_prefix", "dist.")
 	defer config.Datadog.SetDefault("histogram_copy_to_distribution_prefix", "")
 
-	metricOut := make(chan *metrics.MetricSample)
-	eventOut := make(chan metrics.Event)
-	serviceOut := make(chan metrics.ServiceCheck)
+	metricOut := make(chan []*metrics.MetricSample)
+	eventOut := make(chan []*metrics.Event)
+	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
@@ -273,17 +291,15 @@ func TestHistToDist(t *testing.T) {
 	// Test metric
 	conn.Write([]byte("daemon:666|h|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
-	case histMetric := <-metricOut:
+	case histMetrics := <-metricOut:
+		assert.Equal(t, 2, len(histMetrics))
+		histMetric := histMetrics[0]
+		distMetric := histMetrics[1]
 		assert.NotNil(t, histMetric)
 		assert.Equal(t, histMetric.Name, "daemon")
 		assert.EqualValues(t, histMetric.Value, 666.0)
 		assert.Equal(t, metrics.HistogramType, histMetric.Mtype)
-	case <-time.After(2 * time.Second):
-		assert.FailNow(t, "Timeout on receive channel")
-	}
 
-	select {
-	case distMetric := <-metricOut:
 		assert.NotNil(t, distMetric)
 		assert.Equal(t, distMetric.Name, "dist.daemon")
 		assert.EqualValues(t, distMetric.Value, 666.0)
@@ -300,9 +316,9 @@ func TestExtraTags(t *testing.T) {
 	config.Datadog.SetDefault("dogstatsd_tags", []string{"sometag3:somevalue3"})
 	defer config.Datadog.SetDefault("dogstatsd_tags", []string{})
 
-	metricOut := make(chan *metrics.MetricSample)
-	eventOut := make(chan metrics.Event)
-	serviceOut := make(chan metrics.ServiceCheck)
+	metricOut := make(chan []*metrics.MetricSample)
+	eventOut := make(chan []*metrics.Event)
+	serviceOut := make(chan []*metrics.ServiceCheck)
 	s, err := NewServer(metricOut, eventOut, serviceOut)
 	require.NoError(t, err, "cannot start DSD")
 	defer s.Stop()
@@ -316,11 +332,13 @@ func TestExtraTags(t *testing.T) {
 	conn.Write([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"))
 	select {
 	case res := <-metricOut:
-		assert.NotNil(t, res)
-		assert.Equal(t, res.Name, "daemon")
-		assert.EqualValues(t, res.Value, 666.0)
-		assert.Equal(t, res.Mtype, metrics.GaugeType)
-		assert.ElementsMatch(t, res.Tags, []string{"sometag1:somevalue1", "sometag2:somevalue2", "sometag3:somevalue3"})
+		assert.Equal(t, 1, len(res))
+		sample := res[0]
+		assert.NotNil(t, sample)
+		assert.Equal(t, sample.Name, "daemon")
+		assert.EqualValues(t, sample.Value, 666.0)
+		assert.Equal(t, sample.Mtype, metrics.GaugeType)
+		assert.ElementsMatch(t, sample.Tags, []string{"sometag1:somevalue1", "sometag2:somevalue2", "sometag3:somevalue3"})
 	case <-time.After(2 * time.Second):
 		assert.FailNow(t, "Timeout on receive channel")
 	}

--- a/releasenotes/notes/import-dogstatsd-perf-channels-3d0f06b26abe3403.yaml
+++ b/releasenotes/notes/import-dogstatsd-perf-channels-3d0f06b26abe3403.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The performance of the Agent under DogStatsD load has been improved.

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -228,7 +228,7 @@ func main() {
 	mockConfig.Set("dogstatsd_stats_buffer", 100)
 	s := serializer.NewSerializer(f)
 	aggr := aggregator.InitAggregator(s, "localhost")
-	statsd, err := dogstatsd.NewServer(aggr.GetChannels())
+	statsd, err := dogstatsd.NewServer(aggr.GetBufferedChannels())
 	if err != nil {
 		log.Errorf("Problem allocating dogstatsd server: %s", err)
 		return

--- a/test/integration/dogstatsd/origin_detection.go
+++ b/test/integration/dogstatsd/origin_detection.go
@@ -56,9 +56,9 @@ func testUDSOriginDetection(t *testing.T) {
 	mockConfig.Set("dogstatsd_origin_detection", true)
 
 	// Start DSD
-	packetChannel := make(chan *listeners.Packet)
+	packetsChannel := make(chan listeners.Packets)
 	packetPool := listeners.NewPacketPool(mockConfig.GetInt("dogstatsd_buffer_size"))
-	s, err := listeners.NewUDSListener(packetChannel, packetPool)
+	s, err := listeners.NewUDSListener(packetsChannel, packetPool)
 	require.Nil(t, err)
 
 	go s.Listen()
@@ -85,7 +85,8 @@ func testUDSOriginDetection(t *testing.T) {
 	defer stopCmd.Run()
 
 	select {
-	case packet := <-packetChannel:
+	case packets := <-packetsChannel:
+		packet := packets[0]
 		require.NotNil(t, packet)
 		require.Equal(t, "custom_counter1:1|c", string(packet.Contents))
 		require.Equal(t, fmt.Sprintf("docker://%s", containerId), packet.Origin)


### PR DESCRIPTION
### What does this PR do?

Use pointers to the event and service check struct to pass event and service checks to the aggregator.

### Motivation

Asked in a review https://github.com/DataDog/datadog-agent/pull/2950#discussion_r255449516. Created another PR to avoid polluting the first one.


