### PR TITLE
Split start and restart commands

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -257,20 +257,20 @@ else
 fi
 
 
-# Use /usr/sbin/service by default. 
+# Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
 restart_cmd="$sudo_cmd service datadog-agent restart"
 stop_instructions="$sudo_cmd service datadog-agent stop"
 start_instructions="$sudo_cmd service datadog-agent start"
 
-if command -v systemctl 2>&1; then 
+if command -v systemctl 2>&1; then
   # Use systemd if systemctl binary exists
   restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"
   start_instructions="$sudo_cmd systemctl start datadog-agent"
 elif /sbin/init --version 2>&1 | grep -q upstart; then
   # Try to detect Upstart, this works most of the times but still a best effort
-  restart_cmd="$sudo_cmd start datadog-agent"
+  restart_cmd="$sudo_cmd restart datadog-agent"
   stop_instructions="$sudo_cmd stop datadog-agent"
   start_instructions="$sudo_cmd start datadog-agent"
 fi

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -267,6 +267,7 @@ start_instructions="$sudo_cmd service datadog-agent start"
 if command -v systemctl 2>&1; then
   # Use systemd if systemctl binary exists
   restart_cmd="$sudo_cmd systemctl restart datadog-agent.service"
+  start_cmd="$sudo_cmd systemctl start datadog-agent"
   stop_instructions="$sudo_cmd systemctl stop datadog-agent"
   start_instructions="$sudo_cmd systemctl start datadog-agent"
 elif /sbin/init --version 2>&1 | grep -q upstart; then

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -260,6 +260,7 @@ fi
 # Use /usr/sbin/service by default.
 # Some distros usually include compatibility scripts with Upstart or Systemd. Check with: `command -v service | xargs grep -E "(upstart|systemd)"`
 restart_cmd="$sudo_cmd service datadog-agent restart"
+start_cmd="$sudo_cmd service datadog-agent start"
 stop_instructions="$sudo_cmd service datadog-agent stop"
 start_instructions="$sudo_cmd service datadog-agent start"
 
@@ -270,7 +271,8 @@ if command -v systemctl 2>&1; then
   start_instructions="$sudo_cmd systemctl start datadog-agent"
 elif /sbin/init --version 2>&1 | grep -q upstart; then
   # Try to detect Upstart, this works most of the times but still a best effort
-  restart_cmd="$sudo_cmd restart datadog-agent"
+  restart_cmd="$sudo_cmd stop datadog-agent || $sudo_cmd start datadog-agent"
+  start_cmd="$sudo_cmd start datadog-agent"
   stop_instructions="$sudo_cmd stop datadog-agent"
   start_instructions="$sudo_cmd start datadog-agent"
 fi
@@ -281,7 +283,7 @@ if [ $no_start ]; then
 will not be started. You will have to do it manually using the following
 command:
 
-    $restart_cmd
+    $start_cmd
 
 \033[0m\n"
     exit

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -272,7 +272,7 @@ if command -v systemctl 2>&1; then
   start_instructions="$sudo_cmd systemctl start datadog-agent"
 elif /sbin/init --version 2>&1 | grep -q upstart; then
   # Try to detect Upstart, this works most of the times but still a best effort
-  restart_cmd="$sudo_cmd stop datadog-agent || $sudo_cmd start datadog-agent"
+  restart_cmd="$sudo_cmd stop datadog-agent ; $sudo_cmd start datadog-agent"
   start_cmd="$sudo_cmd start datadog-agent"
   stop_instructions="$sudo_cmd stop datadog-agent"
   start_instructions="$sudo_cmd start datadog-agent"


### PR DESCRIPTION
### What does this PR do?

With `upstart`, the script would cause the installation to return an error code `1` when the agent was already installed and running.
This PR aims to split `start` and `restart` while not using `restart` when `upstart is in use due to `restart` failing when the Agent was not already running: https://github.com/DataDog/datadog-agent/pull/3312#discussion_r277054465

### Motivation

A customer reported this behavior. 

### Additional Notes

Replicated the same process when `systemd` is in use.