### PR TITLE
[omnibus] Remove protobuf-py from omnibus deps of Agent

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -10,7 +10,6 @@ name 'datadog-agent-integrations'
 
 dependency 'pip'
 dependency 'datadog-agent'
-dependency 'protobuf-py'
 
 if linux?
   # add nfsiostat script


### PR DESCRIPTION
### What does this PR do?

* Removes protobuf-py from omnibus deps of Agent. protobuf-py is required
and installed by integrations-core: https://github.com/DataDog/integrations-core/blob/99a33cdd6e98b074be3388c1807c5a0c1c12ecc8/datadog_checks_base/datadog_checks/base/data/agent_requirements.in#L32
* Tangentially, upgrades the version of `protobuf` shipped in the Agent from `3.5.1` to `3.7.0` (as a follow-up to https://github.com/DataDog/integrations-core/pull/3272)

### Motivation

On Linux, we want to ship protobuf-py with the cpp extension for perf reasons, and these were not available as binary wheels with the `ucs2` build of the python embedded Agent. This explains why we originally built the protobuf lib in omnibus.

We now build python with `ucs4`. protobuf-py+cpp binary wheels are provided for this build. These wheels use the `manylinux1` policy, which support CentOS 5.
So we're all good relying on these binary wheels instead.