### PR TITLE
DD_PROCESS_AGENT_ENABLED should only have true and false states

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -328,7 +328,6 @@ func NewSystemProbeConfig(loggerName config.LoggerName, yamlPath string) (*Agent
 
 func loadEnvVariables() {
 	for envKey, cfgKey := range map[string]string{
-		"DD_PROCESS_AGENT_ENABLED":          "process_config.enabled",
 		"DD_PROCESS_AGENT_CONTAINER_SOURCE": "process_config.container_source",
 		"DD_SCRUB_ARGS":                     "process_config.scrub_args",
 		"DD_STRIP_PROCESS_ARGS":             "process_config.strip_proc_arguments",

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -79,9 +79,17 @@ func TestOnlyEnvConfig(t *testing.T) {
 	// setting an API Key should be enough to generate valid config
 	os.Setenv("DD_API_KEY", "apikey_from_env")
 	defer os.Unsetenv("DD_API_KEY")
+	os.Setenv("DD_PROCESS_AGENT_ENABLED", "true")
+	defer os.Unsetenv("DD_PROCESS_AGENT_ENABLED")
 
 	agentConfig, _ := NewAgentConfig("test", "", "")
 	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
+	assert.True(t, agentConfig.Enabled)
+
+	os.Setenv("DD_PROCESS_AGENT_ENABLED", "false")
+	agentConfig, _ = NewAgentConfig("test", "", "")
+	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
+	assert.False(t, agentConfig.Enabled)
 }
 
 func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {

--- a/releasenotes/notes/fix-6f81ff164bc42b89.yaml
+++ b/releasenotes/notes/fix-6f81ff164bc42b89.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix issue with process agent where DD_PROCESS_AGENT_ENABLED behaivour where 'false' did not turn off process/container collection.

--- a/releasenotes/notes/fix-6f81ff164bc42b89.yaml
+++ b/releasenotes/notes/fix-6f81ff164bc42b89.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix issue with process agent where DD_PROCESS_AGENT_ENABLED behaivour where 'false' did not turn off process/container collection.
+    Fix issue on process agent for DD_PROCESS_AGENT_ENABLED where 'false' did not turn off process/container collection.


### PR DESCRIPTION
### What does this PR do?

`DD_PROCESS_AGENT_ENABLED` currently expects either true/false/disabled as it's values, which was a breaking change introduced in version 6.11.x. 

This environment variable should only take true or false as values for backwards compatibility with older versions of the agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
