### PR TITLE
Update sentence around APM env tag being "none"

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -778,7 +778,7 @@ api_key:
 #   Whether or not the APM Agent should run
 #   enabled: true
 #   The environment tag that Traces should be tagged with
-#   Will inherit from "env" tag if none is applied here
+#   Will inherit from "env" tag if "none" is applied here
 #   env: none
 #   The port that the Receiver should listen on
 #   receiver_port: 8126


### PR DESCRIPTION
### What does this PR do?

Just change a sentence, since we found it a bit misleading with my team.

### Motivation

> Will inherit from "env" tag if none is applied here

Actually there is one applied, and the value is `none`
[Code](https://github.com/DataDog/datadog-agent/blob/59ae4b2627af49311bf0fd34a10cc02e64f97789/pkg/trace/config/config.go#L119)

That's why we preferred : 
> Will inherit from "env" tag if "none" is applied here

The commented value of the tag was helping to understand the meaning of the sentence, but it might be clearer this way.
