### PR TITLE
Update the instruction for the logs_dd_url parameter

### DIFF
--- a/omnibus/resources/agent/msi/README.md
+++ b/omnibus/resources/agent/msi/README.md
@@ -51,7 +51,7 @@ The following configuration command line options are available when installing t
 * DD_URL="_string_"
   * Sets the **dd_url** variable in datadog.yaml to _string_. 
 * LOGS_DD_URL="_string_"
-  * Sets the **logs_dd_url** variable in the **logs_config** section in datadog.yaml to _<endpoint>:<port>_ .
+  * Sets the **logs_dd_url** variable in the **logs_config** section in datadog.yaml to _string_ . _string_ has to be of the form `<endpoint>:<format>`, for example `agent-intake.logs.datadoghq.com:443`.
 * PROCESS_DD_URL="_string_"
   * Sets the **process_dd_url** variable in the **process_config** section in datadog.yaml to _string_. 
 * TRACE_DD_URL="_string_"

--- a/omnibus/resources/agent/msi/README.md
+++ b/omnibus/resources/agent/msi/README.md
@@ -51,7 +51,7 @@ The following configuration command line options are available when installing t
 * DD_URL="_string_"
   * Sets the **dd_url** variable in datadog.yaml to _string_. 
 * LOGS_DD_URL="_string_"
-  * Sets the **dd_url** variable in the **logs_config** section in datadog.yaml to _string_. 
+  * Sets the **logs_dd_url** variable in the **logs_config** section in datadog.yaml to _<endpoint>:<port>_ .
 * PROCESS_DD_URL="_string_"
   * Sets the **process_dd_url** variable in the **process_config** section in datadog.yaml to _string_. 
 * TRACE_DD_URL="_string_"


### PR DESCRIPTION
### What does this PR do?

Clarify the format and the parameter name in the read me for the log proxy parameter.

### Motivation

A lot of confusion seems to come from this as the real attribute is `logs_dd_url` in the `logs_config` section.
And the expected format is `endpoint:port`
### Additional Notes

Anything else we should know when reviewing?
