### PR TITLE
[Logs][Enhancement]: Expose logs expvar metrics through the agent status

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -206,6 +206,14 @@
 
         Logs Agent is not running </br>
       {{- end }}
+      {{- if .metrics }}
+
+         Metrics
+        {{ printDashes "Metrics" "=" }}
+        {{- range $metric_key, $metric_value := .metrics }}
+          {{$metric_key}}: {{$metric_value}}
+        {{- end }}
+      {{- end }}
       {{- if .errors }}
 
         <span class="error stat_subtitle">Errors</span>

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -208,8 +208,6 @@
       {{- end }}
       {{- if .metrics }}
 
-         Metrics
-        {{ printDashes "Metrics" "=" }}
         {{- range $metric_name, $metric_value := .metrics }}
           {{$metric_name}}: {{$metric_value}}
         {{- end }}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -210,8 +210,8 @@
 
          Metrics
         {{ printDashes "Metrics" "=" }}
-        {{- range $metric_key, $metric_value := .metrics }}
-          {{$metric_key}}: {{$metric_value}}
+        {{- range $metric_name, $metric_value := .metrics }}
+          {{$metric_name}}: {{$metric_value}}
         {{- end }}
       {{- end }}
       {{- if .errors }}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -8,6 +8,7 @@ package logs
 import (
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
@@ -49,7 +50,7 @@ func Start() error {
 	adScheduler = scheduler.NewScheduler(sources, services)
 
 	// setup the status
-	status.Init(&isRunning, sources)
+	status.Init(&isRunning, sources, metrics.LogsExpvars)
 
 	// setup the server config
 	endpoints, err := sender.BuildEndpoints()

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -38,7 +38,7 @@ func (b *Builder) BuildStatus() Status {
 	return Status{
 		IsRunning:     b.getIsRunning(),
 		Integrations:  b.getIntegrations(),
-		StatusMetrics: b.getStatusMetrics(),
+		StatusMetrics: b.getMetricsStatus(),
 		Warnings:      b.getWarnings(),
 		Errors:        b.getErrors(),
 	}
@@ -138,7 +138,8 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 	return dictionary
 }
 
-func (b *Builder) getStatusMetrics() map[string]int64 {
+// getMetricsStatus exposes some aggregated metrics of the log agent on the agent status
+func (b *Builder) getMetricsStatus() map[string]int64 {
 	var metrics = make(map[string]int64, 2)
 	metrics["LogsProcessed"] = b.logsExpVars.Get("LogsProcessed").(*expvar.Int).Value()
 	metrics["LogsSent"] = b.logsExpVars.Get("LogsSent").(*expvar.Int).Value()

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -6,6 +6,7 @@
 package status
 
 import (
+	"expvar"
 	"strings"
 	"sync/atomic"
 
@@ -14,29 +15,32 @@ import (
 
 // Builder is used to build the status.
 type Builder struct {
-	isRunning *int32
-	sources   *config.LogSources
-	warnings  *config.Messages
-	errors    *config.Messages
+	isRunning   *int32
+	sources     *config.LogSources
+	warnings    *config.Messages
+	errors      *config.Messages
+	logsExpVars *expvar.Map
 }
 
 // NewBuilder returns a new builder.
-func NewBuilder(isRunning *int32, sources *config.LogSources, warnings *config.Messages, errors *config.Messages) *Builder {
+func NewBuilder(isRunning *int32, sources *config.LogSources, warnings *config.Messages, errors *config.Messages, logExpVars *expvar.Map) *Builder {
 	return &Builder{
-		isRunning: isRunning,
-		sources:   sources,
-		warnings:  warnings,
-		errors:    errors,
+		isRunning:   isRunning,
+		sources:     sources,
+		warnings:    warnings,
+		errors:      errors,
+		logsExpVars: logExpVars,
 	}
 }
 
 // BuildStatus returns the status of the logs-agent.
 func (b *Builder) BuildStatus() Status {
 	return Status{
-		IsRunning:    b.getIsRunning(),
-		Integrations: b.getIntegrations(),
-		Warnings:     b.getWarnings(),
-		Errors:       b.getErrors(),
+		IsRunning:     b.getIsRunning(),
+		Integrations:  b.getIntegrations(),
+		StatusMetrics: b.getStatusMetrics(),
+		Warnings:      b.getWarnings(),
+		Errors:        b.getErrors(),
 	}
 }
 
@@ -132,4 +136,11 @@ func (b *Builder) toDictionary(c *config.LogsConfig) map[string]interface{} {
 		}
 	}
 	return dictionary
+}
+
+func (b *Builder) getStatusMetrics() map[string]int64 {
+	var metrics = make(map[string]int64, 2)
+	metrics["LogsProcessed"] = b.logsExpVars.Get("LogsProcessed").(*expvar.Int).Value()
+	metrics["LogsSent"] = b.logsExpVars.Get("LogsSent").(*expvar.Int).Value()
+	return metrics
 }

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -36,17 +36,18 @@ type Integration struct {
 
 // Status provides some information about logs-agent.
 type Status struct {
-	IsRunning    bool          `json:"is_running"`
-	Integrations []Integration `json:"integrations"`
-	Errors       []string      `json:"errors"`
-	Warnings     []string      `json:"warnings"`
+	IsRunning     bool             `json:"is_running"`
+	StatusMetrics map[string]int64 `json:"metrics"`
+	Integrations  []Integration    `json:"integrations"`
+	Errors        []string         `json:"errors"`
+	Warnings      []string         `json:"warnings"`
 }
 
 // Init instantiates the builder that builds the status on the fly.
-func Init(isRunning *int32, sources *config.LogSources) {
+func Init(isRunning *int32, sources *config.LogSources, logExpVars *expvar.Map) {
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
-	builder = NewBuilder(isRunning, sources, warnings, errors)
+	builder = NewBuilder(isRunning, sources, warnings, errors, logExpVars)
 }
 
 // Clear clears the status which means it needs to be initialized again to be used.

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -7,6 +7,7 @@ package status
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
 // ConsumeSources ensures that another component is consuming the channel to prevent
@@ -27,7 +28,7 @@ func CreateSources(sourcesArray []*config.LogSource) *config.LogSources {
 	}
 	ConsumeSources(logSources)
 	var isRunning int32 = 1
-	Init(&isRunning, logSources)
+	Init(&isRunning, logSources, metrics.LogsExpvars)
 
 	return logSources
 }

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -14,8 +14,8 @@ Logs Agent
 
    Metrics
   {{ printDashes "Metrics" "=" }}
-  {{- range $metric_key, $metric_value := .metrics }}
-    {{$metric_key}}: {{$metric_value}}
+  {{- range $metric_name, $metric_value := .metrics }}
+    {{$metric_name}}: {{$metric_value}}
   {{- end }}
 {{- end }}
 

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -12,8 +12,6 @@ Logs Agent
 
 {{- if .metrics }}
 
-   Metrics
-  {{ printDashes "Metrics" "=" }}
   {{- range $metric_name, $metric_value := .metrics }}
     {{$metric_name}}: {{$metric_value}}
   {{- end }}

--- a/pkg/status/dist/templates/logsagent.tmpl
+++ b/pkg/status/dist/templates/logsagent.tmpl
@@ -10,6 +10,15 @@ Logs Agent
   Logs Agent is not running
 {{- end }}
 
+{{- if .metrics }}
+
+   Metrics
+  {{ printDashes "Metrics" "=" }}
+  {{- range $metric_key, $metric_value := .metrics }}
+    {{$metric_key}}: {{$metric_value}}
+  {{- end }}
+{{- end }}
+
 {{- if .errors }}
 
   Errors

--- a/releasenotes/notes/add-status-logs-metrics-f91ff2ebea159875.yaml
+++ b/releasenotes/notes/add-status-logs-metrics-f91ff2ebea159875.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Expose the number of logs processed and sent to the agent status


### PR DESCRIPTION
### What does this PR do?

Give the customers more visibility to know if their logs are being processed by the agent or not

Screenshot:
![image](https://user-images.githubusercontent.com/48209202/58093834-a8166f00-7bcf-11e9-8faf-25d76aca31df.png)


### Motivation

[Trello](https://trello.com/c/hpKBtk6E/1023-agent-status-expose-log-related-metrics-that-are-stored-in-the-expvar-data-to-the-agent-status)

