### PR TITLE
blacklist standard dogstatsd prefixes when adding custom namespace

### DIFF
--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -285,7 +285,7 @@ func listChecks(w http.ResponseWriter, r *http.Request) {
 	integrations = append(integrations, goIntegrations...)
 
 	// Get jmx-checks
-	for integration := range check.JMXChecks {
+	for integration := range config.StandardJMXIntegrations {
 		integrations = append(integrations, integration)
 	}
 

--- a/cmd/agent/gui/checks_py.go
+++ b/cmd/agent/gui/checks_py.go
@@ -8,8 +8,8 @@
 package gui
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func getPythonChecks() ([]string, error) {
@@ -23,7 +23,7 @@ func getPythonChecks() ([]string, error) {
 	}
 
 	for _, integration := range integrations {
-		if _, ok := check.JMXChecks[integration]; !ok {
+		if _, ok := config.StandardJMXIntegrations[integration]; !ok {
 			pyChecks = append(pyChecks, integration)
 		}
 	}

--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -9,23 +9,13 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	agentconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
-
-// JMXChecks list of JMXFetch checks supported: implemented as set with an empty struct map
-var JMXChecks = map[string]struct{}{
-	"activemq":    {},
-	"activemq_58": {},
-	"cassandra":   {},
-	"jmx":         {},
-	"solr":        {},
-	"tomcat":      {},
-	"kafka":       {},
-}
 
 // IsJMXConfig checks if a certain YAML config is a JMX config
 func IsJMXConfig(name string, initConf integration.Data) bool {
 
-	if _, ok := JMXChecks[name]; ok {
+	if _, ok := agentconfig.StandardJMXIntegrations[name]; ok {
 		return true
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,6 +221,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("statsd_forward_host", "")
 	config.BindEnvAndSetDefault("statsd_forward_port", 0)
 	config.BindEnvAndSetDefault("statsd_metric_namespace", "")
+	config.BindEnvAndSetDefault("statsd_metric_namespace_blacklist", StandardStatsdPrefixes)
 	// Autoconfig
 	config.BindEnvAndSetDefault("autoconf_template_dir", "/datadog/check_configs")
 	config.BindEnvAndSetDefault("exclude_pause_container", true)

--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -21,7 +21,7 @@ var StandardStatsdPrefixes = []string{
 }
 
 func init() {
-	// JMXFetch sends data through
+	// JMXFetch sends data through dogstatsd
 	for jmxIntegration := range StandardJMXIntegrations {
 		StandardStatsdPrefixes = append(StandardStatsdPrefixes, jmxIntegration)
 	}

--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -1,0 +1,28 @@
+package config
+
+// StandardJMXIntegrations is the list of standard jmx integrations
+var StandardJMXIntegrations = map[string]struct{}{
+	"activemq":    {},
+	"activemq_58": {},
+	"cassandra":   {},
+	"jmx":         {},
+	"presto":      {},
+	"solr":        {},
+	"tomcat":      {},
+	"kafka":       {},
+}
+
+// StandardStatsdPrefixes is a list of the statsd prefixes used by the agent and it's components
+var StandardStatsdPrefixes = []string{
+	"datadog.trace_agent",
+	"datadog.process",
+	"datadog.agent",
+	"datadog.dogstatsd",
+}
+
+func init() {
+	// JMXFetch sends data through
+	for jmxIntegration := range StandardJMXIntegrations {
+		StandardStatsdPrefixes = append(StandardStatsdPrefixes, jmxIntegration)
+	}
+}

--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -14,15 +14,17 @@ var StandardJMXIntegrations = map[string]struct{}{
 
 // StandardStatsdPrefixes is a list of the statsd prefixes used by the agent and it's components
 var StandardStatsdPrefixes = []string{
-	"datadog.trace_agent",
-	"datadog.process",
 	"datadog.agent",
 	"datadog.dogstatsd",
-}
+	"datadog.process",
+	"datadog.trace_agent",
 
-func init() {
-	// JMXFetch sends data through dogstatsd
-	for jmxIntegration := range StandardJMXIntegrations {
-		StandardStatsdPrefixes = append(StandardStatsdPrefixes, jmxIntegration)
-	}
+	"activemq",
+	"activemq_58",
+	"cassandra",
+	"jvm",
+	"presto",
+	"solr",
+	"tomcat",
+	"kafka",
 }

--- a/pkg/config/standard_names.go
+++ b/pkg/config/standard_names.go
@@ -12,7 +12,7 @@ var StandardJMXIntegrations = map[string]struct{}{
 	"kafka":       {},
 }
 
-// StandardStatsdPrefixes is a list of the statsd prefixes used by the agent and it's components
+// StandardStatsdPrefixes is a list of the statsd prefixes used by the agent and its components
 var StandardStatsdPrefixes = []string{
 	"datadog.agent",
 	"datadog.dogstatsd",

--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
@@ -276,7 +274,7 @@ func parseEventMessage(message []byte, defaultHostname string) (*metrics.Event, 
 	return &event, nil
 }
 
-func parseMetricMessage(message []byte, namespace string, defaultHostname string) (*metrics.MetricSample, error) {
+func parseMetricMessage(message []byte, namespace string, namespaceBlacklist []string, defaultHostname string) (*metrics.MetricSample, error) {
 	// daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2
 	// daemon:666|g|@0.1|#sometag:somevalue"
 
@@ -325,7 +323,7 @@ func parseMetricMessage(message []byte, namespace string, defaultHostname string
 	metricName := string(rawName)
 	if namespace != "" {
 		blacklisted := false
-		for _, prefix := range config.Datadog.GetStringSlice("statsd_metric_namespace_blacklist") {
+		for _, prefix := range namespaceBlacklist {
 			if strings.HasPrefix(metricName, prefix) {
 				blacklisted = true
 			}

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -65,7 +65,7 @@ func TestGaugePacketCounter(t *testing.T) {
 }
 
 func TestParseGauge(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -79,7 +79,7 @@ func TestParseGauge(t *testing.T) {
 }
 
 func TestParseCounter(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|c"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -92,7 +92,7 @@ func TestParseCounter(t *testing.T) {
 }
 
 func TestParseCounterWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("custom_counter:1|c|#protocol:http,bench"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -107,7 +107,7 @@ func TestParseCounterWithTags(t *testing.T) {
 }
 
 func TestParseHistogram(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|h"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -120,7 +120,7 @@ func TestParseHistogram(t *testing.T) {
 }
 
 func TestParseTimer(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestParseTimer(t *testing.T) {
 }
 
 func TestParseSet(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:abc|s"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -146,7 +146,7 @@ func TestParseSet(t *testing.T) {
 }
 
 func TestParseDistribution(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:3.5|d"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -158,7 +158,7 @@ func TestParseDistribution(t *testing.T) {
 }
 
 func TestParseSetUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:♬†øU†øU¥ºuT0♪|s"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -171,7 +171,7 @@ func TestParseSetUnicode(t *testing.T) {
 }
 
 func TestParseGaugeWithTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,sometag2:somevalue2"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -186,7 +186,7 @@ func TestParseGaugeWithTags(t *testing.T) {
 }
 
 func TestParseGaugeWithHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -200,7 +200,7 @@ func TestParseGaugeWithHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithEmptyHostTag(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -214,7 +214,7 @@ func TestParseGaugeWithEmptyHostTag(t *testing.T) {
 }
 
 func TestParseGaugeWithNoTags(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -226,7 +226,7 @@ func TestParseGaugeWithNoTags(t *testing.T) {
 }
 
 func TestParseGaugeWithSampleRate(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|@0.21"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -239,7 +239,7 @@ func TestParseGaugeWithSampleRate(t *testing.T) {
 }
 
 func TestParseGaugeWithPoundOnly(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -252,7 +252,7 @@ func TestParseGaugeWithPoundOnly(t *testing.T) {
 }
 
 func TestParseGaugeWithUnicode(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"), "", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
@@ -267,36 +267,36 @@ func TestParseGaugeWithUnicode(t *testing.T) {
 
 func TestParseMetricError(t *testing.T) {
 	// not enough information
-	_, err := parseMetricMessage([]byte("daemon:666"), "", "default-hostname")
+	_, err := parseMetricMessage([]byte("daemon:666"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:666|"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte("daemon:|g"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
-	_, err = parseMetricMessage([]byte(":666|g"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte(":666|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// too many value
-	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666:777|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// unknown metadata prefix
-	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|g|m:test"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	// invalid value
-	_, err = parseMetricMessage([]byte("daemon:abc|g"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:abc|g"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// invalid metric type
-	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|unknown"), "", nil, "default-hostname")
 	assert.Error(t, err)
 
 	// invalid sample rate
-	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "", "default-hostname")
+	_, err = parseMetricMessage([]byte("daemon:666|g|@abc"), "", nil, "default-hostname")
 	assert.Error(t, err)
 }
 
@@ -726,11 +726,20 @@ func TestEventMetadataMultiple(t *testing.T) {
 }
 
 func TestNamespace(t *testing.T) {
-	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:21|ms"), "testNamespace.", nil, "default-hostname")
 
 	assert.NoError(t, err)
 
 	assert.Equal(t, "testNamespace.daemon", parsed.Name)
+	assert.Equal(t, "default-hostname", parsed.Host)
+}
+
+func TestNamespaceBlacklist(t *testing.T) {
+	parsed, err := parseMetricMessage([]byte("datadog.agent.daemon:21|ms"), "testNamespace.", []string{"datadog.agent"}, "default-hostname")
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "datadog.agent.daemon", parsed.Name)
 	assert.Equal(t, "default-hostname", parsed.Host)
 }
 
@@ -742,7 +751,7 @@ func TestEntityOriginDetectionNoTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -763,7 +772,7 @@ func TestEntityOriginDetectionTags(t *testing.T) {
 		return []string{}, nil
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)
@@ -783,7 +792,7 @@ func TestEntityOriginDetectionTagsError(t *testing.T) {
 		return nil, errors.New("cannot get tags")
 	}
 
-	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", "default-hostname")
+	parsed, err := parseMetricMessage([]byte("daemon:666|g|#sometag1:somevalue1,host:my-hostname,dd.internal.entity_id:foo,sometag2:somevalue2"), "", nil, "default-hostname")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "daemon", parsed.Name)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -49,21 +49,22 @@ func init() {
 
 // Server represent a Dogstatsd server
 type Server struct {
-	listeners         []listeners.StatsdListener
-	packetsIn         chan listeners.Packets
-	Statistics        *util.Stats
-	Started           bool
-	packetPool        *listeners.PacketPool
-	stopChan          chan bool
-	health            *health.Handle
-	metricPrefix      string
-	defaultHostname   string
-	histToDist        bool
-	histToDistPrefix  string
-	extraTags         []string
-	debugMetricsStats bool
-	metricsStats      map[string]metricStat
-	statsLock         sync.Mutex
+	listeners             []listeners.StatsdListener
+	packetsIn             chan listeners.Packets
+	Statistics            *util.Stats
+	Started               bool
+	packetPool            *listeners.PacketPool
+	stopChan              chan bool
+	health                *health.Handle
+	metricPrefix          string
+	metricPrefixBlacklist []string
+	defaultHostname       string
+	histToDist            bool
+	histToDistPrefix      string
+	extraTags             []string
+	debugMetricsStats     bool
+	metricsStats          map[string]metricStat
+	statsLock             sync.Mutex
 }
 
 // metricStat holds how many times a metric has been
@@ -123,6 +124,7 @@ func NewServer(metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metr
 	if metricPrefix != "" && !strings.HasSuffix(metricPrefix, ".") {
 		metricPrefix = metricPrefix + "."
 	}
+	metricPrefixBlacklist := config.Datadog.GetStringSlice("statsd_metric_namespace_blacklist")
 
 	defaultHostname, err := util.GetHostname()
 	if err != nil {
@@ -135,20 +137,21 @@ func NewServer(metricOut chan<- []*metrics.MetricSample, eventOut chan<- []*metr
 	extraTags := config.Datadog.GetStringSlice("dogstatsd_tags")
 
 	s := &Server{
-		Started:           true,
-		Statistics:        stats,
-		packetsIn:         packetsChannel,
-		listeners:         tmpListeners,
-		packetPool:        packetPool,
-		stopChan:          make(chan bool),
-		health:            health.Register("dogstatsd-main"),
-		metricPrefix:      metricPrefix,
-		defaultHostname:   defaultHostname,
-		histToDist:        histToDist,
-		histToDistPrefix:  histToDistPrefix,
-		extraTags:         extraTags,
-		debugMetricsStats: metricsStats,
-		metricsStats:      make(map[string]metricStat),
+		Started:               true,
+		Statistics:            stats,
+		packetsIn:             packetsChannel,
+		listeners:             tmpListeners,
+		packetPool:            packetPool,
+		stopChan:              make(chan bool),
+		health:                health.Register("dogstatsd-main"),
+		metricPrefix:          metricPrefix,
+		metricPrefixBlacklist: metricPrefixBlacklist,
+		defaultHostname:       defaultHostname,
+		histToDist:            histToDist,
+		histToDistPrefix:      histToDistPrefix,
+		extraTags:             extraTags,
+		debugMetricsStats:     metricsStats,
+		metricsStats:          make(map[string]metricStat),
 	}
 
 	forwardHost := config.Datadog.GetString("statsd_forward_host")
@@ -293,7 +296,7 @@ func (s *Server) parsePacket(packet *listeners.Packet, metricSamples []*metrics.
 			dogstatsdEventPackets.Add(1)
 			events = append(events, event)
 		} else {
-			sample, err := parseMetricMessage(message, s.metricPrefix, s.defaultHostname)
+			sample, err := parseMetricMessage(message, s.metricPrefix, s.metricPrefixBlacklist, s.defaultHostname)
 			if err != nil {
 				log.Errorf("Dogstatsd: error parsing metrics: %s", err)
 				dogstatsdMetricParseErrors.Add(1)

--- a/releasenotes/notes/blacklist-dogstatsd-standard-prefix-custom-namespace-2fc6d9a23247f969.yaml
+++ b/releasenotes/notes/blacklist-dogstatsd-standard-prefix-custom-namespace-2fc6d9a23247f969.yaml
@@ -1,0 +1,20 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Metrics comming trough dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
+    ``cassandra``, ``jmx`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
+    ``datadog.process``, ``datadog.agent``, ``datadog.dogstatsd`` are no longer affected by the
+    ``statsd_metric_namespace`` option.
+fixes:
+  - |
+    Metrics comming trough dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
+    ``cassandra``, ``jmx`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
+    ``datadog.process``, ``datadog.agent``, ``datadog.dogstatsd`` are no longer affected by the
+    ``statsd_metric_namespace`` option.

--- a/releasenotes/notes/blacklist-dogstatsd-standard-prefix-custom-namespace-2fc6d9a23247f969.yaml
+++ b/releasenotes/notes/blacklist-dogstatsd-standard-prefix-custom-namespace-2fc6d9a23247f969.yaml
@@ -8,13 +8,13 @@
 ---
 upgrade:
   - |
-    Metrics comming trough dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
+    Metrics coming through dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
     ``cassandra``, ``jmx`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
     ``datadog.process``, ``datadog.agent``, ``datadog.dogstatsd`` are no longer affected by the
     ``statsd_metric_namespace`` option.
 fixes:
   - |
-    Metrics comming trough dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
+    Metrics coming through dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
     ``cassandra``, ``jmx`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
     ``datadog.process``, ``datadog.agent``, ``datadog.dogstatsd`` are no longer affected by the
     ``statsd_metric_namespace`` option.

--- a/releasenotes/notes/blacklist-dogstatsd-standard-prefix-custom-namespace-2fc6d9a23247f969.yaml
+++ b/releasenotes/notes/blacklist-dogstatsd-standard-prefix-custom-namespace-2fc6d9a23247f969.yaml
@@ -9,12 +9,12 @@
 upgrade:
   - |
     Metrics coming through dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
-    ``cassandra``, ``jmx`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
+    ``cassandra``, ``jvm`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
     ``datadog.process``, ``datadog.agent``, ``datadog.dogstatsd`` are no longer affected by the
     ``statsd_metric_namespace`` option.
 fixes:
   - |
     Metrics coming through dogstatsd with the following internal prefixes: ``activemq``, ``activemq_58``,
-    ``cassandra``, ``jmx`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
+    ``cassandra``, ``jvm`, ``presto``, ``solr``, ``tomcat``, ``kafka``, ``datadog.trace_agent``,
     ``datadog.process``, ``datadog.agent``, ``datadog.dogstatsd`` are no longer affected by the
     ``statsd_metric_namespace`` option.


### PR DESCRIPTION
### What does this PR do?

Adds a blacklist on the `statsd_metric_namespace` option to avoid applying it to standard dogstatsd prefixes

### Motivation

It does not make sense to apply the prefix on metrics generated by jmxfetch and the agent components.

### Notes

- We could blacklist `datadog*` instead but it makes it more likely to break for some users.
- Added a new jmxfetch integration, `presto`