### PR TITLE
publish the dogstatsd image in the correct place when sending nightlies to dockerhub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1002,7 +1002,7 @@ dev_master_quay:
     - inv -e docker.publish ${SRC_DSD}:${SRC_TAG} quay.io/datawhale/dogstatsd-dev:master
 
 # deploys nightlies to agent-dev
-dev_master_nightly:
+dev_nightly_docker_hub:
   <<: *docker_tag_job_definition
   <<: *run_when_triggered_on_nightly
   variables:
@@ -1010,7 +1010,7 @@ dev_master_nightly:
   script:
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG} datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}
     - inv -e docker.publish --signed-push ${SRC_AGENT}:${SRC_TAG}-jmx datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-jmx
-    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/agent-dev:nightly-${CI_COMMIT_SHORT_SHA}
+    - inv -e docker.publish --signed-push ${SRC_DSD}:${SRC_TAG} datadog/dogstatsd-dev:nightly-${CI_COMMIT_SHORT_SHA}
 
 #
 # Check Deploy


### PR DESCRIPTION
### What does this PR do?

- publish the dogstatsd image in the correct place when sending nightlies to dockerhub
- rename the job to something more consistent with the rest of the jobs

### Motivation

The dogstatsd image was published in the wrong place