### PR TITLE
docs/trace-agent: add 'max_events_per_second' to the example.yaml

### DIFF
--- a/docs/trace-agent/datadog.example.yaml
+++ b/docs/trace-agent/datadog.example.yaml
@@ -67,6 +67,9 @@ apm_config:
 #   # Maximum number of traces per second to sample.
 #   max_traces_per_second: 10
 # 
+#   # Maximum number of APM events per second to sample.
+#   max_events_per_second: 200
+#
 #   # Traces having a root span with this resource will be filtered out.
 #   ignore_resources:
 #     - secret/resource


### PR DESCRIPTION
Adds `max_events_per_second` to `datadog.example.yaml`. Not a new feature, was just missing.