### PR TITLE
[Docker Check] add kernel memory usage metric

### DIFF
--- a/pkg/collector/corechecks/containers/docker.go
+++ b/pkg/collector/corechecks/containers/docker.go
@@ -217,6 +217,7 @@ func (d *DockerCheck) Run() error {
 				}
 			}
 
+			sender.Gauge("docker.kmem.usage", float64(c.KernMemUsage), "", tags)
 			if c.SoftMemLimit > 0 && c.SoftMemLimit < uint64(math.Pow(2, 60)) {
 				sender.Gauge("docker.mem.soft_limit", float64(c.SoftMemLimit), "", tags)
 			}

--- a/pkg/util/containers/container_linux.go
+++ b/pkg/util/containers/container_linux.go
@@ -36,6 +36,10 @@ func (c *Container) FillCgroupLimits() error {
 	if err != nil {
 		return fmt.Errorf("mem limit: %s", err)
 	}
+	c.KernMemUsage, err = c.cgroup.KernelMemoryUsage()
+	if err != nil {
+		return fmt.Errorf("kernel mem usage: %s", err)
+	}
 	c.SoftMemLimit, err = c.cgroup.SoftMemLimit()
 	if err != nil {
 		return fmt.Errorf("soft mem limit: %s", err)

--- a/pkg/util/containers/metrics/cgroup_metrics.go
+++ b/pkg/util/containers/metrics/cgroup_metrics.go
@@ -145,6 +145,20 @@ func (c ContainerCgroup) FailedMemoryCount() (uint64, error) {
 	return v, nil
 }
 
+// KernelMemoryUsage returns the number of bytes of kernel memory used by this cgroup, if it exists.
+// If the file does not exist or there is an error, then this will default to 0
+func (c ContainerCgroup) KernelMemoryUsage() (uint64, error) {
+	v, err := c.ParseSingleStat("memory", "memory.kmem.usage_in_bytes")
+	if os.IsNotExist(err) {
+		log.Debugf("Missing cgroup file: %s",
+			c.cgroupFilePath("memory", "memory.kmem.usage_in_bytes"))
+		return 0, nil
+	} else if err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
 // SoftMemLimit returns the soft memory limit of the cgroup, if it exists. If the file does not
 // exist or there is no limit then this will default to 0.
 func (c ContainerCgroup) SoftMemLimit() (uint64, error) {

--- a/pkg/util/containers/types.go
+++ b/pkg/util/containers/types.go
@@ -54,6 +54,7 @@ type Container struct {
 
 	CPULimit       float64
 	SoftMemLimit   uint64
+	KernMemUsage   uint64
 	MemLimit       uint64
 	MemFailCnt     uint64
 	CPUNrThrottled uint64

--- a/releasenotes/notes/docker-kernel-memory-usage-metric-9ae1fecc1f5c0da8.yaml
+++ b/releasenotes/notes/docker-kernel-memory-usage-metric-9ae1fecc1f5c0da8.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Extends the docker check to accommodate the kernel memory usage metric.
+    This metric shows the cgroup current kernel memory allocation.

--- a/test/integration/corechecks/docker/basemetrics_test.go
+++ b/test/integration/corechecks/docker/basemetrics_test.go
@@ -31,6 +31,7 @@ func TestContainerMetricsTagging(t *testing.T) {
 	expectedMetrics := map[string][]string{
 		"Gauge": {
 			"docker.cpu.shares",
+			"docker.kmem.usage",
 			"docker.mem.cache",
 			"docker.mem.rss",
 			"docker.mem.in_use",


### PR DESCRIPTION
### What does this PR do?

Extends Docker check to provide Kernel Memory Usage Metric

Containers run under cgroups with kernel memory accounting enabled will consume kernel memory which needs to be tracked.

### Motivation

Running Docker under CentOS 7 and hitting issues described in [runc](https://github.com/opencontainers/runc/issues/1725) and [Mesosphere DC/OS](https://support.mesosphere.com/s/article/Critical-Issue-KMEM-MSPH-2018-0006)

### Additional Notes

This metric will be zero under newer Docker (18.09) and CentOS 7 kernels. Running containers will memory limits (not kernel memory limits) under CentOS 7 with Docker 17.06 will account usage. Modern Docker on a modern kernel requires setting kernel memory limits when starting the container for this metric to take effect.

This is the Agent 6 implementation of DataDog/integrations-core#3339
