### PR TITLE
No longer decrypt secret in commands when it's not needed

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -29,7 +29,7 @@ var configCommand = &cobra.Command{
 	Short: "Print the runtime configuration of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/dogstatsd_stats.go
+++ b/cmd/agent/app/dogstatsd_stats.go
@@ -36,7 +36,7 @@ var dogstatsdStatsCmd = &cobra.Command{
 	Short: "Print basic statistics on the metrics processed by dogstatsd",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -31,7 +31,7 @@ var healthCmd = &cobra.Command{
 	Long:         ``,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -28,7 +28,7 @@ var getHostnameCommand = &cobra.Command{
 // query for the version
 func doGetHostname(cmd *cobra.Command, args []string) error {
 	config.SetupLogger("off", "", "", false, true, false)
-	err := common.SetupConfig(confFilePath)
+	err := common.SetupConfigWithoutSecrets(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func launchGui(cmd *cobra.Command, args []string) error {
-	err := common.SetupConfig(confFilePath)
+	err := common.SetupConfigWithoutSecrets(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/listchecks.go
+++ b/cmd/agent/app/listchecks.go
@@ -24,7 +24,7 @@ var listCheckCommand = &cobra.Command{
 	Short: "Query the agent for the list of checks running",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/reloadcheck.go
+++ b/cmd/agent/app/reloadcheck.go
@@ -34,7 +34,7 @@ var reloadCheckCommand = &cobra.Command{
 			return fmt.Errorf("missing arguments")
 		}
 
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/secret.go
+++ b/cmd/agent/app/secret.go
@@ -28,7 +28,7 @@ var secretInfoCommand = &cobra.Command{
 	Short: "Print information about decrypted secrets in configuration.",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := common.SetupConfig(confFilePath); err != nil {
+		if err := common.SetupConfigWithoutSecrets(confFilePath); err != nil {
 			fmt.Printf("unable to set up global agent configuration: %v", err)
 			return nil
 		}

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -38,7 +38,7 @@ var statusCmd = &cobra.Command{
 	Short: "Print the current status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -33,7 +33,7 @@ func init() {
 
 func stop(*cobra.Command, []string) error {
 	// Global Agent configuration
-	err := common.SetupConfig(confFilePath)
+	err := common.SetupConfigWithoutSecrets(confFilePath)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -30,7 +30,7 @@ var taggerListCommand = &cobra.Command{
 	Short: "Print the tagger content of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfigWithoutSecrets(confFilePath)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -153,7 +153,7 @@ func ImportRegistryConfig() error {
 	}
 	defer k.Close()
 
-	err = SetupConfig("")
+	err = SetupConfigWithoutSecrets("")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
@@ -285,7 +285,7 @@ func ImportRegistryConfig() error {
 	config.SetOverrides(overrides)
 
 	// build the global agent configuration
-	err = SetupConfig("")
+	err = SetupConfigWithoutSecrets("")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -14,6 +14,15 @@ import (
 
 // SetupConfig fires up the configuration system
 func SetupConfig(confFilePath string) error {
+	return setupConfig(confFilePath, false)
+}
+
+// SetupConfigWithoutSecrets fires up the configuration system without secrets support
+func SetupConfigWithoutSecrets(confFilePath string) error {
+	return setupConfig(confFilePath, true)
+}
+
+func setupConfig(confFilePath string, withoutSecrets bool) error {
 	// set the paths where a config file is expected
 	if len(confFilePath) != 0 {
 		// if the configuration file path was supplied on the command line,
@@ -26,7 +35,12 @@ func SetupConfig(confFilePath string) error {
 	}
 	config.Datadog.AddConfigPath(DefaultConfPath)
 	// load the configuration
-	err := config.Load()
+	var err error
+	if withoutSecrets {
+		err = config.LoadWithoutSecret()
+	} else {
+		err = config.Load()
+	}
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}

--- a/cmd/systray/doconfigure.go
+++ b/cmd/systray/doconfigure.go
@@ -35,7 +35,7 @@ func onConfigure() {
 }
 func doConfigure() error {
 
-	err := common.SetupConfig("")
+	err := common.SetupConfigWithoutSecrets("")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -477,10 +477,15 @@ func loadProxyFromEnv(config Config) {
 
 // Load reads configs files and initializes the config module
 func Load() error {
-	return load(Datadog, "datadog.yaml")
+	return load(Datadog, "datadog.yaml", true)
 }
 
-func load(config Config, origin string) error {
+// LoadWithoutSecret reads configs files, initializes the config module without decrypting any secrets
+func LoadWithoutSecret() error {
+	return load(Datadog, "datadog.yaml", false)
+}
+
+func load(config Config, origin string, loadSecret bool) error {
 	log.Infof("config.Load()")
 	if err := config.ReadInConfig(); err != nil {
 		log.Warnf("config.load() error %v", err)
@@ -488,32 +493,34 @@ func load(config Config, origin string) error {
 	}
 	log.Infof("config.load succeeded")
 
-	// We have to init the secrets package before we can use it to decrypt
-	// anything.
-	secrets.Init(
-		config.GetString("secret_backend_command"),
-		config.GetStringSlice("secret_backend_arguments"),
-		config.GetInt("secret_backend_timeout"),
-		config.GetInt("secret_backend_output_max_size"),
-	)
+	if loadSecret {
+		// We have to init the secrets package before we can use it to decrypt
+		// anything.
+		secrets.Init(
+			config.GetString("secret_backend_command"),
+			config.GetStringSlice("secret_backend_arguments"),
+			config.GetInt("secret_backend_timeout"),
+			config.GetInt("secret_backend_output_max_size"),
+		)
 
-	if config.GetString("secret_backend_command") != "" {
-		// Viper doesn't expose the final location of the file it
-		// loads. Since we are searching for 'datadog.yaml' in multiple
-		// locations we let viper determine the one to use before
-		// updating it.
-		yamlConf, err := yaml.Marshal(config.AllSettings())
-		if err != nil {
-			return fmt.Errorf("unable to marshal configuration to YAML to decrypt secrets: %v", err)
-		}
+		if config.GetString("secret_backend_command") != "" {
+			// Viper doesn't expose the final location of the file it
+			// loads. Since we are searching for 'datadog.yaml' in multiple
+			// locations we let viper determine the one to use before
+			// updating it.
+			yamlConf, err := yaml.Marshal(config.AllSettings())
+			if err != nil {
+				return fmt.Errorf("unable to marshal configuration to YAML to decrypt secrets: %v", err)
+			}
 
-		finalYamlConf, err := secrets.Decrypt(yamlConf, origin)
-		if err != nil {
-			return fmt.Errorf("unable to decrypt secret from datadog.yaml: %v", err)
-		}
-		r := bytes.NewReader(finalYamlConf)
-		if err = config.MergeConfigOverride(r); err != nil {
-			return fmt.Errorf("could not update main configuration after decrypting secrets: %v", err)
+			finalYamlConf, err := secrets.Decrypt(yamlConf, origin)
+			if err != nil {
+				return fmt.Errorf("unable to decrypt secret from datadog.yaml: %v", err)
+			}
+			r := bytes.NewReader(finalYamlConf)
+			if err = config.MergeConfigOverride(r); err != nil {
+				return fmt.Errorf("could not update main configuration after decrypting secrets: %v", err)
+			}
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -604,7 +604,7 @@ func TestSecretBackendWithMultipleEndpoints(t *testing.T) {
 	conf := setupConf()
 	conf.SetConfigFile("./tests/datadog_secrets.yaml")
 	// load the configuration
-	err := load(conf, "datadog_secrets.yaml")
+	err := load(conf, "datadog_secrets.yaml", true)
 	assert.NoError(t, err)
 
 	expectedKeysPerDomain := map[string][]string{

--- a/releasenotes/notes/no-secret-in-simple-command-03d2636e39fbac31.yaml
+++ b/releasenotes/notes/no-secret-in-simple-command-03d2636e39fbac31.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    Secrets are no longer decrypted in agent command when it's not needed
+    (commands like hostname, launchgui, configuration ...). This reduce the
+    number of times the 'secret_command_backend' executable will be called.


### PR DESCRIPTION
### What does this PR do?

Secrets are no longer decrypted in agent command when it's not needed
(commands like hostname, launchgui, configuration ...). This reduce the
number the number of times the 'secret_command_backend' executable will be
called.
