### PR TITLE
KubeUtil, fix race condition in KubeUtil fields

### DIFF
--- a/releasenotes/notes/fix-race-condition-on-KubeUtil.rawConnectionInfo-254c4d68c325dd8d.yaml
+++ b/releasenotes/notes/fix-race-condition-on-KubeUtil.rawConnectionInfo-254c4d68c325dd8d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Protect KubeUtil.rawConnectionInfo map against race update.
+


### PR DESCRIPTION
### What does this PR do?

`KubeUtil.rawConnectionInfo` map can be updated by different goroutine
in parallel. To avoid any race condition on the map, this PR add
a Mutex in `KubeUtil` to protect the map modification.

### Motivation

This race condition has been discovered when the Kubelet communication configuration (TLS configuration) was wrong, and so `KubeUtil` tries several times to update the map.

### Additional Notes

Anything else we should know when reviewing?
