### PR TITLE
Skip vet on python package

### DIFF
--- a/pkg/collector/python/aggregator_test.go
+++ b/pkg/collector/python/aggregator_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build python
+// +build python,test
 
 package python
 

--- a/pkg/collector/python/datadog_agent_test.go
+++ b/pkg/collector/python/datadog_agent_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build python
+// +build python,test
 
 package python
 

--- a/pkg/collector/python/kubeutil_test.go
+++ b/pkg/collector/python/kubeutil_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build python,kubelet
+// +build python,kubelet,test
 
 package python
 

--- a/pkg/collector/python/tagger_test.go
+++ b/pkg/collector/python/tagger_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build python
+// +build python,test
 
 package python
 

--- a/pkg/collector/python/util_test.go
+++ b/pkg/collector/python/util_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build python
+// +build python,test
 
 package python
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -117,7 +117,6 @@ def vet(ctx, targets, use_embedded_libs=False, six_root=None):
     args = ["{}/...".format(t) for t in targets]
     build_tags = get_default_build_tags()
     build_tags.append("novet")
-    build_tags.append("test")
 
     _, _, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs, six_root=six_root)
 
@@ -229,7 +228,7 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
     start = datetime.datetime.now()
     ctx.run("dep ensure{}".format(verbosity))
     dep_done = datetime.datetime.now()
-    
+
     # If github.com/DataDog/datadog-agent gets vendored too - nuke it
     #
     # This may happen as a result of having to introduce DEPPROJECTROOT

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -91,6 +91,9 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
             use_embedded_libs=use_embedded_libs, six_root=six_root,
             python_home_2=python_home_2, python_home_3=python_home_3)
 
+    if sys.platform == 'win32':
+        ldflags += ' -Wl,--allow-multiple-definition '
+
     if profile:
         test_profiler = TestProfiler()
     else:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -92,7 +92,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
             python_home_2=python_home_2, python_home_3=python_home_3)
 
     if sys.platform == 'win32':
-        ldflags += ' -Wl,--allow-multiple-definition '
+        ldflags += ' --allow-multiple-definition '
 
     if profile:
         test_profiler = TestProfiler()

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -92,7 +92,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
             python_home_2=python_home_2, python_home_3=python_home_3)
 
     if sys.platform == 'win32':
-        ldflags += ' --allow-multiple-definition '
+        env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'
 
     if profile:
         test_profiler = TestProfiler()


### PR DESCRIPTION
### What does this PR do?

Skip `go vet` for the test helpers and the test modules depending on them. Allow duplicate symbols on Windows.

### Motivation

Tests are failing on Windows because of multiple definitions of C code (from Six and from the mocking in the test helpers)
