### PR TITLE
pkg/trace/config: add environment variable DD_APM_MAX_CPU_PERCENT

### DIFF
--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -38,6 +38,7 @@ func applyEnv() {
 		{"DD_MAX_TPS", "apm_config.max_traces_per_second"}, // deprecated
 		{"DD_APM_MAX_TPS", "apm_config.max_traces_per_second"},
 		{"DD_APM_MAX_MEMORY", "apm_config.max_memory"},
+		{"DD_APM_MAX_CPU_PERCENT", "apm_config.max_cpu_percent"},
 	} {
 		if v := os.Getenv(override.env); v != "" {
 			config.Datadog.Set(override.key, v)

--- a/releasenotes/notes/apm-new-env-vars-bcb8c649e482276c.yaml
+++ b/releasenotes/notes/apm-new-env-vars-bcb8c649e482276c.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Maximum allowed CPU percentage usage is now
+    configurable via DD_APM_MAX_CPU_PERCENT.


### PR DESCRIPTION
This change adds the environment variable DD_APM_MAX_CPU_PERCENT (configures `apm_config.max_cpu_percent`)