### PR TITLE
pkg/trace/obfuscate: allow module operators in SQL tokenizer

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -390,6 +390,18 @@ func TestMultipleProcess(t *testing.T) {
 			"SELECT articles.* FROM articles WHERE articles.id IN (1, 3, 5)",
 			"SELECT articles.* FROM articles WHERE articles.id IN ( ? )",
 		},
+		{
+			`SELECT id FROM jq_jobs
+WHERE
+schedulable_at <= 1555367948 AND
+queue_name = 'order_jobs' AND
+status = 1 AND
+id % 8 = 3
+ORDER BY
+schedulable_at
+LIMIT 1000`,
+			"SELECT id FROM jq_jobs WHERE schedulable_at <= ? AND queue_name = ? AND status = ? AND id % ? = ? ORDER BY schedulable_at LIMIT ?",
+		},
 	}
 
 	// The consumer is the same between executions

--- a/releasenotes/notes/apm-sql-obfuscation-modulo-271d765a78d678e5.yaml
+++ b/releasenotes/notes/apm-sql-obfuscation-modulo-271d765a78d678e5.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: fixed a bug where modulo operators caused SQL obfuscation to fail.


### PR DESCRIPTION
This change adds permission for modulo operators in the tokenizer.
Previously, the only use for % was with format parameters. Now, it will
be treated as [any other mathematical operator](https://github.com/DataDog/datadog-agent/blob/7e8914a612d7dc91446bf93e7061cb681427c89c/pkg/trace/obfuscate/sql_tokenizer.go#L112).