### PR TITLE
system-probe: minimize json fields

### DIFF
--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -97,7 +97,7 @@ type ConnectionStats struct {
 	Type          ConnectionType         `json:"type"`
 	Family        ConnectionFamily       `json:"family"`
 	Direction     ConnectionDirection    `json:"direction"`
-	IPTranslation *netlink.IPTranslation `json:"cntrk"`
+	IPTranslation *netlink.IPTranslation `json:"iptr"`
 }
 
 // SourceAddr returns the source address in the Address abstraction

--- a/pkg/ebpf/event_common.go
+++ b/pkg/ebpf/event_common.go
@@ -74,30 +74,30 @@ type Connections struct {
 type ConnectionStats struct {
 	// Source & Dest represented as a string to handle both IPv4 & IPv6
 	// Note: As ebpf.Address is an interface, we need to use interface{} for easyjson
-	Source interface{} `json:"source,string"`
-	Dest   interface{} `json:"dest,string"`
+	Source interface{} `json:"src,string"`
+	Dest   interface{} `json:"dst,string"`
 
-	MonotonicSentBytes uint64 `json:"monotonic_sent_bytes"`
-	LastSentBytes      uint64 `json:"last_sent_bytes"`
+	MonotonicSentBytes uint64 `json:"m_sent_b"`
+	LastSentBytes      uint64 `json:"sent_b"`
 
-	MonotonicRecvBytes uint64 `json:"monotonic_recv_bytes"`
-	LastRecvBytes      uint64 `json:"last_recv_bytes"`
+	MonotonicRecvBytes uint64 `json:"m_recv_b"`
+	LastRecvBytes      uint64 `json:"recv_b"`
 
 	// Last time the stats for this connection were updated
-	LastUpdateEpoch uint64 `json:"last_update_epoch"`
+	LastUpdateEpoch uint64 `json:"epoch"`
 
-	MonotonicRetransmits uint32 `json:"monotonic_retransmits"`
-	LastRetransmits      uint32 `json:"last_retransmits"`
+	MonotonicRetransmits uint32 `json:"m_retr"`
+	LastRetransmits      uint32 `json:"retr"`
 
 	Pid   uint32 `json:"pid"`
-	NetNS uint32 `json:"net_ns"`
+	NetNS uint32 `json:"ns"`
 
 	SPort         uint16                 `json:"sport"`
 	DPort         uint16                 `json:"dport"`
 	Type          ConnectionType         `json:"type"`
 	Family        ConnectionFamily       `json:"family"`
 	Direction     ConnectionDirection    `json:"direction"`
-	IPTranslation *netlink.IPTranslation `json:"conntrack"`
+	IPTranslation *netlink.IPTranslation `json:"cntrk"`
 }
 
 // SourceAddr returns the source address in the Address abstraction

--- a/pkg/ebpf/event_common_easyjson.go
+++ b/pkg/ebpf/event_common_easyjson.go
@@ -142,7 +142,7 @@ func easyjson5f1d7f40DecodeGithubComDataDogDatadogAgentPkgEbpf1(in *jlexer.Lexer
 			continue
 		}
 		switch key {
-		case "source":
+		case "src":
 			if m, ok := out.Source.(easyjson.Unmarshaler); ok {
 				m.UnmarshalEasyJSON(in)
 			} else if m, ok := out.Source.(json.Unmarshaler); ok {
@@ -150,7 +150,7 @@ func easyjson5f1d7f40DecodeGithubComDataDogDatadogAgentPkgEbpf1(in *jlexer.Lexer
 			} else {
 				out.Source = in.Interface()
 			}
-		case "dest":
+		case "dst":
 			if m, ok := out.Dest.(easyjson.Unmarshaler); ok {
 				m.UnmarshalEasyJSON(in)
 			} else if m, ok := out.Dest.(json.Unmarshaler); ok {
@@ -158,23 +158,23 @@ func easyjson5f1d7f40DecodeGithubComDataDogDatadogAgentPkgEbpf1(in *jlexer.Lexer
 			} else {
 				out.Dest = in.Interface()
 			}
-		case "monotonic_sent_bytes":
+		case "m_sent_b":
 			out.MonotonicSentBytes = uint64(in.Uint64())
-		case "last_sent_bytes":
+		case "sent_b":
 			out.LastSentBytes = uint64(in.Uint64())
-		case "monotonic_recv_bytes":
+		case "m_recv_b":
 			out.MonotonicRecvBytes = uint64(in.Uint64())
-		case "last_recv_bytes":
+		case "recv_b":
 			out.LastRecvBytes = uint64(in.Uint64())
-		case "last_update_epoch":
+		case "epoch":
 			out.LastUpdateEpoch = uint64(in.Uint64())
-		case "monotonic_retransmits":
+		case "m_retr":
 			out.MonotonicRetransmits = uint32(in.Uint32())
-		case "last_retransmits":
+		case "retr":
 			out.LastRetransmits = uint32(in.Uint32())
 		case "pid":
 			out.Pid = uint32(in.Uint32())
-		case "net_ns":
+		case "ns":
 			out.NetNS = uint32(in.Uint32())
 		case "sport":
 			out.SPort = uint16(in.Uint16())
@@ -186,7 +186,7 @@ func easyjson5f1d7f40DecodeGithubComDataDogDatadogAgentPkgEbpf1(in *jlexer.Lexer
 			out.Family = ConnectionFamily(in.Uint8())
 		case "direction":
 			out.Direction = ConnectionDirection(in.Uint8())
-		case "conntrack":
+		case "cntrk":
 			if in.IsNull() {
 				in.Skip()
 				out.IPTranslation = nil
@@ -211,7 +211,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"source\":"
+		const prefix string = ",\"src\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -227,7 +227,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		}
 	}
 	{
-		const prefix string = ",\"dest\":"
+		const prefix string = ",\"dst\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -243,7 +243,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		}
 	}
 	{
-		const prefix string = ",\"monotonic_sent_bytes\":"
+		const prefix string = ",\"m_sent_b\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -253,7 +253,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint64(uint64(in.MonotonicSentBytes))
 	}
 	{
-		const prefix string = ",\"last_sent_bytes\":"
+		const prefix string = ",\"sent_b\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -263,7 +263,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint64(uint64(in.LastSentBytes))
 	}
 	{
-		const prefix string = ",\"monotonic_recv_bytes\":"
+		const prefix string = ",\"m_recv_b\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -273,7 +273,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint64(uint64(in.MonotonicRecvBytes))
 	}
 	{
-		const prefix string = ",\"last_recv_bytes\":"
+		const prefix string = ",\"recv_b\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -283,7 +283,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint64(uint64(in.LastRecvBytes))
 	}
 	{
-		const prefix string = ",\"last_update_epoch\":"
+		const prefix string = ",\"epoch\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -293,7 +293,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint64(uint64(in.LastUpdateEpoch))
 	}
 	{
-		const prefix string = ",\"monotonic_retransmits\":"
+		const prefix string = ",\"m_retr\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -303,7 +303,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint32(uint32(in.MonotonicRetransmits))
 	}
 	{
-		const prefix string = ",\"last_retransmits\":"
+		const prefix string = ",\"retr\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -323,7 +323,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint32(uint32(in.Pid))
 	}
 	{
-		const prefix string = ",\"net_ns\":"
+		const prefix string = ",\"ns\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -383,7 +383,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint8(uint8(in.Direction))
 	}
 	{
-		const prefix string = ",\"conntrack\":"
+		const prefix string = ",\"cntrk\":"
 		if first {
 			first = false
 			_ = first

--- a/pkg/ebpf/event_common_easyjson.go
+++ b/pkg/ebpf/event_common_easyjson.go
@@ -186,7 +186,7 @@ func easyjson5f1d7f40DecodeGithubComDataDogDatadogAgentPkgEbpf1(in *jlexer.Lexer
 			out.Family = ConnectionFamily(in.Uint8())
 		case "direction":
 			out.Direction = ConnectionDirection(in.Uint8())
-		case "cntrk":
+		case "iptr":
 			if in.IsNull() {
 				in.Skip()
 				out.IPTranslation = nil
@@ -383,7 +383,7 @@ func easyjson5f1d7f40EncodeGithubComDataDogDatadogAgentPkgEbpf1(out *jwriter.Wri
 		out.Uint8(uint8(in.Direction))
 	}
 	{
-		const prefix string = ",\"cntrk\":"
+		const prefix string = ",\"iptr\":"
 		if first {
 			first = false
 			_ = first

--- a/pkg/ebpf/netlink/event.go
+++ b/pkg/ebpf/netlink/event.go
@@ -3,8 +3,8 @@ package netlink
 // IPTranslation can be associated with a connection to show show the connection is NAT'd
 //easyjson:json
 type IPTranslation struct {
-	ReplSrcIP   string `json:"repl_src_ip"`
-	ReplDstIP   string `json:"repl_dst_ip"`
-	ReplSrcPort uint16 `json:"repl_src_port"`
-	ReplDstPort uint16 `json:"repl_dst_port"`
+	ReplSrcIP   string `json:"r_src"`
+	ReplDstIP   string `json:"r_dst"`
+	ReplSrcPort uint16 `json:"r_sport"`
+	ReplDstPort uint16 `json:"r_dport"`
 }

--- a/pkg/ebpf/netlink/event_easyjson.go
+++ b/pkg/ebpf/netlink/event_easyjson.go
@@ -37,13 +37,13 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgEbpfNetlink(in *jlexer
 			continue
 		}
 		switch key {
-		case "repl_src_ip":
+		case "r_src":
 			out.ReplSrcIP = string(in.String())
-		case "repl_dst_ip":
+		case "r_dst":
 			out.ReplDstIP = string(in.String())
-		case "repl_src_port":
+		case "r_sport":
 			out.ReplSrcPort = uint16(in.Uint16())
-		case "repl_dst_port":
+		case "r_dport":
 			out.ReplDstPort = uint16(in.Uint16())
 		default:
 			in.SkipRecursive()
@@ -60,7 +60,7 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgEbpfNetlink(out *jwrit
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"repl_src_ip\":"
+		const prefix string = ",\"r_src\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -70,7 +70,7 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgEbpfNetlink(out *jwrit
 		out.String(string(in.ReplSrcIP))
 	}
 	{
-		const prefix string = ",\"repl_dst_ip\":"
+		const prefix string = ",\"r_dst\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -80,7 +80,7 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgEbpfNetlink(out *jwrit
 		out.String(string(in.ReplDstIP))
 	}
 	{
-		const prefix string = ",\"repl_src_port\":"
+		const prefix string = ",\"r_sport\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -90,7 +90,7 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgEbpfNetlink(out *jwrit
 		out.Uint16(uint16(in.ReplSrcPort))
 	}
 	{
-		const prefix string = ",\"repl_dst_port\":"
+		const prefix string = ",\"r_dport\":"
 		if first {
 			first = false
 			_ = first


### PR DESCRIPTION
### What does this PR do?

Previously:
```go
ConnectionStats{
        Pid:                123,
        Type:               1,
        Family:             AFINET,
        Source:             util.AddressFromString("192.168.0.1"),
        Dest:               util.AddressFromString("192.168.0.103"),
        SPort:              123,
        DPort:              35000,
        MonotonicSentBytes: 123123,
        MonotonicRecvBytes: 312312,
    }
```

Was taking `314b` and is now `221b`

### Motivation

Decrease the memory usage for encoding / decoding connections payloads

### Additional Notes

Anything else we should know when reviewing?
