### PR TITLE
Ajacquemot/logs kubernetes tags refresh

### DIFF
--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/tag"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -37,13 +38,13 @@ const tagsUpdatePeriod = 10 * time.Second
 // Logs from stdout and stderr are multiplexed into a single channel and needs to be demultiplexed later one.
 // To multiplex logs, docker adds a header to all logs with format '[SEV][TS] [MSG]'.
 type Tailer struct {
-	ContainerID   string
-	outputChan    chan *message.Message
-	decoder       *decoder.Decoder
-	reader        *safeReader
-	cli           *client.Client
-	source        *config.LogSource
-	containerTags []string
+	ContainerID string
+	outputChan  chan *message.Message
+	decoder     *decoder.Decoder
+	reader      *safeReader
+	cli         *client.Client
+	source      *config.LogSource
+	tagProvider *tag.Provider
 
 	sleepDuration      time.Duration
 	shouldStop         bool
@@ -62,6 +63,7 @@ func NewTailer(cli *client.Client, containerID string, source *config.LogSource,
 		outputChan:         outputChan,
 		decoder:            decoder.InitializeDecoder(source, dockerParser),
 		source:             source,
+		tagProvider:        tag.NewProvider(dockerutil.ContainerIDToEntityName(containerID), tagsUpdatePeriod),
 		cli:                cli,
 		sleepDuration:      defaultSleepDuration,
 		stop:               make(chan struct{}, 1),
@@ -82,6 +84,7 @@ func (t *Tailer) Stop() {
 	log.Infof("Stop tailing container: %v", ShortContainerID(t.ContainerID))
 	t.stop <- struct{}{}
 
+	t.tagProvider.Stop()
 	t.reader.Close()
 	// no-op if already closed because of a timeout
 	t.cancelFunc()
@@ -96,6 +99,7 @@ func (t *Tailer) Stop() {
 // start from oldest log otherwise
 func (t *Tailer) Start(since time.Time) error {
 	log.Infof("Start tailing container: %v", ShortContainerID(t.ContainerID))
+	t.tagProvider.Start()
 	return t.tail(since.Format(config.DateFormat))
 }
 
@@ -244,31 +248,9 @@ func (t *Tailer) forwardMessages() {
 			origin.Offset = output.Timestamp
 			t.setLastSince(output.Timestamp)
 			origin.Identifier = t.Identifier()
-			origin.SetTags(t.containerTags)
+			origin.SetTags(t.tagProvider.GetTags())
 			output.Origin = origin
 			t.outputChan <- output
-		}
-	}
-}
-
-func (t *Tailer) keepDockerTagsUpdated() {
-	t.checkForNewDockerTags()
-	ticker := time.NewTicker(tagsUpdatePeriod)
-	for range ticker.C {
-		if t.shouldStop {
-			return
-		}
-		t.checkForNewDockerTags()
-	}
-}
-
-func (t *Tailer) checkForNewDockerTags() {
-	tags, err := tagger.Tag(dockerutil.ContainerIDToEntityName(t.ContainerID), collectors.HighCardinality)
-	if err != nil {
-		log.Warn(err)
-	} else {
-		if !reflect.DeepEqual(tags, t.containerTags) {
-			t.containerTags = tags
 		}
 	}
 }

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	dockerutil "github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -58,7 +59,7 @@ func NewTailer(cli *client.Client, containerID string, source *config.LogSource,
 		outputChan:         outputChan,
 		decoder:            decoder.InitializeDecoder(source, dockerParser),
 		source:             source,
-		tagProvider:        tag.NewProvider(containerID),
+		tagProvider:        tag.NewProvider(dockerutil.ContainerIDToEntityName(containerID)),
 		cli:                cli,
 		sleepDuration:      defaultSleepDuration,
 		stop:               make(chan struct{}, 1),

--- a/pkg/logs/input/docker/tailer_test.go
+++ b/pkg/logs/input/docker/tailer_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/tag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,6 +69,7 @@ func NewTestTailer(reader io.ReadCloser, cancelFunc context.CancelFunc) *Tailer 
 		outputChan:    make(chan *message.Message, 100),
 		decoder:       nil,
 		source:        config.NewLogSource("foo", nil),
+		tagProvider:   tag.NoopProvider,
 		cli:           nil,
 		sleepDuration: defaultSleepDuration,
 		stop:          make(chan struct{}, 1),

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -56,13 +56,16 @@ type Tailer struct {
 // NewTailer returns an initialized Tailer
 func NewTailer(outputChan chan *message.Message, source *config.LogSource, path string, sleepDuration time.Duration, isWildcardPath bool) *Tailer {
 	var parser logParser.Parser
-	var tagProvider tag.Provider
 	if source.GetSourceType() == config.ContainerdType {
 		parser = containerdFileParser
-		tagProvider = tag.NewProvider(source.Config.Identifier)
 	} else {
 		parser = logParser.NoopParser
-		tagProvider = tag.NOOP
+	}
+	var tagProvider tag.Provider
+	if source.Config.Identifier != "" {
+		tagProvider = tag.NewProvider(source.Config.Identifier)
+	} else {
+		tagProvider = tag.NoopProvider
 	}
 	return &Tailer{
 		path:           path,

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -12,7 +12,6 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -202,7 +201,6 @@ func (l *Launcher) getSource(pod *kubelet.Pod, container kubelet.ContainerStatus
 	cfg.Type = config.FileType
 	cfg.Path = l.getPath(pod, container)
 	cfg.Identifier = container.ID
-	cfg.Tags = append(cfg.Tags, l.getTags(container)...)
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid kubernetes annotation: %v", err)
 	}
@@ -241,12 +239,6 @@ func (l *Launcher) getSourceName(pod *kubelet.Pod, container kubelet.ContainerSt
 // getPath returns the path where all the logs of the container of the pod are stored.
 func (l *Launcher) getPath(pod *kubelet.Pod, container kubelet.ContainerStatus) string {
 	return fmt.Sprintf("%s/%s/%s/*.log", podsDirectoryPath, pod.Metadata.UID, container.Name)
-}
-
-// getTags returns all the tags of the container
-func (l *Launcher) getTags(container kubelet.ContainerStatus) []string {
-	tags, _ := tagger.Tag(container.ID, collectors.HighCardinality)
-	return tags
 }
 
 // getShortImageName returns the short image name of a container

--- a/pkg/logs/tag/noop.go
+++ b/pkg/logs/tag/noop.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package tag
+
+type noop struct {
+	tags []string
+}
+
+// GetTags returns an empty list of tags.
+func (p *noop) GetTags() []string {
+	return p.tags
+}
+
+// Start does nothing
+func (p *noop) Start() {}
+
+// Stop does nothing
+func (p *noop) Stop() {}

--- a/pkg/logs/tag/noop_provider.go
+++ b/pkg/logs/tag/noop_provider.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package tag
+
+type noopProvider struct {
+	tags []string
+}
+
+// GetTags returns an empty list of tags.
+func (p *noopProvider) GetTags() []string {
+	return p.tags
+}
+
+// Start does nothing
+func (p *noopProvider) Start() {}
+
+// Stop does nothing
+func (p *noopProvider) Stop() {}

--- a/pkg/logs/tag/noop_provider_test.go
+++ b/pkg/logs/tag/noop_provider_test.go
@@ -5,17 +5,12 @@
 
 package tag
 
-type noop struct {
-	tags []string
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoopProviderShouldReturnEmptyList(t *testing.T) {
+	assert.Equal(t, 0, len(NoopProvider.GetTags()))
 }
-
-// GetTags returns an empty list of tags.
-func (p *noop) GetTags() []string {
-	return p.tags
-}
-
-// Start does nothing
-func (p *noop) Start() {}
-
-// Stop does nothing
-func (p *noop) Stop() {}

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -23,23 +23,23 @@ type Provider interface {
 	Stop()
 }
 
-// NOOP does nothing
-var NOOP Provider = &noop{}
+// NoopProvider does nothing
+var NoopProvider Provider = &noopProvider{}
 
 // provider caches a list of up-to-date tags for a given entity polling periodically the tagger.
 type provider struct {
-	entityName string
-	tags       []string
-	done       chan struct{}
-	mu         sync.Mutex
+	entityID string
+	tags     []string
+	done     chan struct{}
+	mu       sync.Mutex
 }
 
 // NewProvider returns a new Provider.
-func NewProvider(entityName string) Provider {
+func NewProvider(entityID string) Provider {
 	return &provider{
-		entityName: entityName,
-		tags:       []string{},
-		done:       make(chan struct{}),
+		entityID: entityID,
+		tags:     []string{},
+		done:     make(chan struct{}),
 	}
 }
 
@@ -75,7 +75,7 @@ func (p *provider) Stop() {
 func (p *provider) updateTags() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	tags, err := tagger.Tag(p.entityName, collectors.HighCardinality)
+	tags, err := tagger.Tag(p.entityID, collectors.HighCardinality)
 	if err == nil && !reflect.DeepEqual(tags, p.tags) {
 		p.tags = tags
 	}

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package tag
+
+// Provider keeps a list of up-to-date tags for a given entity polling periodically the tagger.
+type Provider struct {
+	entityName string
+	tags       []string
+	done       chan struct{}
+	mu         sync.Mutex
+}
+
+// NewProvider returns a new Provider.
+func NewProvider(entityName string, refreshPeriod time.Duration) *Provider {
+	return &Provider{
+		entityName: entityName,
+		tags:       []string{},
+		done:       make(chan struct{}),
+	}
+}
+
+// GetTags returns the list of up-to-date tags.
+func (p *Provider) GetTags() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.tags
+}
+
+// Start starts the polling of new tags on another go routine.
+func (p *Provider) Start() {
+	go func() {
+		ticker := NewTicker(refreshPeriod)
+		for {
+			select {
+			case <-ticker.C:
+				p.updateTags()
+			case <-p.done:
+				return
+			}
+		}
+		ticker.Stop()
+	}()
+}
+
+// Stop stops the polling of new tags.
+func (p *Provider) Stop() {
+	p.done <- struct{}{}
+}
+
+// updateTags updates the list of tags using tagger.
+func (p *Provider) updateTags() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	tags, err := tagger.Tag(p.entityName, collectors.HighCardinality)
+	if err == nil && !reflect.DeepEqual(tags, p.tags) {
+		p.tags = tags
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Extracted the logic to update tags from the docker integration, made it a package and reuse it for file files.

### Motivation

Be able to have up-to-date tags when tailing logs from kubernetes directories.

### Additional Notes

Anything else we should know when reviewing?
