### PR TITLE
Fix external tag behavioron unicode

### DIFF
--- a/six/common/builtins/datadog_agent.c
+++ b/six/common/builtins/datadog_agent.c
@@ -324,7 +324,6 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
             PyErr_SetString(PyExc_MemoryError, "unable to allocate memory, bailing out");
             goto error;
         }
-        tags[tags_len] = NULL;
 
         // copy the list of tags into an array of char*
         int j, actual_size = 0;
@@ -335,22 +334,16 @@ static PyObject *set_external_tags(PyObject *self, PyObject *args)
             }
 
             char *tag = as_string(s);
-            // cleanup and return error
             if (tag == NULL) {
-                int k;
-                for (k = 0; k < actual_size; k++) {
-                    free(tags[k]);
-                }
-                free(tags);
-                // raise an exception
-                PyErr_SetString(PyExc_MemoryError, "unable to allocate memory, bailing out");
-                goto error;
+                // ignore invalid tag
+                continue;
             }
+
             tags[actual_size] = tag;
             actual_size++;
         }
+        tags[actual_size] = NULL;
 
-        // finally, invoke the Go function
         cb_set_external_tags(hostname, source_type, tags);
 
         // cleanup

--- a/six/common/stringutils.c
+++ b/six/common/stringutils.c
@@ -16,11 +16,18 @@ char *as_string(PyObject *object)
 
 // DATADOG_AGENT_THREE implementation is the default
 #ifdef DATADOG_AGENT_TWO
-    if (!PyString_Check(object)) {
+    if (!PyString_Check(object) && !PyUnicode_Check(object)) {
         return NULL;
     }
 
-    retval = _strdup(PyString_AS_STRING(object));
+    char *tmp = PyString_AsString(object);
+    if (tmp == NULL) {
+        // PyString_AsString might raise an error when python can't encode a
+        // unicode string to byte
+        PyErr_Clear();
+        return  NULL;
+    }
+    retval = _strdup(tmp);
 #else
     if (!PyUnicode_Check(object)) {
         return NULL;

--- a/six/test/datadog_agent/datadog_agent_py2_test.go
+++ b/six/test/datadog_agent/datadog_agent_py2_test.go
@@ -1,0 +1,23 @@
+// +build two
+
+package testdatadogagent
+
+import "testing"
+
+func TestSetExternalTagsUnicodeUnsuported(t *testing.T) {
+	code := `
+	tags = [
+		('hostname1', {'source_type1': [u'tag1', 123, u'tag2\u00E1']}),
+		('hostname2', {'source_type2': [u'tag3', [], u'tag4']}),
+		('hostname3', {'source_type3': [1,2,3]}),
+	]
+	datadog_agent.set_external_tags(tags)
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hostname1,source_type1,tag1\nhostname2,source_type2,tag3,tag4\nhostname3,source_type3," {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}

--- a/six/test/datadog_agent/datadog_agent_py3_test.go
+++ b/six/test/datadog_agent/datadog_agent_py3_test.go
@@ -1,0 +1,23 @@
+// +build three
+
+package testdatadogagent
+
+import "testing"
+
+func TestSetExternalTagsUnicodeUnsuported(t *testing.T) {
+	code := `
+	tags = [
+		('hostname1', {'source_type1': [u'tag1', 123, u'tag2\u00E1']}),
+		('hostname2', {'source_type2': [u'tag3', [], u'tag4']}),
+		('hostname3', {'source_type3': [1,2,3]}),
+	]
+	datadog_agent.set_external_tags(tags)
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hostname1,source_type1,tag1,tag2\u00E1\nhostname2,source_type2,tag3,tag4\nhostname3,source_type3," {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}

--- a/six/test/datadog_agent/datadog_agent_test.go
+++ b/six/test/datadog_agent/datadog_agent_test.go
@@ -137,6 +137,40 @@ func TestSetExternalTags(t *testing.T) {
 	}
 }
 
+func TestSetExternalTagsIgnoreNonString(t *testing.T) {
+	code := `
+	tags = [
+		('hostname', {'source_type': ['tag1', 123, 'tag2']}),
+		('hostname2', {'source_type2': ['tag3', [], 'tag4']}),
+	]
+	datadog_agent.set_external_tags(tags)
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hostname,source_type,tag1,tag2\nhostname2,source_type2,tag3,tag4" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}
+
+func TestSetExternalTagsUnicode(t *testing.T) {
+	code := `
+	tags = [
+		('hostname', {'source_type': [u'tag1', 123, u'tag2']}),
+		('hostname2', {'source_type2': [u'tag3', [], u'tag4']}),
+	]
+	datadog_agent.set_external_tags(tags)
+	`
+	out, err := run(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hostname,source_type,tag1,tag2\nhostname2,source_type2,tag3,tag4" {
+		t.Errorf("Unexpected printed value: '%s'", out)
+	}
+}
+
 func TestSetExternalTagsNotList(t *testing.T) {
 	code := `
 	datadog_agent.set_external_tags({})


### PR DESCRIPTION
### What does this PR do?

To avoid breaking backward compatibility we need to handle "ascii unicode" string in `set_external_tags`.

`PyString_AsString` handles unicode by computing the default encoding and operating on that or raise an error if it can't. We use to call `PyString_AsString` without any check, this means that in many place unicode object containing only ascii characters would work.

This PR add that behavior back by accepting unicode and clearing any error raised by `PyString_AsString`. This improvement is applied to all strings pass to the Go/Python API.

Example:

```python
set_external_tags([
  ('hostname', {'source_type': [u'tag1', 21, [], u'tag2\u00E1']}),
  (u'hostname2', {u'source_type2': [u'tag3', 'tag2', 'tag4']}),
  (u'hostname3', {u'source_type3': [1, 2, 3]}),
  (u'hostname4\u00E1', {u'source_type4': [u'tag3', 'tag2', 'tag4']}),
])
```

Use to produce the following external tags with the GoPython implementation:
```
hostname source_type [tag1]
hostname2 source_type2 [tag3 tag2 tag4]
hostname3 source_type3 [] # not tag added: we should have ignore it
"" source_type4 [tag3 tag2 tag4] # empty host name: we should have ignore it
```

and with the fix in this PR produce:
```
hostname source_type [tag1]
hostname2 source_type2 [tag3 tag2 tag4]
# no call for "(u'hostname3', {u'source_type2': [1, 2, 3]})," since there is no valid tag

#  "(u'hostname4\u00E1', {u'source_type4': [u'tag3', 'tag2', 'tag4']})," raise an error
Traceback (most recent call last):
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/venv/local/lib/python2.7/site-packages/datadog_checks/base/checks/base.py", line 880, in run
    self.check(instance)
  File "/home/hush-hush/dev/go/src/github.com/DataDog/datadog-agent/bin/agent/dist/test.py", line 14, in check
    (u'hostname4\u00E1', {u'source_type4': [u'tag3', 'tag2', 'tag4']}),
TypeError: hostname is not a valid string
```