### PR TITLE
pkg/trace/sampler: add regression test for catalog race

### DIFF
--- a/pkg/trace/sampler/catalog.go
+++ b/pkg/trace/sampler/catalog.go
@@ -30,8 +30,8 @@ func (cat *serviceKeyCatalog) register(svcSig ServiceSignature) Signature {
 // the signatures.
 func (cat *serviceKeyCatalog) ratesByService(rates map[Signature]float64, totalScore float64) map[ServiceSignature]float64 {
 	rbs := make(map[ServiceSignature]float64, len(rates)+1)
-	defer cat.mu.Unlock()
 	cat.mu.Lock()
+	defer cat.mu.Unlock()
 	for key, sig := range cat.lookup {
 		if rate, ok := rates[sig]; ok {
 			rbs[key] = rate

--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -1,10 +1,42 @@
 package sampler
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestCatalogRegression is a regression tests ensuring that there is no race
+// occurring when registering entries in the catalog in parallel to obtaining
+// the rates by service map.
+func TestCatalogRegression(t *testing.T) {
+	cat := newServiceLookup()
+	n := 100
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			cat.register(ServiceSignature{})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			cat.ratesByService(map[Signature]float64{
+				ServiceSignature{}.Hash():                 0.3,
+				ServiceSignature{"web", "staging"}.Hash(): 0.4,
+			}, 0.2)
+		}
+	}()
+
+	wg.Wait()
+}
 
 func TestServiceSignatureString(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
This change adds a test for a race that occurred as a regression in
6.9.0 where the receiver of `(*serviceKeyCatalog).ratesByService` was of
[value type (not pointer)](https://github.com/DataDog/datadog-trace-agent/blob/6.9.0/internal/sampler/catalog.go#L31) resulting in the copying
of the mutex and of the map...

It also fixes wrong ordering in a mutex.