### PR TITLE
Fix host alias for GCE instances with custom hostname

### DIFF
--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -52,12 +51,11 @@ func GetHostname() (string, error) {
 
 // GetHostAlias returns the host alias from GCE
 func GetHostAlias() (string, error) {
-	instanceName, err := getResponseWithMaxLength(metadataURL+"/instance/hostname",
+	instanceName, err := getResponseWithMaxLength(metadataURL+"/instance/name",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 	if err != nil {
-		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
+		return "", fmt.Errorf("unable to retrieve instance name from GCE: %s", err)
 	}
-	instanceName = strings.SplitN(instanceName, ".", 2)[0]
 
 	projectID, err := getResponseWithMaxLength(metadataURL+"/project/project-id",
 		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -50,12 +50,15 @@ func TestGetHostAliases(t *testing.T) {
 	lastRequests := []*http.Request{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		if r.URL.Path == "/instance/hostname" {
-			io.WriteString(w, "gce-hostname.c.datadog-demo.internal")
-		} else if r.URL.Path == "/project/project-id" {
+		switch path := r.URL.Path; path {
+		case "/instance/hostname":
+			io.WriteString(w, "gce-custom-hostname.custom-domain.gce-project")
+		case "/instance/name":
+			io.WriteString(w, "gce-instance-name")
+		case "/project/project-id":
 			io.WriteString(w, "gce-project")
-		} else {
-			t.Fatalf("Unknown URL requested: %s", r.URL.Path)
+		default:
+			t.Fatalf("Unknown URL requested: %s", path)
 		}
 		lastRequests = append(lastRequests, r)
 	}))
@@ -64,7 +67,7 @@ func TestGetHostAliases(t *testing.T) {
 
 	val, err := GetHostAlias()
 	assert.Nil(t, err)
-	assert.Equal(t, "gce-hostname.gce-project", val)
+	assert.Equal(t, "gce-instance-name.gce-project", val)
 }
 
 func TestGetClusterName(t *testing.T) {

--- a/releasenotes/notes/gce-host-alias-instance-name-deb56d01c077f41f.yaml
+++ b/releasenotes/notes/gce-host-alias-instance-name-deb56d01c077f41f.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On Google Compute Engine, the Agent now reports `<instance_name>.<project_id>`
+    as a host alias instead of `<hostname_prefix>.<prefix_id>`, which improves the
+    uniqueness and relevance of the host alias when the GCE instance has a custom hostname.


### PR DESCRIPTION
### What does this PR do?

Currently, datadog agent derives the GCE instance name from the hostname that is fetched from metadata endpoint `/instance/hostname`. For GCE instances with custom hostnames, this approach can result in wrong instance names being derived, because the instance name may not even be part of the custom hostname.

In fact, the GCE instance name can be directly retrieved from metadata endpoint `/instance/name`.

Example for a GCE instance with:

* custom hostname: `web.custom-name.my-project`
* instance name: `gce-instance-name`
* project id: `my-project`

The Agent would previously report `web.my-project` as host alias (may not be unique, and may be irrelevant), and after this change reports `gce-instance-name.my-project` (unique, and relevant)

### Motivation

Wrong host alias for GCE instances with custom hostnames.

### Additional notes

We can consider this change as non-breaking for the following reasons:

* it may change the reported host alias but not the actual hostname, so it does not introduce any risk of double host counting/billing
* for GCE instances with default hostnames: the instance `name` and the `hostname` are the same, so this change will not change the reported host alias
* for GCE instances with custom hostnames: the reported host alias likely didn't make much sense, this change will change it to a host alias that actually makes sense.