### PR TITLE
Fix configcheck crash when agent not ready

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -541,6 +541,10 @@ func (ac *AutoConfig) resolveTemplateForService(tpl integration.Config, svc list
 
 // GetLoadedConfigs returns configs loaded
 func (ac *AutoConfig) GetLoadedConfigs() map[string]integration.Config {
+	if ac.store == nil {
+		log.Error("Autoconfig store not initialized")
+		return map[string]integration.Config{}
+	}
 	return ac.store.getLoadedConfigs()
 }
 

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -344,3 +344,9 @@ func TestRemoveTemplate(t *testing.T) {
 	ac.removeConfigTemplates([]integration.Config{tpl})
 	assert.Len(t, ac.GetLoadedConfigs(), 1)
 }
+
+func TestGetLoadedConfigNotInitialized(t *testing.T) {
+	ac := AutoConfig{}
+	cfgs := ac.GetLoadedConfigs()
+	require.Len(t, cfgs, 0)
+}

--- a/releasenotes/notes/fix-possible-configcheck-crash-e9bcd1304fc19b54.yaml
+++ b/releasenotes/notes/fix-possible-configcheck-crash-e9bcd1304fc19b54.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a potential crash when doing a ``configcheck`` while the agent was not properly initialized yet.


### PR DESCRIPTION
### What does this PR do?

Fix

```
2019-05-16 20:33:22 UTC | CORE | ERROR | (/root/.gimme/versions/go1.11.5.linux.amd64/src/net/http/server.go:1747 in func1) | Error from the agent http API server: http: panic serving 127.0.0.1:39406: runtime error: invalid memory address or nil pointer dereference
goroutine 270 [running]:
net/http.(*conn).serve.func1(0xc0008979a0)
 /root/.gimme/versions/go1.11.5.linux.amd64/src/net/http/server.go:1746 +0xd0
panic(0x2d184a0, 0x498f750)
 /root/.gimme/versions/go1.11.5.linux.amd64/src/runtime/panic.go:513 +0x1b9
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).GetLoadedConfigs(0x0, 0x0)
```
