### PR TITLE
Fix nil pointer access for Containerd Check

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -210,7 +210,7 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 			continue
 		}
 
-		if metrics.Memory.Size() > 0 {
+		if metrics.Memory != nil {
 			computeMem(sender, metrics.Memory, tags)
 		}
 
@@ -280,6 +280,7 @@ func computeHugetlb(sender aggregator.Sender, huge []*cgroups.HugetlbStat, tags 
 }
 
 func computeMem(sender aggregator.Sender, mem *cgroups.MemoryStat, tags []string) {
+
 	memList := map[string]*cgroups.MemoryEntry{
 		"containerd.mem.current":    mem.Usage,
 		"containerd.mem.kernel_tcp": mem.KernelTCP,
@@ -296,7 +297,7 @@ func computeMem(sender aggregator.Sender, mem *cgroups.MemoryStat, tags []string
 }
 
 func parseAndSubmitMem(metricName string, sender aggregator.Sender, stat *cgroups.MemoryEntry, tags []string) {
-	if stat.Size() == 0 {
+	if stat == nil || stat.Size() == 0 {
 		return
 	}
 	sender.Gauge(fmt.Sprintf("%s.usage", metricName), float64(stat.Usage), "", tags)

--- a/pkg/collector/corechecks/containers/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd_test.go
@@ -167,6 +167,96 @@ func TestComputeEvents(t *testing.T) {
 	}
 }
 
+// TestComputeMem checks the computeMem methos
+func TestComputeMem(t *testing.T) {
+	containerdCheck := &ContainerdCheck{
+		instance:  &ContainerdConfig{},
+		CheckBase: corechecks.NewCheckBase("containerd"),
+	}
+	mocked := mocksender.NewMockSender(containerdCheck.ID())
+
+	tests := []struct {
+		name     string
+		mem      *cgroups.MemoryStat
+		expected map[string]float64
+	}{
+		{
+			name:     "nothing",
+			mem:      &cgroups.MemoryStat{},
+			expected: map[string]float64{},
+		},
+		{
+			name: "missing one of the MemoryEntries, missing entries in the others",
+			mem: &cgroups.MemoryStat{
+				Usage: &cgroups.MemoryEntry{
+					Usage: 1,
+				},
+				Kernel: &cgroups.MemoryEntry{
+					Max: 2,
+				},
+				Swap: &cgroups.MemoryEntry{
+					Limit: 3,
+				},
+			},
+			expected: map[string]float64{
+				"containerd.mem.current.usage": 1,
+				"containerd.mem.kernel.max":    2,
+				"containerd.mem.swap.limit":    3,
+			},
+		},
+		{
+			name: "full MemoryEntries, some regular metrics",
+			mem: &cgroups.MemoryStat{
+				Usage: &cgroups.MemoryEntry{
+					Usage:   1,
+					Max:     2,
+					Limit:   3,
+					Failcnt: 0,
+				},
+				Kernel: &cgroups.MemoryEntry{
+					Usage:   1,
+					Max:     2,
+					Limit:   3,
+					Failcnt: 0,
+				},
+				Swap: &cgroups.MemoryEntry{
+					Usage:   1,
+					Max:     2,
+					Limit:   3,
+					Failcnt: 0,
+				},
+				Cache:        20,
+				RSSHuge:      1212,
+				InactiveAnon: 1234,
+			},
+			expected: map[string]float64{
+				"containerd.mem.current.usage":   1,
+				"containerd.mem.current.max":     2,
+				"containerd.mem.current.limit":   3,
+				"containerd.mem.current.failcnt": 0,
+				"containerd.mem.kernel.max":      2,
+				"containerd.mem.kernel.usage":    1,
+				"containerd.mem.kernel.limit":    3,
+				"containerd.mem.kernel.failcnt":  0,
+				"containerd.mem.swap.limit":      3,
+				"containerd.mem.swap.max":        2,
+				"containerd.mem.swap.usage":      1,
+				"containerd.mem.swap.failcnt":    0,
+				"containerd.mem.cache":           20,
+				"containerd.mem.rsshuge":         1212,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			computeMem(mocked, test.mem, []string{})
+			for name, val := range test.expected {
+				mocked.AssertMetric(t, "Gauge", name, val, "", []string{})
+			}
+		})
+	}
+}
+
 // TestConvertTaskToMetrics checks the convertTasktoMetrics
 func TestConvertTaskToMetrics(t *testing.T) {
 	typeurl.Register(&cgroups.Metrics{}, "io.containerd.cgroups.v1.Metrics") // Need to register the type to be used in UnmarshalAny later on.

--- a/pkg/collector/corechecks/containers/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd_test.go
@@ -174,6 +174,7 @@ func TestComputeMem(t *testing.T) {
 		CheckBase: corechecks.NewCheckBase("containerd"),
 	}
 	mocked := mocksender.NewMockSender(containerdCheck.ID())
+	mocked.SetupAcceptAll()
 
 	tests := []struct {
 		name     string

--- a/releasenotes/notes/fix_containerd_nil_pointer-204d5f8b041b67de.yaml
+++ b/releasenotes/notes/fix_containerd_nil_pointer-204d5f8b041b67de.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix nil pointer access for container without memory cgroups.


### PR DESCRIPTION
### What does this PR do?

Fix a nil pointer access for Containerd containers not reporting memory cgroups.

### Motivation

Avoid crashing when running the check.