### PR TITLE
pkg/trace/api: ensure media-type gets extracted correctly

### DIFF
--- a/releasenotes/notes/apm-api-media-type-c5da70310a886488.yaml
+++ b/releasenotes/notes/apm-api-media-type-c5da70310a886488.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Multiple value "Content-Type" headers are now parsed correctly
+    for media type in the HTTP receiver.


### PR DESCRIPTION
This change ensures that media type gets parsed correctly in the
"Content-Type" header. Previously having a header with the (correct)
value "application/json;charset=utf-8" would fail to be parsed
correctly.

Updates #3172 