### PR TITLE
pkg/trace/metrics/timing: add timing package for measuring hot paths

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/event"
 	"github.com/DataDog/datadog-agent/pkg/trace/filters"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
@@ -50,7 +51,8 @@ type Agent struct {
 	dynConf *sampler.DynamicConfig
 
 	// Used to synchronize on a clean exit
-	ctx context.Context
+	ctx   context.Context
+	timer *timing.Set
 }
 
 // NewAgent returns a new Agent object, ready to be started. It takes a context
@@ -84,6 +86,12 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 	sw := writer.NewStatsWriter(conf, statsChan)
 	svcW := writer.NewServiceWriter(conf, filteredServiceChan)
 
+	tset := timing.NewSet(ctx,
+		"datadog.trace_agent.internal.process_trace_ms",
+		"datadog.trace_agent.internal.concentrator_ms",
+		"datadog.trace_agent.internal.sample_ms",
+	)
+
 	return &Agent{
 		Receiver:           r,
 		Concentrator:       c,
@@ -103,6 +111,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 		conf:               conf,
 		dynConf:            dynConf,
 		ctx:                ctx,
+		timer:              tset,
 	}
 }
 
@@ -133,6 +142,7 @@ func (a *Agent) Run() {
 		go a.work()
 	}
 
+	a.timer.Autoreport(10 * time.Second)
 	a.loop()
 }
 
@@ -178,6 +188,8 @@ func (a *Agent) Process(t pb.Trace) {
 		log.Debugf("Skipping received empty trace")
 		return
 	}
+
+	defer a.timer.Measure("datadog.trace_agent.internal.process_trace_ms", time.Now())
 
 	// Root span is used to carry some trace-level metadata, such as sampling rate and priority.
 	root := traceutil.GetRoot(t)
@@ -258,6 +270,7 @@ func (a *Agent) Process(t pb.Trace) {
 
 	go func(pt ProcessedTrace) {
 		defer watchdog.LogOnPanic()
+		defer a.timer.Measure("datadog.trace_agent.internal.concentrator_ms", time.Now())
 		// Everything is sent to concentrator for stats, regardless of sampling.
 		a.Concentrator.Add(&stats.Input{
 			Trace:     pt.WeightedTrace,
@@ -273,6 +286,7 @@ func (a *Agent) Process(t pb.Trace) {
 	// Run both full trace sampling and transaction extraction in another goroutine.
 	go func(pt ProcessedTrace) {
 		defer watchdog.LogOnPanic()
+		defer a.timer.Measure("datadog.trace_agent.internal.sample_ms", time.Now())
 
 		tracePkg := writer.TracePackage{}
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/osutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
@@ -292,10 +293,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 }
 
 func (r *HTTPReceiver) processTraces(ts *info.TagStats, traces pb.Traces) {
-	now := time.Now()
-	defer func() {
-		metrics.Timing("datadog.trace_agent.internal.normalize_ms", time.Since(now), nil, 1)
-	}()
+	defer timing.Since("datadog.trace_agent.internal.normalize_ms", time.Now())
 	for _, trace := range traces {
 		spans := len(trace)
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -294,7 +294,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 func (r *HTTPReceiver) processTraces(ts *info.TagStats, traces pb.Traces) {
 	now := time.Now()
 	defer func() {
-		metrics.Timing("datadog.trace_agent.receiver.process_traces_ms", time.Since(now), nil, 1)
+		metrics.Timing("datadog.trace_agent.internal.normalize_ms", time.Since(now), nil, 1)
 	}()
 	for _, trace := range traces {
 		spans := len(trace)
@@ -373,6 +373,7 @@ func (r *HTTPReceiver) loop() {
 			r.watchdog(now)
 		case now := <-t.C:
 			metrics.Gauge("datadog.trace_agent.heartbeat", 1, nil, 1)
+			metrics.Gauge("datadog.trace_agent.receiver.out_chan_fill", float64(len(r.Out))/float64(cap(r.Out)), nil, 1)
 
 			// We update accStats with the new stats we collected
 			accStats.Acc(r.Stats)

--- a/pkg/trace/atomic/float.go
+++ b/pkg/trace/atomic/float.go
@@ -1,4 +1,4 @@
-package sampler
+package atomic
 
 import (
 	"math"
@@ -7,28 +7,33 @@ import (
 
 // The atomic float64 is copied from: https://github.com/uber-go/atomic/blob/master/atomic.go#L267
 
-// atomicFloat64 is an atomic wrapper around float64.
-type atomicFloat64 struct {
+// Float64 is an atomic wrapper around float64.
+type Float64 struct {
 	v uint64
 }
 
-// newFloat64 creates a atomicFloat64.
-func newFloat64(f float64) *atomicFloat64 {
-	return &atomicFloat64{math.Float64bits(f)}
+// NewFloat creates a Float64.
+func NewFloat(f float64) *Float64 {
+	return &Float64{math.Float64bits(f)}
 }
 
 // Load atomically loads the wrapped value.
-func (f *atomicFloat64) Load() float64 {
+func (f *Float64) Load() float64 {
 	return math.Float64frombits(atomic.LoadUint64(&f.v))
 }
 
 // Store atomically stores the passed value.
-func (f *atomicFloat64) Store(s float64) {
+func (f *Float64) Store(s float64) {
 	atomic.StoreUint64(&f.v, math.Float64bits(s))
 }
 
+// Swap atomically swaps the passed value and returns the old one.
+func (f *Float64) Swap(s float64) (old float64) {
+	return math.Float64frombits(atomic.SwapUint64(&f.v, math.Float64bits(s)))
+}
+
 // Add atomically adds to the wrapped float64 and returns the new value.
-func (f *atomicFloat64) Add(s float64) float64 {
+func (f *Float64) Add(s float64) float64 {
 	for {
 		old := f.Load()
 		new := old + s
@@ -39,11 +44,11 @@ func (f *atomicFloat64) Add(s float64) float64 {
 }
 
 // Sub atomically subtracts from the wrapped float64 and returns the new value.
-func (f *atomicFloat64) Sub(s float64) float64 {
+func (f *Float64) Sub(s float64) float64 {
 	return f.Add(-s)
 }
 
 // CAS is an atomic compare-and-swap.
-func (f *atomicFloat64) CAS(old, new float64) bool {
+func (f *Float64) CAS(old, new float64) bool {
 	return atomic.CompareAndSwapUint64(&f.v, math.Float64bits(old), math.Float64bits(new))
 }

--- a/pkg/trace/metrics/timing/example_test.go
+++ b/pkg/trace/metrics/timing/example_test.go
@@ -1,0 +1,15 @@
+package timing
+
+import "time"
+
+// The most basic usage for the package is timing the execution time of a function.
+func Example() {
+	computeThings := func() {
+		// the easiest way is using a defer statement, which will trigger
+		// when a function returns
+		defer Since("compute.things", time.Now())
+		// do stuff...
+	}
+	computeThings()
+	Flush()
+}

--- a/pkg/trace/metrics/timing/example_test.go
+++ b/pkg/trace/metrics/timing/example_test.go
@@ -11,5 +11,5 @@ func Example() {
 		// do stuff...
 	}
 	computeThings()
-	Flush()
+	Stop()
 }

--- a/pkg/trace/metrics/timing/timing.go
+++ b/pkg/trace/metrics/timing/timing.go
@@ -13,38 +13,28 @@ import (
 // Set represents a set of metrics that can be used for timing. Use NewSet
 // to create a set. It is safe for concurrent use.
 type Set struct {
-	c   map[string]*agg // maps names to their aggregates
-	ctx context.Context // used for cancelling when auto-reporting
-	mu  sync.RWMutex    // synchronizes calls between Report and Time
-}
-
-type agg struct {
-	count, max, avg, sum *atomic.Float64
+	c   map[string]*counter // maps names to their aggregates
+	ctx context.Context     // used for cancelling when auto-reporting
 }
 
 // NewSet returns a new Set containing the given metric names. The context is optional
 // and can be used as cancellation for auto-reporting sets.
 func NewSet(ctx context.Context, names ...string) *Set {
 	set := Set{
-		c:   make(map[string]*agg, len(names)),
+		c:   make(map[string]*counter, len(names)),
 		ctx: ctx,
 	}
 	for _, name := range names {
-		set.c[name] = &agg{
-			count: atomic.NewFloat(0),
-			max:   atomic.NewFloat(0),
-			sum:   atomic.NewFloat(0),
-			avg:   atomic.NewFloat(0),
-		}
+		set.c[name] = newCounter(name)
 	}
 	return &set
 }
 
 // Autoreport enables autoreporting of the Set at the given interval.
 func (s *Set) Autoreport(interval time.Duration) {
-	tick := time.NewTicker(interval)
-	defer tick.Stop()
 	go func() {
+		tick := time.NewTicker(interval)
+		defer tick.Stop()
 		for {
 			select {
 			case <-tick.C:
@@ -56,32 +46,61 @@ func (s *Set) Autoreport(interval time.Duration) {
 	}()
 }
 
-// Time measures the time passed since, for the given name. It aggregates on each
+// Measure measures the time passed since, for the given name. It aggregates on each
 // subsequent call until Report is called.
-func (s *Set) Time(name string, since time.Time) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (s *Set) Measure(name string, since time.Time) {
 	ms := float64(time.Since(since) / time.Millisecond)
 	c, ok := s.c[name]
 	if !ok {
 		panic(fmt.Sprintf("Set: key does not exist: %s", name))
 	}
-	if ms > c.max.Load() {
-		c.max.Store(ms)
-	}
-	c.count.Add(1)
-	c.sum.Add(ms)
-	c.avg.Store(c.sum.Load() / c.count.Load())
+	c.add(ms)
 }
 
 // Report reports all of the Set's metrics to the statsd client.
 func (s *Set) Report() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for name, agg := range s.c {
-		metrics.Gauge(name+".count", agg.count.Swap(0), nil, 1)
-		metrics.Gauge(name+".max", agg.max.Swap(0), nil, 1)
-		metrics.Gauge(name+".avg", agg.avg.Swap(0), nil, 1)
-		agg.sum.Store(0)
+	for _, c := range s.c {
+		c.flush()
 	}
+}
+
+type counter struct {
+	// name specifies the name of this counter
+	name string
+
+	// mu synchronizes calls between add and flush, ensuring
+	// that adding doesn't happen while flushing.
+	mu sync.RWMutex
+
+	count, max, sum *atomic.Float64
+}
+
+func newCounter(name string) *counter {
+	return &counter{
+		name:  name,
+		count: atomic.NewFloat(0),
+		max:   atomic.NewFloat(0),
+		sum:   atomic.NewFloat(0),
+	}
+}
+
+func (c *counter) add(v float64) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if v > c.max.Load() {
+		c.max.Store(v)
+	}
+	c.count.Add(1)
+	c.sum.Add(v)
+}
+
+func (c *counter) flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	metrics.Count(c.name+".count", int64(c.count.Load()), nil, 1)
+	metrics.Gauge(c.name+".avg", c.sum.Load()/c.count.Load(), nil, 1)
+	metrics.Gauge(c.name+".max", c.max.Load(), nil, 1)
+	c.sum.Store(0)
+	c.max.Store(0)
+	c.count.Store(0)
 }

--- a/pkg/trace/metrics/timing/timing.go
+++ b/pkg/trace/metrics/timing/timing.go
@@ -1,0 +1,87 @@
+package timing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/atomic"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+)
+
+// Set represents a set of metrics that can be used for timing. Use NewSet
+// to create a set. It is safe for concurrent use.
+type Set struct {
+	c   map[string]*agg // maps names to their aggregates
+	ctx context.Context // used for cancelling when auto-reporting
+	mu  sync.RWMutex    // synchronizes calls between Report and Time
+}
+
+type agg struct {
+	count, max, avg, sum *atomic.Float64
+}
+
+// NewSet returns a new Set containing the given metric names. The context is optional
+// and can be used as cancellation for auto-reporting sets.
+func NewSet(ctx context.Context, names ...string) *Set {
+	set := Set{
+		c:   make(map[string]*agg, len(names)),
+		ctx: ctx,
+	}
+	for _, name := range names {
+		set.c[name] = &agg{
+			count: atomic.NewFloat(0),
+			max:   atomic.NewFloat(0),
+			sum:   atomic.NewFloat(0),
+			avg:   atomic.NewFloat(0),
+		}
+	}
+	return &set
+}
+
+// Autoreport enables autoreporting of the Set at the given interval.
+func (s *Set) Autoreport(interval time.Duration) {
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	go func() {
+		for {
+			select {
+			case <-tick.C:
+				s.Report()
+			case <-s.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// Time measures the time passed since, for the given name. It aggregates on each
+// subsequent call until Report is called.
+func (s *Set) Time(name string, since time.Time) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ms := float64(time.Since(since) / time.Millisecond)
+	c, ok := s.c[name]
+	if !ok {
+		panic(fmt.Sprintf("Set: key does not exist: %s", name))
+	}
+	if ms > c.max.Load() {
+		c.max.Store(ms)
+	}
+	c.count.Add(1)
+	c.sum.Add(ms)
+	c.avg.Store(c.sum.Load() / c.count.Load())
+}
+
+// Report reports all of the Set's metrics to the statsd client.
+func (s *Set) Report() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for name, agg := range s.c {
+		metrics.Gauge(name+".count", agg.count.Swap(0), nil, 1)
+		metrics.Gauge(name+".max", agg.max.Swap(0), nil, 1)
+		metrics.Gauge(name+".avg", agg.avg.Swap(0), nil, 1)
+		agg.sum.Store(0)
+	}
+}

--- a/pkg/trace/metrics/timing/timing_test.go
+++ b/pkg/trace/metrics/timing/timing_test.go
@@ -22,24 +22,24 @@ func TestTiming(t *testing.T) {
 
 	t.Run("report", func(t *testing.T) {
 		stats.Reset()
-		set := NewSet("counter2")
+		var set Set
 		set.Since("counter1", time.Now().Add(-2*time.Second))
 		set.Since("counter1", time.Now().Add(-3*time.Second))
 		set.Report()
 
 		calls := stats.CountCalls
-		assert.Equal(2, len(calls))
+		assert.Equal(1, len(calls))
 		assert.Equal(2., findCall(assert, calls, "counter1.count").Value)
 
 		calls = stats.GaugeCalls
-		assert.Equal(4, len(calls))
+		assert.Equal(2, len(calls))
 		assert.Equal(2500., float64(findCall(assert, calls, "counter1.avg").Value), "avg")
 		assert.Equal(3000., findCall(assert, calls, "counter1.max").Value, "max")
 	})
 
 	t.Run("autoreport", func(t *testing.T) {
 		stats.Reset()
-		set := NewSet("counter1")
+		var set Set
 		set.Since("counter1", time.Now().Add(-1*time.Second))
 		stop := set.Autoreport(time.Millisecond)
 		time.Sleep(5 * time.Millisecond)
@@ -48,7 +48,7 @@ func TestTiming(t *testing.T) {
 	})
 
 	t.Run("panic", func(t *testing.T) {
-		set := NewSet("counter1")
+		var set Set
 		stop := set.Autoreport(time.Millisecond)
 		stop()
 		stop()
@@ -56,8 +56,10 @@ func TestTiming(t *testing.T) {
 
 	t.Run("race", func(t *testing.T) {
 		stats.Reset()
-		set := NewSet("counter1")
-		var wg sync.WaitGroup
+		var (
+			set Set
+			wg  sync.WaitGroup
+		)
 		for i := 0; i < 150; i++ {
 			wg.Add(1)
 			go func() {
@@ -66,7 +68,6 @@ func TestTiming(t *testing.T) {
 				set.Since(fmt.Sprintf("%d", rand.Int()), time.Now().Add(-time.Second))
 			}()
 		}
-
 		for i := 0; i < 150; i++ {
 			wg.Add(1)
 			go func() {

--- a/pkg/trace/metrics/timing/timing_test.go
+++ b/pkg/trace/metrics/timing/timing_test.go
@@ -22,7 +22,7 @@ func TestTiming(t *testing.T) {
 
 	t.Run("report", func(t *testing.T) {
 		stats.Reset()
-		var set Set
+		set := NewSet()
 		set.Since("counter1", time.Now().Add(-2*time.Second))
 		set.Since("counter1", time.Now().Add(-3*time.Second))
 		set.Report()
@@ -39,7 +39,7 @@ func TestTiming(t *testing.T) {
 
 	t.Run("autoreport", func(t *testing.T) {
 		stats.Reset()
-		var set Set
+		set := NewSet()
 		set.Since("counter1", time.Now().Add(-1*time.Second))
 		stop := set.Autoreport(time.Millisecond)
 		time.Sleep(5 * time.Millisecond)
@@ -48,7 +48,7 @@ func TestTiming(t *testing.T) {
 	})
 
 	t.Run("panic", func(t *testing.T) {
-		var set Set
+		set := NewSet()
 		stop := set.Autoreport(time.Millisecond)
 		stop()
 		stop()
@@ -56,10 +56,8 @@ func TestTiming(t *testing.T) {
 
 	t.Run("race", func(t *testing.T) {
 		stats.Reset()
-		var (
-			set Set
-			wg  sync.WaitGroup
-		)
+		set := NewSet()
+		var wg sync.WaitGroup
 		for i := 0; i < 150; i++ {
 			wg.Add(1)
 			go func() {

--- a/pkg/trace/metrics/timing/timing_test.go
+++ b/pkg/trace/metrics/timing/timing_test.go
@@ -21,23 +21,26 @@ func TestTiming(t *testing.T) {
 	metrics.Client = stats
 
 	set := NewSet(context.TODO(), "counter1")
-	set.Time("counter1", time.Now().Add(-2*time.Second))
-	set.Time("counter1", time.Now().Add(-3*time.Second))
+	set.Measure("counter1", time.Now().Add(-2*time.Second))
+	set.Measure("counter1", time.Now().Add(-3*time.Second))
 	set.Report()
 
-	calls := stats.GaugeCalls
-	assert.Equal(3, len(calls))
+	calls := stats.CountCalls
+	assert.Equal(1, len(calls))
 	assert.Equal(2., findCall(assert, calls, "counter1.count").Value)
+
+	calls = stats.GaugeCalls
+	assert.Equal(2, len(calls))
 	assert.Equal(2500., float64(findCall(assert, calls, "counter1.avg").Value), "avg")
 	assert.Equal(3000., findCall(assert, calls, "counter1.max").Value, "max")
 }
 
-func findCall(assert *assert.Assertions, calls []testutil.StatsClientGaugeArgs, name string) testutil.StatsClientGaugeArgs {
+func findCall(assert *assert.Assertions, calls []testutil.MetricsArgs, name string) testutil.MetricsArgs {
 	for _, c := range calls {
 		if c.Name == name {
 			return c
 		}
 	}
 	assert.Failf("call not found", "key %q missing", name)
-	return testutil.StatsClientGaugeArgs{}
+	return testutil.MetricsArgs{}
 }

--- a/pkg/trace/metrics/timing/timing_test.go
+++ b/pkg/trace/metrics/timing/timing_test.go
@@ -1,7 +1,9 @@
 package timing
 
 import (
-	"context"
+	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,24 +17,65 @@ func TestTiming(t *testing.T) {
 	assert := assert.New(t)
 	stats := &testutil.TestStatsClient{}
 
-	defer func(old metrics.StatsClient) {
-		metrics.Client = old
-	}(metrics.Client)
+	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
 	metrics.Client = stats
 
-	set := NewSet(context.TODO(), "counter1")
-	set.Measure("counter1", time.Now().Add(-2*time.Second))
-	set.Measure("counter1", time.Now().Add(-3*time.Second))
-	set.Report()
+	t.Run("report", func(t *testing.T) {
+		stats.Reset()
+		set := NewSet("counter2")
+		set.Since("counter1", time.Now().Add(-2*time.Second))
+		set.Since("counter1", time.Now().Add(-3*time.Second))
+		set.Report()
 
-	calls := stats.CountCalls
-	assert.Equal(1, len(calls))
-	assert.Equal(2., findCall(assert, calls, "counter1.count").Value)
+		calls := stats.CountCalls
+		assert.Equal(2, len(calls))
+		assert.Equal(2., findCall(assert, calls, "counter1.count").Value)
 
-	calls = stats.GaugeCalls
-	assert.Equal(2, len(calls))
-	assert.Equal(2500., float64(findCall(assert, calls, "counter1.avg").Value), "avg")
-	assert.Equal(3000., findCall(assert, calls, "counter1.max").Value, "max")
+		calls = stats.GaugeCalls
+		assert.Equal(4, len(calls))
+		assert.Equal(2500., float64(findCall(assert, calls, "counter1.avg").Value), "avg")
+		assert.Equal(3000., findCall(assert, calls, "counter1.max").Value, "max")
+	})
+
+	t.Run("autoreport", func(t *testing.T) {
+		stats.Reset()
+		set := NewSet("counter1")
+		set.Since("counter1", time.Now().Add(-1*time.Second))
+		stop := set.Autoreport(time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
+		stop()
+		assert.True(len(stats.CountCalls) > 1)
+	})
+
+	t.Run("panic", func(t *testing.T) {
+		set := NewSet("counter1")
+		stop := set.Autoreport(time.Millisecond)
+		stop()
+		stop()
+	})
+
+	t.Run("race", func(t *testing.T) {
+		stats.Reset()
+		set := NewSet("counter1")
+		var wg sync.WaitGroup
+		for i := 0; i < 150; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				set.Since("counter1", time.Now().Add(-time.Second))
+				set.Since(fmt.Sprintf("%d", rand.Int()), time.Now().Add(-time.Second))
+			}()
+		}
+
+		for i := 0; i < 150; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				set.Report()
+			}()
+		}
+		wg.Wait()
+	})
 }
 
 func findCall(assert *assert.Assertions, calls []testutil.MetricsArgs, name string) testutil.MetricsArgs {

--- a/pkg/trace/metrics/timing/timing_test.go
+++ b/pkg/trace/metrics/timing/timing_test.go
@@ -1,0 +1,43 @@
+package timing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTiming(t *testing.T) {
+	assert := assert.New(t)
+	stats := &testutil.TestStatsClient{}
+
+	defer func(old metrics.StatsClient) {
+		metrics.Client = old
+	}(metrics.Client)
+	metrics.Client = stats
+
+	set := NewSet(context.TODO(), "counter1")
+	set.Time("counter1", time.Now().Add(-2*time.Second))
+	set.Time("counter1", time.Now().Add(-3*time.Second))
+	set.Report()
+
+	calls := stats.GaugeCalls
+	assert.Equal(3, len(calls))
+	assert.Equal(2., findCall(assert, calls, "counter1.count").Value)
+	assert.Equal(2500., float64(findCall(assert, calls, "counter1.avg").Value), "avg")
+	assert.Equal(3000., findCall(assert, calls, "counter1.max").Value, "max")
+}
+
+func findCall(assert *assert.Assertions, calls []testutil.StatsClientGaugeArgs, name string) testutil.StatsClientGaugeArgs {
+	for _, c := range calls {
+		if c.Name == name {
+			return c
+		}
+	}
+	assert.Failf("call not found", "key %q missing", name)
+	return testutil.StatsClientGaugeArgs{}
+}

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/atomic"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 )
@@ -58,11 +59,11 @@ type Sampler struct {
 
 	// Sample any signature with a score lower than scoreSamplingOffset
 	// It is basically the number of similar traces per second after which we start sampling
-	signatureScoreOffset *atomicFloat64
+	signatureScoreOffset *atomic.Float64
 	// Logarithm slope for the scoring function
-	signatureScoreSlope *atomicFloat64
+	signatureScoreSlope *atomic.Float64
 	// signatureScoreFactor = math.Pow(signatureScoreSlope, math.Log10(scoreSamplingOffset))
-	signatureScoreFactor *atomicFloat64
+	signatureScoreFactor *atomic.Float64
 
 	exit chan struct{}
 }
@@ -73,9 +74,9 @@ func newSampler(extraRate float64, maxTPS float64) *Sampler {
 		Backend:              NewMemoryBackend(defaultDecayPeriod, defaultDecayFactor),
 		extraRate:            extraRate,
 		maxTPS:               maxTPS,
-		signatureScoreOffset: newFloat64(0),
-		signatureScoreSlope:  newFloat64(0),
-		signatureScoreFactor: newFloat64(0),
+		signatureScoreOffset: atomic.NewFloat(0),
+		signatureScoreSlope:  atomic.NewFloat(0),
+		signatureScoreFactor: atomic.NewFloat(0),
 
 		exit: make(chan struct{}),
 	}

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 	writerconfig "github.com/DataDog/datadog-agent/pkg/trace/writer/config"
@@ -101,6 +102,8 @@ func (w *StatsWriter) handleStats(s []stats.Bucket) {
 	if len(payloads) == 0 {
 		return
 	}
+
+	defer timing.Since("datadog.trace_agent.stats_writer.encode_ms", time.Now())
 
 	log.Debugf("Going to flush %v entries in %v stat buckets in %v payloads",
 		nbEntries, nbStatBuckets, len(payloads),

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
@@ -206,9 +207,7 @@ func (w *TraceWriter) flush() {
 		return
 	}
 
-	defer func(start time.Time) {
-		metrics.Timing("datadog.trace_agent.trace_writer.encode_ms", time.Since(start), nil, 1)
-	}(time.Now())
+	defer timing.Since("datadog.trace_agent.trace_writer.encode_ms", time.Now())
 
 	atomic.AddInt64(&w.stats.Traces, int64(numTraces))
 	atomic.AddInt64(&w.stats.Events, int64(numEvents))

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -206,6 +206,10 @@ func (w *TraceWriter) flush() {
 		return
 	}
 
+	defer func(start time.Time) {
+		metrics.Timing("datadog.trace_agent.trace_writer.encode_ms", time.Since(start), nil, 1)
+	}(time.Now())
+
 	atomic.AddInt64(&w.stats.Traces, int64(numTraces))
 	atomic.AddInt64(&w.stats.Events, int64(numEvents))
 	atomic.AddInt64(&w.stats.Spans, int64(w.spansInBuffer))


### PR DESCRIPTION
This change adds a new package (`pkg/trace/metrics/timing`) and uses it to aggregate timing measurements.

The set of metrics is namespaced `datadog.trace_agent.internal.*` because they are subject to change or deletion in future refactors.