### PR TITLE
APM does not start by default 

### DIFF
--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -128,8 +128,7 @@ func (c *APMCheck) run() error {
 
 // Configure the APMCheck
 func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// handle the case when apm agent is disabled via the old `datadog.conf` file
-	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
+	if enabled := config.Datadog.GetBool("apm_config.enabled"); !enabled {
 		return fmt.Errorf("APM agent disabled through main configuration file")
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixed check that runs the apm.

### Motivation

APM does not start by default because the check is done against the old configuration instead of the new one.
This should solve #2886.

