### PR TITLE
[macOS/apm] Do not disable APM when the old conf option is not set

### DIFF
--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -128,11 +128,6 @@ func (c *APMCheck) run() error {
 
 // Configure the APMCheck
 func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	// handle the case when apm agent is disabled via the old `datadog.conf` file
-	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
-		return fmt.Errorf("APM agent disabled through main configuration file")
-	}
-
 	var checkConf apmCheckConf
 	if err := yaml.Unmarshal(data, &checkConf); err != nil {
 		return err

--- a/releasenotes/notes/fix-macos-apm-enabled-200b598b30594ebc.yaml
+++ b/releasenotes/notes/fix-macos-apm-enabled-200b598b30594ebc.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: on macOS, trace-agent is now enabled by default, and, similarly to other
+    platforms, can be enabled/disabled with the `apm_config.enabled` config setting
+    or the `DD_APM_ENABLED` env var


### PR DESCRIPTION
### What does this PR do?

On macOS:
* Allow the trace-agent to be enabled/disabled with `apm_config.enabled` (or the `DD_APM_ENABLED` env var), as documented
* Enable the trace-agent by default

### Motivation

Likely because of an oversight, the `apm` check that runs trace-agent
on macOS was still checking that the old `apm_enabled` option was set
to `true` before starting trace-agent. This logic would also make
trace-agent not start by default on macOS.

### Additional Notes

I think the logic here was wrong since 6.0.0... See https://github.com/DataDog/datadog-agent/pull/1242

EDIT: Kudos to @Girbons for initially finding a fix to this issue in https://github.com/DataDog/datadog-agent/pull/3155, which I completely missed before making and merging this PR, sorry about that