### PR TITLE
Fix return type of handleCrashes

### DIFF
--- a/six/include/datadog_agent_six.h
+++ b/six/include/datadog_agent_six.h
@@ -51,7 +51,7 @@ DATADOG_AGENT_SIX_API int run_simple_string(const six_t *, const char *code);
 DATADOG_AGENT_SIX_API int has_error(const six_t *);
 DATADOG_AGENT_SIX_API const char *get_error(const six_t *);
 #ifndef _WIN32
-DATADOG_AGENT_SIX_API int handle_crashes(const six_t *, const int);
+DATADOG_AGENT_SIX_API void handle_crashes(const six_t *, const int);
 #endif
 
 // PYTHON HELPERS

--- a/six/include/six.h
+++ b/six/include/six.h
@@ -56,7 +56,7 @@ public:
     void setError(const std::string &msg) const; // let const methods set errors
     void setError(const char *msg) const;
 #ifndef _WIN32
-    bool handleCrashes(const bool coredump) const;
+    void handleCrashes(const bool coredump) const;
 #endif
 
     // Python Helpers

--- a/six/six/api.cpp
+++ b/six/six/api.cpp
@@ -286,10 +286,10 @@ void clear_error(six_t *six)
  * C-land crash handling
  */
 
-DATADOG_AGENT_SIX_API int handle_crashes(const six_t *six, const int enable)
+DATADOG_AGENT_SIX_API void handle_crashes(const six_t *six, const int enable)
 {
     // enable implicit cast to bool
-    return AS_CTYPE(Six, six)->handleCrashes(enable) ? 1 : 0;
+    AS_CTYPE(Six, six)->handleCrashes(enable);
 }
 #endif
 

--- a/six/six/six.cpp
+++ b/six/six/six.cpp
@@ -55,7 +55,7 @@ void signalHandler(int sig, siginfo_t *, void *)
     }
 }
 
-bool Six::handleCrashes(const bool coredump) const
+void Six::handleCrashes(const bool coredump) const
 {
     // register signal handlers
     struct sigaction sa;


### PR DESCRIPTION
### What does this PR do?

Fix return type of `handleCrashes`.

This fix the following warning:
```
six.cpp: In member function ‘bool Six::handleCrashes(bool) const’:
six.cpp:72:1: warning: no return statement in function returning non-void [-Wreturn-type]
 }
 ^
```