### PR TITLE
Init datadog_agent Python module

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -1,0 +1,143 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build python
+
+package python
+
+import (
+	"encoding/json"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+/*
+#cgo LDFLAGS: -ldatadog-agent-six -ldl
+#include "datadog_agent_six.h"
+*/
+import (
+	"C"
+)
+
+// GetVersion exposes the version of the agent to Python checks.
+//export GetVersion
+func GetVersion(agentVersion **C.char) {
+	av, _ := version.New(version.AgentVersion, version.Commit)
+	// version will be free by six when it's done with it
+	*agentVersion = C.CString(av.GetNumber())
+}
+
+// GetHostname exposes the current hostname of the agent to Python checks.
+//export GetHostname
+func GetHostname(hostname **C.char) {
+	goHostname, err := util.GetHostname()
+	if err != nil {
+		log.Warnf("Error getting hostname: %s\n", err)
+		goHostname = ""
+	}
+	// hostname will be free by six when it's done with it
+	*hostname = C.CString(goHostname)
+}
+
+// GetClusterName exposes the current clustername (if it exists) of the agent to Python checks.
+//export GetClusterName
+func GetClusterName(clusterName **C.char) {
+	goClusterName := clustername.GetClusterName()
+	// clusterName will be free by six when it's done with it
+	*clusterName = C.CString(goClusterName)
+}
+
+// Headers returns a basic set of HTTP headers that can be used by clients in Python checks.
+//export Headers
+func Headers(jsonPayload **C.char) {
+	h := util.HTTPHeaders()
+
+	data, err := json.Marshal(h)
+	if err != nil {
+		log.Errorf("datadog_agent: could not Marshal headers: %s", err)
+		*jsonPayload = nil
+		return
+	}
+	// jsonPayload will be free by six when it's done with it
+	*jsonPayload = C.CString(string(data))
+}
+
+// GetConfig returns a value from the agent configuration.
+// Indirectly used by the C function `get_config` that's mapped to `datadog_agent.get_config`.
+//export GetConfig
+func GetConfig(key *C.char, jsonPayload **C.char) {
+	goKey := C.GoString(key)
+	if !config.Datadog.IsSet(goKey) {
+		*jsonPayload = nil
+		return
+	}
+
+	value := config.Datadog.Get(goKey)
+	data, err := json.Marshal(value)
+	if err != nil {
+		log.Errorf("datadog_agent: could not convert configuration value (%v) to python types: %s", value, err)
+		*jsonPayload = nil
+		return
+	}
+	// jsonPayload will be free by six when it's done with it
+	*jsonPayload = C.CString(string(data))
+}
+
+// LogMessage logs a message from python through the agent logger (see
+// https://docs.python.org/2.7/library/logging.html#logging-levels)
+//export LogMessage
+func LogMessage(message *C.char, logLevel C.int) {
+	goMsg := C.GoString(message)
+
+	switch logLevel {
+	case 50: // CRITICAL
+		log.Critical(goMsg)
+	case 40: // ERROR
+		log.Error(goMsg)
+	case 30: // WARNING
+		log.Warn(goMsg)
+	case 20: // INFO
+		log.Info(goMsg)
+	case 10: // DEBUG
+		log.Debug(goMsg)
+	// Custom log level defined in:
+	// https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/log.py
+	case 7: // TRACE
+		log.Trace(goMsg)
+	default: // unknown log level
+		log.Info(goMsg)
+	}
+
+	return
+}
+
+// SetExternalTags adds a set of tags for a given hostnane to the External Host
+// Tags metadata provider cache.
+//export SetExternalTags
+func SetExternalTags(hostname *C.char, sourceType *C.char, tags **C.char) {
+	hname := C.GoString(hostname)
+	stype := C.GoString(sourceType)
+	tagsStrings := []string{}
+
+	pTags := uintptr(unsafe.Pointer(tags))
+	ptrSize := unsafe.Sizeof(*tags)
+
+	for i := uintptr(0); ; i++ {
+		tagPtr := *(**C.char)(unsafe.Pointer(pTags + ptrSize*i))
+		if tagPtr == nil {
+			break
+		}
+		tag := C.GoString(tagPtr)
+		tagsStrings = append(tagsStrings, tag)
+	}
+
+	externalhost.SetExternalTags(hname, stype, tagsStrings)
+}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -24,6 +24,25 @@ import (
 
 // #include "datadog_agent_six.h"
 // #cgo LDFLAGS: -ldatadog-agent-six -ldl
+/*
+void GetVersion(char **);
+void GetHostname(char **);
+void GetClusterName(char **);
+void Headers(char **);
+void GetConfig(char*, char **);
+void LogMessage(char *, int);
+void SetExternalTags(char *, char *, char **);
+
+void initDatadogAgentModule(six_t *six) {
+	set_get_version_cb(six, GetVersion);
+	set_get_hostname_cb(six, GetHostname);
+	set_get_clustername_cb(six, GetClusterName);
+	set_headers_cb(six, Headers);
+	set_log_cb(six, LogMessage);
+	set_get_config_cb(six, GetConfig);
+	set_set_external_tags_cb(six, SetExternalTags);
+}
+*/
 import "C"
 
 var (
@@ -71,10 +90,10 @@ func Initialize(paths ...string) error {
 
 	pythonHome := ""
 	if pythonVersion == 2 {
-		six = C.make2()
+		six = C.make2(C.CString(pythonHome2))
 		pythonHome = pythonHome2
 	} else if pythonVersion == 3 {
-		six = C.make3()
+		six = C.make3(C.CString(pythonHome3))
 		pythonHome = pythonHome3
 	} else {
 		return fmt.Errorf("unknown requested version of python: %d", pythonVersion)
@@ -93,7 +112,7 @@ func Initialize(paths ...string) error {
 		C.add_python_path(six, C.CString(p))
 	}
 
-	C.init(six, C.CString(pythonHome))
+	C.init(six)
 
 	if C.is_initialized(six) == 0 {
 		err := C.GoString(C.get_error(six))
@@ -113,6 +132,8 @@ func Initialize(paths ...string) error {
 
 	// TODO: query PythonPath
 	// TODO: query PythonHome
+
+	C.initDatadogAgentModule(six)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Init `datadog_agent` Python module to expose Go code to python checks

### Additional Notes

Subprocess and external host tags will come in a later PR.