### PR TITLE
pkg/trace/api: add self oom kill at 1.5x max. memory

### DIFF
--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -16,6 +16,7 @@ type StatsClient interface {
 	Count(name string, value int64, tags []string, rate float64) error
 	Histogram(name string, value float64, tags []string, rate float64) error
 	Timing(name string, value time.Duration, tags []string, rate float64) error
+	Flush() error
 }
 
 // Client is a global Statsd client. When a client is configured via Configure,
@@ -52,6 +53,13 @@ func Timing(name string, value time.Duration, tags []string, rate float64) error
 		return nil // no-op
 	}
 	return Client.Timing(name, value, tags, rate)
+}
+
+func Flush() error {
+	if Client == nil {
+		return nil // no-op
+	}
+	return Client.Flush()
 }
 
 // Configure creates a statsd client for the given agent's configuration, using the specified global tags.

--- a/pkg/trace/metrics/metrics.go
+++ b/pkg/trace/metrics/metrics.go
@@ -55,6 +55,7 @@ func Timing(name string, value time.Duration, tags []string, rate float64) error
 	return Client.Timing(name, value, tags, rate)
 }
 
+// Flush flushes any pending metrics to the agent.
 func Flush() error {
 	if Client == nil {
 		return nil // no-op

--- a/pkg/trace/test/testutil/statsd.go
+++ b/pkg/trace/test/testutil/statsd.go
@@ -75,6 +75,12 @@ func (c *TestStatsClient) Gauge(name string, value float64, tags []string, rate 
 	return c.GaugeErr
 }
 
+// Flush implements metrics.StatsClient
+func (c *TestStatsClient) Flush() error {
+	// TODO
+	return nil
+}
+
 // Count records a call to a Count operation and replies with CountErr
 func (c *TestStatsClient) Count(name string, value int64, tags []string, rate float64) error {
 	c.mu.Lock()


### PR DESCRIPTION
This change adds a mechanism where the agent kills itself if the maximum
memory is exceeded by x1.5 times. 