### PR TITLE
Docker parser per tailer

### DIFF
--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -8,7 +8,6 @@ package docker
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
@@ -29,7 +28,7 @@ type DockerParser struct {
 	containerID string
 }
 
-func newDockerParser(containerID string) *DockerParser {
+func NewDockerParser(containerID string) *DockerParser {
 	return &DockerParser{
 		containerID: containerID,
 	}
@@ -59,7 +58,7 @@ func parse(msg []byte, containerID string) ([]byte, string, string, error) {
 	// [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 	// If we don't have at the very least 8 bytes we can consider this message can't be parsed.
 	if len(msg) < dockerHeaderLength {
-		return msg, message.StatusInfo, "", errors.New(fmt.Sprintf("Container %v, can't parse docker message: expected a 8 bytes header", ShortContainerID(containerID)))
+		return msg, message.StatusInfo, "", fmt.Errorf("Can't parse docker message for container %v: expected a 8 bytes header", ShortContainerID(containerID))
 	}
 
 	// Read the first byte to get the status

--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -26,12 +26,12 @@ const dockerBufferSize = 16 * 1024
 var escapedCRLF = []byte{'\\', 'r', '\\', 'n'}
 
 type DockerParser struct {
-	containerID	string
+	containerID string
 }
 
 func newDockerParser(containerID string) *DockerParser {
-	return &DockerParser {
-		containerID:	containerID,
+	return &DockerParser{
+		containerID: containerID,
 	}
 }
 

--- a/pkg/logs/input/docker/parser.go
+++ b/pkg/logs/input/docker/parser.go
@@ -58,7 +58,7 @@ func parse(msg []byte, containerID string) ([]byte, string, string, error) {
 	// [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 	// If we don't have at the very least 8 bytes we can consider this message can't be parsed.
 	if len(msg) < dockerHeaderLength {
-		return msg, message.StatusInfo, "", fmt.Errorf("Can't parse docker message for container %v: expected a 8 bytes header", ShortContainerID(containerID))
+		return msg, message.StatusInfo, "", fmt.Errorf("cannot parse docker message for container %v: expected a 8 bytes header", ShortContainerID(containerID))
 	}
 
 	// Read the first byte to get the status

--- a/pkg/logs/input/docker/parser_test.go
+++ b/pkg/logs/input/docker/parser_test.go
@@ -75,7 +75,7 @@ func TestDockerStandaloneParserShouldFailWithInvalidInput(t *testing.T) {
 	msg = []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0}...)
 	_, err = container1Parser.Parse(msg)
-	assert.Equal(t, errors.New("Can't parse docker message for container container_1: expected a 8 bytes header"), err)
+	assert.Equal(t, errors.New("cannot parse docker message for container container_1: expected a 8 bytes header"), err)
 
 }
 

--- a/pkg/logs/input/docker/parser_test.go
+++ b/pkg/logs/input/docker/parser_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var dockerHeader = string([]byte{1, 0, 0, 0, 0, 0, 0, 0}) + "2018-06-14T18:27:03.246999277Z"
+var container1Parser = NewDockerParser("container_1")
 
 func TestGetDockerSeverity(t *testing.T) {
 	assert.Equal(t, message.StatusInfo, getDockerSeverity([]byte{1}))
@@ -25,7 +26,7 @@ func TestGetDockerSeverity(t *testing.T) {
 
 func TestDockerStandaloneParserShouldSucceedWithValidInput(t *testing.T) {
 	validMessage := dockerHeader + " " + "anything"
-	parser := newDockerParser("container_1")
+	parser := NewDockerParser("container_1")
 	dockerMsg, err := parser.Parse([]byte(validMessage))
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", dockerMsg.Timestamp)
@@ -34,26 +35,23 @@ func TestDockerStandaloneParserShouldSucceedWithValidInput(t *testing.T) {
 }
 
 func TestDockerStandaloneParserShouldHandleEmptyMessage(t *testing.T) {
-	parser := newDockerParser("container_1")
-	msg, err := parser.Parse([]byte(dockerHeader))
+	msg, err := container1Parser.Parse([]byte(dockerHeader))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg.Content))
 }
 
 func TestDockerStandaloneParserShouldHandleNewlineOnlyMessage(t *testing.T) {
-	parser := newDockerParser("container_1")
 	emptyContent := [3]string{"\\n", "\\r", "\\r\\n"}
 
 	for _, em := range emptyContent {
-		msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z " + em))
+		msg, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z " + em))
 		assert.Nil(t, err)
 		assert.Equal(t, 0, len(msg.Content))
 	}
 }
 
 func TestDockerStandaloneParserShouldHandleTtyMessage(t *testing.T) {
-	parser := newDockerParser("container_1")
-	msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z foo"))
+	msg, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z foo"))
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", msg.Timestamp)
 	assert.Equal(t, message.StatusInfo, msg.GetStatus())
@@ -61,30 +59,27 @@ func TestDockerStandaloneParserShouldHandleTtyMessage(t *testing.T) {
 }
 
 func TestDockerStandaloneParserShouldHandleEmptyTtyMessage(t *testing.T) {
-	parser := newDockerParser("container_1")
-	msg, err := parser.Parse([]byte("2018-06-14T18:27:03.246999277Z"))
+	msg, err := container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z"))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg.Content))
-	msg, err = parser.Parse([]byte("2018-06-14T18:27:03.246999277Z "))
+	msg, err = container1Parser.Parse([]byte("2018-06-14T18:27:03.246999277Z "))
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(msg.Content))
 }
 
 func TestDockerStandaloneParserShouldFailWithInvalidInput(t *testing.T) {
-	parser := newDockerParser("container_1")
 	var msg []byte
 	var err error
 
 	// missing dockerHeader separator
 	msg = []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0}...)
-	_, err = parser.Parse(msg)
-	assert.Equal(t, errors.New("Container container_1, can't parse docker message: expected a 8 bytes header"), err)
+	_, err = container1Parser.Parse(msg)
+	assert.Equal(t, errors.New("Can't parse docker message for container container_1: expected a 8 bytes header"), err)
 
 }
 
 func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
-	parser := newDockerParser("container_1")
 	var msgToClean []byte
 	var dockerMsg *message.Message
 	var expectedMsg []byte
@@ -93,7 +88,7 @@ func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
 	// 16kb log
 	msgToClean = []byte(buildPartialMessage('a', dockerBufferSize) + dockerHeader)
 	expectedMsg = []byte(buildMessage('a', dockerBufferSize))
-	dockerMsg, err = parser.Parse(msgToClean)
+	dockerMsg, err = container1Parser.Parse(msgToClean)
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", dockerMsg.Timestamp)
 	assert.Equal(t, message.StatusInfo, dockerMsg.GetStatus())
@@ -103,7 +98,7 @@ func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
 	// over 16kb
 	msgToClean = []byte(buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('b', 50))
 	expectedMsg = []byte(buildMessage('a', dockerBufferSize) + buildMessage('b', 50))
-	dockerMsg, err = parser.Parse(msgToClean)
+	dockerMsg, err = container1Parser.Parse(msgToClean)
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", dockerMsg.Timestamp)
 	assert.Equal(t, message.StatusInfo, dockerMsg.GetStatus())
@@ -113,7 +108,7 @@ func TestDockerStandaloneParserShouldRemovePartialHeaders(t *testing.T) {
 	// three times over 16kb
 	msgToClean = []byte(buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('a', dockerBufferSize) + buildPartialMessage('b', 50))
 	expectedMsg = []byte(buildMessage('a', 3*dockerBufferSize) + buildMessage('b', 50))
-	dockerMsg, err = parser.Parse(msgToClean)
+	dockerMsg, err = container1Parser.Parse(msgToClean)
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-06-14T18:27:03.246999277Z", dockerMsg.Timestamp)
 	assert.Equal(t, message.StatusInfo, dockerMsg.GetStatus())

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -57,7 +57,7 @@ func NewTailer(cli *client.Client, containerID string, source *config.LogSource,
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,
-		decoder:            decoder.InitializeDecoder(source, dockerParser),
+		decoder:            decoder.InitializeDecoder(source, newDockerParser(containerID)),
 		source:             source,
 		tagProvider:        tag.NewProvider(dockerutil.ContainerIDToEntityName(containerID)),
 		cli:                cli,

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -57,7 +57,7 @@ func NewTailer(cli *client.Client, containerID string, source *config.LogSource,
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,
-		decoder:            decoder.InitializeDecoder(source, newDockerParser(containerID)),
+		decoder:            decoder.InitializeDecoder(source, NewDockerParser(containerID)),
 		source:             source,
 		tagProvider:        tag.NewProvider(dockerutil.ContainerIDToEntityName(containerID)),
 		cli:                cli,

--- a/releasenotes/notes/Docker-parser-per-tailer-c834707af1942d1b.yaml
+++ b/releasenotes/notes/Docker-parser-per-tailer-c834707af1942d1b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Logs docker container ID when parse invalid docker log in DEBUG level.


### PR DESCRIPTION
### What does this PR do?

Update logs docker input parser to be specific per container. Agent logs container ID along with parse failure.

### Motivation

To be able to associate the expected logs with the container, from whom they are generated.

### Additional Notes

Locally tested.
