### PR TITLE
Configurable max logfile size and number of rotation.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("additional_checksd", defaultAdditionalChecksPath)
 	config.BindEnvAndSetDefault("log_payloads", false)
 	config.BindEnvAndSetDefault("log_file", "")
+	config.BindEnvAndSetDefault("log_file_max_size", "10Mb")
+	config.BindEnvAndSetDefault("log_file_max_rolls", 1)
 	config.BindEnvAndSetDefault("log_level", "info")
 	config.BindEnvAndSetDefault("log_to_syslog", false)
 	config.BindEnvAndSetDefault("log_to_console", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -429,6 +429,15 @@ api_key:
 # Set to 'true' to disable logging to the log file
 # disable_file_logging: false
 
+# Maximum size of one log file. Use either a size (e.g. 10MB) or
+# provide value in bytes: 10485760
+# log_file_max_size: 10MB
+
+# Maximum amount of "old" log files to keep.
+# Set to 0 to not limit the number of files
+# to create.
+# log_file_max_rolls: 1
+
 # Set to 'true' to enable logging to syslog.
 # Note: Even if this option is set to 'false', the service launcher of your environment
 # may redirect the agent process' stdout/stderr to syslog. In that case, if you wish

--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cihub/seelog"
 )
 
-const logFileMaxSize = 10 * 1024 * 1024         // 10MB
 const logDateFormat = "2006-01-02 15:04:05 MST" // see time.Format for format syntax
 
 var syslogTLSConfig *tls.Config
@@ -88,7 +87,7 @@ func SetupLogger(logLevel, logFile, uri string, rfc, logToConsole, jsonFormat bo
 		configTemplate += `<console />`
 	}
 	if logFile != "" {
-		configTemplate += fmt.Sprintf(`<rollingfile type="size" filename="%s" maxsize="%d" maxrolls="1" />`, logFile, logFileMaxSize)
+		configTemplate += fmt.Sprintf(`<rollingfile type="size" filename="%s" maxsize="%d" maxrolls="%d" />`, logFile, Datadog.GetSizeInBytes("log_file_max_size"), Datadog.GetInt("log_file_max_rolls"))
 	}
 	if syslog {
 		var syslogTemplate string

--- a/releasenotes/notes/configure-log-sizes-55aa3f9bdb851a35.yaml
+++ b/releasenotes/notes/configure-log-sizes-55aa3f9bdb851a35.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Log file size and number of rotation is now configurable.


### PR DESCRIPTION
### What does this PR do?

Add two configuration fields to configure the maximum size of a log file and how many log files are kept with log rotation.