### PR TITLE
[secrets] Fix multiple endpoints config when secrets is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen7-godeps-{{ .Branch }}-{{ .Revision }}
-          - gen7-godeps-{{ .Branch }}-
-          - gen7-godeps-master-
+          - gen8-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen8-godeps-{{ .Branch }}-
+          - gen8-godeps-master-
     - save_cache: &save_deps
-        key: gen7-godeps-{{ .Branch }}-{{ .Revision }}
+        key: gen8-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,12 +50,12 @@
   revision = "2cfb68475274527a10701355c739f31dd404718c"
 
 [[projects]]
-  digest = "1:b98ee2c3f1469ab3b494859d3a9c9e595ec2c63660dea130a5154cfcd427b608"
+  digest = "1:e9ca79fa28ff0fe0271b63d2d30f4118643746610cd0d75603c7b4255a44f161"
   name = "github.com/DataDog/viper"
   packages = ["."]
   pruneopts = ""
-  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
-  version = "v1.3.1"
+  revision = "23ced3bc6b3751855704445e48da2c53075ade86"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:34d4c1b61fa208e523726ddb85d01b8caa8f2de0cd656d91c81b6b86daea485c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,7 +128,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/viper"
-  version = "=v1.3.1"
+  version = "=v1.4.0"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/pkg/config/tests/datadog_secrets.yaml
+++ b/pkg/config/tests/datadog_secrets.yaml
@@ -1,0 +1,5 @@
+api_key: someapikey
+secret_backend_command: /bin/foo
+
+additional_endpoints:
+  "https://app.datadoghq.com": "someotherapikey"

--- a/releasenotes/notes/fix-secrets-add-endpoints-153635b302752824.yaml
+++ b/releasenotes/notes/fix-secrets-add-endpoints-153635b302752824.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When the secrets feature is enabled, fix bug preventing the ``additional_endpoints``
+    config option from being read correctly


### PR DESCRIPTION
### What does this PR do?

* Pulls in updated version of our fork of viper to pull in: https://github.com/DataDog/viper/pull/2 (also pulls in https://github.com/DataDog/viper/pull/1), in order to fix the issue described in that PR, and which would prevent the Agent from configuring its endpoints correctly when both secrets and multiple endpoints were used at the same time.
* Adds a test to reproduce the issue that's fixed with https://github.com/DataDog/viper/pull/2

### Additional notes

We should avoid using config options that use maps with arbitrary keys in the future.