### PR TITLE
pkg/trace/config: turn log throttling on by default

### DIFF
--- a/pkg/trace/agent/log.go
+++ b/pkg/trace/agent/log.go
@@ -213,7 +213,7 @@ func setupLogger(cfg *config.AgentConfig) error {
 		minLogLvl = seelog.InfoLvl
 	}
 	var duration time.Duration
-	if cfg.LogThrottlingEnabled {
+	if cfg.LogThrottling {
 		duration = 10 * time.Second
 	}
 	format := "common"

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -80,9 +80,9 @@ type AgentConfig struct {
 	StatsdPort int
 
 	// logging
-	LogLevel             string
-	LogFilePath          string
-	LogThrottlingEnabled bool
+	LogLevel      string
+	LogFilePath   string
+	LogThrottling bool
 
 	// watchdog
 	MaxMemory        float64       // MaxMemory is the threshold (bytes allocated) above which program panics and exits, to be restarted
@@ -137,9 +137,9 @@ func New() *AgentConfig {
 		StatsdHost: "localhost",
 		StatsdPort: 8125,
 
-		LogLevel:             "INFO",
-		LogFilePath:          DefaultLogFilePath,
-		LogThrottlingEnabled: true,
+		LogLevel:      "INFO",
+		LogFilePath:   DefaultLogFilePath,
+		LogThrottling: true,
 
 		MaxMemory:        5e8, // 500 Mb, should rarely go above 50 Mb
 		MaxCPU:           0.5, // 50%, well behaving agents keep below 5%

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -165,7 +165,7 @@ func TestFullIniConfig(t *testing.T) {
 	assert.Equal("host.ip", c.StatsdHost)
 	assert.Equal("/path/to/file", c.LogFilePath)
 	assert.Equal("debug", c.LogLevel)
-	assert.False(c.LogThrottlingEnabled)
+	assert.False(c.LogThrottling) // turns off when log_level is "debug"
 	assert.True(c.SkipSSLValidation)
 
 	assert.Equal(map[string]float64{
@@ -257,7 +257,7 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.Equal("mymachine", c.Hostname)
 	assert.Equal("https://user:password@proxy_for_https:1234", c.ProxyURL.String())
 	assert.True(c.SkipSSLValidation)
-	assert.Equal("debug", c.LogLevel)
+	assert.Equal("info", c.LogLevel)
 	assert.Equal(18125, c.StatsdPort)
 	assert.False(c.Enabled)
 	assert.Equal("abc", c.LogFilePath)
@@ -271,6 +271,7 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.EqualValues(123.4, c.MaxMemory)
 	assert.Equal(12, c.MaxConnections)
 	assert.Equal("0.0.0.0", c.ReceiverHost)
+	assert.True(c.LogThrottling)
 
 	noProxy := true
 	if _, ok := os.LookupEnv("NO_PROXY"); ok {

--- a/pkg/trace/config/testdata/full.ini
+++ b/pkg/trace/config/testdata/full.ini
@@ -19,7 +19,6 @@ endpoint: https://datadog.unittests
 [trace.config]
 env: test
 log_file: /path/to/file
-log_throttling: no
 
 [trace.sampler]
 extra_sample_rate: 0.5

--- a/pkg/trace/config/testdata/full.yaml
+++ b/pkg/trace/config/testdata/full.yaml
@@ -9,7 +9,7 @@ use_dogstatsd: yes
 skip_ssl_validation: yes
 dogstatsd_port: 18125
 dogstatsd_non_local_traffic: yes
-log_level: debug
+log_level: info
 apm_config:
   enabled: false
   log_file: abc

--- a/releasenotes/notes/apm-enable-log-throttling-5773fe9a5623dbc5.yaml
+++ b/releasenotes/notes/apm-enable-log-throttling-5773fe9a5623dbc5.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: Log throttling is now automatically enabled by default when
+    `log_level` differs from `debug`. A maximum of no more than 10 error
+    messages every 10 seconds will be displayed.
+    


### PR DESCRIPTION
This change makes sure that the (informerly deprecated) option
`apm_config.log_throttling` is turned on by default. This means that
error logs are rate limited to a maximum of 10 messages every 10 seconds
(hardcoded).

Having this always off resulted in countless spammy logs and support
cases. It is useless to address more than 10 error messages at a time,
which are most of the cases the same one.

For those rare cases, a change has been made where log throttling is
automatically disabled when logging level is set to "debug" and log
throttling is not specifically set by the user in the config.