### PR TITLE
[pkg/config] Fix jmx_check_period default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -313,7 +313,7 @@ func initConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_reconnection_thread_pool_size", 3)
 	config.BindEnvAndSetDefault("jmx_collection_timeout", 60)
-	config.BindEnvAndSetDefault("jmx_check_period", defaults.DefaultCheckInterval/time.Millisecond)
+	config.BindEnvAndSetDefault("jmx_check_period", int(defaults.DefaultCheckInterval/time.Millisecond))
 	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 10)
 
 	// Go_expvar server port


### PR DESCRIPTION



### What does this PR do?

The default JMX check interval is now cast to
an `int`, since we parse it as an `int`.

### Motivation

The default check interval was not cast to an `int` before being saved
as the default config. As such, the default JMX check interval was
wrong for two reasons:
- it's a `time.Duration` of value 15000 (which means 15 microseconds,
and not 15 seconds as expected),
- since it's a `time.Duration`, when the Windows config file is
written, it's written as `15µs`, but parsed afterwards as an `int`, 
which breaks the checks (moreover, there was an encoding 
problem which resulted in `15Âµs` being written).

### Additional Notes

Tested the resulting .msi package on a Windows Server 2016 host.