### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -146,7 +146,7 @@ func TestTrimSingleLine(t *testing.T) {
 func TestMultiLineHandler(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
 	outputChan := make(chan *message.Message, 10)
-	h := NewMultiLineHandler(outputChan, re, 10*time.Millisecond, parser.NoopParser)
+	h := NewMultiLineHandler(outputChan, re, 100*time.Millisecond, parser.NoopParser)
 	h.Start()
 
 	var output *message.Message


### PR DESCRIPTION
### What does this PR do?

This test is flaky because we allocate a 256kB string
and the flush timeout of the MultiLineHandler is set at
10ms. We increase this value to 100ms to avoid unwanted
flush(es) that interfer with the test

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
