### PR TITLE
pkg/trace/api: fix incorrect error message

### DIFF
--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -61,12 +61,10 @@ func normalize(s *pb.Span) error {
 	}
 	s.Name = name
 
-	// Resource
-	resource := toUTF8(s.Resource)
 	if s.Resource == "" {
-		return fmt.Errorf("`Resource` is invalid UTF-8: %q", resource)
+		return errors.New("`Resource` can not be empty")
 	}
-	s.Resource = resource
+	s.Resource = toUTF8(s.Resource)
 
 	// ParentID, TraceID and SpanID set in the client could be the same
 	// Supporting the ParentID == TraceID == SpanID for the root span, is compliant

--- a/releasenotes/notes/apm-resource-empty-error-df551e379831093d.yaml
+++ b/releasenotes/notes/apm-resource-empty-error-df551e379831093d.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: when a span's resource is empty, the error "`Resource` can not be empty"
+    will be returned instead of the wrong "`Resource` is invalid UTF-8".


### PR DESCRIPTION
This change fixes an incorrect error message where previously a "bad
UTF-8" error was returned instead of "empty resource".