### PR TITLE
Allow for configurable limits on map sizes for network and conntrack state

### DIFF
--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -29,8 +29,19 @@ type Config struct {
 	// tcp_close is not intercepted for some reason.
 	TCPConnTimeout time.Duration
 
-	// MaxTrackedConnections specifies the maximum number of connections we can track, this will be the size of the BPF maps
+	// MaxTrackedConnections specifies the maximum number of connections we can track, this will be the size of the eBPF + Conntrack.
 	MaxTrackedConnections uint
+
+	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections
+	// get flushed on every client request (default 30s check interval)
+	MaxClosedConnectionsBuffered int
+
+	// MaxConnectionsStateBuffered represents the maximum number of state objects that we'll store in memory. These state objects store
+	// the stats for a connection so we can accurately determine traffic change between client requests.
+	MaxConnectionsStateBuffered int
+
+	// ClientStateExpiry specifies the max time a client (e.g. process-agent)'s state will be stored in memory before being evicted.
+	ClientStateExpiry time.Duration
 
 	// ProcRoot is the root path to the proc filesystem
 	ProcRoot string
@@ -59,6 +70,10 @@ func NewDefaultConfig() *Config {
 		ProcRoot:              "/proc",
 		BPFDebug:              false,
 		EnableConntrack:       true,
+		// With clients checking connection stats roughly every 30s, this gives us roughly ~1.6k + ~2.5k objects a second respectively.
+		MaxClosedConnectionsBuffered: 50000,
+		MaxConnectionsStateBuffered:  75000,
+		ClientStateExpiry:            2 * time.Minute,
 	}
 }
 

--- a/pkg/ebpf/netlink/conntracker_test.go
+++ b/pkg/ebpf/netlink/conntracker_test.go
@@ -73,6 +73,7 @@ func newConntracker() *realConntracker {
 		state:               make(map[connKey]*IPTranslation),
 		shortLivedBuffer:    make(map[connKey]*IPTranslation),
 		maxShortLivedBuffer: 10000,
+		maxStateSize:        10000,
 	}
 }
 

--- a/pkg/ebpf/state.go
+++ b/pkg/ebpf/state.go
@@ -13,12 +13,6 @@ var _ NetworkState = &networkState{}
 const (
 	// DEBUGCLIENT is the ClientID for debugging
 	DEBUGCLIENT = "-1"
-
-	// defaultMaxClosedConns & defaultMaxClientStats are the maximum number of objects that can be stored in-memory.
-	// With clients checking connection stats roughly every 30s, this gives us roughly ~1.6k + ~2.5k objects a second respectively.
-	defaultMaxClosedConns = 50000 // ~100 bytes per conn = 5MB
-	defaultMaxClientStats = 75000
-	defaultClientExpiry   = 2 * time.Minute
 )
 
 // NetworkState takes care of handling the logic for:
@@ -84,7 +78,8 @@ type networkState struct {
 
 // NewDefaultNetworkState creates a new network state with default settings
 func NewDefaultNetworkState() NetworkState {
-	return NewNetworkState(defaultClientExpiry, defaultMaxClosedConns, defaultMaxClientStats)
+	defaultC := NewDefaultConfig()
+	return NewNetworkState(defaultC.ClientStateExpiry, defaultC.MaxClosedConnectionsBuffered, defaultC.MaxConnectionsStateBuffered)
 }
 
 // NewNetworkState creates a new network state

--- a/pkg/ebpf/state_test.go
+++ b/pkg/ebpf/state_test.go
@@ -217,7 +217,8 @@ func TestCleanupClient(t *testing.T) {
 
 	wait := 100 * time.Millisecond
 
-	state := NewNetworkState(wait, defaultMaxClosedConns, defaultMaxClientStats)
+	defaultC := NewDefaultConfig()
+	state := NewNetworkState(wait, defaultC.MaxClosedConnectionsBuffered, defaultC.MaxConnectionsStateBuffered)
 	clients := state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -87,6 +87,8 @@ type AgentConfig struct {
 	ExcludedBPFLinuxVersions     []string
 	EnableConntrack              bool
 	ConntrackShortTermBufferSize int
+	MaxClosedConnectionsBuffered int
+	MaxConnectionsStateBuffered  int
 
 	// Check config
 	EnabledChecks  []string

--- a/pkg/process/config/tracer_config.go
+++ b/pkg/process/config/tracer_config.go
@@ -42,6 +42,14 @@ func SysProbeConfigFromConfig(cfg *AgentConfig) *ebpf.Config {
 	tracerConfig.EnableConntrack = cfg.EnableConntrack
 	tracerConfig.ConntrackShortTermBufferSize = cfg.ConntrackShortTermBufferSize
 
+	if mccb := cfg.MaxClosedConnectionsBuffered; mccb > 0 {
+		tracerConfig.MaxClosedConnectionsBuffered = mccb
+	}
+
+	if mcsb := cfg.MaxConnectionsStateBuffered; mcsb > 0 {
+		tracerConfig.MaxConnectionsStateBuffered = mcsb
+	}
+
 	return tracerConfig
 }
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -85,6 +85,22 @@ func (a *AgentConfig) loadSysProbeYamlConfig(path string) error {
 		}
 	}
 
+	// MaxClosedConnectionsBuffered represents the maximum number of closed connections we'll buffer in memory. These closed connections
+	// get flushed on every client request (default 30s check interval)
+	if k := "max_closed_connections_buffered"; config.Datadog.IsSet(k) {
+		if mcb := config.Datadog.GetInt(key(spNS, k)); mcb > 0 {
+			a.MaxClosedConnectionsBuffered = mcb
+		}
+	}
+
+	// MaxConnectionsStateBuffered represents the maximum number of state objects that we'll store in memory. These state objects store
+	// the stats for a connection so we can accurately determine traffic change between client requests.
+	if k := "max_connection_state_buffered"; config.Datadog.IsSet(k) {
+		if mcsb := config.Datadog.GetInt(key(spNS, k)); mcsb > 0 {
+			a.MaxConnectionsStateBuffered = mcsb
+		}
+	}
+
 	// Pull additional parameters from the global config file.
 	a.LogLevel = config.Datadog.GetString("log_level")
 	a.StatsdPort = config.Datadog.GetInt("dogstatsd_port")


### PR DESCRIPTION
### What does this PR do?

To protect ourselves from leaks from conntrack or BPF in connection registration/unregistration race conditions, we're adding some configurable max limits to map sizes for what we store in-memory

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
