### PR TITLE
Add a fallback to make sure JMXFetch exits on Windows

### DIFF
--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -282,7 +282,8 @@ func (j *JMXFetch) Stop() error {
 	} else {
 		// Windows
 		if err := ioutil.WriteFile(j.exitFilePath, nil, 0644); err != nil {
-			return err
+			log.Warnf("Could not signal JMXFetch to exit, killing instead", err)
+			return j.cmd.Process.Kill()
 		}
 	}
 	return nil

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -282,7 +282,7 @@ func (j *JMXFetch) Stop() error {
 	} else {
 		// Windows
 		if err := ioutil.WriteFile(j.exitFilePath, nil, 0644); err != nil {
-			log.Warnf("Could not signal JMXFetch to exit, killing instead", err)
+			log.Warnf("Could not signal JMXFetch to exit, killing instead: %v", err)
 			return j.cmd.Process.Kill()
 		}
 	}

--- a/releasenotes/notes/jmxfetch-kill-6dcb1a0b9ab31ca5.yaml
+++ b/releasenotes/notes/jmxfetch-kill-6dcb1a0b9ab31ca5.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed JMXFetch process not being terminated on Windows in certain cases.


### PR DESCRIPTION
### What does this PR do?

In case the file we are using to signal JMXFetch to die can't be created (eg: insufficient permissions), we kill the child process instead. This is similar to the fallback we have for Linux, but for Windows.
