### PR TITLE
consider k8s endpoints as ad svc

### DIFF
--- a/pkg/autodiscovery/listeners/kube_services_test.go
+++ b/pkg/autodiscovery/listeners/kube_services_test.go
@@ -286,12 +286,12 @@ func TestProcessEndpoint(t *testing.T) {
 	}
 
 	endpt := processEndpoint(kendpt, true)
-	assert.Equal(t, "kube_endpoint://test", endpt.GetEntity())
+	assert.Equal(t, "kube_endpoint://default/myendpoint", endpt.GetEntity())
 	assert.Equal(t, integration.Before, endpt.GetCreationTime())
 
 	adID, err := endpt.GetADIdentifiers()
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"kube_endpoint://test"}, adID)
+	assert.Equal(t, []string{"kube_endpoint://default/myendpoint"}, adID)
 
 	hosts, err := endpt.GetHosts()
 	assert.NoError(t, err)

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -27,13 +27,19 @@ const (
 	// AD on the load-balanced service IPs
 	kubeServiceAnnotationPrefix = "ad.datadoghq.com/service."
 	// AD on the individual service endpoints (TODO)
-	// kubeEndpointAnnotationPrefix = "ad.datadoghq.com/endpoints."
+	kubeEndpointAnnotationPrefix = "ad.datadoghq.com/endpoints."
 	// kubeEndpointIDPrefix         = "kube_endpoint://"
 )
 
 // KubeletConfigProvider implements the ConfigProvider interface for the kubelet.
 type KubeServiceConfigProvider struct {
 	lister   listersv1.ServiceLister
+	upToDate bool
+}
+
+// KubeletConfigProvider implements the ConfigProvider interface for the kubelet.
+type KubeEndpointConfigProvider struct {
+	lister   listersv1.EndpointsLister
 	upToDate bool
 }
 
@@ -117,6 +123,130 @@ func (k *KubeServiceConfigProvider) invalidateIfChanged(old, obj interface{}) {
 	}
 }
 
+func parseServiceAnnotations(services []*v1.Service) ([]integration.Config, error) {
+	var configs []integration.Config
+	for _, svc := range services {
+		if svc == nil || svc.ObjectMeta.UID == "" {
+			log.Debug("Ignoring a nil service")
+			continue
+		}
+		service_id := apiserver.EntityForService(svc)
+		c, errors := extractTemplatesFromMap(service_id, svc.Annotations, kubeServiceAnnotationPrefix)
+		for _, err := range errors {
+			log.Errorf("Cannot parse template for service %s/%s: %s", svc.Namespace, svc.Name, err)
+		}
+		// All configurations are cluster checks
+		for i := range c {
+			c[i].ClusterCheck = true
+		}
+		configs = append(configs, c...)
+	}
+
+	return configs, nil
+}
+
+// NewKubeEndpointConfigProvider returns a new ConfigProvider connected to kubelet.
+// Connectivity is not checked at this stage to allow for retries, Collect will do it.
+func NewKubeEndpointConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+	ac, err := apiserver.GetAPIClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)
+	}
+	endpointsInformer := ac.InformerFactory.Core().V1().Endpoints()
+	if endpointsInformer == nil {
+		return nil, fmt.Errorf("cannot get endpoint informer: %s", err)
+	}
+
+	p := &KubeEndpointConfigProvider{
+		lister: endpointsInformer.Lister(),
+	}
+
+	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    p.invalidate,
+		UpdateFunc: p.invalidateIfChanged,
+		DeleteFunc: p.invalidate,
+	})
+
+	return p, nil
+}
+
+// String returns a string representation of the KubeEndpointConfigProvider
+func (k *KubeEndpointConfigProvider) String() string {
+	return KubeServices
+}
+
+// Collect retrieves services from the apiserver, builds Config objects and returns them
+func (k *KubeEndpointConfigProvider) Collect() ([]integration.Config, error) {
+	endpoints, err := k.lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	k.upToDate = true
+
+	return parseEndpointAnnotations(endpoints)
+}
+
+// IsUpToDate allows to cache configs as long as no changes are detected in the apiserver
+func (k *KubeEndpointConfigProvider) IsUpToDate() (bool, error) {
+	return k.upToDate, nil
+}
+
+func (k *KubeEndpointConfigProvider) invalidate(obj interface{}) {
+	if obj != nil {
+		log.Trace("Invalidating configs on new/deleted endpoint")
+		k.upToDate = false
+	}
+}
+
+func (k *KubeEndpointConfigProvider) invalidateIfChanged(old, obj interface{}) {
+	// Cast the updated object, don't invalidate on casting error.
+	// nil pointers are safely handled by the casting logic.
+	castedObj, ok := obj.(*v1.Endpoints)
+	if !ok {
+		log.Errorf("Expected a Endpoints type, got: %v", obj)
+		return
+	}
+	// Cast the old object, invalidate on casting error
+	castedOld, ok := old.(*v1.Endpoints)
+	if !ok {
+		log.Errorf("Expected a Endpoints type, got: %v", old)
+		k.upToDate = false
+		return
+	}
+	// Quick exit if resversion did not change
+	if castedObj.ResourceVersion == castedOld.ResourceVersion {
+		return
+	}
+	// Compare annotations
+	if valuesDiffer(castedObj.Annotations, castedOld.Annotations, kubeEndpointAnnotationPrefix) {
+		log.Trace("Invalidating configs on endpoint change")
+		k.upToDate = false
+		return
+	}
+}
+
+func parseEndpointAnnotations(endpoints []*v1.Endpoints) ([]integration.Config, error) {
+	var configs []integration.Config
+	for _, endpt := range endpoints {
+		if endpt == nil || endpt.ObjectMeta.UID == "" {
+			log.Debug("Ignoring a nil endpoint")
+			continue
+		}
+		endpoint_id := apiserver.EntityForEndpoints(endpt)
+		c, errors := extractTemplatesFromMap(endpoint_id, endpt.Annotations, kubeEndpointAnnotationPrefix)
+		for _, err := range errors {
+			log.Errorf("Cannot parse template for endpoint %s/%s: %s", endpt.Namespace, endpt.Name, err)
+		}
+		// All configurations are cluster checks
+		for i := range c {
+			c[i].ClusterCheck = true
+		}
+		configs = append(configs, c...)
+	}
+
+	return configs, nil
+}
+
 // valuesDiffer returns true if the annotations matching the
 // given prefix are different between map first and second.
 // It also counts the annotation count to catch deletions.
@@ -141,28 +271,6 @@ func valuesDiffer(first, second map[string]string, prefix string) bool {
 	}
 
 	return matchingInFirst != matchingInSecond
-}
-
-func parseServiceAnnotations(services []*v1.Service) ([]integration.Config, error) {
-	var configs []integration.Config
-	for _, svc := range services {
-		if svc == nil || svc.ObjectMeta.UID == "" {
-			log.Debug("Ignoring a nil service")
-			continue
-		}
-		service_id := apiserver.EntityForService(svc)
-		c, errors := extractTemplatesFromMap(service_id, svc.Annotations, kubeServiceAnnotationPrefix)
-		for _, err := range errors {
-			log.Errorf("Cannot parse template for service %s/%s: %s", svc.Namespace, svc.Name, err)
-		}
-		// All configurations are cluster checks
-		for i := range c {
-			c[i].ClusterCheck = true
-		}
-		configs = append(configs, c...)
-	}
-
-	return configs, nil
 }
 
 func init() {

--- a/pkg/autodiscovery/providers/kube_services_test.go
+++ b/pkg/autodiscovery/providers/kube_services_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -141,6 +141,136 @@ func TestInvalidateIfChanged(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf(""), func(t *testing.T) {
 			provider := &KubeServiceConfigProvider{upToDate: true}
+			provider.invalidateIfChanged(tc.old, tc.obj)
+
+			upToDate, err := provider.IsUpToDate()
+			assert.NoError(t, err)
+			assert.Equal(t, !tc.invalidate, upToDate)
+		})
+	}
+}
+
+func TestParseKubeEndpointAnnotations(t *testing.T) {
+	for _, tc := range []struct {
+		endpoint    *v1.Endpoints
+		expectedOut []integration.Config
+	}{
+		{
+			endpoint:    nil,
+			expectedOut: nil,
+		},
+		{
+			endpoint: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("test"),
+					Annotations: map[string]string{
+						"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
+						"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+						"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
+					},
+				},
+			},
+			expectedOut: []integration.Config{
+				{
+					Name:          "etcd",
+					ADIdentifiers: []string{"kube_endpoint://test"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:2379/metrics\",\"use_preview\":\"true\"}")},
+					ClusterCheck:  true,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf(""), func(t *testing.T) {
+			cfgs, _ := parseEndpointAnnotations([]*v1.Endpoints{tc.endpoint})
+			assert.EqualValues(t, tc.expectedOut, cfgs)
+		})
+	}
+}
+
+func TestInvalidateIfChangedEndpoint(t *testing.T) {
+	s88 := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "88",
+		},
+	}
+	s89 := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "89",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
+				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+				"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
+			},
+		},
+	}
+	s90 := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "90",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
+				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+				"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
+			},
+		},
+	}
+	s91 := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "91",
+		},
+	}
+	invalid := &v1.Pod{}
+
+	for _, tc := range []struct {
+		old        interface{}
+		obj        interface{}
+		invalidate bool
+	}{
+		{
+			// Invalid input
+			old:        nil,
+			obj:        nil,
+			invalidate: false,
+		},
+		{
+			// Sync on missed create
+			old:        nil,
+			obj:        s88,
+			invalidate: true,
+		},
+		{
+			// Edit, annotations added
+			old:        s88,
+			obj:        s89,
+			invalidate: true,
+		},
+		{
+			// Informer resync, don't invalidate
+			old:        s89,
+			obj:        s89,
+			invalidate: false,
+		},
+		{
+			// Invalid input, don't invalidate
+			old:        s89,
+			obj:        invalid,
+			invalidate: false,
+		},
+		{
+			// Edit but same annotations
+			old:        s89,
+			obj:        s90,
+			invalidate: false,
+		},
+		{
+			// Edit, annotations removed
+			old:        s89,
+			obj:        s91,
+			invalidate: true,
+		},
+	} {
+		t.Run(fmt.Sprintf(""), func(t *testing.T) {
+			provider := &KubeEndpointConfigProvider{upToDate: true}
 			provider.invalidateIfChanged(tc.old, tc.obj)
 
 			upToDate, err := provider.IsUpToDate()

--- a/pkg/autodiscovery/providers/kube_services_test.go
+++ b/pkg/autodiscovery/providers/kube_services_test.go
@@ -32,11 +32,16 @@ func TestParseKubeServiceAnnotations(t *testing.T) {
 		{
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: types.UID("test"),
+					UID:       types.UID("test"),
+					Namespace: "default",
+					Name:      "myendpoint",
 					Annotations: map[string]string{
-						"ad.datadoghq.com/service.check_names":  "[\"http_check\"]",
-						"ad.datadoghq.com/service.init_configs": "[{}]",
-						"ad.datadoghq.com/service.instances":    "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/service.check_names":    "[\"http_check\"]",
+						"ad.datadoghq.com/service.init_configs":   "[{}]",
+						"ad.datadoghq.com/service.instances":      "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+						"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
+						"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+						"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
 					},
 				},
 			},
@@ -46,6 +51,13 @@ func TestParseKubeServiceAnnotations(t *testing.T) {
 					ADIdentifiers: []string{"kube_service://test"},
 					InitConfig:    integration.Data("{}"),
 					Instances:     []integration.Data{integration.Data("{\"name\":\"My service\",\"timeout\":1,\"url\":\"http://%%host%%\"}")},
+					ClusterCheck:  true,
+				},
+				{
+					Name:          "etcd",
+					ADIdentifiers: []string{"kube_endpoint://default/myendpoint"},
+					InitConfig:    integration.Data("{}"),
+					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:2379/metrics\",\"use_preview\":\"true\"}")},
 					ClusterCheck:  true,
 				},
 			},
@@ -89,6 +101,34 @@ func TestInvalidateIfChanged(t *testing.T) {
 			ResourceVersion: "91",
 		},
 	}
+	s92 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "92",
+			Namespace:       "default",
+			Name:            "myendpoint",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/service.check_names":    "[\"http_check\"]",
+				"ad.datadoghq.com/service.init_configs":   "[{}]",
+				"ad.datadoghq.com/service.instances":      "[{\"name\": \"My service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+				"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
+				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+				"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
+			},
+		},
+	}
+	s93 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: "93",
+			Annotations: map[string]string{
+				"ad.datadoghq.com/service.check_names":    "[\"http_check\"]",
+				"ad.datadoghq.com/service.init_configs":   "[{}]",
+				"ad.datadoghq.com/service.instances":      "[{\"name\": \"My NEW service\", \"url\": \"http://%%host%%\", \"timeout\": 1}]",
+				"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
+				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
+				"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
+			},
+		},
+	}
 	invalid := &v1.Pod{}
 
 	for _, tc := range []struct {
@@ -136,141 +176,23 @@ func TestInvalidateIfChanged(t *testing.T) {
 			// Edit, annotations removed
 			old:        s89,
 			obj:        s91,
+			invalidate: true,
+		},
+		{
+			// Edit, add endpoints annotations
+			old:        s89,
+			obj:        s92,
+			invalidate: true,
+		},
+		{
+			// Edit endpoints annotations
+			old:        s92,
+			obj:        s93,
 			invalidate: true,
 		},
 	} {
 		t.Run(fmt.Sprintf(""), func(t *testing.T) {
 			provider := &KubeServiceConfigProvider{upToDate: true}
-			provider.invalidateIfChanged(tc.old, tc.obj)
-
-			upToDate, err := provider.IsUpToDate()
-			assert.NoError(t, err)
-			assert.Equal(t, !tc.invalidate, upToDate)
-		})
-	}
-}
-
-func TestParseKubeEndpointAnnotations(t *testing.T) {
-	for _, tc := range []struct {
-		endpoint    *v1.Endpoints
-		expectedOut []integration.Config
-	}{
-		{
-			endpoint:    nil,
-			expectedOut: nil,
-		},
-		{
-			endpoint: &v1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					UID: types.UID("test"),
-					Annotations: map[string]string{
-						"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
-						"ad.datadoghq.com/endpoints.init_configs": "[{}]",
-						"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
-					},
-				},
-			},
-			expectedOut: []integration.Config{
-				{
-					Name:          "etcd",
-					ADIdentifiers: []string{"kube_endpoint://test"},
-					InitConfig:    integration.Data("{}"),
-					Instances:     []integration.Data{integration.Data("{\"prometheus_url\":\"http://%%host%%:2379/metrics\",\"use_preview\":\"true\"}")},
-					ClusterCheck:  true,
-				},
-			},
-		},
-	} {
-		t.Run(fmt.Sprintf(""), func(t *testing.T) {
-			cfgs, _ := parseEndpointAnnotations([]*v1.Endpoints{tc.endpoint})
-			assert.EqualValues(t, tc.expectedOut, cfgs)
-		})
-	}
-}
-
-func TestInvalidateIfChangedEndpoint(t *testing.T) {
-	s88 := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: "88",
-		},
-	}
-	s89 := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: "89",
-			Annotations: map[string]string{
-				"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
-				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
-				"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
-			},
-		},
-	}
-	s90 := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: "90",
-			Annotations: map[string]string{
-				"ad.datadoghq.com/endpoints.check_names":  "[\"etcd\"]",
-				"ad.datadoghq.com/endpoints.init_configs": "[{}]",
-				"ad.datadoghq.com/endpoints.instances":    "[{\"use_preview\": \"true\", \"prometheus_url\": \"http://%%host%%:2379/metrics\"}]",
-			},
-		},
-	}
-	s91 := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: "91",
-		},
-	}
-	invalid := &v1.Pod{}
-
-	for _, tc := range []struct {
-		old        interface{}
-		obj        interface{}
-		invalidate bool
-	}{
-		{
-			// Invalid input
-			old:        nil,
-			obj:        nil,
-			invalidate: false,
-		},
-		{
-			// Sync on missed create
-			old:        nil,
-			obj:        s88,
-			invalidate: true,
-		},
-		{
-			// Edit, annotations added
-			old:        s88,
-			obj:        s89,
-			invalidate: true,
-		},
-		{
-			// Informer resync, don't invalidate
-			old:        s89,
-			obj:        s89,
-			invalidate: false,
-		},
-		{
-			// Invalid input, don't invalidate
-			old:        s89,
-			obj:        invalid,
-			invalidate: false,
-		},
-		{
-			// Edit but same annotations
-			old:        s89,
-			obj:        s90,
-			invalidate: false,
-		},
-		{
-			// Edit, annotations removed
-			old:        s89,
-			obj:        s91,
-			invalidate: true,
-		},
-	} {
-		t.Run(fmt.Sprintf(""), func(t *testing.T) {
-			provider := &KubeEndpointConfigProvider{upToDate: true}
 			provider.invalidateIfChanged(tc.old, tc.obj)
 
 			upToDate, err := provider.IsUpToDate()

--- a/pkg/util/kubernetes/apiserver/endpoints.go
+++ b/pkg/util/kubernetes/apiserver/endpoints.go
@@ -9,11 +9,14 @@ package apiserver
 
 import (
 	"errors"
+	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 )
+
+const kubeEndpointIDPrefix = "kube_endpoint://"
 
 // SearchTargetPerName returns the endpoint matching a given target name. It allows
 // to retrieve a given pod's endpoint address from a service.
@@ -32,4 +35,11 @@ func SearchTargetPerName(endpoints *v1.Endpoints, targetName string) (v1.Endpoin
 		}
 	}
 	return v1.EndpointAddress{}, dderrors.NewNotFound("target named " + targetName)
+}
+
+func EntityForEndpoints(endpt *v1.Endpoints) string {
+	if endpt == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s%s", kubeEndpointIDPrefix, endpt.ObjectMeta.UID)
 }

--- a/pkg/util/kubernetes/apiserver/endpoints.go
+++ b/pkg/util/kubernetes/apiserver/endpoints.go
@@ -41,5 +41,5 @@ func EntityForEndpoints(endpt *v1.Endpoints) string {
 	if endpt == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s%s", kubeEndpointIDPrefix, endpt.ObjectMeta.UID)
+	return fmt.Sprintf("%s%s/%s", kubeEndpointIDPrefix, endpt.Namespace, endpt.Name)
 }


### PR DESCRIPTION
### What does this PR do?

Extend `kube_service` listener and config provider to consider k8s endpoints as AD services

### Motivation

This is needed for running AD over k8s service endpoints.

### Additional Notes

