### PR TITLE
Support milliquantities for the External Metrics Provider

### DIFF
--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -100,10 +100,16 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 		extMetric.info = provider.ExternalMetricInfo{
 			Metric: metric.MetricName,
 		}
+		// Avoid overflowing when trying to get a 10^3 precision
+		q, err := resource.ParseQuantity(fmt.Sprintf("%ve3", metric.Value))
+		if err != nil {
+			log.Errorf("Could not parse the metric value: %v into the exponential format", metric.Value)
+			continue
+		}
 		extMetric.value = external_metrics.ExternalMetricValue{
 			MetricName:   metric.MetricName,
 			MetricLabels: metric.Labels,
-			Value:        *resource.NewMilliQuantity(int64(metric.Value*1000), resource.DecimalSI),
+			Value:        *resource.NewMilliQuantity(q.Value(), resource.DecimalSI),
 		}
 		externalMetricsList = append(externalMetricsList, extMetric)
 

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -103,7 +103,7 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 		extMetric.value = external_metrics.ExternalMetricValue{
 			MetricName:   metric.MetricName,
 			MetricLabels: metric.Labels,
-			Value:        *resource.NewQuantity(metric.Value, resource.DecimalSI),
+			Value:        *resource.NewMilliQuantity(int64(metric.Value*1000), resource.DecimalSI),
 		}
 		externalMetricsList = append(externalMetricsList, extMetric)
 

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -101,7 +101,7 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 			Metric: metric.MetricName,
 		}
 		// Avoid overflowing when trying to get a 10^3 precision
-		q, err := resource.ParseQuantity(fmt.Sprintf("%ve3", metric.Value))
+		q, err := resource.ParseQuantity(fmt.Sprintf("%v", metric.Value))
 		if err != nil {
 			log.Errorf("Could not parse the metric value: %v into the exponential format", metric.Value)
 			continue
@@ -109,7 +109,7 @@ func (p *datadogProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo
 		extMetric.value = external_metrics.ExternalMetricValue{
 			MetricName:   metric.MetricName,
 			MetricLabels: metric.Labels,
-			Value:        *resource.NewMilliQuantity(q.Value(), resource.DecimalSI),
+			Value:        q,
 		}
 		externalMetricsList = append(externalMetricsList, extMetric)
 

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -144,7 +144,7 @@ func TestGetExternalMetric(t *testing.T) {
 			[]external_metrics.ExternalMetricValue{},
 		},
 		{
-			"one matching metric with capital letterstored",
+			"one matching metric with capital letter stored",
 			[]ExternalMetricValue{
 				{
 					MetricName: "CapitalMetric",

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -8,16 +8,16 @@
 package custommetrics
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-
-	"fmt"
-
-	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 )
 
 type mockDatadogProvider struct {
@@ -36,6 +36,161 @@ type metricCompare struct {
 	name      provider.ExternalMetricInfo
 	namespace string
 	labels    labels.Set
+}
+
+func TestListAllExternalMetrics(t *testing.T) {
+	metricName := "m1"
+	metric2Name := "m2"
+	metric3Name := "m3"
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	cachedQuantity, _ := resource.ParseQuantity("0.00000000003")
+	tests := []struct {
+		name          string
+		metricsStored []ExternalMetricValue
+		cached        []externalMetric
+		expected      []externalMetric
+		timestamp     int64
+	}{
+		{
+			name:          "no metrics stored",
+			metricsStored: []ExternalMetricValue{},
+			cached:        []externalMetric{},
+			expected:      nil,
+		},
+		{
+			name: "last call is too recent",
+			metricsStored: []ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Labels:     labels,
+					Valid:      true,
+				}},
+			cached: []externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: labels,
+					Value:        cachedQuantity,
+				},
+			}},
+			timestamp: metav1.Now().Unix(),
+			expected: []externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: labels,
+					Value:        cachedQuantity,
+				},
+			}},
+		},
+		{
+			name: "one nano metric stored",
+			metricsStored: []ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Value:      float64(0.000000001),
+					Labels:     labels,
+					Valid:      true,
+				}},
+			cached: []externalMetric{{}},
+			expected: []externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: labels,
+					Value:        resource.MustParse("1e-09"),
+				},
+			},
+			},
+			timestamp: 0,
+		},
+		{
+			name: "multiple types",
+			metricsStored: []ExternalMetricValue{
+				{
+					MetricName: metricName,
+					Value:      float64(0.012),
+					Labels:     labels,
+					Valid:      true,
+				}, {
+					MetricName: metric2Name,
+					Value:      float64(1),
+					Labels:     labels,
+					Valid:      true,
+				}, {
+					MetricName: metric3Name,
+					Value:      float64(1000001),
+					Labels:     labels,
+					Valid:      true,
+				}, {
+					MetricName: "unexpected",
+					Labels:     labels,
+					Valid:      false,
+				},
+			},
+			expected: []externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: labels,
+					Value:        *resource.NewMilliQuantity(12, resource.DecimalSI),
+				},
+			}, {
+				info: provider.ExternalMetricInfo{
+					Metric: metric2Name,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metric2Name,
+					MetricLabels: labels,
+					Value:        resource.MustParse("1"),
+				},
+			},
+				{
+					info: provider.ExternalMetricInfo{
+						Metric: metric3Name,
+					},
+					value: external_metrics.ExternalMetricValue{
+						MetricName:   metric3Name,
+						MetricLabels: labels,
+						Value:        resource.MustParse("1.000001e+06"),
+					}}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := &mockDatadogProvider{
+				mockListAllExternalMetricValues: func() ([]ExternalMetricValue, error) {
+					return test.metricsStored, nil
+				},
+			}
+			dp := datadogProvider{
+				store:           Store(m),
+				timestamp:       test.timestamp,
+				maxAge:          int64(300),
+				externalMetrics: test.cached,
+			}
+			output := dp.ListAllExternalMetrics()
+			require.Equal(t, len(test.expected), len(output))
+
+			for _, q := range dp.externalMetrics {
+				for _, val := range test.expected {
+					if val.info.Metric == q.info.Metric {
+						require.Equal(t, val.value, q.value)
+					}
+				}
+			}
+		})
+	}
 }
 
 func TestGetExternalMetric(t *testing.T) {

--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -12,7 +12,7 @@ type ExternalMetricValue struct {
 	Labels     map[string]string `json:"labels"`
 	Timestamp  int64             `json:"ts"`
 	HPA        ObjectReference   `json:"hpa"`
-	Value      int64             `json:"value"`
+	Value      float64           `json:"value"`
 	Valid      bool              `json:"valid"`
 }
 

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -96,7 +96,7 @@ func (d *fakeDatadogClient) QueryMetrics(from, to int64, query string) ([]datado
 
 var maxAge = time.Duration(30 * time.Second)
 
-func makePoints(ts, val int) datadog.DataPoint {
+func makePoints(ts int, val float64) datadog.DataPoint {
 	if ts == 0 {
 		ts = (int(metav1.Now().Unix()) - int(maxAge.Seconds()/2)) * 1000 // use ms
 	}
@@ -140,18 +140,18 @@ func TestAutoscalerController(t *testing.T) {
 		{
 			Metric: &metricName,
 			Points: []datadog.DataPoint{
-				makePoints(1531492452000, 12),
-				makePoints(penTime, 14),
-				makePoints(0, 25),
+				makePoints(1531492452000, 12.01),
+				makePoints(penTime, 14.123),
+				makePoints(0, 25.12),
 			},
 			Scope: makePtr("foo:bar"),
 		},
 		{
 			Metric: &metricName,
 			Points: []datadog.DataPoint{
-				makePoints(1531492452000, 12),
-				makePoints(penTime, 11),
-				makePoints(0, 19),
+				makePoints(1531492452000, 12.34),
+				makePoints(penTime, 1.01),
+				makePoints(0, 0.902),
 			},
 			Scope: makePtr("dcos_version:2.1.9"),
 		},
@@ -216,7 +216,7 @@ func TestAutoscalerController(t *testing.T) {
 		storedExternal, err := store.ListAllExternalMetricValues()
 		require.NoError(t, err)
 		require.NotZero(t, len(storedExternal))
-		require.Equal(t, storedExternal[0].Value, int64(14))
+		require.Equal(t, storedExternal[0].Value, float64(14.123))
 		require.Equal(t, storedExternal[0].Labels, map[string]string{"foo": "bar"})
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")
@@ -267,7 +267,7 @@ func TestAutoscalerController(t *testing.T) {
 		storedExternal, err := store.ListAllExternalMetricValues()
 		require.NoError(t, err)
 		require.NotZero(t, len(storedExternal))
-		require.Equal(t, storedExternal[0].Value, int64(11))
+		require.Equal(t, storedExternal[0].Value, float64(1.01))
 		require.Equal(t, storedExternal[0].Labels, map[string]string{"dcos_version": "2.1.9"})
 	case <-timeout.C:
 		require.FailNow(t, "Timeout waiting for HPAs to update")

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -133,7 +133,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 			precision := time.Now().Unix() - point.timestamp
 			metricsDelay.WithLabelValues(m).Set(float64(precision))
 
-			log.Debugf("Validated %s | Value:%d at %d after %d/%d buckets", m, point.value, point.timestamp, i+1, len(serie.Points))
+			log.Debugf("Validated %s | Value:%v at %d after %d/%d buckets", m, point.value, point.timestamp, i+1, len(serie.Points))
 			break
 		}
 	}

--- a/pkg/util/kubernetes/hpa/datadogexternal.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 type Point struct {
-	value     int64
+	value     float64
 	timestamp int64
 	valid     bool
 }
@@ -121,7 +121,7 @@ func (p *Processor) queryDatadogExternal(metricNames []string) (map[string]Point
 				skippedLastPoint = true
 				continue
 			}
-			point.value = int64(*serie.Points[i][value])                // store the original value
+			point.value = *serie.Points[i][value]                       // store the original value
 			point.timestamp = int64(*serie.Points[i][timestamp] / 1000) // Datadog's API returns timestamps in s
 			point.valid = true
 

--- a/pkg/util/kubernetes/hpa/datadogexternal_test.go
+++ b/pkg/util/kubernetes/hpa/datadogexternal_test.go
@@ -92,17 +92,17 @@ func TestDatadogExternalQuery(t *testing.T) {
 			[]string{"mymetric{foo:bar,baz:ar}", "mymetric2{foo:baz}", "my.aws.metric{ba:bar}"},
 			map[string]Point{
 				"mymetric{foo:bar,baz:ar}": {
-					value:     42,
+					value:     42.0,
 					valid:     true,
 					timestamp: 300,
 				},
 				"mymetric2{foo:baz}": {
-					value:     70,
+					value:     70.0,
 					valid:     true,
 					timestamp: 110,
 				},
 				"my.aws.metric{ba:bar}": {
-					value:     0,
+					value:     0.0,
 					valid:     false,
 					timestamp: time.Now().Unix(),
 				},


### PR DESCRIPTION
### What does this PR do?

When using the Cluster Agent as an External Metrics Provider, the values are cast into int64 as it is the format of the value in the struct `ExternalMetricValue` that is expected by the interface.
We will now leverage the `NewMilliQuantity` function to allow users to autoscale on metrics [0;1].


### Motivation

Customer Request: https://github.com/DataDog/datadog-agent/issues/3043
