### PR TITLE
pkg/trace/agent: add a throughput benchmark

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -109,33 +109,37 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 
 // Run starts routers routines and individual pieces then stop them when the exit order is received
 func (a *Agent) Run() {
-	// it's really important to use a ticker for this, and with a not too short
-	// interval, for this is our guarantee that the process won't start and kill
-	// itself too fast (nightmare loop)
-	watchdogTicker := time.NewTicker(a.conf.WatchdogInterval)
-	defer watchdogTicker.Stop()
+	info.UpdatePreSampler(*a.Receiver.PreSampler.Stats()) // avoid exposing 0
 
-	// update the data served by expvar so that we don't expose a 0 sample rate
-	info.UpdatePreSampler(*a.Receiver.PreSampler.Stats())
+	a.start()
+	a.loop()
+}
 
-	// TODO: unify components APIs. Use Start/Stop as non-blocking ways of controlling the blocking Run loop.
-	// Like we do with TraceWriter.
-	a.Receiver.Run()
-	a.TraceWriter.Start()
-	a.StatsWriter.Start()
-	a.ServiceMapper.Start()
-	a.ServiceWriter.Start()
-	a.Concentrator.Start()
-	a.ScoreSampler.Run()
-	a.ErrorsScoreSampler.Run()
-	a.PrioritySampler.Run()
-	a.EventProcessor.Start()
+func (a *Agent) start() {
+	for _, starter := range []interface{ Start() }{
+		a.Receiver,
+		a.TraceWriter,
+		a.StatsWriter,
+		a.ServiceMapper,
+		a.ServiceWriter,
+		a.Concentrator,
+		a.ScoreSampler,
+		a.ErrorsScoreSampler,
+		a.PrioritySampler,
+		a.EventProcessor,
+	} {
+		starter.Start()
+	}
+}
 
+func (a *Agent) loop() {
+	ticker := time.NewTicker(a.conf.WatchdogInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case t := <-a.Receiver.Out:
 			a.Process(t)
-		case <-watchdogTicker.C:
+		case <-ticker.C:
 			a.watchdog()
 		case <-a.ctx.Done():
 			log.Info("exiting")

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1,28 +1,34 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/event"
-	"github.com/DataDog/datadog-agent/pkg/trace/pb"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	"github.com/cihub/seelog"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/event"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/writer"
+	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+	"github.com/tinylib/msgp/msgp"
 )
 
 type mockSamplerEngine struct {
@@ -580,4 +586,138 @@ func formatTrace(t pb.Trace) pb.Trace {
 		Truncate(span)
 	}
 	return t
+}
+
+func BenchmarkThroughput(b *testing.B) {
+	env, ok := os.LookupEnv("DD_TRACE_TEST_FOLDER")
+	if !ok {
+		b.SkipNow()
+	}
+
+	ddlog.SetupDatadogLogger(seelog.Disabled, "") // disable logging
+
+	folder := filepath.Join(env, "benchmarks")
+	filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		ext := filepath.Ext(path)
+		if ext != ".msgp" {
+			return nil
+		}
+		b.Run(info.Name(), benchThroughput(path))
+		return nil
+	})
+}
+
+func benchThroughput(file string) func(*testing.B) {
+	return func(b *testing.B) {
+		data, count, err := tracesFromFile(file)
+		if err != nil {
+			b.Fatal(err)
+		}
+		cfg := config.New()
+		cfg.Endpoints[0].APIKey = "irrelevant"
+
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		http.DefaultServeMux = &http.ServeMux{}
+		agnt := NewAgent(ctx, cfg)
+		defer cancelFunc()
+
+		// start the agent without the trace and stats writers; we will be draining
+		// these channels ourselves in the benchmarks, plus we don't want the writers
+		// resource usage to show up in the results.
+		agnt.start()
+		agnt.tracePkgChan = make(chan *writer.TracePackage)
+		go agnt.loop()
+
+		// drain every other channel to avoid blockage.
+		exit := make(chan bool)
+		go func() {
+			defer close(exit)
+			for {
+				select {
+				case <-agnt.ServiceExtractor.outServices:
+				case <-agnt.Concentrator.OutStats:
+				case <-exit:
+					return
+				}
+			}
+		}()
+
+		b.ResetTimer()
+		b.SetBytes(int64(len(data)))
+
+		for i := 0; i < b.N; i++ {
+			req, err := http.NewRequest("PUT", "http://localhost:8126/v0.4/traces", bytes.NewReader(data))
+			if err != nil {
+				b.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/msgpack")
+			w := httptest.NewRecorder()
+
+			// create the request by calling directly into the Handler;
+			// we are not interested in benchmarking HTTP latency. This
+			// also ensures we avoid potential connection failures that
+			// would make the benchmarks inconsistent.
+			http.DefaultServeMux.ServeHTTP(w, req)
+			if w.Code != 200 {
+				b.Fatalf("%d: %v", i, w.Body.String())
+			}
+
+			var got int
+			timeout := time.After(1 * time.Second)
+		loop:
+			for {
+				select {
+				case <-agnt.tracePkgChan:
+					got++
+					if got == count {
+						// processed everything!
+						break loop
+					}
+				case <-timeout:
+					// taking too long...
+					b.Fatalf("time out at %d/%d", got, count)
+					break loop
+				}
+			}
+		}
+
+		exit <- true
+		<-exit
+	}
+}
+
+// tracesFromFile extracts raw msgpack data from the given file, modifying each trace
+// to have sampling.priority=2 to guarantee consistency. It also returns the amount of
+// traces found and any error in obtaining the information.
+func tracesFromFile(file string) (raw []byte, count int, err error) {
+	if file[0] != '/' {
+		file = filepath.Join(os.Getenv("GOPATH"), file)
+	}
+	in, err := os.Open(file)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer in.Close()
+	// prepare the traces in this file by adding sampling.priority=2
+	// everywhere to ensure consistent sampling assumptions and results.
+	var traces pb.Traces
+	if err := msgp.Decode(in, &traces); err != nil {
+		return nil, 0, err
+	}
+	for _, t := range traces {
+		count++
+		for _, s := range t {
+			if s.Metrics == nil {
+				s.Metrics = map[string]float64{"_sampling_priority_v1": 2}
+			} else {
+				s.Metrics["_sampling_priority_v1"] = 2
+			}
+		}
+	}
+	// re-encode the modified payload
+	var data bytes.Buffer
+	if err := msgp.Encode(&data, traces); err != nil {
+		return nil, 0, err
+	}
+	return data.Bytes(), count, nil
 }

--- a/pkg/trace/agent/sampler.go
+++ b/pkg/trace/agent/sampler.go
@@ -53,8 +53,8 @@ func NewPrioritySampler(conf *config.AgentConfig, dynConf *sampler.DynamicConfig
 	}
 }
 
-// Run starts sampling traces
-func (s *Sampler) Run() {
+// Start starts sampling traces
+func (s *Sampler) Start() {
 	go func() {
 		defer watchdog.LogOnPanic()
 		s.engine.Run()

--- a/pkg/trace/agent/service.go
+++ b/pkg/trace/agent/service.go
@@ -119,11 +119,11 @@ const appType = "app_type"
 
 // TraceServiceExtractor extracts service metadata from top-level spans
 type TraceServiceExtractor struct {
-	outServices chan<- pb.ServicesMetadata
+	outServices chan pb.ServicesMetadata
 }
 
 // NewTraceServiceExtractor returns a new TraceServiceExtractor
-func NewTraceServiceExtractor(out chan<- pb.ServicesMetadata) *TraceServiceExtractor {
+func NewTraceServiceExtractor(out chan pb.ServicesMetadata) *TraceServiceExtractor {
 	return &TraceServiceExtractor{out}
 }
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -94,8 +94,8 @@ func NewHTTPReceiver(
 	}
 }
 
-// Run starts doing the HTTP server and is ready to receive traces
-func (r *HTTPReceiver) Run() {
+// Start starts doing the HTTP server and is ready to receive traces
+func (r *HTTPReceiver) Start() {
 	// FIXME[1.x]: remove all those legacy endpoints + code that goes with it
 	http.HandleFunc("/spans", r.httpHandleWithVersion(v01, r.handleTraces))
 	http.HandleFunc("/services", r.httpHandleWithVersion(v01, r.handleServices))

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -62,7 +62,7 @@ func TestReceiverRequestBodyLength(t *testing.T) {
 	conf := newTestReceiverConfig()
 	receiver := newTestReceiverFromConfig(conf)
 	receiver.maxRequestBodyLength = 2
-	go receiver.Run()
+	go receiver.Start()
 
 	defer func() {
 		receiver.Stop()


### PR DESCRIPTION
This change adds a benchmark which sends msgpack payloads to the HTTP
receiver and benchmarks the time it takes for it to reach the writer.