### PR TITLE
pkg/trace/writer: fix panic

### DIFF
--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -178,12 +178,15 @@ func (w *TraceWriter) handleSampledTrace(pkg *TracePackage) {
 		w.flush()
 	}
 
-	log.Tracef("Handling new trace with %d spans: %v", len(pkg.Trace), pkg.Trace)
-	w.traces = append(w.traces, traceutil.APITrace(pkg.Trace))
+	if len(pkg.Trace) > 0 {
+		log.Tracef("Handling new trace with %d spans: %v", len(pkg.Trace), pkg.Trace)
+		w.traces = append(w.traces, traceutil.APITrace(pkg.Trace))
+	}
 	if len(pkg.Events) > 0 {
 		log.Tracef("Handling new APM events: %v", pkg.Events)
 		w.events = append(w.events, pkg.Events...)
 	}
+
 	w.bytesInBuffer += size
 	w.spansInBuffer += len(pkg.Trace) + len(pkg.Events)
 


### PR DESCRIPTION
A panic was detected on our staging environment when packages were sent
having only events:

```
2019-05-02 09:45:57 UTC | TRACE | ERROR | (pkg/trace/watchdog/logonpanic.go:38 in LogOnPanic) | Unexpected panic: runtime error: index out of range
goroutine 73 [running]:
github.com/DataDog/datadog-agent/pkg/trace/watchdog.LogOnPanic()
    /home/jenkins/workspace/raclette-staging/src/github.com/DataDog/datadog-agent/pkg/trace/watchdog/logonpanic.go:29 +0xc5
panic(0xa7a320, 0x108b980)
    /home/jenkins/.gimme/versions/go1.11.linux.amd64/src/runtime/panic.go:513 +0x1b9
github.com/DataDog/datadog-agent/pkg/trace/traceutil.APITrace(0x0, 0x0, 0x0, 0x2)
    /home/jenkins/workspace/raclette-staging/src/github.com/DataDog/datadog-agent/pkg/trace/traceutil/trace.go:77 +0xe4
github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).handleSampledTrace(0xc0003da240, 0xc000161530)
    /home/jenkins/workspace/raclette-staging/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:182 +0x208
github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).Run(0xc0003da240)
    /home/jenkins/workspace/raclette-staging/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:144 +0x413
github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).Start.func1(0xc0003da240)
    /home/jenkins/workspace/raclette-staging/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:98 +0x47
created by github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).Start
    /home/jenkins/workspace/raclette-staging/src/github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:96 +0x5c
```

This change fixes it. The panic does not exist in any current releases.