### PR TITLE
Expose Python init error in the status page

### DIFF
--- a/cmd/agent/gui/views/templates/collectorStatus.tmpl
+++ b/cmd/agent/gui/views/templates/collectorStatus.tmpl
@@ -1,4 +1,19 @@
 {{- with .Stats -}}
+  {{ with .pythonInit }}
+    {{- if .Errors }}
+    <div class="stat">
+      <span class="stat_title">Error initializing Python</span>
+      <span class="stat_data">
+      {{ range $err := .Errors -}}
+        <span class="stat_subdata">
+          {{ $err -}}
+        </span>
+      {{ end }}
+      </span>
+    {{- end -}}
+    </div>
+  {{- end }}
+
   <div class="stat">
     <span class="stat_title">Running Checks</span>
     <span class="stat_data">

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -91,7 +91,7 @@ func getSixError() error {
 // subclasses of the AgentCheck class and returns the corresponding Check
 func (cl *PythonCheckLoader) Load(config integration.Config) ([]check.Check, error) {
 	if six == nil {
-		return nil, fmt.Errorf("six is not initialized")
+		return nil, fmt.Errorf("python is not initialized")
 	}
 
 	checks := []check.Check{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,7 +122,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("bind_host", "localhost")
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
-	config.BindEnvAndSetDefault("python_version", 2)
+	config.BindEnvAndSetDefault("python_version", "2")
 
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward

--- a/pkg/status/dist/templates/collector.tmpl
+++ b/pkg/status/dist/templates/collector.tmpl
@@ -6,6 +6,16 @@ NOTE: Changes made to this template should be reflected on the following templat
 Collector
 =========
 
+{{ with .pythonInit }}
+  {{- if .Errors }}
+  Error initializing Python
+  =========================
+    {{ range $err := .Errors -}}
+    - {{ $err }}
+    {{ end }}
+  {{- end -}}
+{{- end }}
+
   Running Checks
   ==============
 {{- with .RunnerStats }}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -37,6 +37,7 @@ func FormatStatus(data []byte) (string, error) {
 	forwarderStats := stats["forwarderStats"]
 	runnerStats := stats["runnerStats"]
 	pyLoaderStats := stats["pyLoaderStats"]
+	pythonInit := stats["pythonInit"]
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
 	aggregatorStats := stats["aggregatorStats"]
@@ -48,7 +49,7 @@ func FormatStatus(data []byte) (string, error) {
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats, "")
+	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, "")
 	renderJMXFetchStatus(b, jmxStats)
 	renderForwarderStatus(b, forwarderStats)
 	renderEndpointsInfos(b, endpointsInfos)
@@ -76,7 +77,7 @@ func FormatDCAStatus(data []byte) (string, error) {
 	title := fmt.Sprintf("Datadog Cluster Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderHeader(b, stats)
-	renderChecksStats(b, runnerStats, nil, autoConfigStats, checkSchedulerStats, "")
+	renderChecksStats(b, runnerStats, nil, nil, autoConfigStats, checkSchedulerStats, "")
 	renderForwarderStatus(b, forwarderStats)
 	renderEndpointsInfos(b, endpointsInfos)
 
@@ -163,10 +164,11 @@ func renderHPAStats(w io.Writer, hpaStats interface{}) {
 	}
 }
 
-func renderChecksStats(w io.Writer, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats interface{}, onlyCheck string) {
+func renderChecksStats(w io.Writer, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats interface{}, onlyCheck string) {
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
 	checkStats["pyLoaderStats"] = pyLoaderStats
+	checkStats["pythonInit"] = pythonInit
 	checkStats["AutoConfigStats"] = autoConfigStats
 	checkStats["CheckSchedulerStats"] = checkSchedulerStats
 	checkStats["OnlyCheck"] = onlyCheck
@@ -185,9 +187,10 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	json.Unmarshal(data, &stats)
 	runnerStats := stats["runnerStats"]
 	pyLoaderStats := stats["pyLoaderStats"]
+	pythonInit := stats["pythonInit"]
 	autoConfigStats := stats["autoConfigStats"]
 	checkSchedulerStats := stats["checkSchedulerStats"]
-	renderChecksStats(b, runnerStats, pyLoaderStats, autoConfigStats, checkSchedulerStats, checkName)
+	renderChecksStats(b, runnerStats, pyLoaderStats, pythonInit, autoConfigStats, checkSchedulerStats, checkName)
 
 	return b.String(), nil
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -299,6 +299,16 @@ func expvarStats(stats map[string]interface{}) (map[string]interface{}, error) {
 		stats["pyLoaderStats"] = nil
 	}
 
+	pythonInitData := expvar.Get("pythonInit")
+	if pythonInitData != nil {
+		pythonInitJSON := []byte(pythonInitData.String())
+		pythonInit := make(map[string]interface{})
+		json.Unmarshal(pythonInitJSON, &pythonInit)
+		stats["pythonInit"] = pythonInit
+	} else {
+		stats["pythonInit"] = nil
+	}
+
 	hostnameStatsJSON := []byte(expvar.Get("hostname").String())
 	hostnameStats := make(map[string]interface{})
 	json.Unmarshal(hostnameStatsJSON, &hostnameStats)

--- a/six/demo/main.c
+++ b/six/demo/main.c
@@ -74,19 +74,20 @@ int main(int argc, char *argv[])
         python_home = argv[2];
     }
 
+    char *init_error = NULL;
     // Embed Python2
     if (strcmp(argv[1], "2") == 0) {
-        six = make2(python_home);
+        six = make2(python_home, &init_error);
         if (!six) {
-            printf("Unable to init Python2\n");
+            printf("Unable to init Python2: %s\n", init_error);
             return 1;
         }
     }
     // Embed Python3
     else if (strcmp(argv[1], "3") == 0) {
-        six = make3(python_home);
+        six = make3(python_home, &init_error);
         if (!six) {
-            printf("Unable to init Python3\n");
+            printf("Unable to init Python3: %s\n", init_error);
             return 1;
         }
     }

--- a/six/include/datadog_agent_six.h
+++ b/six/include/datadog_agent_six.h
@@ -18,8 +18,8 @@ struct six_pyobject_s;
 typedef struct six_pyobject_s six_pyobject_t;
 
 // FACTORIES
-DATADOG_AGENT_SIX_API six_t *make2(const char *pythonhome);
-DATADOG_AGENT_SIX_API six_t *make3(const char *pythonhome);
+DATADOG_AGENT_SIX_API six_t *make2(const char *pythonhome, char **error);
+DATADOG_AGENT_SIX_API six_t *make3(const char *pythonhome, char **error);
 
 // API
 DATADOG_AGENT_SIX_API void destroy(six_t *);

--- a/six/test/common/common_three.go
+++ b/six/test/common/common_three.go
@@ -14,5 +14,6 @@ const UsingTwo bool = false
 
 // GetSix returns a Six instance using Three
 func GetSix() *C.six_t {
-	return C.make3(nil)
+	var err *C.char = nil
+	return C.make3(nil, &err)
 }

--- a/six/test/common/common_two.go
+++ b/six/test/common/common_two.go
@@ -14,5 +14,6 @@ const UsingTwo bool = true
 
 // GetSix returns a Six instance using Two
 func GetSix() *C.six_t {
-	return C.make2(nil)
+	var err *C.char = nil
+	return C.make2(nil, &err)
 }


### PR DESCRIPTION
### What does this PR do?

Expose Python init errors in the status page. This also allows the error to be added to the log file.

When python could not be init the status page will now include:

```
=========
Collector
=========

  Error initializing Python
  =========================
    - could not load runtime python for version 2: Unable to open two library: libdatadog-agent-two.so: cannot open shared object file: No such file or directory
```

And 
```
  Loading Errors
  ==============
    custom_py_check
    ---
      Core Check Loader:
        Check custom_py_check not found in Catalog
        
      JMX Check Loader:
        check is not a jmx check, or unable to determine if it's so
        
      Python Check Loader:
        python is not initialized
```

Same in the GUI:

![2019-05-08-164108_1124x414_scrot](https://user-images.githubusercontent.com/311563/57413080-288ca700-71b0-11e9-9975-1c7ff18c1482.png)

![2019-05-08-164120_641x409_scrot](https://user-images.githubusercontent.com/311563/57413118-46f2a280-71b0-11e9-88d6-b7c75f6cd726.png)

