### PR TITLE
Improve invoke task to handle multiple python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ templates:
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent
-    environment:
-      PYTHON_HOME_2: /usr/
-      PYTHON_HOME_3: /usr/
-      LD_LIBRARY_PATH: /go/src/github.com/DataDog/datadog-agent/dev/lib
 
   step_templates:
     - restore_cache: &restore_deps

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,18 +145,11 @@ before_script:
 # source_test
 #
 
-.agent_test_variables: &agent_test_variables
-  PYTHON_HOME_2: /usr/
-  PYTHON_HOME_3: /usr/
-  LD_LIBRARY_PATH: $SRC_PATH/dev/lib
-
 # run tests for deb-x64
 run_tests_deb-x64:
   stage: source_test
   image: datadog/datadog-agent-runner-circle:six
   tags: [ "runner:main", "size:2xlarge" ]
-  variables:
-    <<: *agent_test_variables
   before_script:
     - cd $SRC_PATH/six
     - cmake . -DBUILD_DEMO:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=$SRC_PATH/dev
@@ -174,8 +167,6 @@ run_tests_deb-x64:
 #   stage: source_test
 #   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/rpm_x64:latest
 #   tags: [ "runner:main", "size:2xlarge" ]
-#   variables:
-#     <<: *agent_test_variables
 #   script:
 #     # Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
 #     # https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,6 @@ environment:
   # GLIB-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/glib/2.26/glib_2.26.1-1_win64.zip
   # PKG-CONFIG-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/dependencies/pkg-config_0.23-2_win64.zip
   # GETTEXT-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/dependencies/gettext-runtime_0.18.1.1-2_win64.zip
-  # TODO: Following 2 are temporary, remove when we've a better invoke task
-  PYTHON_HOME_2: C:\Python27-x64
-  PYTHON_HOME_3: C:\Python37-x64
 
 install:
   # create 'ddagentuser' user to test the secrets feature on windows
@@ -45,7 +42,7 @@ test_script:
   - bash -c "make -C test run"
   - cd ..
   - inv -e deps
-  - inv -e test --coverage --profile --fail-on-fmt
+  - inv -e test --coverage --profile --fail-on-fmt --python-home-2=C:\Python27-x64 --python-home-3=C:\Python37-x64
   - codecov -f profile.cov -F windows
 
 # uncomment to debug builds

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -32,7 +32,7 @@ build do
     command "inv -e agent.build --six-root=#{Omnibus::Config.source_dir()}/datadog-agent-six --rebuild --use-embedded-libs --no-development --embedded-path=#{install_dir}/embedded", env: env
     command "inv -e systray.build --rebuild --use-embedded-libs --no-development", env: env
   else
-    command "inv -e agent.build --rebuild --use-embedded-libs --no-development --embedded-path=#{install_dir}/embedded", env: env
+    command "inv -e agent.build --rebuild --use-embedded-libs --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded", env: env
   end
 
   if osx?

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -171,6 +171,27 @@ func sendTelemetry(pythonVersion int) {
 func Initialize(paths ...string) error {
 	pythonVersion := config.Datadog.GetInt("python_version")
 
+	if runtime.GOOS == "windows" {
+		_here, _ := executable.Folder()
+		agentpythonHome2 := filepath.Join(_here, "..", "embedded2")
+		agentpythonHome3 := filepath.Join(_here, "..", "embedded3")
+		/*
+		 * want to use the path relative embedded2/3 directories above by default;
+		 * they'll be correct for normal installation (on windows).
+		 * However, if they're not present (for cases like running unit tests) fall
+		 * back to the compile time values
+		 */
+		if _, err := os.Stat(agentpythonHome2); os.IsNotExist(err) {
+			log.Warnf("relative embedded directory not found; using default %s", pythonHome2)
+		} else {
+			pythonHome2 = agentpythonHome2
+		}
+		if _, err := os.Stat(agentpythonHome3); os.IsNotExist(err) {
+			log.Warnf("relative embedded directory not found; using default %s", pythonHome3)
+		} else {
+			pythonHome3 = agentpythonHome3
+		}
+	}
 	if pythonVersion == 2 {
 		six = C.make2(C.CString(pythonHome2))
 		log.Infof("Initializing six with python2 %s", pythonHome2)

--- a/six/three/three.cpp
+++ b/six/three/three.cpp
@@ -51,7 +51,7 @@ Three::~Three()
 
 void Three::initPythonHome(const char *pythonHome)
 {
-    if (pythonHome == NULL) {
+    if (pythonHome == NULL || strlen(pythonHome) == 0) {
         _pythonHome = Py_DecodeLocale(_defaultPythonHome, NULL);
     } else {
         if (_pythonHome) {

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -48,7 +48,7 @@ Two::~Two()
 
 void Two::initPythonHome(const char *pythonHome)
 {
-    if (pythonHome != NULL) {
+    if (pythonHome != NULL && strlen(pythonHome) != 0) {
         _pythonHome = pythonHome;
     }
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -75,7 +75,7 @@ PUPPY_CORECHECKS = [
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
           puppy=False, use_embedded_libs=False, development=True, precompile_only=False,
-          skip_assets=False, use_venv=False, embedded_path=None):
+          skip_assets=False, use_venv=False, embedded_path=None, six_root=None, python_home_2=None, python_home_3=None):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -87,8 +87,10 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
-    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs, use_venv=use_venv,
-                                            embedded_path=embedded_path)
+    ldflags, gcflags, env = get_build_flags(ctx,
+            use_embedded_libs=use_embedded_libs, use_venv=use_venv,
+            embedded_path=embedded_path, six_root=six_root,
+            python_home_2=python_home_2, python_home_3=python_home_3)
 
     if not sys.platform.startswith('linux'):
         for ex in LINUX_ONLY_TAGS:
@@ -153,7 +155,6 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
 
     if not skip_assets:
         refresh_assets(ctx, build_tags, development=development, puppy=puppy)
-
 
 @task
 def refresh_assets(ctx, build_tags, development=True, puppy=False):

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -101,7 +101,7 @@ def lint(ctx, targets):
 
 
 @task
-def vet(ctx, targets, use_embedded_libs=False):
+def vet(ctx, targets, use_embedded_libs=False, six_root=None):
     """
     Run go vet on targets.
 
@@ -118,7 +118,7 @@ def vet(ctx, targets, use_embedded_libs=False):
     build_tags = get_default_build_tags()
     build_tags.append("novet")
 
-    _, _, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
+    _, _, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs, six_root=six_root)
 
     ctx.run("go vet -tags \"{}\" ".format(" ".join(build_tags)) + " ".join(args), env=env)
     # go vet exits with status 1 when it finds an issue, if we're here

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -44,7 +44,8 @@ DEFAULT_TEST_TARGETS = [
 @task()
 def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=None,
     race=False, profile=False, use_embedded_libs=False, fail_on_fmt=False,
-    cpus=0, timeout=120):
+    six_root=None, python_home_2=None, python_home_3=None, cpus=0,
+    timeout=120):
     """
     Run all the tools and tests on the given targets. If targets are not specified,
     the value from `invoke.yaml` will be used.
@@ -76,7 +77,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     lint(ctx, targets=tool_targets)
     lint_licenses(ctx)
     print("--- Vetting:")
-    vet(ctx, targets=tool_targets, use_embedded_libs=use_embedded_libs)
+    vet(ctx, targets=tool_targets, use_embedded_libs=use_embedded_libs, six_root=six_root)
     print("--- Misspelling:")
     misspell(ctx, targets=tool_targets)
     print("--- ineffassigning:")
@@ -85,7 +86,9 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     with open(PROFILE_COV, "w") as f_cov:
         f_cov.write("mode: count")
 
-    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx,
+            use_embedded_libs=use_embedded_libs, six_root=six_root,
+            python_home_2=python_home_2, python_home_3=python_home_3)
 
     if profile:
         test_profiler = TestProfiler()

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -96,7 +96,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
     elif embedded_path:
-        ldflags += "-r {} ".format(embedded_path)
+        ldflags += "-r {}/lib ".format(embedded_path)
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -73,9 +73,7 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use
     """
     gcflags = ""
     ldflags = get_version_ldflags(ctx, prefix)
-    env = {
-        "PKG_CONFIG_PATH": pkg_config_path(use_embedded_libs),
-    }
+    env = {}
 
     if sys.platform == 'win32':
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
@@ -94,8 +92,11 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use
     env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + " -L{}".format(six_lib)
     env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + " -w -I{}".format(six_headers)
 
+    # if `static` was passed ignore setting rpath, even if `embedded_path` was passed as well
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
+    elif embedded_path:
+        ldflags += "-r {} ".format(embedded_path)
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -48,9 +48,23 @@ def pkg_config_path(use_embedded_libs):
 
     return retval
 
+def get_multi_python_location(embedded_path=None, six_root=None):
+    if embedded_path is None:
+        # fall back to local dev path
+        embedded_path = "{}/src/github.com/DataDog/datadog-agent/dev".format(os.environ.get('GOPATH'))
+
+    if six_root is None:
+        six_lib = "{}/lib".format(six_root or embedded_path)
+        six_headers = "{}/include".format(six_root or embedded_path)
+    # if six_root is specified we're working in dev mode from the six folder
+    else:
+        six_lib = "{}/six".format(six_root)
+        six_headers = "{}/include".format(six_root)
+
+    return six_lib, six_headers
 
 def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use_venv=False,
-                    embedded_path=None):
+                    embedded_path=None, six_root=None, python_home_2=None, python_home_3=None):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 
@@ -66,33 +80,22 @@ def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use
     if sys.platform == 'win32':
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
 
-    if embedded_path is None:
-        # fall back to local dev path
-        embedded_path = "{}/src/github.com/DataDog/datadog-agent/dev".format(os.environ.get('GOPATH'))
+    six_lib, six_headers = get_multi_python_location(embedded_path, six_root)
 
-    env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '')
-    env['CGO_LDFLAGS'] += " -L{}/lib ".format(embedded_path)
-    env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '')
-    env['CGO_CFLAGS'] += " -w -I{}/include".format(embedded_path)
+    # setting python homes in the code
+    if python_home_2:
+        ldflags += "-X {}/pkg/collector/python.pythonHome2={} ".format(REPO_PATH, python_home_2)
+    if python_home_3:
+        ldflags += "-X {}/pkg/collector/python.pythonHome3={} ".format(REPO_PATH, python_home_3)
 
-    # Set PYTHONHOME: env vars take precedence, useful on CI systems
-    pythonhome2 = os.environ.get('PYTHON_HOME_2', embedded_path)
-    pythonhome3 = os.environ.get('PYTHON_HOME_3', embedded_path)
-    ldflags += "-X {}/pkg/collector/python.pythonHome2={} ".format(REPO_PATH, pythonhome2)
-    ldflags += "-X {}/pkg/collector/python.pythonHome3={} ".format(REPO_PATH, pythonhome3)
+    # adding six libs and headers to the env
+    env['DYLD_LIBRARY_PATH'] = os.environ.get('DYLD_LIBRARY_PATH', '') + ":{}".format(six_lib) # OSX
+    env['LD_LIBRARY_PATH'] = os.environ.get('LD_LIBRARY_PATH', '') + ":{}".format(six_lib) # linux
+    env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + " -L{}".format(six_lib)
+    env['CGO_CFLAGS'] = os.environ.get('CGO_CFLAGS', '') + " -w -I{}".format(six_headers)
 
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
-    elif use_embedded_libs:
-        embedded_lib_path = ctx.run("pkg-config --variable=libdir python-2.7",
-                                    env=env, hide=True).stdout.strip()
-        embedded_prefix = ctx.run("pkg-config --variable=prefix python-2.7",
-                                  env=env, hide=True).stdout.strip()
-        ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, embedded_prefix)
-        ldflags += "-r {} ".format(embedded_lib_path)
-    elif use_venv and os.getenv('VIRTUAL_ENV'):
-        venv_prefix = os.getenv('VIRTUAL_ENV')
-        ldflags += "-X {}/pkg/collector/py.pythonHome={} ".format(REPO_PATH, venv_prefix)
 
     if os.environ.get("DELVE"):
         gcflags = "-N -l"


### PR DESCRIPTION
### What does this PR do?

Improve invoke to handle mutiple python version:

By default invoke will fetch six in the `dev` directory and use the system python.

Following options have bee added:
- `--six-root` to specify where six is installed
- `--python-home-2`: where python2 is located
- `--python-home-3`: where python3 is located

Locally building the agent without any env var is not possible (2 virtualenvs and a local build of `six`)
```
inv agent.build --python-home-2 /path/to/python2/venv --python-home-3 /path/to/python3/venv --six-root $PWD/six
```