### PR TITLE
[DCA] Improving Lifecycle of the External Metrics Provider

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -207,7 +207,7 @@ func start(cmd *cobra.Command, args []string) error {
 	// HPA Process
 	if config.Datadog.GetBool("external_metrics_provider.enabled") {
 		// Start the k8s custom metrics server. This is a blocking call
-		err = custommetrics.StartServer()
+		err = custommetrics.StartServer(mainCtx)
 		if err != nil {
 			log.Errorf("Could not start the custom metrics API server: %s", err.Error())
 		}

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/fatih/color"
@@ -33,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"sync"
 )
 
 // loggerName is the name of the cluster agent logger
@@ -208,15 +208,13 @@ func start(cmd *cobra.Command, args []string) error {
 	// HPA Process
 	if config.Datadog.GetBool("external_metrics_provider.enabled") {
 		// Start the k8s custom metrics server. This is a blocking call
-		var errServer error
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
 			errServ := custommetrics.RunServer(mainCtx)
-			defer custommetrics.ClearServerResources()
 			if errServ != nil {
-				log.Errorf("Error in the External Metrics API Server: %v", errServer)
+				log.Errorf("Error in the External Metrics API Server: %v", errServ)
 			}
 		}()
 	}

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
+	"context"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -86,7 +87,7 @@ func (a *DatadogMetricsAdapter) makeProviderOrDie() (provider.ExternalMetricsPro
 		return nil, err
 	}
 
-	return custommetrics.NewDatadogProvider(client, mapper, store), nil
+	return custommetrics.NewDatadogProvider(context.Background(), client, mapper, store), nil
 }
 
 // Config creates the configuration containing the required parameters to communicate with the APIServer as an APIService

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -8,6 +8,7 @@
 package custommetrics
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -18,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	"context"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -34,8 +34,8 @@ type DatadogMetricsAdapter struct {
 	basecmd.AdapterBase
 }
 
-// StartServer creates and start a k8s custom metrics API server
-func StartServer(ctx context.Context) error {
+// RunServer creates and start a k8s custom metrics API server
+func RunServer(ctx context.Context) error {
 	cmd = &DatadogMetricsAdapter{}
 	cmd.Flags()
 
@@ -125,9 +125,9 @@ func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 	}, nil
 }
 
-// StopServer closes the connection and the server
+// ClearServerResources closes the connection and the server
 // stops listening to new commands.
-func StopServer() {
+func ClearServerResources() {
 	if stopCh != nil {
 		close(stopCh)
 	}

--- a/cmd/cluster-agent/custommetrics/server.go
+++ b/cmd/cluster-agent/custommetrics/server.go
@@ -36,6 +36,7 @@ type DatadogMetricsAdapter struct {
 
 // RunServer creates and start a k8s custom metrics API server
 func RunServer(ctx context.Context) error {
+	defer clearServerResources()
 	cmd = &DatadogMetricsAdapter{}
 	cmd.Flags()
 
@@ -125,9 +126,9 @@ func (o *DatadogMetricsAdapter) Config() (*apiserver.Config, error) {
 	}, nil
 }
 
-// ClearServerResources closes the connection and the server
+// clearServerResources closes the connection and the server
 // stops listening to new commands.
-func ClearServerResources() {
+func clearServerResources() {
 	if stopCh != nil {
 		close(stopCh)
 	}

--- a/pkg/clusteragent/custommetrics/provider.go
+++ b/pkg/clusteragent/custommetrics/provider.go
@@ -8,8 +8,10 @@
 package custommetrics
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -21,10 +23,8 @@ import (
 	"k8s.io/metrics/pkg/apis/custom_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
-	"context"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"time"
 )
 
 type externalMetric struct {

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -8,29 +8,26 @@
 package custommetrics
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 )
 
-type mockDatadogProvider struct {
+type mockStore struct {
 	mockListAllExternalMetricValues func() ([]ExternalMetricValue, error)
 	metrics                         []ExternalMetricValue
 }
 
-func (m *mockDatadogProvider) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
+func (m *mockStore) ListAllExternalMetricValues() ([]ExternalMetricValue, error) {
 	return m.mockListAllExternalMetricValues()
 }
-func (m *mockDatadogProvider) SetExternalMetricValues([]ExternalMetricValue) error    { return nil }
-func (m *mockDatadogProvider) DeleteExternalMetricValues([]ExternalMetricValue) error { return nil }
-func (m *mockDatadogProvider) GetMetrics() (*MetricsBundle, error)                    { return nil, nil }
+func (m *mockStore) SetExternalMetricValues([]ExternalMetricValue) error    { return nil }
+func (m *mockStore) DeleteExternalMetricValues([]ExternalMetricValue) error { return nil }
+func (m *mockStore) GetMetrics() (*MetricsBundle, error)                    { return nil, nil }
 
 type metricCompare struct {
 	name      provider.ExternalMetricInfo
@@ -42,153 +39,67 @@ func TestListAllExternalMetrics(t *testing.T) {
 	metricName := "m1"
 	metric2Name := "m2"
 	metric3Name := "m3"
-	labels := map[string]string{
-		"foo": "bar",
-	}
-	cachedQuantity, _ := resource.ParseQuantity("0.00000000003")
 	tests := []struct {
-		name          string
-		metricsStored []ExternalMetricValue
-		cached        []externalMetric
-		expected      []externalMetric
-		timestamp     int64
+		name      string
+		res       []provider.ExternalMetricInfo
+		cached    []externalMetric
+		timestamp int64
 	}{
 		{
-			name:          "no metrics stored",
-			metricsStored: []ExternalMetricValue{},
-			cached:        []externalMetric{},
-			expected:      nil,
+			name:   "no metrics stored",
+			res:    []provider.ExternalMetricInfo{},
+			cached: nil,
 		},
 		{
-			name: "last call is too recent",
-			metricsStored: []ExternalMetricValue{
+			name: "one nano metric stored",
+			res: []provider.ExternalMetricInfo{
 				{
-					MetricName: metricName,
-					Labels:     labels,
-					Valid:      true,
-				}},
+					Metric: metricName,
+				},
+			},
 			cached: []externalMetric{{
 				info: provider.ExternalMetricInfo{
 					Metric: metricName,
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: labels,
-					Value:        cachedQuantity,
-				},
-			}},
-			timestamp: metav1.Now().Unix(),
-			expected: []externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
-				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: labels,
-					Value:        cachedQuantity,
-				},
-			}},
-		},
-		{
-			name: "one nano metric stored",
-			metricsStored: []ExternalMetricValue{
-				{
-					MetricName: metricName,
-					Value:      float64(0.000000001),
-					Labels:     labels,
-					Valid:      true,
-				}},
-			cached: []externalMetric{{}},
-			expected: []externalMetric{{
-				info: provider.ExternalMetricInfo{
-					Metric: metricName,
-				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: labels,
-					Value:        resource.MustParse("1e-09"),
-				},
 			},
 			},
-			timestamp: 0,
 		},
 		{
 			name: "multiple types",
-			metricsStored: []ExternalMetricValue{
-				{
-					MetricName: metricName,
-					Value:      float64(0.012),
-					Labels:     labels,
-					Valid:      true,
-				}, {
-					MetricName: metric2Name,
-					Value:      float64(1),
-					Labels:     labels,
-					Valid:      true,
-				}, {
-					MetricName: metric3Name,
-					Value:      float64(1000001),
-					Labels:     labels,
-					Valid:      true,
-				}, {
-					MetricName: "unexpected",
-					Labels:     labels,
-					Valid:      false,
-				},
-			},
-			expected: []externalMetric{{
+			cached: []externalMetric{{
 				info: provider.ExternalMetricInfo{
 					Metric: metricName,
-				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metricName,
-					MetricLabels: labels,
-					Value:        *resource.NewMilliQuantity(12, resource.DecimalSI),
 				},
 			}, {
 				info: provider.ExternalMetricInfo{
 					Metric: metric2Name,
 				},
-				value: external_metrics.ExternalMetricValue{
-					MetricName:   metric2Name,
-					MetricLabels: labels,
-					Value:        resource.MustParse("1"),
+			}, {
+				info: provider.ExternalMetricInfo{
+					Metric: metric3Name,
 				},
 			},
+			},
+			res: []provider.ExternalMetricInfo{
 				{
-					info: provider.ExternalMetricInfo{
-						Metric: metric3Name,
-					},
-					value: external_metrics.ExternalMetricValue{
-						MetricName:   metric3Name,
-						MetricLabels: labels,
-						Value:        resource.MustParse("1.000001e+06"),
-					}}},
+					Metric: metricName,
+				},
+				{
+					Metric: metric2Name,
+				},
+				{
+					Metric: metric3Name,
+				},
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := &mockDatadogProvider{
-				mockListAllExternalMetricValues: func() ([]ExternalMetricValue, error) {
-					return test.metricsStored, nil
-				},
-			}
 			dp := datadogProvider{
-				store:           Store(m),
-				timestamp:       test.timestamp,
-				maxAge:          int64(300),
 				externalMetrics: test.cached,
 			}
 			output := dp.ListAllExternalMetrics()
-			require.Equal(t, len(test.expected), len(output))
-
-			for _, q := range dp.externalMetrics {
-				for _, val := range test.expected {
-					if val.info.Metric == q.info.Metric {
-						require.Equal(t, val.value, q.value)
-					}
-				}
-			}
+			require.Equal(t, len(test.cached), len(output))
 		})
 	}
 }
@@ -205,25 +116,28 @@ func TestGetExternalMetric(t *testing.T) {
 	ns := "default"
 	tests := []struct {
 		name          string
-		metricsStored []ExternalMetricValue
+		metricsStored []externalMetric
 		compared      metricCompare
 		expected      []external_metrics.ExternalMetricValue
 	}{
 		{
 			"nothing stored",
-			nil,
+			[]externalMetric{},
 			metricCompare{},
 			[]external_metrics.ExternalMetricValue{},
 		},
 		{
 			"one matching metric stored",
-			[]ExternalMetricValue{
-				{
-					MetricName: metricName,
-					Labels:     goodLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}},
+			[]externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			},
+			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
 				ns,
@@ -237,13 +151,16 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one non matching metric stored",
-			[]ExternalMetricValue{
-				{
-					MetricName: metricName,
-					Labels:     goodLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}},
+			[]externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			},
+			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
 				ns,
@@ -253,18 +170,24 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one matching name metrics stored",
-			[]ExternalMetricValue{
-				{
-					MetricName: metricName,
-					Labels:     goodLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}, {
-					MetricName: metricName,
-					Labels:     badLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}},
+			[]externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			}, {
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: badLabel,
+				},
+			},
+			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
 				ns,
@@ -279,18 +202,24 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one non matching labels metrics stored",
-			[]ExternalMetricValue{
-				{
-					MetricName: metricName,
-					Labels:     goodLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}, {
-					MetricName: metricName,
-					Labels:     goodLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}},
+			[]externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			}, {
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			},
+			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: metricName},
 				ns,
@@ -300,18 +229,24 @@ func TestGetExternalMetric(t *testing.T) {
 		},
 		{
 			"one matching metric with capital letter stored",
-			[]ExternalMetricValue{
-				{
-					MetricName: "CapitalMetric",
-					Labels:     goodLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}, {
-					MetricName: metricName,
-					Labels:     badLabel,
-					HPA:        ObjectReference{Namespace: ns},
-					Valid:      true,
-				}},
+			[]externalMetric{{
+				info: provider.ExternalMetricInfo{
+					Metric: "CapitalMetric",
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: goodLabel,
+				},
+			}, {
+				info: provider.ExternalMetricInfo{
+					Metric: metricName,
+				},
+				value: external_metrics.ExternalMetricValue{
+					MetricName:   metricName,
+					MetricLabels: badLabel,
+				},
+			},
+			},
 			metricCompare{
 				provider.ExternalMetricInfo{Metric: "capitalmetric"},
 				ns,
@@ -327,13 +262,8 @@ func TestGetExternalMetric(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := &mockDatadogProvider{
-				mockListAllExternalMetricValues: func() ([]ExternalMetricValue, error) {
-					return test.metricsStored, nil
-				},
-			}
 			dp := datadogProvider{
-				store: Store(m),
+				externalMetrics: test.metricsStored,
 			}
 			output, err := dp.GetExternalMetric(test.compared.namespace, test.compared.labels.AsSelector(), test.compared.name)
 			require.NoError(t, err)
@@ -341,7 +271,6 @@ func TestGetExternalMetric(t *testing.T) {
 			// GetExternalMetric should only return one metric
 			if len(output.Items) == 1 {
 				require.Equal(t, test.expected[0].MetricName, output.Items[0].MetricName)
-				fmt.Printf("test is %#v \n \n output is %#v \n \n", test.expected[0].MetricLabels, output.Items[0].MetricLabels)
 				require.True(t, reflect.DeepEqual(test.expected[0].MetricLabels, output.Items[0].MetricLabels))
 			}
 		})

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -98,7 +98,7 @@ func TestListAllExternalMetrics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dp := datadogProvider{
 				externalMetrics: test.cached,
-				serving:         true,
+				isServing:       true,
 			}
 			output := dp.ListAllExternalMetrics()
 			require.Equal(t, len(test.cached), len(output))
@@ -266,7 +266,7 @@ func TestGetExternalMetric(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dp := datadogProvider{
 				externalMetrics: test.metricsStored,
-				serving:         true,
+				isServing:       true,
 				maxAge:          math.MaxInt32, // to avoid flackiness
 			}
 			output, err := dp.GetExternalMetric(test.compared.namespace, test.compared.labels.AsSelector(), test.compared.name)

--- a/pkg/clusteragent/custommetrics/provider_test.go
+++ b/pkg/clusteragent/custommetrics/provider_test.go
@@ -8,6 +8,7 @@
 package custommetrics
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -97,6 +98,7 @@ func TestListAllExternalMetrics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dp := datadogProvider{
 				externalMetrics: test.cached,
+				serving:         true,
 			}
 			output := dp.ListAllExternalMetrics()
 			require.Equal(t, len(test.cached), len(output))
@@ -264,6 +266,8 @@ func TestGetExternalMetric(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dp := datadogProvider{
 				externalMetrics: test.metricsStored,
+				serving:         true,
+				maxAge:          math.MaxInt32, // to avoid flackiness
 			}
 			output, err := dp.GetExternalMetric(test.compared.namespace, test.compared.labels.AsSelector(), test.compared.name)
 			require.NoError(t, err)

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -48,18 +48,18 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 
 	tests := []struct {
 		desc     string
-		metrics  []ExternalMetricValue
+		metrics  map[string]ExternalMetricValue
 		expected []ExternalMetricValue
 	}{
 		{
 			"same metric with different hpas and labels",
-			[]ExternalMetricValue{
-				{
+			map[string]ExternalMetricValue{
+				"external_metric-default-foo-requests_per_s": {
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
 					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
-				{
+				"external_metric-default-bar-requests_per_s": {
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
 					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
@@ -80,13 +80,13 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 		},
 		{
 			"same metric with different owners and same labels",
-			[]ExternalMetricValue{
-				{
+			map[string]ExternalMetricValue{
+				"external_metric-default-foo-requests_per_s": {
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
 					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
-				{
+				"external_metric-default-bar-requests_per_s": {
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "frontend"},
 					HPA:        ObjectReference{Name: "bar", Namespace: "default"},
@@ -106,14 +106,14 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 			},
 		},
 		{
-			"same metric with same owners and different labels",
-			[]ExternalMetricValue{
-				{
-					MetricName: "requests_per_s",
+			"different metric with same owners and different labels",
+			map[string]ExternalMetricValue{
+				"external_metric-default-foo-requests_per_s_2": {
+					MetricName: "requests_per_s_2",
 					Labels:     map[string]string{"role": "frontend"},
 					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
-				{
+				"external_metric-default-foo-requests_per_s": {
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
 					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
@@ -123,6 +123,10 @@ func TestConfigMapStoreExternalMetrics(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"role": "backend"},
+					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
+				}, {
+					MetricName: "requests_per_s_2",
+					Labels:     map[string]string{"role": "frontend"},
 					HPA:        ObjectReference{Name: "foo", Namespace: "default"},
 				},
 			},

--- a/pkg/clusteragent/custommetrics/store_test.go
+++ b/pkg/clusteragent/custommetrics/store_test.go
@@ -184,7 +184,7 @@ func TestExternalMetricValueKeyFunc(t *testing.T) {
 
 	for i, tt := range test {
 		t.Run(fmt.Sprintf("#%d %s", i, tt.desc), func(t *testing.T) {
-			out := externalMetricValueKeyFunc(tt.emval)
+			out := ExternalMetricValueKeyFunc(tt.emval)
 			assert.Equal(t, tt.output, out)
 		})
 	}

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -113,7 +113,7 @@ func (k *KubeASCheck) Run() error {
 		// We start the API Server Client.
 		k.ac, err = apiserver.GetAPIClient()
 		if err != nil {
-			k.Warn("Could not connect to apiserver: %s", err)
+			k.Warnf("Could not connect to apiserver: %s", err)
 			return err
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -380,7 +380,6 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.rollup", 30)                  // Bucket size to circumvent time aggregation side effects.
 	config.BindEnvAndSetDefault("kubernetes_event_collection_timeout", 100)              // timeout between two successful event collections in milliseconds.
 	config.BindEnvAndSetDefault("kubernetes_informers_resync_period", 60*5)              // value in seconds. Default to 5 minutes
-	config.BindEnvAndSetDefault("kubernetes_informers_restclient_timeout", 60)           // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30) // value in seconds
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -108,9 +108,9 @@ func getKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 }
 
 func getInformerFactory() (informers.SharedInformerFactory, error) {
-	timeoutSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_restclient_timeout"))
+	//timeoutSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_restclient_timeout"))
 	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
-	client, err := getKubeClient(timeoutSeconds * time.Second)
+	client, err := getKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
 		return nil, err

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -108,7 +108,6 @@ func getKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 }
 
 func getInformerFactory() (informers.SharedInformerFactory, error) {
-	//timeoutSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_restclient_timeout"))
 	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
 	client, err := getKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -184,8 +184,7 @@ func (h *AutoscalersController) updateExternalMetrics() {
 		if _, ok := globalCache[i]; !ok {
 			globalCache[i] = j
 		} else {
-			eq := reflect.DeepEqual(j.Labels, globalCache[i].Labels)
-			if !eq {
+			if !reflect.DeepEqual(j.Labels, globalCache[i].Labels) {
 				globalCache[i] = j
 			}
 		}
@@ -300,9 +299,9 @@ func (h *AutoscalersController) syncAutoscalers(key interface{}) error {
 		}
 		new := h.hpaProc.ProcessHPAs(hpa)
 		h.toStore.m.Lock()
-		for e, i := range new {
+		for metric, value := range new {
 			// We should only insert placeholders in the local cache.
-			h.toStore.data[e] = i
+			h.toStore.data[metric] = value
 		}
 		h.toStore.m.Unlock()
 

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -75,13 +75,11 @@ type AutoscalersController struct {
 func NewAutoscalersController(client kubernetes.Interface, le LeaderElectorInterface, dogCl hpa.DatadogClient, autoscalingInformer autoscalersinformer.HorizontalPodAutoscalerInformer) (*AutoscalersController, error) {
 	var err error
 
-	s := metricsBatch{
-		data: make(map[string]custommetrics.ExternalMetricValue),
-	}
 	h := &AutoscalersController{
-		queue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "autoscalers"),
-		toStore: s,
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "autoscalers"),
 	}
+
+	h.toStore.data = make(map[string]custommetrics.ExternalMetricValue)
 
 	gcPeriodSeconds := config.Datadog.GetInt("hpa_watcher_gc_period")
 	refreshPeriod := config.Datadog.GetInt("external_metrics_provider.refresh_period")

--- a/pkg/util/kubernetes/apiserver/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller.go
@@ -63,7 +63,7 @@ type AutoscalersController struct {
 	autoscalers chan interface{}
 
 	toStore   metricsBatch
-	hpaProc   *hpa.Processor
+	hpaProc   hpa.ProcessorInterface
 	store     custommetrics.Store
 	clientSet kubernetes.Interface
 	poller    PollerConfig

--- a/pkg/util/kubernetes/apiserver/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/hpa_controller_test.go
@@ -461,10 +461,10 @@ func TestAutoscalerControllerGC(t *testing.T) {
 		{
 			caseName: "hpa exists for metric",
 			metrics: map[string]custommetrics.ExternalMetricValue{
-				"external_metric-default-fobo-requests_per_s": {
+				"external_metric-default-foo-requests_per_s": {
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{Name: "fobo", Namespace: "default", UID: "1111"},
+					HPA:        custommetrics.ObjectReference{Name: "foo", Namespace: "default", UID: "1111"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,
@@ -472,7 +472,7 @@ func TestAutoscalerControllerGC(t *testing.T) {
 			},
 			hpa: &v2beta1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fobo",
+					Name:      "foo",
 					Namespace: "default",
 					UID:       "1111",
 				},
@@ -494,7 +494,7 @@ func TestAutoscalerControllerGC(t *testing.T) {
 				{
 					MetricName: "requests_per_s",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{Name: "fobo", Namespace: "default", UID: "1111"},
+					HPA:        custommetrics.ObjectReference{Name: "foo", Namespace: "default", UID: "1111"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,
@@ -504,10 +504,10 @@ func TestAutoscalerControllerGC(t *testing.T) {
 		{
 			caseName: "no hpa for metric",
 			metrics: map[string]custommetrics.ExternalMetricValue{
-				"external_metric-default-fobo-requests_per_s_b": {
+				"external_metric-default-foo-requests_per_s_b": {
 					MetricName: "requests_per_s_b",
 					Labels:     map[string]string{"bar": "baz"},
-					HPA:        custommetrics.ObjectReference{Name: "fobo", Namespace: "default", UID: "1111"},
+					HPA:        custommetrics.ObjectReference{Name: "foo", Namespace: "default", UID: "1111"},
 					Timestamp:  12,
 					Value:      1,
 					Valid:      false,

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -79,5 +79,13 @@ func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, 
 // We only care about updates of the metrics or their scopes.
 // We also want to process the resync events, which can be identified with the resver.
 func AutoscalerMetricsUpdate(new, old *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return old.ResourceVersion == new.ResourceVersion || old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	var oldAnn, newAnn string
+	if val, ok := old.Annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+		oldAnn = val
+	}
+	if val, ok := new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+		newAnn = val
+	}
+
+	return old.ResourceVersion == new.ResourceVersion || oldAnn != newAnn
 }

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -79,5 +79,5 @@ func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, 
 // We only care about updates of the metrics or their scopes.
 // We also want to process the resync events, which can be identified with the resver.
 func AutoscalerMetricsUpdate(new, old *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return old.ResourceVersion == new.ResourceVersion ||  old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	return old.ResourceVersion == new.ResourceVersion || old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 }

--- a/pkg/util/kubernetes/hpa/hpa.go
+++ b/pkg/util/kubernetes/hpa/hpa.go
@@ -77,6 +77,7 @@ func DiffExternalMetrics(informerList []*autoscalingv2.HorizontalPodAutoscaler, 
 
 // AutoscalerMetricsUpdate will return true if the applied configuration of the Autoscaler has changed.
 // We only care about updates of the metrics or their scopes.
+// We also want to process the resync events, which can be identified with the resver.
 func AutoscalerMetricsUpdate(new, old *autoscalingv2.HorizontalPodAutoscaler) bool {
-	return old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	return old.ResourceVersion == new.ResourceVersion ||  old.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != new.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 }

--- a/pkg/util/kubernetes/hpa/hpa_test.go
+++ b/pkg/util/kubernetes/hpa/hpa_test.go
@@ -10,10 +10,9 @@ package hpa
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/stretchr/testify/assert"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -29,6 +28,7 @@ func TestDiffAutoscalter(t *testing.T) {
 		"No-Op": {
 			&autoscalingv2.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "12",
 					Annotations: map[string]string{
 						"kubectl.kubernetes.io/last-applied-configuration": `
 						"apiVersion":"autoscaling/v2beta1",
@@ -68,6 +68,7 @@ func TestDiffAutoscalter(t *testing.T) {
 			},
 			&autoscalingv2.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "14",
 					Annotations: map[string]string{
 						"kubectl.kubernetes.io/last-applied-configuration": `
 						"apiVersion":"autoscaling/v2beta1",
@@ -106,6 +107,27 @@ func TestDiffAutoscalter(t *testing.T) {
 				},
 			},
 			false,
+		},
+		"Resync": {
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "17",
+					Annotations:     map[string]string{},
+				},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					CurrentReplicas: 12,
+				},
+			},
+			&autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "17",
+					Annotations:     map[string]string{},
+				},
+				Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+					CurrentReplicas: 12,
+				},
+			},
+			true,
 		},
 		"Updated": {
 			&autoscalingv2.HorizontalPodAutoscaler{

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -27,6 +27,11 @@ type DatadogClient interface {
 	QueryMetrics(from, to int64, query string) ([]datadog.Series, error)
 }
 
+type ProcessorInterface interface {
+	UpdateExternalMetrics(emList map[string]custommetrics.ExternalMetricValue) (updated map[string]custommetrics.ExternalMetricValue)
+	ProcessHPAs(hpa *autoscalingv2.HorizontalPodAutoscaler) map[string]custommetrics.ExternalMetricValue
+}
+
 // Processor embeds the configuration to refresh metrics from Datadog and process HPA structs to ExternalMetrics.
 type Processor struct {
 	externalMaxAge time.Duration

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -27,6 +27,7 @@ type DatadogClient interface {
 	QueryMetrics(from, to int64, query string) ([]datadog.Series, error)
 }
 
+// ProcessorInterface is used to easily mock the interface for testing
 type ProcessorInterface interface {
 	UpdateExternalMetrics(emList map[string]custommetrics.ExternalMetricValue) (updated map[string]custommetrics.ExternalMetricValue)
 	ProcessHPAs(hpa *autoscalingv2.HorizontalPodAutoscaler) map[string]custommetrics.ExternalMetricValue

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -110,6 +110,7 @@ func (p *Processor) validateExternalMetric(emList map[string]custommetrics.Exter
 }
 
 func invalidate(emList map[string]custommetrics.ExternalMetricValue) (invList map[string]custommetrics.ExternalMetricValue) {
+	invList = make(map[string]custommetrics.ExternalMetricValue)
 	for id, e := range emList {
 		e.Valid = false
 		e.Timestamp = metav1.Now().Unix()

--- a/pkg/util/kubernetes/hpa/processor.go
+++ b/pkg/util/kubernetes/hpa/processor.go
@@ -44,10 +44,10 @@ func NewProcessor(datadogCl DatadogClient) (*Processor, error) {
 
 // UpdateExternalMetrics does the validation and processing of the ExternalMetrics
 // TODO if a metric's ts in emList is too recent, no need to add it to the batchUpdate.
-func (p *Processor) UpdateExternalMetrics(emList []custommetrics.ExternalMetricValue) (updated []custommetrics.ExternalMetricValue) {
+func (p *Processor) UpdateExternalMetrics(emList map[string]custommetrics.ExternalMetricValue) (updated map[string]custommetrics.ExternalMetricValue) {
 	maxAge := int64(p.externalMaxAge.Seconds())
 	var err error
-
+	updated = make(map[string]custommetrics.ExternalMetricValue)
 	metrics, err := p.validateExternalMetric(emList)
 	if len(metrics) == 0 && err != nil {
 		log.Errorf("Error getting metrics from Datadog: %v", err.Error())
@@ -56,7 +56,7 @@ func (p *Processor) UpdateExternalMetrics(emList []custommetrics.ExternalMetricV
 		return invalidate(emList)
 	}
 
-	for _, em := range emList {
+	for id, em := range emList {
 		// use query (metricName{scope}) as a key to avoid conflict if multiple hpas are using the same metric with different scopes.
 		metricIdentifier := getKey(em.MetricName, em.Labels)
 		metric := metrics[metricIdentifier]
@@ -66,7 +66,7 @@ func (p *Processor) UpdateExternalMetrics(emList []custommetrics.ExternalMetricV
 			em.Valid = false
 			em.Value = metric.value
 			em.Timestamp = time.Now().Unix()
-			updated = append(updated, em)
+			updated[id] = em
 			continue
 		}
 
@@ -74,42 +74,28 @@ func (p *Processor) UpdateExternalMetrics(emList []custommetrics.ExternalMetricV
 		em.Value = metric.value
 		em.Timestamp = metric.timestamp
 		log.Debugf("Updated the external metric %#v", em)
-		updated = append(updated, em)
-
+		updated[id] = em
 	}
 	return updated
 }
 
 // ProcessHPAs processes the HorizontalPodAutoscalers into a list of ExternalMetricValues.
-func (p *Processor) ProcessHPAs(hpa *autoscalingv2.HorizontalPodAutoscaler) []custommetrics.ExternalMetricValue {
-	var externalMetrics []custommetrics.ExternalMetricValue
-	var err error
+func (p *Processor) ProcessHPAs(hpa *autoscalingv2.HorizontalPodAutoscaler) map[string]custommetrics.ExternalMetricValue {
+	externalMetrics := make(map[string]custommetrics.ExternalMetricValue)
 	emList := Inspect(hpa)
-	metrics, err := p.validateExternalMetric(emList)
-	if err != nil && len(metrics) == 0 {
-		log.Errorf("Could not validate external metrics: %v", err)
-		return invalidate(emList)
-	}
 	for _, em := range emList {
-		maxAge := int64(p.externalMaxAge.Seconds())
-		metricIdentifier := getKey(em.MetricName, em.Labels)
-		metric := metrics[metricIdentifier]
-		em.Value = metric.value
-		em.Timestamp = metric.timestamp
-		em.Valid = metric.valid
-		if metav1.Now().Unix()-metric.timestamp > maxAge {
-			// If the maxAge is lower than the freshness of the metric, the metric is invalidated in the global store
-			em.Valid = false
-			em.Timestamp = metav1.Now().Unix() // The Timestamp is not the one of the metric, because we only rely on it to refresh.
-		}
-		log.Debugf("Added external metrics %#v", em)
-		externalMetrics = append(externalMetrics, em)
+		em.Value = 0
+		em.Timestamp = time.Now().Unix()
+		em.Valid = false
+		log.Tracef("Created a boilerplate for the external metrics %#v", em)
+		id := custommetrics.ExternalMetricValueKeyFunc(em)
+		externalMetrics[id] = em
 	}
 	return externalMetrics
 }
 
 // validateExternalMetric queries Datadog to validate the availability and value of one or more external metrics
-func (p *Processor) validateExternalMetric(emList []custommetrics.ExternalMetricValue) (processed map[string]Point, err error) {
+func (p *Processor) validateExternalMetric(emList map[string]custommetrics.ExternalMetricValue) (processed map[string]Point, err error) {
 	var batch []string
 	for _, e := range emList {
 		q := getKey(e.MetricName, e.Labels)
@@ -118,11 +104,11 @@ func (p *Processor) validateExternalMetric(emList []custommetrics.ExternalMetric
 	return p.queryDatadogExternal(batch)
 }
 
-func invalidate(emList []custommetrics.ExternalMetricValue) (invList []custommetrics.ExternalMetricValue) {
-	for _, e := range emList {
+func invalidate(emList map[string]custommetrics.ExternalMetricValue) (invList map[string]custommetrics.ExternalMetricValue) {
+	for id, e := range emList {
 		e.Valid = false
 		e.Timestamp = metav1.Now().Unix()
-		invList = append(invList, e)
+		invList[id] = e
 	}
 	return invList
 }


### PR DESCRIPTION
### What does this PR do?

Update the Lifecycle of the External Metrics Provider.

- Do not ignore the events from the resync
leverage the resver being the same when receiving an update event.
- Removed the calls to Datadog upon initial processing
- Batch to the configmap at a deterministic frequency
We use to make a call to DD to validate the metrics right away. The call would not batch metrics, so it would be suboptimal. This also reduces the access to the CM
- Move the provider logic to leverage a cache that is updated async
This separates the two processes, aligning with the upstream implementation guidelines.

- Update data structure of the local cache to reflect the informer's state. 
This fixes the lifecycle issue, as if a leader churns, the Update method now only update what is necessary by comparing the Global Store (populated by the previous leader) and the local store (populated by the informer's events).

- Improve the key/queue handling
Make sure keys are dropped correctly
- Fix the Delete Key access
For a delete event, every DCA would be able to remove the key from the store. This is suboptimal.

- Leverage contexts
If we can't get the data from the ConfigMap, we permafail after 3 retries. This will lead to the async loop to stop, and therefore, the provider will disable the `serving` which will lead to 503 in the GetExternalMetrics endpoint.

- Update the tests

Next Steps (follow up PRs):
- Better handle deletion of the ConfigMap (have the same pattern as the LE)
- Register the external metrics as a healthcheck
- Investigate stopping the external metrics server completely in case of permafail
- Restart the async loop at some point
- Batch the metrics

### Motivation

Improve the Lifecycle of the External Metrics Provider

### Results

With a 60 seconds resync period
![image](https://user-images.githubusercontent.com/7433560/56046775-023f2d00-5d12-11e9-8965-32ac71ced54e.png)
We get the CM every 30 seconds, and we update it upon refresh from Datadog (which also happens every 30 seconds). So we have 1-2 Update per minute. This does not depend on the activity of the HPA Controller (creation/update)

versus with the current master:
![image](https://user-images.githubusercontent.com/7433560/56048056-b0e46d00-5d14-11e9-87bc-306534dbb98d.png)
We can see 5 calls to the CM, this happens as you create an HPA. Because the process was not streamlined.

Across resources, we also see the watch from the resync of the informer now:
![image](https://user-images.githubusercontent.com/7433560/56047028-8ee9eb00-5d12-11e9-85c4-4f631563e424.png)
Versus with the current master:
![image](https://user-images.githubusercontent.com/7433560/56047975-898da000-5d14-11e9-8544-9edca6a29ac1.png)
We can see many more watches, these were due to the 1 minute timeout hardcoded in the clientset used for the informers. Also, the Resync where not processed, so it would not be leveraged.
