### PR TITLE
pkg/trace/{agent,api,writer}: add debugging metrics

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -181,7 +181,7 @@ func (a *Agent) Process(t pb.Trace) {
 	}
 
 	defer func(start time.Time) {
-		metrics.Timing("datadog.trace_agent.debug.process_trace_ms", time.Since(start), nil, 1)
+		metrics.Timing("datadog.trace_agent.internal.process_trace_ms", time.Since(start), nil, 1)
 	}(time.Now())
 
 	// Root span is used to carry some trace-level metadata, such as sampling rate and priority.
@@ -263,6 +263,9 @@ func (a *Agent) Process(t pb.Trace) {
 
 	go func(pt ProcessedTrace) {
 		defer watchdog.LogOnPanic()
+		defer func(start time.Time) {
+			metrics.Timing("datadog.trace_agent.internal.concentrator_ms", time.Since(start), nil, 1)
+		}(time.Now())
 		// Everything is sent to concentrator for stats, regardless of sampling.
 		a.Concentrator.Add(&stats.Input{
 			Trace:     pt.WeightedTrace,
@@ -279,7 +282,7 @@ func (a *Agent) Process(t pb.Trace) {
 	go func(pt ProcessedTrace) {
 		defer watchdog.LogOnPanic()
 		defer func(start time.Time) {
-			metrics.Timing("datadog.trace_agent.debug.sample_ms", time.Since(start), nil, 1)
+			metrics.Timing("datadog.trace_agent.internal.sample_ms", time.Since(start), nil, 1)
 		}(time.Now())
 
 		tracePkg := writer.TracePackage{}

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -265,7 +265,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 func (r *HTTPReceiver) processTraces(ts *info.TagStats, traces pb.Traces) {
 	now := time.Now()
 	defer func() {
-		metrics.Timing("datadog.trace_agent.receiver.process_traces_ms", time.Since(now), nil, 1)
+		metrics.Timing("datadog.trace_agent.debug.normalize_ms", time.Since(now), nil, 1)
 	}()
 	for _, trace := range traces {
 		spans := len(trace)
@@ -344,6 +344,7 @@ func (r *HTTPReceiver) loop() {
 			r.watchdog(now)
 		case now := <-t.C:
 			metrics.Gauge("datadog.trace_agent.heartbeat", 1, nil, 1)
+			metrics.Gauge("datadog.trace_agent.debug.trace_chan_len", float64(len(r.Out)), nil, 1)
 
 			// We update accStats with the new stats we collected
 			accStats.Acc(r.Stats)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -265,7 +265,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 func (r *HTTPReceiver) processTraces(ts *info.TagStats, traces pb.Traces) {
 	now := time.Now()
 	defer func() {
-		metrics.Timing("datadog.trace_agent.debug.normalize_ms", time.Since(now), nil, 1)
+		metrics.Timing("datadog.trace_agent.internal.normalize_ms", time.Since(now), nil, 1)
 	}()
 	for _, trace := range traces {
 		spans := len(trace)
@@ -344,7 +344,7 @@ func (r *HTTPReceiver) loop() {
 			r.watchdog(now)
 		case now := <-t.C:
 			metrics.Gauge("datadog.trace_agent.heartbeat", 1, nil, 1)
-			metrics.Gauge("datadog.trace_agent.debug.trace_chan_len", float64(len(r.Out)), nil, 1)
+			metrics.Gauge("datadog.trace_agent.receiver.out_chan_fill", float64(len(r.Out)/cap(r.Out)), nil, 1)
 
 			// We update accStats with the new stats we collected
 			accStats.Acc(r.Stats)

--- a/pkg/trace/test/testutil/statsd.go
+++ b/pkg/trace/test/testutil/statsd.go
@@ -6,24 +6,8 @@ import (
 	"time"
 )
 
-// StatsClientGaugeArgs represents arguments to a StatsClient Gauge method call.
-type StatsClientGaugeArgs struct {
-	Name  string
-	Value float64
-	Tags  []string
-	Rate  float64
-}
-
-// StatsClientCountArgs represents arguments to a StatsClient Count method call.
-type StatsClientCountArgs struct {
-	Name  string
-	Value int64
-	Tags  []string
-	Rate  float64
-}
-
-// StatsClientHistogramArgs represents arguments to a StatsClient Histogram method call.
-type StatsClientHistogramArgs struct {
+// MetricsArgs represents arguments to a StatsClient Gauge method call.
+type MetricsArgs struct {
 	Name  string
 	Value float64
 	Tags  []string
@@ -32,13 +16,13 @@ type StatsClientHistogramArgs struct {
 
 // CountSummary contains a summary of all Count method calls to a particular StatsClient for a particular key.
 type CountSummary struct {
-	Calls []StatsClientCountArgs
+	Calls []MetricsArgs
 	Sum   int64
 }
 
 // GaugeSummary contains a summary of all Gauge method calls to a particular StatsClient for a particular key.
 type GaugeSummary struct {
-	Calls []StatsClientGaugeArgs
+	Calls []MetricsArgs
 	Last  float64
 	Max   float64
 }
@@ -48,11 +32,13 @@ type TestStatsClient struct {
 	mu sync.RWMutex
 
 	GaugeErr       error
-	GaugeCalls     []StatsClientGaugeArgs
+	GaugeCalls     []MetricsArgs
 	CountErr       error
-	CountCalls     []StatsClientCountArgs
+	CountCalls     []MetricsArgs
 	HistogramErr   error
-	HistogramCalls []StatsClientHistogramArgs
+	HistogramCalls []MetricsArgs
+	TimingErr      error
+	TimingCalls    []MetricsArgs
 }
 
 // Reset resets client's internal records.
@@ -65,13 +51,15 @@ func (c *TestStatsClient) Reset() {
 	c.CountCalls = c.CountCalls[:0]
 	c.HistogramErr = nil
 	c.HistogramCalls = c.HistogramCalls[:0]
+	c.TimingErr = nil
+	c.TimingCalls = c.TimingCalls[:0]
 }
 
 // Gauge records a call to a Gauge operation and replies with GaugeErr
 func (c *TestStatsClient) Gauge(name string, value float64, tags []string, rate float64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.GaugeCalls = append(c.GaugeCalls, StatsClientGaugeArgs{Name: name, Value: value, Tags: tags, Rate: rate})
+	c.GaugeCalls = append(c.GaugeCalls, MetricsArgs{Name: name, Value: value, Tags: tags, Rate: rate})
 	return c.GaugeErr
 }
 
@@ -79,7 +67,7 @@ func (c *TestStatsClient) Gauge(name string, value float64, tags []string, rate 
 func (c *TestStatsClient) Count(name string, value int64, tags []string, rate float64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.CountCalls = append(c.CountCalls, StatsClientCountArgs{Name: name, Value: value, Tags: tags, Rate: rate})
+	c.CountCalls = append(c.CountCalls, MetricsArgs{Name: name, Value: float64(value), Tags: tags, Rate: rate})
 	return c.CountErr
 }
 
@@ -87,13 +75,16 @@ func (c *TestStatsClient) Count(name string, value int64, tags []string, rate fl
 func (c *TestStatsClient) Histogram(name string, value float64, tags []string, rate float64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.HistogramCalls = append(c.HistogramCalls, StatsClientHistogramArgs{Name: name, Value: value, Tags: tags, Rate: rate})
+	c.HistogramCalls = append(c.HistogramCalls, MetricsArgs{Name: name, Value: value, Tags: tags, Rate: rate})
 	return c.HistogramErr
 }
 
 // Timing records a call to a Timing operation.
 func (c *TestStatsClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
-	panic("(TestStatsClient).Timing is not implemented")
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.TimingCalls = append(c.TimingCalls, MetricsArgs{Name: name, Value: float64(value), Tags: tags, Rate: rate})
+	return c.TimingErr
 }
 
 // GetCountSummaries computes summaries for all names supplied as parameters to Count calls.
@@ -112,7 +103,7 @@ func (c *TestStatsClient) GetCountSummaries() map[string]*CountSummary {
 		}
 
 		summary.Calls = append(summary.Calls, countCall)
-		summary.Sum += countCall.Value
+		summary.Sum += int64(countCall.Value)
 	}
 
 	return result

--- a/pkg/trace/writer/payload.go
+++ b/pkg/trace/writer/payload.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer/backoff"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
@@ -141,9 +140,6 @@ func (s *queuableSender) doSend(payload *payload) (sendStats, error) {
 	}
 
 	startFlush := time.Now()
-	defer func(start time.Time) {
-		metrics.Timing("datadog.trace_agent.debug.send_payload_ms", time.Since(start), nil, 1)
-	}(startFlush)
 	err := s.endpoint.write(payload)
 
 	sendStats := sendStats{

--- a/pkg/trace/writer/payload.go
+++ b/pkg/trace/writer/payload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	"github.com/DataDog/datadog-agent/pkg/trace/writer/backoff"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
@@ -140,6 +141,9 @@ func (s *queuableSender) doSend(payload *payload) (sendStats, error) {
 	}
 
 	startFlush := time.Now()
+	defer func(start time.Time) {
+		metrics.Timing("datadog.trace_agent.debug.send_payload_ms", time.Since(start), nil, 1)
+	}(startFlush)
 	err := s.endpoint.write(payload)
 
 	sendStats := sendStats{

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -209,6 +209,10 @@ func (w *TraceWriter) flush() {
 		return
 	}
 
+	defer func(start time.Time) {
+		metrics.Timing("datadog.trace_agent.debug.trace_writer_flush_ms", time.Since(start), nil, 1)
+	}(time.Now())
+
 	atomic.AddInt64(&w.stats.Traces, int64(numTraces))
 	atomic.AddInt64(&w.stats.Events, int64(numEvents))
 	atomic.AddInt64(&w.stats.Spans, int64(w.spansInBuffer))

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -210,7 +210,7 @@ func (w *TraceWriter) flush() {
 	}
 
 	defer func(start time.Time) {
-		metrics.Timing("datadog.trace_agent.debug.trace_writer_flush_ms", time.Since(start), nil, 1)
+		metrics.Timing("datadog.trace_agent.trace_writer.flush_ms", time.Since(start), nil, 1)
 	}(time.Now())
 
 	atomic.AddInt64(&w.stats.Traces, int64(numTraces))


### PR DESCRIPTION
This change adds a set of metrics prefixed `datadog.trace_agent.internal.*`
which are meant for debugging trace-agent performance and should not be
relied upon as stable. They are subject to change or removal.