### PR TITLE
 {cmd/trace-agent,pkg/trace/*}: use shared logging package

### DIFF
--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -7,7 +7,7 @@ import (
 
 	_ "net/http/pprof"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // handleSignal closes a channel to exit cleanly from routines

--- a/cmd/trace-agent/main_windows.go
+++ b/cmd/trace-agent/main_windows.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/flags"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 
-	log "github.com/cihub/seelog"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -97,7 +96,6 @@ func main() {
 		runService(false)
 		return
 	}
-	defer log.Flush()
 	// sigh.  Go doesn't have boolean xor operator.  The options are mutually exclusive,
 	// make sure more than one wasn't specified
 	optcount := 0

--- a/docs/trace-agent/datadog.example.yaml
+++ b/docs/trace-agent/datadog.example.yaml
@@ -23,6 +23,9 @@ api_key: 1234
 # # logging level
 # log_level: info
 # 
+# # enable logging in JSON format
+# log_format_json: true
+#
 # # Trace agent listening port
 # listen_port: 8126
 # 

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -107,12 +107,12 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 
 	configTemplate += fmt.Sprintf(`</outputs>
 	<formats>
-		<format id="json" format="{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
-		<format id="common" format="%%Date(%s) | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n"/>
+		<format id="json" format="%s"/>
+		<format id="common" format="%s"/>
 		<format id="syslog-json" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`){&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;relfile&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n"/>
 		<format id="syslog-common" format="%%CustomSyslogHeader(20,`+strconv.FormatBool(rfc)+`) %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n" />
 	</formats>
-</seelog>`, logDateFormat, logDateFormat)
+</seelog>`, LogFormatJSON, LogFormatCommon)
 
 	logger, err := seelog.LoggerFromConfigAsString(configTemplate)
 	if err != nil {
@@ -123,6 +123,14 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 	log.SetupDatadogLogger(logger, seelogLogLevel)
 	return nil
 }
+
+var (
+	// LogFormatCommon specifies the common logging format.
+	LogFormatCommon = fmt.Sprintf("%%Date(%s) | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n", logDateFormat)
+
+	// LogFormatJSON specifies the common JSON format.
+	LogFormatJSON = fmt.Sprintf("{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n", logDateFormat)
+)
 
 // ErrorLogWriter is a Writer that logs all written messages with the global seelog logger
 // at an error level

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -25,6 +25,14 @@ const logDateFormat = "2006-01-02 15:04:05 MST" // see time.Format for format sy
 
 var syslogTLSConfig *tls.Config
 
+var (
+	// LogFormatCommon specifies the common logging format.
+	LogFormatCommon = fmt.Sprintf("%%Date(%s) | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n", logDateFormat)
+
+	// LogFormatJSON specifies the common JSON format.
+	LogFormatJSON = fmt.Sprintf("{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n", logDateFormat)
+)
+
 func getSyslogTLSKeyPair() (*tls.Certificate, error) {
 	var syslogTLSKeyPair *tls.Certificate
 	if Datadog.IsSet("syslog_pem") && Datadog.IsSet("syslog_key") {
@@ -123,14 +131,6 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 	log.SetupDatadogLogger(logger, seelogLogLevel)
 	return nil
 }
-
-var (
-	// LogFormatCommon specifies the common logging format.
-	LogFormatCommon = fmt.Sprintf("%%Date(%s) | %%LEVEL | (%%ShortFilePath:%%Line in %%FuncShort) | %%Msg%%n", logDateFormat)
-
-	// LogFormatJSON specifies the common JSON format.
-	LogFormatJSON = fmt.Sprintf("{&quot;time&quot;:&quot;%%Date(%s)&quot;,&quot;level&quot;:&quot;%%LEVEL&quot;,&quot;file&quot;:&quot;%%ShortFilePath&quot;,&quot;line&quot;:&quot;%%Line&quot;,&quot;func&quot;:&quot;%%FuncShort&quot;,&quot;msg&quot;:&quot;%%Msg&quot;}%%n", logDateFormat)
-)
 
 // ErrorLogWriter is a Writer that logs all written messages with the global seelog logger
 // at an error level

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -5,8 +5,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/event"
@@ -21,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const processStatsInterval = time.Minute

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/event"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -550,7 +550,7 @@ func runTraceProcessingBenchmark(b *testing.B, c *config.AgentConfig) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	ta := NewAgent(ctx, c)
-	log.UseLogger(log.Disabled)
+	seelog.UseLogger(seelog.Disabled)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -7,10 +7,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
-	"strings"
 	"time"
-
-	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -19,27 +16,53 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const agentDisabledMessage = `trace-agent not enabled.
-Set env var DD_APM_ENABLED=true or add
-apm_enabled: true
-to your datadog.conf file.
-Exiting.`
+const messageAgentDisabled = `trace-agent not enabled. Set the environment variable
+DD_APM_ENABLED=true or add "apm_config.enabled: true" entry
+to your datadog.yaml. Exiting...`
 
 // Run is the entrypoint of our code, which starts the agent.
 func Run(ctx context.Context) {
-	// configure a default logger before anything so we can observe initialization
-	if flags.Info || flags.Version {
-		log.UseLogger(log.Disabled)
-	} else {
-		SetupDefaultLogger()
-		defer log.Flush()
+	cfg, err := config.Load(flags.ConfigPath)
+	if err != nil {
+		osutil.Exitf("%v", err)
+	}
+	err = info.InitInfo(cfg) // for expvar & -info option
+	if err != nil {
+		panic(err)
+	}
+
+	if flags.Version {
+		fmt.Print(info.VersionString())
+		return
+	}
+
+	if flags.Info {
+		if err := info.Info(os.Stdout, cfg); err != nil {
+			osutil.Exitf("failed to print info: %s\n", err)
+		}
+		return
+	}
+
+	if err := setupLogger(cfg); err != nil {
+		osutil.Exitf("cannot create logger: %v", err)
+	}
+	defer log.Flush()
+
+	if !cfg.Enabled {
+		log.Info(messageAgentDisabled)
+
+		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
+		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
+		// http://supervisord.org/subprocess.html#process-states
+		time.Sleep(5 * time.Second)
+		return
 	}
 
 	defer watchdog.LogOnPanic()
 
-	// start CPU profiling
 	if flags.CPUProfile != "" {
 		f, err := os.Create(flags.CPUProfile)
 		if err != nil {
@@ -50,91 +73,29 @@ func Run(ctx context.Context) {
 		defer pprof.StopCPUProfile()
 	}
 
-	if flags.Version {
-		fmt.Print(info.VersionString())
-		return
-	}
-
-	if !flags.Info && flags.PIDFilePath != "" {
+	if flags.PIDFilePath != "" {
 		err := pidfile.WritePID(flags.PIDFilePath)
 		if err != nil {
-			log.Errorf("Error while writing PID file, exiting: %v", err)
+			log.Criticalf("error writing PID file, exiting: %v", err)
 			os.Exit(1)
 		}
 
 		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), flags.PIDFilePath)
-		defer func() {
-			// remove pidfile if set
-			os.Remove(flags.PIDFilePath)
-		}()
+		defer os.Remove(flags.PIDFilePath)
 	}
 
-	cfg, err := config.Load(flags.ConfigPath)
-	if err != nil {
-		osutil.Exitf("%v", err)
-	}
-	err = info.InitInfo(cfg) // for expvar & -info option
-	if err != nil {
-		panic(err)
-	}
-
-	if flags.Info {
-		if err := info.Info(os.Stdout, cfg); err != nil {
-			os.Stdout.WriteString(fmt.Sprintf("failed to print info: %s\n", err))
-			os.Exit(1)
-		}
-		return
-	}
-
-	// Exit if tracing is not enabled
-	if !cfg.Enabled {
-		log.Info(agentDisabledMessage)
-
-		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
-		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
-		// http://supervisord.org/subprocess.html#process-states
-		time.Sleep(5 * time.Second)
-		return
-	}
-
-	// Initialize logging (replacing the default logger). No need
-	// to defer log.Flush, it was already done when calling
-	// "SetupDefaultLogger" earlier.
-	cfgLogLevel := strings.ToLower(cfg.LogLevel)
-	if cfgLogLevel == "warning" {
-		// to match core agent:
-		// https://github.com/DataDog/datadog-agent/blob/6f2d901aeb19f0c0a4e09f149c7cc5a084d2f708/pkg/config/log.go#L74-L76
-		cfgLogLevel = "warn"
-	}
-	logLevel, ok := log.LogLevelFromString(cfgLogLevel)
-	if !ok {
-		logLevel = log.InfoLvl
-	}
-	duration := 10 * time.Second
-	if !cfg.LogThrottlingEnabled {
-		duration = 0
-	}
-	err = SetupLogger(logLevel, cfg.LogFilePath, duration, 10)
-	if err != nil {
-		osutil.Exitf("cannot create logger: %v", err)
-	}
-
-	// Initialize dogstatsd client
 	err = metrics.Configure(cfg, []string{"version:" + info.Version})
 	if err != nil {
 		osutil.Exitf("cannot configure dogstatsd: %v", err)
 	}
-
-	// count the number of times the agent started
 	metrics.Count("datadog.trace_agent.started", 1, nil, 1)
 
 	// Seed rand
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	ta := NewAgent(ctx, cfg)
-
+	agnt := NewAgent(ctx, cfg)
 	log.Infof("trace-agent running on host %s", cfg.Hostname)
-	ta.Run()
+	agnt.Run()
 
 	// collect memory profile
 	if flags.MemProfile != "" {

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context) {
 	}
 	err = info.InitInfo(cfg) // for expvar & -info option
 	if err != nil {
-		panic(err)
+		osutil.Exitf("%v", err)
 	}
 
 	if flags.Version {

--- a/pkg/trace/agent/sampler.go
+++ b/pkg/trace/agent/sampler.go
@@ -6,12 +6,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Sampler chooses which spans to write to the API

--- a/pkg/trace/agent/service.go
+++ b/pkg/trace/agent/service.go
@@ -7,7 +7,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // serviceApp represents the app to which certain integration belongs to

--- a/pkg/trace/agent/truncator.go
+++ b/pkg/trace/agent/truncator.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/cihub/seelog"
 	"github.com/tinylib/msgp/msgp"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -23,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // rateLimitedListener wraps a regular TCPListener with rate limiting.

--- a/pkg/trace/api/logger.go
+++ b/pkg/trace/api/logger.go
@@ -3,7 +3,7 @@ package api
 import (
 	"sync"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // these could be configurable, but fine with hardcoded for now

--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -11,7 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer/backoff"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // apiEndpointPrefix is the URL prefix prepended to the default site value from YamlAgentConfig.
@@ -271,7 +271,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		for key, rate := range rateBySpan {
 			serviceName, operationName, err := parseServiceAndOp(key)
 			if err != nil {
-				log.Errorf("Error when parsing names", err)
+				log.Errorf("error parsing names: %v", err)
 				continue
 			}
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/flags"
 	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (

--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func applyEnv() {
@@ -49,7 +49,7 @@ func applyEnv() {
 	} {
 		if v := os.Getenv(envKey); v != "" {
 			if r, err := splitString(v, ','); err != nil {
-				log.Warn("%q value not loaded: %v", envKey, err)
+				log.Warnf("%q value not loaded: %v", envKey, err)
 			} else {
 				config.Datadog.Set("apm_config.ignore_resources", r)
 			}

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
-	log.UseLogger(log.Disabled)
+	seelog.UseLogger(seelog.Disabled)
 	os.Exit(m.Run())
 }
 

--- a/pkg/trace/event/sampler_max_eps.go
+++ b/pkg/trace/event/sampler_max_eps.go
@@ -3,11 +3,10 @@ package event
 import (
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const maxEPSReportFrequency = 10 * time.Second

--- a/pkg/trace/filters/blacklister.go
+++ b/pkg/trace/filters/blacklister.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Blacklister holds a list of regular expressions which will match resources

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const sqlQueryTag = "sql.query"

--- a/pkg/trace/osutil/file.go
+++ b/pkg/trace/osutil/file.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/flags"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Exists reports whether the given path exists.

--- a/pkg/trace/sampler/coresampler_test.go
+++ b/pkg/trace/sampler/coresampler_test.go
@@ -5,13 +5,13 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
 func getTestSampler() *Sampler {
 	// Disable debug logs in these tests
-	log.UseLogger(log.Disabled)
+	seelog.UseLogger(seelog.Disabled)
 
 	// No extra fixed sampling, no maximum TPS
 	extraRate := 1.0

--- a/pkg/trace/sampler/presampler.go
+++ b/pkg/trace/sampler/presampler.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +18,7 @@ const (
 
 func getTestPriorityEngine() *PriorityEngine {
 	// Disable debug logs in these tests
-	log.UseLogger(log.Disabled)
+	seelog.UseLogger(seelog.Disabled)
 
 	// No extra fixed sampling, no maximum TPS
 	extraRate := 1.0

--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +14,7 @@ const defaultEnv = "none"
 
 func getTestScoreEngine() *ScoreEngine {
 	// Disable debug logs in these tests
-	log.UseLogger(log.Disabled)
+	seelog.UseLogger(seelog.Disabled)
 
 	// No extra fixed sampling, no maximum TPS
 	extraRate := 1.0

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -5,10 +5,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // defaultBufferLen represents the default buffer length; the number of bucket size

--- a/pkg/trace/stats/subtrace.go
+++ b/pkg/trace/stats/subtrace.go
@@ -3,7 +3,7 @@ package stats
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Subtrace represents the combination of a root span and the trace consisting of all its descendant spans

--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -2,7 +2,7 @@ package traceutil
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetEnv returns the meta value for the "env" key for

--- a/pkg/trace/watchdog/info.go
+++ b/pkg/trace/watchdog/info.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (

--- a/pkg/trace/watchdog/logonpanic.go
+++ b/pkg/trace/watchdog/logonpanic.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const shortErrMsgLen = 17 // 20 char max with tailing "..."

--- a/pkg/trace/watchdog/logonpanic_test.go
+++ b/pkg/trace/watchdog/logonpanic_test.go
@@ -6,21 +6,24 @@ import (
 	"sync"
 	"testing"
 
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
 var testLogBuf bytes.Buffer
 
 func init() {
-	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(&testLogBuf, log.DebugLvl, "%Ns [%Level] %Msg")
+	logger, err := seelog.LoggerFromWriterWithMinLevelAndFormat(&testLogBuf, seelog.DebugLvl, "%Ns [%Level] %Msg")
 	if err != nil {
 		panic(err)
 	}
-	err = log.ReplaceLogger(logger)
+	err = seelog.ReplaceLogger(logger)
 	if err != nil {
 		panic(err)
 	}
+	log.SetupDatadogLogger(logger, "INFO")
 }
 
 func TestLogOnPanicMain(t *testing.T) {

--- a/pkg/trace/watchdog/net.go
+++ b/pkg/trace/watchdog/net.go
@@ -3,10 +3,12 @@
 package watchdog
 
 import (
-	log "github.com/cihub/seelog"
-	"github.com/shirou/gopsutil/net"
 	"os"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/shirou/gopsutil/net"
 )
 
 // Net returns basic network info.

--- a/pkg/trace/writer/endpoint.go
+++ b/pkg/trace/writer/endpoint.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const languageHeaderKey = "X-Datadog-Reported-Languages"

--- a/pkg/trace/writer/payload.go
+++ b/pkg/trace/writer/payload.go
@@ -8,7 +8,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer/backoff"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // payload represents a data payload to be sent to some endpoint

--- a/pkg/trace/writer/service.go
+++ b/pkg/trace/writer/service.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const pathServices = "/api/v0.2/services"

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const pathStats = "/api/v0.2/stats"

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/releasenotes/notes/apm-share-log-pkg-7252042acfd39693.yaml
+++ b/releasenotes/notes/apm-share-log-pkg-7252042acfd39693.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: logging format has been changed to match the format of the core agent.
+fixes:
+  - |
+    APM: sensitive information is now scrubbed from logs.
+features:
+  - |
+    APM: JSON logging is now supported using the `log_format_json: true` setting.


### PR DESCRIPTION
### Changes

* Expose `LogFormatCommon` and `LogFormatJSON` in `pkg/config`.
* Switch to using the shared logging package (`pkg/util/log`) inside the trace-agent
and unify the logging format.
* Slightly refactor and clean up trace-agent start-up logic.

As a side-effect, JSON output is now supported in the trace-agent.