### PR TITLE
Add logging agent in logger setup

### DIFF
--- a/Dockerfiles/agent/s6-services/agent/log/run
+++ b/Dockerfiles/agent/s6-services/agent/log/run
@@ -1,3 +1,0 @@
-#!/usr/bin/execlineb -P
-
-s6-format-filter "[ AGENT ] %s"

--- a/Dockerfiles/agent/s6-services/network/log/run
+++ b/Dockerfiles/agent/s6-services/network/log/run
@@ -1,3 +1,0 @@
-#!/usr/bin/execlineb -P
-
-s6-format-filter "[NETWORK] %s"

--- a/Dockerfiles/agent/s6-services/process/log/run
+++ b/Dockerfiles/agent/s6-services/process/log/run
@@ -1,3 +1,0 @@
-#!/usr/bin/execlineb -P
-
-s6-format-filter "[PROCESS] %s"

--- a/Dockerfiles/agent/s6-services/trace/log/run
+++ b/Dockerfiles/agent/s6-services/trace/log/run
@@ -1,3 +1,0 @@
-#!/usr/bin/execlineb -P
-
-s6-format-filter "[ TRACE ] %s"

--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -13,6 +13,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 var (
@@ -30,6 +32,9 @@ monitoring and performance data.`,
 	confFilePath string
 	flagNoColor  bool
 )
+
+// loggerName is the name of the core agent logger
+const loggerName config.LoggerName = "CORE"
 
 func init() {
 	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -87,7 +87,7 @@ var checkCmd = &cobra.Command{
 		}
 
 		// Setup logger
-		err = config.SetupLogger(logLevel, "", "", false, true, false)
+		err = config.SetupLogger(loggerName, logLevel, "", "", false, true, false)
 		if err != nil {
 			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 			return err

--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -42,6 +42,7 @@ func doDiagnose(cmd *cobra.Command, args []string) {
 	}
 
 	err := config.SetupLogger(
+		loggerName,
 		config.Datadog.GetString("log_level"),
 		common.DefaultLogFile,
 		config.GetSyslogURI(),

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -51,7 +51,7 @@ var flareCmd = &cobra.Command{
 		}
 
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format
-		config.SetupLogger("off", "", "", false, true, false)
+		config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if customerEmail == "" {
 			var err error
 			customerEmail, err = flare.AskForEmail()

--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -27,7 +27,7 @@ var getHostnameCommand = &cobra.Command{
 
 // query for the version
 func doGetHostname(cmd *cobra.Command, args []string) error {
-	config.SetupLogger("off", "", "", false, true, false)
+	config.SetupLogger(loggerName, "off", "", "", false, true, false)
 	err := common.SetupConfigWithoutSecrets(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -145,7 +145,7 @@ func setupAgent() error {
 }
 
 func runJmxCommand(command string) error {
-	err := config.SetupLogger(jmxLogLevel, "", "", false, true, false)
+	err := config.SetupLogger(loggerName, jmxLogLevel, "", "", false, true, false)
 	if err != nil {
 		fmt.Printf("Cannot setup logger, exiting: %v\n", err)
 		return err

--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -97,6 +97,7 @@ func StartAgent() error {
 		}
 
 		err = config.SetupLogger(
+			loggerName,
 			config.Datadog.GetString("log_level"),
 			logFile,
 			syslogURI,
@@ -106,6 +107,7 @@ func StartAgent() error {
 		)
 	} else {
 		err = config.SetupLogger(
+			loggerName,
 			config.Datadog.GetString("log_level"),
 			"", // no log file on android
 			"", // no syslog on android,

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -36,7 +36,7 @@ import (
 )
 
 // loggerName is the name of the cluster agent logger
-const loggerName config.LoggerName = "DCA"
+const loggerName config.LoggerName = "CLUSTER"
 
 // FIXME: move SetupAutoConfig and StartAutoConfig in their own package so we don't import cmd/agent
 var (

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -35,7 +35,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-var stopCh chan struct{}
+// loggerName is the name of the cluster agent logger
+const loggerName config.LoggerName = "DCA"
 
 // FIXME: move SetupAutoConfig and StartAutoConfig in their own package so we don't import cmd/agent
 var (
@@ -82,6 +83,7 @@ metadata for their metrics.`,
 
 	confPath    string
 	flagNoColor bool
+	stopCh      chan struct{}
 )
 
 func init() {
@@ -115,6 +117,7 @@ func start(cmd *cobra.Command, args []string) error {
 	defer mainCtxCancel() // Calling cancel twice is safe
 
 	err = config.SetupLogger(
+		loggerName,
 		config.Datadog.GetString("log_level"),
 		logFile,
 		syslogURI,

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -51,7 +51,7 @@ var flareCmd = &cobra.Command{
 		}
 
 		// The flare command should not log anything, all errors should be reported directly to the console without the log format
-		config.SetupLogger("off", "", "", false, true, false)
+		config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if customerEmail == "" {
 			var err error
 			customerEmail, err = flare.AskForEmail()

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -67,8 +67,12 @@ extensions for special Datadog features.`,
 	socketPath string
 )
 
-// run the host metadata collector every 14400 seconds (4 hours)
-const hostMetadataCollectorInterval = 14400
+const (
+	// run the host metadata collector every 14400 seconds (4 hours)
+	hostMetadataCollectorInterval = 14400
+	// loggerName is the name of the dogstatsd logger
+	loggerName config.LoggerName = "DSD"
+)
 
 func init() {
 	// attach the command to the root
@@ -119,6 +123,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	err := config.SetupLogger(
+		loggerName,
 		config.Datadog.GetString("log_level"),
 		logFile,
 		syslogURI,

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -115,6 +115,7 @@ type AutoConfigTestSuite struct {
 func (suite *AutoConfigTestSuite) SetupSuite() {
 	suite.originalListeners = listeners.ServiceListenerFactories
 	config.SetupLogger(
+		config.LoggerName("test"),
 		"debug",
 		"",
 		"",

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -333,7 +333,9 @@ func parseShortFilePath(params string) seelog.FormatterFunc {
 }
 
 func extractShortPathFromFullPath(fullPath string) string {
-	slices := strings.Split(fullPath, "/datadog-agent/")
+	// We want to trim the part containing the path of the project
+	// ie DataDog/datadog-agent/ or DataDog/datadog-process-agent/
+	slices := strings.Split(fullPath, "-agent/")
 	return slices[len(slices)-1]
 }
 

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -23,6 +23,8 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 	assert.Equal(t, "pkg/collector/scheduler.go", extractShortPathFromFullPath("pkg/collector/scheduler.go"))
 	// no path
 	assert.Equal(t, "main.go", extractShortPathFromFullPath("main.go"))
+	// process agent
+	assert.Equal(t, "cmd/agent/collector.go", extractShortPathFromFullPath("/home/jenkins/workspace/process-agent-build-ddagent/go/src/github.com/DataDog/datadog-process-agent/cmd/agent/collector.go"))
 }
 
 func benchmarkLogFormat(logFormat string, b *testing.B) {

--- a/pkg/trace/agent/log.go
+++ b/pkg/trace/agent/log.go
@@ -33,6 +33,9 @@ type throttledReceiver struct {
 	done chan struct{}
 }
 
+// loggerName is the name of the trace agent logger
+const loggerName coreconfig.LoggerName = "TRACE"
+
 // loggerConfigForwarder is used to forward any raw messages received by the throttled
 // receiver.
 const loggerConfigForwarder = `
@@ -113,8 +116,8 @@ func (r *throttledReceiver) AfterParse(args seelog.CustomReceiverInitArgs) error
 		loggerConfigError,
 		format,
 		logFilePath,
-		coreconfig.LogFormatJSON,
-		coreconfig.LogFormatCommon,
+		coreconfig.BuildJSONFormat(loggerName),
+		coreconfig.BuildCommonFormat(loggerName),
 	)
 	loggerError, err := seelog.LoggerFromConfigAsString(cfgError)
 	if err != nil {
@@ -227,8 +230,8 @@ func setupLogger(cfg *config.AgentConfig) error {
 		duration,
 		format == "json",
 		cfg.LogFilePath,
-		coreconfig.LogFormatJSON,
-		coreconfig.LogFormatCommon,
+		coreconfig.BuildJSONFormat(loggerName),
+		coreconfig.BuildCommonFormat(loggerName),
 	)
 	logger, err := seelog.LoggerFromConfigAsString(logConfig)
 	if err != nil {

--- a/pkg/util/containers/collectors/detector_test.go
+++ b/pkg/util/containers/collectors/detector_test.go
@@ -66,6 +66,7 @@ func (suite *DetectorTestSuite) SetupSuite() {
 	suite.originalCatalog = defaultCatalog
 	suite.originalPriorities = collectorPriorities
 	config.SetupLogger(
+		config.LoggerName("test"),
 		"debug",
 		"",
 		"",

--- a/pkg/util/kubernetes/kubelet/kubelet_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_test.go
@@ -790,6 +790,7 @@ func (suite *KubeletTestSuite) TestGetKubeletHostFromConfig() {
 
 func TestKubeletTestSuite(t *testing.T) {
 	config.SetupLogger(
+		config.LoggerName("test"),
 		"trace",
 		"",
 		"",

--- a/releasenotes/notes/add-logging-component-508126fd23d77e4d.yaml
+++ b/releasenotes/notes/add-logging-component-508126fd23d77e4d.yaml
@@ -1,4 +1,7 @@
 ---
 enhancements:
   - |
-    Change the logging format to include the name of the agent logging
+    Change the logging format to include the name of the agent logging instead of appending it in the agent container logs.
+fixes:
+  - |
+    The agent container will now output valid JSON when using JSON log format.

--- a/releasenotes/notes/add-logging-component-508126fd23d77e4d.yaml
+++ b/releasenotes/notes/add-logging-component-508126fd23d77e4d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Change the logging format to include the name of the agent logging

--- a/releasenotes/notes/add-logging-component-508126fd23d77e4d.yaml
+++ b/releasenotes/notes/add-logging-component-508126fd23d77e4d.yaml
@@ -1,7 +1,7 @@
 ---
 enhancements:
   - |
-    Change the logging format to include the name of the agent logging instead of appending it in the agent container logs.
+    Change the logging format to include the name of the logging agent instead of appending it in the agent container logs.
 fixes:
   - |
     The agent container will now output valid JSON when using JSON log format.

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -135,7 +135,7 @@ func NewStatsdGenerator(uri string) (*net.UDPConn, error) {
 }
 
 func initLogging() error {
-	err := config.SetupLogger("info", "", "", false, true, false)
+	err := config.SetupLogger(config.LoggerName("test"), "info", "", "", false, true, false)
 	if err != nil {
 		return fmt.Errorf("Unable to initiate logger: %s", err)
 	}

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -51,6 +51,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	config.SetupLogger(
+		config.LoggerName("test"),
 		"debug",
 		"",
 		"",

--- a/test/integration/dogstatsd/origin_detection_test.go
+++ b/test/integration/dogstatsd/origin_detection_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestUDSOriginDetection(t *testing.T) {
 	config.SetupLogger(
+		config.LoggerName("test"),
 		"debug",
 		"",
 		"",

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -44,6 +44,7 @@ func (suite *DockerListenerTestSuite) SetupSuite() {
 	tagger.Init()
 
 	config.SetupLogger(
+		config.LoggerName("test"),
 		"debug",
 		"",
 		"",

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -26,7 +26,7 @@ func TimeNowNano() float64 {
 
 // InitLogging inits default logger
 func InitLogging(level string) error {
-	err := config.SetupLogger(level, "", "", false, true, false)
+	err := config.SetupLogger(config.LoggerName("test"), level, "", "", false, true, false)
 	if err != nil {
 		return fmt.Errorf("Unable to initiate logger: %s", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Add logging agent in the logger setup.

Examples:
```
2019-02-19 14:46:01 UTC | CORE | ERROR | (pkg/logs/auditor/auditor.go:159 in recoverRegistry) | open /opt/datadog-agent/run/registry.json: no such file or directory
2019-02-19 14:49:21 UTC | DSD | INFO | (pkg/util/log/log.go:473 in func1) | Config will be read from env variables
2019-02-19 14:48:27 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:34 in GetMyNamespace) | There was an error fetching the namespace from the context, using default
```
Json:
```json
{"agent":"core","time":"2019-02-19 15:24:43 UTC","level":"ERROR","file":"pkg/collector/scheduler.go","line":"184","func":"GetChecksFromConfigs","msg":"Unable to load the check: unable to load any check from config 'redisdb'"}
```

### Motivation

To be merged once all agents are using the core `log` package as it will allow to remove the `s6-format-filter` 

Fix #1599 

### Additional Notes

Anything else we should know when reviewing?
