### PR TITLE
Don't require inv params to build a dev agent that just works & updated the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ To build the Agent you need:
    This will also pull in [Invoke](http://www.pyinvoke.org) if not yet installed.
 
 **Note:** you may want to use a python virtual environment to avoid polluting your
-      system-wide python environment with the agent build/dev dependencies. By default, this environment is only used for dev dependencies listed in `requirements.txt`, if you want the agent to use the virtual environment's interpreter and libraries instead of the system python's ones,
-      add `--use-venv` to the build command.
+      system-wide python environment with the agent build/dev dependencies. You can
+      create a virtual environment using `virtualenv` and then use the `invoke` parameter
+      `--python-home-2=<venv_path>` and/or `--python-home-3=<venv_path>` (depending on
+      the python versions you are using) to use the virtual environment's interpreter
+      and libraries. By default, this environment is only used for dev dependencies
+      listed in `requirements.txt`.
 
 **Note:** You may have previously installed `invoke` via brew on MacOS, or `pip` in
       any other platform. We recommend you use the version pinned in the requirements
@@ -37,11 +41,12 @@ to see the available tasks.
 
 To start working on the Agent, you can build the `master` branch:
 
-1. checkout the repo: `git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent`.
+1. Checkout the repo: `git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent`.
 2. cd into the project folder: `cd $GOPATH/src/github.com/DataDog/datadog-agent`.
-3. install project's dependencies: `invoke deps`.
+3. Install project's dependencies: `invoke deps`.
    Make sure that `$GOPATH/bin` is in your `$PATH` otherwise this step might fail.
-4. build the whole project with `invoke agent.build --build-exclude=systemd` (with `--use-venv` to use a python virtualenv)
+4. Build the `six` dependency with `invoke six.build && invoke six.install`. You will need CMake installed and a C++ compiler for this to work.
+5. Build the agent with `invoke agent.build --build-exclude=systemd`
 
 Please refer to the [Agent Developer Guide](docs/dev/README.md) for more details.
 

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -63,8 +63,6 @@ environment and ensure a clean system python.
 ```pip2 install virtualenv```
 - Create the virtual environment:
 ```virtualenv $GOPATH/src/github.com/DataDog/datadog-agent/venv```
-- Enable the virtual environment:
-```source $GOPATH/src/github.com/DataDog/datadog-agent/venv/bin/activate```
 - Specify the path when building the agent:
 ```invoke agent.build --python-home-2=$GOPATH/src/github.com/DataDog/datadog-agent/venv```
 

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -22,9 +22,9 @@ On Windows, install Python 2.7 via the [official installer](https://www.python.o
 ### Additional Windows Tools
 You will also need the Visual Studio for [Visual Studio for Python installer](http://aka.ms/vcpython27)
 
-Download the [gcc toolchain](http://win-builds.org/). 
-- From the graphical package manager, select and install the needed libraries, leave the default (select all) if you're unsure.  
-- Make sure to select x86_64. 
+Download the [gcc toolchain](http://win-builds.org/).
+- From the graphical package manager, select and install the needed libraries, leave the default (select all) if you're unsure.
+- Make sure to select x86_64.
 - Add installation folder to the %PATH%.
 
 
@@ -55,17 +55,21 @@ variables (see Invoke docs for more details).
 
 ### Note
 
-We don't want to pollute your system-wide python installation, so a python 2.7 virtual
+We don't want to pollute your system-wide python installation, so a python virtual
 environment is recommended (though optional). It will help keep an isolated development
 environment and ensure a clean system python.
 
 - Install the virtualenv module:
-```pip install virtualenv```
+```pip2 install virtualenv```
 - Create the virtual environment:
 ```virtualenv $GOPATH/src/github.com/DataDog/datadog-agent/venv```
 - Enable the virtual environment:
 ```source $GOPATH/src/github.com/DataDog/datadog-agent/venv/bin/activate```
+- Specify the path when building the agent:
+```invoke agent.build --python-home-2=$GOPATH/src/github.com/DataDog/datadog-agent/venv```
 
+If you are using python 3 instead (or switching between python versions), you can also
+add `--python-home-3=<path>` pointing to a python3 virtual environment.
 
 ## Golang
 

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -30,10 +30,6 @@ def bin_name(name, android=False):
 
 
 def get_multi_python_location(embedded_path=None, six_root=None):
-    if embedded_path is None:
-        # fall back to local dev path
-        embedded_path = "{}/src/github.com/DataDog/datadog-agent/dev".format(os.environ.get('GOPATH'))
-
     if six_root is None:
         six_lib = "{}/lib".format(six_root or embedded_path)
         six_headers = "{}/include".format(six_root or embedded_path)
@@ -59,6 +55,10 @@ def get_build_flags(ctx, static=False, prefix=None, use_venv=False, embedded_pat
     if sys.platform == 'win32':
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
 
+    if embedded_path is None:
+        # fall back to local dev path
+        embedded_path = "{}/src/github.com/DataDog/datadog-agent/dev".format(os.environ.get('GOPATH'))
+
     six_lib, six_headers = get_multi_python_location(embedded_path, six_root)
 
     # setting python homes in the code
@@ -76,7 +76,7 @@ def get_build_flags(ctx, static=False, prefix=None, use_venv=False, embedded_pat
     # if `static` was passed ignore setting rpath, even if `embedded_path` was passed as well
     if static:
         ldflags += "-s -w -linkmode=external '-extldflags=-static' "
-    elif embedded_path:
+    else:
         ldflags += "-r {}/lib ".format(embedded_path)
 
     if os.environ.get("DELVE"):


### PR DESCRIPTION
Makes the agent built with default inv commands work (no need to pass `--embedded-path` to inv nor to use `LD_LIBRARY_PATH` to point to dev/lib when loading the binary), just build and run with:

```
    inv six.build
    inv six.install
    inv agent.build
    ./bin/agent/agent
```