### PR TITLE
[omnibus] Fix macOS omnibus build crash on system-probe steps

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -99,8 +99,11 @@ build do
     copy 'bin/process-agent/process-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
   else
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
-    copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
-    block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
+    # We don't use the system-probe in macOS builds
+    if !osx?
+      copy 'bin/system-probe/system-probe', "#{install_dir}/embedded/bin"
+      block { File.chmod(0755, "#{install_dir}/embedded/bin/system-probe") }
+    end
   end
 
   if linux?


### PR DESCRIPTION
### What does this PR do?

Removes two steps (move & chmod the system-probe) that will fail on macOS
builds, since it isn't packaged with the macOS agent.

### Motivation

The macOS build doesn't use the system-probe binary, so we shouldn't try
to move and chmod it. The current build crashes when trying to chmod the
binary.

### Additional Notes

May conflict with [this PR](https://github.com/DataDog/datadog-agent/pull/3508) because of the renaming of `network-tracer`.