### PR TITLE
pkg/trace/{api,writer}: add buffered channels to blocking goroutines

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -58,8 +58,8 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 	dynConf := sampler.NewDynamicConfig(conf.DefaultEnv)
 
 	// inter-component channels
-	rawTraceChan := make(chan pb.Trace, 5000) // about 1000 traces/sec for 5 sec, TODO: move to *model.Trace
-	tracePkgChan := make(chan *writer.TracePackage)
+	rawTraceChan := make(chan pb.Trace, 5000)
+	tracePkgChan := make(chan *writer.TracePackage, 1000)
 	statsChan := make(chan []stats.Bucket)
 	serviceChan := make(chan pb.ServicesMetadata, 50)
 	filteredServiceChan := make(chan pb.ServicesMetadata, 50)

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -772,9 +772,7 @@ func TestWatchdog(t *testing.T) {
 	defer r.Stop()
 	go func() {
 		for {
-			select {
-			case <-r.Out:
-			}
+			<-r.Out
 		}
 	}()
 

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -200,6 +200,7 @@ func TestFullIniConfig(t *testing.T) {
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,
+			InChannelSize:     10,
 			ExponentialBackoff: backoff.ExponentialConfig{
 				MaxDuration: 4 * time.Second,
 				GrowthBase:  2,
@@ -215,6 +216,7 @@ func TestFullIniConfig(t *testing.T) {
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,
+			InChannelSize:     10,
 			ExponentialBackoff: backoff.ExponentialConfig{
 				MaxDuration: 4 * time.Second,
 				GrowthBase:  2,
@@ -227,6 +229,7 @@ func TestFullIniConfig(t *testing.T) {
 		FlushPeriod:      3 * time.Second,
 		UpdateInfoPeriod: 2 * time.Second,
 		SenderConfig: writerconfig.QueuablePayloadSenderConf{
+			InChannelSize:     10,
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,

--- a/pkg/trace/writer/config/payload.go
+++ b/pkg/trace/writer/config/payload.go
@@ -12,6 +12,7 @@ type QueuablePayloadSenderConf struct {
 	MaxQueuedBytes     int64
 	MaxQueuedPayloads  int
 	ExponentialBackoff backoff.ExponentialConfig
+	InChannelSize      int
 }
 
 // DefaultQueuablePayloadSenderConf constructs a QueuablePayloadSenderConf with default sane options.
@@ -21,5 +22,6 @@ func DefaultQueuablePayloadSenderConf() QueuablePayloadSenderConf {
 		MaxQueuedBytes:     64 * 1024 * 1024, // 64 MB
 		MaxQueuedPayloads:  -1,               // Unlimited
 		ExponentialBackoff: backoff.DefaultExponentialConfig(),
+		InChannelSize:      10,
 	}
 }

--- a/pkg/trace/writer/fixtures_test.go
+++ b/pkg/trace/writer/fixtures_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
 )
 
 // payloadConstructedHandlerArgs encodes the arguments passed to a PayloadConstructedHandler call.
@@ -87,9 +88,12 @@ type testPayloadSender struct {
 // newTestPayloadSender creates a new instance of a testPayloadSender.
 func newTestPayloadSender() *testPayloadSender {
 	testEndpoint := &testEndpoint{}
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
+	queuableSender := newSender(testEndpoint, conf)
 	return &testPayloadSender{
 		testEndpoint:   testEndpoint,
-		queuableSender: newDefaultSender(testEndpoint),
+		queuableSender: queuableSender,
 	}
 }
 

--- a/pkg/trace/writer/payload.go
+++ b/pkg/trace/writer/payload.go
@@ -91,12 +91,6 @@ type queuableSender struct {
 	exit chan struct{}
 }
 
-// newDefaultSender constructs a new queuableSender with default configuration to send payloads to the
-// provided endpoint.
-func newDefaultSender(e endpoint) *queuableSender {
-	return newSender(e, writerconfig.DefaultQueuablePayloadSenderConf())
-}
-
 // newSender constructs a new QueuablePayloadSender with custom configuration to send payloads to
 // the provided endpoint.
 func newSender(e endpoint, conf writerconfig.QueuablePayloadSenderConf) *queuableSender {
@@ -104,7 +98,7 @@ func newSender(e endpoint, conf writerconfig.QueuablePayloadSenderConf) *queuabl
 		conf:           conf,
 		queuedPayloads: list.New(),
 		backoffTimer:   backoff.NewCustomExponentialTimer(conf.ExponentialBackoff),
-		in:             make(chan *payload),
+		in:             make(chan *payload, conf.InChannelSize),
 		monitorCh:      make(chan monitorEvent),
 		endpoint:       e,
 		exit:           make(chan struct{}),

--- a/pkg/trace/writer/payload_test.go
+++ b/pkg/trace/writer/payload_test.go
@@ -26,7 +26,9 @@ func TestQueuablePayloadSender_WorkingEndpoint(t *testing.T) {
 	workingEndpoint := &testEndpoint{}
 
 	// And a queuable sender using that endpoint
-	queuableSender := newDefaultSender(workingEndpoint)
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
+	queuableSender := newSender(workingEndpoint, conf)
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)

--- a/pkg/trace/writer/payload_test.go
+++ b/pkg/trace/writer/payload_test.go
@@ -74,6 +74,7 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
@@ -173,6 +174,7 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer and with a meager max queued payloads value of 1
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	conf.MaxQueuedPayloads = 1
 	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
@@ -243,6 +245,7 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	conf.MaxQueuedBytes = 10
 	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
@@ -312,6 +315,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	conf.MaxQueuedBytes = 10
 	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
@@ -368,6 +372,7 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	conf.MaxQueuedBytes = 10
 	queuableSender := newSender(workingEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
@@ -414,6 +419,7 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer and with a meager max age of 100ms
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	conf.MaxAge = 100 * time.Millisecond
 	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
@@ -486,6 +492,7 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer and with a meager max age of 200ms
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
+	conf.InChannelSize = 0 // block in tests
 	conf.MaxAge = 200 * time.Millisecond
 	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer

--- a/releasenotes/notes/apm-buffered-writer-channels-204d42dd86564375.yaml
+++ b/releasenotes/notes/apm-buffered-writer-channels-204d42dd86564375.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: minor improvements to CPU performance.


### PR DESCRIPTION
This change modifies the writer's input channel and the payload sender's
input channel into buffered ones to avoid blocking in goroutines. This is
a much better approach because it is what buffered channels were built
for, avoiding pressure on the runtime scheduler and improving parallelism.

Ref: https://github.com/golang/go/wiki/Performance#blocking-profiler

<img width="449" alt="Screen Shot 2019-04-24 at 4 44 29 PM" src="https://user-images.githubusercontent.com/6686356/56733101-75f42780-675f-11e9-9ac3-fafab5357c67.png">
