### PR TITLE
Wipe autotools from the package

### DIFF
--- a/omnibus/config/patches/libkrb5/aclocal-add-parameter-to-disable-keyutils-detection.patch
+++ b/omnibus/config/patches/libkrb5/aclocal-add-parameter-to-disable-keyutils-detection.patch
@@ -21,7 +21,7 @@ index d6d1279..80ce604 100644
 +AC_HELP_STRING([--disable-keyutils],don't enable using keyutils for keyring ccache @<:@enabled@:>@), , enable_keyutils=yes)
 +if test "$enable_keyutils" = yes; then
    AC_CHECK_HEADERS([keyutils.h],
-     AC_CHECK_LIB(keyutils, add_key,
+     AC_CHECK_LIB(keyutils, add_key, 
        [dnl Pre-reqs were found
         AC_DEFINE(USE_KEYRING_CCACHE, 1, [Define if the keyring ccache should be enabled])
         LIBS="-lkeyutils $LIBS"

--- a/omnibus/config/patches/libkrb5/aclocal-add-parameter-to-disable-keyutils-detection.patch
+++ b/omnibus/config/patches/libkrb5/aclocal-add-parameter-to-disable-keyutils-detection.patch
@@ -1,0 +1,32 @@
+From a9e4057bfda190ad365b503af058b460ab8c7616 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <Martin.Jansa@gmail.com>
+Date: Tue, 1 Oct 2013 22:22:57 +0200
+Subject: [PATCH] aclocal: Add parameter to disable keyutils detection
+
+Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+
+---
+ aclocal.m4 | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/aclocal.m4 b/aclocal.m4
+index d6d1279..80ce604 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1679,12 +1679,16 @@ fi
+ dnl
+ dnl If libkeyutils exists (on Linux) include it and use keyring ccache
+ AC_DEFUN(KRB5_AC_KEYRING_CCACHE,[
++AC_ARG_ENABLE([keyutils],
++AC_HELP_STRING([--disable-keyutils],don't enable using keyutils for keyring ccache @<:@enabled@:>@), , enable_keyutils=yes)
++if test "$enable_keyutils" = yes; then
+   AC_CHECK_HEADERS([keyutils.h],
+     AC_CHECK_LIB(keyutils, add_key,
+       [dnl Pre-reqs were found
+        AC_DEFINE(USE_KEYRING_CCACHE, 1, [Define if the keyring ccache should be enabled])
+        LIBS="-lkeyutils $LIBS"
+       ]))
++fi
+ ])dnl
+ dnl
+ dnl If libkeyutils supports persistent keyrings, use them

--- a/omnibus/config/software/libkrb5.rb
+++ b/omnibus/config/software/libkrb5.rb
@@ -1,0 +1,41 @@
+name "libkrb5"
+default_version "1.16.2"
+
+version "1.16.2" do
+  source url: "https://kerberos.org/dist/krb5/1.16/krb5-1.16.2.tar.gz"
+  source sha256: "9f721e1fe593c219174740c71de514c7228a97d23eb7be7597b2ae14e487f027"
+end
+
+relative_path "krb5-#{version}/src"
+
+reconf_env = { "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}" }
+
+build do
+
+  ship_license "https://raw.githubusercontent.com/krb5/krb5/master/NOTICE"
+
+  patch :source => "aclocal-add-parameter-to-disable-keyutils-detection.patch"
+
+  # after patching we need to recreate configure scripts w/ autoconf
+  autoconf_cmd = ["autoreconf", "--install"].join(" ")
+  command autoconf_cmd, :env => reconf_env
+
+  cmd = ["./configure",
+         "--disable-keyutils",
+         "--without-system-verto", # do not prefer libverto from the system, if installed
+         "--without-libedit", # we don't want to link with libraries outside of the install dir
+         "--prefix=#{install_dir}/embedded"].join(" ")
+  env = {
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  }
+  command cmd, :env => env
+  command "make -j #{workers}", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
+  command "make install", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
+
+  # FIXME: CONDA libs appear to confuse the health checker - manually checked file
+  # are properly linked. Must whitelist for build to succeed.
+  whitelist_file "#{install_dir}/embedded/lib/krb5/plugins/tls/k5tls.so"
+  whitelist_file "#{install_dir}/embedded/lib/krb5/plugins/preauth/pkinit.so"
+end

--- a/releasenotes/notes/dont-ship-autotools-baaf15320a78cfcb.yaml
+++ b/releasenotes/notes/dont-ship-autotools-baaf15320a78cfcb.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Do not ship autotools within the Agent package.


### PR DESCRIPTION
### What does this PR do?

`libkrb5` brought into the package `autoconf` and `automake` which obviously we don't want to distribute. This software definition doesn't depend on those anymore.

### Motivation

Shrink the package + do not ship useless binaries
