### PR TITLE
install_script: env var to manually set the keys server to use.

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -80,7 +80,7 @@ if [ -n "$DD_UPGRADE" ]; then
 fi
 
 keyserver="hkp://keyserver.ubuntu.com:80"
-# use this env var to specify another keys server, such as
+# use this env var to specify another key server, such as
 # hkp://p80.pool.sks-keyservers.net:80 for example.
 if [ -n "$DD_KEYSERVER" ]; then
   keyserver="$DD_KEYSERVER"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -79,9 +79,15 @@ if [ -n "$DD_UPGRADE" ]; then
   dd_upgrade=$DD_UPGRADE
 fi
 
-use_apt_backup_keyserver=
+keyserver="hkp://keyserver.ubuntu.com:80"
+# the user specifies a custom key servers.
+if [ -n "$KEYSERVER" ]; then
+  keyserver=$KEYSERVER
+fi
+# the user wants to use the backup keys server we've chosen,
+# overrides keyserver value.
 if [ -n "$USE_APT_BACKUP_KEYSERVER" ]; then
-  use_apt_backup_keyserver=$USE_APT_BACKUP_KEYSERVER
+  keyserver="hkp://keyserver.cns.vt.edu:80"
 fi
 
 if [ ! $apikey ]; then
@@ -142,11 +148,6 @@ if [ $OS = "RedHat" ]; then
     $sudo_cmd yum -y clean metadata
     $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent || $sudo_cmd yum -y install datadog-agent
 elif [ $OS = "Debian" ]; then
-
-    keyserver="hkp://keyserver.ubuntu.com:80"
-    if [ $use_apt_backup_keyserver ]; then
-        keyserver="hkp://pool.sks-keyservers.net:80"
-    fi
 
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
     $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -81,8 +81,8 @@ fi
 
 keyserver="hkp://keyserver.ubuntu.com:80"
 # the user specifies a custom key servers.
-if [ -n "$KEYSERVER" ]; then
-  keyserver=$KEYSERVER
+if [ -n "$DD_KEYSERVER" ]; then
+  keyserver=$DD_KEYSERVER
 fi
 # the user wants to use the backup keys server we've chosen,
 # overrides keyserver value.

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -80,14 +80,10 @@ if [ -n "$DD_UPGRADE" ]; then
 fi
 
 keyserver="hkp://keyserver.ubuntu.com:80"
-# the user specifies a custom key servers.
+# use this env var to specify another keys server, such as
+# hkp://p80.pool.sks-keyservers.net:80 for example.
 if [ -n "$DD_KEYSERVER" ]; then
-  keyserver=$DD_KEYSERVER
-fi
-# the user wants to use the backup keys server we've chosen,
-# overrides keyserver value.
-if [ -n "$USE_APT_BACKUP_KEYSERVER" ]; then
-  keyserver="hkp://keyserver.cns.vt.edu:80"
+  keyserver="$DD_KEYSERVER"
 fi
 
 if [ ! $apikey ]; then


### PR DESCRIPTION
### What does this PR do?

- Adds the ability to manually set the keys server to use
- Changed the default backup key server to a static one instead of one in the SKS keyservers pool.

I've kept the `USE_APT_BACKUP_KEYSERVER` flag in order to have an easy solution to provide without having to explain what is a keys server for people just wanting to backup on another one.

### Motivation

At the moment of this PR, the SKS keyservers pool sometimes returns servers not responding.

### Additional Notes

Everything is done while declaring `keyserver` at the top of the file instead of having a condition in the middle of the code.