### PR TITLE
Add cluster_checks.extra_tags option

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -31,6 +31,7 @@ func newDispatcher() *dispatcher {
 		store: newClusterStore(),
 	}
 	d.nodeExpirationSeconds = config.Datadog.GetInt64("cluster_checks.node_expiration_timeout")
+	d.extraTags = config.Datadog.GetStringSlice("cluster_checks.extra_tags")
 
 	clusterTagValue := clustername.GetClusterName()
 	clusterTagName := config.Datadog.GetString("cluster_checks.cluster_tag_name")

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -399,19 +399,23 @@ func TestPatchConfiguration(t *testing.T) {
 	assert.Equal(t, true, rawConfig["empty_default_hostname"])
 }
 
-func TestClusterNameTag(t *testing.T) {
+func TestExtraTags(t *testing.T) {
 	for _, tc := range []struct {
+		extraTagsConfig   []string
 		clusterNameConfig string
 		tagNameConfig     string
 		expected          []string
 	}{
-		{"testing", "cluster_name", []string{"cluster_name:testing"}},
-		{"mycluster", "custom_name", []string{"custom_name:mycluster"}},
-		{"", "cluster_name", nil},
-		{"testing", "", nil},
+		{nil, "testing", "cluster_name", []string{"cluster_name:testing"}},
+		{nil, "mycluster", "custom_name", []string{"custom_name:mycluster"}},
+		{nil, "", "cluster_name", nil},
+		{nil, "testing", "", nil},
+		{[]string{"one", "two"}, "", "", []string{"one", "two"}},
+		{[]string{"one", "two"}, "mycluster", "custom_name", []string{"one", "two", "custom_name:mycluster"}},
 	} {
 		t.Run(fmt.Sprintf(""), func(t *testing.T) {
 			mockConfig := config.Mock()
+			mockConfig.Set("cluster_checks.extra_tags", tc.extraTagsConfig)
 			mockConfig.Set("cluster_name", tc.clusterNameConfig)
 			mockConfig.Set("cluster_checks.cluster_tag_name", tc.tagNameConfig)
 
@@ -420,5 +424,4 @@ func TestClusterNameTag(t *testing.T) {
 			assert.EqualValues(t, tc.expected, dispatcher.extraTags)
 		})
 	}
-
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -365,6 +365,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)         // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
+	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 
 	setAssetFs(config)
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -565,6 +565,9 @@ api_key:
 #   You can use another tag name, or disable it by setting an empty name.
 #   cluster_tag_name: cluster_name
 #
+#   Additionnal tags can be set here. They will be added to every cluster-check configuration
+#   extra_tags: []
+#
 {{ end -}}
 {{- if .DockerTagging }}
 # Container detection


### PR DESCRIPTION
### What does this PR do?

Allow to set more constant tags than the `cluster_name` one. They'll be appended to all check configs that go though the clusterchecks logic.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
