### PR TITLE
Allow using .* as wildcard when setting config keys as known

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -550,7 +550,7 @@ func load(config Config, origin string, loadSecret bool) error {
 		return err
 	}
 
-	for key := range findUnknownKeys(config) {
+	for _, key := range findUnknownKeys(config) {
 		log.Warnf("Unknown key in config file: %v", key)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -521,7 +521,7 @@ func LoadWithoutSecret() error {
 	return load(Datadog, "datadog.yaml", false)
 }
 
-func checkForUnknownKeys(config Config) []string {
+func findUnknownKeys(config Config) []string {
 	var unknownKeys []string
 	knownKeys := config.GetKnownKeys()
 	loadedKeys := config.AllKeys()
@@ -550,8 +550,7 @@ func load(config Config, origin string, loadSecret bool) error {
 		return err
 	}
 
-	unknownKeys := checkForUnknownKeys(config)
-	for key := range unknownKeys {
+	for key := range findUnknownKeys(config) {
 		log.Warnf("Unknown key in config file: %v", key)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -521,8 +521,8 @@ func LoadWithoutSecret() error {
 	return load(Datadog, "datadog.yaml", false)
 }
 
-func checkForUnknownKeys(config Config) bool {
-	hasUnknownKeys := false
+func checkForUnknownKeys(config Config) []string {
+	var unknownKeys []string
 	knownKeys := config.GetKnownKeys()
 	loadedKeys := config.AllKeys()
 	for _, key := range loadedKeys {
@@ -537,12 +537,11 @@ func checkForUnknownKeys(config Config) bool {
 				}
 			}
 			if !found {
-				log.Warnf("Unknown key in config file: %v", key)
-				hasUnknownKeys = true
+				unknownKeys = append(unknownKeys, key)
 			}
 		}
 	}
-	return hasUnknownKeys
+	return unknownKeys
 }
 
 func load(config Config, origin string, loadSecret bool) error {
@@ -551,7 +550,10 @@ func load(config Config, origin string, loadSecret bool) error {
 		return err
 	}
 
-	checkForUnknownKeys(config)
+	unknownKeys := checkForUnknownKeys(config)
+	for key := range unknownKeys {
+		log.Warnf("Unknown key in config file: %v", key)
+	}
 
 	if loadSecret {
 		// We have to init the secrets package before we can use it to decrypt

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -531,7 +531,17 @@ func load(config Config, origin string, loadSecret bool) error {
 	loadedKeys := config.AllKeys()
 	for _, key := range loadedKeys {
 		if _, found := knownKeys[key]; !found {
-			log.Warnf("Unknown key in config file: %v", key)
+			//Check if any subkey with a .* is marked as known
+			splitPath := strings.Split(key, ".")
+			for j := range splitPath {
+				subKey := strings.Join(splitPath[:j+1], ".") + ".*"
+				if _, found = knownKeys[subKey]; found {
+					break
+				}
+			}
+			if !found {
+				log.Warnf("Unknown key in config file: %v", key)
+			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -531,7 +531,8 @@ func load(config Config, origin string, loadSecret bool) error {
 	loadedKeys := config.AllKeys()
 	for _, key := range loadedKeys {
 		if _, found := knownKeys[key]; !found {
-			//Check if any subkey with a .* is marked as known
+			// Check if any subkey terminated with a '.*' wildcard is marked as known
+			// e.g.: apm_config.* would match all sub-keys of apm_config
 			splitPath := strings.Split(key, ".")
 			for j := range splitPath {
 				subKey := strings.Join(splitPath[:j+1], ".") + ".*"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -89,17 +89,17 @@ func TestUnknownKeysWarning(t *testing.T) {
 site: datadoghq.eu
 `
 	confBase := setupConfFromYAML(yamlBase)
-	assert.False(t, checkForUnknownKeys(confBase))
+	assert.Len(t, checkForUnknownKeys(confBase), 0)
 
 	yamlWithUnknownKeys := `
 site: datadoghq.eu
 unknown_key.unknown_subkey: true
 `
 	confWithUnknownKeys := setupConfFromYAML(yamlWithUnknownKeys)
-	assert.True(t, checkForUnknownKeys(confWithUnknownKeys))
+	assert.Len(t, checkForUnknownKeys(confWithUnknownKeys), 1)
 
 	confWithUnknownKeys.SetKnown("unknown_key.*")
-	assert.False(t, checkForUnknownKeys(confWithUnknownKeys))
+	assert.Len(t, checkForUnknownKeys(confWithUnknownKeys), 0)
 }
 
 func TestSiteEnvVar(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -89,17 +89,17 @@ func TestUnknownKeysWarning(t *testing.T) {
 site: datadoghq.eu
 `
 	confBase := setupConfFromYAML(yamlBase)
-	assert.Len(t, checkForUnknownKeys(confBase), 0)
+	assert.Len(t, findUnknownKeys(confBase), 0)
 
 	yamlWithUnknownKeys := `
 site: datadoghq.eu
 unknown_key.unknown_subkey: true
 `
 	confWithUnknownKeys := setupConfFromYAML(yamlWithUnknownKeys)
-	assert.Len(t, checkForUnknownKeys(confWithUnknownKeys), 1)
+	assert.Len(t, findUnknownKeys(confWithUnknownKeys), 1)
 
 	confWithUnknownKeys.SetKnown("unknown_key.*")
-	assert.Len(t, checkForUnknownKeys(confWithUnknownKeys), 0)
+	assert.Len(t, findUnknownKeys(confWithUnknownKeys), 0)
 }
 
 func TestSiteEnvVar(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -78,6 +79,22 @@ api_key: fakeapikey
 	assert.Nil(t, err)
 	assert.EqualValues(t, expectedMultipleEndpoints, multipleEndpoints)
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
+}
+
+func TestUnknownKeysWarning(t *testing.T) {
+
+	yamlBase := `
+site: datadoghq.eu
+`
+	confBase := setupConfFromYAML(yamlBase)
+	assert.False(t, checkForUnknownKeys(confBase))
+
+	yamlWithUnknownKeys := `
+site: datadoghq.eu
+unknown_key.unknown_subkey: true
+`
+	confWithUnknownKeys := setupConfFromYAML(yamlWithUnknownKeys)
+	assert.True(t, checkForUnknownKeys(confWithUnknownKeys))
 }
 
 func TestSiteEnvVar(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -98,6 +98,9 @@ unknown_key.unknown_subkey: true
 `
 	confWithUnknownKeys := setupConfFromYAML(yamlWithUnknownKeys)
 	assert.True(t, checkForUnknownKeys(confWithUnknownKeys))
+
+	confWithUnknownKeys.SetKnown("unknown_key.*")
+	assert.False(t, checkForUnknownKeys(confWithUnknownKeys))
 }
 
 func TestSiteEnvVar(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,7 +7,7 @@ package config
 
 import (
 	"bytes"
-	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -28,7 +28,7 @@ func setupConfFromYAML(yamlConfig string) Config {
 	conf.SetConfigType("yaml")
 	e := conf.ReadConfig(bytes.NewBuffer([]byte(yamlConfig)))
 	if e != nil {
-		fmt.Println(e)
+		log.Println(e)
 	}
 	return conf
 }
@@ -85,7 +85,6 @@ api_key: fakeapikey
 }
 
 func TestUnknownKeysWarning(t *testing.T) {
-
 	yamlBase := `
 site: datadoghq.eu
 `

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,7 +25,10 @@ func setupConf() Config {
 func setupConfFromYAML(yamlConfig string) Config {
 	conf := NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	conf.SetConfigType("yaml")
-	conf.ReadConfig(bytes.NewBuffer([]byte(yamlConfig)))
+	e := conf.ReadConfig(bytes.NewBuffer([]byte(yamlConfig)))
+	if e != nil {
+		fmt.Println(e)
+	}
 	initConfig(conf)
 	return conf
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,12 +24,12 @@ func setupConf() Config {
 
 func setupConfFromYAML(yamlConfig string) Config {
 	conf := NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	initConfig(conf)
 	conf.SetConfigType("yaml")
 	e := conf.ReadConfig(bytes.NewBuffer([]byte(yamlConfig)))
 	if e != nil {
 		fmt.Println(e)
 	}
-	initConfig(conf)
 	return conf
 }
 


### PR DESCRIPTION
If a key is not known, we check if we can find a known parent key with a `.*` before printing a warning.