### PR TITLE
fixing yaml spacing to mark as top order element

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -63,8 +63,8 @@ api_key:
 #  With a raw collected tag "foo:1;2;3"
 #  Using the following configuration:
 #
-#    tag_value_split_separator:
-#      foo: ;
+# tag_value_split_separator:
+#   foo: ;
 #
 #  will result in the raw tag being transformed into "foo:1", "foo:2", "foo:3" tags
 


### PR DESCRIPTION
### What does this PR do?

Fixes spacing to denote that this is a first order yaml block and not a sub-block of `tags:`

### Motivation

Troubleshooting onsite with a customer, couldn't get it to work until digging in deeper to the code. Docs incorrect.

### Additional Notes


