### PR TITLE
pkg/trace/agent: parallelize processor

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -184,6 +184,7 @@ func (r *HTTPReceiver) Stop() error {
 		return err
 	}
 	r.wg.Wait()
+	close(r.Out)
 	return nil
 }
 

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -248,3 +248,9 @@ func prepareConfig(path string) (*AgentConfig, error) {
 	cfg.ConfigPath = cfgPath
 	return cfg, nil
 }
+
+// HasFeature returns true if the feature f is present. Features are values
+// of the DD_APM_FEATURES environment variable.
+func HasFeature(f string) bool {
+	return strings.Contains(os.Getenv("DD_APM_FEATURES"), f)
+}

--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -13,7 +13,6 @@ import (
 // concurrent use.
 type Obfuscator struct {
 	opts  *config.ObfuscationConfig
-	sql   *sqlObfuscator
 	es    *jsonObfuscator // nil if disabled
 	mongo *jsonObfuscator // nil if disabled
 }
@@ -23,10 +22,7 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 	if cfg == nil {
 		cfg = new(config.ObfuscationConfig)
 	}
-	o := Obfuscator{
-		opts: cfg,
-		sql:  newSQLObfuscator(),
-	}
+	o := Obfuscator{opts: cfg}
 	if cfg.ES.Enabled {
 		o.es = newJSONObfuscator(&cfg.ES)
 	}

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -206,7 +206,7 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 	if span.Resource == "" {
 		return
 	}
-	result, err := o.sql.obfuscate(span.Resource)
+	result, err := newSQLObfuscator().obfuscate(span.Resource)
 	if err != nil || result == "" {
 		// we have an error, discard the SQL to avoid polluting user resources.
 		log.Debugf("Error parsing SQL query: %q", span.Resource)

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -136,28 +136,26 @@ func (f *groupingFilter) Reset() {
 	f.groupMulti = 0
 }
 
-// sqlObfuscator is a Tokenizer consumer. It calls the Tokenizer Scan() function until tokens
-// are available or if a LEX_ERROR is raised. After retrieving a token, it is sent in the
-// tokenFilter chains so that the token is discarded or replaced.
-type sqlObfuscator struct {
-	tokenizer *Tokenizer
-	filters   []tokenFilter
-	lastToken int
-}
-
 // Process the given SQL or No-SQL string so that the resulting one is properly altered. This
 // function is generic and the behavior changes according to chosen tokenFilter implementations.
 // The process calls all filters inside the []tokenFilter.
-func (t *sqlObfuscator) obfuscate(in string) (string, error) {
-	var out bytes.Buffer
-	t.reset(in)
-	token, buff := t.tokenizer.Scan()
-	for ; token != EOFChar; token, buff = t.tokenizer.Scan() {
+func obfuscateSQLString(in string) (string, error) {
+	tokenizer := NewStringTokenizer(in)
+	filters := []tokenFilter{&discardFilter{}, &replaceFilter{}, &groupingFilter{}}
+	var (
+		out       bytes.Buffer
+		lastToken int
+	)
+	// call Scan() function until tokens are available or if a LEX_ERROR is raised. After
+	// retrieving a token, send it to the tokenFilter chains so that the token is discarded
+	// or replaced.
+	token, buff := tokenizer.Scan()
+	for ; token != EOFChar; token, buff = tokenizer.Scan() {
 		if token == LexError {
 			return "", errors.New("the tokenizer was unable to process the string")
 		}
-		for _, f := range t.filters {
-			if token, buff = f.Filter(token, t.lastToken, buff); token == LexError {
+		for _, f := range filters {
+			if token, buff = f.Filter(token, lastToken, buff); token == LexError {
 				return "", errors.New("the tokenizer was unable to process the string")
 			}
 		}
@@ -166,7 +164,7 @@ func (t *sqlObfuscator) obfuscate(in string) (string, error) {
 				switch token {
 				case ',':
 				case '=':
-					if t.lastToken == ':' {
+					if lastToken == ':' {
 						break
 					}
 					fallthrough
@@ -176,29 +174,9 @@ func (t *sqlObfuscator) obfuscate(in string) (string, error) {
 			}
 			out.Write(buff)
 		}
-		t.lastToken = token
+		lastToken = token
 	}
 	return out.String(), nil
-}
-
-// Reset restores the initial states for all components so that memory can be re-used
-func (t *sqlObfuscator) reset(in string) {
-	t.tokenizer.Reset(in)
-	for _, f := range t.filters {
-		f.Reset()
-	}
-}
-
-// newSQLObfuscator returns a new sqlObfuscator capable to process SQL and No-SQL strings.
-func newSQLObfuscator() *sqlObfuscator {
-	return &sqlObfuscator{
-		tokenizer: NewStringTokenizer(""),
-		filters: []tokenFilter{
-			&discardFilter{},
-			&replaceFilter{},
-			&groupingFilter{},
-		},
-	}
 }
 
 // QuantizeSQL generates resource and sql.query meta for SQL spans
@@ -206,7 +184,7 @@ func (o *Obfuscator) obfuscateSQL(span *pb.Span) {
 	if span.Resource == "" {
 		return
 	}
-	result, err := newSQLObfuscator().obfuscate(span.Resource)
+	result, err := obfuscateSQLString(span.Resource)
 	if err != nil || result == "" {
 		// we have an error, discard the SQL to avoid polluting user resources.
 		log.Debugf("Error parsing SQL query: %q", span.Resource)

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -393,10 +393,8 @@ func TestMultipleProcess(t *testing.T) {
 	}
 
 	// The consumer is the same between executions
-	obf := newSQLObfuscator()
-
 	for _, tc := range testCases {
-		output, err := obf.obfuscate(tc.query)
+		output, err := obfuscateSQLString(tc.query)
 		assert.Nil(err)
 		assert.Equal(tc.expected, output)
 	}
@@ -408,9 +406,8 @@ func TestConsumerError(t *testing.T) {
 	// Malformed SQL is not accepted and the outer component knows
 	// what to do with malformed SQL
 	input := "SELECT * FROM users WHERE users.id = '1 AND users.name = 'dog'"
-	obf := newSQLObfuscator()
 
-	output, err := obf.obfuscate(input)
+	output, err := obfuscateSQLString(input)
 	assert.NotNil(err)
 	assert.Equal("", output)
 }
@@ -424,14 +421,12 @@ func BenchmarkTokenizer(b *testing.B) {
 		{"Escaping", `INSERT INTO delayed_jobs (attempts, created_at, failed_at, handler, last_error, locked_at, locked_by, priority, queue, run_at, updated_at) VALUES (0, '2016-12-04 17:09:59', NULL, '--- !ruby/object:Delayed::PerformableMethod\nobject: !ruby/object:Item\n  store:\n  - a simple string\n  - an \'escaped \' string\n  - another \'escaped\' string\n  - 42\n  string: a string with many \\\\\'escapes\\\\\'\nmethod_name: :show_store\nargs: []\n', NULL, NULL, NULL, 0, NULL, '2016-12-04 17:09:59', '2016-12-04 17:09:59')`},
 		{"Grouping", `INSERT INTO delayed_jobs (created_at, failed_at, handler) VALUES (0, '2016-12-04 17:09:59', NULL), (0, '2016-12-04 17:09:59', NULL), (0, '2016-12-04 17:09:59', NULL), (0, '2016-12-04 17:09:59', NULL)`},
 	}
-	obf := newSQLObfuscator()
-
 	for _, bm := range benchmarks {
 		b.Run(bm.name+"/"+strconv.Itoa(len(bm.query)), func(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, _ = obf.obfuscate(bm.query)
+				_, _ = obfuscateSQLString(bm.query)
 			}
 		})
 	}


### PR DESCRIPTION
This change parallelizes the processor when a feature flag is set. To set the feature flag, an environment variable needs to be set, e.g.
```
DD_APM_FEATURES=parallel_process
```
Change log entry is eluded while this is hidden under feature flag.

Follows from: https://github.com/DataDog/datadog-agent/pull/3354
Other reference: https://github.com/DataDog/datadog-agent/pull/3183