### PR TITLE
Install openjdk-8 from debian stable for 6.11.x

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -63,10 +63,15 @@ ENV DOCKER_DD_AGENT=true \
     S6_READ_ONLY_ROOT=1
 
 # Install openjdk-8-jre-headless on jmx flavor
-RUN if [ -n "$WITH_JMX" ]; then apt-get update \
+RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-8 from stable" \
+ && echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list \
+ && echo "deb http://security.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list.d/stretch.list \
+ && echo "deb http://deb.debian.org/debian stretch-updates main" >> /etc/apt/sources.list.d/stretch.list \
+ && apt-get update \
  && mkdir /usr/share/man/man1 \
  && apt-get install --no-install-recommends -y openjdk-8-jre-headless \
  && apt-get clean \
+ && rm /etc/apt/sources.list.d/stretch.list \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; fi
 
 # make sure we have recent dependencies


### PR DESCRIPTION
### What does this PR do?

`openjdk-8` was removed from Debian Buster (in favor of the newer version 11).
As moving to `openjdk-11` will require extensive testing, this PR temporarily installs `openjdk-8` from the stable repos, for the 6.11.x branch.

We should plan the work to move 6.12.x to the newer JDK.

### Changes

Diff of `dpkg -l` output compared to rc2:

```
--- rc2	2019-04-08 16:38:24.272919659 +0000
+++ rc3	2019-04-08 16:40:52.121341619 +0000
@@ -119,7 +119,7 @@
 ii  mount                        2.33.1-0.1           amd64        tools for mounting and manipulating filesystems
 ii  ncurses-base                 6.1+20181013-2       all          basic terminal type definitions
 ii  ncurses-bin                  6.1+20181013-2       amd64        terminal-related programs and man pages
-ii  openjdk-8-jre-headless:amd64 8u212-b01-1          amd64        OpenJDK Java runtime, using Hotspot JIT (headless)
+ii  openjdk-8-jre-headless:amd64 8u212-b01-1~deb9u1   amd64        OpenJDK Java runtime, using Hotspot JIT (headless)
 ii  openssl                      1.1.1b-1             amd64        Secure Sockets Layer toolkit - cryptographic utility
 ii  passwd                       1:4.5-1.1            amd64        change and administer password and group data
 ii  perl-base                    5.28.1-4             amd64        minimal Perl system
```
