### PR TITLE
Fix crash in `integration` command

### DIFF
--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -654,7 +654,7 @@ func installedVersion(integration string) (*semver.Version, error) {
 
 	outputStr := strings.TrimSpace(string(output))
 	if outputStr == "" {
-		return nil, nil
+		return nil, nil // Either python couldn't import the check or the check didn't have a __version__
 	}
 
 	version, err := semver.NewVersion(outputStr)

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -345,7 +345,7 @@ func install(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not get current version of %s: %v", integration, err)
 	}
 
-	if versionToInstall.Equal(*currentVersion) {
+	if currentVersion != nil && versionToInstall.Equal(*currentVersion) {
 		fmt.Printf("%s %s is already installed. Nothing to do.\n", integration, versionToInstall)
 		return nil
 	}


### PR DESCRIPTION
`installedVersion()` returns null if the integration isn't installed.
