### PR TITLE
pkg/trace/agent: parallelize processor

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -206,7 +206,7 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 	if span.Resource == "" {
 		return
 	}
-	result, err := o.sql.obfuscate(span.Resource)
+	result, err := newSQLObfuscator().obfuscate(span.Resource)
 	if err != nil || result == "" {
 		// we have an error, discard the SQL to avoid polluting user resources.
 		log.Debugf("Error parsing SQL query: %q", span.Resource)


### PR DESCRIPTION
Parallelize the processing of input.

```
benchmark                                old ns/op     new ns/op     delta
BenchmarkThroughput/10.msgp-4            40754302      40393239      -0.89%
BenchmarkThroughput/100traces.msgp-4     11774226      8174593       -30.57%
BenchmarkThroughput/10traces.msgp-4      578199        449316        -22.29%
BenchmarkThroughput/26.msgp-4            18482365      18812769      +1.79%
BenchmarkThroughput/500traces.msgp-4     75211386      52579569      -30.09%

benchmark                                old MB/s     new MB/s     speedup
BenchmarkThroughput/10.msgp-4            59.04        59.57        1.01x
BenchmarkThroughput/100traces.msgp-4     94.86        136.63       1.44x
BenchmarkThroughput/10traces.msgp-4      71.29        91.74        1.29x
BenchmarkThroughput/26.msgp-4            61.59        60.51        0.98x
BenchmarkThroughput/500traces.msgp-4     94.72        135.49       1.43x
```

From @palazzem:

> I would say to make it configurable as we discussed. It means having a config option with 1 as default. That way we can release this patch in 6.12.0 without changing the behavior for everyone, while we continue to test it deeply before making the default a higher value in 6.13.0.