### PR TITLE
[Logs]: Change to a randomized exponential backoff in case of connection failure

### DIFF
--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -144,7 +144,7 @@ func min(a, b int) int {
 	return b
 }
 
-// test if the entire message is in the form of escaped new line
+// isEmptyMessage tests if the entire message is in the form of escaped new line
 // i.e. \\n  or \\r or \\r\\n
 func isEmptyMessage(content []byte) bool {
 	if len(content) == 2 && content[0] == '\\' {

--- a/releasenotes/notes/logs-fix-backoff-duration-cf5d6257025c7a67.yaml
+++ b/releasenotes/notes/logs-fix-backoff-duration-cf5d6257025c7a67.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Change to a randomized exponential backoff in case of connection failure


### PR DESCRIPTION
### What does this PR do?

Change the backoff duration to increase exponentially based on the number of retries.

### Motivation

When there is a sustained server side failure, agent's repeated connection attempts can create loads on the infrastructure.  Exponential backoff helps spacing out the load.


