### PR TITLE
Warn about unknown keys in config yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ templates:
           # If incremental dep fails, increase the cache gen number
           # in restore_deps AND save_deps
           # See https://github.com/DataDog/datadog-agent/pull/2384
-          - gen13-godeps-{{ .Branch }}-{{ .Revision }}
-          - gen13-godeps-{{ .Branch }}-
-          - gen13-godeps-master-
+          - gen14-godeps-{{ .Branch }}-{{ .Revision }}
+          - gen14-godeps-{{ .Branch }}-
+          - gen14-godeps-master-
     - save_cache: &save_deps
-        key: gen13-godeps-{{ .Branch }}-{{ .Revision }}
+        key: gen14-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
         keys:
           # Cache retrieval is faster than full git checkout

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,12 +50,12 @@
   revision = "2cfb68475274527a10701355c739f31dd404718c"
 
 [[projects]]
-  digest = "1:1d7a2553b25c97fa4ee2e3d710a03c08013b3ec79a3ed9d5d7ab206ff53e2d66"
+  digest = "1:a4261d199fb200222fa77f78c343184ddcfd6ebedc71fdd966df3e7e76a1b95b"
   name = "github.com/DataDog/viper"
   packages = ["."]
   pruneopts = ""
-  revision = "991b92b30e71a5ae48f8c2e81a95b1209549ed8d"
-  version = "v1.6.0"
+  revision = "0d6ea091c7f3660c643588f92960e87b0601ab74"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:34d4c1b61fa208e523726ddb85d01b8caa8f2de0cd656d91c81b6b86daea485c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -128,7 +128,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/viper"
-  version = "~v1.6.0"
+  version = "~v1.7.0"
 
 [[constraint]]
   name = "github.com/coreos/go-systemd"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -390,6 +390,34 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 
+	//Declare other keys that don't have a default/env var
+	config.SetKnown("metadata_providers")
+	config.SetKnown("config_providers")
+	config.SetKnown("proxy.http")
+	config.SetKnown("proxy.https")
+	config.SetKnown("proxy.no_proxy")
+	config.SetKnown("process_config.dd_agent_env")
+	config.SetKnown("process_config.enabled")
+	config.SetKnown("process_config.intervals.process_realtime")
+	config.SetKnown("process_config.queue_size")
+	config.SetKnown("process_config.max_per_message")
+	config.SetKnown("process_config.intervals.process")
+	config.SetKnown("process_config.blacklist_patterns")
+	config.SetKnown("process_config.intervals.container")
+	config.SetKnown("process_config.intervals.container_realtime")
+	config.SetKnown("process_config.dd_agent_bin")
+	config.SetKnown("process_config.max_proc_fds")
+	config.SetKnown("apm_config.receiver_port")
+	config.SetKnown("apm_config.env")
+	config.SetKnown("apm_config.apm_non_local_traffic")
+	config.SetKnown("apm_config.extra_sample_rate")
+	config.SetKnown("apm_config.ignore_resources")
+	config.SetKnown("apm_config.max_traces_per_second")
+	config.SetKnown("jmx_pipe_name")
+	config.SetKnown("jmx_pipe_path")
+	config.SetKnown("clustername")
+	config.SetKnown("listeners")
+
 	setAssetFs(config)
 }
 
@@ -494,6 +522,16 @@ func load(config Config, origin string, loadSecret bool) error {
 		log.Warnf("config.load() error %v", err)
 		return err
 	}
+
+	knownKeys := config.GetKnownKeys()
+	loadedKeys := config.AllKeys()
+	for i := range loadedKeys {
+		key := loadedKeys[i]
+		if _, found := knownKeys[key]; !found {
+			log.Warnf("Uknown key in config file: %v", key)
+		}
+	}
+
 	log.Infof("config.load succeeded")
 
 	if loadSecret {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -390,7 +390,8 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 
-	//Declare other keys that don't have a default/env var
+	// Declare other keys that don't have a default/env var.
+	// Mostly, keys we use IsSet() on, because IsSet always returns true if a key has a default.
 	config.SetKnown("metadata_providers")
 	config.SetKnown("config_providers")
 	config.SetKnown("proxy.http")
@@ -406,7 +407,6 @@ func initConfig(config Config) {
 	config.SetKnown("process_config.intervals.container")
 	config.SetKnown("process_config.intervals.container_realtime")
 	config.SetKnown("process_config.dd_agent_bin")
-	config.SetKnown("process_config.max_proc_fds")
 	config.SetKnown("apm_config.receiver_port")
 	config.SetKnown("apm_config.env")
 	config.SetKnown("apm_config.apm_non_local_traffic")
@@ -415,6 +415,13 @@ func initConfig(config Config) {
 	config.SetKnown("apm_config.max_traces_per_second")
 	config.SetKnown("clustername")
 	config.SetKnown("listeners")
+	config.SetKnown("process.strip_proc_arguments")
+	config.SetKnown("process_config.windows.args_refresh_interval")
+	config.SetKnown("process_config.windows.add_new_args")
+	config.SetKnown("process.additional_endpoints")
+	config.SetKnown("additional_endpoints")
+	config.SetKnown("process.container_source")
+	config.SetKnown("process.intervals.connections")
 
 	setAssetFs(config)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -413,8 +413,6 @@ func initConfig(config Config) {
 	config.SetKnown("apm_config.extra_sample_rate")
 	config.SetKnown("apm_config.ignore_resources")
 	config.SetKnown("apm_config.max_traces_per_second")
-	config.SetKnown("jmx_pipe_name")
-	config.SetKnown("jmx_pipe_path")
 	config.SetKnown("clustername")
 	config.SetKnown("listeners")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -525,10 +525,9 @@ func load(config Config, origin string, loadSecret bool) error {
 
 	knownKeys := config.GetKnownKeys()
 	loadedKeys := config.AllKeys()
-	for i := range loadedKeys {
-		key := loadedKeys[i]
+	for _, key := range loadedKeys {
 		if _, found := knownKeys[key]; !found {
-			log.Warnf("Uknown key in config file: %v", key)
+			log.Warnf("Unknown key in config file: %v", key)
 		}
 	}
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -57,6 +57,7 @@ type Config interface {
 	MergeConfigOverride(in io.Reader) error
 
 	AllSettings() map[string]interface{}
+	AllKeys() []string
 
 	AddConfigPath(in string)
 	SetConfigName(in string)
@@ -65,6 +66,12 @@ type Config interface {
 	ConfigFileUsed() string
 
 	BindPFlag(key string, flag *pflag.Flag) error
+
+	// SetKnown adds a key to the set of known valid config keys
+	SetKnown(key string)
+	// GetKnownKeys returns all the keys that meet at least one of these criteria:
+	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
+	GetKnownKeys() map[string]interface{}
 
 	// API not implemented by viper.Viper and that have proven useful for our config usage
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -42,6 +42,21 @@ func (c *safeConfig) SetDefault(key string, value interface{}) {
 	c.Viper.SetDefault(key, value)
 }
 
+// SetKnown adds a key to the set of known valid config keys
+func (c *safeConfig) SetKnown(key string) {
+	c.Lock()
+	defer c.Unlock()
+	c.Viper.SetKnown(key)
+}
+
+// GetKnownKeys returns all the keys that meet at least one of these criteria:
+// 1) have a default, 2) have an environment variable binded or 3) have been SetKnown()
+func (c *safeConfig) GetKnownKeys() map[string]interface{} {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.GetKnownKeys()
+}
+
 // SetFs wraps Viper for concurrent access
 func (c *safeConfig) SetFs(fs afero.Fs) {
 	c.Lock()

--- a/releasenotes/notes/warn-unknown-keys-1724cdee02d841c9.yaml
+++ b/releasenotes/notes/warn-unknown-keys-1724cdee02d841c9.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Added a warning about unknown keys in datadog.yaml.


### PR DESCRIPTION
This makes the agent warn about unknown keys in the config file (eg: typos).

I'm using keys that have a default or a binded env var to consider them "known". Keys that don't fulfill this need to be added manually using the `SetKnown` function.