### PR TITLE
process-agent,system-probe: Add an internal_deploy stage to the pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
   - binary_build
   - integration_test
   - package_build
+  - internal_deploy
   - check_deploy
   - testkitchen_deploy
   - testkitchen_testing
@@ -1188,7 +1189,7 @@ deploy_puppy:
 
 # deploy process agent and system-probe to staging bucket
 deploy_process_and_sysprobe:
-  stage: deploy
+  stage: internal_deploy
   when: manual
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1201,8 +1201,8 @@ deploy_process_and_sysprobe:
     # Use tag or shortened branch with short commit hash to identify the binary
     - export SHORT_REF=$(echo $CI_COMMIT_REF_NAME | cut -d'/' -f2- | cut -c -10 | sed -E 's/[^[:alnum:]]+/-/g')
     - export NAME=${CI_COMMIT_TAG:-$SHORT_REF}
-    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME-${CI_COMMIT_SHA:0:7}
-    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME-${CI_COMMIT_SHA:0:7}
+    - $S3_CP_CMD --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23 ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME-${CI_COMMIT_SHA:0:7}
+    - $S3_CP_CMD --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23 ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME-${CI_COMMIT_SHA:0:7}
 
 #
 # Docker releases

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1198,8 +1198,11 @@ deploy_process_and_sysprobe:
   tags: [ "runner:main", "size:large" ]
   script:
     - dpkg -x datadog-agent_*_amd64.deb ./out
-    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-${CI_COMMIT_SHA:0:7}
-    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-${CI_COMMIT_SHA:0:7}
+    # Use tag or shortened branch with short commit hash to identify the binary
+    - export SHORT_REF=$(echo $CI_COMMIT_REF_NAME | cut -d'/' -f2- | cut -c -10 | sed -E 's/[^[:alnum:]]+/-/g')
+    - export NAME=${CI_COMMIT_TAG:-$SHORT_REF}
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME-${CI_COMMIT_SHA:0:7}
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME-${CI_COMMIT_SHA:0:7}
 
 #
 # Docker releases

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1201,8 +1201,8 @@ deploy_process_and_sysprobe:
     # Use tag or shortened branch with short commit hash to identify the binary
     - export SHORT_REF=$(echo $CI_COMMIT_REF_NAME | cut -d'/' -f2- | cut -c -10 | sed -E 's/[^[:alnum:]]+/-/g')
     - export NAME=${CI_COMMIT_TAG:-$SHORT_REF}
-    - $S3_CP_CMD --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23 ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME-${CI_COMMIT_SHA:0:7}
-    - $S3_CP_CMD --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23 ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME-${CI_COMMIT_SHA:0:7}
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME-${CI_COMMIT_SHA:0:7} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME-${CI_COMMIT_SHA:0:7} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
 
 #
 # Docker releases

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1200,9 +1200,10 @@ deploy_process_and_sysprobe:
     - dpkg -x datadog-agent_*_amd64.deb ./out
     # Use tag or shortened branch with short commit hash to identify the binary
     - export SHORT_REF=$(echo $CI_COMMIT_REF_NAME | cut -d'/' -f2- | cut -c -10 | sed -E 's/[^[:alnum:]]+/-/g')
-    - export NAME=${CI_COMMIT_TAG:-$SHORT_REF}
-    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME-${CI_COMMIT_SHA:0:7} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
-    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME-${CI_COMMIT_SHA:0:7} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - export NAME="${CI_COMMIT_TAG:-$SHORT_REF}-${CI_COMMIT_SHA:0:7}"
+    - echo "Uploading with name=$NAME"
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-$NAME --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-$NAME --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23
 
 #
 # Docker releases

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ variables:
   DEB_S3_BUCKET: apt.datad0g.com
   RPM_S3_BUCKET: yum.datad0g.com
   WIN_S3_BUCKET: dd-agent-mstesting
+  PROCESS_S3_BUCKET: datad0g-process-agent
   ANDROID_S3_BUCKET: dd-agent-androidtesting
   DEB_RPM_BUCKET_BRANCH: nightly  # branch of the DEB_S3_BUCKET and RPM_S3_BUCKET repos to release to, 'nightly' or 'beta'
   DEB_TESTING_S3_BUCKET: apttesting.datad0g.com
@@ -1184,6 +1185,20 @@ deploy_puppy:
     - $S3_CP_CMD $S3_ARTEFACTS_URI/puppy/agent ./agent
     - export PACKAGE_VERSION=$(inv agent.version --url-safe)
     - aws s3 cp --region us-east-1 ./agent $S3_DSD6_URI/puppy/agent-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+
+# deploy process agent and system-probe to staging bucket
+deploy_process_and_sysprobe:
+  stage: deploy
+  when: manual
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/deploy:latest
+  before_script:
+    - cd $OMNIBUS_PACKAGE_DIR
+    - ls
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - dpkg -x datadog-agent_*_amd64.deb ./out
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/process-agent s3://$PROCESS_S3_BUCKET/process-agent-amd64-${CI_COMMIT_SHA:0:7}
+    - $S3_CP_CMD ./out/opt/datadog-agent/embedded/bin/system-probe s3://$PROCESS_S3_BUCKET/system-probe-amd64-${CI_COMMIT_SHA:0:7}
 
 #
 # Docker releases


### PR DESCRIPTION
### What does this PR do?

Add a manual step to deploy the process-agent and system-probe binaries internally

### Motivation

Faster and easier testing / development cycles.

### Additional Notes

Anything else we should know when reviewing?
