### PR TITLE
[windows] add `system.mem.pagefile.pct_free` metric back to memory corecheck.

### DIFF
--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -23,6 +23,7 @@ import (
 // For testing purpose
 var virtualMemory = winutil.VirtualMemory
 var swapMemory = winutil.SwapMemory
+var pageMemory = winutil.PagefileMemory
 var runtimeOS = runtime.GOOS
 
 // MemoryCheck doesn't need additional fields
@@ -115,6 +116,16 @@ func (c *MemoryCheck) Run() error {
 		sender.Gauge("system.swap.free", float64(s.Free)/mbSize, "", nil)
 		sender.Gauge("system.swap.used", float64(s.Used)/mbSize, "", nil)
 		sender.Gauge("system.swap.pct_free", float64(100-s.UsedPercent)/100, "", nil)
+	} else {
+		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
+	}
+
+	p, errPage := pageMemory()
+	if errPage == nil {
+		sender.Gauge("system.mem.pagefile.total", float64(p.Total)/mbSize, "", nil)
+		sender.Gauge("system.mem.pagefile.free", float64(p.Available)/mbSize, "", nil)
+		sender.Gauge("system.mem.pagefile.used", float64(p.Used)/mbSize, "", nil)
+		sender.Gauge("system.mem.pagefile.pct_free", float64(100-s.UsedPercent)/100, "", nil)
 	} else {
 		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
 	}

--- a/pkg/collector/corechecks/system/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory_windows.go
@@ -122,10 +122,7 @@ func (c *MemoryCheck) Run() error {
 
 	p, errPage := pageMemory()
 	if errPage == nil {
-		sender.Gauge("system.mem.pagefile.total", float64(p.Total)/mbSize, "", nil)
-		sender.Gauge("system.mem.pagefile.free", float64(p.Available)/mbSize, "", nil)
-		sender.Gauge("system.mem.pagefile.used", float64(p.Used)/mbSize, "", nil)
-		sender.Gauge("system.mem.pagefile.pct_free", float64(100-s.UsedPercent)/100, "", nil)
+		sender.Gauge("system.mem.pagefile.pct_free", float64(100-p.UsedPercent)/100, "", nil)
 	} else {
 		log.Errorf("system.MemoryCheck: could not retrieve swap memory stats: %s", errSwap)
 	}

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -33,6 +33,15 @@ func SwapMemory() (*winutil.SwapMemoryStat, error) {
 	}, nil
 }
 
+func PagefileMemory() (*winutil.PagefileStat, error) {
+	return &winutil.PagefileStat{
+		Total:       120000,
+		Available:   90000,
+		Used:        30000,
+		UsedPercent: 50,
+	}, nil
+}
+
 func TestMemoryCheckWindows(t *testing.T) {
 	virtualMemory = VirtualMemory
 	swapMemory = SwapMemory
@@ -50,12 +59,17 @@ func TestMemoryCheckWindows(t *testing.T) {
 	mock.On("Gauge", "system.swap.used", 40000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.pct_free", 0.6, "", []string(nil)).Return().Times(1)
 
+	mock.On("Gauge", "system.mem.pagefile.total", 120000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.free", 90000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.used", 30000.0/mbSize, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.pct_free", 0.25, "", []string(nil)).Return().Times(1)
+
 	mock.On("Commit").Return().Times(1)
 
 	err := memCheck.Run()
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 9)
+	mock.AssertNumberOfCalls(t, "Gauge", 13)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/pkg/collector/corechecks/system/memory_windows_test.go
+++ b/pkg/collector/corechecks/system/memory_windows_test.go
@@ -45,6 +45,7 @@ func PagefileMemory() (*winutil.PagefileStat, error) {
 func TestMemoryCheckWindows(t *testing.T) {
 	virtualMemory = VirtualMemory
 	swapMemory = SwapMemory
+	pageMemory = PagefileMemory
 	memCheck := new(MemoryCheck)
 
 	mock := mocksender.NewMockSender(memCheck.ID())
@@ -59,10 +60,7 @@ func TestMemoryCheckWindows(t *testing.T) {
 	mock.On("Gauge", "system.swap.used", 40000.0/mbSize, "", []string(nil)).Return().Times(1)
 	mock.On("Gauge", "system.swap.pct_free", 0.6, "", []string(nil)).Return().Times(1)
 
-	mock.On("Gauge", "system.mem.pagefile.total", 120000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.pagefile.free", 90000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.pagefile.used", 30000.0/mbSize, "", []string(nil)).Return().Times(1)
-	mock.On("Gauge", "system.mem.pagefile.pct_free", 0.25, "", []string(nil)).Return().Times(1)
+	mock.On("Gauge", "system.mem.pagefile.pct_free", 0.5, "", []string(nil)).Return().Times(1)
 
 	mock.On("Commit").Return().Times(1)
 
@@ -70,6 +68,6 @@ func TestMemoryCheckWindows(t *testing.T) {
 	require.Nil(t, err)
 
 	mock.AssertExpectations(t)
-	mock.AssertNumberOfCalls(t, "Gauge", 13)
+	mock.AssertNumberOfCalls(t, "Gauge", 10)
 	mock.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/pkg/util/winutil/winmem.go
+++ b/pkg/util/winutil/winmem.go
@@ -107,12 +107,15 @@ func PagefileMemory() (*PagefileStat, error) {
 	if mem == 0 {
 		return nil, windows.GetLastError()
 	}
-
+	total := memInfo.ullTotalPageFile
+	free := memInfo.ullAvailPageFile
+	used := total - free
+	percent := (float64(used) / float64(total)) * 100
 	ret := &PagefileStat{
-		Total:       memInfo.ullTotalPageFile,
-		Available:   memInfo.ullAvailPageFile,
-		Used:        memInfo.ullTotalPageFile - memInfo.ullAvailPageFile,
-		UsedPercent: float64(((memInfo.ullTotalPageFile - memInfo.ullAvailPageFile) / (memInfo.ullAvailPageFile)) * 100),
+		Total:       total,
+		Available:   free,
+		Used:        used,
+		UsedPercent: percent,
 	}
 
 	return ret, nil

--- a/releasenotes/notes/winpagefilemetrics-b7f354de00af0342.yaml
+++ b/releasenotes/notes/winpagefilemetrics-b7f354de00af0342.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, restore the system.mem.pagefile.* metrics

--- a/releasenotes/notes/winpagefilemetrics-b7f354de00af0342.yaml
+++ b/releasenotes/notes/winpagefilemetrics-b7f354de00af0342.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    On Windows, restore the system.mem.pagefile.* metrics
+    On Windows, restore the ``system.mem.pagefile.pct_free`` metric


### PR DESCRIPTION
Restores metric lost from A5->A6, so that customers upgrading don't lose
metrics

