### PR TITLE
Remove '--use-embedded-libs' option which is no longer used

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -29,10 +29,10 @@ build do
 
   # we assume the go deps are already installed before running omnibus
   if windows?
-    command "inv -e agent.build --six-root=#{Omnibus::Config.source_dir()}/datadog-agent-six --rebuild --use-embedded-libs --no-development --embedded-path=#{install_dir}/embedded", env: env
-    command "inv -e systray.build --rebuild --use-embedded-libs --no-development", env: env
+    command "inv -e agent.build --six-root=#{Omnibus::Config.source_dir()}/datadog-agent-six --rebuild --no-development --embedded-path=#{install_dir}/embedded", env: env
+    command "inv -e systray.build --rebuild --no-development", env: env
   else
-    command "inv -e agent.build --rebuild --use-embedded-libs --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded", env: env
+    command "inv -e agent.build --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded", env: env
   end
 
   if osx?

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -22,7 +22,7 @@ build do
   }
 
   # we assume the go deps are already installed before running omnibus
-  command "invoke dogstatsd.build --rebuild --use-embedded-libs", env: env
+  command "invoke dogstatsd.build --rebuild", env: env
 
   mkdir "#{install_dir}/etc/datadog-dogstatsd"
   unless windows?

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -74,8 +74,8 @@ PUPPY_CORECHECKS = [
 
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-          puppy=False, use_embedded_libs=False, development=True, precompile_only=False,
-          skip_assets=False, use_venv=False, embedded_path=None, six_root=None, python_home_2=None, python_home_3=None):
+          puppy=False, development=True, precompile_only=False, skip_assets=False,
+          use_venv=False, embedded_path=None, six_root=None, python_home_2=None, python_home_3=None):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -87,8 +87,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
-    ldflags, gcflags, env = get_build_flags(ctx,
-            use_embedded_libs=use_embedded_libs, use_venv=use_venv,
+    ldflags, gcflags, env = get_build_flags(ctx, use_venv=use_venv,
             embedded_path=embedded_path, six_root=six_root,
             python_home_2=python_home_2, python_home_3=python_home_3)
 

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -36,8 +36,7 @@ ANDROID_CORECHECKS = [
 CORECHECK_CONFS_DIR = "cmd/agent/android/app/src/main/assets/conf.d"
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-        use_embedded_libs=False, development=True, precompile_only=False,
-          skip_assets=False):
+        development=True, precompile_only=False, skip_assets=False):
     """
     Build the android apk. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.
@@ -55,7 +54,7 @@ def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 
-    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx)
 
     if not sys.platform.startswith('linux'):
         for ex in LINUX_ONLY_TAGS:

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -92,7 +92,7 @@ def get_build_tags(include, exclude):
 
 
 @task
-def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False, csv=False):
+def audit_tag_impact(ctx, build_exclude=None, csv=False):
     """
     Measure each tag's contribution to the binary size
     """
@@ -100,17 +100,17 @@ def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False, csv=False
 
     tags_to_audit = ALL_TAGS.difference(set(build_exclude)).difference(set(PUPPY_TAGS))
 
-    max_size = _compute_build_size(ctx, build_exclude=','.join(build_exclude), use_embedded_libs=use_embedded_libs)
+    max_size = _compute_build_size(ctx, build_exclude=','.join(build_exclude))
     print("size with all tags is {} kB".format(max_size / 1000))
 
-    puppy_size = _compute_build_size(ctx, puppy=True, use_embedded_libs=use_embedded_libs)
+    puppy_size = _compute_build_size(ctx, puppy=True)
     print("puppy size is {} kB\n".format(puppy_size / 1000))
 
     report = {"unaccounted": max_size - puppy_size, "puppy": puppy_size}
 
     for tag in tags_to_audit:
         exclude_string = ','.join(build_exclude + [tag])
-        size = _compute_build_size(ctx, build_exclude=exclude_string, use_embedded_libs=use_embedded_libs)
+        size = _compute_build_size(ctx, build_exclude=exclude_string)
         delta = (max_size - size)
         print("tag {} adds {} kB (excludes: {})".format(tag, delta / 1000, exclude_string))
         report[tag] = delta
@@ -122,11 +122,10 @@ def audit_tag_impact(ctx, build_exclude=None, use_embedded_libs=False, csv=False
             print("{};{}".format(k, v))
 
 
-def _compute_build_size(ctx, build_exclude=None, use_embedded_libs=False, puppy=False):
+def _compute_build_size(ctx, build_exclude=None, puppy=False):
     import os
     from .agent import build as agent_build
-    agent_build(ctx, build_exclude=build_exclude, use_embedded_libs=use_embedded_libs,
-                skip_assets=True, puppy=puppy)
+    agent_build(ctx, build_exclude=build_exclude, skip_assets=True, puppy=puppy)
 
     statinfo = os.stat('bin/agent/agent')
     return statinfo.st_size

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -26,7 +26,7 @@ DEFAULT_BUILD_TAGS = [
 
 @task
 def build(ctx, rebuild=False, build_include=None, build_exclude=None,
-          race=False, use_embedded_libs=False, development=True, skip_assets=False):
+          race=False, development=True, skip_assets=False):
     """
     Build Cluster Agent
 
@@ -38,7 +38,7 @@ def build(ctx, rebuild=False, build_include=None, build_exclude=None,
     build_tags = get_build_tags(build_include, build_exclude)
 
     # We rely on the go libs embedded in the debian stretch image to build dynamically
-    ldflags, gcflags, env = get_build_flags(ctx, static=False, use_embedded_libs=use_embedded_libs, prefix='dca')
+    ldflags, gcflags, env = get_build_flags(ctx, static=False, prefix='dca')
 
     cmd = "go build {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent"

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -33,14 +33,14 @@ DEFAULT_BUILD_TAGS = [
 
 @task
 def build(ctx, rebuild=False, race=False, static=False, build_include=None,
-          build_exclude=None, use_embedded_libs=False):
+          build_exclude=None):
     """
     Build Dogstatsd
     """
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     build_tags = get_build_tags(build_include, build_exclude)
-    ldflags, gcflags, env = get_build_flags(ctx, static=static, use_embedded_libs=use_embedded_libs)
+    ldflags, gcflags, env = get_build_flags(ctx, static=static)
     bin_path = DOGSTATSD_BIN_PATH
 
     if static:

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -10,7 +10,7 @@ import sys
 from invoke import task
 from invoke.exceptions import Exit
 from .build_tags import get_default_build_tags
-from .utils import pkg_config_path, get_build_flags
+from .utils import get_build_flags
 from .bootstrap import get_deps, process_deps
 
 #We use `basestring` in the code for compat with python2 unicode strings.
@@ -101,7 +101,7 @@ def lint(ctx, targets):
 
 
 @task
-def vet(ctx, targets, use_embedded_libs=False, six_root=None):
+def vet(ctx, targets, six_root=None):
     """
     Run go vet on targets.
 
@@ -118,7 +118,7 @@ def vet(ctx, targets, use_embedded_libs=False, six_root=None):
     build_tags = get_default_build_tags()
     build_tags.append("novet")
 
-    _, _, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs, six_root=six_root)
+    _, _, env = get_build_flags(ctx, six_root=six_root)
 
     ctx.run("go vet -tags \"{}\" ".format(" ".join(build_tags)) + " ".join(args), env=env)
     # go vet exits with status 1 when it finds an issue, if we're here

--- a/tasks/systray.py
+++ b/tasks/systray.py
@@ -19,8 +19,7 @@ AGENT_TAG = "datadog/agent:master"
 
 @task
 def build(ctx, rebuild=False, race=False, build_include=None, build_exclude=None,
-          puppy=False, use_embedded_libs=False, development=True, precompile_only=False,
-          skip_assets=False):
+          puppy=False, development=True, precompile_only=False, skip_assets=False):
     """
     Build the agent. If the bits to include in the build are not specified,
     the values from `invoke.yaml` will be used.

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -13,7 +13,7 @@ import invoke
 from invoke import task
 from invoke.exceptions import Exit
 
-from .utils import get_build_flags, get_version, pkg_config_path
+from .utils import get_build_flags, get_version
 from .go import fmt, lint, vet, misspell, ineffassign, lint_licenses
 from .build_tags import get_default_build_tags, get_build_tags
 from .agent import integration_tests as agent_integration_tests
@@ -43,7 +43,7 @@ DEFAULT_TEST_TARGETS = [
 
 @task()
 def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=None,
-    race=False, profile=False, use_embedded_libs=False, fail_on_fmt=False,
+    race=False, profile=False, fail_on_fmt=False,
     six_root=None, python_home_2=None, python_home_3=None, cpus=0,
     timeout=120):
     """
@@ -78,7 +78,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     lint(ctx, targets=tool_targets)
     lint_licenses(ctx)
     print("--- Vetting:")
-    vet(ctx, targets=tool_targets, use_embedded_libs=use_embedded_libs, six_root=six_root)
+    vet(ctx, targets=tool_targets, six_root=six_root)
     print("--- Misspelling:")
     misspell(ctx, targets=tool_targets)
     print("--- ineffassigning:")
@@ -87,8 +87,7 @@ def test(ctx, targets=None, coverage=False, build_include=None, build_exclude=No
     with open(PROFILE_COV, "w") as f_cov:
         f_cov.write("mode: count")
 
-    ldflags, gcflags, env = get_build_flags(ctx,
-            use_embedded_libs=use_embedded_libs, six_root=six_root,
+    ldflags, gcflags, env = get_build_flags(ctx, six_root=six_root,
             python_home_2=python_home_2, python_home_3=python_home_3)
 
     if sys.platform == 'win32':

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -14,8 +14,8 @@ BIN_PATH = os.path.join(".", "bin", "trace-agent")
 DEFAULT_BUILD_TAGS = ["netcgo", "secrets"]
 
 @task
-def build(ctx, rebuild=False, race=False, precompile_only=False, use_embedded_libs=False,
-          build_include=None, build_exclude=None, puppy=False, use_venv=False):
+def build(ctx, rebuild=False, race=False, precompile_only=False, build_include=None,
+          build_exclude=None, puppy=False, use_venv=False):
     """
     Build the trace agent.
     """
@@ -32,7 +32,7 @@ def build(ctx, rebuild=False, race=False, precompile_only=False, use_embedded_li
             patch_ver=patch_ver
         ))
 
-    ldflags, gcflags, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs, use_venv=use_venv)
+    ldflags, gcflags, env = get_build_flags(ctx, use_venv=use_venv)
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
 

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -29,25 +29,6 @@ def bin_name(name, android=False):
     return name
 
 
-def pkg_config_path(use_embedded_libs):
-    """
-    Prepend the full path to either the `system` or `embedded` pkg-config
-    folders provided by the agent to the existing value of `PKG_CONFIG_PATH`
-    environment var.
-    """
-    retval = ""
-
-    base = os.path.join(os.path.dirname("."), "pkg-config", platform.system().lower())
-    if use_embedded_libs:
-        retval = os.path.abspath(os.path.join(base, "embedded"))
-    else:
-        retval = os.path.abspath(os.path.join(base, "system"))
-
-    # append the system wide value of PKG_CONFIG_PATH
-    retval += "{}{}".format(os.pathsep, os.environ.get("PKG_CONFIG_PATH", ""))
-
-    return retval
-
 def get_multi_python_location(embedded_path=None, six_root=None):
     if embedded_path is None:
         # fall back to local dev path
@@ -63,8 +44,8 @@ def get_multi_python_location(embedded_path=None, six_root=None):
 
     return six_lib, six_headers
 
-def get_build_flags(ctx, static=False, use_embedded_libs=False, prefix=None, use_venv=False,
-                    embedded_path=None, six_root=None, python_home_2=None, python_home_3=None):
+def get_build_flags(ctx, static=False, prefix=None, use_venv=False, embedded_path=None,
+                    six_root=None, python_home_2=None, python_home_3=None):
     """
     Build the common value for both ldflags and gcflags, and return an env accordingly.
 


### PR DESCRIPTION
### What does this PR do?

Remove `--use-embedded-libs` option which is no longer used