### PR TITLE
Improve get_class resiliency

### DIFF
--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -375,7 +375,7 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
         return NULL;
     }
 
-    PyObject *klass;
+    PyObject *klass = NULL;
     for (int i = 0; i < PyList_GET_SIZE(dir); i++) {
         // Reset `klass` at every iteration so its state is always clean when we
         // continue the loop or return early. Reset at first iteration is useless

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -415,9 +415,15 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
             continue;
         }
 
-        // `klass` is actually `base` itself, ignore
-        if (PyObject_RichCompareBool(klass, base, Py_EQ)) {
+        // check whether `klass` is actually `base` itself
+        int retval = PyObject_RichCompareBool(klass, base, Py_EQ);
+        if (retval == 1) {
+            // `klass` is `base`, ignore
             Py_XDECREF(klass);
+            continue;
+        } else if (retval == -1) {
+            // an error occurred calling __eq__, clear and continue
+            PyErr_Clear();
             continue;
         }
 

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -377,10 +377,15 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
     PyObject *klass = NULL;
     for (int i = 0; i < PyList_GET_SIZE(dir); i++) {
         // get symbol name
-        char *symbol_name;
+        char *symbol_name = NULL;
         PyObject *symbol = PyList_GetItem(dir, i);
         if (symbol != NULL) {
+            // PyString_AsString returns NULL if `symbol` is not a string object at all
             symbol_name = PyString_AsString(symbol);
+        }
+
+        if (symbol_name == NULL) {
+            continue;
         }
 
         // get symbol instance. It's a new ref but in case of success we don't

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -380,8 +380,8 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
         // Reset `klass` at every iteration so its state is always clean when we
         // continue the loop or return early. Reset at first iteration is useless
         // but it keeps the code readable.
-        klass = NULL;
         Py_XDECREF(klass);
+        klass = NULL;
 
         // get the symbol in current list item
         PyObject *symbol = PyList_GetItem(dir, i);
@@ -454,8 +454,8 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
     // we couldn't find any good subclass, set an error and reset
     // `klass` state for one last time before moving to `done`.
     setError("cannot find a subclass");
-    klass = NULL;
     Py_XDECREF(klass);
+    klass = NULL;
 
 done:
     Py_XDECREF(dir);

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -370,6 +370,7 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
 
     PyObject *dir = PyObject_Dir(module);
     if (dir == NULL) {
+        PyErr_Clear();
         setError("there was an error calling dir() on module object");
         return NULL;
     }
@@ -382,7 +383,7 @@ PyObject *Two::_findSubclassOf(PyObject *base, PyObject *module)
             // This should never happen as it means we're out of bounds
             PyErr_Clear();
             setError("there was an error browsing dir() output");
-            return NULL;
+            goto done;
         }
 
         // get symbol name


### PR DESCRIPTION
### What does this PR do?

Implement the same defensive approach we have in the `Three` library: be sure `symbol_name` can't go around when it's either `NULL` or worse, un-initialized.

### Motivation

`get_class` function from Six API occurs in several cases we're debugging, this is a shot in the dark so investigations will continue but better safe than sorry here.

### Additional Notes

Wanted to add tests but it's overly complicated to recreate cases where the previous behaviour can be exploited. Let's just be good C citizens here.
