### PR TITLE
correctly cleanup pyc files

### DIFF
--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -45,14 +45,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         fi
     fi
 
-    PIP_PATH=$INSTALL_DIR/embedded/bin/pip
-    if [ -x $PIP_PATH ]; then
-        echo "Resetting integrations..."
-        $PIP_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir || true
-    fi
-
     # For versions < 6.10 using the custom datadog-pip, TUF and in-toto files were kept in TUF_REPO_DIR.
-    # We need to clean that up on upgrade now, since it was only removed on uninstall.
+    # They were never being cleaned up, so let's do that now on install/upgrade
     TUF_REPO_DIR=$INSTALL_DIR/repositories
     if [ -d $TUF_REPO_DIR ]; then
         rm -rf $TUF_REPO_DIR
@@ -76,7 +70,15 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                 -c "Datadog Agent" dd-agent && \
                 { usermod -L dd-agent || echo "[ WARNING ]\tCannot lock the 'dd-agent' user account"; }
 
+        # Uninstall every datadog integration
+        PIP_PATH=$INSTALL_DIR/embedded/bin/pip
+        if [ -x $PIP_PATH ]; then
+            echo "Uninstalling integrations..."
+            $PIP_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir || true
+        fi
+
         # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
+        # This MUST be done after using pip or any python, because it might generate .pyc files
         if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
             # (commented lines are filtered out)
             cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f

--- a/omnibus/package-scripts/agent/preinst
+++ b/omnibus/package-scripts/agent/preinst
@@ -46,7 +46,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     fi
 
     # For versions < 6.10 using the custom datadog-pip, TUF and in-toto files were kept in TUF_REPO_DIR.
-    # They were never being cleaned up, so let's do that now on install/upgrade
+    # They were not being cleaned by these versions, so let's do that now on install/upgrade
     TUF_REPO_DIR=$INSTALL_DIR/repositories
     if [ -d $TUF_REPO_DIR ]; then
         rm -rf $TUF_REPO_DIR
@@ -71,6 +71,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
                 { usermod -L dd-agent || echo "[ WARNING ]\tCannot lock the 'dd-agent' user account"; }
 
         # Uninstall every datadog integration
+        # Starting with 6.10, integrations are also uninstalled on package removal
+        # See https://github.com/DataDog/datadog-agent/pull/3066 for more details
         PIP_PATH=$INSTALL_DIR/embedded/bin/pip
         if [ -x $PIP_PATH ]; then
             echo "Uninstalling integrations..."
@@ -78,7 +80,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         fi
 
         # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
-        # This MUST be done after using pip or any python, because it might generate .pyc files
+        # This MUST be done after using pip or any python, because executing python might generate .pyc files
         if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
             # (commented lines are filtered out)
             cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -73,6 +73,7 @@ deregister_agent()
 remove_py_compiled_files()
 {
     # Delete all the .pyc files in the embedded dir that are part of the agent's package
+    # This MUST be done after using pip or any python, because executing python might generate .pyc files
     if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
         # (commented lines are filtered out)
         cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
@@ -92,6 +93,8 @@ remove_downloader_data()
 uninstall_integrations()
 {
     # Uninstall every datadog integration
+    # Starting with 6.10, integrations are uninstalled on package removal
+    # See https://github.com/DataDog/datadog-agent/pull/3066 for more details
     PIP_PATH=$INSTALL_DIR/embedded/bin/pip
     if [ -x $PIP_PATH ]; then
         echo "Uninstalling integrations..."
@@ -102,13 +105,7 @@ uninstall_integrations()
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     stop_agent
     deregister_agent
-    # Starting with 6.10, integrations are uninstalled on package removal
-    # Upgrade from 6.8 or 6.9 to 6.10 won't uninstall integrations because it was previously done in preinst
-    # It might cause weird issues with pip and the integration command
-    # if several integration wheel metadata folders are present (pip wouldn't detect the right version of an integration),
-    # but they would be fairly easy to solve by manually removing them
     uninstall_integrations
-    # This MUST be done after using pip or any python, because it might generate .pyc files
     remove_py_compiled_files
     remove_downloader_data
 elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then

--- a/omnibus/package-scripts/agent/prerm
+++ b/omnibus/package-scripts/agent/prerm
@@ -82,15 +82,33 @@ remove_py_compiled_files()
 remove_downloader_data()
 {
     # Remove all the data that was downloaded using the integration command
+    # This is purely for cleaning up after ourselves
     DOWNLOADER_DATA="$INSTALL_DIR/embedded/lib/python2.7/site-packages/datadog_checks/downloader/data"
     if [ -d $DOWNLOADER_DATA ]; then
         rm -rf $DOWNLOADER_DATA
     fi
 }
 
+uninstall_integrations()
+{
+    # Uninstall every datadog integration
+    PIP_PATH=$INSTALL_DIR/embedded/bin/pip
+    if [ -x $PIP_PATH ]; then
+        echo "Uninstalling integrations..."
+        $PIP_PATH freeze | grep ^datadog- | grep -v datadog-checks-base | xargs $PIP_PATH uninstall -y -q --no-cache-dir || true
+    fi
+}
+
 if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
     stop_agent
     deregister_agent
+    # Starting with 6.10, integrations are uninstalled on package removal
+    # Upgrade from 6.8 or 6.9 to 6.10 won't uninstall integrations because it was previously done in preinst
+    # It might cause weird issues with pip and the integration command
+    # if several integration wheel metadata folders are present (pip wouldn't detect the right version of an integration),
+    # but they would be fairly easy to solve by manually removing them
+    uninstall_integrations
+    # This MUST be done after using pip or any python, because it might generate .pyc files
     remove_py_compiled_files
     remove_downloader_data
 elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
@@ -100,6 +118,7 @@ elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/
     case "$*" in
         0)
             # We're uninstalling.
+            uninstall_integrations
             remove_py_compiled_files
             remove_downloader_data
         ;;


### PR DESCRIPTION
### What does this PR do?

It moves the uninstallation of the integrations with pip to `prerm` for deb and rpm so that wheels upgraded with the integration command are correctly uninstalled on package removal. This is done in `preinst` for rpm in case of an upgrade.

It also makes sure that the removal of `.pyc` files is done after the above step, as using pip was generating `.pyc` files.

> Also, just to add some more details for future reference: leaving `.pyc` files in the install directory after an uninstall/upgrade is pretty bad behavior because these old `.pyc` files may then be read by the python interpreter instead of the new `.py` files that are shipped in a newly installed package

This fixes two issues:
1. Some `.pyc` files were generated in some pip folders, preventing the folders from being removed when upgrading, with warnings like ```dpkg: warning: unable to delete old directory '/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip': Directory not empty```.

1. Uninstalling integrations was not being done on removal, so it could leave wheels upgraded with the integration command in the install folder.

### Additional Notes

This change leaves us with the following edge case:
* Because of the script execution order on debian, upgrade from 6.8 or 6.9 to 6.10+ won't uninstall integrations because it was previously done in `preinst`, so now that it's moved to `prerm`, it won't get executed.
It might cause weird issues with pip and the integration command if several integration wheel metadata folders are present (pip wouldn't detect the right version of an integration), but they would be fairly easy to solve by manually removing them.

QA: 
1. install 6.9, upgrade to 6.10: no `.pyc` files remaining
1. edge case: install 6.9, upgrade integration (version different that what's in 6.10), upgrade to 6.10: two wheel metadata folders in `site-packages`
1. install 6.10, upgrade integration, remove 6.10: nothing remains in `/opt/datadog-agent`

With a subsequent rc, might be good to test upgrade from 6.10.