### PR TITLE
Add Baklava as code owners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,8 @@
 /cmd/agent/app/integrations*.go         @DataDog/prodsec @DataDog/agent-integrations @DataDog/agent-core
 /cmd/cluster-agent/                     @DataDog/container-integrations
 
+/docs/                                  @DataDog/baklava
+
 /pkg/                                   @DataDog/agent-core
 /pkg/aggregator/                        @DataDog/agent-core
 /pkg/collector/                         @DataDog/agent-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /cmd/agent/app/integrations*.go         @DataDog/prodsec @DataDog/agent-integrations @DataDog/agent-core
 /cmd/cluster-agent/                     @DataDog/container-integrations
 
-/docs/                                  @DataDog/baklava
+/docs/                                  @DataDog/baklava @DataDog/agent-core
 
 /pkg/                                   @DataDog/agent-core
 /pkg/aggregator/                        @DataDog/agent-core


### PR DESCRIPTION
### What does this PR do?
-  Add Baklava as code owners for docs for wording review and public docs site updates

### Motivation
- Lots of grammar and style corrections made to integration doc

### Additional Notes
N/A
