### PR TITLE
process-agent: Do not ignore config load errors

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -238,7 +238,10 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 	cfg := NewDefaultAgentConfig()
 
 	// For Agent 6 we will have a YAML config file to use.
-	loadConfigIfExists(yamlPath)
+	if err := loadConfigIfExists(yamlPath); err != nil {
+		return nil, err
+	}
+
 	if err := cfg.loadProcessYamlConfig(yamlPath); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Loading the config can return an error in three cases:

* If the YAML files doesn't exist, which we already check before calling.
* If the YAML can't be unmarshalled, which is bad enough to error out.
* If the secrets command doesn't work. In that case, the config will
 contain unreplaced secrets. We don't want to continue in that case either.