### PR TITLE
disables repo_gpgcheck in for RH

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -138,7 +138,7 @@ if [ $OS = "RedHat" ]; then
         ARCHI="x86_64"
     fi
 
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/stable/6/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.${repo_url}/stable/6/$ARCHI/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.${repo_url}/DATADOG_RPM_KEY.public\n       https://yum.${repo_url}/DATADOG_RPM_KEY_E09422B3.public' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
     $sudo_cmd yum -y clean metadata

--- a/docs/agent/downgrade.md
+++ b/docs/agent/downgrade.md
@@ -38,7 +38,7 @@ sudo apt-get install datadog-agent
 ##### Remove the Beta Yum repo from your system:
 ```shell
 rm /etc/yum.repos.d/datadog-beta.repo
-[ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
+[ ! -f /etc/yum.repos.d/datadog.repo ] && echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public\n       https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public' | sudo tee /etc/yum.repos.d/datadog.repo
 ```
 
 ##### Update your local yum cache and downgrade the agent

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -28,6 +28,7 @@ when 'rhel'
       baseurl = #{node['dd-agent-step-by-step']['yumrepo']}
       enabled=1
       gpgcheck=1
+      repo_gpgcheck=0
       gpgkey=#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public
     EOF
   end


### PR DESCRIPTION
### What does this PR do?

disables repo_gpgcheck for YUM based systems like RH, CentOs

### Motivation

error

```
https://yum.datadoghq.com/stable/6/x86_64/repodata/repomd.xml.asc: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
```

### Additional Notes

- related to card https-error-404-not-found-for-yumdatadoghqcom-while-installing-agent
Fixes: #3523