### PR TITLE
Fix `novet` option semantic

### DIFF
--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -4,7 +4,7 @@
 // Copyright 2016-2019 Datadog, Inc.
 
 // Go vet raise an error when test the "Warn" method: call has possible formatting directive %s
-// +build !novet
+// +build !dovet
 
 package log
 

--- a/pkg/util/winutil/shutil.go
+++ b/pkg/util/winutil/shutil.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build windows,!novet
+// +build windows,!dovet
 
 package winutil
 

--- a/pkg/util/winutil/test_shutil.go
+++ b/pkg/util/winutil/test_shutil.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-2019 Datadog, Inc.
 
-// +build windows,novet
+// +build windows,dovet
 
 package winutil
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -116,7 +116,7 @@ def vet(ctx, targets, use_embedded_libs=False):
     # add the /... suffix to the targets
     args = ["{}/...".format(t) for t in targets]
     build_tags = get_default_build_tags()
-    build_tags.append("novet")
+    build_tags.append("dovet")
 
     _, _, env = get_build_flags(ctx, use_embedded_libs=use_embedded_libs)
 
@@ -228,7 +228,7 @@ def deps(ctx, no_checks=False, core_dir=None, verbose=False, android=False):
     start = datetime.datetime.now()
     ctx.run("dep ensure{}".format(verbosity))
     dep_done = datetime.datetime.now()
-    
+
     # If github.com/DataDog/datadog-agent gets vendored too - nuke it
     #
     # This may happen as a result of having to introduce DEPPROJECTROOT


### PR DESCRIPTION
### What does this PR do?

* Rename `novet` to `dovet` to match what the option actually does.
* Also renamed `shutil_vet.go` to `test_shutil.go` to make more clear that module is only used at test time

### Motivation

r/mildlyinfuriating
