### PR TITLE
update labels/annotations_as_tags on value change

### DIFF
--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -136,6 +136,7 @@ func (w *PodWatcher) Expire() ([]string, error) {
 	if len(expiredContainers) > 0 {
 		for _, id := range expiredContainers {
 			delete(w.lastSeen, id)
+			delete(w.tagsDigests, id)
 		}
 	}
 	return expiredContainers, nil
@@ -161,7 +162,6 @@ func digestMap(m map[string]string) string {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-
 	h := fnv.New64()
 	for _, k := range keys {
 		h.Write([]byte(m[k]))

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -152,7 +152,7 @@ func (w *PodWatcher) GetPodForEntityID(entityID string) (*Pod, error) {
 // digestMap return a unique hash for a map
 // used to track changes in labels and annotations values
 func digestMap(m map[string]string) string {
-	if m == nil {
+	if len(m) == 0 {
 		return ""
 	}
 

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -143,8 +143,9 @@ func (w *PodWatcher) GetPodForEntityID(entityID string) (*Pod, error) {
 	return w.kubeUtil.GetPodForEntityID(entityID)
 }
 
-// digestPodMeta return a unique hash for a pod labels
-// and annotations
+// digestPodMeta returns a unique hash of pod labels
+// and annotations.
+// it hashes labels then annotations and makes a single hash of both maps
 func digestPodMeta(meta PodMetadata) string {
 	h := fnv.New64()
 	h.Write([]byte(digestMapValues(meta.Labels)))
@@ -152,8 +153,10 @@ func digestPodMeta(meta PodMetadata) string {
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 
-// digestMapValues return a unique hash for a map values
+// digestMapValues returns a unique hash of map values
 // used to track changes in labels and annotations values
+// it takes into consideration the random keys order in a map
+// by hashing the values after sorting the keys
 func digestMapValues(m map[string]string) string {
 	if len(m) == 0 {
 		return ""

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -46,7 +46,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
-		tagsDigests:    make(map[string]digests),
+		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -86,7 +86,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
-		tagsDigests:    make(map[string]digests),
+		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -122,7 +122,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
-		tagsDigests:    make(map[string]digests),
+		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -130,7 +130,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	require.Nil(suite.T(), err)
 	// 7 pods (including 2 statics) + 5 container statuses (static pods don't report these)
 	require.Len(suite.T(), watcher.lastSeen, 12)
-	require.Len(suite.T(), watcher.tagsDigests, 7)
+	require.Len(suite.T(), watcher.tagsDigest, 7)
 
 	expire, err := watcher.Expire()
 	require.Nil(suite.T(), err)
@@ -152,8 +152,8 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	require.Len(suite.T(), expire, 1)
 	require.Equal(suite.T(), testContainerID, expire[0])
 	require.Len(suite.T(), watcher.lastSeen, 11)
-	// 0 pods expired, we'll have all the 7 pods entities in tagsDigests
-	require.Len(suite.T(), watcher.tagsDigests, 7)
+	// 0 pods expired, we'll have all the 7 pods entities in tagsDigest
+	require.Len(suite.T(), watcher.tagsDigest, 7)
 }
 
 func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
@@ -163,14 +163,14 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
-		tagsDigests:    make(map[string]digests),
+		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 
 	_, err = watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), watcher.lastSeen, 12)
-	require.Len(suite.T(), watcher.tagsDigests, 7)
+	require.Len(suite.T(), watcher.tagsDigest, 7)
 
 	expire, err := watcher.Expire()
 	require.Nil(suite.T(), err)
@@ -188,7 +188,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 	_, err = watcher.computeChanges(sourcePods[0:5])
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), watcher.lastSeen, 12)
-	require.Len(suite.T(), watcher.tagsDigests, 7)
+	require.Len(suite.T(), watcher.tagsDigest, 7)
 
 	// That one should expire, we'll have 9 entities left
 	expire, err = watcher.Expire()
@@ -204,8 +204,8 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 		assert.Contains(suite.T(), expire, expectedEntity)
 	}
 	require.Len(suite.T(), watcher.lastSeen, 9)
-	// Two pods expired, we'll have 7 - 2 pods entities in tagsDigests
-	require.Len(suite.T(), watcher.tagsDigests, 5)
+	// Two pods expired, we'll have 7 - 2 pods entities in tagsDigest
+	require.Len(suite.T(), watcher.tagsDigest, 5)
 }
 
 func (suite *PodwatcherTestSuite) TestPullChanges() {
@@ -239,7 +239,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherLabelsValueChange() {
 
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
-		tagsDigests:    make(map[string]digests),
+		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 	twoPods := sourcePods[:2]
@@ -280,7 +280,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
-		tagsDigests:    make(map[string]digests),
+		tagsDigest:     make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
 	twoPods := sourcePods[:2]

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -130,6 +130,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	require.Nil(suite.T(), err)
 	// 7 pods (including 2 statics) + 5 container statuses (static pods don't report these)
 	require.Len(suite.T(), watcher.lastSeen, 12)
+	require.Len(suite.T(), watcher.tagsDigests, 7)
 
 	expire, err := watcher.Expire()
 	require.Nil(suite.T(), err)
@@ -151,6 +152,8 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	require.Len(suite.T(), expire, 1)
 	require.Equal(suite.T(), testContainerID, expire[0])
 	require.Len(suite.T(), watcher.lastSeen, 11)
+	// 0 pods expired, we'll have all the 7 pods entities in tagsDigests
+	require.Len(suite.T(), watcher.tagsDigests, 7)
 }
 
 func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
@@ -167,6 +170,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 	_, err = watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), watcher.lastSeen, 12)
+	require.Len(suite.T(), watcher.tagsDigests, 7)
 
 	expire, err := watcher.Expire()
 	require.Nil(suite.T(), err)
@@ -184,6 +188,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 	_, err = watcher.computeChanges(sourcePods[0:5])
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), watcher.lastSeen, 12)
+	require.Len(suite.T(), watcher.tagsDigests, 7)
 
 	// That one should expire, we'll have 9 entities left
 	expire, err = watcher.Expire()
@@ -199,6 +204,8 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 		assert.Contains(suite.T(), expire, expectedEntity)
 	}
 	require.Len(suite.T(), watcher.lastSeen, 9)
+	// Two pods expired, we'll have 7 - 2 pods entities in tagsDigests
+	require.Len(suite.T(), watcher.tagsDigests, 5)
 }
 
 func (suite *PodwatcherTestSuite) TestPullChanges() {

--- a/releasenotes/notes/update-pod-labels-annotations-as-tags-on-value-change-eec756434e21ed64.yaml
+++ b/releasenotes/notes/update-pod-labels-annotations-as-tags-on-value-change-eec756434e21ed64.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Allow tracking pod labels and annotations value change to update labes/annotations_as_tags

--- a/releasenotes/notes/update-pod-labels-annotations-as-tags-on-value-change-eec756434e21ed64.yaml
+++ b/releasenotes/notes/update-pod-labels-annotations-as-tags-on-value-change-eec756434e21ed64.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    Allow tracking pod labels and annotations value change to update labes/annotations_as_tags
+    Allow tracking pod labels and annotations value change to update labels/annotations_as_tags.
+    Make the explicit tagging feature dynamic (introduced in https://github.com/DataDog/datadog-agent/pull/3024).


### PR DESCRIPTION
### What does this PR do?

Currently, pod `labels_as_tags` / `annotations_as_tags` get collected and set on pod/container creation. FR to be able to update these `labels_as_tags` / `annotations_as_tags` when the pod label/annotations values update.

### Motivation

Feature request: update the labels programmatically and monitors them using tags

