### PR TITLE
[serializer] improve stream serialization memory efficiency for small payloads

### DIFF
--- a/pkg/serializer/jsonstream/compressor.go
+++ b/pkg/serializer/jsonstream/compressor.go
@@ -176,13 +176,14 @@ func (c *compressor) close() ([]byte, error) {
 		return nil, err
 	}
 
-	c.input.Reset()
+	payload := make([]byte, c.compressed.Len())
+	copy(payload, c.compressed.Bytes())
 
 	expvarsTotalPayloads.Add(1)
 	expvarsBytesIn.Add(int64(c.uncompressedWritten))
 	expvarsBytesOut.Add(int64(c.compressed.Len()))
 
-	return c.compressed.Bytes(), nil
+	return payload, nil
 }
 
 func (c *compressor) remainingSpace() int {

--- a/pkg/serializer/jsonstream/compressor.go
+++ b/pkg/serializer/jsonstream/compressor.go
@@ -12,12 +12,8 @@ import (
 	"compress/zlib"
 	"errors"
 	"expvar"
-	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/forwarder"
-	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -61,16 +57,6 @@ var (
 
 var jsonSeparator = []byte(",")
 
-// inputBufferPool is an object pool of inputBuffers
-// buffer is pre-allocated at creation to avoid heap trash.
-// As hasRoomForItem is conservative, input buffer should not
-// grow bigger than the compressed payload size.
-var inputBufferPool = sync.Pool{
-	New: func() interface{} {
-		return bytes.NewBuffer(make([]byte, 0, maxPayloadSize))
-	},
-}
-
 // compressor is in charge of compressing items for a single payload
 type compressor struct {
 	input               *bytes.Buffer // temporary buffer for data that has not been compressed yet
@@ -85,17 +71,17 @@ type compressor struct {
 	maxZippedItemSize   int
 }
 
-func newCompressor(header, footer []byte) (*compressor, error) {
+func newCompressor(input, output *bytes.Buffer, header, footer []byte) (*compressor, error) {
 	c := &compressor{
 		header:              header,
 		footer:              footer,
-		compressed:          bytes.NewBuffer(make([]byte, 0, 1*megaByte)),
+		input:               input,
+		compressed:          output,
 		firstItem:           true,
 		maxUnzippedItemSize: maxPayloadSize - len(footer) - len(header),
 		maxZippedItemSize:   maxUncompressedSize - compression.CompressBound(len(footer)+len(header)),
 	}
 
-	c.input = inputBufferPool.Get().(*bytes.Buffer)
 	c.zipper = zlib.NewWriter(c.compressed)
 	n, err := c.zipper.Write(header)
 	c.uncompressedWritten += n
@@ -191,7 +177,6 @@ func (c *compressor) close() ([]byte, error) {
 	}
 
 	c.input.Reset()
-	inputBufferPool.Put(c.input)
 
 	expvarsTotalPayloads.Add(1)
 	expvarsBytesIn.Add(int64(c.uncompressedWritten))
@@ -202,60 +187,4 @@ func (c *compressor) close() ([]byte, error) {
 
 func (c *compressor) remainingSpace() int {
 	return maxPayloadSize - c.compressed.Len() - len(c.footer)
-}
-
-// Payloads serializes a metadata payload and sends it to the forwarder
-func Payloads(m marshaler.StreamJSONMarshaler) (forwarder.Payloads, error) {
-	var output forwarder.Payloads
-	var i int
-	itemCount := m.Len()
-	expvarsTotalCalls.Add(1)
-
-	compressor, err := newCompressor(m.JSONHeader(), m.JSONFooter())
-	if err != nil {
-		return nil, err
-	}
-
-	for i < itemCount {
-		json, err := m.JSONItem(i)
-		if err != nil {
-			log.Warnf("error marshalling an item, skipping: %s", err)
-			i++
-			continue
-		}
-
-		switch compressor.addItem(json) {
-		case errPayloadFull:
-			// payload is full, we need to create a new one
-			payload, err := compressor.close()
-			if err != nil {
-				return output, err
-			}
-			output = append(output, &payload)
-			compressor, err = newCompressor(m.JSONHeader(), m.JSONFooter())
-			if err != nil {
-				return nil, err
-			}
-		case nil:
-			// All good, continue to next item
-			i++
-			expvarsTotalItems.Add(1)
-			continue
-		default:
-			// Unexpected error, drop the item
-			i++
-			log.Warnf("Dropping an item, %s: %s", m.DescribeItem(i), err)
-			expvarsItemDrops.Add(1)
-			continue
-		}
-	}
-
-	// Close last payload
-	payload, err := compressor.close()
-	if err != nil {
-		return output, err
-	}
-	output = append(output, &payload)
-
-	return output, nil
 }

--- a/pkg/serializer/jsonstream/payload_builder.go
+++ b/pkg/serializer/jsonstream/payload_builder.go
@@ -1,0 +1,89 @@
+package jsonstream
+
+import (
+	"bytes"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// PayloadBuilder is used to build payloads. PayloadBuilder allocates memory based
+// on what was previously need to serialize payloads. Keep that in mind and
+// use multiple PayloadBuilders for different sources.
+type PayloadBuilder struct {
+	inputSizeHint, outputSizeHint int
+}
+
+// NewPayloadBuilder creates a new PayloadBuilder with default values.
+func NewPayloadBuilder() *PayloadBuilder {
+	return &PayloadBuilder{
+		inputSizeHint:  4096,
+		outputSizeHint: 4096,
+	}
+}
+
+// Build serializes a metadata payload and sends it to the forwarder
+func (b *PayloadBuilder) Build(m marshaler.StreamJSONMarshaler) (forwarder.Payloads, error) {
+	var payloads forwarder.Payloads
+	var i int
+	itemCount := m.Len()
+	expvarsTotalCalls.Add(1)
+
+	// Inner buffers for the compressor
+	input := bytes.NewBuffer(make([]byte, 0, b.inputSizeHint))
+	output := bytes.NewBuffer(make([]byte, 0, b.outputSizeHint))
+
+	compressor, err := newCompressor(input, output, m.JSONHeader(), m.JSONFooter())
+	if err != nil {
+		return nil, err
+	}
+
+	for i < itemCount {
+		json, err := m.JSONItem(i)
+		if err != nil {
+			log.Warnf("error marshalling an item, skipping: %s", err)
+			i++
+			continue
+		}
+
+		switch compressor.addItem(json) {
+		case errPayloadFull:
+			// payload is full, we need to create a new one
+			payload, err := compressor.close()
+			if err != nil {
+				return payloads, err
+			}
+			payloads = append(payloads, &payload)
+			input.Reset()
+			output.Reset()
+			compressor, err = newCompressor(input, output, m.JSONHeader(), m.JSONFooter())
+			if err != nil {
+				return nil, err
+			}
+		case nil:
+			// All good, continue to next item
+			i++
+			expvarsTotalItems.Add(1)
+			continue
+		default:
+			// Unexpected error, drop the item
+			i++
+			log.Warnf("Dropping an item, %s: %s", m.DescribeItem(i), err)
+			expvarsItemDrops.Add(1)
+			continue
+		}
+	}
+
+	// Close last payload
+	payload, err := compressor.close()
+	if err != nil {
+		return payloads, err
+	}
+	payloads = append(payloads, &payload)
+
+	b.inputSizeHint = input.Cap()
+	b.outputSizeHint = output.Cap()
+
+	return payloads, nil
+}

--- a/pkg/serializer/jsonstream/payload_builder.go
+++ b/pkg/serializer/jsonstream/payload_builder.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+//+build zlib
+
 package jsonstream
 
 import (

--- a/pkg/serializer/jsonstream/payload_builder_nozlib.go
+++ b/pkg/serializer/jsonstream/payload_builder_nozlib.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+//+build !zlib
+
+package jsonstream
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+)
+
+// PayloadBuilder is not implemented when zlib is not available.
+type PayloadBuilder struct {
+}
+
+// NewPayloadBuilder is not implemented when zlib is not available.
+func NewPayloadBuilder() *PayloadBuilder {
+	return nil
+}
+
+// Build is not implemented when zlib is not available.
+func (b *PayloadBuilder) Build(m marshaler.StreamJSONMarshaler) (forwarder.Payloads, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/pkg/serializer/serializer_benchmark_test.go
+++ b/pkg/serializer/serializer_benchmark_test.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018 Datadog, Inc.
+
+//+build zlib
+
 package serializer
 
 import (

--- a/pkg/serializer/serializer_benchmark_test.go
+++ b/pkg/serializer/serializer_benchmark_test.go
@@ -1,0 +1,69 @@
+package serializer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serializer/jsonstream"
+	"github.com/DataDog/datadog-agent/pkg/serializer/split"
+)
+
+func buildSeries(numberOfSeries int) metrics.Series {
+	testSeries := metrics.Series{}
+	for i := 0; i < numberOfSeries; i++ {
+		point := metrics.Serie{
+			Points: []metrics.Point{
+				{Ts: float64(time.Now().UnixNano()), Value: 1.2 * float64(i)},
+			},
+			MType:    metrics.APIGaugeType,
+			Name:     fmt.Sprintf("test.metrics%d", i),
+			Interval: 1,
+			Host:     "localHost",
+			Tags:     []string{"tag1", "tag2:yes"},
+		}
+		testSeries = append(testSeries, &point)
+	}
+	return testSeries
+}
+
+var results forwarder.Payloads
+
+func benchmarkJSONStream(b *testing.B, numberOfSeries int) {
+	series := buildSeries(numberOfSeries)
+	payloadBuilder := jsonstream.NewPayloadBuilder()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		results, _ = payloadBuilder.Build(series)
+	}
+}
+
+func benchmarkSplit(b *testing.B, numberOfSeries int) {
+	series := buildSeries(numberOfSeries)
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		results, _ = split.Payloads(series, true, split.MarshalJSON)
+	}
+}
+
+func BenchmarkJSONStream1(b *testing.B)        { benchmarkJSONStream(b, 1) }
+func BenchmarkJSONStream10(b *testing.B)       { benchmarkJSONStream(b, 10) }
+func BenchmarkJSONStream100(b *testing.B)      { benchmarkJSONStream(b, 100) }
+func BenchmarkJSONStream1000(b *testing.B)     { benchmarkJSONStream(b, 1000) }
+func BenchmarkJSONStream10000(b *testing.B)    { benchmarkJSONStream(b, 10000) }
+func BenchmarkJSONStream100000(b *testing.B)   { benchmarkJSONStream(b, 100000) }
+func BenchmarkJSONStream1000000(b *testing.B)  { benchmarkJSONStream(b, 1000000) }
+func BenchmarkJSONStream10000000(b *testing.B) { benchmarkJSONStream(b, 10000000) }
+
+func BenchmarkSplit1(b *testing.B)        { benchmarkSplit(b, 1) }
+func BenchmarkSplit10(b *testing.B)       { benchmarkSplit(b, 10) }
+func BenchmarkSplit100(b *testing.B)      { benchmarkSplit(b, 100) }
+func BenchmarkSplit1000(b *testing.B)     { benchmarkSplit(b, 1000) }
+func BenchmarkSplit10000(b *testing.B)    { benchmarkSplit(b, 10000) }
+func BenchmarkSplit100000(b *testing.B)   { benchmarkSplit(b, 100000) }
+func BenchmarkSplit1000000(b *testing.B)  { benchmarkSplit(b, 1000000) }
+func BenchmarkSplit10000000(b *testing.B) { benchmarkSplit(b, 10000000) }


### PR DESCRIPTION
### What does this PR do?

Improve `jsonstream` serialization memory efficiency for small payloads. 

For the `jsonstream` logic we need two buffers: one "input" buffer that is used to store uncompressed JSON data and one "output"/"compressed" buffer that is used to store compressed data.

In the original implementation we decided to initialize both buffers to their theoretical maximum value to prevent them from resizing and wasting allocations. This revealed to be very inefficient for agents sending small payloads.

The idea behind this PR is that since payloads will tend to have mostly the same size between runs, we should initialize our buffers based on their previous max size. To do so we keep the previous max size in a new `PayloadBuilder` struct initialized in the serializer.

The following benchmarks compare the new `jsonstream` logic against the old `split` logic and are function of the number of series. CPU and number of allocs are not shown as they are not relevant and stayed mostly unchanged.

Numbers before changes against the `split` logic:
```
benchmark               old bytes       new bytes      delta
Benchmark1-4            815959          2483640        +204.38%
Benchmark10-4           820832          2449308        +198.39%
Benchmark100-4          865648          2375226        +174.39%
Benchmark1000-4         1295288         2172295        +67.71%
Benchmark10000-4        6541046         4162475        -36.36%
Benchmark100000-4       60576750        23577400       -61.08%
Benchmark1000000-4      2051920288      245253000      -88.05%
Benchmark10000000-4     19384356824     2475260688     -87.23%
```

Numbers after changes against the `split` logic:
```
benchmark               old bytes       new bytes      delta
Benchmark1-4            815898          823244         +0.90%
Benchmark10-4           820560          825084         +0.55%
Benchmark100-4          864643          857864         -0.78%
Benchmark1000-4         1303802         1307710        +0.30%
Benchmark10000-4        5134576         5209538        +1.46%
Benchmark100000-4       60576868        28559374       -52.85%
Benchmark1000000-4      2051857568      237122568      -88.44%
Benchmark10000000-4     19384302408     2239079200     -88.45%
```

### Motivation

We noticed a bump in the agent baseline RSS of about 10-15%. 

### Additional Notes

The following was not working:
https://github.com/DataDog/datadog-agent/blob/0c8aee4b9cd2d64a935d095c9e8addffdd463079/pkg/serializer/jsonstream/compressor.go#L68-L72
Indeed, sync.Pool cleans all it's elements on every Go GC run. Since this would most likely happen between two serialization (~15s) the pool was always empty.

We could keep buffer between runs but I think it's over-optimizing at this point (the memory is going to get easily GC'd anyway). We would also need to decide on an heuristic to resize the buffers which might get more complex than just keeping the last size.