### PR TITLE
[docs] Update release note and doc on new JMXFetch version

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -324,25 +324,25 @@ api_key:
 # Duration of the restart interval in seconds
 # jmx_restart_interval: 5
 #
-# JMXFetch collects multiples instances concurrently. The following metrics may
+# JMXFetch collects multiples instances concurrently. The following options may
 # help fine-tune the level of concurrency and timeouts that come into play during the
 # collection of metrics from configured instances:
 #
 # Defines the maximum level of concurrency. Higher concurrency will increase CPU
 # utilization during metric collection. Lower concurrency will result in lower CPU
-# usage but also fewer workers in the event of timeouts to continue work - a value of
-# 1 will process instances serially, each taking up to `jmx_collection_timeout`
+# usage but may increase the total collection time - a value of 1 will process
+# instances serially. The total collection is allowed to take up to `jmx_collection_timeout`
 # seconds.
 # jmx_thread_pool_size: 3
 #
 # Defines the maximum waiting period in seconds before timing up on metric collection.
 # jmx_collection_timeout: 60
 #
-# Defines the maximum level of concurrency in the reconnection pool. Higher concurrency
-# will increase CPU utilization during instance recovery/reconnection. Lower concurrency
-# will result in lower CPU usage but also fewer workers in the event of timeouts to continue
-# work - a value of 1 will process instances serially, each taking up to `jmx_reconnection_timeout`
-# seconds.
+# Defines the maximum level of concurrency. Higher concurrency will increase CPU
+# utilization during reconnection. Lower concurrency will result in lower CPU
+# usage but may increase the total reconnection time - a value of 1 will process
+# instance reconnections serially. In total, reconnections are allowed to take up to
+# `jmx_reconnection_timeout` seconds.
 # jmx_reconnection_thread_pool_size: 3
 #
 # Determines the maximum waiting period in seconds before timing up on instance reconnection.

--- a/releasenotes/notes/jmxfetch-0.26.0-concurrency-support-14de5c08f927bd1c.yaml
+++ b/releasenotes/notes/jmxfetch-0.26.0-concurrency-support-14de5c08f927bd1c.yaml
@@ -8,10 +8,11 @@
 ---
 features:
   - |
-    JMXFetch upgraded to 0.26.1: introduces support for concurrent instance
-    metric collection. Concurrent collection should avoid stalling
+    JMXFetch upgraded to 0.26.1: introduces concurrent metric collection across
+    JMXFetch check instances. Concurrent collection should avoid stalling
     healthy instances in the event of issues (networking, system) in
-    any of the remaining instances configured.
+    any of the remaining instances configured. A timeout of ``jmx_collection_timeout``
+    (default 60s) is enforced on the whole metric collection run.
     See `0.25.0  <https://github.com/DataDog/jmxfetch/releases/tag/0.25.0>`_,
     `0.26.0  <https://github.com/DataDog/jmxfetch/releases/tag/0.26.0>`_ and
     `0.26.1  <https://github.com/DataDog/jmxfetch/releases/tag/0.26.1>`_.


### PR DESCRIPTION
### What does this PR do?

* updates `feature` release note to mention the option `jmx_collection_timeout` (didn't create an `upgrade` note after all, I don't think the change warrants one).
* tries to clarify the docs in the config template (but it isn't easy to explain in a few lines, feel free to add your changes on the branch)
