### PR TITLE
pkg/trace/api: fix content-type header in response

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -204,7 +204,7 @@ func (r *HTTPReceiver) replyTraces(v Version, w http.ResponseWriter) {
 		httpOK(w)
 	case v04:
 		// Return the recommended sampling rate for each service as a JSON.
-		HTTPRateByService(w, r.dynConf)
+		httpRateByService(w, r.dynConf)
 	}
 }
 

--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -61,9 +61,9 @@ func httpOK(w http.ResponseWriter) {
 	io.WriteString(w, "OK\n")
 }
 
-// HTTPRateByService outputs, as a JSON, the recommended sampling rates for all services.
-func HTTPRateByService(w http.ResponseWriter, dynConf *sampler.DynamicConfig) {
-	w.WriteHeader(http.StatusOK)
+// httpRateByService outputs, as a JSON, the recommended sampling rates for all services.
+func httpRateByService(w http.ResponseWriter, dynConf *sampler.DynamicConfig) {
+	w.Header().Set("Content-Type", "application/json")
 	response := traceResponse{
 		Rates: dynConf.RateByService.GetAll(), // this is thread-safe
 	}

--- a/releasenotes/notes/apm-api-response-content-type-d2401b456be2fba3.yaml
+++ b/releasenotes/notes/apm-api-response-content-type-d2401b456be2fba3.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: always reply with correct Content-Type in API responses.


### PR DESCRIPTION
Fixes an issue brought forward in #3207. Agent was sometimes replying with media type `text/plain` when sending JSON.