### PR TITLE
Set logging flags so that installs/uninstalls will always be logged.

### DIFF
--- a/omnibus/resources/agent/msi/cal/strings.cpp
+++ b/omnibus/resources/agent/msi/cal/strings.cpp
@@ -231,9 +231,6 @@ bool loadPropertyString(MSIHANDLE hInstall, LPCWSTR propertyName, wchar_t **dst,
     *dst=szValueBuf;
     *len = cchValueBuf;
     toMbcs(propval, szValueBuf);
-    WcaLog(LOGMSG_STANDARD, "loaded property %s = %s", propertyname.c_str(), propval.c_str());
-
-    
     return true;
 }
 

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -59,6 +59,9 @@
                           Timeout="1"
                           RebootPrompt="no"/>
 
+    <!-- Set property to always log -->
+    <Property Id="MsiLogging" Value="iwearucmop!" />
+
     <!-- No need to restart Windows after the installation -->
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 


### PR DESCRIPTION
Now, by default, installs and uninstalls logged to %TEMP%\MSI?????.log
Supplying `/log` parameter still overrides

