### PR TITLE
Attempt to configure first the kubernetes integration over docker to collect logs

### DIFF
--- a/releasenotes/notes/logs-kubernetes-docker-prio-1bff05d1c058c7b9.yaml
+++ b/releasenotes/notes/logs-kubernetes-docker-prio-1bff05d1c058c7b9.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Change the priotization between the two logic that we have to collect logs on Kubernetes.
+    Now attempt first to collect logs on '/var/log/pods' and fallback to using the docker socket if the initialization failed.


### PR DESCRIPTION
### What does this PR do?

Attempt to configure the kubernetes integration over docker to collect logs

### Motivation

Make sure people that wants to collect logs from `/var/log/pods` and collect metrics from the docker socket can do it.

### Additional Notes

Anything else we should know when reviewing?
