### PR TITLE
pkg/trace/writer: switch flushing threshold to max.

### DIFF
--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -20,12 +20,9 @@ import (
 
 const pathTraces = "/api/v0.2/traces"
 
-// payloadMaxSize is the maximum payload size accepted by the Datadog API, after unpacking
-const payloadMaxSize = 3200000 // 3.2MB
-
 // payloadFlushThreshold specifies the maximum accumulated payload size that is allowed before
 // a flush is triggered; replaced in tests.
-var payloadFlushThreshold = int(payloadMaxSize * 60 / 100) // 60% of max
+var payloadFlushThreshold = 3200000 // 3.2MB is the maximum allowed by the Datadog API
 
 // TracePackage represents the result of a trace sampling operation.
 //


### PR DESCRIPTION
Since the current algorithm implementation [always ensures](https://github.com/DataDog/datadog-agent/blob/141f69ab97a03f843701818e4180b2744dd2debb/pkg/trace/writer/trace.go#L170-L176) that we stay under the set threshold, we should ensure that we use up the maximum amount of bytes possible per request when under pressure, to reduce the number of requests.