### PR TITLE
Fix empty log from container (shows up as \\n)

### DIFF
--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -68,6 +68,8 @@ func (p *parser) Parse(msg []byte) (*message.Message, error) {
 	if idx == -1 {
 		// Nothing after the timestamp: empty message
 		return &message.Message{}, nil
+	} else if len(msg) == idx+3 && string(msg[idx+1:]) == "\\n" {
+		return &message.Message{}, nil
 	}
 	parsedMsg := message.NewMessage(msg[idx+1:], nil, status)
 	parsedMsg.Timestamp = string(msg[:idx])

--- a/pkg/logs/input/docker/parser_test.go
+++ b/pkg/logs/input/docker/parser_test.go
@@ -39,6 +39,13 @@ func TestDockerStandaloneParserShouldHandleEmptyMessage(t *testing.T) {
 	assert.Equal(t, 0, len(msg.Content))
 }
 
+func TestDockerStandaloneParserShouldHandleNewlineOnlyMessage(t *testing.T) {
+	parser := dockerParser
+	msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z \\n"))
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(msg.Content))
+}
+
 func TestDockerStandaloneParserShouldHandleTtyMessage(t *testing.T) {
 	parser := dockerParser
 	msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z foo"))


### PR DESCRIPTION
### What does this PR do?

Fix empty log from container that shows up as \\n

### Motivation

bug fix

