### PR TITLE
[pkg/status] Add host tags to agent status and status gui tab

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -60,6 +60,15 @@
           {{end -}}
         {{- end -}}
       {{- end}}
+      {{- if gt (len .hostTags) 0 }}
+        <span>Host tags: <br>
+          <span class="stat_subdata">
+            {{- range $tag := .hostTags}}
+              {{$tag}}<br>
+            {{- end }}
+          </span>
+        </span>
+      {{- end }}
       Hostname Provider: {{.hostnameStats.provider}}<br>
       {{- if gt (len .hostnameStats.errors) 0 }}
         <span>Unused Hostname Providers: <br>

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -54,10 +54,10 @@ NOTE: Changes made to this template should be reflected on the following templat
   {{- end }}
   {{- if gt (len .hostTags) 0 }}
     host tags:
-  {{- end }}
     {{- range $tag := .hostTags}}
       {{$tag}}
     {{- end }}
+  {{- end }}
     hostname provider: {{.hostnameStats.provider}}
   {{- if gt (len .hostnameStats.errors) 0 }}
     unused hostname providers:

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -52,6 +52,12 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{$name}}: {{$value}}
     {{- end }}
   {{- end }}
+  {{- if gt (len .hostTags) 0 }}
+    host tags:
+  {{- end }}
+    {{- range $tag := .hostTags}}
+      {{$tag}}
+    {{- end }}
     hostname provider: {{.hostnameStats.provider}}
   {{- if gt (len .hostnameStats.errors) 0 }}
     unused hostname providers:

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -45,7 +45,7 @@ func GetStatus() (map[string]interface{}, error) {
 	} else {
 		stats["metadata"] = host.GetPayloadFromCache(hostname)
 	}
-
+	stats["hostTags"] = getHostTagsConfig()
 	stats["config"] = getPartialConfig()
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 
@@ -207,6 +207,11 @@ func getDCAPartialConfig() map[string]string {
 	conf["log_level"] = config.Datadog.GetString("log_level")
 	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	return conf
+}
+
+// getHostTagsConfig returns config host tags applied to all metrics
+func getHostTagsConfig() []string {
+	return config.Datadog.GetStringSlice("tags")
 }
 
 // getPartialConfig returns config parameters of interest for the status page

--- a/releasenotes/notes/add-host-tags-to-status-d7eac72734a20cb4.yaml
+++ b/releasenotes/notes/add-host-tags-to-status-d7eac72734a20cb4.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds host tags in the Hostname section of the
+    agent status command and the status tab of the GUI.


### PR DESCRIPTION
### What does this PR do?

Adds host tags to the stats map returned by GetStatus, and
display them in agent status command and status tab of the GUI.

![image](https://user-images.githubusercontent.com/26872252/57455328-34896f00-726b-11e9-81d9-a5525a562a6e.png)
![image](https://user-images.githubusercontent.com/26872252/57455380-4bc85c80-726b-11e9-87ec-b7e297676f00.png)


### Motivation

Host tags applied to all metrics sent by the agent aren't shown
anywhere.
