### PR TITLE
Upgrade pyyaml to 5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ invoke==1.0.0
 reno==2.9.2
 docker==3.0.1
 requests==2.20.1
-PyYAML==3.13
+PyYAML==5.1
 toml==0.9.4


### PR DESCRIPTION
### What does this PR do?

Update pyyaml to 5.1.

Now that integrations use 5.1, I think we need it here as well. It
creates issues Windows CI too.