### PR TITLE
[kitchen] The --match flag has been removed on task agent.version

### DIFF
--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -78,7 +78,7 @@ set -x
 # on linux it can just download the latest version from the package manager
 if [ -z ${AGENT_VERSION+x} ]; then
   pushd ../..
-    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=9 --match=[0-9]*`
+    export AGENT_VERSION=`inv agent.version --url-safe --git-sha-length=7`
   popd
 fi
 


### PR DESCRIPTION
### What does this PR do?

The `--match` flag has been removed on task agent.version plus we need to get a shasum of 7 chars instead of 9. This is what this PR is doing.

### Motivation

Correctly calling the agent.version task fills the `AGENT_VERSION` variable while running the kitchen tests.