### PR TITLE
[gui] Display Logs error title in red

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -194,7 +194,7 @@
       {{- end }}
       {{- if .errors }}
 
-        <span class="warning stat_subtitle">Errors</span>
+        <span class="error stat_subtitle">Errors</span>
         <span class="stat_subdata">
         {{- range $error := .errors }}
           {{ $error }}</br>


### PR DESCRIPTION
### What does this PR do?

The `Error` title should in red to catch the 👁  (and to differentiate visually from warnings)

### Motivation

Have this:

![Screen Shot 2019-04-04 at 7 47 47 PM](https://user-images.githubusercontent.com/4912500/55577170-395e7e80-5713-11e9-88a2-d69e15a2f45d.png)

instead of this:

![Screen Shot 2019-04-04 at 7 48 26 PM](https://user-images.githubusercontent.com/4912500/55577159-32377080-5713-11e9-88f5-88c31c5ee281.png)

### Additional notes

Setting the 6.11.0 milestone on this since this `Errors` section is a new addition of 6.11.0