### PR TITLE
Ensure that computeMem is safe

### DIFF
--- a/pkg/collector/corechecks/containers/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd.go
@@ -210,9 +210,7 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 			continue
 		}
 
-		if metrics.Memory != nil {
-			computeMem(sender, metrics.Memory, tags)
-		}
+		computeMem(sender, metrics.Memory, tags)
 
 		if metrics.CPU.Throttling != nil && metrics.CPU.Usage != nil {
 			computeCPU(sender, metrics.CPU, tags)
@@ -280,6 +278,9 @@ func computeHugetlb(sender aggregator.Sender, huge []*cgroups.HugetlbStat, tags 
 }
 
 func computeMem(sender aggregator.Sender, mem *cgroups.MemoryStat, tags []string) {
+	if mem == nil {
+		return
+	}
 
 	memList := map[string]*cgroups.MemoryEntry{
 		"containerd.mem.current":    mem.Usage,

--- a/pkg/collector/corechecks/containers/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd_test.go
@@ -182,6 +182,11 @@ func TestComputeMem(t *testing.T) {
 		expected map[string]float64
 	}{
 		{
+			name:     "call with empty mem",
+			mem:      nil,
+			expected: map[string]float64{},
+		},
+		{
 			name:     "nothing",
 			mem:      &cgroups.MemoryStat{},
 			expected: map[string]float64{},

--- a/releasenotes/notes/[containerd]-Ensure-that-computeMem-is-safe-e08c0a29ee46d396.yaml
+++ b/releasenotes/notes/[containerd]-Ensure-that-computeMem-is-safe-e08c0a29ee46d396.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The computeMem is only called in the check when we ensure that it does not get passed with an empty pointer.
+    But if someone was to reuse it without checking for the nil pointer it could cause a segfault.
+    This PR moves the nil checking logic inside the function to ensure it is safe.


### PR DESCRIPTION
### What does this PR do?

The computeMem is only called in the check at the moment where we ensure that it does not get passed with an empty pointer.
But if someone ~were~ was to reuse it without checking for the nil pointer it could cause a segfault.
Moving the nil checking logic inside the function to ensure it is safe.

### Motivation

Making better code.

### Additional Notes

Anything else we should know when reviewing?
