### PR TITLE
Blacklist integrations not building on ARM

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -64,10 +64,10 @@ end
 
 if arm?
   # These two checks don't build on ARM
-  blacklist.push('aerospike')
-  blacklist_req.push(/^aerospike==/)
-  blacklist.push('ibm_mq')
-  blacklist_req.push(/^pymqi==/)
+  blacklist_folders.push('aerospike')
+  blacklist_packages.push(/^aerospike==/)
+  blacklist_folders.push('ibm_mq')
+  blacklist_packages.push(/^pymqi==/)
 end
 
 final_constraints_file = 'final_constraints.txt'

--- a/omnibus/config/software/datadog-agent-integrations.rb
+++ b/omnibus/config/software/datadog-agent-integrations.rb
@@ -62,6 +62,14 @@ if suse?
   blacklist_packages.push(/^aerospike==/)  # Temporarily blacklist Aerospike until builder supports new dependency
 end
 
+if arm?
+  # These two checks don't build on ARM
+  blacklist.push('aerospike')
+  blacklist_req.push(/^aerospike==/)
+  blacklist.push('ibm_mq')
+  blacklist_req.push(/^pymqi==/)
+end
+
 final_constraints_file = 'final_constraints.txt'
 agent_requirements_file = 'agent_requirements.txt'
 agent_requirements_in = 'agent_requirements.in'

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -26,7 +26,7 @@ def windows?()
 end
 
 def arm?()
-    return ohai["kernel"]["machine"].start_with?("aarch") || ohai["kernel"]["machine"].start_with?("arm")
+    return ohai["kernel"]["machine"].start_with?("aarch", "arm")
 end
 
 def os


### PR DESCRIPTION
As part of https://github.com/DataDog/datadog-agent/issues/2499 I'm maintaining patches to allow building the agent on arm platforms.

The `aerospike` and `ibm_mq` checks are not building there, this PR thus blacklists them.