### PR TITLE
System probe should be started/stopped whenever the core agent is started or stopped

### DIFF
--- a/omnibus/config/templates/datadog-agent/systemd.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.service.erb
@@ -1,7 +1,7 @@
 [Unit]
 Description="Datadog Agent"
 After=network.target
-Wants=datadog-agent-trace.service datadog-agent-process.service
+Wants=datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service
 
 [Service]
 Type=simple

--- a/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/datadog-agent/systemd.sysprobe.service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description="Datadog System Probe"
-After=network.target
+After=network.target datadog-agent.service
+BindsTo=datadog-agent.service
 
 [Service]
 Type=simple

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
@@ -6,8 +6,8 @@
 # Description: Datadog Agent
 # Required-Start: $remote_fs
 # Required-Stop: $remote_fs
-# Should-Start: datadog-agent-process datadog-agent-trace
-# Should-Stop: datadog-agent-process datadog-agent-trace
+# Should-Start: datadog-agent-process datadog-agent-trace datadog-agent-sysprobe
+# Should-Stop: datadog-agent-process datadog-agent-trace datadog-agent-sysprobe
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 ### END INIT INFO
@@ -73,6 +73,7 @@ start_and_wait()
 					log_end_msg 0
 					service datadog-agent-process start
 					service datadog-agent-trace start
+					service datadog-agent-sysprobe start
 					return 0
 				else
 					retries=$(($retries - 1))
@@ -114,6 +115,7 @@ stop_and_wait()
 			log_end_msg 0
 			service datadog-agent-process stop
 			service datadog-agent-trace stop
+			service datadog-agent-sysprobe stop
 			return 0
 			;;
 		*) log_end_msg 1 ;; # Failed to stop

--- a/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_debian.sysprobe.conf.erb
@@ -1,5 +1,6 @@
 description "Datadog System Probe"
 
+start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn

--- a/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
+++ b/omnibus/config/templates/datadog-agent/upstart_redhat.sysprobe.conf.erb
@@ -1,5 +1,6 @@
 description "Datadog System Probe"
 
+start on started datadog-agent
 stop on (runlevel [!2345] or stopping datadog-agent)
 
 respawn


### PR DESCRIPTION
### What does this PR do?

Currently the system probe has to be started manually on systems with systemd, upstart, etc. As we prepare for this new component to be widely available, we need an easier way for customers to enable it.

With this, the customer only needs to provide + enable `system-probe.yaml` and it'll run. If it is disabled, or there is no configuration, the system-probe will automatically exit with a status code of 0, like the process-agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
