### PR TITLE
validate length sanity for hostnames from metadata endpoints

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -281,6 +281,12 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 
+	// Metadata endpoints
+
+	// Defines the maximum size of hostame gathered from EC2, GCE, Azure and Alibabacloud metadata endpoints.
+	// Used internally to protect against configurations where metadata endpoints return incorrect values with 200 status codes.
+	config.BindEnvAndSetDefault("metadata_endpoints_max_hostname_size", 255)
+
 	// ECS
 	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected
 	config.BindEnvAndSetDefault("ecs_agent_container_name", "ecs-agent")

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -10,6 +10,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // declare these as vars not const to ease testing
@@ -20,7 +22,8 @@ var (
 
 // GetHostAlias returns the VM ID from the Alibaba Metadata api
 func GetHostAlias() (string, error) {
-	res, err := getResponseWithMaxLength(metadataURL+"/latest/meta-data/instance-id", 255)
+	res, err := getResponseWithMaxLength(metadataURL+"/latest/meta-data/instance-id",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
 		return "", fmt.Errorf("Alibaba HostAliases: unable to query metadata endpoint: %s", err)
 	}

--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -20,9 +20,41 @@ var (
 
 // GetHostAlias returns the VM ID from the Alibaba Metadata api
 func GetHostAlias() (string, error) {
-	res, err := getResponse(metadataURL + "/latest/meta-data/instance-id")
+	res, err := getResponseWithMaxLength(metadataURL+"/latest/meta-data/instance-id", 255)
 	if err != nil {
 		return "", fmt.Errorf("Alibaba HostAliases: unable to query metadata endpoint: %s", err)
+	}
+	return res, err
+}
+
+func getResponseWithMaxLength(endpoint string, maxLength int) (string, error) {
+	result, err := getResponse(endpoint)
+	if err != nil {
+		return result, err
+	}
+	if len(result) > maxLength {
+		return "", fmt.Errorf("%v gave a response with length > to %v", endpoint, maxLength)
+	}
+	return result, err
+}
+
+func getResponse(url string) (string, error) {
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != 200 {
+		return "", fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
 	}
 
 	defer res.Body.Close()
@@ -32,26 +64,4 @@ func GetHostAlias() (string, error) {
 	}
 
 	return string(all), nil
-}
-
-func getResponse(url string) (*http.Response, error) {
-	client := http.Client{
-		Timeout: timeout,
-	}
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
-	}
-
-	return res, nil
 }

--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // declare these as vars not const to ease testing
@@ -22,7 +24,8 @@ var (
 
 // GetHostAlias returns the VM ID from the Azure Metadata api
 func GetHostAlias() (string, error) {
-	res, err := getResponseWithMaxLength(metadataURL+"/metadata/instance/compute/vmId?api-version=2017-04-02&format=text", 255)
+	res, err := getResponseWithMaxLength(metadataURL+"/metadata/instance/compute/vmId?api-version=2017-04-02&format=text",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
 		return "", fmt.Errorf("Azure HostAliases: unable to query metadata endpoint: %s", err)
 	}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -26,12 +26,23 @@ var (
 
 // GetInstanceID fetches the instance id for current host from the EC2 metadata API
 func GetInstanceID() (string, error) {
-	return getMetadataItem("/instance-id")
+	return getMetadataItemWithMaxLength("/instance-id", 255)
 }
 
 // GetHostname fetches the hostname for current host from the EC2 metadata API
 func GetHostname() (string, error) {
-	return getMetadataItem("/hostname")
+	return getMetadataItemWithMaxLength("/hostname", 255)
+}
+
+func getMetadataItemWithMaxLength(endpoint string, maxLength int) (string, error) {
+	result, err := getMetadataItem(endpoint)
+	if err != nil {
+		return result, err
+	}
+	if len(result) > maxLength {
+		return "", fmt.Errorf("%v gave a response with length > to %v", endpoint, maxLength)
+	}
+	return result, err
 }
 
 func getMetadataItem(endpoint string) (string, error) {

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -26,12 +27,12 @@ var (
 
 // GetInstanceID fetches the instance id for current host from the EC2 metadata API
 func GetInstanceID() (string, error) {
-	return getMetadataItemWithMaxLength("/instance-id", 255)
+	return getMetadataItemWithMaxLength("/instance-id", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
 // GetHostname fetches the hostname for current host from the EC2 metadata API
 func GetHostname() (string, error) {
-	return getMetadataItemWithMaxLength("/hostname", 255)
+	return getMetadataItemWithMaxLength("/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 }
 
 func getMetadataItemWithMaxLength(endpoint string, maxLength int) (string, error) {

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // declare these as vars not const to ease testing
@@ -40,7 +42,8 @@ type gceProjectMetadata struct {
 
 // GetHostname returns the hostname querying GCE Metadata api
 func GetHostname() (string, error) {
-	hostname, err := getResponseWithMaxLength(metadataURL+"/instance/hostname", 255)
+	hostname, err := getResponseWithMaxLength(metadataURL+"/instance/hostname",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
 	}
@@ -49,13 +52,15 @@ func GetHostname() (string, error) {
 
 // GetHostAlias returns the host alias from GCE
 func GetHostAlias() (string, error) {
-	instanceName, err := getResponseWithMaxLength(metadataURL+"/instance/hostname", 255)
+	instanceName, err := getResponseWithMaxLength(metadataURL+"/instance/hostname",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
 	}
 	instanceName = strings.SplitN(instanceName, ".", 2)[0]
 
-	projectID, err := getResponseWithMaxLength(metadataURL+"/project/project-id", 255)
+	projectID, err := getResponseWithMaxLength(metadataURL+"/project/project-id",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve project ID from GCE: %s", err)
 	}
@@ -64,7 +69,8 @@ func GetHostAlias() (string, error) {
 
 // GetClusterName returns the name of the cluster containing the current GCE instance
 func GetClusterName() (string, error) {
-	clusterName, err := getResponseWithMaxLength(metadataURL+"/instance/attributes/cluster-name", 255)
+	clusterName, err := getResponseWithMaxLength(metadataURL+"/instance/attributes/cluster-name",
+		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve clustername from GCE: %s", err)
 	}

--- a/releasenotes/notes/metadata-endpoints-max-size-93efc904fd8b3d53.yaml
+++ b/releasenotes/notes/metadata-endpoints-max-size-93efc904fd8b3d53.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    To mitigate issues with the hostname detection on AKS, hostnames gathered from
+    the metadata endpoints of AWS, GCE, Azure, and Alibaba cloud are no longer considered
+    valid if their length exceeds 255 characters.


### PR DESCRIPTION
### What does this PR do?

Validate the length of hostnames and hostname aliases coming from metadata endpoints.

### Motivation

There seems to be a rare bug in AKS where any http requests to `169.254.169.254` will get a 200 status code response. For endpoints that are not valid on Azure this 200 status code is served with a 404 HTML body. 

This PR only mitigate the issue for hostnames. The agent does a lot of calls to this kind of magic IPs to gather metadata. "Fortunately" most of them are supposed to be in JSON format and would error out at unmarshalling. 