### PR TITLE
Fix an AD race leading to checks not unscheduling

### DIFF
--- a/cmd/agent/common/autoconfig.go
+++ b/cmd/agent/common/autoconfig.go
@@ -105,6 +105,5 @@ func SetupAutoConfig(confdPath string) {
 //   1. load all the configurations available at startup
 //   2. run all the Checks for each configuration found
 func StartAutoConfig() {
-	AC.StartTagFreshnessChecker()
 	AC.LoadAndRun()
 }

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -61,10 +61,6 @@ type AutoConfig struct {
 	healthPolling      *health.Handle
 	listenerStop       chan struct{}
 	healthListening    *health.Handle
-	tagFreshnessTicker *time.Ticker
-	tagFreshnessStop   chan struct{}
-	tagFreshnessActive bool
-	healthTagFreshness *health.Handle
 	newService         chan listeners.Service
 	delService         chan listeners.Service
 	store              *store
@@ -79,77 +75,58 @@ func NewAutoConfig(scheduler *scheduler.MetaScheduler) *AutoConfig {
 		listenerRetryStop:  nil, // We'll open it if needed
 		listenerStop:       make(chan struct{}),
 		healthListening:    health.Register("ad-servicelistening"),
-		tagFreshnessStop:   make(chan struct{}),
-		healthTagFreshness: health.Register("ad-tagfreshnesschecker"),
 		newService:         make(chan listeners.Service),
 		delService:         make(chan listeners.Service),
 		store:              newStore(),
 		scheduler:          scheduler,
 	}
 	// We need to listen to the service channels before anything is sent to them
-	ac.startServiceListening()
+	go ac.serviceListening()
 	return ac
 }
 
-// StartTagFreshnessChecker checks periodically if tags associated to a service
-// are up-to-date, act as the service was restarted to reschedule potential checks
-func (ac *AutoConfig) StartTagFreshnessChecker() {
-	ac.tagFreshnessTicker = time.NewTicker(15 * time.Second) // we can miss tags for one run
-	ac.tagFreshnessActive = true
-	go func() {
-		for {
-			select {
-			case <-ac.healthTagFreshness.C:
-			case <-ac.tagFreshnessStop:
-				if ac.tagFreshnessTicker != nil {
-					ac.tagFreshnessTicker.Stop()
-				}
-				ac.healthTagFreshness.Deregister()
-				return
-			case <-ac.tagFreshnessTicker.C:
-				// check if services tags are up to date
-				var servicesToRefresh []listeners.Service
-				for _, service := range ac.store.getServices() {
-					previousHash := ac.store.getTagsHashForService(service.GetEntity())
-					currentHash := tagger.GetEntityHash(service.GetEntity())
-					if currentHash != previousHash {
-						ac.store.setTagsHashForService(service.GetEntity(), currentHash)
-						if previousHash != "" {
-							// only refresh service if we already had a hash to avoid resetting it
-							servicesToRefresh = append(servicesToRefresh, service)
-						}
-					}
-				}
-				for _, service := range servicesToRefresh {
-					log.Debugf("Tags changed for service %s, rescheduling associated checks if any", service.GetEntity())
-					ac.processDelService(service)
-					ac.processNewService(service)
-				}
-			}
+// serviceListening is the main management goroutine for services.
+// It waits for service events to trigger template resolution and
+// checks the tags on existing services are up to date.
+func (ac *AutoConfig) serviceListening() {
+	tagFreshnessTicker := time.NewTicker(15 * time.Second) // we can miss tags for one run
+	defer tagFreshnessTicker.Stop()
+
+	for {
+		select {
+		case <-ac.listenerStop:
+			ac.healthListening.Deregister()
+			return
+		case <-ac.healthListening.C:
+		case svc := <-ac.newService:
+			ac.processNewService(svc)
+		case svc := <-ac.delService:
+			ac.processDelService(svc)
+		case <-tagFreshnessTicker.C:
+			ac.checkTagFreshness()
 		}
-	}()
+	}
 }
 
-// startServiceListening waits on services and templates and process them as they come.
-// It can trigger scheduling decisions or just update its cache.
-func (ac *AutoConfig) startServiceListening() {
-	ac.m.Lock()
-	defer ac.m.Unlock()
-
-	go func() {
-		for {
-			select {
-			case <-ac.listenerStop:
-				ac.healthListening.Deregister()
-				return
-			case <-ac.healthListening.C:
-			case svc := <-ac.newService:
-				ac.processNewService(svc)
-			case svc := <-ac.delService:
-				ac.processDelService(svc)
+func (ac *AutoConfig) checkTagFreshness() {
+	// check if services tags are up to date
+	var servicesToRefresh []listeners.Service
+	for _, service := range ac.store.getServices() {
+		previousHash := ac.store.getTagsHashForService(service.GetEntity())
+		currentHash := tagger.GetEntityHash(service.GetEntity())
+		if currentHash != previousHash {
+			ac.store.setTagsHashForService(service.GetEntity(), currentHash)
+			if previousHash != "" {
+				// only refresh service if we already had a hash to avoid resetting it
+				servicesToRefresh = append(servicesToRefresh, service)
 			}
 		}
-	}()
+	}
+	for _, service := range servicesToRefresh {
+		log.Debugf("Tags changed for service %s, rescheduling associated checks if any", service.GetEntity())
+		ac.processDelService(service)
+		ac.processNewService(service)
+	}
 }
 
 // Stop just shuts down AutoConfig in a clean way.
@@ -158,12 +135,6 @@ func (ac *AutoConfig) startServiceListening() {
 func (ac *AutoConfig) Stop() {
 	ac.m.Lock()
 	defer ac.m.Unlock()
-
-	// stop the tag freshness ticker if running
-	if ac.tagFreshnessActive {
-		ac.tagFreshnessStop <- struct{}{}
-		ac.tagFreshnessActive = false
-	}
 
 	// stop polled config providers
 	for _, pd := range ac.providers {

--- a/releasenotes/notes/ad-race-unscheduling-a23d7d59af5bc9a2.yaml
+++ b/releasenotes/notes/ad-race-unscheduling-a23d7d59af5bc9a2.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a race condition in Autodiscovery leading to some checks not
+    being unscheduled on container exit


### PR DESCRIPTION
### What does this PR do?

Several users are impacted with a bug leading to checks not being unscheduled on container exit. After reproducing and adding additional logging, what is happening is that the check is unscheduled but immediately re-scheduled afterwards.

### Bug investigation

Additional investigation showed the issue comes from a race condition between the goroutines started by [StartTagFreshnessChecker](https://github.com/DataDog/datadog-agent/blob/0c2129ffadff50a946c92a7f104edb951e62086b/pkg/autodiscovery/autoconfig.go#L96-L131) and [startServiceListening](https://github.com/DataDog/datadog-agent/blob/0c2129ffadff50a946c92a7f104edb951e62086b/pkg/autodiscovery/autoconfig.go#L135-L153). The lifecycle (see the following logs) as as follows:

- The freshness logic is triggered by the ticker (if tags for a service change, remove the config and trigger a new config resolution to emit a new config with updated tags)
- It starts working on a copy of the service list (acquired by `ac.store.getServices()`)
- It iterates over them, finds tags for `1d097546` changed, unschedules the configuration with [processDelService](https://github.com/DataDog/datadog-agent/blob/0c2129ffadff50a946c92a7f104edb951e62086b/pkg/autodiscovery/autoconfig.go#L636-L650) 
  - During this time, the kubelet listener deletes the service for the container `1d097546`, as it has exited
  - This triggers [a call to processDelService](https://github.com/DataDog/datadog-agent/blob/0c2129ffadff50a946c92a7f104edb951e62086b/pkg/autodiscovery/autoconfig.go#L148-L149) too, which is a silent NOOP, as the service was already out
- The freshness goroutine calls [processNewService](https://github.com/DataDog/datadog-agent/blob/0c2129ffadff50a946c92a7f104edb951e62086b/pkg/autodiscovery/autoconfig.go#L593-L633) on `1d097546`, unaware that the container actually exited

> 2019-02-28 12:17:10 UTC | DEBUG | (autoconfig.go:124 in func1) | Tags changed for service docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d, rescheduling associated checks if any
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:626 in processDelService) | **Entering processDelService** for docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
2019-02-28 12:17:10 UTC | INFO | (scheduler.go:102 in Cancel) | Unscheduling check redisdb:943fca6af96228a1
2019-02-28 12:17:10 UTC | DEBUG | (runner.go:217 in StopCheck) | Stopping check redisdb:943fca6af96228a1
2019-02-28 12:17:10 UTC | DEBUG | (runner.go:406 in RemoveCheckStats) | Remove stats for redisdb:943fca6af96228a1
...
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:641 in processDelService) | **Exiting processDelService** for docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:581 in processNewService) | **Entering processNewService** for docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
...
2019-02-28 12:17:10 UTC | INFO | (kubelet.go:108 in func1) | Expired entity docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:150 in func1) | Removed service: docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:626 in processDelService) | **Entering processDelService** for docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
...
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:641 in processDelService) | **Exiting processDelService** for docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d
...
2019-02-28 12:17:10 UTC | INFO | (autoconfig.go:620 in processNewService) | **Exiting processNewService** for docker://1d09754677ab55a7f53899bc2ef2506db095324e08c613bedb6bd71d54e2925d

Although `ac.store` reads and writes are protected by a mutex, the methods in `autoconfig.go` make several sequential actions on the store, assuming it does not change. They should ideally hold a mutex to ensure the carpet is not pulled from under their feet.

### Remediation (this PR)

This PR does the following:

- move the tag freshness checker logic into a dedicated `checkTagFreshness` method (extracted with no changed from `StartTagFreshnessChecker`)
- merge the two goroutines (from `StartTagFreshnessChecker` and `startServiceListening`) in a single goroutine `select`ing on chans/tickers, to ensure the two logics do not run concurrently
- make `tagFreshnessTicker` a local method of the goroutine instead of a struct field, as there is no need to access it elsewhere. This simplifies its cancellation.
- cleanup unused fields (stopchan / healthcheck) related to the now removed `tagFreshness` goroutine
- move from `startServiceListening` declaring and running an anonymous goroutine to a direct `go ac.serviceListening()` syntax so logs and stacktraces show a useful function name instead of `func1`

### Future-proofing

Although the current implementation of `configPoller` does not seem to trigger any issue, we are vulnerable to introducing a similar race condition between `AutoConfig.serviceListening` and `configPoller.poll`, as this method also triggers actions that change the AD state, and can run concurrently.

To avoid a future a PR introducing such a race condition, one of the following should be implemented:

- `configPoller` should send added/removed configs via channels that would be read by `AutoConfig.serviceListening`. This would make `serviceListening` the only goroutine allowed to mutate the AD state, and therefore ensure no race condition is possible.
- both methods should lock the `ac.m` mutex around code reading & modifying the state

### Testing

e2e is green on image `datadog/agent-dev:xvello-ad-race`, more intensive manual testing is required before merging.