### PR TITLE
Add ability to pdb into checks

### DIFF
--- a/releasenotes/notes/Add-ability-to-pass-breakpoint-flag-to-Python-checks-3d289df93c6d609b.yaml
+++ b/releasenotes/notes/Add-ability-to-pass-breakpoint-flag-to-Python-checks-3d289df93c6d609b.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the ability to pass down the ``set_breakpoint`` flag to Python checks to start
+    an `interactive debugging session <https://docs.python.org/3/library/pdb.html>`_.

--- a/releasenotes/notes/Add-ability-to-pass-breakpoint-flag-to-Python-checks-3d289df93c6d609b.yaml
+++ b/releasenotes/notes/Add-ability-to-pass-breakpoint-flag-to-Python-checks-3d289df93c6d609b.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Add the ability to pass down the ``set_breakpoint`` flag to Python checks to start
-    an `interactive debugging session <https://docs.python.org/3/library/pdb.html>`_.
+    Add the ability for the ``datadog-agent check`` command to have Python checks start
+    an `interactive debugging session <https://docs.python.org/2/library/pdb.html>`_.


### PR DESCRIPTION
### What does this PR do?

Add the ability to pass down the `set_breakpoint` flag to Python checks to start an [interactive debugging session](https://docs.python.org/3/library/pdb.html).

### Motivation

https://github.com/DataDog/integrations-core/pull/2690
https://github.com/DataDog/integrations-core/pull/3340

### Additional Notes

![Capture](https://user-images.githubusercontent.com/9677399/54727658-60338700-4b4f-11e9-854e-09284623f927.PNG)
