### PR TITLE
Store and display the config file used for each check

### DIFF
--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -12,6 +12,7 @@
           {{- range $CheckInstances }}
             <span class="stat_subdata">
                 Instance ID: {{.CheckID}} {{status .}}<br>
+                Config source: {{.ConfigSource}}<br>
                 Total Runs: {{humanize .TotalRuns}}<br>
                 Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
                 Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>

--- a/cmd/agent/gui/views/templates/singleCheck.tmpl
+++ b/cmd/agent/gui/views/templates/singleCheck.tmpl
@@ -4,6 +4,7 @@
   <span class="stat_subtitle">Instance {{add $i 1}}</span>
     <span class="stat_data">
         Instance ID: {{.CheckID}}<br>
+        Config source: {{.ConfigSource}}<br>
         Total Runs: {{humanize .TotalRuns}}<br>
         Metric Samples: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}<br>
         Events: {{humanize .Events}}, Total: {{humanize .TotalEvents}}<br>

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -43,6 +43,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		Provider:      tpl.Provider,
 		Entity:        svc.GetEntity(),
 		CreationTime:  svc.GetCreationTime(),
+		Source:        tpl.Source,
 	}
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Entity        string       `json:"-"`              // the id of the entity (optional)
 	ClusterCheck  bool         `json:"cluster_check"`  // cluster-check configuration flag
 	CreationTime  CreationTime `json:"-"`              // creation time of service
+	Source        string       `json:"-"`              // the place this config was read from
 }
 
 // CommonInstanceConfig holds the reserved fields for the yaml instance data

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -244,7 +244,7 @@ func (c *FileConfigProvider) collectDir(parentPath string, folder os.FileInfo) c
 // GetIntegrationConfigFromFile returns an instance of integration.Config if `fpath` points to a valid config file
 func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error) {
 	cf := configFormat{}
-	config := integration.Config{Name: name}
+	config := integration.Config{Name: name, Source: fpath}
 
 	// Read file contents
 	// FIXME: ReadFile reads the entire file, possible security implications

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -100,6 +100,11 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 			configs = append(configs, c...)
 		}
 	}
+
+	for _, config := range configs {
+		config.Source = "KubeletConfigProvider"
+	}
+
 	return configs, nil
 }
 

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -6,8 +6,9 @@
 package check
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
 const (
@@ -18,13 +19,15 @@ const (
 
 // Check is an interface for types capable to run checks
 type Check interface {
-	Run() error                                          // run the check
-	Stop()                                               // stop the check if it's running
-	String() string                                      // provide a printable version of the check name
-	Configure(config, initConfig integration.Data) error // configure the check from the outside
-	Interval() time.Duration                             // return the interval time for the check
-	ID() ID                                              // provide a unique identifier for every check instance
-	GetWarnings() []error                                // return the last warning registered by the check
-	GetMetricStats() (map[string]int64, error)           // get metric stats from the sender
-	Version() string                                     // return the version of the check if available
+	Run() error     // run the check
+	Stop()          // stop the check if it's running
+	String() string // provide a printable version of the check name
+	Configure(config, initConfig integration.Data,
+		configSource string) error // configure the check from the outside
+	Interval() time.Duration                   // return the interval time for the check
+	ID() ID                                    // provide a unique identifier for every check instance
+	GetWarnings() []error                      // return the last warning registered by the check
+	GetMetricStats() (map[string]int64, error) // get metric stats from the sender
+	Version() string                           // return the version of the check if available
+	ConfigSource() string                      // returns the source of the configuration for this check
 }

--- a/pkg/collector/check/id_test.go
+++ b/pkg/collector/check/id_test.go
@@ -17,15 +17,16 @@ import (
 // FIXTURE
 type TestCheck struct{}
 
-func (c *TestCheck) String() string                                     { return "TestCheck" }
-func (c *TestCheck) Version() string                                    { return "" }
-func (c *TestCheck) Stop()                                              {}
-func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                            { return 1 }
-func (c *TestCheck) Run() error                                         { return nil }
-func (c *TestCheck) ID() ID                                             { return ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                               { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                                             { return "TestCheck" }
+func (c *TestCheck) Version() string                                            { return "" }
+func (c *TestCheck) Stop()                                                      {}
+func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (c *TestCheck) ConfigSource() string                                       { return "test" }
+func (c *TestCheck) Interval() time.Duration                                    { return 1 }
+func (c *TestCheck) Run() error                                                 { return nil }
+func (c *TestCheck) ID() ID                                                     { return ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                                       { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
 
 func TestIdentify(t *testing.T) {
 	testCheck := &TestCheck{}

--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -15,6 +15,7 @@ type Stats struct {
 	CheckName            string
 	CheckVersion         string
 	CheckID              ID
+	ConfigSource         string
 	TotalRuns            uint64
 	TotalErrors          uint64
 	TotalWarnings        uint64
@@ -39,6 +40,7 @@ func NewStats(c Check) *Stats {
 		CheckID:      c.ID(),
 		CheckName:    c.String(),
 		CheckVersion: c.Version(),
+		ConfigSource: c.ConfigSource(),
 	}
 }
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -122,7 +122,7 @@ func (c *Collector) RunCheck(ch check.Check) (check.ID, error) {
 }
 
 // ReloadCheck stops and restart a check with a new configuration
-func (c *Collector) ReloadCheck(id check.ID, config, initConfig integration.Data) error {
+func (c *Collector) ReloadCheck(id check.ID, config, initConfig integration.Data, configSource string) error {
 	if !c.started() {
 		return fmt.Errorf("the collector is not running")
 	}
@@ -151,7 +151,7 @@ func (c *Collector) ReloadCheck(id check.ID, config, initConfig integration.Data
 
 	// re-configure
 	check := c.checks[id]
-	err = check.Configure(config, initConfig)
+	err = check.Configure(config, initConfig, configSource)
 	if err != nil {
 		return fmt.Errorf("error configuring the check with ID %s", id)
 	}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -23,12 +23,13 @@ type TestCheck struct {
 	stop     chan bool
 }
 
-func (c *TestCheck) Stop()                                     { c.stop <- true }
-func (c *TestCheck) Configure(a, b integration.Data) error     { return nil }
-func (c *TestCheck) Interval() time.Duration                   { return 1 * time.Minute }
-func (c *TestCheck) Run() error                                { <-c.stop; return nil }
-func (c *TestCheck) GetWarnings() []error                      { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
+func (c *TestCheck) Stop()                                                      { c.stop <- true }
+func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (c *TestCheck) ConfigSource() string                                       { return "test" }
+func (c *TestCheck) Interval() time.Duration                                    { return 1 * time.Minute }
+func (c *TestCheck) Run() error                                                 { <-c.stop; return nil }
+func (c *TestCheck) GetWarnings() []error                                       { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
 func (c *TestCheck) ID() check.ID {
 	if c.uniqueID != "" {
 		return c.uniqueID
@@ -109,12 +110,12 @@ func (suite *CollectorTestSuite) TestReloadCheck() {
 	_, err := suite.c.RunCheck(ch)
 
 	// check doesn't exist
-	err = suite.c.ReloadCheck("foo", empty, empty)
+	err = suite.c.ReloadCheck("foo", empty, empty, "test")
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "cannot find a check with ID foo", err.Error())
 
 	// all good
-	err = suite.c.ReloadCheck("TestCheck", empty, empty)
+	err = suite.c.ReloadCheck("TestCheck", empty, empty, "test")
 	assert.Nil(suite.T(), err)
 }
 

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -40,6 +40,7 @@ type CheckBase struct {
 	checkID        check.ID
 	latestWarnings []error
 	checkInterval  time.Duration
+	configSource   string
 }
 
 // NewCheckBase returns a check base struct with a given check name
@@ -59,13 +60,13 @@ func (c *CheckBase) BuildID(instance, initConfig integration.Data) {
 
 // Configure is provided for checks that require no config. If overridden,
 // the call to CommonConfigure must be preserved.
-func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data) error {
-	return c.CommonConfigure(data)
+func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	return c.CommonConfigure(data, configSource)
 }
 
 // CommonConfigure is called when checks implement their own Configure method,
 // in order to setup common options (run interval, empty hostname)
-func (c *CheckBase) CommonConfigure(instance integration.Data) error {
+func (c *CheckBase) CommonConfigure(instance integration.Data, configSource string) error {
 	commonOptions := integration.CommonInstanceConfig{}
 	err := yaml.Unmarshal(instance, &commonOptions)
 	if err != nil {
@@ -97,6 +98,8 @@ func (c *CheckBase) CommonConfigure(instance integration.Data) error {
 		}
 		s.SetCheckCustomTags(commonOptions.Tags)
 	}
+
+	c.configSource = configSource
 
 	return nil
 }
@@ -136,6 +139,11 @@ func (c *CheckBase) String() string {
 // from the agent
 func (c *CheckBase) Version() string {
 	return ""
+}
+
+// ConfigSource returns the source of the config set by CommonConfigure
+func (c *CheckBase) ConfigSource() string {
+	return c.configSource
 }
 
 // ID returns a unique ID for that check instance

--- a/pkg/collector/corechecks/checkbase_test.go
+++ b/pkg/collector/corechecks/checkbase_test.go
@@ -37,13 +37,13 @@ func TestCommonConfigure(t *testing.T) {
 	}
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
-	err := mycheck.CommonConfigure([]byte(defaultsInstance))
+	err := mycheck.CommonConfigure([]byte(defaultsInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, check.DefaultCheckInterval, mycheck.Interval())
 	mockSender.AssertNumberOfCalls(t, "DisableDefaultHostname", 0)
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err = mycheck.CommonConfigure([]byte(customInstance))
+	err = mycheck.CommonConfigure([]byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
 	mycheck.BuildID([]byte(customInstance), []byte(initConfig))
@@ -61,7 +61,7 @@ func TestCommonConfigureCustomID(t *testing.T) {
 	mockSender := mocksender.NewMockSender(mycheck.ID())
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()
-	err := mycheck.CommonConfigure([]byte(customInstance))
+	err := mycheck.CommonConfigure([]byte(customInstance), "test")
 	assert.NoError(t, err)
 	assert.Equal(t, 60*time.Second, mycheck.Interval())
 	mycheck.BuildID([]byte(customInstance), []byte(initConfig))

--- a/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_apiserver.go
@@ -64,8 +64,8 @@ func (c *KubeASConfig) parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check.
-func (k *KubeASCheck) Configure(config, initConfig integration.Data) error {
-	err := k.CommonConfigure(config)
+func (k *KubeASCheck) Configure(config, initConfig integration.Data, configSource string) error {
+	err := k.CommonConfigure(config, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/kubernetes_openshift_test.go
+++ b/pkg/collector/corechecks/cluster/kubernetes_openshift_test.go
@@ -29,7 +29,7 @@ func TestReportClusterQuotas(t *testing.T) {
 	var instanceCfg = []byte("")
 	var initCfg = []byte("")
 	kubeASCheck := KubernetesASFactory().(*KubeASCheck)
-	err = kubeASCheck.Configure(instanceCfg, initCfg)
+	err = kubeASCheck.Configure(instanceCfg, initCfg, "test")
 	require.NoError(t, err)
 
 	mocked := mocksender.NewMockSender(kubeASCheck.ID())

--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -72,9 +72,9 @@ func (co *ContainerdConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (c *ContainerdCheck) Configure(config, initConfig integration.Data) error {
+func (c *ContainerdCheck) Configure(config, initConfig integration.Data, configSource string) error {
 	var err error
-	if err = c.CommonConfigure(config); err != nil {
+	if err = c.CommonConfigure(config, configSource); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/containers/cri.go
+++ b/pkg/collector/corechecks/containers/cri.go
@@ -61,8 +61,8 @@ func (c *CRIConfig) Parse(data []byte) error {
 }
 
 // Configure parses the check configuration and init the check
-func (c *CRICheck) Configure(config, initConfig integration.Data) error {
-	err := c.CommonConfigure(config)
+func (c *CRICheck) Configure(config, initConfig integration.Data, configSource string) error {
+	err := c.CommonConfigure(config, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -374,8 +374,8 @@ func (d *DockerCheck) reportIOMetrics(io *cmetrics.CgroupIOStat, tags []string, 
 }
 
 // Configure parses the check configuration and init the check
-func (d *DockerCheck) Configure(config, initConfig integration.Data) error {
-	err := d.CommonConfigure(config)
+func (d *DockerCheck) Configure(config, initConfig integration.Data, configSource string) error {
+	err := d.CommonConfigure(config, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -32,11 +32,12 @@ type apmCheckConf struct {
 
 // APMCheck keeps track of the running command
 type APMCheck struct {
-	binPath     string
-	commandOpts []string
-	running     uint32
-	stop        chan struct{}
-	stopDone    chan struct{}
+	binPath      string
+	commandOpts  []string
+	running      uint32
+	stop         chan struct{}
+	stopDone     chan struct{}
+	configSource string
 }
 
 func (c *APMCheck) String() string {
@@ -45,6 +46,10 @@ func (c *APMCheck) String() string {
 
 func (c *APMCheck) Version() string {
 	return ""
+}
+
+func (c *APMCheck) ConfigSource() string {
+	return c.configSource
 }
 
 // Run executes the check with retries
@@ -127,7 +132,7 @@ func (c *APMCheck) run() error {
 }
 
 // Configure the APMCheck
-func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data) error {
+func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
 	// handle the case when apm agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("apm_enabled"); !enabled {
 		return fmt.Errorf("APM agent disabled through main configuration file")
@@ -164,6 +169,8 @@ func (c *APMCheck) Configure(data integration.Data, initConfig integration.Data)
 	if _, err := os.Stat(configFile); !os.IsNotExist(err) {
 		c.commandOpts = append(c.commandOpts, fmt.Sprintf("-config=%s", configFile))
 	}
+
+	c.configSource = configSource
 
 	return nil
 }

--- a/pkg/collector/corechecks/embed/jmx/check.go
+++ b/pkg/collector/corechecks/embed/jmx/check.go
@@ -30,7 +30,7 @@ func newJMXCheck(config integration.Config) *JMXCheck {
 		name:   config.Name,
 		id:     check.ID(fmt.Sprintf("%v_%v", config.Name, config.Digest())),
 	}
-	check.Configure(config.InitConfig, config.MetricConfig)
+	check.Configure(config.InitConfig, config.MetricConfig, config.Source)
 
 	return check
 }
@@ -64,7 +64,11 @@ func (c *JMXCheck) Version() string {
 	return ""
 }
 
-func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data) error {
+func (c *JMXCheck) ConfigSource() string {
+	return c.config.Source
+}
+
+func (c *JMXCheck) Configure(config integration.Data, initConfig integration.Data, configSource string) error {
 	return nil
 }
 

--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -40,6 +40,7 @@ func splitConfig(config integration.Config) []integration.Config {
 			MetricConfig:  config.MetricConfig,
 			Name:          config.Name,
 			Provider:      config.Provider,
+			Source:        config.Source,
 		}
 		configs = append(configs, c)
 	}

--- a/pkg/collector/corechecks/embed/process_agent.go
+++ b/pkg/collector/corechecks/embed/process_agent.go
@@ -38,12 +38,13 @@ type processAgentCheckConf struct {
 
 // ProcessAgentCheck keeps track of the running command
 type ProcessAgentCheck struct {
-	enabled     bool
-	binPath     string
-	commandOpts []string
-	running     uint32
-	stop        chan struct{}
-	stopDone    chan struct{}
+	enabled      bool
+	binPath      string
+	commandOpts  []string
+	running      uint32
+	stop         chan struct{}
+	stopDone     chan struct{}
+	configSource string
 }
 
 func (c *ProcessAgentCheck) String() string {
@@ -52,6 +53,10 @@ func (c *ProcessAgentCheck) String() string {
 
 func (c *ProcessAgentCheck) Version() string {
 	return ""
+}
+
+func (c *ProcessAgentCheck) ConfigSource() string {
+	return c.configSource
 }
 
 // Run executes the check with retries
@@ -132,7 +137,7 @@ func (c *ProcessAgentCheck) run() error {
 }
 
 // Configure the ProcessAgentCheck
-func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integration.Data) error {
+func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
 	// handle the case when the agent is disabled via the old `datadog.conf` file
 	if enabled := config.Datadog.GetBool("process_agent_enabled"); !enabled {
 		return fmt.Errorf("Process Agent disabled through main configuration file")
@@ -165,6 +170,8 @@ func (c *ProcessAgentCheck) Configure(data integration.Data, initConfig integrat
 		}
 		c.binPath = defaultBinPath
 	}
+
+	c.configSource = configSource
 
 	return nil
 }

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -71,7 +71,7 @@ func (gl *GoCheckLoader) Load(config integration.Config) ([]check.Check, error) 
 	errors := []string{}
 	for _, instance := range config.Instances {
 		newCheck := factory()
-		if err := newCheck.Configure(instance, config.InitConfig); err != nil {
+		if err := newCheck.Configure(instance, config.InitConfig, config.Source); err != nil {
 			errors = append(errors, fmt.Sprintf("Could not configure check %s: %s", newCheck, err))
 			log.Errorf("core.loader: could not configure check %s: %s", newCheck, err)
 			continue

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -19,19 +19,19 @@ type TestCheck struct{}
 
 func (c *TestCheck) String() string                            { return "TestCheck" }
 func (c *TestCheck) Version() string                           { return "" }
+func (c *TestCheck) ConfigSource() string                      { return "test" }
 func (c *TestCheck) Run() error                                { return nil }
 func (c *TestCheck) Stop()                                     {}
 func (c *TestCheck) Interval() time.Duration                   { return 1 }
 func (c *TestCheck) ID() check.ID                              { return check.ID(c.String()) }
 func (c *TestCheck) GetWarnings() []error                      { return []error{} }
 func (c *TestCheck) GetMetricStats() (map[string]int64, error) { return make(map[string]int64), nil }
-func (c *TestCheck) Configure(data integration.Data, initData integration.Data) error {
+func (c *TestCheck) Configure(data integration.Data, initData integration.Data, configSource string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
 	}
 	return nil
 }
-
 func TestNewGoCheckLoader(t *testing.T) {
 	if checkLoader, _ := NewGoCheckLoader(); checkLoader == nil {
 		t.Fatal("Expected loader instance, found: nil")

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -276,8 +276,8 @@ func netstatTCPExtCounters() (map[string]int64, error) {
 }
 
 // Configure configures the network checks
-func (c *NetworkCheck) Configure(rawInstance integration.Data, rawInitConfig integration.Data) error {
-	err := c.CommonConfigure(rawInstance)
+func (c *NetworkCheck) Configure(rawInstance integration.Data, rawInitConfig integration.Data, configSource string) error {
+	err := c.CommonConfigure(rawInstance, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/network_test.go
+++ b/pkg/collector/corechecks/net/network_test.go
@@ -64,7 +64,7 @@ func (n *fakeNetworkStats) NetstatTCPExtCounters() (map[string]int64, error) {
 
 func TestDefaultConfiguration(t *testing.T) {
 	check := NetworkCheck{}
-	check.Configure([]byte(``), []byte(``))
+	check.Configure([]byte(``), []byte(``), "test")
 
 	assert.Equal(t, false, check.config.instance.CollectConnectionState)
 	assert.Equal(t, []string(nil), check.config.instance.ExcludedInterfaces)
@@ -80,7 +80,7 @@ excluded_interfaces:
     - lo0
 excluded_interface_re: "eth.*"
 `)
-	err := check.Configure(rawInstanceConfig, []byte(``))
+	err := check.Configure(rawInstanceConfig, []byte(``), "test")
 
 	assert.Nil(t, err)
 	assert.Equal(t, true, check.config.instance.CollectConnectionState)
@@ -266,7 +266,7 @@ func TestNetworkCheck(t *testing.T) {
 collect_connection_state: true
 `)
 
-	err := networkCheck.Configure(rawInstanceConfig, []byte(``))
+	err := networkCheck.Configure(rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
@@ -378,7 +378,7 @@ excluded_interfaces:
     - lo0
 `)
 
-	networkCheck.Configure(rawInstanceConfig, []byte(``))
+	networkCheck.Configure(rawInstanceConfig, []byte(``), "test")
 
 	mockSender := mocksender.NewMockSender(networkCheck.ID())
 
@@ -448,7 +448,7 @@ func TestExcludedInterfacesRe(t *testing.T) {
 excluded_interface_re: "eth[0-9]"
 `)
 
-	err := networkCheck.Configure(rawInstanceConfig, []byte(``))
+	err := networkCheck.Configure(rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
 
 	mockSender := mocksender.NewMockSender(networkCheck.ID())

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -112,8 +112,10 @@ func (c *ntpConfig) parse(data []byte, initData []byte) error {
 }
 
 // Configure configure the data from the yaml
-func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.CommonConfigure(data)
+func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data,
+	configSource string) error {
+
+	err := c.CommonConfigure(data, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp_test.go
@@ -48,7 +48,7 @@ func TestNTPOK(t *testing.T) {
 	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -78,7 +78,7 @@ func TestNTPCritical(t *testing.T) {
 	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -107,7 +107,7 @@ func TestNTPError(t *testing.T) {
 	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -136,7 +136,7 @@ func TestNTPNegativeOffsetCritical(t *testing.T) {
 	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -176,7 +176,7 @@ hosts:
 	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -216,7 +216,7 @@ hosts:
 	defer func() { ntpQuery = ntp.Query }()
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(ntpCfg, ntpInitCfg)
+	ntpCheck.Configure(ntpCfg, ntpInitCfg, "test")
 
 	mockSender := mocksender.NewMockSender(ntpCheck.ID())
 
@@ -248,7 +248,7 @@ hosts:
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""))
+	ntpCheck.Configure(testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -265,7 +265,7 @@ hosts:
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""))
+	ntpCheck.Configure(testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -277,7 +277,7 @@ host: time.dogo
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""))
+	ntpCheck.Configure(testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -291,7 +291,7 @@ hosts:
 `)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""))
+	ntpCheck.Configure(testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }
@@ -301,7 +301,7 @@ func TestDefaultHostConfig(t *testing.T) {
 	testedConfig := []byte(``)
 
 	ntpCheck := new(NTPCheck)
-	ntpCheck.Configure(testedConfig, []byte(""))
+	ntpCheck.Configure(testedConfig, []byte(""), "test")
 
 	assert.Equal(t, expectedHosts, ntpCheck.cfg.instance.Hosts)
 }

--- a/pkg/collector/corechecks/system/cpu.go
+++ b/pkg/collector/corechecks/system/cpu.go
@@ -78,8 +78,8 @@ func (c *CPUCheck) Run() error {
 }
 
 // Configure the CPU check
-func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.CommonConfigure(data)
+func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	err := c.CommonConfigure(data, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu_test.go
+++ b/pkg/collector/corechecks/system/cpu_test.go
@@ -77,7 +77,7 @@ func TestCPUCheckLinux(t *testing.T) {
 	times = CPUTimes
 	cpuInfo = CPUInfo
 	cpuCheck := new(CPUCheck)
-	cpuCheck.Configure(nil, nil)
+	cpuCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(cpuCheck.ID())
 

--- a/pkg/collector/corechecks/system/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu_windows.go
@@ -116,8 +116,8 @@ func (c *CPUCheck) Run() error {
 }
 
 // Configure the CPU check doesn't need configuration
-func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	if err := c.CommonConfigure(data); err != nil {
+func (c *CPUCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	if err := c.CommonConfigure(data, configSource); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk_nix.go
@@ -139,8 +139,8 @@ func (c *DiskCheck) sendDiskMetrics(sender aggregator.Sender, ioCounter disk.IOC
 }
 
 // Configure the disk check
-func (c *DiskCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.CommonConfigure(data)
+func (c *DiskCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	err := c.CommonConfigure(data, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk_test.go
+++ b/pkg/collector/corechecks/system/disk_test.go
@@ -93,7 +93,7 @@ func TestDiskCheck(t *testing.T) {
 	diskUsage = diskUsageSampler
 	ioCounters = diskIoSampler
 	diskCheck := new(DiskCheck)
-	diskCheck.Configure(nil, nil)
+	diskCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(diskCheck.ID())
 
@@ -135,7 +135,7 @@ func TestDiskCheckExcludedDiskFilsystem(t *testing.T) {
 	diskUsage = diskUsageSampler
 	ioCounters = diskIoSampler
 	diskCheck := new(DiskCheck)
-	diskCheck.Configure(nil, nil)
+	diskCheck.Configure(nil, nil, "test")
 
 	diskCheck.cfg.excludedFilesystems = []string{"vfat"}
 	diskCheck.cfg.excludedDisks = []string{"/dev/sda2"}
@@ -162,7 +162,7 @@ func TestDiskCheckExcludedRe(t *testing.T) {
 	diskUsage = diskUsageSampler
 	ioCounters = diskIoSampler
 	diskCheck := new(DiskCheck)
-	diskCheck.Configure(nil, nil)
+	diskCheck.Configure(nil, nil, "test")
 
 	diskCheck.cfg.excludedMountpointRe = regexp.MustCompile("/boot/efi")
 	diskCheck.cfg.excludedDiskRe = regexp.MustCompile("/dev/sda2")
@@ -192,7 +192,7 @@ func TestDiskCheckTags(t *testing.T) {
 
 	config := integration.Data([]byte("use_mount: true\ntag_by_filesystem: true\nall_partitions: true\ndevice_tag_re:\n  /boot/efi: role:esp\n  /dev/sda2: device_type:sata,disk_size:large"))
 
-	diskCheck.Configure(config, nil)
+	diskCheck.Configure(config, nil, "test")
 
 	mock := mocksender.NewMockSender(diskCheck.ID())
 

--- a/pkg/collector/corechecks/system/file_handles_test.go
+++ b/pkg/collector/corechecks/system/file_handles_test.go
@@ -46,7 +46,7 @@ func TestFhCheckLinux(t *testing.T) {
 	t.Logf("Testing from file %s", fileNrHandle) // To pass circle ci tests
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(nil, nil)
+	fileHandleCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 

--- a/pkg/collector/corechecks/system/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/file_handles_windows.go
@@ -44,8 +44,8 @@ func (c *fhCheck) Run() error {
 }
 
 // The check doesn't need configuration
-func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
-	if err := c.CommonConfigure(data); err != nil {
+func (c *fhCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) (err error) {
+	if err := c.CommonConfigure(data, configSource); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/file_handles_windows_test.go
+++ b/pkg/collector/corechecks/system/file_handles_windows_test.go
@@ -19,7 +19,7 @@ func TestFhCheckWindows(t *testing.T) {
 	pdhtest.SetQueryReturnValue("\\\\.\\Process(_Total)\\Handle Count", 0.006848775103963421)
 
 	fileHandleCheck := new(fhCheck)
-	fileHandleCheck.Configure(nil, nil)
+	fileHandleCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(fileHandleCheck.ID())
 

--- a/pkg/collector/corechecks/system/iostats.go
+++ b/pkg/collector/corechecks/system/iostats.go
@@ -23,8 +23,8 @@ const (
 )
 
 // Configure the IOstats check
-func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.Data) error {
-	if err := c.CommonConfigure(data); err != nil {
+func (c *IOCheck) commonConfigure(data integration.Data, initConfig integration.Data, configSource string) error {
+	if err := c.CommonConfigure(data, configSource); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/iostats_nix.go
+++ b/pkg/collector/corechecks/system/iostats_nix.go
@@ -38,8 +38,8 @@ type IOCheck struct {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.commonConfigure(data, initConfig)
+func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	err := c.commonConfigure(data, initConfig, configSource)
 	return err
 }
 

--- a/pkg/collector/corechecks/system/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows.go
@@ -68,8 +68,8 @@ func isDrive(instance string) bool {
 }
 
 // Configure the IOstats check
-func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.commonConfigure(data, initConfig)
+func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	err := c.commonConfigure(data, initConfig, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
+++ b/pkg/collector/corechecks/system/iostats_pdh_windows_test.go
@@ -64,7 +64,7 @@ func TestIoCheckWindows(t *testing.T) {
 	addDefaultQueryReturnValues()
 
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil)
+	ioCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -103,7 +103,7 @@ func TestIoCheckInstanceAdded(t *testing.T) {
 	addDriveDReturnValues()
 
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil)
+	ioCheck.Configure(nil, nil, "test")
 
 	pdhtest.AddCounterInstance("LogicalDisk", "Y:")
 	pdhtest.AddCounterInstance("LogicalDisk", "HarddiskVolume2")
@@ -165,7 +165,7 @@ func TestIoCheckInstanceRemoved(t *testing.T) {
 	addDriveDReturnValues()
 
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil)
+	ioCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 

--- a/pkg/collector/corechecks/system/iostats_test.go
+++ b/pkg/collector/corechecks/system/iostats_test.go
@@ -89,7 +89,7 @@ func sampler(samples []map[string]disk.IOCountersStat, names ...string) (map[str
 func TestIOCheckDM(t *testing.T) {
 	ioCounters = ioSamplerDM
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil)
+	ioCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -112,7 +112,7 @@ func TestIOCheck(t *testing.T) {
 
 	ioCounters = ioSampler
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil)
+	ioCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 
@@ -175,7 +175,7 @@ func TestIOCheck(t *testing.T) {
 func TestIOCheckBlacklist(t *testing.T) {
 	ioCounters = ioSampler
 	ioCheck := new(IOCheck)
-	ioCheck.Configure(nil, nil)
+	ioCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(ioCheck.ID())
 

--- a/pkg/collector/corechecks/system/load.go
+++ b/pkg/collector/corechecks/system/load.go
@@ -55,8 +55,8 @@ func (c *LoadCheck) Run() error {
 }
 
 // Configure the CPU check
-func (c *LoadCheck) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.CommonConfigure(data)
+func (c *LoadCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	err := c.CommonConfigure(data, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/load_test.go
+++ b/pkg/collector/corechecks/system/load_test.go
@@ -29,7 +29,7 @@ func TestLoadCheckLinux(t *testing.T) {
 	loadAvg = Avg
 	cpuInfo = CPUInfo
 	loadCheck := new(LoadCheck)
-	loadCheck.Configure(nil, nil)
+	loadCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(loadCheck.ID())
 

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -37,8 +37,8 @@ type MemoryCheck struct {
 const mbSize float64 = 1024 * 1024
 
 // Configure handles initial configuration/initialization of the check
-func (c *MemoryCheck) Configure(data integration.Data, initConfig integration.Data) (err error) {
-	if err := c.CommonConfigure(data); err != nil {
+func (c *MemoryCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) (err error) {
+	if err := c.CommonConfigure(data, configSource); err != nil {
 		return err
 	}
 

--- a/pkg/collector/corechecks/system/uptime_test.go
+++ b/pkg/collector/corechecks/system/uptime_test.go
@@ -18,7 +18,7 @@ func uptimeSampler() (uint64, error) {
 func TestUptimeCheckLinux(t *testing.T) {
 	uptime = uptimeSampler
 	uptimeCheck := new(UptimeCheck)
-	uptimeCheck.Configure(nil, nil)
+	uptimeCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(uptimeCheck.ID())
 

--- a/pkg/collector/corechecks/system/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc_windows.go
@@ -39,8 +39,8 @@ func (c *processChk) Run() error {
 	return nil
 }
 
-func (c *processChk) Configure(data integration.Data, initConfig integration.Data) error {
-	err := c.CommonConfigure(data)
+func (c *processChk) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
+	err := c.CommonConfigure(data, configSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/winproc_windows_test.go
+++ b/pkg/collector/corechecks/system/winproc_windows_test.go
@@ -20,7 +20,7 @@ func TestWinprocCheckWindows(t *testing.T) {
 	pdhtest.SetQueryReturnValue("\\\\.\\System\\Processes", 32.0)
 
 	winprocCheck := new(processChk)
-	winprocCheck.Configure(nil, nil)
+	winprocCheck.Configure(nil, nil, "test")
 
 	mock := mocksender.NewMockSender(winprocCheck.ID())
 

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -36,6 +36,7 @@ type PythonCheck struct {
 	config       *python.PyObject
 	interval     time.Duration
 	lastWarnings []error
+	configSource string
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
@@ -133,6 +134,11 @@ func (c *PythonCheck) Version() string {
 	return c.version
 }
 
+// ConfigSource returns the yaml file that contains this integration's config
+func (c *PythonCheck) ConfigSource() string {
+	return c.configSource
+}
+
 // GetWarnings grabs the last warnings from the struct
 func (c *PythonCheck) GetWarnings() []error {
 	warnings := c.lastWarnings
@@ -199,7 +205,7 @@ func (c *PythonCheck) getInstance(args, kwargs *python.PyObject) (*python.PyObje
 }
 
 // Configure the Python check from YAML data
-func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Data) error {
+func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Data, configSource string) error {
 	// Generate check ID
 	c.id = check.Identify(c, data, initConfig)
 
@@ -296,6 +302,7 @@ func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Da
 
 	c.instance = instance
 	c.config = kwargs
+	c.configSource = configSource
 
 	return nil
 }

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -56,7 +56,7 @@ func getCheckInstance(moduleName, className string) (*PythonCheck, error) {
 
 	checkClass := getClass(moduleName, className)
 	check := NewPythonCheck(moduleName, checkClass)
-	err := check.Configure([]byte("foo_instance: bar_instance"), []byte("foo_init: bar_init"))
+	err := check.Configure([]byte("foo_instance: bar_instance"), []byte("foo_init: bar_init"), "test")
 	return check, err
 }
 
@@ -150,17 +150,17 @@ func TestStr(t *testing.T) {
 func TestInterval(t *testing.T) {
 	c, _ := getCheckInstance("testcheck", "TestCheck")
 	assert.Equal(t, check.DefaultCheckInterval, c.Interval())
-	c.Configure([]byte("min_collection_interval: 1"), []byte("foo: bar"))
+	c.Configure([]byte("min_collection_interval: 1"), []byte("foo: bar"), "test")
 	assert.Equal(t, time.Duration(1)*time.Second, c.Interval())
 }
 
 func TestName(t *testing.T) {
 	c, _ := getCheckInstance("testcheck", "TestCheck")
-	c.Configure([]byte("name: test"), []byte("foo: bar"))
+	c.Configure([]byte("name: test"), []byte("foo: bar"), "test")
 	assert.Equal(t, string(c.ID()), "testcheck:test:bb22958a762de21b")
 
 	c, _ = getCheckInstance("testcheck", "TestCheck")
-	c.Configure([]byte("foo: bar"), []byte("foo: bar"))
+	c.Configure([]byte("foo: bar"), []byte("foo: bar"), "test")
 	assert.Equal(t, string(c.ID()), "testcheck:2144e63501a5cc65")
 }
 
@@ -278,7 +278,7 @@ func BenchmarkConcurrentRun(b *testing.B) {
 		class := getClass("testcheck", "TestCheck")
 		for pb.Next() {
 			check := NewPythonCheck("testcheck", class)
-			err := check.Configure([]byte("foo: bar"), []byte("foo: bar"))
+			err := check.Configure([]byte("foo: bar"), []byte("foo: bar"), "test")
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/collector/py/loader.go
+++ b/pkg/collector/py/loader.go
@@ -229,7 +229,7 @@ func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, err
 		check := NewPythonCheck(moduleName, checkClass)
 
 		// The GIL should be unlocked at this point, `check.Configure` uses its own stickyLock and stickyLocks must not be nested
-		if err := check.Configure(i, config.InitConfig); err != nil {
+		if err := check.Configure(i, config.InitConfig, config.Source); err != nil {
 			addExpvarConfigureError(fmt.Sprintf("%s (%s)", moduleName, wheelVersion), err.Error())
 			continue
 		}

--- a/pkg/collector/runner/num_workers_test.go
+++ b/pkg/collector/runner/num_workers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/py"
 	python "github.com/sbinet/go-python"
@@ -35,9 +36,11 @@ type stickyLock struct {
 	locked uint32 // Flag set to 1 if the lock is locked, 0 otherwise
 }
 
-func (nc *NumWorkersCheck) String() string  { return nc.name }
-func (nc *NumWorkersCheck) Version() string { return "" }
-func (nc *NumWorkersCheck) ID() check.ID    { return check.ID(nc.String()) }
+func (nc *NumWorkersCheck) String() string                                             { return nc.name }
+func (nc *NumWorkersCheck) Version() string                                            { return "" }
+func (nc *NumWorkersCheck) ID() check.ID                                               { return check.ID(nc.String()) }
+func (nc *NumWorkersCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (nc *NumWorkersCheck) ConfigSource() string                                       { return "test" }
 func (nc *NumWorkersCheck) Run() error {
 	if *pythonCheck {
 		e := runPythonCheck() // BUG: this panics occasionally
@@ -204,8 +207,8 @@ func runPythonCheck() error {
 	runtime.UnlockOSThread()
 
 	// Acquire a PythonCheck instance
-	check := py.NewPythonCheck("runner_test", checkClass)              // acquires its own stickyLock
-	e := check.Configure([]byte(config), []byte("foo_init: bar_init")) // acquires its own stickyLock
+	check := py.NewPythonCheck("runner_test", checkClass)                      // acquires its own stickyLock
+	e := check.Configure([]byte(config), []byte("foo_init: bar_init"), "test") // acquires its own stickyLock
 	if check == nil || e != nil {
 		return fmt.Errorf("Unable to acquire check instance")
 	}

--- a/pkg/collector/runner/runner_test.go
+++ b/pkg/collector/runner/runner_test.go
@@ -37,11 +37,12 @@ func newTestCheck(doErr bool, id string) *TestCheck {
 	}
 }
 
-func (c *TestCheck) String() string                                     { return "TestCheck" }
-func (c *TestCheck) Version() string                                    { return "" }
-func (c *TestCheck) Stop()                                              {}
-func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                            { return 1 }
+func (c *TestCheck) String() string                                             { return "TestCheck" }
+func (c *TestCheck) Version() string                                            { return "" }
+func (c *TestCheck) Stop()                                                      {}
+func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (c *TestCheck) ConfigSource() string                                       { return "test" }
+func (c *TestCheck) Interval() time.Duration                                    { return 1 }
 func (c *TestCheck) Run() error {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/collector/scheduler/scheduler_test.go
+++ b/pkg/collector/scheduler/scheduler_test.go
@@ -17,15 +17,16 @@ import (
 // FIXTURE
 type TestCheck struct{ intl time.Duration }
 
-func (c *TestCheck) String() string                                     { return "TestCheck" }
-func (c *TestCheck) Version() string                                    { return "" }
-func (c *TestCheck) Configure(integration.Data, integration.Data) error { return nil }
-func (c *TestCheck) Interval() time.Duration                            { return c.intl }
-func (c *TestCheck) Run() error                                         { return nil }
-func (c *TestCheck) Stop()                                              {}
-func (c *TestCheck) ID() check.ID                                       { return check.ID(c.String()) }
-func (c *TestCheck) GetWarnings() []error                               { return []error{} }
-func (c *TestCheck) GetMetricStats() (map[string]int64, error)          { return make(map[string]int64), nil }
+func (c *TestCheck) String() string                                             { return "TestCheck" }
+func (c *TestCheck) Version() string                                            { return "" }
+func (c *TestCheck) Configure(integration.Data, integration.Data, string) error { return nil }
+func (c *TestCheck) ConfigSource() string                                       { return "test" }
+func (c *TestCheck) Interval() time.Duration                                    { return c.intl }
+func (c *TestCheck) Run() error                                                 { return nil }
+func (c *TestCheck) Stop()                                                      {}
+func (c *TestCheck) ID() check.ID                                               { return check.ID(c.String()) }
+func (c *TestCheck) GetWarnings() []error                                       { return []error{} }
+func (c *TestCheck) GetMetricStats() (map[string]int64, error)                  { return make(map[string]int64), nil }
 
 var initialMinAllowedInterval = minAllowedInterval
 

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -19,6 +19,7 @@ Collector
     {{printDashes $CheckName "-"}}{{- if $version }}{{printDashes $version "-"}}---{{ end }}
     {{- range $CheckInstances }}
       Instance ID: {{.CheckID}} {{status .}}
+      Config source: {{.ConfigSource}}
       Total Runs: {{humanize .TotalRuns}}
       Metric Samples: Last Run: {{humanize .MetricSamples}}, Total: {{humanize .TotalMetricSamples}}
       Events: Last Run: {{humanize .Events}}, Total: {{humanize .TotalEvents}}

--- a/releasenotes/notes/config-source-97c6df806133612e.yaml
+++ b/releasenotes/notes/config-source-97c6df806133612e.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Agent status now includes the path to the config file for each integration.

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -120,7 +120,7 @@ func doRun(m *testing.M) int {
 	var dockerCfg = []byte(dockerCfgString)
 	var dockerInitCfg = []byte("")
 	dockerCheck = containers.DockerFactory()
-	dockerCheck.Configure(dockerCfg, dockerInitCfg)
+	dockerCheck.Configure(dockerCfg, dockerInitCfg, "test")
 
 	// Setup mock sender
 	sender = mocksender.NewMockSender(dockerCheck.ID())


### PR DESCRIPTION
### Motivation

We want to be able to display the source of the config for each check in status/web-gui.

I added this to the Check interface, so it required a ton of changes. If anyone has a better solution for this, it's welcome.