### PR TITLE
Use tag v1.5.0 for viper instead of a commit hash

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,12 +50,11 @@
   revision = "2cfb68475274527a10701355c739f31dd404718c"
 
 [[projects]]
-  branch = "master"
   digest = "1:b22f5da83ac471bbbe2a5aa1f07c8029dc82bcbf6ff832516f035fc3a314d539"
   name = "github.com/DataDog/viper"
   packages = ["."]
   pruneopts = ""
-  revision = "59d5cbf4d7cee2828fca42ff1117894b013ca978"
+  revision = "v1.5.0"
 
 [[projects]]
   digest = "1:34d4c1b61fa208e523726ddb85d01b8caa8f2de0cd656d91c81b6b86daea485c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,7 +128,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/viper"
-  revision = "59d5cbf4d7cee2828fca42ff1117894b013ca978"
+  revision = "v1.5.0"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"


### PR DESCRIPTION
### What does this PR do?

Use tag v1.5.0 for viper instead of a commit hash.