### PR TITLE
Add DD_SITE environment variable to README

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -23,6 +23,7 @@ The agent is highly customizable, here are the most used environment variables:
 #### Global options
 
 - `DD_API_KEY`: your API key (**required**)
+- `DD_SITE`: Destination site for your metrics, traces, and logs. Valid options are datadoghq.com for the Datadog US site, and datadoghq.eu for the Datadog EU site.
 - `DD_HOSTNAME`: hostname to use for metrics (if autodetection fails)
 - `DD_TAGS`: host tags, separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`
 - `DD_CHECK_RUNNERS`: the agent runs all checks in sequence by default (default value = `1` runner). If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel


### PR DESCRIPTION
### What does this PR do?

Adds `DD_SITE` environment variable info to the README. We had a PR on the v5 Agent adding the docs: https://github.com/DataDog/docker-dd-agent/pull/363

### Motivation


### Additional Notes

