### PR TITLE
Support JSON arrays in environment variables

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1160,12 +1160,12 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:d0b38ba6da419a6d4380700218eeec8623841d44a856bb57369c172fbf692ab4"
+  digest = "1:2adc43fd6d031cb1d246e409a4a2d8b5a05abf1abe68d7608d7bca8cf9eaa9e1"
   name = "github.com/spf13/cast"
   packages = ["."]
   pruneopts = ""
-  revision = "8965335b8c7107321228e3e3702cab9832751bac"
-  version = "v1.2.0"
+  revision = "1ee8c8bd14a3d768a7ff681617ed56bc6c204940"
+  source = "github.com/DataDog/cast"
 
 [[projects]]
   digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -183,3 +183,8 @@
   name = "bitbucket.org/ww/goautoneg"
   source = "github.com/adjust/goautoneg"
   revision = "d788f35a0315672bc90f50a6145d1252a230ee0d"
+
+[[override]]
+  name = "github.com/spf13/cast"
+  source = "github.com/DataDog/cast"
+  revision = "1ee8c8bd14a3d768a7ff681617ed56bc6c204940"

--- a/releasenotes/notes/env-vars-json-arrays-ac7c3dd609d3bef9.yaml
+++ b/releasenotes/notes/env-vars-json-arrays-ac7c3dd609d3bef9.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Support JSON arrays within environment variables, in addition to space separated
+    values.


### PR DESCRIPTION
### What does this PR do?

Add support for JSON arrays within environment variables.

### Motivation

Be consistent with formats accepted for environment variables conveying a map, where JSON is supported. The discrepancy between those is error prone.

### Additional Notes

Anything else we should know when reviewing?
