### PR TITLE
Raise an error when check's configuration are not dict

### DIFF
--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -189,7 +189,7 @@ func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Da
 	var check *C.six_pyobject_t
 	res := C.get_check(six, c.class, (*C.char)(cInitConfig), (*C.char)(cInstance), (*C.char)(cCheckID), (*C.char)(cCheckName), &check)
 	if res == 0 {
-		log.Warnf("could not get a check instance with the new api: %s", getSixError())
+		log.Warnf("could not get a '%s' check instance with the new api: %s", c.ModuleName, getSixError())
 		log.Warn("trying to instantiate the check with the old api, passing agentConfig to the constructor")
 
 		allSettings := config.Datadog.AllSettings()
@@ -203,7 +203,7 @@ func (c *PythonCheck) Configure(data integration.Data, initConfig integration.Da
 
 		res := C.get_check_deprecated(six, c.class, (*C.char)(cInitConfig), (*C.char)(cInstance), (*C.char)(cAgentConfig), (*C.char)(cCheckID), (*C.char)(cCheckName), &check)
 		if res == 0 {
-			return fmt.Errorf("could not invoke python check constructor: %s", getSixError())
+			return fmt.Errorf("could not invoke '%s' python check constructor: %s", c.ModuleName, getSixError())
 		}
 		log.Warnf("passing `agentConfig` to the constructor is deprecated, please use the `get_config` function from the 'datadog_agent' package (%s).", c.ModuleName)
 	}

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -196,6 +196,8 @@ func expvarConfigureErrors() interface{} {
 }
 
 func addExpvarConfigureError(check string, errMsg string) {
+	log.Errorf("py.loader: could not configure check '%s': %s", check, errMsg)
+
 	statsLock.Lock()
 	defer statsLock.Unlock()
 

--- a/six/test/python/datadog_checks/base/checks/__init__.py
+++ b/six/test/python/datadog_checks/base/checks/__init__.py
@@ -8,4 +8,7 @@ class AgentCheck(object):
 
     @staticmethod
     def load_config(yaml_str):
-        pass
+        if yaml_str == "":
+            return None
+        else:
+            return {}

--- a/six/test/six/six.go
+++ b/six/test/six/six.go
@@ -107,7 +107,7 @@ func getFakeCheck() (string, error) {
 	}
 
 	// check instance
-	ret = C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString("checkID"), C.CString("fake_check"), &check)
+	ret = C.get_check(six, class, C.CString(""), C.CString("{\"fake_check\": \"/\"}"), C.CString("checkID"), C.CString("fake_check"), &check)
 	if ret != 1 || check == nil {
 		return "", fmt.Errorf(C.GoString(C.get_error(six)))
 	}
@@ -123,7 +123,7 @@ func runFakeCheck() (string, error) {
 
 	C.get_class(six, C.CString("fake_check"), &module, &class)
 	C.get_attr_string(six, module, C.CString("__version__"), &version)
-	C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString("checkID"), C.CString("fake_check"), &check)
+	C.get_check(six, class, C.CString(""), C.CString("{\"fake_check\": \"/\"}"), C.CString("checkID"), C.CString("fake_check"), &check)
 
 	return C.GoString(C.run_check(six, check)), fetchError()
 }
@@ -134,7 +134,7 @@ func runFakeGetWarnings() ([]string, error) {
 	var check *C.six_pyobject_t
 
 	C.get_class(six, C.CString("fake_check"), &module, &class)
-	C.get_check(six, class, C.CString(""), C.CString("[{fake_check: \"/\"}]"), C.CString("checkID"), C.CString("fake_check"), &check)
+	C.get_check(six, class, C.CString(""), C.CString("{\"fake_check\": \"/\"}"), C.CString("checkID"), C.CString("fake_check"), &check)
 
 	warns := C.get_checks_warnings(six, check)
 	if warns == nil {

--- a/six/three/three.cpp
+++ b/six/three/three.cpp
@@ -189,11 +189,22 @@ bool Three::getCheck(SixPyObject *py_class, const char *init_config_str, const c
         setError("error parsing init_config: " + _fetchPythonError());
         goto done;
     }
+    // replace an empty init_config by  a empty dict
+    if (init_config == Py_None) {
+        Py_XDECREF(init_config);
+        init_config = PyDict_New();
+    } else if (!PyDict_Check(init_config)) {
+        setError("error 'init_config' is not a dict");
+        goto done;
+    }
 
     // call `AgentCheck.load_config(instance)`
     instance = PyObject_CallMethod(klass, load_config, format, instance_str);
     if (instance == NULL) {
         setError("error parsing instance: " + _fetchPythonError());
+        goto done;
+    } else if (!PyDict_Check(instance)) {
+        setError("error instance is not a dict");
         goto done;
     }
 
@@ -215,6 +226,9 @@ bool Three::getCheck(SixPyObject *py_class, const char *init_config_str, const c
         agent_config = PyObject_CallMethod(klass, load_config, format, agent_config_str);
         if (agent_config == NULL) {
             setError("error parsing agent_config: " + _fetchPythonError());
+            goto done;
+        } else if (!PyDict_Check(agent_config)) {
+            setError("error agent_config is not a dict");
             goto done;
         }
 

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -228,11 +228,22 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
         setError("error parsing init_config: " + _fetchPythonError());
         goto done;
     }
+    // replace an empty init_config by  a empty dict
+    if (init_config == Py_None) {
+        Py_XDECREF(init_config);
+        init_config = PyDict_New();
+    } else if (!PyDict_Check(init_config)) {
+        setError("error 'init_config' is not a dict");
+        goto done;
+    }
 
     // call `AgentCheck.load_config(instance)`
     instance = PyObject_CallMethod(klass, load_config, format, instance_str);
     if (instance == NULL) {
         setError("error parsing instance: " + _fetchPythonError());
+        goto done;
+    } else if (!PyDict_Check(instance)) {
+        setError("error instance is not a dict");
         goto done;
     }
 
@@ -254,6 +265,9 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
         agent_config = PyObject_CallMethod(klass, load_config, format, agent_config_str);
         if (agent_config == NULL) {
             setError("error parsing agent_config: " + _fetchPythonError());
+            goto done;
+        } else if (!PyDict_Check(agent_config)) {
+            setError("error agent_config is not a dict");
             goto done;
         }
 


### PR DESCRIPTION
### What does this PR do?

This was automatically filter before by Go types when trying to
unmarshal configuration. Now that we use Python's yaml package we have
to check output types.
