### PR TITLE
Tell the checks downloader which Python to use

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -400,7 +400,6 @@ func downloadWheel(integration, version string) (string, error) {
 	args := []string{
 		"-m", downloaderModule,
 		integration,
-		"--python", pyPath,
 		"--version", version,
 	}
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -402,19 +402,19 @@ func downloadWheel(integration, version string) (string, error) {
 	// in turn call in-toto, which will in turn call Python to inspect the wheel,
 	// we will use our embedded Python.
 	// First, get the current PATH as an array.
-	path_arr := filepath.SplitList(os.Getenv("PATH"))
+	pathArr := filepath.SplitList(os.Getenv("PATH"))
 	// Get the directory of our embedded Python.
-	path_dir := filepath.Dir(pyPath)
+	pythonDir := filepath.Dir(pyPath)
 	// Prepend this dir to PATH array.
-	path_arr = append([]string{path_dir}, path_arr...)
+	pathArr = append([]string{pythonDir}, pathArr...)
 	// Build a new PATH string from the array.
-	path_str := strings.Join(path_arr, string(os.PathListSeparator))
+	pathStr := strings.Join(pathArr, string(os.PathListSeparator))
 	// Make a copy of the current environment.
 	environ := os.Environ()
 	// Walk over the copy of the environment, and replace PATH.
 	for key, value := range environ {
 		if strings.HasPrefix(value, "PATH=") {
-			environ[key] = "PATH=" + path_str
+			environ[key] = "PATH=" + pathStr
 			break
 		}
 	}

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -385,6 +385,7 @@ func downloadWheel(integration, version string) (string, error) {
 	args := []string{
 		"-m", downloaderModule,
 		integration,
+		"--python", pyPath,
 		"--version", version,
 	}
 	if verbose > 0 {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -391,7 +391,7 @@ func downloadWheel(integration, version string) (string, error) {
 	// Get the directory of our embedded Python.
 	path_dir := filepath.Dir(pyPath)
 	// Prepend this dir to PATH array.
-	path_arr := append(path_dir, path_arr...)
+	path_arr = append(path_dir, path_arr...)
 	// Build a new PATH string from the array.
 	path_str := strings.Join(path_arr, string(os.PathListSeparator))
 	// Replace the old PATH with the new one.

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -415,7 +415,7 @@ func downloadWheel(integration, version string) (string, error) {
 	for key, value := range environ {
 		if strings.HasPrefix(value, "PATH=") {
 			environ[key] = "PATH=" + pathStr
-			break
+			// NOTE: Don't break so that we replace duplicate PATH-s, too.
 		}
 	}
 	// Now, while downloaderCmd itself won't use the new PATH, any child process,

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -391,7 +391,7 @@ func downloadWheel(integration, version string) (string, error) {
 	// Get the directory of our embedded Python.
 	path_dir := filepath.Dir(pyPath)
 	// Prepend this dir to PATH array.
-	path_arr = append(path_dir, path_arr...)
+	path_arr = append([]string{path_dir}, path_arr...)
 	// Build a new PATH string from the array.
 	path_str := strings.Join(path_arr, string(os.PathListSeparator))
 	// Replace the old PATH with the new one.


### PR DESCRIPTION
### What does this PR do?

Allows Agent to tell the checks downloader which Python to use.

### Motivation

Right now, the downloader is accidentally calling the correct, embedded Python on Windows, and calling the system Python on *nix.

This PR allows the Agent to tell the downloader to always call the embedded Python.

### Additional Notes

N/A.