### PR TITLE
pkg/trace/api: improve normalizeTag algorithm

### DIFF
--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -282,22 +282,18 @@ func normalizeTag(tag string) string {
 	)
 	norm := []byte(tag)
 	for i, c = range tag {
-		if chars >= maxTagLength {
-			// we've reached the maximum
-			break
-		}
 		// fast path; all letters (and colons) are ok
 		switch {
 		case c >= 'a' && c <= 'z' || c == ':':
 			chars++
 			wiping = false
-			continue
+			goto end
 		case c >= 'A' && c <= 'Z':
 			// lower-case
 			norm[i] += 'a' - 'A'
 			chars++
 			wiping = false
-			continue
+			goto end
 		}
 
 		if utf8.ValidRune(c) && unicode.IsUpper(c) {
@@ -317,7 +313,7 @@ func normalizeTag(tag string) string {
 		case chars == 0:
 			// this character can not start the string, trim
 			trim = i + utf8.RuneLen(c)
-			continue
+			goto end
 		case unicode.IsDigit(c) || c == '.' || c == '/' || c == '-':
 			chars++
 			wiping = false
@@ -331,6 +327,15 @@ func normalizeTag(tag string) string {
 				// lengthen current cut
 				wipe[len(wipe)-1][1] += utf8.RuneLen(c)
 			}
+		}
+	end:
+		if i+utf8.RuneLen(c) >= 2*maxTagLength {
+			// too many illegal characters
+			break
+		}
+		if chars >= maxTagLength {
+			// we've reached the maximum
+			break
 		}
 	}
 

--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -331,7 +331,8 @@ func normalizeTag(v string) string {
 		}
 	end:
 		if i+jump >= 2*maxTagLength {
-			// too many illegal characters
+			// bail early if the tag contains a lot of non-letter/digit characters.
+			// If a tag is test🍣🍣[...]🍣, then it's unlikely to be a properly formatted tag
 			break
 		}
 		if chars >= maxTagLength {

--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -266,70 +266,71 @@ const maxTagLength = 200
 
 // normalizeTag applies some normalization to ensure the tags match the
 // backend requirements
-func normalizeTag(tag string) string {
-	if len(tag) == 0 {
+func normalizeTag(v string) string {
+	if len(v) == 0 {
 		return ""
 	}
 	var (
-		trim   int      // start character (if trimming)
-		wiping bool     // true when the previous character has been discarded
-		wipe   [][2]int // sections to discard: (start, end) pairs
-		chars  int      // number of characters processed
+		trim  int      // start character (if trimming)
+		cuts  [][2]int // sections to discard: (start, end) pairs
+		chars int      // number of characters processed
 	)
 	var (
-		i int  // current byte
-		c rune // current rune
+		i    int  // current byte
+		c    rune // current rune
+		jump int  // tracks how much the for range will advance on the next iteration
 	)
-	norm := []byte(tag)
-	for i, c = range tag {
+	tag := []byte(v)
+	for i, c = range v {
+		jump = utf8.RuneLen(c) // next iteration will be i+jump
+		if c == utf8.RuneError {
+			// on invalid UTF-8, the for range advances only 1 byte;
+			// https://golang.org/ref/spec#For_range (point 2)
+			jump = 1
+		}
 		// fast path; all letters (and colons) are ok
 		switch {
 		case c >= 'a' && c <= 'z' || c == ':':
 			chars++
-			wiping = false
 			goto end
 		case c >= 'A' && c <= 'Z':
 			// lower-case
-			norm[i] += 'a' - 'A'
+			tag[i] += 'a' - 'A'
 			chars++
-			wiping = false
 			goto end
 		}
 
-		if utf8.ValidRune(c) && unicode.IsUpper(c) {
+		if c != utf8.RuneError && unicode.IsUpper(c) {
 			// lowercase this character
 			if low := unicode.ToLower(c); utf8.RuneLen(c) == utf8.RuneLen(low) {
 				// but only if the width of the lowercased character is the same;
 				// there are some rare edge-cases where this is not the case, such
 				// as \u017F (ſ)
-				utf8.EncodeRune(norm[i:], low)
+				utf8.EncodeRune(tag[i:], low)
 				c = low
 			}
 		}
 		switch {
 		case unicode.IsLetter(c):
 			chars++
-			wiping = false
 		case chars == 0:
 			// this character can not start the string, trim
-			trim = i + utf8.RuneLen(c)
+			trim = i + jump
 			goto end
 		case unicode.IsDigit(c) || c == '.' || c == '/' || c == '-':
 			chars++
-			wiping = false
 		default:
 			// illegal character
-			if !wiping {
-				// start a new cut
-				wipe = append(wipe, [2]int{i, i + utf8.RuneLen(c)})
-				wiping = true
+			if n := len(cuts); n > 0 && cuts[n-1][1] >= i {
+				// merge intersecting cuts
+				cuts[n-1][1] += jump
 			} else {
-				// lengthen current cut
-				wipe[len(wipe)-1][1] += utf8.RuneLen(c)
+				// start a new cut
+				cuts = append(cuts, [2]int{i, i + jump})
 			}
 		}
 	end:
-		if i+utf8.RuneLen(c) >= 2*maxTagLength {
+		if i+jump >= 2*maxTagLength {
 			// too many illegal characters
 			break
 		}
@@ -339,36 +340,36 @@ func normalizeTag(tag string) string {
 		}
 	}
 
-	norm = norm[trim : i+utf8.RuneLen(c)] // trim start and end
-	if len(wipe) == 0 {
+	tag = tag[trim : i+jump] // trim start and end
+	if len(cuts) == 0 {
 		// tag was ok, return it as it is
-		return string(norm)
+		return string(tag)
 	}
 	delta := trim // cut offsets delta
-	for _, cut := range wipe {
+	for _, cut := range cuts {
 		// start and end of cut, including delta from previous cuts:
 		start, end := cut[0]-delta, cut[1]-delta
 
-		if end >= len(norm) {
+		if end >= len(tag) {
 			// this cut includes the end of the string; discard it
 			// completely and finish the loop.
-			norm = norm[:start]
+			tag = tag[:start]
 			break
 		}
 		// replace the beginning of the cut with '_'
-		norm[start] = '_'
+		tag[start] = '_'
 		if end-start == 1 {
 			// nothing to discard
 			continue
 		}
 		// discard remaining characters in the cut
-		copy(norm[start+1:], norm[end:])
+		copy(tag[start+1:], tag[end:])
 
 		// shorten the slice
-		norm = norm[:len(norm)-(end-start)+1]
+		tag = tag[:len(tag)-(end-start)+1]
 
 		// count the new delta for future cuts
 		delta += cut[1] - cut[0] - 1
 	}
-	return string(norm)
+	return string(tag)
 }

--- a/pkg/trace/api/normalizer.go
+++ b/pkg/trace/api/normalizer.go
@@ -277,47 +277,47 @@ func normalizeTag(v string) string {
 	)
 	var (
 		i    int  // current byte
-		c    rune // current rune
+		r    rune // current rune
 		jump int  // tracks how much the for range will advance on the next iteration
 	)
 	tag := []byte(v)
-	for i, c = range v {
-		jump = utf8.RuneLen(c) // next iteration will be i+jump
-		if c == utf8.RuneError {
+	for i, r = range v {
+		jump = utf8.RuneLen(r) // next iteration will be i+jump
+		if r == utf8.RuneError {
 			// on invalid UTF-8, the for range advances only 1 byte;
 			// https://golang.org/ref/spec#For_range (point 2)
 			jump = 1
 		}
 		// fast path; all letters (and colons) are ok
 		switch {
-		case c >= 'a' && c <= 'z' || c == ':':
+		case r >= 'a' && r <= 'z' || r == ':':
 			chars++
 			goto end
-		case c >= 'A' && c <= 'Z':
+		case r >= 'A' && r <= 'Z':
 			// lower-case
 			tag[i] += 'a' - 'A'
 			chars++
 			goto end
 		}
 
-		if c != utf8.RuneError && unicode.IsUpper(c) {
+		if r != utf8.RuneError && unicode.IsUpper(r) {
 			// lowercase this character
-			if low := unicode.ToLower(c); utf8.RuneLen(c) == utf8.RuneLen(low) {
+			if low := unicode.ToLower(r); utf8.RuneLen(r) == utf8.RuneLen(low) {
 				// but only if the width of the lowercased character is the same;
 				// there are some rare edge-cases where this is not the case, such
 				// as \u017F (ſ)
 				utf8.EncodeRune(tag[i:], low)
-				c = low
+				r = low
 			}
 		}
 		switch {
-		case unicode.IsLetter(c):
+		case unicode.IsLetter(r):
 			chars++
 		case chars == 0:
 			// this character can not start the string, trim
 			trim = i + jump
 			goto end
-		case unicode.IsDigit(c) || c == '.' || c == '/' || c == '-':
+		case unicode.IsDigit(r) || r == '.' || r == '/' || r == '-':
 			chars++
 		default:
 			// illegal character

--- a/pkg/trace/api/normalizer_test.go
+++ b/pkg/trace/api/normalizer_test.go
@@ -427,6 +427,8 @@ func TestNormalizeTag(t *testing.T) {
 		{in: "tag:1/2.3", out: "tag:1/2.3"},
 		{in: "---fun:k####y_ta@#g/1_@@#", out: "fun:k_y_ta_g/1"},
 		{in: "AlsO:œ#@ö))œk", out: "also:œ_ö_œk"},
+		{in: "test\x99\x8faaa", out: "test_aaa"},
+		{in: "test\x99\x8f", out: "test"},
 		{in: strings.Repeat("a", 888), out: strings.Repeat("a", 200)},
 		{
 			in: func() string {

--- a/releasenotes/notes/apm-improve-normalize-tag-truncation-0ca0061eaf2c9666.yaml
+++ b/releasenotes/notes/apm-improve-normalize-tag-truncation-0ca0061eaf2c9666.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixed a bug where normalize tag would not truncate tags correctly
+    in some situations.


### PR DESCRIPTION
This change improves the normalizeTag algorithm to match further
requirements with regards to limiting the maximum tag length allowed.

It also fixes a bug that is encountered when invalid UTF-8 characters are
present.