### PR TITLE
Support list of maps of tags in AD annotation *.instances value

### DIFF
--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -251,7 +251,7 @@ func (p *ConsulConfigProvider) getCheckNames(key string) ([]string, error) {
 	return checks, err
 }
 
-func (p *ConsulConfigProvider) getJSONValue(key string) ([]integration.Data, error) {
+func (p *ConsulConfigProvider) getJSONValue(key string) ([][]integration.Data, error) {
 	rawValue, err := p.getValue(key)
 	if err != nil {
 		err := fmt.Errorf("Couldn't get key %s from consul: %s", key, err)

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -135,7 +135,7 @@ func (p *EtcdConfigProvider) getCheckNames(key string) ([]string, error) {
 	return parseCheckNames(rawNames)
 }
 
-func (p *EtcdConfigProvider) getJSONValue(key string) ([]integration.Data, error) {
+func (p *EtcdConfigProvider) getJSONValue(key string) ([][]integration.Data, error) {
 	rawValue, err := p.getEtcdValue(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key %s from etcd: %s", key, err)

--- a/pkg/autodiscovery/providers/utils.go
+++ b/pkg/autodiscovery/providers/utils.go
@@ -31,32 +31,56 @@ func init() {
 	config.Datadog.SetDefault("autoconf_template_url_timeout", 5)
 }
 
-// parseJSONValue returns a slice of ConfigData parsed from the JSON
+// parseJSONValue returns a slice of slice of ConfigData parsed from the JSON
 // contained in the `value` parameter
-func parseJSONValue(value string) ([]integration.Data, error) {
+func parseJSONValue(value string) ([][]integration.Data, error) {
 	if value == "" {
 		return nil, fmt.Errorf("Value is empty")
 	}
 
 	var rawRes []interface{}
-	var result []integration.Data
+	var result [][]integration.Data
 
 	err := json.Unmarshal([]byte(value), &rawRes)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal JSON: %s", err)
+		return nil, fmt.Errorf("failed to unmarshal JSON: %s", err)
 	}
 
 	for _, r := range rawRes {
 		switch r.(type) {
-		case map[string]interface{}:
-			init, _ := json.Marshal(r)
-			result = append(result, init)
+		case []interface{}:
+			objs := r.([]interface{})
+			var subResult []integration.Data
+			for idx := range objs {
+				var init integration.Data
+				init, err = parseJSONObjToData(objs[idx])
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode JSON Object '%v' to integration.Data struct: %v", objs[idx], err)
+				}
+				subResult = append(subResult, init)
+			}
+			if subResult != nil {
+				result = append(result, subResult)
+			}
 		default:
-			return nil, fmt.Errorf("found non JSON object type, value is: '%v'", r)
+			var init integration.Data
+			init, err = parseJSONObjToData(r)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode JSON Object '%v' to integration.Data struct: %v", r, err)
+			}
+			result = append(result, []integration.Data{init})
 		}
-
 	}
 	return result, nil
+}
+
+func parseJSONObjToData(r interface{}) (integration.Data, error) {
+	switch r.(type) {
+	case map[string]interface{}:
+		return json.Marshal(r)
+	default:
+		return nil, fmt.Errorf("found non JSON object type, value is: '%v'", r)
+	}
 }
 
 func parseCheckNames(names string) (res []string, err error) {
@@ -77,24 +101,30 @@ func buildStoreKey(key ...string) string {
 	return path.Join(parts...)
 }
 
-func buildTemplates(key string, checkNames []string, initConfigs, instances []integration.Data) []integration.Config {
+func buildTemplates(key string, checkNames []string, initConfigs, instances [][]integration.Data) []integration.Config {
 	templates := make([]integration.Config, 0)
 
-	// sanity check
+	// sanity checks
 	if len(checkNames) != len(initConfigs) || len(checkNames) != len(instances) {
 		log.Error("Template entries don't all have the same length, not using them.")
 		return templates
 	}
+	for idx := range initConfigs {
+		if len(initConfigs[idx]) != 1 {
+			log.Error("Templates init Configs list is not valid, not using Templates entries")
+			return templates
+		}
+	}
 
 	for idx := range checkNames {
-		instance := integration.Data(instances[idx])
-
-		templates = append(templates, integration.Config{
-			Name:          checkNames[idx],
-			InitConfig:    integration.Data(initConfigs[idx]),
-			Instances:     []integration.Data{instance},
-			ADIdentifiers: []string{key},
-		})
+		for _, instance := range instances[idx] {
+			templates = append(templates, integration.Config{
+				Name:          checkNames[idx],
+				InitConfig:    integration.Data(initConfigs[idx][0]),
+				Instances:     []integration.Data{instance},
+				ADIdentifiers: []string{key},
+			})
+		}
 	}
 	return templates
 }

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -184,7 +184,7 @@ func (z *ZookeeperConfigProvider) getTemplates(key string) []integration.Config 
 	return buildTemplates(key, checkNames, initConfigs, instances)
 }
 
-func (z *ZookeeperConfigProvider) getJSONValue(key string) ([]integration.Data, error) {
+func (z *ZookeeperConfigProvider) getJSONValue(key string) ([][]integration.Data, error) {
 	rawValue, _, err := z.client.Get(key)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get key '%s' from zookeeper: %s", key, err)

--- a/releasenotes/notes/ad-fix-annotation-value-parsing-152e1a2b2fe10891.yaml
+++ b/releasenotes/notes/ad-fix-annotation-value-parsing-152e1a2b2fe10891.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix an auto-discovery annotation value parsing limitation in version 6
+    compare to version 5.
+    Now, ``ad.datadoghq.com/*.instances`` annotation key supports value like ``[[{"foo":"bar1"}, {"foo":"bar2"}], {"name":"bar3"}]``

--- a/releasenotes/notes/ad-fix-annotation-value-parsing-152e1a2b2fe10891.yaml
+++ b/releasenotes/notes/ad-fix-annotation-value-parsing-152e1a2b2fe10891.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fix an auto-discovery annotation value parsing limitation in version 6
-    compare to version 5.
+    compared to version 5.
     Now, ``ad.datadoghq.com/*.instances`` annotation key supports value like ``[[{"foo":"bar1"}, {"foo":"bar2"}], {"name":"bar3"}]``


### PR DESCRIPTION
### What does this PR do?

it allows in annotations `ad.datadoghq.com/<container_name>.instances` to support several container configs for the same "check_name".

### Motivation

Aim is to improve the UX on datadog-agent configuration thanks to annotations.

### Additional Notes

none
