### PR TITLE
Supporting multiple API keys split on comma

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -714,9 +714,7 @@ func getMultipleEndpointsWithConfig(config Config) (map[string][]string, error) 
 	}
 
 	keysPerDomain := map[string][]string{
-		ddURL: {
-			config.GetString("api_key"),
-		},
+		ddURL: strings.Split(config.GetString("api_key"), ","),
 	}
 
 	var additionalEndpoints map[string][]string


### PR DESCRIPTION
### What does this PR do?

Takes advantage of existing forwarder package functionality by passing a comma separated list of API keys from the config to the default forwarder constructor.

### Motivation

We need to push metrics from one agent to several Datadog Accounts

