### PR TITLE
set default dogstatsd_packet_buffer_size to 512, add a configuration option to control dogstatsd inner packet queue

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -201,7 +201,7 @@ func initConfig(config Config) {
 	// we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
 	// After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue
 	// is `dogstatsd_queue_size`.
-	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*4)
+	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)
 	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 512)
 	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_flush_timeout", 100*time.Millisecond)
 	config.BindEnvAndSetDefault("dogstatsd_queue_size", 100)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -194,10 +194,18 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
 	// Dogstatsd
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
-	config.BindEnvAndSetDefault("dogstatsd_port", 8125)                                        // Notice: 0 means UDP port closed
-	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)                               // 8KB buffer
-	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 4096)                          // Number of packets to buffer at dogstatsd intake before flushing them to parsing/aggregation
-	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_flush_timeout", 100*time.Millisecond) // Timeout after which we force dogstatsd intake buffer to be flushed
+	config.BindEnvAndSetDefault("dogstatsd_port", 8125) // Notice: 0 means UDP port closed
+
+	// The following options allows to configure how the dogstatsd intake buffers and queues incoming datagrams.
+	// When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
+	// we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
+	// After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue
+	// is `dogstatsd_queue_size`.
+	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 4096)
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_flush_timeout", 100*time.Millisecond)
+	config.BindEnvAndSetDefault("dogstatsd_queue_size", 100)
+
 	config.BindEnvAndSetDefault("dogstatsd_non_local_traffic", false)
 	config.BindEnvAndSetDefault("dogstatsd_socket", "") // Notice: empty means feature disabled
 	config.BindEnvAndSetDefault("dogstatsd_stats_port", 5000)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,7 +196,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("use_dogstatsd", true)
 	config.BindEnvAndSetDefault("dogstatsd_port", 8125) // Notice: 0 means UDP port closed
 
-	// The following options allows to configure how the dogstatsd intake buffers and queues incoming datagrams.
+	// The following options allow to configure how the dogstatsd intake buffers and queues incoming datagrams.
 	// When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
 	// we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
 	// After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -201,8 +201,8 @@ func initConfig(config Config) {
 	// we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
 	// After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue
 	// is `dogstatsd_queue_size`.
-	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)
-	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 4096)
+	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*4)
+	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 512)
 	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_flush_timeout", 100*time.Millisecond)
 	config.BindEnvAndSetDefault("dogstatsd_queue_size", 100)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -199,7 +199,7 @@ func initConfig(config Config) {
 	// The following options allow to configure how the dogstatsd intake buffers and queues incoming datagrams.
 	// When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
 	// we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
-	// After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue
+	// After this happens we flush this buffer of datagrams to a queue for processing. The size of this queue
 	// is `dogstatsd_queue_size`.
 	config.BindEnvAndSetDefault("dogstatsd_buffer_size", 1024*8)
 	config.BindEnvAndSetDefault("dogstatsd_packet_buffer_size", 512)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -249,8 +249,15 @@ api_key:
 # If running dogstatsd in a container, host PID mode (e.g. with --pid=host) is required.
 # dogstatsd_origin_detection: false
 #
-# The buffer size use to receive statsd packet, in bytes
-# dogstatsd_buffer_size: 1024
+# The following options allow to configure how dogstatsd buffers and queues incoming datagrams.
+# When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
+# we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
+# After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue
+# is `dogstatsd_queue_size`.
+# dogstatsd_buffer_size: 8192
+# dogstatsd_packet_buffer_size: 512
+# dogstatsd_packet_buffer_flush_timeout: 100ms
+# dogstatsd_queue_size: 100
 #
 # Whether dogstatsd should listen to non local UDP traffic
 # dogstatsd_non_local_traffic: false

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -252,15 +252,6 @@ api_key:
 # The buffer size use to receive statsd packet, in bytes
 # dogstatsd_buffer_size: 8192
 #
-# The following options allow to configure how dogstatsd buffers and queues incoming datagrams.
-# When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
-# we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
-# After this happens we flush this buffer of datagrams to a queue for processing. The size of this queue
-# is `dogstatsd_queue_size`.
-# dogstatsd_packet_buffer_size: 512
-# dogstatsd_packet_buffer_flush_timeout: 100ms
-# dogstatsd_queue_size: 100
-#
 # Whether dogstatsd should listen to non local UDP traffic
 # dogstatsd_non_local_traffic: false
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -252,7 +252,7 @@ api_key:
 # The following options allow to configure how dogstatsd buffers and queues incoming datagrams.
 # When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
 # we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
-# After this happens we flush this buffer of datagrams to a queue for processing. The size if this queue
+# After this happens we flush this buffer of datagrams to a queue for processing. The size of this queue
 # is `dogstatsd_queue_size`.
 # dogstatsd_buffer_size: 8192
 # dogstatsd_packet_buffer_size: 512

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -249,12 +249,14 @@ api_key:
 # If running dogstatsd in a container, host PID mode (e.g. with --pid=host) is required.
 # dogstatsd_origin_detection: false
 #
+# The buffer size use to receive statsd packet, in bytes
+# dogstatsd_buffer_size: 8192
+#
 # The following options allow to configure how dogstatsd buffers and queues incoming datagrams.
 # When a datagram is received it is first added to a datagrams buffer. This buffer fills up until
 # we reach `dogstatsd_packet_buffer_size` datagrams or after `dogstatsd_packet_buffer_flush_timeout` ms.
 # After this happens we flush this buffer of datagrams to a queue for processing. The size of this queue
 # is `dogstatsd_queue_size`.
-# dogstatsd_buffer_size: 8192
 # dogstatsd_packet_buffer_size: 512
 # dogstatsd_packet_buffer_flush_timeout: 100ms
 # dogstatsd_queue_size: 100

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -71,8 +71,7 @@ func NewServer(metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metr
 		stats = s
 		dogstatsdExpvars.Set("PacketsLastSecond", &dogstatsdPacketsLastSec)
 	}
-
-	packetsChannel := make(chan listeners.Packets, 100)
+	packetsChannel := make(chan listeners.Packets, config.Datadog.GetInt("dogstatsd_queue_size"))
 	packetPool := listeners.NewPacketPool(config.Datadog.GetInt("dogstatsd_buffer_size"))
 	tmpListeners := make([]listeners.StatsdListener, 0, 2)
 
@@ -141,7 +140,7 @@ func NewServer(metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metr
 		if err != nil {
 			log.Warnf("Could not connect to statsd forward host : %s", err)
 		} else {
-			s.packetsIn = make(chan listeners.Packets, 100)
+			s.packetsIn = make(chan listeners.Packets, config.Datadog.GetInt("dogstatsd_queue_size"))
 			go s.forwarder(con, packetsChannel)
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

- set default `dogstatsd_packet_buffer_size` to 512
- add a configuration option to control dogstatsd inner packet queue

### Motivation

The worst case is 8KB (`dogstatsd_buffer_size`) * 4096 (`dogstatsd_packet_buffer_size`) * 100 (`dogstatsd_queue_size`) ~= 3.3GB of queued data

Let's go with a less scary 420MB for the default values. From my testing this should not affect performance at sane dogstatsd throughputs.
