### PR TITLE
pkg/trace/api: add back lost profiling endpoints

### DIFF
--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -5,8 +5,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	_ "net/http/pprof"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -103,8 +103,6 @@ func NewHTTPReceiver(
 func (r *HTTPReceiver) Start() {
 	mux := http.NewServeMux()
 
-	runtime.SetBlockProfileRate(1) // ensure the block profile records all blocking events
-
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"runtime"
 	"sort"
 	"strings"
@@ -101,6 +102,15 @@ func NewHTTPReceiver(
 // Start starts doing the HTTP server and is ready to receive traces
 func (r *HTTPReceiver) Start() {
 	mux := http.NewServeMux()
+
+	runtime.SetBlockProfileRate(1) // ensure the block profile records all blocking events
+
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
 	mux.HandleFunc("/spans", r.httpHandleWithVersion(v01, r.handleTraces))
 	mux.HandleFunc("/services", r.httpHandleWithVersion(v01, r.handleServices))
 	mux.HandleFunc("/v0.1/spans", r.httpHandleWithVersion(v01, r.handleTraces))


### PR DESCRIPTION
Switching to a custom mux implementation in https://github.com/DataDog/datadog-agent/pull/3308 caused us to lose pprof
endpoints. This change adds them back. Copied over from standard
library: https://github.com/golang/go/blob/master/src/net/http/pprof/pprof.go#L73-L77