### PR TITLE
pkg/trace/api: fix an edge-case in tag normalization

### DIFF
--- a/pkg/trace/api/normalizer_test.go
+++ b/pkg/trace/api/normalizer_test.go
@@ -431,7 +431,6 @@ func TestNormalizeTag(t *testing.T) {
 		{in: "test\x99\x8faaa", out: "test_aaa"},
 		{in: "test\x99\x8f", out: "test"},
 		{in: strings.Repeat("a", 888), out: strings.Repeat("a", 200)},
-		{in: strings.Repeat("a", 888), out: strings.Repeat("a", 200)},
 		{
 			in: func() string {
 				b := bytes.NewBufferString("a")
@@ -447,6 +446,7 @@ func TestNormalizeTag(t *testing.T) {
 		},
 		{"a" + string(unicode.ReplacementChar), "a"},
 		{"a" + string(unicode.ReplacementChar) + string(unicode.ReplacementChar), "a"},
+		{"a" + string(unicode.ReplacementChar) + string(unicode.ReplacementChar) + "b", "a_b"},
 	} {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, tt.out, normalizeTag(tt.in), tt.in)

--- a/pkg/trace/api/normalizer_test.go
+++ b/pkg/trace/api/normalizer_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/stretchr/testify/assert"
@@ -430,6 +431,7 @@ func TestNormalizeTag(t *testing.T) {
 		{in: "test\x99\x8faaa", out: "test_aaa"},
 		{in: "test\x99\x8f", out: "test"},
 		{in: strings.Repeat("a", 888), out: strings.Repeat("a", 200)},
+		{in: strings.Repeat("a", 888), out: strings.Repeat("a", 200)},
 		{
 			in: func() string {
 				b := bytes.NewBufferString("a")
@@ -443,6 +445,8 @@ func TestNormalizeTag(t *testing.T) {
 			}(),
 			out: "a", // 'b' should have been truncated
 		},
+		{"a" + string(unicode.ReplacementChar), "a"},
+		{"a" + string(unicode.ReplacementChar) + string(unicode.ReplacementChar), "a"},
 	} {
 		t.Run("", func(t *testing.T) {
 			assert.Equal(t, tt.out, normalizeTag(tt.in), tt.in)

--- a/releasenotes/notes/apm-normalize-replacement-char-00bb27b680029ef6.yaml
+++ b/releasenotes/notes/apm-normalize-replacement-char-00bb27b680029ef6.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixed a small issue with normalizing tags that contained the 
+    unicode replacement character.


### PR DESCRIPTION
This change fixes an edge-case in tag normalization where unicode
replacement characters were treated as invalid UTF-8.