### PR TITLE
[serializer] enable stream serialization by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,7 +179,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	config.BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})
 	// Serializer
-	config.BindEnvAndSetDefault("enable_stream_payload_serialization", false)
+	config.BindEnvAndSetDefault("enable_stream_payload_serialization", true)
 	config.BindEnvAndSetDefault("use_v2_api.series", false)
 	config.BindEnvAndSetDefault("use_v2_api.events", false)
 	config.BindEnvAndSetDefault("use_v2_api.service_checks", false)

--- a/releasenotes/notes/stream-serialization-24b820b6244f2339.yaml
+++ b/releasenotes/notes/stream-serialization-24b820b6244f2339.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improved memory efficiency on hosts sending very high numbers of metrics.


### PR DESCRIPTION
### What does this PR do

Enable #2665 by default.

### Motivation

This was tested on our infra in 6.10. It's now considered stable and will get released in 6.11.