### PR TITLE
change missing mount target log to debug

### DIFF
--- a/pkg/util/containers/metrics/cgroup_detect.go
+++ b/pkg/util/containers/metrics/cgroup_detect.go
@@ -50,7 +50,7 @@ func (c ContainerCgroup) ContainerStartTime() (int64, error) {
 func (c ContainerCgroup) cgroupFilePath(target, file string) string {
 	mount, ok := c.Mounts[target]
 	if !ok {
-		log.Errorf("Missing target %s from mounts", target)
+		log.Debugf("Missing target %s from mounts", target)
 		return ""
 	}
 	targetPath, ok := c.Paths[target]

--- a/pkg/util/containers/metrics/cgroup_metrics.go
+++ b/pkg/util/containers/metrics/cgroup_metrics.go
@@ -384,8 +384,7 @@ func (c ContainerCgroup) ThreadLimit() (uint64, error) {
 	statFile := c.cgroupFilePath("pids", "pids.max")
 	lines, err := readLines(statFile)
 	if os.IsNotExist(err) {
-		log.Debugf("Missing cgroup file: %s",
-			c.cgroupFilePath("pids", "pids.max"))
+		log.Debugf("Missing cgroup file: %s", statFile)
 		return 0, nil
 	} else if err != nil {
 		return 0, err


### PR DESCRIPTION
### What does this PR do?
Changes logging from error -> debug. Also includes small refactor.

### Motivation
Errors being raised are not harmful, but will get logged when the agent doesn't find the `pids` controller (available since [linux 4.3](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt)) . Functions that make use of `cgroupFilePath` have their own local logging to handle this.

### What inspired you to submit this pull request?
https://github.com/DataDog/datadog-agent/issues/3355