### PR TITLE
cmd/dogstatsd-stats: ask confirmation before overwriting the output file

### DIFF
--- a/cmd/agent/app/dogstatsd_stats.go
+++ b/cmd/agent/app/dogstatsd_stats.go
@@ -96,22 +96,23 @@ func requestDogstatsdStats() error {
 		}
 	}
 
-	if dsdStatsFilePath != "" {
-		// if the file is already existing, ask for a confirmation.
-		if _, err := os.Stat(dsdStatsFilePath); err == nil {
-			if !input.AskForConfirmation(fmt.Sprintf("'%s' existing, do you wan't to overwrite it?", dsdStatsFilePath)) {
-				fmt.Println("Canceling.")
-				return nil
-			}
-		}
-
-		if err := ioutil.WriteFile(dsdStatsFilePath, []byte(s), 0644); err != nil {
-			fmt.Println("Error while writing the file (is the location writable by the dd-agent user?):", err)
-		} else {
-			fmt.Println("Dogstatsd stats written in:", dsdStatsFilePath)
-		}
-	} else {
+	if dsdStatsFilePath == "" {
 		fmt.Println(s)
+		return nil
+	}
+
+	// if the file is already existing, ask for a confirmation.
+	if _, err := os.Stat(dsdStatsFilePath); err == nil {
+		if !input.AskForConfirmation(fmt.Sprintf("'%s' existing, do you wan't to overwrite it? [Y/N]", dsdStatsFilePath)) {
+			fmt.Println("Canceling.")
+			return nil
+		}
+	}
+
+	if err := ioutil.WriteFile(dsdStatsFilePath, []byte(s), 0644); err != nil {
+		fmt.Println("Error while writing the file (is the location writable by the dd-agent user?):", err)
+	} else {
+		fmt.Println("Dogstatsd stats written in:", dsdStatsFilePath)
 	}
 
 	return nil

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
+	"github.com/DataDog/datadog-agent/pkg/util/input"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -54,7 +55,7 @@ var flareCmd = &cobra.Command{
 		config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if customerEmail == "" {
 			var err error
-			customerEmail, err = flare.AskForEmail()
+			customerEmail, err = input.AskForEmail()
 			if err != nil {
 				fmt.Println("Error reading email, please retry or contact support")
 				return err
@@ -106,7 +107,7 @@ func requestFlare(caseID string) error {
 
 	fmt.Fprintln(color.Output, fmt.Sprintf("%s is going to be uploaded to Datadog", color.YellowString(filePath)))
 	if !autoconfirm {
-		confirmation := flare.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
+		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
 		if !confirmation {
 			fmt.Fprintln(color.Output, fmt.Sprintf("Aborting. (You can still use %s)", color.YellowString(filePath)))
 			return nil

--- a/cmd/cluster-agent/app/flare.go
+++ b/cmd/cluster-agent/app/flare.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
+	"github.com/DataDog/datadog-agent/pkg/util/input"
 )
 
 var (
@@ -54,7 +55,7 @@ var flareCmd = &cobra.Command{
 		config.SetupLogger(loggerName, "off", "", "", false, true, false)
 		if customerEmail == "" {
 			var err error
-			customerEmail, err = flare.AskForEmail()
+			customerEmail, err = input.AskForEmail()
 			if err != nil {
 				fmt.Println("Error reading email, please retry or contact support")
 				return err
@@ -107,7 +108,7 @@ func requestFlare(caseID string) error {
 
 	fmt.Printf("%s is going to be uploaded to Datadog\n", filePath)
 	if !autoconfirm {
-		confirmation := flare.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
+		confirmation := input.AskForConfirmation("Are you sure you want to upload a flare? [Y/N]")
 		if !confirmation {
 			fmt.Printf("Aborting. (You can still use %s) \n", filePath)
 			return nil

--- a/pkg/util/input/input.go
+++ b/pkg/util/input/input.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-package flare
+package input
 
 import (
 	"bufio"

--- a/releasenotes/notes/dogstatsd-stats-do-not-overwrite-f7d1ad227e871391.yaml
+++ b/releasenotes/notes/dogstatsd-stats-do-not-overwrite-f7d1ad227e871391.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Ask confirmation before overwriting the output file while using
+    the dogstatsd-stats command.


### PR DESCRIPTION
### What does this PR do?

While writing the output file of the dogstatsd-stats command, ask for confirmation if the file already exists.
Also, on error writing, added a small hint on the dd-agent user permissions.

### Motivation

A bit more error-proof for the user.

### Additional Notes

I've moved the input methods used in the flare to an util pkg `input` now used in agent flare + cluster-agent flare + dogstats stats command.