### PR TITLE
pkg/trace/api: small improvements to normalization errors

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -253,7 +253,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 			msg := fmt.Sprintf("dropping trace; reason: %s", err)
 			if len(msg) > 150 && !r.debug {
 				// we're not in DEBUG log level, truncate long messages.
-				msg = msg[:150] + "... (set DEBUG for more info)"
+				msg = msg[:150] + "... (set DEBUG log level for more info)"
 			}
 			log.Errorf(msg)
 		} else {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -250,13 +250,12 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 			atomic.AddInt64(&ts.TracesDropped, 1)
 			atomic.AddInt64(&ts.SpansDropped, int64(spans))
 
-			errorMsg := fmt.Sprintf("dropping trace reason: %s (debug for more info), %v", err, trace)
-
-			// avoid truncation in DEBUG mode
-			if len(errorMsg) > 150 && !r.debug {
-				errorMsg = errorMsg[:150] + "..."
+			msg := fmt.Sprintf("dropping trace; reason: %s", err)
+			if len(msg) > 150 && !r.debug {
+				// we're not in DEBUG log level, truncate long messages.
+				msg = msg[:150] + "... (set DEBUG for more info)"
 			}
-			log.Errorf(errorMsg)
+			log.Errorf(msg)
 		} else {
 			select {
 			case r.Out <- trace:
@@ -267,7 +266,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 				atomic.AddInt64(&ts.TracesDropped, 1)
 				atomic.AddInt64(&ts.SpansDropped, int64(spans))
 
-				log.Errorf("dropping trace reason: rate-limited")
+				log.Errorf("dropping trace; reason: rate-limited")
 			}
 		}
 	}

--- a/releasenotes/notes/apm-improve-normalizer-messages-d7e1d88730c8c5bb.yaml
+++ b/releasenotes/notes/apm-improve-normalizer-messages-d7e1d88730c8c5bb.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: slightly improved normalization error logs.


### PR DESCRIPTION
Small improvements to normalization errors.

* remove trace from error message, it was misleading in some cases and doesn't provide much value. The normalization error message itself will reveal the problem exactly.
* ensure that relevant parts of the message don't get lost when truncating (e.g. "debug for more info")