### PR TITLE
ec2 tags collection is broken when kube2iam is used

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -105,7 +105,7 @@ func getSecurityCreds() (*ec2SecurityCred, error) {
 		return iamParams, err
 	}
 
-	res, err := getResponse(metadataURL + "/iam/security-credentials/" + iamRole + "/")
+	res, err := getResponse(metadataURL + "/iam/security-credentials/" + iamRole)
 	if err != nil {
 		return iamParams, fmt.Errorf("unable to fetch EC2 API, %s", err)
 	}

--- a/pkg/util/ec2/ec2_tags_test.go
+++ b/pkg/util/ec2/ec2_tags_test.go
@@ -43,7 +43,7 @@ func TestGetSecurityCreds(t *testing.T) {
 		if r.URL.Path == "/iam/security-credentials/" {
 			w.Header().Set("Content-Type", "text/plain")
 			io.WriteString(w, "test-role")
-		} else if r.URL.Path == "/iam/security-credentials/test-role/" {
+		} else if r.URL.Path == "/iam/security-credentials/test-role" {
 			w.Header().Set("Content-Type", "text/plain")
 			content, err := ioutil.ReadFile("payloads/security_cred.json")
 			require.Nil(t, err, fmt.Sprintf("failed to load json in payloads/security_cred.json: %v", err))

--- a/releasenotes/notes/ec2-tags-collection-is-broken-when-kube2iam-is-used-bf05af7d99a28073.yaml
+++ b/releasenotes/notes/ec2-tags-collection-is-broken-when-kube2iam-is-used-bf05af7d99a28073.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes ec2 tags collection when datadog agent is deployed
+    into a kubernetes cluster along with kube2iam.


### PR DESCRIPTION
### What does this PR do?

Fix ec2 tag collection when datadog agent is used in kubernetes with kube2iam.

### Additional Notes

There is no need to add "/" after a IAM role when composing the url used to get AWS security credentials.

Please see these issues:
[DataDog/datadog-agen#3173](https://github.com/DataDog/datadog-agent/issues/3173)
https://github.com/jtblin/kube2iam/issues/204
