### PR TITLE
'integration freeze' must print datadog packages only

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -9,8 +9,10 @@ package app
 import (
 	"archive/zip"
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -209,7 +211,7 @@ func validateArgs(args []string, local bool) error {
 	return nil
 }
 
-func pip(args []string) error {
+func pip(args []string, stdout io.Writer, stderr io.Writer) error {
 	if !allowRoot && !authorizedUser() {
 		return errors.New("Please use this tool as the agent-running user")
 	}
@@ -238,26 +240,26 @@ func pip(args []string) error {
 	pipCmd := exec.Command(pythonPath, args...)
 
 	// forward the standard output to stdout
-	stdout, err := pipCmd.StdoutPipe()
+	pip_stdout, err := pipCmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
 	go func() {
-		in := bufio.NewScanner(stdout)
+		in := bufio.NewScanner(pip_stdout)
 		for in.Scan() {
-			fmt.Println(in.Text())
+			fmt.Fprintf(stdout, "%s\n", in.Text())
 		}
 	}()
 
 	// forward the standard error to stderr
-	stderr, err := pipCmd.StderrPipe()
+	pip_stderr, err := pipCmd.StderrPipe()
 	if err != nil {
 		return err
 	}
 	go func() {
-		in := bufio.NewScanner(stderr)
+		in := bufio.NewScanner(pip_stderr)
 		for in.Scan() {
-			fmt.Fprintf(os.Stderr, "%s\n", color.RedString(in.Text()))
+			fmt.Fprintf(stderr, "%s\n", color.RedString(in.Text()))
 		}
 	}()
 
@@ -305,7 +307,7 @@ func install(cmd *cobra.Command, args []string) error {
 		} else if !ok {
 			return fmt.Errorf("the wheel %s is not an agent check, it will not be installed", args[0])
 		}
-		return pip(append(pipArgs, args[0]))
+		return pip(append(pipArgs, args[0]), os.Stdout, os.Stderr)
 	}
 
 	// Additional verification for installation
@@ -364,7 +366,7 @@ func install(cmd *cobra.Command, args []string) error {
 	}
 
 	// Install the wheel
-	if err := pip(append(pipArgs, wheelPath)); err != nil {
+	if err := pip(append(pipArgs, wheelPath), os.Stdout, os.Stderr); err != nil {
 		return fmt.Errorf("error installing wheel %s: %v", wheelPath, err)
 	}
 
@@ -711,7 +713,7 @@ func remove(cmd *cobra.Command, args []string) error {
 	pipArgs = append(pipArgs, args...)
 	pipArgs = append(pipArgs, "-y")
 
-	return pip(pipArgs)
+	return pip(pipArgs, os.Stdout, os.Stderr)
 }
 
 func freeze(cmd *cobra.Command, args []string) error {
@@ -720,7 +722,21 @@ func freeze(cmd *cobra.Command, args []string) error {
 		"freeze",
 	}
 
-	return pip(pipArgs)
+	pip_stdo := bytes.NewBuffer(nil)
+	err := pip(pipArgs, io.Writer(pip_stdo), os.Stderr)
+	if err != nil {
+		return err
+	}
+
+	python_libs := strings.Split(pip_stdo.String(), "\n")
+
+	// The agent integration freeze command should only show datadog packages and nothing else
+	for i := range python_libs {
+		if strings.HasPrefix(python_libs[i], "datadog-") {
+			fmt.Println(python_libs[i])
+		}
+	}
+	return nil
 }
 
 func show(cmd *cobra.Command, args []string) error {

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -240,24 +240,24 @@ func pip(args []string, stdout io.Writer, stderr io.Writer) error {
 	pipCmd := exec.Command(pythonPath, args...)
 
 	// forward the standard output to stdout
-	pip_stdout, err := pipCmd.StdoutPipe()
+	pipStdout, err := pipCmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
 	go func() {
-		in := bufio.NewScanner(pip_stdout)
+		in := bufio.NewScanner(pipStdout)
 		for in.Scan() {
 			fmt.Fprintf(stdout, "%s\n", in.Text())
 		}
 	}()
 
 	// forward the standard error to stderr
-	pip_stderr, err := pipCmd.StderrPipe()
+	pipStderr, err := pipCmd.StderrPipe()
 	if err != nil {
 		return err
 	}
 	go func() {
-		in := bufio.NewScanner(pip_stderr)
+		in := bufio.NewScanner(pipStderr)
 		for in.Scan() {
 			fmt.Fprintf(stderr, "%s\n", color.RedString(in.Text()))
 		}

--- a/releasenotes/notes/integration-freeze-must-print-datadog-packages-only-a218e9d9974984de.yaml
+++ b/releasenotes/notes/integration-freeze-must-print-datadog-packages-only-a218e9d9974984de.yaml
@@ -1,0 +1,5 @@
+other:
+  - |
+    The 'integration freeze' cli subcommand now only
+    displays datadog packages instead of the complete
+    result of the 'pip freeze' command.


### PR DESCRIPTION
### What does this PR do?

This PR changes the behavior of the 'integration freeze' cli command. Instead of displaying the result of `pip freeze` with all the python packages, the command will only shows datadog packages.

### Motivation
Since this is a `agent integration` command, it should only show datadog packages and nothing else from the embedded python.

### Additional Notes
--