### PR TITLE
Avoid loading stuff into memory to generate a flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -509,11 +510,6 @@ func zipStackTraces(tempDir, hostname string) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
 	f := filepath.Join(tempDir, hostname, routineDumpFilename)
 	err = ensureParentDirsExist(f)
 	if err != nil {
@@ -526,7 +522,8 @@ func zipStackTraces(tempDir, hostname string) error {
 	}
 	defer w.Close()
 
-	_, err = w.Write(body)
+	_, err = io.Copy(w, resp.Body)
+
 	return err
 }
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -495,7 +495,7 @@ func zipHealth(tempDir, hostname string) error {
 }
 
 func zipStackTraces(tempDir, hostname string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
 
 	client := http.Client{}

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -32,6 +32,7 @@ type flareResponse struct {
 // SendFlareWithHostname sends a flare with a set hostname
 func SendFlareWithHostname(archivePath string, caseID string, email string, hostname string) (string, error) {
 	bodyReader, bodyWriter := io.Pipe()
+	defer bodyReader.Close()
 	writer := multipart.NewWriter(bodyWriter)
 
 	//Write stuff to the pipe will block until it is read from the other end, so we don't load everything in memory

--- a/pkg/flare/writer.go
+++ b/pkg/flare/writer.go
@@ -8,6 +8,7 @@ package flare
 import (
 	"bufio"
 	"errors"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -95,7 +96,11 @@ func (f *RedactingWriter) Write(p []byte) (int, error) {
 		n, err = f.target.Write(cleaned)
 	}
 
-	return n, err
+	if n != len(cleaned) {
+		err = io.ErrShortWrite
+	}
+
+	return len(p), err
 }
 
 //Truncate truncates the file of the target file to the specified size

--- a/pkg/flare/writer_test.go
+++ b/pkg/flare/writer_test.go
@@ -42,7 +42,7 @@ log_level: info`
 	assert.Nil(t, err)
 	err = w.Flush()
 	assert.Nil(t, err)
-	assert.Equal(t, len(redacted), n)
+	assert.Equal(t, len(input), n)
 	assert.Equal(t, redacted, buf.String())
 
 }
@@ -74,7 +74,7 @@ instances:
 	assert.Nil(t, err)
 	err = w.Flush()
 	assert.Nil(t, err)
-	assert.Equal(t, len(redacted), n)
+	assert.Equal(t, len(clear), n)
 	assert.Equal(t, redacted, buf.String())
 }
 
@@ -108,7 +108,7 @@ log_level: info`
 	assert.Nil(t, err)
 	err = w.Flush()
 	assert.Nil(t, err)
-	assert.Equal(t, len(redacted), n)
+	assert.Equal(t, len(input), n)
 	assert.Equal(t, redacted, buf.String())
 
 }

--- a/releasenotes/notes/reduce-flare-memory-f1675ec7c523e714.yaml
+++ b/releasenotes/notes/reduce-flare-memory-f1675ec7c523e714.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Reduced memory usage of the flare command


### PR DESCRIPTION
### What does this PR do?

I identified a couple places where we were loading potentially big files into memory and rewrote them so this is not the case anymore.

### Motivation

Creating a flare shouldn't fail if the system is low on memory.
