### PR TITLE
pkg/trace/api: ensure listener gets closed only once

### DIFF
--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -96,13 +96,12 @@ func (sl *rateLimitedListener) Accept() (net.Conn, error) {
 
 // Close wraps the Close method of the underlying tcp listener
 func (sl *rateLimitedListener) Close() error {
-	if atomic.LoadUint32(&sl.closed) != 0 {
+	if !atomic.CompareAndSwapUint32(&sl.closed, 0, 1) {
 		// already closed; avoid multiple calls if we're on go1.10
 		// https://golang.org/issue/24803
 		return nil
 	}
 	sl.exit <- struct{}{}
 	<-sl.exit
-	atomic.StoreUint32(&sl.closed, 1)
 	return sl.TCPListener.Close()
 }

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -14,7 +14,8 @@ type rateLimitedListener struct {
 	connLease int32 // How many connections are available for this listener before rate-limiting kicks in
 	*net.TCPListener
 
-	exit chan struct{}
+	exit   chan struct{}
+	closed uint32
 }
 
 // newRateLimitedListener returns a new wrapped listener, which is non-initialized
@@ -95,7 +96,13 @@ func (sl *rateLimitedListener) Accept() (net.Conn, error) {
 
 // Close wraps the Close method of the underlying tcp listener
 func (sl *rateLimitedListener) Close() error {
+	if atomic.LoadUint32(&sl.closed) != 0 {
+		// already closed; avoid multiple calls if we're on go1.10
+		// https://golang.org/issue/24803
+		return nil
+	}
 	sl.exit <- struct{}{}
 	<-sl.exit
+	atomic.StoreUint32(&sl.closed, 1)
 	return sl.TCPListener.Close()
 }


### PR DESCRIPTION
This change fixes a non-critical panic which was occurring with go1.10.
In some situations, `Close` would get called multiple times on the
listener when exiting the trace-agent. This was a bug in the `net/http`
package.

For our releases, we use go1.11 where this problem doesn't exist, but better
avoid it if we can.

For details, see golang/go#24803.