### PR TITLE
remove a Py_XDECREF on a ref we lost ownership of

### DIFF
--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -285,6 +285,9 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
     }
 
     instances = PyTuple_New(1);
+    // As stated in the Python C-API documentation https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details,
+    //  `PyTuple_SetItem`  takes over ownership of the given item (instance in this case).
+    // This means that we should NOT DECREF it
     if (PyTuple_SetItem(instances, 0, instance) != 0) {
         setError("Could not create Tuple for instances: " + _fetchPythonError());
         goto done;
@@ -338,6 +341,9 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
     }
 
 done:
+    // We purposefully avoid calling Py_XDECREF on instance because we lost ownership earlier by
+    // calling PyTuple_SetItem. More details are available in the comment above this PyTuple_SetItem
+    // call
     Py_XDECREF(name);
     Py_XDECREF(check_id);
     Py_XDECREF(init_config);

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -341,7 +341,6 @@ done:
     Py_XDECREF(name);
     Py_XDECREF(check_id);
     Py_XDECREF(init_config);
-    Py_XDECREF(instance);
     Py_XDECREF(agent_config);
     Py_XDECREF(args);
     Py_XDECREF(kwargs);

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -285,9 +285,9 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
     }
 
     instances = PyTuple_New(1);
-    // As stated in the Python C-API documentation https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details,
-    // PyTuple_SetItem takes over ownership of the given item (instance in this case).
-    // This means that we should NOT DECREF it
+    // As stated in the Python C-API documentation
+    // https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details, PyTuple_SetItem takes
+    // over ownership of the given item (instance in this case). This means that we should NOT DECREF it
     if (PyTuple_SetItem(instances, 0, instance) != 0) {
         setError("Could not create Tuple for instances: " + _fetchPythonError());
         goto done;

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -286,7 +286,7 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
 
     instances = PyTuple_New(1);
     // As stated in the Python C-API documentation https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details,
-    //  `PyTuple_SetItem`  takes over ownership of the given item (instance in this case).
+    // PyTuple_SetItem takes over ownership of the given item (instance in this case).
     // This means that we should NOT DECREF it
     if (PyTuple_SetItem(instances, 0, instance) != 0) {
         setError("Could not create Tuple for instances: " + _fetchPythonError());


### PR DESCRIPTION
### What does this PR do?

https://docs.python.org/2/extending/extending.html#ownership-rules
> PyTuple_SetItem() and PyList_SetItem(). These functions take over ownership of the item passed to them — even if they fail!

and https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details

https://github.com/DataDog/datadog-agent/blob/6f642b5daf9b35d755b31db853c8346794c48dbc/six/two/two.cpp#L288
https://github.com/DataDog/datadog-agent/blob/6f642b5daf9b35d755b31db853c8346794c48dbc/six/two/two.cpp#L344
