### PR TITLE
Fix the tagger.tag cpython bridge function

### DIFF
--- a/pkg/collector/py/tagger.c
+++ b/pkg/collector/py/tagger.c
@@ -9,6 +9,7 @@
 
 // Functions
 PyObject* GetTags(char *id, int highCard);
+PyObject* Tag(char *id, TaggerCardinality card);
 
 // _must_ be in the same order as the TaggerCardinality enum
 char* TaggerCardinalityNames[] = {
@@ -30,7 +31,7 @@ static PyObject *tag(PyObject *self, PyObject *args) {
     }
 
     PyGILState_Release(gstate);
-    return GetTags(entity, card);
+    return Tag(entity, card);
 }
 
 static PyObject *get_tags(PyObject *self, PyObject *args) {

--- a/pkg/collector/py/tagger_test.go
+++ b/pkg/collector/py/tagger_test.go
@@ -58,11 +58,16 @@ func TestTagger(t *testing.T) {
 	require.NoError(t, err)
 
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "old_method.low_card", []string{"test_entity:low"})
+	mockSender.AssertMetricNotTaggedWith(t, "Gauge", "old_method.low_card", []string{"test_entity:orchestrator", "test_entity:high", "other_tag:high"})
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "old_method.high_card", []string{"test_entity:low", "test_entity:orchestrator", "test_entity:high", "other_tag:high"})
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "old_method.unknown", []string{})
 
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.low_card", []string{"test_entity:low"})
+	mockSender.AssertMetricNotTaggedWith(t, "Gauge", "new_method.low_card", []string{"test_entity:orchestrator", "test_entity:high", "other_tag:high"})
+
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.orch_card", []string{"test_entity:low", "test_entity:orchestrator"})
+	mockSender.AssertMetricNotTaggedWith(t, "Gauge", "new_method.orch_card", []string{"test_entity:high", "other_tag:high"})
+
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.high_card", []string{"test_entity:low", "test_entity:orchestrator", "test_entity:high", "other_tag:high"})
 	mockSender.AssertMetricTaggedWith(t, "Gauge", "new_method.unknown", []string{})
 }


### PR DESCRIPTION
### What does this PR do?

The `tagger.tag` function added by https://github.com/DataDog/datadog-agent/pull/3188 was actually calling the previous logic (not handling orchestrator cardinality).

This was not caught by the unit tests, as `AssertMetricTaggedWith` ignores unexpected tags. I added explicit `AssertMetricNotTaggedWith`s to ensure the test is relevant.