### PR TITLE
ci: allow to provide a list of files to ignore to the ineffassign invoke task

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -165,10 +165,14 @@ def ineffassign(ctx, targets):
 
     files = []
     for target in targets:
-        for d in os.walk(target):
-            for file in glob.glob(os.path.join(os.path.abspath(d[0]), '*.go')):
-                if file not in INEFFASSIGN_IGNORED_TARGETS:
-                    files.append(file)
+        if os.path.isfile(target):
+            if file not in INEFFASSIGN_IGNORED_TARGETS:
+                files.append(file)
+        else:
+            for d in os.walk(target):
+                for file in glob.glob(os.path.join(d[0], '*.go')):
+                    if file not in INEFFASSIGN_IGNORED_TARGETS:
+                        files.append(file)
 
     ctx.run("ineffassign " + " ".join(files))
     # ineffassign exits with status 1 when it finds an issue, if we're here


### PR DESCRIPTION
### What does this PR do?

Allows providing a list of files to ignore when running the ineffassign tool.

### Motivation

I bumped into an issue where generated files from the `process-agent` repo won't pass the ineffassign task, this will allow to whitelist those generated files


### Additional Notes

Anything else we should know when reviewing?
