### PR TITLE
pkg/trace/api: reply using JSON when presampling on v0.4 endpoint

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -201,7 +201,7 @@ func (r *HTTPReceiver) replyTraces(v Version, w http.ResponseWriter) {
 func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.Request) {
 	if !r.PreSampler.Sample(req) {
 		io.Copy(ioutil.Discard, req.Body)
-		HTTPOK(w)
+		r.replyTraces(v, w)
 		return
 	}
 


### PR DESCRIPTION
This change updates the response of the presampler to match the version
endpoint that is in use. Previously the "OK" response was sent for the
`v0.4/traces` endpoint which was incorrect and confusing.