### PR TITLE
remove rawValue for dogstatsd metrics

### DIFF
--- a/pkg/dogstatsd/parser.go
+++ b/pkg/dogstatsd/parser.go
@@ -345,7 +345,6 @@ func parseMetricMessage(message []byte, namespace string, defaultHostname string
 		if err != nil {
 			return nil, fmt.Errorf("invalid metric value for %q", message)
 		}
-		sample.RawValue = string(rawValue)
 		sample.Value = metricValue
 	}
 

--- a/pkg/dogstatsd/parser_test.go
+++ b/pkg/dogstatsd/parser_test.go
@@ -71,7 +71,6 @@ func TestParseGauge(t *testing.T) {
 
 	assert.Equal(t, "daemon", parsed.Name)
 	assert.InEpsilon(t, 666.0, parsed.Value, epsilon)
-	assert.Equal(t, "666", parsed.RawValue)
 	assert.Equal(t, metrics.GaugeType, parsed.Mtype)
 	assert.Equal(t, 0, len(parsed.Tags))
 	assert.Equal(t, "default-hostname", parsed.Host)


### PR DESCRIPTION
### What does this PR do?

Stops setting the RawValue for metrics other than sets. 

### Motivation

Small perf gain. This value isn't used for anything other than sets.
