### PR TITLE
[kitchen] Pin to working 1.24.0

### DIFF
--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -88,7 +88,7 @@ if [ -z ${SERVER_PASSWORD+x} ]; then
   export SERVER_PASSWORD=$(< /dev/urandom tr -dc A-Za-z0-9 | head -c32)
 fi
 
-chef gem install bundler:1.17.3 net-ssh berkshelf rake psych:2.2.2 kitchen-azurerm:0.13.0 test-kitchen
+chef gem install bundler:1.17.3 net-ssh berkshelf rake psych:2.2.2 kitchen-azurerm:0.13.0 test-kitchen:1.24.0
 cp .kitchen-azure.yml .kitchen.yml
 
 ## check to see if we want the windows-installer tester instead


### PR DESCRIPTION
### What does this PR do?

`test-kitchen` 2.0.0 was recently released, but our pipeline fails with it. To unblock the pipeline let's pin it.

### Additional Notes

Follow-up work we should plan to do:

1. pin all the deps, ideally in a `Gemfile.lock` instead of using `gem install` directly
2. upgrade to kitchen `2.0.0`
