### PR TITLE
Collect container thread count and limit

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -230,6 +230,13 @@ func (d *DockerCheck) Run() error {
 			log.Debugf("Empty IO metrics for container %s", c.ID[:12])
 		}
 
+		if c.ThreadCount != 0 {
+			sender.Gauge("docker.thread.count", float64(c.ThreadCount), "", tags)
+		}
+		if c.ThreadLimit != 0 {
+			sender.Gauge("docker.thread.limit", float64(c.ThreadLimit), "", tags)
+		}
+
 		if c.Network != nil {
 			for _, netStat := range c.Network {
 				if netStat.NetworkName == "" {

--- a/pkg/util/containers/container_linux.go
+++ b/pkg/util/containers/container_linux.go
@@ -44,6 +44,11 @@ func (c *Container) FillCgroupLimits() error {
 	if err != nil {
 		return fmt.Errorf("failed mem count: %s", err)
 	}
+	c.ThreadLimit, err = c.cgroup.ThreadLimit()
+	if err != nil {
+		return fmt.Errorf("thread limit: %s", err)
+	}
+
 	return nil
 }
 
@@ -74,6 +79,10 @@ func (c *Container) FillCgroupMetrics() error {
 	c.StartedAt, err = c.cgroup.ContainerStartTime()
 	if err != nil {
 		return fmt.Errorf("start time: %s", err)
+	}
+	c.ThreadCount, err = c.cgroup.ThreadCount()
+	if err != nil {
+		return fmt.Errorf("thread count: %s", err)
 	}
 
 	return nil

--- a/pkg/util/containers/metrics/cgroup_metrics.go
+++ b/pkg/util/containers/metrics/cgroup_metrics.go
@@ -375,7 +375,7 @@ func (c ContainerCgroup) ThreadCount() (uint64, error) {
 	return v, nil
 }
 
-// ThreadCount returns the thread count limit in the pid cgroup
+// ThreadLimit returns the thread count limit in the pid cgroup
 // linked to the container.
 // ref: https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt
 //

--- a/pkg/util/containers/metrics/cgroup_metrics_test.go
+++ b/pkg/util/containers/metrics/cgroup_metrics_test.go
@@ -166,3 +166,61 @@ func TestParseSingleStat(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, value, uint64(1234))
 }
+
+func TestThreadLimit(t *testing.T) {
+	tempFolder, err := newTempFolder("thread-limit")
+	assert.Nil(t, err)
+	defer tempFolder.removeAll()
+
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "pids")
+
+	// No file
+	value, err := cgroup.ThreadLimit()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(0))
+
+	// Invalid file
+	tempFolder.add("pids/pids.max", "ab")
+	value, err = cgroup.ThreadLimit()
+	assert.NotNil(t, err)
+	assert.IsType(t, err, &strconv.NumError{})
+	assert.Equal(t, value, uint64(0))
+
+	// No limit
+	tempFolder.add("pids/pids.max", "max")
+	value, err = cgroup.ThreadLimit()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(0))
+
+	// Valid value
+	tempFolder.add("pids/pids.max", "1234")
+	value, err = cgroup.ThreadLimit()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(1234))
+}
+
+func TestThreadCount(t *testing.T) {
+	tempFolder, err := newTempFolder("thread-count")
+	assert.Nil(t, err)
+	defer tempFolder.removeAll()
+
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "pids")
+
+	// No file
+	value, err := cgroup.ThreadCount()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(0))
+
+	// Invalid file
+	tempFolder.add("pids/pids.current", "ab")
+	value, err = cgroup.ThreadCount()
+	assert.NotNil(t, err)
+	assert.IsType(t, err, &strconv.NumError{})
+	assert.Equal(t, value, uint64(0))
+
+	// Valid value
+	tempFolder.add("pids/pids.current", "123")
+	value, err = cgroup.ThreadCount()
+	assert.Nil(t, err)
+	assert.Equal(t, value, uint64(123))
+}

--- a/pkg/util/containers/types.go
+++ b/pkg/util/containers/types.go
@@ -63,6 +63,8 @@ type Container struct {
 	Network        metrics.ContainerNetStats
 	AddressList    []NetworkAddress
 	StartedAt      int64
+	ThreadCount    uint64
+	ThreadLimit    uint64
 
 	// For internal use only
 	cgroup *metrics.ContainerCgroup

--- a/releasenotes/notes/container-thread-count-431c5c3b29ca1ddb.yaml
+++ b/releasenotes/notes/container-thread-count-431c5c3b29ca1ddb.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Collect container thread count and thread limit

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 )
 
 func init() {
@@ -37,6 +39,7 @@ func TestContainerMetricsTagging(t *testing.T) {
 			"docker.mem.soft_limit",
 			"docker.container.size_rw",
 			"docker.container.size_rootfs",
+			"docker.thread.count",
 		},
 		"Rate": {
 			"docker.cpu.system",
@@ -75,4 +78,7 @@ func TestContainerMetricsTagging(t *testing.T) {
 			}
 		}
 	}
+
+	// redis:3.2 runs one process with 3 threads
+	sender.AssertCalled(t, "Gauge", "docker.thread.count", 3.0, "", mocksender.MatchTagsContains(expectedTags))
 }

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -81,4 +81,6 @@ func TestContainerMetricsTagging(t *testing.T) {
 
 	// redis:3.2 runs one process with 3 threads
 	sender.AssertCalled(t, "Gauge", "docker.thread.count", 3.0, "", mocksender.MatchTagsContains(expectedTags))
+	sender.AssertCalled(t, "Gauge", "docker.thread.limit", 25.0, "", mocksender.MatchTagsContains(expectedTags))
+
 }

--- a/test/integration/corechecks/docker/testdata/basemetrics.compose
+++ b/test/integration/corechecks/docker/testdata/basemetrics.compose
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   pause:
     image: "kubernetes/pause:latest"
@@ -12,3 +12,4 @@ services:
         HIGH_CARD_ENV: "redishighenv"
     mem_limit: 32000000
     mem_reservation: 31000000
+    pids_limit: 25


### PR DESCRIPTION
### What does this PR do?

Add `ThreadCount` and `ThreadLimit` fields to the Container object, and fill them from [the `pids` cgroup accounting](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt) data.

- The live container view will be able to retrieve it for the docker and kubelet backends, pending more work there
- The docker check exposes them as `docker.threads.count` and `docker.threads.limit` gauges

### Threads and PIDs

Although the cgroup is called `pids`, it tracks actual [task ids](https://linux.die.net/man/2/gettid), as that's what needed to protect against fork bombs. Then a process clones itself, the new thread receives a unique TID, but shares its PID with the main process.

Here's the example on the `redis:3.2` container, where the `redis-server` process runs three threads:

> $ docker run -d redis:3.2
> 2dbdb4...2257b9
> $ cat /sys/fs/cgroup/pids/docker/2dbdb4...2257b9/cgroup.procs
> 6991
> $ ps aux|grep redis

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
999       6991  0.1  0.0  33328  3532 ?        Ssl  10:07   0:00 redis-server *:637
```

The container's main process has the PID number 6991.

> $ cat /sys/fs/cgroup/pids/docker/2dbdb4...2257b9/pids.current
>3
> $ cat /sys/fs/cgroup/pids/docker/2dbdb4...2257b9/tasks
> 6991
> 7057
> 7058

There are actually three threads / tasks in this cgroup. We can confirm with `ps`: 

```
UID        PID  PPID   LWP  C NLWP STIME TTY          TIME CMD
999       6991  6963  6991  0    3 10:07 ?        00:00:00 redis-server *:6379
999       6991  6963  7057  0    3 10:07 ?        00:00:00 redis-server *:6379
999       6991  6963  7058  0    3 10:07 ?        00:00:00 redis-server *:6379
```