### PR TITLE
[macOS omnibus][kerberos] Rely on the system libraries

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -22,12 +22,6 @@ end
 relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7"
 
-if osx?
-  # on macOS, the Kerberos shared libraries are provided with the base system
-  # and the pykerberos package expects to be linked against them rather than `libkrb5`
-  whitelist_file "Kerberos"
-end
-
 source git: 'https://github.com/DataDog/integrations-core.git'
 
 PIPTOOLS_VERSION = "2.0.2"

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -15,15 +15,18 @@ if linux?
   # add nfsiostat script
   dependency 'unixodbc'
   dependency 'nfsiostat'
-end
-
-unless windows?
   # need kerberos for hdfs
   dependency 'libkrb5'
 end
 
 relative_path 'integrations-core'
 whitelist_file "embedded/lib/python2.7"
+
+if osx?
+  # on macOS, the Kerberos shared libraries are provided with the base system
+  # and the pykerberos package expects to be linked against them rather than `libkrb5`
+  whitelist_file "Kerberos"
+end
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 


### PR DESCRIPTION
### What does this PR do?

On macOS, makes our omnibus build rely on the system-provided Kerberos lib.

Fixes the macOS omnibus build.

### Motivation

On macOS, the python `pykerberos` package expects to be linked against
the shared Kerberos lib provided by the base system, rather than our
own compiled `libkrb5`. (otherwise, at runtime, importing pykerberos
fails with all kinds of failed symbol lookups)

So let's just rely on the system-provided lib.

Not 100% confident how backward compatibility would work if we were to
upgrade our mac builder to a later macOS version though. (our mac builder
is currently on macOS 10.12)

### Additional Notes

After building the omnibus package on macOS, I checked that the following imports
worked in the embedded python:

```py
import requests_kerberos
import kerberos
```

Follow-up to https://github.com/DataDog/omnibus-software/pull/220 and https://github.com/DataDog/datadog-agent/pull/2655

(later) PR to have a better approach to whitelisting files: https://github.com/DataDog/datadog-agent/pull/3263