### PR TITLE
Fix invoke usage with Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and development, is located under [the docs directory](docs) of the present repo
 
 To build the Agent you need:
  * [Go](https://golang.org/doc/install) 1.11.5 or later.
- * Python 2.7 along with development libraries.
+ * Python 2.7+ along with development libraries.
  * Python dependencies. You may install these with `pip install -r requirements.txt`
    This will also pull in [Invoke](http://www.pyinvoke.org) if not yet installed.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # python development requirements for Agent 6
-invoke==1.0.0
+invoke==1.0.4
 reno==2.9.2
 docker==3.0.1
 requests==2.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # python development requirements for Agent 6
-invoke==1.0.4
+invoke==1.0.0
 reno==2.9.2
 docker==3.0.1
 requests==2.20.1

--- a/tasks/pylauncher.py
+++ b/tasks/pylauncher.py
@@ -11,7 +11,7 @@ from .utils import REPO_PATH, bin_name, get_root
 
 
 #constants
-PYLAUNCHER_BIN_PATH = os.path.join(get_root(), "bin", "pylauncher")
+PYLAUNCHER_BIN_PATH = os.path.join(get_root().decode('utf-8'), "bin", "pylauncher")
 
 @task
 def build(ctx, rebuild=False):


### PR DESCRIPTION
### What does this PR do?

Make `inv` work with Python3

### Motivation

No reason to require 2.7 for tooling
