### PR TITLE
Allow for hostname to be passed as encrypted environment variable

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -271,11 +271,6 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 		cfg.LogLevel = "warn"
 	}
 
-	if v := os.Getenv("DD_HOSTNAME"); v != "" {
-		log.Info("overriding hostname from env DD_HOSTNAME value")
-		cfg.HostName = v
-	}
-
 	if cfg.HostName == "" {
 		if ecsutil.IsFargateInstance() {
 			// Fargate tasks should have no concept of host names, so we're using the task ARN.
@@ -349,6 +344,7 @@ func loadEnvVariables() {
 		"DD_USE_LOCAL_SYSTEM_PROBE": "system_probe_config.use_local_system_probe",
 		"DD_ENABLE_PROFILING":       "system_probe_config.debug_profiling_enabled",
 
+		"DD_HOSTNAME":       "hostname",
 		"DD_DOGSTATSD_PORT": "dogstatsd_port",
 		"DD_BIND_HOST":      "bind_host",
 		"HTTPS_PROXY":       "proxy.https",

--- a/pkg/process/config/config_nix_test.go
+++ b/pkg/process/config/config_nix_test.go
@@ -97,7 +97,9 @@ func TestAgentEncryptedVariablesSecrets(t *testing.T) {
 	config.Datadog.Set("secret_backend_output_max_size", 1024)
 
 	os.Setenv("DD_API_KEY", "ENC[my_api_key]")
+	os.Setenv("DD_HOSTNAME", "ENC[my_host]")
 	defer os.Unsetenv("DD_API_KEY")
+	defer os.Unsetenv("DD_HOSTNAME")
 
 	assert := assert.New(t)
 	agentConfig, err := NewAgentConfig(
@@ -108,4 +110,5 @@ func TestAgentEncryptedVariablesSecrets(t *testing.T) {
 	assert.Equal("secret_my_api_key", config.Datadog.Get("api_key"))
 	ep := agentConfig.APIEndpoints[0]
 	assert.Equal("secret_my_api_key", ep.APIKey)
+	assert.Equal("secret_my_host", agentConfig.HostName)
 }

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -203,6 +203,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
+	assert.Equal("server-01", agentConfig.HostName)
 	assert.Equal(10, agentConfig.QueueSize)
 	assert.Equal(true, agentConfig.AllowRealTime)
 	assert.Equal(true, agentConfig.Enabled)

--- a/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml
+++ b/pkg/process/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig.yaml
@@ -1,4 +1,5 @@
 api_key: apikey_20
+hostname: server-01
 
 process_agent_enabled: true
 process_config:

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -135,6 +135,10 @@ func (a *AgentConfig) loadProcessYamlConfig(path string) error {
 		a.APIEndpoints[0].APIKey = config.Datadog.GetString(key)
 	}
 
+	if config.Datadog.IsSet("hostname") {
+		a.HostName = config.Datadog.GetString("hostname")
+	}
+
 	if k := key(ns, "enabled"); config.Datadog.IsSet(k) {
 		// A string indicate the enabled state of the Agent.
 		// If "false" (the default) we will only collect containers.


### PR DESCRIPTION
### What does this PR do?

A port of https://github.com/DataDog/datadog-process-agent/pull/317 into 6.12.0

We were overwriting the hostname with in incorrect value if it was passed as an encrypted environment value.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
