### PR TITLE
Make sure tags get updated while starting the tagger for logs collection

### DIFF
--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -53,6 +53,7 @@ func (p *provider) GetTags() []string {
 // Start starts the polling of new tags on another go routine.
 func (p *provider) Start() {
 	go func() {
+		p.updateTags()
 		ticker := time.NewTicker(refreshPeriod)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
### What does this PR do?

Make sure tags get updated while starting the tagger for logs collection

### Motivation

Having tags on all logs, now first 10s-logs are not properly tagged

### Additional Notes

Anything else we should know when reviewing?
