### PR TITLE
BugFix: fix metadata retrieve error when clusteragent not active

### DIFF
--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -21,7 +21,7 @@ const defaultGraceDuration = 60 * time.Second
 // ClusterChecksConfigProvider implements the ConfigProvider interface
 // for the cluster check feature.
 type ClusterChecksConfigProvider struct {
-	dcaClient      *clusteragent.DCAClient
+	dcaClient      clusteragent.DCAClientInterface
 	graceDuration  time.Duration
 	heartbeat      time.Time
 	lastChange     int64

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -40,7 +40,7 @@ func getDCAStatus() map[string]string {
 		clusterAgentDetails["DetectionError"] = err.Error()
 		return clusterAgentDetails
 	}
-	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint
+	clusterAgentDetails["Endpoint"] = dcaCl.ClusterAgentAPIEndpoint()
 
 	ver, err := dcaCl.GetVersion()
 	if err != nil {

--- a/pkg/status/status_apiserver.go
+++ b/pkg/status/status_apiserver.go
@@ -47,6 +47,6 @@ func getDCAStatus() map[string]string {
 		clusterAgentDetails["ConnectionError"] = err.Error()
 		return clusterAgentDetails
 	}
-	clusterAgentDetails["Version"] = ver
+	clusterAgentDetails["Version"] = ver.String()
 	return clusterAgentDetails
 }

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -28,7 +28,7 @@ type KubeMetadataCollector struct {
 	kubeUtil  *kubelet.KubeUtil
 	apiClient *apiserver.APIClient
 	infoOut   chan<- []*TagInfo
-	dcaClient *clusteragent.DCAClient
+	dcaClient clusteragent.DCAClientInterface
 	// used to set a custom delay
 	lastUpdate time.Time
 	updateFreq time.Duration

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -20,7 +20,7 @@ import (
 func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	var err error
 	metadataByNsPods := apiv1.NewNamespacesPodsStringsSet()
-	if !c.clusterAgentEnabled {
+	if c.clusterAgentEnabled {
 		var nodeName string
 		nodeName, err = c.kubeUtil.GetNodename()
 		if err != nil {

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -21,7 +21,7 @@ import (
 func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	var err error
 	var metadataByNsPods apiv1.NamespacesPodsStringsSet
-	if c.clusterAgentEnabled && c.dcaClient.ClusterAgentVersion.Major >= 1 && c.dcaClient.ClusterAgentVersion.Minor >= 3 {
+	if c.clusterAgentEnabled && c.dcaClient.Version().Major >= 1 && c.dcaClient.Version().Minor >= 3 {
 		var nodeName string
 		nodeName, err = c.kubeUtil.GetNodename()
 		if err != nil {
@@ -59,7 +59,7 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 		}
 
 		tagList := utils.NewTagList()
-		metadataNames, err = c.getMetadaNames(metadataByNsPods, po)
+		metadataNames, err = c.getMetadaNames(apiserver.GetPodMetadataNames, metadataByNsPods, po)
 		if err != nil {
 			log.Errorf("Could not fetch tags, %v", err)
 		}
@@ -99,9 +99,9 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	return tagInfo
 }
 
-func (c *KubeMetadataCollector) getMetadaNames(metadataByNsPods apiv1.NamespacesPodsStringsSet, po *kubelet.Pod) ([]string, error) {
+func (c *KubeMetadataCollector) getMetadaNames(getPodMetaDataFromApiServerFunc func(string, string, string) ([]string, error), metadataByNsPods apiv1.NamespacesPodsStringsSet, po *kubelet.Pod) ([]string, error) {
 	if !c.clusterAgentEnabled {
-		metadataNames, err := apiserver.GetPodMetadataNames(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
+		metadataNames, err := getPodMetaDataFromApiServerFunc(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
 		if err != nil {
 			err = fmt.Errorf("Could not fetch cluster level tags of pod: %s, %v", po.Metadata.Name, err)
 		}

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
@@ -1,0 +1,225 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// +build kubeapiserver,kubelet
+
+package collectors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type FakeDCAClient struct {
+	LocalVersion                 version.Version
+	LocalClusterAgentAPIEndpoint string
+
+	VersionErr error
+
+	NodeLabel    map[string]string
+	NodeLabelErr error
+
+	PodMetadataForNode    apiv1.NamespacesPodsStringsSet
+	PodMetadataForNodeErr error
+
+	KubernetesMetadataNames    []string
+	KubernetesMetadataNamesErr error
+
+	ClusterCheckStatus    types.StatusResponse
+	ClusterCheckStatusErr error
+
+	ClusterCheckConfigs    types.ConfigResponse
+	ClusterCheckConfigsErr error
+}
+
+func (f *FakeDCAClient) Version() version.Version {
+	return f.LocalVersion
+}
+func (f *FakeDCAClient) ClusterAgentAPIEndpoint() string {
+	return f.LocalClusterAgentAPIEndpoint
+}
+func (f *FakeDCAClient) GetVersion() (version.Version, error) {
+	return f.LocalVersion, f.VersionErr
+}
+func (f *FakeDCAClient) GetNodeLabels(nodeName string) (map[string]string, error) {
+	return f.NodeLabel, f.NodeLabelErr
+}
+func (f *FakeDCAClient) GetPodsMetadataForNode(nodeName string) (apiv1.NamespacesPodsStringsSet, error) {
+	return f.PodMetadataForNode, f.PodMetadataForNodeErr
+}
+func (f *FakeDCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error) {
+	return f.KubernetesMetadataNames, f.KubernetesMetadataNamesErr
+}
+
+func (f *FakeDCAClient) PostClusterCheckStatus(nodeName string, status types.NodeStatus) (types.StatusResponse, error) {
+	return f.ClusterCheckStatus, f.ClusterCheckStatusErr
+}
+
+func (f *FakeDCAClient) GetClusterCheckConfigs(nodeName string) (types.ConfigResponse, error) {
+	return f.ClusterCheckConfigs, f.ClusterCheckConfigsErr
+}
+
+func TestKubeMetadataCollector_getMetadaNames(t *testing.T) {
+	type fields struct {
+		dcaClient           clusteragent.DCAClientInterface
+		clusterAgentEnabled bool
+	}
+	type args struct {
+		getPodMetaDataFromApiServerFunc func(string, string, string) ([]string, error)
+		metadataByNsPods                apiv1.NamespacesPodsStringsSet
+		po                              *kubelet.Pod
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "clusterAgentEnabled not enable",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return []string{"foo=bar"}, nil
+				},
+				po: &kubelet.Pod{},
+			},
+			fields: fields{
+				clusterAgentEnabled: false,
+				dcaClient:           &FakeDCAClient{},
+			},
+			want:    []string{"foo=bar"},
+			wantErr: false,
+		},
+
+		{
+			name: "clusterAgentEnabled not enable, APIserver return error",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return nil, fmt.Errorf("fake error")
+				},
+				po: &kubelet.Pod{},
+			},
+			fields: fields{
+				clusterAgentEnabled: false,
+				dcaClient:           &FakeDCAClient{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+
+		{
+			name: "clusterAgentEnabled enable, but old version",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return []string{"foo=bar"}, nil
+				},
+				po: &kubelet.Pod{},
+			},
+			fields: fields{
+				clusterAgentEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion:            version.Version{Major: 1, Minor: 2},
+					KubernetesMetadataNames: []string{"foo=bar"},
+				},
+			},
+			want:    []string{"foo=bar"},
+			wantErr: false,
+		},
+
+		{
+			name: "clusterAgentEnabled enable, but old version, DCS return error",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return []string{"foo=bar"}, nil
+				},
+				po: &kubelet.Pod{},
+			},
+			fields: fields{
+				clusterAgentEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion:               version.Version{Major: 1, Minor: 2},
+					KubernetesMetadataNamesErr: fmt.Errorf("fake error"),
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+
+		{
+			name: "clusterAgentEnabled enable with new version",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return []string{"foo=bar"}, nil
+				},
+				po: &kubelet.Pod{Metadata: kubelet.PodMetadata{
+					Namespace: "test",
+					Name:      "pod-bar",
+				}},
+				metadataByNsPods: apiv1.NamespacesPodsStringsSet{
+					"test": apiv1.MapStringSet{
+						"pod-bar": sets.NewString("foo=bar"),
+					},
+				},
+			},
+			fields: fields{
+				clusterAgentEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 1, Minor: 3},
+				},
+			},
+			want:    []string{"foo=bar"},
+			wantErr: false,
+		},
+		{
+			name: "clusterAgentEnabled enable with new version (error case, pod not exist)",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return []string{"foo=bar"}, nil
+				},
+				po: &kubelet.Pod{Metadata: kubelet.PodMetadata{
+					Namespace: "test",
+					Name:      "pod-bar",
+				}},
+				metadataByNsPods: apiv1.NamespacesPodsStringsSet{
+					"test": apiv1.MapStringSet{},
+				},
+			},
+			fields: fields{
+				clusterAgentEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 1, Minor: 3},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &KubeMetadataCollector{
+				dcaClient:           tt.fields.dcaClient,
+				clusterAgentEnabled: tt.fields.clusterAgentEnabled,
+			}
+			got, err := c.getMetadaNames(tt.args.getPodMetaDataFromApiServerFunc, tt.args.metadataByNsPods, tt.args.po)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KubeMetadataCollector.getMetadaNames() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KubeMetadataCollector.getMetadaNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

FIx a bug introduce in PR #3145: If the agent is deployed with a cluster-agent, the `kube_service` tag is not added to pods.
Also the `agent check kubelet` return an error: if the cluster-agent is not activated...

### Additional Notes

Anything else we should know when reviewing?
