### PR TITLE
[omnibus] Don't whitelist all the binaries in lib/python2.7

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -20,7 +20,6 @@ if linux?
 end
 
 relative_path 'integrations-core'
-whitelist_file "embedded/lib/python2.7"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 


### PR DESCRIPTION
### What does this PR do?

Not recommended to whitelist this many binaries, let's have a
targeted approach instead.

### Motivation

Have a safer omnibus build.

### Additional Notes

Still a draft, will create final PR once all builds are confirmed to work

Requires https://github.com/DataDog/omnibus-ruby/pull/81