### PR TITLE
Fix initialization sequence for Six

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -84,7 +84,7 @@ func GetConfig(key *C.char, jsonPayload **C.char) {
 	value := config.Datadog.Get(goKey)
 	data, err := json.Marshal(value)
 	if err != nil {
-		log.Errorf("datadog_agent: could not convert configuration value (%v) to python types: %s", value, err)
+		log.Errorf("could not convert configuration value '%v' to JSON: %s", value, err)
 		*jsonPayload = nil
 		return
 	}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -25,10 +25,10 @@ import (
 )
 
 /*
-#include <datadog_agent_six.h>
 #cgo !windows LDFLAGS: -ldatadog-agent-six -ldl
 #cgo windows LDFLAGS: -ldatadog-agent-six -lstdc++ -static
 
+#include <datadog_agent_six.h>
 #include <stdlib.h>
 
 // helpers
@@ -205,6 +205,17 @@ func Initialize(paths ...string) error {
 		C.add_python_path(six, C.CString(p))
 	}
 
+	// Setup custom builtin before Six initialization
+	C.initCgoFree(six)
+	C.initDatadogAgentModule(six)
+	C.initAggregatorModule(six)
+	C.initUtilModule(six)
+	C.initTaggerModule(six)
+	initContainerFilter() // special init for the container go code
+	C.initContainersModule(six)
+	C.initkubeutilModule(six)
+
+	// Init Six machinery
 	C.init(six)
 
 	if C.is_initialized(six) == 0 {
@@ -232,15 +243,6 @@ func Initialize(paths ...string) error {
 	}
 
 	sendTelemetry(pythonVersion)
-
-	C.initCgoFree(six)
-	C.initDatadogAgentModule(six)
-	C.initAggregatorModule(six)
-	C.initUtilModule(six)
-	C.initTaggerModule(six)
-	initContainerFilter() // special init for the container go code
-	C.initContainersModule(six)
-	C.initkubeutilModule(six)
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Setup custom builtins *before* calling `init()` to make such builtins available to the base check during the first import.

### Motivation

Logging system not properly initialized
