### PR TITLE
systemd: let the StartLimitBurst and StartLimitInterval under [Service]

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.network.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.network.service.erb
@@ -1,11 +1,13 @@
 [Unit]
 Description="Datadog Network Tracer"
 After=network.target
-StartLimitInterval=10
-StartLimitBurst=5
 
 [Service]
 Type=simple
 PIDFile=<%= install_dir %>/run/network-tracer.pid
 Restart=on-failure
 ExecStart=<%= install_dir %>/embedded/bin/network-tracer --config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/network-tracer.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5

--- a/omnibus/config/templates/datadog-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.process.service.erb
@@ -2,8 +2,6 @@
 Description="Datadog Process Agent"
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
-StartLimitInterval=10
-StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -11,6 +9,10 @@ PIDFile=<%= install_dir %>/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
 ExecStart=<%= install_dir %>/embedded/bin/process-agent --config=<%= etc_dir %>/datadog.yaml --network-config=<%= etc_dir %>/network-tracer.yaml --pid=<%= install_dir %>/run/process-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -2,8 +2,6 @@
 Description="Datadog Agent"
 After=network.target
 Wants=datadog-agent-trace.service datadog-agent-process.service
-StartLimitInterval=10
-StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -11,6 +9,10 @@ PIDFile=<%= install_dir %>/run/agent.pid
 User=dd-agent
 Restart=on-failure
 ExecStart=<%= install_dir %>/bin/agent/agent run -p <%= install_dir %>/run/agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.trace.service.erb
@@ -2,8 +2,6 @@
 Description="Datadog Trace Agent (APM)"
 After=network.target datadog-agent.service
 BindsTo=datadog-agent.service
-StartLimitInterval=10
-StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -11,6 +9,10 @@ PIDFile=<%= install_dir %>/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
 ExecStart=<%= install_dir %>/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pid <%= install_dir %>/run/trace-agent.pid
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Since systemd v229, `StartLimitBurst` and `StartLimitInterval` should be
in the `[Unit]` section, but for compatibility purposes, it's supported to
let those values under the `[Service]` section.

Tested on Ubuntu 18.10.

### Motivation

We do that in order to support older version of systemd.

### Additional infos

Source in systemd: https://github.com/systemd/systemd/blob/master/src/core/load-fragment-gperf.gperf.m4#L308-L310