### PR TITLE
[Logs]: Properly handle docker container log in multiline mode

### DIFF
--- a/pkg/logs/input/kubernetes/parser.go
+++ b/pkg/logs/input/kubernetes/parser.go
@@ -48,13 +48,14 @@ func (p *parser) Parse(msg []byte) (*message.Message, error) {
 	return parsedMsg, nil
 }
 
-// Unwrap removes the header of the log line.
-func (p *parser) Unwrap(line []byte) ([]byte, error) {
+// Unwrap removes the header of the log line
+// and return the log and timestamp
+func (p *parser) Unwrap(line []byte) ([]byte, string, error) {
 	components, err := splitLine(line)
 	if err != nil {
-		return line, err
+		return line, "", err
 	}
-	return components[3], nil
+	return components[3], string(components[0]), nil
 }
 
 // getStatus returns the status of the message based on

--- a/pkg/logs/parser/parser.go
+++ b/pkg/logs/parser/parser.go
@@ -15,7 +15,7 @@ var NoopParser *noopParser
 // Parser parse messages
 type Parser interface {
 	Parse([]byte) (*message.Message, error)
-	Unwrap([]byte) ([]byte, error)
+	Unwrap([]byte) ([]byte, string, error)
 }
 
 type noopParser struct {
@@ -28,6 +28,6 @@ func (p *noopParser) Parse(msg []byte) (*message.Message, error) {
 }
 
 // Unwrap does nothing for NoopParser
-func (p *noopParser) Unwrap(msg []byte) ([]byte, error) {
-	return msg, nil
+func (p *noopParser) Unwrap(msg []byte) ([]byte, string, error) {
+	return msg, "", nil
 }

--- a/releasenotes/notes/logs-fix-container-log-rotation-0f15727384e0048a.yaml
+++ b/releasenotes/notes/logs-fix-container-log-rotation-0f15727384e0048a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Properly handle docker container logs in multiline mode in case of infrequence log messages, log file rotations or agent restart


### PR DESCRIPTION
### What does this PR do?

Currently docker container log in multiline mode is not correctly handled, it appears as if we resend part of the multiline log in rotation.  This is a bug fix.

### Motivation

Bug fix

### Additional Notes

Anything else we should know when reviewing?
