### PR TITLE
process-agent: Fix initial logging

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -73,18 +73,10 @@ Exiting.`
 )
 
 func runAgent(exit chan bool) {
-	platform, err := util.GetPlatform()
-	if err != nil {
-		log.Debugf("error retrieving platform: %s", err)
-	} else {
-		log.Infof("running on platform: %s", platform)
-	}
-
 	if opts.version {
 		fmt.Print(versionString("\n"))
 		os.Exit(0)
 	}
-	log.Infof("running version: %s", versionString(", "))
 
 	if opts.check == "" && !opts.info && opts.pidfilePath != "" {
 		err := pidfile.WritePID(opts.pidfilePath)
@@ -105,6 +97,16 @@ func runAgent(exit chan bool) {
 		log.Criticalf("Error parsing config: %s", err)
 		os.Exit(1)
 	}
+
+	// Now that the logger is configured log host info
+	platform, err := util.GetPlatform()
+	if err != nil {
+		log.Debugf("error retrieving platform: %s", err)
+	} else {
+		log.Infof("running on platform: %s", platform)
+	}
+
+	log.Infof("running version: %s", versionString(", "))
 
 	// Tagger must be initialized after agent config has been setup
 	tagger.Init()


### PR DESCRIPTION
### What does this PR do?

The version / platform were not logged to the log file at start time (because the logger was not ready yet), this moves the host info logging after the logger is ready.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
