### PR TITLE
ensure flare directory name is valid

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -38,6 +38,9 @@ import (
 
 const (
 	routineDumpFilename = "go-routine-dump.log"
+
+	// Maximum size for the root directory name
+	directoryNameMaxSize = 32
 )
 
 var (
@@ -46,6 +49,9 @@ var (
 
 	// Match .yaml and .yml to ship configuration files in the flare.
 	cnfFileExtRx = regexp.MustCompile(`(?i)\.ya?ml`)
+
+	// Filter to clean the directory name from invalid file name characters
+	directoryNameFilter = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 
 	// Match other services api keys
 	// It is a best effort to match the api key field without matching our
@@ -106,6 +112,8 @@ func createArchive(zipFilePath string, local bool, confSearchPaths SearchPaths, 
 	if err != nil {
 		hostname = "unknown"
 	}
+
+	hostname = cleanDirectoryName(hostname)
 
 	permsInfos := make(permissionsInfos)
 
@@ -610,4 +618,12 @@ func getArchivePath() string {
 	fileName = strings.Join([]string{fileName, "zip"}, ".")
 	filePath := filepath.Join(dir, fileName)
 	return filePath
+}
+
+func cleanDirectoryName(name string) string {
+	filteredName := directoryNameFilter.ReplaceAllString(name, "_")
+	if len(filteredName) > directoryNameMaxSize {
+		return filteredName[:directoryNameMaxSize]
+	}
+	return filteredName
 }

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -179,3 +179,38 @@ func TestIncludeConfigFiles(t *testing.T) {
 	assert.True(yml, "test.yml should've been included")
 	assert.True(yaml, "test.yaml should've been included")
 }
+
+func TestCleanDirectoryName(t *testing.T) {
+	insaneHostname := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+	<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+	<title>404 - File or directory not found.</title>
+	<style type="text/css">
+	<!--
+	body{margin:0;font-size:.7em;font-family:Verdana, Arial, Helvetica, sans-serif;background:#EEEEEE;}
+	fieldset{padding:0 15px 10px 15px;}
+	h1{font-size:2.4em;margin:0;color:#FFF;}
+	h2{font-size:1.7em;margin:0;color:#CC0000;}
+	h3{font-size:1.2em;margin:10px 0 0 0;color:#000000;}
+	background-color:#555555;}
+	.content-container{background:#FFF;width:96%;margin-top:8px;padding:10px;position:relative;}
+	-->
+	</style>
+	</head>
+	<body>
+	<div id="header"><h1>Server Error</h1></div>
+	<div id="content">
+	<div class="content-container"><fieldset>
+	<h2>404 - File or directory not found.</h2>
+	<h3>The resource you are looking for might have been removed, had its name changed, or is temporarily unavailable.</h3>
+	</fieldset></div>
+	</div>
+	</body>
+	</html>`
+
+	cleanedHostname := cleanDirectoryName(insaneHostname)
+
+	assert.Len(t, cleanedHostname, directoryNameMaxSize)
+	assert.True(t, !directoryNameFilter.MatchString(cleanedHostname))
+}

--- a/releasenotes/notes/hostname-invalid-file-name-82862a66abecec0e.yaml
+++ b/releasenotes/notes/hostname-invalid-file-name-82862a66abecec0e.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Hostnames containing characters that are invalid for a filename no longer prevent the agent
+    from generating a flare.
+


### PR DESCRIPTION
### What does this PR do?

Cleans and truncate the hostname before using it as a directory name in the flare.

### Motivation

A few users had issues sending a flare because their hostname was too long or had characters that were not valid for a directory name.

