### PR TITLE
reduce concurrency on circleci unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - run: *enter_venv
       - run:
           name: run unit tests
-          command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 4
+          command: inv -e test --coverage --race --profile --fail-on-fmt --cpus 3
       - run:
           name: upload code coverage results
           # Never fail on coverage upload


### PR DESCRIPTION
### What does this PR do?

Reduce the go test concurrency in circleci to avoid failures on OOMs. Unit tests still finish faster than integration tests or appveyor:

![](https://cl.ly/5f37917932c4/Image%202019-03-12%20at%202.30.13%20PM.png)
