### PR TITLE
Reduce string casts for IP addresses by using Address struct everywhere

### DIFF
--- a/pkg/ebpf/event.go
+++ b/pkg/ebpf/event.go
@@ -4,6 +4,8 @@ package ebpf
 
 import (
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 /*
@@ -69,13 +71,13 @@ func connStats(t *ConnTuple, s *ConnStatsWithTimestamp, tcpStats *TCPStats) Conn
 	metadata := uint(t.metadata)
 	family := connFamily(metadata)
 
-	var source, dest Address
+	var source, dest util.Address
 	if family == AFINET {
-		source = V4Address(uint32(t.saddr_l))
-		dest = V4Address(uint32(t.daddr_l))
+		source = util.V4Address(uint32(t.saddr_l))
+		dest = util.V4Address(uint32(t.daddr_l))
 	} else {
-		source = V6Address(uint64(t.saddr_l), uint64(t.saddr_h))
-		dest = V6Address(uint64(t.daddr_l), uint64(t.daddr_h))
+		source = util.V6Address(uint64(t.saddr_l), uint64(t.saddr_h))
+		dest = util.V6Address(uint64(t.daddr_l), uint64(t.daddr_h))
 	}
 
 	return ConnectionStats{

--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 // ConnectionType will be either TCP or UDP
@@ -100,13 +101,13 @@ type ConnectionStats struct {
 }
 
 // SourceAddr returns the source address in the Address abstraction
-func (c ConnectionStats) SourceAddr() Address {
-	return c.Source.(Address)
+func (c ConnectionStats) SourceAddr() util.Address {
+	return c.Source.(util.Address)
 }
 
 // DestAddr returns the dest address in the Address abstraction
-func (c ConnectionStats) DestAddr() Address {
-	return c.Dest.(Address)
+func (c ConnectionStats) DestAddr() util.Address {
+	return c.Dest.(util.Address)
 }
 
 func (c ConnectionStats) String() string {
@@ -160,11 +161,11 @@ const keyFmt = "p:%d|src:%s:%d|dst:%s:%d|f:%d|t:%d"
 // it should be in sync with ByteKey
 // Note: This is only used in /debug/* endpoints
 func BeautifyKey(key string) string {
-	bytesToAddress := func(buf []byte) Address {
+	bytesToAddress := func(buf []byte) util.Address {
 		if len(buf) == 4 {
-			return V4AddressFromBytes(buf)
+			return util.V4AddressFromBytes(buf)
 		}
-		return V6AddressFromBytes(buf)
+		return util.V6AddressFromBytes(buf)
 	}
 
 	raw := []byte(key)
@@ -178,7 +179,7 @@ func BeautifyKey(key string) string {
 	// Them we have the source addr, family + type and dest addr
 	parts := bytes.Split(raw[8:], []byte{'|'})
 
-	var source, dest Address
+	var source, dest util.Address
 	var family, typ uint8
 	if len(parts) == 3 {
 		source = bytesToAddress(parts[0])

--- a/pkg/ebpf/event_test.go
+++ b/pkg/ebpf/event_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,8 +16,8 @@ var (
 		Pid:                123,
 		Type:               1,
 		Family:             0,
-		Source:             V4AddressFromString("192.168.0.1"),
-		Dest:               V4AddressFromString("192.168.0.103"),
+		Source:             util.AddressFromString("192.168.0.1"),
+		Dest:               util.AddressFromString("192.168.0.103"),
 		SPort:              123,
 		DPort:              35000,
 		MonotonicSentBytes: 123123,
@@ -31,8 +33,8 @@ func TestBeautifyKey(t *testing.T) {
 			Pid:    345,
 			Type:   0,
 			Family: 1,
-			Source: V4AddressFromString("127.0.0.1"),
-			Dest:   V4AddressFromString("192.168.0.103"),
+			Source: util.AddressFromString("127.0.0.1"),
+			Dest:   util.AddressFromString("192.168.0.103"),
 			SPort:  4444,
 			DPort:  8888,
 		},
@@ -46,8 +48,8 @@ func TestBeautifyKey(t *testing.T) {
 
 func TestConnStatsByteKey(t *testing.T) {
 	buf := new(bytes.Buffer)
-	addrA := V4AddressFromString("127.0.0.1")
-	addrB := V4AddressFromString("127.0.0.2")
+	addrA := util.AddressFromString("127.0.0.1")
+	addrB := util.AddressFromString("127.0.0.2")
 
 	for _, test := range []struct {
 		a ConnectionStats
@@ -66,11 +68,11 @@ func TestConnStatsByteKey(t *testing.T) {
 			b: ConnectionStats{Source: addrA, Dest: addrB},
 		},
 		{ // Source is different
-			a: ConnectionStats{Source: V4AddressFromString("123.255.123.0"), Dest: addrB},
+			a: ConnectionStats{Source: util.AddressFromString("123.255.123.0"), Dest: addrB},
 			b: ConnectionStats{Source: addrA, Dest: addrB},
 		},
 		{ // Dest is different
-			a: ConnectionStats{Source: addrA, Dest: V4AddressFromString("129.0.1.2")},
+			a: ConnectionStats{Source: addrA, Dest: util.AddressFromString("129.0.1.2")},
 			b: ConnectionStats{Source: addrA, Dest: addrB},
 		},
 		{ // Source port is different

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+
 	ct "github.com/florianl/go-conntrack"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,7 +31,7 @@ func TestRegisterNonNat(t *testing.T) {
 	c := makeUntranslatedConn("10.0.0.0:8080", "50.30.40.10:12345")
 
 	rt.register(c)
-	translation := rt.GetTranslationForConn("10.0.0.0", 8080)
+	translation := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 8080)
 	assert.Nil(t, translation)
 }
 
@@ -38,7 +40,7 @@ func TestRegisterNat(t *testing.T) {
 	c := makeTranslatedConn("10.0.0.0:12345", "50.30.40.10:80", "20.0.0.0:80")
 
 	rt.register(c)
-	translation := rt.GetTranslationForConn("10.0.0.0", 12345)
+	translation := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
 	assert.NotNil(t, translation)
 	assert.Equal(t, &IPTranslation{
 		ReplSrcIP:   "20.0.0.0",
@@ -49,14 +51,14 @@ func TestRegisterNat(t *testing.T) {
 
 	// even after unregistering, we should be able to access the conn
 	rt.unregister(c)
-	translation2 := rt.GetTranslationForConn("10.0.0.0", 12345)
+	translation2 := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
 	assert.NotNil(t, translation2)
 
 	// double unregisters should never happen, though it will be treated as a no-op
 	rt.unregister(c)
 
 	rt.ClearShortLived()
-	translation3 := rt.GetTranslationForConn("10.0.0.0", 12345)
+	translation3 := rt.GetTranslationForConn(util.AddressFromString("10.0.0.0"), 12345)
 	assert.Nil(t, translation3)
 
 	// triple unregisters should never happen, though it will be treated as a no-op

--- a/pkg/ebpf/netlink/noop.go
+++ b/pkg/ebpf/netlink/noop.go
@@ -2,6 +2,8 @@
 
 package netlink
 
+import "github.com/DataDog/datadog-agent/pkg/process/util"
+
 type noOpConntracker struct{}
 
 // NewNoOpConntracker creates a conntracker which always returns empty information
@@ -9,7 +11,7 @@ func NewNoOpConntracker() Conntracker {
 	return &noOpConntracker{}
 }
 
-func (*noOpConntracker) GetTranslationForConn(ip string, port uint16) *IPTranslation {
+func (*noOpConntracker) GetTranslationForConn(ip util.Address, port uint16) *IPTranslation {
 	return nil
 }
 

--- a/pkg/ebpf/state_test.go
+++ b/pkg/ebpf/state_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,8 +132,8 @@ func TestRemoveConnections(t *testing.T) {
 		Pid:                  123,
 		Type:                 UDP,
 		Family:               AFINET,
-		Source:               V4AddressFromString("127.0.0.1"),
-		Dest:                 V4AddressFromString("127.0.0.1"),
+		Source:               util.AddressFromString("127.0.0.1"),
+		Dest:                 util.AddressFromString("127.0.0.1"),
 		SPort:                31890,
 		DPort:                80,
 		MonotonicSentBytes:   12345,
@@ -166,8 +168,8 @@ func TestRetrieveClosedConnection(t *testing.T) {
 		Pid:                  123,
 		Type:                 TCP,
 		Family:               AFINET,
-		Source:               V4AddressFromString("127.0.0.1"),
-		Dest:                 V4AddressFromString("127.0.0.1"),
+		Source:               util.AddressFromString("127.0.0.1"),
+		Dest:                 util.AddressFromString("127.0.0.1"),
 		SPort:                31890,
 		DPort:                80,
 		MonotonicSentBytes:   12345,
@@ -249,8 +251,8 @@ func TestLastStats(t *testing.T) {
 		Pid:                  123,
 		Type:                 TCP,
 		Family:               AFINET,
-		Source:               V4AddressFromString("127.0.0.1"),
-		Dest:                 V4AddressFromString("127.0.0.1"),
+		Source:               util.AddressFromString("127.0.0.1"),
+		Dest:                 util.AddressFromString("127.0.0.1"),
 		SPort:                31890,
 		DPort:                80,
 		MonotonicSentBytes:   36,
@@ -329,8 +331,8 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 		Pid:                  123,
 		Type:                 TCP,
 		Family:               AFINET,
-		Source:               V4AddressFromString("127.0.0.1"),
-		Dest:                 V4AddressFromString("127.0.0.1"),
+		Source:               util.AddressFromString("127.0.0.1"),
+		Dest:                 util.AddressFromString("127.0.0.1"),
 		SPort:                31890,
 		DPort:                80,
 		MonotonicSentBytes:   36,
@@ -382,8 +384,8 @@ func TestRaceConditions(t *testing.T) {
 				Pid:                  1 + i,
 				Type:                 TCP,
 				Family:               AFINET,
-				Source:               V4AddressFromString("127.0.0.1"),
-				Dest:                 V4AddressFromString("127.0.0.1"),
+				Source:               util.AddressFromString("127.0.0.1"),
+				Dest:                 util.AddressFromString("127.0.0.1"),
 				SPort:                uint16(rand.Int()),
 				DPort:                uint16(rand.Int()),
 				MonotonicSentBytes:   uint64(rand.Int()),
@@ -430,8 +432,8 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		Pid:                123,
 		Type:               TCP,
 		Family:             AFINET,
-		Source:             V4AddressFromString("127.0.0.1"),
-		Dest:               V4AddressFromString("127.0.0.1"),
+		Source:             util.AddressFromString("127.0.0.1"),
+		Dest:               util.AddressFromString("127.0.0.1"),
 		MonotonicSentBytes: 3,
 	}
 
@@ -523,8 +525,8 @@ func TestSameKeyEdgeCases(t *testing.T) {
 			Pid:                123,
 			Type:               TCP,
 			Family:             AFINET,
-			Source:             V4AddressFromString("127.0.0.1"),
-			Dest:               V4AddressFromString("127.0.0.1"),
+			Source:             util.AddressFromString("127.0.0.1"),
+			Dest:               util.AddressFromString("127.0.0.1"),
 			SPort:              9000,
 			DPort:              1234,
 			MonotonicSentBytes: 1,
@@ -974,8 +976,8 @@ func generateRandConnections(n int) []ConnectionStats {
 			Pid:                  123,
 			Type:                 TCP,
 			Family:               AFINET,
-			Source:               V4AddressFromString("127.0.0.1"),
-			Dest:                 V4AddressFromString("127.0.0.1"),
+			Source:               util.AddressFromString("127.0.0.1"),
+			Dest:                 util.AddressFromString("127.0.0.1"),
 			SPort:                uint16(rand.Intn(math.MaxUint16)),
 			DPort:                uint16(rand.Intn(math.MaxUint16)),
 			MonotonicRecvBytes:   rand.Uint64(),

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -1,4 +1,4 @@
-package ebpf
+package util
 
 import (
 	"encoding/binary"
@@ -14,6 +14,24 @@ type Address interface {
 	MarshalEasyJSON(w *jwriter.Writer)
 }
 
+// AddressFromNetIP returns an Address from a provided net.IP
+func AddressFromNetIP(ip net.IP) Address {
+	if v4 := ip.To4(); v4 != nil {
+		var a v4Address
+		copy(a[:], v4)
+		return a
+	}
+
+	var a v6Address
+	copy(a[:], ip)
+	return a
+}
+
+// AddressFromString creates an Address using the string representation of an v4 IP
+func AddressFromString(ip string) Address {
+	return AddressFromNetIP(net.ParseIP(ip))
+}
+
 type v4Address [4]byte
 
 // V4Address creates an Address using the uint32 representation of an v4 IP
@@ -23,13 +41,6 @@ func V4Address(ip uint32) Address {
 	a[1] = byte(ip >> 8)
 	a[2] = byte(ip >> 16)
 	a[3] = byte(ip >> 24)
-	return a
-}
-
-// V4AddressFromString creates an Address using the string representation of an v4 IP
-func V4AddressFromString(ip string) Address {
-	var a v4Address
-	copy(a[:], net.ParseIP(ip).To4())
 	return a
 }
 
@@ -62,13 +73,6 @@ func V6Address(low, high uint64) Address {
 	var a v6Address
 	binary.LittleEndian.PutUint64(a[:8], high)
 	binary.LittleEndian.PutUint64(a[8:], low)
-	return a
-}
-
-// V6AddressFromString creates an Address using the string representation of an v6 IP
-func V6AddressFromString(ip string) Address {
-	var a v6Address
-	copy(a[:], []byte(net.ParseIP(ip)))
 	return a
 }
 

--- a/pkg/process/util/address_test.go
+++ b/pkg/process/util/address_test.go
@@ -1,10 +1,61 @@
-package ebpf
+package util
 
 import (
+	"net"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestNetIPToAddress(t *testing.T) {
+	// V4
+	addr := V4Address(889192575)
+	addrFromIP := AddressFromNetIP(net.ParseIP("127.0.0.53"))
+
+	_, ok := addrFromIP.(v4Address)
+	assert.True(t, ok)
+	assert.Equal(t, addrFromIP, addr)
+
+	// V6
+	addr = V6Address(889192575, 0)
+	addrFromIP = AddressFromNetIP(net.ParseIP("::7f00:35:0:0"))
+
+	_, ok = addrFromIP.(v6Address)
+	assert.True(t, ok)
+	assert.Equal(t, addrFromIP, addr)
+
+	// Mismatch tests
+	a := AddressFromNetIP(net.ParseIP("127.0.0.1"))
+	b := AddressFromNetIP(net.ParseIP("::7f00:35:0:0"))
+	assert.NotEqual(t, a, b)
+
+	a = AddressFromNetIP(net.ParseIP("127.0.0.1"))
+	b = AddressFromNetIP(net.ParseIP("127.0.0.2"))
+	assert.NotEqual(t, a, b)
+
+	a = AddressFromNetIP(net.ParseIP("::7f00:35:0:1"))
+	b = AddressFromNetIP(net.ParseIP("::7f00:35:0:0"))
+	assert.NotEqual(t, a, b)
+}
+
+func TestAddressUsageInMaps(t *testing.T) {
+	addrMap := make(map[Address]struct{})
+
+	addrMap[V4Address(889192575)] = struct{}{}
+	addrMap[V6Address(889192575, 0)] = struct{}{}
+
+	_, ok := addrMap[AddressFromString("127.0.0.53")]
+	assert.True(t, ok)
+
+	_, ok = addrMap[AddressFromString("127.0.0.1")]
+	assert.False(t, ok)
+
+	_, ok = addrMap[AddressFromString("::7f00:35:0:0")]
+	assert.True(t, ok)
+
+	_, ok = addrMap[AddressFromString("::")]
+	assert.False(t, ok)
+}
 
 func TestAddressV4(t *testing.T) {
 	addr := V4Address(889192575)
@@ -12,21 +63,21 @@ func TestAddressV4(t *testing.T) {
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V4AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V4AddressFromString("127.0.0.53"))
+	assert.Equal(t, addr, AddressFromString("127.0.0.53"))
 	assert.Equal(t, "127.0.0.53", addr.String())
 
 	addr = V4Address(0)
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V4AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V4AddressFromString("0.0.0.0"))
+	assert.Equal(t, addr, AddressFromString("0.0.0.0"))
 	assert.Equal(t, "0.0.0.0", addr.String())
 
 	addr = V4Address(16820416)
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V4AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V4AddressFromString("192.168.0.1"))
+	assert.Equal(t, addr, AddressFromString("192.168.0.1"))
 	assert.Equal(t, "192.168.0.1", addr.String())
 }
 
@@ -35,27 +86,27 @@ func TestAddressV6(t *testing.T) {
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V6AddressFromString("::7f00:35:0:0"))
+	assert.Equal(t, addr, AddressFromString("::7f00:35:0:0"))
 	assert.Equal(t, "::7f00:35:0:0", addr.String())
 
 	addr = V6Address(0, 0)
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V6AddressFromString("::"))
+	assert.Equal(t, addr, AddressFromString("::"))
 	assert.Equal(t, "::", addr.String())
 
 	addr = V6Address(72057594037927936, 0)
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V6AddressFromString("::1"))
+	assert.Equal(t, addr, AddressFromString("::1"))
 	assert.Equal(t, "::1", addr.String())
 
 	addr = V6Address(72059793061183488, 3087860000)
 	// Should be able to recreate addr from bytes alone
 	assert.Equal(t, addr, V6AddressFromBytes(addr.Bytes()))
 	// Should be able to recreate addr from IP string
-	assert.Equal(t, addr, V6AddressFromString("2001:db8::2:1"))
+	assert.Equal(t, addr, AddressFromString("2001:db8::2:1"))
 	assert.Equal(t, "2001:db8::2:1", addr.String())
 }


### PR DESCRIPTION
### What does this PR do?

A port of https://github.com/DataDog/datadog-process-agent/pull/315 to this repo

### Motivation

Removing datadog-process-agent usage

### Additional Notes

Anything else we should know when reviewing?
