### PR TITLE
pkg/trace/agent: improve truncator

### DIFF
--- a/pkg/trace/agent/truncator.go
+++ b/pkg/trace/agent/truncator.go
@@ -21,7 +21,7 @@ const (
 func Truncate(s *pb.Span) {
 	// Resource
 	if len(s.Resource) > MaxResourceLen {
-		s.Resource = s.Resource[:MaxResourceLen]
+		s.Resource = truncateString(s.Resource, MaxResourceLen)
 		log.Debugf("span.truncate: truncated `Resource` (max %d chars): %s", MaxResourceLen, s.Resource)
 	}
 
@@ -34,12 +34,12 @@ func Truncate(s *pb.Span) {
 		if len(k) > MaxMetaKeyLen {
 			log.Debugf("span.truncate: truncating `Meta` key (max %d chars): %s", MaxMetaKeyLen, k)
 			delete(s.Meta, k)
-			k = k[:MaxMetaKeyLen] + "..."
+			k = truncateString(k, MaxMetaKeyLen) + "..."
 			modified = true
 		}
 
 		if len(v) > MaxMetaValLen {
-			v = v[:MaxMetaValLen] + "..."
+			v = truncateString(v, MaxMetaValLen) + "..."
 			modified = true
 		}
 
@@ -52,9 +52,23 @@ func Truncate(s *pb.Span) {
 		if len(k) > MaxMetricsKeyLen {
 			log.Debugf("span.truncate: truncating `Metrics` key (max %d chars): %s", MaxMetricsKeyLen, k)
 			delete(s.Metrics, k)
-			k = k[:MaxMetricsKeyLen] + "..."
+			k = truncateString(k, MaxMetricsKeyLen) + "..."
 
 			s.Metrics[k] = v
 		}
 	}
+}
+
+// truncateString truncates the given string to make sure it uses less than limit bytes.
+// If the last character is an utf8 character that would be splitten, it removes it
+// entirely to make sure the resulting string is not broken.
+func truncateString(s string, limit int) string {
+	var lastValidIndex int
+	for i := range s {
+		if i > limit {
+			return s[:lastValidIndex]
+		}
+		lastValidIndex = i
+	}
+	return s
 }

--- a/pkg/trace/agent/truncator_test.go
+++ b/pkg/trace/agent/truncator_test.go
@@ -87,3 +87,12 @@ func TestTruncateMetaValueTooLong(t *testing.T) {
 		assert.True(t, len(v) < MaxMetaValLen+4)
 	}
 }
+func TestTruncateString(t *testing.T) {
+	assert.Equal(t, "", truncateString("", 5))
+	assert.Equal(t, "télé", truncateString("télé", 5))
+	assert.Equal(t, "t", truncateString("télé", 2))
+	assert.Equal(t, "éé", truncateString("ééééé", 5))
+	assert.Equal(t, "ééééé", truncateString("ééééé", 18))
+	assert.Equal(t, "ééééé", truncateString("ééééé", 10))
+	assert.Equal(t, "ééé", truncateString("ééééé", 6))
+}

--- a/releasenotes/notes/apm-truncate-span-fields-utf8-057ea207e37245c0.yaml
+++ b/releasenotes/notes/apm-truncate-span-fields-utf8-057ea207e37245c0.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Ensure UTF-8 characters are not cut mid-way when truncating
+    span fields.


### PR DESCRIPTION
This change ensures that when truncating span properties, no UTF-8
characters will be cut midway.