### PR TITLE
Fix windows build.  Change to allow specifying 2, 3 or both included

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -85,6 +85,7 @@ package :msi do
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
   extra_package_dir "#{Omnibus::Config.source_dir()}\\etc\\datadog-agent\\extra_package_files"
+  
   additional_sign_files [
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\process-agent.exe",
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\trace-agent.exe",
@@ -98,6 +99,8 @@ package :msi do
     'InstallFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files",
     'BinFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent",
     'EtcFiles' => "#{Omnibus::Config.source_dir()}\\etc\\datadog-agent",
+    'IncludePython2' => "#{with_python_runtime? '2'}",
+    'IncludePython3' => "#{with_python_runtime? '3'}",
   })
 end
 

--- a/omnibus/config/software/datadog-a7-py2.rb
+++ b/omnibus/config/software/datadog-a7-py2.rb
@@ -18,7 +18,7 @@ build do
   if windows?
     # this pins a dependency of pylint->datadog-a7, later versions (up to v3.7.1) are broken.
     command "#{python2} -m pip install configparser==3.5.0"
-    command "#{python2} -m pip install datadog-a7==#{version}
+    command "#{python2} -m pip install datadog-a7==#{version}"
   else
     command "#{pip2} install configparser==3.5.0"
     command "#{pip2} install datadog-a7==#{version}"

--- a/omnibus/config/software/datadog-a7-py2.rb
+++ b/omnibus/config/software/datadog-a7-py2.rb
@@ -18,7 +18,7 @@ build do
   if windows?
     # this pins a dependency of pylint->datadog-a7, later versions (up to v3.7.1) are broken.
     command "#{python2} -m pip install configparser==3.5.0"
-    command "#{python2} -m pip install datadog-a7==#{version} --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\""
+    command "#{python2} -m pip install datadog-a7==#{version}
   else
     command "#{pip2} install configparser==3.5.0"
     command "#{pip2} install datadog-a7==#{version}"

--- a/omnibus/config/software/datadog-a7-py3.rb
+++ b/omnibus/config/software/datadog-a7-py3.rb
@@ -18,7 +18,7 @@ build do
   if windows?
     # this pins a dependency of pylint->datadog-a7, later versions (up to v3.7.1) are broken.
     command "#{python3} -m pip install configparser==3.5.0"
-    command "#{python3} -m pip install datadog-a7==#{version} --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\""
+    command "#{python3} -m pip install datadog-a7==#{version}
   else
     command "#{pip3} install configparser==3.5.0"
     command "#{pip3} install datadog-a7==#{version}"

--- a/omnibus/config/software/datadog-a7-py3.rb
+++ b/omnibus/config/software/datadog-a7-py3.rb
@@ -18,7 +18,7 @@ build do
   if windows?
     # this pins a dependency of pylint->datadog-a7, later versions (up to v3.7.1) are broken.
     command "#{python3} -m pip install configparser==3.5.0"
-    command "#{python3} -m pip install datadog-a7==#{version}
+    command "#{python3} -m pip install datadog-a7==#{version}"
   else
     command "#{pip3} install configparser==3.5.0"
     command "#{pip3} install datadog-a7==#{version}"

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -227,17 +227,21 @@
 
         </Component>
         <Component Id="SIXDLLS" Guid="E81FBBB0-7BB9-4D52-A5F1-36A2123E6979">
+          <?if $(var.IncludePython2) = true ?>
           <File Id="twodll"
                 Name="libdatadog-agent-two.dll"
                 Vital="yes"
                 KeyPath="yes"
                 DiskId="1"
                 Source="$(var.BinFiles)/libdatadog-agent-two.dll"/>
+          <?endif ?>
+          <?if $(var.IncludePython3) = true ?>
           <File Id="threedll"
                 Name="libdatadog-agent-three.dll"
                 Vital="yes"
                 DiskId="1"
                 Source="$(var.BinFiles)/libdatadog-agent-three.dll"/>
+            <?endif ?>
         </Component>
         <Component Id="MSVCRUNTIME" Guid="30ce4f57-47ce-47c0-8564-e510d69787a9">
             <Condition> <![CDATA[VersionNT <= 601]]> </Condition>


### PR DESCRIPTION
in build had a couple of problems.

in datadog-a7, windows command had faulty --install-option flag
Also, modified build to conditionally include the right two/three DLL
components in MSI (build fails otherwise)

