### PR TITLE
Fix problem with duplicate DLLs being installed

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -28,6 +28,11 @@ build do
             # TODO why does this get generated at all
             delete "#{install_dir}/bin/agent/agent.exe~"
 
+            #remove unneccessary copies caused by blanked copy of bin to #{install_dir} in datadog-agent recipe
+            delete "#{install_dir}/bin/agent/libdatadog-agent-three.dll"
+            delete "#{install_dir}/bin/agent/libdatadog-agent-two.dll"
+            delete "#{install_dir}/bin/agent/customaction.dll"
+
             # remove the config files for the subservices; they'll be started
             # based on the config file
             delete "#{conf_dir}/apm.yaml.default"


### PR DESCRIPTION
### What does this PR do?

fixes windows omnibus build.  Duplicate copies of datadog-agent-(two|three).dll were getting
installed