### PR TITLE
[omnibus][python2] shared build

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -47,7 +47,8 @@ if ohai["platform"] != "windows"
                           "CC=clang",
                           "MACOSX_DEPLOYMENT_TARGET=10.12")
   elsif linux?
-    python_configure.push("--enable-unicode=ucs4")
+    python_configure.push("--enable-unicode=ucs4",
+                          "--enable-shared")
   end
 
   build do


### PR DESCRIPTION
### What does this PR do?

Shared build for python2, this will allow related projects to link statically, reducing bloat.

### Motivation

Sanity + 6.12 Audit.

### Additional Information

List of affected files:
```
/opt/datadog-agent/embedded/lib/libdatadog-agent-two.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/pymqi/pymqe.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/simplejson/_speedups.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/wrapt/_wrappers.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_ARC4.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_ctr.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_chacha20.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_cbc.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_arc2.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_ofb.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_blowfish.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_aes.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_cast.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_ecb.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_Salsa20.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_ocb.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_aesni.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_des3.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_des.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Cipher/_raw_cfb.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Util/_cpuid.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Util/_galois.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Util/_strxor.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Protocol/_scrypt.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_RIPEMD160.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_keccak.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_BLAKE2s.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_SHA384.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_MD4.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_SHA224.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_BLAKE2b.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_SHA256.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_SHA512.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/Cryptodome/Hash/_MD2.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/_scandir.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/_jpype.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/kerberos.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/_yaml.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/aerospike.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/_posixsubprocess32.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/uptime/_posix.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/msgpack/_packer.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/msgpack/_unpacker.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/psutil/_psutil_posix.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/psutil/_psutil_linux.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/site-packages/pyodbc.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/future_builtins.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_lsprof.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/strop.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_sqlite3.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_multibytecodec.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/cPickle.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_json.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_ctypes.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_io.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/resource.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_codecs_tw.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_collections.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_ctypes_test.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/binascii.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/cmath.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_testcapi.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/fcntl.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_curses_panel.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_socket.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_locale.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_multiprocessing.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/cStringIO.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/termios.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/grp.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_hotshot.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/zlib.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/ossaudiodev.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_elementtree.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_ssl.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/unicodedata.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/syslog.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/operator.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_codecs_cn.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_codecs_hk.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/parser.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/bz2.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_codecs_kr.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/pyexpat.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/array.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_heapq.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/nis.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/spwd.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/datetime.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_codecs_iso2022.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/crypt.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_hashlib.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_csv.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_struct.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/itertools.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/time.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_codecs_jp.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/select.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/math.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_curses.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_random.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/linuxaudiodev.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/mmap.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/audioop.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_bisect.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/lib/python2.7/lib-dynload/_functools.so is dynamically linked to python2.7
/opt/datadog-agent/embedded/bin/python2.7 is dynamically linked to python2.7
```
