### PR TITLE
corechecks: missing call to CommonConfigure in some corechecks.

### DIFF
--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -28,8 +28,7 @@ const (
 
 // CRIConfig holds the config of the check
 type CRIConfig struct {
-	Tags        []string `yaml:"tags"`
-	CollectDisk bool     `yaml:"collect_disk"`
+	CollectDisk bool `yaml:"collect_disk"`
 }
 
 // CRICheck grabs CRI metrics

--- a/pkg/collector/corechecks/system/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu_windows.go
@@ -117,6 +117,10 @@ func (c *CPUCheck) Run() error {
 
 // Configure the CPU check doesn't need configuration
 func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data) error {
+	if err := c.CommonConfigure(data); err != nil {
+		return err
+	}
+
 	// do nothing
 	info, err := cpu.GetCpuInfo()
 	if err != nil {

--- a/pkg/collector/corechecks/system/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/file_handles_windows.go
@@ -45,6 +45,10 @@ func (c *fhCheck) Run() error {
 
 // The check doesn't need configuration
 func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
+	if err := c.CommonConfigure(data); err != nil {
+		return err
+	}
+
 	c.counter, err = pdhutil.GetMultiInstanceCounter("Process", "Handle Count", &[]string{"_Total"}, nil)
 	return err
 }

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -24,6 +24,10 @@ const (
 
 // Configure the IOstats check
 func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.Data) error {
+	if err := c.CommonConfigure(data); err != nil {
+		return err
+	}
+
 	conf := make(map[interface{}]interface{})
 
 	err := yaml.Unmarshal([]byte(initConfig), &conf)

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -38,6 +38,10 @@ const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
 func (c *MemoryCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
+	if err := c.CommonConfigure(data); err != nil {
+		return err
+	}
+
 	c.cacheBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Cache Bytes")
 	if err == nil {
 		c.committedBytes, err = pdhutil.GetSingleInstanceCounter("Memory", "Committed Bytes")


### PR DESCRIPTION
### What does this PR do?

The IOstats corecheck and Windows version of memory, file_handles and CPU were not using the `CommonConfigure` of their `CheckBase` instance, thus, they were not sending the custom tags configured in their conf file.

Also removed an unused attribute. (was still there due to an overlook)