### PR TITLE
pkg/trace/api: add support for Unix Domain Sockets

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -466,6 +466,7 @@ func initConfig(config Config) {
 	config.SetKnown("apm_config.apm_dd_url")
 	config.SetKnown("apm_config.max_cpu_percent")
 	config.SetKnown("apm_config.receiver_port")
+	config.SetKnown("apm_config.receiver_socket")
 	config.SetKnown("apm_config.connection_limit")
 	config.SetKnown("apm_config.ignore_resources")
 	config.SetKnown("apm_config.replace_tags")

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -140,11 +141,27 @@ func (r *HTTPReceiver) Start() {
 		Handler:      mux,
 	}
 
-	// expvar implicitly publishes "/debug/vars" on the same port
 	addr := fmt.Sprintf("%s:%d", r.conf.ReceiverHost, r.conf.ReceiverPort)
-	if err := r.Listen(addr, ""); err != nil {
-		log.Criticalf("Error creating listener: %v", err)
-		killProcess(err.Error())
+	ln, err := r.listenTCP(addr)
+	if err != nil {
+		killProcess("Error creating tcp listener: %v", err)
+	}
+	go func() {
+		defer watchdog.LogOnPanic()
+		r.server.Serve(ln)
+	}()
+	log.Infof("Listening for traces at http://%s", addr)
+
+	if path := r.conf.ReceiverSocket; path != "" {
+		ln, err := r.listenUnix(path)
+		if err != nil {
+			killProcess("Error creating UDS listener: %v", err)
+		}
+		go func() {
+			defer watchdog.LogOnPanic()
+			r.server.Serve(ln)
+		}()
+		log.Infof("Listening for traces at unix://%s", path)
 	}
 
 	go r.RateLimiter.Run()
@@ -188,29 +205,40 @@ func (r *HTTPReceiver) attachDebugHandlers(mux *http.ServeMux) {
 	mux.Handle("/debug/vars", expvar.Handler())
 }
 
-// Listen creates a new HTTP server listening on the provided address.
-func (r *HTTPReceiver) Listen(addr, logExtra string) error {
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("cannot listen on %s: %v", addr, err)
+// listenUnix returns a *net.Listener listening on the given "unix" socket path.
+func (r *HTTPReceiver) listenUnix(path string) (net.Listener, error) {
+	fi, err := os.Stat(path)
+	if err == nil {
+		// already exists
+		if fi.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("cannot reuse %q; not a unix socket", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("unable to remove stale socket: %v", err)
+		}
 	}
-	ln, err := newRateLimitedListener(listener, r.conf.ConnectionLimit)
+	ln, err := net.Listen("unix", path)
 	if err != nil {
-		return fmt.Errorf("cannot create listener: %v", err)
+		return nil, err
 	}
+	if err := os.Chmod(path, 0722); err != nil {
+		return nil, fmt.Errorf("error setting socket permissions: %v", err)
+	}
+	return ln, err
+}
 
-	log.Infof("Listening for traces at http://%s%s", addr, logExtra)
-
+// listenTCP creates a new HTTP server listening on the provided TCP address.
+func (r *HTTPReceiver) listenTCP(addr string) (net.Listener, error) {
+	tcpln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	ln, err := newRateLimitedListener(tcpln, r.conf.ConnectionLimit)
 	go func() {
 		defer watchdog.LogOnPanic()
 		ln.Refresh(r.conf.ConnectionLimit)
 	}()
-	go func() {
-		defer watchdog.LogOnPanic()
-		r.server.Serve(ln)
-	}()
-
-	return nil
+	return ln, err
 }
 
 // Stop stops the receiver and shuts down the HTTP server.
@@ -433,7 +461,7 @@ func (r *HTTPReceiver) loop() {
 }
 
 // killProcess exits the process with the given msg; replaced in tests.
-var killProcess = func(msg string) { osutil.Exitf(msg) }
+var killProcess = func(format string, a ...interface{}) { osutil.Exitf(format, a...) }
 
 // watchdog checks the trace-agent's heap and CPU usage and updates the rate limiter using a correct
 // sampling rate to maintain resource usage within set thresholds. These thresholds are defined by

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -205,7 +205,7 @@ func (r *HTTPReceiver) attachDebugHandlers(mux *http.ServeMux) {
 	mux.Handle("/debug/vars", expvar.Handler())
 }
 
-// listenUnix returns a *net.Listener listening on the given "unix" socket path.
+// listenUnix returns a net.Listener listening on the given "unix" socket path.
 func (r *HTTPReceiver) listenUnix(path string) (net.Listener, error) {
 	fi, err := os.Stat(path)
 	if err == nil {
@@ -227,7 +227,7 @@ func (r *HTTPReceiver) listenUnix(path string) (net.Listener, error) {
 	return ln, err
 }
 
-// listenTCP creates a new HTTP server listening on the provided TCP address.
+// listenTCP creates a new net.Listener on the provided TCP address.
 func (r *HTTPReceiver) listenTCP(addr string) (net.Listener, error) {
 	tcpln, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/pkg/trace/api/api_nix_test.go
+++ b/pkg/trace/api/api_nix_test.go
@@ -1,0 +1,65 @@
+// +build !windows
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+)
+
+func TestUDS(t *testing.T) {
+	sockPath := "/tmp/test-trace.sock"
+	payload := msgpTraces(t, pb.Traces{testutil.RandomTrace(10, 20)})
+	client := http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+
+	t.Run("off", func(t *testing.T) {
+		conf := config.New()
+		conf.Endpoints[0].APIKey = "apikey_2"
+
+		r := newTestReceiverFromConfig(conf)
+		r.Start()
+		defer r.Stop()
+
+		resp, err := client.Post("http://localhost:8126/v0.4/traces", "application/msgpack", bytes.NewReader(payload))
+		if err == nil {
+			t.Fatalf("expected to fail, got response %#v", resp)
+		}
+	})
+
+	t.Run("on", func(t *testing.T) {
+		conf := config.New()
+		conf.Endpoints[0].APIKey = "apikey_2"
+		conf.ReceiverSocket = sockPath
+
+		r := newTestReceiverFromConfig(conf)
+		r.Start()
+		defer r.Stop()
+
+		resp, err := client.Post("http://localhost:8126/v0.4/traces", "application/msgpack", bytes.NewReader(payload))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected http.StatusOK, got response: %#v", resp)
+		}
+	})
+}

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -58,8 +58,8 @@ func newTestReceiverConfig() *config.AgentConfig {
 func TestMain(m *testing.M) {
 	seelog.UseLogger(seelog.Disabled)
 
-	defer func(old func(string)) { killProcess = old }(killProcess)
-	killProcess = func(_ string) {}
+	defer func(old func(string, ...interface{})) { killProcess = old }(killProcess)
+	killProcess = func(_ string, _ ...interface{}) {}
 
 	os.Exit(m.Run())
 }
@@ -887,10 +887,10 @@ func TestWatchdog(t *testing.T) {
 func TestOOMKill(t *testing.T) {
 	var kills uint64
 
-	defer func(old func(string)) { killProcess = old }(killProcess)
-	killProcess = func(msg string) {
-		if msg != "OOM" {
-			t.Fatalf("wrong message: %s", msg)
+	defer func(old func(string, ...interface{})) { killProcess = old }(killProcess)
+	killProcess = func(format string, a ...interface{}) {
+		if format != "OOM" {
+			t.Fatalf("wrong message: %s", fmt.Sprintf(format, a...))
 		}
 		atomic.AddUint64(&kills, 1)
 	}

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -174,6 +174,9 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	if config.Datadog.IsSet("apm_config.receiver_port") {
 		c.ReceiverPort = config.Datadog.GetInt("apm_config.receiver_port")
 	}
+	if config.Datadog.IsSet("apm_config.receiver_socket") {
+		c.ReceiverSocket = config.Datadog.GetString("apm_config.receiver_socket")
+	}
 	if config.Datadog.IsSet("apm_config.connection_limit") {
 		c.ConnectionLimit = config.Datadog.GetInt("apm_config.connection_limit")
 	}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -71,7 +71,8 @@ type AgentConfig struct {
 	// Receiver
 	ReceiverHost    string
 	ReceiverPort    int
-	ConnectionLimit int // for rate-limiting, how many unique connections to allow in a lease period (30s)
+	ReceiverSocket  string // if not empty, UDS will be enabled on unix://<receiver_socket>
+	ConnectionLimit int    // for rate-limiting, how many unique connections to allow in a lease period (30s)
 	ReceiverTimeout int
 
 	// Writers

--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -40,6 +40,7 @@ func loadEnv() {
 		{"DD_APM_MAX_TPS", "apm_config.max_traces_per_second"},
 		{"DD_APM_MAX_MEMORY", "apm_config.max_memory"},
 		{"DD_APM_MAX_CPU_PERCENT", "apm_config.max_cpu_percent"},
+		{"DD_APM_RECEIVER_SOCKET", "apm_config.receiver_socket"},
 	} {
 		if v := os.Getenv(override.env); v != "" {
 			config.Datadog.Set(override.key, v)

--- a/pkg/trace/osutil/file.go
+++ b/pkg/trace/osutil/file.go
@@ -31,7 +31,7 @@ func Exitf(format string, args ...interface{}) {
 		fmt.Printf(format, args...)
 		fmt.Print("")
 	} else {
-		log.Errorf(format, args...)
+		log.Criticalf(format, args...)
 		log.Flush()
 	}
 	os.Exit(1)

--- a/releasenotes/notes/apm-add-unix-domain-sockets-4b4821727cf024fb.yaml
+++ b/releasenotes/notes/apm-add-unix-domain-sockets-4b4821727cf024fb.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: add support for Unix Domain Sockets by means of the `apm_config.receiver_socket` configuration. It is off by default. When set,
+    it must point to a valid sock file.


### PR DESCRIPTION
This change adds support for Unix Domain Sockets by means of a
configuration setting. By default, this feature is disabled. To enable
it, simply point the yaml setting to the right socket path, for example:

    apm_config:
        receiver_socket: /tmp/trace.sock

This will enable the HTTP server to listen on unix:///tmp/trace.sock