### PR TITLE
pkg/trace/config: ensure secrets in environment variables get loaded

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -211,7 +211,6 @@ func Load(path string) (*AgentConfig, error) {
 	} else {
 		log.Infof("Loaded configuration: %s", cfg.ConfigPath)
 	}
-	applyEnv()
 	cfg.applyDatadogConfig()
 	return cfg, cfg.validate()
 }
@@ -236,12 +235,17 @@ func prepareConfig(path string) (*AgentConfig, error) {
 		}
 	case ".yaml":
 		config.Datadog.SetConfigFile(cfgPath)
-		if err := config.Load(); err != nil {
+		// we'll resolve secrets later, after loading environment variable values too
+		if err := config.LoadWithoutSecret(); err != nil {
 			return cfg, err
 		}
 		cfg.DDAgentBin = defaultDDAgentBin
 	default:
 		return cfg, errors.New("unrecognised file extension (need .yaml, .ini or .conf)")
+	}
+	loadEnv() // TODO(gbbr): remove this along with all A5 configuration loading code and use BindEnv in pkg/config
+	if err := config.ResolveSecrets(config.Datadog, filepath.Base(path)); err != nil {
+		return cfg, err
 	}
 	cfg.ConfigPath = cfgPath
 	return cfg, nil

--- a/pkg/trace/config/env.go
+++ b/pkg/trace/config/env.go
@@ -10,7 +10,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func applyEnv() {
+// loadEnv loads all known environment variables into the global config.
+func loadEnv() {
 	// Warning: do not use BindEnv to bind config variables. They will be overridden
 	// when using the legacy config loader.
 	for _, override := range []struct{ env, key string }{

--- a/pkg/trace/test/agent.go
+++ b/pkg/trace/test/agent.go
@@ -74,9 +74,9 @@ func (s *agentRunner) Run(conf []byte) error {
 		case <-timeout:
 			return fmt.Errorf("agent: timed out waiting for start, log:\n%s", s.Log())
 		default:
-			if strings.Contains(s.log.String(), "listening for traces at") {
+			if strings.Contains(s.log.String(), "Listening for traces at") {
 				if s.verbose {
-					log.Print("agent: listening for traces")
+					log.Print("agent: Listening for traces")
 				}
 				return nil
 			}

--- a/pkg/trace/test/testsuite/secrets_test.go
+++ b/pkg/trace/test/testsuite/secrets_test.go
@@ -1,0 +1,72 @@
+package testsuite
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSecrets ensures that secrets placed in environment variables get loaded.
+func TestSecrets(t *testing.T) {
+	tmpDir := os.TempDir()
+
+	// install trace-agent with -tags=secrets
+	binTraceAgent := filepath.Join(tmpDir, "/tmp/trace-agent.test")
+	cmd := exec.Command("go", "build", "-o", binTraceAgent, "-tags=secrets", "github.com/DataDog/datadog-agent/cmd/trace-agent")
+	cmd.Stdout = ioutil.Discard
+	if err := cmd.Run(); err != nil {
+		t.Skip(err.Error())
+	}
+	defer os.Remove(binTraceAgent)
+
+	// install a secrets provider script
+	binSecrets := filepath.Join(tmpDir, "secret-script.test")
+	cmd = exec.Command("go", "build", "-o", binSecrets, "./testdata/secretscript.go")
+	cmd.Stdout = ioutil.Discard
+	if err := cmd.Run(); err != nil {
+		t.Skip(err.Error())
+	}
+	defer os.Remove(binSecrets)
+	if err := os.Chmod(binSecrets, 0700); err != nil {
+		t.Skip(err.Error())
+	}
+
+	// run the trace-agent
+	var buf bytes.Buffer
+	cmd = exec.Command("/tmp/trace-agent.test")
+	cmd.Env = []string{
+		"DD_SECRET_BACKEND_COMMAND=" + binSecrets,
+		"DD_HOSTNAME=ENC[secret1]",
+	}
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	exit := make(chan error, 1)
+	go func() {
+		if err := cmd.Run(); err != nil {
+			exit <- err
+		}
+	}()
+	defer func(cmd *exec.Cmd) {
+		cmd.Process.Kill()
+	}(cmd)
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case <-exit:
+			t.Fatalf("error: %v", buf.String())
+		case <-timeout:
+			t.Fatalf("timed out: %v", buf.String())
+		default:
+			if strings.Contains(buf.String(), "running on host decrypted_secret1") {
+				// test passed
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}

--- a/pkg/trace/test/testsuite/testdata/secretscript.go
+++ b/pkg/trace/test/testsuite/testdata/secretscript.go
@@ -1,0 +1,56 @@
+// This script is a dummy emulating the behavior of a secret command used in the Datadog Agent configuration
+// as the value of the environment variable "DD_SECRET_BACKEND_COMMAND" which mirrors the YAML config setting
+// "secret_backend_command".
+//
+// It takes whatever secret keys it is sent and resolves them to the same string as the key, prefixed with
+// "decrypted_". For example, requesting the secret "secret1" will resolve to "decrypted_secret1".
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type secretsPayload struct {
+	Secrets []string `json:secrets`
+	Version string   `json:version`
+}
+
+func main() {
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read from stdin: %s", err)
+		os.Exit(1)
+	}
+
+	secrets := secretsPayload{}
+	if err := json.Unmarshal(data, &secrets); err != nil {
+		log.Fatal(err)
+	}
+
+	res := map[string]map[string]string{}
+	for _, handle := range secrets.Secrets {
+		res[handle] = map[string]string{
+			"value": "decrypted_" + handle,
+		}
+	}
+
+	output, err := json.Marshal(res)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not serialize res: %s", err)
+		os.Exit(1)
+	}
+	fmt.Printf(string(output))
+
+	f, err := os.OpenFile("/tmp/secrets.out", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(output, '\n')); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/releasenotes/notes/apm-secrets-in-environment-190ecede8cc8fa0b.yaml
+++ b/releasenotes/notes/apm-secrets-in-environment-190ecede8cc8fa0b.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: fixed a bug where secrets in environment variables where ignored.


### PR DESCRIPTION
This change fixes a bug where secrets in environment variables where
ignored by trace-agent.