### PR TITLE
Allow configuring k8s event collection timeout

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -58,7 +58,7 @@ func (c *KubeASConfig) parse(data []byte) error {
 	// default values
 	c.CollectEvent = config.Datadog.GetBool("collect_kubernetes_events")
 	c.CollectOShiftQuotas = true
-	c.EventCollectionTimeoutMs = 100
+	c.EventCollectionTimeoutMs = config.Datadog.GetInt("kubernetes_event_collection_timeout")
 
 	return yaml.Unmarshal(data, c)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -365,6 +365,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                    // aggregator used for the external metrics. Choose from [avg,sum,max,min]
 	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)           // Window to query to get the metric from Datadog.
 	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                  // Bucket size to circumvent time aggregation side effects.
+	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)              // value in milliseconds
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)              // value in seconds. Default to 5 minutes
 	config.BindEnvAndSetDefault("kubernetes_informers_restclient_timeout", 60)           // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30) // value in seconds

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -365,7 +365,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics.aggregator", "avg")                    // aggregator used for the external metrics. Choose from [avg,sum,max,min]
 	config.BindEnvAndSetDefault("external_metrics_provider.bucket_size", 60*5)           // Window to query to get the metric from Datadog.
 	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                  // Bucket size to circumvent time aggregation side effects.
-	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)              // value in milliseconds
+	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)              // timeout between two successful event collections in milliseconds.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)              // value in seconds. Default to 5 minutes
 	config.BindEnvAndSetDefault("kubernetes_informers_restclient_timeout", 60)           // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30) // value in seconds

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -709,7 +709,9 @@ api_key:
 #
 # To collect Kubernetes events, leader election must be enabled and collect_kubernetes_events set to true.
 # Only the leader will collect events. More details about events [here](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#event-collection).
+# You can change the timeout between two successful event collections (in milliseconds).
 # collect_kubernetes_events: false
+# kubernetes_event_collection_timeout: 100
 #
 #
 # Leader Election settings, more details about leader election [here](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#leader-election)

--- a/pkg/util/kubernetes/apiserver/events.go
+++ b/pkg/util/kubernetes/apiserver/events.go
@@ -100,6 +100,7 @@ func (c *APIClient) LatestEvents(since string, eventReadTimeout time.Duration) (
 			watcherTimeout.Reset(eventReadTimeout)
 
 		case <-watcherTimeout.C:
+			log.Debug("Timeout reached while collecting events")
 			// No more events to read or the watch lasted more than `eventReadTimeout`.
 			// so return what was processed.
 			return added, modified, strconv.Itoa(resVersionInt), nil

--- a/releasenotes/notes/kubernetes_event_collection_timeout-138709c7192c296f.yaml
+++ b/releasenotes/notes/kubernetes_event_collection_timeout-138709c7192c296f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Kubernetes event collection timeout can now be configured.


### PR DESCRIPTION
### What does this PR do?

Make it possible to configure the timeout of the Kubernetes event collection.
