### PR TITLE
docker - include "unhealthy" statement

### DIFF
--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -175,11 +175,11 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*containers.C
 //  - 'Up about an hour'
 func parseContainerHealth(status string) string {
 	// Avoid allocations in most cases by just checking for '('
-	if strings.IndexByte(status, '(') == -1 {
-		return ""
-	}
 	if strings.Index(status, "unhealthy") >= 0 {
 		return "unhealthy"
+	}
+	if strings.IndexByte(status, '(') == -1 {
+		return ""
 	}
 	all := healthRe.FindAllStringSubmatch(status, -1)
 	if len(all) < 1 || len(all[0]) < 2 {

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -171,11 +171,15 @@ func (d *DockerUtil) dockerContainers(cfg *ContainerListConfig) ([]*containers.C
 
 // Parse the health out of a container status. The format is either:
 //  - 'Up 5 seconds (health: starting)'
+//  - 'Up 18 hours (unhealthy)'
 //  - 'Up about an hour'
 func parseContainerHealth(status string) string {
 	// Avoid allocations in most cases by just checking for '('
 	if strings.IndexByte(status, '(') == -1 {
 		return ""
+	}
+	if strings.Index(status, "unhealthy") >= 0 {
+		return "unhealthy"
 	}
 	all := healthRe.FindAllStringSubmatch(status, -1)
 	if len(all) < 1 || len(all[0]) < 2 {

--- a/pkg/util/docker/docker_test.go
+++ b/pkg/util/docker/docker_test.go
@@ -45,6 +45,10 @@ func TestParseContainerHealth(t *testing.T) {
 			input:    "Up 1 minute (health: unhealthy)",
 			expected: "unhealthy",
 		},
+		{
+			input:    "Up 1 minute (unhealthy)",
+			expected: "unhealthy",
+		},
 	} {
 		assert.Equal(tc.expected, parseContainerHealth(tc.input), "test %d failed", i)
 	}


### PR DESCRIPTION
### What does this PR do?
Adds logic to mark a container as unhealthy from the status. 

### Motivation

Raised via a support ticket. [`parseContainerHealth`](https://github.com/DataDog/datadog-agent/blob/6.11.x/pkg/util/docker/containers.go#L173-L183) doesn't account for the container's unhealthy status, as it simply sends an empty string. Empty strings will default to a "healthy" green pill in the process-agent and web-ui.

### Additional Notes

Anything else we should know when reviewing?
