### PR TITLE
Add check for empty value; empty value is written if the user doesn't

### DIFF
--- a/cmd/agent/common/common_windows.go
+++ b/cmd/agent/common/common_windows.go
@@ -170,19 +170,19 @@ func ImportRegistryConfig() error {
 
 	var val string
 
-	if val, _, err = k.GetStringValue("api_key"); err == nil {
+	if val, _, err = k.GetStringValue("api_key"); err == nil && val != "" {
 		overrides["api_key"] = val
 		log.Debug("Setting API key")
 	} else {
 		log.Debug("API key not found, not setting")
 	}
-	if val, _, err = k.GetStringValue("tags"); err == nil {
+	if val, _, err = k.GetStringValue("tags"); err == nil && val != "" {
 		overrides["tags"] = strings.Split(val, ",")
 		log.Debugf("Setting tags %s", val)
 	} else {
 		log.Debug("Tags not found, not setting")
 	}
-	if val, _, err = k.GetStringValue("hostname"); err == nil {
+	if val, _, err = k.GetStringValue("hostname"); err == nil && val != "" {
 		overrides["hostname"] = val
 		log.Debugf("Setting hostname %s", val)
 	} else {

--- a/releasenotes/notes/fixup-1b50793d6b2dfe0f.yaml
+++ b/releasenotes/notes/fixup-1b50793d6b2dfe0f.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes bug in which upgrading from agent5 doesn't correctly import the configuration


### PR DESCRIPTION
specify a value.  Empty value was being written over the value inherited
from `datadog.conf` when upgrading from A5

