### PR TITLE
Fix re-scheduling of the same clusterchecks config on the same node

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -64,7 +64,7 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 	d.store.digestToNode[digest] = targetNodeName
 
 	// Remove config from previous node if found
-	if foundCurrent {
+	if foundCurrent && currentNode != targetNode {
 		currentNode.Lock()
 		currentNode.removeConfig(digest)
 		currentNode.Unlock()
@@ -75,11 +75,12 @@ func (d *dispatcher) removeConfig(digest string) {
 	d.store.Lock()
 	defer d.store.Unlock()
 
+	node, found := d.store.getNodeStore(d.store.digestToNode[digest])
+	delete(d.store.digestToNode, digest)
 	delete(d.store.digestToConfig, digest)
 	delete(d.store.danglingConfigs, digest)
 
 	// Remove from node configs if assigned
-	node, found := d.store.getNodeStore(d.store.digestToNode[digest])
 	if found {
 		node.Lock()
 		node.removeConfig(digest)

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -64,6 +64,9 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 	d.store.digestToNode[digest] = targetNodeName
 
 	// Remove config from previous node if found
+	// We double-check the config actually changed nodes, to
+	// prevent de-scheduling the check we just scheduled.
+	// See https://github.com/DataDog/datadog-agent/pull/3023
 	if foundCurrent && currentNode != targetNode {
 		currentNode.Lock()
 		currentNode.removeConfig(digest)

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -93,7 +93,7 @@ func (s *nodeStore) addConfig(config integration.Config) {
 func (s *nodeStore) removeConfig(digest string) {
 	_, found := s.digestToConfig[digest]
 	if !found {
-		log.Debug("unknown digest %s, skipping", digest)
+		log.Debugf("unknown digest %s, skipping", digest)
 		return
 	}
 	s.lastConfigChange = timestampNow()


### PR DESCRIPTION
### What does this PR do?

In case the exact same cluster-check configuration (same digest) was de-scheduled then re-scheduled (kube_service annotation in my case) and the dispatcher sent it to the same node as before, the configuration was actually not dispatched.

The following happens:
  - upon calling `dispatcher.removeConfig`, the digest was cleaned out of the store on all maps but the `digestToNode` map (holding what node a config is dispatched on)
  - when re-scheduling (with `dispatcher.addConfig`) on the same node, the config was successfully dispatched to the node, then immediately removed, because the digest was already present in the `digestToNode` map (logic used when moving a config from one node to another)

New test `TestDescheduleRescheduleSameNode` is red on master, any of the two changes in this PR make it green, both are required to ensure the logic works as intended:
  - on `removeConfig`, ensure the digest is also removed from the `digestToNode` map
  - on `addConfig`, if `currentNode == targetNode` (should not happen anyway now that the map is consistent), don't de-schedule the check.
