### PR TITLE
Update task to compile the agent with six

### DIFF
--- a/cmd/py-launcher/py-launcher.go
+++ b/cmd/py-launcher/py-launcher.go
@@ -17,7 +17,7 @@ import (
 )
 
 // #include "datadog_agent_six.h"
-// #cgo LDFLAGS: -L/home/hush-hush/dev/six/six -ldatadog-agent-six -ldl
+// #cgo LDFLAGS: -ldatadog-agent-six -ldl
 import "C"
 
 func main() {

--- a/pkg/collector/py/datadog_agent_test.go
+++ b/pkg/collector/py/datadog_agent_test.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build cpython
+
 package py
 
 import (

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -20,7 +20,7 @@ import (
 )
 
 // #include "datadog_agent_six.h"
-// #cgo LDFLAGS: -L/home/hush-hush/dev/six/six -ldatadog-agent-six -ldl
+// #cgo LDFLAGS: -ldatadog-agent-six -ldl
 import "C"
 
 var (

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -25,7 +25,7 @@ DEFAULT_BUILD_TAGS = [
     "apm",
     "consul",
     "containerd",
-    "cpython",
+    "python",
     "cri",
     "docker",
     "ec2",
@@ -167,7 +167,7 @@ def refresh_assets(ctx, build_tags, development=True, puppy=False):
         shutil.rmtree(dist_folder)
     os.mkdir(dist_folder)
 
-    if "cpython" in build_tags:
+    if "python" in build_tags:
         copy_tree("./cmd/agent/dist/checks/", os.path.join(dist_folder, "checks"))
         copy_tree("./cmd/agent/dist/utils/", os.path.join(dist_folder, "utils"))
         shutil.copy("./cmd/agent/dist/config.py", os.path.join(dist_folder, "config.py"))

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -10,7 +10,7 @@ ALL_TAGS = set([
     "apm",
     "clusterchecks",
     "consul",
-    "cpython",
+    "python",
     "cri",
     "containerd",
     "docker",

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -62,6 +62,8 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use
         "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs),
         "CGO_CFLAGS_ALLOW": "-static-libgcc",  # whitelist additional flags, here a flag used for net-snmp
     }
+    if 'CGO_LDFLAGS' in os.environ:
+        env['CGO_LDFLAGS'] = os.environ['CGO_LDFLAGS']
 
     if sys.platform == 'win32':
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
@@ -79,6 +81,9 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use
     elif use_venv and os.getenv('VIRTUAL_ENV'):
         venv_prefix = os.getenv('VIRTUAL_ENV')
         ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, venv_prefix)
+
+    ldflags += "-X {}/pkg/collector/python.pythonHome2={} ".format(REPO_PATH, os.environ['PYTHON_HOME_2'])
+    ldflags += "-X {}/pkg/collector/python.pythonHome3={} ".format(REPO_PATH, os.environ['PYTHON_HOME_3'])
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"


### PR DESCRIPTION
### What does this PR do?

Allow compiling the agent with six more easily

## compiling the agent

Export a few env variables (for now):
```
export PYTHON_HOME_3=<PATH_TO_PYTHON3_VENV>
export PYTHON_HOME_2=<PATH_TO_PYTHON2_VENV>
export CGO_LDFLAGS="-L<PATH_TO_SIX_LIB>"
export CGO_CFLAGS="-I<PATH_TO_SIX_INCLUDE_DIR>"
```
then run: `inv agent.build`

To run the agent:
```
export LD_LIBRARY_PATH="<PATH_TO_SIX_LIB>:<PATH_TO_THREE_LIB>:<PATH_TO_TWO_LIB>"
```

Then run the agent: `./bin/agent/agent -c <path_to_datadog.yaml> run`