### PR TITLE
[Agent]: Support Error messages for Logs Status

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -191,6 +191,15 @@
 
         Logs Agent is not running </br>
       {{- end }}
+      {{- if .errors }}
+
+        <span class="warning stat_subtitle">Errors</span>
+        <span class="stat_subdata">
+        {{- range error := .errors }}
+          {{ $error }}</br>
+        {{- end }}
+        </span>
+      {{- end}}
       {{- if .warnings }}
 
         <span class="warning stat_subtitle">Warnings</span>

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -55,7 +55,7 @@ func Start() error {
 	endpoints, err := sender.BuildEndpoints()
 	if err != nil {
 		message := fmt.Sprintf("Invalid endpoints: %v", err)
-		status.AddGlobalWarning(invalidEndpoints, message)
+		status.AddGlobalError(invalidEndpoints, message)
 		return errors.New(message)
 	}
 
@@ -63,7 +63,7 @@ func Start() error {
 	processingRules, err := config.GlobalProcessingRules()
 	if err != nil {
 		message := fmt.Sprintf("Invalid processing rules: %v", err)
-		status.AddGlobalWarning(invalidProcessingRules, message)
+		status.AddGlobalError(invalidProcessingRules, message)
 		return errors.New(message)
 	}
 

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -17,14 +17,16 @@ type Builder struct {
 	isRunning *int32
 	sources   *config.LogSources
 	warnings  *config.Messages
+	errors    *config.Messages
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *int32, sources *config.LogSources, warnings *config.Messages) *Builder {
+func NewBuilder(isRunning *int32, sources *config.LogSources, warnings *config.Messages, errors *config.Messages) *Builder {
 	return &Builder{
 		isRunning: isRunning,
 		sources:   sources,
 		warnings:  warnings,
+		errors:    errors,
 	}
 }
 
@@ -34,6 +36,7 @@ func (b *Builder) BuildStatus() Status {
 		IsRunning:    b.getIsRunning(),
 		Integrations: b.getIntegrations(),
 		Warnings:     b.getWarnings(),
+		Errors:       b.getErrors(),
 	}
 }
 
@@ -48,6 +51,12 @@ func (b *Builder) getIsRunning() bool {
 // have been accumulated during the life cycle of the logs-agent.
 func (b *Builder) getWarnings() []string {
 	return b.warnings.GetMessages()
+}
+
+// getErrors returns all the errors messages which are responsible
+// for shutting down the logs-agent
+func (b *Builder) getErrors() []string {
+	return b.errors.GetMessages()
 }
 
 // getIntegrations returns all the information about the logs integrations.

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -9,14 +9,25 @@ Logs Agent
 
   Logs Agent is not running
 {{- end }}
+
+{{- if .errors }}
+
+  Errors
+  {{ printDashes "Errors" "=" }}
+  {{- range $error := .errors }}
+    {{ $error }}
+  {{- end }}
+{{- end }}
+
 {{- if .warnings }}
 
-  warnings
-  {{ printDashes "warnings" "-" }}
+  Warnings
+  {{ printDashes "warnings" "=" }}
   {{- range $warning := .warnings }}
     {{ $warning }}
   {{- end }}
 {{- end }}
+
 {{- range .integrations }}
 
   {{ .name }}

--- a/releasenotes/notes/logs-error-status-99afc61f269a25df.yaml
+++ b/releasenotes/notes/logs-error-status-99afc61f269a25df.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Improve status page by splitting errors and warnings from the Logs agent


### PR DESCRIPTION
### What does this PR do?

Add support for error messages in the logs status. Errors are triggered when the agent does break.
Warnings are transient errors.

### Motivation

[Trello](https://trello.com/c/G9NllrpI/966-agent-status-should-mention-error-and-not-warning-when-there-is-a-invalid-global-processing-rule)

### Additional Notes

Errors (stopping the agent):

Warnings (transient errors):

![image](https://user-images.githubusercontent.com/48209202/54611169-be307380-4a56-11e9-8c4e-e1f021a965eb.png)

![image](https://user-images.githubusercontent.com/48209202/54611335-0b144a00-4a57-11e9-98e7-64f88209a20f.png)
