### PR TITLE
collect ip, port and protocol for docker

### DIFF
--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -189,7 +189,7 @@ func parseContainerHealth(status string) string {
 func parseContainerNetworkAddresses(ports []types.Port, netSettings *types.SummaryNetworkSettings, container string) []containers.NetworkAddress {
 	addrList := []containers.NetworkAddress{}
 	tempAddrList := []containers.NetworkAddress{}
-	if netSettings == nil || netSettings.Networks == nil || len(netSettings.Networks) == 0 {
+	if netSettings == nil || len(netSettings.Networks) == 0 {
 		log.Debugf("No network settings available from docker")
 		return addrList
 	}

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -189,6 +189,10 @@ func parseContainerHealth(status string) string {
 func parseContainerNetworkAddresses(ports []types.Port, netSettings *types.SummaryNetworkSettings, container string) []containers.NetworkAddress {
 	addrList := []containers.NetworkAddress{}
 	tempAddrList := []containers.NetworkAddress{}
+	if netSettings == nil || netSettings.Networks == nil || len(netSettings.Networks) == 0 {
+		log.Debugf("No network settings available from docker")
+		return addrList
+	}
 	for _, port := range ports {
 		if isExposed(port) {
 			IP := net.ParseIP(port.IP)


### PR DESCRIPTION
### What does this PR do?

Collect ip, port and protocol tuples for docker,  following up on what was done for Kubelet in https://github.com/DataDog/datadog-agent/pull/2664 

### Motivation

needed for network-tracer GA
