### PR TITLE
windows/go1.11 migrate use of syscall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ cmd/trace-agent/windows_resources/trace-agent-msg.rc
 cmd/trace-agent/windows_resources/*.bin
 pkg/trace/info/git_version.go
 trace-agent-msg.h
+*.aps

--- a/cmd/agent/app/control_service_windows.go
+++ b/cmd/agent/app/control_service_windows.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -51,7 +50,7 @@ var restartsvcCommand = &cobra.Command{
 }
 
 var (
-	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")
+	modadvapi32 = windows.NewLazyDLL("advapi32.dll")
 
 	procEnumDependentServices = modadvapi32.NewProc("EnumDependentServicesW")
 )
@@ -206,7 +205,7 @@ func enumDependentServices(h windows.Handle, state enumServiceState) (services [
 		uintptr(unsafe.Pointer(&bufsz)),
 		uintptr(unsafe.Pointer(&count)))
 
-	if err != error(syscall.ERROR_MORE_DATA) {
+	if err != error(windows.ERROR_MORE_DATA) {
 		log.Warnf("Error getting buffer %v", err)
 		return
 	}

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strconv"
 	"sync/atomic"
-	"syscall"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -21,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/lxn/win"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -33,7 +33,7 @@ const (
 
 var (
 	validemail = regexp.MustCompile("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")
-	moduser32  = syscall.NewLazyDLL("user32.dll")
+	moduser32  = windows.NewLazyDLL("user32.dll")
 
 	procGetDlgItem       = moduser32.NewProc("GetDlgItem")
 	procSetWindowPos     = moduser32.NewProc("SetWindowPos")
@@ -103,7 +103,7 @@ func dialogProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (result uintp
 				// get the text, see if it looks kinda like an email address
 				buf := make([]uint16, 256)
 				win.SendDlgItemMessage(hwnd, IDC_EMAIL_EDIT, win.WM_GETTEXT, 255, uintptr(unsafe.Pointer(&buf[0])))
-				emailstr := syscall.UTF16ToString(buf)
+				emailstr := windows.UTF16ToString(buf)
 				edithandle, err := getDlgItem(hwnd, win.IDOK)
 				if err == nil {
 					if validemail.MatchString(emailstr) {
@@ -118,11 +118,11 @@ func dialogProc(hwnd win.HWND, msg uint32, wParam, lParam uintptr) (result uintp
 			buf := make([]uint16, 256)
 
 			win.SendDlgItemMessage(hwnd, IDC_TICKET_EDIT, win.WM_GETTEXT, 255, uintptr(unsafe.Pointer(&buf[0])))
-			info.caseid = syscall.UTF16ToString(buf)
+			info.caseid = windows.UTF16ToString(buf)
 			log.Debugf("ticket number %s", info.caseid)
 
 			win.SendDlgItemMessage(hwnd, IDC_EMAIL_EDIT, win.WM_GETTEXT, 255, uintptr(unsafe.Pointer(&buf[0])))
-			info.email = syscall.UTF16ToString(buf)
+			info.email = windows.UTF16ToString(buf)
 			log.Debugf("email %s", info.email)
 
 			win.EndDialog(hwnd, win.IDOK)
@@ -150,7 +150,7 @@ func onFlare() {
 		log.Errorf("Failed to get my own module handle")
 		return
 	}
-	ret := win.DialogBoxParam(myInst, win.MAKEINTRESOURCE(uintptr(IDD_DIALOG1)), win.HWND(0), syscall.NewCallback(dialogProc), uintptr(0))
+	ret := win.DialogBoxParam(myInst, win.MAKEINTRESOURCE(uintptr(IDD_DIALOG1)), win.HWND(0), windows.NewCallback(dialogProc), uintptr(0))
 	if ret == 1 {
 		// kick off the flare
 		if _, err := strconv.Atoi(info.caseid); err != nil {
@@ -158,12 +158,12 @@ func onFlare() {
 			info.caseid = "0"
 		}
 		r, e := requestFlare(info.caseid, info.email)
-		caption, _ := syscall.UTF16PtrFromString("Datadog Flare")
+		caption, _ := windows.UTF16PtrFromString("Datadog Flare")
 		var text *uint16
 		if e == nil {
-			text, _ = syscall.UTF16PtrFromString(r)
+			text, _ = windows.UTF16PtrFromString(r)
 		} else {
-			text, _ = syscall.UTF16PtrFromString(fmt.Sprintf("Error creating flare %v", e))
+			text, _ = windows.UTF16PtrFromString(fmt.Sprintf("Error creating flare %v", e))
 		}
 		win.MessageBox(win.HWND(0), text, caption, win.MB_OK)
 	}

--- a/cmd/systray/systray.go
+++ b/cmd/systray/systray.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"os"
 	"os/exec"
-	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	seelog "github.com/cihub/seelog"
@@ -32,7 +31,7 @@ var (
 	menuitems []menuItem
 	ni        *walk.NotifyIcon
 	launchgui bool
-	eventname = syscall.StringToUTF16Ptr("ddtray-event")
+	eventname = windows.StringToUTF16Ptr("ddtray-event")
 )
 
 func init() {

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"syscall"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -19,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -47,7 +48,7 @@ type IOCheck struct {
 var pfnGetDriveType = getDriveType
 
 func getDriveType(drive string) uintptr {
-	r, _, _ := procGetDriveType.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(drive))))
+	r, _, _ := procGetDriveType.Call(uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(drive))))
 	return r
 }
 func isDrive(instance string) bool {

--- a/pkg/collector/corechecks/system/uptime_windows.go
+++ b/pkg/collector/corechecks/system/uptime_windows.go
@@ -7,8 +7,9 @@
 package system
 
 import (
-	"golang.org/x/sys/windows"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 // For testing purpose

--- a/pkg/collector/corechecks/system/uptime_windows.go
+++ b/pkg/collector/corechecks/system/uptime_windows.go
@@ -7,7 +7,7 @@
 package system
 
 import (
-	"syscall"
+	"golang.org/x/sys/windows"
 	"time"
 )
 
@@ -15,7 +15,7 @@ import (
 var uptime = calcUptime
 
 var (
-	modkernel = syscall.NewLazyDLL("kernel32.dll")
+	modkernel = windows.NewLazyDLL("kernel32.dll")
 
 	procGetTickCount64 = modkernel.NewProc("GetTickCount64")
 )

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
@@ -29,13 +28,13 @@ func zipCounterStrings(tempDir, hostname string) error {
 		counterlist = make([]uint16, bufferSize)
 		var sz uint32
 		sz = bufferSize
-		regerr := windows.RegQueryValueEx(syscall.HKEY_PERFORMANCE_DATA,
-			syscall.StringToUTF16Ptr("Counter 009"),
+		regerr := windows.RegQueryValueEx(windows.HKEY_PERFORMANCE_DATA,
+			windows.StringToUTF16Ptr("Counter 009"),
 			nil, // reserved
 			&regtype,
 			(*byte)(unsafe.Pointer(&counterlist[0])),
 			&sz)
-		if regerr == error(syscall.ERROR_MORE_DATA) {
+		if regerr == error(windows.ERROR_MORE_DATA) {
 			// buffer's not big enough
 			bufferSize += bufferIncrement
 			continue

--- a/pkg/logs/input/file/open_file_windows.go
+++ b/pkg/logs/input/file/open_file_windows.go
@@ -8,8 +8,9 @@
 package file
 
 import (
-	"golang.org/x/sys/windows"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
 // openFile reimplements the os.Open function for Windows because the default

--- a/pkg/logs/input/file/open_file_windows.go
+++ b/pkg/logs/input/file/open_file_windows.go
@@ -9,7 +9,7 @@ package file
 
 import (
 	"os"
-	"syscall"
+	"golang.org/x/sys/windows"
 )
 
 // openFile reimplements the os.Open function for Windows because the default
@@ -17,18 +17,18 @@ import (
 // cf: https://github.com/golang/go/blob/release-branch.go1.11/src/syscall/syscall_windows.go#L271
 // This prevents users from moving/removing files when the tailer is reading the file.
 func openFile(path string) (*os.File, error) {
-	pathp, err := syscall.UTF16PtrFromString(path)
+	pathp, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, err
 	}
 
-	access := uint32(syscall.GENERIC_READ)
+	access := uint32(windows.GENERIC_READ)
 	// add FILE_SHARE_DELETE that is missing from os.Open implementation
-	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
-	createmode := uint32(syscall.OPEN_EXISTING)
-	var sa *syscall.SecurityAttributes
+	sharemode := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE)
+	createmode := uint32(windows.OPEN_EXISTING)
+	var sa *windows.SecurityAttributes
 
-	r, err := syscall.CreateFile(pathp, access, sharemode, sa, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	r, err := windows.CreateFile(pathp, access, sharemode, sa, createmode, windows.FILE_ATTRIBUTE_NORMAL, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logs/input/file/open_file_windows.go
+++ b/pkg/logs/input/file/open_file_windows.go
@@ -8,8 +8,8 @@
 package file
 
 import (
-	"os"
 	"golang.org/x/sys/windows"
+	"os"
 )
 
 // openFile reimplements the os.Open function for Windows because the default

--- a/pkg/logs/input/windowsevent/launcher_windows.go
+++ b/pkg/logs/input/windowsevent/launcher_windows.go
@@ -15,10 +15,10 @@ import "C"
 
 import (
 	"fmt"
-	"syscall"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows"
 )
 
 /*
@@ -65,7 +65,7 @@ func evtNextChannel(h evtEnumHandle) (ch string, err error) {
 		uintptr(bufSize),
 		uintptr(0),                        //no buffer for now, just getting necessary size
 		uintptr(unsafe.Pointer(&bufUsed))) // filled in with necessary buffer size
-	if err != error(syscall.ERROR_INSUFFICIENT_BUFFER) {
+	if err != error(windows.ERROR_INSUFFICIENT_BUFFER) {
 		log.Warnf("Next: %v %v", ret, err)
 		return
 	}

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows"
 )
 
 // Start starts tailing the event log.
@@ -95,7 +96,7 @@ func goNotificationCallback(handle C.ULONGLONG, ctx C.PVOID) {
 }
 
 var (
-	modWinEvtAPI = syscall.NewLazyDLL("wevtapi.dll")
+	modWinEvtAPI = windows.NewLazyDLL("wevtapi.dll")
 
 	procEvtSubscribe       = modWinEvtAPI.NewProc("EvtSubscribe")
 	procEvtClose           = modWinEvtAPI.NewProc("EvtClose")
@@ -117,7 +118,7 @@ func EvtRender(h C.ULONGLONG) (xml string, err error) {
 		uintptr(0),                        // no buffer for now, just getting necessary size
 		uintptr(unsafe.Pointer(&bufUsed)), // filled in with necessary buffer size
 		uintptr(0))                        // not used but must be provided
-	if err != error(syscall.ERROR_INSUFFICIENT_BUFFER) {
+	if err != error(windows.ERROR_INSUFFICIENT_BUFFER) {
 		log.Warnf("Couldn't render xml event: %s", err)
 		return
 	}

--- a/pkg/metadata/common/common_windows.go
+++ b/pkg/metadata/common/common_windows.go
@@ -8,23 +8,23 @@ package common
 
 import (
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows"
 )
 
 var getUUID = GetUUID
 
 // GetUUID returns the machine GUID on windows; copied from gopsutil
 func GetUUID() string {
-	var h syscall.Handle
-	err := syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE, syscall.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, syscall.KEY_READ|syscall.KEY_WOW64_64KEY, &h)
+	var h windows.Handle
+	err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, windows.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, windows.KEY_READ|windows.KEY_WOW64_64KEY, &h)
 	if err != nil {
 		log.Warnf("Failed to open registry key Cryptography: %v", err)
 		return ""
 	}
-	defer syscall.RegCloseKey(h)
+	defer windows.RegCloseKey(h)
 
 	const windowsRegBufLen = 74 // len(`{`) + len(`abcdefgh-1234-456789012-123345456671` * 2) + len(`}`) // 2 == bytes/UTF16
 	const uuidLen = 36
@@ -32,13 +32,13 @@ func GetUUID() string {
 	var regBuf [windowsRegBufLen]uint16
 	bufLen := uint32(windowsRegBufLen)
 	var valType uint32
-	err = syscall.RegQueryValueEx(h, syscall.StringToUTF16Ptr(`MachineGuid`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+	err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`MachineGuid`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
 	if err != nil {
 		log.Warnf("Could not find machineguid in the registry %v", err)
 		return ""
 	}
 
-	hostID := syscall.UTF16ToString(regBuf[:])
+	hostID := windows.UTF16ToString(regBuf[:])
 	hostIDLen := len(hostID)
 	if hostIDLen != uuidLen {
 		log.Warnf("the hostid was unexpected length (%d != %d)", hostIDLen, uuidLen)

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
@@ -24,10 +23,11 @@ import (
 	"github.com/DataDog/gohai/cpu"
 	"github.com/DataDog/gohai/platform"
 	"github.com/shirou/w32"
+	"golang.org/x/sys/windows"
 )
 
 var (
-	modkernel = syscall.NewLazyDLL("kernel32.dll")
+	modkernel = windows.NewLazyDLL("kernel32.dll")
 
 	procGetTickCount64 = modkernel.NewProc("GetTickCount64")
 )

--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -7,9 +7,9 @@ package pidfile
 
 import (
 	"path/filepath"
-	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -20,13 +20,13 @@ const (
 
 // isProcess checks to see if a given pid is currently valid in the process table
 func isProcess(pid int) bool {
-	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
 		return false
 	}
 	var c uint32
-	err = syscall.GetExitCodeProcess(h, &c)
-	syscall.Close(h)
+	err = windows.GetExitCodeProcess(h, &c)
+	windows.Close(h)
 	if err != nil {
 		return c == stillActive
 	}

--- a/pkg/trace/watchdog/cpu_windows.go
+++ b/pkg/trace/watchdog/cpu_windows.go
@@ -1,8 +1,6 @@
 package watchdog
 
 import (
-	"syscall"
-
 	"golang.org/x/sys/windows"
 )
 
@@ -18,10 +16,10 @@ func cpuTimeUser(pid int32) (float64, error) {
 }
 
 type systemTimes struct {
-	CreateTime syscall.Filetime
-	ExitTime   syscall.Filetime
-	KernelTime syscall.Filetime
-	UserTime   syscall.Filetime
+	CreateTime windows.Filetime
+	ExitTime   windows.Filetime
+	KernelTime windows.Filetime
+	UserTime   windows.Filetime
 }
 
 func getProcessCPUTimes(pid int32) (systemTimes, error) {
@@ -34,8 +32,8 @@ func getProcessCPUTimes(pid int32) (systemTimes, error) {
 	}
 	defer windows.CloseHandle(h)
 
-	err = syscall.GetProcessTimes(
-		syscall.Handle(h),
+	err = windows.GetProcessTimes(
+		windows.Handle(h),
 		&times.CreateTime,
 		&times.ExitTime,
 		&times.KernelTime,

--- a/pkg/util/hostname_windows.go
+++ b/pkg/util/hostname_windows.go
@@ -8,8 +8,9 @@ package util
 import (
 	"C"
 	"os"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 func getSystemFQDN() (string, error) {
@@ -18,7 +19,7 @@ func getSystemFQDN() (string, error) {
 		return "", err
 	}
 
-	he, err := syscall.GetHostByName(hn)
+	he, err := windows.GetHostByName(hn)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -7,13 +7,13 @@
 package pdhutil
 
 import (
-	"syscall"
 	"unsafe"
+	"golang.org/x/sys/windows"
 )
 
 type (
-	PDH_HQUERY   syscall.Handle
-	PDH_HCOUNTER syscall.Handle
+	PDH_HQUERY   windows.Handle
+	PDH_HCOUNTER windows.Handle
 )
 
 // PDH error codes.  Taken from latest PDHMSH.h in Windows SDK
@@ -187,7 +187,7 @@ phCounter [out]
 Handle to the counter that was added to the query. You may need to reference this handle in subsequent calls.
 */
 func PdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
-	ptxt, _ := syscall.UTF16PtrFromString(szFullCounterPath)
+	ptxt, _ := windows.UTF16PtrFromString(szFullCounterPath)
 	ret, _, _ := procPdhAddCounterW.Call(
 		uintptr(hQuery),
 		uintptr(unsafe.Pointer(ptxt)),

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -7,8 +7,8 @@
 package pdhutil
 
 import (
-	"unsafe"
 	"golang.org/x/sys/windows"
+	"unsafe"
 )
 
 type (

--- a/pkg/util/winutil/shutil.go
+++ b/pkg/util/winutil/shutil.go
@@ -11,6 +11,8 @@ import (
 	"C"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // GUID is representation of the C GUID structure
@@ -40,15 +42,15 @@ var (
 )
 
 var (
-	modShell32               = syscall.NewLazyDLL("Shell32.dll")
-	modOle32                 = syscall.NewLazyDLL("Ole32.dll")
+	modShell32               = windows.NewLazyDLL("Shell32.dll")
+	modOle32                 = windows.NewLazyDLL("Ole32.dll")
 	procSHGetKnownFolderPath = modShell32.NewProc("SHGetKnownFolderPath")
 	procCoTaskMemFree        = modOle32.NewProc("CoTaskMemFree")
 )
 
 // SHGetKnownFolderPath syscall to windows native SHGetKnownFOlderPath
-func SHGetKnownFolderPath(rfid *GUID, dwFlags uint32, hToken syscall.Handle, pszPath *uintptr) (retval error) {
-	r0, _, _ := syscall.Syscall6(procSHGetKnownFolderPath.Addr(), 4, uintptr(unsafe.Pointer(rfid)), uintptr(dwFlags), uintptr(hToken), uintptr(unsafe.Pointer(pszPath)), 0, 0)
+func SHGetKnownFolderPath(rfid *GUID, dwFlags uint32, hToken windows.Handle, pszPath *uintptr) (retval error) {
+	r0, _, _ := procSHGetKnownFolderPath.Call(uintptr(unsafe.Pointer(rfid)), uintptr(dwFlags), uintptr(hToken), uintptr(unsafe.Pointer(pszPath)), 0, 0)
 	if r0 != 0 {
 		retval = syscall.Errno(r0)
 	}
@@ -57,7 +59,7 @@ func SHGetKnownFolderPath(rfid *GUID, dwFlags uint32, hToken syscall.Handle, psz
 
 // CoTaskMemFree free memory returned from SHGetKnownFolderPath
 func CoTaskMemFree(pv uintptr) {
-	syscall.Syscall(procCoTaskMemFree.Addr(), 1, uintptr(pv), 0, 0)
+	procCoTaskMemFree.Call(uintptr(pv), 0, 0)
 	return
 }
 
@@ -69,9 +71,9 @@ func GetProgramDataDir() (path string, err error) {
 	if err == nil {
 		// convert the string
 		defer CoTaskMemFree(retstr)
-		// the path = syscall.UTF16ToString... returns a
+		// the path = windows.UTF16ToString... returns a
 		// go vet: "possible misuse of unsafe.Pointer"
-		path = syscall.UTF16ToString((*[1 << 16]uint16)(unsafe.Pointer(retstr))[:])
+		path = windows.UTF16ToString((*[1 << 16]uint16)(unsafe.Pointer(retstr))[:])
 	}
 	return
 }

--- a/pkg/util/winutil/winmem.go
+++ b/pkg/util/winutil/winmem.go
@@ -8,15 +8,14 @@
 package winutil
 
 import (
-	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
-	modPsapi    = syscall.NewLazyDLL("psapi.dll")
+	modkernel32 = windows.NewLazyDLL("kernel32.dll")
+	modPsapi    = windows.NewLazyDLL("psapi.dll")
 
 	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
 	procGetPerformanceInfo   = modPsapi.NewProc("GetPerformanceInfo")

--- a/pkg/util/winutil/winver.go
+++ b/pkg/util/winutil/winver.go
@@ -9,13 +9,14 @@ package winutil
 
 import (
 	"fmt"
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
-	k32        = syscall.NewLazyDLL("kernel32.dll")
-	versiondll = syscall.NewLazyDLL("version.dll")
+	k32        = windows.NewLazyDLL("kernel32.dll")
+	versiondll = windows.NewLazyDLL("version.dll")
 
 	procGetModuleHandle          = k32.NewProc("GetModuleHandleW")
 	procGetModuleFileName        = k32.NewProc("GetModuleFileNameW")
@@ -46,7 +47,7 @@ func GetWindowsBuildString() (verstring string, err error) {
 }
 
 func getModuleHandle(fname string) (handle uintptr, err error) {
-	file := syscall.StringToUTF16Ptr(fname)
+	file := windows.StringToUTF16Ptr(fname)
 	handle, _, err = procGetModuleHandle.Call(uintptr(unsafe.Pointer(file)))
 	if handle == 0 {
 		return handle, err
@@ -62,11 +63,11 @@ func getModuleFileName(h uintptr) (fname string, err error) {
 	for {
 		buf := make([]uint16, size)
 		ret, _, err := procGetModuleFileName.Call(h, uintptr(unsafe.Pointer(&buf[0])), uintptr(size))
-		if ret == uintptr(size) || err == syscall.ERROR_INSUFFICIENT_BUFFER {
+		if ret == uintptr(size) || err == windows.ERROR_INSUFFICIENT_BUFFER {
 			size += sizeIncr
 			continue
 		} else if err != nil {
-			fname = syscall.UTF16ToString(buf)
+			fname = windows.UTF16ToString(buf)
 		}
 		break
 	}
@@ -75,7 +76,7 @@ func getModuleFileName(h uintptr) (fname string, err error) {
 }
 
 func getFileVersionInfo(filename string) (block []uint8, err error) {
-	fname := syscall.StringToUTF16Ptr(filename)
+	fname := windows.StringToUTF16Ptr(filename)
 	ret, _, err := procGetFileVersionInfoSizeEx.Call(uintptr(0x02),
 		uintptr(unsafe.Pointer(fname)), uintptr(0))
 	if ret == 0 {
@@ -110,7 +111,7 @@ type tagVSFIXEDFILEINFO struct {
 
 func getVersionInfo(block []uint8) (ver string, err error) {
 
-	subblock := syscall.StringToUTF16Ptr("\\")
+	subblock := windows.StringToUTF16Ptr("\\")
 	var infoptr unsafe.Pointer
 	var ulen uint32
 	ret, _, err := procVerQueryValue.Call(uintptr(unsafe.Pointer(&block[0])),


### PR DESCRIPTION
Change use of `syscall` to the windows package; the syscall functions
have been moved there for go 1.11

