### PR TITLE
Avoid copying bytes when creating JSON in /connections

### DIFF
--- a/cmd/system-probe/probe.go
+++ b/cmd/system-probe/probe.go
@@ -168,13 +168,13 @@ func writeConnections(w http.ResponseWriter, cs *ebpf.Connections) {
 		w.WriteHeader(500)
 		return
 	}
-	bytes, err := jw.DumpTo(w)
+	bytesWritten, err := jw.DumpTo(w)
 	if err != nil {
-		log.Errorf("unable to dump JSON to response")
+		log.Errorf("unable to dump JSON to response: %s", err)
 		w.WriteHeader(500)
 		return
 	}
-	log.Tracef("/connections: %d connections, %d bytes", len(cs.Conns), bytes)
+	log.Tracef("/connections: %d connections, %d bytes", len(cs.Conns), bytesWritten)
 }
 
 func writeAsJSON(w http.ResponseWriter, data interface{}) {

--- a/cmd/system-probe/probe.go
+++ b/cmd/system-probe/probe.go
@@ -13,11 +13,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/mailru/easyjson"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
+	"github.com/mailru/easyjson/jwriter"
 )
 
 // ErrTracerUnsupported is the unsupported error prefix, for error-class matching from callers
@@ -161,14 +161,20 @@ func getClientID(req *http.Request) string {
 }
 
 func writeConnections(w http.ResponseWriter, cs *ebpf.Connections) {
-	buf, err := easyjson.Marshal(cs)
-	if err != nil {
+	jw := &jwriter.Writer{}
+	cs.MarshalEasyJSON(jw)
+	if err := jw.Error; err != nil {
 		log.Errorf("unable to marshall connections into JSON: %s", err)
 		w.WriteHeader(500)
 		return
 	}
-	w.Write(buf)
-	log.Tracef("/connections: %d connections, %d bytes", len(cs.Conns), len(buf))
+	bytes, err := jw.DumpTo(w)
+	if err != nil {
+		log.Errorf("unable to dump JSON to response")
+		w.WriteHeader(500)
+		return
+	}
+	log.Tracef("/connections: %d connections, %d bytes", len(cs.Conns), bytes)
 }
 
 func writeAsJSON(w http.ResponseWriter, data interface{}) {

--- a/cmd/system-probe/probe_test.go
+++ b/cmd/system-probe/probe_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/netlink"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	in := &ebpf.Connections{
+		Conns: []ebpf.ConnectionStats{
+			{
+				Source: util.AddressFromString("10.1.1.1"),
+				Dest:   util.AddressFromString("10.1.1.1"),
+				SPort:  1000,
+				DPort:  9000,
+				IPTranslation: &netlink.IPTranslation{
+					ReplSrcIP: "20.1.1.1",
+					ReplDstIP: "20.1.1.1",
+				},
+			},
+		},
+	}
+
+	expected, err := in.MarshalJSON()
+	require.NoError(t, err)
+
+	writeConnections(rec, in)
+
+	rec.Flush()
+	out := rec.Body.Bytes()
+	assert.Equal(t, expected, out)
+
+}

--- a/cmd/system-probe/probe_test.go
+++ b/cmd/system-probe/probe_test.go
@@ -18,14 +18,29 @@ func TestDecode(t *testing.T) {
 	in := &ebpf.Connections{
 		Conns: []ebpf.ConnectionStats{
 			{
-				Source: util.AddressFromString("10.1.1.1"),
-				Dest:   util.AddressFromString("10.1.1.1"),
-				SPort:  1000,
-				DPort:  9000,
+				Source:               util.AddressFromString("10.1.1.1"),
+				Dest:                 util.AddressFromString("10.2.2.2"),
+				MonotonicSentBytes:   1,
+				LastSentBytes:        2,
+				MonotonicRecvBytes:   100,
+				LastRecvBytes:        101,
+				LastUpdateEpoch:      50,
+				MonotonicRetransmits: 201,
+				LastRetransmits:      201,
+				Pid:                  6000,
+				NetNS:                7,
+				SPort:                1000,
+				DPort:                9000,
 				IPTranslation: &netlink.IPTranslation{
-					ReplSrcIP: "20.1.1.1",
-					ReplDstIP: "20.1.1.1",
+					ReplSrcIP:   "20.1.1.1",
+					ReplDstIP:   "20.1.1.1",
+					ReplSrcPort: 40,
+					ReplDstPort: 70,
 				},
+
+				Type:      ebpf.UDP,
+				Family:    ebpf.AFINET6,
+				Direction: ebpf.LOCAL,
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

`easyjson.Marshal` will call `jwriter.Writer.BuildBytes()` which allocates
from the heap (instead of the globally shared easyjson pool)

This PR changes the connection endpoint to dump the json writer contents
straight to the http response.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
