### PR TITLE
[proc] Add processes fields to legacy config converter

### DIFF
--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -135,9 +135,6 @@ func FromAgentConfig(agentConfig Config) error {
 		configConverter.Set("bind_host", agentConfig["bind_host"])
 	}
 
-	// Processes-specific configuration
-	extractProcessAgentConfig(agentConfig, configConverter)
-
 	// Trace APM based configurations
 	if agentConfig["apm_enabled"] != "" {
 		if enabled, err := isAffirmative(agentConfig["apm_enabled"]); err == nil {
@@ -153,6 +150,9 @@ func FromAgentConfig(agentConfig Config) error {
 	}
 
 	configConverter.Set("hostname_fqdn", true)
+
+	// Processes-specific configuration
+	extractProcessAgentConfig(agentConfig, configConverter)
 
 	return extractTraceAgentConfig(agentConfig, configConverter)
 }
@@ -328,9 +328,12 @@ func extractURLAPIKeys(agentConfig Config, configConverter *config.LegacyConfigC
 
 	additionalEndpoints := map[string][]string{}
 	for idx, url := range urls {
-		if url == "" || keys[idx] == "" {
-			return fmt.Errorf("Found empty additional 'dd_url' or 'api_key'. Please check that you don't have any misplaced commas")
+		if url == "" {
+			return fmt.Errorf("found empty additional 'dd_url'. Please check that you don't have any misplaced commas")
+		} else if keys[idx] == "" {
+			return fmt.Errorf("found empty additional 'api_key'. Please check that you don't have any misplaced commas")
 		}
+
 		if _, ok := additionalEndpoints[url]; ok {
 			additionalEndpoints[url] = append(additionalEndpoints[url], keys[idx])
 		} else {
@@ -350,9 +353,12 @@ func extractURLAPIKeys(agentConfig Config, configConverter *config.LegacyConfigC
 
 		configConverter.Set("process_config.process_dd_url", processURLs[0])
 		for idx, url := range processURLs[1:] {
-			if url == "" || keys[idx] == "" {
-				return fmt.Errorf("found empty additional 'endpoint' or 'api_key' for processes. Please check that you don't have any misplaced commas")
+			if url == "" {
+				return fmt.Errorf("found empty additional 'endpoint' for processes. Please check that you don't have any misplaced commas")
+			} else if keys[idx] == "" {
+				return fmt.Errorf("found empty additional 'api_key' for processes. Please check that you don't have any misplaced commas")
 			}
+
 			if _, ok := processEndpoints[url]; ok {
 				processEndpoints[url] = append(processEndpoints[url], keys[idx])
 			} else {

--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -153,7 +153,6 @@ func FromAgentConfig(agentConfig Config) error {
 
 	// Processes-specific configuration
 	extractProcessAgentConfig(agentConfig, configConverter)
-
 	return extractTraceAgentConfig(agentConfig, configConverter)
 }
 
@@ -380,7 +379,6 @@ func extractURLAPIKeys(agentConfig Config, configConverter *config.LegacyConfigC
 		}
 	}
 	configConverter.Set("additional_endpoints", additionalEndpoints)
-
 	return nil
 }
 

--- a/pkg/config/legacy/importer.go
+++ b/pkg/config/legacy/importer.go
@@ -109,7 +109,7 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 	config["proxy_settings"] = "{'host': 'my-proxy.com', 'password': 'password', 'port': 3128, 'user': 'user'}"
 	config["service_discovery"] = "True"
 
-	// add trace agent sections as <section>.<key>
+	// add trace + process agent sections as <section>.<key>
 	for _, section := range []string{
 		"trace.api",
 		"trace.config",
@@ -123,6 +123,7 @@ func GetAgentConfig(datadogConfPath string) (Config, error) {
 		"trace.writer.services",
 		"trace.writer.stats",
 		"trace.writer.traces",
+		"process.config",
 	} {
 		s, err := iniFile.GetSection(section)
 		if err != nil {

--- a/pkg/config/legacy/importer_test.go
+++ b/pkg/config/legacy/importer_test.go
@@ -66,4 +66,5 @@ func TestGetAgentConfig(t *testing.T) {
 	require.True(t, pos > 0)
 	require.Equal(t, "1234", agentConfigGo["trace.api.api_key"])
 	require.Equal(t, "http://ip.url", agentConfigGo["trace.api.endpoint"])
+	require.Equal(t, "321", agentConfigGo["process.config.proc_limit"])
 }

--- a/pkg/config/legacy/tests/datadog.conf
+++ b/pkg/config/legacy/tests/datadog.conf
@@ -27,6 +27,9 @@ hostname: mymachine.mydomain
 # Enable the trace agent.
 apm_enabled: false
 
+# Enable the process agent.
+process_agent_enabled: true
+
 # Set the host's tags (optional)
 tags: mytag, env:prod, role:database
 
@@ -355,3 +358,27 @@ resource: "GET|POST /healthcheck","GET /V1"
 [trace.api]
 api_key: 1234
 endpoint: http://ip.url
+
+# ========================================================================== #
+# Processes
+# ========================================================================== #
+
+[process.config]
+allow_real_time: false
+log_file: /mnt/log/process-agent/process.log
+dd_agent_py: /bin/python
+dd_agent_py_env: GOPATH=/go, SHELL=/bin/zsh
+proc_limit: 321
+queue_size: 123
+process_interval: 12
+rtprocess_interval: 13
+container_interval: 14
+rtcontainer_interval: 15
+connections_interval: 16
+scrub_args: false
+blacklist: pass*, *key
+custom_sensitive_words: auth, aws
+strip_proc_arguments: true
+windows_args_refresh_interval: 21
+windows_add_new_args: false
+endpoint: https://dev.burrito.com, https://staging.burrito.com


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/DataDog/datadog-agent/pull/2698, but for processes. We're moving to use the common config util, so we need to move agent 5 configuration parsing to this agent.

@DataDog/agent-guild 

### Motivation

Move to using common config util