### PR TITLE
updating the default based on the change made in this #2246

### DIFF
--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -26,7 +26,7 @@ The agent is highly customizable, here are the most used environment variables:
 - `DD_SITE`: Destination site for your metrics, traces, and logs. Valid options are datadoghq.com for the Datadog US site, and datadoghq.eu for the Datadog EU site.
 - `DD_HOSTNAME`: hostname to use for metrics (if autodetection fails)
 - `DD_TAGS`: host tags, separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`
-- `DD_CHECK_RUNNERS`: the agent runs all checks in sequence by default (default value = `1` runner). If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel
+- `DD_CHECK_RUNNERS`: the agent runs all checks in sequence by default (default value = `4` runners). If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel
 
 #### Proxies
 

--- a/Dockerfiles/agent/README.md
+++ b/Dockerfiles/agent/README.md
@@ -26,7 +26,7 @@ The agent is highly customizable, here are the most used environment variables:
 - `DD_SITE`: Destination site for your metrics, traces, and logs. Valid options are datadoghq.com for the Datadog US site, and datadoghq.eu for the Datadog EU site.
 - `DD_HOSTNAME`: hostname to use for metrics (if autodetection fails)
 - `DD_TAGS`: host tags, separated by spaces. For example: `simple-tag-0 tag-key-1:tag-value-1`
-- `DD_CHECK_RUNNERS`: the agent runs all checks in sequence by default (default value = `4` runners). If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel
+- `DD_CHECK_RUNNERS`: the agent runs all checks concurrently by default (default value = `4` runners). To run the checks sequentially, set the value to `1`. If you need to run a high number of checks (or slow checks) the `collector-queue` component might fall behind and fail the healthcheck. You can increase the number of runners to run checks in parallel
 
 #### Proxies
 


### PR DESCRIPTION
### What does this PR do?

Updates the `DD_CHECK_RUNNERS` from 1 to 4 based on https://github.com/DataDog/datadog-agent/pull/2246/files

### Motivation

Docs bug fix