### PR TITLE
pkg/trace/writer: introduce concurrent writing

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -87,7 +87,6 @@ type AgentConfig struct {
 	// watchdog
 	MaxMemory        float64       // MaxMemory is the threshold (bytes allocated) above which program panics and exits, to be restarted
 	MaxCPU           float64       // MaxCPU is the max UserAvg CPU the program should consume
-	MaxConnections   int           // (deprecated) MaxConnections is the threshold (opened TCP connections) above which program panics and exits, to be restarted
 	WatchdogInterval time.Duration // WatchdogInterval is the delay between 2 watchdog checks
 
 	// http/s proxying
@@ -143,7 +142,6 @@ func New() *AgentConfig {
 
 		MaxMemory:        5e8, // 500 Mb, should rarely go above 50 Mb
 		MaxCPU:           0.5, // 50%, well behaving agents keep below 5%
-		MaxConnections:   200, // (deprecated) - use ConnectionLimit
 		WatchdogInterval: 20 * time.Second,
 
 		Ignore:                      make(map[string][]string),

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -189,7 +189,6 @@ func TestFullIniConfig(t *testing.T) {
 	assert.Equal(4, c.ReceiverTimeout)
 	assert.Equal(1234.5, c.MaxMemory)
 	assert.Equal(.85, c.MaxCPU)
-	assert.Equal(40, c.MaxConnections)
 	assert.Equal(5*time.Second, c.WatchdogInterval)
 	assert.EqualValues([]string{"/health", "/500"}, c.Ignore["resource"])
 
@@ -200,6 +199,7 @@ func TestFullIniConfig(t *testing.T) {
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,
+			MaxConnections:    1,
 			InChannelSize:     10,
 			ExponentialBackoff: backoff.ExponentialConfig{
 				MaxDuration: 4 * time.Second,
@@ -216,6 +216,7 @@ func TestFullIniConfig(t *testing.T) {
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,
+			MaxConnections:    1,
 			InChannelSize:     10,
 			ExponentialBackoff: backoff.ExponentialConfig{
 				MaxDuration: 4 * time.Second,
@@ -233,6 +234,7 @@ func TestFullIniConfig(t *testing.T) {
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,
+			MaxConnections:    200,
 			ExponentialBackoff: backoff.ExponentialConfig{
 				MaxDuration: 4 * time.Second,
 				GrowthBase:  2,
@@ -271,7 +273,6 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.Equal(50.0, c.MaxEPS)
 	assert.Equal(0.5, c.MaxCPU)
 	assert.EqualValues(123.4, c.MaxMemory)
-	assert.Equal(12, c.MaxConnections)
 	assert.Equal("0.0.0.0", c.ReceiverHost)
 	assert.True(c.LogThrottling)
 
@@ -349,7 +350,6 @@ func TestUndocumentedYamlConfig(t *testing.T) {
 	// watchdog
 	assert.Equal(0.07, c.MaxCPU)
 	assert.Equal(30e6, c.MaxMemory)
-	assert.Equal(50, c.MaxConnections)
 
 	// Assert Trace Writer
 	assert.Equal(22*time.Second, c.TraceWriterConfig.FlushPeriod)

--- a/pkg/trace/config/testdata/full.ini
+++ b/pkg/trace/config/testdata/full.ini
@@ -49,7 +49,7 @@ timeout: 4
 [trace.watchdog]
 max_memory: 1234.5
 max_cpu_percent: 85
-max_connections: 40
+max_connections: 40 # deprecated
 check_delay_seconds: 5
 
 [trace.writer.services]

--- a/pkg/trace/config/testdata/full.yaml
+++ b/pkg/trace/config/testdata/full.yaml
@@ -16,7 +16,7 @@ apm_config:
   apm_dd_url: https://datadog.unittests
   max_cpu_percent: 50
   max_memory: 123.4
-  max_connections: 12
+  max_connections: 12 # deprecated
   additional_endpoints:
     https://my1.endpoint.com:
       - apikey1

--- a/pkg/trace/config/testdata/undocumented.yaml
+++ b/pkg/trace/config/testdata/undocumented.yaml
@@ -7,7 +7,7 @@ apm_config:
   max_events_per_second: 1000.0
   receiver_port: 25
   max_cpu_percent: 7
-  max_connections: 50
+  max_connections: 50 # deprecated
   max_memory: 30000000
   trace_writer:
     flush_period_seconds: 22

--- a/pkg/trace/writer/config/payload.go
+++ b/pkg/trace/writer/config/payload.go
@@ -11,6 +11,7 @@ type QueuablePayloadSenderConf struct {
 	MaxAge             time.Duration
 	MaxQueuedBytes     int64
 	MaxQueuedPayloads  int
+	MaxConnections     int
 	ExponentialBackoff backoff.ExponentialConfig
 	InChannelSize      int
 }
@@ -21,6 +22,7 @@ func DefaultQueuablePayloadSenderConf() QueuablePayloadSenderConf {
 		MaxAge:             20 * time.Minute,
 		MaxQueuedBytes:     64 * 1024 * 1024, // 64 MB
 		MaxQueuedPayloads:  -1,               // Unlimited
+		MaxConnections:     1,
 		ExponentialBackoff: backoff.DefaultExponentialConfig(),
 		InChannelSize:      10,
 	}

--- a/pkg/trace/writer/fixtures_test.go
+++ b/pkg/trace/writer/fixtures_test.go
@@ -112,7 +112,7 @@ func (c *testPayloadSender) Run() {
 			stats, err := c.doSend(payload)
 
 			if err != nil {
-				c.notifyError(payload, err, stats)
+				c.notifyError(payload, err)
 			} else {
 				c.notifySuccess(payload, stats)
 			}

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"container/list"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
@@ -74,15 +75,15 @@ type payloadSender interface {
 // queuableSender is a specific implementation of a payloadSender that will queue new payloads on error and
 // retry sending them according to some configurable BackoffTimer.
 type queuableSender struct {
-	conf              writerconfig.QueuablePayloadSenderConf
+	conf writerconfig.QueuablePayloadSenderConf
+
+	mu                sync.RWMutex // guards below group
 	queuedPayloads    *list.List
-	queuing           bool
 	currentQueuedSize int64
+	backoffTimer      backoff.Timer
 
-	backoffTimer backoff.Timer
-
-	// Test helper
-	syncBarrier <-chan interface{}
+	syncBarrier <-chan interface{} // used only in tests
+	wg          sync.WaitGroup     // tracks active sends
 
 	in        chan *payload
 	monitorCh chan monitorEvent
@@ -115,6 +116,7 @@ func (s *queuableSender) Stop() {
 	s.exit <- struct{}{}
 	<-s.exit
 	close(s.in)
+	s.wg.Wait()
 	close(s.monitorCh)
 }
 
@@ -155,14 +157,34 @@ func (s *queuableSender) Start() {
 // Run executes the queuableSender main logic synchronously.
 func (s *queuableSender) Run() {
 	defer close(s.exit)
+	sema := make(chan struct{}, s.conf.MaxConnections)
 
 	for {
 		select {
 		case payload := <-s.in:
-			if stats, err := s.sendOrQueue(payload); err != nil {
-				log.Debugf("Error while sending or queueing payload. err=%v", err)
-				s.notifyError(payload, err, stats)
+			if payload == nil {
+				continue
 			}
+			s.mu.RLock()
+			queuing := s.queuedPayloads.Len() > 0
+			s.mu.RUnlock()
+			if queuing {
+				if err := s.enqueue(payload); err != nil {
+					log.Debugf("Error while queueing payload: %v", err)
+					s.notifyError(payload, err)
+				}
+				continue
+			}
+			sema <- struct{}{}
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+				if err := s.trySend(payload); err != nil {
+					log.Debugf("Error while sending or queueing payload. err=%v", err)
+					s.notifyError(payload, err)
+				}
+				<-sema
+			}()
 		case <-s.backoffTimer.ReceiveTick():
 			s.flushQueue()
 		case <-s.syncBarrier:
@@ -177,47 +199,33 @@ func (s *queuableSender) Run() {
 	}
 }
 
-// NumQueuedPayloads returns the number of payloads currently waiting in the queue for a retry
-func (s *queuableSender) NumQueuedPayloads() int {
-	return s.queuedPayloads.Len()
-}
-
-// sendOrQueue sends the provided payload or queues it if this sender is currently queueing payloads.
-func (s *queuableSender) sendOrQueue(payload *payload) (sendStats, error) {
-	var stats sendStats
-
-	if payload == nil {
-		return stats, nil
-	}
-
-	var err error
-
-	if !s.queuing {
-		if stats, err = s.doSend(payload); err != nil {
-			if _, ok := err.(*retriableError); ok {
-				// If error is retriable, start a queue and schedule a retry
-				retryNum, delay := s.backoffTimer.ScheduleRetry(err)
-				log.Debugf("Got retriable error. Starting a queue. delay=%s, err=%v", delay, err)
-				s.notifyRetry(payload, err, delay, retryNum)
-				return stats, s.enqueue(payload)
-			}
-		} else {
-			// If success, notify
-			log.Tracef("Successfully sent direct payload: %v", payload)
-			s.notifySuccess(payload, stats)
+// trySend sends the provided payload or queues it if this sender is currently queueing payloads.
+func (s *queuableSender) trySend(payload *payload) error {
+	stats, err := s.doSend(payload)
+	if err != nil {
+		if _, ok := err.(*retriableError); ok {
+			// start a retry queue
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			retryNum, delay := s.backoffTimer.ScheduleRetry(err)
+			log.Debugf("Got retriable error. Starting a queue. delay=%s, err=%v", delay, err)
+			s.notifyRetry(payload, err, delay, retryNum)
+			return s.enqueueLocked(payload)
 		}
-	} else {
-		return stats, s.enqueue(payload)
+		return err
 	}
-
-	return stats, err
+	log.Tracef("Successfully sent direct payload: %v", payload)
+	s.notifySuccess(payload, stats)
+	return nil
 }
 
-func (s *queuableSender) enqueue(payload *payload) error {
-	if !s.queuing {
-		s.queuing = true
-	}
+func (s *queuableSender) enqueue(p *payload) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.enqueueLocked(p)
+}
 
+func (s *queuableSender) enqueueLocked(payload *payload) error {
 	// Start by discarding payloads that are too old, freeing up memory
 	s.discardOldPayloads()
 
@@ -251,7 +259,9 @@ func (s *queuableSender) enqueue(payload *payload) error {
 }
 
 func (s *queuableSender) flushQueue() error {
-	log.Debugf("Attempting to flush queue with %d payloads", s.NumQueuedPayloads())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	log.Debugf("Attempting to flush queue with %d payloads", s.queuedPayloads.Len())
 
 	// Start by discarding payloads that are too old
 	s.discardOldPayloads()
@@ -277,7 +287,7 @@ func (s *queuableSender) flushQueue() error {
 
 			// If send failed due to non-retriable error, notify error and drop it
 			log.Debugf("Dropping payload due to non-retriable error: err=%v, payload=%v", err, payload)
-			s.notifyError(payload, err, stats)
+			s.notifyError(payload, err)
 			next = s.removeQueuedPayload(e)
 			// Try sending next ones
 			continue
@@ -289,7 +299,6 @@ func (s *queuableSender) flushQueue() error {
 		next = s.removeQueuedPayload(e)
 	}
 
-	s.queuing = false
 	s.backoffTimer.Reset()
 
 	return nil
@@ -324,7 +333,7 @@ func (s *queuableSender) discardOldPayloads() {
 
 		err := fmt.Errorf("payload is older than max age: age=%v, max age=%v", age, s.conf.MaxAge)
 		log.Tracef("Discarding payload: err=%v, payload=%v", err, payload)
-		s.notifyError(payload, err, sendStats{})
+		s.notifyError(payload, err)
 		next = s.removeQueuedPayload(e)
 	}
 }
@@ -338,7 +347,7 @@ func (s *queuableSender) dropOldestPayload(reason string) (*payload, error) {
 	err := fmt.Errorf("payload dropped: %s", reason)
 	droppedPayload := s.queuedPayloads.Front().Value.(*payload)
 	s.removeQueuedPayload(s.queuedPayloads.Front())
-	s.notifyError(droppedPayload, err, sendStats{})
+	s.notifyError(droppedPayload, err)
 
 	return droppedPayload, nil
 }
@@ -351,7 +360,7 @@ func (s *queuableSender) notifySuccess(payload *payload, sendStats sendStats) {
 	})
 }
 
-func (s *queuableSender) notifyError(payload *payload, err error, sendStats sendStats) {
+func (s *queuableSender) notifyError(payload *payload, err error) {
 	s.sendEvent(&monitorEvent{
 		typ:     eventTypeFailure,
 		payload: payload,

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -56,9 +56,9 @@ func TestQueuablePayloadSender_WorkingEndpoint(t *testing.T) {
 	// Then we expect all sent payloads to have been successfully sent
 	successPayloads := monitor.SuccessPayloads()
 	errorPayloads := monitor.FailurePayloads()
-	assert.Equal([]*payload{payload1, payload2, payload3, payload4, payload5}, successPayloads,
+	assert.ElementsMatch([]*payload{payload1, payload2, payload3, payload4, payload5}, successPayloads,
 		"Expect all sent payloads to have been successful")
-	assert.Equal(successPayloads, workingEndpoint.SuccessPayloads(), "Expect sender and endpoint to match on successful payloads")
+	assert.ElementsMatch(successPayloads, workingEndpoint.SuccessPayloads(), "Expect sender and endpoint to match on successful payloads")
 	assert.Len(errorPayloads, 0, "No payloads should have errored out on send")
 	assert.Len(workingEndpoint.ErrorPayloads(), 0, "No payloads should have errored out on send")
 }
@@ -79,6 +79,10 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -93,16 +97,18 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	payload2 := randomPayload()
 	queuableSender.Send(payload2)
 
-	// Make sure sender processed both payloads
-	syncBarrier <- nil
+	wait()
 
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "Expect no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "Expect no queued payloads")
 
 	// With a failing endpoint with a retriable error
 	flakyEndpoint.SetError(&retriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint})
 	// We send some payloads
 	payload3 := randomPayload()
 	queuableSender.Send(payload3)
+
+	wait()
+
 	payload4 := randomPayload()
 	queuableSender.Send(payload4)
 	// And retry once
@@ -110,20 +116,18 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	// And retry twice
 	testBackoffTimer.TriggerTick()
 
-	// Make sure sender processed both ticks
-	syncBarrier <- nil
+	wait()
 
-	assert.Equal(2, queuableSender.NumQueuedPayloads(), "Expect 2 queued payloads")
+	assert.Equal(2, queuableSender.queuedPayloads.Len(), "Expect 2 queued payloads")
 
 	// With the previously failing endpoint working again
 	flakyEndpoint.SetError(nil)
 	// We retry for the third time
 	testBackoffTimer.TriggerTick()
 
-	// Make sure sender processed previous tick
-	syncBarrier <- nil
+	wait()
 
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "Expect no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "Expect no queued payloads")
 
 	// Finally, with a failing endpoint with a non-retriable error
 	flakyEndpoint.SetError(fmt.Errorf("non retriable bleh"))
@@ -133,10 +137,9 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	payload6 := randomPayload()
 	queuableSender.Send(payload6)
 
-	// Make sure sender processed previous payloads
-	syncBarrier <- nil
+	wait()
 
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "Expect no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "Expect no queued payloads")
 
 	// With the previously failing endpoint working again
 	flakyEndpoint.SetError(nil)
@@ -153,13 +156,13 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	successPayloads := monitor.SuccessPayloads()
 	errorPayloads := monitor.FailurePayloads()
 	retryPayloads := monitor.RetryPayloads()
-	assert.Equal([]*payload{payload1, payload2, payload3, payload4}, successPayloads,
+	assert.ElementsMatch([]*payload{payload1, payload2, payload3, payload4}, successPayloads,
 		"Expect all sent payloads to have been successful")
-	assert.Equal(successPayloads, flakyEndpoint.SuccessPayloads(), "Expect sender and endpoint to match on successful payloads")
+	assert.ElementsMatch(successPayloads, flakyEndpoint.SuccessPayloads(), "Expect sender and endpoint to match on successful payloads")
 	// Expect 3 retry events for payload 3 (one because of first send, two others because of the two retries)
-	assert.Equal([]*payload{payload3, payload3, payload3}, retryPayloads, "Expect payload 3 to have been retries 3 times")
+	assert.ElementsMatch([]*payload{payload3, payload3, payload3}, retryPayloads, "Expect payload 3 to have been retries 3 times")
 	// We expect payloads 5 and 6 to appear in error payloads as they failed for non-retriable errors.
-	assert.Equal([]*payload{payload5, payload6}, errorPayloads, "Expect errored payloads to have been discarded as expected")
+	assert.ElementsMatch([]*payload{payload5, payload6}, errorPayloads, "Expect errored payloads to have been discarded as expected")
 }
 
 func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
@@ -180,6 +183,10 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -190,29 +197,27 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	// When sending a first payload
 	payload1 := randomPayload()
 	queuableSender.Send(payload1)
+	wait()
 
 	// Followed by another one
 	payload2 := randomPayload()
 	queuableSender.Send(payload2)
+	wait()
 
 	// Followed by a third
 	payload3 := randomPayload()
 	queuableSender.Send(payload3)
-
-	// Ensure previous payloads were processed
-	syncBarrier <- nil
+	wait()
 
 	// Then, when the endpoint finally works
 	flakyEndpoint.SetError(nil)
 
 	// And we trigger a retry
 	testBackoffTimer.TriggerTick()
-
-	// Ensure tick was processed
-	syncBarrier <- nil
+	wait()
 
 	// Then we should have no queued payloads
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "We should have no queued payloads")
 
 	// When we stop the sender
 	queuableSender.Stop()
@@ -220,12 +225,12 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 
 	// Then endpoint should have received only payload3. Other should have been discarded because max queued payloads
 	// is 1
-	assert.Equal([]*payload{payload3}, flakyEndpoint.SuccessPayloads(), "Endpoint should have received only payload 3")
+	assert.ElementsMatch([]*payload{payload3}, flakyEndpoint.SuccessPayloads(), "Endpoint should have received only payload 3")
 
 	// Monitor should agree on previous fact
-	assert.Equal([]*payload{payload3}, monitor.SuccessPayloads(),
+	assert.ElementsMatch([]*payload{payload3}, monitor.SuccessPayloads(),
 		"Monitor should agree with endpoint on successful payloads")
-	assert.Equal([]*payload{payload1, payload2}, monitor.FailurePayloads(),
+	assert.ElementsMatch([]*payload{payload1, payload2}, monitor.FailurePayloads(),
 		"Monitor should agree with endpoint on failed payloads")
 	assert.Contains(monitor.FailureEvents()[0].err.Error(), "max queued payloads",
 		"Monitor failure event should mention correct reason for error")
@@ -251,6 +256,10 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -261,17 +270,17 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	// When sending a first payload of 4 bytes
 	payload1 := randomSizedPayload(4)
 	queuableSender.Send(payload1)
+	wait()
 
 	// Followed by another one of 2 bytes
 	payload2 := randomSizedPayload(2)
 	queuableSender.Send(payload2)
+	wait()
 
 	// Followed by a third of 8 bytes
 	payload3 := randomSizedPayload(8)
 	queuableSender.Send(payload3)
-
-	// Ensure previous payloads were processed
-	syncBarrier <- nil
+	wait()
 
 	// Then, when the endpoint finally works
 	flakyEndpoint.SetError(nil)
@@ -279,11 +288,10 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	// And we trigger a retry
 	testBackoffTimer.TriggerTick()
 
-	// Ensure tick was processed
-	syncBarrier <- nil
+	wait()
 
 	// Then we should have no queued payloads
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "We should have no queued payloads")
 
 	// When we stop the sender
 	queuableSender.Stop()
@@ -291,13 +299,13 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 
 	// Then endpoint should have received payload2 and payload3. Payload1 should have been discarded because keeping all
 	// 3 would have put us over the max size of sender
-	assert.Equal([]*payload{payload2, payload3}, flakyEndpoint.SuccessPayloads(),
+	assert.ElementsMatch([]*payload{payload2, payload3}, flakyEndpoint.SuccessPayloads(),
 		"Endpoint should have received only payload 2 and 3 (in that order)")
 
 	// Monitor should agree on previous fact
-	assert.Equal([]*payload{payload2, payload3}, monitor.SuccessPayloads(),
+	assert.ElementsMatch([]*payload{payload2, payload3}, monitor.SuccessPayloads(),
 		"Monitor should agree with endpoint on successful payloads")
-	assert.Equal([]*payload{payload1}, monitor.FailurePayloads(),
+	assert.ElementsMatch([]*payload{payload1}, monitor.FailurePayloads(),
 		"Monitor should agree with endpoint on failed payloads")
 	assert.Contains(monitor.FailureEvents()[0].err.Error(), "max queued bytes",
 		"Monitor failure event should mention correct reason for error")
@@ -321,6 +329,10 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -332,8 +344,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	payload1 := randomSizedPayload(12)
 	queuableSender.Send(payload1)
 
-	// Ensure previous payloads were processed
-	syncBarrier <- nil
+	wait()
 
 	// Then, when the endpoint finally works
 	flakyEndpoint.SetError(nil)
@@ -341,11 +352,10 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	// And we trigger a retry
 	testBackoffTimer.TriggerTick()
 
-	// Ensure tick was processed
-	syncBarrier <- nil
+	wait()
 
 	// Then we should have no queued payloads
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "We should have no queued payloads")
 
 	// When we stop the sender
 	queuableSender.Stop()
@@ -355,7 +365,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	assert.Len(flakyEndpoint.SuccessPayloads(), 0, "Endpoint should have received no payloads")
 
 	// And monitor should have received failed event for payload1 with correct reason
-	assert.Equal([]*payload{payload1}, monitor.FailurePayloads(),
+	assert.ElementsMatch([]*payload{payload1}, monitor.FailurePayloads(),
 		"Monitor should agree with endpoint on failed payloads")
 	assert.Contains(monitor.FailureEvents()[0].err.Error(), "bigger than max size",
 		"Monitor failure event should mention correct reason for error")
@@ -378,6 +388,10 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -389,21 +403,20 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	payload1 := randomSizedPayload(12)
 	queuableSender.Send(payload1)
 
-	// Ensure previous payloads were processed
-	syncBarrier <- nil
+	wait()
 
 	// Then we should have no queued payloads
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "We should have no queued payloads")
 
 	// When we stop the sender
 	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then endpoint should have received payload1 because although it was big, it didn't get queued.
-	assert.Equal([]*payload{payload1}, workingEndpoint.SuccessPayloads(), "Endpoint should have received payload1")
+	assert.ElementsMatch([]*payload{payload1}, workingEndpoint.SuccessPayloads(), "Endpoint should have received payload1")
 
 	// And monitor should have received success event for payload1
-	assert.Equal([]*payload{payload1}, monitor.SuccessPayloads(),
+	assert.ElementsMatch([]*payload{payload1}, monitor.SuccessPayloads(),
 		"Monitor should agree with endpoint on success payloads")
 }
 
@@ -425,6 +438,10 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -448,8 +465,7 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	// And then triggering a retry
 	testBackoffTimer.TriggerTick()
 
-	// Ensure tick was processed
-	syncBarrier <- nil
+	wait()
 
 	// Then, when the endpoint finally works
 	flakyEndpoint.SetError(nil)
@@ -457,11 +473,10 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	// And we trigger a retry
 	testBackoffTimer.TriggerTick()
 
-	// Ensure tick was processed
-	syncBarrier <- nil
+	wait()
 
 	// Then we should have no queued payloads
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "We should have no queued payloads")
 
 	// When we stop the sender
 	queuableSender.Stop()
@@ -469,10 +484,10 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 
 	// Then endpoint should have received only payload3. Because payload1 and payload2 were too old after the failed
 	// retry (first TriggerTick).
-	assert.Equal([]*payload{payload3}, flakyEndpoint.SuccessPayloads(), "Endpoint should have received only payload 3")
+	assert.ElementsMatch([]*payload{payload3}, flakyEndpoint.SuccessPayloads(), "Endpoint should have received only payload 3")
 
 	// And monitor should have received failed events for payload1 and payload2 with correct reason
-	assert.Equal([]*payload{payload1, payload2}, monitor.FailurePayloads(),
+	assert.ElementsMatch([]*payload{payload1, payload2}, monitor.FailurePayloads(),
 		"Monitor should agree with endpoint on failed payloads")
 	assert.Contains(monitor.FailureEvents()[0].err.Error(), "older than max age",
 		"Monitor failure event should mention correct reason for error")
@@ -498,6 +513,10 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
+	wait := func() {
+		syncBarrier <- nil
+		queuableSender.wg.Wait()
+	}
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -521,8 +540,7 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 	payload3 := randomPayload()
 	queuableSender.Send(payload3)
 
-	// Wait for payload to be queued
-	syncBarrier <- nil
+	wait()
 
 	// Then, when the endpoint finally works
 	flakyEndpoint.SetError(nil)
@@ -535,14 +553,14 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 	monitor.Stop()
 
 	// Then we should have no queued payloads
-	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+	assert.Equal(0, queuableSender.queuedPayloads.Len(), "We should have no queued payloads")
 
 	// Then endpoint should have received only payload3. Because payload1 and payload2 were too old after the failed
 	// retry (first TriggerTick).
-	assert.Equal([]*payload{payload3}, flakyEndpoint.SuccessPayloads(), "Endpoint should have received only payload 3")
+	assert.ElementsMatch([]*payload{payload3}, flakyEndpoint.SuccessPayloads(), "Endpoint should have received only payload 3")
 
 	// And monitor should have received failed events for payload1 and payload2 with correct reason
-	assert.Equal([]*payload{payload1, payload2}, monitor.FailurePayloads(),
+	assert.ElementsMatch([]*payload{payload1, payload2}, monitor.FailurePayloads(),
 		"Monitor should agree with endpoint on failed payloads")
 	assert.Contains(monitor.FailureEvents()[0].err.Error(), "older than max age",
 		"Monitor failure event should mention correct reason for error")

--- a/releasenotes/notes/apm-concurrent-writing-bfb28ce8db427391.yaml
+++ b/releasenotes/notes/apm-concurrent-writing-bfb28ce8db427391.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: improved trace writer performance by introducing concurrent writing.


### PR DESCRIPTION
Allow sending concurrent HTTP requests in the trace writer. We should consider parallelizing the retry queue as well.

⚠️ Tests for this component are becoming more hacky and we're introducing a bit of technical debt: this component needs a slight (follow-up) refactor to allow better unit testing.