### PR TITLE
{pkg/trace/api,pkg/trace/agent}: container tagging

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -188,14 +188,19 @@ func (a *Agent) Process(t *api.Trace) {
 	}
 	a.Replacer.Replace(t.Spans)
 
-	// Extract the client sampling rate.
-	clientSampleRate := sampler.GetGlobalRate(root)
-	sampler.SetClientRate(root, clientSampleRate)
-	// Combine it with the pre-sampling rate.
-	rateLimiterRate := a.Receiver.RateLimiter.RealRate()
-	sampler.SetPreSampleRate(root, rateLimiterRate)
-	// Update root's global sample rate to include the presampler rate as well
-	sampler.AddGlobalRate(root, rateLimiterRate)
+	{
+		// this section sets up any necessary tags on the root:
+		clientSampleRate := sampler.GetGlobalRate(root)
+		rateLimiterRate := a.Receiver.RateLimiter.RealRate()
+
+		sampler.SetClientRate(root, clientSampleRate)
+		sampler.SetPreSampleRate(root, rateLimiterRate)
+		sampler.AddGlobalRate(root, rateLimiterRate)
+
+		for k, v := range t.ContainerTags {
+			root.Meta[k] = v
+		}
+	}
 
 	// Figure out the top-level spans and sublayers now as it involves modifying the Metrics map
 	// which is not thread-safe while samplers and Concentrator might modify it too.

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/flags"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
@@ -99,8 +100,10 @@ func Run(ctx context.Context) {
 
 	metrics.Count("datadog.trace_agent.started", 1, nil, 1)
 
-	// Seed rand
 	rand.Seed(time.Now().UTC().UnixNano())
+
+	tagger.Init()
+	defer tagger.Stop()
 
 	agnt := NewAgent(ctx, cfg)
 	log.Infof("Trace agent running on host %s", cfg.Hostname)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -589,14 +589,12 @@ func tracesFromSpans(spans []pb.Span) pb.Traces {
 // getContainerTags returns container and orchestrator tags belonging to containerID. If containerID
 // is empty or no tags are found, an empty map is returned.
 func getContainerTags(containerID string) map[string]string {
-	if containerID == "" {
-		return map[string]string{}
-	}
-	// for now, only Kubernetes is supported
 	list, err := tagger.Tag("container_id://"+containerID, collectors.HighCardinality)
 	if err != nil {
+		log.Tracef("Getting container tags for ID %q: %v", containerID, err)
 		return map[string]string{}
 	}
+	log.Tracef("Getting container tags for ID %q: %v", containerID, list)
 	tags := make(map[string]string, len(list))
 	for _, tag := range list {
 		// this is a metrics product style tag; either a "key:value" pair,

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/tinylib/msgp/msgp"
 
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
@@ -294,6 +296,10 @@ const (
 	// with the number of traces contained in the payload.
 	headerTraceCount = "X-Datadog-Trace-Count"
 
+	// headerContainerID specifies the name of the header which contains the ID of the
+	// container where the request originated.
+	headerContainerID = "Datadog-Container-ID"
+
 	// headerLang specifies the name of the header which contains the language from
 	// which the traces originate.
 	headerLang = "Datadog-Meta-Lang"
@@ -380,7 +386,8 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 			r.wg.Done()
 			watchdog.LogOnPanic()
 		}()
-		r.processTraces(ts, traces)
+		containerID := req.Header.Get(headerContainerID)
+		r.processTraces(ts, containerID, traces)
 	}()
 }
 
@@ -390,12 +397,18 @@ type Trace struct {
 	// language, interpreter, tracer version, etc.
 	Source *info.Tags
 
+	// ContainerTags specifies orchestrator tags corresponding to the origin of this
+	// trace (e.g. K8S pod, Docker image, ECS, etc).
+	ContainerTags map[string]string
+
 	// Spans holds the spans of this trace.
 	Spans pb.Trace
 }
 
-func (r *HTTPReceiver) processTraces(ts *info.TagStats, traces pb.Traces) {
+func (r *HTTPReceiver) processTraces(ts *info.TagStats, containerID string, traces pb.Traces) {
 	defer timing.Since("datadog.trace_agent.internal.normalize_ms", time.Now())
+
+	containerTags := getContainerTags(containerID)
 	for _, trace := range traces {
 		spans := len(trace)
 
@@ -409,8 +422,9 @@ func (r *HTTPReceiver) processTraces(ts *info.TagStats, traces pb.Traces) {
 		}
 
 		r.out <- &Trace{
-			Source: &ts.Tags,
-			Spans:  trace,
+			Source:        &ts.Tags,
+			ContainerTags: containerTags,
+			Spans:         trace,
 		}
 	}
 }
@@ -570,6 +584,37 @@ func tracesFromSpans(spans []pb.Span) pb.Traces {
 	}
 
 	return traces
+}
+
+// getContainerTags returns container and orchestrator tags belonging to containerID. If containerID
+// is empty or no tags are found, an empty map is returned.
+func getContainerTags(containerID string) map[string]string {
+	if containerID == "" {
+		return map[string]string{}
+	}
+	// for now, only Kubernetes is supported
+	list, err := tagger.Tag("container_id://"+containerID, collectors.HighCardinality)
+	if err != nil {
+		return map[string]string{}
+	}
+	tags := make(map[string]string, len(list))
+	for _, tag := range list {
+		// this is a metrics product style tag; either a "key:value" pair,
+		// or simply "key", without a value.
+		parts := strings.Split(tag, ":")
+		if parts[0] == "" {
+			continue
+		}
+		k := "container." + parts[0]
+		if len(parts) > 1 {
+			// key and value
+			tags[k] = parts[1]
+		} else {
+			// key only
+			tags[k] = ""
+		}
+	}
+	return tags
 }
 
 // getMediaType attempts to return the media type from the Content-Type MIME header. If it fails

--- a/releasenotes/notes/apm-container-tagging-e68b49f196813659.yaml
+++ b/releasenotes/notes/apm-container-tagging-e68b49f196813659.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: add support for container tagging. It can be used with any client tracer that supports it.

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -11,7 +11,14 @@ from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS,
 from .go import deps
 
 BIN_PATH = os.path.join(".", "bin", "trace-agent")
-DEFAULT_BUILD_TAGS = ["netcgo", "secrets"]
+DEFAULT_BUILD_TAGS = [
+    "netcgo",
+    "secrets",
+    "kubeapiserver",
+    "kubelet",
+    "ec2",
+    "docker",
+]
 
 @task
 def build(ctx, rebuild=False, race=False, precompile_only=False, build_include=None,
@@ -35,6 +42,11 @@ def build(ctx, rebuild=False, race=False, precompile_only=False, build_include=N
     ldflags, gcflags, env = get_build_flags(ctx)
     build_include = DEFAULT_BUILD_TAGS if build_include is None else build_include.split(",")
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
+
+    if not sys.platform.startswith('linux'):
+        for ex in LINUX_ONLY_TAGS:
+            if ex not in build_exclude:
+                build_exclude.append(ex)
 
     if puppy:
         # Puppy mode overrides whatever passed through `--build-exclude` and `--build-include`

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -19,6 +19,7 @@ DEFAULT_BUILD_TAGS = [
     "containerd",
     "ec2",
     "docker",
+    "cri",
 ]
 
 @task

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -16,6 +16,7 @@ DEFAULT_BUILD_TAGS = [
     "secrets",
     "kubeapiserver",
     "kubelet",
+    "containerd",
     "ec2",
     "docker",
 ]

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -11,15 +11,13 @@ from .build_tags import get_build_tags, get_default_build_tags, LINUX_ONLY_TAGS,
 from .go import deps
 
 BIN_PATH = os.path.join(".", "bin", "trace-agent")
+
 DEFAULT_BUILD_TAGS = [
     "netcgo",
     "secrets",
+    "docker",
     "kubeapiserver",
     "kubelet",
-    "containerd",
-    "ec2",
-    "docker",
-    "cri",
 ]
 
 @task


### PR DESCRIPTION
This change adds support for container tagging. When the incoming
payload contains the header "Datadog-Container-ID", its value is used to
obtain orchestrator tags from the "tagger" service (pkg/tagger). These
tags are then set on each root span as tags `orchestrator.<tag> = <value>`.