### PR TITLE
Use Yaml instead of JSON

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:six
+      - image: datadog/datadog-agent-runner-circle:six-pip3
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex \
         gnupg ca-certificates \
         gcc g++ make git ssh curl pkg-config file \
         python-dev python-setuptools python-pip \
-        python3.7-dev python3-distutils \
+        python3.7-dev python3-distutils python3-pip python3-yaml \
         libssl-dev libsnmp-base libsnmp-dev libpq-dev snmp-mibs-downloader libsystemd-dev
 
 # Golang

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,7 +147,7 @@ before_script:
 # run tests for deb-x64
 run_tests_deb-x64:
   stage: source_test
-  image: datadog/datadog-agent-runner-circle:six
+  image: datadog/datadog-agent-runner-circle:six-pip3
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - pip install wheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - set PATH=%APPVEYOR_BUILD_FOLDER%\dev\lib;%GOPATH%\bin;%Python2_ROOT_DIR%;%Python2_ROOT_DIR%\Scripts;%Python3_ROOT_DIR%;%Python3_ROOT_DIR%\Scripts;%MSYS_ROOT%\mingw64\bin;%MSYS_ROOT%\usr\bin\;%PATH%
   - git clone --depth 1 https://github.com/datadog/integrations-core
   - "%PIP2% install codecov -r requirements.txt"
+  - "%PIP3% install PyYAML==5.1"
 
 cache:
   - '%GOPATH%\bin'

--- a/six/common/sixstrings.c
+++ b/six/common/sixstrings.c
@@ -44,13 +44,18 @@ PyObject *from_json(const char *data) {
         goto done;
     }
 
-    char module_name[] = "json";
+    // JSON return unicode strings under Python2, even if this is a better
+    // behavior it would be a breaking change compare to the previous version
+    // of the Agent not using this lib to embed Python. Yaml returns bytes
+    // under Python2 and Unicode under Python3. Since JSON is a subset of Yaml
+    // we use 'yaml' here.
+    char module_name[] = "yaml";
     json = PyImport_ImportModule(module_name);
     if (json == NULL) {
         goto done;
     }
 
-    char func_name[] = "loads";
+    char func_name[] = "safe_load";
     loads = PyObject_GetAttrString(json, func_name);
     if (loads == NULL) {
         goto done;


### PR DESCRIPTION
### What does this PR do?

JSON return unicode strings under Python2, even if this is a better
behavior it would be a breaking change compare to the previous version
of the Agent not using this lib to embed Python. Yaml returns bytes
under Python2 and Unicode under Python3. Since JSON is a subset of Yaml
we use 'yaml' here.
