### PR TITLE
Add validation of NTP responses

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -147,11 +147,12 @@
   version = "v1.12.79"
 
 [[projects]]
-  digest = "1:6be42bbbddbfee4a16898ac880e57f98db1a458c45059ff0fbb95a5824143ad9"
+  digest = "1:69cd4c6b99da8496362f344d4ef292bb353877a91b998935a44eab294b593a20"
   name = "github.com/beevik/ntp"
   packages = ["."]
   pruneopts = ""
-  revision = "cb3dae3a7588ae35829eb5724df611cd75152fba"
+  revision = "62c80a04de2086884d8296004b6d74ee1846c582"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
@@ -1268,14 +1269,18 @@
   digest = "1:1b5927d8f58faa4702a58cee18096fe7aa4c074dcd20f3b5c60d23a18059676d"
   name = "golang.org/x/net"
   packages = [
+    "bpf",
     "context",
     "context/ctxhttp",
     "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
+    "internal/iana",
+    "internal/socket",
     "internal/socks",
     "internal/timeseries",
+    "ipv4",
     "proxy",
     "trace",
     "websocket",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/beevik/ntp"
-  revision = "cb3dae3a7588ae35829eb5724df611cd75152fba"
+  version = "~0.2.0"
 
 [[constraint]]
   name = "github.com/cihub/seelog"

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -28,7 +28,7 @@ const ntpCheckName = "ntp"
 var (
 	ntpExpVar = expvar.NewFloat("ntpOffset")
 	// for testing purpose
-	ntpQuery = ntp.Query
+	ntpQuery = ntp.QueryWithOptions
 )
 
 // NTPCheck only has sender and config
@@ -175,12 +175,12 @@ func (c *NTPCheck) queryOffset() (float64, error) {
 	offsets := []float64{}
 
 	for _, host := range c.cfg.instance.Hosts {
-		response, err := ntpQuery(host, c.cfg.instance.Version)
+		response, err := ntpQuery(host, ntp.QueryOptions{Version: c.cfg.instance.Version})
 		if err != nil {
 			log.Infof("There was an error querying the ntp host %s: %s", host, err)
-		} else {
-			offsets = append(offsets, response.ClockOffset.Seconds())
+			continue
 		}
+		offsets = append(offsets, response.ClockOffset.Seconds())
 	}
 
 	if len(offsets) == 0 {

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -180,6 +180,11 @@ func (c *NTPCheck) queryOffset() (float64, error) {
 			log.Infof("There was an error querying the ntp host %s: %s", host, err)
 			continue
 		}
+		err = response.Validate()
+		if err != nil {
+			log.Infof("The ntp response is not valid for host %s: %s", host, err)
+			continue
+		}
 		offsets = append(offsets, response.ClockOffset.Seconds())
 	}
 

--- a/pkg/collector/corechecks/net/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp_test.go
@@ -29,13 +29,14 @@ timeout: 5
 	offset = 10
 )
 
-func testNTPQueryError(host string, version int) (*ntp.Response, error) {
+func testNTPQueryError(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
 	return nil, fmt.Errorf("test error from NTP")
 }
 
-func testNTPQuery(host string, version int) (*ntp.Response, error) {
+func testNTPQuery(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
 	return &ntp.Response{
 		ClockOffset: time.Duration(offset) * time.Second,
+		Stratum:     1,
 	}, nil
 }
 
@@ -45,7 +46,7 @@ func TestNTPOK(t *testing.T) {
 
 	offset = 21
 	ntpQuery = testNTPQuery
-	defer func() { ntpQuery = ntp.Query }()
+	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
@@ -75,7 +76,7 @@ func TestNTPCritical(t *testing.T) {
 
 	offset = 100
 	ntpQuery = testNTPQuery
-	defer func() { ntpQuery = ntp.Query }()
+	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
@@ -104,7 +105,7 @@ func TestNTPError(t *testing.T) {
 	var ntpInitCfg = []byte("")
 
 	ntpQuery = testNTPQueryError
-	defer func() { ntpQuery = ntp.Query }()
+	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
@@ -133,7 +134,7 @@ func TestNTPNegativeOffsetCritical(t *testing.T) {
 
 	offset = -100
 	ntpQuery = testNTPQuery
-	defer func() { ntpQuery = ntp.Query }()
+	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
@@ -167,13 +168,14 @@ hosts:
 	var ntpInitCfg = []byte("")
 
 	offset = 1
-	ntpQuery = func(host string, version int) (*ntp.Response, error) {
+	ntpQuery = func(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
 		o, _ := strconv.Atoi(host)
 		return &ntp.Response{
 			ClockOffset: time.Duration(o) * time.Second,
+			Stratum:     15,
 		}, nil
 	}
-	defer func() { ntpQuery = ntp.Query }()
+	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)
@@ -207,13 +209,14 @@ hosts:
 	var ntpInitCfg = []byte("")
 
 	offset = 1
-	ntpQuery = func(host string, version int) (*ntp.Response, error) {
+	ntpQuery = func(host string, opt ntp.QueryOptions) (*ntp.Response, error) {
 		o, _ := strconv.Atoi(host)
 		return &ntp.Response{
 			ClockOffset: time.Duration(o) * time.Second,
+			Stratum:     15,
 		}, nil
 	}
-	defer func() { ntpQuery = ntp.Query }()
+	defer func() { ntpQuery = ntp.QueryWithOptions }()
 
 	ntpCheck := new(NTPCheck)
 	ntpCheck.Configure(ntpCfg, ntpInitCfg)

--- a/releasenotes/notes/ntp-validation-f1ed49f573443607.yaml
+++ b/releasenotes/notes/ntp-validation-f1ed49f573443607.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Added validity checks to NTP responses


### PR DESCRIPTION
### What does this PR do?

Makes the NTP check discard invalid responses from NTP servers.

This is the validation function used:
https://github.com/beevik/ntp/blob/master/ntp.go#L238-L279