### PR TITLE
Fixes assumption that group name for "Performance Monitor Users" is

### DIFF
--- a/omnibus/resources/agent/msi/cal/customaction.h
+++ b/omnibus/resources/agent/msi/cal/customaction.h
@@ -22,6 +22,7 @@ bool InitLsaString(
 	LPCWSTR pwszString);
 
 PSID GetSidForUser(LPCWSTR host, LPCWSTR user);
+bool GetNameForSid(LPCWSTR host, PSID sid, std::wstring& namestr);
 
 LSA_HANDLE GetPolicyHandle();
 

--- a/omnibus/resources/agent/msi/cal/userrights.cpp
+++ b/omnibus/resources/agent/msi/cal/userrights.cpp
@@ -51,6 +51,56 @@ cleanAndFail:
 	}
 	return NULL;
 }
+
+bool GetNameForSid(LPCWSTR host, PSID sid, std::wstring& namestr) 
+{
+    wchar_t * name = NULL;
+    DWORD cchName = 0;
+    LPWSTR refDomain = NULL;
+    DWORD cchRefDomain = 0;
+    SID_NAME_USE use;
+    std::string narrowdomain;
+    BOOL success = false;
+    BOOL bRet = LookupAccountSid(host, sid, name, &cchName, refDomain, &cchRefDomain, &use);
+    if (bRet) {
+        // this should *never* happen, because we didn't pass in a buffer large enough for
+        // the sid or the domain name.
+        WcaLog(LOGMSG_STANDARD, "Unexpected success looking up account sid");
+        return false;
+    }
+    DWORD err = GetLastError();
+    if (ERROR_INSUFFICIENT_BUFFER != err) {
+        WcaLog(LOGMSG_STANDARD, "Unexpected failure looking up account sid %d", err);
+        // we don't know what happened
+        return false;
+    }
+    name = (wchar_t*) new wchar_t[cchName];
+    ZeroMemory(name, cchName * sizeof(wchar_t));
+
+    refDomain = new wchar_t[cchRefDomain + 1];
+    ZeroMemory(refDomain, (cchRefDomain + 1) * sizeof(wchar_t));
+
+    // try it again
+    bRet = LookupAccountSid(host, sid, name, &cchName, refDomain, &cchRefDomain, &use);
+    if (!bRet) {
+        WcaLog(LOGMSG_STANDARD, "Failed to lookup account name %d", GetLastError());
+        goto cleanAndDone;
+    }
+    success = true;
+    toMbcs(narrowdomain, refDomain);
+    WcaLog(LOGMSG_STANDARD, "Got account from sid from %s\n", narrowdomain.c_str());
+    namestr = name;
+
+cleanAndDone:
+    if (name) {
+        delete[](wchar_t*)name;
+    }
+    if (refDomain) {
+        delete[] refDomain;
+    }
+    return success;
+}
+
 bool RemovePrivileges(PSID AccountSID, LSA_HANDLE PolicyHandle, LPCWSTR rightToAdd)
 {
 	LSA_UNICODE_STRING lucPrivilege;

--- a/releasenotes/notes/fixlocalized-d55db28b708fb627.yaml
+++ b/releasenotes/notes/fixlocalized-d55db28b708fb627.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes problem in which agent wouldn't install on non-English machines
+    due to assumption that "Performance Monitor Users" didn't need to be
+    localized


### PR DESCRIPTION
always in English; look up based on the well known SID

### Motivation

Customer install failure

