### PR TITLE
[omnibus/pip] Use the direct download URL to avoid redirection

### DIFF
--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -4,7 +4,7 @@ default_version "19.0.3"
 
 dependency "setuptools2"
 
-source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
+source :url => "https://codeload.github.com/pypa/pip/tar.gz/#{version}",
        :sha256 => "afe5d018b19a8ef00996d6bc3629e6df401efd295c99b38cc4872e07568482ff",
        :extract => :seven_zip
 

--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -4,7 +4,7 @@ default_version "19.0.3"
 
 dependency "setuptools3"
 
-source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
+source :url => "https://codeload.github.com/pypa/pip/tar.gz/#{version}",
        :sha256 => "afe5d018b19a8ef00996d6bc3629e6df401efd295c99b38cc4872e07568482ff",
        :extract => :seven_zip
 


### PR DESCRIPTION
**Note: this change doesn't work because the downloaded doesn't have the `tar.gz` extension anymore, so omnibus doesn't extract it... Looking at alternative solutions/modifying omnibus**

### What does this PR do?

Uses the direct download URL to avoid redirection on `pip2` and `pip3`

### Motivation

Should hopefully solve the hashsum mismatch errors that sometimes
happen, seemingly because omnibus doesn't follow redirections.
