### PR TITLE
support a common variant of the json mime type

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -421,6 +421,8 @@ func decodeReceiverPayload(r io.Reader, dest msgp.Decodable, v Version, contentT
 
 	case "application/json":
 		fallthrough
+	case "application/json;charset=utf-8":
+		fallthrough
 	case "text/json":
 		fallthrough
 	case "":


### PR DESCRIPTION
### What does this PR do?

Supports a common variant of the json mime type.

### Motivation

The agent is unable to accept payloads from many programming languages and frameworks without this fix.

### Additional Notes

This fixes #3172 