### PR TITLE
system-probe: Fix underflows/stats resets caused by unordered connections

### DIFF
--- a/pkg/ebpf/state.go
+++ b/pkg/ebpf/state.go
@@ -48,6 +48,7 @@ type telemetry struct {
 	closedConnDropped int64
 	connDropped       int64
 	statsResets       int64
+	simultaneousConns int64
 }
 
 type stats struct {
@@ -233,16 +234,36 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 
 	// Closed connections
 	for key, closedConn := range client.closedConnections {
-		activeConn, ok := active[key]
-		// Consider that the connection has become active again only if it has a more recent epoch than the closed one
-		isActive := ok && closedConn.LastUpdateEpoch < activeConn.LastUpdateEpoch
-		if isActive {
-			closedConn.MonotonicSentBytes += activeConn.MonotonicSentBytes
-			closedConn.MonotonicRecvBytes += activeConn.MonotonicRecvBytes
-			closedConn.MonotonicRetransmits += activeConn.MonotonicRetransmits
+		// If the connection is also active, check the epochs to understand what's going on
+		if activeConn, ok := active[key]; ok {
+			// If closed conn is newer it means that the active connection is outdated, let's ignore it
+			if closedConn.LastUpdateEpoch > activeConn.LastUpdateEpoch {
+				ns.updateConnWithStats(client, key, &closedConn)
+			} else if closedConn.LastUpdateEpoch < activeConn.LastUpdateEpoch {
+				// Else if the active conn is newer, it likely means that it became active again
+				// in this case we aggregate the two
+				closedConn.MonotonicSentBytes += activeConn.MonotonicSentBytes
+				closedConn.MonotonicRecvBytes += activeConn.MonotonicRecvBytes
+				closedConn.MonotonicRetransmits += activeConn.MonotonicRetransmits
 
-			ns.createStatsForKey(client, key)
-			ns.updateConnWithStatWithActiveConn(client, key, *activeConn, &closedConn)
+				ns.createStatsForKey(client, key)
+				ns.updateConnWithStatWithActiveConn(client, key, *activeConn, &closedConn)
+
+				// We also update the counters to reflect only the active connection
+				// The monotonic counters will be the sum of all connections that cross our interval start + finish.
+				if stats, ok := client.stats[key]; ok {
+					stats.totalRetransmits = activeConn.MonotonicRetransmits
+					stats.totalSent = activeConn.MonotonicSentBytes
+					stats.totalRecv = activeConn.MonotonicRecvBytes
+				}
+			} else {
+				// Else the closed connection and the active connection have the same epoch
+				// XXX: For now we assume that the closed connection is the more recent one but this is not guaranteed
+				// To fix this we should have a way to uniquely identify a connection
+				// (using the startTimestamp or a monotonic counter)
+				ns.telemetry.unorderedConns++
+				ns.updateConnWithStats(client, key, &closedConn)
+			}
 		} else {
 			ns.updateConnWithStats(client, key, &closedConn)
 		}
@@ -252,22 +273,9 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 
 	// Active connections
 	for key, c := range active {
-		if closed, ok := client.closedConnections[key]; ok {
-			// If this connection was closed while we were collecting active connections it means the active
-			// connection is no more up-to date and we already went through the closed connection so let's
-			// skip it and not update the stats counters
-			if closed.LastUpdateEpoch >= c.LastUpdateEpoch {
-				continue
-			}
-
-			// If this connection was both closed and reopened, update the counters to reflect only the active connection.
-			// The monotonic counters will be the sum of all connections that cross our interval start + finish.
-			if stats, ok := client.stats[key]; ok {
-				stats.totalRetransmits = c.MonotonicRetransmits
-				stats.totalSent = c.MonotonicSentBytes
-				stats.totalRecv = c.MonotonicRecvBytes
-			}
-			continue // We processed this connection during the closed connection pass, so lets not do it again.
+		// If the connection was closed, it has already been processed so skip it
+		if _, ok := client.closedConnections[key]; ok {
+			continue
 		}
 
 		ns.createStatsForKey(client, key)
@@ -372,12 +380,13 @@ func (ns *networkState) RemoveConnections(keys []string) {
 	}
 
 	// Flush log line if any metric is non zero
-	if ns.telemetry.unorderedConns > 0 || ns.telemetry.statsResets > 0 || ns.telemetry.closedConnDropped > 0 || ns.telemetry.connDropped > 0 {
-		log.Warnf("state telemetry: [%d unordered conns] [%d stats stats_resets] [%d connections dropped due to stats] [%d closed connections dropped]",
+	if ns.telemetry.unorderedConns > 0 || ns.telemetry.statsResets > 0 || ns.telemetry.closedConnDropped > 0 || ns.telemetry.connDropped > 0 || ns.telemetry.simultaneousConns > 0 {
+		log.Warnf("state telemetry: [%d unordered conns] [%d stats stats_resets] [%d connections dropped due to stats] [%d closed connections dropped] [%d simultaneous connections]",
 			ns.telemetry.unorderedConns,
 			ns.telemetry.statsResets,
 			ns.telemetry.closedConnDropped,
-			ns.telemetry.connDropped)
+			ns.telemetry.connDropped,
+			ns.telemetry.simultaneousConns)
 	}
 
 	ns.telemetry = telemetry{}
@@ -404,6 +413,7 @@ func (ns *networkState) GetStats(closedPollLost, closedPollReceived, tracerSkipp
 			"unordered_conns":              ns.telemetry.unorderedConns,
 			"closed_conn_dropped":          ns.telemetry.closedConnDropped,
 			"conn_dropped":                 ns.telemetry.connDropped,
+			"simultaneous_conns":           ns.telemetry.simultaneousConns,
 			"closed_conn_polling_lost":     closedPollLost,
 			"closed_conn_polling_received": closedPollReceived,
 			"ok_conns_skipped":             tracerSkipped, // Skipped connections (e.g. Local DNS requests)

--- a/pkg/ebpf/state.go
+++ b/pkg/ebpf/state.go
@@ -195,6 +195,8 @@ func (ns *networkState) StoreClosedConnection(conn ConnectionStats) {
 			prev.MonotonicSentBytes += conn.MonotonicSentBytes
 			prev.MonotonicRecvBytes += conn.MonotonicRecvBytes
 			prev.MonotonicRetransmits += conn.MonotonicRetransmits
+			// Also update the timestamp
+			prev.LastUpdateEpoch = conn.LastUpdateEpoch
 			client.closedConnections[string(key)] = prev
 		} else if len(client.closedConnections) >= ns.maxClosedConns {
 			ns.telemetry.closedConnDropped++

--- a/pkg/ebpf/state.go
+++ b/pkg/ebpf/state.go
@@ -231,7 +231,10 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 
 	// Closed connections
 	for key, closedConn := range client.closedConnections {
-		if activeConn, ok := active[key]; ok { // This closed connection has become active again
+		activeConn, ok := active[key]
+		// Consider that the connection has become active again only if it has a more recent epoch than the closed one
+		isActive := ok && closedConn.LastUpdateEpoch < activeConn.LastUpdateEpoch
+		if isActive {
 			closedConn.MonotonicSentBytes += activeConn.MonotonicSentBytes
 			closedConn.MonotonicRecvBytes += activeConn.MonotonicRecvBytes
 			closedConn.MonotonicRetransmits += activeConn.MonotonicRetransmits

--- a/pkg/ebpf/state.go
+++ b/pkg/ebpf/state.go
@@ -261,7 +261,8 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 				// XXX: For now we assume that the closed connection is the more recent one but this is not guaranteed
 				// To fix this we should have a way to uniquely identify a connection
 				// (using the startTimestamp or a monotonic counter)
-				ns.telemetry.unorderedConns++
+				ns.telemetry.simultaneousConns++
+				log.Debugf("Simulatenous connections: closed:%+v, active:%+v", closedConn, *activeConn)
 				ns.updateConnWithStats(client, key, &closedConn)
 			}
 		} else {

--- a/pkg/ebpf/state.go
+++ b/pkg/ebpf/state.go
@@ -260,7 +260,7 @@ func (ns *networkState) mergeConnections(id string, active map[string]*Connectio
 				// To fix this we should have a way to uniquely identify a connection
 				// (using the startTimestamp or a monotonic counter)
 				ns.telemetry.timeSyncCollisions++
-				log.Debugf("Time collision for connections: closed:%+v, active:%+v", closedConn, *activeConn)
+				log.Tracef("Time collision for connections: closed:%+v, active:%+v", closedConn, *activeConn)
 				ns.updateConnWithStats(client, key, &closedConn)
 			}
 		} else {

--- a/pkg/ebpf/state_test.go
+++ b/pkg/ebpf/state_test.go
@@ -1091,10 +1091,15 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	state.StoreClosedConnection(conn)
 
 	conns = state.Connections(client, latestEpochTime(), nil)
+	require.Len(t, conns, 1)
+	assert.EqualValues(t, 2, conns[0].LastSentBytes)
+	assert.EqualValues(t, 0, conns[0].LastRecvBytes)
 
 	// Ensure we don't have underflows / unordered conns
 	assert.Zero(t, state.(*networkState).telemetry.statsResets)
 	assert.Zero(t, state.(*networkState).telemetry.unorderedConns)
+
+	assert.Len(t, state.Connections(client, latestEpochTime(), nil), 0)
 }
 
 func generateRandConnections(n int) []ConnectionStats {


### PR DESCRIPTION
### What does this PR do?

This fixes another case where we could encounter underflows / stats resets.
It happens when we receive a close event while reading the connections from the eBPF map.

It's related to: https://github.com/DataDog/datadog-process-agent/pull/279

If the close event is for a connection we already read from the map we might:
- Not clear the stats objects in state because we would consider the connection to still be active (when it's not because it closed)
- Lose some stats (we would lose `closed - active`) resulting in wrong counts for bytes sent/ bytes received/ retransmits

This is an example of when this could happen:
```
Ebpf logs
---
         foo-8325  [002] d... 440164.806546: : DEBUG: update stats dport: 5470, daddr: -1088023124, recv: 3160
         foo-7896  [002] d... 440164.865161: : DEBUG: update stats dport: 5470, daddr: -1088023124, recv: 3160
         foo-7896  [002] d... 440164.865209: : DEBUG: cleanup dport: 5470, daddr: -1088023124, recv: 3160

         foo-20913 [003] d... 440645.884578: : DEBUG: update stats dport: 5470, daddr: -1088023124, recv: 1346
         foo-7893  [001] d... 440645.889738: : DEBUG: update stats dport: 5470, daddr: -1088023124, recv: 1346
         foo-7893  [001] d... 440645.889774: : DEBUG: cleanup dport: 5470, daddr: -1088023124, recv: 1346


Dump
---
CLOSE (ts: 1559148407): [TCP] [PID: 7890] [172.21.33.250:9000 ⇄ 172.21.38.191:5470] (incoming) 158 bytes sent (+0), 3160 bytes received (+0), 0 retransmits (+0)

Get connections (ts: 1559148407): [[TCP] [PID: 7890] [172.21.33.250:9000 ⇄ 172.21.38.191:5470] (incoming) 0 bytes sent (+0), 3160 bytes received (+0), 0 retransmits (+0)]

...

Get connections (ts: 1559148887): []

...

CLOSE (ts: 1559148888): [TCP] [PID: 7890] [172.21.33.250:9000 ⇄ 172.21.38.191:5470] (incoming) 142 bytes sent (+0), 1346 bytes received (+0), 0 retransmits (+0)

...

Get connections (ts: 1559148917): []


Logs
---
Stats reset triggered for key:p:7890|src:172.21.33.250:9000|dst:172.21.38.191:5470|f:0|t:0, stats:{totalSent:0 totalRecv:3160 totalRetransmits:0}, connection:[TCP] [PID: 7890] [172.21.33.250:9000 ⇄ 172.21.38.191:5470] (incoming) 142 bytes sent (+0), 1346 bytes received (+0), 0 retransmits (+0)
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
