### PR TITLE
Ensure dangling cluster checks can be re-scheduled

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -76,6 +76,14 @@ func (d *dispatcher) Unschedule(configs []integration.Config) {
 	}
 }
 
+// reschdule sends configurations to dispatching without checking or patching them as Schedule does.
+func (d *dispatcher) reschedule(configs []integration.Config) {
+	for _, c := range configs {
+		log.Debugf("Rescheduling the check %s from %s", c.Name, c.Entity)
+		d.add(c)
+	}
+}
+
 // add stores and delegates a given configuration
 func (d *dispatcher) add(config integration.Config) {
 	target := d.getLeastBusyNode()
@@ -130,7 +138,8 @@ func (d *dispatcher) run(ctx context.Context) {
 
 			// Re-dispatch dangling configs
 			if d.shouldDispatchDanling() {
-				d.Schedule(d.retrieveAndClearDangling())
+				danglingConfs := d.retrieveAndClearDangling()
+				d.reschedule(danglingConfs)
 			}
 		}
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -79,7 +79,7 @@ func (d *dispatcher) Unschedule(configs []integration.Config) {
 // reschdule sends configurations to dispatching without checking or patching them as Schedule does.
 func (d *dispatcher) reschedule(configs []integration.Config) {
 	for _, c := range configs {
-		log.Debugf("Rescheduling the check %s from %s", c.Name, c.Entity)
+		log.Debugf("Rescheduling the check %s:%s", c.Name, c.Digest())
 		d.add(c)
 	}
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -105,8 +105,7 @@ func (d *dispatcher) expireNodes() {
 			}
 			for digest, config := range node.digestToConfig {
 				delete(d.store.digestToNode, digest)
-				// Dangling configs are meant to be rescheduled, ensure they re-enter the pool of schedulable Cluster Checks.
-				config.ClusterCheck = true
+				log.Debugf("Adding %s:%s as a dangling Cluster Check config", config.Name, digest)
 				d.store.danglingConfigs[digest] = config
 				danglingConfigs.Inc()
 			}

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -105,6 +105,8 @@ func (d *dispatcher) expireNodes() {
 			}
 			for digest, config := range node.digestToConfig {
 				delete(d.store.digestToNode, digest)
+				// Dangling configs are meant to be rescheduled, ensure they re-enter the pool of schedulable Cluster Checks.
+				config.ClusterCheck = true
 				d.store.danglingConfigs[digest] = config
 				danglingConfigs.Inc()
 			}

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -228,6 +228,56 @@ func TestExpireNodes(t *testing.T) {
 	requireNotLocked(t, dispatcher.store)
 }
 
+func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
+	// This test case can represent a rollout of the cluster check workers
+	dispatcher := newDispatcher()
+
+	// Register a node with a correct status & schedule a Check
+	dispatcher.processNodeStatus("nodeA", types.NodeStatus{})
+	dispatcher.Schedule([]integration.Config{
+		generateIntegration("A")})
+
+	// Ensure it's dispatch correctly
+	allConfigs, err := dispatcher.getAllConfigs()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(allConfigs))
+	assert.Equal(t, []string{"A"}, extractCheckNames(allConfigs))
+
+	// Ensure it's running correctly
+	configsA, _, err := dispatcher.getNodeConfigs("nodeA")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(configsA))
+
+	// Expire NodeA
+	dispatcher.store.nodes["nodeA"].heartbeat = timestampNow() - 35
+
+	// Assert config becomes dangling when we trigger a expireNodes.
+	assert.Equal(t, 0, len(dispatcher.store.danglingConfigs))
+	dispatcher.expireNodes()
+	assert.Equal(t, 0, len(dispatcher.store.nodes))
+	assert.Equal(t, 1, len(dispatcher.store.danglingConfigs))
+
+	requireNotLocked(t, dispatcher.store)
+
+	// Register new node as healthy
+	dispatcher.processNodeStatus("nodeB", types.NodeStatus{})
+
+	// Ensure we have 1 dangling to schedule, as new available node is registered
+	assert.True(t, dispatcher.shouldDispatchDanling())
+	configs := dispatcher.retrieveAndClearDangling()
+	// Assert the check is scheduled
+	dispatcher.Schedule(configs)
+	danglingConfig, err := dispatcher.getAllConfigs()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(danglingConfig))
+	assert.Equal(t, []string{"A"}, extractCheckNames(danglingConfig))
+
+	// Make sure make sure the dangling check is rescheduled on the new node
+	configsB, _, err := dispatcher.getNodeConfigs("nodeB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(configsB))
+}
+
 func TestDispatchFourConfigsTwoNodes(t *testing.T) {
 	dispatcher := newDispatcher()
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -266,7 +266,7 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	assert.True(t, dispatcher.shouldDispatchDanling())
 	configs := dispatcher.retrieveAndClearDangling()
 	// Assert the check is scheduled
-	dispatcher.Schedule(configs)
+	dispatcher.reschedule(configs)
 	danglingConfig, err := dispatcher.getAllConfigs()
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(danglingConfig))


### PR DESCRIPTION
### What does this PR do?

Fix proposal for a bug I encountered in the QA of the Datadog Cluster Agent 1.2.0
Essentially, configurations that had been scheduled once could not be rescheduled as Cluster Level Checks.

### Investigation

Context: Cluster Agent schedules a check on a Cluster Check Worker. Rolling out of an update for the Cluster Check Worker, the new Worker does not pick up the Cluster Level Checks left dangling by its churned predecessor(s).

#### What we observe 

In the Cluster Agent:

```
    Check Configurations: 2
      - Dispatched: 0
      - Unassigned: 0
```

Adding some logging:

When scheduling:

```
2019-02-13 22:22:56 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_main.go:51 in Schedule) | [DEV] Scheduling [{kubernetes_state [[107 ...105 110 103 10]] [123 125] [] [] [kube_service://24dc8f6a-1845-11e9-b2b4-12b196e72d60] kubernetes-services kube_service://24dc8f6a-1845-11e9-b2b4-12b196e72d60 true 1}
```
Note the `true`, Cluster Level Check configuration is processed for the first time.

Once [patched](https://github.com/DataDog/datadog-agent/blob/master/pkg/clusteragent/clusterchecks/dispatcher_configs.go#L128):
```
2019-02-13 22:22:56 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_main.go:61 in Schedule) | [DEV] Add {kubernetes_state [[101 109 ...110 103 10]] [123 125] [] [] [] kubernetes-services kube_service://24dc8f6a-1845-11e9-b2b4-12b196e72d60 false 1}
```
It's now false.

Although the configuration will be retrieved in the [retrieveAndClearDangling
](https://github.com/DataDog/datadog-agent/blob/master/pkg/clusteragent/clusterchecks/dispatcher_configs.go#L110-L117), it will **not** be rescheduled as it's marked as a non Cluster Check (from the patching above), in the [next Scheduling](https://github.com/DataDog/datadog-agent/blob/master/pkg/clusteragent/clusterchecks/dispatcher_main.go#L52-L54).

As a reminder, we need to patch this variable so that the checks are not scheduled on the Cluster Agent, but [an be scheduled](https://github.com/DataDog/datadog-agent/blob/master/pkg/collector/scheduler.go#L199-L202) on a Node Agent. See [here](https://github.com/DataDog/datadog-agent/pull/2862#discussion_r248359935).

With this fix:

```
2019-02-13 22:54:16 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_nodes.go:107 in expireNodes) | [DEV] Removing fa9da93b28dcbfae
2019-02-13 22:54:16 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_nodes.go:108 in expireNodes) | [DEV] d.store.digestToNode map[fa9da93b28dcbfae:ip-10-1XXX2-149.ec2.internal]
2019-02-13 22:54:16 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_nodes.go:110 in expireNodes) | [DEV] DanglingConfigs map[7a5d781a60553256:{kubernetes_state [[101 109 112 116 ... 103 10]] [123 125] [] [] [] kubernetes-services kube_service://24dc8f6a-1845-11e9-b2b4-12b196e72d60 true 1}]
[...]
2019-02-13 22:54:16 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_configs.go:118 in retrieveAndClearDangling) | [DEV] State of danglingConfigs after clear map[]
[...]
2019-02-13 22:54:16 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_main.go:61 in Schedule) | [DEV] Add {kubernetes_state [[101 109 112 ... 105 110 103 10]] [123 125] [] [] [] kubernetes-services kube_service://24dc8f6a-1845-11e9-b2b4-12b196e72d60 false 1}
[...]
2019-02-13 22:54:16 UTC | INFO | (pkg/clusteragent/clusterchecks/dispatcher_main.go:90 in add) | Dispatching configuration kubernetes_state:fa9da93b28dcbfae to node ip-1XXX1-98.ec2.internal
```
Note that the `DanglingConfigs` config is marked as a true Cluster Check config after having been removed from the node `ip-10-1XXX2-149.ec2.internal`
Later on, we can see the same configuration `kubernetes_state:fa9da93b28dcbfae` is scheduled on `ip-1XXX1-98.ec2.internal`

### Additional Notes

Tried adding a comprehensive test to reproduce this scenario - It fails on master.
