### PR TITLE
pkg/trace/agent: add stream decoder

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -131,10 +132,20 @@ func (a *Agent) Run() {
 	a.PrioritySampler.Run()
 	a.EventProcessor.Start()
 
+	ts := a.Receiver.Stats.GetTagStats(info.Tags{})
+
 	for {
 		select {
 		case t := <-a.Receiver.Out:
-			a.Process(t)
+			err := api.NormalizeTrace(t)
+			if err != nil {
+				atomic.AddInt64(&ts.TracesDropped, 1)
+				atomic.AddInt64(&ts.SpansDropped, int64(len(t)))
+
+				log.Errorf(fmt.Sprintf("dropping trace; reason: %s", err))
+			} else {
+				a.Process(t)
+			}
 		case <-watchdogTicker.C:
 			a.watchdog()
 		case <-a.ctx.Done():

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -617,7 +617,7 @@ func benchThroughput(file string) func(*testing.B) {
 
 		// start the agent without the trace writer; we will be draining
 		// the write channel ourselves in the benchmarks.
-		startAgentWithoutTraceWriter(ctx, b, agnt)
+		startMinimalAgent(ctx, b, agnt)
 
 		// drain every other channel to avoid blockage.
 		exit := make(chan bool)
@@ -679,12 +679,8 @@ func benchThroughput(file string) func(*testing.B) {
 
 // startAgentWithoutTraceWriter starts everything in the given agent except the trace writer.
 // It is used in benchmarks where the benchmark awaits on the trace writer channel.
-func startAgentWithoutTraceWriter(ctx context.Context, b *testing.B, agnt *Agent) {
+func startMinimalAgent(ctx context.Context, b *testing.B, agnt *Agent) {
 	agnt.Receiver.Run()
-	agnt.StatsWriter.Start()
-	agnt.ServiceMapper.Start()
-	agnt.ServiceWriter.Start()
-	agnt.Concentrator.Start()
 	agnt.ScoreSampler.Run()
 	agnt.ErrorsScoreSampler.Run()
 	agnt.PrioritySampler.Run()
@@ -699,10 +695,6 @@ func startAgentWithoutTraceWriter(ctx context.Context, b *testing.B, agnt *Agent
 				if err := agnt.Receiver.Stop(); err != nil {
 					b.Fatal(err)
 				}
-				agnt.Concentrator.Stop()
-				agnt.StatsWriter.Stop()
-				agnt.ServiceMapper.Stop()
-				agnt.ServiceWriter.Stop()
 				agnt.ScoreSampler.Stop()
 				agnt.ErrorsScoreSampler.Stop()
 				agnt.PrioritySampler.Stop()

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1,28 +1,33 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/event"
-	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	"github.com/cihub/seelog"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/event"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+	"github.com/tinylib/msgp/msgp"
 )
 
 type mockSamplerEngine struct {
@@ -580,4 +585,166 @@ func formatTrace(t pb.Trace) pb.Trace {
 		Truncate(span)
 	}
 	return t
+}
+
+func BenchmarkThroughput(b *testing.B) {
+	if _, ok := os.LookupEnv("DD_TRACE_TEST_PRIVATE_DATA"); !ok {
+		b.SkipNow()
+	}
+
+	ddlog.SetupDatadogLogger(seelog.Disabled, "") // disable logging
+
+	b.Run("39KB/10", benchThroughput("src/github.com/DataDog/trace-agent-test/payloads/10traces.msgp"))
+	b.Run("1.1MB/100", benchThroughput("src/github.com/DataDog/trace-agent-test/payloads/100traces.msgp"))
+	b.Run("1.1MB/1951", benchThroughput("src/github.com/DataDog/trace-agent-test/payloads/26.msgp"))
+	b.Run("2.2MB/4161", benchThroughput("src/github.com/DataDog/trace-agent-test/payloads/10.msgp"))
+	b.Run("6.6MB/500", benchThroughput("src/github.com/DataDog/trace-agent-test/payloads/500traces.msgp"))
+}
+
+func benchThroughput(file string) func(*testing.B) {
+	return func(b *testing.B) {
+		data, count, err := tracesFromFile(file)
+		if err != nil {
+			b.Fatal(err)
+		}
+		cfg := config.New()
+		cfg.Endpoints[0].APIKey = "irrelevant"
+
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		http.DefaultServeMux = &http.ServeMux{}
+		agnt := NewAgent(ctx, cfg)
+		defer cancelFunc()
+
+		// start the agent without the trace writer; we will be draining
+		// the write channel ourselves in the benchmarks.
+		startAgentWithoutTraceWriter(ctx, b, agnt)
+
+		// drain every other channel to avoid blockage.
+		exit := make(chan bool)
+		go func() {
+			defer close(exit)
+			for {
+				select {
+				case <-agnt.ServiceExtractor.outServices:
+				case <-agnt.Concentrator.OutStats:
+				case <-exit:
+					return
+				}
+			}
+		}()
+
+		b.ResetTimer()
+		b.SetBytes(int64(len(data)))
+
+		for i := 0; i < b.N; i++ {
+			req, err := http.NewRequest("PUT", "http://localhost:8126/v0.4/traces", bytes.NewReader(data))
+			if err != nil {
+				b.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/msgpack")
+			w := httptest.NewRecorder()
+
+			// create the request by calling directly into the Handler;
+			// we are not interested in benchmarking HTTP latency. This
+			// also ensures we avoid potential connection failures that
+			// would make the benchmarks inconsistent.
+			http.DefaultServeMux.ServeHTTP(w, req)
+			if w.Code != 200 {
+				b.Fatalf("%d: %v", i, w.Body.String())
+			}
+
+			var got int
+			timeout := time.After(1 * time.Second)
+		loop:
+			for {
+				select {
+				case <-agnt.tracePkgChan:
+					got++
+					if got == count {
+						// processed everything!
+						break loop
+					}
+				case <-timeout:
+					// taking too long...
+					b.Fatalf("time out at %d/%d", got, count)
+					break loop
+				}
+			}
+		}
+
+		exit <- true
+		<-exit
+	}
+}
+
+// startAgentWithoutTraceWriter starts everything in the given agent except the trace writer.
+// It is used in benchmarks where the benchmark awaits on the trace writer channel.
+func startAgentWithoutTraceWriter(ctx context.Context, b *testing.B, agnt *Agent) {
+	agnt.Receiver.Run()
+	agnt.StatsWriter.Start()
+	agnt.ServiceMapper.Start()
+	agnt.ServiceWriter.Start()
+	agnt.Concentrator.Start()
+	agnt.ScoreSampler.Run()
+	agnt.ErrorsScoreSampler.Run()
+	agnt.PrioritySampler.Run()
+	agnt.EventProcessor.Start()
+
+	go func() {
+		for {
+			select {
+			case t := <-agnt.Receiver.Out:
+				agnt.Process(t)
+			case <-agnt.ctx.Done():
+				if err := agnt.Receiver.Stop(); err != nil {
+					b.Fatal(err)
+				}
+				agnt.Concentrator.Stop()
+				agnt.StatsWriter.Stop()
+				agnt.ServiceMapper.Stop()
+				agnt.ServiceWriter.Stop()
+				agnt.ScoreSampler.Stop()
+				agnt.ErrorsScoreSampler.Stop()
+				agnt.PrioritySampler.Stop()
+				agnt.EventProcessor.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// tracesFromFile extracts raw msgpack data from the given file, modifying each trace
+// to have sampling.priority=2 to guarantee consistency. It also returns the amount of
+// traces found and any error in obtaining the information.
+func tracesFromFile(file string) (raw []byte, count int, err error) {
+	if file[0] != '/' {
+		file = filepath.Join(os.Getenv("GOPATH"), file)
+	}
+	in, err := os.Open(file)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer in.Close()
+	// prepare the traces in this file by adding sampling.priority=2
+	// everywhere to ensure consistent sampling assumptions and results.
+	var traces pb.Traces
+	if err := msgp.Decode(in, &traces); err != nil {
+		return nil, 0, err
+	}
+	for _, t := range traces {
+		count++
+		for _, s := range t {
+			if s.Metrics == nil {
+				s.Metrics = map[string]float64{"_sampling_priority_v1": 2}
+			} else {
+				s.Metrics["_sampling_priority_v1"] = 2
+			}
+		}
+	}
+	// re-encode the modified payload
+	var data bytes.Buffer
+	if err := msgp.Encode(&data, traces); err != nil {
+		return nil, 0, err
+	}
+	return data.Bytes(), count, nil
 }

--- a/pkg/trace/agent/service.go
+++ b/pkg/trace/agent/service.go
@@ -119,11 +119,11 @@ const appType = "app_type"
 
 // TraceServiceExtractor extracts service metadata from top-level spans
 type TraceServiceExtractor struct {
-	outServices chan<- pb.ServicesMetadata
+	outServices chan pb.ServicesMetadata
 }
 
 // NewTraceServiceExtractor returns a new TraceServiceExtractor
-func NewTraceServiceExtractor(out chan<- pb.ServicesMetadata) *TraceServiceExtractor {
+func NewTraceServiceExtractor(out chan pb.ServicesMetadata) *TraceServiceExtractor {
 	return &TraceServiceExtractor{out}
 }
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -229,21 +229,21 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		for trace := range decodeTraces(w, req, v) {
 			r.sendTrace(ts, trace)
 		}
+		r.replyTraces(v, w)
 	default:
 		traces, ok := getTraces(v, w, req)
 		if !ok {
 			return
 		}
+		r.replyTraces(v, w)
 		for _, trace := range traces {
 			r.sendTrace(ts, trace)
 		}
 	}
-
 	bytesRead := req.Body.(*LimitedReader).Count
 	if bytesRead > 0 {
 		atomic.AddInt64(&ts.TracesBytes, int64(bytesRead))
 	}
-	r.replyTraces(v, w)
 }
 
 func (r *HTTPReceiver) sendTrace(ts *info.TagStats, trace pb.Trace) {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -96,7 +96,7 @@ func NewHTTPReceiver(
 
 // Run starts doing the HTTP server and is ready to receive traces
 func (r *HTTPReceiver) Run() {
-	// FIXME[1.x]: remove all those legacy endpoints + code that goes with it
+	// TODO(gbbr): Do not use http.DefaultServeMux!
 	http.HandleFunc("/spans", r.httpHandleWithVersion(v01, r.handleTraces))
 	http.HandleFunc("/services", r.httpHandleWithVersion(v01, r.handleServices))
 	http.HandleFunc("/v0.1/spans", r.httpHandleWithVersion(v01, r.handleTraces))

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -200,10 +201,8 @@ func (r *HTTPReceiver) replyTraces(v Version, w http.ResponseWriter) {
 	case v02:
 		fallthrough
 	case v03:
-		// Simple response, simply acknowledge with "OK"
 		httpOK(w)
 	case v04:
-		// Return the recommended sampling rate for each service as a JSON.
 		httpRateByService(w, r.dynConf)
 	}
 }
@@ -216,62 +215,81 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		return
 	}
 
-	traces, ok := getTraces(v, w, req)
-	if !ok {
-		return
-	}
-
-	// We successfully decoded the payload
-	r.replyTraces(v, w)
-
-	// We parse the tags from the header
-	tags := info.Tags{
+	ts := r.Stats.GetTagStats(info.Tags{
 		Lang:          req.Header.Get("Datadog-Meta-Lang"),
 		LangVersion:   req.Header.Get("Datadog-Meta-Lang-Version"),
 		Interpreter:   req.Header.Get("Datadog-Meta-Lang-Interpreter"),
 		TracerVersion: req.Header.Get("Datadog-Meta-Tracer-Version"),
-	}
+	})
 
-	// We get the address of the struct holding the stats associated to the tags
-	ts := r.Stats.GetTagStats(tags)
+	mediaType := getMediaType(req)
+	switch mediaType {
+	case "application/msgpack":
+		// process sequentially as we decode
+		for trace := range decodeTraces(w, req, v) {
+			r.sendTrace(ts, trace)
+		}
+	default:
+		traces, ok := getTraces(v, w, req)
+		if !ok {
+			return
+		}
+		for _, trace := range traces {
+			r.sendTrace(ts, trace)
+		}
+	}
 
 	bytesRead := req.Body.(*LimitedReader).Count
 	if bytesRead > 0 {
 		atomic.AddInt64(&ts.TracesBytes, int64(bytesRead))
 	}
+	r.replyTraces(v, w)
+}
 
-	// normalize data
-	for _, trace := range traces {
-		spans := len(trace)
+func (r *HTTPReceiver) sendTrace(ts *info.TagStats, trace pb.Trace) {
+	atomic.AddInt64(&ts.TracesReceived, 1)
+	atomic.AddInt64(&ts.SpansReceived, int64(len(trace)))
 
-		atomic.AddInt64(&ts.TracesReceived, 1)
-		atomic.AddInt64(&ts.SpansReceived, int64(spans))
+	select {
+	case r.Out <- trace:
+		// OK
+	default:
+		atomic.AddInt64(&ts.TracesDropped, 1)
+		atomic.AddInt64(&ts.SpansDropped, int64(len(trace)))
 
-		err := normalizeTrace(trace)
-		if err != nil {
-			atomic.AddInt64(&ts.TracesDropped, 1)
-			atomic.AddInt64(&ts.SpansDropped, int64(spans))
-
-			msg := fmt.Sprintf("dropping trace; reason: %s", err)
-			if len(msg) > 150 && !r.debug {
-				// we're not in DEBUG log level, truncate long messages.
-				msg = msg[:150] + "... (set DEBUG log level for more info)"
-			}
-			log.Errorf(msg)
-		} else {
-			select {
-			case r.Out <- trace:
-				// if our downstream consumer is slow, we drop the trace on the floor
-				// this is a safety net against us using too much memory
-				// when clients flood us
-			default:
-				atomic.AddInt64(&ts.TracesDropped, 1)
-				atomic.AddInt64(&ts.SpansDropped, int64(spans))
-
-				log.Errorf("dropping trace; reason: rate-limited")
-			}
-		}
+		log.Errorf("dropping trace; reason: rate-limited")
 	}
+}
+
+// decodeTraces decodes traces one by one from the given http.Request and sends them via
+// the returned channel. When it completes, it closes the channel. Any potential error
+// will be written to the http.ResponseWriter and the channel closed prematurely.
+func decodeTraces(w http.ResponseWriter, req *http.Request, v Version) (out chan pb.Trace) {
+	out = make(chan pb.Trace)
+	go func() {
+		var rd *msgp.Reader
+		size, err := strconv.ParseInt(req.Header.Get("Content-Length"), 10, 64)
+		if err != nil {
+			rd = msgp.NewReader(req.Body)
+		} else {
+			rd = msgp.NewReaderSize(req.Body, int(size))
+		}
+		items, err := rd.ReadArrayHeader()
+		if err != nil {
+			httpDecodingError(err, []string{tagTraceHandler, fmt.Sprintf("v:%s", v)}, w)
+			return
+		}
+		for i := uint32(0); i < items; i++ {
+			var trace pb.Trace
+			if err := trace.DecodeMsg(rd); err != nil {
+				httpDecodingError(err, []string{tagTraceHandler, fmt.Sprintf("v:%s", v)}, w)
+				return
+			}
+			out <- trace
+		}
+		close(out)
+	}()
+	return out
 }
 
 // handleServices handle a request with a list of several services

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -229,13 +229,11 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		for trace := range decodeTraces(w, req, v) {
 			r.sendTrace(ts, trace)
 		}
-		r.replyTraces(v, w)
 	default:
 		traces, ok := getTraces(v, w, req)
 		if !ok {
 			return
 		}
-		r.replyTraces(v, w)
 		for _, trace := range traces {
 			r.sendTrace(ts, trace)
 		}
@@ -244,6 +242,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	if bytesRead > 0 {
 		atomic.AddInt64(&ts.TracesBytes, int64(bytesRead))
 	}
+	r.replyTraces(v, w)
 }
 
 func (r *HTTPReceiver) sendTrace(ts *info.TagStats, trace pb.Trace) {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -145,8 +145,8 @@ func TestLegacyReceiver(t *testing.T) {
 				span := rt[0]
 				assert.Equal(uint64(42), span.TraceID)
 				assert.Equal(uint64(52), span.SpanID)
-				assert.Equal("fennel_is_amazing", span.Service)
-				assert.Equal("something_that_should_be_a_metric", span.Name)
+				assert.Equal("fennel_IS amazing!", span.Service)
+				assert.Equal("something &&<@# that should be a metric!", span.Name)
 				assert.Equal("NOT touched because it is going to be hashed", span.Resource)
 				assert.Equal("192.168.0.1", span.Meta["http.host"])
 				assert.Equal(41.99, span.Metrics["http.monitor"])
@@ -208,8 +208,8 @@ func TestReceiverJSONDecoder(t *testing.T) {
 				span := rt[0]
 				assert.Equal(uint64(42), span.TraceID)
 				assert.Equal(uint64(52), span.SpanID)
-				assert.Equal("fennel_is_amazing", span.Service)
-				assert.Equal("something_that_should_be_a_metric", span.Name)
+				assert.Equal("fennel_IS amazing!", span.Service)
+				assert.Equal("something &&<@# that should be a metric!", span.Name)
 				assert.Equal("NOT touched because it is going to be hashed", span.Resource)
 				assert.Equal("192.168.0.1", span.Meta["http.host"])
 				assert.Equal(41.99, span.Metrics["http.monitor"])
@@ -275,8 +275,8 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 					span := rt[0]
 					assert.Equal(uint64(42), span.TraceID)
 					assert.Equal(uint64(52), span.SpanID)
-					assert.Equal("fennel_is_amazing", span.Service)
-					assert.Equal("something_that_should_be_a_metric", span.Name)
+					assert.Equal("fennel_IS amazing!", span.Service)
+					assert.Equal("something &&<@# that should be a metric!", span.Name)
 					assert.Equal("NOT touched because it is going to be hashed", span.Resource)
 					assert.Equal("192.168.0.1", span.Meta["http.host"])
 					assert.Equal(41.99, span.Metrics["http.monitor"])
@@ -297,8 +297,8 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 					span := rt[0]
 					assert.Equal(uint64(42), span.TraceID)
 					assert.Equal(uint64(52), span.SpanID)
-					assert.Equal("fennel_is_amazing", span.Service)
-					assert.Equal("something_that_should_be_a_metric", span.Name)
+					assert.Equal("fennel_IS amazing!", span.Service)
+					assert.Equal("something &&<@# that should be a metric!", span.Name)
 					assert.Equal("NOT touched because it is going to be hashed", span.Resource)
 					assert.Equal("192.168.0.1", span.Meta["http.host"])
 					assert.Equal(41.99, span.Metrics["http.monitor"])

--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -127,7 +127,7 @@ func normalize(s *pb.Span) error {
 	return nil
 }
 
-// normalizeTrace takes a trace and
+// NormalizeTrace takes a trace and
 // * rejects the trace if there is a trace ID discrepancy between 2 spans
 // * rejects the trace if two spans have the same span_id
 // * rejects empty traces
@@ -135,7 +135,7 @@ func normalize(s *pb.Span) error {
 // * return the normalized trace and an error:
 //   - nil if the trace can be accepted
 //   - an error string if the trace needs to be dropped
-func normalizeTrace(t pb.Trace) error {
+func NormalizeTrace(t pb.Trace) error {
 	if len(t) == 0 {
 		return errors.New("empty trace")
 	}

--- a/pkg/trace/api/normalizer_test.go
+++ b/pkg/trace/api/normalizer_test.go
@@ -253,7 +253,7 @@ func TestSpecialZipkinRootSpan(t *testing.T) {
 func TestNormalizeTraceEmpty(t *testing.T) {
 	trace := pb.Trace{}
 
-	err := normalizeTrace(trace)
+	err := NormalizeTrace(trace)
 	assert.Error(t, err)
 }
 
@@ -266,7 +266,7 @@ func TestNormalizeTraceTraceIdMismatch(t *testing.T) {
 
 	trace := pb.Trace{span1, span2}
 
-	err := normalizeTrace(trace)
+	err := NormalizeTrace(trace)
 	assert.Error(t, err)
 }
 
@@ -278,7 +278,7 @@ func TestNormalizeTraceInvalidSpan(t *testing.T) {
 
 	trace := pb.Trace{span1, span2}
 
-	err := normalizeTrace(trace)
+	err := NormalizeTrace(trace)
 	assert.Error(t, err)
 }
 
@@ -289,7 +289,7 @@ func TestNormalizeTraceDuplicateSpanID(t *testing.T) {
 
 	trace := pb.Trace{span1, span2}
 
-	err := normalizeTrace(trace)
+	err := NormalizeTrace(trace)
 	assert.Error(t, err)
 }
 
@@ -301,7 +301,7 @@ func TestNormalizeTrace(t *testing.T) {
 
 	trace := pb.Trace{span1, span2}
 
-	err := normalizeTrace(trace)
+	err := NormalizeTrace(trace)
 	assert.NoError(t, err)
 }
 

--- a/pkg/trace/test/testutil/trace.go
+++ b/pkg/trace/test/testutil/trace.go
@@ -51,7 +51,7 @@ func genNextLevel(prevLevel []*pb.Span, maxSpans int) []*pb.Span {
 			news.Start = prev.Start + randStart
 			// random duration
 			timeLeft -= randStart
-			news.Duration = rand.Int63n(timeLeft)
+			news.Duration = rand.Int63n(timeLeft) + 1
 			timeLeft -= news.Duration
 
 			curSpans = append(curSpans, news)

--- a/releasenotes/notes/apm-sequential-processing-f01280809a19ee2d.yaml
+++ b/releasenotes/notes/apm-sequential-processing-f01280809a19ee2d.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: increase payload processing speed for application/msgpack payloads.


### PR DESCRIPTION
This change adds a stream decoder which decodes traces and sends them for processing one at a time, instead of decoding everything and then iterating through everything once more to process.

Benchmark results are:
```
name                     old time/op    new time/op     delta
Throughput/39KB/10-4        584µs ± 0%      503µs ± 0%  -13.92%
Throughput/1.1MB/100-4     11.5ms ± 0%      8.7ms ± 0%  -24.06%
Throughput/1.1MB/1951-4    18.0ms ± 0%     15.1ms ± 0%  -16.09%
Throughput/2.2MB/4161-4    40.2ms ± 0%     31.8ms ± 0%  -20.98%
Throughput/6.6MB/500-4     73.5ms ± 0%     57.3ms ± 0%  -22.06%

name                     old speed      new speed       delta
Throughput/39KB/10-4     70.6MB/s ± 0%   82.0MB/s ± 0%  +16.17%
Throughput/1.1MB/100-4   97.4MB/s ± 0%  128.3MB/s ± 0%  +31.69%
Throughput/1.1MB/1951-4  63.1MB/s ± 0%   75.2MB/s ± 0%  +19.17%
Throughput/2.2MB/4161-4  59.8MB/s ± 0%   75.7MB/s ± 0%  +26.56%
Throughput/6.6MB/500-4   96.9MB/s ± 0%  124.3MB/s ± 0%  +28.32%

name                     old alloc/op   new alloc/op    delta
Throughput/39KB/10-4        234kB ± 0%      233kB ± 0%   -0.49%
Throughput/1.1MB/100-4     5.60MB ± 0%     5.51MB ± 0%   -1.69%
Throughput/1.1MB/1951-4    7.30MB ± 0%     7.18MB ± 0%   -1.67%
Throughput/2.2MB/4161-4    15.4MB ± 0%     15.1MB ± 0%   -1.57%
Throughput/6.6MB/500-4     37.6MB ± 0%     37.0MB ± 0%   -1.75%

name                     old allocs/op  new allocs/op   delta
Throughput/39KB/10-4        3.37k ± 0%      3.24k ± 0%   -3.91%
Throughput/1.1MB/100-4      79.7k ± 0%      75.5k ± 0%   -5.21%
Throughput/1.1MB/1951-4      145k ± 0%       138k ± 0%   -5.16%
Throughput/2.2MB/4161-4      307k ± 0%       292k ± 0%   -5.05%
Throughput/6.6MB/500-4       524k ± 0%       497k ± 0%   -5.23%
````