### PR TITLE
pkg/trace/event: make event service & operation matching insensitive

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -101,7 +101,7 @@ type AgentConfig struct {
 	// It maps tag keys to a set of replacements. Only supported in A6.
 	ReplaceTags []*ReplaceRule
 
-	// transaction analytics
+	// transaction analytics, all map keys are lower-cased by Viper.
 	AnalyzedRateByServiceLegacy map[string]float64
 	AnalyzedSpansByService      map[string]map[string]float64
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -101,7 +101,7 @@ type AgentConfig struct {
 	// It maps tag keys to a set of replacements. Only supported in A6.
 	ReplaceTags []*ReplaceRule
 
-	// transaction analytics, all map keys are lower-cased by Viper.
+	// transaction analytics
 	AnalyzedRateByServiceLegacy map[string]float64
 	AnalyzedSpansByService      map[string]map[string]float64
 

--- a/pkg/trace/event/extractor_fixed_rate.go
+++ b/pkg/trace/event/extractor_fixed_rate.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 )
@@ -13,6 +15,7 @@ type fixedRateExtractor struct {
 
 // NewFixedRateExtractor returns an APM event extractor that decides whether to extract APM events from spans following
 // the provided extraction rates for a span's (service name, operation name) pair.
+// The map keys must strictly be lower-cased, as provided by Viper.
 func NewFixedRateExtractor(rateByServiceAndName map[string]map[string]float64) Extractor {
 	return &fixedRateExtractor{
 		rateByServiceAndName: rateByServiceAndName,
@@ -24,11 +27,11 @@ func NewFixedRateExtractor(rateByServiceAndName map[string]map[string]float64) E
 // extraction rate and a true value. If no extraction happened, false is returned as the third value and the others
 // are invalid.
 func (e *fixedRateExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
-	operations, ok := e.rateByServiceAndName[s.Service]
+	operations, ok := e.rateByServiceAndName[strings.ToLower(s.Service)]
 	if !ok {
 		return 0, false
 	}
-	extractionRate, ok := operations[s.Name]
+	extractionRate, ok := operations[strings.ToLower(s.Name)]
 	if !ok {
 		return 0, false
 	}

--- a/pkg/trace/event/extractor_fixed_rate_test.go
+++ b/pkg/trace/event/extractor_fixed_rate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/stretchr/testify/assert"
 )
 
 func createTestSpans(serviceName string, operationName string) []*pb.Span {
@@ -15,16 +16,37 @@ func createTestSpans(serviceName string, operationName string) []*pb.Span {
 	return spans
 }
 
+func TestFixedCases(t *testing.T) {
+	assert := assert.New(t)
+	e := NewFixedRateExtractor(map[string]map[string]float64{
+		"service1": {
+			"op1": 1,
+			"op2": 0.5,
+		},
+	})
+
+	span1 := &pb.Span{Service: "service1", Name: "op1"}
+	span2 := &pb.Span{Service: "SerVice1", Name: "Op2"}
+
+	rate, ok := e.Extract(span1, 0)
+	assert.Equal(rate, 1.)
+	assert.True(ok)
+
+	rate, ok = e.Extract(span2, 0)
+	assert.Equal(rate, 0.5)
+	assert.True(ok)
+}
+
 func TestAnalyzedExtractor(t *testing.T) {
 	config := make(map[string]map[string]float64)
-	config["serviceA"] = make(map[string]float64)
-	config["serviceA"]["opA"] = 0
+	config["servicea"] = make(map[string]float64)
+	config["servicea"]["opa"] = 0
 
-	config["serviceB"] = make(map[string]float64)
-	config["serviceB"]["opB"] = 0.5
+	config["serviceb"] = make(map[string]float64)
+	config["serviceb"]["opb"] = 0.5
 
-	config["serviceC"] = make(map[string]float64)
-	config["serviceC"]["opC"] = 1
+	config["servicec"] = make(map[string]float64)
+	config["servicec"]["opc"] = 1
 
 	tests := []extractorTestCase{
 		// Name: <priority>/(<no match reason>/<extraction rate>)

--- a/pkg/trace/event/extractor_fixed_rate_test.go
+++ b/pkg/trace/event/extractor_fixed_rate_test.go
@@ -19,8 +19,8 @@ func createTestSpans(serviceName string, operationName string) []*pb.Span {
 func TestFixedCases(t *testing.T) {
 	assert := assert.New(t)
 	e := NewFixedRateExtractor(map[string]map[string]float64{
-		"service1": {
-			"op1": 1,
+		"sERvice1": {
+			"OP1": 1,
 			"op2": 0.5,
 		},
 	})
@@ -39,14 +39,14 @@ func TestFixedCases(t *testing.T) {
 
 func TestAnalyzedExtractor(t *testing.T) {
 	config := make(map[string]map[string]float64)
-	config["servicea"] = make(map[string]float64)
-	config["servicea"]["opa"] = 0
+	config["serviceA"] = make(map[string]float64)
+	config["serviceA"]["opA"] = 0
 
-	config["serviceb"] = make(map[string]float64)
-	config["serviceb"]["opb"] = 0.5
+	config["serviceB"] = make(map[string]float64)
+	config["serviceB"]["opB"] = 0.5
 
-	config["servicec"] = make(map[string]float64)
-	config["servicec"]["opc"] = 1
+	config["serviceC"] = make(map[string]float64)
+	config["serviceC"]["opC"] = 1
 
 	tests := []extractorTestCase{
 		// Name: <priority>/(<no match reason>/<extraction rate>)

--- a/pkg/trace/event/extractor_legacy.go
+++ b/pkg/trace/event/extractor_legacy.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
@@ -13,7 +15,7 @@ type legacyExtractor struct {
 }
 
 // NewLegacyExtractor returns an APM event extractor that decides whether to extract APM events from spans following the
-// specified extraction rates for a span's service.
+// specified extraction rates for a span's service. The map keys must strictly be lower-cased.
 func NewLegacyExtractor(rateByService map[string]float64) Extractor {
 	return &legacyExtractor{
 		rateByService: rateByService,
@@ -28,7 +30,7 @@ func (e *legacyExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority)
 	if !traceutil.HasTopLevel(s) {
 		return 0, false
 	}
-	extractionRate, ok := e.rateByService[s.Service]
+	extractionRate, ok := e.rateByService[strings.ToLower(s.Service)]
 	if !ok {
 		return 0, false
 	}

--- a/pkg/trace/event/extractor_legacy.go
+++ b/pkg/trace/event/extractor_legacy.go
@@ -15,11 +15,14 @@ type legacyExtractor struct {
 }
 
 // NewLegacyExtractor returns an APM event extractor that decides whether to extract APM events from spans following the
-// specified extraction rates for a span's service. The map keys must strictly be lower-cased.
+// specified extraction rates for a span's service.
 func NewLegacyExtractor(rateByService map[string]float64) Extractor {
-	return &legacyExtractor{
-		rateByService: rateByService,
+	// lower-case keys for case insensitive matching (see #3113)
+	rbs := make(map[string]float64, len(rateByService))
+	for k, v := range rateByService {
+		rbs[strings.ToLower(k)] = v
 	}
+	return &legacyExtractor{rateByService: rbs}
 }
 
 // Extract decides to extract an apm event from the provided span if there's an extraction rate configured for that

--- a/pkg/trace/event/extractor_legacy_test.go
+++ b/pkg/trace/event/extractor_legacy_test.go
@@ -1,0 +1,20 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLegacyCases(t *testing.T) {
+	assert := assert.New(t)
+	e := NewLegacyExtractor(map[string]float64{"service1": 1})
+	span := &pb.Span{Service: "SeRvIcE1"}
+	traceutil.SetTopLevel(span, true)
+
+	rate, ok := e.Extract(span, 0)
+	assert.Equal(rate, 1.)
+	assert.True(ok)
+}

--- a/pkg/trace/event/extractor_legacy_test.go
+++ b/pkg/trace/event/extractor_legacy_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestLegacyCases(t *testing.T) {
 	assert := assert.New(t)
-	e := NewLegacyExtractor(map[string]float64{"service1": 1})
+	e := NewLegacyExtractor(map[string]float64{"serviCE1": 1})
 	span := &pb.Span{Service: "SeRvIcE1"}
 	traceutil.SetTopLevel(span, true)
 

--- a/releasenotes/notes/apm-analyzed-spans-insensitive-f0c03d742df708df.yaml
+++ b/releasenotes/notes/apm-analyzed-spans-insensitive-f0c03d742df708df.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Mixing cases in `apm_config.analyzed_spans` and `apm_config.analyzed_rate_by_service`
+    entries is now allowed. Service names and operation names will be treated as case insensitive.


### PR DESCRIPTION
This change makes `apm_config.analyzed_rate_by_service` and `apm_config.analyzed_spans`
entries case insensitive.

The reasoning behind this is that Viper always lower-cases keys in the yaml file,
making it impossible to make case-sensitive comparisons against the orginal value.

See spf13/viper#411.