### PR TITLE
Fix Issue when cluster-agent seams enable, but dca client not initialized

### DIFF
--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -21,7 +21,7 @@ import (
 func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	var err error
 	var metadataByNsPods apiv1.NamespacesPodsStringsSet
-	if c.clusterAgentEnabled && c.dcaClient.Version().Major >= 1 && c.dcaClient.Version().Minor >= 3 {
+	if c.isClusterAgentEnabled() && c.dcaClient.Version().Major >= 1 && c.dcaClient.Version().Minor >= 3 {
 		var nodeName string
 		nodeName, err = c.kubeUtil.GetNodename()
 		if err != nil {
@@ -106,7 +106,7 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 }
 
 func (c *KubeMetadataCollector) getMetadaNames(getPodMetaDataFromApiServerFunc func(string, string, string) ([]string, error), metadataByNsPods apiv1.NamespacesPodsStringsSet, po *kubelet.Pod) ([]string, error) {
-	if !c.clusterAgentEnabled {
+	if !c.isClusterAgentEnabled() {
 		metadataNames, err := getPodMetaDataFromApiServerFunc(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
 		if err != nil {
 			err = fmt.Errorf("Could not fetch cluster level tags of pod: %s, %v", po.Metadata.Name, err)

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper_test.go
@@ -149,6 +149,22 @@ func TestKubeMetadataCollector_getMetadaNames(t *testing.T) {
 		},
 
 		{
+			name: "clusterAgentEnabled enable, but old version",
+			args: args{
+				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
+					return []string{"foo=bar"}, nil
+				},
+				po: &kubelet.Pod{},
+			},
+			fields: fields{
+				clusterAgentEnabled: true,
+				dcaClient:           &clusteragent.DCAClient{},
+			},
+			want:    []string{"foo=bar"},
+			wantErr: false,
+		},
+
+		{
 			name: "clusterAgentEnabled enable, but old version, DCS return error",
 			args: args{
 				getPodMetaDataFromApiServerFunc: func(string, string, string) ([]string, error) {
@@ -301,6 +317,26 @@ func TestKubeMetadataCollector_getTagInfos(t *testing.T) {
 						"kube_service:svc1",
 						"kube_service:svc2",
 					},
+				},
+			},
+		},
+		{
+			name: "clusterAgentEnabled enable but client init failed",
+			args: args{
+				pods: pods,
+			},
+			fields: fields{
+				kubeUtil:            kubeUtilFake,
+				clusterAgentEnabled: true,
+				dcaClient:           &FakeDCAClient{},
+			},
+			want: []*TagInfo{
+				{
+					Source:               kubeMetadataCollectorName,
+					Entity:               kubelet.PodUIDToEntityName("foouid"),
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags:          []string{},
 				},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

Fix an Agent issue, when configuration says that Cluster-Agent is activated but the cluster-agent is not available (connection failed).

In addition to the check if Cluster-Agent is activated, we check that the DCAClient is properly created.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
