### PR TITLE
Incorrect sampler precedence causing partial distributed traces

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -277,16 +277,22 @@ func TestSampling(t *testing.T) {
 			scoreSampled: true,
 			wantSampled:  true,
 		},
+		"score not sampled priority not sampled": {
+			hasPriority:     true,
+			scoreSampled:    false,
+			prioritySampled: false,
+			wantSampled:     false,
+		},
 		"score sampled priority not sampled": {
 			hasPriority:     true,
 			scoreSampled:    true,
 			prioritySampled: false,
-			wantSampled:     true,
+			wantSampled:     false,
 		},
-		"score not sampled priority sampled": {
-			hasPriority:     true,
-			scoreSampled:    false,
-			prioritySampled: true,
+		"score sampled priority not enabled": {
+			hasPriority:     false,
+			scoreSampled:    true,
+			prioritySampled: false,
 			wantSampled:     true,
 		},
 		"score sampled priority sampled": {
@@ -314,7 +320,7 @@ func TestSampling(t *testing.T) {
 		"error sampled priority not sampled": {
 			hasErrors:         true,
 			hasPriority:       true,
-			scoreErrorSampled: true,
+			scoreErrorSampled: false,
 			prioritySampled:   false,
 			wantSampled:       true,
 		},

--- a/releasenotes/notes/apm-fixing-upsampling-partial-distributed-traces-62003da0a4ec3d25.yaml
+++ b/releasenotes/notes/apm-fixing-upsampling-partial-distributed-traces-62003da0a4ec3d25.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixing a sampling issue where distributed traces could only be partially sent.


### PR DESCRIPTION
### What does this PR do?

When priority sampling is set to AUTO_REJECT a trace, sometimes some spans will be sampled by the score sampler, causing partial distributed traces to show up in the DataDog UI.

This PR adjusts the sampler logic to always take the precedence of the priority sampler, over the score sampler, should the priority sampler field have been set in the spans of the trace. It does not adjust the rate output.

### Motivation

According to the documentation:

> Note: Spans dropped by priority sampler can still be sampled by the signature sampler. [...] The distributed traces that are kept will all be complete.

The first part is true, however the last part ("distributed traces that are kept will be complete") is not given the current logic of the sampler.

A users perspective: In the UI when we see a partial trace, it is confusing to the developer to not know if the trace that is displayed is correct. "Is that trace missing services in its trace or did it actually not call those services this time?" is a question I often get and ask myself. By enforcing distributed traces more reliably end up as complete distributed traces on the backend, will allow for developers to confidently trust the picture that is painted of their applications workflows.

### Additional Notes

Most likely the "distributed traces that are kept will be complete" portion cannot truly be implemented given without significant additional work. I believe this limitation currently exists because a distributed trace can be comprised from many different services and be sent to many different agents. The agent does not currently keep a global state of sampling rates shared amongst the agents so it is effectively impossible to make truly consistent decisions on weather to consistently upsample a AUTO_REJECT'ed distributed trace that come in portions into different agents.

This is related to investigation work that has culminated in support ticket #202844