### PR TITLE
Remove unused dep constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -107,10 +107,6 @@
   version = "~v2.1.0"
 
 [[constraint]]
-  name = "github.com/sbinet/go-python"
-  branch = "master"
-
-[[constraint]]
   name = "github.com/shirou/gopsutil"
   version = "^v2.18.12"
 


### PR DESCRIPTION
Fixes the following warning:

```
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/sbinet/go-python

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.
```
