### PR TITLE
Reset logs TCP connections every hour

### DIFF
--- a/pkg/logs/client/destination.go
+++ b/pkg/logs/client/destination.go
@@ -27,9 +27,9 @@ const separator = " "
 
 var (
 	// The maximum duration after which a connection get reset.
-	connLifetimeInHours = 12 * time.Hour
+	connLifetimeInHours = 2 * time.Hour
 	// The width of the connection-reset spread.
-	connLifetimeSpread = 120
+	connLifetimeSpread = 5
 	// The time unit of the spread.
 	connLifetimeSpreadUnit = time.Minute
 )
@@ -80,9 +80,11 @@ func (d *Destination) Send(payload []byte) error {
 	if d.isConnectionExpired() {
 		// reset the connection to make sure the load is evenly spread
 		// and the agent can target new nodes.
+		log.Debug("Connection is expired")
 		d.closeConnection()
 	}
 	if d.conn == nil {
+		log.Debug("Opening a new connection")
 		if err := d.openConnection(); err != nil {
 			return err
 		}
@@ -96,6 +98,7 @@ func (d *Destination) Send(payload []byte) error {
 
 	_, err = d.conn.Write(frame)
 	if err != nil {
+		log.Debug("Closing the connection")
 		d.closeConnection()
 		return err
 	}

--- a/pkg/logs/client/destination.go
+++ b/pkg/logs/client/destination.go
@@ -24,19 +24,8 @@ const (
 // API key / message separator
 const separator = " "
 
-var (
-	// The maximum duration after which a connection get reset.
-	connLifetimeInHours = 2 * time.Hour
-	// The width of the connection-reset spread.
-	connLifetimeSpread = 5
-	// The time unit of the spread.
-	connLifetimeSpreadUnit = time.Minute
-	// DefaultExpirationState is the default expiration state.
-	DefaultExpirationState = NewExpirationState(
-		connLifetimeInHours,
-		connLifetimeSpread,
-		connLifetimeSpreadUnit)
-)
+// DefaultExpirationState expires after two hours +|- 2 minutes and 30 seconds.
+var DefaultExpirationState = NewExpirationState(2*time.Hour, 5, time.Minute)
 
 // FramingError represents a kind of error that can occur when a log can not properly
 // be transformed into a frame.

--- a/pkg/logs/client/destination.go
+++ b/pkg/logs/client/destination.go
@@ -24,8 +24,8 @@ const (
 // API key / message separator
 const separator = " "
 
-// DefaultExpirationState expires after two hours +|- 2 minutes and 30 seconds.
-var DefaultExpirationState = NewExpirationState(2*time.Hour, 5, time.Minute)
+// DefaultExpirationState expires after 1h00 +- 15 minutes.
+var DefaultExpirationState = NewExpirationState(1*time.Hour, 30*60, time.Second)
 
 // FramingError represents a kind of error that can occur when a log can not properly
 // be transformed into a frame.

--- a/pkg/logs/client/expiration_state.go
+++ b/pkg/logs/client/expiration_state.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package client
+
+import (
+	"math/rand"
+	"time"
+)
+
+// ExpirationState holds an expiration time that can used to
+// invalidate an entity.
+type ExpirationState struct {
+	lifetime       time.Duration
+	maxSpread      int
+	spreadUnit     time.Duration
+	expirationTime time.Time
+}
+
+// NewExpirationState returns a new ExpirationState.
+func NewExpirationState(lifetime time.Duration, maxSpread int, spreadUnit time.Duration) *ExpirationState {
+	return &ExpirationState{
+		lifetime:   lifetime,
+		maxSpread:  maxSpread,
+		spreadUnit: spreadUnit,
+	}
+}
+
+// Reset resets the expiration time.
+func (s *ExpirationState) Reset() {
+	s.expirationTime = time.Now().Add(s.lifetime + s.computeSpread())
+}
+
+// IsExpired returns true if the time passed expiration.
+func (s *ExpirationState) IsExpired() bool {
+	return s.expirationTime != time.Time{} && s.expirationTime.Before(time.Now())
+}
+
+// Clear clears the expiration time,
+// the state should no longer be used unless it is reset.
+func (s *ExpirationState) Clear() {
+	s.expirationTime = time.Time{}
+}
+
+// computeSpread creates randomness.
+func (s *ExpirationState) computeSpread() time.Duration {
+	spread := rand.Intn(s.maxSpread) - int(s.maxSpread/2)
+	return time.Duration(spread) * s.spreadUnit
+}

--- a/pkg/logs/client/expiration_state_test.go
+++ b/pkg/logs/client/expiration_state_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsExpiredReturnsTrueWhenTimeElapsed(t *testing.T) {
+	expirationState := NewExpirationState(10*time.Millisecond, 1, time.Millisecond)
+	assert.False(t, expirationState.IsExpired())
+
+	expirationState.Reset()
+	assert.False(t, expirationState.IsExpired())
+
+	time.Sleep(20 * time.Millisecond)
+	assert.True(t, expirationState.IsExpired())
+}
+
+func TestIsExpiredReturnsFalseAfterClear(t *testing.T) {
+	expirationState := NewExpirationState(10*time.Millisecond, 1, time.Millisecond)
+	expirationState.Reset()
+	assert.False(t, expirationState.IsExpired())
+
+	time.Sleep(20 * time.Millisecond)
+	assert.True(t, expirationState.IsExpired())
+
+	expirationState.Clear()
+	assert.False(t, expirationState.IsExpired())
+}

--- a/pkg/logs/client/test_utils.go
+++ b/pkg/logs/client/test_utils.go
@@ -28,5 +28,5 @@ func AddrToEndPoint(addr net.Addr) Endpoint {
 
 // AddrToDestination creates a Destination from an Addr
 func AddrToDestination(addr net.Addr, ctx *DestinationsContext) *Destination {
-	return NewDestination(AddrToEndPoint(addr), ctx)
+	return NewDestination(AddrToEndPoint(addr), ctx, DefaultExpirationState)
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -23,12 +23,12 @@ type Pipeline struct {
 // NewPipeline returns a new Pipeline
 func NewPipeline(outputChan chan *message.Message, processingRules []*config.ProcessingRule, endpoints *client.Endpoints, destinationsContext *client.DestinationsContext) *Pipeline {
 	// initialize the main destination
-	main := client.NewDestination(endpoints.Main, destinationsContext)
+	main := client.NewDestination(endpoints.Main, destinationsContext, client.DefaultExpirationState)
 
 	// initialize the additional destinations
 	var additionals []*client.Destination
 	for _, endpoint := range endpoints.Additionals {
-		additionals = append(additionals, client.NewDestination(endpoint, destinationsContext))
+		additionals = append(additionals, client.NewDestination(endpoint, destinationsContext, client.DefaultExpirationState))
 	}
 
 	// initialize the sender

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -67,7 +67,7 @@ func TestSenderNotBlockedByAdditional(t *testing.T) {
 
 	mainDestination := client.AddrToDestination(l.Addr(), destinationsCtx)
 	// This destination doesn't exists
-	additionalDestination := client.NewDestination(client.Endpoint{Host: "dont.exist.local", Port: 0}, destinationsCtx)
+	additionalDestination := client.NewDestination(client.Endpoint{Host: "dont.exist.local", Port: 0}, destinationsCtx, client.DefaultExpirationState)
 	destinations := client.NewDestinations(mainDestination, []*client.Destination{additionalDestination})
 
 	sender := NewSender(input, output, destinations)


### PR DESCRIPTION
### What does this PR do?

Reset logs TCP connections every hour to better balance the traffic over the logs-intake backend, target new nodes when added.

### Motivation

Ease migration and spread.

### Additional Notes

Anything else we should know when reviewing?
