### PR TITLE
add presto to jmxchecks struct

### DIFF
--- a/pkg/collector/check/jmx.go
+++ b/pkg/collector/check/jmx.go
@@ -20,6 +20,7 @@ var JMXChecks = map[string]struct{}{
 	"solr":        {},
 	"tomcat":      {},
 	"kafka":       {},
+	"presto":      {},
 }
 
 // IsJMXConfig checks if a certain YAML config is a JMX config

--- a/releasenotes/notes/update-jmxchecks-list-with-presto-check-d4008157706cc069.yaml
+++ b/releasenotes/notes/update-jmxchecks-list-with-presto-check-d4008157706cc069.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add Presto check to list of default JMXChecks.


### PR DESCRIPTION
### What does this PR do?

This PR adds Presto as one of the OOTB JMX checks.

### Motivation

- New JMX check, [Presto](https://github.com/DataDog/integrations-core/tree/master/presto)
- Maintain a safe-guard against a user failing to enable `is_jmx: true` in the check's [`conf.yaml`](https://github.com/DataDog/integrations-core/blob/master/presto/datadog_checks/presto/data/conf.yaml.example#L6). 

### Additional Notes

Anything else we should know when reviewing?
