### PR TITLE
Add reno entry for systemd < 229 compatibility.

### DIFF
--- a/releasenotes/notes/systemd-229-compat-startlimit-7adee37449ab40f1.yaml
+++ b/releasenotes/notes/systemd-229-compat-startlimit-7adee37449ab40f1.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    In order to ensure compatibility with systemd < 229,
+    ``StartLimitBurst`` and ``StartLimitInterval`` have been
+    moved to the Service section of the service files.


### PR DESCRIPTION
About StartLimit{Burst,Interval} moved to section Service.
