### PR TITLE
[invoke] get_version should always return string

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -206,7 +206,9 @@ def get_version(ctx, include_git=False, url_safe=False, git_sha_length=7, prefix
             version = "{0}.git.{1}.{2}".format(version, commits_since_version,git_sha)
         else:
             version = "{0}+git.{1}.{2}".format(version, commits_since_version,git_sha)
-    return version
+
+    # version could be unicode as it comes from `query_version`
+    return str(version)
 
 def get_version_numeric_only(ctx):
     version, _, _, _ = query_version(ctx)


### PR DESCRIPTION
### What does this PR do?

I believe this is breaking the windows pipelines.

Noticed the `env['PACKAGE_VERSION']` was unicode for the `6.10.0` pipeline, depending on the order we commit stuff `get_version()` will normally generate a string, but if we return the version extracted by `query_version` in the invoke task, this could well be unicode. Given that it should be ASCII anyways, a straight-forward conversion to `str()` should fix it.

I also noticed the pipeline did not fail with non-unicode `env['PACKAGE_VERSION']`

### Motivation

Agent release `6.10.0` windows pipeline broken.

```
Traceback (most recent call last):
  File "c:\python27\lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "c:\python27\scripts\inv.exe\__main__.py", line 9, in <module>
  File "c:\python27\lib\site-packages\invoke\program.py", line 293, in run
    self.execute()
  File "c:\python27\lib\site-packages\invoke\program.py", line 414, in execute
    executor.execute(*self.tasks)
  File "c:\python27\lib\site-packages\invoke\executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "c:\python27\lib\site-packages\invoke\tasks.py", line 115, in __call__
    result = self.body(*args, **kwargs)
  File "c:\dev\go\src\github.com\DataDog\datadog-agent\tasks\agent.py", line 311, in omnibus_build
    ctx.run(cmd.format(**args), env=env)
  File "c:\python27\lib\site-packages\invoke\context.py", line 82, in run
    return self._run(runner, command, **kwargs)
  File "c:\python27\lib\site-packages\invoke\context.py", line 89, in _run
    return runner.run(command, **kwargs)
  File "c:\python27\lib\site-packages\invoke\runners.py", line 262, in run
    return self._run_body(command, **kwargs)
  File "c:\python27\lib\site-packages\invoke\runners.py", line 276, in _run_body
    self.start(command, shell, env)
  File "c:\python27\lib\site-packages\invoke\runners.py", line 981, in start
    stdin=PIPE,
  File "c:\python27\lib\subprocess.py", line 390, in __init__
    errread, errwrite)
  File "c:\python27\lib\subprocess.py", line 640, in _execute_child
    startupinfo)
TypeError: environment can only contain strings
```

### Additional Notes

