### PR TITLE
handle errors set by from_yaml and as_yaml

### DIFF
--- a/six/common/builtins/datadog_agent.c
+++ b/six/common/builtins/datadog_agent.c
@@ -138,6 +138,8 @@ PyObject *get_config(PyObject *self, PyObject *args)
     PyObject *value = from_yaml(data);
     cgo_free(data);
     if (value == NULL) {
+        // clear error set by `from_yaml`
+        PyErr_Clear();
         Py_RETURN_NONE;
     }
     return value;
@@ -166,6 +168,8 @@ PyObject *headers(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *headers_dict = from_yaml(data);
     cgo_free(data);
     if (headers_dict == NULL || !PyDict_Check(headers_dict)) {
+        // clear error set by `from_yaml`
+        PyErr_Clear();
         // if headers_dict is not a dict we don't need to hold a ref to it
         Py_XDECREF(headers_dict);
         Py_RETURN_NONE;

--- a/six/common/builtins/kubeutil.c
+++ b/six/common/builtins/kubeutil.c
@@ -56,6 +56,8 @@ PyObject *get_connection_info(PyObject *self, PyObject *args)
     cgo_free(data);
 
     if (conn_info_dict == NULL || !PyDict_Check(conn_info_dict)) {
+        // clear error set by `from_yaml`
+        PyErr_Clear();
         // create a new ref and drop the other one
         Py_XDECREF(conn_info_dict);
         return PyDict_New();


### PR DESCRIPTION
### What does this PR do?

`from_yaml` and `as_yaml` are setting errors: https://github.com/DataDog/datadog-agent/blob/c6d08a48595da8d0dc90b9239694b8a5cde8d4c0/six/common/stringutils.c#L98 This PR takes care of those errors when those functions fail.

### Motivation

Six audit