### PR TITLE
Use a reusable buffer when reading http response into bytes

### DIFF
--- a/pkg/process/net/network_linux.go
+++ b/pkg/process/net/network_linux.go
@@ -33,15 +33,16 @@ func init() {
 
 // RemoteSysProbeUtil wraps interactions with a remote system probe service
 type RemoteSysProbeUtil struct {
-	mu *sync.Mutex
-
 	// Retrier used to setup system probe
 	initRetry retry.Retrier
 
 	socketPath string
 	httpClient http.Client
 
+	// buf is a shared buffer used when reading JSON off the unix-socket. mu is used to synchronize
+	// access to buf
 	buf bytes.Buffer
+	mu  sync.Mutex
 }
 
 // SetSystemProbeSocketPath provides a unix socket path location to be used by the remote system probe.
@@ -113,7 +114,7 @@ func ShouldLogTracerUtilError() bool {
 func newSystemProbe() *RemoteSysProbeUtil {
 	return &RemoteSysProbeUtil{
 		socketPath: globalSocketPath,
-		mu:         &sync.Mutex{},
+		mu:         sync.Mutex{},
 		httpClient: http.Client{
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{


### PR DESCRIPTION
### What does this PR do?

This reduces allocations by usinga  re-usable byte.Buffer when decoding the json payload from system-probe. The results from system-probe can be rather large, so not allocating once per request is good.  

### Motivation

N/a

### Additional Notes

N/a
