### PR TITLE
Remove spurious error log

### DIFF
--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -77,7 +77,7 @@ func SubmitServiceCheck(checkID *C.char, scName *C.char, status C.int, tags **C.
 
 func eventParseString(value *C.char, fieldName string) string {
 	if value == nil {
-		log.Errorf("Can't parse value for key '%s' in event submitted from python check", fieldName)
+		log.Tracef("Can't parse value for key '%s' in event submitted from python check", fieldName)
 		return ""
 	}
 	return C.GoString(value)


### PR DESCRIPTION
### What does this PR do?

This removes a spurious log happening when emitting local events, and turns it into a trace instead.

### Motivation

When testing win32event, I got a lot of these errors which didn't make sense.