### PR TITLE
Make install more resilient to missing domain controller

### DIFF
--- a/omnibus/resources/agent/msi/cal/CustomAction.cpp
+++ b/omnibus/resources/agent/msi/cal/CustomAction.cpp
@@ -38,9 +38,13 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
     regkeybase.createSubKey(strRollbackKeyName.c_str(), keyRollback, REG_OPTION_VOLATILE);
     regkeybase.createSubKey(strUninstallKeyName.c_str(), keyInstall);
 
+    // check to see if we're a domain controller.
+    WcaLog(LOGMSG_STANDARD, "checking if this is a domain controller");
+    isDC = isDomainController(hInstall);
+
     // check to see if the supplied dd-agent-user exists
     WcaLog(LOGMSG_STANDARD, "checking to see if the user is already present");
-    if ((ddUserExists = doesUserExist(hInstall, data)) == -1) {
+    if ((ddUserExists = doesUserExist(hInstall, data, isDC)) == -1) {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;
     }
@@ -50,10 +54,7 @@ extern "C" UINT __stdcall FinalizeInstall(MSIHANDLE hInstall) {
         er = ERROR_INSTALL_FAILURE;
         goto LExit;
     }
-    // check to see if we're a domain controller.
-    WcaLog(LOGMSG_STANDARD, "checking if this is a domain controller");
-    isDC = isDomainController(hInstall);
-
+    
     // now we have all the information we need to decide if this is a
     // new installation or an upgrade, and what steps need to be taken
 

--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -7,7 +7,7 @@ int doCreateUser(const std::wstring& name, const wchar_t * domain, std::wstring&
 DWORD changeRegistryAcls(CustomActionData& data, const wchar_t* name);
 DWORD addDdUserPermsToFile(CustomActionData& data, std::wstring &filename);
 bool isDomainController(MSIHANDLE hInstall);
-int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data);
+int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC = false);
 
 void removeUserPermsFromFile(std::wstring &filename, PSID sidremove);
 

--- a/omnibus/resources/agent/msi/cal/stopservices.cpp
+++ b/omnibus/resources/agent/msi/cal/stopservices.cpp
@@ -766,12 +766,13 @@ int installServices(MSIHANDLE hInstall, CustomActionData& data, const wchar_t *p
         retval = services[i].create(hScManager);
         if (retval != 0) {
             WcaLog(LOGMSG_STANDARD, "Failed to install service %d %d 0x%x, rolling back", i, retval, retval);
-            for (i = i - 1; i >= 0; i--) {
-                DWORD rbret = services[i].destroy(hScManager);
+            for (int rbi = i - 1; rbi >= 0; rbi--) {
+                DWORD rbret = services[rbi].destroy(hScManager);
                 if (rbret != 0) {
                     WcaLog(LOGMSG_STANDARD, "Failed to roll back service install %d 0x%x", rbret, rbret);
                 }
             }
+            break;
         }
     }
     WcaLog(LOGMSG_STANDARD, "done installing services");

--- a/omnibus/resources/agent/msi/cal/usercreate.cpp
+++ b/omnibus/resources/agent/msi/cal/usercreate.cpp
@@ -317,7 +317,6 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
         return 0;
     }
     if (ERROR_INSUFFICIENT_BUFFER != err) {
-        err = GetLastError();
         if (!isDC) {
             // can only try this if we're not on a primary/backup DC; on DCs we must
             // be able to contact the domain authority.  

--- a/omnibus/resources/agent/msi/cal/usercreate.cpp
+++ b/omnibus/resources/agent/msi/cal/usercreate.cpp
@@ -291,7 +291,7 @@ bool isDomainController(MSIHANDLE hInstall)
     return ret;
 }
 
-int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data)
+int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data, bool isDC)
 {
     int retval = 0;
     SID *newsid = NULL;
@@ -301,7 +301,9 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data)
     SID_NAME_USE use;
     std::string narrowdomain;
     DWORD err = 0;
-    BOOL bRet = LookupAccountName(NULL, data.getQualifiedUsername().c_str(), newsid, &cbSid, refDomain, &cchRefDomain, &use);
+    const wchar_t * userToTry = data.getQualifiedUsername().c_str();
+
+    BOOL bRet = LookupAccountName(NULL, userToTry, newsid, &cbSid, refDomain, &cchRefDomain, &use);
     if (bRet) {
         err = GetLastError();
         // this should *never* happen, because we didn't pass in a buffer large enough for
@@ -315,9 +317,51 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data)
         return 0;
     }
     if (ERROR_INSUFFICIENT_BUFFER != err) {
-        // we don't know what happened
-        WcaLog(LOGMSG_STANDARD, "doesUserExist: Lookup Account Name: Expected insufficient buffer, got error %d 0x%x", err, err);
-        return -1;
+        err = GetLastError();
+        if (!isDC) {
+            // can only try this if we're not on a primary/backup DC; on DCs we must
+            // be able to contact the domain authority.  
+            if (err >= ERROR_NO_TRUST_LSA_SECRET && err <= ERROR_TRUST_FAILURE) {
+                WcaLog(LOGMSG_STANDARD, "Can't reach domain controller %d", err);
+                // if the user specified a domain, then also must be able to contact
+                // the domain authority
+                if (data.getDomainPtr() == NULL) {
+                    WcaLog(LOGMSG_STANDARD, "trying fully qualified local account");
+                    bRet = LookupAccountName(NULL, data.getFullUsername().c_str(), newsid, &cbSid, refDomain, &cchRefDomain, &use);
+                    if (bRet) {
+                        // this should *never* happen, because we didn't pass in a buffer large enough for
+                        // the sid or the domain name.
+                        WcaLog(LOGMSG_STANDARD, "doesUserExist: Lookup Account Name: Unexpected error %d 0x%x", err, err);
+                        return -1;
+                    }
+                    err = GetLastError();
+                    if (ERROR_NONE_MAPPED == err) {
+                        // this user doesn't exist.  We're done
+                        WcaLog(LOGMSG_STANDARD, "retried user doesn't exist");
+                        return 0;
+                    }
+                    if (ERROR_INSUFFICIENT_BUFFER != err) {
+                        WcaLog(LOGMSG_STANDARD, "Failed retry of lookup account name %d", err);
+                        return -1;
+                    }
+                }
+                else {
+                    WcaLog(LOGMSG_STANDARD, "doesUserExist: Lookup Account Name: supplied domain, but can't check user database %d 0x%x", err, err);
+                    return -1;
+                }
+            }
+            else {
+                WcaLog(LOGMSG_STANDARD, "doesUserExist: Lookup Account Name: Unexpected error %d 0x%x", err, err);
+                return -1;
+            }
+            userToTry = data.getFullUsername().c_str();
+
+        }
+        else {        // we don't know what happened
+            // on a DC, can't try without domain access
+            WcaLog(LOGMSG_STANDARD, "doesUserExist: Lookup Account Name: Expected insufficient buffer, got error %d 0x%x", err, err);
+            return -1;
+        }
     }
     newsid = (SID *) new BYTE[cbSid];
     ZeroMemory(newsid, cbSid);
@@ -326,15 +370,17 @@ int doesUserExist(MSIHANDLE hInstall, const CustomActionData& data)
     ZeroMemory(refDomain, (cchRefDomain + 1) * sizeof(wchar_t));
 
     // try it again
-    bRet = LookupAccountName(NULL, data.getQualifiedUsername().c_str(), newsid, &cbSid, refDomain, &cchRefDomain, &use);
+    bRet = LookupAccountName(NULL, userToTry, newsid, &cbSid, refDomain, &cchRefDomain, &use);
     if (!bRet) {
         err = GetLastError();
         WcaLog(LOGMSG_STANDARD, "Failed to lookup account name %d", GetLastError());
         retval = -1;
+        goto cleanAndFail;
     }
     if (!IsValidSid(newsid)) {
         WcaLog(LOGMSG_STANDARD, "New SID is invalid");
         retval = -1;
+        goto cleanAndFail;
     }
     retval = 1;
     toMbcs(narrowdomain, refDomain);


### PR DESCRIPTION
### What does this PR do?

Adds some additional error checking, and resiliency if a target machine is in a domain,
but the domain controller isn't reachable.

Adds add'l logging _and_ handles the case where we were going to install in the local
user database, anyway. In that case, allow the error and continue.

### Motivation

more resilient installs.

