### PR TITLE
[Metadata]: Correctly stop scheduler go routine

### DIFF
--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -70,7 +70,8 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 	health := health.Register("metadata-" + name)
 
 	go func() {
-		ctx := context.Context(c.context)
+		ctx, cancelCtxFunc := context.WithCancel(c.context)
+		defer cancelCtxFunc()
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -6,6 +6,7 @@
 package metadata
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -31,8 +32,5 @@ func TestStopScheduler(t *testing.T) {
 	c.AddCollector("test", time.Duration(60))
 	c.AddCollector("test2", time.Duration(60))
 	c.Stop()
-	for _, s := range c.stopChannels {
-		_, ok := <-s
-		assert.False(t, ok)
-	}
+	assert.Equal(t, context.Canceled, c.context.Err())
 }

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -7,6 +7,7 @@ package metadata
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -20,4 +21,18 @@ func TestNewScheduler(t *testing.T) {
 	c := NewScheduler(s, "hostname")
 	assert.Equal(t, fwd, c.srl.Forwarder)
 	assert.Equal(t, "hostname", c.hostname)
+}
+
+func TestStopScheduler(t *testing.T) {
+	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd.Start()
+	s := serializer.NewSerializer(fwd)
+	c := NewScheduler(s, "hostname")
+	c.AddCollector("test", time.Duration(60))
+	c.AddCollector("test2", time.Duration(60))
+	c.Stop()
+	for _, s := range c.stopChannels {
+		_, ok := <-s
+		assert.False(t, ok)
+	}
 }

--- a/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
+++ b/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Correctly exits the metadata collector goroutines when scheduler stop is invoked
+    Fix a bug where when the log agent is mis-configured, it temporarily hog on resources after being killed

--- a/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
+++ b/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Correctly exits the metadata collector goroutines when scheduler stop is invoked


### PR DESCRIPTION
### What does this PR do?

Gracefully stop the metadata scheduler. When the log agent receives a stop, it flushes the buffered messages. However, this scheduler is not stopped due to the go routine created when "AddCollector" is called. The sendTicker (from tick.go) stop function does not close the channel, hence the issue.

### Motivation

[Trello](https://trello.com/c/39VFt4i2/1073-fidelity-cloud-foundry-agent-consume-all-resources-when-logs-cannot-be-forwarded)


