### PR TITLE
Merge partial logs for kubernetes

### DIFF
--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -57,7 +57,7 @@ type Decoder struct {
 func InitializeDecoder(source *config.LogSource, parser parser.Parser, contentLenLimit int) *Decoder {
 	inputChan := make(chan *Input)
 	outputChan := make(chan *Output)
-	return New(inputChan, outputChan, NewLineHandler(outputChan, parser, source, contentLenLimit), contentLenLimit)
+	return New(inputChan, outputChan, NewLineHandlerRunner(outputChan, parser, source, contentLenLimit), contentLenLimit)
 }
 
 // NewDecoderWithLineHandlerRunner returns a initialized decoder by passing specified LineHandlerRunner

--- a/pkg/logs/decoder/line_buffer.go
+++ b/pkg/logs/decoder/line_buffer.go
@@ -51,7 +51,7 @@ func (l *LineBuffer) AddIncompleteLine(line []byte) {
 }
 
 // AddTruncate stores TRUNCATED in buffer
-func (l *LineBuffer) AddTruncate(line []byte) {
+func (l *LineBuffer) AddTruncate() {
 	l.buffer.Write(TRUNCATED)
 }
 

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -7,6 +7,8 @@ package decoder
 
 import (
 	"bytes"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"regexp"
 	"time"
 
@@ -17,154 +19,39 @@ import (
 // TRUNCATED is the warning we add at the beginning or/and at the end of a truncated message
 var TRUNCATED = []byte("...TRUNCATED...")
 
-// LineHandler handles byte slices to form line output
-type LineHandler interface {
+// LineHandlerRunner handles byte slices to form line output
+type LineHandlerRunner interface {
 	Handle(content []byte)
 	Start()
 	Stop()
 }
 
-// SingleLineHandler creates and forward outputs to outputChan from single-lines
-type SingleLineHandler struct {
-	lineChan       chan []byte
-	outputChan     chan *Output
-	shouldTruncate bool
-	parser         parser.Parser
-	lineLimit      int
+// Handler defines the input and output chan for handling a line.
+type Handler struct {
+	InputChan  chan []byte
+	OutputChan chan *Output
 }
 
-// NewSingleLineHandler returns a new SingleLineHandler
-func NewSingleLineHandler(outputChan chan *Output, parser parser.Parser, lineLimit int) *SingleLineHandler {
-	return &SingleLineHandler{
-		lineChan:   make(chan []byte),
-		outputChan: outputChan,
-		parser:     parser,
-		lineLimit:  lineLimit,
+// Run takes a function for handling the message from input chan.
+func (h *Handler) Run(process func([]byte)) {
+	for line := range h.InputChan {
+		process(line)
 	}
+	close(h.OutputChan)
 }
 
-// Handle trims leading and trailing whitespaces from content,
-// and sends it as a new Line to lineChan.
-func (h *SingleLineHandler) Handle(content []byte) {
-	h.lineChan <- content
-}
-
-// Stop stops the handler from processing new lines
-func (h *SingleLineHandler) Stop() {
-	close(h.lineChan)
-}
-
-// Start starts the handler
-func (h *SingleLineHandler) Start() {
-	go h.run()
-}
-
-// run consumes lines from lineChan to process them
-func (h *SingleLineHandler) run() {
-	for line := range h.lineChan {
-		h.process(line)
-	}
-	close(h.outputChan)
-}
-
-// process creates outputs from lines and forwards them to outputChan
-// When lines are too long, they are truncated
-func (h *SingleLineHandler) process(line []byte) {
-	lineLen := len(line)
-	line = bytes.TrimSpace(line)
-	if len(line) == 0 {
-		return
-	}
-
-	var content []byte
-	if h.shouldTruncate {
-		// add TRUNCATED at the beginning of content
-		content = append(TRUNCATED, line...)
-		h.shouldTruncate = false
-	} else {
-		// keep content the same
-		content = line
-	}
-
-	if lineLen < h.lineLimit {
-		// send content
-		// add 1 to take into account '\n' that we didn't include in content
-		output, status, timestamp, err := h.parser.Parse(content)
-		if err != nil {
-			log.Debug(err)
-		}
-		if len(output) > 0 {
-			h.outputChan <- NewOutput(output, status, lineLen+1, timestamp)
-		}
-	} else {
-		// add TRUNCATED at the end of content and send it
-		content := append(content, TRUNCATED...)
-		output, status, timestamp, err := h.parser.Parse(content)
-		if err != nil {
-			log.Debug(err)
-		}
-		if len(output) > 0 {
-			h.outputChan <- NewOutput(output, status, lineLen, timestamp)
-			h.shouldTruncate = true
-		}
-	}
-}
-
-// defaultFlushTimeout represents the time we want to wait before flushing lineBuffer
-// when no more line is received
-const defaultFlushTimeout = 1000 * time.Millisecond
-
-// MultiLineHandler reads lines from lineChan and uses lineBuffer to send them
-// when a new line matches with re or flushTimer is fired
-type MultiLineHandler struct {
-	lineChan          chan []byte
-	outputChan        chan *Output
-	lineBuffer        *LineBuffer
-	lastSeenTimestamp string
-	newContentRe      *regexp.Regexp
-	flushTimeout      time.Duration
-	parser            parser.Parser
-	lineLimit         int
-}
-
-// NewMultiLineHandler returns a new MultiLineHandler
-func NewMultiLineHandler(outputChan chan *Output, newContentRe *regexp.Regexp, flushTimeout time.Duration, parser parser.Parser, lineLimit int) *MultiLineHandler {
-	return &MultiLineHandler{
-		lineChan:     make(chan []byte),
-		outputChan:   outputChan,
-		lineBuffer:   NewLineBuffer(),
-		newContentRe: newContentRe,
-		flushTimeout: flushTimeout,
-		parser:       parser,
-		lineLimit:    lineLimit,
-	}
-}
-
-// Handle forward lines to lineChan to process them
-func (h *MultiLineHandler) Handle(content []byte) {
-	h.lineChan <- content
-}
-
-// Stop stops the lineHandler from processing lines
-func (h *MultiLineHandler) Stop() {
-	close(h.lineChan)
-}
-
-// Start starts the handler
-func (h *MultiLineHandler) Start() {
-	go h.run()
-}
-
-// run processes new lines from lineChan and flushes the buffer when the timeout expires
-func (h *MultiLineHandler) run() {
-	flushTimer := time.NewTimer(h.flushTimeout)
+// RunWithTimer takes a timer, a function for handling the message and a function for sending the transformed message.
+func (h *Handler) RunWithTimer(timeout time.Duration, process func([]byte), sendContent func()) {
+	flushTimer := time.NewTimer(timeout)
 	defer func() {
 		flushTimer.Stop()
-		close(h.outputChan)
+		if h.OutputChan != nil {
+			close(h.OutputChan)
+		}
 	}()
 	for {
 		select {
-		case line, isOpen := <-h.lineChan:
+		case line, isOpen := <-h.InputChan:
 			if !isOpen {
 				// lineChan has been closed, no more lines are expected
 				return
@@ -179,20 +66,143 @@ func (h *MultiLineHandler) run() {
 				default:
 				}
 			}
-			h.process(line)
-			flushTimer.Reset(h.flushTimeout)
+			process(line)
+			flushTimer.Reset(timeout)
 		case <-flushTimer.C:
 			// the timout expired, the content is ready to be sent
-			h.sendContent()
+			sendContent()
 		}
 	}
+}
+
+// NewLineHandler returns appropriate LineHandler according to the source.
+func NewLineHandler(outputChan chan *Output, parser parser.Parser, source *config.LogSource, contentLenLimit int) LineHandlerRunner {
+	var lineHandlerRunner LineHandlerRunner
+	for _, rule := range source.Config.ProcessingRules {
+		if rule.Type == config.MultiLine {
+			lineHandlerRunner = NewMultiLineHandler(outputChan, rule.Regex, DefaultFlushTimeout, parser, contentLenLimit)
+		}
+	}
+	if lineHandlerRunner == nil {
+		lineHandlerRunner = NewSingleLineHandler(outputChan, parser, contentLenLimit)
+	}
+	return lineHandlerRunner
+}
+
+// SingleLineHandler creates and forward outputs to outputChan from single-lines
+type SingleLineHandler struct {
+	Handler
+	lineLimit      int
+	shouldTruncate bool
+	parser.Parser
+}
+
+// NewSingleLineHandler returns a new SingleLineHandler
+func NewSingleLineHandler(outputChan chan *Output, parser parser.Parser, lineLimit int) *SingleLineHandler {
+	return &SingleLineHandler{
+		Handler:   Handler{InputChan: make(chan []byte), OutputChan: outputChan},
+		lineLimit: lineLimit,
+		Parser:    parser,
+	}
+}
+
+// Handle trims leading and trailing whitespaces from content,
+// and sends it as a new Line to lineChan.
+func (h *SingleLineHandler) Handle(content []byte) {
+	h.InputChan <- content
+}
+
+// Stop stops the handler from processing new lines
+func (h *SingleLineHandler) Stop() {
+	close(h.InputChan)
+}
+
+// Start starts the handler
+func (h *SingleLineHandler) Start() {
+	go h.Run(h.process)
+}
+
+// process creates outputs from lines and forwards them to outputChan
+// When the line length exceed (include equals) line length limit,
+// "...TRUNCATED..." flag will be appended.
+func (h *SingleLineHandler) process(line []byte) {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return
+	}
+	content, status, timestamp, err := h.Parse(line)
+	lineLen := len(content)
+	if err != nil {
+		log.Debug(err)
+	}
+
+	if h.shouldTruncate {
+		content = append(TRUNCATED, content...)
+		h.shouldTruncate = false
+	}
+
+	if lineLen < h.lineLimit {
+		if len(content) > 0 {
+			h.OutputChan <- NewOutput(content, status, lineLen+1, timestamp)
+		}
+	} else {
+		content = append(content, TRUNCATED...)
+		h.OutputChan <- NewOutput(content, status, lineLen, timestamp)
+		h.shouldTruncate = true
+	}
+}
+
+// DefaultFlushTimeout represents the time we want to wait before flushing lineBuffer
+// when no more line is received
+const DefaultFlushTimeout = 1000 * time.Millisecond
+
+// MultiLineHandler reads lines from lineChan and uses lineBuffer to send them
+// when a new line matches with re or flushTimer is fired
+type MultiLineHandler struct {
+	Handler
+	lineBuffer        *LineBuffer
+	lastSeenTimestamp string
+	newContentRe      *regexp.Regexp
+	flushTimeout      time.Duration
+	lineLimit         int
+	parser.Parser
+}
+
+// NewMultiLineHandler returns a new MultiLineHandler
+func NewMultiLineHandler(outputChan chan *Output, newContentRe *regexp.Regexp, flushTimeout time.Duration, parser parser.Parser, lineLimit int) *MultiLineHandler {
+	return &MultiLineHandler{
+		Handler:      Handler{InputChan: make(chan []byte), OutputChan: outputChan},
+		lineBuffer:   NewLineBuffer(),
+		newContentRe: newContentRe,
+		flushTimeout: flushTimeout,
+		lineLimit:    lineLimit,
+		Parser:       parser,
+	}
+}
+
+// Handle forward lines to lineChan to process them
+func (h *MultiLineHandler) Handle(content []byte) {
+	h.InputChan <- content
+}
+
+// Stop stops the lineHandler from processing lines
+func (h *MultiLineHandler) Stop() {
+	close(h.InputChan)
+}
+
+// Start starts the handler
+func (h *MultiLineHandler) Start() {
+	go h.RunWithTimer(h.flushTimeout, h.process, h.sendContent)
 }
 
 // process accumulates lines in lineBuffer and flushes lineBuffer when a new line matches with newContentRe
 // When lines are too long, they are truncated
 func (h *MultiLineHandler) process(line []byte) {
-	unwrappedLine, _, timestamp, err := h.parser.Parse(line)
-	h.lastSeenTimestamp = timestamp
+	unwrappedLine, _, timestamp, err := h.Parse(line)
+	if timestamp != "" {
+		h.lastSeenTimestamp = timestamp
+	}
+
 	if err != nil {
 		log.Debug(err)
 	}
@@ -206,6 +216,9 @@ func (h *MultiLineHandler) process(line []byte) {
 		// add '\n' to content in lineBuffer
 		h.lineBuffer.AddEndOfLine()
 	}
+
+	line = unwrappedLine
+
 	// NOTES: this check takes into account the length of "...TRUNCATED..."
 	// which in some scenario is outputting an ending message with
 	// ...TRUNCATED... as only content, see unit test line_handler_test.go/TestMultiLineHandler
@@ -215,11 +228,11 @@ func (h *MultiLineHandler) process(line []byte) {
 	} else {
 		// add line and truncate and flush content in lineBuffer
 		h.lineBuffer.AddIncompleteLine(line)
-		h.lineBuffer.AddTruncate(line)
+		h.lineBuffer.AddTruncate()
 		// send content from lineBuffer
 		h.sendContent()
 		// truncate next content
-		h.lineBuffer.AddTruncate(line)
+		h.lineBuffer.AddTruncate()
 	}
 }
 
@@ -229,16 +242,10 @@ func (h *MultiLineHandler) sendContent() {
 	content, rawDataLen := h.lineBuffer.Content()
 	content = bytes.TrimSpace(content)
 	if len(content) > 0 {
-		output, status, _, err := h.parser.Parse(content)
-		if err != nil {
-			log.Debug(err)
-		}
-		if len(output) > 0 {
-			// The output.Timestamp filled by the Parse function is the ts of the first
-			// log line, in order to be useful to setLastSince function, we need to replace
-			// it with the ts of the last log line. Note: this timestamp is NOT used for stamp
-			// the log record, it's ONLY used to recover well when tailing back the container.
-			h.outputChan <- NewOutput(output, status, rawDataLen, h.lastSeenTimestamp)
-		}
+		// The output.Timestamp filled by the Parse function is the ts of the first
+		// log line, in order to be useful to setLastSince function, we need to replace
+		// it with the ts of the last log line. Note: this timestamp is NOT used for stamp
+		// the log record, it's ONLY used to recover well when tailing back the container.
+		h.OutputChan <- NewOutput(content, message.StatusInfo, rawDataLen, h.lastSeenTimestamp)
 	}
 }

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -75,8 +75,8 @@ func (h *Handler) RunWithTimer(timeout time.Duration, process func([]byte), send
 	}
 }
 
-// NewLineHandler returns appropriate LineHandler according to the source.
-func NewLineHandler(outputChan chan *Output, parser parser.Parser, source *config.LogSource, contentLenLimit int) LineHandlerRunner {
+// NewLineHandlerRunner returns appropriate LineHandler according to the source.
+func NewLineHandlerRunner(outputChan chan *Output, parser parser.Parser, source *config.LogSource, contentLenLimit int) LineHandlerRunner {
 	var lineHandlerRunner LineHandlerRunner
 	for _, rule := range source.Config.ProcessingRules {
 		if rule.Type == config.MultiLine {
@@ -210,14 +210,11 @@ func (h *MultiLineHandler) process(line []byte) {
 		// send content from lineBuffer
 		h.sendContent()
 	}
+	line = unwrappedLine
 	if !h.lineBuffer.IsEmpty() {
-		// unwrap all the following lines
-		line = unwrappedLine
 		// add '\n' to content in lineBuffer
 		h.lineBuffer.AddEndOfLine()
 	}
-
-	line = unwrappedLine
 
 	// NOTES: this check takes into account the length of "...TRUNCATED..."
 	// which in some scenario is outputting an ending message with

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -120,7 +120,7 @@ func TestTrimSingleLine(t *testing.T) {
 	h.Handle([]byte(line))
 	output = <-outputChan
 	assert.Equal(t, "foo"+whitespace+"bar", string(output.Content))
-	assert.Equal(t, len(line)+1, output.RawDataLen)
+	assert.Equal(t, len("foo"+whitespace+"bar")+1, output.RawDataLen)
 
 	h.Stop()
 }

--- a/pkg/logs/input/docker/tailer.go
+++ b/pkg/logs/input/docker/tailer.go
@@ -57,7 +57,7 @@ func NewTailer(cli *client.Client, containerID string, source *config.LogSource,
 	return &Tailer{
 		ContainerID:        containerID,
 		outputChan:         outputChan,
-		decoder:            decoder.InitializeDecoder(source, NewDockerParser(containerID)),
+		decoder:            decoder.InitializeDecoder(source, NewDockerParser(containerID), decoder.DefaultContentLenLimit),
 		source:             source,
 		tagProvider:        tag.NewProvider(dockerutil.ContainerIDToEntityName(containerID)),
 		cli:                cli,

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -62,7 +62,7 @@ func NewTailer(outputChan chan *message.Message, source *config.LogSource, path 
 	var flushTimeout = decoder.DefaultFlushTimeout
 	if source.GetSourceType() == config.KubernetesSourceType {
 		var outputChan = make(chan *decoder.Output)
-		var lineHandlerRunner = decoder.NewLineHandler(outputChan, kubernetes.Parser, source, contentLenLimit)
+		var lineHandlerRunner = decoder.NewLineHandlerRunner(outputChan, kubernetes.Parser, source, contentLenLimit)
 		var lineHandlerWrapper = kubernetes.NewLineHandler(lineHandlerRunner, flushTimeout, contentLenLimit)
 		dc = decoder.NewDecoderWithLineHandlerRunner(outputChan, lineHandlerWrapper, contentLenLimit)
 	} else {

--- a/pkg/logs/input/kubernetes/line_handler.go
+++ b/pkg/logs/input/kubernetes/line_handler.go
@@ -1,0 +1,120 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2019 Datadog, Inc.
+ */
+
+package kubernetes
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"time"
+)
+
+// LineHandler receive line as byte slice and merge lines.
+// The inputChan receives:
+// [timestamp stream flag message]
+// T1 S1 P M1
+// T2 S2 F M2
+// The content send to nextRunner should be:
+// T2 S2 F M1M2
+// Normally, a line (T1 S1 P M1) should be less than 16K which is way less than contentLenLimit(256K).
+type LineHandler struct {
+	decoder.Handler
+	nextRunner decoder.LineHandlerRunner
+	prefix
+	flushTimeout    time.Duration
+	lineBuffer      *decoder.LineBuffer
+	contentLenLimit int
+	parser
+}
+
+const (
+	fullMessage = "F"
+)
+
+type prefix struct {
+	timestamp string
+	status    string
+	flag      string
+}
+
+func (p *prefix) formatBytes() []byte {
+	return []byte(fmt.Sprintf("%v %v %v ", p.timestamp, p.status, p.flag))
+}
+
+// NewLineHandler returns a initialized LineHandler with given parameters.
+func NewLineHandler(lineHandlerRunner decoder.LineHandlerRunner, flushTimeout time.Duration, contentLenLimit int) *LineHandler {
+	return &LineHandler{
+		Handler: decoder.Handler{
+			InputChan: make(chan []byte),
+		},
+		nextRunner:      lineHandlerRunner,
+		flushTimeout:    flushTimeout,
+		lineBuffer:      decoder.NewLineBuffer(),
+		contentLenLimit: contentLenLimit,
+	}
+}
+
+// Handle send the content to input chan
+func (h *LineHandler) Handle(content []byte) {
+	h.InputChan <- content
+}
+
+// Stop close the inout chan and stops the next runner.
+func (h *LineHandler) Stop() {
+	close(h.InputChan)
+	h.nextRunner.Stop()
+}
+
+// Start starts the nextRunner and start handler runner with timer.
+func (h *LineHandler) Start() {
+	h.nextRunner.Start()
+	go h.RunWithTimer(h.flushTimeout, h.process, h.sendAndReset)
+}
+
+// process assumes line length does not exceed contentLenLimit, since the
+// contentLenLimit normally is 256K and kubernetes log each line doesn't
+// exceed 16K.
+func (h *LineHandler) process(line []byte) {
+	content, status, timestamp, flag, err := h.ParseFull(line)
+	if err != nil { // this case should not happen with length limitation.
+		log.Debug(err)
+	} else {
+		h.prefix = prefix{timestamp: timestamp, status: status, flag: flag}
+	}
+
+	content0, content1 := split(content, h.contentLenLimit-h.lineBuffer.Length())
+	h.lineBuffer.AddIncompleteLine(content0)
+	isFullContent := h.lineBuffer.Length() >= h.contentLenLimit
+	if fullMessage == h.prefix.flag || isFullContent {
+		h.sendAndReset()
+	}
+
+	if content1 != nil {
+		h.lineBuffer.AddIncompleteLine(content1)
+		h.sendAndReset()
+	}
+}
+
+func split(content []byte, threshold int) ([]byte, []byte) {
+
+	var limit = len(content)
+	if limit <= threshold || threshold < 0 {
+		return content[0:limit], nil
+	}
+	return content[0:threshold], content[threshold:]
+}
+
+func (h *LineHandler) sendAndReset() {
+	defer h.lineBuffer.Reset()
+	content, _ := h.lineBuffer.Content()
+	if len(content) > 0 {
+		content = append(h.prefix.formatBytes(), content...)
+		h.nextRunner.Handle(content)
+	}
+
+}

--- a/pkg/logs/input/kubernetes/line_handler_test.go
+++ b/pkg/logs/input/kubernetes/line_handler_test.go
@@ -1,0 +1,219 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2019 Datadog, Inc.
+ */
+
+package kubernetes
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestMultiLineHandler_SendMultiKubesLines(t *testing.T) {
+	outputChan := make(chan *decoder.Output, 3)
+	var h = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 29)
+	h.Start()
+
+	h.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout F 1. message cut by kubernetes "))
+	h.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout F continue"))
+	h.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F 2. full message"))
+
+	var output *decoder.Output
+
+	output = <-outputChan
+	assert.Equal(t, "1. message cut by kubernetes ...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "...TRUNCATED...continue", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "2. full message", string(output.Content))
+
+	h.Stop()
+}
+
+func TestSingleLineHandler_HandleKubesLine(t *testing.T) {
+	outputChan := make(chan *decoder.Output, 3)
+	h := decoder.NewSingleLineHandler(outputChan, Parser, 10)
+	h.Start()
+
+	h.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout F 1. message longer "))
+	h.Handle([]byte("than 10"))
+	h.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F 2. message longer than limit"))
+
+	var output *decoder.Output
+
+	output = <-outputChan
+	assert.Equal(t, "1. message longer...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "...TRUNCATED...than 10", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "2. message longer than limit...TRUNCATED...", string(output.Content))
+}
+
+func TestLineHandler_FailedParseMessage(t *testing.T) {
+	var outputChan = make(chan *decoder.Output)
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 60)
+	var wrapper = NewLineHandler(lineHandlerRunner, 10*time.Microsecond, 60)
+	wrapper.Start()
+	wrapper.Handle([]byte("1. invalid"))
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "1. invalid", string(output.Content))
+	wrapper.Stop()
+}
+
+func TestLineHandler_HandleFullMessage(t *testing.T) {
+	var outputChan = make(chan *decoder.Output)
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 100)
+	var wrapper = NewLineHandler(lineHandlerRunner, 2*time.Second, 100)
+	wrapper.Start()
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout F 1. first full message"))
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123506Z", output.Timestamp)
+	assert.Equal(t, "1. first full message", string(output.Content))
+	wrapper.Stop()
+}
+
+func TestLineHandler_MergePartialMessage(t *testing.T) {
+	var outputChan = make(chan *decoder.Output)
+
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 70)
+	var wrapper = NewLineHandler(lineHandlerRunner, 100*time.Microsecond, 70)
+	wrapper.Start()
+
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout P 1. message cut by "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123507Z stdout F kubernetes"))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F 2. full message"))
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "1. message cut by kubernetes", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "2. full message", string(output.Content))
+
+	wrapper.Stop()
+}
+
+func TestLineHandler_CutByDecoder(t *testing.T) {
+	var outputChan = make(chan *decoder.Output, 2)
+
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 56)
+	var wrapper = NewLineHandler(lineHandlerRunner, 2*time.Second, 56)
+	wrapper.Start()
+
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout P 1. message cut by "))
+	wrapper.Handle([]byte("decoder "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F last message"))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F 2. second message"))
+
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "1. message cut by decoder last message", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "2. second message", string(output.Content))
+
+	wrapper.Stop()
+}
+
+func TestLineHandler_FullMessageCutByDecoder(t *testing.T) {
+	var outputChan = make(chan *decoder.Output, 2)
+
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 56)
+	var wrapper = NewLineHandler(lineHandlerRunner, 10*time.Microsecond, 56)
+	wrapper.Start()
+
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout F 1. message cut by "))
+	wrapper.Handle([]byte("decoder"))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F 2. second message"))
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "1. message cut by \\ndecoder", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "2. second message", string(output.Content))
+
+	wrapper.Stop()
+}
+
+func TestLineHandler_ContentLineTooLong(t *testing.T) {
+	var outputChan = make(chan *decoder.Output, 3)
+
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 20)
+	var wrapper = NewLineHandler(lineHandlerRunner, 10*time.Microsecond, 20)
+	wrapper.Start()
+
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout P 1. message cut by "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout F application"))
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "1. message cut by ap...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123506Z", output.Timestamp)
+	assert.Equal(t, "...TRUNCATED...plication...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123506Z", output.Timestamp)
+	assert.Equal(t, "...TRUNCATED...", string(output.Content))
+
+	wrapper.Stop()
+}
+
+func TestLineHandler_ExceedContentLengthLimit(t *testing.T) {
+	var outputChan = make(chan *decoder.Output, 3)
+	var lineHandlerRunner = decoder.NewMultiLineHandler(outputChan, regexp.MustCompile("[0-9]+\\. "), 10*time.Microsecond, Parser, 22)
+	var wrapper = NewLineHandler(lineHandlerRunner, 10*time.Microsecond, 22)
+	wrapper.Start()
+
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout P 1. message cut "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123507Z stdout P by "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F application"))
+	var output *decoder.Output
+	output = <-outputChan
+	assert.Equal(t, "1. message cut by appl...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "...TRUNCATED...ication...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "...TRUNCATED...", string(output.Content))
+	wrapper.Stop()
+}
+
+func TestLineHandler_WrapSingleLineHandler(t *testing.T) {
+	var outputChan = make(chan *decoder.Output, 2)
+	var lineHandlerRunner = decoder.NewSingleLineHandler(outputChan, Parser, 22)
+	var wrapper = NewLineHandler(lineHandlerRunner, 10*time.Microsecond, 22)
+	wrapper.Start()
+
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123506Z stdout P 1. message cut "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123507Z stdout P by "))
+	wrapper.Handle([]byte("2019-05-15T13:34:26.011123508Z stdout F application"))
+	var output *decoder.Output
+	output = <-outputChan
+
+	assert.Equal(t, "1. message cut by appl...TRUNCATED...", string(output.Content))
+
+	output = <-outputChan
+
+	assert.Equal(t, "2019-05-15T13:34:26.011123508Z", output.Timestamp)
+	assert.Equal(t, "...TRUNCATED...ication", string(output.Content))
+	wrapper.Stop()
+}

--- a/pkg/logs/input/kubernetes/parser.go
+++ b/pkg/logs/input/kubernetes/parser.go
@@ -37,11 +37,11 @@ type parser struct {
 // Example:
 // 2018-09-20T11:54:11.753589172Z stdout F This is my message
 func (p *parser) Parse(msg []byte) ([]byte, string, string, error) {
-	content, status, timestamp, _, err := parse(msg)
+	content, status, timestamp, _, err := p.ParseFull(msg)
 	return content, status, timestamp, err
 }
 
-func parse(msg []byte) ([]byte, string, string, string, error) {
+func (p *parser) ParseFull(msg []byte) ([]byte, string, string, string, error) {
 	var status = message.StatusInfo
 	var flag string
 	var timestamp string

--- a/pkg/logs/input/listener/tailer.go
+++ b/pkg/logs/input/listener/tailer.go
@@ -35,7 +35,7 @@ func NewTailer(source *config.LogSource, conn net.Conn, outputChan chan *message
 		conn:       conn,
 		outputChan: outputChan,
 		read:       read,
-		decoder:    decoder.InitializeDecoder(source, parser.NoopParser),
+		decoder:    decoder.InitializeDecoder(source, parser.NoopParser, decoder.DefaultContentLenLimit),
 		stop:       make(chan struct{}, 1),
 		done:       make(chan struct{}, 1),
 	}

--- a/releasenotes/notes/logs-merge-partial-containerd-logs-d6cc3e666516afe5.yaml
+++ b/releasenotes/notes/logs-merge-partial-containerd-logs-d6cc3e666516afe5.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Merge the logs cut by containerd due to its length limitation.
+fixes:
+  - |
+    logs input decoder truncation unexpected behaviour.


### PR DESCRIPTION
### What does this PR do?

* Refactor on logs/decoder, logs/line_handler
* Add logic to aggregate partial logs to one full log

### Motivation

Client requests

### Additional Notes

The process logic changed to fix the issue with "...TRUNCATED..." prepend before timestamp.
