### PR TITLE
[status/GUI] Avoid displaying log file path if it's empty

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -8,7 +8,9 @@
         <br>Check Workers: {{.runnerStats.Workers}}
       {{end}}
       <br>Agent start: {{.agent_start}}
-      <br>Log File: {{.config.log_file}}
+      {{- if .config.log_file}}
+        <br>Log File: {{.config.log_file}}
+      {{end}}
       <br>Log Level: {{.config.log_level}}
       <br>Config File: {{if .conf_file}}{{.conf_file}}
                        {{else}}There is no config file

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -14,7 +14,9 @@ NOTE: Changes made to this template should be reflected on the following templat
   {{- if .runnerStats.Workers}}
   Check Runners: {{.runnerStats.Workers}}
   {{end -}}
-  Log file: {{.config.log_file}}
+  {{- if .config.log_file}}
+  Log File: {{.config.log_file}}
+  {{end -}}
   Log Level: {{.config.log_level}}
 
   Paths


### PR DESCRIPTION
### What does this PR do?

Avoid displaying log file path if it's empty.

Having an empty `log_file` entry in the config is actually the default, since unlike other config params the default isn't set on `config.Datadog`.

Follow-up to https://github.com/DataDog/datadog-agent/pull/3200

### Motivation

Avoid displaying an empty `Log File` entry on the status page and GUI. We'll only display it if it was customized by the user.

### Additional Notes

A better fix would be to make it so that the `log_file` config option has a sane default value on the config struct, but it's a significant change that I don't want to do this late in the `6.11.0` release process.
