### PR TITLE
Avoid deadlock when go switch thread

### DIFF
--- a/six/common/_util.c
+++ b/six/common/_util.c
@@ -143,7 +143,11 @@ PyObject *subprocess_output(PyObject *self, PyObject *args)
         raise = 1;
 
     PyGILState_Release(gstate);
+    PyThreadState *Tstate = PyEval_SaveThread();
+
     cb_get_subprocess_output(subprocess_args, &c_stdout, &c_stderr, &ret_code, &exception);
+
+    PyEval_RestoreThread(Tstate);
     gstate = PyGILState_Ensure();
 
     if (raise && strlen(c_stdout) == 0) {

--- a/six/test/aggregator/aggregator.go
+++ b/six/test/aggregator/aggregator.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -14,6 +15,8 @@ import (
 // #cgo CFLAGS: -I../../include
 // #cgo !windows LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
 // #cgo windows LDFLAGS: -L../../six/ -ldatadog-agent-six -lstdc++ -static
+//
+// #include <stdlib.h>
 // #include <datadog_agent_six.h>
 //
 // extern void submitMetric(char *, metric_type_t, char *, float, char **, char *);
@@ -82,7 +85,6 @@ func setUp() error {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
 
-	C.ensure_gil(six)
 	return nil
 }
 
@@ -103,7 +105,15 @@ except Exception as e:
 		f.write("{}: {}\n".format(type(e).__name__, e))
 `, call, tmpfile.Name()))
 
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	ret := C.run_simple_string(six, code) == 1
+	C.free(unsafe.Pointer(code))
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	if !ret {
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}

--- a/six/test/common/cgo_free.go
+++ b/six/test/common/cgo_free.go
@@ -41,7 +41,6 @@ func setUp() error {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
 
-	C.ensure_gil(six)
 	return nil
 }
 

--- a/six/test/datadog_agent/datadog_agent.go
+++ b/six/test/datadog_agent/datadog_agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -14,6 +15,8 @@ import (
 // #cgo CFLAGS: -I../../include
 // #cgo !windows LDFLAGS: -L../../six/ -ldatadog-agent-six -ldl
 // #cgo windows LDFLAGS: -L../../six/ -ldatadog-agent-six -lstdc++ -static
+//
+// #include <stdlib.h>
 // #include <datadog_agent_six.h>
 //
 // extern void getVersion(char **);
@@ -67,7 +70,6 @@ func setUp() error {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
 
-	C.ensure_gil(six)
 	return nil
 }
 
@@ -86,7 +88,15 @@ except Exception as e:
 		f.write("{}: {}\n".format(type(e).__name__, e))
 `, call, tmpfile.Name()))
 
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	ret := C.run_simple_string(six, code) == 1
+	C.free(unsafe.Pointer(code))
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	if !ret {
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}

--- a/six/test/six/six.go
+++ b/six/test/six/six.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/six/test/common"
@@ -43,7 +44,7 @@ func setUp() error {
 	if ok != 1 {
 		return fmt.Errorf("`init` failed: %s", C.GoString(C.get_error(six)))
 	}
-	C.ensure_gil(six)
+
 	return nil
 }
 
@@ -52,13 +53,28 @@ func tearDown() {
 }
 
 func getVersion() string {
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	ret := C.GoString(C.get_py_version(six))
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	return ret
 }
 
 func runString(code string) (string, error) {
 	tmpfile.Truncate(0)
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	ret := C.run_simple_string(six, C.CString(code)) == 1
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	if !ret {
 		return "", fmt.Errorf("`run_simple_string` errored")
 	}
@@ -75,14 +91,28 @@ func fetchError() error {
 }
 
 func getError() string {
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	// following is supposed to raise an error
 	C.get_class(six, C.CString("foo"), nil, nil)
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	return C.GoString(C.get_error(six))
 }
 
 func hasError() bool {
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	// following is supposed to raise an error
 	C.get_class(six, C.CString("foo"), nil, nil)
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	ret := C.has_error(six) == 1
 	C.clear_error(six)
 	return ret
@@ -93,6 +123,9 @@ func getFakeCheck() (string, error) {
 	var class *C.six_pyobject_t
 	var check *C.six_pyobject_t
 	var version *C.char
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
 
 	// class
 	ret := C.get_class(six, C.CString("fake_check"), &module, &class)
@@ -112,6 +145,9 @@ func getFakeCheck() (string, error) {
 		return "", fmt.Errorf(C.GoString(C.get_error(six)))
 	}
 
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	return C.GoString(version), fetchError()
 }
 
@@ -121,11 +157,20 @@ func runFakeCheck() (string, error) {
 	var check *C.six_pyobject_t
 	var version *C.char
 
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	C.get_class(six, C.CString("fake_check"), &module, &class)
 	C.get_attr_string(six, module, C.CString("__version__"), &version)
 	C.get_check(six, class, C.CString(""), C.CString("{\"fake_check\": \"/\"}"), C.CString("checkID"), C.CString("fake_check"), &check)
 
-	return C.GoString(C.run_check(six, check)), fetchError()
+	out, err := C.GoString(C.run_check(six, check)), fetchError()
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
+	return out, err
+
 }
 
 func runFakeGetWarnings() ([]string, error) {
@@ -133,10 +178,17 @@ func runFakeGetWarnings() ([]string, error) {
 	var class *C.six_pyobject_t
 	var check *C.six_pyobject_t
 
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	C.get_class(six, C.CString("fake_check"), &module, &class)
 	C.get_check(six, class, C.CString(""), C.CString("{\"fake_check\": \"/\"}"), C.CString("checkID"), C.CString("fake_check"), &check)
 
 	warns := C.get_checks_warnings(six, check)
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	if warns == nil {
 		return nil, fmt.Errorf("get_checks_warnings return NULL: %s", C.GoString(C.get_error(six)))
 	}
@@ -158,7 +210,14 @@ func runFakeGetWarnings() ([]string, error) {
 }
 
 func getIntegrationList() ([]string, error) {
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	cstr := C.GoString(C.get_integration_list(six))
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
+
 	var out []string
 	err := json.Unmarshal([]byte(cstr), &out)
 	fmt.Println(cstr)
@@ -171,5 +230,11 @@ func getIntegrationList() ([]string, error) {
 }
 
 func setModuleAttrString(module string, attr string, value string) {
+	runtime.LockOSThread()
+	state := C.ensure_gil(six)
+
 	C.set_module_attr_string(six, C.CString(module), C.CString(attr), C.CString(value))
+
+	C.release_gil(six, state)
+	runtime.UnlockOSThread()
 }

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -18,7 +18,6 @@
 #include <util.h>
 
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 
 extern "C" DATADOG_AGENT_SIX_API Six *create(const char *pythonHome)


### PR DESCRIPTION
### What does this PR do?

Locking the GIL in the setup could end up in a python deadlock. As go
might switch threads python will end up with a GIL locked but in a
different thread. This would cause 'PyRun_SimpleString' to block
indefinitely.

We now lock the OS thread and acquire the GIL just when we need it (like
we do in the agent).
