### PR TITLE
Remove lingering log processing changes from dockerfile

### DIFF
--- a/Dockerfiles/agent/s6-services/agent/run
+++ b/Dockerfiles/agent/s6-services/agent/run
@@ -1,5 +1,4 @@
 #!/usr/bin/execlineb -P
 
 foreground { /initlog.sh "starting agent" }
-fdmove -c 2 1
 agent run

--- a/Dockerfiles/agent/s6-services/network/finish
+++ b/Dockerfiles/agent/s6-services/network/finish
@@ -7,7 +7,6 @@ ifthenelse
     {
         foreground { /initlog.sh "network-tracer exited with code ${1}, disabling" }
         foreground { /bin/s6-svc -d /var/run/s6/services/network/ }
-        foreground { /bin/s6-svc -d /var/run/s6/services/network/log }
     }
     {
         foreground { /initlog.sh "network-tracer exited with code ${1}, signal ${2}, restarting in 2 seconds" }

--- a/Dockerfiles/agent/s6-services/network/run
+++ b/Dockerfiles/agent/s6-services/network/run
@@ -1,5 +1,4 @@
 #!/usr/bin/execlineb -P
 
 foreground { /initlog.sh "starting network-tracer" }
-fdmove -c 2 1
 network-tracer --config=/etc/datadog-agent/network-tracer.yaml

--- a/Dockerfiles/agent/s6-services/process/finish
+++ b/Dockerfiles/agent/s6-services/process/finish
@@ -7,7 +7,6 @@ ifthenelse
     {
         foreground { /initlog.sh "process-agent exited with code ${1}, disabling" }
         foreground { /bin/s6-svc -d /var/run/s6/services/process/ }
-        foreground { /bin/s6-svc -d /var/run/s6/services/process/log }
     }
     {
         foreground { /initlog.sh "process-agent exited with code ${1}, signal ${2}, restarting in 2 seconds" }

--- a/Dockerfiles/agent/s6-services/process/run
+++ b/Dockerfiles/agent/s6-services/process/run
@@ -1,5 +1,4 @@
 #!/usr/bin/execlineb -P
 
 foreground { /initlog.sh "starting process-agent" }
-fdmove -c 2 1
 process-agent --config=/etc/datadog-agent/datadog.yaml

--- a/Dockerfiles/agent/s6-services/trace/finish
+++ b/Dockerfiles/agent/s6-services/trace/finish
@@ -7,7 +7,6 @@ ifthenelse
     {
         foreground { /initlog.sh "trace-agent exited with code ${1}, disabling" }
         foreground { /bin/s6-svc -d /var/run/s6/services/trace/ }
-        foreground { /bin/s6-svc -d /var/run/s6/services/trace/log }
     }
     {
         foreground { /initlog.sh "trace-agent exited with code ${1}, signal ${2}, restarting in 2 seconds" }

--- a/Dockerfiles/agent/s6-services/trace/run
+++ b/Dockerfiles/agent/s6-services/trace/run
@@ -1,5 +1,4 @@
 #!/usr/bin/execlineb -P
 
 foreground { /initlog.sh "starting trace-agent" }
-fdmove -c 2 1
 trace-agent --config=/etc/datadog-agent/datadog.yaml


### PR DESCRIPTION
### What does this PR do?

- Remove the code in unit `finish` scripts that stops the log handler (removed in 6.11). Removes the following error lines:

```
network-tracer exited with code 0, disabling
s6-svc: fatal: unable to control /var/run/s6/services/network/log: No such file or directory
trace-agent exited with code 0, disabling
s6-svc: fatal: unable to control /var/run/s6/services/trace/log: No such file or directory
process-agent exited with code 0, disabling
s6-svc: fatal: unable to control /var/run/s6/services/process/log: No such file or directory
```

- Remove the `fdmove -c 2 1` call (moving stderr to stdout), that was required for the log wrapper