### PR TITLE
[Logs]: Detect and handle Docker logs with only header and empty content

### DIFF
--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -23,6 +23,9 @@ const dockerHeaderLength = 8
 // https://github.com/moby/moby/blob/master/daemon/logger/copier.go#L19-L22
 const dockerBufferSize = 16 * 1024
 
+// Escaped CRLF, used for determine empty messages
+var escapedCRLF = []byte{'\\', 'r', '\\', 'n'}
+
 // dockerParser is the parser for stdout/stderr docker logs
 var dockerParser *parser
 
@@ -65,10 +68,11 @@ func (p *parser) Parse(msg []byte) (*message.Message, error) {
 
 	// timestamp goes till first space
 	idx := bytes.Index(msg, []byte{' '})
-	if idx == -1 {
+	if idx == -1 || isEmptyMessage(msg[idx+1:]) {
 		// Nothing after the timestamp: empty message
 		return &message.Message{}, nil
 	}
+
 	parsedMsg := message.NewMessage(msg[idx+1:], nil, status)
 	parsedMsg.Timestamp = string(msg[:idx])
 	return parsedMsg, nil
@@ -138,4 +142,16 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// test if the entire message is in the form of escaped new line
+// i.e. \\n  or \\r or \\r\\n
+func isEmptyMessage(content []byte) bool {
+	if len(content) == 2 && content[0] == '\\' {
+		switch content[1] {
+		case 'n', 'r':
+			return true
+		}
+	}
+	return bytes.Equal(content, escapedCRLF)
 }

--- a/pkg/logs/input/docker/parser_test.go
+++ b/pkg/logs/input/docker/parser_test.go
@@ -39,6 +39,17 @@ func TestDockerStandaloneParserShouldHandleEmptyMessage(t *testing.T) {
 	assert.Equal(t, 0, len(msg.Content))
 }
 
+func TestDockerStandaloneParserShouldHandleNewlineOnlyMessage(t *testing.T) {
+	parser := dockerParser
+	emptyContent := [3]string{"\\n", "\\r", "\\r\\n"}
+
+	for _, em := range emptyContent {
+		msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z " + em))
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(msg.Content))
+	}
+}
+
 func TestDockerStandaloneParserShouldHandleTtyMessage(t *testing.T) {
 	parser := dockerParser
 	msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z foo"))

--- a/releasenotes/notes/logs-fix-docker-empty-log-content-7e3045cea1be5be7.yaml
+++ b/releasenotes/notes/logs-fix-docker-empty-log-content-7e3045cea1be5be7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Detect and handle Docker logs with only header and empty content


### PR DESCRIPTION
### What does this PR do?

Bug fix: docker logs with proper headers but only "\\n" as content will be treated as empty logs

### Motivation

