### PR TITLE
Use Yaml instead of JSON between six and the agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:six
+      - image: datadog/datadog-agent-runner-circle:six-pip3
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex \
         gnupg ca-certificates \
         gcc g++ make git ssh curl pkg-config file \
         python-dev python-setuptools python-pip \
-        python3.7-dev python3-distutils \
+        python3.7-dev python3-distutils python3-pip python3-yaml \
         libssl-dev libsnmp-base libsnmp-dev libpq-dev snmp-mibs-downloader libsystemd-dev
 
 # Golang

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,11 +148,12 @@ before_script:
 # run tests for deb-x64
 run_tests_deb-x64:
   stage: source_test
-  image: datadog/datadog-agent-runner-circle:six
+  image: datadog/datadog-agent-runner-circle:six-pip3
   tags: [ "runner:main", "size:2xlarge" ]
   before_script:
     - pip install wheel
     - pip install -r requirements.txt
+    - go get gopkg.in/yaml.v2
     - inv -e six.build --install-prefix=$SRC_PATH/dev
     - inv -e six.install
     - inv -e six.format

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - set PATH=%APPVEYOR_BUILD_FOLDER%\dev\lib;%GOPATH%\bin;%Python2_ROOT_DIR%;%Python2_ROOT_DIR%\Scripts;%Python3_ROOT_DIR%;%Python3_ROOT_DIR%\Scripts;%MSYS_ROOT%\mingw64\bin;%MSYS_ROOT%\usr\bin\;%PATH%
   - git clone --depth 1 https://github.com/datadog/integrations-core
   - "%PIP2% install codecov -r requirements.txt"
+  - "%PIP3% install PyYAML==5.1"
 
 cache:
   - '%GOPATH%\bin'

--- a/pkg/collector/python/helpers.go
+++ b/pkg/collector/python/helpers.go
@@ -8,12 +8,13 @@
 package python
 
 import (
-	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
 	"sync/atomic"
 	"unsafe"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 /*
@@ -144,7 +145,7 @@ func GetPythonIntegrationList() ([]string, error) {
 	payload := C.GoString(integrationsList)
 
 	ddIntegrations := []string{}
-	if err := json.Unmarshal([]byte(payload), &ddIntegrations); err != nil {
+	if err := yaml.Unmarshal([]byte(payload), &ddIntegrations); err != nil {
 		return nil, fmt.Errorf("Could not Unmarshal integration list payload: %s", err)
 	}
 

--- a/pkg/collector/python/kubeutil.go
+++ b/pkg/collector/python/kubeutil.go
@@ -8,13 +8,13 @@
 package python
 
 import (
-	"encoding/json"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 /*
@@ -66,7 +66,7 @@ func GetKubeletConnectionInfo(payload **C.char) {
 			return
 		}
 
-		data, err := json.Marshal(connections)
+		data, err := yaml.Marshal(connections)
 		if err != nil {
 			log.Errorf("could not serialized kubelet connections (%s): %s", connections, err)
 			return

--- a/pkg/collector/python/test_datadog_agent.go
+++ b/pkg/collector/python/test_datadog_agent.go
@@ -8,11 +8,11 @@
 package python
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -54,8 +54,8 @@ func testHeaders(t *testing.T) {
 	require.NotNil(t, headers)
 
 	h := util.HTTPHeaders()
-	jsonPayload, _ := json.Marshal(h)
-	assert.Equal(t, string(jsonPayload), C.GoString(headers))
+	yamlPayload, _ := yaml.Marshal(h)
+	assert.Equal(t, string(yamlPayload), C.GoString(headers))
 }
 
 func testGetConfig(t *testing.T) {
@@ -66,7 +66,7 @@ func testGetConfig(t *testing.T) {
 
 	GetConfig(C.CString("cmd_port"), &config)
 	require.NotNil(t, config)
-	assert.Equal(t, "5001", C.GoString(config))
+	assert.Equal(t, "5001\n", C.GoString(config))
 }
 
 func testSetExternalTags(t *testing.T) {
@@ -77,8 +77,8 @@ func testSetExternalTags(t *testing.T) {
 	payload := externalhost.GetPayload()
 	require.NotNil(t, payload)
 
-	jsonPayload, _ := json.Marshal(payload)
+	yamlPayload, _ := yaml.Marshal(payload)
 	assert.Equal(t,
-		"[[\"test_hostname\",{\"test_source_type\":[\"tag1\",\"tag2\"]}]]",
-		string(jsonPayload))
+		"- - test_hostname\n  - test_source_type:\n    - tag1\n    - tag2\n",
+		string(yamlPayload))
 }

--- a/pkg/collector/python/test_kubeutil.go
+++ b/pkg/collector/python/test_kubeutil.go
@@ -47,11 +47,11 @@ func testGetKubeletConnectionInfoNotCached(t *testing.T) {
 
 	var payload *C.char
 	GetKubeletConnectionInfo(&payload)
-	assert.Equal(t, "{\"conn1\":\"a\",\"conn2\":\"b\"}", C.GoString(payload))
+	assert.Equal(t, "conn1: a\nconn2: b\n", C.GoString(payload))
 
 	testConnections = map[string]string{"conn3": "c"}
 
 	// testing caching
 	GetKubeletConnectionInfo(&payload)
-	assert.Equal(t, "{\"conn1\":\"a\",\"conn2\":\"b\"}", C.GoString(payload))
+	assert.Equal(t, "conn1: a\nconn2: b\n", C.GoString(payload))
 }

--- a/six/common/builtins/datadog_agent.c
+++ b/six/common/builtins/datadog_agent.c
@@ -110,11 +110,14 @@ PyObject *get_version(PyObject *self, PyObject *args)
 /**
  * Before Six the Agent used reflection to inspect the contents of a configuration
  * value and the CPython API to perform conversion to a Python equivalent. Such
- * a conversion wouldn't be possible in a Python-agnostic way so we use JSON to
+ * a conversion wouldn't be possible in a Python-agnostic way so we use YAML to
  * pass the data from Go to Python. The configuration value is loaded in the Agent,
- * marshalled into JSON and passed as a `char*` to Six, where the string is
- * decoded back to Python and passed to the caller. JSON usage is transparent to
- * the caller, who would receive a Python object as returned from `json.loads`.
+ * marshalled into YAML and passed as a `char*` to Six, where the string is
+ * decoded back to Python and passed to the caller. YAML usage is transparent to
+ * the caller, who would receive a Python object as returned from `yaml.safe_load`.
+ * YAML is used instead of JSON since the `json.load` return unicode for
+ * string, for python2, which would be a breaking change from the previous
+ * version of the agent.
  */
 PyObject *get_config(PyObject *self, PyObject *args)
 {
@@ -132,7 +135,7 @@ PyObject *get_config(PyObject *self, PyObject *args)
     cb_get_config(key, &data);
 
     // new ref
-    PyObject *value = from_json(data);
+    PyObject *value = from_yaml(data);
     cgo_free(data);
     if (value == NULL) {
         Py_RETURN_NONE;
@@ -160,7 +163,7 @@ PyObject *headers(PyObject *self, PyObject *args, PyObject *kwargs)
     cb_headers(&data);
 
     // new ref
-    PyObject *headers_dict = from_json(data);
+    PyObject *headers_dict = from_yaml(data);
     cgo_free(data);
     if (headers_dict == NULL || !PyDict_Check(headers_dict)) {
         Py_RETURN_NONE;

--- a/six/common/builtins/kubeutil.c
+++ b/six/common/builtins/kubeutil.c
@@ -52,7 +52,7 @@ PyObject *get_connection_info(PyObject *self, PyObject *args)
     cb_get_connection_info(&data);
 
     // create a new ref
-    PyObject *conn_info_dict = from_json(data);
+    PyObject *conn_info_dict = from_yaml(data);
 
     // free the memory allocated by the Agent
     cgo_free(data);

--- a/six/common/stringutils.c
+++ b/six/common/stringutils.c
@@ -36,61 +36,59 @@ char *as_string(PyObject *object)
     return retval;
 }
 
-PyObject *from_json(const char *data)
-{
+PyObject *from_yaml(const char *data) {
     PyObject *retval = NULL;
-    PyObject *json = NULL;
-    PyObject *loads = NULL;
+    PyObject *yaml = NULL;
+    PyObject *safe_load = NULL;
 
     if (!data) {
         goto done;
     }
 
-    char module_name[] = "json";
-    json = PyImport_ImportModule(module_name);
-    if (json == NULL) {
+    char module_name[] = "yaml";
+    yaml = PyImport_ImportModule(module_name);
+    if (yaml == NULL) {
         goto done;
     }
 
-    char func_name[] = "loads";
-    loads = PyObject_GetAttrString(json, func_name);
-    if (loads == NULL) {
+    char func_name[] = "safe_load";
+    safe_load = PyObject_GetAttrString(yaml, func_name);
+    if (safe_load == NULL) {
         goto done;
     }
 
-    retval = PyObject_CallFunction(loads, "s", data);
+    retval = PyObject_CallFunction(safe_load, "s", data);
 
 done:
-    Py_XDECREF(json);
-    Py_XDECREF(loads);
+    Py_XDECREF(yaml);
+    Py_XDECREF(safe_load);
     return retval;
 }
 
-char *as_json(PyObject *object)
-{
+char *as_yaml(PyObject *object) {
     char *retval = NULL;
-    PyObject *json = NULL;
-    PyObject *dumps = NULL;
+    PyObject *yaml = NULL;
+    PyObject *safe_dump = NULL;
     PyObject *dumped = NULL;
 
-    char module_name[] = "json";
-    json = PyImport_ImportModule(module_name);
-    if (json == NULL) {
+    char module_name[] = "yaml";
+    yaml = PyImport_ImportModule(module_name);
+    if (yaml == NULL) {
         goto done;
     }
 
-    char func_name[] = "dumps";
-    dumps = PyObject_GetAttrString(json, func_name);
-    if (dumps == NULL) {
+    char func_name[] = "safe_dump";
+    safe_dump = PyObject_GetAttrString(yaml, func_name);
+    if (safe_dump == NULL) {
         goto done;
     }
 
-    dumped = PyObject_CallFunctionObjArgs(dumps, object, NULL);
+    dumped = PyObject_CallFunctionObjArgs(safe_dump, object, NULL);
     retval = as_string(dumped);
 
 done:
-    Py_XDECREF(json);
-    Py_XDECREF(dumps);
+    Py_XDECREF(yaml);
+    Py_XDECREF(safe_dump);
     Py_XDECREF(dumped);
     return retval;
 }

--- a/six/common/stringutils.h
+++ b/six/common/stringutils.h
@@ -13,8 +13,8 @@ extern "C" {
 #include <Python.h>
 
 char *as_string(PyObject *);
-PyObject *from_json(const char *);
-char *as_json(PyObject *);
+PyObject *from_yaml(const char *);
+char *as_yaml(PyObject *);
 
 #ifdef DATADOG_AGENT_THREE
 #    define PyStringFromCString(x) PyUnicode_FromString(x)

--- a/six/include/six_types.h
+++ b/six/include/six_types.h
@@ -82,9 +82,9 @@ typedef void (*cb_submit_event_t)(char *, event_t *);
 //
 // (version)
 typedef void (*cb_get_version_t)(char **);
-// (key, json_result)
+// (key, yaml_result)
 typedef void (*cb_get_config_t)(char *, char **);
-// (json_result)
+// (yaml_result)
 typedef void (*cb_headers_t)(char **);
 // (hostname)
 typedef void (*cb_get_hostname_t)(char **);
@@ -110,7 +110,7 @@ typedef char **(*cb_tags_t)(char *, int);
 
 // kubeutil
 //
-// (json_result)
+// (yaml_result)
 typedef void (*cb_get_connection_info_t)(char **);
 
 // containers

--- a/six/test/containers/containers.go
+++ b/six/test/containers/containers.go
@@ -31,9 +31,9 @@ var (
 )
 
 type message struct {
-	Name string `json:"name"`
-	Body string `json:"body"`
-	Time int64  `json:"time"`
+	Name string `yaml:"name"`
+	Body string `yaml:"body"`
+	Time int64  `yaml:"time"`
 }
 
 func setUp() error {

--- a/six/test/datadog_agent/datadog_agent.go
+++ b/six/test/datadog_agent/datadog_agent.go
@@ -1,7 +1,6 @@
 package testdatadogagent
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,6 +9,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/six/test/common"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -44,9 +44,9 @@ var (
 )
 
 type message struct {
-	Name string `json:"name"`
-	Body string `json:"body"`
-	Time int64  `json:"time"`
+	Name string `yaml:"name"`
+	Body string `yaml:"body"`
+	Time int64  `yaml:"time"`
 }
 
 func setUp() error {
@@ -121,7 +121,7 @@ func getConfig(key *C.char, in **C.char) {
 		*in = C.CString("\"warning\"")
 	case "foo":
 		m := message{C.GoString(key), "Hello", 123456}
-		b, _ := json.Marshal(m)
+		b, _ := yaml.Marshal(m)
 		*in = C.CString(string(b))
 	default:
 		*in = C.CString("null")
@@ -135,7 +135,7 @@ func headers(in **C.char) {
 		"Content-Type": "application/x-www-form-urlencoded",
 		"Accept":       "text/html, */*",
 	}
-	retval, _ := json.Marshal(h)
+	retval, _ := yaml.Marshal(h)
 
 	*in = C.CString(string(retval))
 }

--- a/six/test/kubeutil/kubeutil.go
+++ b/six/test/kubeutil/kubeutil.go
@@ -1,7 +1,6 @@
 package testkubeutil
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +8,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/six/test/common"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -98,7 +98,7 @@ func getConnectionInfo(in **C.char) {
 		"FooKey": "FooValue",
 		"BarKey": "BarValue",
 	}
-	retval, _ := json.Marshal(h)
+	retval, _ := yaml.Marshal(h)
 
 	*in = C.CString(string(retval))
 }

--- a/six/test/six/six.go
+++ b/six/test/six/six.go
@@ -9,7 +9,6 @@ package testsix
 import "C"
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"unsafe"
 
 	common "github.com/DataDog/datadog-agent/six/test/common"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -219,7 +219,7 @@ func getIntegrationList() ([]string, error) {
 	runtime.UnlockOSThread()
 
 	var out []string
-	err := json.Unmarshal([]byte(cstr), &out)
+	err := yaml.Unmarshal([]byte(cstr), &out)
 	fmt.Println(cstr)
 	fmt.Println(out)
 	if err != nil {

--- a/six/test/util/util.go
+++ b/six/test/util/util.go
@@ -1,13 +1,13 @@
 package testutil
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"runtime"
 
 	common "github.com/DataDog/datadog-agent/six/test/common"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // #cgo CFLAGS: -I../../include
@@ -28,9 +28,9 @@ var (
 )
 
 type message struct {
-	Name string `json:"name"`
-	Body string `json:"body"`
-	Time int64  `json:"time"`
+	Name string `yaml:"name"`
+	Body string `yaml:"body"`
+	Time int64  `yaml:"time"`
 }
 
 func setUp() error {
@@ -97,7 +97,7 @@ func headers(in **C.char) {
 		"Content-Type": "application/x-www-form-urlencoded",
 		"Accept":       "text/html, */*",
 	}
-	retval, _ := json.Marshal(h)
+	retval, _ := yaml.Marshal(h)
 
 	*in = C.CString(string(retval))
 }

--- a/six/three/three.cpp
+++ b/six/three/three.cpp
@@ -738,7 +738,7 @@ char *Three::getIntegrationList()
         goto done;
     }
 
-    wheels = as_json(packages);
+    wheels = as_yaml(packages);
 
 done:
     Py_XDECREF(pyPackages);

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -760,7 +760,7 @@ char *Two::getIntegrationList()
         goto done;
     }
 
-    wheels = as_json(packages);
+    wheels = as_yaml(packages);
 
 done:
     Py_XDECREF(pyPackages);


### PR DESCRIPTION
### What does this PR do?

JSON return unicode strings under Python2, even if this is a better
behavior it would be a breaking change compare to the previous version
of the Agent not using this lib to embed Python. Yaml returns bytes
under Python2 and Unicode under Python3.
