### PR TITLE
tasks/android: don't spawn the gradle daemon for the android build.

### DIFF
--- a/tasks/android.py
+++ b/tasks/android.py
@@ -89,9 +89,9 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     pwd = os.getcwd()
     os.chdir("cmd/agent/android")
     if sys.platform == 'win32':
-        cmd = "gradlew.bat build"
+        cmd = "gradlew.bat --no-daemon build"
     else:
-        cmd = "./gradlew build"
+        cmd = "./gradlew --no-daemon build"
     ctx.run(cmd)
     os.chdir(pwd)
     ver = get_version(ctx, include_git=True, git_sha_length=7)


### PR DESCRIPTION
### What does this PR do?

Do not use the gradle daemon in the CI while building for Android.