### PR TITLE
pkg/ebpf: Fix beautify key

### DIFF
--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -128,10 +128,9 @@ func (c ConnectionStats) String() string {
 
 // ByteKey returns a unique key for this connection represented as a byte array
 // It's as following:
-
+//
 //    32b     16b     16b      4b      4b     32/128b      32/128b
 // |  PID  | SPORT | DPORT | Family | Type |  SrcAddr  |  DestAddr
-//
 func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) ([]byte, error) {
 	buffer.Reset()
 	// Byte-packing to improve creation speed

--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -129,8 +129,8 @@ func (c ConnectionStats) String() string {
 // ByteKey returns a unique key for this connection represented as a byte array
 // It's as following:
 
-//    32b     16b     16b      4b      4b      4/16b       4/16b
-// |  PID  | SPORT | DPORT | Family | Type |  SrcAddr  | DestAddr
+//    32b     16b     16b      4b      4b     32/128b      32/128b
+// |  PID  | SPORT | DPORT | Family | Type |  SrcAddr  |  DestAddr
 //
 func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) ([]byte, error) {
 	buffer.Reset()

--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -192,7 +192,6 @@ func BeautifyKey(key string) string {
 	if ConnectionFamily(family) == AFINET6 {
 		addrSize = 16
 	}
-	fmt.Printf("addrSize = %+v\n", addrSize)
 
 	source := bytesToAddress(raw[9 : 9+addrSize])
 	dest := bytesToAddress(raw[9+addrSize : 9+2*addrSize])

--- a/pkg/ebpf/event_test.go
+++ b/pkg/ebpf/event_test.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -15,7 +16,7 @@ var (
 	testConn = ConnectionStats{
 		Pid:                123,
 		Type:               1,
-		Family:             0,
+		Family:             AFINET,
 		Source:             util.AddressFromString("192.168.0.1"),
 		Dest:               util.AddressFromString("192.168.0.103"),
 		SPort:              123,
@@ -32,11 +33,21 @@ func TestBeautifyKey(t *testing.T) {
 		{
 			Pid:    345,
 			Type:   0,
-			Family: 1,
-			Source: util.AddressFromString("127.0.0.1"),
-			Dest:   util.AddressFromString("192.168.0.103"),
+			Family: AFINET6,
+			Source: util.AddressFromNetIP(net.ParseIP("::7f00:35:0:1")),
+			Dest:   util.AddressFromNetIP(net.ParseIP("2001:db8::2:1")),
 			SPort:  4444,
 			DPort:  8888,
+		},
+		{
+			Pid:       32065,
+			Type:      0,
+			Family:    AFINET,
+			Direction: 2,
+			Source:    util.AddressFromString("172.21.148.124"),
+			Dest:      util.AddressFromString("130.211.21.187"),
+			SPort:     52012,
+			DPort:     443,
 		},
 	} {
 		bk, err := c.ByteKey(buf)


### PR DESCRIPTION
### What does this PR do?

Now that addresses are encoded in bytes we can have issues by using a separator to find the fields, example :

From the system-probe `debug/net_state` endpoint
```
"p:7857|src:%!s(<nil>):49438|dst:%!s(<nil>):443|f:0|t:0": {
   "total_recv": 6620,
   "total_retransmits": 0,
   "total_sent": 4836
 }
```

From the system-probe `connections` endpoint:
```
{
 "source": "172.21.148.124",
 "dest": "130.211.21.187",
 "pid": 32065,
 "net_ns": 4026531957,
 "sport": 52012,
 "dport": 443,
 "type": 0,
 "family": 0,
 "direction": 2,
}
```

`124` was the ASCII code of the separator (we used `|`)

This fixes the issue by hardcoding the number of bytes we have to read for each field.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
