### PR TITLE
Fix getShortImageName on old docker version

### DIFF
--- a/pkg/logs/input/docker/client.go
+++ b/pkg/logs/input/docker/client.go
@@ -68,6 +68,7 @@ func computeClientAPIVersion(serverVersion string) (string, error) {
 func GetContainer(client *client.Client, id string) (types.Container, error) {
 	args := filters.NewArgs()
 	args.Add("id", id)
+	// TODO(achntrl): Call dockerUtil inspect instead
 	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
 		Filters: args,
 	})

--- a/pkg/logs/input/docker/container.go
+++ b/pkg/logs/input/docker/container.go
@@ -73,8 +73,7 @@ func (c *Container) getShortImageName() (string, error) {
 		log.Debugf("Cannot get DockerUtil: %v", err)
 		return shortName, err
 	}
-
-	imageName := c.container.Image
+	imageName := c.container.ImageID
 	imageName, err = du.ResolveImageName(imageName)
 	if err != nil {
 		log.Debugf("Could not resolve image name %s: %s", imageName, err)

--- a/releasenotes/notes/fix-short-image-name-bug-99f957d51625a8f9.yaml
+++ b/releasenotes/notes/fix-short-image-name-bug-99f957d51625a8f9.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug where short image name wouldn't be properly set on
+    old docker versions


### PR DESCRIPTION
### What does this PR do?

Fix a bug where the short image name would be the short container name on old docker version

### Motivation

What inspired you to submit this pull request?

### Additional Notes

We should call inspect from the dockerutil instead of `ContainerList` in `GetContainer` method, but that is bigger refactoring to do (we would need to change the type of `Container.container` from `type.Container` to `type.ContainerJSON`