### PR TITLE
[serializer] Compress metadata payloads

### DIFF
--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -267,8 +267,7 @@ func TestSendSketch(t *testing.T) {
 
 func TestSendMetadata(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
-	payloads, _ := mkPayloads(jsonString, false)
-	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(nil).Times(1)
+	f.On("SubmitV1Intake", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := NewSerializer(f)
 
@@ -277,7 +276,7 @@ func TestSendMetadata(t *testing.T) {
 	require.Nil(t, err)
 	f.AssertExpectations(t)
 
-	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(fmt.Errorf("some error")).Times(1)
+	f.On("SubmitV1Intake", jsonPayloads, jsonExtraHeadersWithCompression).Return(fmt.Errorf("some error")).Times(1)
 	err = s.SendMetadata(payload)
 	require.NotNil(t, err)
 	f.AssertExpectations(t)
@@ -331,7 +330,6 @@ func TestSendWithDisabledKind(t *testing.T) {
 	s := NewSerializer(f)
 
 	payload := &testPayload{}
-	payloads, _ := mkPayloads(jsonString, false)
 
 	s.SendEvents(payload)
 	s.SendSeries(payload)
@@ -348,7 +346,7 @@ func TestSendWithDisabledKind(t *testing.T) {
 	f.AssertNotCalled(t, "SubmitSketchSeries")
 
 	// We never disable metadata
-	f.On("SubmitV1Intake", payloads, jsonExtraHeaders).Return(nil).Times(1)
+	f.On("SubmitV1Intake", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)
 	s.SendMetadata(payload)
 	f.AssertNumberOfCalls(t, "SubmitV1Intake", 1) // called once for the metadata
 }

--- a/pkg/serializer/split/split.go
+++ b/pkg/serializer/split/split.go
@@ -45,19 +45,19 @@ func init() {
 
 // CheckSizeAndSerialize Check the size of a payload and marshall it (optionally compress it)
 // The dual role makes sense as you will never serialize without checking the size of the payload
-func CheckSizeAndSerialize(m marshaler.Marshaler, compress bool, mType MarshalType) (bool, []byte, error) {
-	payload, _, err := serializeMarshaller(m, compress, mType)
+func CheckSizeAndSerialize(m marshaler.Marshaler, compress bool, mType MarshalType) (bool, []byte, []byte, error) {
+	compressedPayload, payload, err := serializeMarshaller(m, compress, mType)
 	if err != nil {
-		return false, nil, err
+		return false, nil, nil, err
 	}
-	return checkSize(payload), payload, nil
+	return checkSize(compressedPayload), compressedPayload, payload, nil
 }
 
 // Payloads serializes a metadata payload and sends it to the forwarder
 func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarder.Payloads, error) {
 	marshallers := []marshaler.Marshaler{m}
 	smallEnoughPayloads := forwarder.Payloads{}
-	nottoobig, payload, err := CheckSizeAndSerialize(m, compress, mType)
+	nottoobig, payload, _, err := CheckSizeAndSerialize(m, compress, mType)
 	if err != nil {
 		return smallEnoughPayloads, err
 	}
@@ -103,7 +103,7 @@ func Payloads(m marshaler.Marshaler, compress bool, mType MarshalType) (forwarde
 			// after the payload has been split, loop through the chunks
 			for _, chunk := range chunks {
 				// serialize the payload
-				smallEnough, payload, err := CheckSizeAndSerialize(chunk, compress, mType)
+				smallEnough, payload, _, err := CheckSizeAndSerialize(chunk, compress, mType)
 				if err != nil {
 					log.Debugf("Error serializing a chunk: %s", err)
 					continue

--- a/releasenotes/notes/compress-metadata-payload-b217b255aaaef22a.yaml
+++ b/releasenotes/notes/compress-metadata-payload-b217b255aaaef22a.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Host metadata payloads are now zlib-compressed


### PR DESCRIPTION
### What does this PR do?

Zlib-compresses metadata payloads before sending them.

### Motivation

Some Agents would send so many `external_host_tags` that the serializer would consider the payloads too big and not send them (the serializer always compares the payload size to a maximum that actually only applies to compressed payloads).

Even though Agent v6 doesn't compress these metadata payloads at the moment, there's actually no reason not to compress these payloads. The Agent v5 did compress them, see https://github.com/DataDog/dd-agent/blob/5.31.0/emitter.py

### Additional Notes

I've checked the compressed payloads are actually ingested by the intake: it worked fine and the metadata is correctly updated on DD.

Note that a better solution to large metadata payloads would be to have some split logic as well, however I think it's overkill for now: we can reach very good compression ratios for typical host metadata payloads, so this change should give us plenty of headroom.