### PR TITLE
Fix s6 un-tarring due to base image changes

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -90,11 +90,11 @@ COPY entrypoint /etc/cont-init.d/
 COPY probe.sh initlog.sh secrets-helper/readsecret.py /
 
 # Extract s6-overlay
-# Done in 2 steps to avoid overriding the /bin --> /usr/bin symlink
-# FIXME: copying it from the extract stage does not work
-RUN tar xzf s6.tgz -C / --exclude="./bin" \
-  && tar xzf s6.tgz -C /usr ./bin \
-  && rm s6.tgz \
+# Buster used to have /bin/ symlinked to /usr/bin, which broke
+# the tar invocation, see #1591 for the changes we made then
+# Is is now back to a dedicated folder
+RUN tar xzf s6.tgz \
+ && rm s6.tgz \
 # Prepare for running without root
 # - Create a dd-agent:root user and give it permissions on relevant folders
 # - Remove the /var/run -> /run symlink and create a legit /var/run folder


### PR DESCRIPTION
### What does this PR do?

Debian buster used to have `/bin` symlinked to `/usr/bin`, which required us to un-tar the S6 binaries in `/usr/bin`, see https://github.com/DataDog/datadog-agent/pull/1591/files#diff-c0e62e43e3f3ef321994872f8fef948dR96

They reverted back to `/bin/` being a real folder, so we need to un-tar in `/bin` again. Left a comment in the dockerfile in case that were to happen again with the next debian testing cycle.

> $ docker run -it datadog/agent:6.10.0 ls -lh / | grep bin
lrwxrwxrwx   1 root root    7 Feb  4 00:00 bin -> usr/bin
lrwxrwxrwx   1 root root    8 Feb  4 00:00 sbin -> usr/sbin
$ docker run -it datadog/agent-dev:master ls -lh / | grep bin
drwxr-xr-x   2 root root 4.0K Feb 28 00:00 bin
drwxr-xr-x   2 root root 4.0K Feb 28 00:00 sbin

Setting 6.10.1 as milestone, as we'll need to backport this for a bugfix release to start correctly. 6.10.0 was built just before this breaking change.