### PR TITLE
Log errors when parsing configuration values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: source ./venv/bin/activate && pip install -r requirements.txt
       - run:
           name: grab go deps
-          command: source ./venv/bin/activate && inv deps
+          command: source ./venv/bin/activate && inv deps --verbose
       - run:
           name: pre-compile go deps
           command: inv -e agent.build --race --precompile-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen8-godeps-{{ .Branch }}-{{ .Revision }}
-          - gen8-godeps-{{ .Branch }}-
-          - gen8-godeps-master-
+          - gen9-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen9-godeps-{{ .Branch }}-
+          - gen9-godeps-master-
     - save_cache: &save_deps
-        key: gen8-godeps-{{ .Branch }}-{{ .Revision }}
+        key: gen9-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,12 +50,12 @@
   revision = "2cfb68475274527a10701355c739f31dd404718c"
 
 [[projects]]
-  digest = "1:e9ca79fa28ff0fe0271b63d2d30f4118643746610cd0d75603c7b4255a44f161"
+  branch = "master"
+  digest = "1:b22f5da83ac471bbbe2a5aa1f07c8029dc82bcbf6ff832516f035fc3a314d539"
   name = "github.com/DataDog/viper"
   packages = ["."]
   pruneopts = ""
-  revision = "23ced3bc6b3751855704445e48da2c53075ade86"
-  version = "v1.4.0"
+  revision = "59d5cbf4d7cee2828fca42ff1117894b013ca978"
 
 [[projects]]
   digest = "1:34d4c1b61fa208e523726ddb85d01b8caa8f2de0cd656d91c81b6b86daea485c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,7 +128,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/viper"
-  branch = "master"
+  revision = "59d5cbf4d7cee2828fca42ff1117894b013ca978"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,7 +128,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/viper"
-  version = "=v1.4.0"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -349,28 +349,28 @@ func TestExtractURLAPIKeys(t *testing.T) {
 	agentConfig["api_key"] = ""
 	err := extractURLAPIKeys(agentConfig, configConverter)
 	assert.Nil(t, err)
-	assert.Equal(t, "", config.Datadog.Get("dd_url"))
-	assert.Equal(t, "", config.Datadog.Get("api_key"))
-	assert.Nil(t, config.Datadog.Get("additional_endpoints"))
+	assert.Equal(t, "", config.Datadog.GetString("dd_url"))
+	assert.Equal(t, "", config.Datadog.GetString("api_key"))
+	assert.Empty(t, config.Datadog.GetStringMapStringSlice("additional_endpoints"))
 
 	// one url and one key
 	agentConfig["dd_url"] = "https://datadoghq.com"
 	agentConfig["api_key"] = "123456789"
 	err = extractURLAPIKeys(agentConfig, configConverter)
 	assert.Nil(t, err)
-	assert.Equal(t, "https://datadoghq.com", config.Datadog.Get("dd_url"))
-	assert.Equal(t, "123456789", config.Datadog.Get("api_key"))
-	assert.Nil(t, config.Datadog.Get("additional_endpoints"))
+	assert.Equal(t, "https://datadoghq.com", config.Datadog.GetString("dd_url"))
+	assert.Equal(t, "123456789", config.Datadog.GetString("api_key"))
+	assert.Empty(t, config.Datadog.GetStringMapStringSlice("additional_endpoints"))
 
 	// multiple dd_url and api_key
 	agentConfig["dd_url"] = "https://datadoghq.com,https://datadoghq.com,https://datadoghq.com,https://staging.com"
 	agentConfig["api_key"] = "123456789,abcdef,secret_key,secret_key2"
 	err = extractURLAPIKeys(agentConfig, configConverter)
 	assert.Nil(t, err)
-	assert.Equal(t, "https://datadoghq.com", config.Datadog.Get("dd_url"))
-	assert.Equal(t, "123456789", config.Datadog.Get("api_key"))
+	assert.Equal(t, "https://datadoghq.com", config.Datadog.GetString("dd_url"))
+	assert.Equal(t, "123456789", config.Datadog.GetString("api_key"))
 
-	endpoints := config.Datadog.Get("additional_endpoints").(map[string][]string)
+	endpoints := config.Datadog.GetStringMapStringSlice("additional_endpoints")
 	assert.Equal(t, 2, len(endpoints))
 	assert.Equal(t, []string{"abcdef", "secret_key"}, endpoints["https://datadoghq.com"])
 	assert.Equal(t, []string{"secret_key2"}, endpoints["https://staging.com"])

--- a/pkg/config/legacy/docker_test.go
+++ b/pkg/config/legacy/docker_test.go
@@ -102,7 +102,7 @@ func TestConvertDocker(t *testing.T) {
 	assert.Equal(t, "/host/test/proc", config.Datadog.GetString("container_proc_root"))
 	assert.Equal(t, "/host/test/sys/fs/cgroup", config.Datadog.GetString("container_cgroup_root"))
 	assert.Equal(t, map[string]string{"test1": "test1", "test2": "test2"},
-		config.Datadog.Get("docker_labels_as_tags").(map[string]string))
+		config.Datadog.GetStringMapString("docker_labels_as_tags"))
 
 	// test overwrite
 	err = ImportDockerConf(src, dst, false)

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
 	"github.com/DataDog/viper"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
@@ -58,91 +60,143 @@ func (c *safeConfig) IsSet(key string) bool {
 func (c *safeConfig) Get(key string) interface{} {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.Get(key)
+	val, err := c.Viper.GetE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetString wraps Viper for concurrent access
 func (c *safeConfig) GetString(key string) string {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetString(key)
+	val, err := c.Viper.GetStringE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetBool wraps Viper for concurrent access
 func (c *safeConfig) GetBool(key string) bool {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetBool(key)
+	val, err := c.Viper.GetBoolE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetInt wraps Viper for concurrent access
 func (c *safeConfig) GetInt(key string) int {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetInt(key)
+	val, err := c.Viper.GetIntE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetInt64 wraps Viper for concurrent access
 func (c *safeConfig) GetInt64(key string) int64 {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetInt64(key)
+	val, err := c.Viper.GetInt64E(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetFloat64 wraps Viper for concurrent access
 func (c *safeConfig) GetFloat64(key string) float64 {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetFloat64(key)
+	val, err := c.Viper.GetFloat64E(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetTime wraps Viper for concurrent access
 func (c *safeConfig) GetTime(key string) time.Time {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetTime(key)
+	val, err := c.Viper.GetTimeE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetDuration wraps Viper for concurrent access
 func (c *safeConfig) GetDuration(key string) time.Duration {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetDuration(key)
+	val, err := c.Viper.GetDurationE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetStringSlice wraps Viper for concurrent access
 func (c *safeConfig) GetStringSlice(key string) []string {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetStringSlice(key)
+	val, err := c.Viper.GetStringSliceE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetStringMap wraps Viper for concurrent access
 func (c *safeConfig) GetStringMap(key string) map[string]interface{} {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetStringMap(key)
+	val, err := c.Viper.GetStringMapE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetStringMapString wraps Viper for concurrent access
 func (c *safeConfig) GetStringMapString(key string) map[string]string {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetStringMapString(key)
+	val, err := c.Viper.GetStringMapStringE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetStringMapStringSlice wraps Viper for concurrent access
 func (c *safeConfig) GetStringMapStringSlice(key string) map[string][]string {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetStringMapStringSlice(key)
+	val, err := c.Viper.GetStringMapStringSliceE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // GetSizeInBytes wraps Viper for concurrent access
 func (c *safeConfig) GetSizeInBytes(key string) uint {
 	c.RLock()
 	defer c.RUnlock()
-	return c.Viper.GetSizeInBytes(key)
+	val, err := c.Viper.GetSizeInBytesE(key)
+	if err != nil {
+		log.Warnf("failed to get configuration value for key %q: %s", key, err)
+	}
+	return val
 }
 
 // SetEnvPrefix wraps Viper for concurrent access, and keeps the envPrefix for

--- a/pkg/metrics/histogram_test.go
+++ b/pkg/metrics/histogram_test.go
@@ -42,8 +42,8 @@ func TestConfigureDefault(t *testing.T) {
 func TestConfigure(t *testing.T) {
 	mockConfig := config.Mock()
 
-	aggregatesBk := config.Datadog.Get("histogram_aggregates")
-	percentilesBk := config.Datadog.Get("histogram_percentiles")
+	aggregatesBk := config.Datadog.GetStringSlice("histogram_aggregates")
+	percentilesBk := config.Datadog.GetStringSlice("histogram_percentiles")
 	defer func() {
 		mockConfig.Set("histogram_aggregates", aggregatesBk)
 		mockConfig.Set("histogram_percentiles", percentilesBk)

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -39,7 +39,7 @@ func TestLoadEnv(t *testing.T) {
 			if tt.envNew == "DD_APM_IGNORE_RESOURCES" {
 				assert.Equal([]string{"4", "5", "6"}, config.Datadog.GetStringSlice(tt.key))
 			} else {
-				assert.Equal("4,5,6", config.Datadog.Get(tt.key))
+				assert.Equal("4,5,6", config.Datadog.GetString(tt.key))
 			}
 		}
 	})


### PR DESCRIPTION
### What does this PR do?

Log a warning message every time a parsing error appears while retrieving a configuration parameter.

### Motivation

For now, these errors are silently ignored potentially leading to unclear situations for the user. We want to make sure there's an easier way to detect them.

### Additional Notes

Anything else we should know when reviewing?
