### PR TITLE
[Logs][Enhancement]: Expose logs expvar metrics through the agent status

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -194,6 +194,14 @@
 
         Logs Agent is not running </br>
       {{- end }}
+      {{- if .metrics }}
+
+        Metrics
+        {{ printDashes "Metrics" "=" }}
+        {{- range $metric_key, $metric_value := .metrics }}
+          {{$metric_key}}: {{$metric_value}}
+        {{- end }}
+      {{- end }}
       {{- if .errors }}
 
         <span class="error stat_subtitle">Errors</span>

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -8,6 +8,7 @@ package logs
 import (
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
@@ -49,7 +50,7 @@ func Start() error {
 	adScheduler = scheduler.NewScheduler(sources, services)
 
 	// setup the status
-	status.Init(&isRunning, sources)
+	status.Init(&isRunning, sources, metrics.LogsExpvars)
 
 	// setup the server config
 	endpoints, err := sender.BuildEndpoints()

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -6,6 +6,7 @@
 package status
 
 import (
+	"expvar"
 	"strings"
 	"sync/atomic"
 
@@ -14,29 +15,32 @@ import (
 
 // Builder is used to build the status.
 type Builder struct {
-	isRunning *int32
-	sources   *config.LogSources
-	warnings  *config.Messages
-	errors    *config.Messages
+	isRunning   *int32
+	sources     *config.LogSources
+	warnings    *config.Messages
+	errors      *config.Messages
+	logsExpVars *expvar.Map
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *int32, sources *config.LogSources, warnings *config.Messages, errors *config.Messages) *Builder {
+func NewBuilder(isRunning *int32, sources *config.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
 	return &Builder{
-		isRunning: isRunning,
-		sources:   sources,
-		warnings:  warnings,
-		errors:    errors,
+		isRunning:   isRunning,
+		sources:     sources,
+		warnings:    warnings,
+		errors:      errors,
+		logsExpVars: logExpVars,
 	}
 }
 
 // BuildStatus returns the status of the logs-agent.
 func (b *Builder) BuildStatus() Status {
 	return Status{
-		IsRunning:    b.getIsRunning(),
-		Integrations: b.getIntegrations(),
-		Warnings:     b.getWarnings(),
-		Errors:       b.getErrors(),
+		IsRunning:     b.getIsRunning(),
+		Integrations:  b.getIntegrations(),
+		StatusMetrics: b.getStatusMetrics(),
+		Warnings:      b.getWarnings(),
+		Errors:        b.getErrors(),
 	}
 }
 
@@ -132,4 +136,11 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		}
 	}
 	return dictionary
+}
+
+func (b *Builder) getStatusMetrics() map[string]int64 {
+	var metrics = make(map[string]int64, 2)
+	metrics["LogsProcessed"] = b.logsExpVars.Get("LogsProcessed").(*expvar.Int).Value()
+	metrics["LogsSent"] = b.logsExpVars.Get("LogsSent").(*expvar.Int).Value()
+	return metrics
 }

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -36,17 +36,18 @@ type Integration struct {
 
 // Status provides some information about logs-agent.
 type Status struct {
-	IsRunning    bool          `json:"is_running"`
-	Integrations []Integration `json:"integrations"`
-	Errors       []string      `json:"errors"`
-	Warnings     []string      `json:"warnings"`
+	IsRunning     bool             `json:"is_running"`
+	StatusMetrics map[string]int64 `json:"metrics"`
+	Integrations  []Integration    `json:"integrations"`
+	Errors        []string         `json:"errors"`
+	Warnings      []string         `json:"warnings"`
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *int32, sources *config.LogSources) {
+func Init(isRunning *int32, sources *config.LogSources, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
-	builder = NewBuilder(isRunning, sources, warnings, errors)
+	builder = NewBuilder(isRunning, sources, warnings, errors, logExpVars)
 }
 
 // Clear clears the status which means it needs to be initialized again to be used.

--- a/pkg/logs/status/status_test.go
+++ b/pkg/logs/status/status_test.go
@@ -7,6 +7,7 @@ package status
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,4 +100,26 @@ func TestMetrics(t *testing.T) {
 	AddGlobalError("bar", "I am an error")
 	expected = `{"DestinationErrors": 0, "DestinationLogsDropped": {}, "Errors": "I am an error", "IsRunning": true, "LogsDecoded": 0, "LogsProcessed": 0, "LogsSent": 0, "Warnings": "Unique Warning"}`
 	assert.Equal(t, expected, metrics.LogsExpvars.String())
+}
+
+func TestStatusMetrics(t *testing.T) {
+	defer Clear()
+	createSources()
+
+	status := Get()
+	assert.Equal(t, int64(0), status.StatusMetrics["LogsProcessed"])
+	assert.Equal(t, int64(0), status.StatusMetrics["LogsSent"])
+
+	metrics.LogsProcessed.Set(5)
+	metrics.LogsSent.Set(3)
+	status = Get()
+
+	assert.Equal(t, int64(5), status.StatusMetrics["LogsProcessed"])
+	assert.Equal(t, int64(3), status.StatusMetrics["LogsSent"])
+
+	//Overflow test
+	metrics.LogsProcessed.Set(math.MaxInt64)
+	metrics.LogsProcessed.Add(1)
+	status = Get()
+	assert.Equal(t, int64(math.MinInt64), status.StatusMetrics["LogsProcessed"])
 }

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -7,6 +7,7 @@ package status
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // ConsumeSources ensures that another component is consuming the channel to prevent
@@ -27,7 +28,7 @@ func CreateSources(sourcesArray []*config.LogSource) *config.LogSources {
 	}
 	ConsumeSources(logSources)
 	var isRunning int32 = 1
-	Init(&isRunning, logSources)
+	Init(&isRunning, logSources, metrics.LogsExpvars)
 
 	return logSources
 }

--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -70,7 +70,8 @@ func (c *Scheduler) AddCollector(name string, interval time.Duration) error {
 	health := health.Register("metadata-" + name)
 
 	go func() {
-		ctx := context.Context(c.context)
+		ctx, cancelCtxFunc := context.WithCancel(c.context)
+		defer cancelCtxFunc()
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -6,6 +6,7 @@
 package metadata
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -31,8 +32,5 @@ func TestStopScheduler(t *testing.T) {
 	c.AddCollector("test", time.Duration(60))
 	c.AddCollector("test2", time.Duration(60))
 	c.Stop()
-	for _, s := range c.stopChannels {
-		_, ok := <-s
-		assert.False(t, ok)
-	}
+	assert.Equal(t, context.Canceled, c.context.Err())
 }

--- a/pkg/metadata/scheduler_test.go
+++ b/pkg/metadata/scheduler_test.go
@@ -7,6 +7,7 @@ package metadata
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -20,4 +21,18 @@ func TestNewScheduler(t *testing.T) {
 	c := NewScheduler(s, "hostname")
 	assert.Equal(t, fwd, c.srl.Forwarder)
 	assert.Equal(t, "hostname", c.hostname)
+}
+
+func TestStopScheduler(t *testing.T) {
+	fwd := forwarder.NewDefaultForwarder(nil)
+	fwd.Start()
+	s := serializer.NewSerializer(fwd)
+	c := NewScheduler(s, "hostname")
+	c.AddCollector("test", time.Duration(60))
+	c.AddCollector("test2", time.Duration(60))
+	c.Stop()
+	for _, s := range c.stopChannels {
+		_, ok := <-s
+		assert.False(t, ok)
+	}
 }

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -10,6 +10,15 @@ Logs Agent
   Logs Agent is not running
 {{- end }}
 
+{{- if .metrics }}
+
+  Metrics
+  {{ printDashes "Metrics" "=" }}
+  {{- range $metric_key, $metric_value := .metrics }}
+    {{$metric_key}}: {{$metric_value}}
+  {{- end }}
+{{- end }}
+
 {{- if .errors }}
 
   Errors

--- a/releasenotes/notes/add-status-logs-metrics-09bc9c9738e9a61b.yaml
+++ b/releasenotes/notes/add-status-logs-metrics-09bc9c9738e9a61b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Expose the number of logs processed and sent to the agent status

--- a/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
+++ b/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Correctly exits the metadata collector goroutines when scheduler stop is invoked
+    Fix a bug where when the log agent is mis-configured, it temporarily hog on resources after being killed

--- a/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
+++ b/releasenotes/notes/fix-metadata-scheduler-goroutine-8ea11479c918087d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Correctly exits the metadata collector goroutines when scheduler stop is invoked


### PR DESCRIPTION
### What does this PR do?

Give the customers more visibility to know if their logs are being processed by the agent or not

### Motivation

[Trello](https://trello.com/c/hpKBtk6E/1023-agent-status-expose-log-related-metrics-that-are-stored-in-the-expvar-data-to-the-agent-status)

