### PR TITLE
[config] Remove doc entries on unused JMXFetch settings

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/loader_test.go
+++ b/pkg/collector/corechecks/embed/jmx/loader_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,9 +36,6 @@ func TestLoadCheckConfig(t *testing.T) {
 	}
 
 	defer os.RemoveAll(tmp) // clean up
-
-	mockConfig := config.Mock()
-	mockConfig.Set("jmx_pipe_path", tmp)
 
 	jl, err := NewJMXCheckLoader()
 	assert.Nil(t, err)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -334,9 +334,6 @@ api_key:
 {{- if .JMX }}
 # JMX
 #
-# jmx_pipe_path:
-# jmx_pipe_name: dd-auto_discovery
-#
 # If you only run Autodiscovery tests, jmxfetch might fail to pick up custom_jar_paths
 # set in the check templates. If that is the case, you can force custom jars here.
 # jmx_custom_jars:
@@ -811,9 +808,9 @@ api_key:
 #   dd_agent_bin:
 #   Overrides of the environment we pass to fetch the hostname. The default is usually fine.
 #   dd_agent_env:
-#   Hide sensitive data on the Live Processes page, default value: true  
+#   Hide sensitive data on the Live Processes page, default value: true
 #   scrub_args: true
-#   Define your own list of sensitive data to be merged with the default one 
+#   Define your own list of sensitive data to be merged with the default one
 #   custom_sensitive_words: ['personal_key', '*token', 'sql*', *pass*d*']
 {{ end -}}
 


### PR DESCRIPTION
### What does this PR do?

Remove doc entries on unused JMXFetch settings.

### Motivation

`jmx_pipe_name` and `jmx_pipe_path` are options that are not used by
the Agent/JMXFetch anymore (they date back to when the Agent 6 was
communicating with JMXFetch through a unix socket, which isn't the case
anymore). Remove them from docs/tests.
