### PR TITLE
datadog-agent, limit number of DCA call from Agent

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -107,12 +107,14 @@ func StopServer() {
 func validateToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.String()
-		if isExternalPath(path) {
-			if err := util.ValidateDCARequest(w, r); err != nil {
-				return
+		var isValid bool
+		if !isExternalPath(path) {
+			if err := util.Validate(w, r); err == nil {
+				isValid = true
 			}
-		} else {
-			if err := util.Validate(w, r); err != nil {
+		}
+		if !isValid {
+			if err := util.ValidateDCARequest(w, r); err != nil {
 				return
 			}
 		}
@@ -124,7 +126,7 @@ func validateToken(next http.Handler) http.Handler {
 func isExternalPath(path string) bool {
 	return strings.HasPrefix(path, "/api/v1/metadata/") && len(strings.Split(path, "/")) == 7 || // support for agents < 6.5.0
 		path == "/version" ||
-		strings.HasPrefix(path, "/api/v1/tags/pod/") && len(strings.Split(path, "/")) == 8 ||
+		strings.HasPrefix(path, "/api/v1/tags/pod/") && (len(strings.Split(path, "/")) == 6 || len(strings.Split(path, "/")) == 8) ||
 		strings.HasPrefix(path, "/api/v1/tags/node/") && len(strings.Split(path, "/")) == 6 ||
 		strings.HasPrefix(path, "/api/v1/clusterchecks/") && len(strings.Split(path, "/")) == 6
 }

--- a/cmd/cluster-agent/api/v1/install.go
+++ b/cmd/cluster-agent/api/v1/install.go
@@ -175,7 +175,7 @@ func getPodMetadataForNode(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Fetching metadata map on all pods of the node %s", nodeName)
 	metaList, errNodes := as.GetMetadataMapBundleOnNode(nodeName)
 	if errNodes != nil {
-		log.Errorf("Could not collect the service map for %s", nodeName)
+		log.Errorf("Could not collect the service map for %s, err: %v", nodeName, errNodes)
 	}
 	slcB, err := json.Marshal(metaList)
 	if err != nil {

--- a/pkg/clusteragent/api/v1/types.go
+++ b/pkg/clusteragent/api/v1/types.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package v1
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// NamespacesPodsStringsSet maps pod names to a set of strings
+// keyed by the namespace a pod belongs to.
+// This data structure allows for O(1) lookups of services given a
+// namespace and pod name.
+//
+// The data is stored in the following schema:
+// {
+// 	"namespace1": {
+// 		"pod": [ "svc1", "svc2", "svc3" ]
+// 	},
+//  "namespace2": {
+// 		"pod2": [ "svc1", "svc2", "svc3" ]
+// 	}
+// }
+type NamespacesPodsStringsSet map[string]MapStringSet
+
+// MapStringSet maps a set of string by a string key
+type MapStringSet map[string]sets.String
+
+/*
+ TODO: we should replace the NamespacesPodsStringsSet struct by the following struct.
+	   It may improves the API consistency.
+type NamespacesPodsStringsSet struct {
+	Namespaces map[string]PodsStringsSet `json:"namespaces"`
+}
+
+type PodsStringsSet struct {
+	Pods map[string]sets.String `json:"pods"`
+}
+*/
+
+// NewNamespacesPodsStringsSet return new initialized NamespacesPodsStringsSet instance
+func NewNamespacesPodsStringsSet() NamespacesPodsStringsSet {
+	return make(NamespacesPodsStringsSet)
+}
+
+// Get returns the list of strings for a given namespace and pod name.
+func (m NamespacesPodsStringsSet) Get(namespace, podName string) ([]string, bool) {
+	if _, ok := m[namespace]; !ok {
+		return nil, false
+	}
+	if _, ok := m[namespace][podName]; !ok {
+		return nil, false
+	}
+	return m[namespace][podName].UnsortedList(), true
+}
+
+// Set updates strings for a given namespace and pod name.
+func (m NamespacesPodsStringsSet) Set(namespace, podName string, strings ...string) {
+	if _, ok := m[namespace]; !ok {
+		m[namespace] = make(map[string]sets.String)
+	}
+	if _, ok := m[namespace][podName]; !ok {
+		m[namespace][podName] = sets.NewString()
+	}
+	m[namespace][podName].Insert(strings...)
+}
+
+// Delete deletes strings for a given namespace.
+func (m NamespacesPodsStringsSet) Delete(namespace string, strings ...string) {
+	if _, ok := m[namespace]; !ok {
+		// Nothing to delete.
+		return
+	}
+	for podName, svcSet := range m[namespace] {
+		svcSet.Delete(strings...)
+
+		if svcSet.Len() == 0 {
+			delete(m[namespace], podName)
+		}
+	}
+	if len(m[namespace]) == 0 {
+		delete(m, namespace)
+	}
+}
+
+// MetadataMapperBundle maps pod names to associated metadata.
+type MetadataMapperBundle struct {
+	// Services maps pod names to the names of the services targeting the pod.
+	// keyed by the namespace a pod belongs to.
+	Services NamespacesPodsStringsSet `json:"services,omitempty"`
+}
+
+// NewMetadataMapperBundle returns new MetadataMapperBundle initialized instance
+func NewMetadataMapperBundle() *MetadataMapperBundle {
+	return &MetadataMapperBundle{
+		Services: NewNamespacesPodsStringsSet(),
+	}
+}
+
+// MetadataResponse use to encore /api/v1/tags payloads
+type MetadataResponse struct {
+	Nodes    map[string]*MetadataMapperBundle `json:"Nodes,omitempty"`    // Nodes with uppercase for backward compatibility
+	Warnings []string                         `json:"Warnings,omitempty"` // Warnings with uppercase for backward compatibility
+	Errors   string                           `json:"Errors,omitempty"`   // Errors with uppercase for backward compatibility
+	// TODO: Since it is Errors, it should be []string and not string
+}
+
+// NewMetadataResponse returns new NewMetadataResponse initialized instance
+func NewMetadataResponse() *MetadataResponse {
+	return &MetadataResponse{
+		Nodes: make(map[string]*MetadataMapperBundle),
+	}
+}

--- a/pkg/clusteragent/api/v1/types.go
+++ b/pkg/clusteragent/api/v1/types.go
@@ -85,31 +85,31 @@ func (m NamespacesPodsStringsSet) Delete(namespace string, strings ...string) {
 	}
 }
 
-// MetadataMapperBundle maps pod names to associated metadata.
-type MetadataMapperBundle struct {
+// MetadataResponseBundle maps pod names to associated metadata.
+type MetadataResponseBundle struct {
 	// Services maps pod names to the names of the services targeting the pod.
 	// keyed by the namespace a pod belongs to.
 	Services NamespacesPodsStringsSet `json:"services,omitempty"`
 }
 
-// NewMetadataMapperBundle returns new MetadataMapperBundle initialized instance
-func NewMetadataMapperBundle() *MetadataMapperBundle {
-	return &MetadataMapperBundle{
+// NewMetadataResponseBundle returns new MetadataResponseBundle initialized instance
+func NewMetadataResponseBundle() *MetadataResponseBundle {
+	return &MetadataResponseBundle{
 		Services: NewNamespacesPodsStringsSet(),
 	}
 }
 
 // MetadataResponse use to encore /api/v1/tags payloads
 type MetadataResponse struct {
-	Nodes    map[string]*MetadataMapperBundle `json:"Nodes,omitempty"`    // Nodes with uppercase for backward compatibility
-	Warnings []string                         `json:"Warnings,omitempty"` // Warnings with uppercase for backward compatibility
-	Errors   string                           `json:"Errors,omitempty"`   // Errors with uppercase for backward compatibility
+	Nodes    map[string]*MetadataResponseBundle `json:"Nodes,omitempty"`    // Nodes with uppercase for backward compatibility
+	Warnings []string                           `json:"Warnings,omitempty"` // Warnings with uppercase for backward compatibility
+	Errors   string                             `json:"Errors,omitempty"`   // Errors with uppercase for backward compatibility
 	// TODO: Since it is Errors, it should be []string and not string
 }
 
 // NewMetadataResponse returns new NewMetadataResponse initialized instance
 func NewMetadataResponse() *MetadataResponse {
 	return &MetadataResponse{
-		Nodes: make(map[string]*MetadataMapperBundle),
+		Nodes: make(map[string]*MetadataResponseBundle),
 	}
 }

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mholt/archiver"
 
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -165,10 +166,10 @@ func zipDCAStatusFile(tempDir, hostname string) error {
 }
 
 func zipMetadataMap(tempDir, hostname string) error {
-	metaList := make(map[string]interface{})
+	metaList := apiv1.NewMetadataResponse()
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {
-		metaList["Errors"] = fmt.Sprintf("Can't create client to query the API Server: %s", err.Error())
+		metaList.Errors = fmt.Sprintf("Can't create client to query the API Server: %s", err.Error())
 	} else {
 		// Grab the metadata map for all nodes.
 		metaList, err = apiserver.GetMetadataMapBundleOnAllNodes(cl)

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -23,17 +23,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type dummyClusterAgent struct {
-	node         map[string]map[string]string
-	responses    map[string][]string
-	rawResponses map[string]string
-	requests     chan *http.Request
+	node            map[string]map[string]string
+	responses       map[string][]string
+	responsesByNode apiv1.MetadataResponse
+	rawResponses    map[string]string
+	requests        chan *http.Request
 	sync.RWMutex
 	token       string
 	redirectURL string
@@ -59,6 +62,28 @@ func newDummyClusterAgent() (*dummyClusterAgent, error) {
 			"pod/node2/bar/pod-00004": {"kube_service:svc2"},
 			"pod/node2/bar/pod-00005": {"kube_service:svc3"},
 			"pod/node2/bar/pod-00006": {},
+		},
+		responsesByNode: apiv1.MetadataResponse{
+			Nodes: map[string]*apiv1.MetadataMapperBundle{
+				"node1": {
+					Services: apiv1.NamespacesPodsStringsSet{
+						"foo": {
+							"pod-00001": sets.NewString("kube_service:svc1"),
+							"pod-00002": sets.NewString("kube_service:svc1", "kube_service:svc2"),
+						},
+						"bar": {
+							"pod-00004": sets.NewString("kube_service:svc2"),
+						},
+					},
+				},
+				"node2": {
+					Services: apiv1.NamespacesPodsStringsSet{
+						"foo": {
+							"pod-00003": sets.NewString("kube_service:svc1"),
+						},
+					},
+				},
+			},
 		},
 		rawResponses: map[string]string{
 			"/version": `{"Major":0, "Minor":0, "Patch":0, "Pre":"test", "Meta":"test", "Commit":"1337"}`,
@@ -124,18 +149,37 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	case 6:
 		nodeName := s[5]
-		key := fmt.Sprintf("node/%s", nodeName)
 		d.RLock()
 		defer d.RUnlock()
-		labels, found := d.node[key]
-		if found {
-			b, err := json.Marshal(labels)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
+		switch s[4] {
+		case "pod":
+			if nodeResp, found := d.responsesByNode.Nodes[nodeName]; found {
+				resp := apiv1.MetadataResponse{
+					Nodes: map[string]*apiv1.MetadataMapperBundle{
+						nodeName: nodeResp,
+					},
+				}
+				b, err := json.Marshal(resp)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.Write(b)
 				return
 			}
-			w.Write(b)
-			return
+		case "node":
+			key := fmt.Sprintf("node/%s", nodeName)
+			labels, found := d.node[key]
+			if found {
+				b, err := json.Marshal(labels)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.Write(b)
+				return
+			}
+		default:
 		}
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
@@ -440,6 +484,77 @@ func (suite *clusterAgentSuite) TestGetKubernetesMetadataNames() {
 	}
 }
 
+func (suite *clusterAgentSuite) TestGetPodsMetadataForNode() {
+	dca, err := newDummyClusterAgent()
+	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+
+	ts, p, err := dca.StartTLS()
+	defer ts.Close()
+	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+
+	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
+
+	ca, err := GetClusterAgentClient()
+	require.Nil(suite.T(), err, fmt.Sprintf("%v", err))
+
+	testSuite := []struct {
+		name              string
+		nodeName          string
+		expectedMetadatas apiv1.NamespacesPodsStringsSet
+		expectedErr       error
+	}{
+		{
+			name:     "basic case with 2 namespaces",
+			nodeName: "node1",
+			expectedMetadatas: apiv1.NamespacesPodsStringsSet{
+				"foo": apiv1.MapStringSet{
+					"pod-00001": sets.NewString("kube_service:svc1"),
+					"pod-00002": sets.NewString("kube_service:svc1", "kube_service:svc2"),
+				},
+				"bar": {
+					"pod-00004": sets.NewString("kube_service:svc2"),
+				},
+			},
+		},
+		{
+			name:     "basic case",
+			nodeName: "node2",
+			expectedMetadatas: apiv1.NamespacesPodsStringsSet{
+				"foo": apiv1.MapStringSet{
+					"pod-00003": sets.NewString("kube_service:svc1"),
+				},
+			},
+		},
+		{
+			name:        "error case: node not found",
+			nodeName:    "node3",
+			expectedErr: fmt.Errorf("unexpected status code from cluster agent: 404"),
+		},
+	}
+
+	for _, testCase := range testSuite {
+		suite.T().Run(testCase.name, func(t *testing.T) {
+			metadatas, err := ca.GetPodsMetadataForNode(testCase.nodeName)
+			if testCase.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, testCase.expectedErr, err)
+			} else {
+				assert.NoError(t, err)
+				t.Logf("metadatas: %s", metadatas)
+
+				require.Nil(t, err, fmt.Sprintf("%v", err))
+				require.Equal(t, len(testCase.expectedMetadatas), len(metadatas))
+				for ns, expectedNSValues := range testCase.expectedMetadatas {
+					for podName, expectedMetadatas := range expectedNSValues {
+						for _, elt := range expectedMetadatas.List() {
+							assert.Contains(t, metadatas[ns][podName].List(), elt)
+						}
+					}
+				}
+			}
+		})
+	}
+}
 func TestClusterAgentSuite(t *testing.T) {
 	clusterAgentAuthTokenFilename := "cluster_agent.auth_token"
 

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -64,7 +64,7 @@ func newDummyClusterAgent() (*dummyClusterAgent, error) {
 			"pod/node2/bar/pod-00006": {},
 		},
 		responsesByNode: apiv1.MetadataResponse{
-			Nodes: map[string]*apiv1.MetadataMapperBundle{
+			Nodes: map[string]*apiv1.MetadataResponseBundle{
 				"node1": {
 					Services: apiv1.NamespacesPodsStringsSet{
 						"foo": {
@@ -155,7 +155,7 @@ func (d *dummyClusterAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case "pod":
 			if nodeResp, found := d.responsesByNode.Nodes[nodeName]; found {
 				resp := apiv1.MetadataResponse{
-					Nodes: map[string]*apiv1.MetadataMapperBundle{
+					Nodes: map[string]*apiv1.MetadataResponseBundle{
 						nodeName: nodeResp,
 					},
 				}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -153,7 +153,7 @@ type metadataMapperBundle struct {
 	m        sync.RWMutex
 }
 
-func newMetadataMapperBundle() *metadataMapperBundle {
+func newMetadataResponseBundle() *metadataMapperBundle {
 	return &metadataMapperBundle{
 		Services: apiv1.NewNamespacesPodsStringsSet(),
 		mapOnIP:  config.Datadog.GetBool("kubernetes_map_services_on_ip"),
@@ -364,8 +364,8 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	return result.Into(output)
 }
 
-func convertmetadataMapperBundleToAPI(input *metadataMapperBundle) *apiv1.MetadataMapperBundle {
-	output := apiv1.NewMetadataMapperBundle()
+func convertmetadataMapperBundleToAPI(input *metadataMapperBundle) *apiv1.MetadataResponseBundle {
+	output := apiv1.NewMetadataResponseBundle()
 	output.Services = input.Services
 	return output
 }

--- a/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
@@ -56,7 +56,7 @@ func processKubeServices(nodeList *v1.NodeList, pods []*kubelet.Pod, endpointLis
 		freshnessCache, freshnessFound := cache.Cache.Get(freshness) // if expired, freshness not found deal with that
 
 		if !found {
-			metaBundle = newMetadataMapperBundle()
+			metaBundle = newMetadataResponseBundle()
 			cache.Cache.Set(freshness, len(pods), metadataMapExpire)
 		}
 
@@ -64,7 +64,7 @@ func processKubeServices(nodeList *v1.NodeList, pods []*kubelet.Pod, endpointLis
 		// If a pod is killed and rescheduled during a run, we will only keep the old entry for another run, which is acceptable.
 		if found && freshnessCache != len(pods) || !freshnessFound {
 			cache.Cache.Delete(nodeNameCacheKey)
-			metaBundle = newMetadataMapperBundle()
+			metaBundle = newMetadataResponseBundle()
 			cache.Cache.Set(freshness, len(pods), metadataMapExpire)
 			log.Debugf("Refreshing cache for %s", nodeNameCacheKey)
 		}

--- a/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
@@ -8,11 +8,12 @@
 package apiserver
 
 import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NodeMetadataMapping only fetch the endpoints from Kubernetes apiserver and add the metadataMapper of the
@@ -68,7 +69,7 @@ func processKubeServices(nodeList *v1.NodeList, pods []*kubelet.Pod, endpointLis
 			log.Debugf("Refreshing cache for %s", nodeNameCacheKey)
 		}
 
-		err := metaBundle.(*MetadataMapperBundle).mapServices(nodeName, pods, *endpointList)
+		err := metaBundle.(*metadataMapperBundle).mapServices(nodeName, pods, *endpointList)
 		if err != nil {
 			log.Errorf("Could not map the services on node %s: %s", node.Name, err.Error())
 			continue

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -10,6 +10,7 @@ package apiserver
 import (
 	"errors"
 
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -24,8 +25,8 @@ type APIClient struct {
 	Cl interface{}
 }
 
-// MetadataMapperBundle maps the podNames to the metadata they are associated with.
-type MetadataMapperBundle struct{}
+// metadataMapperBundle maps the podNames to the metadata they are associated with.
+type metadataMapperBundle struct{}
 
 // GetAPIClient returns the shared ApiClient instance.
 func GetAPIClient() (*APIClient, error) {
@@ -40,13 +41,13 @@ func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 }
 
 // GetMetadataMapBundleOnNode is used for the CLI svcmap command to output given a nodeName
-func GetMetadataMapBundleOnNode(nodeName string) (map[string]interface{}, error) {
+func GetMetadataMapBundleOnNode(nodeName string) (*apiv1.MetadataResponse, error) {
 	log.Errorf("GetMetadataMapBundleOnNode not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }
 
 // GetMetadataMapBundleOnAllNodes is used for the CLI svcmap command to run fetch the service map of all nodes.
-func GetMetadataMapBundleOnAllNodes(_ *APIClient) (map[string]interface{}, error) {
+func GetMetadataMapBundleOnAllNodes(_ *APIClient) (*apiv1.MetadataResponse, error) {
 	log.Errorf("GetMetadataMapBundleOnAllNodes not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
 }

--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -294,7 +294,7 @@ func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 		return nil, nil
 	}
 
-	metaBundle, ok := metaBundleInterface.(*MetadataMapperBundle)
+	metaBundle, ok := metaBundleInterface.(*metadataMapperBundle)
 	if !ok {
 		return nil, fmt.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
 	}

--- a/pkg/util/kubernetes/apiserver/services.go
+++ b/pkg/util/kubernetes/apiserver/services.go
@@ -9,67 +9,15 @@ package apiserver
 
 import (
 	"fmt"
-	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 const kubeServiceIDPrefix = "kube_service://"
 
-// ServicesMapper maps pod names to the names of the services targeting the pod
-// keyed by the namespace a pod belongs to. This data structure allows for O(1)
-// lookups of services given a namespace and pod name.
-//
-// The data is stored in the following schema:
-// {
-// 	"namespace": {
-// 		"pod": [ "svc1", "svc2", "svc3" ]
-// 	}
-// }
-type ServicesMapper map[string]map[string]sets.String
-
-// Get returns the list of services for a given namespace and pod name.
-func (m ServicesMapper) Get(namespace, podName string) ([]string, bool) {
-	if _, ok := m[namespace]; !ok {
-		return nil, false
-	}
-	if _, ok := m[namespace][podName]; !ok {
-		return nil, false
-	}
-	return m[namespace][podName].UnsortedList(), true
-}
-
-// Set updates services for a given namespace and pod name.
-func (m ServicesMapper) Set(namespace, podName string, svcs ...string) {
-	if _, ok := m[namespace]; !ok {
-		m[namespace] = make(map[string]sets.String)
-	}
-	if _, ok := m[namespace][podName]; !ok {
-		m[namespace][podName] = sets.NewString()
-	}
-	m[namespace][podName].Insert(svcs...)
-}
-
-// Delete deletes services for a given namespace.
-func (m ServicesMapper) Delete(namespace string, svcs ...string) {
-	if _, ok := m[namespace]; !ok {
-		// Nothing to delete.
-		return
-	}
-	for podName, svcSet := range m[namespace] {
-		svcSet.Delete(svcs...)
-
-		if svcSet.Len() == 0 {
-			delete(m[namespace], podName)
-		}
-	}
-	if len(m[namespace]) == 0 {
-		delete(m, namespace)
-	}
-}
-
 // ServicesForPod returns the services mapped to a given pod and namespace.
 // If nothing is found, the boolean is false. This call is thread-safe.
-func (metaBundle *MetadataMapperBundle) ServicesForPod(ns, podName string) ([]string, bool) {
+func (metaBundle *metadataMapperBundle) ServicesForPod(ns, podName string) ([]string, bool) {
 	metaBundle.m.RLock()
 	defer metaBundle.m.RUnlock()
 

--- a/pkg/util/kubernetes/apiserver/services_kubelet_test.go
+++ b/pkg/util/kubernetes/apiserver/services_kubelet_test.go
@@ -12,13 +12,16 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
 func TestMapServices(t *testing.T) {
@@ -62,7 +65,7 @@ func TestMapServices(t *testing.T) {
 		nodeName        string
 		kubeletPods     []*kubelet.Pod
 		endpoints       []v1.Endpoints
-		expectedMapping ServicesMapper
+		expectedMapping apiv1.NamespacesPodsStringsSet
 	}{
 		{
 			"1 node, 1 pod, 1 service",
@@ -80,7 +83,7 @@ func TestMapServices(t *testing.T) {
 					},
 				},
 			},
-			ServicesMapper{
+			apiv1.NamespacesPodsStringsSet{
 				"foo": {"pod1_name": sets.NewString("svc1")},
 			},
 		},
@@ -110,7 +113,7 @@ func TestMapServices(t *testing.T) {
 					},
 				},
 			},
-			ServicesMapper{
+			apiv1.NamespacesPodsStringsSet{
 				"default": {"pod_name": sets.NewString("svc1")},
 				"other":   {"pod_name": sets.NewString("svc2")},
 			},
@@ -157,7 +160,7 @@ func TestMapServices(t *testing.T) {
 					},
 				},
 			},
-			ServicesMapper{
+			apiv1.NamespacesPodsStringsSet{
 				"foo": {
 					"pod1_name": sets.NewString("svc1", "svc3"),
 					"pod3_name": sets.NewString("svc2"),
@@ -168,7 +171,7 @@ func TestMapServices(t *testing.T) {
 
 	// Test the final state after all cases run to make
 	// sure mapping does not affect unlisted services
-	expectedAggregatedMapping := ServicesMapper{
+	expectedAggregatedMapping := apiv1.NamespacesPodsStringsSet{
 		"foo": {
 			"pod1_name": sets.NewString("svc1", "svc3"),
 			"pod3_name": sets.NewString("svc2"),
@@ -182,7 +185,7 @@ func TestMapServices(t *testing.T) {
 	}
 
 	mu := sync.RWMutex{}
-	var aggregatedBundle *MetadataMapperBundle
+	var aggregatedBundle *metadataMapperBundle
 
 	aggregatedBundle = newMetadataMapperBundle()
 	for i, tt := range tests {
@@ -238,15 +241,15 @@ func TestMapServices(t *testing.T) {
 	mu.RUnlock()
 }
 
-func runMapOnRefTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endpointsList v1.EndpointsList, expectedMapping ServicesMapper) {
+func runMapOnRefTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endpointsList v1.EndpointsList, expectedMapping apiv1.NamespacesPodsStringsSet) {
 	runMapServicesTest(t, nodeName, pods, endpointsList, expectedMapping, false)
 }
 
-func runMapOnIPTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endpointsList v1.EndpointsList, expectedMapping ServicesMapper) {
+func runMapOnIPTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endpointsList v1.EndpointsList, expectedMapping apiv1.NamespacesPodsStringsSet) {
 	runMapServicesTest(t, nodeName, pods, endpointsList, expectedMapping, true)
 }
 
-func runMapServicesTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endpointsList v1.EndpointsList, expectedMapping ServicesMapper, mapOnIP bool) {
+func runMapServicesTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endpointsList v1.EndpointsList, expectedMapping apiv1.NamespacesPodsStringsSet, mapOnIP bool) {
 	testName := "mapOnRef"
 	if mapOnIP {
 		testName = "mapOnIP"

--- a/pkg/util/kubernetes/apiserver/services_kubelet_test.go
+++ b/pkg/util/kubernetes/apiserver/services_kubelet_test.go
@@ -187,7 +187,7 @@ func TestMapServices(t *testing.T) {
 	mu := sync.RWMutex{}
 	var aggregatedBundle *metadataMapperBundle
 
-	aggregatedBundle = newMetadataMapperBundle()
+	aggregatedBundle = newMetadataResponseBundle()
 	for i, tt := range tests {
 		endpointsList := v1.EndpointsList{Items: tt.endpoints}
 
@@ -208,7 +208,7 @@ func TestMapServices(t *testing.T) {
 	mu.RUnlock()
 
 	// Run the tests again for legacy versions of Kubernetes
-	aggregatedBundle = newMetadataMapperBundle()
+	aggregatedBundle = newMetadataResponseBundle()
 	for i, tt := range tests {
 		// Kubernetes 1.3.x does not include `NodeName`
 		var legacyEndpoints []v1.Endpoints
@@ -255,7 +255,7 @@ func runMapServicesTest(t *testing.T, nodeName string, pods []*kubelet.Pod, endp
 		testName = "mapOnIP"
 	}
 	t.Run(testName, func(t *testing.T) {
-		bundle := newMetadataMapperBundle()
+		bundle := newMetadataResponseBundle()
 		bundle.mapOnIP = mapOnIP
 		err := bundle.mapServices(nodeName, pods, endpointsList)
 		require.NoError(t, err)

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 )
 
-func TestServicesMapper(t *testing.T) {
-	mapper := ServicesMapper{}
+func TestNamespacesPodsStringsSet(t *testing.T) {
+	mapper := apiv1.NewNamespacesPodsStringsSet()
 
 	mapper.Set("default", "pod1", "svc1")
 	mapper.Set("default", "pod2", "svc1")

--- a/pkg/util/kubernetes/apiserver/store.go
+++ b/pkg/util/kubernetes/apiserver/store.go
@@ -21,7 +21,7 @@ var globalMetaBundleStore = &metaBundleStore{
 	cache: agentcache.Cache,
 }
 
-// metaBundleStore is a cache for MetadataMapperBundles for each node in the cluster
+// metaBundleStore is a cache for metadataMapperBundles for each node in the cluster
 // and allows multiple goroutines to safely get or create meta bundles for the same nodes
 // without overwriting each other.
 type metaBundleStore struct {
@@ -33,10 +33,10 @@ type metaBundleStore struct {
 	cache *cache.Cache
 }
 
-func (m *metaBundleStore) get(nodeName string) (*MetadataMapperBundle, bool) {
+func (m *metaBundleStore) get(nodeName string) (*metadataMapperBundle, bool) {
 	cacheKey := agentcache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
 
-	var metaBundle *MetadataMapperBundle
+	var metaBundle *metadataMapperBundle
 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -46,7 +46,7 @@ func (m *metaBundleStore) get(nodeName string) (*MetadataMapperBundle, bool) {
 		return nil, false
 	}
 
-	metaBundle, ok = v.(*MetadataMapperBundle)
+	metaBundle, ok = v.(*metadataMapperBundle)
 	if !ok {
 		log.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
 		return nil, false
@@ -55,17 +55,17 @@ func (m *metaBundleStore) get(nodeName string) (*MetadataMapperBundle, bool) {
 	return metaBundle, true
 }
 
-func (m *metaBundleStore) getOrCreate(nodeName string) *MetadataMapperBundle {
+func (m *metaBundleStore) getOrCreate(nodeName string) *metadataMapperBundle {
 	cacheKey := agentcache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
 
-	var metaBundle *MetadataMapperBundle
+	var metaBundle *metadataMapperBundle
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	v, ok := m.cache.Get(cacheKey)
 	if ok {
-		metaBundle, ok := v.(*MetadataMapperBundle)
+		metaBundle, ok := v.(*metadataMapperBundle)
 		if ok {
 			return metaBundle
 		}
@@ -79,7 +79,7 @@ func (m *metaBundleStore) getOrCreate(nodeName string) *MetadataMapperBundle {
 	return metaBundle
 }
 
-func (m *metaBundleStore) set(nodeName string, metaBundle *MetadataMapperBundle) {
+func (m *metaBundleStore) set(nodeName string, metaBundle *metadataMapperBundle) {
 	cacheKey := agentcache.BuildAgentKey(metadataMapperCachePrefix, nodeName)
 
 	m.mu.Lock()

--- a/pkg/util/kubernetes/apiserver/store.go
+++ b/pkg/util/kubernetes/apiserver/store.go
@@ -72,7 +72,7 @@ func (m *metaBundleStore) getOrCreate(nodeName string) *metadataMapperBundle {
 		log.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
 	}
 
-	metaBundle = newMetadataMapperBundle()
+	metaBundle = newMetadataResponseBundle()
 
 	m.cache.Set(cacheKey, metaBundle, cache.NoExpiration)
 

--- a/releasenotes/notes/cluster-agent-aggregate-agent-to-dca-api-call-69321589e1bd52bf.yaml
+++ b/releasenotes/notes/cluster-agent-aggregate-agent-to-dca-api-call-69321589e1bd52bf.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    In order to decrease the number API DCA request from the Agents,
+    The Agent no use a different API endpoint in order to call only 
+    once the DCA API in order to retrieve the Pods metadata.
+

--- a/releasenotes/notes/cluster-agent-aggregate-agent-to-dca-api-call-69321589e1bd52bf.yaml
+++ b/releasenotes/notes/cluster-agent-aggregate-agent-to-dca-api-call-69321589e1bd52bf.yaml
@@ -1,7 +1,7 @@
 ---
 enhancements:
   - |
-    In order to decrease the number API DCA request from the Agents,
-    The Agent no use a different API endpoint in order to call only 
-    once the DCA API in order to retrieve the Pods metadata.
-
+    In order to decrease the number of API DCA requests,
+    The Agent now uses a different API endpoint to call
+    the DCA's API only once in order to retrieve the Pods
+    metadata.


### PR DESCRIPTION
### What does this PR do?

- instead of calling the DCA api for each Pod, the datadog-agent is
calling once the DCA api by node.
- code refactoring between DCA api encode/decode function: now agent and
cluster agent use the same structs for the DCA api payload.

### Motivation

Limit the number of http call from `agent` to `cluster-agent`.

### Additional Notes

This PR also include a some Cluster-Agent API struct refactoring.
