### PR TITLE
pkg/trace/config: allow stats payload sends to be parallel

### DIFF
--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -252,8 +252,12 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	c.StatsWriterConfig = readStatsWriterConfigYaml()
 	c.TraceWriterConfig = readTraceWriterConfigYaml()
 
-	// allow an extra 10% of the maximum number of connections for parallel writes to the Datadog API
-	c.TraceWriterConfig.SenderConfig.MaxConnections = int(math.Max(1, float64(c.ConnectionLimit)/10))
+	// allow 1% of maximum connnections for concurrent stats flushes
+	conns1percent := int(math.Max(1, float64(c.ConnectionLimit)/100))
+	c.StatsWriterConfig.SenderConfig.MaxConnections = conns1percent
+	// allow 10% of maximum connnections for concurrent trace flushes
+	conns10percent := int(math.Max(1, float64(c.ConnectionLimit)/10))
+	c.TraceWriterConfig.SenderConfig.MaxConnections = conns10percent
 
 	// undocumented deprecated
 	if config.Datadog.IsSet("apm_config.analyzed_rate_by_service") {

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -216,7 +216,7 @@ func TestFullIniConfig(t *testing.T) {
 			MaxAge:            time.Second,
 			MaxQueuedBytes:    456,
 			MaxQueuedPayloads: 4,
-			MaxConnections:    1,
+			MaxConnections:    20,
 			InChannelSize:     10,
 			ExponentialBackoff: backoff.ExponentialConfig{
 				MaxDuration: 4 * time.Second,

--- a/releasenotes/notes/apm-parallel-stats-writer-45f4c572015748b0.yaml
+++ b/releasenotes/notes/apm-parallel-stats-writer-45f4c572015748b0.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: the stats writer now writes concurrently to the Datadog API, improving resource usage and processing speed of the trace-agent.
+


### PR DESCRIPTION
This change allows 5% of the maximum connections (by default 100) to be
used as concurrent connections to the Datadog API when flushing stats.

We've already made this change for traces, and we should make sure we
have it especially for stats, where it is quite common to flush multiple
payloads at once which would normally result in long blocking times in
the pipeline.