### PR TITLE
config: Allow env override of jmxfetch check_period

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -10,12 +10,6 @@ import (
 	"time"
 )
 
-const (
-	// DefaultCheckInterval is the interval in seconds the scheduler should apply
-	// when no value was provided in Check configuration.
-	DefaultCheckInterval time.Duration = 15 * time.Second
-)
-
 // Check is an interface for types capable to run checks
 type Check interface {
 	Run() error                                          // run the check

--- a/pkg/collector/check/defaults/defaults.go
+++ b/pkg/collector/check/defaults/defaults.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package defaults
+
+import (
+	"time"
+)
+
+const (
+	// DefaultCheckInterval is the interval in seconds the scheduler should apply
+	// when no value was provided in Check configuration.
+	DefaultCheckInterval time.Duration = 15 * time.Second
+)

--- a/pkg/collector/check/defaults/doc.go
+++ b/pkg/collector/check/defaults/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+// Package defaults provides common defaults used in agent checks
+package defaults

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -47,7 +48,7 @@ func NewCheckBase(name string) CheckBase {
 	return CheckBase{
 		checkName:     name,
 		checkID:       check.ID(name),
-		checkInterval: check.DefaultCheckInterval,
+		checkInterval: defaults.DefaultCheckInterval,
 	}
 }
 

--- a/pkg/collector/corechecks/checkbase_test.go
+++ b/pkg/collector/corechecks/checkbase_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 )
 
 var (
@@ -39,7 +39,7 @@ func TestCommonConfigure(t *testing.T) {
 
 	err := mycheck.CommonConfigure([]byte(defaultsInstance))
 	assert.NoError(t, err)
-	assert.Equal(t, check.DefaultCheckInterval, mycheck.Interval())
+	assert.Equal(t, defaults.DefaultCheckInterval, mycheck.Interval())
 	mockSender.AssertNumberOfCalls(t, "DisableDefaultHostname", 0)
 
 	mockSender.On("DisableDefaultHostname", true).Return().Once()

--- a/pkg/collector/py/check.go
+++ b/pkg/collector/py/check.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -46,7 +47,7 @@ func NewPythonCheck(name string, class *python.PyObject) *PythonCheck {
 	pyCheck := &PythonCheck{
 		ModuleName:   name,
 		class:        class,
-		interval:     check.DefaultCheckInterval,
+		interval:     defaults.DefaultCheckInterval,
 		lastWarnings: []error{},
 	}
 	runtime.SetFinalizer(pyCheck, pythonCheckFinalizer)

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/config"
 
 	python "github.com/sbinet/go-python"
@@ -149,7 +150,7 @@ func TestStr(t *testing.T) {
 
 func TestInterval(t *testing.T) {
 	c, _ := getCheckInstance("testcheck", "TestCheck")
-	assert.Equal(t, check.DefaultCheckInterval, c.Interval())
+	assert.Equal(t, defaults.DefaultCheckInterval, c.Interval())
 	c.Configure([]byte("min_collection_interval: 1"), []byte("foo: bar"))
 	assert.Equal(t, time.Duration(1)*time.Second, c.Interval())
 }

--- a/pkg/collector/py/check_test.go
+++ b/pkg/collector/py/check_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/config"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -310,6 +310,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_reconnection_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_collection_timeout", 60)
+	config.BindEnvAndSetDefault("jmx_check_period", (15*time.Second)/time.Millisecond)
 	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 10)
 
 	// Go_expvar server port

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/secrets"
@@ -310,7 +311,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_reconnection_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_collection_timeout", 60)
-	config.BindEnvAndSetDefault("jmx_check_period", (15*time.Second)/time.Millisecond)
+	config.BindEnvAndSetDefault("jmx_check_period", defaults.DefaultCheckInterval/time.Millisecond)
 	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 10)
 
 	// Go_expvar server port

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	api "github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/executable"

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -170,12 +170,15 @@ func (j *JMXFetch) Start(manage bool) error {
 	}
 
 	// checks are now enabled via IPC on JMXFetch
+	checkPeriodOverrideMs := config.Datadog.GetInt("jmx_check_period")
+	log.Infof("Confluent: overriding jmxfetch check interval (ms): %d", checkPeriodOverrideMs)
+
 	subprocessArgs = append(subprocessArgs,
 		"-classpath", classpath,
 		jmxMainClass,
 		"--ipc_host", ipcHost,
 		"--ipc_port", fmt.Sprintf("%v", ipcPort),
-		"--check_period", fmt.Sprintf("%v", int(check.DefaultCheckInterval/time.Millisecond)), // Period of the main loop of jmxfetch in ms
+		"--check_period", fmt.Sprintf("%v", checkPeriodOverrideMs), // Period of the main loop of jmxfetch in ms
 		"--thread_pool_size", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_thread_pool_size")), // Size for the JMXFetch thread pool
 		"--collection_timeout", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_collection_timeout")), // Timeout for metric collection in seconds
 		"--reconnection_timeout", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_reconnection_timeout")), // Timeout for instance reconnection in seconds

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -169,15 +169,12 @@ func (j *JMXFetch) Start(manage bool) error {
 	}
 
 	// checks are now enabled via IPC on JMXFetch
-	checkPeriodOverrideMs := config.Datadog.GetInt("jmx_check_period")
-	log.Infof("Confluent: overriding jmxfetch check interval (ms): %d", checkPeriodOverrideMs)
-
 	subprocessArgs = append(subprocessArgs,
 		"-classpath", classpath,
 		jmxMainClass,
 		"--ipc_host", ipcHost,
 		"--ipc_port", fmt.Sprintf("%v", ipcPort),
-		"--check_period", fmt.Sprintf("%v", checkPeriodOverrideMs), // Period of the main loop of jmxfetch in ms
+		"--check_period", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_check_period")), // Period of the main loop of jmxfetch in ms
 		"--thread_pool_size", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_thread_pool_size")), // Size for the JMXFetch thread pool
 		"--collection_timeout", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_collection_timeout")), // Timeout for metric collection in seconds
 		"--reconnection_timeout", fmt.Sprintf("%v", config.Datadog.GetInt("jmx_reconnection_timeout")), // Timeout for instance reconnection in seconds


### PR DESCRIPTION
### What does this PR do?

Allows the `--check_period` flag of `jmxfetch` to be overriden by the `DD_JMX_CHECK_PERIOD` environment variable.

### Motivation
We occasionally see `jmxfetch` create CPU pressure on the metrics source (in our case Kafka) particularly when there are a large number of MBeans to scrape. This flag has allowed us to configure less frequent scrapes and protect the CPU cycles of our JMX applications.

### Additional Notes
We have a custom build running internally with `DD_JMX_CHECK_PERIOD=60000` (1 minute interval) and this works as expected without side effects thus far