### PR TITLE
Add example for dd_dogstatsd_tags

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -57,6 +57,7 @@ Send custom metrics via [the statsd protocol](https://docs.datadoghq.com/develop
 - `DD_HISTOGRAM_AGGREGATES`: histogram aggregates to compute, separated by spaces. The default is "max median avg count"
 - `DD_DOGSTATSD_SOCKET`: path to the unix socket to listen to. Must be in a `rw` mounted volume.
 - `DD_DOGSTATSD_ORIGIN_DETECTION`: enable container detection and tagging for unix socket metrics. Running in host PID mode (e.g. with --pid=host) is required.
+- `DD_DOGSTATSD_TAGS`: Attach an arbitrary list of tags to all custom metrics that pass through the agent, for example: `["env:golden", "group:retrievers"]`.
 
 #### Tagging
 

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -57,7 +57,7 @@ Send custom metrics via [the statsd protocol](https://docs.datadoghq.com/develop
 - `DD_HISTOGRAM_AGGREGATES`: histogram aggregates to compute, separated by spaces. The default is "max median avg count"
 - `DD_DOGSTATSD_SOCKET`: path to the unix socket to listen to. Must be in a `rw` mounted volume.
 - `DD_DOGSTATSD_ORIGIN_DETECTION`: enable container detection and tagging for unix socket metrics. Running in host PID mode (e.g. with --pid=host) is required.
-- `DD_DOGSTATSD_TAGS`: Attach an arbitrary list of tags to all custom metrics that pass through the agent, for example: `["env:golden", "group:retrievers"]`.
+- `DD_DOGSTATSD_TAGS`: Additional tags to append to all metrics, events and service checks received by this dogstatsd server, for example: `["env:golden", "group:retrievers"]`.
 
 #### Tagging
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a single line of documentation to README of the the docker agent container to describe how to use the `DD_DOGSTATSD_TAGS` environment variable.

### Motivation

I had filed [this issue](https://github.com/DataDog/datadog-agent/issues/3079) before really understanding how DD tag collectors worked in the agent, and this would have saved me a good chunk of time.

As far as I can tell, this feature is undocumented, except to an allusion in [this release note](https://github.com/DataDog/datadog-agent/blob/0a67fbcbfd25dce0108b87c419f1de28bf065cca/CHANGELOG.rst#enhancement-notes-3).

### Additional Notes

(Excuse the feature request in a pull request, alas) I think it would be helpful if there was some sort of API reference (everything and the kitchen sink) style documentation of everything that can be set in [this function](https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config.go#L86-L379). The agent is insanely powerful and customizable, but it can be frustrating at times to only get to its potential while having to dig through the code.
