### PR TITLE
[pkg/gui/checks] Prevent crash when creating custom check config with the GUI

### DIFF
--- a/releasenotes/notes/fix-custom-check-config-add-gui-3cff9efb4acdc0d3.yaml
+++ b/releasenotes/notes/fix-custom-check-config-add-gui-3cff9efb4acdc0d3.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an error when adding a custom check config through the GUI 
+    when the folder where the config will reside does not 
+    exist yet.


### PR DESCRIPTION
### What does this PR do?

Changes the POST /checks/setConfig endpoint so that the directory where the
custom check config will reside is indeed present before saving the file.

### Motivation

The saving of a config file for a custom check created with the GUI could fail
because the directory where the config file should be saved may not exist.
