### PR TITLE
[pkg/status] Fix status page and agent status crash because of host tags

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -39,13 +39,21 @@ func GetStatus() (map[string]interface{}, error) {
 
 	stats["version"] = version.AgentVersion
 	hostname, err := util.GetHostname()
+
+	var metadata *host.Payload
 	if err != nil {
 		log.Errorf("Error grabbing hostname for status: %v", err)
-		stats["metadata"] = host.GetPayloadFromCache("unknown")
+		metadata = host.GetPayloadFromCache("unknown")
 	} else {
-		stats["metadata"] = host.GetPayloadFromCache(hostname)
+		metadata = host.GetPayloadFromCache(hostname)
 	}
-	stats["hostTags"] = getHostTagsConfig()
+	stats["metadata"] = metadata
+
+	hostTags := make([]string, 0, len(metadata.HostTags.System)+len(metadata.HostTags.GoogleCloudPlatform))
+	hostTags = append(hostTags, metadata.HostTags.System...)
+	hostTags = append(hostTags, metadata.HostTags.GoogleCloudPlatform...)
+	stats["hostTags"] = hostTags
+
 	stats["config"] = getPartialConfig()
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -217,11 +217,6 @@ func getDCAPartialConfig() map[string]string {
 	return conf
 }
 
-// getHostTagsConfig returns config host tags applied to all metrics
-func getHostTagsConfig() []string {
-	return config.Datadog.GetStringSlice("tags")
-}
-
 // getPartialConfig returns config parameters of interest for the status page
 func getPartialConfig() map[string]string {
 	conf := make(map[string]string)


### PR DESCRIPTION
### What does this PR do?

The way of getting tags has been changed so that the host tags are never
`nil`.
Moreover, platform-dependent host tags (such as ec2, k8s tags) weren't
shown. They have been added as a side-effect of changing the way of
getting host tags.

### Motivation

There was a possibility that the host tags field of the stats structure
(used to render the agent status command and the status GUI page) could
be `nil`, leading to a crash during template rendering.
