### PR TITLE
[invoke][release] nothing to do if there are no release notes

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -7,6 +7,7 @@ import sys
 from datetime import date
 
 from invoke import task, Failure
+from invoke.exceptions import UnexpectedExit
 
 
 @task
@@ -59,8 +60,12 @@ def update_changelog(ctx, new_version):
 
     # removing releasenotes from bugfix on the old minor.
     previous_minor = "%s.%s" % (new_version_int[0], new_version_int[1] - 1)
-    ctx.run("git rm --ignore-unmatch `git log {}.0...remotes/origin/{}.x --name-only \
-            | grep releasenotes/notes/`".format(previous_minor, previous_minor))
+    try:
+        log_result = ctx.run("git log {}.0...remotes/origin/{}.x --name-only | \
+                grep releasenotes/notes/".format(previous_minor, previous_minor))
+        ctx.run("git rm --ignore-unmatch {}".format(log_result.stdin))
+    except UnexpectedExit:
+        pass  # non-zero exit code means no matches - nothing to do
 
     # generate the new changelog
     ctx.run("reno report \

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -22,8 +22,6 @@ def add_prelude(ctx, version):
 
     - Please refer to the `{0} tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-{2}>`_ for the list of changes on the Core Checks.
 
-    - Please refer to the `{0} tag on trace-agent <https://github.com/DataDog/datadog-trace-agent/releases/tag/{0}>`_ for the list of changes on the Trace Agent.
-
     - Please refer to the `{0} tag on process-agent <https://github.com/DataDog/datadog-process-agent/releases/tag/{0}>`_ for the list of changes on the Process Agent.\n""".format(version, date.today(), version.replace('.', '')))
 
     ctx.run("git add {}".format(new_releasenote))


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the changelog generating task would fail if there were no release notes between `6.X.0...6.X.Y`. If the list comes empty, we'll have a non-zero exit code, and we can just continue without removing any of the release notes.

### Motivation

`6.9` had no bugfixes so we encountered this during the release.