### PR TITLE
Fix string type in the datadog_agent module

### DIFF
--- a/six/common/_util.h
+++ b/six/common/_util.h
@@ -11,7 +11,6 @@
 
 #ifdef DATADOG_AGENT_THREE
 PyMODINIT_FUNC PyInit__util(void);
-#    define PyStringFromCString(x) PyUnicode_FromString(x)
 #endif
 
 #ifdef __cplusplus
@@ -20,7 +19,6 @@ extern "C" {
 
 #ifdef DATADOG_AGENT_TWO
 void Py2_init__util();
-#    define PyStringFromCString(x) PyString_FromString(x)
 #endif
 
 void _set_get_subprocess_output_cb(cb_get_subprocess_output_t);

--- a/six/common/datadog_agent.c
+++ b/six/common/datadog_agent.c
@@ -100,7 +100,7 @@ PyObject *get_version(PyObject *self, PyObject *args)
     cb_get_version(&v);
 
     if (v != NULL) {
-        PyObject *retval = PyUnicode_FromString(v);
+        PyObject *retval = PyStringFromCString(v);
         cgo_free(v);
         return retval;
     }
@@ -199,7 +199,7 @@ PyObject *get_hostname(PyObject *self, PyObject *args)
     cb_get_hostname(&v);
 
     if (v != NULL) {
-        PyObject *retval = PyUnicode_FromString(v);
+        PyObject *retval = PyStringFromCString(v);
         cgo_free(v);
         return retval;
     }
@@ -217,7 +217,7 @@ PyObject *get_clustername(PyObject *self, PyObject *args)
     cb_get_clustername(&v);
 
     if (v != NULL) {
-        PyObject *retval = PyUnicode_FromString(v);
+        PyObject *retval = PyStringFromCString(v);
         cgo_free(v);
         return retval;
     }

--- a/six/test/datadog_agent/datadog_agent.go
+++ b/six/test/datadog_agent/datadog_agent.go
@@ -80,6 +80,7 @@ func tearDown() {
 func run(call string) (string, error) {
 	tmpfile.Truncate(0)
 	code := C.CString(fmt.Sprintf(`
+import sys
 try:
 	import datadog_agent
 	%s

--- a/six/test/datadog_agent/datadog_agent_test.go
+++ b/six/test/datadog_agent/datadog_agent_test.go
@@ -22,7 +22,12 @@ func TestMain(m *testing.M) {
 func TestGetVersion(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
-		f.write(datadog_agent.get_version())
+		version = datadog_agent.get_version()
+		if sys.version_info.major == 2:
+			assert type(version) == type(b"")
+		else:
+			assert type(version) == type(u"")
+		f.write(version)
 	`, tmpfile.Name())
 	out, err := run(code)
 	if err != nil {
@@ -66,7 +71,12 @@ func TestHeaders(t *testing.T) {
 func TestGetHostname(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
-		f.write(datadog_agent.get_hostname())
+		name = datadog_agent.get_hostname()
+		if sys.version_info.major == 2:
+			assert type(name) == type(b"")
+		else:
+			assert type(name) == type(u"")
+		f.write(name)
 	`, tmpfile.Name())
 	out, err := run(code)
 	if err != nil {
@@ -80,7 +90,12 @@ func TestGetHostname(t *testing.T) {
 func TestGetClustername(t *testing.T) {
 	code := fmt.Sprintf(`
 	with open(r'%s', 'w') as f:
-		f.write(datadog_agent.get_clustername())
+		name = datadog_agent.get_clustername()
+		if sys.version_info.major == 2:
+			assert type(name) == type(b"")
+		else:
+			assert type(name) == type(u"")
+		f.write(name)
 	`, tmpfile.Name())
 
 	out, err := run(code)


### PR DESCRIPTION
### What does this PR do?

Fix string type in the datadog_agent module
We want to return byte for python2 and unicode for python3.
