### PR TITLE
Explicit tagging feature

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -8,6 +8,7 @@
 package collectors
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+const (
+	podAnnotationPrefix              = "ad.datadoghq.com/"
+	podContainerTagsAnnotationFormat = podAnnotationPrefix + "%s.tags"
+	podTagsAnnotation                = podAnnotationPrefix + "tags"
 )
 
 // KubeAllowedEncodeStringAlphaNums holds the charactes allowed in replicaset names from as parent deployment
@@ -49,6 +56,11 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		// Pod annotations
 		for name, value := range pod.Metadata.Annotations {
 			if tagName, found := c.annotationsAsTags[strings.ToLower(name)]; found {
+				tags.AddAuto(tagName, value)
+			}
+		}
+		if podTags, found := extractTagsFromMap(podTagsAnnotation, pod.Metadata.Annotations); found {
+			for tagName, value := range podTags {
 				tags.AddAuto(tagName, value)
 			}
 		}
@@ -129,6 +141,17 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 				}
 			}
 
+			// container-specific tags provided through pod annotation
+			containerTags, found := extractTagsFromMap(
+				fmt.Sprintf(podContainerTagsAnnotationFormat, container.Name),
+				pod.Metadata.Annotations,
+			)
+			if found {
+				for tagName, value := range containerTags {
+					cTags.AddAuto(tagName, value)
+				}
+			}
+
 			cLow, cOrch, cHigh := cTags.Compute()
 			info := &TagInfo{
 				Source:               kubeletCollectorName,
@@ -163,4 +186,38 @@ func (c *KubeletCollector) parseDeploymentForReplicaset(name string) string {
 	}
 
 	return name[:lastDash]
+}
+
+// extractTagsFromMap extracts tags contained in a JSON string stored at the
+// given key. If no valid tag definition is found at this key, it will return
+// false. Otherwise it returns a map containing extracted tags.
+func extractTagsFromMap(key string, input map[string]string) (map[string]string, bool) {
+	jsonTags, found := input[key]
+	if !found {
+		return nil, false
+	}
+
+	tags, err := parseJSONValue(jsonTags)
+	if err != nil {
+		log.Errorf("can't parse value for annotation %s: %s", key, err)
+		return nil, false
+	}
+
+	return tags, true
+}
+
+// parseJSONValue returns a map from the given JSON string.
+func parseJSONValue(value string) (map[string]string, error) {
+	if value == "" {
+		return nil, fmt.Errorf("value is empty")
+	}
+
+	var result map[string]string
+
+	err := json.Unmarshal([]byte(value), &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %s", err)
+	}
+
+	return result, nil
 }

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -355,9 +355,11 @@ func TestParsePods(t *testing.T) {
 						"pod-template-hash": "490794276",
 					},
 					Annotations: map[string]string{
-						"noTag":     "don't collect",
-						"GitCommit": "ea38b55f07e40b68177111a2bff1e918132fd5fb",
-						"OwnerTeam": "Kenafeh",
+						"noTag":                          "don't collect",
+						"GitCommit":                      "ea38b55f07e40b68177111a2bff1e918132fd5fb",
+						"OwnerTeam":                      "Kenafeh",
+						"ad.datadoghq.com/tags":          `{"pod_template_version": "1.0.0"}`,
+						"ad.datadoghq.com/dd-agent.tags": `{"agent_version": "6.9.0"}`,
 					},
 				},
 				Status: dockerContainerStatus,
@@ -382,6 +384,8 @@ func TestParsePods(t *testing.T) {
 					"image_tag:latest5",
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
+					"pod_template_version:1.0.0",
+					"agent_version:6.9.0",
 				},
 				OrchestratorCardTags: []string{},
 				HighCardTags: []string{

--- a/releasenotes/notes/annotation-tagging-334ca6d9929882dd.yaml
+++ b/releasenotes/notes/annotation-tagging-334ca6d9929882dd.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Introduce pod and container tagging through annotations.


### PR DESCRIPTION
### What does this PR do?

It introduces pod-level and container-level tagging through annotations.

### Motivation

Being able to configure per-container and per-pod tags with a more dynamic approach (so we can dispense with rollouts implied by label or configuration change).

### Example

The intended usage is:

```yaml
metadata:
  annotations:
    ad.datadoghq.com/tags: {"pod_tag": "value", ...}
    ad.datadoghq.com/<container_name>.tags: {"container_tag": "value", ...}
```