### PR TITLE
Consider non ready services in autodiscovery

### DIFF
--- a/pkg/autodiscovery/common_test.go
+++ b/pkg/autodiscovery/common_test.go
@@ -59,3 +59,8 @@ func (s *dummyService) GetHostname() (string, error) {
 func (s *dummyService) GetCreationTime() integration.CreationTime {
 	return s.CreationTime
 }
+
+// IsReady returns if the service is ready
+func (s *dummyService) IsReady() bool {
+	return true
+}

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -48,6 +48,10 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 	copy(resolvedConfig.InitConfig, tpl.InitConfig)
 	copy(resolvedConfig.Instances, tpl.Instances)
 
+	if resolvedConfig.IsCheckConfig() && !svc.IsReady() {
+		return resolvedConfig, errors.New("unable to resolve, service not ready")
+	}
+
 	tags, err := svc.GetTags()
 	if err != nil {
 		return resolvedConfig, err

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -70,6 +70,11 @@ func (s *dummyService) GetCreationTime() integration.CreationTime {
 	return s.CreationTime
 }
 
+// IsReady returns if the service is ready
+func (s *dummyService) IsReady() bool {
+	return true
+}
+
 func TestGetFallbackHost(t *testing.T) {
 	ip, err := getFallbackHost(map[string]string{"bridge": "172.17.0.1"})
 	assert.Equal(t, "172.17.0.1", ip)

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -104,6 +104,16 @@ func (c *Config) IsTemplate() bool {
 	return len(c.ADIdentifiers) > 0
 }
 
+// IsCheckConfig returns true if the config is a node-agent check configuration,
+func (c *Config) IsCheckConfig() bool {
+	return c.ClusterCheck == false && len(c.Instances) > 0
+}
+
+// IsLogConfig returns true if config contains a logs config.
+func (c *Config) IsLogConfig() bool {
+	return c.LogsConfig != nil
+}
+
 // AddMetrics adds metrics to a check configuration
 func (c *Config) AddMetrics(metrics Data) error {
 	var rawInitConfig RawMap

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -57,6 +57,24 @@ func TestConfigEqual(t *testing.T) {
 	assert.Equal(t, checkConfigWithOrderedTags.Digest(), checkConfigWithUnorderedTags.Digest())
 }
 
+func TestIsLogConfig(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.IsLogConfig())
+	config.Instances = []Data{Data("tags: [\"foo:bar\", \"bar:foo\"]")}
+	assert.False(t, config.IsLogConfig())
+	config.LogsConfig = Data("[{\"service\":\"any_service\",\"source\":\"any_source\"}]")
+	assert.True(t, config.IsLogConfig())
+}
+
+func TestIsCheckConfig(t *testing.T) {
+	config := &Config{}
+	assert.False(t, config.IsCheckConfig())
+	config.Instances = []Data{Data("tags: [\"foo:bar\", \"bar:foo\"]")}
+	assert.True(t, config.IsCheckConfig())
+	config.ClusterCheck = true
+	assert.False(t, config.IsCheckConfig())
+}
+
 func TestString(t *testing.T) {
 	config := &Config{}
 	assert.False(t, config.Equal(nil))

--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -558,3 +558,8 @@ func findKubernetesInLabels(labels map[string]string) bool {
 	}
 	return false
 }
+
+// IsReady returns if the service is ready
+func (s *DockerService) IsReady() bool {
+	return true
+}

--- a/pkg/autodiscovery/listeners/docker_kubelet.go
+++ b/pkg/autodiscovery/listeners/docker_kubelet.go
@@ -95,3 +95,13 @@ func (s *DockerKubeletService) GetPorts() ([]ContainerPort, error) {
 	s.Ports = ports
 	return ports, nil
 }
+
+// IsReady returns if the service is ready
+func (s *DockerKubeletService) IsReady() bool {
+	pod, err := s.getPod()
+	if err != nil {
+		return false
+	}
+
+	return kubelet.IsPodReady(pod)
+}

--- a/pkg/autodiscovery/listeners/ecs.go
+++ b/pkg/autodiscovery/listeners/ecs.go
@@ -240,3 +240,7 @@ func (s *ECSService) GetHostname() (string, error) {
 func (s *ECSService) GetCreationTime() integration.CreationTime {
 	return s.creationTime
 }
+
+func (s *ECSService) IsReady() bool {
+	return true
+}

--- a/pkg/autodiscovery/listeners/kube_services.go
+++ b/pkg/autodiscovery/listeners/kube_services.go
@@ -274,6 +274,11 @@ func (s *KubeServiceService) GetCreationTime() integration.CreationTime {
 	return s.creationTime
 }
 
+// IsReady returns if the service is ready
+func (s *KubeServiceService) IsReady() bool {
+	return true
+}
+
 func isServiceAnnotated(ksvc *v1.Service) bool {
 	_, found := ksvc.Annotations[kubeServiceAnnotationFormat]
 	return found

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -46,6 +46,7 @@ type KubeContainerService struct {
 	hosts         map[string]string
 	ports         []ContainerPort
 	creationTime  integration.CreationTime
+	ready         bool
 }
 
 // KubePodService registers pod as a Service, implements and store results from the Service interface for the Kubelet listener
@@ -75,9 +76,10 @@ func NewKubeletListener() (ServiceListener, error) {
 		watcher:  watcher,
 		filter:   filter,
 		services: make(map[string]Service),
-		ticker:   time.NewTicker(15 * time.Second),
-		stop:     make(chan bool),
-		health:   health.Register("ad-kubeletlistener"),
+		// FIXME make it configurable
+		ticker: time.NewTicker(1 * time.Second),
+		stop:   make(chan bool),
+		health: health.Register("ad-kubeletlistener"),
 	}, nil
 }
 
@@ -128,9 +130,15 @@ func (l *KubeletListener) Stop() {
 
 func (l *KubeletListener) processNewPods(pods []*kubelet.Pod, firstRun bool) {
 	for _, pod := range pods {
-		// Ignore pending/failed/succeeded/unknown states
-		if pod.Status.Phase == "Running" {
-			for _, container := range pod.Status.Containers {
+		// We ignore the state of the pod but only taking containers with ids
+		// into consideration (not pending)
+		for _, container := range pod.Status.InitContainers {
+			if container.ID != "" {
+				l.createService(container.ID, pod, firstRun)
+			}
+		}
+		for _, container := range pod.Status.Containers {
+			if container.ID != "" {
 				l.createService(container.ID, pod, firstRun)
 			}
 			l.createPodService(pod, firstRun)
@@ -196,12 +204,13 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 	svc := KubeContainerService{
 		entity:       entity,
 		creationTime: crTime,
+		ready:        kubelet.IsPodReady(pod),
 	}
 	podName := pod.Metadata.Name
 
 	// AD Identifiers
 	var containerName string
-	for _, container := range pod.Status.Containers {
+	for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
 		if container.ID == svc.entity {
 			if l.filter.IsExcluded(container.Name, container.Image) {
 				log.Debugf("container %s filtered out: name %q image %q", container.ID, container.Name, container.Image)
@@ -332,6 +341,11 @@ func (s *KubeContainerService) GetCreationTime() integration.CreationTime {
 	return s.creationTime
 }
 
+// IsReady returns if the service is ready
+func (s *KubeContainerService) IsReady() bool {
+	return s.ready
+}
+
 // GetEntity returns the unique entity name linked to that service
 func (s *KubePodService) GetEntity() string {
 	return s.entity
@@ -370,4 +384,9 @@ func (s *KubePodService) GetHostname() (string, error) {
 // GetCreationTime returns the creation time of the container compare to the agent start.
 func (s *KubePodService) GetCreationTime() integration.CreationTime {
 	return s.creationTime
+}
+
+// IsReady returns if the service is ready
+func (s *KubePodService) IsReady() bool {
+	return true
 }

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -76,10 +77,9 @@ func NewKubeletListener() (ServiceListener, error) {
 		watcher:  watcher,
 		filter:   filter,
 		services: make(map[string]Service),
-		// FIXME make it configurable
-		ticker: time.NewTicker(1 * time.Second),
-		stop:   make(chan bool),
-		health: health.Register("ad-kubeletlistener"),
+		ticker:   time.NewTicker(config.Datadog.GetDuration("kubelet_listener_polling_interval") * time.Second),
+		stop:     make(chan bool),
+		health:   health.Register("ad-kubeletlistener"),
 	}, nil
 }
 

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -141,8 +141,8 @@ func (l *KubeletListener) processNewPods(pods []*kubelet.Pod, firstRun bool) {
 			if container.ID != "" {
 				l.createService(container.ID, pod, firstRun)
 			}
-			l.createPodService(pod, firstRun)
 		}
+		l.createPodService(pod, firstRun)
 	}
 }
 

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -132,7 +132,7 @@ func (l *KubeletListener) processNewPods(pods []*kubelet.Pod, firstRun bool) {
 	for _, pod := range pods {
 		// We ignore the state of the pod but only taking containers with ids
 		// into consideration (not pending)
-		for _, container := range pod.Status.AllContainers() {
+		for _, container := range pod.Status.GetAllContainers() {
 			if !container.IsPending() {
 				l.createService(container.ID, pod, firstRun)
 			}
@@ -205,7 +205,7 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 
 	// AD Identifiers
 	var containerName string
-	for _, container := range pod.Status.AllContainers() {
+	for _, container := range pod.Status.GetAllContainers() {
 		if container.ID == svc.entity {
 			if l.filter.IsExcluded(container.Name, container.Image) {
 				log.Debugf("container %s filtered out: name %q image %q", container.ID, container.Name, container.Image)

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -33,6 +33,7 @@ type Service interface {
 	GetPid() (int, error)                      // process identifier
 	GetHostname() (string, error)              // hostname.domainname for the entity
 	GetCreationTime() integration.CreationTime // created before or after the agent start
+	IsReady() bool                             // is the service ready to serve checks
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/pkg/autodiscovery/listeners/types.go
+++ b/pkg/autodiscovery/listeners/types.go
@@ -33,7 +33,7 @@ type Service interface {
 	GetPid() (int, error)                      // process identifier
 	GetHostname() (string, error)              // hostname.domainname for the entity
 	GetCreationTime() integration.CreationTime // created before or after the agent start
-	IsReady() bool                             // is the service ready to serve checks
+	IsReady() bool                             // is the service ready
 }
 
 // ServiceListener monitors running services and triggers check (un)scheduling

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -89,7 +89,7 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 				legacyPodAnnotationPrefix, pod.Metadata.Name, newPodAnnotationPrefix)
 		}
 
-		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
+		for _, container := range pod.Status.AllContainers() {
 			c, errors := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
 				fmt.Sprintf(adExtractFormat, container.Name))
 

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -89,7 +89,7 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 				legacyPodAnnotationPrefix, pod.Metadata.Name, newPodAnnotationPrefix)
 		}
 
-		for _, container := range pod.Status.Containers {
+		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
 			c, errors := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
 				fmt.Sprintf(adExtractFormat, container.Name))
 

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -89,7 +89,7 @@ func parseKubeletPodlist(podlist []*kubelet.Pod) ([]integration.Config, error) {
 				legacyPodAnnotationPrefix, pod.Metadata.Name, newPodAnnotationPrefix)
 		}
 
-		for _, container := range pod.Status.AllContainers() {
+		for _, container := range pod.Status.GetAllContainers() {
 			c, errors := extractTemplatesFromMap(container.ID, pod.Metadata.Annotations,
 				fmt.Sprintf(adExtractFormat, container.Name))
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -72,7 +72,7 @@ func (s *CheckScheduler) Schedule(configs []integration.Config) {
 // Unschedule unschedules checks matching configs
 func (s *CheckScheduler) Unschedule(configs []integration.Config) {
 	for _, config := range configs {
-		if !isCheckConfig(config) {
+		if !config.IsCheckConfig() {
 			// skip non check configs.
 			continue
 		}
@@ -173,7 +173,7 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 
 	var allChecks []check.Check
 	for _, config := range configs {
-		if !isCheckConfig(config) {
+		if !config.IsCheckConfig() {
 			// skip non check configs.
 			continue
 		}
@@ -193,11 +193,6 @@ func (s *CheckScheduler) GetChecksFromConfigs(configs []integration.Config, popu
 	}
 
 	return allChecks
-}
-
-// isCheckConfig returns true if the config is a node-agent check configuration,
-func isCheckConfig(config integration.Config) bool {
-	return config.ClusterCheck == false && len(config.Instances) > 0
 }
 
 // GetLoaderErrors returns the check loader errors

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,7 +265,8 @@ func initConfig(config Config) {
 
 	config.BindEnvAndSetDefault("kubernetes_pod_expiration_duration", 15*60) // in seconds, default 15 minutes
 	config.BindEnvAndSetDefault("kubelet_wait_on_missing_container", 0)
-	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 5) // Polling frequency in seconds of the agent to the kubelet "/pods" endpoint
+	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 5)       // Polling frequency in seconds of the agent to the kubelet "/pods" endpoint
+	config.BindEnvAndSetDefault("kubelet_listener_polling_interval", 5) // Polling frequency in seconds of the pod watcher to detect new pods/containers (affected by kubelet_cache_pods_duration setting)
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1156,8 +1156,9 @@ api_key:
 #
 # kubernetes_pod_expiration_duration: 900
 
-## @param kubelet_cache_pods_duration - integer - optional - default: 5
-## Polling frequency in seconds of the pod watcher to detect new pods/containers (affected by kubelet_cache_pods_duration).
+## @param kubelet_listener_polling_interval - integer - optional - default: 5
+## Polling frequency in seconds at which autodiscovery will query the pod watcher to detect new pods/containers.
+## Note that kubelet_cache_pods_duration needs to be lower than this setting, or autodiscovery will only poll more frequently the same cached data (kubelet_cache_pods_duration controls the cache refresh frequency).
 #
 # kubelet_listener_polling_interval: 5
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1156,6 +1156,11 @@ api_key:
 #
 # kubernetes_pod_expiration_duration: 900
 
+## @param kubelet_cache_pods_duration - integer - optional - default: 5
+## Polling frequency in seconds of the pod watcher to detect new pods/containers (affected by kubelet_cache_pods_duration).
+#
+# kubelet_listener_polling_interval: 5
+
 {{ end -}}
 {{- if .KubeApiServer }}
 

--- a/pkg/logs/input/docker/ad_identifier_kubelet.go
+++ b/pkg/logs/input/docker/ad_identifier_kubelet.go
@@ -37,7 +37,7 @@ func ContainsADIdentifier(c *Container) bool {
 	if err != nil {
 		return false
 	}
-	for _, container := range pod.Status.Containers {
+	for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
 		if container.ID == entityID {
 			// looks for the container name specified in the pod manifest as it's different from the name of the container
 			// returns by a docker inspect which is a concatenation of the container name specified in the pod manifest and a hash

--- a/pkg/logs/input/docker/ad_identifier_kubelet.go
+++ b/pkg/logs/input/docker/ad_identifier_kubelet.go
@@ -37,7 +37,7 @@ func ContainsADIdentifier(c *Container) bool {
 	if err != nil {
 		return false
 	}
-	for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
+	for _, container := range pod.Status.AllContainers() {
 		if container.ID == entityID {
 			// looks for the container name specified in the pod manifest as it's different from the name of the container
 			// returns by a docker inspect which is a concatenation of the container name specified in the pod manifest and a hash

--- a/pkg/logs/input/docker/ad_identifier_kubelet.go
+++ b/pkg/logs/input/docker/ad_identifier_kubelet.go
@@ -37,7 +37,7 @@ func ContainsADIdentifier(c *Container) bool {
 	if err != nil {
 		return false
 	}
-	for _, container := range pod.Status.AllContainers() {
+	for _, container := range pod.Status.GetAllContainers() {
 		if container.ID == entityID {
 			// looks for the container name specified in the pod manifest as it's different from the name of the container
 			// returns by a docker inspect which is a concatenation of the container name specified in the pod manifest and a hash

--- a/pkg/logs/input/kubernetes/launcher.go
+++ b/pkg/logs/input/kubernetes/launcher.go
@@ -120,7 +120,7 @@ func (l *Launcher) addSource(svc *service.Service) {
 		log.Warnf("Could not add source for container %v: %v", svc.Identifier, err)
 		return
 	}
-	container, err := searchContainer(svc, pod)
+	container, err := l.kubeutil.GetStatusForContainerID(pod, svc.GetEntityID())
 	if err != nil {
 		log.Warn(err)
 		return
@@ -144,15 +144,6 @@ func (l *Launcher) addSource(svc *service.Service) {
 
 	l.sourcesByContainer[svc.GetEntityID()] = source
 	l.sources.AddSource(source)
-}
-
-func searchContainer(service *service.Service, pod *kubelet.Pod) (kubelet.ContainerStatus, error) {
-	for _, container := range pod.Status.Containers {
-		if service.GetEntityID() == container.ID {
-			return container, nil
-		}
-	}
-	return kubelet.ContainerStatus{}, fmt.Errorf("Container %v not found", service.GetEntityID())
 }
 
 // removeSource removes a new log-source from a service

--- a/pkg/logs/input/kubernetes/launcher_test.go
+++ b/pkg/logs/input/kubernetes/launcher_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
-	"github.com/DataDog/datadog-agent/pkg/logs/service"
 )
 
 func TestGetSource(t *testing.T) {
@@ -125,47 +124,6 @@ func TestGetSourceAddContainerdParser(t *testing.T) {
 	source, err := launcher.getSource(pod, container)
 	assert.Nil(t, err)
 	assert.Equal(t, config.FileType, source.Config.Type)
-}
-
-func TestSearchContainer(t *testing.T) {
-	containerFoo := kubelet.ContainerStatus{
-		Name:  "fooName",
-		Image: "fooImage",
-		ID:    "docker://fooID",
-	}
-	containerBar := kubelet.ContainerStatus{
-		Name:  "barName",
-		Image: "barImage",
-		ID:    "docker://barID",
-	}
-	pod := &kubelet.Pod{
-		Metadata: kubelet.PodMetadata{
-			Name:      "podName",
-			Namespace: "podNamespace",
-			UID:       "podUID",
-			Annotations: map[string]string{
-				"ad.datadoghq.com/fooName.logs": `[{"source":"any_source","service":"any_service","tags":["tag1","tag2"]}]`,
-			},
-		},
-		Status: kubelet.Status{
-			Containers: []kubelet.ContainerStatus{containerFoo, containerBar},
-		},
-	}
-
-	serviceFoo := &service.Service{
-		Type:       "docker",
-		Identifier: "fooID",
-	}
-	serviceBaz := &service.Service{
-		Type:       "docker",
-		Identifier: "bazID",
-	}
-
-	container, _ := searchContainer(serviceFoo, pod)
-	assert.Equal(t, containerFoo, container)
-
-	_, err := searchContainer(serviceBaz, pod)
-	assert.EqualError(t, err, "Container docker://bazID not found")
 }
 
 func TestContainerCollectAll(t *testing.T) {

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -44,7 +44,7 @@ func (s *Scheduler) Stop() {}
 // An entity represents a unique identifier for a process that be reused to query logs.
 func (s *Scheduler) Schedule(configs []integration.Config) {
 	for _, config := range configs {
-		if !s.isLogConfig(config) {
+		if !config.IsLogConfig() {
 			continue
 		}
 		switch {
@@ -76,7 +76,7 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 // Unschedule removes all the sources and services matching the integration configs.
 func (s *Scheduler) Unschedule(configs []integration.Config) {
 	for _, config := range configs {
-		if !s.isLogConfig(config) {
+		if !config.IsLogConfig() {
 			continue
 		}
 		switch {
@@ -108,11 +108,6 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 			continue
 		}
 	}
-}
-
-// isLogConfig returns true if config contains a logs config.
-func (s *Scheduler) isLogConfig(config integration.Config) bool {
-	return config.LogsConfig != nil
 }
 
 // newSources returns true if the config can be mapped to sources.

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -117,7 +117,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		}
 
 		// container tags
-		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
+		for _, container := range pod.Status.AllContainers() {
 			cTags := tags.Copy()
 			cTags.AddLow("kube_container_name", container.Name)
 			cTags.AddHigh("container_id", kubelet.TrimRuntimeFromCID(container.ID))

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -117,7 +117,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		}
 
 		// container tags
-		for _, container := range pod.Status.Containers {
+		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
 			cTags := tags.Copy()
 			cTags.AddLow("kube_container_name", container.Name)
 			cTags.AddHigh("container_id", kubelet.TrimRuntimeFromCID(container.ID))

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -117,7 +117,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 		}
 
 		// container tags
-		for _, container := range pod.Status.AllContainers() {
+		for _, container := range pod.Status.GetAllContainers() {
 			cTags := tags.Copy()
 			cTags.AddLow("kube_container_name", container.Name)
 			cTags.AddHigh("container_id", kubelet.TrimRuntimeFromCID(container.ID))

--- a/pkg/util/kubernetes/kubelet/containers.go
+++ b/pkg/util/kubernetes/kubelet/containers.go
@@ -32,7 +32,7 @@ func (ku *KubeUtil) ListContainers() ([]*containers.Container, error) {
 	var ctrList []*containers.Container
 
 	for _, pod := range pods {
-		for _, c := range pod.Status.Containers {
+		for _, c := range append(pod.Status.InitContainers, pod.Status.Containers...) {
 			if ku.filter.IsExcluded(c.Name, c.Image) {
 				continue
 			}

--- a/pkg/util/kubernetes/kubelet/containers.go
+++ b/pkg/util/kubernetes/kubelet/containers.go
@@ -32,7 +32,7 @@ func (ku *KubeUtil) ListContainers() ([]*containers.Container, error) {
 	var ctrList []*containers.Container
 
 	for _, pod := range pods {
-		for _, c := range append(pod.Status.InitContainers, pod.Status.Containers...) {
+		for _, c := range pod.Status.AllContainers() {
 			if ku.filter.IsExcluded(c.Name, c.Image) {
 				continue
 			}

--- a/pkg/util/kubernetes/kubelet/containers.go
+++ b/pkg/util/kubernetes/kubelet/containers.go
@@ -32,7 +32,7 @@ func (ku *KubeUtil) ListContainers() ([]*containers.Container, error) {
 	var ctrList []*containers.Container
 
 	for _, pod := range pods {
-		for _, c := range pod.Status.AllContainers() {
+		for _, c := range pod.Status.GetAllContainers() {
 			if ku.filter.IsExcluded(c.Name, c.Image) {
 				continue
 			}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -271,6 +271,11 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 		return nil, fmt.Errorf("containerID is empty")
 	}
 	for _, pod := range podList {
+		for _, container := range pod.Status.InitContainers {
+			if container.ID == containerID {
+				return pod, nil
+			}
+		}
 		for _, container := range pod.Status.Containers {
 			if container.ID == containerID {
 				return pod, nil
@@ -278,6 +283,21 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 		}
 	}
 	return nil, errors.NewNotFound(fmt.Sprintf("container %s in PodList", containerID))
+}
+
+// GetStatusForContainerID returns the container status from the pod given an ID
+func (ku *KubeUtil) GetStatusForContainerID(pod *Pod, containerID string) (ContainerStatus, error) {
+	for _, container := range pod.Status.InitContainers {
+		if containerID == container.ID {
+			return container, nil
+		}
+	}
+	for _, container := range pod.Status.Containers {
+		if containerID == container.ID {
+			return container, nil
+		}
+	}
+	return ContainerStatus{}, fmt.Errorf("Container %v not found", containerID)
 }
 
 func (ku *KubeUtil) GetPodFromUID(podUID string) (*Pod, error) {

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -271,12 +271,7 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 		return nil, fmt.Errorf("containerID is empty")
 	}
 	for _, pod := range podList {
-		for _, container := range pod.Status.InitContainers {
-			if container.ID == containerID {
-				return pod, nil
-			}
-		}
-		for _, container := range pod.Status.Containers {
+		for _, container := range pod.Status.AllContainers() {
 			if container.ID == containerID {
 				return pod, nil
 			}
@@ -287,12 +282,7 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 
 // GetStatusForContainerID returns the container status from the pod given an ID
 func (ku *KubeUtil) GetStatusForContainerID(pod *Pod, containerID string) (ContainerStatus, error) {
-	for _, container := range pod.Status.InitContainers {
-		if containerID == container.ID {
-			return container, nil
-		}
-	}
-	for _, container := range pod.Status.Containers {
+	for _, container := range pod.Status.AllContainers() {
 		if containerID == container.ID {
 			return container, nil
 		}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -271,7 +271,7 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 		return nil, fmt.Errorf("containerID is empty")
 	}
 	for _, pod := range podList {
-		for _, container := range pod.Status.AllContainers() {
+		for _, container := range pod.Status.GetAllContainers() {
 			if container.ID == containerID {
 				return pod, nil
 			}
@@ -282,7 +282,7 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 
 // GetStatusForContainerID returns the container status from the pod given an ID
 func (ku *KubeUtil) GetStatusForContainerID(pod *Pod, containerID string) (ContainerStatus, error) {
-	for _, container := range pod.Status.AllContainers() {
+	for _, container := range pod.Status.GetAllContainers() {
 		if containerID == container.ID {
 			return container, nil
 		}

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -83,7 +83,8 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 		// Detect new containers
 		newContainer := false
 		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
-			if container.Ready {
+			// init containers are never ready, we check for ID
+			if container.ID != "" {
 				if _, found := w.lastSeen[container.ID]; found == false {
 					newContainer = true
 				}

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -63,11 +63,6 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 	w.Lock()
 	defer w.Unlock()
 	for _, pod := range podList {
-		// Only process ready pods
-		if IsPodReady(pod) == false {
-			continue
-		}
-
 		podEntity := PodUIDToEntityName(pod.Metadata.UID)
 		newStaticPod := false
 		_, foundPod := w.lastSeen[podEntity]
@@ -87,11 +82,13 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 
 		// Detect new containers
 		newContainer := false
-		for _, container := range pod.Status.Containers {
-			if _, foundContainer := w.lastSeen[container.ID]; foundContainer == false {
-				newContainer = true
+		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
+			if container.Ready {
+				if _, found := w.lastSeen[container.ID]; found == false {
+					newContainer = true
+				}
+				w.lastSeen[container.ID] = now
 			}
-			w.lastSeen[container.ID] = now
 		}
 
 		// Detect changes in labels and annotations values

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -82,9 +82,9 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 
 		// Detect new containers
 		newContainer := false
-		for _, container := range append(pod.Status.InitContainers, pod.Status.Containers...) {
+		for _, container := range pod.Status.AllContainers() {
 			// init containers are never ready, we check for ID
-			if container.ID != "" {
+			if !container.IsPending() {
 				if _, found := w.lastSeen[container.ID]; found == false {
 					newContainer = true
 				}

--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -82,8 +82,9 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 
 		// Detect new containers
 		newContainer := false
-		for _, container := range pod.Status.AllContainers() {
-			// init containers are never ready, we check for ID
+		for _, container := range pod.Status.GetAllContainers() {
+			// We don't check container readiness as init containers are never ready
+			// We check if the container has an ID instead (has run or is running)
 			if !container.IsPending() {
 				if _, found := w.lastSeen[container.ID]; found == false {
 					newContainer = true

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -92,9 +92,15 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 
 	changes, err := watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
-	require.Len(suite.T(), changes, 5, fmt.Sprintf("%d", len(changes)))
+	require.Len(suite.T(), changes, 6, fmt.Sprintf("%d", len(changes)))
 	for _, po := range changes {
-		require.True(suite.T(), IsPodReady(po))
+		// nginx pod is not ready but still detected by the podwatcher
+		if po.Metadata.Name == "nginx-99d8b564-4r4vq" {
+			require.False(suite.T(), IsPodReady(po))
+		} else {
+			fmt.Println(po.Metadata)
+			require.True(suite.T(), IsPodReady(po))
+		}
 	}
 
 	// Same list should detect no change
@@ -113,6 +119,62 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 	require.Len(suite.T(), changes, 2)
 	assert.Equal(suite.T(), "nginx", changes[0].Spec.Containers[0].Name)
 	require.True(suite.T(), IsPodReady(changes[0]))
+}
+
+func (suite *PodwatcherTestSuite) TestPodWatcherWithInitContainers() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_init_container_running.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 5)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		tagsDigest:     make(map[string]string),
+		expiryDuration: 5 * time.Minute,
+	}
+
+	changes, err := watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 5, fmt.Sprintf("%d", len(changes)))
+
+	// Init container finishes
+	sourcePods, err = loadPodsFixture("./testdata/podlist_init_container_terminated.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 5)
+
+	// Should detect the change with the main container being started
+	changes, err = watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+	assert.Equal(suite.T(), "myapp-container", changes[0].Spec.Containers[0].Name)
+	require.True(suite.T(), IsPodReady(changes[0]))
+}
+
+func (suite *PodwatcherTestSuite) TestPodWatcherWithShortLivedContainers() {
+	sourcePods, err := loadPodsFixture("./testdata/podlist_short_lived_absent.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 4)
+
+	watcher := &PodWatcher{
+		lastSeen:       make(map[string]time.Time),
+		tagsDigest:     make(map[string]string),
+		expiryDuration: 5 * time.Minute,
+	}
+
+	changes, err := watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 4, fmt.Sprintf("%d", len(changes)))
+
+	// Short lived pod started and is already terminated
+	sourcePods, err = loadPodsFixture("./testdata/podlist_short_lived_terminated.json")
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), sourcePods, 5)
+
+	// Should detect the change of the terminated short lived pod
+	changes, err = watcher.computeChanges(sourcePods)
+	require.Nil(suite.T(), err)
+	require.Len(suite.T(), changes, 1)
+	assert.Equal(suite.T(), "short-lived-container", changes[0].Spec.Containers[0].Name)
+	require.False(suite.T(), IsPodReady(changes[0]))
 }
 
 func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -68,6 +68,8 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 
 	// A new container ID in an existing pod should trigger
 	remainingPods[0].Status.Containers[0].ID = "testNewID"
+	// we're modifying the container list here, we need to reset the lazy all containers list
+	remainingPods[0].Status.AllContainers = []ContainerStatus{}
 	changes, err = watcher.computeChanges(remainingPods)
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), changes, 1)
@@ -98,7 +100,6 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 		if po.Metadata.Name == "nginx-99d8b564-4r4vq" {
 			require.False(suite.T(), IsPodReady(po))
 		} else {
-			fmt.Println(po.Metadata)
 			require.True(suite.T(), IsPodReady(po))
 		}
 	}

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_init_container_running.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_init_container_running.json
@@ -1,0 +1,859 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "name": "coredns-747dbcf5df-qmtnl",
+                "generateName": "coredns-747dbcf5df-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-747dbcf5df-qmtnl",
+                "uid": "23476f2c-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "245",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "dns": "coredns",
+                    "pod-template-hash": "3038679189"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:55.913393966Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "coredns-747dbcf5df",
+                        "uid": "2338976b-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config-volume",
+                        "configMap": {
+                            "name": "coredns",
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "coredns-token-k52rj",
+                        "secret": {
+                            "secretName": "coredns-token-k52rj",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "coredns/coredns:1.1.1",
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "ports": [
+                            {
+                                "name": "dns",
+                                "containerPort": 53,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "name": "dns-tcp",
+                                "containerPort": 53,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "metrics",
+                                "containerPort": 9153,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config-volume",
+                                "mountPath": "/etc/coredns"
+                            },
+                            {
+                                "name": "coredns-token-k52rj",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "Default",
+                "serviceAccountName": "coredns",
+                "serviceAccount": "coredns",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:55:00Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.58",
+                "startTime": "2019-04-18T13:44:55Z",
+                "containerStatuses": [
+                    {
+                        "name": "coredns",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:57Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:42Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://b0428bd7c7be12cdf0b9b06e94804a8c922cefe1f949903d759b8b1b5bcdc159"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "docker.io/coredns/coredns:1.1.1",
+                        "imageID": "docker.io/coredns/coredns@sha256:399cc5b2e2f0d599ef22f43aab52492e88b4f0fd69da9b10545e95a4253c86ce",
+                        "containerID": "containerd://509057eef9c66fcae1627a278216e29a0504d9b2e85ccc79c09b316dba7554e2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "myapp-pod",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/myapp-pod",
+                "uid": "7760601b-65a6-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "73283",
+                "creationTimestamp": "2019-04-23T09:02:05Z",
+                "labels": {
+                    "app": "myapp"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"myapp\"},\"name\":\"myapp-pod\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"for i in `seq 1 3600`; do echo logging stuff $i; sleep 1; done;\"],\"image\":\"busybox\",\"name\":\"myapp-container\"}],\"initContainers\":[{\"command\":[\"sh\",\"-c\",\"for i in `seq 1 360`; do echo init stuff $i; sleep 1; done;\"],\"image\":\"busybox\",\"name\":\"init-myservice\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-04-23T09:02:05.335687965Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-nv6x5",
+                        "secret": {
+                            "secretName": "default-token-nv6x5",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-myservice",
+                        "image": "busybox",
+                        "command": [
+                            "sh",
+                            "-c",
+                            "for i in `seq 1 360`; do echo init stuff $i; sleep 1; done;"
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-nv6x5",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "myapp-container",
+                        "image": "busybox",
+                        "command": [
+                            "sh",
+                            "-c",
+                            "for i in `seq 1 3600`; do echo logging stuff $i; sleep 1; done;"
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-nv6x5",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Pending",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "False",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:02:05Z",
+                        "reason": "ContainersNotInitialized",
+                        "message": "containers with incomplete status: [init-myservice]"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:02:05Z",
+                        "reason": "ContainersNotReady",
+                        "message": "containers with unready status: [myapp-container]"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:02:05Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.82",
+                "startTime": "2019-04-23T09:02:05Z",
+                "initContainerStatuses": [
+                    {
+                        "name": "init-myservice",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-23T09:02:07Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": false,
+                        "restartCount": 0,
+                        "image": "docker.io/library/busybox:latest",
+                        "imageID": "docker.io/library/busybox@sha256:954e1f01e80ce09d0887ff6ea10b13a812cb01932a0781d6b0cc23f743a874fd",
+                        "containerID": "containerd://922a2f3f14d1724d7eeb6cad2b5138bcbd85948c802fead1af2a1e5d79807e4e"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "name": "myapp-container",
+                        "state": {
+                            "waiting": {
+                                "reason": "PodInitializing"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": false,
+                        "restartCount": 0,
+                        "image": "busybox",
+                        "imageID": ""
+                    }
+                ],
+                "qosClass": "BestEffort"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-scheduler-8mpwh",
+                "generateName": "kube-scheduler-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-8mpwh",
+                "uid": "2358fd3b-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "200",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-scheduler",
+                    "controller-revision-hash": "2740278040",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.521042779Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-scheduler",
+                        "uid": "204abed8-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-xr795",
+                        "secret": {
+                            "secretName": "default-token-xr795",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-scheduler",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "scheduler",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--housekeeping-interval=15s"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-xr795",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:52Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-scheduler",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:43Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:52:34Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://cbeb7e0c866f6f7de6225f994b5253cc15109248e50aa98673b097970fe556b8"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 5,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://6f23d0cd20742a67eb07581b2a7b79b48f6814c4fef313b51d0af76813482c2a"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-proxy-fbv92",
+                "generateName": "kube-proxy-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-fbv92",
+                "uid": "2358e669-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "199",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-proxy",
+                    "controller-revision-hash": "713792516",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.520393704Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-proxy",
+                        "uid": "20496ca0-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "configMap": {
+                            "name": "kube-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "kube-proxy-token-j88lh",
+                        "secret": {
+                            "secretName": "kube-proxy-token-j88lh",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "proxy",
+                            "--config=/var/lib/kubernetes/config.yaml"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/var/lib/kubernetes/"
+                            },
+                            {
+                                "name": "kube-proxy-token-j88lh",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-proxy",
+                "serviceAccount": "kube-proxy",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:59Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-proxy",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T13:44:51Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://7fe704a201c2603b1df543c3c450c289cbe0c08319b26bbae69b03d6932ec9a2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-controller-manager",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-controller-manager",
+                "uid": "2041aca9-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "149",
+                "creationTimestamp": "2019-04-18T13:44:45Z",
+                "labels": {
+                    "app": "kube-controller-manager"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"kube-controller-manager\"},\"name\":\"kube-controller-manager\",\"namespace\":\"kube-system\"},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/hyperkube\",\"controller-manager\",\"--master=http://127.0.0.1:8080\",\"--leader-elect=true\",\"--leader-elect-lease-duration=150s\",\"--leader-elect-renew-deadline=100s\",\"--leader-elect-retry-period=20s\",\"--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate\",\"--cluster-signing-key-file=/etc/secrets/pupernetes.private_key\",\"--root-ca-file=/etc/secrets/pupernetes.issuing_ca\",\"--service-account-private-key-file=/etc/secrets/service-accounts.rsa\",\"--concurrent-deployment-syncs=2\",\"--concurrent-endpoint-syncs=2\",\"--concurrent-gc-syncs=5\",\"--concurrent-namespace-syncs=3\",\"--concurrent-replicaset-syncs=2\",\"--concurrent-resource-quota-syncs=2\",\"--concurrent-service-syncs=1\",\"--concurrent-serviceaccount-token-syncs=2\",\"--horizontal-pod-autoscaler-use-rest-clients=true\"],\"image\":\"gcr.io/google_containers/hyperkube:v1.10.7\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":15},\"name\":\"kube-controller-manager\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"100m\"}},\"volumeMounts\":[{\"mountPath\":\"/etc/secrets\",\"name\":\"secrets\"}]}],\"hostNetwork\":true,\"nodeName\":\"ci-pierremargueritte\",\"serviceAccountName\":\"kube-controller-manager\",\"volumes\":[{\"hostPath\":{\"path\":\"/opt/state/secrets\"},\"name\":\"secrets\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:45.333744312Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "secrets",
+                        "hostPath": {
+                            "path": "/opt/state/secrets",
+                            "type": ""
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-controller-manager",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "controller-manager",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate",
+                            "--cluster-signing-key-file=/etc/secrets/pupernetes.private_key",
+                            "--root-ca-file=/etc/secrets/pupernetes.issuing_ca",
+                            "--service-account-private-key-file=/etc/secrets/service-accounts.rsa",
+                            "--concurrent-deployment-syncs=2",
+                            "--concurrent-endpoint-syncs=2",
+                            "--concurrent-gc-syncs=5",
+                            "--concurrent-namespace-syncs=3",
+                            "--concurrent-replicaset-syncs=2",
+                            "--concurrent-resource-quota-syncs=2",
+                            "--concurrent-service-syncs=1",
+                            "--concurrent-serviceaccount-token-syncs=2",
+                            "--horizontal-pod-autoscaler-use-rest-clients=true"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "250m"
+                            },
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secrets",
+                                "mountPath": "/etc/secrets"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-controller-manager",
+                "serviceAccount": "kube-controller-manager",
+                "automountServiceAccountToken": false,
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:50Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:45Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-controller-manager",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:41Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:41Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://fb4c383b0f4aae6412d65af03ece7dd1ad04ca47554ff2f75d8ccac3296fbfbf"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://380f36a6fa8887c3613f4adbe57411972cde49e5dd419dabbcebc2ae767e6e6b"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        }
+    ]
+}

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_init_container_terminated.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_init_container_terminated.json
@@ -1,0 +1,860 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "name": "kube-scheduler-8mpwh",
+                "generateName": "kube-scheduler-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-8mpwh",
+                "uid": "2358fd3b-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "200",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-scheduler",
+                    "controller-revision-hash": "2740278040",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.521042779Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-scheduler",
+                        "uid": "204abed8-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-xr795",
+                        "secret": {
+                            "secretName": "default-token-xr795",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-scheduler",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "scheduler",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--housekeeping-interval=15s"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-xr795",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:52Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-scheduler",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:43Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:52:34Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://cbeb7e0c866f6f7de6225f994b5253cc15109248e50aa98673b097970fe556b8"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 5,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://6f23d0cd20742a67eb07581b2a7b79b48f6814c4fef313b51d0af76813482c2a"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "coredns-747dbcf5df-qmtnl",
+                "generateName": "coredns-747dbcf5df-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-747dbcf5df-qmtnl",
+                "uid": "23476f2c-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "245",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "dns": "coredns",
+                    "pod-template-hash": "3038679189"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:55.913393966Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "coredns-747dbcf5df",
+                        "uid": "2338976b-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config-volume",
+                        "configMap": {
+                            "name": "coredns",
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "coredns-token-k52rj",
+                        "secret": {
+                            "secretName": "coredns-token-k52rj",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "coredns/coredns:1.1.1",
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "ports": [
+                            {
+                                "name": "dns",
+                                "containerPort": 53,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "name": "dns-tcp",
+                                "containerPort": 53,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "metrics",
+                                "containerPort": 9153,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config-volume",
+                                "mountPath": "/etc/coredns"
+                            },
+                            {
+                                "name": "coredns-token-k52rj",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "Default",
+                "serviceAccountName": "coredns",
+                "serviceAccount": "coredns",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:55:00Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.58",
+                "startTime": "2019-04-18T13:44:55Z",
+                "containerStatuses": [
+                    {
+                        "name": "coredns",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:57Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:42Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://b0428bd7c7be12cdf0b9b06e94804a8c922cefe1f949903d759b8b1b5bcdc159"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "docker.io/coredns/coredns:1.1.1",
+                        "imageID": "docker.io/coredns/coredns@sha256:399cc5b2e2f0d599ef22f43aab52492e88b4f0fd69da9b10545e95a4253c86ce",
+                        "containerID": "containerd://509057eef9c66fcae1627a278216e29a0504d9b2e85ccc79c09b316dba7554e2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "myapp-pod",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/myapp-pod",
+                "uid": "7760601b-65a6-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "73283",
+                "creationTimestamp": "2019-04-23T09:02:05Z",
+                "labels": {
+                    "app": "myapp"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"myapp\"},\"name\":\"myapp-pod\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"for i in `seq 1 3600`; do echo logging stuff $i; sleep 1; done;\"],\"image\":\"busybox\",\"name\":\"myapp-container\"}],\"initContainers\":[{\"command\":[\"sh\",\"-c\",\"for i in `seq 1 360`; do echo init stuff $i; sleep 1; done;\"],\"image\":\"busybox\",\"name\":\"init-myservice\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-04-23T09:02:05.335687965Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-nv6x5",
+                        "secret": {
+                            "secretName": "default-token-nv6x5",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-myservice",
+                        "image": "busybox",
+                        "command": [
+                            "sh",
+                            "-c",
+                            "for i in `seq 1 360`; do echo init stuff $i; sleep 1; done;"
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-nv6x5",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "myapp-container",
+                        "image": "busybox",
+                        "command": [
+                            "sh",
+                            "-c",
+                            "for i in `seq 1 3600`; do echo logging stuff $i; sleep 1; done;"
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-nv6x5",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:08:09Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:08:11Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:02:05Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.82",
+                "startTime": "2019-04-23T09:02:05Z",
+                "initContainerStatuses": [
+                    {
+                        "name": "init-myservice",
+                        "state": {
+                            "terminated": {
+                                "exitCode": 0,
+                                "reason": "Completed",
+                                "startedAt": "2019-04-23T09:02:07Z",
+                                "finishedAt": "2019-04-23T09:08:08Z",
+                                "containerID": "containerd://922a2f3f14d1724d7eeb6cad2b5138bcbd85948c802fead1af2a1e5d79807e4e"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "docker.io/library/busybox:latest",
+                        "imageID": "docker.io/library/busybox@sha256:954e1f01e80ce09d0887ff6ea10b13a812cb01932a0781d6b0cc23f743a874fd",
+                        "containerID": "containerd://922a2f3f14d1724d7eeb6cad2b5138bcbd85948c802fead1af2a1e5d79807e4e"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "name": "myapp-container",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-23T09:08:10Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "docker.io/library/busybox:latest",
+                        "imageID": "docker.io/library/busybox@sha256:954e1f01e80ce09d0887ff6ea10b13a812cb01932a0781d6b0cc23f743a874fd",
+                        "containerID": "containerd://aa4f77272e3407f4ba15cd14f885d3799f6373e8a2b2ef883f9acfccd3c73ba3"
+                    }
+                ],
+                "qosClass": "BestEffort"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-proxy-fbv92",
+                "generateName": "kube-proxy-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-fbv92",
+                "uid": "2358e669-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "199",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-proxy",
+                    "controller-revision-hash": "713792516",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.520393704Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-proxy",
+                        "uid": "20496ca0-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "configMap": {
+                            "name": "kube-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "kube-proxy-token-j88lh",
+                        "secret": {
+                            "secretName": "kube-proxy-token-j88lh",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "proxy",
+                            "--config=/var/lib/kubernetes/config.yaml"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/var/lib/kubernetes/"
+                            },
+                            {
+                                "name": "kube-proxy-token-j88lh",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-proxy",
+                "serviceAccount": "kube-proxy",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:59Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-proxy",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T13:44:51Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://7fe704a201c2603b1df543c3c450c289cbe0c08319b26bbae69b03d6932ec9a2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-controller-manager",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-controller-manager",
+                "uid": "2041aca9-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "149",
+                "creationTimestamp": "2019-04-18T13:44:45Z",
+                "labels": {
+                    "app": "kube-controller-manager"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"kube-controller-manager\"},\"name\":\"kube-controller-manager\",\"namespace\":\"kube-system\"},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/hyperkube\",\"controller-manager\",\"--master=http://127.0.0.1:8080\",\"--leader-elect=true\",\"--leader-elect-lease-duration=150s\",\"--leader-elect-renew-deadline=100s\",\"--leader-elect-retry-period=20s\",\"--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate\",\"--cluster-signing-key-file=/etc/secrets/pupernetes.private_key\",\"--root-ca-file=/etc/secrets/pupernetes.issuing_ca\",\"--service-account-private-key-file=/etc/secrets/service-accounts.rsa\",\"--concurrent-deployment-syncs=2\",\"--concurrent-endpoint-syncs=2\",\"--concurrent-gc-syncs=5\",\"--concurrent-namespace-syncs=3\",\"--concurrent-replicaset-syncs=2\",\"--concurrent-resource-quota-syncs=2\",\"--concurrent-service-syncs=1\",\"--concurrent-serviceaccount-token-syncs=2\",\"--horizontal-pod-autoscaler-use-rest-clients=true\"],\"image\":\"gcr.io/google_containers/hyperkube:v1.10.7\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":15},\"name\":\"kube-controller-manager\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"100m\"}},\"volumeMounts\":[{\"mountPath\":\"/etc/secrets\",\"name\":\"secrets\"}]}],\"hostNetwork\":true,\"nodeName\":\"ci-pierremargueritte\",\"serviceAccountName\":\"kube-controller-manager\",\"volumes\":[{\"hostPath\":{\"path\":\"/opt/state/secrets\"},\"name\":\"secrets\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:45.333744312Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "secrets",
+                        "hostPath": {
+                            "path": "/opt/state/secrets",
+                            "type": ""
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-controller-manager",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "controller-manager",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate",
+                            "--cluster-signing-key-file=/etc/secrets/pupernetes.private_key",
+                            "--root-ca-file=/etc/secrets/pupernetes.issuing_ca",
+                            "--service-account-private-key-file=/etc/secrets/service-accounts.rsa",
+                            "--concurrent-deployment-syncs=2",
+                            "--concurrent-endpoint-syncs=2",
+                            "--concurrent-gc-syncs=5",
+                            "--concurrent-namespace-syncs=3",
+                            "--concurrent-replicaset-syncs=2",
+                            "--concurrent-resource-quota-syncs=2",
+                            "--concurrent-service-syncs=1",
+                            "--concurrent-serviceaccount-token-syncs=2",
+                            "--horizontal-pod-autoscaler-use-rest-clients=true"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "250m"
+                            },
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secrets",
+                                "mountPath": "/etc/secrets"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-controller-manager",
+                "serviceAccount": "kube-controller-manager",
+                "automountServiceAccountToken": false,
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:50Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:45Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-controller-manager",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:41Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:41Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://fb4c383b0f4aae6412d65af03ece7dd1ad04ca47554ff2f75d8ccac3296fbfbf"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://380f36a6fa8887c3613f4adbe57411972cde49e5dd419dabbcebc2ae767e6e6b"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        }
+    ]
+}

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_short_lived_absent.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_short_lived_absent.json
@@ -1,0 +1,716 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "name": "kube-controller-manager",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-controller-manager",
+                "uid": "2041aca9-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "149",
+                "creationTimestamp": "2019-04-18T13:44:45Z",
+                "labels": {
+                    "app": "kube-controller-manager"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"kube-controller-manager\"},\"name\":\"kube-controller-manager\",\"namespace\":\"kube-system\"},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/hyperkube\",\"controller-manager\",\"--master=http://127.0.0.1:8080\",\"--leader-elect=true\",\"--leader-elect-lease-duration=150s\",\"--leader-elect-renew-deadline=100s\",\"--leader-elect-retry-period=20s\",\"--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate\",\"--cluster-signing-key-file=/etc/secrets/pupernetes.private_key\",\"--root-ca-file=/etc/secrets/pupernetes.issuing_ca\",\"--service-account-private-key-file=/etc/secrets/service-accounts.rsa\",\"--concurrent-deployment-syncs=2\",\"--concurrent-endpoint-syncs=2\",\"--concurrent-gc-syncs=5\",\"--concurrent-namespace-syncs=3\",\"--concurrent-replicaset-syncs=2\",\"--concurrent-resource-quota-syncs=2\",\"--concurrent-service-syncs=1\",\"--concurrent-serviceaccount-token-syncs=2\",\"--horizontal-pod-autoscaler-use-rest-clients=true\"],\"image\":\"gcr.io/google_containers/hyperkube:v1.10.7\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":15},\"name\":\"kube-controller-manager\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"100m\"}},\"volumeMounts\":[{\"mountPath\":\"/etc/secrets\",\"name\":\"secrets\"}]}],\"hostNetwork\":true,\"nodeName\":\"ci-pierremargueritte\",\"serviceAccountName\":\"kube-controller-manager\",\"volumes\":[{\"hostPath\":{\"path\":\"/opt/state/secrets\"},\"name\":\"secrets\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:45.333744312Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "secrets",
+                        "hostPath": {
+                            "path": "/opt/state/secrets",
+                            "type": ""
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-controller-manager",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "controller-manager",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate",
+                            "--cluster-signing-key-file=/etc/secrets/pupernetes.private_key",
+                            "--root-ca-file=/etc/secrets/pupernetes.issuing_ca",
+                            "--service-account-private-key-file=/etc/secrets/service-accounts.rsa",
+                            "--concurrent-deployment-syncs=2",
+                            "--concurrent-endpoint-syncs=2",
+                            "--concurrent-gc-syncs=5",
+                            "--concurrent-namespace-syncs=3",
+                            "--concurrent-replicaset-syncs=2",
+                            "--concurrent-resource-quota-syncs=2",
+                            "--concurrent-service-syncs=1",
+                            "--concurrent-serviceaccount-token-syncs=2",
+                            "--horizontal-pod-autoscaler-use-rest-clients=true"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "250m"
+                            },
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secrets",
+                                "mountPath": "/etc/secrets"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-controller-manager",
+                "serviceAccount": "kube-controller-manager",
+                "automountServiceAccountToken": false,
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:50Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:45Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-controller-manager",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:41Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:41Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://fb4c383b0f4aae6412d65af03ece7dd1ad04ca47554ff2f75d8ccac3296fbfbf"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://380f36a6fa8887c3613f4adbe57411972cde49e5dd419dabbcebc2ae767e6e6b"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-scheduler-8mpwh",
+                "generateName": "kube-scheduler-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-8mpwh",
+                "uid": "2358fd3b-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "200",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-scheduler",
+                    "controller-revision-hash": "2740278040",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.521042779Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-scheduler",
+                        "uid": "204abed8-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-xr795",
+                        "secret": {
+                            "secretName": "default-token-xr795",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-scheduler",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "scheduler",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--housekeeping-interval=15s"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-xr795",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:52Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-scheduler",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:43Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:52:34Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://cbeb7e0c866f6f7de6225f994b5253cc15109248e50aa98673b097970fe556b8"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 5,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://6f23d0cd20742a67eb07581b2a7b79b48f6814c4fef313b51d0af76813482c2a"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "coredns-747dbcf5df-qmtnl",
+                "generateName": "coredns-747dbcf5df-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-747dbcf5df-qmtnl",
+                "uid": "23476f2c-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "245",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "dns": "coredns",
+                    "pod-template-hash": "3038679189"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:55.913393966Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "coredns-747dbcf5df",
+                        "uid": "2338976b-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config-volume",
+                        "configMap": {
+                            "name": "coredns",
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "coredns-token-k52rj",
+                        "secret": {
+                            "secretName": "coredns-token-k52rj",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "coredns/coredns:1.1.1",
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "ports": [
+                            {
+                                "name": "dns",
+                                "containerPort": 53,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "name": "dns-tcp",
+                                "containerPort": 53,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "metrics",
+                                "containerPort": 9153,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config-volume",
+                                "mountPath": "/etc/coredns"
+                            },
+                            {
+                                "name": "coredns-token-k52rj",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "Default",
+                "serviceAccountName": "coredns",
+                "serviceAccount": "coredns",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:55:00Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.58",
+                "startTime": "2019-04-18T13:44:55Z",
+                "containerStatuses": [
+                    {
+                        "name": "coredns",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:57Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:42Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://b0428bd7c7be12cdf0b9b06e94804a8c922cefe1f949903d759b8b1b5bcdc159"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "docker.io/coredns/coredns:1.1.1",
+                        "imageID": "docker.io/coredns/coredns@sha256:399cc5b2e2f0d599ef22f43aab52492e88b4f0fd69da9b10545e95a4253c86ce",
+                        "containerID": "containerd://509057eef9c66fcae1627a278216e29a0504d9b2e85ccc79c09b316dba7554e2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-proxy-fbv92",
+                "generateName": "kube-proxy-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-fbv92",
+                "uid": "2358e669-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "199",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-proxy",
+                    "controller-revision-hash": "713792516",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.520393704Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-proxy",
+                        "uid": "20496ca0-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "configMap": {
+                            "name": "kube-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "kube-proxy-token-j88lh",
+                        "secret": {
+                            "secretName": "kube-proxy-token-j88lh",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "proxy",
+                            "--config=/var/lib/kubernetes/config.yaml"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/var/lib/kubernetes/"
+                            },
+                            {
+                                "name": "kube-proxy-token-j88lh",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-proxy",
+                "serviceAccount": "kube-proxy",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:59Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-proxy",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T13:44:51Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://7fe704a201c2603b1df543c3c450c289cbe0c08319b26bbae69b03d6932ec9a2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        }
+    ]
+}

--- a/pkg/util/kubernetes/kubelet/testdata/podlist_short_lived_terminated.json
+++ b/pkg/util/kubernetes/kubelet/testdata/podlist_short_lived_terminated.json
@@ -1,0 +1,824 @@
+{
+    "kind": "PodList",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "metadata": {
+                "name": "coredns-747dbcf5df-qmtnl",
+                "generateName": "coredns-747dbcf5df-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/coredns-747dbcf5df-qmtnl",
+                "uid": "23476f2c-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "245",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "dns": "coredns",
+                    "pod-template-hash": "3038679189"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:55.913393966Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "name": "coredns-747dbcf5df",
+                        "uid": "2338976b-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config-volume",
+                        "configMap": {
+                            "name": "coredns",
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "coredns-token-k52rj",
+                        "secret": {
+                            "secretName": "coredns-token-k52rj",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "coredns",
+                        "image": "coredns/coredns:1.1.1",
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "ports": [
+                            {
+                                "name": "dns",
+                                "containerPort": 53,
+                                "protocol": "UDP"
+                            },
+                            {
+                                "name": "dns-tcp",
+                                "containerPort": 53,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "metrics",
+                                "containerPort": 9153,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config-volume",
+                                "mountPath": "/etc/coredns"
+                            },
+                            {
+                                "name": "coredns-token-k52rj",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "Default",
+                "serviceAccountName": "coredns",
+                "serviceAccount": "coredns",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:55:00Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:55Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.58",
+                "startTime": "2019-04-18T13:44:55Z",
+                "containerStatuses": [
+                    {
+                        "name": "coredns",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:57Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:42Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://b0428bd7c7be12cdf0b9b06e94804a8c922cefe1f949903d759b8b1b5bcdc159"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "docker.io/coredns/coredns:1.1.1",
+                        "imageID": "docker.io/coredns/coredns@sha256:399cc5b2e2f0d599ef22f43aab52492e88b4f0fd69da9b10545e95a4253c86ce",
+                        "containerID": "containerd://509057eef9c66fcae1627a278216e29a0504d9b2e85ccc79c09b316dba7554e2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "my-short-lived-pod",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/my-short-lived-pod",
+                "uid": "eec6d906-65ab-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "73777",
+                "creationTimestamp": "2019-04-23T09:41:13Z",
+                "labels": {
+                    "app": "short-lived"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"short-lived\"},\"name\":\"my-short-lived-pod\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"for i in `seq 1 10`; do echo logging stuff $i; done\"],\"image\":\"busybox\",\"name\":\"short-lived-container\"}],\"restartPolicy\":\"Never\"}}\n",
+                    "kubernetes.io/config.seen": "2019-04-23T09:41:13.143826058Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-nv6x5",
+                        "secret": {
+                            "secretName": "default-token-nv6x5",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "short-lived-container",
+                        "image": "busybox",
+                        "command": [
+                            "sh",
+                            "-c",
+                            "for i in `seq 1 10`; do echo logging stuff $i; done"
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-nv6x5",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Never",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Succeeded",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:41:13Z",
+                        "reason": "PodCompleted"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "False",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:41:13Z",
+                        "reason": "PodCompleted"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-23T09:41:13Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "192.168.253.83",
+                "startTime": "2019-04-23T09:41:13Z",
+                "containerStatuses": [
+                    {
+                        "name": "short-lived-container",
+                        "state": {
+                            "terminated": {
+                                "exitCode": 0,
+                                "reason": "Completed",
+                                "startedAt": "2019-04-23T09:41:16Z",
+                                "finishedAt": "2019-04-23T09:41:16Z",
+                                "containerID": "containerd://45dbe6934f4a07b2f8418ee345cb0904b726dfa0d0729b0cabc0f5fb56d4f8e6"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": false,
+                        "restartCount": 0,
+                        "image": "docker.io/library/busybox:latest",
+                        "imageID": "docker.io/library/busybox@sha256:954e1f01e80ce09d0887ff6ea10b13a812cb01932a0781d6b0cc23f743a874fd",
+                        "containerID": "containerd://45dbe6934f4a07b2f8418ee345cb0904b726dfa0d0729b0cabc0f5fb56d4f8e6"
+                    }
+                ],
+                "qosClass": "BestEffort"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-scheduler-8mpwh",
+                "generateName": "kube-scheduler-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-8mpwh",
+                "uid": "2358fd3b-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "200",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-scheduler",
+                    "controller-revision-hash": "2740278040",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.521042779Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-scheduler",
+                        "uid": "204abed8-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-xr795",
+                        "secret": {
+                            "secretName": "default-token-xr795",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-scheduler",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "scheduler",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--housekeeping-interval=15s"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-xr795",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10251,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:52Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-scheduler",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:43Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:52:34Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://cbeb7e0c866f6f7de6225f994b5253cc15109248e50aa98673b097970fe556b8"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 5,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://6f23d0cd20742a67eb07581b2a7b79b48f6814c4fef313b51d0af76813482c2a"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-proxy-fbv92",
+                "generateName": "kube-proxy-",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-proxy-fbv92",
+                "uid": "2358e669-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "199",
+                "creationTimestamp": "2019-04-18T13:44:50Z",
+                "labels": {
+                    "app": "kube-proxy",
+                    "controller-revision-hash": "713792516",
+                    "pod-template-generation": "1"
+                },
+                "annotations": {
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:50.520393704Z",
+                    "kubernetes.io/config.source": "api"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "DaemonSet",
+                        "name": "kube-proxy",
+                        "uid": "20496ca0-61e0-11e9-bc12-02f121c1eeb4",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "configMap": {
+                            "name": "kube-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "kube-proxy-token-j88lh",
+                        "secret": {
+                            "secretName": "kube-proxy-token-j88lh",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-proxy",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "proxy",
+                            "--config=/var/lib/kubernetes/config.yaml"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m"
+                            },
+                            "requests": {
+                                "cpu": "50m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/var/lib/kubernetes/"
+                            },
+                            {
+                                "name": "kube-proxy-token-j88lh",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10256,
+                                "scheme": "HTTP"
+                            },
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-proxy",
+                "serviceAccount": "kube-proxy",
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:59Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:50Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:50Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-proxy",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T13:44:51Z"
+                            }
+                        },
+                        "lastState": {},
+                        "ready": true,
+                        "restartCount": 0,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://7fe704a201c2603b1df543c3c450c289cbe0c08319b26bbae69b03d6932ec9a2"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        },
+        {
+            "metadata": {
+                "name": "kube-controller-manager",
+                "namespace": "kube-system",
+                "selfLink": "/api/v1/namespaces/kube-system/pods/kube-controller-manager",
+                "uid": "2041aca9-61e0-11e9-bc12-02f121c1eeb4",
+                "resourceVersion": "149",
+                "creationTimestamp": "2019-04-18T13:44:45Z",
+                "labels": {
+                    "app": "kube-controller-manager"
+                },
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"kube-controller-manager\"},\"name\":\"kube-controller-manager\",\"namespace\":\"kube-system\"},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/hyperkube\",\"controller-manager\",\"--master=http://127.0.0.1:8080\",\"--leader-elect=true\",\"--leader-elect-lease-duration=150s\",\"--leader-elect-renew-deadline=100s\",\"--leader-elect-retry-period=20s\",\"--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate\",\"--cluster-signing-key-file=/etc/secrets/pupernetes.private_key\",\"--root-ca-file=/etc/secrets/pupernetes.issuing_ca\",\"--service-account-private-key-file=/etc/secrets/service-accounts.rsa\",\"--concurrent-deployment-syncs=2\",\"--concurrent-endpoint-syncs=2\",\"--concurrent-gc-syncs=5\",\"--concurrent-namespace-syncs=3\",\"--concurrent-replicaset-syncs=2\",\"--concurrent-resource-quota-syncs=2\",\"--concurrent-service-syncs=1\",\"--concurrent-serviceaccount-token-syncs=2\",\"--horizontal-pod-autoscaler-use-rest-clients=true\"],\"image\":\"gcr.io/google_containers/hyperkube:v1.10.7\",\"imagePullPolicy\":\"IfNotPresent\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":15},\"name\":\"kube-controller-manager\",\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":10252},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"250m\"},\"requests\":{\"cpu\":\"100m\"}},\"volumeMounts\":[{\"mountPath\":\"/etc/secrets\",\"name\":\"secrets\"}]}],\"hostNetwork\":true,\"nodeName\":\"ci-pierremargueritte\",\"serviceAccountName\":\"kube-controller-manager\",\"volumes\":[{\"hostPath\":{\"path\":\"/opt/state/secrets\"},\"name\":\"secrets\"}]}}\n",
+                    "kubernetes.io/config.seen": "2019-04-18T13:44:45.333744312Z",
+                    "kubernetes.io/config.source": "api"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "secrets",
+                        "hostPath": {
+                            "path": "/opt/state/secrets",
+                            "type": ""
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "kube-controller-manager",
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "command": [
+                            "/hyperkube",
+                            "controller-manager",
+                            "--master=http://127.0.0.1:8080",
+                            "--leader-elect=true",
+                            "--leader-elect-lease-duration=150s",
+                            "--leader-elect-renew-deadline=100s",
+                            "--leader-elect-retry-period=20s",
+                            "--cluster-signing-cert-file=/etc/secrets/pupernetes.certificate",
+                            "--cluster-signing-key-file=/etc/secrets/pupernetes.private_key",
+                            "--root-ca-file=/etc/secrets/pupernetes.issuing_ca",
+                            "--service-account-private-key-file=/etc/secrets/service-accounts.rsa",
+                            "--concurrent-deployment-syncs=2",
+                            "--concurrent-endpoint-syncs=2",
+                            "--concurrent-gc-syncs=5",
+                            "--concurrent-namespace-syncs=3",
+                            "--concurrent-replicaset-syncs=2",
+                            "--concurrent-resource-quota-syncs=2",
+                            "--concurrent-service-syncs=1",
+                            "--concurrent-serviceaccount-token-syncs=2",
+                            "--horizontal-pod-autoscaler-use-rest-clients=true"
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "250m"
+                            },
+                            "requests": {
+                                "cpu": "100m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secrets",
+                                "mountPath": "/etc/secrets"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 15,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 10252,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "timeoutSeconds": 1,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "failureThreshold": 3
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "kube-controller-manager",
+                "serviceAccount": "kube-controller-manager",
+                "automountServiceAccountToken": false,
+                "nodeName": "ci-pierremargueritte",
+                "hostNetwork": true,
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "Initialized",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    },
+                    {
+                        "type": "Ready",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T15:54:50Z"
+                    },
+                    {
+                        "type": "PodScheduled",
+                        "status": "True",
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2019-04-18T13:44:45Z"
+                    }
+                ],
+                "hostIP": "10.0.2.15",
+                "podIP": "10.0.2.15",
+                "startTime": "2019-04-18T13:44:45Z",
+                "containerStatuses": [
+                    {
+                        "name": "kube-controller-manager",
+                        "state": {
+                            "running": {
+                                "startedAt": "2019-04-18T15:54:41Z"
+                            }
+                        },
+                        "lastState": {
+                            "terminated": {
+                                "exitCode": 137,
+                                "reason": "Error",
+                                "startedAt": "2019-04-18T15:51:41Z",
+                                "finishedAt": "2019-04-18T15:54:36Z",
+                                "containerID": "containerd://fb4c383b0f4aae6412d65af03ece7dd1ad04ca47554ff2f75d8ccac3296fbfbf"
+                            }
+                        },
+                        "ready": true,
+                        "restartCount": 4,
+                        "image": "gcr.io/google_containers/hyperkube:v1.10.7",
+                        "imageID": "gcr.io/google_containers/hyperkube@sha256:d8afe405e650f0e4b5ba1c76a22fbbca4d0deb6bd6498c3818df58b5e30f8daf",
+                        "containerID": "containerd://380f36a6fa8887c3613f4adbe57411972cde49e5dd419dabbcebc2ae767e6e6b"
+                    }
+                ],
+                "qosClass": "Burstable"
+            }
+        }
+    ]
+}

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -69,11 +69,12 @@ type ContainerProbe struct {
 
 // Status contains fields for unmarshalling a Pod.Status
 type Status struct {
-	Phase      string            `json:"phase,omitempty"`
-	HostIP     string            `json:"hostIP,omitempty"`
-	PodIP      string            `json:"podIP,omitempty"`
-	Containers []ContainerStatus `json:"containerStatuses,omitempty"`
-	Conditions []Conditions      `json:"conditions,omitempty"`
+	Phase          string            `json:"phase,omitempty"`
+	HostIP         string            `json:"hostIP,omitempty"`
+	PodIP          string            `json:"podIP,omitempty"`
+	Containers     []ContainerStatus `json:"containerStatuses,omitempty"`
+	InitContainers []ContainerStatus `json:"initContainerStatuses,omitempty"`
+	Conditions     []Conditions      `json:"conditions,omitempty"`
 }
 
 // Conditions contains fields for unmarshalling a Pod.Status.Conditions

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -77,6 +77,11 @@ type Status struct {
 	Conditions     []Conditions      `json:"conditions,omitempty"`
 }
 
+// AllContainers returns the list of init and regular containers
+func (s *Status) AllContainers() []ContainerStatus {
+	return append(s.InitContainers, s.Containers...)
+}
+
 // Conditions contains fields for unmarshalling a Pod.Status.Conditions
 type Conditions struct {
 	Type   string `json:"type,omitempty"`
@@ -90,6 +95,11 @@ type ContainerStatus struct {
 	ID    string         `json:"containerID"`
 	Ready bool           `json:"ready"`
 	State ContainerState `json:"state"`
+}
+
+// IsPending returns if the container doesn't have an ID
+func (c *ContainerStatus) IsPending() bool {
+	return c.ID == ""
 }
 
 // ContainerState holds a possible state of container.

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -74,12 +74,18 @@ type Status struct {
 	PodIP          string            `json:"podIP,omitempty"`
 	Containers     []ContainerStatus `json:"containerStatuses,omitempty"`
 	InitContainers []ContainerStatus `json:"initContainerStatuses,omitempty"`
-	Conditions     []Conditions      `json:"conditions,omitempty"`
+	AllContainers  []ContainerStatus
+	Conditions     []Conditions `json:"conditions,omitempty"`
 }
 
-// AllContainers returns the list of init and regular containers
-func (s *Status) AllContainers() []ContainerStatus {
-	return append(s.InitContainers, s.Containers...)
+// GetAllContainers returns the list of init and regular containers
+// the list is created lazily assuming container statuses are not modified
+func (s *Status) GetAllContainers() []ContainerStatus {
+	if len(s.AllContainers) > 0 {
+		return s.AllContainers
+	}
+	s.AllContainers = append(s.InitContainers, s.Containers...)
+	return s.AllContainers
 }
 
 // Conditions contains fields for unmarshalling a Pod.Status.Conditions

--- a/releasenotes/notes/init-stopped-container-ad-a76798efc547412c.yaml
+++ b/releasenotes/notes/init-stopped-container-ad-a76798efc547412c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Logs can now be collected from init and stopped containers (possibly short-lived).


### PR DESCRIPTION
### What does this PR do?

* Add init containers to autodiscovery
* Remove pod readiness requirements in the pod watcher
* Add readiness notion in autodiscovery services
* Add service readiness requirements in check config resolution

### Motivation

* Being able to collect logs from terminated pods (possibly short lived)
* Being able to collect logs from init containers

### Additional Notes

Anything else we should know when reviewing?
