### PR TITLE
Use MergeConfigOverride to allow secrets from environment variables to be resolved

### DIFF
--- a/docs/agent/secrets.md
+++ b/docs/agent/secrets.md
@@ -37,7 +37,8 @@ in your configuration (not the key), in any section (`init_config`, `instances`,
 `logs`, ...).
 
 Secrets are supported in every configuration backend: file, etcd, consul ...
-But for now, secrets are **NOT** supported in environment variables.
+
+Starting version `6.10.0`, secrets are supported in environment variables.
 
 Secrets are also supported in `datadog.yaml`. The agent will first load the
 main configuration and reload it after decrypting the secrets. This means the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -487,7 +487,7 @@ func load(config Config, origin string) error {
 			return fmt.Errorf("unable to decrypt secret from datadog.yaml: %v", err)
 		}
 		r := bytes.NewReader(finalYamlConf)
-		if err = config.MergeConfig(r); err != nil {
+		if err = config.MergeConfigOverride(r); err != nil {
 			return fmt.Errorf("could not update main configuration after decrypting secrets: %v", err)
 		}
 	}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -54,6 +54,7 @@ type Config interface {
 	ReadInConfig() error
 	ReadConfig(in io.Reader) error
 	MergeConfig(in io.Reader) error
+	MergeConfigOverride(in io.Reader) error
 
 	AllSettings() map[string]interface{}
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -217,6 +217,13 @@ func (c *safeConfig) MergeConfig(in io.Reader) error {
 	return c.Viper.MergeConfig(in)
 }
 
+// MergeConfigOverride wraps Viper for concurrent access
+func (c *safeConfig) MergeConfigOverride(in io.Reader) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.MergeConfigOverride(in)
+}
+
 // AllSettings wraps Viper for concurrent access
 func (c *safeConfig) AllSettings() map[string]interface{} {
 	c.Lock()

--- a/releasenotes/notes/secret-in-env-9b3426310822892c.yaml
+++ b/releasenotes/notes/secret-in-env-9b3426310822892c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Secrets are now resolved in environment variables.


### PR DESCRIPTION
### What does this PR do?
Use MergeConfigOverride to allow secrets from environment variables to be resolved
