### PR TITLE
Add fallback APM extractor and default rate config key

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -353,6 +353,8 @@ func eventProcessorFromConf(conf *config.AgentConfig) *event.Processor {
 		extractors = append(extractors, event.NewFixedRateExtractor(conf.AnalyzedSpansByService))
 	} else if len(conf.AnalyzedRateByServiceLegacy) > 0 {
 		extractors = append(extractors, event.NewLegacyExtractor(conf.AnalyzedRateByServiceLegacy))
+	} else if conf.DefaultAnalyzedRate > 0 {
+		extractors = append(extractors, event.NewFallbackExtractor(conf.DefaultAnalyzedRate))
 	}
 
 	return event.NewProcessor(extractors, conf.MaxEPS)

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -286,6 +286,11 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		}
 	}
 
+	// undocumeted
+	if config.Datadog.IsSet("apm_config.default_analyzed_rate") {
+		c.DefaultAnalyzedRate = config.Datadog.GetFloat64("apm_config.default_analyzed_rate")
+	}
+
 	// undocumented
 	if config.Datadog.IsSet("apm_config.dd_agent_bin") {
 		c.DDAgentBin = config.Datadog.GetString("apm_config.dd_agent_bin")

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -104,6 +104,7 @@ type AgentConfig struct {
 	// transaction analytics
 	AnalyzedRateByServiceLegacy map[string]float64
 	AnalyzedSpansByService      map[string]map[string]float64
+	DefaultAnalyzedRate         float64
 
 	// infrastructure agent binary
 	DDAgentBin string // DDAgentBin will be "" for Agent5 scenarios

--- a/pkg/trace/event/extractor_fallback.go
+++ b/pkg/trace/event/extractor_fallback.go
@@ -1,0 +1,22 @@
+package event
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
+)
+
+// fallbackExtractor is an event extractor that always decides to extract APM events based on a fixed sample rate
+type fallbackExtractor struct {
+	defaultRate float64
+}
+
+// NewFixedRateExtractor returns an APM event extractor that always decides to extract APM events based on a fixed
+// sample rate
+func NewFallbackExtractor(defaultRate float64) Extractor {
+	return &fallbackExtractor{defaultRate: defaultRate}
+}
+
+// Extract always returns the default extraction rate and a true value.
+func (e *fallbackExtractor) Extract(s *pb.Span, priority sampler.SamplingPriority) (float64, bool) {
+	return e.defaultRate, true
+}


### PR DESCRIPTION
### What does this PR do?

Add fallback APM extractor and default rate config key

### Motivation

We want to be able to allow-all services/spans by default, and instead use a deny list to retroactively limit/sample spans that are too noisy/costly. At the moment, we rely on having to maintain a list of services to sample which is not scalable as the list of services grows.

### Additional Notes

N/A

/cc @eatwithforks @jonmoter @grosser
