### PR TITLE
[kitchen] Actually pin chef version

### DIFF
--- a/test/kitchen/kitchen-azure-winstall.yml
+++ b/test/kitchen/kitchen-azure-winstall.yml
@@ -16,6 +16,7 @@
 
 provisioner:
   name: chef_solo
+  product_name: chef
   product_version: 14.12.9
   install_strategy: always
 

--- a/test/kitchen/kitchen-azure.yml
+++ b/test/kitchen/kitchen-azure.yml
@@ -16,6 +16,7 @@
 
 provisioner:
   name: chef_solo
+  product_name: chef
   product_version: 14.12.9
   install_strategy: always
 


### PR DESCRIPTION
### What does this PR do?

Actually make Kitchen pin the version of Chef that it installs.

I've checked this actually works on a test gitlab pipeline.

### Motivation

Kitchen wasn't pinning the Chef version (I _think_ this has been broken since we upgraded Kitchen to 2.x in https://github.com/DataDog/datadog-agent/pull/3395, but not 100% sure), because the `product_name` option on the provisioner was not set.

Not pinning meant that Chef 15 started to be used, which introduced a license acceptance prompt that our version of kitchen doesn't handle well.

### Additional notes

Let's plan to use Chef 15 once its support by Kitchen seems a bit more stable. Will make a card in our backlog for that.

For reference, I found out about `product_name` by looking through the source code of `test-kitchen`, typically https://github.com/test-kitchen/test-kitchen/blob/9996427de56183166f17f6cd4641f883fc205cf0/lib/kitchen/provisioner/chef_base.rb#L122