### PR TITLE
FIX kube_service tag with cluster-agent 1.3.0 call

### DIFF
--- a/pkg/clusteragent/api/v1/types.go
+++ b/pkg/clusteragent/api/v1/types.go
@@ -17,10 +17,10 @@ import (
 // The data is stored in the following schema:
 // {
 // 	"namespace1": {
-// 		"pod": [ "svc1", "svc2", "svc3" ]
+// 		"pod": { "svc1": {}, "svc2": {}, "svc3": {} ]
 // 	},
 //  "namespace2": {
-// 		"pod2": [ "svc1", "svc2", "svc3" ]
+// 		"pod2": [ "svc1": {}, "svc2": {}, "svc3": {} ]
 // 	}
 // }
 type NamespacesPodsStringsSet map[string]MapStringSet

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -66,10 +66,16 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 		for _, tagDCA := range metadataNames {
 			log.Tracef("Tagging %s with %s", po.Metadata.Name, tagDCA)
 			tag = strings.Split(tagDCA, ":")
-			if len(tag) != 2 {
+			switch len(tag) {
+			case 1:
+				// c.dcaClient.GetPodsMetadataForNode returns only a list of services
+				// but not the tag key
+				tagList.AddLow("kube_service", tag[0])
+			case 2:
+				tagList.AddLow(tag[0], tag[1])
+			default:
 				continue
 			}
-			tagList.AddLow(tag[0], tag[1])
 		}
 
 		low, orchestrator, high := tagList.Compute()


### PR DESCRIPTION
### What does this PR do?

fix adding "kube_service" tag on pods. when running with cluster-agent 1.3.X

### Motivation


### Additional Notes

need to be tested with a cluster-agent 1.3.x
