### PR TITLE
[py3] allow test kitchen to fail on SUSE 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -738,7 +738,7 @@ kitchen_ubuntu:
 # run dd-agent-testing on suse
 kitchen_suse:
   stage: testkitchen_testing
-  allow_failure: false
+  allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:latest
   <<: *run_when_testkitchen_triggered
   before_script:


### PR DESCRIPTION
### What does this PR do?

Allow test kitchen to fail on SUSE (not supported yet w/ py3)

