### PR TITLE
[six/two] Fix missing decref on `instances`

### DIFF
--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -269,11 +269,16 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
     }
 
     instances = PyTuple_New(1);
+    if (instances == NULL) {
+        setError("could not create tuple for instances: " + _fetchPythonError());
+        Py_XDECREF(instance); // we still own the reference to instance, so we need to decref it here
+        goto done;
+    }
     // As stated in the Python C-API documentation
     // https://github.com/python/cpython/blob/2.7/Doc/c-api/intro.rst#reference-count-details, PyTuple_SetItem takes
     // over ownership of the given item (instance in this case). This means that we should NOT DECREF it
     if (PyTuple_SetItem(instances, 0, instance) != 0) {
-        setError("Could not create Tuple for instances: " + _fetchPythonError());
+        setError("could not set instance item on instances: " + _fetchPythonError());
         goto done;
     }
 
@@ -331,6 +336,7 @@ done:
     Py_XDECREF(name);
     Py_XDECREF(check_id);
     Py_XDECREF(init_config);
+    Py_XDECREF(instances);
     Py_XDECREF(agent_config);
     Py_XDECREF(args);
     Py_XDECREF(kwargs);

--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -265,6 +265,7 @@ bool Two::getCheck(SixPyObject *py_class, const char *init_config_str, const cha
         goto done;
     } else if (!PyDict_Check(instance)) {
         setError("error instance is not a dict");
+        Py_XDECREF(instance); // we still own the reference to instance, so we need to decref it here
         goto done;
     }
 


### PR DESCRIPTION
### What does this PR do?

* although `instance` must not be `decref`'ed once it's been added to the `instances` tuple with `PyTuple_SetItem`, the tuple itself (`instances`) does need to be `decref`'ed.
* also, improve very slightly the error handling (in case `Py_NewTuple` failed for some reason...)

### Motivation

Fix small memory leak: would leak one tuple per check.