### PR TITLE
add auth_token exclusion from flare

### DIFF
--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -71,8 +71,9 @@ func getWhitelistedEnvvars() []string {
 	for _, envvar := range os.Environ() {
 		parts := strings.SplitN(envvar, "=", 2)
 		key := strings.ToUpper(parts[0])
-		if strings.Contains(key, "_KEY") {
+		if strings.Contains(key, "_KEY") || strings.Contains(key, "_AUTH_TOKEN") {
 			// `_key`-suffixed env vars are sensitive: don't track them
+			// `_auth_token`-suffixed env vars are sensitive: don't track them
 			continue
 		}
 		for _, whitelisted := range envVarWhiteList {

--- a/pkg/flare/envvars_test.go
+++ b/pkg/flare/envvars_test.go
@@ -49,6 +49,18 @@ func TestEnvvarWhitelisting(t *testing.T) {
 			},
 		},
 		{
+			name: "_auth_token env var case",
+			in: map[string]string{
+				"DOCKER_HOST":                 "tcp://10.0.0.10:8888",
+				"DD_CLUSTER_AGENT_AUTH_TOKEN": "don't pickup",
+				"GOGC":                        "120",
+			},
+			out: []string{
+				"GOGC=120",
+				"DOCKER_HOST=tcp://10.0.0.10:8888",
+			},
+		},
+		{
 			name: "process config options",
 			in: map[string]string{
 				"DOCKER_HOST":              "tcp://10.0.0.10:8888",


### PR DESCRIPTION
### What does this PR do?
filter `auth_token` and exclude it so it doesn't show up in flare

### Motivation

looks like we only have logic for api_key/app_key, DCA uses `auth_token`, We should include that, or have some blacklisting

