### PR TITLE
[Logs]: Update sender config to ignore empty logs_dd_url configuration coming from agent migrations

### DIFF
--- a/pkg/logs/sender/config.go
+++ b/pkg/logs/sender/config.go
@@ -40,7 +40,7 @@ func BuildEndpoints() (*client.Endpoints, error) {
 		ProxyAddress: proxyAddress,
 	}
 	switch {
-	case config.Datadog.IsSet("logs_config.logs_dd_url"):
+	case config.Datadog.IsSet("logs_config.logs_dd_url") && config.Datadog.GetString("logs_config.logs_dd_url") != "":
 		// Proxy settings, expect 'logs_config.logs_dd_url' to respect the format '<HOST>:<PORT>'
 		// and '<PORT>' to be an integer.
 		// By default ssl is enabled ; to disable ssl set 'logs_config.logs_no_ssl' to true.

--- a/pkg/logs/sender/config.go
+++ b/pkg/logs/sender/config.go
@@ -24,6 +24,10 @@ var logsEndpoints = map[string]int{
 	"agent-intake.logs.datad0g.eu":    443,
 }
 
+func isSetAndNotEmpty(config config.Config, key string) bool {
+	return config.IsSet(key) && len(config.GetString(key)) > 0
+}
+
 // BuildEndpoints returns the endpoints to send logs to.
 func BuildEndpoints() (*client.Endpoints, error) {
 	if config.Datadog.GetBool("logs_config.dev_mode_no_ssl") {
@@ -40,7 +44,7 @@ func BuildEndpoints() (*client.Endpoints, error) {
 		ProxyAddress: proxyAddress,
 	}
 	switch {
-	case config.Datadog.IsSet("logs_config.logs_dd_url") && config.Datadog.GetString("logs_config.logs_dd_url") != "":
+	case isSetAndNotEmpty(config.Datadog, "logs_config.logs_dd_url"):
 		// Proxy settings, expect 'logs_config.logs_dd_url' to respect the format '<HOST>:<PORT>'
 		// and '<PORT>' to be an integer.
 		// By default ssl is enabled ; to disable ssl set 'logs_config.logs_no_ssl' to true.

--- a/pkg/logs/sender/config_test.go
+++ b/pkg/logs/sender/config_test.go
@@ -137,6 +137,14 @@ func (suite *ConfigTestSuite) TestBuildEndpointsShouldSucceedWhenMigratingToAgen
 	suite.Equal(10516, endpoints.Main.Port)
 }
 
+func (suite *ConfigTestSuite) TestIsSetAndNotEmpty() {
+	suite.config.Set("bob", "vanilla")
+	suite.config.Set("empty", "")
+	suite.True(isSetAndNotEmpty(suite.config, "bob"))
+	suite.False(isSetAndNotEmpty(suite.config, "empty"))
+	suite.False(isSetAndNotEmpty(suite.config, "wassup"))
+}
+
 func TestConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(ConfigTestSuite))
 }

--- a/pkg/logs/sender/config_test.go
+++ b/pkg/logs/sender/config_test.go
@@ -128,6 +128,15 @@ func (suite *ConfigTestSuite) TestBuildEndpointsShouldFailWithInvalidOverride() 
 	}
 }
 
+//When migrating the agent v5 to v6, logs_dd_url is set to empty. Default to the dd_url/site already set instead.
+func (suite *ConfigTestSuite) TestBuildEndpointsShouldSucceedWhenMigratingToAgentV6() {
+	suite.config.Set("logs_config.logs_dd_url", "")
+	endpoints, err := BuildEndpoints()
+	suite.Nil(err)
+	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
+	suite.Equal(10516, endpoints.Main.Port)
+}
+
 func TestConfigTestSuite(t *testing.T) {
 	suite.Run(t, new(ConfigTestSuite))
 }

--- a/releasenotes/notes/releasenotes/notes/logs-fix-config-after-migration-30e368fd371ea8b5.yaml
+++ b/releasenotes/notes/releasenotes/notes/logs-fix-config-after-migration-30e368fd371ea8b5.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Ignore empty logs_dd_url to fall back on default config for logs agent.


### PR DESCRIPTION

### What does this PR do?

Ignore empty logs_dd_url configuration
[Trello](https://trello.com/c/W8uHSqtr/940-agent-logsddurl-should-be-ignored-if-empty)

### Motivation

Some customers had issues setting up their agent for logs after migrating due to this bug as the empty logs_dd_url was making the agent fail

