### PR TITLE
Make sure logs global processing rules can be set with a env var

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -321,6 +321,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.frame_size", 9000)
 	// increase the number of files that can be tailed in parallel:
 	config.BindEnvAndSetDefault("logs_config.open_files_limit", 100)
+	// add global processing rules that are applied on all logs
+	config.BindEnv("logs_config.processing_rules")
 
 	// Internal Use Only: avoid modifying those configuration parameters, this could lead to unexpected results.
 	config.BindEnvAndSetDefault("logset", "")

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -38,6 +38,7 @@ func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {
 	suite.Equal("", suite.config.GetString("logs_config.logs_dd_url"))
 	suite.Equal(false, suite.config.GetBool("logs_config.logs_no_ssl"))
 	suite.Equal(30, suite.config.GetInt("logs_config.stop_grace_period"))
+	suite.Equal(nil, suite.config.Get("logs_config.processing_rules"))
 }
 
 func (suite *ConfigTestSuite) TestDefaultSources() {


### PR DESCRIPTION
### What does this PR do?

Bound `logs_config.processing_rules`

### Motivation

Make sure logs global processing rules can be set with a env var for containerised environments for example

### Additional Notes

Anything else we should know when reviewing?
