### PR TITLE
REmove setx from python definition; it's not needed, and it messes with

### DIFF
--- a/omnibus/config/software/python.rb
+++ b/omnibus/config/software/python.rb
@@ -88,6 +88,5 @@ else
     #
     # expand python zip into the embedded directory
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(install_dir)}\\embedded\""
-    command "SETX PYTHONPATH \"#{windows_safe_path(install_dir)}\\embedded\""
   end
 end


### PR DESCRIPTION
the build system

### What does this PR do?

remove the `setx` command from the build definition.

### Motivation

It's not necessary, and it leaves an artifact; namely, it sets your PYTHON path to your embedded directory rather than the system path.  All of our definitions explicitly call the python from the embedded directory, so it's not necessary

### Additional Notes

Anything else we should know when reviewing?
