### PR TITLE
pkg/trace/api: avoid deadlock

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -263,9 +263,10 @@ func (r *HTTPReceiver) sendTrace(ts *info.TagStats, trace pb.Trace) {
 // decodeTraces decodes traces one by one from the given http.Request and sends them via
 // the returned channel. When it completes, it closes the channel. Any potential error
 // will be written to the http.ResponseWriter and the channel closed prematurely.
-func decodeTraces(w http.ResponseWriter, req *http.Request, v Version) (out chan pb.Trace) {
-	out = make(chan pb.Trace)
+func decodeTraces(w http.ResponseWriter, req *http.Request, v Version) (out <-chan pb.Trace) {
+	ch := make(chan pb.Trace)
 	go func() {
+		defer close(ch)
 		var rd *msgp.Reader
 		size, err := strconv.ParseInt(req.Header.Get("Content-Length"), 10, 64)
 		if err != nil {
@@ -284,11 +285,10 @@ func decodeTraces(w http.ResponseWriter, req *http.Request, v Version) (out chan
 				httpDecodingError(err, []string{tagTraceHandler, fmt.Sprintf("v:%s", v)}, w)
 				return
 			}
-			out <- trace
+			ch <- trace
 		}
-		close(out)
 	}()
-	return out
+	return ch
 }
 
 // handleServices handle a request with a list of several services


### PR DESCRIPTION
This change avoids a deadlock when exiting prematurely due to an error
in the stream msgpack decoder. Previously the channel was not closed
when returning early.