### PR TITLE
Add macos-specific logic for user checking

### DIFF
--- a/cmd/agent/app/integrations_darwin.go
+++ b/cmd/agent/app/integrations_darwin.go
@@ -26,3 +26,7 @@ var (
 func authorizedUser() bool {
 	return true
 }
+
+func isIntegrationUser() bool {
+	return true
+}

--- a/cmd/agent/app/integrations_darwin.go
+++ b/cmd/agent/app/integrations_darwin.go
@@ -24,5 +24,5 @@ var (
 )
 
 func authorizedUser() bool {
-	return (os.Geteuid() != 0)
+	return true
 }

--- a/cmd/agent/app/integrations_darwin.go
+++ b/cmd/agent/app/integrations_darwin.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build !windows !darwin
 // +build cpython
 
 package app
@@ -26,8 +25,4 @@ var (
 
 func authorizedUser() bool {
 	return (os.Geteuid() != 0)
-}
-
-func isIntegrationUser() bool {
-	return true
 }

--- a/cmd/agent/app/integrations_darwin.go
+++ b/cmd/agent/app/integrations_darwin.go
@@ -8,7 +8,6 @@
 package app
 
 import (
-	"os"
 	"path/filepath"
 )
 

--- a/cmd/agent/app/integrations_nix.go
+++ b/cmd/agent/app/integrations_nix.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build !windows !darwin
+// +build !windows,!darwin
 // +build cpython
 
 package app

--- a/releasenotes/notes/integration_mac-7fde5a422f656f20.yaml
+++ b/releasenotes/notes/integration_mac-7fde5a422f656f20.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Allow macOS users to invoke the `datadog-agent integration` command as root since the installation directory is owned by root.


### PR DESCRIPTION
### What does this PR do?

Wheels need to be installed as root on macOS, since the `/opt/datadog-agent` repository is owned by root. This allow to execute the command as sudo for macOS user.

### Motivation

Need this for workshop

### Additional Notes

Anything else we should know when reviewing?