### PR TITLE
Bump the minimum kernel version needed for system-probe

### DIFF
--- a/pkg/ebpf/common.go
+++ b/pkg/ebpf/common.go
@@ -15,9 +15,9 @@ var (
 	// Minimum kernel version -> max(3.15 - eBPF,
 	//                               3.18 - tables/maps,
 	//                               4.1 - kprobes,
-	//                               4.3 - perf events)
-	// 	                      -> 4.3
-	minRequiredKernelCode = linuxKernelVersionCode(4, 3, 0)
+	//                               4.4 - perf events)
+	// 	                      -> 4.4
+	minRequiredKernelCode = linuxKernelVersionCode(4, 4, 0)
 )
 
 var (


### PR DESCRIPTION
### What does this PR do?

The minimum kernel version was incorrectly listed as `4.3.0` when it's actually `4.4.0`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
