### PR TITLE
Improve tagger python bridge with the new orchestrator cardinality level

### DIFF
--- a/pkg/collector/py/tagger.c
+++ b/pkg/collector/py/tagger.c
@@ -10,6 +10,29 @@
 // Functions
 PyObject* GetTags(char *id, int highCard);
 
+// _must_ be in the same order as the TaggerCardinality enum
+char* TaggerCardinalityNames[] = {
+  "LOW",
+  "ORCHESTRATOR",
+  "HIGH"
+};
+
+static PyObject *tag(PyObject *self, PyObject *args) {
+    char *entity;
+    int  card;
+
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    if (!PyArg_ParseTuple(args, "si", &entity, &card)) {
+      PyGILState_Release(gstate);
+      return NULL;
+    }
+
+    PyGILState_Release(gstate);
+    return GetTags(entity, card);
+}
+
 static PyObject *get_tags(PyObject *self, PyObject *args) {
     char *entity;
     int  high_card;
@@ -27,7 +50,8 @@ static PyObject *get_tags(PyObject *self, PyObject *args) {
 }
 
 static PyMethodDef taggerMethods[] = {
-  {"get_tags", get_tags, METH_VARARGS, "Get tags for an entity."},
+  {"tag", tag, METH_VARARGS, "Get tags for an entity."},
+  {"get_tags", get_tags, METH_VARARGS, "(Deprecated) Get tags for an entity."},
   {NULL, NULL}
 };
 
@@ -37,6 +61,11 @@ void inittagger()
   gstate = PyGILState_Ensure();
 
   PyObject *tagger = Py_InitModule("tagger", taggerMethods);
+
+  int i;
+  for (i=TC_FIRST; i<=TC_LAST; i++) {
+    PyModule_AddIntConstant(tagger, TaggerCardinalityNames[i], i);
+  }
 
   PyGILState_Release(gstate);
 }

--- a/pkg/collector/py/tagger.go
+++ b/pkg/collector/py/tagger.go
@@ -18,24 +18,23 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 )
 
-// GetTags queries the agent6 tagger and returns a string array containing
-// tags for the entity. If entity not found, or tagging error, the returned
-// array is empty but valid.
-//export GetTags
-// FIXME: replace highCard with a TagCardinality
-func GetTags(id *C.char, highCard int) *C.PyObject {
+// Tag bridges towards tagger.Tag to retrieve container tags
+//export Tag
+func Tag(id *C.char, card C.TaggerCardinality) *C.PyObject {
 	goID := C.GoString(id)
-	var highCardBool bool
 	var tags []string
-	if highCard > 0 {
-		highCardBool = true
+	var cardinality collectors.TagCardinality
+
+	switch card {
+	case C.LOW_CARD:
+		cardinality = collectors.LowCardinality
+	case C.ORCHESTRATOR_CARD:
+		cardinality = collectors.OrchestratorCardinality
+	case C.HIGH_CARD:
+		cardinality = collectors.HighCardinality
 	}
 
-	if highCardBool == true {
-		tags, _ = tagger.Tag(goID, collectors.HighCardinality)
-	} else {
-		tags, _ = tagger.Tag(goID, collectors.LowCardinality)
-	}
+	tags, _ = tagger.Tag(goID, cardinality)
 	output := C.PyList_New(0)
 
 	for _, t := range tags {
@@ -47,6 +46,16 @@ func GetTags(id *C.char, highCard int) *C.PyObject {
 	}
 
 	return output
+}
+
+// GetTags is deprecated, Tag should be used now instead
+//export GetTags
+func GetTags(id *C.char, highCard int) *C.PyObject {
+	if highCard > 0 {
+		return Tag(id, C.HIGH_CARD)
+	} else {
+		return Tag(id, C.LOW_CARD)
+	}
 }
 
 func initTagger() {

--- a/pkg/collector/py/tagger.h
+++ b/pkg/collector/py/tagger.h
@@ -10,6 +10,15 @@
 
 #include <Python.h>
 
+typedef enum {
+  TC_FIRST = 0,
+  LOW_CARD = TC_FIRST,
+  ORCHESTRATOR_CARD,
+  HIGH_CARD,
+  TC_LAST = HIGH_CARD
+} TaggerCardinality;
+
+
 void inittagger();
 
 #endif /* TAGGER_HEADER */

--- a/pkg/collector/py/tagger_test.go
+++ b/pkg/collector/py/tagger_test.go
@@ -34,7 +34,7 @@ func (c *DummyCollector) Fetch(entity string) ([]string, []string, []string, err
 	}
 }
 
-func TestGetTags(t *testing.T) {
+func TestTagger(t *testing.T) {
 	collectors.DefaultCatalog = map[string]collectors.CollectorFactory{
 		"dummy": func() collectors.Collector {
 			return &DummyCollector{}
@@ -57,7 +57,12 @@ func TestGetTags(t *testing.T) {
 	err = check.Run()
 	require.NoError(t, err)
 
-	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.low_card", []string{"test_entity:low"})
-	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.high_card", []string{"test_entity:low", "test_entity:high", "other_tag:high"})
-	mockSender.AssertMetricTaggedWith(t, "Gauge", "metric.unknown", []string{})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "old_method.low_card", []string{"test_entity:low"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "old_method.high_card", []string{"test_entity:low", "test_entity:orchestrator", "test_entity:high", "other_tag:high"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "old_method.unknown", []string{})
+
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.low_card", []string{"test_entity:low"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.orch_card", []string{"test_entity:low", "test_entity:orchestrator"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.high_card", []string{"test_entity:low", "test_entity:orchestrator", "test_entity:high", "other_tag:high"})
+	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.unknown", []string{})
 }

--- a/pkg/collector/py/tests/testtagger.py
+++ b/pkg/collector/py/tests/testtagger.py
@@ -4,16 +4,28 @@
 # Copyright 2016-2019 Datadog, Inc.
 
 from checks import AgentCheck
-from tagger import get_tags
+import tagger
 
 
 class TestCheck(AgentCheck):
     def check(self, instance):
-        lowtags = get_tags("test_entity", False)
-        self.gauge("metric.low_card", 1, tags=lowtags)
+        lowtags = tagger.get_tags("test_entity", False)
+        self.gauge("old_method.low_card", 1, tags=lowtags)
 
-        alltags = get_tags("test_entity", True)
-        self.gauge("metric.high_card", 1, tags=alltags)
+        alltags = tagger.get_tags("test_entity", True)
+        self.gauge("old_method.high_card", 1, tags=alltags)
 
-        notags = get_tags("404", True)
-        self.gauge("metric.unknown", 1, tags=notags)
+        notags = tagger.get_tags("404", True)
+        self.gauge("old_method.unknown", 1, tags=notags)
+
+        lowtags = tagger.tag("test_entity", tagger.LOW)
+        self.gauge("new_method.low_card", 1, tags=lowtags)
+
+        orchtags = tagger.tag("test_entity", tagger.ORCHESTRATOR)
+        self.gauge("new_method.orch_card", 1, tags=orchtags)
+
+        alltags = tagger.tag("test_entity", tagger.HIGH)
+        self.gauge("new_method.high_card", 1, tags=alltags)
+
+        notags = tagger.tag("404", tagger.LOW)
+        self.gauge("new_method.unknown", 1, tags=notags)


### PR DESCRIPTION
### What does this PR do?

We need to access the orchestrator tag cardinality introduced in https://github.com/DataDog/datadog-agent/pull/2714 from python checks, so the python bridge needs to evolve.

To keep the transition smooth, the existing `tagger.get_tags` function stays the same, and just wraps around the new `tagger.tag` function, that mimics the go API. Usage example in the unit tests:

```
import tagger

        lowtags = tagger.tag("test_entity", tagger.LOW)
        orchtags = tagger.tag("test_entity", tagger.ORCHESTRATOR)
        alltags = tagger.tag("test_entity", tagger.HIGH)
```
