### PR TITLE
pkg/trace/api: allow empty Type in normalizer

### DIFF
--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -97,11 +97,7 @@ func normalize(s *pb.Span) error {
 	// ParentID set on the client side, no way of checking
 
 	// Type
-	typ := toUTF8(s.Type)
-	if typ == "" {
-		return fmt.Errorf("`Type` is invalid UTF-8: %q", typ)
-	}
-	s.Type = typ
+	s.Type = toUTF8(s.Type)
 	if len(s.Type) > MaxTypeLen {
 		return fmt.Errorf("`Type` too long (%d chars max): %s", MaxTypeLen, s.Type)
 	}


### PR DESCRIPTION
This change fixes a regression where an error occurred when the Type
field of a span wasn't set.