### PR TITLE
[pkg/util/log] Scrub 'pwd' and certificates when sending flare

### DIFF
--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -39,14 +39,17 @@ func TestBasicLogging(t *testing.T) {
 	// Trace will not be logged
 	assert.Equal(t, strings.Count(b.String(), "foo"), 5)
 
-	Err := Error // Alias to avoid go-vet false positive
+	// Alias to avoid go-vet false positives
+	Wn := Warn
+	Err := Error
+	Crt := Critical
 
 	Trace("%s", "bar")
 	Debug("%s", "bar")
 	Info("%s", "bar")
-	Warn("%s", "bar")
+	Wn("%s", "bar")
 	Err("%s", "bar")
-	Critical("%s", "bar")
+	Crt("%s", "bar")
 	w.Flush()
 
 	// Trace will not be logged

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -200,6 +200,12 @@ func TestConfigPassword(t *testing.T) {
 	assertClean(t,
 		`pwd: p@ssw0r`,
 		`pwd: ********`)
+	assertClean(t,
+		`cert_key_password: p@ssw0r`,
+		`cert_key_password: ********`)
+	assertClean(t,
+		`cert_key_password: 🔑 🔒 🔐 🔓`,
+		`cert_key_password: ********`)
 }
 
 func TestSNMPConfig(t *testing.T) {

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -139,8 +139,8 @@ func TestTextStripApiKey(t *testing.T) {
 
 func TestTextStripURLPassword(t *testing.T) {
 	assertClean(t,
-		`Connection droped : ftp://user:password@host:port`,
-		`Connection droped : ftp://user:********@host:port`)
+		`Connection dropped : ftp://user:password@host:port`,
+		`Connection dropped : ftp://user:********@host:port`)
 }
 
 func TestDockerSelfInspectApiKey(t *testing.T) {
@@ -194,6 +194,12 @@ func TestConfigPassword(t *testing.T) {
 	assertClean(t,
 		`   mysql_password:   'password'   `,
 		`   mysql_password: ********`)
+	assertClean(t,
+		`pwd: 'password'`,
+		`pwd: ********`)
+	assertClean(t,
+		`pwd: p@ssw0r`,
+		`pwd: ********`)
 }
 
 func TestSNMPConfig(t *testing.T) {
@@ -227,6 +233,49 @@ func TestSNMPConfig(t *testing.T) {
 	assertClean(t,
 		`   community_string:   'password'   `,
 		`   community_string: ********`)
+}
+
+func TestCertConfig(t *testing.T) {
+	assertClean(t,
+		`cert_key: >
+		   -----BEGIN PRIVATE KEY-----
+		   MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAOLJKRals8tGoy7K
+		   ljG6/hMcoe16W6MPn47Q601ttoFkMoSJZ1Jos6nxn32KXfG6hCiB0bmf1iyZtaMa
+		   idae/ceT7ZNGvqcVffpDianq9r08hClhnU8mTojl38fsvHf//yqZNzn1ZUcLsY9e
+		   wG6wl7CsbWCafxaw+PfaCB1uWlnhAgMBAAECgYAI+tQgrHEBFIvzl1v5HiFfWlvj
+		   DlxAiabUvdsDVtvKJdCGRPaNYc3zZbjd/LOZlbwT6ogGZJjTbUau7acVk3gS8uKl
+		   ydWWODSuxVYxY8Poxt9SIksOAk5WmtMgIg2bTltTb8z3AWAT3qZrHth03la5Zbix
+		   ynEngzyj1+ND7YwQAQJBAP00t8/1aqub+rfza+Ddd8OYSMARFH22oxgy2W1O+Gwc
+		   Y8Gn3z6TkadfhPxFaUPnBPx8wm3mN+XeSB1nf0KCAWECQQDlSc7jQ/Ps5rxcoekB
+		   ldB+VmuR8TfcWdrWSOdHUiLyoJoj+Z7yfrf70gONPP9tUnwX6MYdT8YwzHK34aWv
+		   8KiBAkBHddlql5jDVgIsaEbJ77cdPJ1Ll4Zw9FqTOcajUuZJnLmKrhYTUxKIaize
+		   BbjvsQN3Pr6gxZiBB3rS0aLY4lgBAkApsH3ZfKWBUYK2JQpEq4S5M+VjJ8TMX9oW
+		   VDMZGKoaC3F7UQvBc6DoPItAxvJ6YiEGB+Ddu3+Bp+rD3FdP4iYBAkBh17O56A/f
+		   QX49RjRCRIT0w4nvZ3ph9gHEe50E4+Ky5CLQNOPLD/RbBXSEzez8cGysVvzDO3DZ
+		   /iN4a8gloY3d
+		   -----END PRIVATE KEY-----`,
+		`cert_key: >
+		   ********`)
+	assertClean(t,
+		`cert_key: |
+			-----BEGIN CERTIFICATE-----
+			MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAOLJKRals8tGoy7K
+			ljG6/hMcoe16W6MPn47Q601ttoFkMoSJZ1Jos6nxn32KXfG6hCiB0bmf1iyZtaMa
+			idae/ceT7ZNGvqcVffpDianq9r08hClhnU8mTojl38fsvHf//yqZNzn1ZUcLsY9e
+			wG6wl7CsbWCafxaw+PfaCB1uWlnhAgMBAAECgYAI+tQgrHEBFIvzl1v5HiFfWlvj
+			DlxAiabUvdsDVtvKJdCGRPaNYc3zZbjd/LOZlbwT6ogGZJjTbUau7acVk3gS8uKl
+			ydWWODSuxVYxY8Poxt9SIksOAk5WmtMgIg2bTltTb8z3AWAT3qZrHth03la5Zbix
+			ynEngzyj1+ND7YwQAQJBAP00t8/1aqub+rfza+Ddd8OYSMARFH22oxgy2W1O+Gwc
+			Y8Gn3z6TkadfhPxFaUPnBPx8wm3mN+XeSB1nf0KCAWECQQDlSc7jQ/Ps5rxcoekB
+			ldB+VmuR8TfcWdrWSOdHUiLyoJoj+Z7yfrf70gONPP9tUnwX6MYdT8YwzHK34aWv
+			8KiBAkBHddlql5jDVgIsaEbJ77cdPJ1Ll4Zw9FqTOcajUuZJnLmKrhYTUxKIaize
+			BbjvsQN3Pr6gxZiBB3rS0aLY4lgBAkApsH3ZfKWBUYK2JQpEq4S5M+VjJ8TMX9oW
+			VDMZGKoaC3F7UQvBc6DoPItAxvJ6YiEGB+Ddu3+Bp+rD3FdP4iYBAkBh17O56A/f
+			QX49RjRCRIT0w4nvZ3ph9gHEe50E4+Ky5CLQNOPLD/RbBXSEzez8cGysVvzDO3DZ
+			/iN4a8gloY3d
+			-----END CERTIFICATE-----`,
+		`cert_key: |
+			********`)
 }
 
 func assertClean(t *testing.T, contents, cleanContents string) {

--- a/releasenotes/notes/improve-flare-strip-8bc243604521af44.yaml
+++ b/releasenotes/notes/improve-flare-strip-8bc243604521af44.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Improved credentials scrubbing logic.


### PR DESCRIPTION
### What does this PR do?

`pwd` has been added to the list of password keys to scrub if encountered.
To remove private certificates / keys, multiline replacers have been introduced in the credentials scrubbing phase (since certificates are usually written on multiple lines).
Searching for certificates / keys is done by a regex which follows [RFC 7468](https://tools.ietf.org/html/rfc7468)'s ABNF as closely as possible. However, the lack of backreferences makes it impossible to check in the regex that the same label is used in the `BEGIN` and `END` parts.
Tests have been added for these two cases.

### Motivation

The `pwd` and `cert_key` fields of [this integration config file](https://github.com/DataDog/integrations-core/blob/c603898bbcb7a9d2801322b8353d729e54dcf6a1/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example) weren't properly scrubbed when sending a flare.

### Benchmarks

Before change:

```
goos: darwin
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/util/log
BenchmarkLogVanilla-8                1000000          2297 ns/op        1068 B/op         15 allocs/op
BenchmarkLogVanillaLevels-8         30000000            57.5 ns/op        64 B/op          2 allocs/op
BenchmarkLogScrubbing-8               100000         13699 ns/op        6605 B/op         38 allocs/op
BenchmarkLogScrubbingLevels-8       20000000            71.2 ns/op        16 B/op          1 allocs/op
BenchmarkLogScrubbingMulti-8          100000         16601 ns/op        7564 B/op         54 allocs/op
PASS
coverage: 26.3% of statements
```

After change:
```
goos: darwin
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/util/log
BenchmarkLogVanilla-8                1000000          2243 ns/op        1068 B/op         15 allocs/op
BenchmarkLogVanillaLevels-8         30000000            58.1 ns/op        64 B/op          2 allocs/op
BenchmarkLogScrubbing-8               100000         14468 ns/op        6698 B/op         40 allocs/op
BenchmarkLogScrubbingLevels-8       20000000            71.8 ns/op        16 B/op          1 allocs/op
BenchmarkLogScrubbingMulti-8          100000         16225 ns/op        7660 B/op         56 allocs/op
PASS
coverage: 27.7% of statements
```