### PR TITLE
Allow users to install RCs of integrations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1949,6 +1949,7 @@
     "github.com/containerd/containerd/namespaces",
     "github.com/containerd/typeurl",
     "github.com/coreos/etcd/client",
+    "github.com/coreos/go-semver/semver",
     "github.com/coreos/go-systemd/sdjournal",
     "github.com/docker/docker/api/types",
     "github.com/docker/docker/api/types/container",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,6 +31,10 @@
   version = "~3.2.0"
 
 [[constraint]]
+  name = "github.com/coreos/go-semver"
+  version = "~v0.2.0"
+
+[[constraint]]
   name = "github.com/docker/docker"
   version = "~v1.13.1"
 

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -564,10 +564,10 @@ func installedVersion(integration string) (*semver.Version, error) {
 	integrationName := getIntegrationName(integration)
 	validName, err := regexp.MatchString("^[0-9a-z_-]+$", integration)
 	if err != nil {
-		return fmt.Errorf("Error validating integration name: %s", err)
+		return nil, fmt.Errorf("Error validating integration name: %s", err)
 	}
 	if !validName {
-		return fmt.Errorf("Cannot get installed version of %s: invalid integration name", integration)
+		return nil, fmt.Errorf("Cannot get installed version of %s: invalid integration name", integration)
 	}
 	pythonCmd := exec.Command(pythonPath, "-c", fmt.Sprintf(versionScript, integrationName))
 	output, err := pythonCmd.Output()

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -30,7 +30,7 @@ import (
 const (
 	reqAgentReleaseFile = "requirements-agent-release.txt"
 	constraintsFile     = "final_constraints.txt"
-	datadogPkgPattern   = "datadog-.*"
+	datadogPkgPattern   = "^datadog-[a-z0-9_-]*$"
 	reqLinePattern      = "%s==(\\d+\\.\\d+\\.\\d+)"
 	// Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
 	versionSpecifiersPattern = "([><=!]{1,2})([0-9.]*)"

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -30,7 +30,7 @@ import (
 const (
 	reqAgentReleaseFile = "requirements-agent-release.txt"
 	constraintsFile     = "final_constraints.txt"
-	datadogPkgPattern   = "^datadog-[a-z0-9_-]*$"
+	datadogPkgPattern   = "^datadog-[a-z0-9_-]*(\\s*==\\s*.*)?$"
 	reqLinePattern      = "%s==(\\d+\\.\\d+\\.\\d+)"
 	// Matches version specifiers defined in https://packaging.python.org/specifications/core-metadata/#requires-dist-multiple-use
 	versionSpecifiersPattern = "([><=!]{1,2})([0-9.]*)"
@@ -181,7 +181,7 @@ func validateArgs(args []string, local bool) error {
 			return fmt.Errorf("internal error: %v", err)
 		}
 
-		if !exp.MatchString(args[0]) {
+		if !exp.MatchString(strings.TrimSpace(args[0])) {
 			return fmt.Errorf("invalid package name - this manager only handles datadog packages")
 		}
 	} else {

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,69 +45,15 @@ func TestMoveConfigurationsFiles(t *testing.T) {
 	}
 }
 
-func TestParseVersion(t *testing.T) {
-	version, err := parseVersion("1.2.3")
-	assert.Nil(t, err)
-	assert.Equal(t, 1, version.major)
-	assert.Equal(t, 2, version.minor)
-	assert.Equal(t, 3, version.fix)
-
-	version, err = parseVersion("1.2")
-	assert.Nil(t, version)
-	assert.NotNil(t, err)
-
-	version, err = parseVersion("")
-	assert.Nil(t, version)
-	assert.Nil(t, err)
-}
-
-func TestIsAboveOrEqualTo(t *testing.T) {
-	baseVersion, _ := parseVersion("1.2.3")
-
-	version, _ := parseVersion("1.2.3")
-	assert.True(t, version.isAboveOrEqualTo(baseVersion))
-
-	version, _ = parseVersion("1.2.4")
-	assert.True(t, version.isAboveOrEqualTo(baseVersion))
-
-	version, _ = parseVersion("1.3.0")
-	assert.True(t, version.isAboveOrEqualTo(baseVersion))
-
-	version, _ = parseVersion("2.0.0")
-	assert.True(t, version.isAboveOrEqualTo(baseVersion))
-
-	version, _ = parseVersion("1.1.9")
-	assert.False(t, version.isAboveOrEqualTo(baseVersion))
-
-	version, _ = parseVersion("0.0.1")
-	assert.False(t, version.isAboveOrEqualTo(baseVersion))
-
-	version, _ = parseVersion("1.2.2")
-	assert.False(t, version.isAboveOrEqualTo(baseVersion))
-
-	baseVersion = nil
-	assert.True(t, version.isAboveOrEqualTo(baseVersion))
-}
-
-func TestEquals(t *testing.T) {
-	v1, _ := parseVersion("1.2.3")
-	v2, _ := parseVersion("1.2.3")
-
-	assert.True(t, v1.equals(v2))
-
-	v2 = nil
-	assert.False(t, v1.equals(v2))
-}
-
 func TestGetVersionFromReqLine(t *testing.T) {
 	reqLines := "package1==3.2.1\npackage2==2.3.1"
 
 	version, _ := getVersionFromReqLine("package1", reqLines)
-	expectedVersion, _ := parseVersion("3.2.1")
+	expectedVersion, _ := semver.NewVersion("3.2.1")
 	assert.Equal(t, expectedVersion, version)
 
 	version, _ = getVersionFromReqLine("package2", reqLines)
-	expectedVersion, _ = parseVersion("2.3.1")
+	expectedVersion, _ = semver.NewVersion("2.3.1")
 	assert.Equal(t, expectedVersion, version)
 
 	version, _ = getVersionFromReqLine("package3", reqLines)
@@ -141,8 +88,8 @@ func TestValidateArgs(t *testing.T) {
 
 func TestValidateRequirement(t *testing.T) {
 	// Case baseVersion < versionReq
-	baseVersion, _ := parseVersion("4.1.0")
-	versionReq, _ := parseVersion("4.2.0")
+	baseVersion, _ := semver.NewVersion("4.1.0")
+	versionReq, _ := semver.NewVersion("4.2.0")
 	assert.True(t, validateRequirement(baseVersion, "<", versionReq))
 	assert.True(t, validateRequirement(baseVersion, "<=", versionReq))
 	assert.False(t, validateRequirement(baseVersion, "==", versionReq))
@@ -152,8 +99,8 @@ func TestValidateRequirement(t *testing.T) {
 	assert.False(t, validateRequirement(baseVersion, "anythingElse", versionReq))
 
 	// Case baseVersion == versionReq
-	baseVersion, _ = parseVersion("4.2.0")
-	versionReq, _ = parseVersion("4.2.0")
+	baseVersion, _ = semver.NewVersion("4.2.0")
+	versionReq, _ = semver.NewVersion("4.2.0")
 	assert.False(t, validateRequirement(baseVersion, "<", versionReq))
 	assert.True(t, validateRequirement(baseVersion, "<=", versionReq))
 	assert.True(t, validateRequirement(baseVersion, "==", versionReq))
@@ -163,8 +110,8 @@ func TestValidateRequirement(t *testing.T) {
 	assert.False(t, validateRequirement(baseVersion, "anythingElse", versionReq))
 
 	// Case baseVersion > versionReq
-	baseVersion, _ = parseVersion("4.2.1")
-	versionReq, _ = parseVersion("4.2.0")
+	baseVersion, _ = semver.NewVersion("4.2.1")
+	versionReq, _ = semver.NewVersion("4.2.0")
 	assert.False(t, validateRequirement(baseVersion, "<", versionReq))
 	assert.False(t, validateRequirement(baseVersion, "<=", versionReq))
 	assert.False(t, validateRequirement(baseVersion, "==", versionReq))

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -140,5 +140,5 @@ func TestGetIntegrationName(t *testing.T) {
 
 func TestNormalizePackageName(t *testing.T) {
 	assert.Equal(t, normalizePackageName("datadog-checks_base"), "datadog-checks-base")
-	assert.Equal(t, getIntegrationName("datadog_checks_downloader"), "datadog-checks-downloader")
+	assert.Equal(t, normalizePackageName("datadog_checks_downloader"), "datadog-checks-downloader")
 }

--- a/cmd/agent/app/integrations_test.go
+++ b/cmd/agent/app/integrations_test.go
@@ -121,3 +121,24 @@ func TestValidateRequirement(t *testing.T) {
 	assert.False(t, validateRequirement(baseVersion, "anythingElse", versionReq))
 
 }
+
+func TestSemverToPEP440(t *testing.T) {
+	assert.Equal(t, semverToPEP440(semver.New("1.3.4")), "1.3.4")
+	assert.Equal(t, semverToPEP440(semver.New("1.3.4-rc.1")), "1.3.4rc1")
+	assert.Equal(t, semverToPEP440(semver.New("1.3.4-pre.1")), "1.3.4rc1")
+	assert.Equal(t, semverToPEP440(semver.New("1.3.4-alpha.1")), "1.3.4a1")
+	assert.Equal(t, semverToPEP440(semver.New("1.3.4-beta.1")), "1.3.4b1")
+	assert.Equal(t, semverToPEP440(semver.New("1.3.4-beta")), "1.3.4b")
+}
+
+func TestGetIntegrationName(t *testing.T) {
+	assert.Equal(t, getIntegrationName("datadog-checks-base"), "base")
+	assert.Equal(t, getIntegrationName("datadog-checks-downloader"), "downloader")
+	assert.Equal(t, getIntegrationName("datadog-go-metro"), "go-metro")
+	assert.Equal(t, getIntegrationName("datadog-nginx-ingress-controller"), "nginx_ingress_controller")
+}
+
+func TestNormalizePackageName(t *testing.T) {
+	assert.Equal(t, normalizePackageName("datadog-checks_base"), "datadog-checks-base")
+	assert.Equal(t, getIntegrationName("datadog_checks_downloader"), "datadog-checks-downloader")
+}

--- a/releasenotes/notes/int_rc-7079c8f49d7ac324.yaml
+++ b/releasenotes/notes/int_rc-7079c8f49d7ac324.yaml
@@ -1,0 +1,14 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The `datadog-agent integration` subcommand is now capable of installing prereleases of official integration wheels.
+fixes:
+  - |
+    The `datadog-agent integration show` subcommand now properly accept only Datadog integrations as argument.

--- a/releasenotes/notes/int_rc-7079c8f49d7ac324.yaml
+++ b/releasenotes/notes/int_rc-7079c8f49d7ac324.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    The `datadog-agent integration` subcommand is now capable of installing prereleases of official integration wheels.
+    The ``datadog-agent integration`` subcommand is now capable of installing prereleases of official integration wheels
 fixes:
   - |
-    The `datadog-agent integration show` subcommand now properly accept only Datadog integrations as argument.
+    The ``datadog-agent integration show`` subcommand now properly accepts only Datadog integrations as argument

--- a/releasenotes/notes/int_rc-7079c8f49d7ac324.yaml
+++ b/releasenotes/notes/int_rc-7079c8f49d7ac324.yaml
@@ -6,7 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-features:
+enhancements:
   - |
     The `datadog-agent integration` subcommand is now capable of installing prereleases of official integration wheels.
 fixes:


### PR DESCRIPTION
### What does this PR do?

Allow users to install RCs of integrations. 

Since wheels versioning does not follow semver strictly (see https://www.python.org/dev/peps/pep-0440), I had to make some small adjustments and add a function to translate the semver version of the integration to the wheel version to download from our index.

I also changed the way we get the currently installed version to not rely on pip freeze, because that would give us the wheel version, and not the actual version specified in `__about__.py` (it's also faster 🙂), which I use to make comparisons.

Lastly, I just added argument verification for the show command since I was modifying it anyway, now it will only work for `datadog-` packages, and I also removed the unused function `pipCheck`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?