### PR TITLE
[omnibus][datadog-agent-integrations] use erb for filtered reqs file

### DIFF
--- a/omnibus/config/templates/datadog-agent-integrations/static_requirements.txt.erb
+++ b/omnibus/config/templates/datadog-agent-integrations/static_requirements.txt.erb
@@ -1,0 +1,3 @@
+<% requirements.each do |requirement| -%>
+<%= requirement -%>
+<% end -%>


### PR DESCRIPTION
### What does this PR do?

Resorts to an erb file to properly generate filtered requirements file. Necessary due to the awkward runtime omnibus constraints.

### Motivation

Previous approach was rendering an empty requirements file.

### Additional Notes

Anything else we should know when reviewing?
