### PR TITLE
pkg/trace/writer: be less verbose about flushes

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -87,7 +87,9 @@ $> reno new <topic-of-my-pr> --edit
 ```
 
 Then just add and commit the new releasenote (located in `releasenotes/notes/`)
-with your PR.
+with your PR. If the change is on the `trace-agent` (folders `cmd/trace-agent` or `pkg/trace`)
+please prefix the release note with "APM :" and the <topic-of-my-pr> argument with
+"apm-".
 
 #### Reno sections
 

--- a/pkg/trace/writer/service.go
+++ b/pkg/trace/writer/service.go
@@ -74,7 +74,7 @@ func (w *ServiceWriter) Run() {
 			switch event.typ {
 			case eventTypeSuccess:
 				url := event.stats.host
-				log.Infof("flushed service payload; url:%s, time:%s, size:%d bytes", url, event.stats.sendTime,
+				log.Debugf("flushed service payload; url:%s, time:%s, size:%d bytes", url, event.stats.sendTime,
 					len(event.payload.bytes))
 				tags := []string{"url:" + url}
 				metrics.Gauge("datadog.trace_agent.service_writer.flush_duration",

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -262,7 +262,7 @@ func (w *StatsWriter) monitor() {
 			switch e.typ {
 			case eventTypeSuccess:
 				url := e.stats.host
-				log.Infof("flushed stat payload; url: %s, time:%s, size:%d bytes", url, e.stats.sendTime,
+				log.Debugf("flushed stat payload; url: %s, time:%s, size:%d bytes", url, e.stats.sendTime,
 					len(e.payload.bytes))
 				tags := []string{"url:" + url}
 				metrics.Gauge("datadog.trace_agent.stats_writer.flush_duration",

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -100,7 +100,7 @@ func (w *TraceWriter) Run() {
 		for event := range w.sender.Monitor() {
 			switch event.typ {
 			case eventTypeSuccess:
-				log.Infof("flushed trace payload to the API, time:%s, size:%d bytes", event.stats.sendTime,
+				log.Debugf("flushed trace payload to the API, time:%s, size:%d bytes", event.stats.sendTime,
 					len(event.payload.bytes))
 				tags := []string{"url:" + event.stats.host}
 				metrics.Gauge("datadog.trace_agent.trace_writer.flush_duration",

--- a/releasenotes/notes/apm-move-flush-log-to-debug-221e5f16ca6f2ad5.yaml
+++ b/releasenotes/notes/apm-move-flush-log-to-debug-221e5f16ca6f2ad5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: move flush notifications from level "INFO" to "DEBUG"


### PR DESCRIPTION
This change modifies the logging level applied when reporting that a
flush to the Datadog API has occurred from "INFO" to "DEBUG". This
matches the behaviour in the core agent.

Closes #2939