### PR TITLE
[agent-gui] Fix variable declaration

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -195,7 +195,7 @@
 
         <span class="warning stat_subtitle">Errors</span>
         <span class="stat_subdata">
-        {{- range error := .errors }}
+        {{- range $error := .errors }}
           {{ $error }}</br>
         {{- end }}
         </span>


### PR DESCRIPTION
### What does this PR do?

Fixes the template for the agent gui webpage.

### Motivation

Was getting:
```
Error generating status html: template: generalStatus.tmpl:198: function "error" not defined
```

