### PR TITLE
Add option to alias with hostname in addition to bosh_id

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -302,6 +302,7 @@ func initConfig(config Config) {
 	// Cloud Foundry
 	config.BindEnvAndSetDefault("cloud_foundry", false)
 	config.BindEnvAndSetDefault("bosh_id", "")
+	config.BindEnvAndSetDefault("cf_os_hostname_aliasing", false)
 
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -106,11 +106,11 @@ func getHostAliases() []string {
 		aliases = append(aliases, gceAlias)
 	}
 
-	cfAlias, err := cloudfoudry.GetHostAlias()
+	cfAliases, err := cloudfoundry.GetHostAliases()
 	if err != nil {
 		log.Debugf("no Cloud Foundry Host Alias: %s", err)
-	} else if cfAlias != "" {
-		aliases = append(aliases, cfAlias)
+	} else if cfAliases != nil {
+		aliases = append(aliases, cfAliases...)
 	}
 
 	k8sAlias, err := k8s.GetHostAlias()

--- a/pkg/util/cloudfoundry/cloudfoundry.go
+++ b/pkg/util/cloudfoundry/cloudfoundry.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
+var utilFqdn = util.Fqdn
+
 // GetHostAliases returns the host aliases from Cloud Foundry
 func GetHostAliases() ([]string, error) {
 	if !config.Datadog.GetBool("cloud_foundry") {
@@ -30,7 +32,7 @@ func GetHostAliases() ([]string, error) {
 	}
 
 	hostname, _ := os.Hostname()
-	fqdn := util.Fqdn(hostname)
+	fqdn := utilFqdn(hostname)
 
 	if config.Datadog.GetBool("cf_os_hostname_aliasing") {
 		// If set, send os hostname and fqdn as additional aliases

--- a/pkg/util/cloudfoundry/cloudfoundry.go
+++ b/pkg/util/cloudfoundry/cloudfoundry.go
@@ -14,7 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
-var utilFqdn = util.Fqdn
+// Define alias in order to mock in the tests
+var getFqdn = util.Fqdn
 
 // GetHostAliases returns the host aliases from Cloud Foundry
 func GetHostAliases() ([]string, error) {
@@ -32,7 +33,7 @@ func GetHostAliases() ([]string, error) {
 	}
 
 	hostname, _ := os.Hostname()
-	fqdn := utilFqdn(hostname)
+	fqdn := getFqdn(hostname)
 
 	if config.Datadog.GetBool("cf_os_hostname_aliasing") {
 		// If set, send os hostname and fqdn as additional aliases

--- a/pkg/util/cloudfoundry/cloudfoundry.go
+++ b/pkg/util/cloudfoundry/cloudfoundry.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-package cloudfoudry
+package cloudfoundry
 
 import (
 	"os"
@@ -14,18 +14,34 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
-// GetHostAlias returns the host alias from Cloud Foundry
-func GetHostAlias() (string, error) {
+// GetHostAliases returns the host aliases from Cloud Foundry
+func GetHostAliases() ([]string, error) {
 	if !config.Datadog.GetBool("cloud_foundry") {
 		log.Debugf("cloud_foundry is not enabled in the conf: no cloudfoudry host alias")
-		return "", nil
+		return nil, nil
 	}
 
+	aliases := []string{}
+
+	// Always send the bosh_id if specified
 	boshID := config.Datadog.GetString("bosh_id")
 	if boshID != "" {
-		return boshID, nil
+		aliases = append(aliases, boshID)
 	}
 
 	hostname, _ := os.Hostname()
-	return util.Fqdn(hostname), nil
+	fqdn := util.Fqdn(hostname)
+
+	if config.Datadog.GetBool("cf_os_hostname_aliasing") {
+		// If set, send os hostname and fqdn as additional aliases
+		aliases = append(aliases, hostname)
+		if fqdn != hostname {
+			aliases = append(aliases, fqdn)
+		}
+	} else if boshID == "" {
+		// If no hostname aliasing, only alias with fqdn if no bosh id
+		aliases = append(aliases, fqdn)
+	}
+
+	return aliases, nil
 }

--- a/pkg/util/cloudfoundry/cloudfoundry_test.go
+++ b/pkg/util/cloudfoundry/cloudfoundry_test.go
@@ -22,7 +22,7 @@ func TestHostAliasDisable(t *testing.T) {
 }
 
 func TestHostAlias(t *testing.T) {
-	defer func() { utilFqdn = util.Fqdn }()
+	defer func() { getFqdn = util.Fqdn }()
 	mockConfig := config.Mock()
 
 	mockConfig.Set("cloud_foundry", true)
@@ -35,7 +35,7 @@ func TestHostAlias(t *testing.T) {
 
 	mockConfig.Set("cf_os_hostname_aliasing", true)
 	// mock Fqdn returning hostname unchanged
-	utilFqdn = func(hostname string) string {
+	getFqdn = func(hostname string) string {
 		return hostname
 	}
 	aliases, err = GetHostAliases()
@@ -48,10 +48,11 @@ func TestHostAlias(t *testing.T) {
 	assert.Contains(t, aliases, hostname)
 
 	// mock Fqdn returning something different
-	utilFqdn = func(hostname string) string {
+	getFqdn = func(hostname string) string {
 		return hostname + "suffix"
 	}
 	aliases, err = GetHostAliases()
+	assert.Nil(t, err)
 	assert.Len(t, aliases, 3)
 	assert.Contains(t, aliases, "ID_CF")
 	assert.Contains(t, aliases, hostname)

--- a/releasenotes/notes/pcf_alias-0d227fd4f5d7af93.yaml
+++ b/releasenotes/notes/pcf_alias-0d227fd4f5d7af93.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add option ``cf_os_hostname_alias`` to send the OS hostname as an alias when using the BOSH agent on Cloud Foundry


### PR DESCRIPTION
### What does this PR do?

Add the option to set the OS hostname as an alias in addition to the bosh_id when running on CloudFoundry, so that it can be used alongside the `friendly_hostname` of the bosh agent (https://github.com/DataDog/datadog-agent-boshrelease/blob/2a3a3fddcbdc58ac2d1f23c94b6bf023825f9633/jobs/dd-agent/templates/config/datadog.yaml.erb#L55-L65).

### Motivation

Use case of PCF installed on vSphere managed VMs, where the vSphere integration sends OS hostnames, so that there is no host duplication, while still being able to use the friendly_hostname to identify the machines (PCF sets the OS hostname of its VMs to a GUID, so they are difficult to identify)

### Additional Notes

Anything else we should know when reviewing?