### PR TITLE
HPA support for custom aggregation function and extended tag expressions

### DIFF
--- a/pkg/clusteragent/custommetrics/types.go
+++ b/pkg/clusteragent/custommetrics/types.go
@@ -8,12 +8,14 @@
 package custommetrics
 
 type ExternalMetricValue struct {
-	MetricName string            `json:"metricName"`
-	Labels     map[string]string `json:"labels"`
-	Timestamp  int64             `json:"ts"`
-	HPA        ObjectReference   `json:"hpa"`
-	Value      float64           `json:"value"`
-	Valid      bool              `json:"valid"`
+	MetricName       string            `json:"metricName"`
+	Labels           map[string]string `json:"labels"`
+	CustomAggregator string            `json:"customAggregator"`
+	CustomTags       map[string]string `json:"customTags"`
+	Timestamp        int64             `json:"ts"`
+	HPA              ObjectReference   `json:"hpa"`
+	Value            float64           `json:"value"`
+	Valid            bool              `json:"valid"`
 }
 
 // ObjectReference contains enough information to let you identify the referred resource.

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"gopkg.in/zorkian/go-datadog-api.v2"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -38,4 +39,43 @@ func InitLogging(level string) error {
 func SetHostname(hostname string) {
 	mockConfig := config.Mock()
 	mockConfig.Set("hostname", hostname)
+}
+
+// BuildQuery builds a datadog query using the given aggregator function and
+// metric query (i.e. metric{scope}) to which is applied the default rollup.
+func BuildQuery(aggregator, metricQuery string) string {
+	rollup := config.Datadog.GetInt("external_metrics_provider.rollup")
+	return fmt.Sprintf("%s:%s.rollup(%d)", aggregator, metricQuery, rollup)
+}
+
+// BuildQueryWithDefaults is the same as BuildQuery except that it uses the
+// default aggregation function.
+func BuildQueryWithDefaults(metricQuery string) string {
+	agg := config.Datadog.GetString("external_metrics.aggregator")
+	return BuildQuery(agg, metricQuery)
+}
+
+// BuildSeries builds a time series from the given data points and associate it
+// to a datadog query defined by the metric name, aggregation function and
+// scope to which is applied the default rollup.
+func BuildSeries(name, agg, scope string, points []datadog.DataPoint) datadog.Series {
+	query := BuildQuery(agg, fmt.Sprintf("%s{%s}", name, scope))
+	return datadog.Series{
+		Expression: &query,
+		Metric:     &name,
+		Points:     points,
+		Scope:      &scope,
+	}
+}
+
+// BuildSeriesWithDefaults is the same as BuildSeries except that it uses the
+// default aggregation function.
+func BuildSeriesWithDefaults(name, scope string, points []datadog.DataPoint) datadog.Series {
+	query := BuildQueryWithDefaults(fmt.Sprintf("%s{%s}", name, scope))
+	return datadog.Series{
+		Expression: &query,
+		Metric:     &name,
+		Points:     points,
+		Scope:      &scope,
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Allow to use, within an HPA relying on the external metric provider, the following:
- A custom aggregation function.
- Extended tag expressions.

Both of these are provided through annotations of the following form:

```yaml
annotations:
  custom.datadog.agg: "<AGGREGATOR>"
  custom.datadog.tag.<TAG_ID>: "<TAG_VALUE>"
```

For the tag to be resolved to a metric selector label, the corresponding annotation key should be set as a label value, i.e.:

```yaml
metricSelector:
  matchLabels:
    tag_name: custom.datadog.tag.<TAG_ID>
```

### Motivation

Make it possible to define per-HPA aggregators, and to define tag values disallowed within k8s labels.

### Additional Notes

N/A.
