### PR TITLE
Added agent uptime to status log and status gui

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -7,6 +7,7 @@
       {{- if .runnerStats.Workers}}
         <br>Check Workers: {{.runnerStats.Workers}}
       {{end}}
+      <br>Agent uptime: {{.agent_uptime}}
       <br>Log File: {{.config.log_file}}
       <br>Log Level: {{.config.log_level}}
       <br>Config File: {{if .conf_file}}{{.conf_file}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -7,7 +7,7 @@
       {{- if .runnerStats.Workers}}
         <br>Check Workers: {{.runnerStats.Workers}}
       {{end}}
-      <br>Agent uptime: {{.agent_uptime}}
+      <br>Agent start: {{.agent_start}}
       <br>Log File: {{.config.log_file}}
       <br>Log Level: {{.config.log_level}}
       <br>Config File: {{if .conf_file}}{{.conf_file}}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -6,6 +6,7 @@ NOTE: Changes made to this template should be reflected on the following templat
 {{printDashes .title "="}}
 
   Status date: {{.time}}
+  Agent start: {{.agent_start}}
   Pid: {{.pid}}
   {{- if .python_version }}
   Python Version: {{.python_version}}
@@ -13,7 +14,6 @@ NOTE: Changes made to this template should be reflected on the following templat
   {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers}}
   {{end -}}
-  Agent uptime: {{.agent_uptime}}
   Log file: {{.config.log_file}}
   Log Level: {{.config.log_level}}
 

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -10,10 +10,11 @@ NOTE: Changes made to this template should be reflected on the following templat
   {{- if .python_version }}
   Python Version: {{.python_version}}
   {{- end }}
-  Logs: {{.config.log_file}}
   {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers}}
   {{end -}}
+  Agent uptime: {{.agent_uptime}}
+  Log file: {{.config.log_file}}
   Log Level: {{.config.log_level}}
 
   Paths

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -8,6 +8,7 @@ package status
 import (
 	"encoding/json"
 	"expvar"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -26,7 +27,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
+var startTime = time.Now()
 var timeFormat = "2006-01-02 15:04:05.000000 MST"
+
+// FormatUptime formats a duration into a human-readable, uptime-like string
+func FormatUptime(d time.Duration) string {
+	seconds := int(d.Seconds())
+	minutes := int(seconds / 60)
+	seconds -= minutes * 60
+	hours := int(minutes / 60)
+	minutes -= hours * 60
+	days := hours / 24
+	hours -= days * 24
+	return fmt.Sprintf("%d days %02d:%02d:%02d", int(days), int(hours), int(minutes), int(seconds))
+}
 
 // GetStatus grabs the status from expvar and puts it into a map
 func GetStatus() (map[string]interface{}, error) {
@@ -55,6 +69,8 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["pid"] = os.Getpid()
 	pythonVersion := host.GetPythonVersion()
 	stats["python_version"] = strings.Split(pythonVersion, " ")[0]
+	uptime := time.Since(startTime)
+	stats["agent_uptime"] = FormatUptime(uptime)
 	stats["platform"] = platformPayload
 	stats["hostinfo"] = host.GetStatusInformation()
 	now := time.Now()

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -8,7 +8,6 @@ package status
 import (
 	"encoding/json"
 	"expvar"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -29,18 +28,6 @@ import (
 
 var startTime = time.Now()
 var timeFormat = "2006-01-02 15:04:05.000000 MST"
-
-// FormatUptime formats a duration into a human-readable, uptime-like string
-func FormatUptime(d time.Duration) string {
-	seconds := int(d.Seconds())
-	minutes := int(seconds / 60)
-	seconds -= minutes * 60
-	hours := int(minutes / 60)
-	minutes -= hours * 60
-	days := hours / 24
-	hours -= days * 24
-	return fmt.Sprintf("%d days %02d:%02d:%02d", int(days), int(hours), int(minutes), int(seconds))
-}
 
 // GetStatus grabs the status from expvar and puts it into a map
 func GetStatus() (map[string]interface{}, error) {
@@ -69,8 +56,7 @@ func GetStatus() (map[string]interface{}, error) {
 	stats["pid"] = os.Getpid()
 	pythonVersion := host.GetPythonVersion()
 	stats["python_version"] = strings.Split(pythonVersion, " ")[0]
-	uptime := time.Since(startTime)
-	stats["agent_uptime"] = FormatUptime(uptime)
+	stats["agent_start"] = startTime.Format(timeFormat)
 	stats["platform"] = platformPayload
 	stats["hostinfo"] = host.GetStatusInformation()
 	now := time.Now()


### PR DESCRIPTION
### What does this PR do?

Adds the agent uptime to the status log and status gui

### Motivation

While using a flare, if the log files have already rotated, you can't easily get the Agent uptime, which could be helpful to debug a problem.
