### PR TITLE
pkg/trace/writer: switch from flushing based on spans to size

### DIFF
--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -88,7 +88,6 @@ type ReplaceRule struct {
 }
 
 type traceWriter struct {
-	MaxSpansPerPayload     int                    `mapstructure:"max_spans_per_payload"`
 	FlushPeriod            float64                `mapstructure:"flush_period_seconds"`
 	UpdateInfoPeriod       int                    `mapstructure:"update_info_period_seconds"`
 	QueueablePayloadSender queueablePayloadSender `mapstructure:"queue"`
@@ -391,9 +390,6 @@ func readTraceWriterConfigYaml() writerconfig.TraceWriterConfig {
 	c := writerconfig.DefaultTraceWriterConfig()
 
 	if err := config.Datadog.UnmarshalKey("apm_config.trace_writer", &w); err == nil {
-		if w.MaxSpansPerPayload > 0 {
-			c.MaxSpansPerPayload = w.MaxSpansPerPayload
-		}
 		if w.FlushPeriod > 0 {
 			c.FlushPeriod = time.Duration(w.FlushPeriod*1000) * time.Millisecond
 		}

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -224,9 +224,8 @@ func TestFullIniConfig(t *testing.T) {
 	}, c.StatsWriterConfig)
 
 	assert.Equal(writerconfig.TraceWriterConfig{
-		MaxSpansPerPayload: 100,
-		FlushPeriod:        3 * time.Second,
-		UpdateInfoPeriod:   2 * time.Second,
+		FlushPeriod:      3 * time.Second,
+		UpdateInfoPeriod: 2 * time.Second,
 		SenderConfig: writerconfig.QueuablePayloadSenderConf{
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
@@ -350,7 +349,6 @@ func TestUndocumentedYamlConfig(t *testing.T) {
 	assert.Equal(50, c.MaxConnections)
 
 	// Assert Trace Writer
-	assert.Equal(11, c.TraceWriterConfig.MaxSpansPerPayload)
 	assert.Equal(22*time.Second, c.TraceWriterConfig.FlushPeriod)
 	assert.Equal(33*time.Second, c.TraceWriterConfig.UpdateInfoPeriod)
 	assert.Equal(15*time.Second, c.TraceWriterConfig.SenderConfig.MaxAge)

--- a/pkg/trace/config/testdata/full.ini
+++ b/pkg/trace/config/testdata/full.ini
@@ -73,7 +73,6 @@ exp_backoff_base_milliseconds: 1
 exp_backoff_growth_base: 2
 
 [trace.writer.traces]
-max_spans_per_payload: 100
 flush_period_seconds: 3
 update_info_period_seconds: 2
 queue_max_age_seconds: 1

--- a/pkg/trace/config/testdata/undocumented.yaml
+++ b/pkg/trace/config/testdata/undocumented.yaml
@@ -10,7 +10,6 @@ apm_config:
   max_connections: 50
   max_memory: 30000000
   trace_writer:
-    max_spans_per_payload: 11
     flush_period_seconds: 22
     update_info_period_seconds: 33
     queue:

--- a/pkg/trace/info/writer.go
+++ b/pkg/trace/info/writer.go
@@ -2,14 +2,16 @@ package info
 
 // TraceWriterInfo represents statistics from the trace writer.
 type TraceWriterInfo struct {
-	Payloads       int64
-	Traces         int64
-	Events         int64
-	Spans          int64
-	Errors         int64
-	Retries        int64
-	Bytes          int64
-	SingleMaxSpans int64
+	Payloads          int64
+	Traces            int64
+	Events            int64
+	Spans             int64
+	Errors            int64
+	Retries           int64
+	Bytes             int64
+	BytesUncompressed int64
+	BytesEstimated    int64
+	SingleMaxSize     int64
 }
 
 // ServiceWriterInfo represents statistics from the service writer.

--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -3,8 +3,6 @@ package traceutil
 import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/tinylib/msgp/msgp"
 )
 
 // GetEnv returns the meta value for the "env" key for
@@ -63,11 +61,9 @@ func GetRoot(t pb.Trace) *pb.Span {
 
 // APITrace returns an APITrace from t, as required by the Datadog API.
 // It also returns an estimated size in bytes.
-func APITrace(t pb.Trace) (trace *pb.APITrace, size int) {
+func APITrace(t pb.Trace) *pb.APITrace {
 	var earliest, latest int64
-	size = msgp.ArrayHeaderSize
 	for _, s := range t {
-		size += s.Msgsize()
 		start := s.Start
 		if start < earliest {
 			earliest = start
@@ -82,7 +78,7 @@ func APITrace(t pb.Trace) (trace *pb.APITrace, size int) {
 		Spans:     t,
 		StartTime: earliest,
 		EndTime:   latest,
-	}, size
+	}
 }
 
 // ChildrenMap returns a map containing for each span id the list of its

--- a/pkg/trace/writer/config/trace_writer.go
+++ b/pkg/trace/writer/config/trace_writer.go
@@ -4,18 +4,16 @@ import "time"
 
 // TraceWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
 type TraceWriterConfig struct {
-	MaxSpansPerPayload int
-	FlushPeriod        time.Duration
-	UpdateInfoPeriod   time.Duration
-	SenderConfig       QueuablePayloadSenderConf
+	FlushPeriod      time.Duration
+	UpdateInfoPeriod time.Duration
+	SenderConfig     QueuablePayloadSenderConf
 }
 
 // DefaultTraceWriterConfig creates a new instance of a TraceWriterConfig using default values.
 func DefaultTraceWriterConfig() TraceWriterConfig {
 	return TraceWriterConfig{
-		MaxSpansPerPayload: 1000,
-		FlushPeriod:        5 * time.Second,
-		UpdateInfoPeriod:   1 * time.Minute,
-		SenderConfig:       DefaultQueuablePayloadSenderConf(),
+		FlushPeriod:      5 * time.Second,
+		UpdateInfoPeriod: 1 * time.Minute,
+		SenderConfig:     DefaultQueuablePayloadSenderConf(),
 	}
 }

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -180,9 +180,6 @@ func (w *TraceWriter) handleSampledTrace(pkg *TracePackage) {
 	w.payloadSize += size
 	w.spansInBuffer += len(pkg.Trace) + len(pkg.Events)
 
-	if size > payloadMaxSize {
-		log.Warnf("Trace might be dropped by API; size exceeds maximum (%d): %d", payloadMaxSize, size)
-	}
 	if size > payloadFlushThreshold {
 		// we've added a single package that surpasses our threshold, we should count this occurrence,
 		// it could be an indication of "over instrumentation" on the client side, where too many spans

--- a/pkg/trace/writer/trace_nix_test.go
+++ b/pkg/trace/writer/trace_nix_test.go
@@ -152,11 +152,7 @@ func TestPeriodicStats(t *testing.T) {
 
 	expectStats := summaryCompareFunc(assert, statsClient)
 	for key, sum := range want {
-		delta := 1.
-		if key == "bytes_uncompressed" {
-			delta = 1000.
-		}
-		expectStats("datadog.trace_agent.trace_writer."+key, 7, sum, delta)
+		expectStats("datadog.trace_agent.trace_writer."+key, 6, sum, 1)
 	}
 }
 

--- a/pkg/trace/writer/trace_nix_test.go
+++ b/pkg/trace/writer/trace_nix_test.go
@@ -3,13 +3,14 @@
 package writer
 
 import (
+	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,141 +52,121 @@ func TestPeriodicFlush(t *testing.T) {
 func TestPeriodicStats(t *testing.T) {
 	assert := assert.New(t)
 
+	defer func(old int) {
+		payloadFlushThreshold = old // reset original setting
+	}(payloadFlushThreshold)
+
 	testFlushPeriod := 100 * time.Millisecond
 
 	// Create a trace writer, its incoming channel and the endpoint that receives the payloads
 	traceWriter, traceChannel, testEndpoint, statsClient := testTraceWriter()
-	traceWriter.conf.FlushPeriod = 100 * time.Millisecond
+	traceWriter.conf.FlushPeriod = testFlushPeriod
 	traceWriter.conf.UpdateInfoPeriod = 100 * time.Millisecond
-	traceWriter.conf.MaxSpansPerPayload = 10
 	traceWriter.Start()
 
-	var (
-		expectedNumPayloads       int64
-		expectedNumSpans          int64
-		expectedNumTraces         int64
-		expectedNumBytes          int64
-		expectedNumErrors         int64
-		expectedMinNumRetries     int64
-		expectedNumSingleMaxSpans int64
-	)
+	want := make(map[string]int) // maps metric name to expected sum
 
-	// Send a bunch of sampled traces that should go together in a single payload
-	payload1SampledTraces := []*TracePackage{
-		randomTracePackage(2, 0),
-		randomTracePackage(2, 0),
-		randomTracePackage(2, 0),
-	}
-	expectedNumPayloads++
-	expectedNumSpans += 6
-	expectedNumTraces += 3
-	expectedNumBytes += calculateTracePayloadSize(payload1SampledTraces)
-
-	for _, sampledTrace := range payload1SampledTraces {
-		traceChannel <- sampledTrace
+	payload1 := []*TracePackage{
+		randomTracePackage(10, 0),
+		randomTracePackage(10, 0),
+		randomTracePackage(10, 0),
 	}
 
-	// Send a single trace that goes over the span limit
-	payload2SampledTraces := []*TracePackage{
-		randomTracePackage(20, 0),
-	}
-	expectedNumPayloads++
-	expectedNumSpans += 20
-	expectedNumTraces++
-	expectedNumBytes += calculateTracePayloadSize(payload2SampledTraces)
-	expectedNumSingleMaxSpans++
+	// this payload will fit
+	payloadFlushThreshold = int(calculateTracePayloadEstimatedSize(payload1))
 
-	for _, sampledTrace := range payload2SampledTraces {
-		traceChannel <- sampledTrace
+	for _, trace := range payload1 {
+		traceChannel <- trace
 	}
 
-	// Wait for twice the flush period
-	time.Sleep(2 * testFlushPeriod)
+	want["spans"] = 30
+	want["traces"] = len(payload1)
+	want["bytes_estimated"] = calculateTracePayloadEstimatedSize(payload1)
+	want["bytes_uncompressed"] = calculateTracePayloadSize(payload1)
 
-	// Send a third payload with other 3 traces with an errored out endpoint
-	testEndpoint.SetError(fmt.Errorf("non retriable error"))
-	payload3SampledTraces := []*TracePackage{
-		randomTracePackage(2, 0),
-		randomTracePackage(2, 0),
-		randomTracePackage(2, 0),
+	pkg1 := randomTracePackage(90, 0)
+	traceChannel <- pkg1 // pushes us over AND flushes itself due to huge size
+
+	want["payloads"] = 2
+	want["traces"]++
+	want["spans"] += 90
+	want["bytes_estimated"] += calculateTracePayloadEstimatedSize([]*TracePackage{pkg1})
+	want["bytes_uncompressed"] += calculateTracePayloadSize([]*TracePackage{pkg1})
+	want["single_max_size"]++
+
+	// this will fit again
+	for _, trace := range payload1 {
+		traceChannel <- trace
 	}
 
-	expectedNumErrors++
-	expectedNumTraces += 3
-	expectedNumSpans += 6
-	expectedNumBytes += calculateTracePayloadSize(payload3SampledTraces)
+	time.Sleep(2 * testFlushPeriod) // flush
 
-	for _, sampledTrace := range payload3SampledTraces {
-		traceChannel <- sampledTrace
+	want["payloads"]++
+	want["traces"] += len(payload1)
+	want["spans"] += 30 // spans in payload1
+	want["bytes_estimated"] += calculateTracePayloadEstimatedSize(payload1)
+	want["bytes_uncompressed"] += calculateTracePayloadSize(payload1)
+
+	// trigger some errors
+	testEndpoint.SetError(errors.New("non retriable error"))
+
+	for _, trace := range payload1 {
+		traceChannel <- trace
 	}
 
-	// Wait for twice the flush period
-	time.Sleep(2 * testFlushPeriod)
+	time.Sleep(2 * testFlushPeriod) // flush
 
-	// And then send a fourth payload with other 3 traces with an errored out endpoint but retriable
+	want["errors"] = 1
+	want["traces"] += len(payload1)
+	want["spans"] += 30 // spans in payload1
+	want["bytes_estimated"] += calculateTracePayloadEstimatedSize(payload1)
+	want["bytes_uncompressed"] += calculateTracePayloadSize(payload1)
+
+	// trigger retriable error
 	testEndpoint.SetError(&retriableError{
-		err:      fmt.Errorf("non retriable error"),
+		err:      errors.New("retriable error"),
 		endpoint: testEndpoint,
 	})
-	payload4SampledTraces := []*TracePackage{
+
+	payload4 := []*TracePackage{
 		randomTracePackage(2, 0),
 		randomTracePackage(2, 0),
 		randomTracePackage(2, 0),
 	}
 
-	expectedMinNumRetries++
-	expectedNumTraces += 3
-	expectedNumSpans += 6
-	expectedNumBytes += calculateTracePayloadSize(payload4SampledTraces)
-
-	for _, sampledTrace := range payload4SampledTraces {
+	for _, sampledTrace := range payload4 {
 		traceChannel <- sampledTrace
 	}
 
-	// Wait for twice the flush period to see at least one retry
 	time.Sleep(2 * testFlushPeriod)
+
+	want["retries"] = 2
+	want["traces"] += len(payload1)
+	want["spans"] += 6
+	want["bytes_estimated"] += calculateTracePayloadEstimatedSize(payload4)
+	want["bytes_uncompressed"] += calculateTracePayloadSize(payload4)
 
 	// Close and stop
 	close(traceChannel)
 	traceWriter.Stop()
 
-	// Then we expect some counts to have been sent to the stats client for each update tick (there should have been
-	// at least 3 ticks)
-	countSummaries := statsClient.GetCountSummaries()
+	expectStats := summaryCompareFunc(assert, statsClient)
+	for key, sum := range want {
+		delta := 1.
+		if key == "bytes_uncompressed" {
+			delta = 1000.
+		}
+		expectStats("datadog.trace_agent.trace_writer."+key, 7, sum, delta)
+	}
+}
 
-	// Payload counts
-	payloadSummary := countSummaries["datadog.trace_agent.trace_writer.payloads"]
-	assert.True(len(payloadSummary.Calls) >= 3, "There should have been multiple payload count calls")
-	assert.Equal(expectedNumPayloads, payloadSummary.Sum)
-
-	// Traces counts
-	tracesSummary := countSummaries["datadog.trace_agent.trace_writer.traces"]
-	assert.True(len(tracesSummary.Calls) >= 3, "There should have been multiple traces count calls")
-	assert.Equal(expectedNumTraces, tracesSummary.Sum)
-
-	// Spans counts
-	spansSummary := countSummaries["datadog.trace_agent.trace_writer.spans"]
-	assert.True(len(spansSummary.Calls) >= 3, "There should have been multiple spans count calls")
-	assert.Equal(expectedNumSpans, spansSummary.Sum)
-
-	// Bytes counts
-	bytesSummary := countSummaries["datadog.trace_agent.trace_writer.bytes"]
-	assert.True(len(bytesSummary.Calls) >= 3, "There should have been multiple bytes count calls")
-	// FIXME: Is GZIP non-deterministic? Why won't equal work here?
-	assert.True(math.Abs(float64(expectedNumBytes-bytesSummary.Sum)) < 100., "Bytes should be within expectations")
-
-	// Retry counts
-	retriesSummary := countSummaries["datadog.trace_agent.trace_writer.retries"]
-	assert.True(len(retriesSummary.Calls) >= 2, "There should have been multiple retries count calls")
-	assert.True(retriesSummary.Sum >= expectedMinNumRetries)
-
-	// Error counts
-	errorsSummary := countSummaries["datadog.trace_agent.trace_writer.errors"]
-	assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
-	assert.Equal(expectedNumErrors, errorsSummary.Sum)
-
-	// Single trace max spans
-	singleMaxSpansSummary := countSummaries["datadog.trace_agent.trace_writer.single_max_spans"]
-	assert.True(len(singleMaxSpansSummary.Calls) >= 3, "There should have been multiple single max spans count calls")
-	assert.Equal(expectedNumSingleMaxSpans, singleMaxSpansSummary.Sum)
+func summaryCompareFunc(assert *assert.Assertions, statsClient *testutil.TestStatsClient) func(name string, calls int, sum int, delta float64) {
+	summaries := statsClient.GetCountSummaries()
+	return func(name string, minCalls int, sum int, delta float64) {
+		summary, ok := summaries[name]
+		assert.True(ok, fmt.Sprintf("%s not found", name))
+		calls := len(summary.Calls)
+		assert.True(calls >= minCalls, fmt.Sprintf("%s: expected at least %d calls, got %d", name, minCalls, calls))
+		assert.InDelta(sum, summary.Sum, delta, fmt.Sprintf("%s: expected %d, got %d", name, sum, summary.Sum))
+	}
 }

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -85,7 +85,7 @@ func calculateTracePayloadSize(sampledTraces []*TracePackage) int {
 	apiTraces := make([]*pb.APITrace, len(sampledTraces))
 
 	for i, trace := range sampledTraces {
-		apiTraces[i], _ = traceutil.APITrace(trace.Trace)
+		apiTraces[i] = traceutil.APITrace(trace.Trace)
 	}
 
 	tracePayload := pb.TracePayload{
@@ -142,8 +142,7 @@ func assertPayloads(
 		for _, seenAPITrace := range tracePayload.Traces {
 			numSpans += len(seenAPITrace.Spans)
 
-			apiTrace, _ := traceutil.APITrace(expectedTraces[expectedTraceIdx])
-			if !assert.True(proto.Equal(apiTrace, seenAPITrace),
+			if !assert.True(proto.Equal(traceutil.APITrace(expectedTraces[expectedTraceIdx]), seenAPITrace),
 				"Unmarshalled trace should match expectation at index %d", expectedTraceIdx) {
 				return
 			}

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -74,8 +74,7 @@ func TestTraceWriter(t *testing.T) {
 func calculateTracePayloadEstimatedSize(sampledTraces []*TracePackage) int {
 	var size int
 	for _, pkg := range sampledTraces {
-		size += pkg.Trace.Msgsize()
-		size += pb.Trace(pkg.Events).Msgsize()
+		size += pkg.size()
 	}
 	return size
 }

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -39,15 +39,15 @@ func TestTraceWriter(t *testing.T) {
 
 		// Send a few sampled traces through the writer
 		sampledTraces := []*TracePackage{
-			// these two will no trigger a flush, because they are
+			// these two will not trigger a flush, because they are
 			// below the size threshold.
 			tracePkg,
 			tracePkg,
 			// this one will trigger a flush of the previous two,
-			// and possibly of itself.
-			randomTracePackage(5, 1),
-			// this one will also trigger a flush of itself.
+			// and of itself because of the big size.
 			randomTracePackage(10, 1),
+			// this one will also trigger a flush of itself.
+			randomTracePackage(15, 1),
 			// this one will be flushed at shutdown.
 			tracePkg,
 		}
@@ -65,8 +65,7 @@ func TestTraceWriter(t *testing.T) {
 			"Content-Encoding":             "gzip",
 		}
 
-		// Ensure that the number of payloads and their contents match our expectations. The MaxSpansPerPayload we
-		// set to 4 at the beginning should have been respected whenever possible.
+		// we should have 4 payloads based on the configured flush threshold for this test.
 		assert.Len(testEndpoint.SuccessPayloads(), 4, "We expected 4 different payloads")
 		assertPayloads(assert, traceWriter, expectedHeaders, sampledTraces, testEndpoint.SuccessPayloads())
 	})

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"bytes"
 	"compress/gzip"
+	"math"
 	"strings"
 	"testing"
 
@@ -27,20 +28,28 @@ func TestTraceWriter(t *testing.T) {
 		// Create a trace writer, its incoming channel and the endpoint that receives the payloads
 		traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
 		// Set a maximum of 4 spans per payload
-		traceWriter.conf.MaxSpansPerPayload = 4
 		traceWriter.Start()
+
+		tracePkg := randomTracePackage(1, 1)
+		size := calculateTracePayloadEstimatedSize([]*TracePackage{tracePkg})
+		defer func(old int) {
+			payloadFlushThreshold = old // reset original setting
+		}(payloadFlushThreshold)
+		payloadFlushThreshold = int(size + size + 1)
 
 		// Send a few sampled traces through the writer
 		sampledTraces := []*TracePackage{
-			// These 2 should be grouped together in a single payload
-			randomTracePackage(1, 1),
-			randomTracePackage(1, 1),
-			// This one should be on its own in a single payload
-			randomTracePackage(3, 1),
-			// This one should be on its own in a single payload
+			// these two will no trigger a flush, because they are
+			// below the size threshold.
+			tracePkg,
+			tracePkg,
+			// this one will trigger a flush of the previous two,
+			// and possibly of itself.
 			randomTracePackage(5, 1),
-			// This one should be on its own in a single payload
-			randomTracePackage(1, 1),
+			// this one will also trigger a flush of itself.
+			randomTracePackage(10, 1),
+			// this one will be flushed at shutdown.
+			tracePkg,
 		}
 		for _, sampledTrace := range sampledTraces {
 			traceChannel <- sampledTrace
@@ -63,11 +72,20 @@ func TestTraceWriter(t *testing.T) {
 	})
 }
 
-func calculateTracePayloadSize(sampledTraces []*TracePackage) int64 {
+func calculateTracePayloadEstimatedSize(sampledTraces []*TracePackage) int {
+	var size int
+	for _, pkg := range sampledTraces {
+		size += pkg.Trace.Msgsize()
+		size += pb.Trace(pkg.Events).Msgsize()
+	}
+	return size
+}
+
+func calculateTracePayloadSize(sampledTraces []*TracePackage) int {
 	apiTraces := make([]*pb.APITrace, len(sampledTraces))
 
 	for i, trace := range sampledTraces {
-		apiTraces[i] = traceutil.APITrace(trace.Trace)
+		apiTraces[i], _ = traceutil.APITrace(trace.Trace)
 	}
 
 	tracePayload := pb.TracePayload{
@@ -77,30 +95,20 @@ func calculateTracePayloadSize(sampledTraces []*TracePackage) int64 {
 	}
 
 	serialized, _ := proto.Marshal(&tracePayload)
-
-	compressionBuffer := bytes.Buffer{}
-	gz, err := gzip.NewWriterLevel(&compressionBuffer, gzip.BestSpeed)
-
-	if err != nil {
-		panic(err)
-	}
-
-	_, err = gz.Write(serialized)
-	gz.Close()
-
-	if err != nil {
-		panic(err)
-	}
-
-	return int64(len(compressionBuffer.Bytes()))
+	return len(serialized)
 }
 
-func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expectedHeaders map[string]string,
-	sampledTraces []*TracePackage, payloads []*payload) {
-
-	var expectedTraces []pb.Trace
-	var expectedEvents []*pb.Span
-
+func assertPayloads(
+	assert *assert.Assertions,
+	traceWriter *TraceWriter,
+	expectedHeaders map[string]string,
+	sampledTraces []*TracePackage,
+	payloads []*payload,
+) {
+	var (
+		expectedTraces []pb.Trace
+		expectedEvents []*pb.Span
+	)
 	for _, sampledTrace := range sampledTraces {
 		expectedTraces = append(expectedTraces, sampledTrace.Trace)
 
@@ -109,9 +117,10 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 		}
 	}
 
-	var expectedTraceIdx int
-	var expectedEventIdx int
-
+	var (
+		expectedTraceIdx int
+		expectedEventIdx int
+	)
 	for _, payload := range payloads {
 		assert.Equal(expectedHeaders, payload.headers, "Payload headers should match expectation")
 
@@ -133,7 +142,8 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 		for _, seenAPITrace := range tracePayload.Traces {
 			numSpans += len(seenAPITrace.Spans)
 
-			if !assert.True(proto.Equal(traceutil.APITrace(expectedTraces[expectedTraceIdx]), seenAPITrace),
+			apiTrace, _ := traceutil.APITrace(expectedTraces[expectedTraceIdx])
+			if !assert.True(proto.Equal(apiTrace, seenAPITrace),
 				"Unmarshalled trace should match expectation at index %d", expectedTraceIdx) {
 				return
 			}
@@ -155,7 +165,11 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 		// If there's more than 1 trace or transaction in this payload, don't let it go over the limit. Otherwise,
 		// a single trace+transaction combination is allows to go over the limit.
 		if len(tracePayload.Traces) > 1 || len(tracePayload.Transactions) > 1 {
-			assert.True(numSpans <= traceWriter.conf.MaxSpansPerPayload)
+			size := pb.Trace(tracePayload.Transactions).Msgsize()
+			for _, tt := range tracePayload.Traces {
+				size += pb.Trace(tt.Spans).Msgsize()
+			}
+			assert.True(size <= payloadFlushThreshold)
 		}
 	}
 }
@@ -192,5 +206,18 @@ func randomTracePackage(numSpans, numEvents int) *TracePackage {
 	return &TracePackage{
 		Trace:  trace,
 		Events: events,
+	}
+}
+
+func BenchmarkHandleSampledTrace(b *testing.B) {
+	// ensure we never flush, as that would increase the scope of the benchmark
+	defer func(old int) {
+		payloadFlushThreshold = old
+	}(payloadFlushThreshold)
+	payloadFlushThreshold = math.MaxInt64
+	tw := TraceWriter{sender: newMockSender()}
+	pkg := randomTracePackage(2, 2)
+	for i := 0; i < b.N; i++ {
+		tw.handleSampledTrace(pkg)
 	}
 }

--- a/releasenotes/notes/apm-flush-based-on-bytes-1141964701cbf725.yaml
+++ b/releasenotes/notes/apm-flush-based-on-bytes-1141964701cbf725.yaml
@@ -1,0 +1,17 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    APM: the writer will now flush based on an estimated number of bytes
+    in accumulated buffer size, as opposed to a maximum number of spans.
+deprecations:
+  - |
+    APM: the yaml setting `apm_config.trace_writer.max_spans_per_payload`
+    is no longer in use; writes are now based solely on accumulated byte
+    size.


### PR DESCRIPTION
This change modifies the flushing logic to flush based on an estimated
payload size as opposed to a maximum number of spans.

Adding the payload size computation slightly decreases the
trace-handling method's speed, but is negligible considering that the
only thing this function is doing is technically two `append` calls.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkHandleSampledTrace-4     1117          1373          +22.92%
```