### PR TITLE
send a count named datadog.agent.started equal to 1 when the agent start

### DIFF
--- a/cmd/agent/app/start.go
+++ b/cmd/agent/app/start.go
@@ -185,7 +185,7 @@ func StartAgent() error {
 	// setup the aggregator
 	s := serializer.NewSerializer(common.Forwarder)
 	agg := aggregator.InitAggregator(s, hostname, "agent")
-	agg.AddAgentStartupEvent(version.AgentVersion)
+	agg.AddAgentStartupTelemetry(version.AgentVersion)
 
 	// start dogstatsd
 	if config.Datadog.GetBool("use_dogstatsd") {

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -163,7 +163,7 @@ func start(cmd *cobra.Command, args []string) error {
 	s := serializer.NewSerializer(f)
 
 	aggregatorInstance := aggregator.InitAggregator(s, hostname, "cluster_agent")
-	aggregatorInstance.AddAgentStartupEvent(fmt.Sprintf("%s - Datadog Cluster Agent", version.AgentVersion))
+	aggregatorInstance.AddAgentStartupTelemetry(fmt.Sprintf("%s - Datadog Cluster Agent", version.AgentVersion))
 
 	log.Infof("Datadog Cluster Agent is now running.")
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -265,7 +265,17 @@ func (agg *BufferedAggregator) AddAgentStartupEvent(agentVersion string) {
 		Host:           agg.hostname,
 		EventType:      "Agent Startup",
 	}
+	metric := &metrics.MetricSample{
+		Name:       fmt.Sprintf("datadog.%s.started", agg.agentName),
+		Value:      1,
+		Tags:       []string{fmt.Sprintf("version:%s", agentVersion)},
+		Host:       agg.hostname,
+		Mtype:      metrics.CountType,
+		SampleRate: 1,
+		Timestamp:  0,
+	}
 	agg.eventIn <- event
+	agg.metricIn <- metric
 }
 
 func (agg *BufferedAggregator) registerSender(id check.ID) error {

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -257,8 +257,8 @@ func (agg *BufferedAggregator) SetHostname(hostname string) {
 	<-agg.hostnameUpdateDone
 }
 
-// AddAgentStartupEvent adds the startup event to the events that'll be sent on the next flush
-func (agg *BufferedAggregator) AddAgentStartupEvent(agentVersion string) {
+// AddAgentStartupTelemetry adds a startup event and count to be sent on the next flush
+func (agg *BufferedAggregator) AddAgentStartupTelemetry(agentVersion string) {
 	event := metrics.Event{
 		Text:           fmt.Sprintf("Version %s", agentVersion),
 		SourceTypeName: "System",
@@ -268,7 +268,7 @@ func (agg *BufferedAggregator) AddAgentStartupEvent(agentVersion string) {
 	metric := &metrics.MetricSample{
 		Name:       fmt.Sprintf("datadog.%s.started", agg.agentName),
 		Value:      1,
-		Tags:       []string{fmt.Sprintf("version:%s", agentVersion)},
+		Tags:       []string{fmt.Sprintf("version:%s", version.AgentVersion)},
 		Host:       agg.hostname,
 		Mtype:      metrics.CountType,
 		SampleRate: 1,

--- a/releasenotes/notes/agent-startup-count-f58520a7257f6c99.yaml
+++ b/releasenotes/notes/agent-startup-count-f58520a7257f6c99.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    A count named ``datadog.agent.started`` is now sent with a value of 1 when the agent starts.
+


### PR DESCRIPTION
### What does this PR do?

Sends a count `datadog.agent.started` with a value of 1 when the agent starts, alongside the regular event sent at agent startup.

### Motivation

Need it to track restarts more easily.