### PR TITLE
pkg/trace/agent: ensure version is displayed no matter config

### DIFF
--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -25,6 +25,11 @@ to your datadog.yaml. Exiting...`
 
 // Run is the entrypoint of our code, which starts the agent.
 func Run(ctx context.Context) {
+	if flags.Version {
+		fmt.Print(info.VersionString())
+		return
+	}
+
 	cfg, err := config.Load(flags.ConfigPath)
 	if err != nil {
 		osutil.Exitf("%v", err)
@@ -32,11 +37,6 @@ func Run(ctx context.Context) {
 	err = info.InitInfo(cfg) // for expvar & -info option
 	if err != nil {
 		osutil.Exitf("%v", err)
-	}
-
-	if flags.Version {
-		fmt.Print(info.VersionString())
-		return
 	}
 
 	if flags.Info {

--- a/releasenotes/notes/apm-show-version-500d3138999675a1.yaml
+++ b/releasenotes/notes/apm-show-version-500d3138999675a1.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix issue with `--version` flag when API key is unset.


### PR DESCRIPTION
This change ensures that the `--version` flag correctly displays the
version. Previously it wouldn't and instead an error would be shown that
the API key is missing (when it wasn't set by any means).