### PR TITLE
[pkg/status] Add explicit warning when ntp offset is too high

### DIFF
--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -147,4 +147,3 @@ func displayStatus(check map[string]interface{}) template.HTML {
 	}
 	return template.HTML("[<span class=\"ok\">OK</span>]")
 }
-

--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -23,7 +23,6 @@ func init() {
 	fmap["lastErrorMessage"] = lastErrorMessage
 	fmap["pythonLoaderError"] = pythonLoaderError
 	fmap["status"] = displayStatus
-	fmap["displayNtpWarning"] = displayNtpWarning
 }
 
 // Data is a struct used for filling templates
@@ -149,7 +148,3 @@ func displayStatus(check map[string]interface{}) template.HTML {
 	return template.HTML("[<span class=\"ok\">OK</span>]")
 }
 
-func displayNtpWarning() template.HTML {
-	return template.HTML("<br><span class=\"warning\">NTP Offset is high. " +
-		"The application may ignore metrics sent by this agent.</span>")
-}

--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -23,6 +23,7 @@ func init() {
 	fmap["lastErrorMessage"] = lastErrorMessage
 	fmap["pythonLoaderError"] = pythonLoaderError
 	fmap["status"] = displayStatus
+	fmap["displayNtpWarning"] = displayNtpWarning
 }
 
 // Data is a struct used for filling templates
@@ -146,4 +147,9 @@ func displayStatus(check map[string]interface{}) template.HTML {
 		return template.HTML("[<span class=\"warning\">WARNING</span>]")
 	}
 	return template.HTML("[<span class=\"ok\">OK</span>]")
+}
+
+func displayNtpWarning() template.HTML {
+	return template.HTML("<br><span class=\"warning\">NTP Offset is high. " +
+		"The application may ignore metrics sent by this agent.</span>")
 }

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -27,7 +27,7 @@
       {{- if .ntpOffset}}
         <br>NTP Offset: {{ humanizeDuration .ntpOffset "s"}}
         {{- if ntpWarning .ntpOffset}}
-        {{displayNtpWarning}}
+        <br><span class="warning">NTP Offset is high. The application may ignore metrics sent by this agent.</span>
         {{- end}}
       {{end}}
       <br>Go Version: {{.platform.goV}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -26,6 +26,9 @@
       System UTC Time: {{.time}}
       {{- if .ntpOffset}}
         <br>NTP Offset: {{ humanizeDuration .ntpOffset "s"}}
+        {{- if ntpWarning .ntpOffset}}
+        {{displayNtpWarning}}
+        {{- end}}
       {{end}}
       <br>Go Version: {{.platform.goV}}
       <br>Python Version: {{.python_version}}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -27,7 +27,7 @@
       {{- if .ntpOffset}}
         <br>NTP Offset: {{ humanizeDuration .ntpOffset "s"}}
         {{- if ntpWarning .ntpOffset}}
-        <br><span class="warning">NTP Offset is high. The application may ignore metrics sent by this agent.</span>
+        <br><span class="warning">NTP Offset is high. The web application may ignore metrics sent by this agent.</span>
         {{- end}}
       {{end}}
       <br>Go Version: {{.platform.goV}}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -31,6 +31,9 @@ NOTE: Changes made to this template should be reflected on the following templat
   ======
     {{- if .ntpOffset }}
     NTP offset: {{ humanizeDuration .ntpOffset "s"}}
+    {{- if ntpWarning .ntpOffset}}
+    {{displayNtpWarning}}
+    {{- end }}
     {{- end }}
     System UTC time: {{.time}}
 

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -32,7 +32,7 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{- if .ntpOffset }}
     NTP offset: {{ humanizeDuration .ntpOffset "s"}}
     {{- if ntpWarning .ntpOffset}}
-    {{displayNtpWarning}}
+    {{yellowText "NTP offset is high. The application may ignore metrics sent by this agent."}}
     {{- end }}
     {{- end }}
     System UTC time: {{.time}}

--- a/pkg/status/dist/templates/header.tmpl
+++ b/pkg/status/dist/templates/header.tmpl
@@ -32,7 +32,7 @@ NOTE: Changes made to this template should be reflected on the following templat
     {{- if .ntpOffset }}
     NTP offset: {{ humanizeDuration .ntpOffset "s"}}
     {{- if ntpWarning .ntpOffset}}
-    {{yellowText "NTP offset is high. The application may ignore metrics sent by this agent."}}
+    {{yellowText "NTP offset is high. The web application may ignore metrics sent by this agent."}}
     {{- end }}
     {{- end }}
     System UTC time: {{.time}}

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -36,7 +36,9 @@ func Fmap() template.FuncMap {
 		"formatTitle":        formatTitle,
 		"add":                add,
 		"status":             status,
-		"displayNtpWarning":  displayNtpWarning,
+		"redText":            redText,
+		"yellowText":         yellowText,
+		"greenText":          greenText,
 		"ntpWarning":         ntpWarning,
 		"version":            getVersion,
 	}
@@ -185,9 +187,19 @@ func status(check map[string]interface{}) string {
 	return fmt.Sprintf("[%s]", color.GreenString("OK"))
 }
 
-// Renders the ntp warning message in a yellow color
-func displayNtpWarning() string {
-	return color.YellowString("NTP offset is high. The application may ignore metrics sent by this agent.")
+// Renders the message in a yellow color
+func redText(message string) string {
+	return color.RedString(message)
+}
+
+// Renders the message in a yellow color
+func yellowText(message string) string {
+	return color.YellowString(message)
+}
+
+// Renders the message in a yellow color
+func greenText(message string) string {
+	return color.GreenString(message)
 }
 
 // Tells if the ntp offset may be too large, resulting in metrics

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -187,7 +187,7 @@ func status(check map[string]interface{}) string {
 	return fmt.Sprintf("[%s]", color.GreenString("OK"))
 }
 
-// Renders the message in a yellow color
+// Renders the message in a red color
 func redText(message string) string {
 	return color.RedString(message)
 }
@@ -197,7 +197,7 @@ func yellowText(message string) string {
 	return color.YellowString(message)
 }
 
-// Renders the message in a yellow color
+// Renders the message in a green color
 func greenText(message string) string {
 	return color.GreenString(message)
 }

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -185,7 +185,7 @@ func status(check map[string]interface{}) string {
 	return fmt.Sprintf("[%s]", color.GreenString("OK"))
 }
 
-// Renders the message in a yellow color
+// Renders the ntp warning message in a yellow color
 func displayNtpWarning() string {
 	return color.YellowString("NTP offset is high. The application may ignore metrics sent by this agent.")
 }

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -36,6 +36,8 @@ func Fmap() template.FuncMap {
 		"formatTitle":        formatTitle,
 		"add":                add,
 		"status":             status,
+		"displayNtpWarning":  displayNtpWarning,
+		"ntpWarning":         ntpWarning,
 		"version":            getVersion,
 	}
 }
@@ -181,6 +183,20 @@ func status(check map[string]interface{}) string {
 		return fmt.Sprintf("[%s]", color.YellowString("WARNING"))
 	}
 	return fmt.Sprintf("[%s]", color.GreenString("OK"))
+}
+
+// Renders the message in a yellow color
+func displayNtpWarning() string {
+	return color.YellowString("NTP offset is high. The application may ignore metrics sent by this agent.")
+}
+
+// Tells if the ntp offset may be too large, resulting in metrics
+// from the agent being dropped by metrics-intake
+func ntpWarning(ntpOffset float64) bool {
+	// Negative offset => clock is in the future, 10 minutes (600s) allowed
+	// Positive offset => clock is in the past, 60 minutes (3600s) allowed
+	// According to https://docs.datadoghq.com/developers/metrics/#submitting-metrics
+	return ntpOffset <= -600 || ntpOffset >= 3600
 }
 
 func getVersion(instances map[string]interface{}) string {

--- a/pkg/status/helpers_test.go
+++ b/pkg/status/helpers_test.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+func TestNtpWarning(t *testing.T) {
+	require.False(t, ntpWarning(1))
+	require.False(t, ntpWarning(-1))
+	require.True(t, ntpWarning(3601))
+	require.True(t, ntpWarning(-601))
+}

--- a/pkg/status/helpers_test.go
+++ b/pkg/status/helpers_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
 func TestNtpWarning(t *testing.T) {
 	require.False(t, ntpWarning(1))
 	require.False(t, ntpWarning(-1))

--- a/releasenotes/notes/add-warning-ntp-offset-too-high-4ecabb07d0fd3417.yaml
+++ b/releasenotes/notes/add-warning-ntp-offset-too-high-4ecabb07d0fd3417.yaml
@@ -10,4 +10,4 @@ enhancements:
   - |
     Added a warning message on agent status command and status gui
     tab when ntp offset is too large and may result in metrics
-    ignored by the main application.
+    ignored by the web application.

--- a/releasenotes/notes/add-warning-ntp-offset-too-high-4ecabb07d0fd3417.yaml
+++ b/releasenotes/notes/add-warning-ntp-offset-too-high-4ecabb07d0fd3417.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added a warning message on agent status command and status gui
+    tab when ntp offset is too large and may result in metrics
+    ignored by the main application.


### PR DESCRIPTION
### What does this PR do?

When the NTP offset is large, it prevents all metrics sent by the agent from being ingested by DD.
This PR adds explicit warning messages in both the `agent status` command and the status tab of the GUI.

The thresholds used are on this page: https://docs.datadoghq.com/developers/metrics/#submitting-metrics

![image](https://user-images.githubusercontent.com/26872252/57524898-855f9d00-7329-11e9-8789-46b614a4f409.png)

![image](https://user-images.githubusercontent.com/26872252/57525073-028b1200-732a-11e9-9f79-d9a607603e42.png)

### Motivation

Currently, there's no indication in the agent status that the metrics 
sent could be discarded because of the NTP offset.

### Additional Notes

Don't hesitate to tell me if you find a nicer formulation for the warning message!