### PR TITLE
Add support for env vars in integrations config

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -24,7 +24,6 @@ var templateVariables = map[string]variableGetter{
 	"host":     getHost,
 	"pid":      getPid,
 	"port":     getPort,
-	"env":      getEnvvar,
 	"hostname": getHostname,
 }
 
@@ -45,6 +44,30 @@ func SubstituteTemplateVariables(config *integration.Config, getters map[string]
 		}
 	}
 	return nil
+}
+
+// SubstituteTemplateEnvVars replaces %%ENV_VARIABLE%% from environment variables
+func SubstituteTemplateEnvVars(config *integration.Config) error {
+	var retErr error
+	for i := 0; i < len(config.Instances); i++ {
+		vars := config.GetTemplateVariablesForInstance(i)
+		for _, v := range vars {
+			if "env" == string(v.Name) {
+				resolvedVar, err := getEnvvar(v.Key)
+				if err != nil {
+					log.Warnf("variable not replaced: %s", err)
+					if retErr == nil {
+						retErr = err
+					}
+					continue
+				}
+				// init config vars are replaced by the first found
+				config.InitConfig = bytes.Replace(config.InitConfig, v.Raw, resolvedVar, -1)
+				config.Instances[i] = bytes.Replace(config.Instances[i], v.Raw, resolvedVar, -1)
+			}
+		}
+	}
+	return retErr
 }
 
 // Resolve takes a template and a service and generates a config with
@@ -79,6 +102,12 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 	err = SubstituteTemplateVariables(&resolvedConfig, templateVariables, svc)
 	if err != nil {
 		return resolvedConfig, err
+	}
+
+	err = SubstituteTemplateEnvVars(&resolvedConfig)
+	if err != nil {
+		// We add the service name to the error here, since SubstituteTemplateEnvVars doesn't know about that
+		return resolvedConfig, fmt.Errorf("%s, skipping service %s", err, svc.GetEntity())
 	}
 
 	for i := 0; i < len(resolvedConfig.Instances); i++ {
@@ -183,13 +212,13 @@ func getHostname(tplVar []byte, svc listeners.Service) ([]byte, error) {
 }
 
 // getEnvvar returns a system environment variable if found
-func getEnvvar(tplVar []byte, svc listeners.Service) ([]byte, error) {
-	if len(tplVar) == 0 {
-		return nil, fmt.Errorf("envvar name is missing, skipping service %s", svc.GetEntity())
+func getEnvvar(envVar []byte) ([]byte, error) {
+	if len(envVar) == 0 {
+		return nil, fmt.Errorf("envvar name is missing")
 	}
-	value, found := os.LookupEnv(string(tplVar))
+	value, found := os.LookupEnv(string(envVar))
 	if !found {
-		return nil, fmt.Errorf("failed to retrieve envvar %s, skipping service %s", tplVar, svc.GetEntity())
+		return nil, fmt.Errorf("failed to retrieve envvar %s", envVar)
 	}
 	return []byte(value), nil
 }

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -6,7 +6,9 @@
 package providers
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -55,6 +57,36 @@ func NewFileConfigProvider(paths []string) *FileConfigProvider {
 	return &FileConfigProvider{
 		paths:  paths,
 		Errors: make(map[string]string),
+	}
+}
+
+func getEnvvar(envVar []byte) ([]byte, error) {
+	if len(envVar) == 0 {
+		return nil, fmt.Errorf("env var name is missing")
+	}
+	value, found := os.LookupEnv(string(envVar))
+	if !found {
+		return nil, fmt.Errorf("failed to retrieve envvar %s", envVar)
+	}
+	return []byte(value), nil
+}
+
+// replaceEnvVars replaces variables with the format %%env_MY_VAR%%
+func replaceEnvVars(config *integration.Config) {
+	for i := 0; i < len(config.Instances); i++ {
+		vars := config.GetTemplateVariablesForInstance(i)
+		for _, v := range vars {
+			if "env" == string(v.Name) {
+				resolvedVar, err := getEnvvar(v.Key)
+				if err != nil {
+					log.Warnf("variable not replaced: %s", err)
+					continue
+				}
+				// init config vars are replaced by the first found
+				config.InitConfig = bytes.Replace(config.InitConfig, v.Raw, resolvedVar, -1)
+				config.Instances[i] = bytes.Replace(config.Instances[i], v.Raw, resolvedVar, -1)
+			}
+		}
 	}
 }
 
@@ -304,6 +336,8 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {
 		return config, errors.New("the 'docker_images' section is deprecated, please use 'ad_identifiers' instead")
 	}
+
+	replaceEnvVars(&config)
 
 	return config, err
 }

--- a/pkg/autodiscovery/providers/tests/envvars.d/conf.yaml
+++ b/pkg/autodiscovery/providers/tests/envvars.d/conf.yaml
@@ -1,0 +1,6 @@
+init_config:
+  foo: "%%env_test_envvar_key%%"
+
+instances:
+  - bar: "%%env_test_envvar_key%%"
+  - baz: "%%env_test_envvar_not_set%%"

--- a/releasenotes/notes/config-env-vars-13f26d3b52b32813.yaml
+++ b/releasenotes/notes/config-env-vars-13f26d3b52b32813.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add support for environment variables in checks' config files
+    using the format "%%env_XXXX%%".
+


### PR DESCRIPTION
Adds support for environment variables in checks' config files, using the same format we use in check templates, ie: `%%env_XXXX%%`.
