### PR TITLE
add system_probe_config as known flags to get rid of the warnings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -420,8 +420,10 @@ func initConfig(config Config) {
 	config.SetKnown("process.additional_endpoints")
 	config.SetKnown("process.container_source")
 	config.SetKnown("process.intervals.connections")
-	config.SetKnown("network_tracer_config.enabled")
-	config.SetKnown("network_tracer_config.log_file")
+	config.SetKnown("system_probe_config.enabled")
+	config.SetKnown("system_probe_config.log_file")
+	config.SetKnown("system_probe_config.debug_port")
+	config.SetKnown("system_probe_config.bpf_debug")
 
 	// APM
 	config.SetKnown("apm_config.enabled")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,6 +414,8 @@ func initConfig(config Config) {
 	config.SetKnown("process_config.intervals.container")
 	config.SetKnown("process_config.intervals.container_realtime")
 	config.SetKnown("process_config.dd_agent_bin")
+	config.SetKnown("process_config.custom_sensitive_words")
+	config.SetKnown("process_config.scrub_args")
 	config.SetKnown("process.strip_proc_arguments")
 	config.SetKnown("process_config.windows.args_refresh_interval")
 	config.SetKnown("process_config.windows.add_new_args")


### PR DESCRIPTION
### What does this PR do?

Add `system_probe_config` to known flags for datadog-agent config to get rid of the warnings when it starts.

### Motivation

Remove warning messages:
```
2019-05-31 15:33:03 UTC | PROCESS | WARN | (pkg/config/config.go:607 in load) | Unknown key in config file: system_probe_config.debug_port
2019-05-31 15:33:03 UTC | PROCESS | WARN | (pkg/config/config.go:607 in load) | Unknown key in config file: system_probe_config.enabled
2019-05-31 15:33:03 UTC | PROCESS | WARN | (pkg/config/config.go:607 in load) | Unknown key in config file: system_probe_config.log_file
2019-05-31 15:33:03 UTC | PROCESS | WARN | (pkg/config/config.go:607 in load) | Unknown key in config file: system_probe_config.bpf_debug
```

### Additional Notes

@DataDog/burrito 
