### PR TITLE
[codecov] Remove PR comments and github status of project coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,4 @@
-comment:
-  layout: "diff, flags, files"
-  behavior: default
-  branches: null
-
+comment: off
 
 coverage:
   range: 20..100
@@ -10,6 +6,7 @@ coverage:
   precision: 2
 
   status:
+    project: off
     patch:
       default:
         target: '30'


### PR DESCRIPTION
### What does this PR do?

Silences most codecov reports on Github.

### Motivation

We've determined the only information that's useful to have on Github
from codecov is the github status on the patch coverage:

* PR comments are intrusive and provide info that's often wrong
* project coverage isn't accurate enough to be useful for most PRs

Coverage is still uploaded to codecov, so all the info is still
available on codecov.io.

### Additional Notes

If this worked, codecov should only report the patch status on this PR