### PR TITLE
Minor nits to `six/two/two.cpp` (part I)

### DIFF
--- a/six/two/two.cpp
+++ b/six/two/two.cpp
@@ -229,8 +229,9 @@ bool Two::getClass(const char *module, SixPyObject *&pyModule, SixPyObject *&pyC
 
     obj_class = _findSubclassOf(_baseClass, obj_module);
     if (obj_class == NULL) {
+        // `_findSubclassOf` does not set the interpreter's error flag, but leaves an error on six
         std::ostringstream err;
-        err << "unable to find a subclass of the base check in module '" << module << "': " << _fetchPythonError();
+        err << "unable to find a subclass of the base check in module '" << module << "': " << getError();
         setError(err.str());
         Py_XDECREF(obj_module);
         return false;

--- a/six/two/two.h
+++ b/six/two/two.h
@@ -83,7 +83,10 @@ public:
 
 private:
     void initPythonHome(const char *pythonHome = NULL);
+    // return new reference, returns NULL on error with clean interpreter error flag
     PyObject *_importFrom(const char *module, const char *name);
+    // return new reference, returns NULL on error with clean interpreter error flag
+    // and an error set on six
     PyObject *_findSubclassOf(PyObject *base, PyObject *moduleName);
     PyObject *_getClass(const char *module, const char *base);
     std::string _fetchPythonError();


### PR DESCRIPTION
### What does this PR do?

Part I of my audit of `six/two/two.cpp`:

* Handle very unlikely errors in Two::init()
* Pull error correctly after calling _findSubclassOf

### Additional Notes

I've audited the file from the top until the end of `Two::getClass`. I'll continue in a future PR.
